### PR TITLE
fix(acp): inline attached images on the dashboard prompt path

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -16,7 +16,6 @@ Permission flow:
 from __future__ import annotations
 
 import asyncio
-import base64
 import difflib
 import glob
 import json
@@ -35,6 +34,7 @@ from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator
 
 from kiro_crew import model_registry, platform_compat
+from kiro_crew.acp.prompt_content import build_prompt_content
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     EVENT_AGENT_SWITCHED,
@@ -3330,39 +3330,15 @@ class AcpClient:
 
     # ── Private Helpers ──
 
-    _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
-    _IMAGE_MEDIA_TYPES = {
-        ".png": "image/png",
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-        ".bmp": "image/bmp",
-        ".svg": "image/svg+xml",
-    }
-
     async def _send_prompt(self, message: str) -> int:
-        content: list[dict] = []
-        # Extract image paths from message and inline them as image blocks
-        path_re = re.compile(r"(/[\w./@~\s()\-]+\.(?:png|jpg|jpeg|gif|webp|bmp))", re.IGNORECASE)
-        remaining = message
-        for match in path_re.finditer(message):
-            p = Path(match.group(1).strip())
-            if p.is_file() and p.suffix.lower() in self._IMAGE_EXTENSIONS:
-                try:
-                    data = base64.b64encode(p.read_bytes()).decode()
-                    media = self._IMAGE_MEDIA_TYPES.get(p.suffix.lower(), "image/png")
-                    content.append({"type": "image", "data": data, "mimeType": media})
-                    remaining = remaining.replace(match.group(1), f"[image: {p.name}]")
-                except Exception:
-                    pass  # skip unreadable files
-        content.insert(0, {"type": "text", "text": remaining})
-
+        # Build the prompt content array (text + inlined base64 image blocks)
+        # via the shared builder so this path and AcpSessionHandle.prompt
+        # behave identically. See kiro_crew.acp.prompt_content.
         return await self._send_request(
             METHOD_PROMPT,
             {
                 "sessionId": self._session_id,
-                "prompt": content,
+                "prompt": build_prompt_content(message),
             },
         )
 

