### PR TITLE
feat: theme-reactive two-color app icons

### DIFF
--- a/website/public/app-assets/app-store/icon.svg
+++ b/website/public/app-assets/app-store/icon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <rect x="2" y="2" width="9" height="9" rx="2.5" fill="#6366f1"/>
-  <rect x="13" y="2" width="9" height="9" rx="2.5" fill="#10b981"/>
-  <rect x="2" y="13" width="9" height="9" rx="2.5" fill="#f97316"/>
-  <rect x="13" y="13" width="9" height="9" rx="2.5" fill="#ec4899"/>
-  <circle cx="6.5" cy="6.5" r="1.8" fill="#fff" fill-opacity="0.9"/>
-  <circle cx="17.5" cy="6.5" r="1.8" fill="#fff" fill-opacity="0.9"/>
-  <circle cx="6.5" cy="17.5" r="1.8" fill="#fff" fill-opacity="0.9"/>
-  <circle cx="17.5" cy="17.5" r="1.8" fill="#fff" fill-opacity="0.9"/>
+  <rect x="2" y="2" width="9" height="9" rx="2.5" fill="var(--ico-a, currentColor)"/>
+  <rect x="13" y="2" width="9" height="9" rx="2.5" fill="var(--ico-a, currentColor)" fill-opacity="0.75"/>
+  <rect x="2" y="13" width="9" height="9" rx="2.5" fill="var(--ico-a, currentColor)" fill-opacity="0.75"/>
+  <rect x="13" y="13" width="9" height="9" rx="2.5" fill="var(--ico-b, currentColor)"/>
+  <circle cx="6.5" cy="6.5" r="1.8" fill="var(--ico-b, currentColor)"/>
+  <circle cx="17.5" cy="6.5" r="1.8" fill="var(--ico-b, currentColor)"/>
+  <circle cx="6.5" cy="17.5" r="1.8" fill="var(--ico-b, currentColor)"/>
+  <circle cx="17.5" cy="17.5" r="1.8" fill="var(--ico-a, currentColor)"/>
 </svg>

--- a/website/public/app-assets/auto-research/icon.svg
+++ b/website/public/app-assets/auto-research/icon.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <path d="M9,2 L9,8 L4,17 Q2.5,20 5,22 L19,22 Q21.5,20 20,17 L15,8 L15,2" fill="#8b5cf6" fill-opacity="0.25" stroke="#8b5cf6" stroke-width="2.2"/>
-  <line x1="7.5" y1="2" x2="16.5" y2="2" stroke="#8b5cf6" stroke-width="2.8" stroke-linecap="round"/>
-  <path d="M5.5,15 Q8.5,14 12,14.5 Q15.5,15 18.5,15 L20,17 Q21.5,20 19,22 L5,22 Q2.5,20 4,17 Z" fill="#8b5cf6" fill-opacity="0.35"/>
-  <circle cx="9" cy="17.5" r="1.8" fill="#f97316"/>
-  <circle cx="13" cy="16" r="1.5" fill="#10b981"/>
-  <circle cx="11" cy="19.5" r="1.2" fill="#06b6d4"/>
-  <circle cx="15" cy="18.5" r="1" fill="#eab308"/>
+  <path d="M9,2 L9,8 L4,17 Q2.5,20 5,22 L19,22 Q21.5,20 20,17 L15,8 L15,2" fill="var(--ico-a, currentColor)" fill-opacity="0.2" stroke="var(--ico-a, currentColor)" stroke-width="1.8"/>
+  <line x1="7.5" y1="2" x2="16.5" y2="2" stroke="var(--ico-a, currentColor)" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M5.5,15 Q8.5,14 12,14.5 Q15.5,15 18.5,15 L20,17 Q21.5,20 19,22 L5,22 Q2.5,20 4,17 Z" fill="var(--ico-a, currentColor)" fill-opacity="0.5"/>
+  <circle cx="9" cy="17.5" r="1.7" fill="var(--ico-b, currentColor)"/>
+  <circle cx="13" cy="16" r="1.4" fill="var(--ico-b, currentColor)"/>
+  <circle cx="11" cy="19.5" r="1.05" fill="var(--ico-b, currentColor)" fill-opacity="0.85"/>
 </svg>

