### PR TITLE
ci(publish-cli): serve CLI via CloudFront over dedicated dist bucket

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Publish wheel and channel manifest
         if: env.HAS_SIGNING_SECRETS
         env:
-          BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+          BUCKET: ${{ vars.CLI_DIST_BUCKET }}
+          CDN_BASE: ${{ vars.CLI_CDN_BASE }}
           WHEEL_PATH: ${{ steps.wheel.outputs.path }}
           WHEEL_NAME: ${{ steps.wheel.outputs.name }}
           SUMS_DIR: ${{ steps.wheel.outputs.sumsdir }}
@@ -91,23 +92,38 @@ jobs:
           SHA256: ${{ steps.wheel.outputs.sha256 }}
         run: |
           set -euo pipefail
+          # The origin bucket is private (OAC), so the raw S3 URL is not publicly
+          # reachable. Publish only when both the dist bucket and the CloudFront
+          # base are configured, and never emit a manifest that points at private
+          # S3. Fail closed (before any upload) otherwise.
+          if [ -z "${BUCKET}" ] || [ -z "${CDN_BASE}" ]; then
+            echo "::error::CLI_DIST_BUCKET and CLI_CDN_BASE repo variables must be set (bucket='${BUCKET}', cdn='${CDN_BASE}')."
+            exit 1
+          fi
+          CDN_BASE="${CDN_BASE%/}"
           PREFIX="cli/${CHANNEL}/${WHEEL_VERSION}"
           aws s3 cp "$WHEEL_PATH" "s3://${BUCKET}/${PREFIX}/${WHEEL_NAME}"
           aws s3 cp "${SUMS_DIR}/SHA256SUMS" "s3://${BUCKET}/${PREFIX}/SHA256SUMS"
 
-          WHEEL_URL="https://${BUCKET}.s3.us-west-2.amazonaws.com/${PREFIX}/${WHEEL_NAME}"
+          WHEEL_URL="${CDN_BASE}/${PREFIX}/${WHEEL_NAME}"
+
+          # Requires-Python straight from the wheel metadata so the manifest never drifts.
+          PYREQ=$(unzip -p "$WHEEL_PATH" '*.dist-info/METADATA' 2>/dev/null \
+            | awk -F': ' 'tolower($1)=="requires-python"{print $2; exit}' | tr -d '\r')
+          PYREQ="${PYREQ:->=3.9}"
+
           cat > /tmp/latest-cli.json <<EOF
           {
             "channel": "${CHANNEL}",
             "version": "${WHEEL_VERSION}",
             "wheel_url": "${WHEEL_URL}",
             "sha256": "${SHA256}",
-            "python_requires": ">=3.10",
+            "python_requires": "${PYREQ}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
           aws s3 cp /tmp/latest-cli.json "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json" \
-            --content-type application/json
+            --content-type application/json --cache-control no-cache
 
           {
             echo "## CLI Published (${CHANNEL})"


### PR DESCRIPTION
## What
Repoints the reusable CLI publish to the new public-distribution layer (deployed as `KiroCrewDistribution`):
- Uploads wheel + `SHA256SUMS` to **`CLI_DIST_BUCKET`** (`kirocrew-updates-116101834266`) — the dedicated CloudFront origin — instead of the signing-artifacts bucket.
- Builds `wheel_url` from **`CLI_CDN_BASE`** (`https://d28nxu9if70cmc.cloudfront.net`). The origin bucket is private via OAC, so the previous raw S3 REST URL is no longer publicly reachable.
- **Fail-closed**: if `CLI_DIST_BUCKET`/`CLI_CDN_BASE` are unset, the job errors before any upload — it never publishes a manifest pointing at the private S3 origin.
- Derives `python_requires` from the wheel `METADATA` (was hardcoded `>=3.10`; the package is `>=3.9`) so the manifest can't drift.
- Marks the feed manifest `no-cache` (matches the `feed/*` CloudFront CACHING_DISABLED behavior).

## Config (repo variables — set)
- `CLI_DIST_BUCKET = kirocrew-updates-116101834266`
- `CLI_CDN_BASE = https://d28nxu9if70cmc.cloudfront.net`

## Why
The public-distribution stack (private S3 origin + CloudFront + OAC) is deployed and verified live. This routes the nightly CLI publish through it. Serving public content through CloudFront (not directly from S3) follows Cloud Security policy (S3BucketNotPubliclyExposed / OAC).

## After merge
A nightly on `main` lands `cli/nightly/<ver>/` + `feed/nightly/latest-cli.json` in the dist bucket, served over CloudFront — enabling the full client-path proof (`curl <CLI_CDN_BASE>/feed/nightly/latest-cli.json` + `pip install` from the CloudFront wheel URL).