### PR TITLE
fix(subagent): reap startup-stalled subagents fast instead of at the 30-min deadline

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -201,6 +201,7 @@ _TIMEOUT_SECS = 1800  # 30 minutes
 _TURN_LIMIT = 100
 _REAPER_INTERVAL = 60  # seconds between reaper sweeps
 _RESET_TIMEOUT = 30.0  # max seconds for session reset in finally block
+_STARTUP_TIMEOUT_SECS = 120  # max seconds a subagent may sit pre-first-turn with no runtime before the startup watchdog reaps it
 _ON_DONE_TIMEOUT = 1200.0  # outer cap: max total seconds for semaphore wait + injection
 INJECTION_TIMEOUT = 300.0  # inner cap: max seconds for a single stream_and_collect call
 
@@ -588,6 +589,12 @@ class SubagentInfo:
     # ``AgentConfig.subagent_cwd_allowed_roots``.
     cwd: str = ""
     _pid: int | None = None  # PID of kiro-cli child process, for tombstone diagnostics
+    # Wall-clock (time.time) when _run_inner actually began executing. Distinct
+    # from ``started`` (set at registration): a subagent may sit in ``_agents``
+    # awaiting spawn approval for an arbitrary time before execution begins. The
+    # startup watchdog measures from THIS timestamp so it never reaps an agent
+    # that is merely waiting for approval. None until execution starts.
+    _exec_started: float | None = None
     # Learned-cost high-water marks (dynamic-subagent-sizing.md §4.1), sampled
     # periodically by the reaper loop and folded into the cost store at exit.
     peak_rss_gb: float = 0.0
@@ -632,6 +639,7 @@ class SubagentManager:
         max_concurrent: int = _MAX_CONCURRENT,
         default_turn_limit: int = _TURN_LIMIT,
         default_timeout: int = _TIMEOUT_SECS,
