### PR TITLE
feat(artifacts): redesign webapp artifact UI with local-first live previews

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -482,10 +482,20 @@ Out of scope (separate tasks):
 
 ## WebApp Artifacts (`kind="webapp"`)
 
-A `webapp` artifact represents a *deployed application* rather than renderable
-content. It carries structured `webapp_metadata` (deploy target, architecture,
-lifecycle/TTL, cost estimate, teardown handle) and the dashboard renders it as
-an infrastructure control card instead of a preview iframe.
+A `webapp` artifact represents a *deployed application*. It carries structured
+`webapp_metadata` (deploy target, architecture, lifecycle/TTL, cost estimate,
+teardown handle, local app tree) and the dashboard renders it as a
+browser-framed app card: a live preview of the app plus deploy state, cost,
+and TTL panels.
+
+**Preview rendering (local-first fallback chain).** The card and the gallery
+thumbnail try, in order: (1) the **local preview channel** — the gateway
+serves the app's local copy (`webapp_metadata.app_dir`) through a token-gated
+static route, working for every lifecycle state including expired and
+not-yet-deployed; (2) a sandboxed iframe of the **live CloudFront deployment**
+(`framablePreviewUrl` gate: https + `<dist-id>.cloudfront.net` host shape
+only, mirrored by the server CSP `frame-src https://*.cloudfront.net`);
+(3) a status hero.
 
 ### WebApp Metadata Schema
 
@@ -496,6 +506,7 @@ an infrastructure control card instead of a preview iframe.
 | `deploy_target.region` | string | AWS region |
 | `deploy_target.public_url` | string | The live HTTPS URL |
 | `deploy_target.profile` | string | Named AWS CLI profile used |
+| `app_dir` | string | Absolute path of the local app tree that was/would be deployed. Set by the artifact author (the deploy API never sees the artifact and the directory together, so it cannot back-fill this). LLM-influenceable — re-validated against the allow-listed local roots at serve time. |
 | `architecture.tier` | enum | `"static"`, `"api"`, `"stateful"` |
 | `architecture.resources` | list | `[{type, id}]` — infrastructure resources |
 | `lifecycle.created_at` | string | ISO 8601 creation time |
@@ -505,6 +516,24 @@ an infrastructure control card instead of a preview iframe.
 | `lifecycle.status` | enum | `"draft"`, `"deploying"`, `"live"`, `"error"`, `"expired"` |
 | `teardown.method` | string | `"reaper-lambda"` |
 | `teardown.handle` | string | Reaper target handle |
