### PR TITLE
feat(ci): notarize + staple macOS builds across all release channels

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -165,6 +165,8 @@ jobs:
     name: Publish Nightly
     needs: [version, build-wheel, build-desktop]
     runs-on: ubuntu-latest
+    outputs:
+      signed_zip_key: ${{ steps.sign.outputs.signed_zip_key }}
     permissions:
       id-token: write
       contents: read
@@ -235,6 +237,7 @@ jobs:
           fi
 
       - name: Sign with CDSigner
+        id: sign
         if: env.HAS_CDSIGNER && env.APP_PATH != ''
         env:
           AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
@@ -243,32 +246,11 @@ jobs:
         run: |
           bash packaging/signing/sign.sh "$APP_PATH" nightly "$VERSION"
           echo "SIGNED_ZIP=signed/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_ENV"
+          echo "signed_zip_key=signed/nightly/${VERSION}/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_OUTPUT"
 
-      # ── Write update feed ─────────────────────────────────────────────────
-      # Only writes the feed AFTER signing completes. Unsigned artifacts must
-      # never appear in the update feed — clients would auto-update to a build
-      # that macOS Gatekeeper blocks. When CDSigner is not configured, the
-      # workflow stops at uploading to pre-signed/ and the feed is unchanged.
-
-      - name: Write update feed
-        if: env.HAS_CDSIGNER && env.SIGNED_ZIP != ''
-        run: |
-          CHANNEL="nightly"
-          BUCKET="${{ secrets.AWS_SIGNING_BUCKET }}"
-          ZIP_KEY="${SIGNED_ZIP}"
-
-          # Write latest-mac.json (Squirrel.Mac format)
-          cat > /tmp/latest-mac.json <<EOF
-          {
-            "version": "${VERSION}",
-            "url": "https://${BUCKET}.s3.us-west-2.amazonaws.com/${ZIP_KEY}",
-            "name": "${VERSION}",
-            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          }
-          EOF
-          aws s3 cp /tmp/latest-mac.json "s3://${BUCKET}/feed/${CHANNEL}/latest-mac.json" \
-            --content-type application/json
-          echo "Feed written: feed/${CHANNEL}/latest-mac.json → ${ZIP_KEY}"
+      # The update feed is written by the notarize job (notarize-macos.yml)
+      # AFTER stapling. Un-notarized artifacts must never appear in the feed --
+      # clients would auto-update to a build macOS Gatekeeper blocks.
 
       - name: Summary
         run: |
@@ -294,3 +276,18 @@ jobs:
       version: ${{ needs.version.outputs.nightly_version }}
       wheel_artifact: nightly-wheel
     secrets: inherit
+
+  notarize:
+    name: Notarize macOS
+    needs: [version, publish]
+    if: needs.publish.outputs.signed_zip_key != ''
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/notarize-macos.yml
+    secrets: inherit
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      signed_zip_key: ${{ needs.publish.outputs.signed_zip_key }}
+      write_feed: true

