### PR TITLE
feat: enable Task Runner by default and improve Artifacts navigation

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -229,7 +229,7 @@ The Artifacts page is a single unified, searchable table with two conceptual
 inputs, distinguished by the leading **star** column:
 
 - **Starred artifacts** — real, saved artifacts with `pinned=true`. The
-  **Starred** view (default) shows only these; the star toggles `pinned` via
+  **Starred** view shows only these; the star toggles `pinned` via
   `PATCH /api/artifacts/{slug}/pin` (metadata-only, no version bump).
 - **Session documents** — a *virtual* firehose of non-code documents the agent
   produced across chats (from message `file_changes`), surfaced only in the
@@ -238,6 +238,10 @@ inputs, distinguished by the leading **star** column:
   pinned, file-backed artifact via `POST /api/artifacts/materialize`
   ("Virtual All + materialize-on-save"). Search matches name/source (incl. the
   originating session title); the file-type filter applies to both inputs.
+
+The page opens on the **All** view by default. The Starred/All selection is
+persisted per-browser (`localStorage['mc-artifacts-pinned-only']`), so a user
+who last chose **Starred** resumes there on their next visit.
 
 Materialization is authorization-gated: the requested path must appear in the
 recorded chat `file_changes` (never an arbitrary client path), and the read is

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1044,7 +1044,7 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "description": "Autonomous multi-step task execution — compose ideas, generate plans, and run them to completion",
         "author": "kirocrew",
         "tags": ["tasks", "autonomy", "execution"],
-        "defaultEnabled": False,
+        "defaultEnabled": True,
         "iconUrl": "/app-assets/projects/icon.svg",
         "heroImage": "/app-assets/projects/hero-light.svg",
         "heroImageDark": "/app-assets/projects/hero-dark.svg",
@@ -1288,6 +1288,14 @@ def register_builtin_apps() -> int:
         else:
             # Use defaultEnabled from definition (defaults to True for backward compat)
             default_enabled = app_data.get("defaultEnabled", True)