--- a/src/kiro_crew/acp/prompt_content.py
+++ b/src/kiro_crew/acp/prompt_content.py
@@ -1,0 +1,92 @@
+"""Shared ACP prompt-content builder.
+
+Both ACP send paths must turn a user-message string into the ACP ``prompt``
+content array, inlining any referenced local image files as base64 image
+blocks so the model actually receives every attached image:
+
+* ``AcpClient._send_prompt`` — the standalone client / worker-pool (and the
+  Claude-Code backend).
+* ``AcpSessionHandle.prompt`` — the shared-runtime kiro backend, which is the
+  path the **dashboard** actually uses.
+
+Previously only the client path inlined images; the dashboard runtime path
+sent a single ``{"type": "text"}`` block, so uploaded images never reached the
+model as image content (kiro-cli only ever saw the raw ``![image](path)``
+markdown text). Centralizing the logic here guarantees both paths behave
+identically.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+IMAGE_MEDIA_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".svg": "image/svg+xml",
+}
+
+# Absolute image-path matcher.
+#
+# The character class allows a literal space (so paths like
+# "/a/My Screenshots/x.png" still match) but deliberately NOT arbitrary
+# whitespace. The earlier pattern used ``\s`` inside the class, which — with
+# the greedy ``+`` — let a single match bridge across multiple
+# newline-separated paths, coalescing e.g. "/a/one.png\n/a/two.png" into ONE
+# capture. ``Path(...).is_file()`` was then False, so EVERY image was silently
+# dropped whenever more than one was attached (only a lone image survived).
+# Since both producers emit one path per line — the dashboard as
+# "![image](path)" lines and Slack as "\n".join(image_paths) — forbidding
+# newlines in the class keeps multi-image uploads intact.
+#
+# ``svg`` is included in the alternation so SVG uploads (already accepted by
+# the uploader and present in IMAGE_EXTENSIONS) are actually inlined.
+_IMAGE_PATH_RE = re.compile(
+    r"(/[\w./@~ ()\-]+\.(?:png|jpe?g|gif|webp|bmp|svg))",
+    re.IGNORECASE,
+)
+
+
+def build_prompt_content(message: str) -> list[dict]:
+    """Turn a message string into an ACP ``prompt`` content array.
+
+    Every referenced local image file is read, base64-encoded, and appended as
+    a separate ``{"type": "image", "data", "mimeType"}`` block; its path in the
+    text is replaced with a ``[image: <name>]`` placeholder. Matches that are
+    not existing files, have an unsupported suffix, or cannot be read are left
+    untouched in the text (never dropped silently).
+
+    Returns ``[{"type": "text", "text": <remaining>}, <image blocks...>]`` — the
+    text block is always first, matching the prior AcpClient behavior.
+    """
+    images: list[dict] = []
+    remaining = message
+    for match in _IMAGE_PATH_RE.finditer(message):
+        raw = match.group(1)
+        p = Path(raw.strip())
+        suffix = p.suffix.lower()
+        if suffix not in IMAGE_EXTENSIONS:
+            continue
+        if not p.is_file():
+            continue
+        try:
+            data = base64.b64encode(p.read_bytes()).decode()
+        except Exception:
+            # Unreadable file: leave the path in the text, skip the block.
+            logger.debug("build_prompt_content: unreadable image %s", p, exc_info=True)
+            continue
+        media = IMAGE_MEDIA_TYPES.get(suffix, "image/png")
+        images.append({"type": "image", "data": data, "mimeType": media})
+        remaining = remaining.replace(raw, f"[image: {p.name}]")
+
+    return [{"type": "text", "text": remaining}, *images]

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -55,6 +55,7 @@ from kiro_crew.acp.liveness import (
     LivenessOracle,
     ToolCallState,
 )
+from kiro_crew.acp.prompt_content import build_prompt_content
 from kiro_crew.acp.types import (
     EVENT_AGENT_SWITCHED,
     EVENT_CLEAR_STATUS,
@@ -373,7 +374,14 @@ class AcpSessionHandle:
         try:
             req_id = await self._runtime.send_request(
                 METHOD_PROMPT,
-                {"sessionId": self._session_id, "prompt": [{"type": "text", "text": message}]},
+                {
+                    "sessionId": self._session_id,
+                    # Inline referenced local images as base64 blocks (shared
+                    # with AcpClient._send_prompt). Without this the dashboard
+                    # runtime path sent a single text block, so uploaded images
+                    # never reached the model as image content.
+                    "prompt": build_prompt_content(message),
+                },
             )
         except Exception:
             self._turn_done.set()

--- a/test/test_acp_prompt_content.py
+++ b/test/test_acp_prompt_content.py
@@ -1,0 +1,103 @@
+"""Tests for kiro_crew.acp.prompt_content.build_prompt_content.
+
+Regression coverage for the multi-image inlining bug: the previous regex
+included ``\\s`` in its character class, so multiple newline-separated image
+paths were greedily coalesced into one invalid path and every image was
+dropped. These tests pin the behavior for both producers (dashboard
+"![image](path)" lines and Slack "\\n".join(paths)), SVG support, and the
+non-image / missing-file passthrough.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from kiro_crew.acp.prompt_content import build_prompt_content
+
+# 1x1 PNG (smallest valid), reused as raw bytes for on-disk fixtures.
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+_SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg"/>'
+
+
+def _write(path, data=_PNG_BYTES):
+    path.write_bytes(data)
+    return str(path)
+
+
+def _images(content):
+    return [b for b in content if b.get("type") == "image"]
+
+
+def _text(content):
+    assert content[0]["type"] == "text", "text block must be first"
+    return content[0]["text"]
+
+
+def test_single_image_inlined(tmp_path):
+    p = _write(tmp_path / "a.png")
+    content = build_prompt_content(f"look at ![image]({p})")
+    imgs = _images(content)
+    assert len(imgs) == 1
+    assert imgs[0]["mimeType"] == "image/png"
+    assert imgs[0]["data"] == base64.b64encode(_PNG_BYTES).decode()
+    assert "[image: a.png]" in _text(content)
+    assert p not in _text(content)
+
+
+def test_multiple_images_dashboard_markdown(tmp_path):
+    """Dashboard emits '![image](path)' lines joined by newlines."""
+    paths = [_write(tmp_path / f"img{i}.png") for i in range(3)]
+    msg = "\n".join(f"![image]({p})" for p in paths) + "\n\nwhat are these?"
+    content = build_prompt_content(msg)
+    assert len(_images(content)) == 3
+    assert "what are these?" in _text(content)
+
+
+def test_multiple_images_bare_newline_paths(tmp_path):
+    """Slack path: bare absolute paths joined by '\\n' (the regression case).
+
+    The old '\\s'-in-class regex merged these into one match that failed
+    is_file(), dropping every image. All must now be inlined.
+    """
+    paths = [_write(tmp_path / f"s{i}.png") for i in range(3)]
+    content = build_prompt_content("\n".join(paths))
+    assert len(_images(content)) == 3
+
+
+def test_svg_is_inlined(tmp_path):
+    p = _write(tmp_path / "logo.svg", _SVG_BYTES)
+    content = build_prompt_content(f"![image]({p})")
+    imgs = _images(content)
+    assert len(imgs) == 1
+    assert imgs[0]["mimeType"] == "image/svg+xml"
+
+
+def test_path_with_space_still_matches(tmp_path):
+    d = tmp_path / "My Screenshots"
+    d.mkdir()
+    p = _write(d / "shot.png")
+    content = build_prompt_content(f"![image]({p})")
+    assert len(_images(content)) == 1
+
+
+def test_missing_file_left_in_text(tmp_path):
+    missing = str(tmp_path / "nope.png")
+    content = build_prompt_content(f"see {missing}")
+    assert _images(content) == []
+    assert missing in _text(content)
+
+
+def test_no_images_returns_single_text_block():
+    content = build_prompt_content("just text, no attachments")
+    assert content == [{"type": "text", "text": "just text, no attachments"}]
+
+
+def test_mixed_existing_and_missing(tmp_path):
+    good = _write(tmp_path / "good.png")
+    missing = str(tmp_path / "gone.jpg")
+    content = build_prompt_content(f"![image]({good})\n![image]({missing})")
+    assert len(_images(content)) == 1
+    assert "[image: good.png]" in _text(content)
+    assert missing in _text(content)


