### PR TITLE
fix(agent): grant tool_search built-in so MCP Tool Search actually activates

### DIFF
--- a/src/kiro_crew/config/defaults.json
+++ b/src/kiro_crew/config/defaults.json
@@ -14,6 +14,7 @@
     "introspect",
     "session",
     "report",
+    "tool_search",
     "@kirocrew-cron",
     "@kirocrew-core"
   ],


### PR DESCRIPTION
## Problem
The `agent.tool_search` setting is **on by default** and KiroCrew writes the kiro-cli overlay `<work_dir>/.kiro/settings/cli.json` = `{toolSearch.enabled:true, minPct:0, minTokens:0}` on every spawn — yet MCP Tool Search never actually engages. Empirically, across **5,653 recorded `toolUse` calls in 265 kiro-cli sessions, `tool_search` was invoked 0 times**, and MCP/builder tools (`ReadInternalWebsites`, `InternalSearch`, `CRRevisionCreator`, `BrazilBuildAnalyzerTool`, …) were called **directly** — which is only possible when their full specs are present (not deferred).

## Why it matters
Tool Search exists to keep the context window clear when many MCP servers are configured. With it silently inert, every turn ships the **full JSON schemas of all MCP tools** (well past kiro-cli's default 50k-token trigger for KiroCrew sessions), wasting context/tokens on every request and partially defeating a feature we advertise as enabled-by-default.

## Fix (symptoms → root cause → change)
- **Symptom:** overlay is written correctly (verified: `enabled=true`, thresholds `0`) and read correctly (kiro-cli builds its settings DB `with_workspace(current_dir()/.kiro/settings/cli.json)` and is spawned with `cwd=work_dir`), but no deferral happens.
- **Root cause:** in kiro-cli `crates/agent/src/agent/mod.rs` `make_tool_spec`, `tool_search_active = tool_names.contains(BuiltIn(ToolSearch)) && should_activate_tool_search(...)`. `get_available_tool_names` (`tools/mod.rs`) only inserts `ToolSearch` when the agent lists it explicitly **or** uses `"*"` — there is no unconditional insert (only `Summary` is force-added, for subagents). Our base agent template `config/defaults.json` uses an **explicit** `tools` allowlist that omitted `tool_search`, so `contains(ToolSearch)` was `false` → `tool_search_active=false` → the branch removes it and `filter_tool_names` keeps every MCP tool. The setting + overlay were a no-op.
- **Change:** add `"tool_search"` to the base `tools` allowlist in `config/defaults.json` (inherited by the kirocrew agent and its variants). `tool_search` is a **read-only, auto-allowed** built-in (kiro-cli `permissions.rs` → `Allow`), so no `allowedTools` entry is required. With the built-in now granted, the overlay's `enabled=true` + zeroed thresholds gate on a present tool → tool search activates and MCP specs are deferred/loaded on demand.

## Tests
Ran `test/test_agent.py` + `test/test_acp_tool_search.py` — **136 passed**. No test asserts the exact `defaults.json` tools list (existing `==` assertions use custom user-override configs; membership checks use `in`), so adding one entry is non-breaking. The overlay-writer tests are unaffected.

## Manual verification
Pending (owner will confirm): start a fresh kiro-cli-backend session and confirm the model now issues a `tool_search` tool call before invoking an MCP tool, and that non-activated MCP tools no longer appear as full specs in the request. Config-side wiring (overlay path/content, spawn cwd, kiro-cli settings-read path) was traced and confirmed working; this change closes the last gap (granting the built-in).
