### PR TITLE
fix(app-sdk): harden scoped-API guard against path traversal and 204 bodies

### DIFF
--- a/website/src/app-sdk/index.ts
+++ b/website/src/app-sdk/index.ts
@@ -203,22 +203,44 @@ export function useChatLauncher(): {
 import React from 'react'
 
 function createScopedApi(allowedPaths: string[], appName: string): AppApi {
-  const check = (path: string) => {
-    const pathOnly = path.split('?')[0]
-    const allowed = allowedPaths.some(p => pathOnly === p || pathOnly.startsWith(p.endsWith('/') ? p : p + '/'))
-    if (!allowed) {
-      throw new Error(`[app-sdk] App "${appName}" not permitted to access ${path}. Declared: [${allowedPaths.join(', ')}]`)
+  const check = (path: string): string => {
+    // Reject absolute and protocol-relative URLs to prevent SSRF. Backslashes
+    // are rejected too: the URL parser treats `\` like `/`, so `/\evil.com` or
+    // `\\evil.com` would otherwise be parsed as a protocol-relative authority.
+    if (/^(?:https?:)?[/\\]{2}/i.test(path) || path.includes('\\')) {
+      throw new Error(`[app-sdk] Absolute URLs are not allowed: ${path}`)
     }
+    // Normalize BEFORE the allowlist check so `..` traversal cannot escape the
+    // declared scope (e.g. `/api/apps/x/../../secret` → `/api/secret`).
+    const parsed = new URL(path, 'http://localhost')
+    const normalized = parsed.pathname
+    const allowed = allowedPaths.some(p => normalized === p || normalized.startsWith(p.endsWith('/') ? p : p + '/'))
+    if (!allowed) {
+      throw new Error(`[app-sdk] App "${appName}" not permitted to access ${normalized}. Declared: [${allowedPaths.join(', ')}]`)
+    }
+    return normalized + parsed.search
   }
 
   const jsonFetch = async <T,>(path: string, init?: RequestInit): Promise<T> => {
-    check(path)
-    const res = await fetch(path, init)
+    const safePath = check(path)
+    const res = await fetch(safePath, init)
     if (!res.ok) {
       const text = await res.text().catch(() => res.statusText)
       throw new Error(`API ${res.status}: ${text}`)
     }
-    return res.json()
+    // An empty-body response is not JSON — res.json() would throw a SyntaxError
+    // (e.g. a 204 No Content on DELETE, or a 200 with an empty body and no
+    // Content-Length header). Read the body as text and only parse when it is
+    // non-empty, so any empty body returns undefined regardless of status or
+    // whether a Content-Length: 0 header was sent.
+    if (res.status === 204 || res.status === 205) {
+      return undefined as T
+    }
+    const text = await res.text()
+    if (text.trim() === '') {
+      return undefined as T
+    }
+    return JSON.parse(text) as T
   }
 
   return {

--- a/website/src/test/appSdkScopedApi.test.tsx
+++ b/website/src/test/appSdkScopedApi.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Tests for the permission-scoped API client created by AppApiProvider
+ * (app-sdk/index.ts::createScopedApi).
+ *
+ * Locks in the SSRF / permission guard: the scoped client MUST reject absolute,
+ * protocol-relative, and backslash-authority URLs, reject paths outside the
+ * declared allowlist (including `..` traversal that would escape scope), and
+ * permit declared paths (with query strings). It must also tolerate 204 /
+ * empty-body responses without throwing. These are security- and
+ * correctness-sensitive, so they are enforced deterministically here.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import React from 'react'
+import { AppApiProvider, useAppApi, type AppApi } from '../app-sdk/index'
+
+// Render the provider and hand back the scoped API client it builds.
+function getScopedApi(allowedApiPaths: string[]): AppApi {
+  let captured: AppApi | null = null
+
+  function Probe() {
+    captured = useAppApi()
+    return null
+  }
+
+  act(() => {
+    render(
+      React.createElement(
+        AppApiProvider,
+        {
+          appName: 'test-app',
+          appVersion: '1.0.0',
+          allowedApiPaths,
+          allowedEvents: [],
+          subscribeFn: () => () => {},
+          navigateFn: () => {},
+          notifyFn: () => {},
+        },
+        React.createElement(Probe),
+      ),
+    )
+  })
+
+  if (!captured) throw new Error('failed to capture scoped api')
+  return captured
+}
+
+describe('createScopedApi (via AppApiProvider) — SSRF / permission guard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('rejects absolute http(s) URLs (SSRF)', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.get('https://evil.example.com/steal')).rejects.toThrow(/Absolute URLs are not allowed/)
+    await expect(api.get('http://169.254.169.254/latest/meta-data')).rejects.toThrow(/Absolute URLs are not allowed/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects protocol-relative URLs (SSRF)', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.get('//evil.example.com/steal')).rejects.toThrow(/Absolute URLs are not allowed/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects backslash authority tricks (URL parser treats \\ like /)', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    for (const bad of ['\\\\evil.example.com/steal', '/\\evil.example.com', '\\/evil.example.com']) {
+      await expect(api.get(bad)).rejects.toThrow(/Absolute URLs are not allowed/)
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects paths outside the declared allowlist', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.get('/api/apps/other/secrets')).rejects.toThrow(/not permitted to access/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects `..` traversal that escapes the allowlist', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    // Normalizes to /api/secret — outside the allowlist.
+    await expect(api.get('/api/apps/test/../../secret')).rejects.toThrow(/not permitted to access/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a sibling prefix as allowed (prefix boundary)', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.get('/api/apps/test-evil')).rejects.toThrow(/not permitted to access/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('permits a declared path and forwards the normalized path to fetch', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await api.get('/api/apps/test')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/apps/test')
+  })
+
+  it('permits a declared path with a query string', async () => {
+    const api = getScopedApi(['/api/apps/test'])
+    await api.get('/api/apps/test/items?limit=10')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/apps/test/items?limit=10')
+  })
+
+  it('returns undefined for a 204 No Content response (does not call res.json)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.del('/api/apps/test/item/1')).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for a 200 with content-length 0', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 200, headers: { 'content-length': '0' } }))
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.post('/api/apps/test/action')).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for a 200 with an empty body and NO content-length header', async () => {
+    // res.json() would throw SyntaxError here; the client reads text and
+    // returns undefined for an empty body regardless of the header.
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 200, headers: { 'content-type': 'application/json' } }))
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.post('/api/apps/test/action')).resolves.toBeUndefined()
+  })
+
+  it('still parses a normal JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, n: 3 }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }))
+    const api = getScopedApi(['/api/apps/test'])
+    await expect(api.get('/api/apps/test/data')).resolves.toEqual({ ok: true, n: 3 })
+  })
+})


