### PR TITLE
ci: run stubbed E2E on PR via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,61 @@ jobs:
         with:
           name: coverage-frontend
           path: website/coverage/
+
+  e2e:
+    name: E2E (stub ACP backend, offline)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install backend (+ dev)
+        # setuptools is explicit: Python 3.12 no longer bundles it, and an
+        # editable install doesn't add it to the runtime venv -- but
+        # `setup.py test_e2e` imports setuptools.Command, so it must be present.
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install -e ".[voice,desktop]" --group dev
+
+      - name: Install frontend deps
+        working-directory: website
+        run: npm ci --no-audit --no-fund
+
+      - name: Build frontend
+        working-directory: website
+        run: npm run build
+
+      - name: Stage frontend into package
+        # The dashboard Playwright specs render the bundled UI the harness
+        # gateway serves from src/kiro_crew/static/dist. Mirror nightly.yml's
+        # build-wheel staging so the specs hit a real dashboard, not a 404.
+        run: |
+          rm -rf src/kiro_crew/static/dist
+          mkdir -p src/kiro_crew/static
+          cp -R website/dist src/kiro_crew/static/dist
+
+      - name: Install Playwright browser (Chromium)
+        working-directory: website
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E (smoke + Playwright)
+        # KIROCREW_E2E=1 is set by `setup.py test_e2e` itself. KIROCREW_E2E_REQUIRE=1
+        # turns environment-resolution misses (missing website dir, Playwright CLI,
+        # or node<18) into HARD failures -- without it a skipped suite counts as a
+        # pass and the gate goes green having run zero browser specs. The suite
+        # wires the packaged fake ACP backend (KIROCREW_KIRO_BIN) internally, so
+        # every turn is deterministic and offline: no Kiro/model calls, no cost.
+        env:
+          KIROCREW_E2E_REQUIRE: "1"
+        run: python setup.py test_e2e


### PR DESCRIPTION
## Description

Adds an `e2e` job to `ci.yml` so the offline E2E gate (`setup.py test_e2e` — HTTP smoke + Playwright dashboard specs) runs on every PR and push to `main`.

Today that suite runs in **no** workflow — only via a manual `python setup.py test_e2e`. So gateway↔subprocess↔ACP regressions (e.g. the PID-namespace subagent-routing break that shipped and had to be reverted) reach `main` uncaught. This shifts that check left to PR time.

**Zero AI cost:** the suite wires the packaged fake ACP backend internally via `KIROCREW_KIRO_BIN` (read at `src/kiro_crew/acp/client.py:232`). Every turn is deterministic and offline — no Kiro/model calls, no Bedrock, no auth. It still exercises our own code end to end (gateway spawn → ACP handshake → streamed reply → persistence → dashboard render).

`KIROCREW_E2E_REQUIRE=1` is set on the run step so an environment-resolution miss (missing `website/` dir, Playwright CLI, or node<18) is a **hard failure** rather than a silent skip — otherwise the gate could go green having run zero browser specs.

Job shape mirrors the existing `nightly.yml` build-wheel pattern (build `website/` → stage `website/dist` into `src/kiro_crew/static/dist`) so the Playwright specs render a real dashboard, and reuses `python setup.py test_e2e` as the single entry point (no command drift).

## Related Issues

<!-- link the subagent-routing tracking issue if one exists -->

## Testing

- [ ] Existing tests pass (`make test`) — not run locally (CI-config-only change, no source touched)
- [x] Workflow YAML validated: parses, `e2e` job registers 9 steps, triggers on PR + push to `main`
- [x] Contract verified against `setup.py::E2eTestCommand`, `test/test_e2e_smoke.py`, `test/test_playwright_e2e.py`, `website/playwright.config.ts`
- [ ] **Authoritative validation is this PR's own `e2e` run** (~10-min vite + Playwright suite; not practical on the dev host)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

---
_Authored with the assistance of an AI agent (MeshClaw/Kiro); reviewed by @smeyffret._
