### PR TITLE
fix(ci): unique nightly wheel version (append HHMM) so version keys are never republished

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,17 +35,26 @@ jobs:
         id: stamp
         run: |
           DATE=$(date -u +%Y%m%d)
+          # Wheel stamp includes HHMM so re-running a nightly on the same UTC date can
+          # never republish an existing version key with different bytes. CloudFront
+          # caches cli/* as immutable (CACHING_OPTIMIZED); a republished key leaves
+          # stale wheels on some edges while the no-cache manifest is fresh, causing
+          # sha256 mismatch failures. All .dev stamps are 12 digits from now on, so
+          # PEP 440 integer ordering stays monotonic across days. Seconds close the
+          # same-minute double-dispatch window; publish-cli.yml additionally enforces
+          # never-republish with an S3 conditional write (If-None-Match).
+          STAMP=$(date -u +%Y%m%d%H%M%S)
           BASE=$(grep -m1 '__version__' src/kiro_crew/__init__.py | sed -E 's/.*= *"([^"]+)".*/\1/')
           # Desktop/Squirrel needs semver; the pip wheel needs PEP 440. Emit both:
           #   nightly_version (semver):  <base>-nightly.<date>  -> Electron app + S3 build path
-          #   wheel_version   (PEP 440): <base>.dev<date>       -> pip wheel, unique/pinnable per day
+          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS> -> pip wheel, unique per RUN (see below)
           # The old shared "-nightly.<date>" is invalid PEP 440, so setuptools normalized
           # every nightly wheel down to the base version (all became 0.1.0). ".dev<date>"
           # is valid PEP 440 and keeps nightly wheels uniquely versioned.
           echo "version=${BASE}-nightly.${DATE}" >> "$GITHUB_OUTPUT"
-          echo "wheel_version=${BASE}.dev${DATE}" >> "$GITHUB_OUTPUT"
+          echo "wheel_version=${BASE}.dev${STAMP}" >> "$GITHUB_OUTPUT"
           echo "Nightly (semver): ${BASE}-nightly.${DATE}"
-          echo "Wheel (PEP 440):  ${BASE}.dev${DATE}"
+          echo "Wheel (PEP 440):  ${BASE}.dev${STAMP}"
 
   build-wheel:
     name: Build Wheel (CLI)

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -102,8 +102,37 @@ jobs:
           fi
           CDN_BASE="${CDN_BASE%/}"
           PREFIX="cli/${CHANNEL}/${WHEEL_VERSION}"
-          aws s3 cp "$WHEEL_PATH" "s3://${BUCKET}/${PREFIX}/${WHEEL_NAME}"
-          aws s3 cp "${SUMS_DIR}/SHA256SUMS" "s3://${BUCKET}/${PREFIX}/SHA256SUMS"
+          # Conditional writes (If-None-Match: *): a versioned wheel key is IMMUTABLE.
+          # CloudFront caches cli/* as immutable, so republishing a key with different
+          # bytes leaves stale wheels on some edges while the no-cache manifest is
+          # fresh -> sha256 mismatch for some clients. A republish attempt gets HTTP
+          # 412. Retry idempotency: a job retry after a later-step failure re-uploads
+          # the same bytes -- on 412 we compare content and continue when identical,
+          # failing only on a genuine different-bytes republish.
+          put_immutable() {
+            key="$1"; body="$2"
+            if aws s3api put-object --bucket "${BUCKET}" --key "$key" \
+                --body "$body" --if-none-match '*' > /dev/null 2> /tmp/put_err; then
+              return 0
+            fi
+            if ! grep -q "PreconditionFailed" /tmp/put_err; then
+              cat /tmp/put_err >&2; return 1   # real error (creds, network), not 412
+            fi
+            # Compare via the CDN (no extra IAM needed): under the If-None-Match
+            # invariant an existing key was written exactly once, so the CDN's
+            # copy -- cached or origin-fetched -- is the only content that has
+            # ever existed at this key. This also compares against exactly the
+            # bytes clients receive.
+            curl -fsSL --retry 3 -o /tmp/existing "${CDN_BASE}/${key}"
+            if [ "$(sha256sum /tmp/existing | awk '{print $1}')" = "$(sha256sum "$body" | awk '{print $1}')" ]; then
+              echo "::notice::$key already exists with identical content (idempotent retry); skipping"
+              return 0
+            fi
+            echo "::error::$key exists with DIFFERENT content -- refusing to republish an immutable versioned key"
+            return 1
+          }
+          put_immutable "${PREFIX}/${WHEEL_NAME}" "$WHEEL_PATH"
+          put_immutable "${PREFIX}/SHA256SUMS" "${SUMS_DIR}/SHA256SUMS"
 
           WHEEL_URL="${CDN_BASE}/${PREFIX}/${WHEEL_NAME}"
 


### PR DESCRIPTION
## Problem
Two nightly runs on the same UTC date produce the same `.dev<date>` wheel version with different bytes, republishing the same S3 key. CloudFront caches `cli/*` as immutable (`CACHING_OPTIMIZED`), so some edges keep serving the first run's wheel while the no-cache manifest advertises the second run's sha256 — installers fail closed with a checksum mismatch on those edges.

Observed in production 2026-07-20: EC2 (us-west-2 edge) got the stale wheel for `0.1.0.dev20260719` while a Mac (different edge) got fresh bytes; both `cli.sh` and pip's `--require-hashes`-style verification refused to install. Repaired live with a targeted CloudFront invalidation.

## Fix
Stamp the wheel version with `date -u +%Y%m%d%H%M` instead of `%Y%m%d`. Every run's version is now unique, so a version key is never republished with different bytes — restoring the immutability assumption the CDN cache policy depends on.

- PEP 440 ordering stays monotonic: all new stamps are 12 digits, which sort above every existing 8-digit stamp.
- `publish-cli.yml` and `cli.sh` are format-agnostic (version is parsed from the wheel filename / feed manifest) — no other changes needed.
- The semver `nightly_version` (desktop/Squirrel path) is unchanged.

## Testing
- YAML validated.
- Verified no other workflow or script assumes the 8-digit `dev<date>` format.