### PR TITLE
fix: fail closed on untrusted sandbox probes

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -170,10 +170,10 @@ def _probe_unshare() -> bool:
 def _probe_sandbox_exec() -> bool:
     """Return True if macOS ``sandbox-exec`` actually works.
 
-    Uses a file-based profile and targets kiro-cli (or /usr/bin/true as
-    fallback) to match the real sandbox_exec_argv() invocation.  The probe
-    tests with an ``(allow default)`` profile and a representative binary
-    to detect any kernel-level rejection (not just sandbox-exec presence).
+    Uses a file-based profile with fixed system paths for both
+    ``sandbox-exec`` and its ``/usr/bin/true`` target. The probe tests with an
+    ``(allow default)`` profile to detect kernel-level rejection, not merely
+    executable presence.
     """
     if sys.platform != "darwin":
         return False
@@ -189,8 +189,8 @@ def _probe_sandbox_exec() -> bool:
     # deprecated — it's the same enforcement layer that backs App Sandbox and
     # iOS. All major AI CLIs (Claude Code, Codex, Gemini) rely on it.
     # Rather than hard-coding version checks, we probe empirically below.
-    sb = shutil.which("sandbox-exec")
-    if sb is None:
+    sb = "/usr/bin/sandbox-exec"
+    if not os.path.exists(sb):
         return False
     # Probe with a file-based (allow default) profile against a TRUSTED, fixed
     # system binary. We deliberately do NOT probe the (user-writable) kiro-cli
@@ -200,7 +200,7 @@ def _probe_sandbox_exec() -> bool:
     # accepts sandbox_apply, which /usr/bin/true validates safely.
     target = "/usr/bin/true"
     if not os.path.exists(target):
-        target = shutil.which("true") or target
+        return False
     fd, profile_path = tempfile.mkstemp(suffix=".sb", prefix="kirocrew_probe_")
     try:
         os.write(fd, b"(version 1)(allow default)")

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -15,25 +15,25 @@ def test_non_darwin_returns_false(mock_sys):
 
 
 @patch("kiro_crew.sandbox.sys")
-@patch("kiro_crew.sandbox.shutil.which", return_value=None)
-def test_which_not_found_returns_false(mock_which, mock_sys):
+@patch("kiro_crew.sandbox.os.path.exists", return_value=False)
+def test_sandbox_exec_not_found_returns_false(mock_exists, mock_sys):
     mock_sys.platform = "darwin"
     assert _probe_sandbox_exec() is False
 
 
 @patch("kiro_crew.sandbox.sys")
-@patch("kiro_crew.sandbox.shutil.which", return_value="/usr/bin/sandbox-exec")
+@patch("kiro_crew.sandbox.os.path.exists", return_value=True)
 @patch("kiro_crew.sandbox.subprocess.run")
-def test_sandbox_exec_works(mock_run, mock_which, mock_sys):
+def test_sandbox_exec_works(mock_run, mock_exists, mock_sys):
     mock_sys.platform = "darwin"
     mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
     assert _probe_sandbox_exec() is True
 
 
 @patch("kiro_crew.sandbox.sys")
-@patch("kiro_crew.sandbox.shutil.which", return_value="/usr/bin/sandbox-exec")
+@patch("kiro_crew.sandbox.os.path.exists", return_value=True)
 @patch("kiro_crew.sandbox.subprocess.run")
-def test_sandbox_exec_works_on_macos_26(mock_run, mock_which, mock_sys):
+def test_sandbox_exec_works_on_macos_26(mock_run, mock_exists, mock_sys):
     """macOS 26 (Tahoe) is NOT hard-blocked: sandbox-exec + the Seatbelt kernel
     subsystem still work there, so the probe decides empirically. A passing probe
     returns True regardless of OS version — the old ``major >= 26 -> return False``
@@ -45,17 +45,28 @@ def test_sandbox_exec_works_on_macos_26(mock_run, mock_which, mock_sys):
 
 
 @patch("kiro_crew.sandbox.sys")
-@patch("kiro_crew.sandbox.shutil.which", return_value="/usr/bin/sandbox-exec")
+@patch("kiro_crew.sandbox.os.path.exists", return_value=True)
 @patch("kiro_crew.sandbox.subprocess.run")
-def test_sandbox_exec_fails_returns_false(mock_run, mock_which, mock_sys):
+def test_sandbox_exec_fails_returns_false(mock_run, mock_exists, mock_sys):
     mock_sys.platform = "darwin"
     mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
     assert _probe_sandbox_exec() is False
 
 
 @patch("kiro_crew.sandbox.sys")
-@patch("kiro_crew.sandbox.shutil.which", return_value="/usr/bin/sandbox-exec")
+@patch("kiro_crew.sandbox.os.path.exists", side_effect=[True, False])
+@patch("kiro_crew.sandbox.subprocess.run")
+def test_missing_trusted_probe_binary_fails_closed(mock_run, mock_exists, mock_sys):
+    mock_sys.platform = "darwin"
+
+    assert _probe_sandbox_exec() is False
+    mock_run.assert_not_called()
+    assert mock_exists.call_count == 2
+
+
+@patch("kiro_crew.sandbox.sys")
+@patch("kiro_crew.sandbox.os.path.exists", return_value=True)
 @patch("kiro_crew.sandbox.subprocess.run", side_effect=OSError("timeout"))
-def test_subprocess_exception_returns_false(mock_run, mock_which, mock_sys):
+def test_subprocess_exception_returns_false(mock_run, mock_exists, mock_sys):
     mock_sys.platform = "darwin"
     assert _probe_sandbox_exec() is False


### PR DESCRIPTION
## Description

Pins the macOS sandbox capability probe to `/usr/bin/sandbox-exec` and `/usr/bin/true`. If either trusted system binary is missing, the probe now fails closed instead of resolving and executing a user-writable `PATH` fallback.

This closes security scan Finding 8 and adds host-independent regression coverage.

## Related Issues

Security scan Finding 8; no public GitHub issue.

## Testing

- [x] 7 sandbox probe tests pass
- [x] 114 dependent sandbox/spawn-audit tests pass
- [x] New regression proves no subprocess runs when the trusted target is missing
- [x] Black, isort, flake8, mypy, py_compile, and `git diff --check` pass

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff