### PR TITLE
feat(telegram): live editMessageText streaming, tool-activity footer, steer render fixes

### DIFF
--- a/docs/mid-turn-queue-and-cancel.md
+++ b/docs/mid-turn-queue-and-cancel.md
@@ -28,22 +28,33 @@ Either way, a hard **`/stop`** aborts the running turn and clears everything.
 With `queue_mode="steer"`, a mid-turn message is injected into the in-flight
 turn via kiro-cli's `_session/steer`. kiro-cli folds it in at its next
 **generation boundary** (a tool-call edge on agentic turns — seconds; the
-end-of-stream on a single long text turn — later), signalled by the
-`steering_consumed` / `AgentExecutionSteeringInjected` notification.
+end-of-stream on a single long text turn — later), and emits an inline
+`[STEERING steer-<id>: <ack summary>]` marker in the text stream at the exact
+fold point.
 
-At that boundary the Telegram renderer **seals the pre-steer output** as its own
-message and opens a **fresh message for the steered continuation that replies to
-the user's steer message**:
+The Telegram renderer streams the turn **live** (one real message, edited in
+place as text arrives, with a transient `🔧 {tool}…` footer during tool calls)
+and rotates at each complete marker: the pre-steer output **seals** as its own
+message, and the steered continuation opens a **fresh message headed by a
+summary chip** quoting the marker's ack text (the same summary the dashboard
+shows as its "Steered — …" chip):
 
 ```
-[reply ▸ "stop, only reply BANANA"]
-BANANA
+> ↪️ answered the weather question in parallel with the directory summary
+<steered continuation…>
 ```
 
-The native reply link is the record of what was folded in and where it took
-effect — no separate receipt bubble is posted. kiro-cli also emits an inline
-`[STEERING steer-<id>: …]` ack marker in the text stream (the dashboard renders
-it as a chip); Telegram **strips** it, since the reply link already conveys it.
+The user's own steer message receives an emoji **reaction** as the delivery
+receipt. The chip is **lazily materialized** — it lands only when real
+post-steer text follows the marker. A marker at the very end of the stream
+(the steer was already covered by the answer) therefore produces **no tail
+message at all**: the reaction is the only acknowledgement. Raw markers never
+appear in posted text.
+
+Per-message overrides: prefixing a mid-turn message with **`/steer <msg>`** or
+**`/queue <msg>`** forces that message down the steer or queue path
+respectively, overriding the global `messaging.queue_mode` for that message
+only (a bare `/steer` / `/queue` with no body is treated as a normal message).
 
 Steer is kiro-cli only (claude-agent-acp has no `_session/steer`); when
 unsupported the message falls back to the queue path below.

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -143,6 +143,44 @@ Session keys are namespaced as `f"{channel_type}:{conversation_id}"` (`session_k
 
 `MessagingConfig.use_transport` (`config/loader.py`, default `True` in KiroCrew; exposed in `config.json` under `messaging`) is the single switch. `slack/events.py::_route_message` checks `orch._cfg.messaging.use_transport`; when `True` it creates a task on `handle_message_transport` and skips the native `handle_message` monolith. (There is no challenge-redirect in this fork — Slack messages are processed inline.) Approval mode is resolved by `_resolve_approval_mode(orch)` (respects configured mode + operator YOLO/SafetyOverride TTL), and the per-channel `slack.channels.<id>.agent` override is passed through.
 
+## Mid-turn routing & per-message overrides (Telegram)
+
+A message arriving while a turn is in flight is routed by
+`messaging.queue_mode` (default `steer`):
+
+- **`steer`** — inject into the running turn via kiro-cli `_session/steer`.
+  kiro-cli folds it at its next generation boundary and emits an inline
+  `[STEERING steer-<id>: <ack summary>]` marker at the fold point. The user's
+  steer message receives an emoji **reaction** (`setMessageReaction`;
+  `TELEGRAM_CAPABILITIES.reactions=True`) as the delivery receipt.
+- **`queue`** — hold the message; a single in-place "⏳ Queued (N)" receipt
+  tracks the burst. When the turn ends, queued texts collapse into ONE combined
+  follow-up turn (order preserved).
+
+**Per-message overrides:** a `/steer <msg>` or `/queue <msg>` prefix forces
+that message down the corresponding path, overriding `queue_mode` for that
+message only. The prefix is only recognized when the original text is not
+itself a command; the payload after the prefix is **turn content, never a
+command** — `/queue /new` queues the literal text `/new`. Bare `/steer` /
+`/queue` (no body) are treated as normal messages.
+
+**Drain semantics:** the queue-drain replay calls `handle_message(...,
+interpret_commands=False)`; drained payloads bypass both the command intercept
+and override parsing, so queued command-lookalike text reaches the model as
+literal content instead of executing on drain.
+
+**Telegram rendering contract:** turns stream live via one real message edited
+in place (throttled plaintext frames; transient `🔧 {tool}…` footer during tool
+calls; trailing `[OPTIONS:]` markup held back from live frames). Segments seal
+to Telegram-HTML at rotation points: each complete `[STEERING]` marker (the
+pre-steer output seals; the continuation opens a fresh message headed by a
+`↪️ <ack summary>` chip, lazily materialized only when real continuation text
+follows — an end-of-stream marker posts no tail message) and length overflow
+(fence-balanced via `_split_markdown`; a trailing incomplete directive is
+detached before splitting). If sealing edits fail because the live message was
+deleted, the final content is re-sent as a fresh message. See
+`docs/mid-turn-queue-and-cancel.md` for the full behavioral walkthrough.
+
 ## Slack reference implementation
 
 ### `SlackTransport` (`slack/transport.py`)

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -56,6 +56,10 @@ log.
 
 - `/new` (or `/start`) — start a fresh conversation
 - `/compact` — free up room when the context fills
+- `/steer <msg>` — while a reply is generating, fold this message into it
+  (overrides `queue_mode` for this message)
+- `/queue <msg>` — while a reply is generating, hold this message and answer
+  it after the current turn (overrides `queue_mode` for this message)
 - `/help` — list the commands
 
 ## Settings & reference

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -249,6 +249,24 @@ class TelegramClient:
         """Delete a message (e.g. remove stale inline keyboards)."""
         await self._api("deleteMessage", {"chat_id": chat_id, "message_id": message_id})
 
+    async def set_message_reaction(
+        self, chat_id: int, message_id: int, emoji: str
+    ) -> None:
+        """Set a single emoji reaction on a message (Bot API 7.0+ ``setMessageReaction``).
+
+        Used as an instant, no-extra-bubble acknowledgement that a mid-turn steer
+        was received. ``emoji`` must be one of Telegram's allowed reaction emojis
+        (e.g. "🫡"). Best-effort: callers should treat failures as non-fatal.
+        """
+        await self._api(
+            "setMessageReaction",
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "reaction": [{"type": "emoji", "emoji": emoji}],
+            },
+        )
+
     # ── Polling loop ──
 
     async def _polling_loop(self) -> None:

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -8,6 +8,11 @@ Commands:
   /stop        — stop the current reply and clear the queue (alias: /cancel)
   /help        — show available commands
 
+Mid-turn overrides (prefix a message sent WHILE a reply is running; they
+override the global ``messaging.queue_mode`` for that one message):
+  /queue <msg> — hold this message and answer it after the current turn
+  /steer <msg> — fold this message into the running turn right now
+
 Per-conversation generation + awaiting-compact state lives in the shared
 ``messaging.conversation.ConversationState`` (re-exported here so existing
 callers importing it from this module keep working).
@@ -45,3 +50,28 @@ def parse_command(text: str) -> str | None:
     if cmd in _STOP_ALIASES:
         return "stop"
     return None
+
+
+_QUEUE_ALIASES = frozenset(("/queue",))
+_STEER_ALIASES = frozenset(("/steer",))
+
+
+def parse_mid_turn_override(text: str) -> tuple[str | None, str]:
+    """Detect a per-message mid-turn override.
+
+    ``/queue <msg>`` forces the message to be queued (answered after the current
+    turn); ``/steer <msg>`` forces it to steer the running turn. Each overrides
+    the global ``messaging.queue_mode`` for THIS message only. Returns
+    ``(mode, rest)`` with the directive stripped -- ``mode`` is ``"queue"`` or
+    ``"steer"`` -- or ``(None, text)`` when there is no directive (or the
+    directive carries no message body, e.g. a bare ``/queue``).
+    """
+    parts = text.lstrip().split(None, 1)
+    if len(parts) != 2:  # needs a directive AND a message body
+        return None, text
+    cmd, rest = parts[0].lower(), parts[1]
+    if cmd in _QUEUE_ALIASES:
+        return "queue", rest
+    if cmd in _STEER_ALIASES:
+        return "steer", rest
+    return None, text

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -47,13 +47,13 @@ logger = logging.getLogger(__name__)
 # renderer -- the shared messaging event stream (and Slack/WeCom) is untouched.
 #
 # Telegram's "typing" chat action lasts ~5s, so refresh it just under that
-# (used only as the fallback when native draft streaming is unavailable).
+# for the duration of a turn (shown while we accumulate before posting).
 _TYPING_REFRESH_S = 4.0
 
-# How often to push an animated draft update while streaming. Drafts animate in
-# place and are cheap, so a brisk cadence stays smooth; the client's 429
-# backstop covers the rare long turn.
-_DRAFT_THROTTLE_S = 0.5
+# Min seconds between live streaming edits to one message. Telegram rate-limits
+# edits (~this cadence), so we coalesce chunks and edit the message in place at
+# most this often. The final formatted edit always lands regardless of throttle.
+_EDIT_THROTTLE_S = 1.0
 
 # Interactive approval wait; deny-by-default when it elapses with no press.
 _APPROVAL_TIMEOUT_S = 300.0
@@ -78,17 +78,62 @@ def _extract_options(text: str) -> tuple[str, list[str]]:
 
 # kiro-cli emits an inline "[STEERING steer-<id>: …]" ack marker when it folds a
 # mid-turn steer at a boundary. The dashboard parses it into a chip; Telegram has
-# no parser, so strip it — the user's own steer message (which the steered reply
-# threads under, see on_steer_consumed) already shows the instruction, so the raw
-# inline marker is redundant noise in the bubble.
+# no parser, so strip it — the user's own steer message already shows the
+# instruction (and gets a steer-ack reaction), so the raw inline marker is just
+# redundant noise in the bubble.
 _STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]]*\]", re.IGNORECASE)
+# Same marker, capturing the ack SUMMARY kiro-cli embeds after "steer-<id>:".
+# The dashboard renders this summary as its "Steered — …" chip; we prefer it
+# for the Telegram chip too (the user's own words are already on screen as
+# their message — the summary is the only NEW information).
+_STEER_SUMMARY_RE = re.compile(
+    r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]]*)\]", re.IGNORECASE
+)
 
 
 def _strip_steering(text: str) -> str:
-    """Remove kiro-cli's inline ``[STEERING …]`` steer-ack marker from output."""
-    cleaned = _STEER_MARKER_RE.sub("", text)
+    """Remove kiro-cli's inline ``[STEERING …]`` steer-ack marker from output.
+
+    Also strips an UNCLOSED trailing ``[STEERING …`` (still streaming, no closing
+    ``]`` yet): otherwise the marker's long rephrase streams into the live draft
+    and then vanishes when ``on_done`` finally strips the completed marker — a
+    jarring show-then-vanish. Stripping the partial marker keeps the draft in
+    sync with the final message.
+    """
+    cleaned = _STEER_MARKER_RE.sub("", text)  # complete markers anywhere
+    cleaned = re.sub(r"\[STEERING\b[^\]]*$", "", cleaned)  # unclosed, still streaming
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)  # collapse gaps left behind
     return cleaned.strip()
+
+
+def _neutralize_md(raw: str) -> str:
+    """Collapse whitespace, cap length, and strip Markdown control chars from a
+    steer's text so the chip renders literally (inside a blockquote) and can't
+    perturb surrounding formatting."""
+    t = " ".join((raw or "").split())[:120]
+    return re.sub(r"[*_`\[\]()]", "", t)
+
+
+def _strip_hr(text: str) -> str:
+    """Drop Markdown horizontal rules (``---`` / ``***`` / ``___`` on their own
+    line) — they render as literal dashes on Telegram and just add noise.
+    Fenced code blocks are stashed first so a standalone ``---`` INSIDE a code
+    block (e.g. a YAML document separator) is never touched. An unclosed fence
+    mid-stream isn't stashed, but live frames are throttled previews — the
+    final seal sees the closed fence and preserves its content."""
+    stash: list[str] = []
+
+    def _keep(fragment: str) -> str:
+        stash.append(fragment)
+        return f"\x00H{len(stash) - 1}\x00"
+
+    text = _FENCE_RE.sub(lambda m: _keep(m.group(0)), text)
+    # Max 3 leading spaces (markdown HR rule) — a 4-space-indented "---" is
+    # indented CODE (e.g. a YAML separator) and must survive.
+    out = re.sub(r"(?m)^[ ]{0,3}([-*_])\1{2,}[ \t]*$", "", text)
+    out = re.sub(r"\n{3,}", "\n\n", out)
+    out = re.sub(r"\x00H(\d+)\x00", lambda m: stash[int(m.group(1))], out)
+    return out.strip()
 
 
 def build_inline_keyboard(options: list[str]) -> dict | None:
@@ -198,6 +243,17 @@ def _md_to_telegram_html(text: str) -> str:
     text = _ITALIC_USCORE_RE.sub(lambda m: f"<i>{m.group(1)}</i>", text)
     text = _LINK_RE.sub(lambda m: f'<a href="{m.group(2)}">{m.group(1)}</a>', text)
     text = _BULLET_RE.sub(lambda m: f"{m.group(1)}\u2022 ", text)
+    # Group consecutive "> " lines (escaped to "&gt; ") into a native Telegram
+    # <blockquote> — the ▎ quote bar. Runs after inline formatting so bold/italic
+    # inside a quote still work; before un-stashing so code/pre placeholders ride
+    # through untouched.
+    text = re.sub(
+        r"(?m)^&gt;[ \t]?.*(?:\n&gt;[ \t]?.*)*",
+        lambda m: "<blockquote>"
+        + re.sub(r"(?m)^&gt;[ \t]?", "", m.group(0)).rstrip("\n")
+        + "</blockquote>",
+        text,
+    )
     text = re.sub(r"\x00(\d+)\x00", lambda m: stash[int(m.group(1))], text)
     return text
 
@@ -273,47 +329,42 @@ class TelegramRenderer(Renderer):
         self._session_key = session_key
         self._buf: list[str] = []
         self._last_tool = ""
+        # Transient tool-activity footer ("🔧 {tool}…") shown ONLY on live
+        # streaming frames — never stored in _buf, so seals/finals stay clean.
+        # Set by on_tool_call, cleared when text resumes (on_text_chunk).
+        self._tool = ""
         self._finalized = False
         self._closed = False
         self._typing_task: "asyncio.Task[None] | None" = None
-        # Native draft streaming (smooth, no editMessageText reflow). draft_id
-        # must be non-zero and stable across the turn so updates animate in
-        # place. _draft_ok: None=untried, True=streaming, False=fell back.
-        self._draft_id = abs(id(self)) % 1_000_000_000 + 1
-        self._draft_ok: bool | None = None
-        self._last_draft = 0.0
-        # Mid-turn steer (M1): the user's steer message id (reply target) and the
-        # pre/post-steer split offset in _buf, so on_done renders the steered
-        # continuation as its own message threaded under the user's message.
-        self._steer_reply_to: int | None = None
-        self._steer_split_at: int | None = None
-
-    def set_steer_reply_to(self, message_id: int) -> None:
-        """Dispatcher hook: record the user's steer message id so the post-steer
-        continuation threads under it (M1 reply-linkage).
-
-        First-steer-wins: on a rapid multi-steer burst the dispatcher calls this
-        for every steer, but ``on_steer_consumed`` records the split only at the
-        first consumed boundary. Keeping the *first* steer's id here aligns the
-        reply target with that split so the cause->effect link stays consistent.
-        """
-        if self._steer_reply_to is None:
-            self._steer_reply_to = message_id or None
+        # Live edit-streaming (send one real message, edit it in place as text
+        # arrives — no draft, which fails for bots / ghosts). On a steer boundary
+        # we STOP editing the current message and open a fresh one for the
+        # steered continuation ("rotate"). _stream_mid = the message being edited
+        # (None -> next render sends a new one). _shown = last text pushed (skip
+        # no-op edits). _last_edit throttles edits. _buf = the CURRENT segment's
+        # text; a rotation seals _buf into its message and starts _buf fresh.
+        self._stream_mid: int | None = None
+        self._shown = ""
+        self._last_edit = 0.0
+        self._seal_count = 0  # rotations so far == index into _steer_texts for chips
+        # Chip pending from the last rotation, NOT yet in _buf. It materializes
+        # (prepends to the segment) only when real post-steer text arrives — so
+        # an end-of-stream marker (no continuation text) never posts a chip-only
+        # ack bubble: the answer already covered the steer and the user's
+        # message carries the reaction receipt.
+        self._pending_chip = ""
+        # User's own mid-turn steer texts (in order), recorded by the dispatcher
+        # via note_steer. Each rotation seeds the new segment with that steer's
+        # chip; a no-rotation turn shows them as one summary chip at on_done.
+        self._steer_texts: list[str] = []
 
     # -- lifecycle ----------------------------------------------------------
     async def on_turn_start(self) -> None:
-        # Prefer native draft streaming (smooth, animated, no edit reflow). An
-        # empty draft renders a "Thinking…" placeholder. If drafts are rejected
-        # (e.g. Forum Topic Mode off), fall back to a live "typing…" indicator.
-        # Idempotent (dispatch + driver both call this).
-        if self._draft_ok is not None or self._closed:
+        # Typing indicator only — no draft preview. Idempotent (dispatch + driver
+        # both call this).
+        if self._typing_task is not None or self._closed:
             return
