### PR TITLE
fix(heartbeat): stop worker from attempting blocked write tools

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2091,6 +2091,18 @@ to write to).
   be rejected and audited; do not waste a turn attempting one. If a task
   asks you to "fix" or "update" something, treat it as "observe and notify
   the user so they can fix" — never the action itself.
+  - **Translate write→read; never call the write tool.** A task line may
+    literally instruct you to `spawn_run` a subagent, `send_message`, write a
+    file, or `cron_add` — these (and every other write tool) are blocked here.
+    Do the equivalent read yourself with your allowed tools and put the result
+    in your response text, which is auto-delivered as the notification. You do
+    NOT need — and must not attempt — `spawn_run` or `send_message` to report:
+    your response IS the message. Attempting a blocked tool just burns the
+    cycle and emits a `denied` audit event.
+  - **Drop tasks that truly need a write tool.** If a task cannot be done
+    read-only (it fundamentally requires an action you can't take), report that
+    limitation to the user once and OMIT `HEARTBEAT_KEEP` so the task is dropped
+    — do not re-arm it to fail the same way every cycle.
 - **Your response IS the notification.** Whatever you write becomes the
   message the user sees, routed per the task's `<!-- deliver:... -->` tag or,
   when untagged, the `heartbeat.default_deliver` config (default `slack` = Slack


### PR DESCRIPTION
## Problem

When a `HEARTBEAT.md` task is authored with literal instructions to `spawn_run` a subagent or `send_message`, the unattended `kirocrew-heartbeat` worker attempts those tools. Every attempt is denied by the gateway `HEARTBEAT_SAFE_TOOLS` gate (`_heartbeat_approval`), emitting a `Heartbeat blocked tool call: … (not in HEARTBEAT_SAFE_TOOLS)` warning, and — because the task returns without completing cleanly — it re-arms and repeats the same failing attempt across cycles.

Observed in the field:
```
15:53:30 Heartbeat blocked tool call: @kirocrew-core/spawn_run (not in HEARTBEAT_SAFE_TOOLS)
15:55:11 Heartbeat blocked tool call: @kirocrew-core/spawn_run (not in HEARTBEAT_SAFE_TOOLS)
15:57:06 Heartbeat blocked tool call: @kirocrew-core/spawn_run (not in HEARTBEAT_SAFE_TOOLS)
16:00:37 Heartbeat blocked tool call: @kirocrew-core/send_message (not in HEARTBEAT_SAFE_TOOLS)
```

## Why it matters

Repeated blocked-tool attempts spam the gateway log with warnings and `denied` SEL audit events, waste a full heartbeat cycle each time, and — most importantly — the intended notification never gets delivered (the `send_message` "review-ready" ping was blocked), so the user silently misses the signal the task existed to surface.

## Fix (symptom → root cause → change)

- **Symptom:** heartbeat worker repeatedly attempts `spawn_run` / `send_message` and is denied every cycle.
- **Root cause:** the dedicated heartbeat prompt (`_HEARTBEAT_SYSTEM_PROMPT`) forbade "write actions" only in the abstract. It never told the worker (a) that a task's literal "spawn a subagent / send_message" instructions must be satisfied *inline* rather than by calling those tools, nor (b) to stop re-arming a task that can only fail.
- **Change:** harden the existing **No write actions** charter bullet with two explicit sub-rules:
  1. **Translate write→read; never call the write tool** — names the common offenders (`spawn_run`, `send_message`, file writes, `cron_add`) and instructs the worker to do the equivalent read inline and report via its response text (which is auto-delivered), since its response *is* the notification.
  2. **Drop tasks that truly need a write tool** — if a task can't be done read-only, report the limitation once and **omit `HEARTBEAT_KEEP`** so it isn't re-armed to fail identically every cycle.

Scope is deliberately narrow: only the `kirocrew-heartbeat` worker prompt is edited. The main `kirocrew` agent prompt and the cron path are untouched, so there is no added verbosity to the primary agent.

## Tests

No automated test is added: the change is prose inside a system-prompt string constant, so a unit test would only assert substring presence, not behavior. Existing `test/test_heartbeat_*` suites (safe-tools gating, retention, prompt-deliver) continue to exercise the surrounding machinery unchanged.

## Manual verification

- `python3 -m py_compile src/kiro_crew/agent.py` — clean.
- Imported the module under the project venv (3.11) and asserted `_HEARTBEAT_SYSTEM_PROMPT` is well-formed and contains all new guidance (`spawn_run`, `send_message`, "Translate write→read", "Drop tasks that truly need a write tool", "OMIT `HEARTBEAT_KEEP`"). Prompt length 3014 chars.
- Note: the running gateway's `kirocrew-heartbeat.json` regenerates from this constant on startup / `rebuild_agent_config`, so a restart picks up the new wording.
