### PR TITLE
feat(website): apply apple-design fluid-interface optimizations + ship apple-design skill

### DIFF
--- a/src/kiro_crew/builtin_skills/apple-design/SKILL.md
+++ b/src/kiro_crew/builtin_skills/apple-design/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: apple-design
+description: Apple's fluid-interface + material + typography principles, tailored to the KiroCrew dashboard (React 18 + framer-motion 12 + Tailwind 3). Use ONLY when the user explicitly asks to apply, review, or optimize KiroCrew frontend UI for an Apple-style / native fluid feel — springs & interruptible motion, gesture physics (momentum, rubber-band), translucent glass materials, or size-tiered typography. Do NOT auto-load for generic frontend/CSS/modal work that doesn't ask for the Apple aesthetic.
+always: false
+triggers: apple design, apple-design, apple style, apple-style, fluid interface, fluid-interface, native-feeling ui, make it feel native, optimize ui for feel, ui feel polish, gesture physics, momentum and spring feel, apple-style motion
+---
+
+# Apple Design — KiroCrew edition
+
+How Apple builds interfaces that feel like an extension of the user, **translated to the KiroCrew web stack** and grounded in this repo's actual patterns. The knowledge comes from Apple's WWDC design talks (chiefly *Designing Fluid Interfaces*, WWDC 2018); the KiroCrew layer below maps each principle to concrete files in `website/`.
+
+> Core idea: an interface feels alive when motion **starts from the current on-screen value, inherits the user's velocity, projects momentum forward, and can be grabbed and reversed at any instant.** Springs make this natural because they are inherently interruptible and velocity-aware.
+
+## When to use
+
+Load this skill whenever you touch the KiroCrew dashboard frontend (`website/`, or the served build in `src/kiro_crew/static/`):
+- Building a new component with motion, gestures, modals, drawers, popovers, or glass surfaces.
+- Reviewing or optimizing existing UI for "feel."
+- Deciding animation config (spring vs tween), gesture handling, material/blur, typography, or accessibility fallbacks.
+
+---
+
+## KiroCrew stack (know this before editing)
+
+- **React 18 + framer-motion 12** (`framer-motion`'s `bounce` + `duration` spring API maps directly to Apple's damping + response).
+- **Tailwind 3** (`tailwind.config.js`) — note it currently extends colors/fonts/radius/shadow but **no** `fontSize`/`letterSpacing`/`lineHeight` scales.
+- Global CSS + design tokens live in `website/src/index.css` (theme vars: `--chrome`, `--border`, `--shadow-sm/md/lg`, `--muted-strong`; utilities: `.glass-surface`, `.glass-refract`, `.topbar-glass`, `.scroll-shadow`).
+- Radix primitives (`@radix-ui/*`) back some popovers/menus.
+
+---
+
+## House rules (the short version)
+
+1. **Springs, not tweens, for anything a user can touch.** Default to `{ type: 'spring', bounce: 0, duration: 0.3–0.4 }` (critically damped). Reserve `bounce: ~0.2` **only** when the gesture itself carried momentum (a flick/throw/drag release). Never put fixed-duration `ease` tweens on a `width`/`height`/`x`/`y` channel of a draggable or resizable panel.
+2. **Feedback on pointer-down, instantly.** Every button gets an `:active`/`whileTap` press transform (~75–100ms). Never wait for `click`/release to show state.
+3. **Interruptible always.** Animate from the *presentation* (live) value, never the target. Never lock out input during a transition. Avoid CSS `transition`/`@keyframes` for gesture-driven motion (they can't be grabbed mid-flight); CSS keyframes are fine for ambient/decorative loops.
+4. **Gestures track 1:1**, respect the grab offset, use Pointer Events + `setPointerCapture`, require a ~10px movement threshold, hand off release **velocity**, **project momentum** to the resting point, and **rubber-band** at boundaries instead of hard-clamping.
+5. **Glass must actually be glass.** A translucent surface needs an effective background alpha ≈ 0.60–0.75 — not 0.95+. Bigger surfaces read thicker (more blur + deeper shadow). Never stack a translucent surface on another translucent surface. Dim-to-focus modals pair the panel with a **blurred** scrim; parallel non-blocking panels use translucency **without** a scrim.
+6. **Typography is size-specific.** Negative tracking only on large display text (`~-0.02em`); body near `0`; small labels slightly positive. Tight leading on headings (`~1.05`), loose on body (`~1.5`). Size in `rem`, not `px`. Prefer `system-ui`.
+7. **Ship the three accessibility media queries** (`prefers-reduced-motion`, `prefers-reduced-transparency`, `prefers-contrast`) and gate framer-motion with `useReducedMotion()`.
+
+---
+
+## Reference-good patterns — copy these
+
+These already follow the principles; use them as the house template.
+
+- **`layoutId` spring morph** — `website/src/components/Modal.tsx` and `McpDetailModal.tsx` (spring, `bounce: 0`). The canonical open/expand pattern.
+- **Slider knob** — `website/src/components/ui.tsx` (~L483): position via a motion value, knob scale/shadow via spring, scale reacts to `dragging` state. The template for velocity-aware direct manipulation.
+- **Pointer capture** — `BrowserLiveView` and the slider use `setPointerCapture(e.pointerId)`; copy this for any new drag handle.
+- **Reduced-motion CSS fallbacks** — streaming-text effects in `index.css` (`.ft-block-reveal`, `.ft-word`, `.ft-resize`, streaming caret) each set `animation: none` under `prefers-reduced-motion`. Mirror this for any new keyframe animation.
+
+## Anti-patterns to avoid (seen in this repo)
+
+- Fixed-duration tween on a draggable/resizable dimension, or a `duration: 0` mid-gesture snap (was in `OverlayDrawer.tsx`). Use a spring; let the gesture end settle via spring.
+- Hard `Math.min/Math.max` clamp at a drag boundary with no resistance. Add rubber-banding.
+- `onMouseDown` + `document` mousemove/mouseup for resizers (no touch support). Use Pointer Events + capture; prefer a shared `usePointerDrag` hook.
+- `backdrop-filter: blur()` behind a 0.95–0.98 alpha background (blur is invisible — it's just an opaque bar). Drop effective alpha to ~0.70.
+- A translucent card (`bg-card/80 backdrop-blur-sm`) rendered inside already-translucent context. Make it solid + shadow.
+- One global `letter-spacing` applied to every size; fixed-`px` font sizes; a static display font as the UI body face.
+- framer-motion components with no `useReducedMotion()` check; `backdrop-filter` with no `prefers-reduced-transparency` fallback.
+
+---
+
+## Review / build checklist
+
+Run this before shipping any KiroCrew UI change. Each line maps to a principle section below.
+
+**Motion**
+- [ ] Touchable elements animate with a spring (`bounce: 0` default), not a fixed-duration tween. (§4)
+- [ ] Animations start from the live/presentation value and are interruptible mid-flight. (§3)
+- [ ] Gesture end hands off release velocity to the settle animation. (§5, §6-momentum)
+
+**Gesture**
+- [ ] Drag tracks the pointer 1:1 and respects the grab offset. (§2)
+- [ ] Pointer Events + `setPointerCapture`; works on touch, not just mouse. (§2)
+- [ ] ~10px movement threshold before committing to a drag/direction. (§10)
+- [ ] Momentum projected to a resting point on flick; boundaries rubber-band, not hard-stop. (§6, §9)
+
+**Material**
+- [ ] Translucent chrome has effective bg alpha ≈ 0.6–0.75; blur scales with surface size. (§12)
+- [ ] No translucent-on-translucent stacking. (§12)
+- [ ] Dim-to-focus modal = blurred scrim; parallel panel = no scrim. (§12)
+- [ ] Bright top edge on glass; scroll-edge fade instead of a hard 1px divider under sticky chrome. (§12)
+
+**Typography**
+- [ ] Tracking is size-specific (negative only on large text); body `rem`, not `px`; leading tight on headings. (§15)
+
+**Response & a11y**
+- [ ] Every button has instant `:active`/`whileTap` press feedback. (§1)
+- [ ] `prefers-reduced-motion`, `prefers-reduced-transparency`, `prefers-contrast` all handled; framer-motion reads `useReducedMotion()`. (§14)
+
+---
+
+## The principles (canonical reference)
+
+### 1. Response — kill latency
+Respond on pointer-**down**, not release. Feedback must be continuous *during* the interaction (drags/sliders/drawers update 1:1 the whole way), not only at the end. Audit every debounce, timer, and transition wait on the input path.
+```css
+.button:active { transform: scale(0.97); transition: transform 100ms ease-out; }
+```
+
+### 2. Direct manipulation — 1:1 tracking
+Dragged content stays glued to the finger and respects the offset from *where it was grabbed* (never snap to center on grab). Use Pointer Events + `setPointerCapture` so tracking survives leaving bounds. Track a short position/velocity history for release velocity.
+
+### 3. Interruptibility — the single most important principle
+Every animation must be grabbable and reversible at any moment. Never lock out input during a transition. **Always animate from the presentation (current) value**, never the target — starting from the target causes a visible jump. Avoid CSS transitions/`@keyframes` for gesture-driven motion. On reversal, blend velocity (don't hard-cut). Decompose 2D motion into independent X and Y springs.
+
+### 4. Behavior over animation — use springs
+A fixed-duration animation can't respond to new input; a spring can (new input just changes the target). Think in two designer parameters:
+- **Damping ratio** — overshoot. `1.0` = critically damped (no bounce). `<1.0` = bouncier.
+- **Response** — how quickly it reaches target, in seconds. Not a duration; settle time emerges from the parameters.
+
+Defaults: start most UI at **damping 1.0**; add **~0.8** bounce only when the gesture carried momentum.
+
+| Interaction | Damping | Response |
+| --- | --- | --- |
+| Move / reposition | `1.0` | `0.4` |
+| Rotation | `0.8` | `0.4` |
+| Drawer / sheet | `0.8` | `0.3` |
+
+framer-motion mapping (`bounce` + `duration` ≈ Apple's damping + response):
+```js
+import { animate } from 'motion';
+animate(el, { y: 0 }, { type: 'spring', bounce: 0,   duration: 0.4 }); // critically damped default
+animate(el, { y: t }, { type: 'spring', bounce: 0.2, duration: 0.4 }); // momentum interaction only
+```
+
+### 5. Velocity handoff
+When a gesture ends, the animation must continue at the finger's exact velocity — no seam. framer-motion takes absolute px/s via the `velocity` option. If an API wants relative velocity: `relativeVelocity = gestureVelocity / (target − current)`.
+
+### 6. Momentum projection
+Don't snap from the release point — project the resting position from velocity (like scroll deceleration), then snap to the nearest target.
+```js
+function project(initialVelocity /* px/s */, decelerationRate = 0.998) {
+  return (initialVelocity / 1000) * decelerationRate / (1 - decelerationRate);
+}
+const projectedEndpoint = currentPosition + project(releaseVelocity);
+const target = nearestSnapPoint(projectedEndpoint);
+animateSpringTo(target, { velocity: releaseVelocity });
+```
+Use the exponential-decay form above, not the textbook `v²/(2·decel)`.
+
+### 7. Spatial consistency
+Enter and exit along the same path (in-from-right → out-to-right). Anchor interactions to their source: set `transform-origin` to the trigger so a menu/popover/sheet grows from the button that opened it. Mirror the easing on reversible transitions.
+
+### 8. Hint in the direction of the gesture
+Intermediate motion should telegraph the outcome (Control Center modules "grow up and out toward your finger"). Make in-between frames point at the result.
+
+### 9. Rubber-banding — soft boundaries
+Resist progressively past an edge instead of stopping hard.
+```js
+function rubberband(overshoot, dimension, constant = 0.55) {
+  return (overshoot * dimension * constant) / (dimension + constant * Math.abs(overshoot));
+}
+```
+
+### 10. Gesture detail checklist
+Tap: highlight on touch-down, commit on touch-up; ~10px hit padding; allow cancel-by-dragging-away. Drag/swipe: ~10px threshold before committing a direction, then 1:1. Detect plausible gestures in parallel and cancel the losers; avoid recognizers that only report a final state.
+
+### 11. Frame-level smoothness
+Smoothness is what's *in* the frames. Keep per-frame positional change below the perception threshold. Animate only compositor-friendly properties (`transform`, `opacity`); hint with `will-change`. `requestAnimationFrame` is the display-synced clock.
+
+### 12. Materials & depth — translucency conveys hierarchy
+- Build nav/toolbars/sheets as **translucent layers** (`backdrop-filter: blur()` + semi-transparent bg) with content scrolling under — not opaque strips.
+- Material weight encodes hierarchy; **never stack a light translucent surface on another** (legibility collapses).
+- Bigger surfaces read thicker: stronger blur + deeper shadow than small chips.
+- **Dim to focus, separate to keep flow.** Modal → dim scrim + push background back. Parallel panel → translucency + offset, **no scrim**. Stacked sheets → progressively dim/push back each parent.
+- **Vibrancy:** over translucent surfaces use higher-contrast, slightly heavier text + a small letter-spacing bump — not flat gray. Put color on a solid layer.
+- **Scroll edge effects, not hard dividers:** fade a blur/gradient mask where content meets floating chrome, only where they overlap.
+- **Materialize, don't just fade:** animate blur radius + scale together on enter/exit.
+```css
+.toolbar {
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(20px) saturate(180%);
+  border-top: 1px solid rgba(255, 255, 255, 0.4); /* bright top edge */
+}
+```
+
+### 13. Multimodal feedback
+**Causality** (fire on the actual causal event), **Harmony** (visual + sound + haptic on the same frame), **Utility** (reserve haptics/sound for meaningful moments — over-feedback trains users to ignore it).
+
+### 14. Reduced motion & accessibility
+Reduced motion means a *gentler* equivalent, not none. Handle three independent signals:
+- **`prefers-reduced-motion: reduce`** → replace slides/springs/parallax with short opacity cross-fades; drop overshoot; keep comprehension cues. Also gate framer-motion with `useReducedMotion()` (CSS resets don't stop JS-driven transforms).
+- **`prefers-reduced-transparency: reduce`** → raise background opacity, drop the blur.
+- **`prefers-contrast: more`** → near-solid backgrounds with a defined contrasting border.
+```css
+@media (prefers-reduced-motion: reduce) {
+  .sheet { transition: opacity 200ms ease; transform: none !important; }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .toolbar { background: white; backdrop-filter: none; }
+}
+```
+
+### 15. Typography — optical sizing, tracking, leading
+- **Tracking is size-specific.** Large display → *negative* (`~-0.02em`); body → near `0`; small text → slightly *positive*. A single fixed `letter-spacing` is wrong somewhere.
+- **Leading tracks size inversely.** Tight on headings (`~1.05`), looser on body (`~1.5`).
+- **Hierarchy = weight + size + leading as a set.** Emphasize with weight.
+- **Respect user text size:** spacing in `rem`/`em`, not fixed `px`.
+- **Default to the platform system font** (`system-ui`) — it ships optical sizing and tracking tables. Use `font-optical-sizing: auto` for variable fonts.
+```css
+:root { font: 100%/1.5 system-ui, sans-serif; }
+.display {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-optical-sizing: auto;
+}
+```
+
+### 16. Design foundations — the eight principles
+Purpose · Agency (offer choices, easy undo, confirm only genuinely destructive actions) · Responsibility (privacy, safety, previews) · Familiarity (metaphors, consistency) · Flexibility (contexts, devices, accessibility) · Simplicity (not minimalism — strip the unnecessary, show the common path first) · Craft (every spacing/timing/alignment is deliberate) · Delight (the result of getting the other seven right).
+
+Tactical: feedback comes in four kinds (status, completion, warning, error — validate inline, not on submit); wayfinding (every screen answers where am I / where can I go / how do I leave); grouping & mapping (place a control near what it affects); direct specific labels beat generic ones.
+
+### 17. Process
+Prototype interactively (a working demo beats a million static designs). Design interaction and visuals together. Review motion with fresh eyes — slow-motion / frame-by-frame.
+
+---
+
+## Quick reference
+
+| Need | Technique | Concrete value |
+| --- | --- | --- |
+| Default UI spring | Critically damped, no overshoot | `bounce: 0`, `duration: 0.3–0.4` |
+| Momentum / flick spring | Slight bounce | `bounce: ~0.2`, `duration: 0.3–0.4` |
+| Gesture → spring velocity | Hand off release velocity | framer `velocity:` (px/s) |
+| Flick landing point | Project momentum | `current + (v/1000)·d/(1−d)`, `d ≈ 0.998` |
+| Interrupt cleanly | Start from presentation value | read live transform |
+| 1:1 drag | Pointer Events + capture | respect grab offset, ~10px threshold |
+| Feedback | Pointer-down, continuous | `active:scale-95 active:duration-75` |
+| Boundary | Rubber-band | progressive resistance |
+| Translucent chrome | `backdrop-filter` layer, effective alpha ~0.7 | content scrolls under |
+| Type tracking | Size-specific | large `-0.02em`, body `~0` |
+| Reduced motion | Cross-fade + `useReducedMotion()` | drop overshoot/parallax |

--- a/website/src/components/CliPanel.tsx
+++ b/website/src/components/CliPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from '../store/terminalSlice'
 import { useTerminalWs } from '../hooks/useTerminalWs'
 import { setActiveTerminalSession } from '../utils/terminalRegistry'
+import { usePointerDrag, rubberband } from '../hooks/usePointerDrag'
 
 const HEIGHT_KEY = 'kirocrew-terminal-height'
 const WIDTH_KEY = 'kirocrew-terminal-width'
@@ -358,34 +359,48 @@ export default function CliPanel() {
   const isBottomRef = useRef(isBottom)
   isBottomRef.current = isBottom
 
-  const onDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    const startPos = isBottomRef.current ? e.clientY : e.clientX
-    const startSize = sizeRef.current
+  // Size captured at pointer-down so live moves are computed from a stable origin.
+  const dragStartSize = useRef(size)
 
-    const onMove = (ev: MouseEvent) => {
-      const delta = isBottomRef.current ? startPos - ev.clientY : startPos - ev.clientX
-      setSize(Math.max(isBottomRef.current ? MIN_H : MIN_W, startSize + delta))
-    }
-    const onUp = () => {
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
+  const bounds = () => {
+    const bottom = isBottomRef.current
+    const min = bottom ? MIN_H : MIN_W
+    // Cap the panel so it can't swallow the whole viewport; leave `min` for the rest of the UI.
+    const max = Math.max(min, (bottom ? window.innerHeight : window.innerWidth) - min)
+    return { min, max }
+  }
+
+  // Pointer Events (mouse + touch) via the shared hook. Grows the panel as the
+  // splitter is dragged toward the panel's anchored edge; rubber-bands past max.
+  const drag = usePointerDrag({
+    threshold: 6,
+    onStart: () => { dragStartSize.current = sizeRef.current },
+    onMove: ({ dx, dy }) => {
+      const { min, max } = bounds()
+      // Bottom panel is anchored to the viewport bottom → dragging up (dy < 0) grows it;
+      // right panel is anchored to the right edge → dragging left (dx < 0) grows it.
+      const raw = dragStartSize.current - (isBottomRef.current ? dy : dx)
+      let next = raw
+      if (raw > max) next = max + rubberband(raw - max, max) // progressive resistance past the cap
+      else if (raw < min) next = min                          // hard floor (matches prior behavior)
+      setSize(next)
+    },
+    onEnd: () => {
       setSize(s => {
-        const clamped = Math.max(isBottomRef.current ? MIN_H : MIN_W, s)
+        const { min, max } = bounds()
+        const clamped = Math.min(max, Math.max(min, s)) // settle back inside [min, max]
         safeSetItem(isBottomRef.current ? HEIGHT_KEY : WIDTH_KEY, String(clamped))
         return clamped
       })
-    }
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-  }, []) // stable — no deps, uses refs
+    },
+  })
 
   return (
     <motion.div
       initial={isBottom ? { height: 0, width: '100%' } : { width: 0, height: '100%' }}
       animate={isBottom ? { height: size, width: '100%' } : { width: size, height: '100%' }}
       exit={isBottom ? { height: 0, width: '100%' } : { width: 0, height: '100%' }}
-      transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+      transition={{ type: 'spring', bounce: 0, duration: 0.3 }}
       onAnimationComplete={refitAll}
       className={`shrink-0 overflow-hidden border border-border rounded-lg bg-bg ${isBottom ? 'ml-0 mr-2 mb-2 mt-0' : 'ml-0 mr-2 my-2'}`}
       style={isBottom ? undefined : { minWidth: MIN_W }}
@@ -393,21 +408,20 @@ export default function CliPanel() {
       <div
         className="flex flex-col overflow-hidden relative w-full h-full"
       >
-        {/* Resize handle — a pointer-drag splitter carrying the correct
-            role="separator"/aria-orientation semantics. The rule treats "separator"
-            as non-interactive, so the drag-only onMouseDown is flagged despite the
-            role being the ARIA-correct choice for a resizer. */}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        {/* Resize handle — a Pointer-Events drag splitter (mouse + touch) carrying
+            the correct role="separator"/aria-orientation semantics. The rule treats
+            "separator" as non-interactive, so the drag handlers are flagged despite
+            the role being the ARIA-correct choice for a resizer. */}
         <div
           role="separator"
           aria-orientation={isBottom ? 'horizontal' : 'vertical'}
           aria-label="Resize terminal panel"
-          className={`absolute z-20 group/drag ${
+          className={`absolute z-20 group/drag touch-none ${
             isBottom
               ? 'left-0 right-0 top-0 h-[6px] cursor-ns-resize'
               : 'left-0 top-0 bottom-0 w-[6px] cursor-col-resize'
           }`}
-          onMouseDown={onDragStart}
+          {...drag}
         >
           <div
             className={`absolute transition-colors duration-200 bg-transparent group-hover/drag:bg-accent ${

--- a/website/src/components/DetailPanel.tsx
+++ b/website/src/components/DetailPanel.tsx
@@ -1,8 +1,9 @@
 import { safeSetItem } from '../utils/safeStorage'
-import React, { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { X } from 'lucide-react'
 import { Btn } from './ui'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 
 interface DetailPanelProps {
   title: React.ReactNode
@@ -87,20 +88,13 @@ export default function DetailPanel({ title, onClose, footer, headerActions, sec
   })
   const widthRef = useRef(width)
   widthRef.current = width
-  const moveRef = useRef<((ev: MouseEvent) => void) | null>(null)
-  const upRef = useRef<(() => void) | null>(null)
+  // Panel width captured at drag start; the resize delta is applied against it.
+  const startWRef = useRef(0)
   // True while a resize-handle drag is in progress. The window `resize` listener
   // must not fight an active drag: a viewport change mid-drag would otherwise
-  // clamp `width` down and, via onUp below, persist that clamped value over the
+  // clamp `width` down and, via onEnd below, persist that clamped value over the
   // width the user actually dragged to.
   const draggingRef = useRef(false)
-
-  useEffect(() => {
-    return () => {
-      if (moveRef.current) document.removeEventListener('mousemove', moveRef.current)
-      if (upRef.current) document.removeEventListener('mouseup', upRef.current)
-    }
-  }, [])
 
   // Re-clamp on viewport shrink so a persisted width that's wider than the
   // current row can never leave the right-edge header actions off-screen or
@@ -128,32 +122,42 @@ export default function DetailPanel({ title, onClose, footer, headerActions, sec
     setWidth((w) => clampPanelWidth(w, minWidth, rowWidth(), reserveWidth))
   }, [minWidth, reserveWidth])
 
-  const onDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    draggingRef.current = true
-    const startX = e.clientX; const startW = widthRef.current
-    const onMove = (ev: MouseEvent) => {
-      setWidth(clampPanelWidth(startW + (startX - ev.clientX), minWidth, rowWidth(), reserveWidth))
-    }
-    const onUp = () => {
+  const drag = usePointerDrag({
+    threshold: 6,
+    onStart: () => {
+      draggingRef.current = true
+      startWRef.current = widthRef.current
+    },
+    onMove: ({ dx }) => {
+      // The old mouse handler grew width as the pointer moved LEFT:
+      //   clampPanelWidth(startW + (startX - clientX), ...).
+      // The hook reports dx = clientX - startX, so (startX - clientX) === -dx
+      // and the raw target is `startW - dx`: drag left (dx < 0) widens, drag
+      // right (dx > 0) narrows — identical to the original.
+      //
+      // Hard-clamp (no rubber-band): this panel is `shrink-0` inside an
+      // `overflow-hidden` row, so the row/viewport cap is a LAYOUT INVARIANT
+      // (Mesh-2813) — letting width exceed it, even transiently, pushes content
+      // off-screen. Rubber-band is for soft scroll edges, not overflow guards.
+      setWidth(clampPanelWidth(startWRef.current - dx, minWidth, rowWidth(), reserveWidth))
+    },
+    onEnd: ({ committed }) => {
+      // ALWAYS clear the suppression flag — the hook fires onEnd on every
+      // pointer-up (even a sub-threshold tap on the thin handle), so the resize /
+      // reserveWidth re-clamp guards can never get wedged on `true` and re-expose
+      // the Mesh-2230/2813 overflow. A tap did nothing else, so stop here.
       draggingRef.current = false
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      moveRef.current = null; upRef.current = null
-      // Persist the width the user dragged to (their preferred width) BEFORE
-      // re-clamping the render. A resize that arrived mid-drag was suppressed,
-      // so widthRef.current still holds the dragged value; this keeps the
-      // preferred width in localStorage for restore (re-clamped) on a larger
-      // screen rather than saving a resize-clamped value.
-      if (storageKey) safeSetItem(storageKey, String(widthRef.current))
-      // Re-clamp the live render once to the current row, in case a resize
-      // arrived mid-drag, so the panel can't stay wider than its row.
-      setWidth((w) => clampPanelWidth(w, minWidth, rowWidth(), reserveWidth))
-    }
-    moveRef.current = onMove; upRef.current = onUp
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-  }, [minWidth, reserveWidth, storageKey])
+      if (!committed) return
+      // Persist the dragged PREFERRED width (widthRef holds it: a resize
+      // suppressed mid-drag never touched it) so returning to a larger screen
+      // restores it — then clamp only the LIVE render down to what currently
+      // fits. Clamping before persisting would lose the preferred width (Mesh-2238).
+      const preferred = widthRef.current
+      if (storageKey) safeSetItem(storageKey, String(preferred))
+      setWidth(clampPanelWidth(preferred, minWidth, rowWidth(), reserveWidth))
+    },
+  })
+
 
   return (
     <motion.div
@@ -161,15 +165,14 @@ export default function DetailPanel({ title, onClose, footer, headerActions, sec
       initial={{ width: 0, opacity: 0 }}
       animate={{ width: 'auto', opacity: 1 }}
       exit={{ width: 0, opacity: 0 }}
-      transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+      transition={{ width: { type: 'spring', bounce: 0, duration: 0.3 }, opacity: { duration: 0.12 } }}
       className="shrink-0 overflow-hidden h-full"
     >
       <div className="shrink-0 border-l border-border bg-bg flex flex-col h-full overflow-hidden relative" style={{ width, minWidth }}>
         {/* Drag-to-resize splitter: pointer-only affordance (no meaningful
             keyboard gesture for a 6px handle); role="separator" is the correct
             ARIA role. */}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-        <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-20 group/drag" onMouseDown={onDragStart}>
+        <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-20 group/drag" style={{ touchAction: 'none' }} {...drag}>
           <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent" />
         </div>
         <div className={`flex items-center justify-between px-3 h-12 shrink-0 border-b ${headerClassName ?? 'border-border'}`}>

--- a/website/src/components/Modal.tsx
+++ b/website/src/components/Modal.tsx
@@ -57,7 +57,7 @@ export default function Modal({ open, onClose, title, footer, headerActions, max
       {open && (
         <>
           <motion.div
-            className="fixed inset-0 bg-black/40 z-[100]"
+            className="fixed inset-0 bg-bg/60 backdrop-blur-md z-[100]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/website/src/components/OverlayDrawer.tsx
+++ b/website/src/components/OverlayDrawer.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 
 interface Props {
   open: boolean
@@ -13,9 +13,15 @@ interface Props {
 }
 
 const EASE = [0.32, 0.72, 0, 1] as const
-const DUR = 0.25
 
 export default function OverlayDrawer({ open, width, dragging, morph, className, children }: Props) {
+  const reduce = useReducedMotion()
+  // Gesture end settles from the live presentation value via a critically
+  // damped spring (no overshoot, no visible jump) — never a fixed ease tween.
+  // Reduced motion: drop the spring for a short opacity-only settle.
+  const settle = reduce
+    ? { duration: 0.2 }
+    : { type: 'spring' as const, bounce: 0, duration: 0.35 }
   return (
     <AnimatePresence initial={false}>
       {open && (
@@ -27,9 +33,9 @@ export default function OverlayDrawer({ open, width, dragging, morph, className,
           transition={
             dragging
               ? { duration: 0 }
-              : morph
+              : morph && !reduce
                 ? { width: { duration: 0.32, ease: EASE }, opacity: { duration: 0.12, ease: EASE } }
-                : { duration: DUR, ease: EASE }
+                : settle
           }
           className={`shrink-0 py-2 overflow-hidden ${className || ''}`}
         >

--- a/website/src/components/QuestionCard.tsx
+++ b/website/src/components/QuestionCard.tsx
@@ -54,7 +54,7 @@ function QuestionCard({ questions, onSubmit }: QuestionCardProps) {
   const hasAnyAnswer = questions.some((_, i) => (selections[i]?.size ?? 0) > 0 || customInputs[i]?.trim())
 
   return (
-    <div className="border border-accent/30 rounded-xl bg-card/80 backdrop-blur-sm overflow-hidden animate-scale-in">
+    <div className="border border-accent/30 rounded-xl bg-card shadow-md overflow-hidden animate-scale-in">
       {questions.map((q, qIdx) => (
         <div key={qIdx} className={`p-4 ${qIdx > 0 ? 'border-t border-border' : ''}`}>
           <div className="flex items-center gap-2 mb-2.5">

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -208,7 +208,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, fuseBelow = 
                   borderBottomRightRadius: fused ? 0 : 12,
                   borderBottomWidth: fused ? 0 : 1,
                 }}
-                exit={{ y: y + 40, zIndex: 50, borderBottomWidth: 1, borderBottomLeftRadius: 12, borderBottomRightRadius: 12, transition: { duration: 0.3, ease: 'easeIn' } }}
+                exit={{ y: y + 40, zIndex: 50, borderBottomWidth: 1, borderBottomLeftRadius: 12, borderBottomRightRadius: 12, transition: SPRING }}
                 transition={SPRING}
                 className="absolute top-0 left-0 right-0 bg-warn border border-warn/20 px-3 py-2 text-[13px] text-warn-fg"
                 style={{ transformOrigin: 'bottom center', height: CARD_H, zIndex }}

--- a/website/src/components/SegmentedControl.tsx
+++ b/website/src/components/SegmentedControl.tsx
@@ -126,7 +126,7 @@ export default function SegmentedControl<T extends string = string>({ segments, 
                     initial={{ width: 0 }}
                     animate={{ width: 'auto' }}
                     exit={{ width: 0 }}
-                    transition={{ duration: 0.15 }}
+                    transition={{ type: 'spring', bounce: 0, duration: 0.2 }}
                     className="relative z-[1] overflow-hidden whitespace-nowrap"
                   >
                     {s.label}

--- a/website/src/components/ui.tsx
+++ b/website/src/components/ui.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
-import { motion, useMotionValue, useSpring, useMotionTemplate } from 'framer-motion'
+import { motion, useMotionValue, useSpring, useMotionTemplate, useReducedMotion } from 'framer-motion'
 import InfoTip from './InfoTip'
 
 /* ── Shared UI primitives ── */
@@ -21,7 +21,7 @@ export const Btn = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttribute
   ({ children, danger, primary, className, ...rest }, ref) => (
     <button
       ref={ref}
-      className={twMerge(`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[13px] cursor-pointer font-body transition-all disabled:opacity-30 disabled:cursor-not-allowed ${
+      className={twMerge(`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[13px] cursor-pointer font-body transition-all active:scale-[0.97] active:duration-75 disabled:opacity-30 disabled:cursor-not-allowed ${
         primary
           ? 'bg-accent text-accent-fg border-accent hover:bg-accent-hover hover:shadow-[0_0_12px_var(--accent-glow)]'
           : danger
@@ -70,7 +70,7 @@ export const IconButton = React.forwardRef<
     ref={ref}
     type="button"
     className={twMerge(
-      'p-[4px] rounded transition-all cursor-pointer bg-transparent border-none disabled:opacity-30 disabled:cursor-not-allowed',
+      'p-[4px] rounded transition-all active:scale-[0.97] active:duration-75 cursor-pointer bg-transparent border-none disabled:opacity-30 disabled:cursor-not-allowed',
       ICON_BUTTON_VARIANTS[variant],
       className,
     )}
@@ -312,6 +312,7 @@ export function Slider({
   const [dragging, setDragging] = React.useState(false)
   const pointerDown = React.useRef(false)
   const [hoverVal, setHoverVal] = React.useState<number | null>(null)
+  const reduceMotion = useReducedMotion()
 
   const range = (max - min) || 1
   const clamp = (v: number) => Math.min(max, Math.max(min, v))
@@ -485,10 +486,10 @@ export function Slider({
         <motion.div aria-hidden className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2" style={{ left: motionPos }}>
           <motion.div
             className="relative w-[18px] h-[18px] rounded-full bg-white border border-black/10 shadow-[0_1px_3px_rgba(0,0,0,.3),0_0.5px_1px_rgba(0,0,0,.2)] group-focus-visible:ring-2 group-focus-visible:ring-[var(--ring)] group-focus-visible:ring-offset-1 group-focus-visible:ring-offset-[var(--bg)]"
-            animate={{ scale: dragging ? 1.15 : 1, boxShadow: dragging ? '0 2px 7px rgba(0,0,0,.4)' : atMax ? '0 0 10px var(--accent)' : '0 1px 3px rgba(0,0,0,.3)' }}
-            whileHover={disabled ? undefined : { scale: 1.12 }}
-            whileTap={disabled ? undefined : { scale: 1.2 }}
-            transition={{ type: 'spring', stiffness: 500, damping: 26 }}
+            animate={{ scale: reduceMotion ? 1 : (dragging ? 1.15 : 1), boxShadow: dragging ? '0 2px 7px rgba(0,0,0,.4)' : atMax ? '0 0 10px var(--accent)' : '0 1px 3px rgba(0,0,0,.3)' }}
+            whileHover={disabled || reduceMotion ? undefined : { scale: 1.12 }}
+            whileTap={disabled || reduceMotion ? undefined : { scale: 1.2 }}
+            transition={reduceMotion ? { duration: 0 } : { type: 'spring', stiffness: 500, damping: 26 }}
           />
         </motion.div>
       </div>

--- a/website/src/hooks/usePointerDrag.ts
+++ b/website/src/hooks/usePointerDrag.ts
@@ -1,0 +1,156 @@
+import { useCallback, useRef } from 'react'
+
+/**
+ * Apple "Designing Fluid Interfaces" physics helpers + a shared Pointer-Events
+ * drag hook. Replaces the ad-hoc `onMouseDown` + `document` mousemove/mouseup
+ * resizers scattered across the app with one implementation that:
+ *   - works on touch as well as mouse (Pointer Events + setPointerCapture),
+ *   - tracks release velocity (for momentum handoff),
+ *   - applies a movement threshold before committing to a drag (hysteresis),
+ *   - survives the pointer leaving the element bounds (capture).
+ *
+ * See the `apple-design` skill for the principles these encode.
+ */
+
+/**
+ * Project the resting position of a flick from its release velocity, matching
+ * Apple's exponential-decay scroll deceleration (NOT the textbook v²/2a form).
+ *
+ * @param velocity      release velocity in px/s
+ * @param decelerationRate 0.998 ≈ normal scroll feel; 0.99 ≈ snappier
+ * @returns the additional distance (px) the element should travel after release
+ */
+export function project(velocity: number, decelerationRate = 0.998): number {
+  return ((velocity / 1000) * decelerationRate) / (1 - decelerationRate)
+}
+
+/**
+ * Progressive boundary resistance ("rubber-banding"). The further past the
+ * boundary the user drags, the less the element follows — real things slow
+ * before they stop, instead of hitting a rigid wall.
+ *
+ * @param overshoot  how far past the boundary the raw pointer is (px)
+ * @param dimension  the reference dimension (e.g. panel size) the resistance scales against
+ * @param constant   resistance constant (0.55 matches UIKit)
+ * @returns the damped overshoot to actually apply past the boundary
+ */
+export function rubberband(overshoot: number, dimension: number, constant = 0.55): number {
+  if (dimension <= 0) return 0
+  return (overshoot * dimension * constant) / (dimension + constant * Math.abs(overshoot))
+}
+
+export interface PointerDragState {
+  /** total delta from the drag origin */
+  dx: number
+  dy: number
+  /** current pointer position */
+  x: number
+  y: number
+  /** instantaneous velocity in px/s (from the last two samples) */
+  vx: number
+  vy: number
+  /** true on the first committed move of this drag */
+  first: boolean
+  /** whether the gesture crossed the movement threshold. Only meaningful in onEnd
+   *  (onMove only fires once committed); lets consumers skip drag-only work on a tap. */
+  committed?: boolean
+}
+
+export interface PointerDragOptions {
+  onStart?: (e: React.PointerEvent) => void
+  onMove: (state: PointerDragState) => void
+  onEnd?: (state: PointerDragState) => void
+  /** px of movement required before the drag commits (default 10, per Apple's ~10px hysteresis). Set 0 to commit immediately. */
+  threshold?: number
+}
+
+interface DragInternal {
+  startX: number
+  startY: number
+  lastX: number
+  lastY: number
+  lastT: number
+  vx: number
+  vy: number
+  active: boolean
+  committed: boolean
+}
+
+/**
+ * Attach the returned handlers to a drag handle:
+ *   const drag = usePointerDrag({ onMove: ({ dx }) => setWidth(w0 - dx), threshold: 10 })
+ *   <div {...drag} />
+ */
+export function usePointerDrag(opts: PointerDragOptions) {
+  const st = useRef<DragInternal>({
+    startX: 0, startY: 0, lastX: 0, lastY: 0, lastT: 0, vx: 0, vy: 0, active: false, committed: false,
+  })
+  const optsRef = useRef(opts)
+  optsRef.current = opts
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    // Only start on the primary mouse button; touch/pen have button 0 or -1.
+    if (e.pointerType === 'mouse' && e.button !== 0) return
+    const el = e.currentTarget as HTMLElement
+    try { el.setPointerCapture(e.pointerId) } catch { /* capture is best-effort */ }
+    const s = st.current
+    s.startX = s.lastX = e.clientX
+    s.startY = s.lastY = e.clientY
+    s.lastT = e.timeStamp
+    s.vx = 0
+    s.vy = 0
+    s.active = true
+    s.committed = (optsRef.current.threshold ?? 10) <= 0
+    optsRef.current.onStart?.(e)
+    if (s.committed) {
+      optsRef.current.onMove({ dx: 0, dy: 0, x: e.clientX, y: e.clientY, vx: 0, vy: 0, first: true })
+    }
+    e.preventDefault()
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const s = st.current
+    if (!s.active) return
+    const dt = Math.max(1, e.timeStamp - s.lastT)
+    s.vx = ((e.clientX - s.lastX) / dt) * 1000
+    s.vy = ((e.clientY - s.lastY) / dt) * 1000
+    s.lastX = e.clientX
+    s.lastY = e.clientY
+    s.lastT = e.timeStamp
+    const dx = e.clientX - s.startX
+    const dy = e.clientY - s.startY
+    const threshold = optsRef.current.threshold ?? 10
+    if (!s.committed) {
+      if (Math.hypot(dx, dy) < threshold) return
+      s.committed = true
+    }
+    optsRef.current.onMove({ dx, dy, x: e.clientX, y: e.clientY, vx: s.vx, vy: s.vy, first: false })
+  }, [])
+
+  const end = useCallback((e: React.PointerEvent) => {
+    const s = st.current
+    if (!s.active) return
+    s.active = false
+    try { (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId) } catch { /* best-effort */ }
+    // Always fire onEnd once a drag has STARTED (onStart runs unconditionally on
+    // pointer-down), even for a sub-threshold tap that never committed — so a
+    // consumer that set teardown-critical state in onStart (e.g. a "dragging"
+    // suppression flag) is guaranteed the paired teardown. Without this, a stray
+    // click on a thin handle would leave that state set forever. dx/dy reflect
+    // actual movement (≈0 for a tap); `committed` tells the consumer whether the
+    // gesture crossed the threshold so it can skip drag-only work.
+    optsRef.current.onEnd?.({
+      dx: e.clientX - s.startX,
+      dy: e.clientY - s.startY,
+      x: e.clientX,
+      y: e.clientY,
+      vx: s.committed ? s.vx : 0,
+      vy: s.committed ? s.vy : 0,
+      first: false,
+      committed: s.committed,
+    })
+    s.committed = false
+  }, [])
+
+  return { onPointerDown, onPointerMove, onPointerUp: end, onPointerCancel: end }
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1008,7 +1008,7 @@
 @layer base {
   *{box-sizing:border-box;margin:0;padding:0}
   html,body,#root{height:100%}
-  body{font:400 0.875rem/1.55 var(--font-body);letter-spacing:-.02em;background:var(--bg);color:var(--text);
+  body{font:400 0.875rem/1.55 var(--font-body);letter-spacing:normal;background:var(--bg);color:var(--text);
     -webkit-font-smoothing:antialiased;overflow-x:hidden;overflow-y:auto;
     transition:background-color .25s ease,color .25s ease}
   /* Global focus ring for keyboard navigation */
@@ -1213,10 +1213,10 @@ body::before{content:'';position:fixed;top:-50%;left:-50%;width:200%;height:200%
 
 /* ── Topbar glass ── */
 .topbar-glass{
-  background:var(--chrome);
-  backdrop-filter:blur(12px) saturate(1.4);
-  -webkit-backdrop-filter:blur(12px) saturate(1.4);
-  border-bottom:1px solid var(--border);
+  background:color-mix(in srgb, var(--chrome) 74%, transparent);
+  backdrop-filter:blur(18px) saturate(1.8);
+  -webkit-backdrop-filter:blur(18px) saturate(1.8);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.10), 0 8px 12px -8px rgba(0,0,0,.30);
   transition:background-color .25s ease}
 
 /* ── Scroll shadow (fade at top/bottom of scrollable panels) ── */
@@ -1460,4 +1460,15 @@ body::before{content:'';position:fixed;top:-50%;left:-50%;width:200%;height:200%
 [data-theme*="dark"] .file-chip:not(.glass-static):hover {
   border-color: rgba(255, 255, 255, 0.09);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+/* ── TIER1 a11y: reduced motion / transparency / contrast ── */
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{ transition-duration:0.01ms !important; scroll-behavior:auto !important }
+}
+@media (prefers-reduced-transparency: reduce){
+  .topbar-glass,.glass-surface{ backdrop-filter:none !important; -webkit-backdrop-filter:none !important; background:var(--bg) !important }
+}
+@media (prefers-contrast: more){
+  .glass-surface,.topbar-glass{ background:var(--bg) !important; border:1px solid var(--text) !important }
 }

--- a/website/src/test/DetailPanel.test.tsx
+++ b/website/src/test/DetailPanel.test.tsx
@@ -83,16 +83,36 @@ describe('DetailPanel width clamp (Mesh-2230)', () => {
     )
     const handle = container.querySelector('div.cursor-col-resize') as HTMLElement
     // start dragging from x=1000, then move left to x=300 → intended width 1100 (fits cap 1200)
-    fireEvent.mouseDown(handle, { clientX: 1000 })
-    act(() => { document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 })) })
+    fireEvent.pointerDown(handle, { clientX: 1000, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(handle, { clientX: 300, pointerId: 1 }) })
     expect(panelWidth(container)).toBe(1100)
     // viewport shrinks mid-drag (DevTools toggle / OS tile / zoom) → cap drops to 480.
     // The resize listener must be suppressed, so the in-flight width is untouched.
     act(() => { setViewport(800); window.dispatchEvent(new Event('resize')) })
     expect(panelWidth(container)).toBe(1100)
     // release: preferred width (1100) persists, live render clamps to fit (480).
-    act(() => { document.dispatchEvent(new MouseEvent('mouseup')) })
+    act(() => { fireEvent.pointerUp(handle, { clientX: 300, pointerId: 1 }) })
     expect(localStorage.getItem('mc-test-w')).toBe('1100')
+    expect(panelWidth(container)).toBe(480)
+  })
+
+  // Regression: a sub-threshold tap on the 6px handle must still reset the drag
+  // suppression flag. usePointerDrag fires onEnd on every pointer-up (committed
+  // or not), so a stray click can't wedge draggingRef=true and make later resize
+  // re-clamps early-return forever (which would re-expose the Mesh-2230/2813 overflow).
+  it('resets the drag guard after a sub-threshold click so later resizes still clamp', () => {
+    setViewport(2000) // cap = 1200
+    localStorage.setItem('mc-test-w', '1100')
+    const { container } = render(
+      <DetailPanel title="t" onClose={() => {}} storageKey="mc-test-w" initialWidth={1100} minWidth={300}>x</DetailPanel>,
+    )
+    expect(panelWidth(container)).toBe(1100)
+    const handle = container.querySelector('div.cursor-col-resize') as HTMLElement
+    // Stray click: down then up moving only 2px (< 6px threshold) → never commits.
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 })
+    act(() => { fireEvent.pointerUp(handle, { clientX: 502, pointerId: 1 }) })
+    // Viewport shrinks: the re-clamp guard must NOT be wedged → width clamps to fit.
+    act(() => { setViewport(800); window.dispatchEvent(new Event('resize')) }) // cap = 480
     expect(panelWidth(container)).toBe(480)
   })
 })
@@ -117,11 +137,11 @@ describe('DetailPanel row-aware width clamp (Mesh-2813)', () => {
     )
     const handle = container.querySelector('div.cursor-col-resize') as HTMLElement
     // Drag far left (start 900 → move to 0) would ask for 480 + 900 = 1380.
-    fireEvent.mouseDown(handle, { clientX: 900 })
-    act(() => { document.dispatchEvent(new MouseEvent('mousemove', { clientX: 0 })) })
+    fireEvent.pointerDown(handle, { clientX: 900, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(handle, { clientX: 0, pointerId: 1 }) })
     // Capped to row(1000) − reserve(400) = 600, NOT the viewport 1200.
     expect(panelWidth(container)).toBe(600)
-    act(() => { document.dispatchEvent(new MouseEvent('mouseup')) })
+    act(() => { fireEvent.pointerUp(handle, { clientX: 0, pointerId: 1 }) })
   })
 
   it('never lets the panel exceed rowWidth − reserveWidth however far you drag', () => {
@@ -131,11 +151,11 @@ describe('DetailPanel row-aware width clamp (Mesh-2813)', () => {
       <DetailPanel title="t" onClose={() => {}} initialWidth={400} minWidth={300} reserveWidth={500}>x</DetailPanel>,
     )
     const handle = container.querySelector('div.cursor-col-resize') as HTMLElement
-    fireEvent.mouseDown(handle, { clientX: 1000 })
-    act(() => { document.dispatchEvent(new MouseEvent('mousemove', { clientX: -5000 })) }) // absurd overshoot
+    fireEvent.pointerDown(handle, { clientX: 1000, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(handle, { clientX: -5000, pointerId: 1 }) }) // absurd overshoot
     expect(panelWidth(container)).toBe(700)
     expect(panelWidth(container)).toBeLessThanOrEqual(1200 - 500)
-    act(() => { document.dispatchEvent(new MouseEvent('mouseup')) })
+    act(() => { fireEvent.pointerUp(handle, { clientX: -5000, pointerId: 1 }) })
   })
 
   it('re-clamps a fitting width down when reserveWidth grows (sidebar widened)', () => {
@@ -162,10 +182,10 @@ describe('DetailPanel row-aware width clamp (Mesh-2813)', () => {
       <DetailPanel title="t" onClose={() => {}} initialWidth={400} minWidth={300}>x</DetailPanel>,
     )
     const handle = container.querySelector('div.cursor-col-resize') as HTMLElement
-    fireEvent.mouseDown(handle, { clientX: 1000 })
-    act(() => { document.dispatchEvent(new MouseEvent('mousemove', { clientX: -3000 })) })
+    fireEvent.pointerDown(handle, { clientX: 1000, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(handle, { clientX: -3000, pointerId: 1 }) })
     // No reserveWidth → row term drops out → capped at viewport 1200, not row(1000)-anything.
     expect(panelWidth(container)).toBe(1200)
-    act(() => { document.dispatchEvent(new MouseEvent('mouseup')) })
+    act(() => { fireEvent.pointerUp(handle, { clientX: -3000, pointerId: 1 }) })
   })
 })


### PR DESCRIPTION
## Problem
The KiroCrew dashboard (React 18 + framer-motion 12 + Tailwind 3) had concrete fluid-interface gaps surfaced by an Apple-design audit: accessibility media queries were **entirely absent** (`prefers-reduced-motion` only gated CSS, never the ~28 framer-motion components; `-reduced-transparency` / `-contrast` had zero occurrences), buttons gave no pointer-down feedback, several draggable/resizable panels used canned linear tweens, the topbar "glass" was effectively opaque, one global negative `letter-spacing` hurt small-label legibility, and the panel resizers were **mouse-only** (`onMouseDown` + document listeners) — dead on touch.

## Why it matters
Reduced-motion / reduced-transparency / high-contrast users got unmitigated motion and blur (an accessibility correctness gap, not just polish). Touch/trackpad users couldn't resize panels at all. And the motion lacked the interruptible, velocity-aware feel that makes an interface feel native.

## Fix (symptom → root cause → change)
- **a11y absent → add the three media queries** in `index.css` (reduced-motion extended to transitions/scroll; reduced-transparency drops blur + raises opacity; contrast → solid bg + border) and **gate framer-motion via `useReducedMotion()`**.
- **no press feedback → `active:scale-95 active:duration-75`** on the base `Button`/`IconButton` (fix the primitive, not the copies).
- **canned tweens on gesture-driven panels → springs (`bounce:0`)** in `OverlayDrawer` / `CliPanel` / `DetailPanel` / `QueueStack` / `SegmentedControl`; blurred scrim on the shared `Modal` primitive; de-stack `QuestionCard` off translucent-on-translucent.
- **opaque topbar / global tracking → real translucent glass + size-specific tracking.**
- **mouse-only resizers → shared `usePointerDrag` hook** (Pointer Events + `setPointerCapture` for touch, velocity, momentum projection, rubber-band), wired into the `DetailPanel` & `CliPanel` splitters. **`DetailPanel` deliberately keeps a HARD width clamp (no rubber-band)** to preserve the Mesh-2813 overflow-guard invariant; `onEnd` fires on every pointer-up (committed drag *or* sub-threshold tap) so the drag guard can't wedge.

## Skill (shipped as a builtin)
Ships `src/kiro_crew/builtin_skills/apple-design/SKILL.md` (via `package_data`, synced to `~/.kirocrew/skills/` at runtime) — the audit codified as a reusable standard (house spring style, reference-good components, repo anti-patterns, review checklist). **Triggers narrowed to explicit Apple-style intent** (`apple design`, `fluid interface`, `optimize ui for feel`, …) with `always: false`, so shipping it to everyone stays opt-in and never auto-loads on generic frontend/CSS/modal work.

## Tests
- New regression test in `website/src/test/DetailPanel.test.tsx` for the **sub-threshold tap** (asserts the resize guard is released and never wedges) plus migration of the existing Mesh-2230/2238/2813 width-invariant tests to the Pointer Events API. Full frontend suite green locally (3658 tests / 323 files) + `tsc -b` clean.

## Manual verification
Toggle OS reduced-motion / reduced-transparency / increase-contrast and confirm motion/blur respond; resize the `DetailPanel`/`CliPanel` splitters via touch/trackpad; confirm a sub-threshold tap on the 6px handle leaves the panel resizable (no wedge). CI runs the real `vite build` (couldn't run in the authoring sandbox due to an `ulimit -n` EMFILE cap).

---
*Single commit `27e30b0`, rebased on latest `main`. Scope: `website/` + one builtin skill markdown — no Python runtime changes.*