-        self._draft_ok = await self._client.send_message_draft(
-            self._chat_id, self._draft_id, ""
-        )
-        self._last_draft = time.monotonic()
-        if not self._draft_ok and self._typing_task is None:
-            self._typing_task = asyncio.create_task(self._typing_loop())
+        self._typing_task = asyncio.create_task(self._typing_loop())
 
     async def _typing_loop(self) -> None:
         """Keep the 'typing…' chat action alive (it expires after ~5s) for the
@@ -336,23 +387,179 @@ class TelegramRenderer(Renderer):
 
     async def on_text_chunk(self, text: str) -> None:
         self._buf.append(text)
-        # Stream the growing answer as an animated draft (plaintext, so partial
-        # markdown never 400s). The finished, formatted message is posted in
-        # on_done. If a draft update is rejected mid-turn, fall back to typing.
-        if not self._draft_ok:
+        self._tool = ""  # text resumed -> drop the transient tool footer
+        # 1) Rotate to a fresh message at each COMPLETE [STEERING …] marker
+        #    (kiro-cli's in-stream steer injection point). Text before the marker
+        #    seals into the current message; the steered continuation opens a new
+        #    message headed by the steer chip. Splitting at the marker's real
+        #    position — not the racy STEER_CONSUMED offset — avoids the
+        #    "used.BANANA" leak.
+        await self._rotate_at_markers()
+        # 1b) Materialize the pending chip once real post-steer text exists.
+        self._materialize_chip()
+        # 2) Rotate when a segment would exceed one Telegram message.
+        await self._rotate_on_length()
+        # 3) Live-stream the current segment: edit the message in place (throttled).
+        await self._stream_live()
+
+    def _materialize_chip(self) -> None:
+        """Prepend the pending steer chip to the segment — but only when the
+        segment carries real text. Keeps an end-of-stream marker from ever
+        posting a chip-only ack bubble."""
+        if self._pending_chip and self._segment_text().strip():
+            body = "".join(self._buf).lstrip("\n")
+            self._buf = [f"{self._pending_chip}\n\n{body}"]
+            self._pending_chip = ""
+
+    async def _rotate_at_markers(self) -> None:
+        while True:
+            # A chip pending from a PREVIOUS marker materializes now if this
+            # segment carries real text — so a single chunk containing two
+            # markers can't overwrite the first steer's chip (its continuation
+            # seals WITH the chip below). A chip with no continuation text stays
+            # pending and is deliberately dropped on overwrite (no-tail design).
+            self._materialize_chip()
+            raw = "".join(self._buf)
+            m = _STEER_MARKER_RE.search(raw)  # first COMPLETE marker only
+            if m is None:
+                return
+            self._buf = [raw[: m.start()]]
+            # Length-rotate the pre-marker segment BEFORE sealing: a chunk can
+            # deliver oversized text and the marker together, and sealing an
+            # over-limit segment would silently truncate it at Telegram's cap.
+            await self._rotate_on_length()
+            sealed = bool(self._segment_text().strip())
+            await self._seal_current()  # freeze the pre-steer message as-is
+            # Chip: prefer the SUMMARY embedded in the marker itself (what the
+            # dashboard shows as its "Steered — …" chip) — the user's own words
+            # are already on screen as their message, so the summary is the only
+            # new information. Fall back to the recorded user text.
+            sm = _STEER_SUMMARY_RE.match(raw, m.start())
+            summary = _neutralize_md(sm.group(1)) if sm else ""
+            if summary:
+                chip: str | None = f"> ↪️ {summary}"
+            else:
+                chip = self._chip_for_seal(self._seal_count)
+            self._seal_count += 1
+            # Hold the chip as PENDING — it prepends only when real post-steer
+            # text arrives (see on_text_chunk). An end-of-stream marker thus
+            # produces no chip-only ack bubble.
+            self._pending_chip = chip or ""
+            self._buf = [raw[m.end():]]  # new segment: steered continuation only
+            if sealed:
+                self._open_new_message()
+            # else: the pre-marker segment was empty (e.g. a tool-only live
+            # "🔧 …" message) — nothing was sealed, so KEEP _stream_mid and let
+            # the steered continuation replace the transient footer in place
+            # instead of orphaning it as a permanent tool-footer bubble.
+
+    async def _rotate_on_length(self) -> None:
+        """Rotate when the segment exceeds one Telegram message. Uses
+        ``_split_markdown`` so a fenced code block spanning a cut is rebalanced
+        (fence closed at the seal, reopened in the next segment) instead of
+        leaving literal backticks in both messages. A trailing protocol
+        directive — a COMPLETE ``[OPTIONS: …]`` block or a still-streaming
+        ``[STEERING …`` / ``[OPTIONS …`` fragment — is detached first and
+        reattached to the surviving tail, so length splitting can never cut a
+        directive in half (which would leak protocol fragments and lose the
+        steer rotation / options keyboard)."""
+        limit = self._limit()
+        raw = "".join(self._buf)
+        if len(raw) <= limit:
             return
+        partial = ""
+        cm = _OPTIONS_RE.search(raw)
+        if cm:
+            # Complete trailing [OPTIONS: …] — keep it intact on the tail so
+            # finalization can extract the inline keyboard (a bare split would
+            # leak "NS: A | B]" as raw text and lose the keyboard).
+            raw, partial = raw[: cm.start()], raw[cm.start():]
+        else:
+            idx = max(raw.rfind("[STEERING"), raw.rfind("[OPTIONS"))
+            if idx != -1 and "]" not in raw[idx:]:
+                raw, partial = raw[:idx], raw[idx:]
+        chunks = _split_markdown(raw, limit)
+        for ch in chunks[:-1]:
+            self._buf = [ch]
+            await self._seal_current()
+            self._open_new_message()
+        self._buf = [(chunks[-1] if chunks else "") + partial]
+
+    def _open_new_message(self) -> None:
+        """Next render creates a fresh message instead of editing the old one."""
+        self._stream_mid = None
+        self._shown = ""
+
+    def _segment_text(self) -> str:
+        """Current segment's markdown source (chip already seeded into _buf),
+        with the steer marker and horizontal-rule noise stripped."""
+        return _strip_hr(_strip_steering("".join(self._buf)))
+
+    async def _stream_live(self, *, force: bool = False) -> None:
+        """Throttled in-place edit of the current segment (plaintext, so partial
+        markdown never 400s). Sends the message on first render. The transient
+        ``🔧 {tool}…`` footer is appended ONLY here (live frames) — seals and
+        the final render read ``_segment_text`` and never carry it. ``force``
+        bypasses the throttle so a tool-call event surfaces immediately."""
         now = time.monotonic()
-        if now - self._last_draft < _DRAFT_THROTTLE_S:
+        if not force and now - self._last_edit < _EDIT_THROTTLE_S:
             return
-        self._last_draft = now
-        body = _strip_md(self._text())
-        if not body:
+        # Hold back trailing [OPTIONS:] markup (complete or still-streaming
+        # partial) from live frames — it is an internal directive, extracted
+        # into the inline keyboard at finalization.
+        seg, _ = _extract_options(self._segment_text())
+        body = _strip_md(seg)
+        footer = f"🔧 {self._tool}…" if self._tool else ""
+        if footer:
+            # Keep the footer visible even when it must displace body tail chars.
+            room = self._limit() - len(footer) - 2
+            text = f"{body[:room]}\n\n{footer}".strip() if room > 0 else footer
+        else:
+            text = body[: self._limit()]
+        if not text or text == self._shown:
             return
-        ok = await self._client.send_message_draft(self._chat_id, self._draft_id, body)
-        if not ok:
-            self._draft_ok = False
-            if self._typing_task is None and not self._closed:
-                self._typing_task = asyncio.create_task(self._typing_loop())
+        self._last_edit = now
+        self._shown = text
+        if self._stream_mid is None:
+            mid = await self._client.send_message(self._chat_id, text)
+            if mid is not None:
+                self._stream_mid = mid
+        else:
+            await self._client.edit_message(self._chat_id, self._stream_mid, text)
+
+    async def _seal_current(self, *, keyboard: dict | None = None) -> None:
+        """Finalize the current segment: replace its live plaintext with the
+        formatted HTML (and optional keyboard). Edits the streamed message in
+        place, or sends one if the segment never streamed (e.g. throttled out).
+        Empty segments are skipped so a bare steer doesn't post a blank bubble."""
+        text = self._segment_text().strip()
+        if not text:
+            return
+        html_text = _md_to_telegram_html(text)
+        if self._stream_mid is not None:
+            ok = await self._client.edit_message(
+                self._chat_id, self._stream_mid, html_text,
+                parse_mode="HTML", reply_markup=keyboard, retry_plain=False,
+            )
+            if not ok:  # malformed HTML -> clean plaintext, never raw tags
+                ok = await self._client.edit_message(
+                    self._chat_id, self._stream_mid, _strip_md(text),
+                    reply_markup=keyboard,
+                )
+            if ok:
+                return
+            # Both edits failed — the live message is gone (e.g. the user
+            # deleted it mid-turn). Fall through and SEND the final content so
+            # the completed answer (and its keyboard) is never silently lost.
+            self._stream_mid = None
+        mid = await self._client.send_message(
+            self._chat_id, html_text, parse_mode="HTML",
+            reply_markup=keyboard, retry_plain=False,
+        )
+        if mid is None:
+            await self._client.send_message(
+                self._chat_id, _strip_md(text), reply_markup=keyboard,
+            )
 
     async def on_thinking(self, text: str) -> None:
         # Telegram does not surface reasoning inline (parity with prior behavior).
@@ -361,9 +568,16 @@ class TelegramRenderer(Renderer):
     async def on_tool_call(
         self, tool_call_id: str, title: str, tool_kind: str = "", tool_purpose: str = ""
     ) -> None:
-        # Remember the tool for a possible approval prompt; the live typing
-        # indicator already signals "working", so nothing is posted here.
+        # Surface mid-turn tool activity as a transient "🔧 {tool}…" footer on
+        # the live bubble (force=True so it shows immediately, not throttled).
+        # We deliberately do NOT seal a message here: models interleave tool
+        # calls mid-sentence, so sealing at a tool boundary chops a sentence
+        # into broken bare messages on a channel with no tool cards (proven on
+        # Telegram). The footer lives only on live frames — on_text_chunk clears
+        # it and seals/finals never carry it.
         self._last_tool = title or tool_kind or "tool"
+        self._tool = self._last_tool
+        await self._stream_live(force=True)
 
     async def on_prompt_choice(
         self, options: list[dict[str, Any]], request_id: str | int
@@ -392,73 +606,78 @@ class TelegramRenderer(Renderer):
         except Exception:
             logger.debug("Telegram: compaction notice send failed", exc_info=True)
 
+    def note_steer(self, text: str) -> None:
+        """Record the user's own mid-turn steer text (their typed words, NOT the
+        redacted backend echo). Called by the dispatcher when a steer is actually
+        injected; rendered as an inline "↪️ steered: …" chip in on_done. Capped to
+        avoid unbounded growth on a pathological steer burst."""
+        t = (text or "").strip()
+        if t and len(self._steer_texts) < 50:
+            self._steer_texts.append(t)
+
     async def on_done(self, stop_reason: str = "") -> None:
         if self._finalized:
             return
         self._finalized = True
         self._stop_typing()
         ok = stop_reason != "error"
+        # Flush any trailing rotation, then finalize the current segment: replace
+        # its live plaintext with formatted HTML + the [OPTIONS:] keyboard. Each
+        # mid-turn steer already rotated its own message; this seals the last one.
+        await self._rotate_at_markers()
+        self._materialize_chip()  # chip lands only if real post-steer text exists
+        # Extract the trailing [OPTIONS:] BEFORE length rotation: if the body
+        # overflows, rotation would otherwise seal the options text into an
+        # earlier message and the keyboard would never attach.
+        body_raw, opts = _extract_options("".join(self._buf))
+        self._buf = [body_raw]
+        keyboard = build_inline_keyboard(opts) if opts else None
+        # No-rotation fallback: steers were injected but kiro-cli emitted no
+        # marker to rotate at — prepend one summary chip so they're still shown.
+        # This happens BEFORE length rotation so the summary counts against the
+        # transport limit and can never push the final segment past it.
+        if self._seal_count == 0 and self._steer_texts:
+            quoted = [q for q in (_neutralize_md(t) for t in self._steer_texts) if q]
+            if quoted:
+                body = self._segment_text().strip()
+                summary = "> " + " · ".join(quoted)
+                self._buf = [summary + ("\n\n" + body if body else "")]
+        await self._rotate_on_length()
+        if not self._segment_text().strip():
+            # Nothing to post. Earlier rotated segments carried the turn -> stay
+            # silent; otherwise show a placeholder. An extracted keyboard (an
+            # options-only body) is user-facing content and must ALWAYS reach
+            # the user — attach it to the placeholder instead of dropping it.
+            if self._seal_count > 0 and keyboard is None:
+                return
+            placeholder = "…" if ok else "⚠️ Error — please try again"
+            if self._stream_mid is not None:
+                await self._client.edit_message(
+                    self._chat_id, self._stream_mid, placeholder,
+                    reply_markup=keyboard,
+                )
+            else:
+                await self._client.send_message(
+                    self._chat_id, placeholder, reply_markup=keyboard
+                )
+            return
+        await self._seal_current(keyboard=keyboard)
+
+    def _limit(self) -> int:
         # Leave headroom below the char cap for the HTML tags we add, so a
         # formatted chunk can't overflow Telegram's 4096 limit and get cut
         # mid-tag.
         cap = self.capabilities.max_message_chars or 4000
-        limit = max(500, cap - 256)
+        return max(500, cap - 256)
 
-        # Mid-turn steer split (M1): render the pre-steer output and the steered
-        # continuation as SEPARATE messages, with the continuation threaded under
-        # the user's steer message. Split the RAW buffer at the boundary recorded
-        # by on_steer_consumed (real messages are only posted here, in on_done).
-        raw = "".join(self._buf)
-        split = self._steer_split_at
-        if split is not None and 0 < split < len(raw.rstrip()):
-            pre = _strip_steering(_extract_options(raw[:split].strip())[0])
-            post_body, opts = _extract_options(raw[split:].strip())
-            post = _strip_steering(post_body)
-            keyboard = build_inline_keyboard(opts) if opts else None
-            if pre:
-                await self._send_blocks(pre, limit, keyboard=None, reply_to=None)
-            await self._send_blocks(
-                post or "…", limit, keyboard=keyboard, reply_to=self._steer_reply_to
-            )
-            return
-
-        body = self._text()
-        full = body or ("…" if ok else "⚠️ Error — please try again")
-        opts = self._options()
-        keyboard = build_inline_keyboard(opts) if opts else None
-        await self._send_blocks(full, limit, keyboard=keyboard, reply_to=None)
-
-    async def _send_blocks(
-        self, text: str, limit: int, *, keyboard: dict | None, reply_to: int | None
-    ) -> None:
-        """Post ``text`` as one or more Telegram HTML blocks. The RAW markdown is
-        split into <=limit chunks with fenced code kept balanced (_split_markdown)
-        then each chunk is formatted -- so a fence never straddles a chunk edge and
-        leaks a literal ``` / unescaped body. Keyboard on the last chunk only;
-        reply threading on the first chunk only."""
-        chunks = _split_markdown(text, limit) or [text]
-        last = len(chunks) - 1
-        for i, chunk in enumerate(chunks):
-            kb = keyboard if i == last else None
-            rt = reply_to if i == 0 else None
-            html_chunk = _md_to_telegram_html(chunk)
-            mid = await self._client.send_message(
-                self._chat_id, html_chunk, parse_mode="HTML",
-                reply_markup=kb, reply_to_message_id=rt, retry_plain=False,
-            )
-            if mid is None:  # malformed HTML -> clean plaintext, never raw tags
-                await self._client.send_message(
-                    self._chat_id, _strip_md(chunk),
-                    reply_markup=kb, reply_to_message_id=rt,
-                )
-
-    async def on_steer_consumed(self) -> None:
-        """Record the pre/post-steer boundary in _buf so on_done renders the
-        steered continuation as its own message, threaded under the user's steer.
-        (Block streaming: real messages are only posted in on_done, so we mark
-        the split offset here rather than sealing a live message.)"""
-        if self._steer_split_at is None:  # first steer marks the split
-            self._steer_split_at = len("".join(self._buf))
+    def _chip_for_seal(self, i: int) -> str | None:
+        """The steer chip (a "> quote" blockquote of the USER's own words) that
+        heads the segment opened by the i-th rotation. None when we have no
+        recorded text for that rotation (chip is simply omitted)."""
+        if 0 <= i < len(self._steer_texts):
+            t = _neutralize_md(self._steer_texts[i])
+            return f"> {t}" if t else None
+        return None
 
     async def close(self) -> None:
         """Idempotent teardown: stop the typing indicator and finalize the turn
@@ -468,11 +687,6 @@ class TelegramRenderer(Renderer):
             await self.on_done(stop_reason="error")
 
     # -- helpers ------------------------------------------------------------
-    def _text(self) -> str:
-        raw = "".join(self._buf).strip()
-        body, _ = _extract_options(raw)
-        return _strip_steering(body)
-
     def _options(self) -> list[str]:
         raw = "".join(self._buf).strip()
         _, opts = _extract_options(raw)

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -49,12 +49,13 @@ class TelegramInboundMessage(InboundMessage):
 DispatchFn = Callable[[InboundMessage], Awaitable[None]]
 
 # Telegram's capabilities: edit-based streaming, a 4096-char cap (we chunk at
-# 4000 for headroom), ~8 inline buttons/row, and no threads/reactions in a
-# bot DM. Single source of truth for the renderer's degradation decisions.
+# 4000 for headroom), ~8 inline buttons/row, emoji reactions (setMessageReaction,
+# used for steer-ack receipts), and no threads in a bot DM. Single source of
+# truth for the renderer's degradation decisions.
 TELEGRAM_CAPABILITIES = TransportCapabilities(
     streaming=True,
     edit=True,
-    reactions=False,
+    reactions=True,  # setMessageReaction — used for the steer-ack receipt
     files=False,
     rich_blocks=False,
     threads=False,

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -41,7 +41,11 @@ from kiro_crew.messaging.link import (
 )
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.sel import sel
-from kiro_crew.telegram.commands import ConversationState, parse_command
+from kiro_crew.telegram.commands import (
+    ConversationState,
+    parse_command,
+    parse_mid_turn_override,
+)
 from kiro_crew.telegram.renderer import TelegramApprovalDecider, TelegramRenderer
 from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
 
@@ -76,6 +80,10 @@ Commands:
 /stop — Stop the current reply and clear the queue
 /help — Show this message
 
+While a reply is running, prefix a message to control it:
+/queue <msg> — answer it after the current turn
+/steer <msg> — fold it into the running turn now
+
 Just send a message to chat. Replies stream in real-time.
 """
 
@@ -87,6 +95,10 @@ def _short(text: str, limit: int = 40) -> str:
 
 
 _RECEIPT_MAX_ITEMS = 5  # verbatim items shown in a receipt before "…and N more"
+# Instant, no-extra-bubble acknowledgement that a mid-turn steer was accepted
+# and folded into the running turn (not merely "seen" — 👀 read as passive).
+# Must be one of Telegram's allowed reaction emojis (Bot API 7.0+).
+_STEER_ACK_EMOJI = "🫡"
 
 
 def _receipt_text(
@@ -152,26 +164,52 @@ class TelegramDispatcher:
         # session_key -> the single in-place "queued" receipt bubble tracking
         # messages that arrived mid-turn (collapsed into one record + one turn).
         self._queue_receipts: dict[str, _QueueReceipt] = {}
-        # session_key -> the live TelegramRenderer for the CURRENTLY-running turn.
-        # A mid-turn steer reaches into it (via _handle_busy) to set the reply
-        # target so the steered continuation threads under the user's message.
-        self._active_renderers: dict[str, TelegramRenderer] = {}
         # Serializes the check-then-send-then-store receipt bookkeeping so a
         # burst of concurrently-dispatched mid-turn messages can't each post a
         # fresh bubble and orphan the earlier one.
         self._receipt_lock = asyncio.Lock()
+        # session_key -> the running turn's renderer, so a concurrent mid-turn
+        # steer (handled in a separate _handle_busy task) can hand it the user's
+        # typed steer text for the inline "↪️ steered: …" chip. Set on turn
+        # start, popped in finally. Records text only — no buffer slicing, so
+        # none of the old steer-split fragility.
+        self._active_renderers: dict[str, TelegramRenderer] = {}
 
     # ── Turn dispatch (transport's dispatch callback) ──────────────────────
 
-    async def handle_message(self, msg: InboundMessage, *, drain: bool = True) -> None:
+    async def handle_message(
+        self,
+        msg: InboundMessage,
+        *,
+        drain: bool = True,
+        interpret_commands: bool = True,
+    ) -> None:
         """Drive one authorized inbound message through TurnDriver end-to-end."""
         assert self.client is not None, "TelegramDispatcher.client must be set"
         user_id = int(msg.user_id)
         chat_id = int(msg.conversation_id)
         text = msg.text
 
-        # ── Command intercept (no LLM session needed) ──
-        cmd = parse_command(text)
+        # Per-message mid-turn override: "/queue …" / "/steer …" let the user
+        # choose how THIS message is handled if it lands while a turn is running
+        # (overriding the global queue_mode). Ordinary commands are parsed
+        # against the ORIGINAL text — and when an override prefix IS present,
+        # its payload is turn CONTENT, never a command: "/queue /new" queues the
+        # literal "/new" text for after the turn instead of executing it now.
+        # interpret_commands=False (the queue-drain path) skips BOTH: a drained
+        # payload is replayed as pure content, so a queued "/new" reaches the
+        # model as text instead of executing on drain.
+        override_mode = None
+        if interpret_commands and parse_command(text) is None:
+            override_mode, text = parse_mid_turn_override(text)
+
+        # ── Command intercept (no LLM session needed; skipped for override
+        # payloads and drained queue content — see above) ──
+        cmd = (
+            parse_command(text)
+            if interpret_commands and override_mode is None
+            else None
+        )
         if cmd == "new":
             self._conv.bump_gen(user_id)
             await self.client.send_message(chat_id, "✅ New conversation started.")
@@ -200,7 +238,7 @@ class TelegramDispatcher:
         # of a silent block.
         session_key = self._session_key(user_id)
         if self.sessions.is_busy(session_key):
-            await self._handle_busy(session_key, msg)
+            await self._handle_busy(session_key, msg, text, override_mode)
             return
 
         self._conv.maybe_rotate(
@@ -225,8 +263,9 @@ class TelegramDispatcher:
         renderer = TelegramRenderer(
             self.client, chat_id, TELEGRAM_CAPABILITIES, session_key=session_key
         )
-        # Register the live renderer so a mid-turn steer (_handle_busy) can set
-        # its reply target; cleared in the finally below.
+        # Expose this turn's renderer so a concurrent mid-turn steer (a separate
+        # _handle_busy task) can hand it the user's typed steer text for the
+        # inline "↪️ steered: …" chip. Popped in finally.
         self._active_renderers[session_key] = renderer
 
         # Everything acquire-dependent runs INSIDE the try so the finally always
@@ -324,10 +363,9 @@ class TelegramDispatcher:
             # get_or_create raised before the semaphore was held. Only release
             # the semaphore if we actually acquired it.
             await renderer.close()
+            self._active_renderers.pop(session_key, None)
             if _acquired:
                 self.sessions.release(session_key)
-            # Drop the live-renderer registration for this turn.
-            self._active_renderers.pop(session_key, None)
 
         # Now that the turn is released, run anything that queued during it
         # (queue_mode == "queue"). ``drain`` is False for drained turns so the
@@ -335,45 +373,72 @@ class TelegramDispatcher:
         if drain:
             await self._drain_queue(session_key, user_id, chat_id)
 
-    async def _handle_busy(self, session_key: str, msg: InboundMessage) -> None:
-        """A message arrived mid-turn: steer the running turn or queue for after it."""
+    async def _handle_busy(
+        self,
+        session_key: str,
+        msg: InboundMessage,
+        text: str,
+        override_mode: str | None,
+    ) -> None:
+        """A message arrived mid-turn: steer the running turn or queue for after
+        it. ``text`` is the message with any ``/queue``|``/steer`` directive
+        stripped; ``override_mode`` ('queue' | 'steer' | None) forces the path for
+        THIS message, overriding the global ``queue_mode``."""
         assert self.client is not None
         chat_id = int(msg.conversation_id)
-        if self.cfg.messaging.queue_mode != "queue":
+        mode = override_mode or self.cfg.messaging.queue_mode
+        if mode != "queue":
             provider = self.sessions.get_provider(session_key)
             steer = getattr(provider, "steer", None)
             # Only steer when a turn is GENUINELY in flight. ``is_busy`` stays
             # True through post-turn bookkeeping (record_success / _persist_turn
             # / _maybe_notice / SEL audit -- all await points), so without this
             # guard a steer could reach kiro-cli for a prompt that already ended
-            # -> silently swallowed (no fresh turn, no queue entry), and
-            # ``set_steer_reply_to`` would land on a renderer whose ``on_done``
-            # already ran. When no live turn, fall through to the queue/handle
-            # path below (mirrors the queue path's ``force=False`` fallback), so
-            # the message is re-run or queued instead of lost.
+            # -> silently swallowed (no fresh turn, no queue entry), and the
+            # steer-ack reaction would land on a message whose turn already
+            # finished. When no live turn, fall through to the queue/handle path
+            # below (mirrors the queue path's ``force=False`` fallback), so the
+            # message is re-run or queued instead of lost.
             has_active = getattr(provider, "has_active_turn", None)
             live = has_active is None or bool(has_active())
             steered = bool(
                 live
                 and getattr(provider, "supports_steer", False)
                 and steer is not None
-                and await steer(msg.text)
+                and await steer(text)
             )
             if steered:
-                # Thread the steered continuation under the user's message: hand
-                # the inbound message id to the live renderer, which replies to
-                # it when it opens the post-steer bubble (see on_steer_consumed).
-                renderer = self._active_renderers.get(session_key)
-                if renderer is not None:
-                    renderer.set_steer_reply_to(getattr(msg, "message_id", 0))
+                # Record the user's OWN words on the running turn's renderer so
+                # it can render an inline "↪️ steered: <text>" chip (never the
+                # redacted backend echo). Best-effort: no active renderer -> skip.
+                r = self._active_renderers.get(session_key)
+                if r is not None:
+                    r.note_steer(text)
+                # Instant, no-extra-bubble ack: react to the user's steer message
+                # so a mid-turn steer isn't silent while it waits for the next
+                # generation boundary. The steered reply lands at the end of the
+                # turn's output (no pre/post split -- that retroactive slice of a
+                # single stream leaked fragments across the cut). Best-effort --
+                # reactions need Bot API 7.0+.
+                steer_mid = getattr(msg, "message_id", 0)
+                if steer_mid:
+                    try:
+                        await self.client.set_message_reaction(
+                            chat_id, steer_mid, _STEER_ACK_EMOJI
+                        )
+                    except Exception:
+                        logger.debug(
+                            "telegram: steer ack reaction failed", exc_info=True
+                        )
                 return
-        # queue mode, or steer unavailable. Enqueue + receipt happen atomically
-        # under ``_receipt_lock`` (see ``_enqueue_with_receipt``) so the
-        # end-of-turn drain -- which takes the same lock to dequeue + flip --
-        # cannot interleave between the enqueue and the receipt and orphan a
-        # bubble. If the turn finished in the window the message is not queued,
-        # so we run it now instead of stranding it.
-        if not await self._enqueue_with_receipt(session_key, chat_id, msg.text):
+        # queue mode (or /queue override, or steer unavailable). Enqueue + receipt
+        # happen atomically under ``_receipt_lock`` (see ``_enqueue_with_receipt``)
+        # so the end-of-turn drain -- which takes the same lock to dequeue + flip
+        # -- cannot interleave between the enqueue and the receipt and orphan a
+        # bubble. If the turn finished in the window the message is not queued, so
+        # we run it now (re-entering handle_message, which re-strips the directive
+        # and runs it as a fresh turn) instead of stranding it.
+        if not await self._enqueue_with_receipt(session_key, chat_id, text):
             await self.handle_message(msg)
 
     async def _drain_queue(self, session_key: str, user_id: int, chat_id: int) -> None:
@@ -429,6 +494,9 @@ class TelegramDispatcher:
                 text=combined,
             ),
             drain=False,
+            # Drained payloads are pure turn content: a queued "/new" must reach
+            # the model as literal text, not execute as a command on drain.
+            interpret_commands=False,
         )
 
     # ── Mid-turn queue receipt (single, in-place, persistent record) ───────

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -24,7 +24,11 @@ from kiro_crew.messaging.renderer import (
 )
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.telegram.client import TELEGRAM_CHUNK_LIMIT, TelegramInbound
-from kiro_crew.telegram.commands import ConversationState, parse_command
+from kiro_crew.telegram.commands import (
+    ConversationState,
+    parse_command,
+    parse_mid_turn_override,
+)
 from kiro_crew.telegram.renderer import (
     TelegramApprovalDecider,
     TelegramRenderer,
@@ -32,10 +36,15 @@ from kiro_crew.telegram.renderer import (
     _md_to_telegram_html,
     _split_markdown,
     _split_text,
+    _strip_steering,
     build_inline_keyboard,
 )
-from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES, TelegramTransport
-from kiro_crew.telegram.transport_dispatch import TelegramDispatcher
+from kiro_crew.telegram.transport import (
+    TELEGRAM_CAPABILITIES,
+    TelegramInboundMessage,
+    TelegramTransport,
+)
+from kiro_crew.telegram.transport_dispatch import _STEER_ACK_EMOJI, TelegramDispatcher
 
 # ── Fakes ──────────────────────────────────────────────────────────────────
 
@@ -50,6 +59,7 @@ class FakeClient:
         self.markup_edits: list[tuple[int, Any]] = []
         self.answered: list[str] = []
         self.reply_targets: list[Any] = []
+        self.reactions: list[tuple[int, str]] = []
         self._mid = 100
 
     async def send_typing(self, chat_id: int) -> None:
@@ -87,6 +97,23 @@ class FakeClient:
 
     async def answer_callback(self, callback_query_id: str, text: str = "") -> None:
         self.answered.append(callback_query_id)
+
+    async def set_message_reaction(
+        self, chat_id: int, message_id: int, emoji: str
+    ) -> None:
+        self.reactions.append((message_id, emoji))
+
+    def final_text(self) -> Any:
+        """Text the user ultimately sees on the live message: the last edit if it
+        was edited (edit-streaming), else the last send."""
+        if self.edits:
+            return self.edits[-1][1]
+        return self.sent[-1][0] if self.sent else None
+
+    def final_markup(self) -> Any:
+        if self.edits:
+            return self.edits[-1][2]
+        return self.sent[-1][1] if self.sent else None
 
 
 class _Ev:
@@ -285,6 +312,22 @@ class TestParseCommand:
     def test_unknown_slash_is_not_a_command(self) -> None:
         assert parse_command("/frobnicate") is None
 
+    def test_mid_turn_override_queue(self) -> None:
+        assert parse_mid_turn_override("/queue do this after") == ("queue", "do this after")
+
+    def test_mid_turn_override_steer(self) -> None:
+        assert parse_mid_turn_override("/steer stop now") == ("steer", "stop now")
+
+    def test_mid_turn_override_case_insensitive_and_leading_space(self) -> None:
+        assert parse_mid_turn_override("  /QUEUE later") == ("queue", "later")
+
+    def test_mid_turn_override_none_for_plain_text(self) -> None:
+        assert parse_mid_turn_override("hello there") == (None, "hello there")
+
+    def test_mid_turn_override_none_without_body(self) -> None:
+        # A bare directive with no message body is not an override.
+        assert parse_mid_turn_override("/queue") == (None, "/queue")
+
 
 class TestConversationState:
     def test_gen_starts_at_zero_and_bumps(self) -> None:
@@ -470,6 +513,16 @@ class TestTransportReceive:
 
 
 class TestRenderer:
+    def test_strip_steering_complete_and_unclosed(self) -> None:
+        # Complete marker is removed anywhere in the text.
+        out = _strip_steering("BANANA [STEERING steer-x: rephrase] tail")
+        assert "STEERING" not in out and out.startswith("BANANA") and out.endswith("tail")
+        # UNCLOSED trailing marker (still streaming, no closing "]") is also
+        # removed, so the live draft never previews text that on_done strips.
+        assert _strip_steering("BANANA\n\n[STEERING steer-abc: interpreted as wanting") == "BANANA"
+        # No marker -> unchanged.
+        assert _strip_steering("just text") == "just text"
+
     def _drive(self, events: list[OutputEvent]) -> FakeClient:
         cli = FakeClient()
         r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
@@ -491,17 +544,18 @@ class TestRenderer:
                 OutputEvent(kind=DONE, stop_reason=""),
             ]
         )
-        # Block streaming: no placeholder edit-stream; the finished answer is
-        # sent as one block with the [OPTIONS:] keyboard attached.
-        final_text, final_kb = cli.sent[-1]
+        # Edit-streaming: the finished answer is the last edit, carrying the
+        # [OPTIONS:] keyboard; the raw [OPTIONS:] directive is stripped from text.
+        final_text = cli.final_text()
+        final_kb = cli.final_markup()
         assert final_text == "Hello. Pick."  # [OPTIONS:] stripped
         labels = [b["text"] for row in final_kb["inline_keyboard"] for b in row]
         assert labels == ["A", "B"]
 
-    def test_streams_via_drafts_and_persists_once_without_edits(self) -> None:
-        # The core of the fix: growing text streams as native animated drafts,
-        # the finished answer is persisted with ONE sendMessage, and
-        # editMessageText is never used (no reflow stutter).
+    def test_streams_live_via_send_then_edit(self) -> None:
+        # Edit-streaming (OpenClaw-style): send one real message, then edit it in
+        # place as text arrives. No draft (the ghost/vanish source). The final
+        # formatted content is the last edit; the initial send seeds the bubble.
         cli = self._drive(
             [
                 OutputEvent(kind=TEXT_CHUNK, text="one "),
@@ -510,14 +564,47 @@ class TestRenderer:
                 OutputEvent(kind=DONE, stop_reason=""),
             ]
         )
-        assert cli.edits == []  # never edits -> no reflow stutter
-        assert cli.drafts  # streamed as native animated drafts
-        assert len(cli.sent) == 1  # one persisted block
-        assert cli.sent[-1][0] == "one two three"
+        assert cli.drafts == []  # no draft preview -> no ghost bubble
+        assert cli.sent  # a real message was sent (live seed)
+        assert cli.final_text() == "one two three"  # final formatted content
+
+    def test_tool_footer_surfaces_immediately_on_tool_call(self) -> None:
+        # A mid-turn tool call surfaces a transient "🔧 {tool}…" footer on the
+        # live bubble immediately (force bypasses the edit throttle), so long
+        # agentic turns show activity instead of a dead typing indicator.
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text="Checking the logs. "),
+                OutputEvent(kind=TOOL_CALL, tool_call_id="t1", title="grep"),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        frames = [t for t, _ in cli.sent] + [t for _, t, _ in cli.edits]
+        assert any("🔧 grep…" in f for f in frames)  # footer shown live
+
+    def test_tool_footer_cleared_by_text_and_absent_from_final(self) -> None:
+        # The footer is transient: cleared the moment text resumes, and never
+        # part of the sealed/final message (seals read _segment_text, which the
+        # footer is deliberately kept out of).
+        cli = self._drive(
+            [
+                OutputEvent(kind=TOOL_CALL, tool_call_id="t1", title="fs_read"),
+                OutputEvent(kind=TEXT_CHUNK, text="Found it. "),
+                OutputEvent(kind=TOOL_CALL, tool_call_id="t2", title="shell"),
+                OutputEvent(kind=TEXT_CHUNK, text="All done."),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        frames = [t for t, _ in cli.sent] + [t for _, t, _ in cli.edits]
+        assert any("🔧 fs_read…" in f for f in frames)
+        assert any("🔧 shell…" in f for f in frames)
+        assert "🔧" not in cli.final_text()  # final is clean
+        assert cli.final_text() == "Found it. All done."
 
     def test_strips_steering_marker_from_output(self) -> None:
-        # kiro-cli's inline "[STEERING steer-<id>: …]" ack marker must not leak
-        # into the posted message (block renderer posts the final via sendMessage).
+        # kiro-cli's inline "[STEERING steer-<id>: …]" ack marker must never leak
+        # raw into any posted message. An end-of-stream marker (no continuation
+        # text after it) produces NO extra message — just the sealed answer.
         cli = self._drive(
             [
                 OutputEvent(kind=TEXT_CHUNK, text="UTC is 09:03. BANANA\n\n"),
@@ -529,63 +616,324 @@ class TestRenderer:
                 OutputEvent(kind=DONE, stop_reason=""),
             ]
         )
-        final_text = cli.sent[-1][0]
-        assert "STEERING" not in final_text and "steer-f078" not in final_text
-        assert final_text == "UTC is 09:03. BANANA"
+        texts = [t for t, _ in cli.sent]
+        assert texts == ["UTC is 09:03. BANANA"]  # sealed clean, no ack tail
+        assert "STEERING" not in " ".join(texts)
 
-    def test_steer_consumed_splits_into_two_messages(self) -> None:
-        # On steer-consumed, on_done posts the pre-steer output and the steered
-        # continuation as SEPARATE messages (block renderer splits at on_done).
-        cli = self._drive(
-            [
-                OutputEvent(kind=TEXT_CHUNK, text="Running date. UTC is 09:03."),
-                OutputEvent(kind=STEER_CONSUMED),
-                OutputEvent(kind=TEXT_CHUNK, text="BANANA"),
-                OutputEvent(kind=DONE, stop_reason=""),
-            ]
-        )
-        assert len(cli.sent) == 2
-        assert "UTC is 09:03." in cli.sent[0][0] and "BANANA" not in cli.sent[0][0]
-        assert cli.sent[-1][0] == "BANANA"
-
-    def test_steer_consumed_threads_reply_to_steer_message(self) -> None:
-        # M1: the steered-continuation message replies to the user's steer
-        # message (set_steer_reply_to); the pre-steer message does not.
+    def test_steer_seals_at_marker_into_new_bubble(self) -> None:
+        # Seal-on-steer: the [STEERING] marker (kiro-cli's in-stream injection
+        # point) seals the pre-steer text as its own message; the steered
+        # continuation opens a FRESH message headed by a chip. The chip prefers
+        # the SUMMARY embedded in the marker (dashboard parity) over the user's
+        # own words — those are already on screen as the user's message.
         cli = FakeClient()
         r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
-        r.set_steer_reply_to(4242)  # the user's steer message id
+        r.note_steer("stop and say BANANA")  # the dispatcher records the user's words
 
         async def _go() -> None:
             await r.on_turn_start()
-            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="date answer"))
-            await r.dispatch(OutputEvent(kind=STEER_CONSUMED))
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="Root at 86% used. "))
+            await r.dispatch(
+                OutputEvent(kind=TEXT_CHUNK, text="[STEERING steer-abc: stop]")
+            )
+            await r.dispatch(OutputEvent(kind=STEER_CONSUMED))  # event: render no-op
             await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="BANANA"))
             await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
 
         asyncio.run(_go())
