### PR TITLE
ci: upsert AI-review summaries (marker dedup) + team-wide CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
 # KiroCrew Code Owners
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Owners are auto-requested for review. Branch protection enforces approval.
-# General code review: any team member can approve (via branch protection rule).
-# Frontend: requires @CrysisDeu approval specifically.
+# Owners are auto-requested for review on every PR. Branch protection can
+# additionally enforce approval ("Require review from Code Owners").
+#
+# All components are owned by the kirocrew-team. Enable review
+# auto-assignment on the team (Org -> Teams -> kirocrew-team -> Settings ->
+# Code review, round-robin or load-balance) so each PR's team request
+# resolves to individual members instead of notifying the whole team.
 
-# ── Frontend (dashboard, Electron shell, UI components) ──────────────
-website/                            @CrysisDeu
+*                                   @kirodotdev/kirocrew-team

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -188,10 +188,16 @@ jobs:
       # Post the review summary for humans (best-effort, NON-gating). Reads the
       # summary from the action's structured output — not from a model-posted
       # comment — so it works even when the model doesn't call gh pr comment.
+      # UPSERT a single marker-keyed comment per PR: re-scanning on every push
+      # UPDATEs that one comment (PATCH) instead of stacking a new one —
+      # otherwise the PR fills with N near-duplicate Claude summaries as the
+      # branch evolves (PR #14 accumulated 3). Fully workflow-owned, so the
+      # dedup does not depend on the model following posting instructions.
       - name: Post Claude review summary
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
           HEAD: ${{ github.event.pull_request.head.sha }}
           SO: ${{ steps.review.outputs.structured_output }}
@@ -200,8 +206,40 @@ jobs:
           summary=$(printf '%s' "$SO" | jq -r '.summary // ""')
           verdict=$(printf '%s' "$SO" | jq -r 'if .block_merge then "🔴 changes requested (blocking)" else "✅ no blocking findings" end')
           [ -z "$summary" ] && exit 0
-          { echo "## Claude Review — $verdict"; echo; printf '%s\n' "$summary"; echo; echo "_Verdict recorded via the action's structured output for commit \`$HEAD\`._"; } > /tmp/claude-summary.md
-          gh pr comment "$PR" --body-file /tmp/claude-summary.md || true
+          MARKER="<!-- claude-ai-review -->"
+          {
+            echo "$MARKER"
+            echo "## Claude Review — $verdict"
+            echo
+            echo "_Reviewed \`$HEAD\` — this comment is updated in place on each push._"
+            echo
+            printf '%s\n' "$summary"
+            echo
+            echo "_Verdict recorded via the action's structured output for commit \`$HEAD\`._"
+          } > /tmp/claude-summary.md
+          # Find the bot's existing marker comment (first match wins) and PATCH
+          # it in place; create once if absent. PR timeline comments are issue
+          # comments, so list/create/update via the issues/comments API. Two
+          # guards on the lookup:
+          #   - author filter: only a github-actions[bot] comment can match —
+          #     otherwise any PR commenter could plant the hidden marker and
+          #     this step would PATCH (overwrite) THEIR comment with the
+          #     write-scoped token.
+          #   - per-page jq: with --paginate the --jq filter runs PER PAGE, so
+          #     emit only matching ids (never null placeholders) and take the
+          #     first line across all pages — a multi-page comment list must
+          #     not produce a malformed multi-line id.
+          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\"))) | .id" 2>/dev/null \
+            | head -n1 || true)"
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+              --field body="$(cat /tmp/claude-summary.md)" >/dev/null || true
+            echo "Updated existing Claude summary comment #$existing"
+          else
+            gh pr comment "$PR" --body-file /tmp/claude-summary.md || true
+            echo "Created new Claude summary comment"
+          fi
 
       # Fail-CLOSED gate. Gates on the action's OWN structured output
       # (steps.review.outputs.structured_output, produced by the --json-schema in

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -227,21 +227,59 @@ jobs:
             perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' codex-review-output.md
           fi
 