--- a/website/public/app-assets/code-review-sage/icon.svg
+++ b/website/public/app-assets/code-review-sage/icon.svg
@@ -1,9 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <circle cx="10" cy="10" r="8" fill="#0ea5e9" fill-opacity="0.18" stroke="#0ea5e9" stroke-width="2.5"/>
-  <line x1="16" y1="16" x2="22" y2="22" stroke="#0ea5e9" stroke-width="3" stroke-linecap="round"/>
-  <path d="M7,8 L4.5,10 L7,12" stroke="#0ea5e9" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M13,8 L15.5,10 L13,12" stroke="#0ea5e9" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <line x1="12" y1="6.5" x2="8" y2="13.5" stroke="#0ea5e9" stroke-width="1.5" stroke-opacity="0.5"/>
-  <rect x="5" y="15" width="5" height="2" rx="1" fill="#4ade80"/>
-  <rect x="11" y="15" width="3.5" height="2" rx="1" fill="#f87171"/>
+  <circle cx="10" cy="10" r="8" fill="var(--ico-a, currentColor)" fill-opacity="0.16" stroke="var(--ico-a, currentColor)" stroke-width="2"/>
+  <line x1="16" y1="16" x2="22" y2="22" stroke="var(--ico-a, currentColor)" stroke-width="2.4" stroke-linecap="round"/>
+  <path d="M7,8 L4.5,10 L7,12" stroke="var(--ico-b, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M13,8 L15.5,10 L13,12" stroke="var(--ico-b, currentColor)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="12" y1="6.5" x2="8" y2="13.5" stroke="var(--ico-b, currentColor)" stroke-width="1.4"/>
 </svg>

--- a/website/public/app-assets/file-explorer/icon.svg
+++ b/website/public/app-assets/file-explorer/icon.svg
@@ -1,9 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <path d="M7,3 L18,3 L21,6 L21,19 L9,19 L9,6 Z" fill="#f59e0b" fill-opacity="0.15" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.5"/>
-  <path d="M3,5 L13,5 L16,8 L16,22 L3,22 Z" fill="#f59e0b" fill-opacity="0.2" stroke="#f59e0b" stroke-width="2.2"/>
-  <path d="M13,5 L13,8 L16,8" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="5.5" y="11" width="6" height="2" rx="1" fill="#8b5cf6"/>
-  <rect x="5.5" y="14" width="4" height="2" rx="1" fill="#10b981"/>
-  <rect x="10" y="14" width="4" height="2" rx="1" fill="#f97316"/>
-  <rect x="5.5" y="17" width="7" height="2" rx="1" fill="#3b82f6"/>
+  <mask id="fe-cut">
+    <rect width="24" height="24" fill="white"/>
+    <path d="M4.3,5 L11.7,5 Q13,5 13.92,5.92 L15.08,7.08 Q16,8 16,9.3 L16,20.7 Q16,22 14.7,22 L4.3,22 Q3,22 3,20.7 L3,6.3 Q3,5 4.3,5 Z" fill="black" stroke="black" stroke-width="2.2" stroke-linejoin="round"/>
+  </mask>
+  <g mask="url(#fe-cut)">
+    <path d="M8.3,3 L16.7,3 Q18,3 18.92,3.92 L20.08,5.08 Q21,6 21,7.3 L21,17.7 Q21,19 19.7,19 L10.3,19 Q9,19 9,17.7 L9,7.3 Q9,6 8.28,4.92 L7.72,4.08 Q7,3 8.3,3 Z" fill="var(--ico-a, currentColor)" fill-opacity="0.14" stroke="var(--ico-a, currentColor)" stroke-width="1.3" stroke-opacity="0.55" stroke-linejoin="round"/>
+  </g>
+  <path d="M4.3,5 L11.7,5 Q13,5 13.92,5.92 L15.08,7.08 Q16,8 16,9.3 L16,20.7 Q16,22 14.7,22 L4.3,22 Q3,22 3,20.7 L3,6.3 Q3,5 4.3,5 Z" fill="var(--ico-a, currentColor)" fill-opacity="0.25" stroke="var(--ico-a, currentColor)" stroke-width="1.8" stroke-linejoin="round"/>
+  <rect x="5.5" y="11" width="6" height="2" rx="1" fill="var(--ico-b, currentColor)"/>
+  <rect x="5.5" y="14" width="4" height="2" rx="1" fill="var(--ico-b, currentColor)" fill-opacity="0.8"/>
+  <rect x="5.5" y="17" width="7" height="2" rx="1" fill="var(--ico-b, currentColor)" fill-opacity="0.8"/>
 </svg>