-        # Two posted messages: pre-steer (reply_to=None), steered (reply_to=4242).
-        assert cli.reply_targets == [None, 4242]
+        texts = [t for t, _ in cli.sent]
+        assert len(texts) == 2  # pre-steer bubble sealed + steered continuation
+        assert texts[0] == "Root at 86% used."  # frozen pre-steer bubble
+        assert "STEERING" not in texts[0] and "STEERING" not in texts[1]
+        # The chip heads the new bubble with the MARKER's summary (not the quote).
+        assert texts[1].startswith("<blockquote>↪️ stop</blockquote>")
+        assert "BANANA" in texts[1] and "used.BANANA" not in texts[1]  # no leak
 
-    def test_multi_steer_reply_targets_first_steer_message(self) -> None:
-        # First-steer-wins: on a rapid multi-steer burst the dispatcher calls
-        # set_steer_reply_to for every steer, but the split is recorded at the
-        # first boundary, so the reply target must stay on the FIRST steer id
-        # (100), not the last (200) -- keeping cause->effect consistent.
+    def test_end_of_stream_marker_posts_no_tail_bubble(self) -> None:
+        # Marker at the very END of the stream (kiri-cli folded the steer but
+        # emitted no post-steer text): NO tail message at all. The answer already
+        # covered the steer and the user's message carries the reaction receipt —
+        # any trailing ack bubble (quote OR summary) is pure noise. Regression
+        # for the trailing bubbles seen live on 2026-07-19.
         cli = FakeClient()
         r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
