### PR TITLE
fix(wechat): guard WeCom frames against malformed payloads

### DIFF
--- a/src/kiro_crew/wechat/client.py
+++ b/src/kiro_crew/wechat/client.py
@@ -259,7 +259,10 @@ class WeComClient:
             try:
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
-                        await self._handle_message(msg.data)
+                        try:
+                            await self._handle_message(msg.data)
+                        except Exception:
+                            logger.exception("WeCom WS: frame handler error; dropping frame")
                     elif msg.type in (
                         aiohttp.WSMsgType.CLOSED,
                         aiohttp.WSMsgType.CLOSING,
@@ -302,11 +305,21 @@ class WeComClient:
             logger.warning("WeCom WS: unparseable frame: %s", _redact_frame(raw)[:200])
             return
 
+        if not isinstance(data, dict):
+            # Log only safe metadata (the Python type), never the parsed payload:
+            # a non-dict frame may be a bare scalar carrying secret-like content.
+            logger.warning("WeCom WS: dropping non-object frame (type=%s)", type(data).__name__)
+            return
+
         cmd = data.get("cmd", "")
 
         # Cmd-less frame carrying errcode: either a pong ACK or a stream-reply ACK.
         if "errcode" in data and not cmd:
-            rid = data.get("headers", {}).get("req_id", "")
+            headers = data.get("headers", {})
+            if not isinstance(headers, dict):
+                logger.warning("WeCom WS: malformed ACK headers")
+                return
+            rid = headers.get("req_id", "")
             if rid in self._ping_reqs:
                 self._ping_reqs.discard(rid)
                 self._pending_pongs = max(0, self._pending_pongs - 1)
@@ -340,12 +353,20 @@ class WeComClient:
         false disconnect.
         """
         headers = data.get("headers", {})
-        req_id = headers.get("req_id", "")
         body = data.get("body", {})
+        if not isinstance(headers, dict) or not isinstance(body, dict):
+            logger.warning("WeCom WS: malformed callback object fields")
+            return
+
         from_obj = body.get("from", {})
-        userid = from_obj.get("userid", "")
         text_obj = body.get("text", {})
-        text_content = text_obj.get("content", "") if text_obj else ""
+        if not isinstance(from_obj, dict) or not isinstance(text_obj, dict):
+            logger.warning("WeCom WS: malformed callback object fields")
+            return
+
+        req_id = headers.get("req_id", "")
+        userid = from_obj.get("userid", "")
+        text_content = text_obj.get("content", "")
         response_url = body.get("response_url", "")
         chatid = body.get("chatid", "")
         msgtype = body.get("msgtype", "text")
@@ -363,9 +384,7 @@ class WeComClient:
         self._handler_tasks.add(task)
         task.add_done_callback(self._handler_tasks.discard)
 
-    def set_message_handler(
-        self, on_message: Callable[[WeComInbound], Awaitable[None]]
-    ) -> None:
+    def set_message_handler(self, on_message: Callable[[WeComInbound], Awaitable[None]]) -> None:
         """Set the inbound handler post-construction.
 
         Avoids the client<->transport construction cycle: the transport needs

--- a/test/test_wechat_client.py
+++ b/test/test_wechat_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -598,3 +599,109 @@ class TestThresholdClamp:
         c = WeComConfig(soft_threshold_pct=-10, hard_threshold_pct=200)
         assert c.soft_threshold_pct == 0
         assert c.hard_threshold_pct == 100
+
+
+# ------------------------------------------------------------------
+# Tests: malformed frames are isolated from the receive loop
+# ------------------------------------------------------------------
+
+
+class TestMalformedFrames:
+    """Malformed external frames must not terminate the WeCom client."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [None, [], "text", 5, True])
+    async def test_non_object_json_is_ignored(self, payload: object) -> None:
+        handler = AsyncMock()
+        client = WeComClient(
+            bot_id="bot1",
+            secret="sec1",
+            ws_url="wss://fake",
+            on_message=handler,
+        )
+
+        await client._handle_message(json.dumps(payload))
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "frame",
+        [
+            {"cmd": "aibot_msg_callback", "headers": None, "body": {}},
+            {"cmd": "aibot_msg_callback", "headers": {}, "body": []},
+            {
+                "cmd": "aibot_msg_callback",
+                "headers": {},
+                "body": {"from": "user", "text": {}},
+            },
+            {
+                "cmd": "aibot_msg_callback",
+                "headers": {},
+                "body": {"from": {}, "text": "message"},
+            },
+        ],
+    )
+    async def test_malformed_nested_objects_are_ignored(self, frame: dict) -> None:
+        handler = AsyncMock()
+        client = WeComClient(
+            bot_id="bot1",
+            secret="sec1",
+            ws_url="wss://fake",
+            on_message=handler,
+        )
+
+        await client._handle_message(json.dumps(frame))
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handler_error_does_not_abort_receive_loop(self) -> None:
+        fake_ws = FakeWS(["first", "second"])
+
+        class FakeConnection:
+            async def __aenter__(self):
+                return fake_ws
+
+            async def __aexit__(self, *args):
+                return None
+
+        class FakeSession:
+            closed = False
+
+            def ws_connect(self, url, proxy=None):
+                return FakeConnection()
+
+        client = WeComClient(bot_id="bot1", secret="sec1", ws_url="wss://fake")
+        client._session = FakeSession()  # type: ignore[assignment]
+        client._handle_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[ValueError("malformed"), None]
+        )
+        client._ping_loop = AsyncMock()  # type: ignore[method-assign]
+
+        await client._connect_and_serve()
+
+        assert client._handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_object_frame_warning_omits_payload(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A dropped non-dict frame logs only its type, never the payload content."""
+        handler = AsyncMock()
+        client = WeComClient(
+            bot_id="bot1",
+            secret="sec1",
+            ws_url="wss://fake",
+            on_message=handler,
+        )
+
+        secret = "sk-live-DEADBEEF-super-secret-scalar-payload"
+        with caplog.at_level(logging.WARNING):
+            await client._handle_message(json.dumps(secret))
+
+        handler.assert_not_awaited()
+        # The scalar payload (potentially a secret) must never reach the
+        # warning log; only safe metadata (the Python type) is recorded.
+        assert secret not in caplog.text
+        assert "type=str" in caplog.text


### PR DESCRIPTION
Supersedes #32 (rebased onto latest `main`; #32 will be closed in favor of this PR).

Same fix as #32 — guards WeCom WS frames against malformed payloads (a non-object top-level JSON value, or non-dict nested `headers`/`body`/`from`/`text` fields) and wraps per-frame handling so one bad frame drops that frame instead of tearing down the receive loop until the next gateway restart.

**Addresses Codex's review comment on #32** (payload logging): for a dropped **non-object** frame we now log only safe metadata — the Python type — instead of the parsed payload. A bare scalar frame may carry secret-like content, so it must never reach the logs. Existing object-frame `response_url` redaction is unchanged, and no unrelated logging call sites were touched.

Added a focused regression test asserting a secret-like scalar payload never appears in the warning log (`test_non_object_frame_warning_omits_payload`).

Single commit, based directly on current `main` (`c46ddf9`). Local validation: full `test_wechat_client.py` (33 passed), black/isort/flake8/mypy/py_compile clean, `git diff --check` clean.