### PR TITLE
fix(build): install Node 16 on Amazon Linux 2 so make build works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ all: test
 build: frontend backend
 
 frontend:
+	bash ensure-node.sh || true
 	cd website && \
+	  NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null)" && \
+	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; } && \
 	  if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi && \
 	  npm run build
 	rm -rf src/kiro_crew/static/dist

--- a/ensure-node.sh
+++ b/ensure-node.sh
@@ -1,17 +1,36 @@
 #!/bin/bash
-# Ensure Node.js >= 18 is available. Installs via mise (preferred) or nvm.
-# Called by: setup.sh, kirocrew update, kirocrew gateway
-# Platforms: macOS, Linux
+# Ensure Node.js is available for the build. Installs via mise (preferred) or nvm.
+# Called by: setup.sh, kirocrew update, kirocrew gateway, Makefile (frontend)
+# Platforms: macOS, Amazon Linux 2 (glibc 2.26), Amazon Linux 2023, Linux
+#
+# On success this records the resolved node bin directory in
+# "$HOME/.kirocrew/node-bin-dir" so non-interactive callers (e.g. make) can put
+# the right node on PATH without re-running a version manager.
 
 MIN_VERSION=18
 TARGET_VERSION=20
+
+# Amazon Linux 2 ships glibc 2.26, but official Node >= 18 binaries are linked
+# against glibc >= 2.28 and fail to load ("GLIBC_2.28 not found"). Official
+# Node 16 was built on a glibc-2.17 baseline, so it runs on AL2 for both x86_64
+# and aarch64 and is enough for the frontend build (tsc + vite). Test-only
+# tooling that wants >= 18 runs in CI, not on the AL2 build host. This mirrors
+# the sibling deployment's approach.
+AL2_NODE_VERSION=16
 
 _node_major() {
     node -v 2>/dev/null | sed 's/v//' | cut -d. -f1
 }
 
