### PR TITLE
fix(signing): full nested Mach-O coverage so notarization passes

### DIFF
--- a/docs/signing-runbook.md
+++ b/docs/signing-runbook.md
@@ -1,0 +1,113 @@
+# macOS Signing and Notarization Runbook
+
+Operational reference for KiroCrew's macOS signing chain: CDSigner signing,
+Apple notarization, and rotation of the notary credential.
+
+## Chain overview
+
+```
+electron-builder (unsigned .app)
+  -> sign.sh: strip ad-hoc sigs, metadata-clean tar, upload to S3
+  -> CDSigner /v2/sign-tasks (manifest from generate-manifest.py)
+  -> signed zip in s3://kirocrew-signing-artifacts-116101834266/signed/...
+  -> notarytool submit --wait (Apple notary service)
+  -> stapler staple -> spctl assess (want: source=Notarized Developer ID)
+```
+
+Key facts:
+
+- Apple Team ID: `94KV3E626L` (AMZN Mobile LLC, central ADP account). Public, safe to share.
+- Bundle ID: `com.amazon.kiro.crew`
+- Signing account: `116101834266`. CI role: `kirocrew-signing-invoker` (OIDC,
+  main + environment:prod only). S3 access role: `kirocrew-cdsigner-access`.
+- CDSigner endpoint: `https://api.signer.builder-tools.aws.dev` (SigV4,
+  service `signer-builder-tools`, region `us-west-2`).
+- The signing manifest is generated at sign time by
+  `packaging/signing/generate-manifest.py` from the actual .app contents.
+  Do not hand-maintain binary lists.
+
+## Notary credential
+
+The notarization credential is an Apple app-specific password tied to the
+team's enrolled Apple account (Developer role under 94KV3E626L).
+
+Storage rules:
+
+- CI copy: AWS Secrets Manager in account `116101834266`, fetched by name at
+  build time. Never a GitHub secret, never a workflow env literal
+  (SAX-03: Amazon-standard custody, CloudTrail audit, rotation lifecycle).
+- Local copy: macOS Keychain via
+  `xcrun notarytool store-credentials "KiroCrewNotary" ...`. All local
+  commands use `--keychain-profile "KiroCrewNotary"`.
+- Never paste the password into chat, tickets, docs, or shell command lines
+  in shared logs. Type it only into the Apple portal, `store-credentials`
+  in your own terminal, or the Secrets Manager console/CLI.
+- If the value is ever exposed, revoke it immediately at appleid.apple.com
+  (app-specific passwords are individually revocable) and rotate.
+
+## Rotation runbook (manual mint, zero downtime)
+
+Apple exposes no API to mint app-specific passwords or App Store Connect API
+keys, so the mint step is manual by necessity (ARCC "credential source not
+controlled by the team" case). Everything around it is automated. Apple
+allows up to 25 concurrent app-specific passwords, so rotate
+generate-first, revoke-last and CI never breaks mid-rotation.
+
+Procedure (about 2 minutes, quarterly or on any exposure/departure):
+
+1. Sign in at `https://appleid.apple.com` with the enrolled account. The
+   Amazon Federate step must run in the AEA-managed browser (standalone
+   Safari fails device posture).
+2. Sign-In and Security -> App-Specific Passwords -> generate a new one.
+   Label with a version, e.g. `KiroCrew notarization v3`.
+3. Put the new value into the Secrets Manager secret in `116101834266`
+   yourself (console, or `aws secretsmanager put-secret-value` in your own
+   terminal).
+4. Verify before revoking the old one:
+   `xcrun notarytool history --apple-id <account> --team-id 94KV3E626L
+   --password <new>` returns history, or wait for the next green
+   notarization canary run.
+5. Revoke the old password at appleid.apple.com.
+6. Optional: refresh your local Keychain profile with
+   `xcrun notarytool store-credentials "KiroCrewNotary" ...`.
+
+Forced-rotation triggers (do not wait for the schedule): the credential
+appeared anywhere outside Keychain/Secrets Manager; the owning Apple account
+holder departs; Shepherd UnrotatedSecrets finding.
+
+Reducing forced rotations: an App Store Connect API key (team-scoped, not
+person-bound) has the same manual mint but survives departures. Request via
+Mobile Build (Admin-gated) when convenient; not urgent while the password
+path works.
+
+## Troubleshooting
+
+- Notarization returns `Invalid`: pull the itemized log with
+  `xcrun notarytool log <submission-id> --keychain-profile KiroCrewNotary`.
+  Every listed binary must be Developer ID signed with hardened runtime and
+  secure timestamp. If binaries are listed, the signing manifest coverage
+  regressed; check `generate-manifest.py` scope rules.
+- CDSigner fails with "detection of a security issue": generic Electric
+  Company scan rejection. Known trigger: macOS tar metadata. bsdtar embeds
+  `com.apple.provenance`/quarantine xattrs as pax headers unless suppressed;
+  `sign.sh` packages with `COPYFILE_DISABLE=1 tar --no-xattrs
+  --no-mac-metadata --no-acls --no-fflags` on Darwin. If it recurs with a
+  clean tar, isolate with a probe matrix (vary manifest and input tarball
+  independently) before blaming the manifest.
+- Verify a signed bundle locally: `codesign --verify --deep --strict App.app`
+  and `codesign -dvvv <binary>` (must show `Authority=Developer ID
+  Application: AMZN Mobile LLC (94KV3E626L)` and `Timestamp=`). Use `-dvvv`,
+  not `-dv`, or the Authority lines are omitted.
+- Gatekeeper end state: `spctl --assess --type execute --verbose App.app`
+  must print `source=Notarized Developer ID` after stapling.
+
+## Known limitations (tracked)
+
+1. The manifest template still hand-lists the Electron shell entries
+   (framework, crashpad, helper apps); an Electron major upgrade or app
+   rename can stale them. Fix: derive them from the bundle at sign time.
+2. Nested bundles (.app/.framework/.appex) under Contents/Resources are not
+   supported by the per-file manifest generation; they require bundle-level
+   signing. The generator should fail loudly if one appears.
+3. CI does not yet notarize. Until the nightly notarize+staple step lands,
+   signing regressions surface only on manual notarization.

--- a/packaging/signing/generate-manifest.py
+++ b/packaging/signing/generate-manifest.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Generate the CDSigner signing manifest with full nested Mach-O coverage.
+
+Why this exists: Apple notarization requires EVERY nested Mach-O binary to be
+Developer-ID signed with hardened runtime + secure timestamp. CDSigner only
+auto-detects frameworks/dylibs under Contents/Frameworks; everything under
+Contents/Resources (our embedded Python backend: the interpreter, every .so
+C-extension, every vendored .dylib) plus Squirrel's ShipIt helper must be
+listed explicitly in `embedded_requirements`, or notarization returns
+`Invalid` (confirmed: submission 3fefb424, 72 rejected binaries).
+
+The backend's binary set changes whenever a Python dependency changes, so the
+list is generated at sign time from the actual .app rather than maintained by
+hand (same pattern as other Amazon Electron/CDSigner pipelines).
+
+Usage:
+    generate-manifest.py <manifest-template.json> <path/to/App.app>
+
+Reads S3 substitution values from env (SIGNER_ACCESS_ROLE_ARN, SIGNING_BUCKET,
+INPUT_KEY, OUTPUT_KEY) and prints the final manifest JSON to stdout. A summary
+line is printed to stderr for build logs.
+"""
+
+import json
+import os
+import re
+import struct
+import sys
+
+APP_ID = "com.amazon.kiro.crew"
+
+# Mach-O magic numbers (thin, both endiannesses).
+_THIN_MAGICS = {0xFEEDFACE, 0xFEEDFACF, 0xCEFAEDFE, 0xCFFAEDFE}
+# Universal (fat) binary magics; nfat_arch coherence check distinguishes them
+# from Java .class files, which share the 0xCAFEBABE magic.
+_FAT_MAGIC, _FAT_CIGAM = 0xCAFEBABE, 0xBEBAFECA
+
+
+def is_macho(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(8)
+    except OSError:
+        return False
+    if len(head) < 8:
+        return False
+    (magic,) = struct.unpack(">I", head[:4])
+    if magic in _THIN_MAGICS:
+        return True
+    if magic == _FAT_MAGIC:
+        (nfat,) = struct.unpack(">I", head[4:8])
+        return 0 < nfat < 30
+    if magic == _FAT_CIGAM:
+        (nfat,) = struct.unpack("<I", head[4:8])
+        return 0 < nfat < 30
+    return False
+
+
+def identifier_for(rel_path: str) -> str:
+    """Stable, unique bundle id derived from the full relative path.
+
+    Derived from the whole path (not the basename) so duplicate filenames in
+    different packages get distinct identifiers.
+    """
+    stem = rel_path
+    if stem.startswith("Contents/Resources/"):
+        stem = stem[len("Contents/Resources/"):]
+    stem = os.path.splitext(stem)[0]
+    # Proven pattern (matches other Amazon CDSigner pipelines): collapse
+    # everything non-alphanumeric, including dots, to hyphens so every
+    # identifier segment is well-formed.
+    suffix = re.sub(r"[^A-Za-z0-9]+", "-", stem).strip("-")
+    return f"{APP_ID}.{suffix}"
+
+
+def collect_all_machos(app_path: str) -> "list[str]":
+    """Every non-symlink Mach-O in the bundle (relative paths). Used for the
+    pre-sign ad-hoc signature strip."""
+    out: "list[str]" = []
+    for root, _dirs, files in os.walk(app_path):
+        for name in files:
+            full = os.path.join(root, name)
+            if os.path.islink(full):
+                continue
+            if is_macho(full):
+                out.append(os.path.relpath(full, app_path))
+    return out
+
+
+def collect_entries(app_path: str) -> "dict[str, dict]":
+    """Manifest entries, matching the recipe proven to both sign and
+    notarize for Python-runtime apps on this API:
+      - EXCLUDE .dylib files (CDSigner signs dynamic libraries
+        automatically during the app pass; listing them explicitly is
+        rejected by the signing server's validation)
+      - EXCLUDE Contents/MacOS/* (main executable, signed by the app pass)
+      - INCLUDE everything else (interpreter, .so extensions, ShipIt) that
+        lives under Contents/Resources or is a loose framework executable,
+        each with the app entitlements
+    """
+    entries: "dict[str, dict]" = {}
+    for rel in collect_all_machos(app_path):
+        if rel.endswith(".dylib") and not rel.startswith("Contents/Resources/"):
+            # Frameworks dylibs are auto-signed by CDSigner's app pass;
+            # Resources dylibs are NOT (verified empirically) and must be listed.
+            continue
+        if rel.startswith("Contents/MacOS/"):
+            continue
+        in_resources = rel.startswith("Contents/Resources/")
+        is_shipit = os.path.basename(rel) == "ShipIt"
+        # Framework bundles are handled by the static template entries +
+        # CDSigner auto-detection; ShipIt is the exception (a loose
+        # executable in a framework's Resources dir that is NOT covered).
+        if not (in_resources or is_shipit):
+            continue
+        entries[rel] = {
+            "full_identifier": identifier_for(rel),
+            "signing_args": {
+                "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements"
+            },
+        }
+    # Inside-out: sign the deepest binaries first.
+    return dict(
+        sorted(entries.items(), key=lambda kv: (-kv[0].count("/"), kv[0]))
+    )
+
+
+def main() -> int:
+    # --list-machos <App.app>: print every Mach-O in the bundle, one
+    # absolute path per line, for the pre-sign ad-hoc signature strip in
+    # sign.sh (strip everything; CDSigner re-signs dylibs and the main
+    # executable itself during the app pass).
+    if len(sys.argv) == 3 and sys.argv[1] == "--list-machos":
+        app_path = sys.argv[2]
+        if not os.path.isdir(app_path):
+            print(f"ERROR: .app not found at {app_path}", file=sys.stderr)
+            return 1
+        for rel in collect_all_machos(app_path):
+            print(os.path.join(app_path, rel))
+        return 0
+
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <manifest-template.json> <App.app>", file=sys.stderr)
+        return 1
+    template_path, app_path = sys.argv[1], sys.argv[2]
+    if not os.path.isdir(app_path):
+        print(f"ERROR: .app not found at {app_path}", file=sys.stderr)
+        return 1
+
+    raw = open(template_path, encoding="utf-8").read()
+    for var in ("SIGNER_ACCESS_ROLE_ARN", "SIGNING_BUCKET", "INPUT_KEY", "OUTPUT_KEY"):
+        value = os.environ.get(var)
+        if not value:
+            print(f"ERROR: env {var} is required", file=sys.stderr)
+            return 1
+        raw = raw.replace("${%s}" % var, value)
+    doc = json.loads(raw)
+
+    generated = collect_entries(app_path)
+    static = doc["manifest"]["app"].get("embedded_requirements", {})
+    # Generated (deepest-first) ahead of the static Electron entries; a
+    # static entry for the same path wins so hand overrides stay possible.
+    merged = dict(generated)
+    merged.update(static)
+    doc["manifest"]["app"]["embedded_requirements"] = merged
+
+    print(
+        f"embedded_requirements: {len(merged)} total "
+        f"({len(generated)} generated non-dylib Mach-Os, {len(static)} static; "
+        "dylibs auto-signed by CDSigner)",
+        file=sys.stderr,
+    )
+    json.dump(doc, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/signing/sign.sh
+++ b/packaging/signing/sign.sh
@@ -16,7 +16,8 @@
 #   1. Packages the .app into a tar.gz with entitlements metadata
 #   2. Uploads to pre-signed/{channel}/{version}/ in S3
 #   3. Submits a signing request to CDSigner API
-#   4. Polls until signing + notarization completes
+#   4. Polls until signing completes (CDSigner signs only; notarization is a
+#      separate post-signing step via notarytool)
 #   5. Downloads the signed artifact to signed/ locally
 #   6. Verifies the signature
 #
@@ -70,12 +71,33 @@ mkdir -p "$PACKAGE_DIR/SIGNING_METADATA"
 # Copy the .app
 cp -R "$APP_PATH" "$PACKAGE_DIR/${APP_NAME}.app"
 
+# Strip pre-existing ad-hoc signatures from nested Mach-Os (macOS only --
+# codesign is unavailable elsewhere). electron-builder and the Python
+# runtime ship arm64 binaries with mandatory linker ad-hoc signatures;
+# stripping them first lets CDSigner apply clean Developer ID signatures
+# to every explicitly-listed embedded binary.
+if [ "$(uname -s)" = "Darwin" ]; then
+  STRIPPED=0
+  while IFS= read -r MACHO; do
+    codesign --remove-signature "$MACHO" 2>/dev/null && STRIPPED=$((STRIPPED + 1)) || true
+  done < <(python3 "$SCRIPT_DIR/generate-manifest.py" --list-machos "$PACKAGE_DIR/${APP_NAME}.app")
+  log "Stripped ad-hoc signatures from ${STRIPPED} nested Mach-O binaries"
+fi
+
 # Copy entitlements
 cp "$SCRIPT_DIR/Entitlements.entitlements" "$PACKAGE_DIR/SIGNING_METADATA/Entitlements.entitlements"
 
-# Create tar.gz
+# Create tar.gz. On macOS, suppress AppleDouble (._*) entries and
+# xattr/ACL/flag metadata -- bsdtar embeds them by default and CDSigner's
+# artifact security scan rejects archives containing them. GNU tar on the
+# Linux CI runners never emits this metadata (flags kept Darwin-only since
+# GNU tar does not know --no-mac-metadata).
 TAR_PATH="$WORK_DIR/${APP_NAME}.tar.gz"
-( cd "$PACKAGE_DIR" && tar czf "$TAR_PATH" "${APP_NAME}.app" SIGNING_METADATA/ )
+TAR_FLAGS=()
+if [ "$(uname -s)" = "Darwin" ]; then
+  TAR_FLAGS=(--no-xattrs --no-mac-metadata --no-acls --no-fflags)
+fi
+( cd "$PACKAGE_DIR" && COPYFILE_DISABLE=1 tar "${TAR_FLAGS[@]+"${TAR_FLAGS[@]}"}" -czf "$TAR_PATH" "${APP_NAME}.app" SIGNING_METADATA/ )
 
 TAR_SIZE=$(du -h "$TAR_PATH" | cut -f1)
 log "Package created: ${TAR_SIZE}"
@@ -91,12 +113,20 @@ aws s3 cp "$TAR_PATH" "s3://${AWS_SIGNING_BUCKET}/${INPUT_KEY}" --quiet || {
 # ── 3. Submit signing request ───────────────────────────────────────────────
 log "Submitting CDSigner request..."
 
-# Build manifest from template
-MANIFEST=$(cat "$SCRIPT_DIR/manifest-template.json" \
-  | sed "s|\${SIGNER_ACCESS_ROLE_ARN}|${AWS_SIGNER_ROLE_ARN}|g" \
-  | sed "s|\${SIGNING_BUCKET}|${AWS_SIGNING_BUCKET}|g" \
-  | sed "s|\${INPUT_KEY}|${INPUT_KEY}|g" \
-  | sed "s|\${OUTPUT_KEY}|${OUTPUT_KEY}|g")
+# Build the manifest with full nested Mach-O coverage. Notarization requires
+# every nested binary (embedded Python backend, Squirrel ShipIt) to be
+# Developer-ID signed; generate-manifest.py enumerates them from the actual
+# .app so the list never goes stale as backend dependencies change.
+MANIFEST=$(SIGNER_ACCESS_ROLE_ARN="${AWS_SIGNER_ROLE_ARN}" \
+  SIGNING_BUCKET="${AWS_SIGNING_BUCKET}" \
+  INPUT_KEY="${INPUT_KEY}" \
+  OUTPUT_KEY="${OUTPUT_KEY}" \
+  python3 "$SCRIPT_DIR/generate-manifest.py" \
+    "$SCRIPT_DIR/manifest-template.json" \
+    "$PACKAGE_DIR/${APP_NAME}.app") || {
+  echo "ERROR: manifest generation failed" >&2
+  exit 4
+}
 
 # CD Signer ad-hoc signing API v2: POST /v2/sign-tasks. awscurl SigV4-signs
 # from the AWS credential chain (env vars, incl. AWS_SESSION_TOKEN) -- no


### PR DESCRIPTION
Apple notarization of the CDSigner-signed app returned Invalid (72 nested binaries unsigned: embedded Python backend + Squirrel ShipIt). The static manifest only covered 6 Electron shell entries.

Fix:
- generate-manifest.py (new): builds embedded_requirements dynamically from the actual .app at sign time -- every non-dylib Mach-O under Contents/Resources, ShipIt, and Resources dylibs (CDSigner auto-signs dylibs only under Contents/Frameworks, verified empirically). Inside-out order, app entitlements per entry, static Electron entries preserved.
- sign.sh: strip pre-existing ad-hoc signatures before submission; package with COPYFILE_DISABLE=1 + --no-mac-metadata on Darwin. bsdtar's com.apple.provenance xattr pax headers trip CDSigner's artifact scan with the generic 'detection of a security issue' failure (isolated via a 4-way probe matrix). No-op on Linux CI.

Validated locally end-to-end: CDSigner sign success (86 entries), codesign --deep --strict VALID, notarytool Accepted (ce39d04a), stapler staple+validate OK, spctl 'source=Notarized Developer ID'.

Follow-up (separate PR): macOS notarize+staple step in nightly.yml.