-      - name: Post review comment
+      # Upsert a SINGLE Codex summary comment per PR, keyed by a hidden marker.
+      # Re-scanning on every push must UPDATE that one comment (PATCH), never
+      # stack a new one — otherwise the PR fills with N near-duplicate Codex
+      # summaries as the branch evolves (each push = one more comment). GitHub
+      # PR timeline comments are issue comments, so list/create/update via the
+      # issues/comments API; the marker is an HTML comment (invisible in render).
+      - name: Post/update review comment
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -f codex-review-output.md ] && [ -s codex-review-output.md ]; then
-            # Prefix with Codex header to distinguish from Claude review
-            {
-              echo "## Codex Review (GPT-5.6 Sol via Bedrock)"
-              echo ""
+          MARKER="<!-- codex-ai-review -->"
+          {
+            echo "$MARKER"
+            echo "## Codex Review (GPT-5.6 Sol via Bedrock)"
+            echo ""
+            echo "_Reviewed \`$HEAD\` — this comment is updated in place on each push._"
+            echo ""
+            if [ -f codex-review-output.md ] && [ -s codex-review-output.md ]; then
               cat codex-review-output.md
-            } > /tmp/codex-comment.md
+            else
+              # The review step errored / produced no output (e.g. a transient
+              # Bedrock failure). Say so in the SAME comment rather than leaving a
+              # stale prior body; the gate step still fails the check.
+              echo "_Codex produced no output for this commit (the review may have"
+              echo "errored). See the Codex Review job logs; re-run to refresh._"
+            fi
+          } > /tmp/codex-comment.md
 
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              --body-file /tmp/codex-comment.md
+          # Find the bot's existing marker comment (first match wins). Two
+          # guards on the lookup:
+          #   - author filter: only a github-actions[bot] comment can match —
+          #     otherwise any PR commenter could plant the hidden marker and
+          #     this step would PATCH (overwrite) THEIR comment with the
+          #     write-scoped token.
+          #   - per-page jq: with --paginate the --jq filter runs PER PAGE, so
+          #     emit only matching ids (never null placeholders) and take the
+          #     first line across all pages — a multi-page comment list must
+          #     not produce a malformed multi-line id.
+          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\"))) | .id" 2>/dev/null \
+            | head -n1 || true)"
+
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+              --field body="$(cat /tmp/codex-comment.md)" >/dev/null || true
+            echo "Updated existing Codex comment #$existing"
+          else
+            gh pr comment "$PR" --body-file /tmp/codex-comment.md
+            echo "Created new Codex comment"
           fi
 
       # Fail-CLOSED gate, harmonized with claude-review.yml. We do NOT block on


### PR DESCRIPTION
## Problem

1. Both AI reviewers post a fresh summary comment on **every push** via create-only `gh pr comment`, so a PR accumulates N near-duplicate summaries as the branch evolves. On PR #14 this stacked **8 Codex + 3 Claude** summaries across re-scans.
2. PRs sit in `REVIEW_REQUIRED` with no human reviewer auto-assigned unless they touch `website/`.

## Fix 1 — one updatable comment per reviewer (marker upsert)

Key each reviewer's summary on a hidden HTML-comment marker and UPDATE that one comment in place instead of stacking a new one. Both upserts are **workflow-owned** shell steps — dedup does not depend on the model following posting instructions.

- **`codex-review.yml`** — "Post/update review comment" finds the existing `<!-- codex-ai-review -->` comment and PATCHes it, else creates once. An empty/errored Codex run writes an explicit "no output" note into the **same** comment (no stale body); the gate step still fails the check.
- **`claude-review.yml`** — the "Post Claude review summary" step (reading the action's structured output) upserts a single `<!-- claude-ai-review -->` comment the same way.

Hardening (both found by the new Codex gate on this very PR — the contract works):
- **Author filter**: the marker lookup only matches `github-actions[bot]` comments, so a PR commenter planting the hidden marker cannot get their comment overwritten by the write-scoped token.
- **Pagination**: `--paginate` runs `--jq` per page; the lookup emits only matching ids and takes the first line, so multi-page comment lists can't produce a malformed id.

Gate semantics from #22 are untouched: Claude's gate reads the action's structured output and Codex's gate reads `codex-review-output.md` — neither reads PR comments, so the upsert cannot affect a verdict.

## Fix 2 — team-wide CODEOWNERS (folded from #35)

`.github/CODEOWNERS` now assigns **all components to @kirodotdev/kirocrew-team** via a single `*` rule (replacing the frontend-only `website/` rule), so every PR auto-requests a team review on open.

**Follow-up (org admin, not doable in-repo):** enable review auto-assignment on the team — Org → Teams → kirocrew-team → Settings → Code review → round-robin or load-balance, 1 member per PR, optionally "never notify the entire team" — so the team request resolves to an individual instead of pinging everyone. Notes: `kirocrew-team` has `maintain` access (satisfies the CODEOWNERS requirement); CODEOWNERS never assigns the PR author; takes effect on the first PR opened after this merges.

## Follow-up (not in this PR)

Persistent finding-state registry with human feedback commands (`/ai fixed` / `/ai false-positive` / `/ai wont-fix`), permission-checked acknowledgement, fingerprint + code-signature keyed suppression with pr/code/repo scopes, and runtime hard-filtering before the prompt. The upserted summary comment this PR introduces is the natural home for the hidden `<!-- ai-review-state -->` JSON block that design needs.