+# node is "usable" only if it is on PATH AND actually executes. A binary built
+# for a newer glibc is present on PATH but exits non-zero with a loader error,
+# so a plain "command -v node" is not enough.
+_node_usable() {
+    command -v node >/dev/null 2>&1 && node -v >/dev/null 2>&1
+}
+
 _needs_install() {
-    if ! command -v node &>/dev/null; then return 0; fi
+    if ! _node_usable; then return 0; fi
     local cur
     cur=$(_node_major)
     [ -z "$cur" ] || [ "$cur" -lt "$MIN_VERSION" ]
@@ -19,15 +38,28 @@ _needs_install() {
 
 _get_platform() {
     if [[ "$(uname)" == "Darwin" ]]; then echo "mac"
+    # AL2023 must be checked before AL2: "Amazon Linux release 2" is a
+    # substring of "Amazon Linux release 2023".
+    elif grep -q 'Amazon Linux release 2023' /etc/system-release 2>/dev/null; then echo "al2023"
+    elif grep -q 'Amazon Linux release 2' /etc/system-release 2>/dev/null; then echo "al2"
     else echo "linux"; fi
 }
 
 _source_mise() {
-    if [ -f "$HOME/.local/bin/mise" ]; then
-        eval "$("$HOME/.local/bin/mise" activate bash 2>/dev/null)" 2>/dev/null || true
+    local mise_bin=""
+    if [ -x "$HOME/.local/bin/mise" ]; then
+        mise_bin="$HOME/.local/bin/mise"
     elif command -v mise &>/dev/null; then
-        eval "$(mise activate bash 2>/dev/null)" 2>/dev/null || true
+        mise_bin="mise"
     fi
+    [ -z "$mise_bin" ] && return 0
+    eval "$("$mise_bin" activate bash 2>/dev/null)" 2>/dev/null || true
+    # `mise activate` sets up a prompt hook and does not reliably inject tools
+    # onto PATH in a non-interactive script (e.g. when invoked from make), so
+    # also add the resolved node bin dir directly.
+    local nb
+    nb="$("$mise_bin" which node 2>/dev/null)"
+    [ -n "$nb" ] && export PATH="$(dirname "$nb"):$PATH"
 }
 
 _source_nvm() {
@@ -37,17 +69,33 @@ _source_nvm() {
     fi
 }
 
+# Record where node ended up so make / other callers can find it.
+_record_node_bin() {
+    if command -v node >/dev/null 2>&1; then
+        mkdir -p "$HOME/.kirocrew"
+        dirname "$(command -v node)" > "$HOME/.kirocrew/node-bin-dir" 2>/dev/null || true
+    fi
+}
+
+PLATFORM=$(_get_platform)
+
+# On Amazon Linux 2, target Node 16 (see AL2_NODE_VERSION note above).
+if [ "$PLATFORM" = "al2" ]; then
+    MIN_VERSION="$AL2_NODE_VERSION"
+    TARGET_VERSION="$AL2_NODE_VERSION"
+fi
+
 # Source existing managers first — node may already be installed but not in PATH
 _source_mise
 _source_nvm
 
 if ! _needs_install; then
     echo "  ✅ node v$(_node_major) ($(which node))"
+    _record_node_bin
     exit 0
 fi
 
-PLATFORM=$(_get_platform)
-echo "  → Node.js missing or < $MIN_VERSION, installing on $PLATFORM…"
+echo "  → Node.js missing or < $MIN_VERSION, installing node@$TARGET_VERSION on $PLATFORM…"
 
 _ensure_mise() {
     _source_mise
@@ -59,12 +107,14 @@ _ensure_mise() {
 }
 
 case $PLATFORM in
-    mac)
+    mac|al2|al2023)
+        # macOS + AL2023 use the default target (20); AL2 uses 16 (set above).
+        # All are official mise builds that run on the host's glibc.
         _ensure_mise
         mise use -g "node@$TARGET_VERSION" 2>/dev/null
         ;;
     *)
-        # Generic Linux — try mise, fall back to nvm
+        # Generic Linux — try mise, fall back to nvm.
         _ensure_mise
         if command -v mise &>/dev/null; then
             mise use -g "node@$TARGET_VERSION" 2>/dev/null
@@ -77,6 +127,22 @@ case $PLATFORM in
             nvm install "$TARGET_VERSION" 2>/dev/null
             nvm alias default "$TARGET_VERSION" 2>/dev/null
         fi
+        # If the stock binary can't load (old glibc on a non-AL2-labelled host),
+        # fall back to Node 16, whose official build runs on glibc 2.17+.
+        _source_mise
+        _source_nvm
+        if ! _node_usable; then
+            echo "  → node@$TARGET_VERSION won't run here (likely old glibc); falling back to node@$AL2_NODE_VERSION…"
+            MIN_VERSION="$AL2_NODE_VERSION"
+            TARGET_VERSION="$AL2_NODE_VERSION"
+            if command -v mise &>/dev/null; then
+                mise use -g "node@$TARGET_VERSION" 2>/dev/null
+            else
+                _source_nvm
+                nvm install "$TARGET_VERSION" 2>/dev/null
+                nvm alias default "$TARGET_VERSION" 2>/dev/null
+            fi
+        fi
         ;;
 esac
 
@@ -84,8 +150,9 @@ esac
 _source_mise
 _source_nvm
 
-if command -v node &>/dev/null && [ "$(_node_major)" -ge "$MIN_VERSION" ]; then
+if _node_usable && [ "$(_node_major)" -ge "$MIN_VERSION" ]; then
     echo "  ✅ node $(node -v) installed ($(which node))"
+    _record_node_bin
 else
     echo "  ⚠️  Node install failed — frontend will use legacy fallback"
     echo "     Install manually: curl https://mise.run | sh && mise use -g node@$TARGET_VERSION"


### PR DESCRIPTION
## Problem

`make build` fails on Amazon Linux 2 during the frontend step:

```
node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by node)
node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by node)
make: *** [frontend] Error 1
```

## Why it matters

AL2 is a common Amazon build/dev host. AL2 ships **glibc 2.26**, but official Node.js ≥ 18 binaries are linked against **glibc ≥ 2.28**, so the dynamic loader refuses to run them. Two independent gaps caused the failure:

1. The `frontend` Make target ran `npm`/`vite` against whatever `node` was on `PATH`, never invoking `ensure-node.sh`.
2. `ensure-node.sh` had no AL2 handling — it targets Node 20 (glibc-2.28 floor) on every Linux, which crashes on AL2 as above.

## Fix

Symptom → root cause → change:

- **Symptom:** `GLIBC_2.28 not found` when the build runs `node`.
  **Root cause:** official Node ≥ 18 needs glibc ≥ 2.28; AL2 has 2.26.
  **Change:** `ensure-node.sh` now detects Amazon Linux 2 and targets **Node 16**, whose official binaries were built on a glibc-2.17 baseline and run on AL2 for **both x86_64 and aarch64** via plain `mise` — no special or non-official build required. Node 16 is sufficient for the frontend build (`tsc -b && vite build`); test-only tooling that prefers ≥ 18 runs in CI, not on the AL2 build host. macOS and AL2023 (glibc 2.34) keep Node 20.
- **Symptom:** even a correct node isn't picked up by `make`.
  **Root cause:** the `frontend` target never provisioned node, and each recipe line is a fresh shell, so a version-manager activation wouldn't persist.
  **Change:** `ensure-node.sh` records the resolved node bin dir in `~/.kirocrew/node-bin-dir`; the `frontend` target now runs `ensure-node.sh` and prepends that dir to `PATH` before `npm`.
- **Robustness:**
  - `_node_usable()` treats an on-`PATH`-but-won't-execute binary (wrong glibc) as "needs install", so a broken newer node doesn't mask the fix.
  - `_source_mise()` no longer relies on `mise activate` (which only injects PATH via an interactive prompt hook); it resolves the bin dir directly via `mise which node`, so node is found in non-interactive `make` runs. This was a real bug — without it the AL2 x64 run failed to locate the installed node.
  - The generic-Linux path auto-falls-back to Node 16 if the stock (20) binary can't load on an old-glibc host that isn't labelled AL2.
- **Public-repo hygiene / portability:** uses only official Node builds via `mise`/`nvm` — no non-official mirrors and no internal references. Works on AL2 x86_64 and aarch64.

## Tests

No unit-test harness exists for these shell scripts; validated with `bash -n` (syntax) on both changed files and by direct execution + a full frontend build on real AL2 hosts (below).

## Manual verification

- **Full frontend build on AL2 x86_64 under Node 16** (`ldd (GNU libc) 2.26`): copied the `website/` source, ran `npm ci` (914 packages; only `EBADENGINE` warnings, no failures) then `npm run build` (`tsc -b && vite build`) → **`✓ built in 55.92s`**, produced `dist/index.html` + assets.
- **`ensure-node.sh` on AL2 x86_64:** `✅ node v16.20.2 installed`; marker `~/.kirocrew/node-bin-dir` → `…/mise/installs/node/16.20.2/bin`; `node -v` from it → `v16.20.2`.
- **`ensure-node.sh` on AL2 aarch64** (`5.10` kernel host): `✅ node v16`; marker written; `node -v` → `v16.20.2`. Confirmed the official Node 16 aarch64 binary needs only ≤ `GLIBC_2.25` (via `objdump -T`), so it loads on AL2's 2.26.

macOS and AL2023 paths are unchanged (mise Node 20).