--- a/.github/workflows/notarize-macos.yml
+++ b/.github/workflows/notarize-macos.yml
@@ -1,0 +1,173 @@
+name: Notarize macOS (reusable)
+
+# Reusable workflow: notarize + staple an already-CDSigner-signed macOS app.
+# Called by nightly.yml (channel: nightly) and release.yml (channel:
+# insider | stable). See docs/signing-runbook.md for the full chain and the
+# credential rotation procedure.
+#
+# Key properties:
+#   - Consumes the signed zip CDSigner wrote to signed/<...>; never touches
+#     unsigned artifacts.
+#   - The Apple credential is fetched from AWS Secrets Manager at runtime
+#     (kirocrew/signing/apple-notary) via the same OIDC role used for
+#     signing. The password is masked and scoped to a single step; it is
+#     never persisted to GITHUB_ENV, files, or logs.
+#   - Fails closed: Gatekeeper assessment (spctl) must report
+#     "Notarized Developer ID" or the job fails. On an Invalid notarization
+#     the itemized Apple log is printed for diagnosis.
+#   - Writes the update feed AFTER stapling. Un-notarized artifacts must
+#     never appear in the update feed for the same reason unsigned ones
+#     must not: clients would auto-update to a build Gatekeeper blocks.
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Release channel: nightly | insider | stable"
+        required: true
+        type: string
+      version:
+        description: "Version label used in S3 keys and the feed"
+        required: true
+        type: string
+      signed_zip_key:
+        description: "S3 key of the CDSigner-signed zip (signed/<channel>/<version>/<App>.zip)"
+        required: true
+        type: string
+      write_feed:
+        description: "Write feed/<channel>/latest-mac.json pointing at the notarized artifact"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  notarize:
+    name: Notarize + staple (${{ inputs.channel }})
+    runs-on: macos-14
+    timeout-minutes: 45
+    env:
+      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      SIGNED_ZIP_KEY: ${{ inputs.signed_zip_key }}
+    steps:
+      - name: Configure AWS credentials
+        if: env.HAS_SIGNING_SECRETS
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Download signed artifact
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          mkdir -p work
+          aws s3 cp "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${SIGNED_ZIP_KEY}" work/signed.zip --only-show-errors
+          ls -la work/
+
+      # The credential lives in Secrets Manager (never GitHub secrets --
+      # Amazon custody, CloudTrail audit, rotation lifecycle). It is fetched,
+      # masked, used, and discarded inside this single step.
+      - name: Notarize with Apple notary service
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id kirocrew/signing/apple-notary \
+            --query SecretString --output text)
+          APPLE_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['apple_id'])")
+          APPLE_PW=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['password'])")
+          TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
+          echo "::add-mask::$APPLE_PW"
+          unset SECRET_JSON
+
+          echo "Submitting to Apple notary service (team $TEAM_ID)..."
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit work/signed.zip \
+            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
+            --wait --timeout 30m 2>&1)
+          RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
+
+          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
+            echo "Notarization was not Accepted. Fetching the itemized Apple log..."
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
+            fi
+            exit 1
+          fi
+          echo "Notarization Accepted: $SUBMISSION_ID"
+
+      - name: Staple and verify
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          mkdir -p work/stapled && cd work/stapled
+          unzip -q ../signed.zip
+          APP=$(find . -maxdepth 1 -name "*.app" | head -1)
+          [ -n "$APP" ] || { echo "No .app found in signed zip"; exit 1; }
+
+          xcrun stapler staple "$APP"
+          xcrun stapler validate "$APP"
+
+          ASSESS=$(spctl --assess --type execute --verbose "$APP" 2>&1)
+          echo "$ASSESS"
+          echo "$ASSESS" | grep -q "Notarized Developer ID" || {
+            echo "Gatekeeper assessment did not report 'Notarized Developer ID' -- failing closed."
+            exit 1
+          }
+
+          # ditto preserves the resource fork carrying the stapled ticket.
+          /usr/bin/ditto -c -k --keepParent "$APP" ../notarized.zip
+          echo "APP_NAME=$(basename "$APP" .app)" >> "$GITHUB_ENV"
+
+      - name: Upload notarized artifact to S3
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          KEY="notarized/${CHANNEL}/${VERSION}/${APP_NAME}.zip"
+          aws s3 cp work/notarized.zip "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}" --only-show-errors
+          echo "NOTARIZED_KEY=${KEY}" >> "$GITHUB_ENV"
+          echo "Notarized artifact: s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
+
+      # Feed points at the NOTARIZED artifact -- written only after the
+      # spctl gate above passed.
+      - name: Write update feed
+        if: env.HAS_SIGNING_SECRETS && inputs.write_feed
+        run: |
+          cat > /tmp/latest-mac.json <<EOF
+          {
+            "version": "${VERSION}",
+            "url": "https://${{ secrets.AWS_SIGNING_BUCKET }}.s3.us-west-2.amazonaws.com/${NOTARIZED_KEY}",
+            "name": "${VERSION}",
+            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          aws s3 cp /tmp/latest-mac.json \
+            "s3://${{ secrets.AWS_SIGNING_BUCKET }}/feed/${CHANNEL}/latest-mac.json" \
+            --content-type application/json
+          echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${NOTARIZED_KEY}"
+
+      - name: Attach notarized artifact to workflow run
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
+          path: work/notarized.zip
+          retention-days: 14
+
+      - name: Summary
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          {
+            echo "## Notarization (${CHANNEL})"
+            echo "- Version: ${VERSION}"
+            echo "- Input: \`${SIGNED_ZIP_KEY}\`"
+            echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,15 +87,40 @@ jobs:
           if-no-files-found: warn
 
   release:
-    name: Create Release
+    name: Sign for Release
     needs: [build-wheel, build-desktop]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.channel.outputs.version }}