### PR DESCRIPTION
## Description

The in-tree app SDK (`website/src/app-sdk/index.ts`) — the copy the dashboard
serves to installed apps at runtime via the import map (`__kirocrew_modules`) —
has two latent issues in `createScopedApi`, surfaced while building the public
[`@kirocrew/app-sdk`](https://github.com/kirodotdev/KiroCrewAppSDK) package. This
brings the host copy to parity with the hardened standalone package.

### 1. Permission-scope escape via path traversal (security)

`check()` matched the allowlist against the **raw** request path:

```
app granted:  /api/apps/x
app calls:    api.get('/api/apps/x/../../secret')
old check():  ALLOWED  (raw string starts with "/api/apps/x")
browser fetches: /api/secret   ← escapes the app's declared scope
```

Fix: normalize with `new URL(path, 'http://localhost')` **before** the allowlist
check, so `..` traversal collapses first and the scope check runs on the real
target. Also explicitly reject absolute, protocol-relative, and
backslash-authority URLs (`/\evil.com`, `\\evil.com`) — the URL parser treats
`\` like `/`, so those would otherwise parse as an authority.

### 2. 204 / empty-body responses throw (correctness)

`jsonFetch` called `res.json()` unconditionally, which throws a `SyntaxError`
on a `204 No Content` (e.g. a `DELETE`). Fix: return `undefined` for 204 /
`content-length: 0` responses.

## Impact / compatibility

- The only in-repo callers of the scoped client are `useChatSession.ts` and
  `ChatEmbed.tsx`; both pass plain relative paths (`/api/chat`, `/api/chat/slots/…`)
  that normalize to themselves and pass the allowlist unchanged. No behavior
  change for them.
- Query strings are preserved; the normalized path + search is what's fetched.

## Testing

- [x] New `src/test/appSdkScopedApi.test.tsx` — 10 cases covering absolute /
      protocol-relative / backslash rejection, `..` traversal, prefix-boundary,
      allowed paths (with query), and 204 / empty-body handling.
- [x] `npx vitest run` on the app-sdk + chat suites — 54 passing (was 35 baseline,
      +10 new + existing), 0 regressions.
- [x] `npx tsc -b` clean; `eslint` clean on changed files.

## Related

Companion to [KiroCrewAppSDK#1](https://github.com/kirodotdev/KiroCrewAppSDK/pull/1),
which introduced the standalone package with this same hardening.