### PR TITLE
fix(prompt): dedupe diff-block rule from injected critical rules

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -555,14 +555,13 @@ def _load_steering_resources() -> str:
 
 
 # Critical rules reinforced every session (supplements the system prompt)
+# NOTE: The diff-block output rule is stated authoritatively in the base system
+# prompt (config/prompt.md, "## Output Format") and is intentionally NOT repeated
+# here — restating it duplicated ~7 lines into every dashboard turn. Keep this
+# block scoped to the rules that are NOT in prompt.md (absolute-path + [OPTIONS:]).
+# Do not re-add the diff-block rule here; edit prompt.md instead.
 _CRITICAL_RULES = (
     "[CRITICAL RULES — always follow these]\n"
-    "After ANY file change (create, edit, append, delete), you MUST show a "
-    "```diff code block with the change using standard unified diff format "
-    "including `--- old_path` / `+++ new_path` headers and an `@@` hunk line "
-    "(use /dev/null for new files / deletions). The headers are required so "
-    "the dashboard's diff viewer can link to the file. No exceptions — even "
-    "single-line changes MUST get a diff block.\n"
     "When referencing file paths in your response, ALWAYS use the absolute path "
     "inside inline `code` backticks (e.g. `/home/user/project/src/main.py`). "
     "Never use relative paths or bare filenames. This enables the UI file viewer panel.\n"

--- a/test/test_agent_model_propagation.py
+++ b/test/test_agent_model_propagation.py
@@ -1,0 +1,76 @@
+"""Regression tests for Mesh-2292 model propagation.
+
+On refresh of an existing kirocrew.json, the user-facing authority is
+``config.json`` ``agent.model``. An explicit pick (not the "auto" sentinel)
+MUST be propagated into the agent file so kiro-cli's ``--agent`` startup load
+matches it -- otherwise a stale agent-file model shadows config.json and
+session/set_model loses the startup race (the model appears not to change).
+The "auto" sentinel must defer to managed/shipped resolution and must never be
+written as the literal model.
+
+Reuses the install harness from test_agent.py. _run_install seeds the mc
+config file only if it does not already exist, so pre-writing it lets us drive
+the agent.model branch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from test_agent import _bundled_defaults, _run_install
+
+from kiro_crew import agent_state
+
+
+def _seed_mc_config(tmp_path: Path, agent_model: str | None) -> None:
+    """Pre-create the mc config file _run_install would otherwise write."""
+    agent_section: dict = {"kiro_hooks_autoimport": False}
+    if agent_model is not None:
+        agent_section["model"] = agent_model
+    (tmp_path / "empty_mc_config.json").write_text(json.dumps({"agent": agent_section}))
+
+
+def _write_existing_agent(tmp_path: Path, model: str) -> None:
+    kiro_dir = tmp_path / "kiro_agents"
+    kiro_dir.mkdir(exist_ok=True)
+    (kiro_dir / "kirocrew.json").write_text(
+        json.dumps(
+            {
+                "name": "kirocrew",
+                "model": model,
+                "tools": ["ReadFile"],
+                "allowedTools": ["ReadFile"],
+                "mcpServers": {},
+                "toolsSettings": {"execute_bash": {"deniedCommands": ["old"]}},
+            }
+        )
+    )
+
+
+def test_explicit_config_model_propagates_into_agent_file(tmp_path: Path):
+    """config.json agent.model (explicit) overrides a stale agent-file model."""
+    cfg_dir = _bundled_defaults(tmp_path)
+    _write_existing_agent(tmp_path, model="stale-agent-model")
+    _seed_mc_config(tmp_path, agent_model="claude-explicit-pick")
+
+    path = _run_install(tmp_path, cfg_dir)
+    config = json.loads(path.read_text())
+
+    assert config["model"] == "claude-explicit-pick"
+
+
+def test_auto_sentinel_never_written_as_literal_model(tmp_path: Path):
+    """agent.model == "auto" must defer, never become the literal model."""
+    cfg_dir = _bundled_defaults(tmp_path)
+    _write_existing_agent(tmp_path, model="stale-agent-model")
+    # Unmanaged so refresh does not re-sync to the shipped default; the existing
+    # model should be preserved and "auto" must not overwrite it.
+    agent_state.set_model_managed("kirocrew", False)
+    _seed_mc_config(tmp_path, agent_model="auto")
+
+    path = _run_install(tmp_path, cfg_dir)
+    config = json.loads(path.read_text())
+
+    assert config["model"] != "auto"
+    assert config["model"] == "stale-agent-model"

--- a/test/test_memory_smoke.py
+++ b/test/test_memory_smoke.py
@@ -121,7 +121,10 @@ class TestMemoryInjectionAllAgents:
         builder = _builder(tmp_path)
         ctx = builder.build_session_context(agent="my-custom-agent")
         assert "[CRITICAL RULES" in ctx
-        assert "diff" in ctx
+        # The diff-block rule is authoritative in the base system prompt
+        # (config/prompt.md), not restated in the injected _CRITICAL_RULES block;
+        # assert a rule that legitimately remains in the injected block.
+        assert "absolute path" in ctx
 
     def test_custom_agent_skips_skills(self, tmp_path: Path) -> None:
         skills_dir = tmp_path / "skills" / "test"

--- a/test/test_prompt_dedupe.py
+++ b/test/test_prompt_dedupe.py
@@ -1,0 +1,42 @@
+"""Regression guard for the prompt.md <-> _CRITICAL_RULES dedupe.
+
+The diff-block output rule must be stated exactly once in what a dashboard
+session receives: authoritatively in the base system prompt (config/prompt.md),
+and NOT re-stated in the per-turn injected _CRITICAL_RULES block. The dashboard
+session gets both prompt.md (system prompt) and _CRITICAL_RULES (injected), so
+duplicating the rule wastes ~7 lines on every turn. The absolute-path and
+[OPTIONS:] rules are dashboard-only and must remain in _CRITICAL_RULES.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.agent import _BUNDLED_CFG_DIR
+from kiro_crew.context import _CRITICAL_RULES
+
+# Distinctive fragment of the diff-block mandate.
+_DIFF_RULE_FRAGMENT = "diff code block"
+
+
+def _prompt_md_text() -> str:
+    return (Path(_BUNDLED_CFG_DIR) / "prompt.md").read_text(encoding="utf-8")
+
+
+def test_diff_rule_is_authoritative_in_prompt_md():
+    """The diff-block mandate must live in the base system prompt."""
+    assert _DIFF_RULE_FRAGMENT in _prompt_md_text()
+
+
+def test_diff_rule_not_duplicated_in_critical_rules():
+    """The diff-block mandate must NOT be restated in _CRITICAL_RULES (dedupe)."""
+    assert _DIFF_RULE_FRAGMENT not in _CRITICAL_RULES
+
+
+def test_critical_rules_retains_dashboard_only_rules():
+    """Dedupe must not drop the rules that are unique to _CRITICAL_RULES."""
+    # Absolute-path rule (drives the UI file viewer) and the [OPTIONS:] rule
+    # are not in prompt.md, so they must survive in _CRITICAL_RULES.
+    assert "absolute path" in _CRITICAL_RULES
+    assert "[OPTIONS:" in _CRITICAL_RULES
+    assert "[CRITICAL RULES" in _CRITICAL_RULES


### PR DESCRIPTION
Bundles two confirmed findings from the MeshClaw pain-point audit that both live in prompt/agent-config assembly. The first is a behavior fix; the second is test-only regression coverage, folded in at the author's request.

## Problem
1. **Duplicated diff-block rule.** The mandatory diff-block output rule is stated **twice** in what every dashboard turn receives: once in the base system prompt (`config/prompt.md`, "## Output Format") and again, verbatim, in the per-turn injected `_CRITICAL_RULES` block (`src/kiro_crew/context.py`). A dashboard session is sent both, so the ~7-line rule is duplicated on every turn — the concrete "system prompt and injected prompt overlapped" complaint from user feedback.
2. **No regression coverage for Mesh-2292 model propagation.** The already-shipped fix that propagates `config.json` `agent.model` into the refreshed agent file had no test, so a future refactor could silently reintroduce the "model won't change" bug.

## Why it matters
The duplication burns ~7 prompt-token lines on every dashboard turn for zero behavioral benefit and lets the two copies drift out of sync — contributing to the context bloat users report. The missing test leaves a confirmed, user-visible bug (model selection appearing to do nothing) unguarded.

## Fix (symptom → root cause → change)
- **Symptom:** the diff-block mandate appears twice per dashboard turn.
- **Root cause:** `prompt.md` (base system prompt, also governs kiro-cli terminal sessions) already states the rule; `_CRITICAL_RULES` restated it as per-turn reinforcement, but dashboard sessions receive *both* — pure duplication.
- **Change:** remove the diff-block restatement from `_CRITICAL_RULES`, keeping it authoritative in `prompt.md`, with a guard comment so it is not re-added. The absolute-path and `[OPTIONS:]` rules are unique to `_CRITICAL_RULES` (not in `prompt.md`) and are retained unchanged — no rule is dropped from any path. No production code change for item 2 (already fixed on main); this PR only adds its missing test.

## Tests
- `test/test_prompt_dedupe.py` (new) — locks the dedupe: diff-block rule present in `prompt.md`, absent from `_CRITICAL_RULES`, and the dashboard-only rules (absolute-path, `[OPTIONS:]`) survive.
- `test/test_agent_model_propagation.py` (new) — locks Mesh-2292: `config.json` `agent.model` (explicit) propagates into the refreshed agent file, and the `"auto"` sentinel never becomes the literal model.
- `test/test_memory_smoke.py` (updated) — `test_custom_agent_gets_critical_rules` previously asserted the diff rule inside the injected `_CRITICAL_RULES`; post-dedupe that rule lives in `prompt.md`, so the test now asserts a rule that legitimately remains in the injected block (absolute-path).

## Manual verification
N/A — prompt-text + test changes, fully covered by unit tests. The diff-block rule still reaches the model once via the system prompt, so diff rendering is unaffected.
