### PR TITLE
fix(dashboard): serve /app-assets, apply builtin icons+hero in store and nav

### DIFF
--- a/src/kiro_crew/apps/builtins/deploy_web/app.json
+++ b/src/kiro_crew/apps/builtins/deploy_web/app.json
@@ -6,6 +6,7 @@
   "author": "zejiangg",
   "tags": ["aws", "publish", "deploy", "artifacts"],
   "defaultEnabled": false,
+  "hidden": true,
   "skills": ["skills/deploy-web"],
   "permissions": {
     "api": ["/api/apps/deploy-web", "/api/apps/deploy-web/*"]

--- a/src/kiro_crew/apps/builtins/workflows/app.json
+++ b/src/kiro_crew/apps/builtins/workflows/app.json
@@ -11,6 +11,7 @@
     "agents"
   ],
   "defaultEnabled": false,
+  "hidden": true,
   "permissions": {
     "api": [
       "/apps/workflows/api"

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1011,6 +1011,9 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "author": "kirocrew",
         "tags": ["visualization", "agents"],
         "defaultEnabled": False,
+        "iconUrl": "/app-assets/worlds/icon.svg",
+        "heroImage": "/app-assets/worlds/hero-light.svg",
+        "heroImageDark": "/app-assets/worlds/hero-dark.svg",
         "ui": {
             "pages": [{"route": "/worlds", "label": "Worlds", "icon": "Gamepad2"}],
         },

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -328,6 +328,17 @@ def _register_dist_static_routes(app: web.Application, dist_dir: Path) -> None:
             show_index=False,
             append_version=False,  # stable URLs, no cache-busting
         )
+    # App Store brand assets — builtin app icons + hero images live at
+    # dist/app-assets/ and are referenced by absolute url('/app-assets/...')
+    # from each builtin's app.json (iconUrl / heroImage / heroImageDark).
+    # These resolve in the Vite dev server (public/ served at root) but, once
+    # the gateway serves the built dist/, they need an explicit mount: without
+    # it the request falls through to the SPA fallback (index.html) and the
+    # App Store <img> tags try to parse HTML as an image → onError placeholder
+    # (generic lucide icon / "KIROCREW" hero). Stable, un-hashed filenames, so
+    # no append_version cache-busting.
+    if (dist_dir / "app-assets").is_dir():
+        app.router.add_static("/app-assets", dist_dir / "app-assets", show_index=False)
     logger.info("Serving React build from %s", dist_dir)
 
 

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -380,6 +380,7 @@ SPA_FALLBACK_EXCLUDED_PREFIXES = (
     "/sprites/",
     "/vendor/",
     "/fonts/",
+    "/app-assets/",
 )
 
 # Regex that matches /apps/{name} sub-namespace paths that have real server-side

--- a/test/test_builtin_app_assets.py
+++ b/test/test_builtin_app_assets.py
@@ -1,0 +1,62 @@
+"""Guards that builtin app icon/hero art referenced as ``/app-assets/...`` exists.
+
+Builtin manifests point at brand SVGs via absolute ``/app-assets/<app>/<file>``
+paths (top-level ``iconUrl`` / ``heroImage`` / ``heroImageDark``). Those files
+live in ``website/public/app-assets/`` and are served by the gateway's
+``/app-assets`` static mount. A manifest that references a non-existent file
+renders the ``<img onError>`` placeholder instead of the intended art — the exact
+failure mode this suite prevents (e.g. Agent Worlds shipping a lucide glyph with
+its ``icon.svg`` left unreferenced, or an iconUrl pointing at a missing file).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import kiro_crew.apps.manager as mgr
+from kiro_crew.apps.discovery import discover_builtin_apps
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_APP_ASSETS_DIR = _REPO_ROOT / "website" / "public" / "app-assets"
+_ASSET_FIELDS = ("iconUrl", "heroImage", "heroImageDark")
+
+
+def _asset_refs(app: dict) -> list[tuple[str, str]]:
+    """Return (field, path) for each /app-assets/ reference on an app dict."""
+    refs: list[tuple[str, str]] = []
+    for field in _ASSET_FIELDS:
+        val = app.get(field)
+        if isinstance(val, str) and val.startswith("/app-assets/"):
+            refs.append((field, val))
+    return refs
+
+
+def _resolve(app_assets_path: str) -> Path:
+    """Map a served ``/app-assets/<rel>`` URL to its public/ source file."""
+    rel = app_assets_path[len("/app-assets/") :]
+    return _APP_ASSETS_DIR / rel
+
+
+def _all_builtin_apps() -> list[dict]:
+    return [*mgr._BUILTIN_APPS, *discover_builtin_apps()]
+
+
+def test_all_builtin_app_assets_exist() -> None:
+    """Every ``/app-assets/...`` icon/hero referenced by a builtin exists on disk."""
+    missing: list[str] = []
+    for app in _all_builtin_apps():
+        for field, path in _asset_refs(app):
+            if not _resolve(path).is_file():
+                missing.append(f"{app.get('name')}.{field} -> {path}")
+    assert not missing, "builtin app-asset references with no file:\n" + "\n".join(missing)
+
+
+def test_agent_worlds_icon_wired_to_svg() -> None:
+    """Agent Worlds surfaces its colorful icon via top-level iconUrl.
+
+    Regression: the shipped ``worlds/icon.svg`` was present but unreferenced, so
+    the app fell back to the lucide Gamepad2 glyph in both the store and nav.
+    """
+    worlds = next((a for a in mgr._BUILTIN_APPS if a["name"] == "agent-worlds"), None)
+    assert worlds is not None, "agent-worlds builtin missing from _BUILTIN_APPS"
+    assert worlds.get("iconUrl") == "/app-assets/worlds/icon.svg"
+    assert _resolve(worlds["iconUrl"]).is_file()

--- a/test/test_builtin_discovery.py
+++ b/test/test_builtin_discovery.py
@@ -202,3 +202,37 @@ class TestBuiltinClassification:
         app = apps[0]
         assert app["backend"]["hooks"]["routes"] == "backend.routes:register_routes"
         assert app["backend"]["hooks"]["on_startup"] == "backend.hooks:startup"
+
+
+# ---------------------------------------------------------------------------
+# Store visibility: hidden builtins stay installed but drop out of Browse
+# ---------------------------------------------------------------------------
+
+
+class TestHiddenBuiltins:
+    """The `hidden` manifest flag hides a builtin from the App Store Browse grid
+    (filter at website AppsPage) while keeping it installed, routable, and on the
+    Installed tab. `hidden` is not a _KNOWN_FIELDS key, so it must survive as an
+    ``extra`` field through discovery and reach the frontend as manifest.hidden.
+    """
+
+    def test_hidden_flag_preserved_through_discovery(self, tmp_path: Path) -> None:
+        """A `hidden: true` manifest field is preserved in discovery output."""
+        manifest = _valid_manifest("hidden-app")
+        manifest["hidden"] = True
+        _write_manifest(tmp_path / "hidden-app", manifest)
+
+        apps = discover_builtin_apps(tmp_path)
+        assert len(apps) == 1
+        assert apps[0]["hidden"] is True
+
+    def test_shipped_workflows_and_deploy_web_are_hidden(self) -> None:
+        """The shipped `workflows` and `deploy-web` builtins ship hidden from the
+        store. Regression: these two must not appear in the Browse grid."""
+        shipped = {a["name"]: a for a in discover_builtin_apps()}
+        for name in ("workflows", "deploy-web"):
+            assert name in shipped, f"{name} builtin not discovered"
+            assert shipped[name].get("hidden") is True, (
+                f"{name} must ship with hidden=True so it is excluded from the "
+                f"App Store Browse grid (got {shipped[name].get('hidden')!r})"
+            )

--- a/test/test_dashboard_static_routes.py
+++ b/test/test_dashboard_static_routes.py
@@ -65,14 +65,66 @@ def test_fonts_route_skipped_when_fonts_dir_absent(tmp_path) -> None:
 
 
 def test_optional_subdirs_registered_only_when_present(tmp_path) -> None:
-    """sprites/ and vendor/ mount only when they exist; /assets is always on."""
-    dist = _make_dist(tmp_path, "assets", "sprites", "fonts", "vendor")
+    """sprites/, vendor/ and app-assets/ mount only when they exist; /assets is always on."""
+    dist = _make_dist(tmp_path, "assets", "sprites", "fonts", "vendor", "app-assets")
     app = web.Application()
 
     _register_dist_static_routes(app, dist)
 
     prefixes = _registered_prefixes(app)
-    assert {"/assets", "/sprites", "/fonts", "/vendor"} <= prefixes
+    assert {"/assets", "/sprites", "/fonts", "/vendor", "/app-assets"} <= prefixes
+
+
+def test_app_assets_route_registered_when_dir_present(tmp_path) -> None:
+    """A dist/ with an app-assets/ subdir gets an /app-assets static route.
+
+    Regression: builtin app.json files reference brand art via absolute
+    ``url('/app-assets/...')`` (iconUrl / heroImage / heroImageDark). Without
+    this mount the request falls through to the SPA fallback (index.html) and
+    the App Store <img> tags load HTML as an image, tripping their onError
+    placeholder (generic lucide icon / "KIROCREW" hero).
+    """
+    dist = _make_dist(tmp_path, "assets", "app-assets")
+    app = web.Application()
+
+    _register_dist_static_routes(app, dist)
+
+    assert "/app-assets" in _registered_prefixes(app)
+
+
+def test_app_assets_route_skipped_when_dir_absent(tmp_path) -> None:
+    """No app-assets/ subdir -> no /app-assets route (only the always-on /assets)."""
+    dist = _make_dist(tmp_path, "assets")
+    app = web.Application()
+
+    _register_dist_static_routes(app, dist)
+
+    prefixes = _registered_prefixes(app)
+    assert "/app-assets" not in prefixes
+    assert "/assets" in prefixes
+
+
+@pytest.mark.asyncio
+async def test_app_assets_svg_served_not_spa_shell(tmp_path: Path) -> None:
+    """An SVG under /app-assets is served verbatim (the file, not index.html).
+
+    Proves the builtin icon/hero art is reachable through the gateway once the
+    build's dist/app-assets/ is mounted — the exact failure mode that made the
+    "recently added" colorful icons and hero images not render.
+    """
+    dist = _make_dist(tmp_path, "assets", "app-assets")
+    (dist / "app-assets" / "auto-research").mkdir()
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+    (dist / "app-assets" / "auto-research" / "icon.svg").write_bytes(svg)
+
+    app = web.Application()
+    _register_dist_static_routes(app, dist)
+
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/app-assets/auto-research/icon.svg")
+        assert resp.status == 200
+        assert (await resp.read()) == svg
+        assert resp.content_type == "image/svg+xml"
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -527,6 +527,35 @@ def test_apps_sub_paths_are_not_spa_shell(path: str) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/app-assets/auto-research/icon.svg",
+        "/app-assets/workflows/hero-light.svg",
+        "/app-assets/auto-research/hero-dark.svg",
+    ],
+)
+def test_app_assets_paths_are_not_spa_shell(path: str) -> None:
+    """/app-assets/* are static brand files (builtin icons + hero images), not
+    SPA navigation. They MUST be excluded from the SPA shell fallback so a
+    request resolves against the /app-assets static mount (or 404s cleanly,
+    letting the <img onError> fallback run) instead of being answered with
+    index.html.
+
+    Regression for: recently added colorful builtin icons / hero images did not
+    render because /app-assets/ had no static route AND was not in
+    SPA_FALLBACK_EXCLUDED_PREFIXES, so the SVG requests were served index.html
+    (HTML) and every <img> tripped its placeholder fallback.
+    """
+    import kiro_crew.dashboard.token_auth as ta
+
+    assert "/app-assets/" in ta.SPA_FALLBACK_EXCLUDED_PREFIXES
+    req = _make_request(path=path, method="GET")
+    assert not ta._is_spa_shell_request(req), (
+        f"GET {path} should NOT be a SPA shell request (static brand asset)"
+    )
+
+
 # -- Property 9: Loopback no longer bypasses auth (port-forward fix) --
 
 

--- a/website/public/app-assets/worlds/hero-dark.svg
+++ b/website/public/app-assets/worlds/hero-dark.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 270" fill="none">
+  <rect width="480" height="270" fill="#0f172a"/>
+  <!-- Stars -->
+  <circle cx="50" cy="30" r="1" fill="#e2e8f0" opacity="0.7"/>
+  <circle cx="120" cy="50" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="200" cy="25" r="1.2" fill="#e2e8f0" opacity="0.6"/>
+  <circle cx="300" cy="40" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="380" cy="20" r="1" fill="#e2e8f0" opacity="0.7"/>
+  <circle cx="430" cy="55" r="0.8" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="80" cy="80" r="0.6" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="350" cy="70" r="1" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="150" cy="90" r="0.7" fill="#e2e8f0" opacity="0.3"/>
+  <circle cx="450" cy="90" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <!-- Moon -->
+  <circle cx="380" cy="60" r="22" fill="#fde68a" opacity="0.9"/>
+  <circle cx="372" cy="55" r="18" fill="#0f172a"/>
+  <!-- Moon glow -->
+  <circle cx="380" cy="60" r="30" fill="#fde68a" opacity="0.05"/>
+  <!-- Ground -->
+  <rect x="0" y="200" width="480" height="70" fill="#064e3b" opacity="0.6"/>
+  <rect x="0" y="195" width="480" height="8" rx="4" fill="#059669" opacity="0.3"/>
+  <!-- Pixel character 1 -->
+  <rect x="140" y="170" width="20" height="20" rx="2" fill="#4ade80" opacity="0.8"/>
+  <rect x="144" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+  <rect x="152" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+  <rect x="146" y="182" width="8" height="2" rx="1" fill="#0f172a"/>
+  <!-- Glow around char 1 -->
+  <rect x="138" y="168" width="24" height="24" rx="3" stroke="#4ade80" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Pixel character 2 -->
+  <rect x="240" y="165" width="22" height="22" rx="2" fill="#60a5fa" opacity="0.8"/>
+  <rect x="245" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+  <rect x="253" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+  <rect x="247" y="178" width="8" height="2" rx="1" fill="#0f172a"/>
+  <!-- Glow around char 2 -->
+  <rect x="238" y="163" width="26" height="26" rx="3" stroke="#60a5fa" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Pixel character 3 -->
+  <rect x="330" y="172" width="18" height="18" rx="2" fill="#f472b6" opacity="0.8"/>
+  <rect x="334" y="176" width="3" height="3" rx="1" fill="#0f172a"/>
+  <rect x="341" y="176" width="3" height="3" rx="1" fill="#0f172a"/>
+  <rect x="335" y="183" width="7" height="2" rx="1" fill="#0f172a"/>
+  <!-- Glow around char 3 -->
+  <rect x="328" y="170" width="22" height="22" rx="3" stroke="#f472b6" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Pixel trees -->
+  <rect x="80" y="180" width="6" height="15" fill="#065f46" opacity="0.7"/>
+  <polygon points="83,155 70,180 96,180" fill="#059669" opacity="0.6"/>
+  <rect x="400" y="178" width="5" height="17" fill="#065f46" opacity="0.7"/>
+  <polygon points="402,153 391,178 414,178" fill="#059669" opacity="0.6"/>
+</svg>

--- a/website/public/app-assets/worlds/hero-light.svg
+++ b/website/public/app-assets/worlds/hero-light.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 270" width="480" height="270">
+<defs><linearGradient id="s" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a8e6cf"/><stop offset="100%" stop-color="#dcedc1"/></linearGradient></defs>
+<rect width="480" height="270" fill="url(#s)"/>
+<circle cx="400" cy="50" r="24" fill="#ffd93d"/><circle cx="400" cy="50" r="18" fill="#ffec8b"/>
+<rect x="0" y="210" width="480" height="60" fill="#6bba75"/>
+<rect x="0" y="210" width="480" height="8" fill="#4a9e5c"/>
+<rect x="60" y="180" width="8" height="30" fill="#8b5e3c"/>
+<polygon points="44,180 84,180 64,148" fill="#2d8a4e"/>
+<polygon points="48,165 80,165 64,138" fill="#34a853"/>
+<rect x="380" y="185" width="6" height="25" fill="#8b5e3c"/>
+<polygon points="368,185 398,185 383,158" fill="#2d8a4e"/>
+<polygon points="371,170 395,170 383,148" fill="#34a853"/>
+<rect x="440" y="188" width="5" height="22" fill="#8b5e3c"/>
+<polygon points="430,188 455,188 443,165" fill="#2d8a4e"/>
+<rect x="140" y="168" width="36" height="42" rx="4" fill="#4a90d9"/>
+<rect x="144" y="174" width="12" height="8" rx="2" fill="#fff"/>
+<rect x="160" y="174" width="12" height="8" rx="2" fill="#fff"/>
+<circle cx="148" cy="177" r="3" fill="#1a1a2e"/>
+<circle cx="164" cy="177" r="3" fill="#1a1a2e"/>
+<rect x="152" y="188" width="12" height="4" rx="2" fill="#2c5f8a"/>
+<rect x="146" y="196" width="24" height="8" rx="2" fill="#3a7bc8"/>
+<rect x="144" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+<rect x="162" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+<rect x="150" y="156" width="16" height="12" rx="6" fill="#6ba8e8"/>
+<rect x="230" y="178" width="28" height="32" rx="3" fill="#f4845f"/>
+<rect x="234" y="182" width="8" height="6" rx="1" fill="#fff"/>
+<rect x="246" y="182" width="8" height="6" rx="1" fill="#fff"/>
+<circle cx="237" cy="184" r="2" fill="#1a1a2e"/>
+<circle cx="249" cy="184" r="2" fill="#1a1a2e"/>
+<rect x="238" y="194" width="12" height="3" rx="1" fill="#d4644a"/>
+<rect x="234" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+<rect x="246" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+<polygon points="244,168 248,178 240,178" fill="#f7a072"/>
+<rect x="310" y="186" width="22" height="24" rx="3" fill="#9b59b6"/>
+<rect x="313" y="190" width="6" height="5" rx="1" fill="#fff"/>
+<rect x="323" y="190" width="6" height="5" rx="1" fill="#fff"/>
+<circle cx="316" cy="192" r="2" fill="#1a1a2e"/>
+<circle cx="326" cy="192" r="2" fill="#1a1a2e"/>
+<rect x="316" y="200" width="10" height="2" rx="1" fill="#7d3c98"/>
+<rect x="313" y="210" width="6" height="8" rx="1" fill="#9b59b6"/>
+<rect x="323" y="210" width="6" height="8" rx="1" fill="#9b59b6"/>
+<circle cx="321" cy="180" r="5" fill="#bb8fd0"/>
+<rect x="100" y="230" width="12" height="4" rx="2" fill="#5aad68"/>
+<rect x="200" y="240" width="8" height="3" rx="1" fill="#5aad68"/>
+<rect x="350" y="235" width="10" height="4" rx="2" fill="#5aad68"/>
+</svg>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -89,6 +89,7 @@ interface AppListEntry {
   origin?: string
   orphaned?: boolean
   manifest?: {
+    iconUrl?: string
     ui?: {
       entry?: string
       pages?: Array<{ route: string; icon?: string; iconUrl?: string; label?: string }>
@@ -820,11 +821,19 @@ export default function App() {
               ? `/apps/migrate/${a.name}`
               : dynamicApp ? `/apps/${a.name}` : page.route
             const iconName = page.icon || ''
-            const baseIcon = isBuiltin && BUILTIN_ICONS[iconName]
-              ? BUILTIN_ICONS[iconName]
+            // Prefer the app's custom top-level iconUrl (an absolute
+            // /app-assets/... path — the same source the App Store card renders
+            // via AppIcon) so builtin colorful SVG icons also show in the left
+            // nav. Fall back to a page-relative ui/ icon (installed apps), then
+            // the builtin lucide glyph, then the generic package icon.
+            const customIconUrl = a.manifest?.iconUrl || ''
+            const baseIcon = customIconUrl
+              ? <img src={customIconUrl} alt="" className="w-4 h-4 rounded-sm object-contain" />
               : page.iconUrl
                 ? <img src={'/apps/' + a.name + '/ui/' + page.iconUrl} alt="" className="w-4 h-4 rounded-sm object-contain" />
-                : <Package size={16} />
+                : isBuiltin && BUILTIN_ICONS[iconName]
+                  ? BUILTIN_ICONS[iconName]
+                  : <Package size={16} />
             // Orphaned apps get a warn-colored icon to signal migration needed
             const icon = isOrphaned
               ? <span className="text-warn">{baseIcon}</span>

--- a/website/src/surfaces/builtins.tsx
+++ b/website/src/surfaces/builtins.tsx
@@ -7,7 +7,7 @@
  * Order in this file = order in the rail (within each group). Add new
  * built-in surfaces here; do not add hardcoded badge logic to `App.tsx`.
  */
-import { MessageSquare, Bell, BookOpen, Component, CalendarDays, Users, Plug, Settings, Store, ClipboardCheck } from 'lucide-react'
+import { MessageSquare, Bell, BookOpen, Component, CalendarDays, Users, Plug, Settings, ClipboardCheck } from 'lucide-react'
 import { createSelector } from '@reduxjs/toolkit'
 import { registerBuiltinSurface } from './registry'
 import type { RootState } from '../store'
@@ -75,7 +75,7 @@ registerBuiltinSurface({
   navId: 'apps',
   route: '/apps',
   label: 'App Store',
-  icon: <Store size={16} />,
+  icon: <img src="/app-assets/app-store/icon.svg" width={16} height={16} alt="" style={{ borderRadius: 4 }} />,
   group: 'Apps',
 })
 


### PR DESCRIPTION
## Problem
Four related App Store issues in the KiroCrew dashboard:
1. The recently added colorful **icons and hero images** for builtin apps did not render — the store showed the lucide fallback icon and the "KIROCREW" placeholder hero.
2. Even after the store cards were fixed, the **left sidebar nav** still showed the old lucide/placeholder icons for builtin apps.
3. **Agent Worlds** never picked up its colorful icon.
4. The **Workflows** and **Web Deploy** builtins appear in the store Browse grid but should be hidden.

## Why it matters
The App Store and the left nav are the primary entry points for apps. Missing/placeholder brand art makes shipped builtins look broken, and surfacing Workflows + Web Deploy in Browse exposes apps not meant to be discovered/installed that way.

## Fix (symptoms → root cause → change)
**(1) Icons/hero not served (symptom → root cause):** builtin `app.json` manifests reference art via absolute `url('/app-assets/...')` (`iconUrl`/`heroImage`/`heroImageDark`). The SVGs build into `dist/app-assets/` and the fields reach the frontend correctly, but the aiohttp gateway had **no `/app-assets/` static mount** and `/app-assets/` was **not** in `SPA_FALLBACK_EXCLUDED_PREFIXES`, so requests fell through to the SPA catch-all and returned `index.html` (HTML 200); the `<img>` tags then tripped their `onError` placeholder. Works in the Vite dev server but breaks once the gateway serves the built `dist/`. **Change:** mount `/app-assets` in `_register_dist_static_routes` (mirrors `/sprites`, `/fonts`, `/vendor`) and add `/app-assets/` to `SPA_FALLBACK_EXCLUDED_PREFIXES` so a genuinely missing asset 404s cleanly.

**(2) Nav icons not updated (root cause → change):** `refreshAppNav` in `website/src/App.tsx` resolved a nav row's icon as *builtin lucide (`ui.pages[0].icon`) → `ui.pages[0].iconUrl` (resolved `/apps/<name>/ui/…`) → Package* and **never read the top-level `manifest.iconUrl`** the store card renders via `AppIcon`. So any builtin with a lucide `page.icon` always drew the lucide glyph in the nav. **Change:** prefer the top-level custom `iconUrl` (absolute `/app-assets/…`) first, then the page-relative `ui/` iconUrl (installed apps), then the builtin lucide, then Package; widen `AppListEntry.manifest` to include `iconUrl`.

**(3) Agent Worlds (root cause → change):** the `agent-worlds` builtin in `_BUILTIN_APPS` shipped only the lucide `Gamepad2` name; its `icon.svg` was unreferenced and it had **no hero art**. **Change:** add top-level `"iconUrl"`, author `hero-light.svg` / `hero-dark.svg` (480×270, worlds green + orange-robot palette with pixel-art agent characters, matching the other builtins), and wire `heroImage` / `heroImageDark`.

**(4) Store visibility (root cause → change):** the existing `hidden` manifest flag (consumed by the `AppsPage` Browse filter; used today by the `channels` builtin) hides an app from Browse while keeping it installed. **Change:** add `"hidden": true` to `workflows/app.json` and `deploy_web/app.json`. Both are already `defaultEnabled: false`, so they stay installed, routable, and on the Installed tab.

**(5) App Store nav icon:** the App Store builtin *surface* used a lucide `<Store>` glyph. **Change:** point it at the brand SVG `/app-assets/app-store/icon.svg` in `surfaces/builtins.tsx` and drop the now-unused `Store` import.

## Tests
- `test_dashboard_static_routes.py`: `/app-assets` route registers when present / skipped when absent; an SVG under `/app-assets` is served verbatim as `image/svg+xml` (not the SPA shell).
- `test_token_auth.py`: `/app-assets/` is in `SPA_FALLBACK_EXCLUDED_PREFIXES` and `/app-assets/*` paths are not SPA shell requests.
- `test_builtin_discovery.py`: a `hidden: true` manifest field survives discovery; shipped `workflows` + `deploy-web` are `hidden=True`.
- `test_builtin_app_assets.py` (new): every builtin `/app-assets/…` icon+hero reference resolves to a real file (guards Agent Worlds’s icon **and** hero + future builtins), and `agent-worlds` is wired to its SVG.

## Manual verification
`make build` + gateway restart, then open the dashboard: confirm builtin icons/hero render in the store, the **left nav** shows the colorful icons (incl. Agent Worlds), and Workflows + Web Deploy are absent from Browse but still reachable via their routes / Installed tab. The nav change is a small icon-precedence reorder in `refreshAppNav`; it is exercised by the existing `App.test.tsx` render suite (kept green) and typechecked, with the visual confirmation covering the end-to-end served-`dist/` path.
