### PR TITLE
fix(dashboard): render viewBox-only SVG image previews so they don't collapse

### DIFF
--- a/website/integration/SvgPreviewSizing.integration.test.tsx
+++ b/website/integration/SvgPreviewSizing.integration.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../src/components/MarkdownRenderer'
+
+/**
+ * Regression: SVGs authored with only a `viewBox` (no width/height) have no
+ * intrinsic size and collapse to ~0px under max-w/max-h-only CSS, so a message
+ * with several SVGs appeared to render only the one that declared width/height
+ * (see the app-store / hero-dark / hero-light upload report). ImgWithFallback
+ * now gives SVG previews a definite width basis so they stay visible.
+ */
+describe('MarkdownRenderer SVG preview sizing', () => {
+  it('gives every SVG image a definite width so viewBox-only SVGs do not collapse', () => {
+    const paths = ['/u/app-store.svg', '/u/hero-dark.svg', '/u/hero-light.svg']
+    const content = paths.map(p => `![image](${p})`).join('\n')
+    const { container } = render(<MarkdownRenderer content={content} softBreaks />)
+    const imgs = container.querySelectorAll('img')
+    expect(imgs.length).toBe(3)
+    imgs.forEach(img => {
+      expect((img as HTMLImageElement).style.width).toBe('240px')
+    })
+  })
+
+  it('does not force a fixed width on raster images (keeps intrinsic sizing)', () => {
+    const { container } = render(<MarkdownRenderer content={'![image](/u/photo.png)'} softBreaks />)
+    const img = container.querySelector('img') as HTMLImageElement
+    expect(img).toBeTruthy()
+    expect(img.style.width).toBe('')
+  })
+})

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -224,6 +224,12 @@ function ImgWithFallback({
       </span>
     )
   }
+  // SVGs authored with only a `viewBox` (no width/height) carry no intrinsic
+  // size. Under the max-w/max-h-only CSS below they collapse to ~0px and look
+  // missing — so uploading several SVGs appears to render only the ones that
+  // happen to declare width/height. Give SVGs a definite width basis; the
+  // viewBox aspect ratio then derives the height, clamped by max-h.
+  const isSvg = /\.svg([?#]|$)/i.test(src)
   return (
     <span className="inline-block my-2">
       {/* The <img> is the lightbox trigger; dispatchLightbox needs the image
@@ -235,6 +241,7 @@ function ImgWithFallback({
       <img
         src={url} alt={alt || ''} loading="lazy"
         className="max-w-[240px] max-h-[160px] object-contain rounded-md border border-border cursor-pointer hover:opacity-90 transition-opacity"
+        style={isSvg ? { width: '240px', height: 'auto' } : undefined}
         onClick={(e) => dispatchLightbox(e.currentTarget)}
         data-lightbox-image=""
         title={alt || src}


### PR DESCRIPTION
## Problem
Uploading several SVGs in dashboard chat rendered only **one** of them in the sent message bubble, so it looked like the other uploads never happened.

## Why it matters
Silent image loss in the UI erodes trust — the user attaches N images and only one appears, with no indication the rest are there. The images were never actually lost (the model receives all of them), which makes the missing previews purely a display bug that's confusing to diagnose.

## Fix (symptom → root cause → change)
- **Symptom:** three SVGs uploaded, only one visible in the bubble (the other two collapse to two faint dots).
- **Root cause:** SVGs authored with only a `viewBox` and no `width`/`height` have **no intrinsic size**. The preview `<img>` in `MarkdownRenderer`'s `ImgWithFallback` sets only `max-w-[240px] max-h-[160px]` — a cap, not a size — so a no-intrinsic-size SVG collapses to ~0px in the browser. SVGs that declare `width`/`height` (and all raster images, which have intrinsic dimensions) render normally, which is exactly why one of three uploaded SVGs showed.
- **Change:** give SVG previews a definite width basis (`width: 240px; height: auto`); the `viewBox` aspect ratio then derives a real height (still clamped by `max-h`). Raster images are untouched and keep intrinsic sizing.

## Tests
`website/integration/SvgPreviewSizing.integration.test.tsx` — asserts every SVG `<img>` receives the definite width, and that raster images do **not** get a forced width (keep intrinsic sizing). Note: jsdom does not paint, so this locks in the applied sizing style rather than pixel dimensions; the visible collapse was confirmed manually in-browser.

## Manual verification
Rebuild the frontend bundle and hard-reload the dashboard, then upload multiple SVGs including at least one with only a `viewBox` (no width/height). All previews render at a visible size instead of collapsing.