+        startup_timeout: int = _STARTUP_TIMEOUT_SECS,
         on_tool_approval: ToolApprovalCallback | None = None,
         on_tool_approval_factory: (
             Callable[["SubagentInfo"], Callable[[LLMEvent], Awaitable[bool]]] | None
@@ -648,6 +656,7 @@ class SubagentManager:
         self._max_concurrent = max_concurrent
         self._default_turn_limit = default_turn_limit
         self._default_timeout = default_timeout if default_timeout > 0 else _TIMEOUT_SECS
+        self._startup_deadline = startup_timeout if startup_timeout > 0 else _STARTUP_TIMEOUT_SECS
         self._on_tool_approval = on_tool_approval  # fallback for non-auto sessions
         self._on_tool_approval_factory = on_tool_approval_factory
         self._on_spawn_approval = on_spawn_approval
@@ -1066,6 +1075,29 @@ class SubagentManager:
                 if info.done:
                     continue
                 elapsed = now - info.started
+                # Startup watchdog: a subagent that entered execution but is
+                # still on turn 0 with no runtime PID after the startup window
+                # is wedged in startup (e.g. a hung provider/ACP handshake that
+                # never launches the child process). Reap it fast with a clear
+                # "failed to start" error instead of burning the full deadline
+                # and surfacing a misleading 30-minute turn-0 timeout.
+                if self._is_startup_stalled(info, now):
+                    logger.warning(
+                        "Reaper: subagent %s failed to start within %ds "
+                        "(turn 0, no runtime launched), force-killing",
+                        agent_id,
+                        self._startup_deadline,
+                    )
+                    try:
+                        await self._force_reap(
+                            agent_id,
+                            info,
+                            now - (info._exec_started or now),
+                            reason="startup_timeout",
+                        )
+                    except Exception:
+                        logger.exception("Reaper: failed to reap %s", agent_id)
+                    continue
                 if elapsed <= self._default_timeout:
                     continue
                 logger.warning(
@@ -1092,7 +1124,26 @@ class SubagentManager:
             except Exception:
                 logger.debug("Reaper: tombstone pruning failed", exc_info=True)
 
-    async def _force_reap(self, agent_id: str, info: SubagentInfo, elapsed: float) -> None:
+    def _is_startup_stalled(self, info: SubagentInfo, now: float) -> bool:
+        """True if a subagent is wedged in startup and should be reaped early.
+
+        A subagent qualifies only once it has actually entered execution
+        (``_exec_started`` set by ``_run_inner``) yet has launched no runtime
+        (``_pid is None``) and produced no turn (``turns == 0``) within
+        ``_startup_deadline`` seconds. Keying on ``_exec_started`` — not the
+        registration timestamp ``started`` — means an agent merely awaiting
+        spawn approval (never entered ``_run_inner``) is never caught here.
+        """
+        exec_started = info._exec_started
+        if exec_started is None:
+            return False
+        return (
+            info.turns == 0 and info._pid is None and (now - exec_started) > self._startup_deadline
+        )
+
+    async def _force_reap(
+        self, agent_id: str, info: SubagentInfo, elapsed: float, *, reason: str = ""
+    ) -> None:
         """Kill a subagent's session process and mark it done."""
         session_key = f"subagent:{agent_id}"
 
@@ -1148,11 +1199,14 @@ class SubagentManager:
         if not info.done:
             info.done = True
             if not info.error:
-                info.error = f"Reaped after {int(elapsed)}s (exceeded {self._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False)}]"
+                if reason == "startup_timeout":
+                    info.error = f"Failed to start within {self._startup_deadline}s (no runtime launched, no turn produced) [{_timeout_context(info, include_elapsed=False)}]"
+                else:
+                    info.error = f"Reaped after {int(elapsed)}s (exceeded {self._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False)}]"
             self._running_count = max(0, self._running_count - 1)
             freed_slot = True
             Stats().inc_subagent_failed()
-            self._write_tombstone(info, "reaped")
+            self._write_tombstone(info, reason or "reaped")
             self._record_cost(info)
         info.reaped = True
         # A reap/cancel frees a slot but — unlike normal completion (the `if not
@@ -1992,6 +2046,10 @@ class SubagentManager:
 
     async def _run_inner(self, info: SubagentInfo, session_key: str) -> None:
         """Inner execution — called within timeout wrapper."""
+        # Mark the real start of execution BEFORE any await so the startup
+        # watchdog measures from here, not from registration (which may include
+        # an arbitrary spawn-approval wait). Must be the first statement.
+        info._exec_started = time.time()
         # Inherit approval policy from parent session; yolo/trust overrides
         parent_policy = self._sessions.get_approval_policy(info.parent_session_key)
         # Explicit approval_mode from spawn caller (e.g. Mochi bg agent)

--- a/tests/test_subagent_startup_watchdog.py
+++ b/tests/test_subagent_startup_watchdog.py
@@ -1,0 +1,122 @@
+"""Tests for the subagent startup watchdog (subagent.py).
+
+Covers ``SubagentManager._is_startup_stalled`` (which a wedged, never-started
+subagent trips) and ``_force_reap(reason="startup_timeout")`` (the clear
+"failed to start" error + tombstone cause it produces).
+
+Regression target: a subagent whose ``_run_inner`` wedged before launching its
+runtime (no pid) and before its first turn used to sit for the full 1800s
+deadline and then surface a misleading "Reaped after 1800s [turn 0/100]"
+error. The startup watchdog now reaps it after a short window with an accurate
+"Failed to start" message, while never touching an agent that is merely
+awaiting spawn approval.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+
+def _make_manager(startup_timeout: int = 120) -> SubagentManager:
+    return SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        startup_timeout=startup_timeout,
+    )
+
+
+def _info(**overrides) -> SubagentInfo:
+    info = SubagentInfo(id="a1b2c3d4", task="t", agent="")
+    for k, v in overrides.items():
+        setattr(info, k, v)
+    return info
+
+
+# ── _is_startup_stalled ──────────────────────────────────────────────
+
+
+def test_stalled_true_when_execution_started_but_no_runtime_or_turn():
+    mgr = _make_manager(startup_timeout=120)
+    now = 1_000.0
+    # entered _run_inner 200s ago, never launched a runtime, never took a turn
+    info = _info(_exec_started=now - 200, _pid=None, turns=0)
+    assert mgr._is_startup_stalled(info, now) is True
+
+
+def test_stalled_false_when_awaiting_approval():
+    """An agent awaiting spawn approval never entered _run_inner.
+
+    ``_exec_started`` is None, so it must NEVER trip the watchdog even though
+    it has been registered (``started``) far longer than the window.
+    """
+    mgr = _make_manager(startup_timeout=120)
+    now = 1_000.0
+    info = _info(started=now - 5_000, _exec_started=None, _pid=None, turns=0)
+    assert mgr._is_startup_stalled(info, now) is False
+
+
+def test_stalled_false_when_runtime_launched():
+    mgr = _make_manager(startup_timeout=120)
+    now = 1_000.0
+    # runtime pid assigned -> past startup; a slow first turn must not be reaped
+    info = _info(_exec_started=now - 600, _pid=4242, turns=0)
+    assert mgr._is_startup_stalled(info, now) is False
+
+
+def test_stalled_false_when_a_turn_was_produced():
+    mgr = _make_manager(startup_timeout=120)
+    now = 1_000.0
+    info = _info(_exec_started=now - 600, _pid=None, turns=1)
+    assert mgr._is_startup_stalled(info, now) is False
+
+
+def test_stalled_false_within_startup_window():
+    mgr = _make_manager(startup_timeout=120)
+    now = 1_000.0
+    info = _info(_exec_started=now - 30, _pid=None, turns=0)
+    assert mgr._is_startup_stalled(info, now) is False
+
+
+# ── _force_reap(reason="startup_timeout") ────────────────────────────
+
+
+def _neuter_force_reap_collaborators(mgr: SubagentManager) -> None:
+    mgr._sessions.reset = AsyncMock()
+    mgr._sigkill_session = MagicMock()
+    mgr._write_tombstone = MagicMock()
+    mgr._record_cost = MagicMock()
+    mgr._drain_queue = MagicMock()
+    mgr._fire_event = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_force_reap_startup_timeout_error_and_tombstone_cause():
+    mgr = _make_manager(startup_timeout=120)
+    _neuter_force_reap_collaborators(mgr)
+    info = _info(_exec_started=1.0, _pid=None, turns=0)
+
+    await mgr._force_reap("a1b2c3d4", info, 130.0, reason="startup_timeout")
+
+    assert info.done is True
+    assert "Failed to start within 120s" in info.error
+    assert "exceeded" not in info.error  # not the generic deadline message
+    mgr._write_tombstone.assert_called_once()
+    assert mgr._write_tombstone.call_args.args[1] == "startup_timeout"
+
+
+@pytest.mark.asyncio
+async def test_force_reap_default_reason_keeps_deadline_message():
+    """Regression: the default (no-reason) reap message/cause are unchanged."""
+    mgr = _make_manager(startup_timeout=120)
+    _neuter_force_reap_collaborators(mgr)
+    info = _info(_exec_started=1.0, _pid=None, turns=0)
+
+    await mgr._force_reap("a1b2c3d4", info, 1810.0)
+
+    assert info.done is True
+    assert "Reaped after 1810s" in info.error
+    assert mgr._write_tombstone.call_args.args[1] == "reaped"


### PR DESCRIPTION
## Problem
A subagent whose `_run_inner` wedges during startup — before it launches its runtime process and before producing a first turn — was only caught by the 1800s (30-minute) deadline. The Activity card sat on "turn 0/100" for half an hour and then surfaced a misleading `Reaped after 1800s ... [turn 0/100]` error, even though the subagent never actually started.

Observed in the wild: during ACP runtime instability a spawn registered, its `_run` task hung in provider startup (no pid ever assigned), and the reaper force-killed it 30 minutes later with a turn-0 timeout. The user sees a "Subagent Error / Reaped after 1816s" card with no useful signal.

## Why it matters
Thirty minutes is a long time to discover a subagent never launched. The generic "exceeded deadline" message hides the real failure mode (startup wedge) and makes these incidents look like runaway/long-running work rather than a dead-on-arrival spawn. Faster, accurate failure means the parent session (and the user) learns the truth in ~2 minutes instead of 30.

## Fix (symptom -> root cause -> change)
- Symptom: turn-0 subagent reaped only at the 30-min deadline with a misleading "exceeded deadline" message.
- Root cause: the reaper's only liveness check is `elapsed > default_timeout` (1800s). There is no shorter deadline for the narrow "entered execution but never launched a runtime or produced a turn" window.
- Change: add a startup watchdog to the reaper.
  - New `SubagentInfo._exec_started` timestamp, set as the first statement of `_run_inner` (before any await), marks true execution start.
  - New `_is_startup_stalled(info, now)` helper: true when `_exec_started` is set, `turns == 0`, `_pid is None`, and `now - _exec_started > startup_deadline`.
  - New `_STARTUP_TIMEOUT_SECS = 120` constant and `startup_timeout` constructor parameter (mirrors `default_timeout`), exposed as `self._startup_deadline`.
  - `_force_reap` gains a keyword `reason`; `reason="startup_timeout"` yields the error `Failed to start within {N}s (no runtime launched, no turn produced) [...]` and a distinct `startup_timeout` tombstone cause.

Keying on `_exec_started` (execution start), not the registration timestamp `started`, means an agent merely **awaiting spawn approval** is never caught — it has not entered `_run_inner`, so `_exec_started` is `None`. Healthy agents are also excluded: once a runtime pid is assigned, a slow first turn is left to the normal full deadline.

## Tests
`tests/test_subagent_startup_watchdog.py` (7 tests):
- `_is_startup_stalled`: wedged (exec-started, turn 0, no pid, past window) -> reap; and four no-reap cases — awaiting approval (`_exec_started is None`), runtime launched (pid set), a turn produced (`turns > 0`), and still within the window.
- `_force_reap(reason="startup_timeout")` sets the "Failed to start within 120s" error and a `startup_timeout` tombstone cause.
- Regression: default `_force_reap` keeps the "Reaped after Ns ... deadline" message and `reaped` cause.

All 7 pass. Source additions are flake8-clean (E501 is repo-ignored) and black-clean under the repo's black 24.10.0 / line-length 100.

## Manual verification
N/A beyond the unit tests — the change is in reaper decision logic exercised directly by the tests. No runtime/provider process is needed to validate the predicate or the reap error/cause.

## Note for reviewers
`src/kiro_crew/subagent.py` has **pre-existing** black drift on lines unrelated to this change (present on `main` at the same black version). I deliberately did not reformat those lines to keep this diff focused on the fix. If CI's black gate flags the whole file, I'll address the pre-existing drift in a separate formatting-only commit.
