### PR TITLE
fix: use Kiro Crew product name

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 
-    <meta name="description" content="KiroCrew — an autonomous agent management layer" />
-    <title>KiroCrew 🐾</title>
+    <meta name="description" content="Kiro Crew — an autonomous agent management layer" />
+    <title>Kiro Crew 🐾</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/site/src/AppPreview.tsx
+++ b/site/src/AppPreview.tsx
@@ -90,7 +90,7 @@ export function AppPreview() {
             <div className="w-7 h-7 rounded-md flex items-center justify-center" style={{ background: '#18181b' }}>
               <span style={{ color: '#f59e0b', fontSize: 13 }}>🐾</span>
             </div>
-            <span className="text-[13px] font-bold tracking-[.08em]" style={{ color: C.textStrong }}>KIROCREW</span>
+            <span className="text-[13px] font-bold tracking-[.08em]" style={{ color: C.textStrong }}>KIRO CREW</span>
           </div>
           <div className="hidden lg:flex items-center gap-1.5">
             <Pill>Request a Feature</Pill>
@@ -239,7 +239,7 @@ export function AppPreview() {
             {/* Input bar */}
             <div className="px-4 pb-2 shrink-0">
               <div className="rounded-2xl px-3 py-2.5" style={{ background: C.bg, border: `1px solid ${C.border}` }}>
-                <div className="text-[12px] mb-2.5" style={{ color: C.mutedSoft }}>Message KiroCrew... <span style={{ color: C.mutedSoft }}>(/command · @file · $skill)</span></div>
+                <div className="text-[12px] mb-2.5" style={{ color: C.mutedSoft }}>Message Kiro Crew... <span style={{ color: C.mutedSoft }}>(/command · @file · $skill)</span></div>
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2" style={{ color: C.muted }}>
                     <Plus size={14} />

--- a/site/src/SectionsBottom.tsx
+++ b/site/src/SectionsBottom.tsx
@@ -66,7 +66,7 @@ export function HowItWorks() {
   const steps = [
     { n: '1', title: 'Clone & Install', code: 'git clone https://github.com/kirodotdev/KiroCrew.git\ncd kirocrew && pip install .' },
     { n: '2', title: 'Start', code: 'kirocrew gateway', note: 'Dashboard opens at localhost:7777. Run kirocrew doctor to verify.' },
-    { n: '3', title: 'Connect', note: 'DM KiroCrew in Slack, or open the dashboard. Type !dashboard in Slack for a 1-click link.' },
+    { n: '3', title: 'Connect', note: 'DM Kiro Crew in Slack, or open the dashboard. Type !dashboard in Slack for a 1-click link.' },
   ];
   return (
     <section className="max-w-[800px] mx-auto px-6 pt-24 pb-24" id="how-it-works">
@@ -164,9 +164,9 @@ export function Cta() {
     <section className="text-center px-6 pt-24 pb-16 bg-[radial-gradient(ellipse_60%_50%_at_50%_100%,rgba(245,158,11,0.06),transparent)]">
       <Parallax speed={-0.15}>
         <FadeUp><h2 className="text-4xl md:text-5xl font-bold mb-4 font-space">Ready to get started?</h2></FadeUp>
-        <FadeUp delay={0.1}><p className="text-slate-500 dark:text-slate-400 text-lg mb-8">One command to install. Every engineer's KiroCrew ends up different — that's the point.</p></FadeUp>
+        <FadeUp delay={0.1}><p className="text-slate-500 dark:text-slate-400 text-lg mb-8">One command to install. Every engineer's Kiro Crew ends up different — that's the point.</p></FadeUp>
         <FadeUp delay={0.2}>
-          <a href="#how-it-works" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl text-[15px] font-semibold bg-gradient-to-r from-amber-500 to-orange-600 text-white shadow-[0_0_24px_rgba(245,158,11,0.35)] hover:-translate-y-0.5 transition-all no-underline font-space">Install KiroCrew</a>
+          <a href="#how-it-works" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl text-[15px] font-semibold bg-gradient-to-r from-amber-500 to-orange-600 text-white shadow-[0_0_24px_rgba(245,158,11,0.35)] hover:-translate-y-0.5 transition-all no-underline font-space">Install Kiro Crew</a>
         </FadeUp>
         <FadeUp delay={0.3}>
           <div className="flex gap-4 justify-center mt-6 text-sm">
@@ -190,7 +190,7 @@ export function Footer() {
           <a key={label} href={href} target="_blank" rel="noopener noreferrer" className="text-amber-400 no-underline hover:underline">{label}</a>
         ))}
       </div>
-      <p>KiroCrew — Persistent, self-learning AI agent for engineers</p>
+      <p>Kiro Crew — Persistent, self-learning AI agent for engineers</p>
     </footer>
   );
 }

--- a/site/src/SectionsTop.tsx
+++ b/site/src/SectionsTop.tsx
@@ -34,9 +34,9 @@ export function Nav() {
     <motion.nav initial={{ y: -20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ duration: 0.5 }}
       className={`fixed top-0 left-0 right-0 z-[100] flex items-center justify-between px-6 md:px-10 py-4 max-w-[1200px] mx-auto transition-all duration-300 ${scrolled ? 'bg-white/85 dark:bg-[#06080f]/85 backdrop-blur-xl border-b border-amber-500/10' : ''}`}>
       <a href={import.meta.env.BASE_URL} className="flex items-center gap-2 no-underline">
-        <img src={`${import.meta.env.BASE_URL}kirocrew-logo.png`} alt="KiroCrew" className="w-8 h-8 rounded-lg" />
+        <img src={`${import.meta.env.BASE_URL}kirocrew-logo.png`} alt="Kiro Crew" className="w-8 h-8 rounded-lg" />
         <span className="text-xl font-bold text-slate-900 dark:text-white font-space tracking-tight">
-          <span className="text-amber-500">Kiro</span>Crew
+          <span className="text-amber-500">Kiro</span> Crew
         </span>
       </a>
       <div className="flex gap-1 items-center">

--- a/site/src/data.ts
+++ b/site/src/data.ts
@@ -27,7 +27,7 @@ export const ARCH = [
 
 export const TERMINAL_LINES = [
   { prompt: true, text: 'kirocrew gateway' },
-  { text: 'KiroCrew v2.1 starting...' },
+  { text: 'Kiro Crew v2.1 starting...' },
   { text: '   Dashboard:  ', hl: 'http://localhost:7777' },
   { text: '   Slack:      ', hl: 'connected (Socket Mode)' },
   { text: '   MCP:        ', hl: '12 servers loaded' },
@@ -46,7 +46,7 @@ export const IN_ACTION = [
 ];
 
 export const FAQ = [
-  { q: 'Does any data leave my machine?', a: 'No. KiroCrew runs entirely locally. Dashboard is bound to localhost. Voice transcription uses local Whisper. The only external calls are to the LLM provider for inference.' },
+  { q: 'Does any data leave my machine?', a: 'No. Kiro Crew runs entirely locally. Dashboard is bound to localhost. Voice transcription uses local Whisper. The only external calls are to the LLM provider for inference.' },
   { q: 'What LLM models are supported?', a: 'ACP (default) and Bedrock. Switch models mid-session from the dashboard. Claude Sonnet 4 is the default.' },
   { q: 'Can non-engineers use it?', a: 'Yes — PMs, designers, data scientists, and any role. The Slack interface requires zero setup beyond the install.' },
   { q: 'How do I add custom tools?', a: "Drop an MCP server config in ~/.kirocrew/mcp.json. It's auto-discovered and synced. Or install via the dashboard MCP tab." },

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -165,7 +165,7 @@ async def api_branding(request: web.Request) -> web.Response:
     cfg = KiroCrewConfig.load()
     return web.json_response(
         {
-            "bot_name": cfg.dashboard.bot_name or "KiroCrew",
+            "bot_name": cfg.dashboard.bot_name or "Kiro Crew",
             "avatar": "/logo.png",
         }
     )

--- a/test/test_dashboard_branding.py
+++ b/test/test_dashboard_branding.py
@@ -115,7 +115,7 @@ class TestBrandingEndpoint:
         with patch("kiro_crew.dashboard.handlers.KiroCrewConfig.load", return_value=cfg):
             resp = await api_branding(req)
         body = json.loads(resp.body)
-        assert body["bot_name"] == "KiroCrew"
+        assert body["bot_name"] == "Kiro Crew"
         assert body["avatar"] == "/logo.png"
 
     @pytest.mark.asyncio

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -163,11 +163,11 @@ function initAutoUpdate(deps) {
       buttons: ["Restart & Update", "Later"],
       defaultId: 0,
       cancelId: 1,
-      title: "KiroCrew update ready",
-      message: `KiroCrew ${versionName || ""} is ready to install.`.trim(),
+      title: "Kiro Crew update ready",
+      message: `Kiro Crew ${versionName || ""} is ready to install.`.trim(),
       detail:
         (notes || "").slice(0, 500) +
-        "\n\nKiroCrew will stop the local gateway, install the update, and relaunch.",
+        "\n\nKiro Crew will stop the local gateway, install the update, and relaunch.",
     });
     if (response === 0) {
       await applyUpdateAndRestart();
@@ -176,7 +176,7 @@ function initAutoUpdate(deps) {
       try {
         new Notification({
           title: "Update deferred",
-          body: "KiroCrew will finish updating the next time you quit.",
+          body: "Kiro Crew will finish updating the next time you quit.",
         }).show();
       } catch { /* notifications optional */ }
     }

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -88,7 +88,7 @@ const { validateRemoteSettings } = require("./validation");
 const { attachContextMenu } = require("./context-menu");
 
 // Set app name for macOS menu bar and dock
-app.name = "KiroCrew";
+app.name = "Kiro Crew";
 
 // Single-instance lock. On macOS LaunchServices reuses the already-running .app
 // when the user relaunches from the Dock / Spotlight, so a second instance is
@@ -479,7 +479,7 @@ function setupWindowContents(win, backendUrl) {
 
   function applyTitle() {
     const suffix = customName || getRemoteHostConfig(store, port)?.defaultName || `[:${port}]`;
-    win.setTitle(`KiroCrew ${suffix}`);
+    win.setTitle(`Kiro Crew ${suffix}`);
   }
 
   win._mcSetCustomName = (name) => { customName = name; applyTitle(); };
@@ -677,12 +677,12 @@ function createTray() {
   const iconPath = path.join(__dirname, "icon.png");
   const icon = nativeImage.createFromPath(iconPath).resize({ width: 18, height: 18 });
   tray = new Tray(icon);
-  tray.setToolTip("KiroCrew");
+  tray.setToolTip("Kiro Crew");
   // Each connection opens as its own window on every platform (native window
   // tabs were removed with the single-surface shell redesign).
   tray.setContextMenu(
     Menu.buildFromTemplate([
-      { label: "Show KiroCrew", click: () => mainWindow?.show() },
+      { label: "Show Kiro Crew", click: () => mainWindow?.show() },
       { type: "separator" },
       { label: "New Connection Window…", click: () => openNewConnectionWindow() },
       { type: "separator" },
@@ -1035,8 +1035,8 @@ async function showUnrecoverableGatewayError(win, port) {
   let logTail = "";
   try { logTail = tailLines(fs.readFileSync(gatewayLogPath(), "utf8"), 60); } catch { /* no log yet */ }
   const action = await showGatewayErrorDialog(win, {
-    title: `KiroCrew — backend stuck on port ${port}`,
-    message: `The KiroCrew backend is wedged and cannot be stopped — it is in an `
+    title: `Kiro Crew — backend stuck on port ${port}`,
+    message: `The Kiro Crew backend is wedged and cannot be stopped — it is in an `
       + `uninterruptible state and is still holding port ${port}, so it can't be `
       + `force-stopped or restarted in place. Restart your computer to clear it. `
       + `(This is a known backend hang; see the launch log below for the cause.)`,
@@ -1108,16 +1108,16 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
 
     let title, message;
     if (portConflict) {
-      title = `KiroCrew — port ${PORT} already in use`;
-      message = `Another KiroCrew gateway is already using port ${PORT} (it may be wedged). `
+      title = `Kiro Crew — port ${PORT} already in use`;
+      message = `Another Kiro Crew gateway is already using port ${PORT} (it may be wedged). `
         + `Force-stop it and retry, or quit. From a terminal you can also run: `
         + `kirocrew stop --port ${PORT}`;
     } else if (failedToStart) {
-      title = "KiroCrew — gateway failed to start";
+      title = "Kiro Crew — gateway failed to start";
       message = err.message;
     } else {
-      title = "KiroCrew — can't reach the gateway";
-      message = "Could not connect to the KiroCrew backend. Make sure "
+      title = "Kiro Crew — can't reach the gateway";
+      message = "Could not connect to the Kiro Crew backend. Make sure "
         + "'kirocrew gateway' is running, or check kirocrew doctor.";
     }
 
@@ -1186,7 +1186,7 @@ async function openNewConnectionWindow() {
   </style></head><body>
     <label>Gateway port</label>
     <input id="p" type="number" value="7778" min="1" max="65535" autofocus>
-    <div class="hint">Connect to a KiroCrew gateway running on another port</div>
+    <div class="hint">Connect to a Kiro Crew gateway running on another port</div>
     <div class="row"><button class="ok" onclick="go()">Connect</button>
     <button class="cancel" onclick="window.close()">Cancel</button></div>
     <script>
@@ -1260,7 +1260,7 @@ function renameCurrentWindow() {
     .check-row label { margin:0; font-size:12px; }
   </style></head><body>
     <label>Window name</label>
-    <input id="n" value="${esc(currentTitle.replace(/^KiroCrew /g, ''))}" autofocus>
+    <input id="n" value="${esc(currentTitle.replace(/^Kiro ?Crew /g, ''))}" autofocus>
     <div class="row"><button class="ok" onclick="go()">Rename</button>
     <button class="cancel" onclick="window.close()">Cancel</button></div>
     <div class="check-row"><input type="checkbox" id="d"><label for="d">Set as default name for :${port} windows</label></div>
@@ -1307,9 +1307,9 @@ function showScreenPermissionDialog() {
     .showMessageBox({
       type: "info",
       title: "Screen Recording permission needed",
-      message: "Allow KiroCrew to capture the screen",
+      message: "Allow Kiro Crew to capture the screen",
       detail:
-        "The screen-snip tool needs macOS Screen Recording permission. Open System Settings › Privacy & Security › Screen Recording, enable KiroCrew, then try the snip again.",
+        "The screen-snip tool needs macOS Screen Recording permission. Open System Settings › Privacy & Security › Screen Recording, enable Kiro Crew, then try the snip again.",
       buttons: ["Open System Settings", "Cancel"],
       defaultId: 0,
       cancelId: 1,

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kirocrew-electron-mac",
   "version": "0.1.0",
-  "description": "KiroCrew \u2014 AI agent desktop app",
+  "description": "Kiro Crew \u2014 AI agent desktop app",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" onload="this.rel='stylesheet'" />
   <noscript><link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" /></noscript>
-  <title>KiroCrew</title>
+  <title>Kiro Crew</title>
   <script>
     // Set data-ui from localStorage before React hydrates to prevent flash of
     // chat layout when the user's preferred mode is 'cli'. Mirrors the

--- a/website/src/hooks/useBranding.tsx
+++ b/website/src/hooks/useBranding.tsx
@@ -3,7 +3,7 @@ import { api } from '../api/client'
 
 interface Branding { botName: string; avatar: string }
 
-const defaults: Branding = { botName: 'KiroCrew', avatar: '/logo.png' }
+const defaults: Branding = { botName: 'Kiro Crew', avatar: '/logo.png' }
 const BrandingContext = createContext<Branding>(defaults)
 
 export function BrandingProvider({ children }: { children: ReactNode }) {

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -601,7 +601,7 @@ export default function AppsPage() {
                               />
                             ) : null}
                             <div className={`absolute inset-0 flex items-center justify-center bg-[var(--bg-elevated)] ${hero ? 'hidden' : ''} hero-fallback`}>
-                              <span className="text-2xl font-bold text-[var(--text)] opacity-10 tracking-widest">KIROCREW</span>
+                              <span className="text-2xl font-bold text-[var(--text)] opacity-10 tracking-widest">KIRO CREW</span>
                             </div>
                           </div>
                         )

--- a/website/src/pages/ArtifactPopoutFrame.tsx
+++ b/website/src/pages/ArtifactPopoutFrame.tsx
@@ -39,7 +39,7 @@ export default function ArtifactPopoutFrame() {
   // distinguishable at the OS level.
   useEffect(() => {
     const label = artifact?.name || slug || 'Artifact'
-    document.title = `${label} — KiroCrew`
+    document.title = `${label} — Kiro Crew`
   }, [slug, artifact?.name])
 
   return (

--- a/website/src/pages/PopoutFrame.tsx
+++ b/website/src/pages/PopoutFrame.tsx
@@ -30,7 +30,7 @@ export default function PopoutFrame() {
   // distinguishable at the OS level.
   useEffect(() => {
     const label = title && title !== sid ? title : 'Session'
-    document.title = `${label} — KiroCrew`
+    document.title = `${label} — Kiro Crew`
   }, [sid, title])
 
   return (

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -200,7 +200,7 @@ export function AboutPanel() {
           />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2.5 flex-wrap">
-              <span className="text-[19px] font-extrabold tracking-tight text-text-strong">{botName || 'KiroCrew'}</span>
+              <span className="text-[19px] font-extrabold tracking-tight text-text-strong">{botName || 'Kiro Crew'}</span>
               <span className="text-[12px] font-mono font-semibold text-accent rounded-full px-2.5 py-0.5 border" style={ACCENT_TINT}>v{version}</span>
               {!isDesktop && (updateAvailable
                 ? <span className="inline-flex items-center gap-1.5 text-[11.5px] font-semibold rounded-full px-2 py-0.5"
@@ -252,7 +252,7 @@ export function AboutPanel() {
           ) : (
             <div className="flex flex-col gap-2.5">
               <p className="text-sm text-muted">
-                {botName || 'KiroCrew'} checks for updates automatically. You can also check now.
+                {botName || 'Kiro Crew'} checks for updates automatically. You can also check now.
               </p>
               <div>
                 <Btn primary onClick={() => checkMutation.mutate()} disabled={checking}>
@@ -278,7 +278,7 @@ export function AboutPanel() {
             ) : (
               <>
                 <p className="text-sm text-muted">
-                  {botName || 'KiroCrew'} checks for updates automatically. You can also check now.
+                  {botName || 'Kiro Crew'} checks for updates automatically. You can also check now.
                 </p>
                 <div>
                   <Btn onClick={() => gwCheck.mutate()} disabled={gwCheck.isPending}>

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -318,9 +318,9 @@ describe('App routing', () => {
     fireEvent.keyDown(rows[0], { key: 'Enter' })
   })
 
-  it('renders KIROCREW branding', () => {
+  it('renders KIRO CREW branding', () => {
     renderWithProviders(<App />, { route: '/chat' })
-    expect(screen.getAllByText('KIROCREW').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('KIRO CREW').length).toBeGreaterThan(0)
   })
 
   it('renders connection status', () => {


### PR DESCRIPTION
## Problem
Customer-facing surfaces use the technical identifier `KiroCrew` as the product name instead of the approved display name, `Kiro Crew`.

## Why it matters
The dashboard, desktop app, browser titles, update dialogs, and public site present inconsistent branding to users.

## Fix
Update canonical customer-facing labels and default branding from `KiroCrew` to `Kiro Crew`. Keep technical identifiers unchanged, including package names, commands, repository URLs, API names, bundle compatibility paths, `KiroCrew.app`, and Electron `productName`.

## Tests
- Dashboard: 56 tests pass and production build passes
- Electron: 170 tests pass, JavaScript syntax checks pass, and package metadata is valid
- Public site: test and production build pass
- Backend: branding endpoint smoke test and Python compilation pass
- ESLint: no errors in the dashboard

## Manual verification
Reviewed the dashboard and public-site previews before publishing. Confirmed the spaced display name appears in the intended user-facing surfaces while technical identifiers remain unchanged.