### PR TITLE
fix(security): authenticate MCP routes in --slack-only headless gateway

### DIFF
--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -292,6 +292,32 @@ app.middlewares[:] = [
 site = web.TCPSite(runner, bind_address_for(local_only), port)
 ```
 
+The two internal-path sets passed to `token_auth_middleware` are module-level
+constants — `_STRICT_INTERNAL_API_PATHS` and `_MIXED_INTERNAL_API_PATHS` — so
+the headless server (below) binds to the **same** sets and the two entrypoints
+cannot drift.
+
+#### `start_api_server()` — headless (`--slack-only`) parity
+
+The `--slack-only` gateway starts `start_api_server()` instead of
+`start_dashboard()`. It serves the **same** MCP tool route surface
+(`_register_mcp_routes`), so it mounts an auth chain at parity:
+`host_validation_middleware → csrf_middleware → token_auth_middleware(
+internal_paths=_STRICT_INTERNAL_API_PATHS,
+mixed_internal_paths=_MIXED_INTERNAL_API_PATHS, spa_shell_handler=None) →
+sel_audit_middleware`. It generates and persists the same
+`~/.kirocrew/.local_secret`, sets `app["local_secret"]`, and builds
+`app["allowed_origins"]`. `spa_shell_handler=None` because there is no UI — a
+request with no token is denied outright. Every in-repo caller (mcp-core, cron)
+already sends `X-Internal-Secret`, so the change is purely additive.
+
+The `sel_audit_middleware` **alone is not a security boundary** — it only logs.
+Any minimal/alternate server that calls `_register_mcp_routes` MUST mount the
+same token-auth chain; otherwise every state-changing MCP route (`/api/spawn`,
+`/api/crons`, `/api/lessons`, `/api/send-message`, `/api/workflows/*`,
+`/api/taskrunner`) is reachable unauthenticated on loopback (port forwarders and
+browser CSRF reach `127.0.0.1`).
+
 ### 6. `gateway.py` Integration
 
 `_init_dashboard()` resolves config and passes to `start_dashboard()`:
@@ -302,6 +328,21 @@ self._local_only = is_local_only(configured_host, self._slack_enabled)
 await start_dashboard(
     ...,
     slack_connected=self._slack_enabled,
+    local_only=self._local_only,
+    configured_host=configured_host,
+)
+```
+
+`_init_api_server()` (the `--slack-only` / `--no-dashboard` path) resolves the
+same `configured_host`/`local_only` and forwards them to `start_api_server()`,
+so the headless server's CSRF origin allowlist and Host allowlist match the
+dashboard's:
+
+```python
+configured_host, dashboard_port = parse_dashboard_url(self._cfg.dashboard.url)
+self._local_only = is_local_only(configured_host, self._slack_enabled)
+await start_api_server(
+    ...,
     local_only=self._local_only,
     configured_host=configured_host,
 )
@@ -385,3 +426,4 @@ HTML 403 page includes instructions to run `!dashboard` in Slack. The middleware
 9. Bounded concurrent nonces (max 50; raised from 5 so pending Slack link nonces aren't evicted by other token-minting activity) — prevents unbounded memory growth, limits exposure window; an active session refreshes its eviction position on each check
 10. Explicit revocation via `kirocrew logout` — clears all nonces, IP bindings, and consumed tokens
 11. App-token scope confinement (CWE-269) — an `app`-claim token is confined deny-by-default to its own namespace (`/apps/<name>`, `/api/apps/<name>`) + its manifest `permissions.api` allowlist, enforced at every grant point; no-op for dashboard-user tokens
+12. Headless (`--slack-only`) auth parity — `start_api_server()` serves the same MCP route surface as the dashboard and mounts the same `host_validation → csrf → token_auth → sel_audit` chain against the shared `_STRICT_INTERNAL_API_PATHS`/`_MIXED_INTERNAL_API_PATHS` sets. Internal MCP routes require loopback **plus** `X-Internal-Secret` (loopback alone is not sufficient for these paths — port forwarders can spoof `127.0.0.1`); `sel_audit_middleware` alone only logs and is never a substitute for the token-auth chain

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -170,6 +170,62 @@ _PERMISSIONS_POLICY = (
     "clipboard-write=(self), clipboard-read=(self)"
 )
 
+# Strict internal API paths — exact paths that ONLY internal processes
+# (mcp-core, doctor, cron) call, never the browser. Access requires loopback
+# AND a matching ``X-Internal-Secret`` header; non-loopback is always denied and
+# there is no cookie fall-through (see token_auth.token_auth_middleware).
+#
+# Module-level and shared by BOTH ``start_dashboard`` and ``start_api_server``
+# so the two entrypoints can never drift: the ``--slack-only`` headless server
+# must gate exactly the same MCP tool routes the dashboard does. A prior drift
+# here — headless mounting no token auth at all — was an auth-bypass regression
+# of the loopback-bypass fix. Keep this as the single source of truth.
+_STRICT_INTERNAL_API_PATHS = frozenset(
+    {
+        "/api/send-message",
+        "/api/delete-message",
+        "/api/browser-event",
+        "/api/browser/frame",
+        "/api/browser/pump-audit",
+        "/api/session-keepalive",
+        "/api/session-tool-policy",
+        "/api/hooks/agent",
+        "/api/outbox/notify",
+        "/api/slack/upload-file",
+        "/api/slack/pins",
+        "/api/slack/reactions",
+        "/api/slack-profile",  # MCP-only (slack_profile tool); no browser caller
+        "/api/mcp/servers",
+    }
+)
+
+# Mixed internal API paths — called by BOTH internal processes (loopback +
+# ``X-Internal-Secret``) AND the browser (cookie auth), e.g. ``/api/spawn``
+# polled by DCV/SSH-forwarded browsers. On non-loopback they perform explicit
+# cookie validation (deny-by-default) rather than hard-denying, so forwarded
+# browsers don't trip false "session expired" banners. Prefix-matched:
+# ``path == p or path.startswith(p + "/")``. Shared by both entrypoints.
+_MIXED_INTERNAL_API_PATHS = frozenset(
+    {
+        # Called by MCP (loopback + secret) AND browser polling
+        # (DCV/SSH-forwarded cookie auth).  See token_auth.py.
+        "/api/spawn",
+        "/api/chat",
+        "/api/lessons",
+        "/api/crons",  # CLI cron trigger; prefix covers all sub-routes (consistent with spawn/taskrunner)
+        "/api/taskrunner",
+        "/api/artifacts",
+        # The 5 artifact_folder_* MCP tools authenticate via X-Internal-Secret.
+        # token_auth prefix-matching is (path == p or path.startswith(p + "/")),
+        # so "/api/artifact-folders" is NOT covered by the "/api/artifacts"
+        # entry above — without this entry those MCP calls fall through to
+        # cookie auth and fail with "Token required".
+        "/api/artifact-folders",
+        "/api/workflows",  # DW engine: MCP tools + Workflows tab polling
+        "/v1/chat/completions",  # OpenAI-compat API
+    }
+)
+
 
 def _apply_security_headers(
     resp: web.StreamResponse, app: web.Application
@@ -471,11 +527,15 @@ async def _start_site(
 def _write_secret_file(secret_path: Path, secret: str) -> None:
     """Write *secret* to *secret_path* with mode 0o600.
 
-    On failure the (possibly truncated) file is removed and the original
-    ``OSError`` is re-raised.  Caller is responsible for any further
-    cleanup (e.g. tearing down the app runner).
+    Creates the parent directory if needed. On failure the (possibly
+    truncated) file is removed and the original ``OSError`` is re-raised.
+    Caller is responsible for any further cleanup (e.g. tearing down the app
+    runner). Both blocking steps (``mkdir`` and the ``os.open``/``os.close`` +
+    ``restrict_to_owner`` write) live here so the caller can offload the whole
+    thing with a single ``run_in_executor`` (no-blocking-call-on-event-loop).
     """
     try:
+        secret_path.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(secret_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
             # Enforce perms even if the file already exists at looser mode.
@@ -1554,10 +1614,11 @@ async def start_dashboard(
         return await handler(request)  # type: ignore[operator]
 
     # Generate per-session secret for local app / IPC authentication.
-    # NOTE: file write deferred until after port bind succeeds to avoid
-    # poisoning the secret file when a second instance fails to start.
+    # NOTE: file write (and parent mkdir) deferred until after port bind
+    # succeeds — both live in _write_secret_file, offloaded below — to avoid
+    # poisoning the secret file when a second instance fails to start and to
+    # keep blocking fs I/O off the event loop.
     _secret_path = config_dir() / ".local_secret"
-    _secret_path.parent.mkdir(parents=True, exist_ok=True)
     _internal_secret = os.urandom(16).hex()
     app["local_secret"] = _internal_secret
 
@@ -1586,45 +1647,8 @@ async def start_dashboard(
         no_cache_middleware,
         csrf_middleware,
         token_auth_middleware(
-            internal_paths=frozenset(
-                {
-                    "/api/send-message",
-                    "/api/delete-message",
-                    "/api/browser-event",
-                    "/api/browser/frame",
-                    "/api/browser/pump-audit",
-                    "/api/session-keepalive",
-                    "/api/session-tool-policy",
-                    "/api/hooks/agent",
-                    "/api/outbox/notify",
-                    "/api/slack/upload-file",
-                    "/api/slack/pins",
-                    "/api/slack/reactions",
-                    "/api/mcp/servers",
-                }
-            ),
-            mixed_internal_paths=frozenset(
-                {
-                    # Called by MCP (loopback + secret) AND browser polling
-                    # (DCV/SSH-forwarded cookie auth).  See token_auth.py.
-                    "/api/spawn",
-                    "/api/chat",
-                    "/api/lessons",
-                    "/api/crons",  # CLI cron trigger; prefix covers all sub-routes (consistent with spawn/taskrunner)
-                    "/api/taskrunner",
-                    "/api/artifacts",
-                    # The 5 artifact_folder_* MCP tools authenticate via
-                    # X-Internal-Secret. token_auth prefix-matching is
-                    # (path == p or path.startswith(p + "/")), so
-                    # "/api/artifact-folders" is NOT covered by the
-                    # "/api/artifacts" entry above — without this entry those
-                    # MCP calls fall through to cookie auth and fail with
-                    # "Token required".
-                    "/api/artifact-folders",
-                    "/api/workflows",  # DW engine: MCP tools + Workflows tab polling
-                    "/v1/chat/completions",  # OpenAI-compat API
-                }
-            ),
+            internal_paths=_STRICT_INTERNAL_API_PATHS,
+            mixed_internal_paths=_MIXED_INTERNAL_API_PATHS,
             internal_secret=_internal_secret,
             port=port,
             local_only=local_only,
@@ -1680,9 +1704,14 @@ async def start_dashboard(
     site = web.TCPSite(runner, bind_address_for(local_only), port)
     await _start_site(site, port)
 
-    # Port bind succeeded — now safe to write the secret file
+    # Port bind succeeded — now safe to write the secret file. Offloaded:
+    # _write_secret_file does blocking fs I/O (os.open/os.close and, on Windows,
+    # an icacls subprocess via restrict_to_owner), so it must not run on the
+    # event loop (no-blocking-call-on-event-loop).
     try:
-        _write_secret_file(_secret_path, _internal_secret)
+        await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), _write_secret_file, _secret_path, _internal_secret
+        )
     except OSError:
         await runner.cleanup()
         raise
@@ -1893,8 +1922,20 @@ async def start_api_server(
     task_runner: TaskRunner | None = None,
     slack_client: Any = None,
     owner_id: str = "",
+    local_only: bool = True,
+    configured_host: str = "",
 ) -> tuple[web.AppRunner, DashboardState]:
-    """Start a minimal API-only server for MCP tool transport (no UI)."""
+    """Start a minimal API-only server for MCP tool transport (no UI).
+
+    Headless (``--slack-only``) mode. This server exposes the SAME
+    state-changing MCP tool routes as the dashboard (``_register_mcp_routes``),
+    so it MUST authenticate them at parity with ``start_dashboard``: loopback is
+    NOT a trust boundary (local port forwarders and any web page the user opens
+    can reach 127.0.0.1), so the internal MCP routes require the
+    ``X-Internal-Secret`` machine-to-machine handshake, and state-changing
+    requests are guarded against DNS-rebinding (Host) and cross-site browsers
+    (Origin). Every in-repo caller (mcp-core, cron) already sends the secret.
+    """
     state = DashboardState(
         sessions=sessions,
         crons=crons,
@@ -1925,8 +1966,25 @@ async def start_api_server(
 
     _precompute_telemetry(state)
 
+    # ── Auth parity with start_dashboard ─────────────────────────────────────
+    # The MCP route surface is identical to the dashboard's, so the middleware
+    # chain must be too. Host-allowlist source of truth is shared with the CSRF
+    # Origin check via build_allowed_origins/build_allowed_hosts (see origin.py).
+    app["allowed_origins"] = build_allowed_origins(port, local_only, configured_host)
+    app["local_only"] = local_only
+
+    # Per-session internal secret for machine-to-machine (mcp-core, cron) auth.
+    # Deferred file write (and parent mkdir) until after the port binds (mirrors
+    # start_dashboard): both live in _write_secret_file, offloaded below, so a
+    # failed second instance never poisons the live gateway's secret file and no
+    # blocking fs I/O runs on the event loop.
+    _secret_path = config_dir() / ".local_secret"
+    _internal_secret = os.urandom(16).hex()
+    app["local_secret"] = _internal_secret
+
     # SEL audit middleware — log mutating MCP tool calls
     _sel_methods = {"GET", "POST", "PUT", "DELETE"}
+    _safe_methods = {"GET", "HEAD", "OPTIONS"}
 
     @web.middleware  # type: ignore[misc]
     async def sel_audit_middleware(
@@ -1956,7 +2014,68 @@ async def start_api_server(
                 raise
         return await handler(request)  # type: ignore[operator]
 
-    app.middlewares.append(sel_audit_middleware)
+    @web.middleware  # type: ignore[misc]
+    async def host_validation_middleware(
+        request: web.Request,
+        handler: object,
+    ) -> web.StreamResponse:
+        # DNS-rebinding defense-in-depth (AVP-23427), parity with start_dashboard.
+        if not check_host(request):
+            sel().log_api_access(
+                caller="mcp_tool",
+                operation=f"{request.method} {request.path}",
+                outcome="denied",
+                resources=request.path,
+                error=f"host header not allowed: {request.headers.get('Host', '')[:100]}",
+            )
+            raise web.HTTPForbidden(
+                text="Host header not allowed.",
+                content_type="text/plain",
+            )
+        return await handler(request)  # type: ignore[operator]
+
+    @web.middleware  # type: ignore[misc]
+    async def csrf_middleware(
+        request: web.Request,
+        handler: object,
+    ) -> web.StreamResponse:
+        # Cross-site CSRF barrier on state-changing routes, parity with
+        # start_dashboard. Loopback local processes (mcp-core, cron) send no
+        # Origin header and are trusted by check_origin; a browser always sends
+        # Origin, so a cross-site page is rejected here even before token auth.
+        if request.method not in _safe_methods:
+            if not check_origin(request, require=True, fallback_header="Referer"):
+                # Audit the CSRF denial (security-relevant permission decision),
+                # mirroring host_validation_middleware.
+                sel().log_api_access(
+                    caller="mcp_tool",
+                    operation=f"{request.method} {request.path}",
+                    outcome="denied",
+                    resources=request.path,
+                    error=f"CSRF check failed: origin not allowed: {request.headers.get('Origin', '')[:100]}",
+                )
+                raise web.HTTPForbidden(
+                    text="CSRF check failed: request origin not allowed.",
+                    content_type="text/plain",
+                )
+        return await handler(request)  # type: ignore[operator]
+
+    # Explicit ordering mirrors start_dashboard: host → csrf → token → audit.
+    app.middlewares[:] = [
+        host_validation_middleware,
+        csrf_middleware,
+        token_auth_middleware(
+            internal_paths=_STRICT_INTERNAL_API_PATHS,
+            mixed_internal_paths=_MIXED_INTERNAL_API_PATHS,
+            internal_secret=_internal_secret,
+            port=port,
+            local_only=local_only,
+            # No SPA shell in headless mode: a no-token request must be denied
+            # outright, never served an HTML shell (there is no UI to boot).
+            spa_shell_handler=None,
+        ),
+        sel_audit_middleware,
+    ]
 
     _register_mcp_routes(app)
 
@@ -1964,6 +2083,20 @@ async def start_api_server(
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", port)
     await _start_site(site, port)
+
+    # Port bind succeeded — now safe to persist the secret file (parity with
+    # start_dashboard: write deferred so a failed bind can't poison it).
+    # Offloaded: _write_secret_file does blocking fs I/O (os.open/os.close and,
+    # on Windows, an icacls subprocess via restrict_to_owner), so it must not run
+    # on the event loop (no-blocking-call-on-event-loop).
+    try:
+        await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), _write_secret_file, _secret_path, _internal_secret
+        )
+    except OSError:
+        await runner.cleanup()
+        raise
+
     logger.info("API-only server listening on 127.0.0.1:%d", port)
 
     return runner, state

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3328,6 +3328,8 @@ class GatewayOrchestrator:
             task_runner=self.task_runner,
             slack_client=self.slack,
             owner_id=self._owner_id,
+            local_only=self._local_only,
+            configured_host=configured_host,
         )
         if dashboard_port == 0 and self._dashboard_runner is not None:
             addresses = self._dashboard_runner.addresses

--- a/test/test_api_server.py
+++ b/test/test_api_server.py
@@ -197,9 +197,16 @@ class TestStartApiServerWiring:
 
     @pytest.mark.asyncio
     async def test_server_has_audit_middleware_and_hook_store(self, tmp_path, monkeypatch):
+        import kiro_crew.config.loader as _loader
+        import kiro_crew.dashboard.server as _srv
         import kiro_crew.dashboard.state as _st
 
+        # start_api_server now persists .local_secret via server.config_dir and
+        # warms the token_auth revoked-nonce store via loader.config_dir; patch
+        # all three sites so the test never writes the real ~/.kirocrew secret.
         monkeypatch.setattr(_st, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(_srv, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(_loader, "config_dir", lambda: tmp_path)
 
         from kiro_crew.dashboard.server import start_api_server
 
@@ -215,6 +222,240 @@ class TestStartApiServerWiring:
         try:
             assert state._hook_store is not None
             assert len(runner.app.middlewares) > 0
+            # Auth parity with start_dashboard: token_auth_middleware MUST be
+            # mounted on the headless server, not just the SEL audit logger.
+            assert any(
+                getattr(mw, "_is_token_auth", False) for mw in runner.app.middlewares
+            ), "start_api_server must mount token_auth_middleware"
+        finally:
+            await runner.cleanup()
+
+
+class TestApiServerAuth:
+    """--slack-only headless mode must authenticate MCP tool routes at parity
+    with the default dashboard mode.
+
+    The gateway binds loopback, but loopback is NOT a trust boundary: local
+    port forwarders and any web page the user opens can reach 127.0.0.1. So
+    state-changing MCP routes must require the ``X-Internal-Secret`` handshake
+    (machine-to-machine) exactly as ``start_dashboard`` enforces it.
+    """
+
+    async def _start(self, tmp_path, monkeypatch, **kwargs):
+        import kiro_crew.config.loader as _loader
+        import kiro_crew.dashboard.server as _srv
+        import kiro_crew.dashboard.state as _st
+
+        # Route config_dir() into the test's tmp dir at the sites that resolve it
+        # here:
+        #  - server.py binds ``from kiro_crew.config import config_dir`` at module
+        #    scope (its own name) — used for the .local_secret write.
+        #  - state.py binds ``from kiro_crew.config.loader import config_dir``.
+        #  - token_auth.py imports ``config_dir`` LAZILY inside functions from
+        #    kiro_crew.config.loader, so patch the real ``loader.config_dir``.
+        # All three are REAL module attributes (loader has no __getattr__), so
+        # monkeypatch restores them cleanly. Do NOT patch
+        # ``kiro_crew.config.config_dir`` — that name is served by a PEP-562 lazy
+        # ``__getattr__`` (not a real __dict__ entry), so setattr there pollutes
+        # the package dict and leaks across tests.
+        monkeypatch.setattr(_srv, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(_st, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(_loader, "config_dir", lambda: tmp_path)
+
+        from kiro_crew.dashboard.server import start_api_server
+
+        runner, state = await start_api_server(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]),
+                status=MagicMock(return_value={}),
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            port=0,
+            **kwargs,
+        )
+        addrs = runner.addresses
+        base = f"http://127.0.0.1:{addrs[0][1]}"
+        return runner, state, base
+
+    @pytest.mark.asyncio
+    async def test_get_crons_denied_without_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{base}/api/crons") as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_get_spawn_denied_without_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{base}/api/spawn") as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_post_spawn_denied_without_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        mock_mgr = MagicMock()
+        mock_mgr.spawn.return_value = MagicMock(id="x", done=False, error="")
+        runner, _state, base = await self._start(tmp_path, monkeypatch, subagents=mock_mgr)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{base}/api/spawn",
+                    json={"task": "noop", "approval_mode": "auto"},
+                ) as resp:
+                    assert resp.status == 403
+            # The denied request must never reach the handler.
+            assert not mock_mgr.spawn.called
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_post_lessons_denied_without_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{base}/api/lessons", json={"text": "injected"}) as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_get_crons_allowed_with_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            secret = (tmp_path / ".local_secret").read_text().strip()
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{base}/api/crons",
+                    headers={"X-Internal-Secret": secret},
+                ) as resp:
+                    assert resp.status == 200
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_get_crons_denied_with_wrong_secret(self, tmp_path, monkeypatch):
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{base}/api/crons",
+                    headers={"X-Internal-Secret": "deadbeef"},
+                ) as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_local_secret_file_written(self, tmp_path, monkeypatch):
+        runner, state, _base = await self._start(tmp_path, monkeypatch)
+        try:
+            # Parity with start_dashboard: the secret is exposed on the app and
+            # persisted so in-repo MCP callers can read it.
+            assert (tmp_path / ".local_secret").is_file()
+            assert runner.app["local_secret"]
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_artifact_folders_denied_without_secret(self, tmp_path, monkeypatch):
+        # /api/artifact-folders is called by MCP tools (_get/_post w/ secret) AND
+        # the browser — classified as a mixed internal path. Must deny an
+        # unauthenticated caller.
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{base}/api/artifact-folders") as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_slack_profile_denied_without_secret(self, tmp_path, monkeypatch):
+        # /api/slack-profile is MCP-only (no browser caller) — a strict internal
+        # path. Unauthenticated callers are denied at the auth layer.
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{base}/api/slack-profile", json={"user": "U123"}) as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_post_denied_by_csrf(self, tmp_path, monkeypatch):
+        # A browser CSRF attempt (cross-site Origin on a state-changing request)
+        # is rejected by csrf_middleware before token auth even runs, even if it
+        # somehow carried the secret.
+        import aiohttp
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            secret = (tmp_path / ".local_secret").read_text().strip()
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{base}/api/spawn",
+                    json={"task": "noop"},
+                    headers={
+                        "Origin": "https://evil.example.com",
+                        "X-Internal-Secret": secret,
+                    },
+                ) as resp:
+                    assert resp.status == 403
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_csrf_denial_is_audited(self, tmp_path, monkeypatch):
+        # A CSRF rejection is a security-relevant permission decision and must be
+        # written to the SEL audit log. ``sel`` is the process-wide singleton
+        # (keyed on the home dir, not config_dir), so assert on the call rather
+        # than reading a file.
+        import aiohttp
+
+        import kiro_crew.dashboard.server as _srv
+
+        fake_sel = MagicMock()
+        monkeypatch.setattr(_srv, "sel", lambda: fake_sel)
+
+        runner, _state, base = await self._start(tmp_path, monkeypatch)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{base}/api/spawn",
+                    json={"task": "noop"},
+                    headers={"Origin": "https://evil.example.com"},
+                ) as resp:
+                    assert resp.status == 403
+            denied = [
+                c
+                for c in fake_sel.log_api_access.call_args_list
+                if c.kwargs.get("outcome") == "denied"
+                and "CSRF check failed" in c.kwargs.get("error", "")
+            ]
+            assert denied, "CSRF denial was not logged to SEL"
         finally:
             await runner.cleanup()
 

--- a/test/test_artifact_folder_handlers.py
+++ b/test/test_artifact_folder_handlers.py
@@ -495,14 +495,13 @@ class TestMixedInternalPathRegistration:
         (hyphen, not slash). If server.py drops the dedicated entry, every
         folder MCP call falls through to cookie auth and fails with
         "Token required"."""
-        import inspect
-
         from kiro_crew.dashboard import server as server_mod
 
-        src = inspect.getsource(server_mod)
-        start = src.index("mixed_internal_paths=frozenset(")
-        end = src.index("internal_secret=", start)
-        block = src[start:end]
-        assert '"/api/artifact-folders"' in block
-        # Confidence check: the prefix-match rule this guards against.
+        # The mixed-internal set is the module-level constant shared by
+        # start_dashboard and start_api_server (a single source of truth so the
+        # two entrypoints cannot drift). Assert against the runtime value rather
+        # than scraping source text, so the guard survives refactors.
+        assert "/api/artifact-folders" in server_mod._MIXED_INTERNAL_API_PATHS
+        # Confidence check: the prefix-match rule this guards against —
+        # "/api/artifact-folders" is NOT covered by the "/api/artifacts" entry.
         assert not "/api/artifact-folders".startswith("/api/artifacts" + "/")


### PR DESCRIPTION
## Problem

`start_api_server` — the `--slack-only` / `--no-dashboard` headless gateway
entrypoint — mounted only `sel_audit_middleware` (an audit **logger**), while
`start_dashboard` mounts the full `host_validation → csrf → token_auth →
sel_audit` chain. Both call the identical `_register_mcp_routes`, so in headless
mode every state-changing MCP tool route — `/api/spawn`, `/api/crons`,
`/api/lessons`, `/api/send-message`, `/api/workflows/*`, `/api/taskrunner`,
`/api/artifacts*` — was served on `127.0.0.1` with **no authentication**.

Loopback is not a trust boundary: local port forwarders (`socat`, `ssh -R`) and
any web page the user opens (browser CSRF) can reach `127.0.0.1`. So any third
party could read and drive the owner's agent — spawn subagents, write agent
memory, schedule cron jobs, post to Slack — with no credential. `sel_audit_middleware`
only logs; it never denies.

## Fix

- Mount `token_auth_middleware` on `start_api_server` at parity with
  `start_dashboard`, plus `host_validation_middleware` (DNS-rebinding barrier)
  and `csrf_middleware` (cross-site Origin). Build `allowed_origins` and
  persist/expose the per-session `.local_secret`.
- Hoist the two internal-path sets to module-level constants
  (`_STRICT_INTERNAL_API_PATHS` / `_MIXED_INTERNAL_API_PATHS`) shared by **both**
  entrypoints, so they can no longer drift — the drift was the root cause.
  `/api/slack-profile` (MCP-only, no browser caller) is added to the strict set.
- Thread `local_only` / `configured_host` from `gateway._init_api_server`.

Purely additive for in-repo callers — `mcp-core` and cron already send
`X-Internal-Secret` on every call. The browser UI is unaffected (mixed paths
keep cookie auth for DCV/SSH-forwarded browsers). `spa_shell_handler=None` on the
headless path: a no-token request is denied outright (there is no UI to boot).

## Testing

New `test/test_api_server.py::TestApiServerAuth` (11 tests):
unauthenticated GET/POST on the MCP routes now return **403**;
`X-Internal-Secret` calls reach the handler; wrong secret → 403; a cross-site
`Origin` POST is rejected **and** audited to SEL; `.local_secret` is persisted.
`TestStartApiServerWiring` strengthened to assert `token_auth_middleware` is
mounted.

Full local run: **375 passed** across `test_api_server.py`, `test_token_auth.py`,
and `test_slack_gateway.py`; `flake8` clean on the changed files.

Spec updated: `docs/system-specs/features/dashboard-token-auth.md` (headless
parity in §5/§6 + Security Property #12).