+            # Governance chokepoint. enable_app() normally enforces the ``apps``
+            # activation allowlist, but a *default-enabled* builtin is persisted
+            # here on first registration and never routes through enable_app() —
+            # which would let it bypass a host deny-by-default policy. Re-apply the
+            # same gate so a governance-denied app registers DISABLED. This is a
+            # no-op for default-disabled builtins (the historical case).
+            if default_enabled and _app_activation_denied(name):
+                default_enabled = False
             meta = InstalledApp(
                 name=name,
                 version=app_data["version"],

--- a/test/test_builtin_app_optional_enable.py
+++ b/test/test_builtin_app_optional_enable.py
@@ -373,20 +373,35 @@ class TestValidateBuiltinApp:
             assert errors == [], f"{app_data['name']} failed validation: {errors}"
 
     def test_all_builtins_default_disabled(self):
-        """Every shipped builtin app defaults to disabled (opt-in via App Store).
+        """Builtin apps default to disabled (opt-in via App Store), except for a
+        small, explicit allowlist of core surfaces we intentionally ship enabled.
 
         Builtin apps are hidden on a fresh install so the sidebar stays minimal;
-        users enable the ones they want from the Browse tab. Each entry must set
-        ``defaultEnabled: False`` explicitly rather than relying on the field's
-        backward-compat default of True.
+        users enable the ones they want from the Browse tab. Entries not on the
+        intentional default-on allowlist must set ``defaultEnabled: False``
+        explicitly rather than relying on the field's backward-compat default of
+        True. Adding an app to the allowlist is a deliberate product decision —
+        keep it small and update this test in the same change.
         """
         import kiro_crew.apps.manager as mgr
 
+        # Core surfaces intentionally enabled on a fresh install. A default-on
+        # builtin still honors the ``apps`` governance allowlist at registration
+        # (see test_default_enabled_builtin_respects_governance_deny).
+        intentionally_default_on = {"projects"}  # Task Runner
+
         for app_data in mgr._BUILTIN_APPS:
-            assert app_data.get("defaultEnabled") is False, (
-                f"{app_data['name']} must ship with defaultEnabled=False "
-                f"(got {app_data.get('defaultEnabled')!r})"
-            )
+            name = app_data["name"]
+            if name in intentionally_default_on:
+                assert app_data.get("defaultEnabled") is True, (
+                    f"{name} is on the intentional default-on allowlist but does "
+                    f"not set defaultEnabled=True (got {app_data.get('defaultEnabled')!r})"
+                )
+            else:
+                assert app_data.get("defaultEnabled") is False, (
+                    f"{name} must ship with defaultEnabled=False "
+                    f"(got {app_data.get('defaultEnabled')!r})"
+                )
 
     def test_all_file_based_builtins_default_disabled(self):
         """File-based builtin apps (apps/builtins/*/app.json) also default to disabled.
@@ -403,6 +418,56 @@ class TestValidateBuiltinApp:
                 f"{app_data['name']} (file-based builtin) must ship with "
                 f"defaultEnabled=False (got {app_data.get('defaultEnabled')!r})"
             )
+
+    def test_default_enabled_builtin_respects_governance_deny(self, app_home, monkeypatch):
+        """A default-enabled builtin still honors the ``apps`` allowlist.
+
+        register_builtin_apps() persists a default-enabled app on first
+        registration without routing through enable_app(), so it must re-apply
+        the same ``_app_activation_denied`` gate — otherwise a host deny-by-default
+        policy would be bypassed for default-on apps. When governance denies the
+        app, it must register DISABLED.
+        """
+        import kiro_crew.apps.manager as mgr
+
+        monkeypatch.setattr(mgr, "_app_activation_denied", lambda name: "denied by policy")
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "gov-denied-default-on",
+            "version": "1.0.0",
+            "displayName": "Governed",
+            "description": "Default-on app that governance denies",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+
+        register_builtin_apps()
+
+        meta = _read_installed("gov-denied-default-on")
+        assert meta is not None
+        assert meta.enabled is False, "governance-denied default-on builtin must register disabled"
+
+    def test_default_enabled_builtin_enabled_when_governance_permits(self, app_home, monkeypatch):
+        """When governance permits (the common case), a default-enabled builtin
+        registers enabled — the gate is a no-op absent a deny policy."""
+        import kiro_crew.apps.manager as mgr
+
+        monkeypatch.setattr(mgr, "_app_activation_denied", lambda name: None)
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "gov-ok-default-on",
+            "version": "1.0.0",
+            "displayName": "Permitted",
+            "description": "Default-on app that governance permits",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+
+        register_builtin_apps()
+
+        meta = _read_installed("gov-ok-default-on")
+        assert meta is not None
+        assert meta.enabled is True
 
 
 # ---------------------------------------------------------------------------

--- a/website/src/pages/ArtifactDeployPage.tsx
+++ b/website/src/pages/ArtifactDeployPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import Clickable from '../components/Clickable'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Globe, Copy, ExternalLink, RefreshCw, Trash2, Undo2, ShieldCheck, Terminal, ChevronDown, ChevronRight, Lock, CheckCircle, XCircle, Rocket, Plus, Star } from 'lucide-react'
+import { Globe, Copy, ExternalLink, RefreshCw, Trash2, Undo2, ShieldCheck, Terminal, ChevronDown, ChevronRight, ChevronLeft, Lock, CheckCircle, XCircle, Rocket, Plus, Star } from 'lucide-react'
 import type { Artifact } from '../types'
 import { PageHeader, Card, CardTitle, StatCard, Btn, Input, Toggle , Badge} from '../components/ui'
 import StyledSelect from '../components/StyledSelect'
@@ -211,6 +211,15 @@ export default function ArtifactDeployPage() {
     <>
       <PageHeader title="Artifact Deploy" subtitle="One console for deploying artifacts to your own AWS — set up access, check health, and manage everything deployed." />
       <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0" style={{ color: 'var(--text)' }}>
+
+      {/* Back-navigation: Artifact Deploy is a sub-surface of Artifacts, not a
+          standalone page — give users a clear path back to the library. */}
+      <Link
+        to="/artifacts"
+        className="inline-flex items-center gap-1 mb-4 text-[12.5px] font-medium text-muted hover:text-text no-underline"
+      >
+        <ChevronLeft size={15} /> Back to Artifacts
+      </Link>
 
       {/* StatCard row — mirrors AgentsPage/ArtifactsPage pattern */}
       <div className="grid gap-3.5 grid-cols-[repeat(auto-fit,minmax(150px,1fr))] mb-6">

--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -1135,7 +1135,11 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
   const [filter, setFilter] = useState('')
   const [tagFilter, setTagFilter] = useState('')
   const [kindFilter, setKindFilter] = useState<string>('')
-  const [pinnedOnly, setPinnedOnly] = useState(true)
+  // Default to "All" artifacts, but remember the last visit's choice: if the
+  // user last selected "Starred", start there again.
+  const [pinnedOnly, setPinnedOnly] = useState(
+    () => localStorage.getItem('mc-artifacts-pinned-only') === '1',
+  )
   const [view, setView] = useState<'grid' | 'table'>(
     () => (localStorage.getItem('mc-artifacts-view') === 'table' ? 'table' : 'grid'),
   )
@@ -1537,7 +1541,7 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
             <div className="inline-flex items-center rounded-lg border border-border bg-bg-elevated p-0.5" role="group" aria-label="Filter starred">
               <button
                 type="button"
-                onClick={() => setPinnedOnly(true)}
+                onClick={() => { setPinnedOnly(true); safeSetItem('mc-artifacts-pinned-only', '1') }}
                 aria-pressed={pinnedOnly}
                 className={`px-2.5 py-1 rounded-md text-[12px] font-medium transition-colors cursor-pointer border-none inline-flex items-center gap-1 ${pinnedOnly ? 'bg-accent text-accent-fg' : 'bg-transparent text-muted hover:text-text'}`}
               >
@@ -1545,7 +1549,7 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
               </button>
               <button
                 type="button"
-                onClick={() => setPinnedOnly(false)}
+                onClick={() => { setPinnedOnly(false); safeSetItem('mc-artifacts-pinned-only', '0') }}
                 aria-pressed={!pinnedOnly}
                 className={`px-2.5 py-1 rounded-md text-[12px] font-medium transition-colors cursor-pointer border-none ${!pinnedOnly ? 'bg-accent text-accent-fg' : 'bg-transparent text-muted hover:text-text'}`}
               >


### PR DESCRIPTION
## Problem
Three small UX/default gaps in the dashboard:

1. **Task Runner** ships as an opt-in builtin (`defaultEnabled: False`), so new installs don't see it in the sidebar until they discover and enable it from the App Store — despite it being a core surface we want available out of the box.
2. **Artifact Deploy** page is a dead end: there is no on-page navigation back to the Artifacts library it belongs to, so it reads like a standalone page.
3. **Artifacts** page always opens filtered to **Starred**, hiding everything else on first view and ignoring what the user looked at last time.

## Why it matters
New users never see Task Runner unless they hunt for it; users on the Deploy page have to use browser back / the sidebar to return to Artifacts; and users who keep most artifacts unstarred land on an empty-looking "Starred" view every visit.

## Fix (symptoms → root cause → change)
1. **Task Runner default** — root cause: the `projects` entry in `_BUILTIN_APPS` (`src/kiro_crew/apps/manager.py`) set `defaultEnabled: False`. Flipped to `True` so it registers enabled on first registration. `register_builtin_apps()` applies `defaultEnabled` only on first registration and preserves user state on restart, so this changes only the out-of-the-box experience for new installs; existing users keep their choice.
   - **Governance follow-on (found in review):** a default-enabled builtin is persisted at registration *without* routing through `enable_app()`, which is where the `apps` activation allowlist (`_app_activation_denied`) is enforced. As the first default-on builtin, `projects` would have bypassed a host deny-by-default policy on fresh installs. Fixed by re-applying `_app_activation_denied(name)` in the registration path: a governance-denied default-on app now registers **disabled**. No-op for default-disabled builtins.
2. **Deploy back-nav** — root cause: `ArtifactDeployPage` rendered only a `PageHeader` with no link home. Added a "← Back to Artifacts" link (`Link to="/artifacts"`, `ChevronLeft` icon) as the first child *inside* the standard content container, keeping `PageHeader` first so the established page skeleton is preserved.
3. **Artifacts default filter** — root cause: `pinnedOnly` state initialized to `true` with no persistence. Changed the initializer to read `localStorage['mc-artifacts-pinned-only']` (defaults to All when unset) and persist the choice via `safeSetItem` on each Starred/All toggle click — mirroring the existing `mc-artifacts-view` persistence pattern.

## Tests
- `test_builtin_app_optional_enable.py`: updated `test_all_builtins_default_disabled` to allow `projects` as an explicit, documented default-on exception (all other builtins still asserted `defaultEnabled=False`); added `test_default_enabled_builtin_respects_governance_deny` (denied → registers disabled) and `test_default_enabled_builtin_enabled_when_governance_permits` (permitted → enabled).
- Frontend changes are UI wiring; no unit-test surface in this repo.
- Docs: updated `docs/system-specs/modules/artifacts.md` to state **All** is the default view with the Starred/All selection persisted per-browser.

## Manual verification
- `test/test_builtin_app_optional_enable.py` + `test/test_governance_chokepoints.py`: 98 passed locally.
- `tsc --noEmit` on the website package: 0 errors.
- Artifacts filter: no stored key → All; choose Starred, reload → resumes on Starred.
- Deploy back-nav: the link routes to `/artifacts`; `PageHeader` remains the first element in the shell.
