### PR TITLE
fix(build): require Python >=3.10 and auto-provision it on Amazon Linux

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -110,7 +110,7 @@ jobs:
           # Requires-Python straight from the wheel metadata so the manifest never drifts.
           PYREQ=$(unzip -p "$WHEEL_PATH" '*.dist-info/METADATA' 2>/dev/null \
             | awk -F': ' 'tolower($1)=="requires-python"{print $2; exit}' | tr -d '\r')
-          PYREQ="${PYREQ:->=3.9}"
+          PYREQ="${PYREQ:->=3.10}"
 
           cat > /tmp/latest-cli.json <<EOF
           {

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ frontend:
 	cp -R website/dist src/kiro_crew/static/dist
 
 backend:
-	test -x $(VENV)/bin/python || $(PY) -m venv $(VENV)
+	bash ensure-python.sh || true
+	PY="$$(cat $$HOME/.kirocrew/python-bin 2>/dev/null)"; [ -n "$$PY" ] || PY="$(PY)"; \
+	  if [ -x $(VENV)/bin/python ] && ! $(VENV)/bin/python -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then \
+	    echo "  → recreating $(VENV) (existing interpreter < 3.10)"; rm -rf $(VENV); fi; \
+	  test -x $(VENV)/bin/python || "$$PY" -m venv $(VENV)
 	$(PIP) install --upgrade pip setuptools wheel
 	KIROCREW_SKIP_FRONTEND=1 $(PIP) install -e ".[dev]"
 	bash packaging/resign-macos-libs.sh $(VENV)/bin/python

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Ensure a Python >= 3.10 interpreter is available for the backend venv.
+# Called by: Makefile (backend), setup.sh
+# Platforms: macOS, Amazon Linux 2 (system python3 is 3.7), Amazon Linux 2023
+#            (system python3 is 3.9), Linux
+#
+# The package requires Python >= 3.10 (pyproject `requires-python`; the code
+# uses stdlib features such as contextlib.aclosing that need 3.10). Amazon
+# Linux 2 ships Python 3.7 and Amazon Linux 2023 ships 3.9 as `python3`, so
+# `python3 -m venv` produces a too-old venv and either `pip install -e .` fails
+# to resolve modern deps (AL2/3.7) or the install "succeeds" and then crashes at
+# import (AL2023/3.9). Prefer any already-usable system Python >= 3.10;
+# otherwise install one via mise, whose python-build-standalone binaries run on
+# AL2's glibc 2.26. On success the chosen interpreter path is recorded in
+# "$HOME/.kirocrew/python-bin" so non-interactive callers (make) can use it
+# without re-running a version manager.
+
+MIN_MAJOR=3
+MIN_MINOR=10
+TARGET_PY="${KIROCREW_PYTHON_VERSION:-3.12}"
+
+# True if $1 is a python that runs AND is >= MIN_MAJOR.MIN_MINOR.
+_py_ok() {
+    [ -n "$1" ] || return 1
+    "$1" -c "import sys; sys.exit(0 if sys.version_info >= ($MIN_MAJOR, $MIN_MINOR) else 1)" >/dev/null 2>&1
+}
+
+_pyver() {
+    "$1" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null
+}
+
+# First usable system python >= 3.9, preferring newer explicit minors.
+_find_system_python() {
+    local c resolved
+    for c in python3.13 python3.12 python3.11 python3.10 python3 python; do
+        resolved="$(command -v "$c" 2>/dev/null)" || continue
+        if _py_ok "$resolved"; then
+            echo "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
+_mise_bin() {
+    if [ -x "$HOME/.local/bin/mise" ]; then
+        echo "$HOME/.local/bin/mise"
+    elif command -v mise >/dev/null 2>&1; then
+        echo "mise"
+    fi
+}
+
+_record() {
+    mkdir -p "$HOME/.kirocrew"
+    printf '%s\n' "$1" > "$HOME/.kirocrew/python-bin" 2>/dev/null || true
+}
+
+# 1. Existing usable system python.
+PY="$(_find_system_python)"
+if [ -n "$PY" ]; then
+    echo "  ✅ python $(_pyver "$PY") ($PY)"
+    _record "$PY"
+    exit 0
+fi
+
+MISE="$(_mise_bin)"
+
+# 2. Already-installed mise python. `mise which` resolves the path directly —
+# `mise activate` does not reliably inject PATH in non-interactive scripts.
+if [ -n "$MISE" ]; then
+    CAND="$("$MISE" which python 2>/dev/null)"
+    if _py_ok "$CAND"; then
+        echo "  ✅ python $(_pyver "$CAND") (mise: $CAND)"
+        _record "$CAND"
+        exit 0
+    fi
+fi
+
+# 3. Install via mise.
+echo "  → No Python >= $MIN_MAJOR.$MIN_MINOR found; installing python@$TARGET_PY via mise…"
+if [ -z "$MISE" ]; then
+    echo "  → Installing mise…"
+    curl -fsSL https://mise.run | sh
+    MISE="$(_mise_bin)"
+fi
+if [ -z "$MISE" ]; then
+    echo "  ⚠️  mise unavailable — install Python >= $MIN_MAJOR.$MIN_MINOR manually and re-run."
+    exit 1
+fi
+
+"$MISE" use -g "python@$TARGET_PY" 2>/dev/null
+CAND="$("$MISE" which python 2>/dev/null)"
+if _py_ok "$CAND"; then
+    echo "  ✅ python $(_pyver "$CAND") installed ($CAND)"
+    _record "$CAND"
+else
+    echo "  ⚠️  Python install failed — install manually: curl https://mise.run | sh && mise use -g python@$TARGET_PY"
+    exit 1
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ name = "kirocrew"
 version = "0.1.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, Slack, or desktop app"
 readme = "README.md"
-# macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.9-3.13.
+# macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.
 # Must be declared in this [project] table: when it exists, setuptools reads
 # requires-python from here (not setup.cfg), and an absent value makes the
 # build backend raise SpecifierSet(None) -> TypeError during wheel builds.
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["dependencies"]
 
 [project.urls]


### PR DESCRIPTION
## Problem

`make build` produces a backend that either fails to install or crashes at startup on Amazon Linux, depending on the host's default Python:

- **Amazon Linux 2** (system `python3` = 3.7): `pip install -e .` fails — `No matching distribution found for aiohttp<4,>=3.9`.
- **Amazon Linux 2023** (system `python3` = 3.9): install "succeeds", then `kirocrew gateway` crashes:
  ```
  ImportError: cannot import name 'aclosing' from 'contextlib' (/usr/lib64/python3.9/contextlib.py)
  ```

## Why it matters

The package's real minimum is **Python 3.10** — `src/kiro_crew/acp/client.py` uses `contextlib.aclosing` (added in 3.10) and CI's `ci.yml` matrix is `["3.10", "3.12"]` (3.9 is never tested). But `pyproject` declared `requires-python = ">=3.9"`, which is a stale under-statement: it lets pip install on 3.9, so the failure surfaces as a confusing runtime `ImportError` instead of a clear install-time error. And `make backend` built the venv with whatever `python3` is default, which on both AL2 (3.7) and AL2023 (3.9) is below the true floor.

## Fix

Symptom → root cause → change:

- **Symptom:** `No matching distribution for aiohttp>=3.9` (AL2) / `cannot import name 'aclosing'` (AL2023).
  **Root cause:** the venv is built with a default `python3` below the package's true 3.10 floor, and `requires-python` mis-declared 3.9 so nothing caught it at install time.
  **Change (declare the truth):** bump `requires-python` to `>=3.10` (matches the code + CI matrix); fix the stale "CPython 3.9-3.13" comment and the `publish-cli` fallback default.
  **Change (provision correctly):** new `ensure-python.sh` guarantees a Python ≥3.10 interpreter — it prefers any already-usable system Python ≥3.10 (e.g. AL2023's `/usr/bin/python3.11`), and only installs via **mise** if none exists (its python-build-standalone binaries run on AL2's glibc 2.26). The chosen interpreter is recorded in `~/.kirocrew/python-bin`; the `backend` target builds the venv with it and recreates a stale `<3.10` venv left by a prior failed run.
- **Robustness / consistency with #49:** resolves the mise interpreter via `mise which python` (not `mise activate`, unreliable in non-interactive `make`); target pinned to 3.12 (matches CI), overridable via `KIROCREW_PYTHON_VERSION`.
- **Scope:** macOS and any host with a system Python ≥3.10 are unaffected (system interpreter used directly; mise never invoked). Nobody could have been running successfully on 3.9 before — the code already required 3.10 — so raising the declared floor only converts a runtime crash into a clear install-time message.

## Tests

No unit-test harness exists for these build scripts; validated with `bash -n` (syntax) and by direct execution on real Amazon Linux hosts (below).

## Manual verification

- **AL2023 x86_64** (glibc 2.34, default `python3` = 3.9.25): `ensure-python.sh` selected the system `/usr/bin/python3.11` (3.11.15), skipping mise; `from contextlib import aclosing` imports OK under it; the `backend` recipe recreated a planted 3.9 venv → 3.11.15.
- **AL2 x86_64** (glibc 2.26, default `python3` = 3.7.16): `ensure-python.sh` installs Python 3.12.13 via mise (runs on 2.26); a venv from it + `pip install "aiohttp>=3.9,<4"` resolves → aiohttp 3.14.1; the `backend` recipe recreated a planted 3.7 venv → 3.12.13.

macOS/other ≥3.10 hosts unchanged.