--- a/website/public/app-assets/projects/icon.svg
+++ b/website/public/app-assets/projects/icon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <path d="M12,1 Q7,5.5 7,12 L9.5,15 L14.5,15 L17,12 Q17,5.5 12,1 Z" fill="#f97316" fill-opacity="0.3" stroke="#f97316" stroke-width="2.2"/>
-  <circle cx="12" cy="8" r="2.5" fill="#f97316" fill-opacity="0.6" stroke="#f97316" stroke-width="1.5"/>
-  <path d="M7,12 L4,16 L7.5,14" fill="#f97316" fill-opacity="0.4" stroke="#f97316" stroke-width="1.5"/>
-  <path d="M17,12 L20,16 L16.5,14" fill="#f97316" fill-opacity="0.4" stroke="#f97316" stroke-width="1.5"/>
-  <path d="M9.5,15 L9,18 L10.5,16.8 L12,19.5 L13.5,16.8 L15,18 L14.5,15" fill="#fbbf24"/>
-  <circle cx="12" cy="21" r="1.3" fill="#f97316" fill-opacity="0.5"/>
-  <circle cx="9.5" cy="22.5" r="0.9" fill="#f97316" fill-opacity="0.3"/>
-  <circle cx="14.5" cy="22.5" r="0.9" fill="#f97316" fill-opacity="0.3"/>
+  <path d="M12,1 Q7,5.5 7,12 L9.5,15 L14.5,15 L17,12 Q17,5.5 12,1 Z" fill="var(--ico-a, currentColor)" fill-opacity="0.26" stroke="var(--ico-a, currentColor)" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M7,12 L4,16 L7.5,14" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="1.3" stroke-linejoin="round"/>
+  <path d="M17,12 L20,16 L16.5,14" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="1.3" stroke-linejoin="round"/>
+  <circle cx="12" cy="8" r="2.5" fill="var(--ico-b, currentColor)"/>
+  <path d="M9.5,15 L9,18 L10.5,16.8 L12,19.5 L13.5,16.8 L15,18 L14.5,15" fill="var(--ico-b, currentColor)"/>
+  <circle cx="12" cy="21" r="1.3" fill="var(--ico-b, currentColor)"/>
+  <circle cx="9.5" cy="22.5" r="0.9" fill="var(--ico-b, currentColor)" fill-opacity="0.6"/>
+  <circle cx="14.5" cy="22.5" r="0.9" fill="var(--ico-b, currentColor)" fill-opacity="0.6"/>
 </svg>

