### PR TITLE
ci(publish-cli): write simple-index trailing-slash keys with s3api put-object

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -180,13 +180,16 @@ jobs:
 
           # CloudFront+OAC does NOT resolve directory indexes (no S3-website
           # hosting), so ALSO upload the literal trailing-slash keys pip hits.
+          # Must use `s3api put-object` (writes the EXACT key): `s3 cp` treats a
+          # trailing-slash destination as a directory prefix and would silently
+          # write .../kirocrew/project.html instead of the .../kirocrew/ key.
           for DEST in "${SIMPLE}/kirocrew/index.html" "${SIMPLE}/kirocrew/"; do
-            aws s3 cp project.html "s3://${BUCKET}/${DEST}" \
-              --content-type "text/html" --cache-control no-cache
+            aws s3api put-object --bucket "${BUCKET}" --key "${DEST}" --body project.html \
+              --content-type "text/html" --cache-control no-cache > /dev/null
           done
           for DEST in "${SIMPLE}/index.html" "${SIMPLE}/"; do
-            aws s3 cp root.html "s3://${BUCKET}/${DEST}" \
-              --content-type "text/html" --cache-control no-cache
+            aws s3api put-object --bucket "${BUCKET}" --key "${DEST}" --body root.html \
+              --content-type "text/html" --cache-control no-cache > /dev/null
           done
           echo "- Simple index: \`${CDN_BASE}/${SIMPLE}/\` ($(wc -l < links.txt) version(s))" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
First CI run of the PEP 503 index step (nightly 29669301496) exposed a real bug: `aws s3 cp` treats a trailing-slash destination as a **directory prefix**, so it wrote `…/kirocrew/project.html` instead of the literal `…/kirocrew/` key that pip actually requests. The merge logic and the explicit `index.html` keys were correct (the merged page contained both dev20260718 + dev20260719); only the trailing-slash copies were stale.

Fix: use `aws s3api put-object`, which writes the exact key.

Evidence: S3 timestamps showed `…/kirocrew/index.html` rewritten at 01:55 (641 B, two versions) while `…/kirocrew/` remained the 23:52 seed (394 B, one version), plus orphan `project.html`/`root.html` objects at the cp-prefixed keys. After manually copying the merged content to the literal keys, `pip install --pre kirocrew --extra-index-url …/feed/nightly/simple/` resolves `0.1.0.dev20260719` through CloudFront. The next nightly validates this fix end-to-end in CI.