### PR TITLE
fix(electron): Align appId with CDSigner identity (com.amazon.kiro.crew)

### DIFF
--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -19,7 +19,7 @@
     "electron-builder": "^25.1.8"
   },
   "build": {
-    "appId": "dev.kirocrew.desktop",
+    "appId": "com.amazon.kiro.crew",
     "productName": "KiroCrew",
     "mac": {
       "category": "public.app-category.developer-tools",


### PR DESCRIPTION
## Summary
Set the macOS electron-builder `appId` to `com.amazon.kiro.crew` so the built app's `CFBundleIdentifier` matches the identity CDSigner signs and authorizes against.

## Why
The CDSigner manifest (`packaging/signing/manifest-template.json`) already uses `app.identifier: com.amazon.kiro.crew`, and the app's Bindle resource is `94KV3E626L.com.amazon.kiro.crew`. But electron-builder still built the bundle as `dev.kirocrew.desktop`, so the signed app's real identifier (and all derived helper bundle IDs) would not match what CDSigner authorizes/signs. This aligns the built app, the signing manifest, and the Bindle on a single identity.

## Verified
- Against the live CDSigner API (SigV4): submitting the canonical manifest creates/authorizes the `94KV3E626L.com.amazon.kiro.crew` Bindle (`amzn1.bindle.resource.hmezoyvbymtwiwp2niwa`).
- One-line change; `productName` (KiroCrew) unchanged.

## Follow-up (out of scope, human-gated)
- Bindle ownership transfer + `CanSign` grant on the new resource for account `116101834266`.
