### PR TITLE
chore: auto-request kirocrew-team review on every PR via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
 # KiroCrew Code Owners
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Owners are auto-requested for review. Branch protection enforces approval.
-# General code review: any team member can approve (via branch protection rule).
-# Frontend: requires @CrysisDeu approval specifically.
+# Owners are auto-requested for review on every PR. Branch protection can
+# additionally enforce approval ("Require review from Code Owners").
+#
+# All components are owned by the kirocrew-team. Enable review
+# auto-assignment on the team (Org -> Teams -> kirocrew-team -> Settings ->
+# Code review, round-robin or load-balance) so each PR's team request
+# resolves to individual members instead of notifying the whole team.
 
-# ── Frontend (dashboard, Electron shell, UI components) ──────────────
-website/                            @CrysisDeu
+*                                   @kirodotdev/kirocrew-team


### PR DESCRIPTION
## What

Replace the frontend-only CODEOWNERS rule with a single `*` rule: **all components are owned by @kirodotdev/kirocrew-team**, so every PR automatically requests a review from the team on open — no manual reviewer picking.

## Why

PRs currently sit in `REVIEW_REQUIRED` with no reviewer auto-assigned unless they touch `website/`.

## Follow-up (org settings, not doable in-repo)

To have the team request resolve to **individual members** (round-robin / load-balanced) instead of notifying the whole team, an org admin should enable review auto-assignment:

**Org → Teams → kirocrew-team → Settings → Code review → Enable auto assignment**
- Algorithm: *Load balance* (fewest recent requests) or *Round robin*
- Member count per PR: 1 (or 2 for stricter coverage)
- Optionally "Never notify the entire team" so only the chosen member is pinged

Notes:
- `kirocrew-team` has `maintain` access on this repo (verified), which satisfies the CODEOWNERS write-access requirement.
- CODEOWNERS never assigns the PR author to their own PR.
- CODEOWNERS only takes effect once merged to `main` — this PR itself won't get an auto-request; the next PR after merge will.
- If branch protection later enables "Require review from Code Owners", every merge will require a team member's approval — today this rule only auto-*requests*.