-        r.set_steer_reply_to(100)  # first steer
-        r.set_steer_reply_to(200)  # second steer (same turn) -- ignored
+        r.note_steer("顺便看看今天悉尼什么天气")
 
         async def _go() -> None:
             await r.on_turn_start()
-            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="pre"))
-            await r.dispatch(OutputEvent(kind=STEER_CONSUMED))
-            await r.dispatch(OutputEvent(kind=STEER_CONSUMED))  # second consume
-            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="post"))
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="目录总结。天气:多云。"))
+            await r.dispatch(
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text="\n\n[STEERING steer-a180ae7f: 已并行查询悉尼天气,一并答复。]",
+                )
+            )
             await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
 
         asyncio.run(_go())
-        assert cli.reply_targets == [None, 100]
+        texts = [t for t, _ in cli.sent]
+        assert len(texts) == 1  # only the sealed answer — no ack tail
+        assert "STEERING" not in texts[0]
+        assert "已并行查询" not in texts[0] and "顺便看看" not in texts[0]
+
+    def test_options_keyboard_survives_length_rotation(self) -> None:
+        # Codex finding: [OPTIONS:] must be extracted BEFORE length rotation.
+        # A body long enough to rotate must still attach the keyboard to the
+        # FINAL message — not strand the options text in a sealed segment and
+        # fall into the "…" placeholder branch.
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text=("line\n" * 1200)),  # > limit
+                OutputEvent(kind=TEXT_CHUNK, text="Pick one.\n\n[OPTIONS: A | B]"),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        kb = cli.final_markup()
+        assert kb is not None
+        labels = [b["text"] for row in kb["inline_keyboard"] for b in row]
+        assert labels == ["A", "B"]
+        # The options directive never leaks into any posted text.
+        all_text = " ".join(t for t, _ in cli.sent) + " ".join(
+            t for _, t, _ in cli.edits
+        )
+        assert "[OPTIONS" not in all_text
+
+    def test_tool_only_message_not_orphaned_at_steer_boundary(self) -> None:
+        # Codex finding: a tool call BEFORE any assistant text creates a live
+        # "🔧 tool…" message. If a steer marker then arrives with no pre-marker
+        # text, nothing is sealed — the renderer must KEEP that message id so
+        # the steered continuation replaces the transient footer in place,
+        # instead of orphaning a permanent tool-footer bubble.
+        cli = self._drive(
+            [
+                OutputEvent(kind=TOOL_CALL, tool_call_id="t1", title="grep"),
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text="[STEERING steer-abc123: checked] steered answer.",
+                ),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        # Exactly ONE message ever sent (the tool-footer one, reused).
+        assert len(cli.sent) == 1
+        assert cli.final_text() is not None
+        assert "steered answer" in cli.final_text()
+        assert "🔧" not in cli.final_text()
+
+    def test_options_only_response_keeps_keyboard(self) -> None:
+        # Codex finding: a response that is ONLY "[OPTIONS: A | B]" leaves an
+        # empty body after extraction — the placeholder must still carry the
+        # keyboard, not silently drop the user's choices.
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text="[OPTIONS: A | B]"),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        markups = [m for _, m in cli.sent if m] + [m for _, _, m in cli.edits if m]
+        assert len(markups) == 1
+        labels = [
+            b["text"] for row in markups[0]["inline_keyboard"] for b in row
+        ]
+        assert labels == ["A", "B"]
+
+    def test_complete_options_straddling_length_cut_stays_intact(self) -> None:
+        # Codex finding: a COMPLETE trailing [OPTIONS: A | B] whose text
+        # crosses the length-rotation boundary must be detached whole before
+        # _split_markdown — a bare split would put "[OPTIO" in one message and
+        # "NS: A | B]" in the next, leaking protocol text and losing the
+        # keyboard. Body sized so the directive itself straddles the cut.
+        body = "x" * 3730  # just under the ~3840 limit; directive crosses it
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text=body),
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text="\n\nPick one below please.\n\n[OPTIONS: A | B]",
+                ),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        # The final segment never live-streamed (rotation happened at the very
+        # end), so the seal SENDS a fresh message — find the keyboard across
+        # both sends and edits rather than via final_markup().
+        markups = [m for _, m in cli.sent if m] + [m for _, _, m in cli.edits if m]
+        assert len(markups) == 1
+        labels = [
+            b["text"] for row in markups[0]["inline_keyboard"] for b in row
+        ]
+        assert labels == ["A", "B"]
+        # The options directive never leaks — whole or split — into any text.
+        all_text = " ".join(t for t, _ in cli.sent) + " ".join(
+            t for _, t, _ in cli.edits
+        )
+        assert "[OPTIO" not in all_text and "NS: A | B]" not in all_text
+
+    def test_double_marker_chunk_keeps_first_chip(self) -> None:
+        # Codex finding: one chunk carrying TWO complete [STEERING] markers must
+        # not overwrite the first steer's chip — its continuation seals WITH the
+        # chip before the second rotation.
+        cli = self._drive(
+            [
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text=(
+                        "base answer. "
+                        "[STEERING steer-aaa111: first ack] first continuation. "
+                        "[STEERING steer-bbb222: second ack] second continuation."
+                    ),
+                ),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        texts = [t for t, _ in cli.sent]
+        assert len(texts) == 3  # base + two steered continuations
+        assert "first ack" in texts[1] and "first continuation" in texts[1]
+        assert "second ack" in texts[2] and "second continuation" in texts[2]
+        assert "STEERING" not in " ".join(texts)
+
+    def test_hr_inside_code_fence_preserved(self) -> None:
+        # Codex finding: _strip_hr must not delete a standalone "---" INSIDE a
+        # fenced code block (e.g. a YAML document separator).
+        cli = self._drive(
+            [
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text="Config:\n```yaml\na: 1\n---\nb: 2\n```\ndone",
+                ),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        assert "---" in cli.final_text()  # YAML separator survives
+        # A bare HR OUTSIDE a fence is still stripped.
+        cli2 = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text="above\n\n---\n\nbelow"),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        assert "---" not in cli2.final_text()
+
+    def test_live_frames_never_leak_options_markup(self) -> None:
+        # Codex finding: a live frame streamed from a chunk that already carries
+        # the complete [OPTIONS:] directive must hold it back, not show it.
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text="Pick one.\n\n[OPTIONS: A | B]"),
+                OutputEvent(kind=TEXT_CHUNK, text=""),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        frames = [t for t, _ in cli.sent] + [t for _, t, _ in cli.edits]
+        assert all("[OPTIONS" not in f for f in frames)
+        labels = [
+            b["text"] for row in cli.final_markup()["inline_keyboard"] for b in row
+        ]
+        assert labels == ["A", "B"]
+
+    def test_length_rotation_keeps_fences_balanced(self) -> None:
+        # Codex finding: length rotation must not cut a fenced code block in
+        # half — every sealed message carries balanced fences (via
+        # _split_markdown's close-and-reopen).
+        big_code = "```python\n" + ("x = 1\n" * 1500) + "```"
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text=big_code),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        assert len(cli.sent) >= 2  # rotated at least once
+        # Sealed HTML frames render the code as <pre> (fence recognized), and
+        # no posted frame carries an odd number of literal fences.
+        finals = [t for t, _ in cli.sent]
+        assert any("<pre>" in t for t in finals)
+        for t in finals:
+            assert t.count("```") % 2 == 0
+
+    def test_steer_summary_respects_transport_limit(self) -> None:
+        # Codex finding: the no-marker steer summary is prepended BEFORE length
+        # rotation, so the final message can never exceed Telegram's cap.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+        for i in range(10):
+            r.note_steer(f"steer number {i} " + "y" * 100)
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="body " * 780))
+            await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
+
+        asyncio.run(_go())
+        for t, _ in cli.sent:
+            assert len(t) <= 4096
+        for _, t, _ in cli.edits:
+            assert len(t) <= 4096
+
+    def test_oversized_pre_marker_segment_rotates_before_seal(self) -> None:
+        # Codex finding: a chunk can deliver over-limit text AND a complete
+        # [STEERING] marker together. The pre-marker segment must length-rotate
+        # before sealing, or the client truncates it at Telegram's cap.
+        big = "word " * 1300  # ~6500 chars > limit
+        cli = self._drive(
+            [
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text=big + "[STEERING steer-abc123: ack] tail answer.",
+                ),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        finals = [t for t, _ in cli.sent]
+        assert len(finals) >= 3  # pre-marker rotated into >=2 + continuation
+        for t in finals:
+            assert len(t) <= 4096  # nothing exceeds the transport cap
+        joined = " ".join(finals)
+        assert joined.count("word") >= 1290  # no pre-marker content lost
+        assert "tail answer" in finals[-1]
+
+    def test_partial_directive_never_split_by_length_rotation(self) -> None:
+        # Codex finding: an INCOMPLETE trailing directive crossing the length
+        # limit must be detached before splitting and reattached to the tail —
+        # never cut in half (which would leak fragments and lose the rotation).
+        big = "text " * 1300
+        cli = self._drive(
+            [
+                OutputEvent(kind=TEXT_CHUNK, text=big + "[STEERING steer-ddd444: par"),
+                OutputEvent(kind=TEXT_CHUNK, text="tial ack] steered tail."),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+        finals = [t for t, _ in cli.sent]
+        joined = " ".join(finals)
+        assert "STEERING" not in joined  # directive never leaked, whole or split
+        assert "steered tail" in joined  # rotation still happened
+        frames = [t for _, t, _ in cli.edits]
+        assert all("[STEERING" not in f for f in frames)  # nor on live frames
+
+    def test_seal_resends_when_live_message_deleted(self) -> None:
+        # Codex finding: if the user deletes the streamed message mid-turn,
+        # both seal edits fail — the final answer (and keyboard) must be
+        # re-SENT as a fresh message, never silently lost.
+        class _EditsFailClient(FakeClient):
+            async def edit_message(self, *a: Any, **kw: Any) -> bool:
+                await super().edit_message(*a, **kw)
+                return False  # message gone — every edit fails
+
+        cli = _EditsFailClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="final answer"))
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="\n\n[OPTIONS: A | B]"))
+            await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
+
+        asyncio.run(_go())
+        # Last SENT message carries the final content + keyboard.
+        final_text, final_kb = cli.sent[-1]
+        assert "final answer" in final_text
+        labels = [b["text"] for row in final_kb["inline_keyboard"] for b in row]
+        assert labels == ["A", "B"]
 
     def test_error_done_renders_error_when_no_text(self) -> None:
         cli = self._drive([OutputEvent(kind=DONE, stop_reason="error")])