--- a/website/public/app-assets/worlds/icon.svg
+++ b/website/public/app-assets/worlds/icon.svg
@@ -1,10 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <circle cx="12" cy="12" r="10" fill="#10b981" fill-opacity="0.3"/>
-  <circle cx="12" cy="12" r="10" stroke="#10b981" stroke-width="2.2"/>
-  <ellipse cx="12" cy="12" rx="4.5" ry="10" stroke="#10b981" stroke-width="2"/>
-  <path d="M2.5,9 Q7,11 12,11 Q17,11 21.5,9" stroke="#10b981" stroke-width="1.8" stroke-opacity="0.7"/>
-  <path d="M2.5,15 Q7,13 12,13 Q17,13 21.5,15" stroke="#10b981" stroke-width="1.8" stroke-opacity="0.7"/>
-  <rect x="15" y="2.5" width="6" height="8" rx="2.5" fill="#f97316"/>
-  <rect x="16.5" y="4.5" width="1.8" height="1.8" rx="0.9" fill="#fff"/>
-  <rect x="18.7" y="4.5" width="1.8" height="1.8" rx="0.9" fill="#fff"/>
+  <circle cx="12" cy="12" r="10" fill="var(--ico-a, currentColor)" fill-opacity="0.2" stroke="var(--ico-a, currentColor)" stroke-width="1.8"/>
+  <ellipse cx="12" cy="12" rx="4.5" ry="10" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="1.6"/>
+  <path d="M2.5,9 Q7,11 12,11 Q17,11 21.5,9" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-opacity="0.7"/>
+  <path d="M2.5,15 Q7,13 12,13 Q17,13 21.5,15" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-opacity="0.7"/>
+  <rect x="15" y="2.5" width="6" height="8" rx="2.5" fill="var(--ico-b, currentColor)"/>
+  <rect x="16.5" y="4.5" width="1.8" height="1.8" rx="0.9" fill="var(--bg, #fff)"/>
+  <rect x="18.7" y="4.5" width="1.8" height="1.8" rx="0.9" fill="var(--bg, #fff)"/>
 </svg>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -40,6 +40,7 @@ import PopoutFrame from './pages/PopoutFrame'
 import ArtifactPopoutFrame from './pages/ArtifactPopoutFrame'
 
 import ErrorBoundary from './components/ErrorBoundary'
+import AppIcon from './components/AppIcon'
 import Clickable from './components/Clickable'
 import MarkdownRenderer, { Lightbox } from './components/MarkdownRenderer'
 import NotificationsPage from './pages/NotificationsPage'