### PR DESCRIPTION
## Problem
Uploading **multiple images** in dashboard chat resulted in only **one** being used by the model. Users reasonably concluded that only one image had actually uploaded.

## Why it matters
Silent image loss is a correctness and trust bug: the user attaches N images, the model answers about one, and there is no feedback that the others were dropped. It affects every multi-image dashboard turn and any image at all on some paths (see below).

## Fix (symptom → root cause → change)
- **Symptom:** only one attached image reaches the model on the dashboard.
- **Root cause:** the dashboard's kiro backend sends prompts through `AcpSessionHandle.prompt`, which wrapped the whole message as a single `{"type": "text"}` block and inlined **no** images — so kiro-cli only ever saw the raw `![image](path)` markdown as text and surfaced one. Image inlining lived **only** in `AcpClient._send_prompt` (the CC / worker-pool path). That path's extraction regex additionally had two latent defects: `\s` inside the character class let the greedy match bridge across newline-separated paths (coalescing them into one invalid path that failed `is_file()`, dropping **every** image on bare-path / Slack input), and `svg` was missing from the alternation even though the uploader accepts it.
- **Change:** extract a single shared `build_prompt_content()` helper (`src/kiro_crew/acp/prompt_content.py`) with a hardened regex — a literal space instead of `\s` (keeps paths-with-spaces working while forbidding the cross-newline merge) and `svg` added — and wire it into **both** `AcpClient._send_prompt` and `AcpSessionHandle.prompt`. Now every ACP send path inlines all attached images identically as base64 image blocks.

## Tests
`test/test_acp_prompt_content.py` — 8 regression tests: single image; multiple images in dashboard `![image](path)` markdown; multiple **bare newline-separated** paths (the Slack / greedy-merge regression); SVG inlining; path-with-spaces still matches; missing file left in text (not dropped); no-image single-text-block; mixed existing/missing. Existing ACP suites (`test_acp_client`, `test_acp_session_provider`, `test_acp_provider`) continue to pass — 499 total.

## Manual verification
Restart the dashboard from source and upload 2+ images via the file-picker (`+` menu) or drag-drop; all are inlined and reflected in the response. (Clipboard paste of multiple images is an OS limitation — often only one image is placed on the clipboard — and is out of scope here.)