@@ -637,7 +985,7 @@ class TestDispatcher:
             )
 
         asyncio.run(_go())
-        assert cli.sent[-1][0] == "Answer: hello world"
+        assert cli.final_text() == "Answer: hello world"
         assert sess.successes == ["telegram:kirocrew:direct:7"]
         assert sess.released == ["telegram:kirocrew:direct:7"]
 
@@ -743,9 +1091,9 @@ class TestDispatcher:
         # overwriting its text, echoes the picked choice as its own block, then
         # re-dispatches the choice so the answer arrives as a NEW message.
         assert cli.markup_edits[-1] == (99, {"inline_keyboard": []})
-        assert cli.edits == []  # original answer text is never clobbered
+        assert all(mid != 99 for mid, _, _ in cli.edits)  # original text never clobbered
         assert "Say Hi" in cli.sent[0][0]  # choice echoed as its own block first
-        assert cli.sent[-1][0] == "Answer: Say Hi"  # answer arrives as a new message
+        assert cli.final_text() == "Answer: Say Hi"  # answer streamed as a NEW message
 
     def test_callback_approval_resolves_decider(self) -> None:
         d, cli, _ = _dispatcher({7})
@@ -934,6 +1282,68 @@ class TestTelegramMidTurn:
         # Not steered (dead turn); preserved via the queue path instead of lost.
         assert sess._gp.steered == []
         assert [text for _ts, text, _ in sess.queued] == ["landed after turn"]