@@ -366,7 +367,7 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
   path: string; label: string; icon: React.ReactNode; active: boolean; collapsed: boolean; badge?: React.ReactNode; onClickOverride?: () => void; onClick?: () => void; navId?: string
 }) {
   const navigate = useNavigate()
-  const iconEl = <span className={`w-4 h-4 flex items-center justify-center shrink-0 transition-opacity ${active ? 'opacity-100 text-accent' : 'opacity-70'}`}>{icon}</span>
+  const iconEl = <span className={`app-icon-nav w-4 h-4 flex items-center justify-center shrink-0 transition-opacity ${active ? 'opacity-100 text-accent is-lit' : 'opacity-70'}`}>{icon}</span>
   const { tip, tipOn, rowRef, showTip, hideTip } = useNavTip<HTMLDivElement>(collapsed)
   const activate = () => { onClick?.(); (onClickOverride || (() => navigate(path)))() }
   return (
@@ -401,7 +402,7 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
           className={`fixed flex items-center gap-2.5 pl-3 pr-3 rounded-md bg-card border border-border shadow-lg text-text text-sm font-medium z-[9999] pointer-events-none whitespace-nowrap transition-opacity duration-150 ${tipOn ? 'opacity-100' : 'opacity-0'}`}
           style={{ top: tip.top, left: tip.left, height: tip.height }}
         >
-          <span className={`w-4 h-4 flex items-center justify-center shrink-0 ${active ? 'text-accent' : ''}`}>{icon}</span>
+          <span className={`app-icon-nav w-4 h-4 flex items-center justify-center shrink-0 ${active ? 'text-accent is-lit' : ''}`}>{icon}</span>
           {label}
         </div>,
         document.body
@@ -862,7 +863,7 @@ export default function App() {
             // the builtin lucide glyph, then the generic package icon.
             const customIconUrl = a.manifest?.iconUrl || ''
             const baseIcon = customIconUrl
-              ? <img src={customIconUrl} alt="" className="w-4 h-4 rounded-sm object-contain" />
+              ? <AppIcon iconUrl={customIconUrl} icon={iconName} size={16} />
               : page.iconUrl
                 ? <img src={'/apps/' + a.name + '/ui/' + page.iconUrl} alt="" className="w-4 h-4 rounded-sm object-contain" />
                 : isBuiltin && BUILTIN_ICONS[iconName]

--- a/website/src/components/AppIcon.tsx
+++ b/website/src/components/AppIcon.tsx
@@ -1,13 +1,17 @@
 /**
  * AppIcon — shared icon component for app cards and detail pages.
  *
- * Renders an image from iconUrl (with fallback on error) or a lucide-react
- * icon from the ICON_MAP.  Falls back to the Package icon.
- *
- * Builtin apps declare `iconUrl` in their manifest pointing to static SVGs
- * in /app-assets/ — no special mapping needed here.
+ * Two rendering paths:
+ *  1. iconUrl SVGs (builtin apps, served from /app-assets/) are fetched and
+ *     inlined so the theme's CSS variables cascade into them. Each icon paints
+ *     with two tokens driven by `selected`:
+ *       idle      → --ico-a: var(--muted)  --ico-b: var(--accent)
+ *       selected  → --ico-a: var(--accent) --ico-b: var(--text)
+ *     Non-app-asset iconUrls (e.g. registry blob proxy) render as a plain <img>.
+ *  2. A lucide-react icon from ICON_MAP (falls back to Package).
  */
-import { useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
+import DOMPurify from 'dompurify'
 import {
   Shield, Bot, Search, Tag, Users, Zap, Star, Package, Cat,
 } from 'lucide-react'
@@ -16,11 +20,124 @@ const ICON_MAP: Record<string, typeof Shield> = {
   Shield, Bot, Search, Tag, Users, Zap, Star, Package, Cat,
 }
 
-export default function AppIcon({ icon, iconUrl, size = 20 }: { icon?: string; iconUrl?: string; size?: number }) {
+// In-memory cache of fetched inline SVG markup, keyed by url.
+const svgCache = new Map<string, string>()
+
+/**
+ * True only for our own first-party themeable builtin icons that use the
+ * --ico-a/--ico-b tokens. Deliberately strict: exactly two clean path
+ * segments under /app-assets/ ending in .svg, with NO '.' or '/' inside a
+ * segment — so traversal payloads like `/app-assets/../apps/evil/ui/icon.svg`
+ * (which pass a naive startsWith check but normalize elsewhere in the browser)
+ * are rejected. Anything else takes the plain <img> path.
+ */
+const APP_ASSET_ICON_RE = /^\/app-assets\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\.svg$/
+function isAppAssetSvg(url?: string): url is string {
+  return !!url && APP_ASSET_ICON_RE.test(url)
+}
+
+/**
+ * Prefix every `id="x"` (and its `url(#x)` references) with a per-instance
+ * token so multiple inlined copies of the same icon don't collide on ids
+ * like the file-explorer overlap mask.
+ */
+function uniquifyIds(markup: string, prefix: string): string {
+  const ids = new Set<string>()
+  markup.replace(/\bid="([^"]+)"/g, (_m, id) => { ids.add(id); return _m })
+  let out = markup
+  ids.forEach((id) => {
+    const safe = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    out = out
+      .replace(new RegExp(`id="${safe}"`, 'g'), `id="${prefix}-${id}"`)
+      .replace(new RegExp(`url\\(#${safe}\\)`, 'g'), `url(#${prefix}-${id})`)
+  })
+  return out
+}
+
+export default function AppIcon({
+  icon,
+  iconUrl,
+  size = 20,
+  selected = false,
+}: {
+  icon?: string
+  iconUrl?: string
+  size?: number
+  /** Lit (accent-dominant) vs idle (muted + accent highlight). */
+  selected?: boolean
+}) {
   const [imgFailed, setImgFailed] = useState(false)
-  if (iconUrl && !imgFailed) {
-    return <img src={iconUrl} alt="" className="rounded-lg object-contain" style={{ width: size, height: size }} onError={() => setImgFailed(true)} />
+  const [markup, setMarkup] = useState<string | null>(
+    isAppAssetSvg(iconUrl) ? svgCache.get(iconUrl) ?? null : null,
+  )
+  const rawId = useId()
+  // React's useId yields ':r0:' style tokens; sanitize for use in SVG ids.
+  const idPrefix = `ai${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+  // Sanitize the fetched SVG (strips <script>/<foreignObject onload> etc.)
+  // BEFORE inlining — required by the frontend-security AUTOSDE rule and a
+  // defense-in-depth backstop on top of the strict isAppAssetSvg allowlist.
+  // The SVG profile preserves the <mask>/url(#…)/fill markup these icons need.
+  const scopedMarkup = useMemo(() => {
+    if (!markup) return null
+    const clean = DOMPurify.sanitize(markup, {
+      USE_PROFILES: { svg: true, svgFilters: true },
+    })
+    return uniquifyIds(clean, idPrefix)
+  }, [markup, idPrefix])
+
+  useEffect(() => {
+    // Reset per-URL state so a reused AppIcon instance never shows a stale
+    // icon or a sticky failure when its iconUrl changes. Hydrate synchronously
+    // from cache when available; otherwise clear and fetch below.
+    setImgFailed(false)
+    const cached = isAppAssetSvg(iconUrl) ? svgCache.get(iconUrl) ?? null : null
+    setMarkup(cached)
+    if (!isAppAssetSvg(iconUrl) || svgCache.has(iconUrl)) return
+    let cancelled = false
+    fetch(iconUrl)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error('fetch failed'))))
+      .then((text) => {
+        if (text.trim().startsWith('<svg')) {
+          svgCache.set(iconUrl, text)
+          if (!cancelled) setMarkup(text)
+        }
+      })
+      .catch(() => { if (!cancelled) setImgFailed(true) })
+    return () => { cancelled = true }
+  }, [iconUrl])
+
+  // Themeable inline SVG path. The `.app-icon` class sets idle tokens
+  // (--ico-a: muted, --ico-b: accent); `data-selected` OR an ancestor
+  // `.group:hover` promotes to the lit accent-dominant state (see index.css).
+  if (isAppAssetSvg(iconUrl) && !imgFailed) {
+    if (scopedMarkup) {
+      return (
+        <span
+          aria-hidden
+          data-selected={selected || undefined}
+          className="app-icon inline-flex shrink-0 [&>svg]:w-full [&>svg]:h-full"
+          style={{ width: size, height: size }}
+          dangerouslySetInnerHTML={{ __html: scopedMarkup }}
+        />
+      )
+    }
+    // While fetching (or before sanitize), reserve space to avoid layout shift.
+    return <span className="inline-flex shrink-0" style={{ width: size, height: size }} />
   }
+
+  // Non-app-asset image (e.g. registry blob proxy).
+  if (iconUrl && !imgFailed) {
+    return (
+      <img
+        src={iconUrl}
+        alt=""
+        className="rounded-lg object-contain"
+        style={{ width: size, height: size }}
+        onError={() => setImgFailed(true)}
+      />
+    )
+  }
+
   const Icon = icon && ICON_MAP[icon] ? ICON_MAP[icon] : Package
   return <Icon size={size} />
 }

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1042,6 +1042,22 @@ body::before{content:'';position:fixed;top:-50%;left:-50%;width:200%;height:200%
 .nav-brand-glow::after{content:'';position:absolute;bottom:0;left:16px;right:16px;height:1px;
   background:linear-gradient(90deg,transparent,var(--accent),transparent);opacity:.3}
 
+/* ── App icons (two-color, theme-reactive) ──
+   Idle: muted structure + accent detail. Lit (selected OR hovered inside a
+   .group container): accent structure + text detail. Icons are inlined SVGs
+   that paint via --ico-a / --ico-b (see AppIcon.tsx). */
+.app-icon{--ico-a:var(--muted);--ico-b:var(--accent)}
+.app-icon svg *{transition:fill .2s ease,stroke .2s ease,fill-opacity .2s ease}
+.app-icon[data-selected],
+.group:hover .app-icon,
+a:hover .app-icon,
+button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
+/* Left-nav icons: lit when the row is active, and on row hover. The nav row
+   uses Tailwind's named group `group/nav` (not `.group`) and is a div, so it
+   needs its own selectors. */
+.app-icon-nav.is-lit .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
+.group\/nav:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
+
 /* ── Streaming highlight (shimmer sweep on trailing words) ── */
 .streaming-glow{background:linear-gradient(90deg,transparent 0%,var(--accent-glow) 40%,var(--accent-glow) 100%);border-radius:2px;padding:0 8px 0 2px;margin:0 -2px;position:relative;overflow:hidden}
 .streaming-glow::before{content:'';position:absolute;inset:0;border-radius:inherit;background:linear-gradient(90deg,transparent 25%,color-mix(in srgb,var(--accent) 50%,transparent) 50%,transparent 75%);background-size:250% 100%;animation:stream-sweep 2.5s ease-in-out infinite;-webkit-mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%);mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%)}

--- a/website/src/surfaces/builtins.tsx
+++ b/website/src/surfaces/builtins.tsx
@@ -11,6 +11,7 @@ import { MessageSquare, Bell, BookOpen, Component, CalendarDays, Users, Plug, Se
 import { createSelector } from '@reduxjs/toolkit'
 import { registerBuiltinSurface } from './registry'
 import type { RootState } from '../store'
+import AppIcon from '../components/AppIcon'
 
 // Memoized at the source so `selectAllSurfacesAttention`'s per-dispatch
 // invocation only re-runs the .filter().length when the items array changes
@@ -75,7 +76,7 @@ registerBuiltinSurface({
   navId: 'apps',
   route: '/apps',
   label: 'App Store',
-  icon: <img src="/app-assets/app-store/icon.svg" width={16} height={16} alt="" style={{ borderRadius: 4 }} />,
+  icon: <AppIcon iconUrl="/app-assets/app-store/icon.svg" size={16} />,
   group: 'Apps',
 })
 


### PR DESCRIPTION
## Summary

Built-in app icons hardcoded a rainbow palette that ignored the active theme, causing contrast problems across the 22 light/dark themes. This recolors the six builtin icons to **two theme-reactive tokens** and routes every render path through the inline `AppIcon` so the theme actually applies.

- **Two-color scheme** driven by CSS vars on `.app-icon`:
  - idle → `--ico-a: var(--muted)`, `--ico-b: var(--accent)`
  - selected/hover → `--ico-a: var(--accent)`, `--ico-b: var(--text)`
- **`AppIcon` now inlines** `/app-assets/*` SVGs (CSS vars can't cascade into an `<img>`), with per-instance SVG-id uniquification so the file-explorer overlap mask can't collide. Non-app-asset icons (registry blob proxy) still render as `<img>`.
- **Fixed black icons**: the left-nav (`App.tsx`) and the App Store surface icon (`surfaces/builtins.tsx`) rendered these SVGs as raw `<img>`, so `currentColor` fell back to black. Both now use `AppIcon`.
- **Selected state**: active nav rows (and row hover) promote the icon to the accent-dominant look.

### Icon touch-ups
- `file-explorer`: rounded corners + a mask so the back file no longer bleeds through the translucent front file (only the top-right sliver shows).
- `projects` (rocket): exhaust dots restored.
- `app-store`: bottom-right grid inverts its two tones.

## Testing
- `tsc --noEmit` — clean
- `eslint` on changed files — 0 errors (1 pre-existing warning on `AppIcon`'s `<img onError>`, unchanged from `main`)
- Previewed live across light/dark themes via the isolated dev gateway

## Notes
- Hero images (`hero-*.svg`) are unchanged — they're intentionally full-color art loaded as `<img>`.

<img width="2644" height="1028" alt="image" src="https://github.com/user-attachments/assets/6b9dc8f0-4772-448b-8d8d-b81baaf74f8c" />

