### PR TITLE
ci(publish-cli): publish a PEP 503 simple index per channel

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -132,6 +132,64 @@ jobs:
             echo "- Feed: \`feed/${CHANNEL}/latest-cli.json\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Publish PEP 503 simple index
+        if: env.HAS_SIGNING_SECRETS
+        env:
+          BUCKET: ${{ vars.CLI_DIST_BUCKET }}
+          CDN_BASE: ${{ vars.CLI_CDN_BASE }}
+          WHEEL_NAME: ${{ steps.wheel.outputs.name }}
+          WHEEL_VERSION: ${{ steps.wheel.outputs.version }}
+          SHA256: ${{ steps.wheel.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          # PEP 503 static "simple" index per channel, so pip/uv can install
+          # natively (verified invocation; --index-url alone would cut off PyPI
+          # and fail on dependencies):
+          #   pip install --pre kirocrew --extra-index-url ${CDN_BASE}/feed/<channel>/simple/
+          # pip verifies the #sha256= fragment on each link, giving the same
+          # fail-closed integrity as the feed. Lives under feed/ because that
+          # prefix is CI-writable and CloudFront serves it no-cache.
+          CDN_BASE="${CDN_BASE%/}"
+          SIMPLE="feed/${CHANNEL}/simple"
+          PROJ_URL="${CDN_BASE}/${SIMPLE}/kirocrew/"
+          NEW_LINK="<a href=\"${CDN_BASE}/cli/${CHANNEL}/${WHEEL_VERSION}/${WHEEL_NAME}#sha256=${SHA256}\">${WHEEL_NAME}</a><br/>"
+
+          # Merge with the existing (public) project page so prior versions
+          # stay installable; replace any stale entry for the same wheel name.
+          # Fail-closed on transient fetch errors: only a clean 200 (merge) or
+          # an absent page (403/404 -- S3 behind CloudFront returns 403 for
+          # missing keys) may proceed. Anything else (5xx, timeout, DNS) aborts
+          # the step and leaves the published index untouched, so a CDN blip
+          # can never truncate the version history.
+          STATUS=$(curl -sS --max-time 15 -o existing.html -w '%{http_code}' "$PROJ_URL") || STATUS=000
+          case "$STATUS" in
+            200) ;;
+            403|404) : > existing.html ;;
+            *) echo "::error::Fetching existing index returned HTTP ${STATUS}; aborting without touching the published index."; exit 1 ;;
+          esac
+          { grep -oE '<a href="[^"]+">[^<]+</a><br/>' existing.html || true; } \
+            | { grep -v ">${WHEEL_NAME}<" || true; } > links.txt
+          echo "$NEW_LINK" >> links.txt
+
+          {
+            echo '<!DOCTYPE html><html><head><meta name="pypi:repository-version" content="1.0"><title>kirocrew</title></head><body><h1>kirocrew</h1>'
+            cat links.txt
+            echo '</body></html>'
+          } > project.html
+          printf '%s' '<!DOCTYPE html><html><head><meta name="pypi:repository-version" content="1.0"><title>Simple index</title></head><body><a href="kirocrew/">kirocrew</a><br/></body></html>' > root.html
+
+          # CloudFront+OAC does NOT resolve directory indexes (no S3-website
+          # hosting), so ALSO upload the literal trailing-slash keys pip hits.
+          for DEST in "${SIMPLE}/kirocrew/index.html" "${SIMPLE}/kirocrew/"; do
+            aws s3 cp project.html "s3://${BUCKET}/${DEST}" \
+              --content-type "text/html" --cache-control no-cache
+          done
+          for DEST in "${SIMPLE}/index.html" "${SIMPLE}/"; do
+            aws s3 cp root.html "s3://${BUCKET}/${DEST}" \
+              --content-type "text/html" --cache-control no-cache
+          done
+          echo "- Simple index: \`${CDN_BASE}/${SIMPLE}/\` ($(wc -l < links.txt) version(s))" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Skipped (no signing secrets)
         if: ${{ !env.HAS_SIGNING_SECRETS }}
         run: |


### PR DESCRIPTION
Adds a **Publish PEP 503 simple index** step to the reusable CLI publish.

Each channel now serves a static simple index at `feed/<channel>/simple/`, so pip/uv can install natively:

```
pip install --pre kirocrew --extra-index-url https://d28nxu9if70cmc.cloudfront.net/feed/nightly/simple/
```

- Links carry `#sha256=` fragments — **pip verifies them natively**, same fail-closed integrity as the feed/cli.sh path.
- Merges with the existing project page (fetched via the public CDN, no new IAM read grants) so prior versions remain installable; replaces stale same-name entries.
- Uploads literal trailing-slash S3 keys (`…/simple/` and `…/simple/kirocrew/`) because CloudFront+OAC performs no directory-index resolution.
- Lives under `feed/` (CI-writable prefix, CloudFront no-cache behavior — an index must update promptly).

**Verified live**: seeded the nightly index with the exact same shell logic; `pip install --pre kirocrew --extra-index-url …/feed/nightly/simple/` in a clean venv installed `kirocrew 0.1.0.dev20260718` through CloudFront with deps from PyPI. (`--index-url` alone is documented against — it replaces PyPI and dependency resolution fails.)

Complements PR #24 (cli.sh installer) — same distribution layer, pip-native surface.