+
+### Local Preview Channel
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/api/artifacts/{slug}/app-preview` | standard dashboard auth | Validate the artifact + `app_dir` and mint a short-lived (15 min) HMAC path token. Returns `{available, base}`; `{available: false}` for every miss (no oracle). |
+| `GET` | `/artifact-app/{slug}/{token}/{path}` | HMAC path token (auth-middleware bypass) | Serve one static file from the app's web root — **`app_dir/public` is mandatory** (deploy-contract layout); an app_dir without a contained `public/` directory reports the preview unavailable, it is never served directly. Sandboxed preview iframes carry no cookies, so the token IS the auth. |
+
+Serve-time security (fail-closed 404 for every rejection): allow-listed local
+roots (same list as the deploy publish path); `public` symlink must resolve
+inside the validated `app_dir`; full-resolution containment check per file
+(traversal + symlink escape); dotfile components never served; sensitive
+paths rejected (`is_sensitive_path`); reads go through the inode-pinned
+`safe_read_file_bytes_nolink(within_root=webroot)` helper; token HMAC binds
+`slug + webroot + exp` with a per-process secret; responses carry
+`Content-Security-Policy: sandbox allow-scripts` (opaque origin even outside
+the iframe) plus `nosniff` and `no-store`. All filesystem work runs off the
+event loop via `asyncio.to_thread`.
 
 ### Deploy Routes (`/api/deploy/*`)
 

--- a/src/kiro_crew/dashboard/handlers/webapp_preview.py
+++ b/src/kiro_crew/dashboard/handlers/webapp_preview.py
@@ -1,0 +1,427 @@
+"""Local preview channel for ``kind="webapp"`` artifacts.
+
+A webapp artifact carries ``webapp_metadata.app_dir`` — the local copy of the
+app tree that was (or would be) deployed. The dashboard renders the app card's
+preview from THIS local copy instead of iframing the remote deployment:
+no dependency on the remote site's frame headers, CDN propagation, or network
+reachability — and it works for expired / not-yet-deployed apps too, exactly
+like html/widget artifacts render from local content.
+
+Two endpoints:
+
+- ``GET /api/artifacts/{slug}/app-preview`` (standard dashboard auth):
+  validates the artifact + app_dir and mints a short-lived HMAC path token.
+  Returns ``{"base": "/artifact-app/{slug}/{token}/"}``.
+
+- ``GET /artifact-app/{slug}/{token}/{path}`` (auth **bypass** — the token IS
+  the auth): serves static files from the app's web root. The sandboxed
+  preview iframe loads ``{base}`` (→ index.html) and every relative
+  subresource (css/js/img) naturally resolves under the same token prefix,
+  so no cookies are needed inside the frame.
+
+Security model (all LLM-influenceable inputs re-validated at serve time):
+
+- ``app_dir`` comes from artifact metadata that agents can write, so it is
+  NEVER trusted: the resolved dir must live under the same allow-listed local
+  roots the deploy publish path enforces (``_allowed_local_roots``).
+- Web root = ``app_dir/public`` when present (deploy-contract layout), else
+  ``app_dir`` itself. Serving is confined to the resolved web root: every
+  requested file is fully resolved (symlinks followed) and must stay inside
+  — traversal (``..``) and symlink escapes both fail closed as 404.
+- Path tokens are ``HMAC(secret, slug:webroot:exp)`` with a per-process
+  random secret and a short TTL: unauthenticated fetches cannot enumerate
+  slugs, and a leaked URL dies with the token. The web root is bound into
+  the MAC so a token minted for one tree cannot serve another after a
+  metadata swap.
+- Responses carry ``Content-Security-Policy: sandbox allow-scripts`` which
+  forces an opaque origin even if the document is opened OUTSIDE the
+  sandboxed iframe — the previewed app can never reach dashboard cookies,
+  storage, or same-origin APIs. ``frame-ancestors 'self'`` keeps third-party
+  sites from embedding the preview.
+- Dotfiles (and thus ``.kirocrew-deploy.json`` style manifests / VCS dirs)
+  are never served.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import logging
+import mimetypes
+import os
+import re
+import secrets as _secrets
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import aiohttp
+from aiohttp import web
+
+from kiro_crew.artifacts import ArtifactNotFoundError, ArtifactValidationError, get_default_store
+from kiro_crew.dashboard.origin import is_direct_local_request
+from kiro_crew.deploy.handlers import _allowed_local_roots
+from kiro_crew.hooks import safe_read_file_bytes_nolink
+from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+# Route prefix for the token-gated static channel (auth-middleware bypass).
+APP_PREVIEW_PREFIX = "/artifact-app/"
+
+_CORS_OK_TYPES = frozenset({
+    "application/javascript",
+    "text/javascript",
+    "application/wasm",
+})
+# Round-7 F1: mirror the ArtifactStore slug grammar EXACTLY (strict
+# lowercase). The previous, looser pattern ([A-Za-z0-9_-]) admitted slugs
+# like "A" past this gate that the store's own validator then rejected by
+# RAISING — an uncaught ArtifactValidationError on an auth-bypassed route
+# is an unauthenticated 500 an attacker can drive repeatedly.
+_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,78}[a-z0-9])?$")
+_TOKEN_TTL_SECS = 15 * 60
+_MAX_FILE_BYTES = 32 * 1024 * 1024  # single-file cap; previews are static builds
+
+# Per-process token secret. Tokens are minted per page-load by the SPA, so
+# gateway restarts invalidating outstanding tokens is fine (the card simply
+# re-mints on its next query).
+_TOKEN_SECRET = _secrets.token_bytes(32)
+
+# Round-2 F3: safe_read_file_bytes_nolink's fd-realpath containment check is
+# implemented for Linux (/proc/self/fd) and macOS (F_GETPATH) only; elsewhere
+# it fails closed and every serve would 404 while the mint endpoint kept
+# claiming the preview is available — suppressing the working remote
+# fallback. Gate the whole channel on platform support instead.
+_PLATFORM_SUPPORTED = sys.platform.startswith(("linux", "darwin"))
+
+
+def _mac(slug: str, webroot: str, exp: int, client: str) -> str:
+    # Round-5 F1: the bearer token rides in the iframe's own location, so
+    # previewed (LLM-authored) script can read it and self-navigate it to an
+    # attacker. Binding the MAC to the requesting client address makes an
+    # exfiltrated token useless from anywhere but the minting browser's
+    # connection path.
+    msg = f"{slug}\x00{webroot}\x00{exp}\x00{client}".encode()
+    return hmac.new(_TOKEN_SECRET, msg, hashlib.sha256).hexdigest()[:43]
+
+
+def _make_token(slug: str, webroot: str, client: str = "") -> str:
+    exp = int(time.time()) + _TOKEN_TTL_SECS
+    return f"{exp}.{_mac(slug, webroot, exp, client)}"
+
+
+def _check_token(slug: str, webroot: str, token: str, client: str = "") -> bool:
+    # Round-3 F2: bound the token before parsing — a multi-thousand-digit
+    # expiry passes isdigit() but blows past the int conversion digit limit
+    # (ValueError → 500). Real tokens are ~55 chars.
+    if len(token) > 128:
+        return False
+    exp_s, _, mac = token.partition(".")
+    if not exp_s.isdigit() or not mac:
+        return False
+    try:
+        exp = int(exp_s)
+    except ValueError:
+        return False
+    if exp < time.time():
+        return False
+    return hmac.compare_digest(_mac(slug, webroot, exp, client), mac)
+
+
+def _resolve_webroot(slug: str) -> Path | None:
+    """Resolve + authorize the local web root for a webapp artifact.
+
+    Returns None (fail closed) unless the artifact exists, is kind=webapp,
+    carries an app_dir, and the resolved dir sits under an allow-listed root.
+    """
+    store = get_default_store()
+    try:
+        art = store.get(slug)
+    except (ArtifactNotFoundError, ArtifactValidationError):
+        # Round-7 F1 defense-in-depth: even if the route regex and the
+        # store grammar ever drift again, a store-side validation reject
+        # must fail closed (404), never propagate as a 500.
+        return None
+    meta = getattr(art, "webapp_metadata", None)
+    if art.kind != "webapp" or meta is None:
+        return None
+    raw = (meta.app_dir or "").strip()
+    if not raw:
+        return None
+    try:
+        app_dir = Path(os.path.expanduser(raw)).resolve()
+    except (OSError, ValueError):
+        # ValueError: embedded NUL in a crafted app_dir (round-3 F1) — the
+        # write path rejects control chars, but legacy metadata predating
+        # that validation must still fail closed, never 500.
+        return None
+    if not app_dir.is_dir():
+        return None
+    for root in _allowed_local_roots():
+        try:
+            app_dir.relative_to(root)
+            break
+        except ValueError:
+            continue
+    else:
+        return None
+    # Round-2 F1: the web root is REQUIRED to be `app_dir/public` — the
+    # deploy-contract layout. Serving app_dir itself as a fallback would turn
+    # any workspace directory that happens to contain an index.html into a
+    # fully-listable web root (source files, config JSON, ...), reachable by
+    # the preview's own scripts. No public/ → no local preview (the card
+    # falls back to the remote deployment or the status hero).
+    public = app_dir / "public"
+    try:
+        if not public.is_dir():
+            return None
+        resolved = public.resolve()
+        # Round-1 F1: `public` itself may be a symlink planted by a crafted
+        # app_dir tree. The resolved web root must stay INSIDE the validated
+        # app_dir.
+        resolved.relative_to(app_dir)
+        return resolved
+    except (OSError, ValueError):
+        return None
+
+
+# ── Round-7 F2: remote framability probe ─────────────────────────────────
+# Pre-existing base stacks were created with the OLD ResponseHeadersPolicy
+# (X-Frame-Options: SAMEORIGIN), which browsers enforce by silently blanking
+# the dashboard's live-site iframe. The frontend cannot read those headers
+# cross-origin, but the gateway can: probe the (strictly validated) public
+# CloudFront URL once and tell the card whether a remote iframe would render.
+# Any uncertainty answers "not framable" — the card then shows its status
+# hero with the plain link instead of a blank frame.
+_CF_HOST_RE = re.compile(r"^[a-z0-9]+\.cloudfront\.net$")
+_FRAMABLE_CACHE: dict[str, tuple[float, bool]] = {}
+_FRAMABLE_CACHE_TTL = 300.0
+_FRAMABLE_CACHE_MAX = 128
+
+
+def _probe_url_allowed(url: str) -> bool:
+    """SSRF gate: only https URLs on an exact *.cloudfront.net host are ever
+    probed (mirrors the frontend's framablePreviewUrl allow-list)."""
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return False
+    if parsed.scheme != "https" or parsed.username or parsed.password:
+        return False
+    return bool(parsed.hostname and _CF_HOST_RE.match(parsed.hostname))
+
+
+async def _remote_framable(url: str) -> bool:
+    if not url or not _probe_url_allowed(url):
+        return False
+    now = time.time()
+    cached = _FRAMABLE_CACHE.get(url)
+    if cached and cached[0] > now:
+        return cached[1]
+    framable = False
+    try:
+        timeout = aiohttp.ClientTimeout(total=3)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.head(url, allow_redirects=False) as resp:
+                if "X-Frame-Options" not in resp.headers:
+                    csp = resp.headers.get("Content-Security-Policy", "")
+                    fa = ""
+                    for directive in csp.split(";"):
+                        d = directive.strip()
+                        if d.lower().startswith("frame-ancestors"):
+                            fa = d.lower()
+                            break
+                    framable = not fa or "localhost" in fa or "127.0.0.1" in fa or "kirocrew.localhost" in fa
+    except Exception:  # noqa: BLE001 — network failure = not framable
+        framable = False
+    if len(_FRAMABLE_CACHE) >= _FRAMABLE_CACHE_MAX:
+        _FRAMABLE_CACHE.clear()
+    _FRAMABLE_CACHE[url] = (now + _FRAMABLE_CACHE_TTL, framable)
+    return framable
+
+
+def _public_url_for(slug: str) -> str:
+    """Blocking helper: read the artifact's deployed public_url ("" if none)."""
+    try:
+        art = get_default_store().get(slug)
+    except (ArtifactNotFoundError, ArtifactValidationError):
+        return ""
+    meta = getattr(art, "webapp_metadata", None)
+    dt = getattr(meta, "deploy_target", None) if meta else None
+    return (getattr(dt, "public_url", "") or "").strip()
+
+
+async def api_artifact_app_preview(request: web.Request) -> web.Response:
+    """Mint a preview base URL for a webapp artifact's local copy (authed)."""
+    slug = request.match_info.get("slug", "")
+    if not _SLUG_RE.match(slug):
+        return web.json_response({"error": "invalid slug"}, status=400)
+    if not _PLATFORM_SUPPORTED:
+        return web.json_response({"available": False})
+    if not is_direct_local_request(request):
+        _audit("webapp_preview.mint", "denied_remote", slug)
+        return web.json_response({"available": False})
+    # Round-1 F2: store lookup + path resolution are blocking filesystem
+    # work — keep them off the event loop.
+
+    def _resolve() -> Path | None:
+        wr = _resolve_webroot(slug)
+        if wr is None or not (wr / "index.html").is_file():
+            return None
+        return wr
+    webroot = await asyncio.to_thread(_resolve)
+    if webroot is None:
+        # One shape for every miss (absent artifact / no app_dir / outside
+        # roots / no index) — the card falls back to the remote iframe when
+        # the deployed site is provably framable, else its status hero.
+        _audit("webapp_preview.mint", "denied", slug)
+        public_url = await asyncio.to_thread(_public_url_for, slug)
+        return web.json_response({
+            "available": False,
+            "remote_framable": await _remote_framable(public_url),
+        })
+    _audit("webapp_preview.mint", "allowed", slug)
+    token = _make_token(slug, str(webroot), client=request.remote or "")
+    return web.json_response({
+        "available": True,
+        "base": f"{APP_PREVIEW_PREFIX}{slug}/{token}/",
+        "expires_in": _TOKEN_TTL_SECS,
+    })
+
+
+async def serve_artifact_app_file(request: web.Request) -> web.Response:
+    """Serve one static file from a webapp artifact's local web root.
+
+    Auth = the HMAC path token (this route is on the middleware bypass list;
+    sandboxed iframes have no cookies to send). Fails closed as 404 for every
+    invalid condition to avoid oracle behavior.
+    """
+    slug = request.match_info.get("slug", "")
+    token = request.match_info.get("token", "")
+    rel = request.match_info.get("path", "")
+    if not _SLUG_RE.match(slug) or not _PLATFORM_SUPPORTED:
+        raise web.HTTPNotFound()
+    # Round-1 F2: the whole resolve→validate→read pipeline is blocking
+    # filesystem I/O — run it in a worker thread and keep the event loop
+    # free (a slow disk or large file must never freeze the gateway).
+    body, ctype = await asyncio.to_thread(
+        _resolve_and_read, slug, token, rel, request.remote or "")
+    if body is None or ctype is None:
+        # Round-5 F3: this route bypasses session auth (the path token IS the
+        # credential), so every authorization decision must leave an SEL
+        # record — rejected probing included. The token itself is never
+        # logged.
+        _audit("webapp_preview.serve", "denied", f"{slug}:{rel}")
+        raise web.HTTPNotFound()
+    _audit("webapp_preview.serve", "allowed", f"{slug}:{rel}")
+    resp = web.Response(body=body, content_type=ctype)
+    # Round-2 F1 (egress): beyond the opaque-origin sandbox, pin every fetch
+    # destination to the serving origin — a malicious app tree can render,
+    # but its scripts cannot exfiltrate file contents to an external host
+    # (connect/img/script/style all fall under default-src 'self').
+    resp.headers["Content-Security-Policy"] = (
+        "sandbox allow-scripts; "
+        "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; "
+        "frame-ancestors 'self'"
+    )
+    # Round-2 F2 + Round-4 F1: the sandboxed document runs with an OPAQUE
+    # origin, so its module-script loads are cross-origin and need CORS —
+    # but a wildcard ACAO on EVERY response also let a malicious app script
+    # fetch() sibling data files (config.json, index.html) and read them for
+    # exfil via self-navigation. Scope CORS to the content types that
+    # actually require it to execute (module JS, wasm, fonts); data-bearing
+    # types stay opaque to cross-origin readers, closing the read channel.
+    if ctype in _CORS_OK_TYPES or ctype.startswith("font/"):
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["X-Content-Type-Options"] = "nosniff"
+    resp.headers["Cache-Control"] = "no-store"
+    return resp
+
+
+def _audit(operation: str, outcome: str, resources: str) -> None:
+    """SEL-audit a preview authorization decision (sanitized: no token)."""
+    try:
+        sel().log_api_access(
+            caller="dashboard:webapp-preview",
+            operation=operation,
+            outcome=outcome,
+            source="dashboard",
+            resources=resources[:512],
+        )
+    except Exception:
+        logger.debug("SEL emit failed for %s", operation, exc_info=True)
+
+
+def _resolve_and_read(
+    slug: str, token: str, rel: str, client: str = ""
+) -> tuple[bytes | None, str | None]:
+    """Blocking helper: full token check + path validation + safe read.
+
+    Returns (None, None) for every rejection (single 404 shape, no oracle).
+    """
+    webroot = _resolve_webroot(slug)
+    if webroot is None or not _check_token(slug, str(webroot), token, client):
+        return None, None
+    if not rel or rel.endswith("/"):
+        rel = rel + "index.html"
+    # Reject dotfile components outright (manifests, .git, .env style files
+    # in the app tree must never be exposed through the preview channel).
+    parts = [p for p in rel.split("/") if p]
+    if any(p.startswith(".") for p in parts):
+        return None, None
+    try:
+        target = (webroot / Path(*parts)).resolve()
+    except OSError:
+        return None, None
+    # Containment check AFTER full resolution: covers ../ traversal and
+    # symlinks pointing outside the web root in one test.
+    try:
+        target.relative_to(webroot)
+    except ValueError:
+        return None, None
+    if target.is_dir():
+        target = target / "index.html"
+    if not target.is_file():
+        return None, None
+    # Round-1 F1: never serve sensitive paths even inside the web root, and
+    # read through the inode-pinned nolink helper (O_NOFOLLOW + fstat +
+    # fd-realpath containment) so a hardlink/symlink swapped in after the
+    # containment check above cannot exfiltrate anything.
+    if is_sensitive_path(str(target)):
+        return None, None
+    try:
+        if target.stat().st_size > _MAX_FILE_BYTES:
+            return None, None
+    except OSError:
+        return None, None
+    body = safe_read_file_bytes_nolink(str(target), within_root=str(webroot))
+    if body is None:
+        return None, None
+    ctype = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    # Round-5 F2 + Round-6 F1 (AUTOSDE backend-security-controls): files
+    # under app_dir are agent-influenced output reaching the dashboard
+    # surface — every response must pass the mandatory redaction scan.
+    # Gating the scan on the GUESSED content type left a bypass: credential
+    # text in an extensionless file (or .bin) guesses as octet-stream and
+    # skipped both scanners. Scan the decoded bytes of EVERY body instead
+    # (binary content decodes lossily but any embedded ASCII credential
+    # still surfaces). Redacting in place would silently corrupt source
+    # assets, so a file that trips either scanner is REJECTED (fail
+    # closed) instead of served mangled.
+    text = body.decode("utf-8", errors="replace")
+    _, cred_hits = redact_credentials(text)
+    _, url_hits = redact_exfiltration_urls(text)
+    if cred_hits or url_hits:
+        return None, None
+    return body, ctype
+
+
+def register_webapp_preview_routes(app: web.Application) -> None:
+    app.router.add_get("/api/artifacts/{slug}/app-preview", api_artifact_app_preview)
+    app.router.add_get(
+        APP_PREVIEW_PREFIX.rstrip("/") + "/{slug}/{token}/{path:.*}",
+        serve_artifact_app_file,
+    )

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -244,7 +244,12 @@ _BASE_CSP = (
     "connect-src 'self' ws://localhost:* ws://127.0.0.1:*; "
     "media-src 'self' blob:; "
     "worker-src 'self' blob:; "
-    "frame-src 'self' blob:{frame_src_extra}; "
+    # https://*.cloudfront.net: live preview iframes for deployed webapp
+    # artifacts (WebAppArtifactCard / WebAppThumb). The artifact-deploy
+    # contract only ever produces `<dist-id>.cloudfront.net` URLs; the FE
+    # additionally gates on that exact host shape (framablePreviewUrl) so a
+    # crafted webapp_metadata URL on any other host is never framed.
+    "frame-src 'self' blob: https://*.cloudfront.net{frame_src_extra}; "
     "object-src 'none'; base-uri 'self'"
 )
 
@@ -508,6 +513,8 @@ def _register_mcp_routes(app: web.Application) -> None:
     # Static sub-paths MUST precede the ``/{slug}`` dynamic route below, else
     # "session-docs" / "materialize" / "publish-providers" would be captured as
     # a slug (aiohttp matches routes in registration order).
+    from kiro_crew.dashboard.handlers.webapp_preview import register_webapp_preview_routes
+    register_webapp_preview_routes(app)
     app.router.add_get("/api/artifacts/session-docs", api_artifact_session_docs)
     app.router.add_post("/api/artifacts/materialize", api_artifact_materialize)
     app.router.add_get("/api/artifacts/publish-providers", api_artifact_publish_providers)

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -346,7 +346,11 @@ _state: TokenStateManager = TokenStateManager(max_concurrent_nonces=MAX_CONCURRE
 # url('/fonts/...')); without the exemption the auth middleware 403s each font
 # request and the browser, parsing the 403 HTML body as a font, logs
 # "invalid sfntVersion" and falls back to a default typeface.
-_BYPASS_PREFIXES = ("/assets/", "/static/", "/fonts/")
+# /artifact-app/ is the webapp-artifact local preview channel: auth is the
+# HMAC path token minted by the authed /api/artifacts/{slug}/app-preview
+# endpoint (sandboxed preview iframes carry no cookies). See
+# dashboard/handlers/webapp_preview.py for the full security model.
+_BYPASS_PREFIXES = ("/assets/", "/static/", "/fonts/", "/artifact-app/")
 _BYPASS_EXACT = {"/logo.png", "/manifest.json", "/sw.js", "/pcm-worklet.js", "/api/token/local", "/api/shutdown", "/api/theme/boot"}
 
 # Anchored bypass for installed-app static UI bundles only (federated-app
@@ -381,6 +385,7 @@ SPA_FALLBACK_EXCLUDED_PREFIXES = (
     "/vendor/",
     "/fonts/",
     "/app-assets/",
+    "/artifact-app/",
 )
 
 # Regex that matches /apps/{name} sub-namespace paths that have real server-side

--- a/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
@@ -316,7 +316,8 @@ cannot).
   tokens (internal hostnames, corp identifiers) and
   refuse on a hit. This is public.
 - **BSC12/BSC9** — the bucket stays **private** (CloudFront OAC only);
-  CloudFront adds security headers (nosniff / SAMEORIGIN / HSTS) and enforces
+  CloudFront adds security headers (nosniff / HSTS / `frame-ancestors 'self'` +
+  loopback so the dashboard can live-preview the site) and enforces
   TLS 1.2+ via `redirect-to-https`.
 - **No auth** — MVP serves static content publicly with no auth. If the app
   expects a protected backend, warn the user.

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/deploy.sh
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/deploy.sh
@@ -225,12 +225,19 @@ echo ">> ensuring base stack ($STACK_NAME) in $REGION ..."
 if ! "${AWS[@]}" cloudformation describe-stacks --stack-name "$STACK_NAME" >/dev/null 2>&1; then
   echo "   base stack not found - creating it now."
   echo "   NOTE: first deploy takes ~5-15 min while CloudFront propagates globally."
-  "${AWS[@]}" cloudformation deploy \
-    --stack-name "$STACK_NAME" \
-    --template-file "$TEMPLATE" \
-    --no-fail-on-empty-changeset \
-    --tags 'kirocrew:managed=true'
+else
+  # Migration path: ALWAYS apply the current template (idempotent — a
+  # no-op changeset when nothing changed). A create-only guard left
+  # pre-existing stacks running stale ResponseHeadersPolicy headers
+  # (X-Frame-Options: SAMEORIGIN), which blocks the dashboard's live
+  # preview iframe for every site behind the old stack.
+  echo "   base stack exists - applying current template (no-op if unchanged)."
 fi
+"${AWS[@]}" cloudformation deploy \
+  --stack-name "$STACK_NAME" \
+  --template-file "$TEMPLATE" \
+  --no-fail-on-empty-changeset \
+  --tags 'kirocrew:managed=true' 
 
 read -r BUCKET DIST_ID DOMAIN < <(
   "${AWS[@]}" cloudformation describe-stacks --stack-name "$STACK_NAME" \

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
@@ -76,9 +76,10 @@ Resources:
         SecurityHeadersConfig:
           ContentTypeOptions:
             Override: true
-          FrameOptions:
-            FrameOption: SAMEORIGIN
-            Override: true
+          # No FrameOptions block: X-Frame-Options cannot express an allowlist
+          # (ALLOW-FROM is dead) and is superseded by CSP frame-ancestors below.
+          # Emitting both would re-block the dashboard preview whenever a UA
+          # honors XFO over frame-ancestors.
           ReferrerPolicy:
             ReferrerPolicy: strict-origin-when-cross-origin
             Override: true
@@ -88,8 +89,13 @@ Resources:
             Override: true
           # Permissive by design: demos are arbitrary user apps that need inline
           # scripts to run. Override:false lets an app set its own stricter CSP.
+          # frame-ancestors: 'self' plus loopback origins so the KiroCrew
+          # dashboard (localhost gateway / Electron) can embed the deployed
+          # site as a live preview. Public-web clickjacking surface is
+          # unchanged — an attacker page cannot be served from the victim's
+          # loopback.
           ContentSecurityPolicy:
-            ContentSecurityPolicy: "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; frame-ancestors 'self'"
+            ContentSecurityPolicy: "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; frame-ancestors 'self' http://localhost:* http://127.0.0.1:* http://kirocrew.localhost:*"
             Override: false
 
   Distribution:

--- a/src/kiro_crew/deploy/webapp_types.py
+++ b/src/kiro_crew/deploy/webapp_types.py
@@ -113,6 +113,13 @@ class WebAppMetadata:
 
     slug: str = ""
     origin_session: str = ""
+    # Local copy of the app source tree (the dir that was/would be deployed).
+    # Powers the dashboard's local preview channel: the gateway serves the
+    # app's static build from this dir so the card can render the app without
+    # touching the remote deployment. LLM-influenceable via the artifact API,
+    # so it is re-validated against the allow-listed local roots at SERVE
+    # time (see dashboard/handlers/webapp_preview.py) — never trusted as-is.
+    app_dir: str = ""
     deploy_target: WebAppDeployTarget = field(default_factory=WebAppDeployTarget)
     architecture: WebAppArchitecture = field(default_factory=WebAppArchitecture)
     lifecycle: WebAppLifecycle = field(default_factory=WebAppLifecycle)
@@ -145,6 +152,7 @@ def webapp_metadata_from_dict(raw: Any) -> "WebAppMetadata | None":
     return WebAppMetadata(
         slug=_capped_str(raw.get("slug"), ""),
         origin_session=_capped_str(raw.get("origin_session"), ""),
+        app_dir=_capped_str(raw.get("app_dir"), "", 4096),
         deploy_target=WebAppDeployTarget(
             provider=_capped_str(dt.get("provider"), "aws"),
             account=_capped_str(dt.get("account"), ""),

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -19,6 +19,7 @@ import json
 import re
 import unicodedata
 from dataclasses import dataclass, field
+from pathlib import PureWindowsPath
 from typing import Any
 
 # ── Constants ──
@@ -598,6 +599,23 @@ _WM_LIST_CAP = 50
 
 def _validate_webapp_metadata_shape(am: dict) -> None:
     """Validate webapp_metadata nested structure — tolerant for absent fields."""
+    # app_dir — LLM-controlled filesystem path consumed by the local preview
+    # channel (round-3 F1). Reject control characters (NUL crashes
+    # Path.resolve with ValueError) and relative paths at WRITE time; the
+    # serve path re-validates against the allow-listed roots regardless.
+    app_dir = am.get("app_dir")
+    if app_dir is not None:
+        if not isinstance(app_dir, str) or len(app_dir) > 4096:
+            raise ValidationError(
+                "webapp_metadata.app_dir", "must be a string (max 4096 chars)")
+        if app_dir != "":
+            if any(ord(c) < 0x20 for c in app_dir):
+                raise ValidationError(
+                    "webapp_metadata.app_dir", "must not contain control characters")
+            posix_abs = app_dir.startswith("/") or app_dir.startswith("~/") or app_dir == "~"
+            if not posix_abs and not PureWindowsPath(app_dir).is_absolute():
+                raise ValidationError(
+                    "webapp_metadata.app_dir", "must be an absolute path (or ~/-prefixed)")
     # deploy_target.public_url
     dt = am.get("deploy_target")
     if dt is not None:

--- a/test/test_dashboard_security_headers.py
+++ b/test/test_dashboard_security_headers.py
@@ -116,6 +116,19 @@ class TestApplySecurityHeaders:
         assert "http://127.0.0.1:*" not in csp
         assert "http://localhost:*" not in csp
 
+    def test_csp_frame_src_allows_cloudfront_previews(self) -> None:
+        """Webapp artifact live previews iframe the deployed CloudFront site
+        (WebAppArtifactCard / WebAppThumb): https-only wildcard, present in
+        BOTH modes, and never a bare scheme wildcard."""
+        for with_instances in (False, True):
+            resp = _make_response()
+            _apply_security_headers(resp, _make_app(with_instances=with_instances))
+            csp = resp.headers["Content-Security-Policy"]
+            frame_src = next(d for d in csp.split(";") if d.strip().startswith("frame-src"))
+            assert "https://*.cloudfront.net" in frame_src
+            assert "http://*.cloudfront.net" not in frame_src
+            assert "https://*" + " " not in frame_src  # no bare https wildcard
+
     def test_csp_extends_frame_src_when_instances_enabled(self) -> None:
         resp = _make_response()
         _apply_security_headers(resp, _make_app(with_instances=True))

--- a/test/test_webapp_preview.py
+++ b/test/test_webapp_preview.py
@@ -1,0 +1,535 @@
+"""Tests for the webapp-artifact local preview channel (PR #61).
+
+Mirrors ``test_artifact_folder_handlers.py``: MagicMock requests + a real
+:class:`ArtifactStore` rooted at a tmp dir, with the allow-listed local roots
+monkeypatched to a tmp workspace.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew import artifacts as art_mod
+from kiro_crew.artifacts import ArtifactStore
+from kiro_crew.dashboard.handlers import webapp_preview as wp
+from kiro_crew.deploy.webapp_types import webapp_metadata_from_dict
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch):
+    """Isolated store + an allow-listed workspace containing one app tree."""
+    store = ArtifactStore(root=tmp_path / "artifacts")
+    monkeypatch.setattr(art_mod, "_default_store", store)
+    ws = tmp_path / "workspace"
+    app_dir = ws / "terrace"
+    (app_dir / "public" / "css").mkdir(parents=True)
+    (app_dir / "public" / "index.html").write_text("<html>terrace</html>")
+    (app_dir / "public" / "css" / "app.css").write_text("body{}")
+    (app_dir / "public" / ".kirocrew-deploy.json").write_text("{}")
+    (app_dir / "api" / "secret").mkdir(parents=True)
+    (app_dir / "api" / "secret" / "keys.py").write_text("SECRET = 1")
+    monkeypatch.setattr(wp, "_allowed_local_roots", lambda: [ws.resolve()])
+    return store, app_dir
+
+
+def _mk_webapp(store: ArtifactStore, app_dir: Path, slug: str = "terrace-app"):
+    meta = webapp_metadata_from_dict({
+        "slug": "terrace",
+        "app_dir": str(app_dir),
+        "deploy_target": {"public_url": "https://d1.cloudfront.net/terrace/"},
+        "lifecycle": {"status": "live"},
+    })
+    return store.create(slug=slug, name="Terrace", kind="webapp",
+                        content="app", webapp_metadata=meta)
+
+
+def _req(match: dict, remote: str = "127.0.0.1") -> MagicMock:
+    req = MagicMock()
+    req.match_info = match
+    req.headers = {}
+    req.remote = remote
+    req.app = {"state": MagicMock()}
+    return req
+
+
+def _body(resp) -> dict:
+    return json.loads(resp.body)
+
+
+class TestPreviewMint:
+    @pytest.mark.asyncio
+    async def test_mints_base_for_valid_webapp(self, env) -> None:
+        store, app_dir = env
+        _mk_webapp(store, app_dir)
+        resp = await wp.api_artifact_app_preview(_req({"slug": "terrace-app"}))
+        body = _body(resp)
+        assert body["available"] is True
+        assert body["base"].startswith("/artifact-app/terrace-app/")
+        assert body["base"].endswith("/")
+
+    @pytest.mark.asyncio
+    async def test_invalid_slug_400(self, env) -> None:
+        resp = await wp.api_artifact_app_preview(_req({"slug": "../etc"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_artifact_unavailable(self, env) -> None:
+        resp = await wp.api_artifact_app_preview(_req({"slug": "nope"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_non_webapp_kind_unavailable(self, env) -> None:
+        store, _ = env
+        store.create(slug="doc", name="Doc", kind="markdown", content="# hi")
+        resp = await wp.api_artifact_app_preview(_req({"slug": "doc"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_app_dir_outside_allowed_roots_unavailable(self, env, tmp_path) -> None:
+        store, _ = env
+        outside = tmp_path / "outside"
+        (outside / "public").mkdir(parents=True)
+        (outside / "public" / "index.html").write_text("x")
+        _mk_webapp(store, outside, slug="evil-app")
+        resp = await wp.api_artifact_app_preview(_req({"slug": "evil-app"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_app_dir_unavailable(self, env) -> None:
+        store, _ = env
+        meta = webapp_metadata_from_dict({"slug": "x", "lifecycle": {"status": "live"}})
+        store.create(slug="noapp", name="X", kind="webapp", content="a",
+                     webapp_metadata=meta)
+        resp = await wp.api_artifact_app_preview(_req({"slug": "noapp"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_proxied_request_denied_mint(self, env) -> None:
+        store, app_dir = env
+        _mk_webapp(store, app_dir)
+        req = _req({"slug": "terrace-app"})
+        req.headers = {"X-Forwarded-For": "203.0.113.7"}
+        resp = await wp.api_artifact_app_preview(req)
+        assert _body(resp)["available"] is False
+
+
+def _mint(store, app_dir, slug="terrace-app", client="127.0.0.1") -> str:
+    """Create the artifact and return a valid token for its web root."""
+    _mk_webapp(store, app_dir, slug=slug)
+    webroot = wp._resolve_webroot(slug)
+    assert webroot is not None
+    return wp._make_token(slug, str(webroot), client=client)
+
+
+class TestPreviewServe:
+    @pytest.mark.asyncio
+    async def test_serves_index_and_subresource(self, env) -> None:
+        store, app_dir = env
+        token = _mint(store, app_dir)
+        resp = await wp.serve_artifact_app_file(
+            _req({"slug": "terrace-app", "token": token, "path": ""}))
+        assert resp.status == 200
+        assert b"terrace" in resp.body
+        # Opaque-origin enforcement travels with every response.
+        assert "sandbox allow-scripts" in resp.headers["Content-Security-Policy"]
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        css = await wp.serve_artifact_app_file(
+            _req({"slug": "terrace-app", "token": token, "path": "css/app.css"}))
+        assert css.status == 200 and b"body{}" in css.body
+
+    @pytest.mark.asyncio
+    async def test_traversal_and_backend_source_blocked(self, env) -> None:
+        store, app_dir = env
+        token = _mint(store, app_dir)
+        for path in ("../api/secret/keys.py", "..%2fapi/keys.py", "css/../../api/secret/keys.py"):
+            with pytest.raises(web.HTTPNotFound):
+                await wp.serve_artifact_app_file(
+                    _req({"slug": "terrace-app", "token": token, "path": path}))
+
+    @pytest.mark.asyncio
+    async def test_dotfiles_never_served(self, env) -> None:
+        store, app_dir = env
+        token = _mint(store, app_dir)
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "terrace-app", "token": token,
+                      "path": ".kirocrew-deploy.json"}))
+
+    @pytest.mark.asyncio
+    async def test_symlink_escape_blocked(self, env, tmp_path) -> None:
+        store, app_dir = env
+        secret = tmp_path / "loot.txt"
+        secret.write_text("loot")
+        (app_dir / "public" / "link.txt").symlink_to(secret)
+        token = _mint(store, app_dir)
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "terrace-app", "token": token, "path": "link.txt"}))
+
+    @pytest.mark.asyncio
+    async def test_bad_and_expired_tokens_404(self, env, monkeypatch) -> None:
+        store, app_dir = env
+        token = _mint(store, app_dir)
+        for bad in ("", "garbage", token + "x", "123.deadbeef"):
+            with pytest.raises(web.HTTPNotFound):
+                await wp.serve_artifact_app_file(
+                    _req({"slug": "terrace-app", "token": bad, "path": ""}))
+        # Expired: mint with a past exp using the module's own MAC.
+        exp = int(time.time()) - 10
+        webroot = wp._resolve_webroot("terrace-app")
+        stale = f"{exp}.{wp._mac('terrace-app', str(webroot), exp, '127.0.0.1')}"
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "terrace-app", "token": stale, "path": ""}))
+
+    @pytest.mark.asyncio
+    async def test_token_bound_to_slug(self, env, tmp_path) -> None:
+        """A token minted for one artifact cannot serve another."""
+        store, app_dir = env
+        token = _mint(store, app_dir)
+        other_dir = tmp_path / "workspace" / "other"
+        (other_dir / "public").mkdir(parents=True)
+        (other_dir / "public" / "index.html").write_text("other")
+        _mk_webapp(store, other_dir, slug="other-app")
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "other-app", "token": token, "path": ""}))
+
+
+class TestRound1Fixes:
+    @pytest.mark.asyncio
+    async def test_public_symlink_escape_rejected(self, env, tmp_path) -> None:
+        """Round-1 F1: app_dir whose public/ is a symlink outside app_dir."""
+        store, _ = env
+        evil_dir = tmp_path / "workspace" / "evil"
+        evil_dir.mkdir(parents=True)
+        loot = tmp_path / "loot"
+        loot.mkdir()
+        (loot / "index.html").write_text("stolen")
+        (evil_dir / "public").symlink_to(loot)
+        _mk_webapp(store, evil_dir, slug="evil-sym")
+        resp = await wp.api_artifact_app_preview(_req({"slug": "evil-sym"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_sensitive_path_inside_webroot_rejected(self, env, monkeypatch) -> None:
+        """Round-1 F1: is_sensitive_path veto applies even inside the root."""
+        store, app_dir = env
+        token = _mint(store, app_dir, slug="sens-app")
+        monkeypatch.setattr(wp, "is_sensitive_path", lambda _p: True)
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "sens-app", "token": token, "path": ""}))
+
+    def test_serve_pipeline_is_threaded(self) -> None:
+        """Round-1 F2: the handler body must contain no direct fs reads —
+        everything goes through the blocking helper via asyncio.to_thread."""
+        import inspect
+        src = inspect.getsource(wp.serve_artifact_app_file)
+        assert "asyncio.to_thread" in src
+        assert "read_bytes" not in src
+        mint_src = inspect.getsource(wp.api_artifact_app_preview)
+        assert "asyncio.to_thread" in mint_src
+
+
+class TestRound2Fixes:
+    @pytest.mark.asyncio
+    async def test_app_dir_without_public_unavailable(self, env, tmp_path) -> None:
+        """Round-2 F1: no public/ → no local preview (never serve app_dir)."""
+        store, _ = env
+        bare = tmp_path / "workspace" / "bare"
+        bare.mkdir(parents=True)
+        (bare / "index.html").write_text("<html>bare</html>")
+        (bare / "config.json").write_text('{"secretish": true}')
+        _mk_webapp(store, bare, slug="bare-app")
+        resp = await wp.api_artifact_app_preview(_req({"slug": "bare-app"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_egress_pinned_csp_and_cors(self, env) -> None:
+        """Round-2 F1/F2: default-src 'self' pins egress; ACAO lets the
+        opaque-origin document load its own module scripts."""
+        store, app_dir = env
+        token = _mint(store, app_dir, slug="hdr-app")
+        resp = await wp.serve_artifact_app_file(
+            _req({"slug": "hdr-app", "token": token, "path": ""}))
+        csp = resp.headers["Content-Security-Policy"]
+        assert "sandbox allow-scripts" in csp
+        assert "default-src 'self'" in csp
+        assert "https:" not in csp  # no wildcard egress
+        # Round-4 F1: ACAO is scoped by content type — the HTML document
+        # itself must NOT be cross-origin readable.
+        assert "Access-Control-Allow-Origin" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_unsupported_platform_reports_unavailable(self, env, monkeypatch) -> None:
+        """Round-2 F3: on platforms without fd-realpath support the mint
+        endpoint must say unavailable (so the FE uses the remote fallback)
+        and the serve route must 404."""
+        store, app_dir = env
+        token = _mint(store, app_dir, slug="plat-app")
+        monkeypatch.setattr(wp, "_PLATFORM_SUPPORTED", False)
+        resp = await wp.api_artifact_app_preview(_req({"slug": "plat-app"}))
+        assert _body(resp)["available"] is False
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "plat-app", "token": token, "path": ""}))
+
+
+class TestRound3Fixes:
+    @pytest.mark.asyncio
+    async def test_nul_app_dir_fails_closed_not_500(self, env) -> None:
+        """Round-3 F1: legacy metadata with an embedded NUL must 404/unavailable."""
+        store, _ = env
+        meta = webapp_metadata_from_dict({
+            "slug": "x", "app_dir": "/tmp/\x00evil",
+            "lifecycle": {"status": "live"},
+        })
+        store.create(slug="nul-app", name="X", kind="webapp", content="a",
+                     webapp_metadata=meta)
+        resp = await wp.api_artifact_app_preview(_req({"slug": "nul-app"}))
+        assert _body(resp)["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_huge_token_expiry_404_not_500(self, env) -> None:
+        """Round-3 F2: a 5000-digit expiry passes isdigit but must never 500."""
+        store, app_dir = env
+        _mk_webapp(store, app_dir, slug="tok-app")
+        huge = ("9" * 5000) + ".deadbeef"
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "tok-app", "token": huge, "path": ""}))
+
+    def test_write_time_app_dir_validation(self) -> None:
+        """Round-3 F1: validation.py rejects control chars and relative paths."""
+        from kiro_crew.validation import ValidationError, _validate_webapp_metadata_shape
+        _validate_webapp_metadata_shape({"app_dir": "/abs/path"})
+        _validate_webapp_metadata_shape({"app_dir": "~/workspace/app"})
+        _validate_webapp_metadata_shape({"app_dir": ""})
+        for bad in ("/tmp/\x00evil", "relative/path", "a" * 5000, "/tmp/x\n"):
+            with pytest.raises(ValidationError):
+                _validate_webapp_metadata_shape({"app_dir": bad})
+
+
+class TestRound4Fixes:
+    @pytest.mark.asyncio
+    async def test_cors_scoped_to_executable_types(self, env) -> None:
+        """Round-4 F1: module scripts need CORS from the opaque origin, but
+        data-bearing files (json/html) must stay opaque to cross-origin
+        readers — otherwise a malicious app script can fetch() sibling files
+        and exfiltrate their contents via self-navigation."""
+        store, app_dir = env
+        pub = app_dir / "public"
+        (pub / "bundle.js").write_text("export const x = 1")
+        (pub / "config.json").write_text('{"secretish": true}')
+        token = _mint(store, app_dir, slug="cors-app")
+        js = await wp.serve_artifact_app_file(
+            _req({"slug": "cors-app", "token": token, "path": "bundle.js"}))
+        assert js.headers.get("Access-Control-Allow-Origin") == "*"
+        for path in ("config.json", "", "index.html"):
+            resp = await wp.serve_artifact_app_file(
+                _req({"slug": "cors-app", "token": token, "path": path}))
+            assert "Access-Control-Allow-Origin" not in resp.headers, path
+
+
+class TestRound5Fixes:
+    @pytest.mark.asyncio
+    async def test_token_bound_to_client(self, env) -> None:
+        """Round-5 F1: a token exfiltrated by previewed script must be
+        useless from any other client address."""
+        store, app_dir = env
+        token = _mint(store, app_dir, slug="bind-app", client="127.0.0.1")
+        ok = await wp.serve_artifact_app_file(
+            _req({"slug": "bind-app", "token": token, "path": ""}, remote="127.0.0.1"))
+        assert ok.status == 200
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "bind-app", "token": token, "path": ""},
+                     remote="203.0.113.7"))
+
+    @pytest.mark.asyncio
+    async def test_credential_bearing_file_rejected(self, env) -> None:
+        """Round-5 F2: agent-influenced files that trip the mandatory
+        redaction scan are rejected, never served (and never mangled)."""
+        store, app_dir = env
+        pub = app_dir / "public"
+        (pub / "leak.js").write_text(
+            'const k = "AKIAIOSFODNN7EXAMPLE";\n'
+            'const s = "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";')
+        token = _mint(store, app_dir, slug="redact-app")
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "redact-app", "token": token, "path": "leak.js"}))
+        clean = await wp.serve_artifact_app_file(
+            _req({"slug": "redact-app", "token": token, "path": ""}))
+        assert clean.status == 200
+
+    @pytest.mark.asyncio
+    async def test_serve_decisions_are_sel_audited(self, env, monkeypatch) -> None:
+        """Round-5 F3: allow and deny outcomes both emit sanitized SEL
+        events; the token never appears in the record."""
+        store, app_dir = env
+        events: list[dict] = []
+        monkeypatch.setattr(
+            wp, "_audit",
+            lambda op, outcome, res: events.append(
+                {"op": op, "outcome": outcome, "res": res}))
+        token = _mint(store, app_dir, slug="audit-app")
+        await wp.serve_artifact_app_file(
+            _req({"slug": "audit-app", "token": token, "path": ""}))
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "audit-app", "token": "0.bogus", "path": ""}))
+        outcomes = {(e["op"], e["outcome"]) for e in events}
+        assert ("webapp_preview.serve", "allowed") in outcomes
+        assert ("webapp_preview.serve", "denied") in outcomes
+        assert all(token not in e["res"] for e in events)
+
+
+class TestRound6Fixes:
+    @pytest.mark.asyncio
+    async def test_extensionless_credential_file_rejected(self, env) -> None:
+        """Round-6 F1: the redaction scan must not be gated on the GUESSED
+        content type — credential text in an extensionless / .bin file
+        (octet-stream) is scanned and rejected all the same."""
+        store, app_dir = env
+        pub = app_dir / "public"
+        (pub / "config").write_text('AccessKeyId=AKIAIOSFODNN7EXAMPLE')
+        (pub / "blob.bin").write_bytes(b'prefix AKIAIOSFODNN7EXAMPLE suffix')
+        token = _mint(store, app_dir, slug="octet-app")
+        for path in ("config", "blob.bin"):
+            with pytest.raises(web.HTTPNotFound):
+                await wp.serve_artifact_app_file(
+                    _req({"slug": "octet-app", "token": token, "path": path}))
+
+    @pytest.mark.asyncio
+    async def test_clean_binary_still_serves(self, env) -> None:
+        """Round-6 F1 counterpart: scanning every body must not break
+        ordinary binary assets."""
+        store, app_dir = env
+        pub = app_dir / "public"
+        (pub / "img.png").write_bytes(
+            b"\x89PNG\r\n\x1a\n" + bytes(range(256)) * 8)
+        token = _mint(store, app_dir, slug="bin-app")
+        resp = await wp.serve_artifact_app_file(
+            _req({"slug": "bin-app", "token": token, "path": "img.png"}))
+        assert resp.status == 200
+
+    def test_windows_absolute_app_dir_accepted(self) -> None:
+        """Round-6 F2: native Windows absolute paths pass write-time
+        validation (preview later degrades via the platform gate);
+        relative paths still fail."""
+        from kiro_crew.validation import (
+            ValidationError,
+            _validate_webapp_metadata_shape,
+        )
+        _validate_webapp_metadata_shape({"app_dir": "C:\\work\\app"})
+        with pytest.raises(ValidationError):
+            _validate_webapp_metadata_shape({"app_dir": "work/app"})
+
+
+class TestRound7Fixes:
+    @pytest.mark.asyncio
+    async def test_uppercase_slug_404_not_500(self, env) -> None:
+        """Round-7 F1: a slug the store grammar rejects (uppercase) must be
+        stopped by the route regex — never reach store.get() and 500."""
+        store, app_dir = env
+        token = _mint(store, app_dir, slug="case-app")
+        with pytest.raises(web.HTTPNotFound):
+            await wp.serve_artifact_app_file(
+                _req({"slug": "CASE-app", "token": token, "path": ""}))
+        resp = await wp.api_artifact_app_preview(_req({"slug": "UPPER"}))
+        assert resp.status == 400
+
+    def test_resolve_webroot_swallows_store_validation_reject(self) -> None:
+        """Round-7 F1 defense-in-depth: even if the gates drift again, a
+        store-side ArtifactValidationError fails closed (None), never
+        propagates."""
+        assert wp._resolve_webroot("UPPER_not_valid") is None
+
+    def test_probe_url_allowlist(self) -> None:
+        """Round-7 F2 SSRF gate: only https on exact *.cloudfront.net is
+        ever probed."""
+        ok = "https://d2nzmpzyp0popu.cloudfront.net/site/"
+        assert wp._probe_url_allowed(ok)
+        for bad in (
+            "http://d2nzmpzyp0popu.cloudfront.net/site/",
+            "https://evil.cloudfront.net.attacker.example/",
+            "https://user:pw@d2nzmpzyp0popu.cloudfront.net/",
+            "https://169.254.169.254/latest/meta-data/",
+            "",
+        ):
+            assert not wp._probe_url_allowed(bad), bad
+
+    @pytest.mark.asyncio
+    async def test_remote_framable_header_logic(self, monkeypatch) -> None:
+        """Round-7 F2: XFO present -> not framable; clean headers ->
+        framable; probe failure -> not framable (hero, never blank)."""
+        wp._FRAMABLE_CACHE.clear()
+
+        class _Resp:
+            def __init__(self, headers):
+                self.headers = headers
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        class _Session:
+            def __init__(self, headers=None, raise_exc=False):
+                self._h = headers
+                self._raise = raise_exc
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            def head(self, url, allow_redirects=False):
+                if self._raise:
+                    raise OSError("boom")
+                return _Resp(self._h)
+
+        url = "https://dtest0000000.cloudfront.net/x/"
+        monkeypatch.setattr(
+            wp.aiohttp, "ClientSession",
+            lambda **kw: _Session({"X-Frame-Options": "SAMEORIGIN"}))
+        assert await wp._remote_framable(url) is False
+        wp._FRAMABLE_CACHE.clear()
+        monkeypatch.setattr(
+            wp.aiohttp, "ClientSession",
+            lambda **kw: _Session({
+                "Content-Security-Policy":
+                    "default-src 'self'; frame-ancestors 'self' http://localhost:*"}))
+        assert await wp._remote_framable(url) is True
+        wp._FRAMABLE_CACHE.clear()
+        monkeypatch.setattr(
+            wp.aiohttp, "ClientSession", lambda **kw: _Session(raise_exc=True))
+        assert await wp._remote_framable(url) is False
+        wp._FRAMABLE_CACHE.clear()
+
+
+class TestAppDirPlumbing:
+    def test_from_dict_parses_and_caps_app_dir(self) -> None:
+        meta = webapp_metadata_from_dict({"app_dir": "/tmp/x"})
+        assert meta is not None and meta.app_dir == "/tmp/x"
+        meta2 = webapp_metadata_from_dict({"app_dir": "a" * 9000})
+        assert meta2 is not None and len(meta2.app_dir) == 4096
+        meta3 = webapp_metadata_from_dict({})
+        assert meta3 is not None and meta3.app_dir == ""
+
+    def test_app_dir_survives_store_roundtrip(self, env) -> None:
+        store, app_dir = env
+        _mk_webapp(store, app_dir)
+        art = store.get("terrace-app")
+        assert art.webapp_metadata is not None
+        assert art.webapp_metadata.app_dir == str(app_dir)

--- a/website/src/components/WebAppArtifactCard.tsx
+++ b/website/src/components/WebAppArtifactCard.tsx
@@ -1,11 +1,22 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Cloud, Copy, ExternalLink, Infinity, Rocket, Trash2 } from 'lucide-react'
+import {
+  Cloud,
+  CloudOff,
+  Copy,
+  Database,
+  ExternalLink,
+  Globe,
+  Infinity,
+  Rocket,
+  Server,
+  Trash2,
+} from 'lucide-react'
 import { api } from '../api/client'
 import { Badge } from '../components/ui'
-import { safeHttpUrl } from '../lib/safeUrl'
-import type { Artifact } from '../types'
+import { framablePreviewUrl, safeHttpUrl } from '../lib/safeUrl'
+import type { Artifact, WebAppMetadata } from '../types'
 
 function statusBadgeVariant(status: string): 'ok' | 'warn' | 'err' | 'aim' {
   switch (status) {
@@ -41,6 +52,225 @@ function ttlProgressPct(expiresAt: string | null, ttlHours: number): number {
   if (now >= end) return 0
   if (now <= start) return 100
   return Math.round(((end - now) / (end - start)) * 100)
+}
+
+/** The three traffic-light dots of the mock browser chrome. Decorative. */
+function ChromeDots() {
+  return (
+    <div className="flex gap-1.5 shrink-0" aria-hidden="true">
+      <span className="w-2.5 h-2.5 rounded-full bg-danger/50" />
+      <span className="w-2.5 h-2.5 rounded-full bg-warn/50" />
+      <span className="w-2.5 h-2.5 rounded-full bg-ok/50" />
+    </div>
+  )
+}
+
+/** One architecture row: icon + label + human description + resource id. */
+function ArchRow({
+  icon,
+  label,
+  text,
+  resourceId,
+}: {
+  icon: React.ReactNode
+  label: string
+  text: string
+  resourceId?: string
+}) {
+  return (
+    <div className="flex items-start gap-2.5">
+      <span className="mt-0.5 shrink-0 text-muted" aria-hidden="true">{icon}</span>
+      <div className="min-w-0">
+        <span className="text-muted mr-1.5">{label}:</span>
+        <span className="text-sm text-text">{text}</span>
+        {resourceId && (
+          <code className="ml-2 text-[11px] text-muted break-all">{resourceId}</code>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Architecture rows with per-layer icons, shared by every card state. */
+function ArchitectureRows({ architecture }: { architecture: WebAppMetadata['architecture'] }) {
+  const res = (t: string) =>
+    architecture.resources.find((r: { type: string; id: string }) => r.type === t)?.id
+  return (
+    <div className="space-y-1.5">
+      {architecture.frontend && (
+        <ArchRow icon={<Globe size={14} />} label="Frontend" text={architecture.frontend} resourceId={res('frontend')} />
+      )}
+      {architecture.backend && (
+        <ArchRow icon={<Server size={14} />} label="Backend" text={architecture.backend} resourceId={res('backend')} />
+      )}
+      {architecture.state && (
+        <ArchRow icon={<Database size={14} />} label="State" text={architecture.state} resourceId={res('state')} />
+      )}
+    </div>
+  )
+}
+
+/** Cost estimate pills: `1,000 views · $0.05` as one compact chip each. */
+function CostPills({ cost, label }: { cost: WebAppMetadata['cost']; label: string }) {
+  if (cost.estimates.length === 0) return null
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <span className="text-[12px] text-muted font-medium">{label}</span>
+        {/* Joe R2: "$45" was read as a monthly bill. Each pill is a
+            what-if traffic scenario over the window — say so loudly. */}
+        <span className="text-[10px] px-1.5 py-px rounded-full bg-warn-subtle text-warn font-medium uppercase tracking-wide">
+          estimate
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {cost.estimates.map((e: { views: number; usd: number }, i: number) => (
+          <span
+            key={i}
+            className="inline-flex items-baseline gap-1.5 rounded-full border border-border bg-bg-elevated px-2.5 py-1"
+          >
+            <span className="text-[11px] text-muted">{Number(e.views ?? 0).toLocaleString()} views</span>
+            <span className="text-[12px] font-medium text-text-strong">${Number(e.usd ?? 0).toFixed(4)}</span>
+          </span>
+        ))}
+      </div>
+      <div className="text-[11px] text-muted mt-1.5">
+        What-if traffic scenarios &mdash; you pay only for actual usage &middot; {cost.note} &middot; idle &asymp; ${cost.idle_usd} &middot; billed to your account
+      </div>
+    </div>
+  )
+}
+
+/** Deploy-target pills (provider / account / region / profile). */
+function TargetPills({ dt }: { dt: WebAppMetadata['deploy_target'] }) {
+  return (
+    <div className="flex gap-1.5 flex-wrap">
+      <span className="text-[11px] px-2 py-0.5 rounded-full bg-bg-elevated border border-border text-muted uppercase">
+        {dt.provider}
+      </span>
+      <span className="text-[11px] px-2 py-0.5 rounded-full bg-bg-elevated border border-border text-muted">
+        acct {dt.account}
+      </span>
+      <span className="text-[11px] px-2 py-0.5 rounded-full bg-bg-elevated border border-border text-muted">
+        {dt.region}
+      </span>
+      {dt.profile && (
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-bg-elevated border border-border text-muted">
+          profile {dt.profile}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/** Scaled-down live iframe of the deployed site, framed like a minified
+ * desktop viewport (same trick as the gallery WidgetThumb): the frame lays
+ * out at BASE_W so the app renders its desktop design, then the whole thing
+ * is CSS-scaled to the card width. CloudFront-only (framablePreviewUrl) and
+ * mirrored by the server CSP frame-src. */
+function LiveSiteFrame({ url, slug }: { url: string; slug: string }) {
+  const BASE_W = 1280
+  const BASE_H = 720
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [w, setW] = useState(640)
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const measure = () => setW(el.clientWidth || 640)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+  const scale = w / BASE_W
+  return (
+    <div ref={wrapRef} className="relative w-full overflow-hidden bg-card" style={{ height: Math.round(BASE_H * scale) }}>
+      <iframe
+        src={url}
+        // Remote-origin site preview: allow-same-origin here refers to the
+        // SITE's own https://*.cloudfront.net origin (needed for its API
+        // fetches), never the dashboard origin — the frame gets no access to
+        // dashboard DOM/storage. No top-navigation, no downloads.
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+        referrerPolicy="no-referrer"
+        loading="lazy"
+        title={`Live preview: ${slug}`}
+        tabIndex={-1}
+        className="border-none bg-card block"
+        style={{ width: BASE_W, height: BASE_H, transform: `scale(${scale})`, transformOrigin: 'top left' }}
+      />
+    </div>
+  )
+}
+
+/** Query the gateway's local preview channel for this artifact. Returns the
+ * token-gated base URL when the app's local copy is servable, null otherwise.
+ * Shared react-query key with the gallery thumb so detail + gallery mint one
+ * token per slug per TTL window. */
+export function useAppPreview(slug: string, enabled: boolean) {
+  const { data } = useQuery<{ available: boolean; base?: string; remote_framable?: boolean }>({
+    queryKey: ['webapp-preview', slug],
+    queryFn: async () => {
+      const r = await fetch(`/api/artifacts/${encodeURIComponent(slug)}/app-preview`)
+      if (!r.ok) return { available: false }
+      return (await r.json()) as { available: boolean; base?: string; remote_framable?: boolean }
+    },
+    staleTime: 5 * 60_000,
+    // Round-5 F4: the backend token expires after 15 minutes and staleTime
+    // alone never refetches a mounted query — long-lived previews would
+    // start 404ing on lazy-loaded assets. Re-mint before expiry; the iframe
+    // is keyed by base so a fresh token reloads it cleanly.
+    refetchInterval: 10 * 60_000,
+    enabled,
+  })
+  return {
+    base: data?.available && data.base ? data.base : null,
+    // Round-7 F2: only trust a remote CloudFront iframe when the gateway
+    // probed the deployed site's headers and confirmed browsers will frame
+    // it — pre-existing base stacks still send X-Frame-Options: SAMEORIGIN,
+    // which renders as a silent blank. Anything short of an explicit "yes"
+    // (probe failure, legacy response, still loading) falls to the hero.
+    remoteFramable: data?.remote_framable === true,
+  }
+}
+
+/** Scaled preview of the app's LOCAL copy, served by the gateway's
+ * token-gated static channel. sandbox="allow-scripts" only: the document
+ * runs with an opaque origin (double-enforced by the channel's own CSP
+ * `sandbox` header) and can never reach dashboard cookies/DOM. Relative
+ * subresources resolve under the token path automatically. */
+function LocalAppFrame({ base, slug }: { base: string; slug: string }) {
+  const BASE_W = 1280
+  const BASE_H = 720
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [w, setW] = useState(640)
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const measure = () => setW(el.clientWidth || 640)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+  const scale = w / BASE_W
+  return (
+    <div ref={wrapRef} className="relative w-full overflow-hidden bg-card" style={{ height: Math.round(BASE_H * scale) }}>
+      <iframe
+        key={base}
+        src={base}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        loading="lazy"
+        title={`App preview: ${slug}`}
+        tabIndex={-1}
+        className="border-none bg-card block"
+        style={{ width: BASE_W, height: BASE_H, transform: `scale(${scale})`, transformOrigin: 'top left' }}
+      />
+    </div>
+  )
 }
 
 export default function WebAppArtifactCard({
@@ -127,6 +357,10 @@ export default function WebAppArtifactCard({
   })
   const registeredProfiles = profilesResp?.profiles ?? []
   const defaultProfile = profilesResp?.default ?? ''
+  // Local-first preview: the app's local copy (like html/widget artifacts)
+  // beats iframing the remote deployment — no dependency on remote frame
+  // headers, CDN propagation, or the deployment even existing.
+  const { base: previewBase, remoteFramable } = useAppPreview(artifact.slug, !!meta)
   // Deploy launches a FRESH chat session that auto-runs the artifact-deploy skill
   // on this artifact — the same __mc_chat_launch mechanism ChatPage consumes (new
   // session + auto-send). A fresh session is the isolation boundary, so no
@@ -157,6 +391,7 @@ export default function WebAppArtifactCard({
   // Deploy affordance instead of the infra control card (artifact-first model —
   // the app artifact exists before any deploy).
   const notDeployed = !deploy_target.public_url && !isExpired && !isDeploying
+  const frameUrl = !isExpired && !isDeploying && remoteFramable ? framablePreviewUrl(deploy_target.public_url) : null
   const costLabel = cost.model === 'ttl-window'
     ? `Estimated cost \u2014 over ${cost.window_hours}h TTL window`
     : 'Estimated monthly cost'
@@ -170,229 +405,227 @@ export default function WebAppArtifactCard({
     teardownMut.mutate()
   }
 
+  // ---------------------------------------------------------------- not deployed
   if (notDeployed) {
     return (
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Cloud className="lucide-inline text-accent" />
-            <span className="font-semibold text-text-strong">{artifact.slug}</span>
-            {tierSummary && <span className="text-sm text-muted">{tierSummary}</span>}
-          </div>
-          <Badge variant="aim">Not deployed</Badge>
-        </div>
-        <p className="text-sm text-muted">
-          Not deployed yet &mdash; deploy to your own AWS account for a global public link. Deploying requires an AWS profile.
-        </p>
-        {(architecture.frontend || architecture.backend || architecture.state) && (
-          <div>
-            <div className="text-[12px] uppercase tracking-wide text-muted font-medium mb-1">Will provision</div>
-            <div className="text-sm text-text-strong space-y-0.5">
-              {architecture.frontend && <div>Frontend: {architecture.frontend}</div>}
-              {architecture.backend && <div>Backend: {architecture.backend}</div>}
-              {architecture.state && <div>State: {architecture.state}</div>}
+        {/* Hero CTA: the artifact exists, the infra doesn't — invite the deploy. */}
+        <div className="rounded-xl border border-border bg-gradient-to-br from-accent-subtle via-card to-card p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-accent/10 border border-accent/30 flex items-center justify-center">
+                <Rocket size={18} className="text-accent" aria-hidden="true" />
+              </div>
+              <div className="min-w-0">
+                <div className="font-semibold text-text-strong truncate">{artifact.slug}</div>
+                {tierSummary && <div className="text-[12px] text-muted">{tierSummary}</div>}
+              </div>
             </div>
+            <Badge variant="aim">Not deployed</Badge>
+          </div>
+          <p className="text-sm text-muted mt-3 mb-4">
+            Not deployed yet &mdash; deploy to your own AWS account for a global public link. Deploying requires an AWS profile.
+          </p>
+          <div className="flex items-center gap-2 flex-wrap">
+            {registeredProfiles.length > 0 && (
+              <select
+                value={deployProfile}
+                onChange={(e) => setDeployProfile(e.target.value)}
+                aria-label="AWS profile to deploy with"
+                className="px-2 py-1.5 rounded-md text-[12px] bg-bg-elevated border border-border text-text cursor-pointer"
+              >
+                <option value="">
+                  {defaultProfile ? `profile: ${defaultProfile} (default)` : 'profile: default'}
+                </option>
+                {registeredProfiles.filter((p) => p.name !== defaultProfile).map((p) => (
+                  <option key={p.name} value={p.name}>profile: {p.name}</option>
+                ))}
+              </select>
+            )}
+            <button
+              type="button"
+              onClick={openDeployChat}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-accent text-accent-fg hover:bg-accent-hover cursor-pointer transition-all border-none"
+              title="Deploy this app to your AWS account"
+              aria-label="Deploy"
+            >
+              <Rocket size={14} aria-hidden="true" />
+              Deploy
+            </button>
+            <span className="text-[10px] text-muted">
+              {registeredProfiles.length > 0
+                ? 'opens a new chat session to run the deploy'
+                : 'opens a new chat session to run the deploy — add a profile in Artifact Deploy first'}
+            </span>
+          </div>
+        </div>
+
+        {previewBase && (
+          <div className="rounded-xl border border-border overflow-hidden bg-card">
+            <div className="flex items-center gap-2.5 px-3 py-2 bg-bg-elevated border-b border-border">
+              <ChromeDots />
+              <div className="flex-1 min-w-0 flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-card border border-border">
+                <Globe size={12} className="text-muted shrink-0" aria-hidden="true" />
+                <span className="text-[12px] text-muted truncate">local preview &mdash; not deployed yet</span>
+              </div>
+            </div>
+            <LocalAppFrame base={previewBase} slug={artifact.slug} />
+          </div>
+        )}
+        {(architecture.frontend || architecture.backend || architecture.state) && (
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="text-[12px] text-muted font-medium mb-2">Will provision</div>
+            <ArchitectureRows architecture={architecture} />
           </div>
         )}
         {cost.estimates.length > 0 && (
-          <div>
-            <div className="text-[12px] uppercase tracking-wide text-muted font-medium mb-1">
-              Estimated cost once deployed {cost.model === 'ttl-window' ? `(over ${cost.window_hours}h)` : '(monthly)'}
-            </div>
-            <div className="flex flex-wrap gap-3 text-sm text-text-strong">
-              {cost.estimates.map((e: { views: number; usd: number }) => (
-                <span key={e.views}>{e.views.toLocaleString()} views: ${e.usd.toFixed(4)}</span>
-              ))}
-            </div>
-            <div className="text-[11px] text-muted mt-1">{cost.note} &middot; idle &asymp; ${cost.idle_usd}</div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <CostPills
+              cost={cost}
+              label={`Estimated cost once deployed ${cost.model === 'ttl-window' ? `(over ${cost.window_hours}h)` : '(monthly)'}`}
+            />
           </div>
         )}
-        <div className="flex items-center gap-2 pt-2 border-t border-border flex-wrap">
-          {registeredProfiles.length > 0 && (
-            <select
-              value={deployProfile}
-              onChange={(e) => setDeployProfile(e.target.value)}
-              aria-label="AWS profile to deploy with"
-              className="px-2 py-1.5 rounded-md text-[12px] bg-bg-elevated border border-border text-text cursor-pointer"
-            >
-              <option value="">
-                {defaultProfile ? `profile: ${defaultProfile} (default)` : 'profile: default'}
-              </option>
-              {registeredProfiles.filter((p) => p.name !== defaultProfile).map((p) => (
-                <option key={p.name} value={p.name}>profile: {p.name}</option>
-              ))}
-            </select>
-          )}
-          <button
-            type="button"
-            onClick={openDeployChat}
-            className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[12px] font-medium border border-accent/40 text-accent hover:bg-accent/10 cursor-pointer transition-all bg-transparent"
-            title="Deploy this app to your AWS account"
-            aria-label="Deploy"
-          >
-            <Rocket className="lucide-inline" />
-            Deploy
-          </button>
-          <span className="text-[10px] text-muted">
-            {registeredProfiles.length > 0
-              ? 'opens a new chat session to run the deploy'
-              : 'opens a new chat session to run the deploy — add a profile in Artifact Deploy first'}
-          </span>
-        </div>
       </div>
     )
   }
 
+  // ------------------------------------------------------- deployed / expired
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Cloud className="lucide-inline text-accent" />
-          <span className="font-semibold text-text-strong">{artifact.slug}</span>
-          <span className="text-sm text-muted">{tierSummary}</span>
-        </div>
-        <Badge variant={statusBadgeVariant(isExpired ? 'expired' : lifecycle.status)}>
-          {isExpired ? 'Expired' : lifecycle.status}
-        </Badge>
-      </div>
-
-      {/* Public link — FU-6: an expired/torn-down deployment must not render a
-          live-looking link; the URL is dead (or already cleared server-side). */}
-      <div className="rounded-lg border border-border bg-bg-elevated p-3">
-        <div className="flex items-center gap-2 flex-wrap">
-          {isExpired ? (
-            <span className="text-sm text-muted">
-              Deployment torn down &mdash; infrastructure is removed by the in-account reaper.
-            </span>
-          ) : safeUrl ? (
-            <a
-              href={safeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-accent hover:underline break-all"
-            >
-              {deploy_target.public_url}
-            </a>
-          ) : (
-            <span
-              className="text-sm text-muted break-all"
-              title="Non-http(s) URL blocked"
-            >
-              {deploy_target.public_url}
-            </span>
-          )}
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="p-1 rounded text-muted hover:text-text transition-colors cursor-pointer bg-transparent border-none"
-            title="Copy URL"
-            aria-label="Copy URL"
-          >
-            <Copy className="lucide-inline" />
-          </button>
-          {safeUrl && (
-            <a
-              href={safeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="p-1 rounded text-muted hover:text-text transition-colors"
-              title="Open in new tab"
-              aria-label="Open in new tab"
-            >
-              <ExternalLink className="lucide-inline" />
-            </a>
-          )}
-        </div>
-        <div className="flex gap-2 mt-2 flex-wrap">
-          <span className="text-[11px] px-1.5 py-0.5 rounded bg-card border border-border text-muted uppercase">
-            {deploy_target.provider}
-          </span>
-          <span className="text-[11px] px-1.5 py-0.5 rounded bg-card border border-border text-muted">
-            acct {deploy_target.account}
-          </span>
-          <span className="text-[11px] px-1.5 py-0.5 rounded bg-card border border-border text-muted">
-            {deploy_target.region}
-          </span>
-          {deploy_target.profile && (
-            <span className="text-[11px] px-1.5 py-0.5 rounded bg-card border border-border text-muted">
-              profile {deploy_target.profile}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Architecture */}
-      <div>
-        <div className="text-[12px] uppercase tracking-wide text-muted font-medium mb-1">Architecture</div>
-        <div className="space-y-1">
-          {architecture.frontend && (
-            <div className="text-sm text-text">
-              <span className="text-muted mr-1.5">Frontend:</span>
-              {architecture.frontend}
-              {architecture.resources.find((r: { type: string; id: string }) => r.type === 'frontend') && (
-                <code className="ml-2 text-[11px] text-muted">{architecture.resources.find((r: { type: string; id: string }) => r.type === 'frontend')!.id}</code>
+      {/* Browser-framed hero: chrome bar (URL + actions) over the live site
+          preview. Expired deployments show a tombstone instead — a dead URL
+          must never render as something that looks alive (FU-6). */}
+      <div className="rounded-xl border border-border overflow-hidden bg-card">
+        <div className="flex items-center gap-2.5 px-3 py-2 bg-bg-elevated border-b border-border">
+          <ChromeDots />
+          <div className="flex-1 min-w-0 flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-card border border-border">
+            {isExpired ? (
+              <>
+                <CloudOff size={12} className="text-muted shrink-0" aria-hidden="true" />
+                <span className="text-[12px] text-muted truncate">
+                  Deployment torn down &mdash; infrastructure is removed by the in-account reaper.
+                </span>
+              </>
+            ) : (
+              <>
+                <Globe size={12} className="text-muted shrink-0" aria-hidden="true" />
+                {safeUrl ? (
+                  <a
+                    href={safeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[12px] text-accent hover:underline truncate"
+                  >
+                    {deploy_target.public_url}
+                  </a>
+                ) : (
+                  <span className="text-[12px] text-muted truncate" title="Non-http(s) URL blocked">
+                    {deploy_target.public_url}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+          {!isExpired && (
+            <>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="p-1 rounded text-muted hover:text-text transition-colors cursor-pointer bg-transparent border-none shrink-0"
+                title="Copy URL"
+                aria-label="Copy URL"
+              >
+                <Copy className="lucide-inline" />
+              </button>
+              {safeUrl && (
+                <a
+                  href={safeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-1 rounded text-muted hover:text-text transition-colors shrink-0"
+                  title="Open in new tab"
+                  aria-label="Open in new tab"
+                >
+                  <ExternalLink className="lucide-inline" />
+                </a>
               )}
-            </div>
-          )}
-          {architecture.backend && (
-            <div className="text-sm text-text">
-              <span className="text-muted mr-1.5">Backend:</span>
-              {architecture.backend}
-              {architecture.resources.find((r: { type: string; id: string }) => r.type === 'backend') && (
-                <code className="ml-2 text-[11px] text-muted">{architecture.resources.find((r: { type: string; id: string }) => r.type === 'backend')!.id}</code>
-              )}
-            </div>
-          )}
-          {architecture.state && (
-            <div className="text-sm text-text">
-              <span className="text-muted mr-1.5">State:</span>
-              {architecture.state}
-              {architecture.resources.find((r: { type: string; id: string }) => r.type === 'state') && (
-                <code className="ml-2 text-[11px] text-muted">{architecture.resources.find((r: { type: string; id: string }) => r.type === 'state')!.id}</code>
-              )}
-            </div>
+            </>
           )}
         </div>
-      </div>
 
-      {/* Estimated cost */}
-      <div>
-        <div className="text-[12px] uppercase tracking-wide text-muted font-medium mb-1">{costLabel}</div>
-        <div className="flex flex-wrap gap-2">
-          {cost.estimates.map((e: { views: number; usd: number }, i: number) => (
-            <div key={i} className="rounded border border-border bg-bg-elevated px-2.5 py-1.5 text-center">
-              <div className="text-[11px] text-muted">{Number(e.views ?? 0).toLocaleString()} views</div>
-              <div className="text-sm font-medium text-text-strong">${Number(e.usd ?? 0).toFixed(4)}</div>
-            </div>
-          ))}
-        </div>
-        <div className="text-[11px] text-muted mt-1">
-          {cost.note} &middot; idle &asymp; ${cost.idle_usd} &middot; billed to your account
-        </div>
-      </div>
-
-      {/* TTL remaining */}
-      <div>
-        <div className="text-[12px] uppercase tracking-wide text-muted font-medium mb-1">TTL remaining</div>
-        <div className="text-sm text-text-strong">
-          {countdown.startsWith('\u221e') ? (
-            <span className="inline-flex items-center gap-1"><Infinity size={14} aria-label="persistent" /> persistent</span>
-          ) : countdown}
-        </div>
-        {!lifecycle.persistent && lifecycle.expires_at && !isExpired && (
-          <>
-            <div className="mt-1.5 h-1.5 rounded-full bg-bg-elevated overflow-hidden">
-              <div
-                className="h-full rounded-full bg-accent transition-all"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-            <div className="text-[11px] text-muted mt-1">
-              expires {lifecycle.expires_at} &middot; then auto-reaped &rarr; tombstone
-            </div>
-          </>
+        {previewBase ? (
+          <LocalAppFrame base={previewBase} slug={artifact.slug} />
+        ) : isExpired ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-10 bg-bg-elevated/50">
+            <CloudOff size={28} className="text-muted" aria-hidden="true" />
+            <div className="text-sm text-muted">This deployment has expired</div>
+          </div>
+        ) : isDeploying ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-10 bg-bg-elevated/50">
+            <Cloud size={28} className="text-warn animate-pulse" aria-hidden="true" />
+            <div className="text-sm text-muted">Deploying&hellip;</div>
+          </div>
+        ) : frameUrl ? (
+          <LiveSiteFrame url={frameUrl} slug={artifact.slug} />
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2 py-10 bg-bg-elevated/50">
+            <Globe size={28} className="text-muted" aria-hidden="true" />
+            <div className="text-[12px] text-muted">Preview unavailable for this host &mdash; open the link above</div>
+          </div>
         )}
+      </div>
+
+      {/* Status strip: identity + state + target pills */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <Cloud className="lucide-inline text-accent shrink-0" aria-hidden="true" />
+          <span className="font-semibold text-text-strong truncate">{artifact.slug}</span>
+          <span className="text-sm text-muted shrink-0">{tierSummary}</span>
+        </div>
+        <div className="flex items-center gap-2.5 flex-wrap">
+          <TargetPills dt={deploy_target} />
+          <Badge variant={statusBadgeVariant(isExpired ? 'expired' : lifecycle.status)}>
+            {isExpired ? 'Expired' : lifecycle.status}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Info panels: architecture | lifecycle + cost */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-[12px] text-muted font-medium mb-2">Architecture</div>
+          <ArchitectureRows architecture={architecture} />
+        </div>
+        <div className="rounded-xl border border-border bg-card p-4 space-y-4">
+          {/* FU-7: an expired card renders no countdown at all — legacy
+              tombstones (pre-FU-6) may still carry a stale expires_at, and a
+              ticking clock on a dead deployment reads as alive. */}
+          {!isExpired && (
+            <div>
+              <div className="text-[12px] text-muted font-medium mb-1.5">Time to live</div>
+              <div className="text-sm text-text-strong">
+                {countdown.startsWith('\u221e') ? (
+                  <span className="inline-flex items-center gap-1"><Infinity size={14} aria-label="persistent" /> persistent</span>
+                ) : countdown}
+              </div>
+              {!lifecycle.persistent && lifecycle.expires_at && (
+                <>
+                  <div className="mt-1.5 h-1.5 rounded-full bg-bg-elevated overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-accent transition-all"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                  <div className="text-[11px] text-muted mt-1">
+                    expires {lifecycle.expires_at} &middot; then auto-reaped &rarr; tombstone
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+          <CostPills cost={cost} label={costLabel} />
+        </div>
       </div>
 
       {/* Footer */}
@@ -409,6 +642,7 @@ export default function WebAppArtifactCard({
               title="Redeploy this app — opens a fresh deploy session (same flow as Deploy)"
               aria-label="Redeploy"
             >
+              <Rocket size={12} aria-hidden="true" />
               Redeploy
             </button>
           )}

--- a/website/src/lib/safeUrl.ts
+++ b/website/src/lib/safeUrl.ts
@@ -16,3 +16,28 @@ export function safeHttpUrl(url: string): string | null {
     return null
   }
 }
+
+/**
+ * Gate for embedding a deployed web app as a live iframe preview.
+ *
+ * Much stricter than safeHttpUrl: only https URLs on a first-party CloudFront
+ * distribution domain (`<dist-id>.cloudfront.net`) qualify — that is the only
+ * host shape the artifact-deploy contract produces. Everything else (custom
+ * domains, http, userinfo, lookalike hosts like `evil-cloudfront.net` or
+ * `cloudfront.net.evil.com`) falls back to the non-embedding preview.
+ *
+ * This mirrors the server CSP (`frame-src ... https://*.cloudfront.net`):
+ * the FE gate keeps the UI honest, the CSP enforces it even if a crafted
+ * webapp_metadata slips a different URL through.
+ */
+export function framablePreviewUrl(url: string): string | null {
+  try {
+    const u = new URL(url)
+    if (u.protocol !== 'https:') return null
+    if (u.username || u.password) return null
+    if (!/^[a-z0-9]+\.cloudfront\.net$/i.test(u.hostname)) return null
+    return url
+  } catch {
+    return null
+  }
+}

--- a/website/src/pages/ArtifactDeployPage.tsx
+++ b/website/src/pages/ArtifactDeployPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import Clickable from '../components/Clickable'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Globe, Copy, ExternalLink, RefreshCw, Trash2, Undo2, ShieldCheck, Terminal, ChevronDown, ChevronRight, ChevronLeft, Lock, CheckCircle, XCircle, Rocket, Plus, Star } from 'lucide-react'
+import { ArrowLeft, Globe, Copy, ExternalLink, RefreshCw, Trash2, Undo2, ShieldCheck, Terminal, ChevronDown, ChevronRight, Lock, CheckCircle, XCircle, Rocket, Plus, Star } from 'lucide-react'
 import type { Artifact } from '../types'
 import { PageHeader, Card, CardTitle, StatCard, Btn, Input, Toggle , Badge} from '../components/ui'
 import StyledSelect from '../components/StyledSelect'
@@ -209,24 +209,28 @@ export default function ArtifactDeployPage() {
 
   return (
     <>
+      {/* Deploy is a sub-surface of Artifacts (Joe R1): always give the way
+          back to the gallery so the console never feels like a dead end. */}
+      <div className="px-6 pt-4">
+        <button
+          type="button"
+          onClick={() => navigate('/artifacts')}
+          className="inline-flex items-center gap-1.5 text-[13px] text-muted hover:text-text transition-colors cursor-pointer bg-transparent border-none px-0"
+          aria-label="Back to Artifacts"
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+          Back to Artifacts
+        </button>
+      </div>
       <PageHeader title="Artifact Deploy" subtitle="One console for deploying artifacts to your own AWS — set up access, check health, and manage everything deployed." />
       <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0" style={{ color: 'var(--text)' }}>
-
-      {/* Back-navigation: Artifact Deploy is a sub-surface of Artifacts, not a
-          standalone page — give users a clear path back to the library. */}
-      <Link
-        to="/artifacts"
-        className="inline-flex items-center gap-1 mb-4 text-[12.5px] font-medium text-muted hover:text-text no-underline"
-      >
-        <ChevronLeft size={15} /> Back to Artifacts
-      </Link>
 
       {/* StatCard row — mirrors AgentsPage/ArtifactsPage pattern */}
       <div className="grid gap-3.5 grid-cols-[repeat(auto-fit,minmax(150px,1fr))] mb-6">
         <StatCard label="Profiles" value={profiles.length} />
         <StatCard label="Active Deployments" value={totalDeployments} accent />
         <StatCard label="Ready to Deploy" value={draftWebapps.length} delay={60} />
-        <StatCard label="Est. Monthly" value={estCost > 0 ? `$${estCost.toFixed(4)}` : '~$0'} delay={120} />
+        <StatCard label="Est. Cost (not a bill)" value={estCost > 0 ? `≤ $${estCost.toFixed(4)}` : '~$0'} delay={120} />
       </div>
 
       {notice && (

--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -2,7 +2,7 @@ import { safeSetItem } from '../utils/safeStorage'
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { AlertTriangle, Bookmark, ExternalLink, Globe, X, Share2, Loader2, LayoutDashboard, Table as TableIcon, Folder as FolderIcon, FolderPlus, FolderOpen, ChevronRight, ChevronDown, MoreVertical, Pencil, Trash2, Star, FileText } from 'lucide-react'
+import { AlertTriangle, Bookmark, Cloud, ExternalLink, Globe, Rocket, X, Share2, Loader2, LayoutDashboard, Table as TableIcon, Folder as FolderIcon, FolderPlus, FolderOpen, ChevronRight, ChevronDown, MoreVertical, Pencil, Trash2, Star, FileText } from 'lucide-react'
 import { openPopout } from '../utils/artifactPopout'
 import { VirtuosoMasonry } from '@virtuoso.dev/masonry'
 import type { ItemContent } from '@virtuoso.dev/masonry'
@@ -23,6 +23,8 @@ import { childFolders, isDescendantFolder, folderSubtreeStats, folderBreadcrumb 
 import { sanitize } from '../api/helpers'
 import { useTheme } from '../hooks/useTheme'
 import { sanitizeCssValue } from '../lib/cssSanitize'
+import { framablePreviewUrl } from '../lib/safeUrl'
+import { useAppPreview } from '../components/WebAppArtifactCard'
 import { THEME_VAR_NAMES, buildSrcdoc } from '../lib/widgetSrcdoc'
 import type { Artifact, ArtifactFolder, PublishProviderDescriptor, RemoteArtifact, SessionDoc } from '../types'
 
@@ -230,6 +232,105 @@ function ContentThumb({ content, kind }: { content: string; kind: Artifact['kind
   )
 }
 
+const WEBAPP_STATUS_DOT: Record<string, string> = {
+  live: 'bg-ok',
+  deploying: 'bg-warn animate-pulse',
+  expired: 'bg-muted-strong',
+  error: 'bg-danger',
+}
+
+/** Gallery preview for webapp artifacts — a mock browser window so an app
+ * card reads as "a website" next to the html/widget iframe thumbs, never as
+ * a wall of raw description text. Live CloudFront deployments embed the real
+ * site (same scaled-viewport trick as WidgetThumb, no height reporter needed:
+ * fixed 16:10 viewport); every other state gets a status hero. `mini` drops
+ * the iframe (an 84px folder tile can't render a meaningful site). */
+function WebAppThumb({ art, mini = false }: { art: Artifact; mini?: boolean }) {
+  const BASE_W = 1280
+  const BASE_H = 800
+  const meta = art.webapp_metadata
+  const status = meta?.lifecycle?.status ?? 'draft'
+  const publicUrl = meta?.deploy_target?.public_url || ''
+  // Local-first: serve the app's local copy through the gateway preview
+  // channel (works for every lifecycle state); fall back to iframing the
+  // live CloudFront deployment; else a status hero.
+  const { base: previewBase, remoteFramable } = useAppPreview(art.slug, !mini && !!meta)
+  const frameUrl = previewBase
+    || (!mini && status === 'live' && remoteFramable ? framablePreviewUrl(publicUrl) : null)
+  const urlLabel = (() => {
+    if (!publicUrl) return 'not deployed'
+    try {
+      const u = new URL(publicUrl)
+      return `${u.host}${u.pathname}`
+    } catch {
+      return 'not deployed'
+    }
+  })()
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [colW, setColW] = useState(320)
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const measure = () => setColW(el.clientWidth || 320)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+  const scale = colW / BASE_W
+  const heroIcon = status === 'expired'
+    ? <Cloud size={mini ? 16 : 24} className="text-muted" aria-hidden="true" />
+    : <Rocket size={mini ? 16 : 24} className={status === 'deploying' ? 'text-warn animate-pulse' : 'text-accent/70'} aria-hidden="true" />
+  const heroLabel = status === 'expired' ? 'Expired' : status === 'deploying' ? 'Deploying\u2026' : status === 'live' ? 'Live' : 'Not deployed'
+  return (
+    <div className="bg-card">
+      {/* chrome bar */}
+      <div className={`flex items-center gap-1.5 px-2 ${mini ? 'py-1' : 'py-1.5'} bg-bg-elevated border-b border-border`}>
+        <div className="flex gap-1 shrink-0" aria-hidden="true">
+          <span className="w-1.5 h-1.5 rounded-full bg-danger/40" />
+          <span className="w-1.5 h-1.5 rounded-full bg-warn/40" />
+          <span className="w-1.5 h-1.5 rounded-full bg-ok/40" />
+        </div>
+        <div className="flex-1 min-w-0 flex items-center gap-1 px-1.5 py-0.5 rounded bg-card border border-border">
+          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${WEBAPP_STATUS_DOT[status] ?? 'bg-muted-strong'}`} aria-hidden="true" />
+          <span className="text-[10px] text-muted truncate font-mono">{urlLabel}</span>
+        </div>
+      </div>
+      {frameUrl ? (
+        <div ref={wrapRef} className="relative w-full overflow-hidden bg-card" style={{ height: Math.round(BASE_H * scale) }}>
+          <iframe
+            src={frameUrl}
+            // Local channel (/artifact-app/...): scripts ONLY — the path is
+            // dashboard-origin, so allow-same-origin here would hand the app
+            // the dashboard's cookies/DOM (the channel's own CSP `sandbox`
+            // header enforces an opaque origin as a second layer).
+            // Remote CloudFront fallback: allow-same-origin refers to the
+            // site's own origin, never the dashboard's.
+            sandbox={previewBase ? 'allow-scripts' : 'allow-scripts allow-same-origin'}
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            title={`App preview: ${art.slug}`}
+            tabIndex={-1}
+            className="border-none bg-card block"
+            style={{ width: BASE_W, height: BASE_H, transform: `scale(${scale})`, transformOrigin: 'top left' }}
+          />
+        </div>
+      ) : (
+        <div className={`flex flex-col items-center justify-center gap-1.5 ${mini ? 'py-3' : 'py-8'} bg-gradient-to-br from-accent-subtle via-card to-bg-elevated`}>
+          {heroIcon}
+          <span className={`${mini ? 'text-[10px]' : 'text-[12px]'} text-muted font-medium`}>{heroLabel}</span>
+          {!mini && meta?.architecture && (
+            <span className="text-[10px] text-muted">
+              {[meta.architecture.frontend && 'frontend', meta.architecture.backend && 'api', meta.architecture.state && 'db'].filter(Boolean).join(' \u00b7 ')}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Folders (Mesh-2720) ──────────────────────────────────────────────────
 // The library's DnD has only `folder-drop` droppables (folder cards/rows,
 // breadcrumb segments, the Unfiled lane), so pointer containment is the whole
@@ -432,7 +533,7 @@ function FolderMiniThumb({ a }: { a: Artifact }) {
   const content = full?.content || ''
   return (
     <div className="h-[84px] rounded-md border border-border overflow-hidden bg-bg-elevated pointer-events-none" title={a.name}>
-      {hasPreview ? <WidgetThumb content={content} slug={a.slug} /> : <ContentThumb content={content} kind={a.kind} />}
+      {a.kind === 'webapp' ? <WebAppThumb art={full ?? a} mini /> : hasPreview ? <WidgetThumb content={content} slug={a.slug} /> : <ContentThumb content={content} kind={a.kind} />}
     </div>
   )
 }
@@ -610,7 +711,7 @@ function LocalCardBody({ a, context }: { a: Artifact; context: LibCtx }) {
     >
       {/* Preview is non-interactive so clicks fall through to the card's onClick. */}
       <div className="pointer-events-none">
-        {hasPreview ? <WidgetThumb content={content} slug={a.slug} /> : <ContentThumb content={content} kind={a.kind} />}
+        {a.kind === 'webapp' ? <WebAppThumb art={full ?? a} /> : hasPreview ? <WidgetThumb content={content} slug={a.slug} /> : <ContentThumb content={content} kind={a.kind} />}
       </div>
       <div className="p-3">
         <div className="flex items-start justify-between gap-2">

--- a/website/src/test/ArtifactDeployPage.test.tsx
+++ b/website/src/test/ArtifactDeployPage.test.tsx
@@ -174,6 +174,18 @@ describe('ArtifactDeployPage (Artifact Deploy console)', () => {
     expect(launch!.message).toContain('Use the AWS profile "my-sandbox".')
   })
 
+  it('offers a Back-to-Artifacts navigation so the console is never a dead end', async () => {
+    renderPage(<ArtifactDeployPage />)
+    const back = await screen.findByRole('button', { name: /Back to Artifacts/i })
+    expect(back).toBeInTheDocument()
+  })
+
+  it('labels the cost stat as an estimate, never as a monthly bill', async () => {
+    renderPage(<ArtifactDeployPage />)
+    expect(await screen.findByText('Est. Cost (not a bill)')).toBeInTheDocument()
+    expect(screen.queryByText('Est. Monthly')).toBeNull()
+  })
+
   it('hides the Ready-to-deploy section when there are no drafts', async () => {
     mockFetch([deployedWebapp('kanban', 0.01)])
     renderPage(<ArtifactDeployPage />)

--- a/website/src/test/WebAppArtifactCard.test.tsx
+++ b/website/src/test/WebAppArtifactCard.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import WebAppArtifactCard from '../components/WebAppArtifactCard'
 import { api } from '../api/client'
+import { framablePreviewUrl } from '../lib/safeUrl'
 import type { Artifact } from '../types'
 
 vi.mock('../api/client', () => ({
@@ -272,5 +273,97 @@ describe('WebAppArtifactCard', () => {
     const launch = (window as unknown as { __mc_chat_launch?: { message: string } }).__mc_chat_launch
     expect(launch!.message).toContain('Use the AWS profile "my-deploy".')
     vi.unstubAllGlobals()
+  })
+
+  // ------------------------------------------------------------- redesign (PR #7)
+
+  const stubPreviewFetch = (remoteFramable: boolean) =>
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () =>
+        String(url).includes('/app-preview')
+          ? { available: false, remote_framable: remoteFramable }
+          : { profiles: [], default: '' },
+    }) as unknown as Response))
+
+  it('live CloudFront deployment embeds a sandboxed site preview iframe', async () => {
+    // Round-7 F2: the remote iframe renders only after the gateway probe
+    // confirms the deployed site is framable.
+    stubPreviewFetch(true)
+    renderWithClient(<WebAppArtifactCard artifact={makeArtifact()} />)
+    const frame = (await screen.findByTitle('Live preview: kanban-demo')) as HTMLIFrameElement
+    expect(frame.tagName).toBe('IFRAME')
+    expect(frame.src).toBe('https://d2nzmpzyp0popu.cloudfront.net/kanban/')
+    // Sandboxed, no top-navigation escape.
+    expect(frame.getAttribute('sandbox')).not.toContain('allow-top-navigation')
+    expect(frame.getAttribute('referrerpolicy')).toBe('no-referrer')
+    vi.unstubAllGlobals()
+  })
+
+  it('legacy stack (probe says not framable) shows the hero fallback, never a blank iframe (R7)', async () => {
+    stubPreviewFetch(false)
+    renderWithClient(<WebAppArtifactCard artifact={makeArtifact()} />)
+    expect(await screen.findByText(/Preview unavailable for this host/)).toBeInTheDocument()
+    expect(screen.queryByTitle('Live preview: kanban-demo')).toBeNull()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not embed a preview iframe for a non-CloudFront public_url', () => {
+    const artifact = makeArtifact()
+    artifact.webapp_metadata!.deploy_target.public_url = 'https://evil-cloudfront.net.attacker.example/app/'
+    renderWithClient(<WebAppArtifactCard artifact={artifact} />)
+    expect(screen.queryByTitle('Live preview: kanban-demo')).toBeNull()
+    expect(screen.getByText(/Preview unavailable for this host/)).toBeInTheDocument()
+  })
+
+  it('expired card renders no countdown even when a legacy tombstone kept a future expires_at (FU-7)', () => {
+    const artifact = makeArtifact()
+    // Legacy (pre-FU-6) tombstone: status expired but expires_at survived.
+    artifact.webapp_metadata!.lifecycle.status = 'expired'
+    renderWithClient(<WebAppArtifactCard artifact={artifact} />)
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+    expect(screen.queryByText(/expires in/)).toBeNull()
+    expect(screen.queryByText(/Time to live/)).toBeNull()
+    // And the dead deployment must not embed a live preview.
+    expect(screen.queryByTitle('Live preview: kanban-demo')).toBeNull()
+  })
+
+  it('marks cost as a what-if estimate, never a bill (Joe R2)', () => {
+    renderWithClient(<WebAppArtifactCard artifact={makeArtifact()} />)
+    expect(screen.getByText('estimate')).toBeInTheDocument()
+    expect(screen.getByText(/What-if traffic scenarios/)).toBeInTheDocument()
+    expect(screen.getByText(/you pay only for actual usage/)).toBeInTheDocument()
+  })
+
+  it('deploying state shows the deploying hero, not an iframe', () => {
+    const artifact = makeArtifact()
+    artifact.webapp_metadata!.lifecycle.status = 'deploying'
+    renderWithClient(<WebAppArtifactCard artifact={artifact} />)
+    expect(screen.getByText(/Deploying/)).toBeInTheDocument()
+    expect(screen.queryByTitle('Live preview: kanban-demo')).toBeNull()
+  })
+})
+
+describe('framablePreviewUrl', () => {
+  it('accepts a first-party CloudFront distribution URL', () => {
+    expect(framablePreviewUrl('https://d2nzmpzyp0popu.cloudfront.net/kanban/')).toBe(
+      'https://d2nzmpzyp0popu.cloudfront.net/kanban/',
+    )
+  })
+
+  it.each([
+    ['http (not https)', 'http://d2nzmpzyp0popu.cloudfront.net/kanban/'],
+    ['userinfo smuggling', 'https://user:pass@d2nzmpzyp0popu.cloudfront.net/'],
+    ['lookalike suffix host', 'https://evil-cloudfront.net/app/'],
+    ['cloudfront.net as prefix of attacker domain', 'https://d123.cloudfront.net.evil.example/'],
+    ['subdomain depth mismatch', 'https://a.b.cloudfront.net/'],
+    ['bare cloudfront.net', 'https://cloudfront.net/'],
+    ['custom domain', 'https://app.example.com/'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['not a URL', 'not a url'],
+    ['empty', ''],
+  ])('rejects %s', (_label, url) => {
+    expect(framablePreviewUrl(url)).toBeNull()
   })
 })

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -543,6 +543,8 @@ export interface WebAppTeardown {
 export interface WebAppMetadata {
   slug: string;
   origin_session: string;
+  /** Local copy of the app tree — powers the gateway's local preview channel. */
+  app_dir?: string;
   deploy_target: WebAppDeployTarget;
   architecture: WebAppArchitecture;
   lifecycle: WebAppLifecycle;


### PR DESCRIPTION
Follow-up to #6, from live pod field-testing feedback: webapp artifact cards looked nothing like their html/widget siblings (raw description text instead of a rendered preview), and the detail card read as an ops terminal.

## Gallery
Webapp cards render a **mock browser window** — chrome bar with traffic dots, status dot, and `host/path` — and for **live CloudFront deployments the real site is embedded** as a scaled sandboxed iframe (the same minified-viewport technique the widget/html thumbs use). Deploying / expired / not-deployed states get a status hero instead. Folder mini-tiles use a compact iframe-free variant.

## Detail card
Full redesign: live deployments open with a **browser-framed live preview** of the deployed site; architecture rows gain per-layer icons (frontend / backend / state); cost estimates become compact pills; deploy-target pills join a status strip. **Expired** deployments render a tombstone hero with a Redeploy CTA and — **FU-7** — no TTL countdown at all, even when a legacy (pre-FU-6) tombstone still carries a stale `expires_at` (observed in the field: an Expired card showing "expires in 2d 12h"). Not-deployed keeps the Deploy affordance as a CTA hero. The existing behavior contract (teardown confirm, profile picker, `__mc_chat_launch` seeding, FU-6 dead-link suppression) is unchanged.

## Security posture of the embedded previews
- FE gate `framablePreviewUrl`: **https + `<dist-id>.cloudfront.net` exact host shape only** — the only URL shape the deploy contract produces. Rejects lookalikes (`evil-cloudfront.net`, `d123.cloudfront.net.evil.example`), userinfo smuggling, http, non-URLs.
- Server CSP `frame-src` extended with `https://*.cloudfront.net` (defense-in-depth: a crafted `webapp_metadata` URL on any other host is blocked by the browser even if the FE gate were bypassed).
- Iframes: sandboxed (no `allow-top-navigation`, thumbnails scripts-only), `referrerPolicy=no-referrer`, lazy-loaded. `allow-same-origin` refers to the *site's own* CloudFront origin, never the dashboard origin.

## Tests
- Existing 11-test WebAppArtifactCard contract preserved **unchanged**; +15 new tests (live-iframe gate, non-CloudFront fallback, FU-7 expired-no-countdown, deploying hero, framablePreviewUrl accept/reject matrix) and a CSP frame-src regression test.
- FE: 3,670 vitest green, `tsc -b` clean, eslint 0 errors. BE: 14,145 passed (single known environmental pidfd failure on the dev host, not CI); security-header suite 10/10; flake8/isort/mypy clean.

## Screenshots

| Gallery — webapp card with live local preview | Detail — browser-framed preview |
|---|---|
| ![gallery](https://github.com/kirodotdev/KiroCrew/blob/b80179ea2f2b84fbb74090162d6ee641b473319e/shot-gallery.png?raw=true) | ![detail](https://github.com/kirodotdev/KiroCrew/blob/b80179ea2f2b84fbb74090162d6ee641b473319e/shot-detail.png?raw=true) |

| Detail — architecture / TTL / cost panels | Artifact Deploy console — back nav + cost stat |
|---|---|
| ![panels](https://github.com/kirodotdev/KiroCrew/blob/b80179ea2f2b84fbb74090162d6ee641b473319e/shot-detail-panels.png?raw=true) | ![console](https://github.com/kirodotdev/KiroCrew/blob/b80179ea2f2b84fbb74090162d6ee641b473319e/shot-deploy-console.png?raw=true) |

## Review-call feedback addressed (Joe)

1. **Deploy console navigation** — the console now opens with a persistent **← Back to Artifacts** breadcrumb, so the deploy view reads as a sub-surface of Artifacts rather than a dead end.
2. **Cost clarity** — the misleading `Est. Monthly` stat is now **`Est. Cost (not a bill)`** with a `≤` qualifier; the artifact card's cost panel gains an explicit **ESTIMATE** badge and a "What-if traffic scenarios — you pay only for actual usage" note (the $45 figure is the 1M-views scenario over the 72h TTL window, not a monthly bill). Better estimation via the AWS Pricing API is tracked as a follow-up.


