### PR TITLE
fix(install): clear PYTHONPATH/PYTHONHOME so venv deps actually install

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -20,6 +20,13 @@
 # ──────────────────────────────────────────────────────────────────────
 set -eu
 
+# Isolate the managed venv from any inherited PYTHONPATH/PYTHONHOME. If the
+# caller's environment points these at foreign site-packages (e.g. another
+# app's interpreter on a different Python version), pip treats those packages
+# as already satisfied and silently skips installing our dependencies into the
+# venv -- producing a broken install (ImportError: No module named 'aiohttp').
+unset PYTHONPATH PYTHONHOME
+
 CDN="${KIROCREW_CDN_BASE:-https://d28nxu9if70cmc.cloudfront.net}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""

--- a/cloud-install.sh
+++ b/cloud-install.sh
@@ -15,6 +15,13 @@
 # ======================================================================
 set -euo pipefail
 
+# Isolate the managed venv from any inherited PYTHONPATH/PYTHONHOME. If the
+# caller's environment points these at foreign site-packages (e.g. another
+# app's interpreter on a different Python version), pip treats those packages
+# as already satisfied and silently skips installing our dependencies into the
+# venv -- producing a broken install (ImportError: No module named 'aiohttp').
+unset PYTHONPATH PYTHONHOME
+
 SIZE=""
 NONINTERACTIVE=0
 # while+shift (not `for arg in "$@"`): the space-separated `--size <tier>`

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,13 @@
 # ──────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Isolate the managed venv from any inherited PYTHONPATH/PYTHONHOME. If the
+# caller's environment points these at foreign site-packages (e.g. another
+# app's interpreter on a different Python version), pip treats those packages
+# as already satisfied and silently skips installing our dependencies into the
+# venv -- producing a broken install (ImportError: No module named 'aiohttp').
+unset PYTHONPATH PYTHONHOME
+
 # ── Parse arguments ──
 USE_MISE=0
 WITH_VOICE=0

--- a/minimal_install.sh
+++ b/minimal_install.sh
@@ -18,6 +18,13 @@
 # ──────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Isolate the managed venv from any inherited PYTHONPATH/PYTHONHOME. If the
+# caller's environment points these at foreign site-packages (e.g. another
+# app's interpreter on a different Python version), pip treats those packages
+# as already satisfied and silently skips installing our dependencies into the
+# venv -- producing a broken install (ImportError: No module named 'aiohttp').
+unset PYTHONPATH PYTHONHOME
+
 # ── Parse arguments ──
 WITH_VOICE=0
 for _arg in "$@"; do


### PR DESCRIPTION
## Problem

All four installers — `cli.sh` (wheel), `install.sh`, `minimal_install.sh`, and `cloud-install.sh` — create a managed venv and then run `"$VENV/bin/pip" install …` **inheriting the caller's environment**. If `PYTHONPATH` (or `PYTHONHOME`) points at foreign site-packages, those packages land on the venv interpreter's `sys.path`, pip concludes the dependencies are already satisfied, and **silently skips installing them into the venv**.

The venv then only appears to work while that external `PYTHONPATH` is set. In a clean shell it fails at runtime:

```
Traceback (most recent call last):
  File ".../.local/bin/kirocrew", line 3, in <module>
    from kiro_crew.cli import main
  ...
    from aiohttp import web
ModuleNotFoundError: No module named 'aiohttp'
```

### Real-world repro

On a machine that also runs the sibling MeshClaw build, the runtime exports:

```
PYTHONPATH=/…/.toolbox/tools/meshclaw/3.2.3/lib/python3.10/site-packages
```

Running `curl … cli.sh | sh -s -- --channel nightly` from that environment produced a `~/.kirocrew/venv` (Python 3.13) with **no `aiohttp`** — pip saw the foreign 3.10 `aiohttp` on the path and skipped it. `kirocrew` then crashed in any clean shell. Re-running the installer with `PYTHONPATH` unset installed the full dependency set and fixed it.

## Fix

`unset PYTHONPATH PYTHONHOME` near the top of each installer (right after the `set -e…` line) so the managed venv is fully isolated and pip resolves/installs the real dependency set. Installers have no need for an inherited `PYTHONPATH`.

## Scope / notes

- Install-time only. A separate, larger concern is **runtime** shadowing (a foreign `PYTHONPATH` prepends to `sys.path` even inside a venv); that would need console-script / `sitecustomize` hardening and is intentionally out of scope here.
- No functional change for users without a contaminating `PYTHONPATH`.

## Testing

- `sh -n cli.sh` and `bash -n` on the three bash scripts — all pass.
- Verified the documented repro: with a foreign `PYTHONPATH` set, the pre-fix installer omits `aiohttp` from the venv; unsetting it (this change) installs it correctly and `kirocrew --version` / `kirocrew doctor` run in a clean env.