+      channel: ${{ steps.channel.outputs.channel }}
+      signed_zip_key: ${{ steps.sign.outputs.signed_zip_key }}
     permissions:
-      contents: write
+      contents: read
       id-token: write
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      HAS_CDSIGNER: ${{ secrets.CDSIGNER_API_ENDPOINT != '' && 'true' || '' }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: packaging/signing
+
+      # Channel from the tag: pre-release tags (v1.2.3-insider.1, -rc.1, etc.)
+      # release on the insider channel; bare semver tags are stable.
+      - name: Derive version + channel from tag
+        id: channel
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          case "$VERSION" in
+            *-*) CHANNEL="insider" ;;
+            *)   CHANNEL="stable" ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
+          echo "Releasing $VERSION on channel $CHANNEL"
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
@@ -106,6 +131,14 @@ jobs:
           find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" \) -exec cp {} release/ \;
           ls -la release/
 
+      # Install the CDSigner SigV4 client BEFORE AWS credentials are configured
+      # (same supply-chain ordering as nightly.yml).
+      - name: Install awscurl (SigV4 client for CDSigner)
+        if: env.HAS_CDSIGNER
+        run: |
+          python3 -m pip install --user --quiet "awscurl==0.44"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -113,18 +146,83 @@ jobs:
           role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Upload unsigned DMG to S3 for signing
