### PR TITLE
fix: pin woke release with checksum verification

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -134,9 +134,22 @@ jobs:
           fetch-depth: 0
 
       - name: Install woke
+        env:
+          WOKE_VERSION: "0.19.0"
+          WOKE_SHA256: "db5ed0906c81323a8c478cc57e00301dbf184db7a0293d70ba9f4729b6169d8c"
         run: |
-          curl -sSfL https://raw.githubusercontent.com/get-woke/woke/main/install.sh \
-            | bash -s -- -b /usr/local/bin
+          asset="woke-${WOKE_VERSION}-linux-amd64.tar.gz"
+          archive="${RUNNER_TEMP}/${asset}"
+          bin_dir="${RUNNER_TEMP}/woke-bin"
+          curl -sSfL \
+            "https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/${asset}" \
+            -o "$archive"
+          printf '%s  %s\n' "$WOKE_SHA256" "$archive" | sha256sum -c -
+          mkdir -p "$bin_dir"
+          tar -xzf "$archive" -C "$bin_dir" --strip-components=1 \
+            "woke-${WOKE_VERSION}-linux-amd64/woke"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+          "$bin_dir/woke" --version
 
       - name: Scan only changed lines
         env:

--- a/test/test_github_workflow_security.py
+++ b/test/test_github_workflow_security.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CODE_REVIEW_WORKFLOW = ROOT / ".github" / "workflows" / "code-review.yml"
+
+
+def test_woke_install_is_version_pinned_and_checksum_verified():
+    workflow = CODE_REVIEW_WORKFLOW.read_text()
+    install_step = workflow.split("      - name: Install woke\n", 1)[1].split(
+        "      - name: Scan only changed lines\n", 1
+    )[0]
+
+    assert "raw.githubusercontent.com/get-woke/woke/main/install.sh" not in install_step
+    assert "| bash" not in install_step
+    assert 'WOKE_VERSION: "0.19.0"' in install_step
+    assert (
+        'WOKE_SHA256: "db5ed0906c81323a8c478cc57e00301dbf184db7a0293d70ba9f4729b6169d8c"'
+        in install_step
+    )
+    assert "releases/download/v${WOKE_VERSION}/${asset}" in install_step
+    assert "sha256sum -c -" in install_step
+    assert "--strip-components=1 \\" in install_step
+    assert '"woke-${WOKE_VERSION}-linux-amd64/woke"' in install_step
+    assert 'echo "$bin_dir" >> "$GITHUB_PATH"' in install_step


### PR DESCRIPTION
## Description

Replaces the mutable `get-woke/woke/main/install.sh | bash` CI install with a pinned `woke` v0.19.0 release artifact. The workflow verifies the vendor-published SHA-256 before extraction and adds only the verified binary to subsequent-step `PATH`.

This closes security scan Finding 7 without introducing another third-party GitHub Action.

## Related Issues

Security scan Finding 7; no public GitHub issue.

## Testing

- [x] Existing targeted tests pass
- [x] New workflow security regression test added
- [x] Manual verification performed: release download, SHA-256 check, archive extraction, and `woke --version`
- [x] Negative checksum test rejects a mismatched digest
- [x] Workflow YAML parses successfully

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not applicable)
- [x] No secrets, credentials, or internal references in the diff