+
+    def test_busy_steer_reacts_to_user_message(self) -> None:
+        # Instant ack: a mid-turn steer reacts to the user's message (no extra
+        # bubble) so it isn't silent while it waits for the next generation
+        # boundary (the steered continuation only posts at turn end).
+        d, cli, sess = _dispatcher({7})
+        sess._busy = True
+
+        async def _go() -> None:
+            await d.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="7",
+                    text="stop, only banana",
+                    message_id=4242,
+                )
+            )
+
+        asyncio.run(_go())
+        assert sess._gp.steered == ["stop, only banana"]  # steered
+        assert cli.reactions == [(4242, _STEER_ACK_EMOJI)]  # reacted on the user's steer msg
+        # No extra receipt/steer bubble is posted (the ack is the reaction only).
+        assert not any("Steered" in t or "Queued" in t for t, _ in cli.sent)
+
+    def test_queue_override_forces_queue_in_steer_mode(self) -> None:
+        # "/queue …" holds the message even though the global mode is steer;
+        # the directive is stripped from the queued text.
+        d, cli, sess = _dispatcher({7})
+        sess._busy = True  # global queue_mode defaults to "steer"
+
+        async def _go() -> None:
+            await d.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram", user_id="7", conversation_id="7",
+                    text="/queue check disk after", message_id=11,
+                )
+            )
+
+        asyncio.run(_go())
+        assert sess._gp.steered == []  # NOT steered
+        assert [t for _ts, t, _ in sess.queued] == ["check disk after"]  # queued, stripped
+
+    def test_steer_override_forces_steer_in_queue_mode(self) -> None:
+        # "/steer …" folds into the running turn even though the global mode is
+        # queue; the directive is stripped from the steered text.
+        d, cli, sess = _dispatcher({7})
+        sess._busy = True
+        d.cfg.messaging.queue_mode = "queue"
+
+        async def _go() -> None:
+            await d.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram", user_id="7", conversation_id="7",
+                    text="/steer stop now", message_id=12,
+                )
+            )
+
+        asyncio.run(_go())
+        assert sess._gp.steered == ["stop now"]  # steered, stripped
+        assert sess.queued == []  # NOT queued
+        assert cli.reactions == [(12, _STEER_ACK_EMOJI)]  # steer-ack on the steer message
 
     def test_busy_queue_mode_enqueues(self) -> None:
         d, cli, sess = _dispatcher({7})


