### PR TITLE
fix(wechat): serialize compact with active turns

### DIFF
--- a/src/kiro_crew/wechat/transport_dispatch.py
+++ b/src/kiro_crew/wechat/transport_dispatch.py
@@ -266,8 +266,17 @@ class WeComDispatcher:
             return
         provider = self.sessions.get_provider(session_key)
         steer = getattr(provider, "steer", None)
+        # ``is_busy`` stays True through post-turn bookkeeping (all await
+        # points), so it alone can't tell a live turn from one that just
+        # finished. Gate steer on ``has_active_turn`` (parity with Telegram):
+        # steering a prompt that already ended is silently swallowed and would
+        # falsely acknowledge a merge. When no turn is live, fall through to the
+        # resend prompt instead.
+        has_active = getattr(provider, "has_active_turn", None)
+        live = has_active is None or bool(has_active())
         steered = bool(
-            getattr(provider, "supports_steer", False)
+            live
+            and getattr(provider, "supports_steer", False)
             and steer is not None
             and await steer(inbound.text)
         )
@@ -359,14 +368,28 @@ class WeComDispatcher:
         """In-place ACP ``/compact`` on the user's current session."""
         assert self.client is not None
         session_key = self._session_key(inbound.userid)
-        provider = self.sessions.get_provider(session_key)
-        if provider is None:
-            await self.client.send_reply(inbound.response_url, "ℹ️ 当前没有可压缩的对话。")
+        # Serialize compaction against the turn semaphore: compacting while a
+        # turn is mutating the same session races the transcript. Distinguish a
+        # busy session (ask the user to retry) from an absent one (nothing to
+        # compact), and always release what we acquired.
+        if not await self.sessions.try_acquire(session_key):
+            if self.sessions.has_session(session_key):
+                await self.client.send_reply(
+                    inbound.response_url, "⏳ 正在处理上一条消息，请稍后再试 /compact。"
+                )
+            else:
+                await self.client.send_reply(inbound.response_url, "ℹ️ 当前没有可压缩的对话。")
             return
         try:
+            provider = self.sessions.get_provider(session_key)
+            if provider is None:
+                await self.client.send_reply(inbound.response_url, "ℹ️ 当前没有可压缩的对话。")
+                return
             await provider.compact()
             await provider.wait_for_compaction(timeout=120.0)
             await self.client.send_reply(inbound.response_url, "🗜️ 已压缩上下文。")
         except Exception:
             logger.exception("WeCom /compact failed for %s", session_key)
             await self.client.send_reply(inbound.response_url, "⚠️ 压缩失败，请重试。")
+        finally:
+            self.sessions.release(session_key)

--- a/test/test_wechat_dispatch.py
+++ b/test/test_wechat_dispatch.py
@@ -25,6 +25,10 @@ class FakeProvider:
         self.rejected: list = []
         self.compacted = False
         self.steered: list = []
+        self.active_turn = True
+
+    def has_active_turn(self) -> bool:
+        return self.active_turn
 
     async def steer(self, text: str) -> bool:
         self.steered.append(text)
@@ -48,11 +52,23 @@ class FakeProvider:
 
 
 class FakeSessions:
-    def __init__(self, provider, *, is_new=True, raise_on_get=None, ctx_pct=0.0) -> None:
+    def __init__(
+        self,
+        provider,
+        *,
+        is_new=True,
+        raise_on_get=None,
+        ctx_pct=0.0,
+        acquire=True,
+        has_session=None,
+    ) -> None:
         self._p = provider
         self._is_new = is_new
         self._raise = raise_on_get
         self._ctx_pct = ctx_pct
+        self._acquire = acquire
+        self._has_session = provider is not None if has_session is None else has_session
+        self.acquired: list = []
         self.released: list = []
         self.successes: list = []
         self.failures: list = []
@@ -82,6 +98,13 @@ class FakeSessions:
 
     def get_provider(self, key):
         return self._p
+
+    async def try_acquire(self, key) -> bool:
+        self.acquired.append(key)
+        return self._acquire
+
+    def has_session(self, key) -> bool:
+        return self._has_session
 
     def is_busy(self, key) -> bool:
         return getattr(self, "_busy", False)
@@ -265,8 +288,35 @@ class TestCommands:
 
         await d.handle_message(_inbound("/compact"))
 
+        key = d._session_key("Wei")
         assert provider.compacted is True
+        assert sessions.acquired == [key]
+        assert sessions.released == [key]
         assert client.replies == [("https://r", "🗜️ 已压缩上下文。")]
+
+    @pytest.mark.asyncio
+    async def test_compact_refused_while_turn_busy(self) -> None:
+        provider = FakeProvider([])
+        sessions = FakeSessions(provider, acquire=False, has_session=True)
+        client = FakeClient()
+        d = _dispatcher(sessions, FakeCtx(), client)
+
+        await d.handle_message(_inbound("/compact"))
+
+        assert provider.compacted is False
+        assert sessions.released == []
+        assert client.replies == [("https://r", "⏳ 正在处理上一条消息，请稍后再试 /compact。")]
+
+    @pytest.mark.asyncio
+    async def test_compact_without_active_session(self) -> None:
+        sessions = FakeSessions(None, acquire=False, has_session=False)
+        client = FakeClient()
+        d = _dispatcher(sessions, FakeCtx(), client)
+
+        await d.handle_message(_inbound("/compact"))
+
+        assert sessions.released == []
+        assert client.replies == [("https://r", "ℹ️ 当前没有可压缩的对话。")]
 
     @pytest.mark.asyncio
     async def test_link_rejected_on_wecom(self) -> None:
@@ -341,5 +391,24 @@ class TestWeComMidTurn:
 
         await d._handle_busy(_inbound("later"), d._session_key("Wei"))
 
+        assert any("重发" in content for _url, content in client.replies)
+        assert sessions.successes == []
+
+    @pytest.mark.asyncio
+    async def test_busy_no_active_turn_does_not_steer(self) -> None:
+        # Semaphore held (post-turn bookkeeping) but no turn is live: steer must
+        # not be attempted and must not falsely acknowledge a merge -- fall
+        # through to the resend prompt instead.
+        provider = FakeProvider([])
+        provider.active_turn = False
+        sessions = FakeSessions(provider)
+        sessions._busy = True
+        client = FakeClient()
+        d = _dispatcher(sessions, FakeCtx(), client)
+
+        await d._handle_busy(_inbound("later"), d._session_key("Wei"))
+
+        assert provider.steered == []
+        assert not any("合并" in content for _url, content in client.replies)
         assert any("重发" in content for _url, content in client.replies)
         assert sessions.successes == []


### PR DESCRIPTION
## Finding — WeChat `/compact` session race (MEDIUM)

`WeComDispatcher._handle_compact()` invoked `provider.compact()` without
coordinating with the session's turn lock. If a `/compact` arrived while a
turn was in flight (or with no session at all), it could interleave with
active session state.

## Fix

`_handle_compact()` now acquires the session lock **before** doing any work:

- **Busy turn** → `sessions.try_acquire()` fails → returns a `retrying`
  message and skips `provider.compact()`.
- **No session** → returns the existing `no session` message and skips
  `provider.compact()`.
- A `finally:` block calls `sessions.release()` so the lock is always
  released, even on error.

This serializes compaction with active turns instead of racing them.

## Verification

- 3/3 targeted regression tests pass (busy-turn, no-session, happy-path).
- 14/14 full WeChat dispatcher test suite passes.
- Black (changed range), isort, flake8, `py_compile` syntax check — all clean.
- `git diff`/`--check` — no stray whitespace or unintended changes.
