### PR TITLE
ci: scope workflow permissions to publishing jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: nightly-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-wheel:

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -1,0 +1,86 @@
+"""Regression tests for least-privilege GitHub workflow permissions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _lines(name: str) -> list[str]:
+    return (WORKFLOWS / name).read_text().splitlines()
+
+
+def _permission_block(lines: list[str], marker: str) -> dict[str, str] | None:
+    """Return the permissions nested directly under an exact YAML marker."""
+    start = lines.index(marker)
+    marker_indent = len(marker) - len(marker.lstrip())
+
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= marker_indent:
+            break
+        if line.strip() != "permissions:" or indent != marker_indent + 2:
+            continue
+
+        permissions: dict[str, str] = {}
+        for permission_line in lines[index + 1 :]:
+            if not permission_line.strip():
+                continue
+            permission_indent = len(permission_line) - len(permission_line.lstrip())
+            if permission_indent <= indent:
+                break
+            key, value = permission_line.strip().split(":", 1)
+            permissions[key] = value.strip()
+        return permissions
+
+    return None
+
+
+def _workflow_permissions(name: str) -> dict[str, str]:
+    lines = _lines(name)
+    start = lines.index("permissions:")
+    permissions: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            continue
+        if not line.startswith("  "):
+            break
+        key, value = line.strip().split(":", 1)
+        permissions[key] = value.strip()
+    return permissions
+
+
+class TestNightlyPermissions:
+    def test_only_publish_jobs_can_mint_oidc_tokens(self) -> None:
+        lines = _lines("nightly.yml")
+
+        assert _workflow_permissions("nightly.yml") == {"contents": "read"}
+        assert _permission_block(lines, "  version:") is None
+        assert _permission_block(lines, "  build-wheel:") is None
+        assert _permission_block(lines, "  build-desktop:") is None
+        assert _permission_block(lines, "  publish:") == {
+            "id-token": "write",
+            "contents": "read",
+        }
+        assert _permission_block(lines, "  publish-cli:") == {
+            "contents": "read",
+            "id-token": "write",
+        }
+
+
+class TestReleasePermissions:
+    def test_only_release_job_has_write_and_oidc_permissions(self) -> None:
+        lines = _lines("release.yml")
+
+        assert _workflow_permissions("release.yml") == {"contents": "read"}
+        assert _permission_block(lines, "  build-wheel:") is None
+        assert _permission_block(lines, "  build-desktop:") is None
+        assert _permission_block(lines, "  release:") == {
+            "contents": "write",
+            "id-token": "write",
+        }


### PR DESCRIPTION
Supersedes #31.

Clean replacement for #31: rebased directly onto the latest `main` (base `c46ddf92`) as a single commit, and additionally addresses Codex's review feedback left on #31.

## Changes (same least-privilege fix as #31)
- **nightly.yml** — remove the workflow-level `id-token: write`; the `publish` and `publish-cli` jobs keep their job-level `id-token: write`.
- **release.yml** — downgrade the workflow-level `contents` from `write` to `read`; the `release` job keeps job-level `contents: write` + `id-token: write`.
- Add `test/test_workflow_permissions.py` regression test locking in the workflow- and job-level permissions.

Non-publishing jobs now inherit the read-only default and can no longer mint OIDC tokens, shrinking the blast radius of a compromised step.

## Codex feedback addressed
Added `from __future__ import annotations` to the regression test. Its `dict[str, str] | None` return annotations are PEP 604 unions that are eagerly evaluated at import on Python 3.9 and raise `TypeError: unsupported operand type(s) for |`. The future import defers annotation evaluation so the module imports cleanly on 3.9 while remaining correct on the 3.10/3.12 CI matrix.

## Why a new PR instead of a force-push
KiroCrew CI enforces exactly one commit per PR and #31's branch is already published, so per project hygiene this lands as a fresh single-commit branch (`fix/ci-least-privilege-permissions-v2`) and #31 is closed.

## Validation
- Tests pass on Python 3.9, 3.10, 3.11, 3.12 (pytest: 2 passed on 3.12).
- Confirmed the pre-fix file raises `TypeError` at import under 3.9; fixed file imports cleanly.
- black (`--target-version py310`), isort (black profile), flake8, mypy — all clean.
- YAML parse of both workflow files OK; `git diff --check` clean.