### PR DESCRIPTION
## Problem

Telegram had no real streaming and broken steer rendering:

1. **No streaming**: the renderer streamed exclusively via `sendMessageDraft` (Bot API 9.3+, requires Forum Topic Mode), which silently fails for ordinary private-chat bots. `_draft_ok=False` made `on_text_chunk` a no-op, so the whole answer arrived as one block at `on_done` after a long dead "typing…" indicator.
2. **No mid-turn tool visibility**: `on_tool_call` stored the tool name but never displayed anything — a long agentic turn showed zero activity.
3. **Steer render bugs** (verified live): a mid-turn steer produced a spurious trailing bubble containing only a quote of the user's own message (empty post-steer segment still posted), plus the racy STEER_CONSUMED-offset split behind the `used.BANANA`-style leak.

## Changes (3 commits)

**1. Live editMessageText streaming + transient tool footer**
- Stream by sending one real message and editing it in place (1s throttle, plaintext frames so partial markdown never 400s); seal to formatted HTML at rotation points and `on_done`.
- Rotate to a fresh message at each complete `[STEERING …]` marker (split at the marker's real stream position, not the racy consumed-offset) and on length overflow (fence-balanced chunking).
- Transient `🔧 {tool}…` footer on live frames only: `on_tool_call` sets it and force-refreshes past the throttle; text resumption clears it; seals/finals never carry it. Deliberately no message seal at tool boundaries — models interleave tool calls mid-sentence, sealing there fragments the answer.

**2. Steer chip shows the marker's ack summary, not the user's echoed words**
- kiro-cli embeds an ack summary in the `[STEERING steer-<id>: …]` marker (the dashboard's "Steered — …" chip parses it). The rotation chip now prefers that summary (`↪️ {summary}` blockquote); the user's own words are already on screen as their message. Falls back to the recorded user text when the marker carries no summary.

**3. Suppress chip-only ack tails for end-of-stream markers**
- The chip is now held *pending* at rotation and materializes only when real post-steer text follows. An end-of-stream marker (steer folded, no continuation text) posts no tail message at all — the answer already covered the steer and the user's message carries the reaction receipt.

## Verification

- 85/85 tests in `test/test_telegram.py` (includes new regression tests for the tool footer, summary chip, and no-tail behavior); flake8 clean.
- Verified end-to-end against a live Telegram bot: live bubble growth, tool footer, steer folding with clean rendering; the trailing-bubble regressions were each reproduced live before the fix and gone after.

## Notes

- Streaming granularity is bounded by Telegram itself (each update is a full `editMessageText` round-trip; ~1s cadence avoids per-chat 429s) — block-by-block growth, not per-token.
- Design provenance: this consolidates the editMessageText approach the draft-based path had replaced; the draft path is removed entirely (it cannot work for private-chat bots).