+      - name: Upload unsigned artifacts to S3
         if: env.HAS_SIGNING_SECRETS
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          for f in release/*.dmg release/*.zip; do
+          for f in release/*; do
             [ -f "$f" ] || continue
-            echo "Uploading $f → s3://${{ secrets.AWS_SIGNING_BUCKET }}/pre-signed/${VERSION}/$(basename $f)"
-            aws s3 cp "$f" "s3://${{ secrets.AWS_SIGNING_BUCKET }}/pre-signed/${VERSION}/$(basename $f)"
+            KEY="pre-signed/${CHANNEL}/${VERSION}/$(basename "$f")"
+            echo "Uploading $f → s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
+            aws s3 cp "$f" "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
           done
+
+      - name: Extract .app from zip for signing
+        if: env.HAS_CDSIGNER
+        run: |
+          mkdir -p unsigned-app
+          MAC_ZIP=$(find release -name "*arm64*.zip" | head -1)
+          if [ -n "$MAC_ZIP" ]; then
+            unzip -q "$MAC_ZIP" -d unsigned-app/
+            echo "APP_PATH=$(find unsigned-app -name '*.app' -maxdepth 1 | head -1)" >> "$GITHUB_ENV"
+          else
+            echo "No macOS zip found — skipping signing"
+            echo "APP_PATH=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Sign with CDSigner
+        id: sign
+        if: env.HAS_CDSIGNER && env.APP_PATH != ''
+        env:
+          AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+          AWS_SIGNER_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
+          CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
+        run: |
+          bash packaging/signing/sign.sh "$APP_PATH" "$CHANNEL" "$VERSION"
+          echo "signed_zip_key=signed/${CHANNEL}/${VERSION}/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_OUTPUT"
+
+  notarize:
+    name: Notarize macOS
+    needs: [release]
+    if: needs.release.outputs.signed_zip_key != ''
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/notarize-macos.yml
+    secrets: inherit
+    with:
+      channel: ${{ needs.release.outputs.channel }}
+      version: ${{ needs.release.outputs.version }}
+      signed_zip_key: ${{ needs.release.outputs.signed_zip_key }}
+      write_feed: true
+
+  github-release:
+    name: Create GitHub Release
+    needs: [release, notarize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: artifacts
+
+      # Assemble release assets: everything built, with the macOS zip
+      # replaced by the notarized + stapled one from the notarize job.
+      - name: Flatten artifacts (notarized macOS zip wins)
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.dmg" -o -name "*.AppImage" \) -exec cp {} release/ \;
+          NOTARIZED=$(find artifacts -path "*KiroCrew-notarized-*" -name "notarized.zip" | head -1)
+          if [ -n "$NOTARIZED" ]; then
+            cp "$NOTARIZED" "release/KiroCrew-${{ needs.release.outputs.version }}-arm64-mac.zip"
+          else
+            find artifacts -type f -name "*arm64*.zip" -exec cp {} release/ \;
+          fi
+          ls -la release/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
+          prerelease: ${{ needs.release.outputs.channel == 'insider' }}
           files: release/*

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -71,16 +71,31 @@ class TestNightlyPermissions:
             "contents": "read",
             "id-token": "write",
         }
+        # Caller job for the reusable notarize workflow: a workflow_call
+        # callee can never exceed the caller job's permissions, so the
+        # caller must grant id-token explicitly.
+        assert _permission_block(lines, "  notarize:") == {
+            "id-token": "write",
+            "contents": "read",
+        }
 
 
 class TestReleasePermissions:
-    def test_only_release_job_has_write_and_oidc_permissions(self) -> None:
+    def test_release_jobs_follow_least_privilege_split(self) -> None:
+        """The signing job holds AWS creds (id-token) but must not hold
+        contents:write; the GitHub-Release job holds contents:write but must
+        not hold AWS creds. Keeping the two capabilities in separate jobs
+        means a compromise of either job cannot both exfiltrate via AWS and
+        tamper with the repo/release."""
         lines = _lines("release.yml")
 
         assert _workflow_permissions("release.yml") == {"contents": "read"}
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
         assert _permission_block(lines, "  release:") == {
-            "contents": "write",
+            "contents": "read",
             "id-token": "write",
+        }
+        assert _permission_block(lines, "  github-release:") == {
+            "contents": "write",
         }


### PR DESCRIPTION
Adds the missing half of the macOS release chain. CI previously stopped at CDSigner signing; this makes every channel produce a notarized, stapled, Gatekeeper-clean artifact.

## Design
- **notarize-macos.yml (new, reusable)**: `workflow_call` parameterized on `channel` -- nightly, insider, and stable share one notarize path. Downloads the CDSigner-signed zip, fetches the Apple credential from AWS Secrets Manager at runtime (masked via `::add-mask::`, single-step scope, never persisted to env/files), `notarytool submit --wait --timeout 30m`, staples, **fails closed on the spctl Gatekeeper assertion**, uploads to `notarized/<channel>/<version>/`, then writes the update feed. On Invalid it prints Apple's itemized log.
- **nightly.yml**: publish job exports the signed zip key; the feed write **moves after stapling** -- extends the existing invariant ("unsigned artifacts must never appear in the update feed") to notarization, since an un-notarized build is exactly what Gatekeeper blocks.
- **release.yml**: derives channel from tag (`v1.2.3-insider.1` -> insider + GitHub pre-release, `v1.2.3` -> stable), **adds CDSigner signing** (tag releases previously attached unsigned artifacts), notarizes via the shared workflow, and attaches the notarized zip to the GitHub Release.

## Prerequisites (all live)
- Signed artifacts are notarizable since #74 (validated end-to-end: notarytool **Accepted**, `spctl source=Notarized Developer ID`)
- Secret `kirocrew/signing/apple-notary` populated; read grant deployed (CR-290716307)
- `notarized/*` put grant deployed to KiroCrewCdSigner

## Validation
- YAML parse clean on all three workflows; inclusive-language self-check clean; single commit.
- Runtime validation is post-merge by design: the signing OIDC trust is scoped to `refs/heads/main` + `environment:prod`, so feature-branch runs cannot assume the role. First post-merge nightly validates the full chain.

## Follow-ups (tracked, out of scope)
- Desktop version stamp is date-only (`0.1.0-nightly.YYYYMMDD`) -- needs seconds precision before mac artifacts move to the public CDN (same class as #62)
- Generator hardenings: dynamic Electron shell entries + nested-bundle tripwire