### PR TITLE
feat(code-review-sage): single-runtime review pool + repo-wide review

### DIFF
--- a/docs/plans/code-review-sage-scale.md
+++ b/docs/plans/code-review-sage-scale.md
@@ -1,0 +1,86 @@
+# Code Review Sage — Scale & CPU Optimization Plan
+
+Status: proposed · Owner: zejiangg · Scope: `apps/builtins/code_review_sage` + `acp/` + `website/src/apps/code-review-sage`
+
+## Problem
+
+1. **CPU "roar"** when reviewing. Root cause (verified, not a spin loop):
+   - Up to 5 full kiro-cli **subprocesses** at once (`review_pool.py` `MAX_CONCURRENT=5`).
+   - Convergence loop stacks ~5 agent turns/PR (`review_driver.py` `max_review_rounds` default 3).
+   - Full **process respawn on every worker reuse** (`AcpReviewWorker.reset()` = `shutdown()`+`start()`), because `AcpClient` has no in-process reset.
+2. No way to point at a **repo** and review all open PRs; only pasted PR links.
+3. Pool = one subprocess per worker → cannot scale concurrency without multiplying processes.
+
+## Decisions (locked)
+
+- **D1 Sequencing:** #2 (shared runtime) first, then #1 (repo review). #2 makes #1 safe to scale.
+- **D2 Single, batch-scoped runtime:** exactly **one shared `AcpRuntime`** at a time, multiplexing all in-flight reviews as **one `AcpSessionHandle` per PR** (isolated context, no cross-PR pollution). Lifecycle is tied to the batch, tracked by an in-flight counter under a lock:
+  - Lazy `spawn()` on the first review task when no runtime is running.
+  - `create_session()` per PR; `handle.destroy()` as each PR finishes (frees that session's memory during large batches).
+  - When the in-flight count drains to **zero (all reviews done)**, `shutdown()` the entire runtime (kills the subprocess → reclaims all RSS). A new review task spawns a fresh runtime.
+  - This makes the "no per-turn compaction" RSS caveat moot — memory is bounded to a single batch and released on drain. No stale-threshold recycling needed.
+- **D3 Concurrency:** default stays **5**, configurable up to **~30** via `review.max_concurrent`. "Review all" does not implicitly raise it.
+- **D4 Dedup:** a PR is "not yet reviewed" if absent from the reviewed-index **or its head SHA changed**. Force-all ignores the index.
+
+---
+
+## Phase 0 — Immediate CPU relief (config only, no structural change)
+
+Make the three amplifiers tunable and default them gentler-friendly:
+- `review.max_concurrent` (new, default 5) — replaces the hardcoded `MAX_CONCURRENT` constant as source of truth (driver fan-out + pool both read it).
+- Confirm `review.max_review_rounds` (exists, default 3) and `review.effort` are surfaced in settings.
+
+Deliverable: config plumbing + settings UI already exposes model/effort; add max_concurrent + max_review_rounds sliders. Ships value even before the re-architecture.
+
+## Phase 1 — #2 Shared AcpRuntime migration (the core CPU fix)
+
+Goal: replace the `AcpClient`-per-worker pool with **one shared, batch-scoped `AcpRuntime`** hosting one `AcpSessionHandle` per PR.
+
+Files:
+- `sage_lib/review_pool.py` — rewrite the worker abstraction:
+  - A single-runtime holder guarded by a lock + an **in-flight counter**: lazy `spawn()` when the count goes 0→1; `shutdown()` when it drains 1→0 (batch-scoped teardown).
+  - `AcpReviewWorker` becomes a thin per-PR wrapper: `runtime.create_session(...)` for the PR, run the review on that handle, `handle.destroy()` on completion.
+  - Per-PR isolation is the distinct `sessionId`; no more `reset()` respawn.
+  - Concurrency bounded by a `review.max_concurrent` semaphore over session-handles (still one subprocess regardless of width).
+- `acp/runtime.py` / `session_handle.py` — reuse as-is (API confirmed: `spawn`, `create_session`, `handle.prompt`, `handle.destroy`, `shutdown`, `has_active_sessions`). No core edits expected.
+- `review_driver.py` — dispatch unchanged in shape; fan-out width reads `review.max_concurrent`.
+
+Guard: a stuck session must not block batch teardown — the existing `DEFAULT_TASK_TIMEOUT` bounds each task; on timeout, force `handle.destroy()` and decrement the in-flight count so the runtime can still drain to zero and shut down.
+
+Tests: adapt `code_review_sage/tests/` pool tests to the single-runtime model; add a concurrency test (N sessions on the one runtime), a `destroy()`-on-finish test, and a **batch-drain teardown** test (runtime `shutdown()` fires when the last review completes; a new task spawns a fresh runtime).
+
+Risk: RSS growth (no per-turn compaction) → mitigated by D2 (per-PR `destroy()` + whole-runtime teardown on batch drain).
+
+## Phase 2 — #1 Repo review + reviewed-index
+
+Files:
+- `sage_lib/adapters.py` — add repo-URL parse + hostname allowlist (`github.com/<owner>/<repo>` with no `/pull/`), mirroring `detect_platform`.
+- `sage_lib/pipeline.py` — `list_open_prs(repo)` via backend `gh api repos/<o>/<r>/pulls?state=open --paginate` (token-free, host `gh` auth), returning `[{url, number, head_sha, title}]`.
+- `sage_lib/results.py` (or `store.py`) — new durable **reviewed-index** `data/reviewed.json`: `{ "GH-<owner>-<repo>-<n>": {"head_sha", "reviewed_at", "run_id"} }`, atomic-write + 0600 (mirror existing pattern).
+- `backend/routes.py`:
+  - `POST /review-repo` `{repo, skip_reviewed=true, max_concurrent?}` → enumerate → dedup (unless `skip_reviewed=false`) → `run_review(changes=...)`.
+  - `GET /repo-prs?repo=...` → list open PRs annotated with reviewed/not-reviewed (+ stale-SHA) for the UI.
+  - After a run finishes, write reviewed-index entries (change-id + head SHA).
+
+Tests: repo-URL parsing + allowlist; enumeration parsing; dedup by head-SHA (new / unchanged / SHA-changed / force-all); index write/read.
+
+## Phase 3 — Frontend (`website/src/apps/code-review-sage/CodeReviewSagePage.tsx`)
+
+- Add a **repo-link input** alongside the existing paste box.
+- On enter: `GET /repo-prs` → render open PRs with **reviewed / not-reviewed / updated** badges.
+- **"Review all"** button → `POST /review-repo` with `skip_reviewed=true`; a **"Force review ALL"** secondary → `skip_reviewed=false`.
+- A **concurrency control** (slider/select, default 5, max from backend) wired to `review.max_concurrent`.
+- Reuse existing `/runs` polling + Focus Report display unchanged.
+
+Verify: `tsc -b` + touched vitest specs.
+
+## Phase 4 — Verify & ship
+
+- Backend: `pytest code_review_sage/tests` + `test_governance_*` unaffected; `flake8` on touched files.
+- Frontend: `tsc -b`, `npm run build`.
+- Manual: point at a repo with several open PRs; confirm dedup, force-all, and that concurrency cap holds; watch process count (should be ≤ pool size, not per-PR) and CPU.
+
+## Out of scope / caveats
+
+- 30 *simultaneous* agent turns is still real load; the win is process/memory overhead + churn, not eliminating inference cost. Concurrency stays capped/configurable.
+- GitLab/other hosts: enumeration is GitHub-only in v1 (matches current `gh`/GitHub-only posting).

--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -288,7 +288,7 @@ Subprocess lifecycle:
 
 ### Worker-pool tool audit (`audit_source`)
 
-The `audit_source` constructor param (default `None`) tags an `AcpClient` that runs tools **outside** the chat_runner / SubagentManager audit loop — App / worker-pool clients (code-review-sage, knowledge `llm_pool`) whose tool calls would otherwise never reach the security audit log. When set, `_maybe_audit_tool_call()` emits a per-tool-call SEL `tool_invocation` record; when `None` (chat / subagent clients) it is a no-op so those paths never double-log. The `sel().log_tool_invocation` call is offloaded onto `subprocess_executor()` (so SEL-backend I/O can never block the event loop) and bounded by `asyncio.wait_for(..., _SEL_AUDIT_TIMEOUT_SECONDS=5.0)`; a timeout or any SEL failure is swallowed (logged at `WARNING`) so tool dispatch always proceeds.
+The `audit_source` constructor param (default `None`) tags an `AcpClient` that runs tools **outside** the chat_runner / SubagentManager audit loop — the knowledge `llm_pool` worker-pool client, whose tool calls would otherwise never reach the security audit log. When set, `_maybe_audit_tool_call()` emits a per-tool-call SEL `tool_invocation` record; when `None` (chat / subagent clients) it is a no-op so those paths never double-log. The `sel().log_tool_invocation` call is offloaded onto `subprocess_executor()` (so SEL-backend I/O can never block the event loop) and bounded by `asyncio.wait_for(..., _SEL_AUDIT_TIMEOUT_SECONDS=5.0)`; a timeout or any SEL failure is swallowed (logged at `WARNING`) so tool dispatch always proceeds. **Note:** Code Review Sage's `ReviewPool` used to be an `audit_source` `AcpClient` consumer here, but it migrated to the shared `AcpRuntime` path (see "Additional consumers" above) — the runtime layer has no `audit_source`, so the pool re-emits the same per-tool SEL `tool_invocation` audit itself from `sage_lib/review_pool.py` (preserving audit parity).
 
 ## Image Support
 
@@ -324,5 +324,12 @@ Every kiro session runs on `AcpRuntime` + `AcpSessionHandle`:
 `_start_kiro_runtime()` for the kiro backend, wrapping an `AcpSessionHandle` in
 `AcpSessionProvider` — so main chat, dashboard, cron, and subagents all run on
 the runtime rather than a per-session `AcpClient`. Additional consumers:
-`AcpRuntime` also powers the `_bg` pool and (when `agent.session_sharing` is on)
-the shared parent+subagents runtime. See `providers.md` and `subagent.md`.
+`AcpRuntime` also powers the `_bg` pool, (when `agent.session_sharing` is on)
+the shared parent+subagents runtime, and **Code Review Sage's `ReviewPool`**
+(`apps/builtins/code_review_sage/sage_lib/review_pool.py`) — one batch-scoped
+`AcpRuntime` multiplexing one `AcpSessionHandle` per PR under a concurrency
+semaphore (`review.max_concurrent`, default 5, ceiling 30), spawned on batch
+start and `kill()`ed when the batch drains, with each per-PR session
+`destroy()`ed on completion for context isolation. Because the runtime layer has
+no `audit_source`, the pool re-emits the equivalent per-tool SEL audit itself
+(see the `audit_source` note above). See `providers.md` and `subagent.md`.

--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -80,7 +80,7 @@ Default 365 days. Pruned daily by heartbeat service (`_PRUNE_TICKS`).
 | MCP core tools | `spawn_run`, `learn_add`, `task_run` calls and outcomes | `mcp_core.py` |
 | MCP cron tools | `cron_add`, `cron_remove`, etc. calls and outcomes | `mcp_cron.py` |
 | Dashboard API | All POST/PUT/DELETE operations via middleware | `dashboard/server.py` |
-| ACP worker-pool audit | Per-tool_call `auto_approved` `tool_invocation` via `_maybe_audit_tool_call`, gated on the `audit_source` ctor param (code-review-sage ReviewPool + knowledge LLMPool, `source=subagent`); offloaded to `subprocess_executor()` and bounded by `_SEL_AUDIT_TIMEOUT_SECONDS` (5.0s) so a wedged SEL backend never gates dispatch | `acp/client.py` |
+| ACP worker-pool audit | Per-`tool_call` `auto_approved` `tool_invocation` (`source=subagent`), bounded by `_SEL_AUDIT_TIMEOUT_SECONDS` (5.0s) and offloaded off the event loop so a wedged SEL backend never gates dispatch. Two emitters: the knowledge LLMPool via `AcpClient._maybe_audit_tool_call` (gated on the `audit_source` ctor param, offloaded to `subprocess_executor()`); and **code-review-sage's ReviewPool**, which migrated to the shared `AcpRuntime` (no `audit_source`) and re-emits the same per-tool record itself | `acp/client.py`, `apps/builtins/code_review_sage/sage_lib/review_pool.py` |
 | Token auth | `internal_auth`, `app_scope_check`, `dashboard_sessions_revoked`, `refresh_token_initial_mint`, `nonce_evicted` (`source=token_auth`) | `dashboard/token_auth.py` |
 | Refresh tokens | `refresh_token_use`, `refresh_token_logout`, `access_cookie_revoked` (`source=refresh_tokens`) | `dashboard/handlers/auth_refresh.py` |
 | ACP transport | `tool_interrupted` per-turn cancellation audit (`source=acp`) | `acp/client.py` |

--- a/skills/prepare-pr/SKILL.md
+++ b/skills/prepare-pr/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: prepare-pr
-description: End-to-end prepares a pull request for review — commits local changes, syncs with the base branch, squashes to a single commit, opens or updates the PR, then polls CI + code-review bots for up to 10 rounds and fixes every legitimate High/Medium finding and build failure until the PR is review-ready. Use when the user says "prepare PR", "prep the PR", "ship this PR", "get the PR review-ready", "raise/open/update a PR", or "make my changes ready for review".
+description: End-to-end drives working-tree changes to a review-ready pull request — commit, sync base, squash to one commit, open/update the PR — then, for a full-loop request, KEEPS RUNNING IN-SESSION (poll CI + code-review bots in ~5-min rounds, up to 10) fixing every legitimate High/Medium finding and build failure until the PR is review-ready (never merges). Two modes chosen from the user's wording. FULL LOOP (commit through drive-green, staying in-session until review-ready) when the user says "prepare PR/CR", "prep/ship this PR", "get the PR review-ready", "make it green", "make my changes ready for review", "handle/address the review comments", "fix CI", or "keep going until it's green". PREPARE-ONLY (commit, push, one status snapshot, stop) when the user says "update the PR", "push my changes", "sync my branch", "just update the body/description", or "don't wait for CI". Do NOT load for merging/landing a PR, plain git commit/push with no PR intent, or code-authoring requests.
 always: false
-triggers: prepare pr, prep pr, prepare pull request, ship pr, raise pr, open pr, create pr, update pr, get pr ready, review ready pr, prepare cr, prepare code review
+triggers: prepare pr, prep pr, prepare pull request, ship pr, ship this pr, raise pr, open pr, create pr, update pr, get pr ready, get the pr review ready, review ready pr, make it green, make the pr green, drive pr green, handle review comments, address review comments, fix ci, pr ci failing, poll ci, keep going until green, prepare cr, prep cr, prepare code review, ship cr
 ---
 
 # Prepare PR
@@ -13,7 +13,7 @@ Drive whatever is in the working tree to a **clean, review-ready PR**: commit �
 ## Usage
 Trigger when the user wants a change turned into a reviewable PR, or an existing PR made green/clean. Pick the scope from their wording:
 - **Prepare-only (Phases 0–1, then STOP):** "update the PR", "push my changes", "sync my branch", "just update the body", "don't wait for CI". Run preflight → commit → sync → squash → reconcile description → push, take **one** `pr_status.py` snapshot, report, stop. No polling, no fixing.
-- **Full loop (Phases 0–4):** "prepare PR", "make it review-ready/green", "handle the review comments", "ship this PR".
+- **Full loop (Phases 0–4):** "prepare PR", "make it review-ready/green", "handle the review comments", "ship this PR", "fix CI", "keep going until it's green". Runs preflight → commit → sync → squash → push → then **stays in this session** polling CI + review bots in ~5-min rounds and fixing every legitimate High/Medium finding + build failure, until the PR is review-ready or it escalates. Do NOT stop after the first snapshot for a full-loop request.
 - **Ambiguous → default to prepare-only**, report status once, and ask before entering the poll-and-fix loop. Never silently commit the user to 10 rounds.
 
 Do **not** merge/land a PR — that is the user's separate, explicit call.
@@ -64,7 +64,9 @@ The scripts are stdlib **Python 3** (run with `python3`; no third-party deps), p
 6. **Create/update PR.** New → `gh pr create --base <base> --head <branch> --title "<CC title>" --body-file <body>` (body from `$SKILL_DIR/assets/pr-body-template.md`). Existing → `gh pr edit` to keep title/body matching the diff. Capture the PR number/URL.
 
 ### Phase 2 — Poll (full loop only; max 10 rounds, ~5 min)
-Loop on `python3 $SKILL_DIR/scripts/pr_status.py <pr#>`: **10** → `wait(seconds=300, reason="Round N/10 …")` then re-poll; **20** → Phase 3; **0** → Phase 4. A round is complete only when every required check has finished **and** every bot has posted. For long/unattended runs, drive the same loop from a **Heartbeat** task instead of holding the session.
+**Keep the loop running in THIS session** — this is the default and the expected behavior of a full-loop request. Loop on `python3 $SKILL_DIR/scripts/pr_status.py <pr#>`: **10** → `wait(seconds=300, reason="Round N/10 …")` then re-poll (the `wait` tool holds the session alive across the round without ending your turn); **20** → Phase 3; **0** → Phase 4. A round is complete only when every required check has finished **and** every bot has posted. Do not end the turn between rounds — chain `wait` → re-poll → act until convergence or escalation. The 10-round / escalation caps (Phase 4) bound it so "keep running" never means "run forever".
+
+> **Heartbeat is a FALLBACK, not the default.** Only hand the loop to a Heartbeat task if the session genuinely cannot stay open (the user explicitly asks you to detach, or you must free the session for other work). Otherwise keep polling in-session — a detached heartbeat loses the working context and is harder to follow. If you do fall back to heartbeat, say so explicitly.
 
 ### Phase 3 — Triage & fix (on exit 20)
 `python3 $SKILL_DIR/scripts/pr_findings.py <pr#>`, then fix in this order and re-push (`--force-with-lease`, still one commit):

--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -52,7 +52,15 @@ if str(_APP_ROOT) not in sys.path:
 # dir is hyphenated, so these are not auto-discovered packages). Imported at the
 # top per the top-level-imports guideline; the sys.path setup above executes at
 # module load, so this resolves on first import.
-from sage_lib import learning, pipeline, review_driver, review_pool, store  # noqa: E402
+from sage_lib import (  # noqa: E402,E501
+    adapters,
+    learning,
+    pipeline,
+    results,
+    review_driver,
+    review_pool,
+    store,
+)
 
 # In-memory run registry, most-recent first. Bounded so it can't grow unbounded.
 # Holds lightweight run descriptors the page polls; on-disk result records carry
@@ -60,6 +68,11 @@ from sage_lib import learning, pipeline, review_driver, review_pool, store  # no
 _RUNS: list[dict[str, Any]] = []
 _RUNS_MAX = 25
 _LOCK = asyncio.Lock()
+# Serializes whole review runs. run_review clears + writes the SHARED data/results
+# dir and the report index, so two overlapping runs (from /review and /review-repo,
+# or two /review-repo calls) would clobber each other's records/report. Concurrent
+# starts queue on this lock instead of interleaving.
+_RUN_LOCK = asyncio.Lock()
 # Guards copy-on-write updates to a run's per-change ``progress`` map, which the
 # (threaded) driver writes and the /runs handler reads concurrently.
 _PROGRESS_LOCK = threading.Lock()
@@ -140,6 +153,39 @@ async def _record(run: dict) -> None:
         _save_runs()
 
 
+def _dedup_changes_under_lock(run: dict, changes: list[str]) -> list[str]:
+    """Re-filter a repo-review run's ``changes`` against the CURRENT reviewed index,
+    dropping any PR already reviewed at the exact head SHA this run intended to
+    review. Called under ``_RUN_LOCK`` to close the TOCTOU where two concurrent
+    repo-reviews both deduped against a stale index before the lock (the second
+    would otherwise re-review + re-post a PR the first just delivered).
+
+    No-op for forced runs and pasted-link runs (no ``head_shas``). Keeps
+    ``run['changes'|'change_ids'|'head_shas']`` consistent with the kept subset so
+    ``_record_reviewed`` still round-trips. Sync (reads the index) — call via a
+    thread from the event loop.
+    """
+    head_shas = run.get("head_shas") or {}
+    if run.get("force") or not head_shas:
+        return changes
+    index = results.read_reviewed()
+    kept: list[str] = []
+    kept_shas: dict[str, str] = {}
+    for url in changes:
+        rkey = review_driver.reviewed_key_for(url)
+        intended = head_shas.get(rkey, "")
+        rec = index.get(rkey) or {}
+        if intended and rec.get("head_sha") == intended:
+            continue   # a concurrent run already reviewed this exact head
+        kept.append(url)
+        if rkey in head_shas:
+            kept_shas[rkey] = head_shas[rkey]
+    run["changes"] = kept
+    run["change_ids"] = [review_driver.change_id_for(c) for c in kept]
+    run["head_shas"] = kept_shas
+    return kept
+
+
 async def _run_review_bg(run: dict, changes: list[str]) -> None:
     """Run the (blocking) driver in a worker thread; update the run record.
 
@@ -150,23 +196,49 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
     card, no ``:lock:``, no Slack relay) and warm workers are reused across CRs
     with a clean-slate reset between them. We just surface the driver's summary."""
     try:
-        # Bridge the threaded driver to the async pool running on THIS (gateway)
-        # event loop. The pool is a lazily-created process-wide singleton.
-        loop = asyncio.get_running_loop()
-        pool = review_pool.get_pool()
-        dispatch = review_pool.make_sync_dispatch(loop, pool)
+        # Serialize whole runs (see _RUN_LOCK): concurrent starts queue here rather
+        # than interleaving over the shared results dir / report index.
+        async with _RUN_LOCK:
+            # TOCTOU guard (Codex Finding 2): the dedup in _handle_review_repo ran
+            # BEFORE this lock, so a concurrent repo-review that finished first may
+            # have just recorded some of these PRs. Re-dedup against the now-current
+            # reviewed index under the lock so we never re-review + re-post a PR that
+            # another run already delivered. No-op for forced / pasted-link runs.
+            changes = await asyncio.to_thread(_dedup_changes_under_lock, run, changes)
+            if not changes:
+                run["summary"] = {"ok": True, "changes": 0,
+                                  "note": "all PRs already reviewed by a concurrent run"}
+                run["status"] = "done"
+                return
+            # Bridge the threaded driver to the async pool running on THIS (gateway)
+            # event loop. The pool is a lazily-created process-wide singleton.
+            loop = asyncio.get_running_loop()
+            pool = review_pool.get_pool()
+            dispatch = review_pool.make_sync_dispatch(loop, pool)
 
-        summary = await asyncio.to_thread(
-            review_driver.run_review, changes,  # type: ignore[attr-defined]
-            dispatch=dispatch, progress=_make_progress(run),
-        )
-        run["summary"] = summary
-        run["report_slug"] = summary.get("report_slug") or run.get("report_slug")
-        # "done" even if some changes failed — the failures are surfaced in the
-        # summary; "error" is reserved for the driver itself blowing up.
-        run["status"] = "done" if summary.get("ok") else "error"
-        if not summary.get("ok"):
-            run["error"] = summary.get("error", "review failed")
+            # Bracket the batch: begin_batch() lazily spawns the ONE shared runtime;
+            # end_batch() (in finally) kills it once this run's reviews all drain — so
+            # the subprocess (and its memory) lives exactly as long as the batch.
+            await pool.begin_batch()
+            try:
+                summary = await asyncio.to_thread(
+                    review_driver.run_review, changes,  # type: ignore[attr-defined]
+                    dispatch=dispatch, progress=_make_progress(run),
+                )
+            finally:
+                await pool.end_batch()
+            run["summary"] = summary
+            run["report_slug"] = summary.get("report_slug") or run.get("report_slug")
+            # "done" even if some changes failed — the failures are surfaced in the
+            # summary; "error" is reserved for the driver itself blowing up.
+            run["status"] = "done" if summary.get("ok") else "error"
+            if not summary.get("ok"):
+                run["error"] = summary.get("error", "review failed")
+            else:
+                # Durable dedup index: record each reviewed PR's head SHA so a later
+                # repo-review skips it until its head changes. Only repo-review runs
+                # carry head_shas; pasted-link runs skip this (no-op).
+                await asyncio.to_thread(_record_reviewed, run)
     except Exception as exc:  # pragma: no cover - defensive
         run["status"] = "error"
         run["error"] = str(exc)
@@ -223,6 +295,176 @@ async def _handle_review(request: web.Request) -> web.Response:
     return web.json_response(
         {"run_id": run["run_id"], "changes": changes, "status": "running"}
     )
+
+
+def _record_reviewed(run: dict) -> None:
+    """Upsert this run's SUCCESSFULLY-reviewed PRs into the durable dedup index
+    (by head SHA), so a later repo-review skips them until their head changes.
+
+    Only PRs whose deep review actually ran + recorded are marked — a gate crash,
+    no-verdict, or dispatch failure must NOT be written to the index, otherwise the
+    next non-forced repo-review would silently skip a PR that was never really
+    reviewed. (``run_review`` returns ``ok=True`` for any run with >=1 change even
+    when individual changes failed, so we intersect ``head_shas`` with the
+    per-change outcomes rather than trusting the run-level ok.) Best-effort — a
+    failure here never fails the run. No-op for runs without a ``head_shas`` map
+    (i.e. pasted-link reviews, where we don't know each PR's head SHA)."""
+    shas = run.get("head_shas") or {}
+    if not shas:
+        return
+    per_change = (run.get("summary") or {}).get("per_change") or []
+    # per_change records carry the (lossy) change_id; head_shas is keyed by the
+    # collision-free reviewed key. Map change_id -> reviewed key via the run's
+    # parallel `changes` (URLs) so we can intersect the two keyings and index
+    # ONLY the PRs whose deep review recorded a result AND whose draft was
+    # actually delivered are indexed. `post_ok` alone is insufficient: it only
+    # means the poster AGENT's turn ended normally, not that `gh api` succeeded
+    # (a 422 / network error can still end the turn cleanly). So additionally
+    # require the poster to have persisted at least the EXPECTED comment count
+    # (`posted_comments >= posting_expected`, both written by the deep-review
+    # branch). A failed/partial post leaves posted_comments below expected -> the
+    # PR is NOT indexed and is re-reviewed next time (fail-safe: re-review, never
+    # silent-skip a PR that was never really delivered).
+    changes = run.get("changes") or []
+    cid_to_rkey = {
+        review_driver.change_id_for(u): review_driver.reviewed_key_for(u)
+        for u in changes
+    }
+    reviewed_ok = {
+        cid_to_rkey.get(r.get("change_id"))
+        for r in per_change
+        if r.get("deep_reviewed") and r.get("post_ok")
+        and (r.get("posted_comments") or 0) >= (r.get("posting_expected") or 1)
+    }
+    reviewed_ok.discard(None)
+    now = _now()
+    rid = run.get("run_id", "")
+    entries = {rkey: {"head_sha": sha, "reviewed_at": now, "run_id": rid}
+               for rkey, sha in shas.items() if sha and rkey in reviewed_ok}
+    if not entries:
+        return
+    try:
+        results.mark_reviewed(entries)
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("code-review-sage: failed to update reviewed index", exc_info=True)
+
+
+async def _list_repo_prs(repo: str) -> tuple[str, list[dict]]:
+    """Resolve owner/repo from a repo URL and enumerate its OPEN PRs (via `gh`).
+    Returns ``("<owner>/<repo>", prs)``. Raises ValueError for a bad URL and
+    RuntimeError for a `gh` failure (mapped to 400/502 by the handlers)."""
+    owner, name = adapters.parse_repo_url(repo)   # raises on non-GitHub / no owner/repo
+    prs = await asyncio.to_thread(pipeline.list_open_prs, owner, name)
+    return f"{owner}/{name}", prs
+
+
+async def _handle_repo_prs(request: web.Request) -> web.Response:
+    """GET .../repo-prs?repo=<url> — list a repo's OPEN PRs annotated with
+    reviewed / not-reviewed / stale (by head SHA). Does NOT start a review."""
+    repo = (request.query.get("repo") or "").strip()
+    if not repo:
+        return web.json_response({"error": "missing ?repo=<github repo url>"}, status=400)
+    try:
+        slug, prs = await _list_repo_prs(repo)
+    except (adapters.AdapterParseError, adapters.UnsupportedPlatform, ValueError) as e:
+        return web.json_response({"error": f"invalid repo url: {e}"}, status=400)
+    except Exception as e:  # gh not authed / network / repo not found
+        return web.json_response({"error": str(e)}, status=502)
+    index = await asyncio.to_thread(results.read_reviewed)
+    out = []
+    for pr in prs:
+        url = pr.get("url", "")
+        cid = review_driver.change_id_for(url)      # display / response field only
+        # Read the dedup index with the SAME collision-free key it is written
+        # under (reviewed_key_for), NOT the lossy change-id — otherwise every
+        # reviewed PR reads back as "new" (read/write key mismatch).
+        rkey = review_driver.reviewed_key_for(url)
+        rec = index.get(rkey) or {}
+        stored = rec.get("head_sha") or ""
+        cur = pr.get("head_sha") or ""
+        out.append({
+            **pr, "change_id": cid,
+            "reviewed": bool(stored) and stored == cur,
+            "reviewed_stale": bool(stored) and stored != cur,
+            "reviewed_at": rec.get("reviewed_at", ""),
+        })
+    return web.json_response({"repo": slug, "prs": out, "count": len(out)})
+
+
+async def _handle_review_repo(request: web.Request) -> web.Response:
+    """POST .../review-repo — review all OPEN PRs of a repo in one batch.
+
+    Body: ``{"repo": "<github repo url>", "force": bool}``. By default only PRs
+    NOT yet reviewed at their current head SHA are queued; ``force=true`` reviews
+    ALL open PRs regardless of the dedup index."""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    repo = str(body.get("repo") or "").strip()
+    # Strict boolean: only a literal JSON `true` forces a full re-review. A string
+    # ("false"), object, or number must NOT accidentally bypass dedup and trigger a
+    # costly review of every open PR.
+    force = body.get("force") is True
+    if not repo:
+        return web.json_response({"error": "missing 'repo' (a github repo url)"}, status=400)
+    try:
+        slug, prs = await _list_repo_prs(repo)
+    except (adapters.AdapterParseError, adapters.UnsupportedPlatform, ValueError) as e:
+        return web.json_response({"error": f"invalid repo url: {e}"}, status=400)
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=502)
+
+    index = await asyncio.to_thread(results.read_reviewed)
+    changes: list[str] = []
+    head_shas: dict[str, str] = {}
+    skipped = 0
+    for pr in prs:
+        url = pr.get("url") or ""
+        if not url:
+            continue
+        # Dedup by a COLLISION-FREE canonical key (NOT the lossy change-id, which
+        # sanitizes '-'->'_' and would let acme/service-api and acme/service_api
+        # share one reviewed.json entry). head_shas is keyed the same way so
+        # _record_reviewed round-trips against this index.
+        rkey = review_driver.reviewed_key_for(url)
+        cur = pr.get("head_sha") or ""
+        if not force:
+            rec = index.get(rkey) or {}
+            if rec.get("head_sha") and rec.get("head_sha") == cur:
+                skipped += 1
+                continue   # already reviewed at this exact head SHA
+        changes.append(url)
+        head_shas[rkey] = cur
+
+    if not changes:
+        return web.json_response({
+            "repo": slug, "changes": [], "skipped": skipped, "status": "noop",
+            "message": "all open PRs already reviewed at their current head "
+                       "(use force=true to re-review all)",
+        })
+
+    run: dict[str, Any] = {
+        "run_id": uuid.uuid4().hex[:12],
+        "repo": slug,
+        "changes": changes,
+        "change_ids": [review_driver.change_id_for(c) for c in changes],
+        "head_shas": head_shas,        # consumed by _record_reviewed on success
+        "force": force,                # skip the under-lock re-dedup for a forced run
+        "status": "running",
+        "started_at": _now(),
+        "progress": {},
+    }
+    await _record(run)
+    task = asyncio.create_task(_run_review_bg(run, changes))
+    _TASKS.add(task)
+    task.add_done_callback(_TASKS.discard)
+    return web.json_response({
+        "run_id": run["run_id"], "repo": slug,
+        "changes": changes, "skipped": skipped, "status": "running",
+    })
 
 
 async def _handle_runs(request: web.Request) -> web.Response:
@@ -303,6 +545,7 @@ def _load_review_section() -> dict:
         "model": review.get("model") or None,
         "effort": review.get("effort", ""),
         "active_namespaces": review.get("active_namespaces") or ["default"],
+        "max_concurrent": review_pool.effective_max_concurrent(),
     }
 
 
@@ -344,6 +587,15 @@ def _write_review_section(patch: dict) -> dict:
             avail = set(learning.list_namespaces())
             cleaned = [str(n) for n in ns if str(n) in avail]
             review["active_namespaces"] = cleaned or ["default"]
+    if "max_concurrent" in patch:
+        # How many reviews run at once on the shared runtime. Clamped to
+        # [1, MAX_CONCURRENT_CEIL] so "review all" can fan out without letting a
+        # user set an unbounded value that would saturate the host.
+        try:
+            mc = int(patch["max_concurrent"])
+        except (TypeError, ValueError):
+            raise ValueError("max_concurrent must be an integer")
+        review["max_concurrent"] = max(1, min(mc, review_pool.MAX_CONCURRENT_CEIL))
 
     cfg["review"] = review
     tmp = cfg_path.with_name(cfg_path.name + ".tmp")
@@ -377,6 +629,7 @@ async def _handle_settings(request: web.Request) -> web.Response:
                 "efforts": list(review_pool.VALID_EFFORTS),
                 "namespaces": namespaces,
                 "reviewer": reviewer,
+                "max_concurrent_max": review_pool.MAX_CONCURRENT_CEIL,
             }
         return web.json_response(await asyncio.to_thread(_build_settings_response))
     # PUT
@@ -412,6 +665,7 @@ async def _handle_settings(request: web.Request) -> web.Response:
             "model": review.get("model") or None,
             "effort": review.get("effort", ""),
             "active_namespaces": review.get("active_namespaces") or ["default"],
+            "max_concurrent": review.get("max_concurrent") or review_pool.effective_max_concurrent(),
         }})
     except ValueError as exc:
         # Bad client input (e.g. unknown model) — a 4xx, not a server fault.
@@ -544,6 +798,8 @@ def register_routes(app: web.Application) -> None:
         logger.warning("code-review-sage: ensure_layout failed at startup", exc_info=True)
     _load_runs()  # restore durable job status (mark orphaned 'running' as 'interrupted')
     app.router.add_post("/api/apps/code-review-sage/review", _handle_review)
+    app.router.add_post("/api/apps/code-review-sage/review-repo", _handle_review_repo)
+    app.router.add_get("/api/apps/code-review-sage/repo-prs", _handle_repo_prs)
     app.router.add_get("/api/apps/code-review-sage/runs", _handle_runs)
     app.router.add_get("/api/apps/code-review-sage/settings", _handle_settings)
     app.router.add_put("/api/apps/code-review-sage/settings", _handle_settings)

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/adapters.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/adapters.py
@@ -98,10 +98,60 @@ def github_pr_parts(link: str) -> tuple[str, str, str]:
     return owner, repo, number
 
 
+def parse_repo_url(link: str) -> tuple[str, str]:
+    """Parse ``(owner, repo)`` from a GitHub REPO URL (no ``/pull/``).
+
+    Mirrors ``detect_platform``'s PARSED-hostname allowlist (default-deny, ARCC
+    SSRF/allowlist guidance) but accepts a bare repo URL like
+    ``https://github.com/<owner>/<repo>`` so a batch of that repo's open PRs can
+    be enumerated. Raises ``UnsupportedPlatform`` for a non-GitHub host and
+    ``AdapterParseError`` when the owner/repo path segments are missing."""
+    if not link or not isinstance(link, str):
+        raise UnsupportedPlatform("empty or non-string repo link")
+    parsed = urlparse(link)
+    host = (parsed.hostname or "").lower()
+    if host not in {"github.com", "www.github.com"}:
+        raise UnsupportedPlatform(
+            f"unsupported repo host: {link!r} (expected a github.com repo URL)")
+    path = parsed.path or ""
+    if "/pull/" in path:
+        # A PR URL, not a repo URL — route the user to the paste flow so we don't
+        # silently review the PR's whole repo.
+        raise AdapterParseError(
+            f"that's a PR URL, not a repo URL: {link!r} (paste it in the PR box)")
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 2:
+        raise AdapterParseError(f"not a GitHub repo link: {link!r}")
+    owner, repo = parts[0], re.sub(r"\.git$", "", parts[1])
+    _seg = re.compile(r"^[A-Za-z0-9._-]+$")
+    if owner in (".", "..") or repo in (".", "..") or not (_seg.match(owner) and _seg.match(repo)):
+        raise AdapterParseError(f"invalid owner/repo in {link!r}")
+    return owner, repo
+
+
 def github_change_id(owner: str, repo: str, number: str | int) -> str:
     """Filesystem-safe, platform-namespaced change id: ``GH-<owner>-<repo>-<n>``.
     Unlike a raw URL, this is a valid filename."""
     return f"GH-{_sanitize_seg(owner)}-{_sanitize_seg(repo)}-{number}"
+
+
+def github_review_key(owner: str, repo: str, number: str | int) -> str:
+    """Collision-free canonical identity for the durable reviewed-index key.
+
+    Distinct from ``github_change_id``: that value ALSO names an on-disk result
+    file, so it runs owner/repo through ``_sanitize_seg`` — which collapses ``-``
+    to ``_`` to keep ``-`` unambiguous as its segment delimiter. That sanitization
+    is lossy: ``acme/service-api`` and ``acme/service_api`` both become
+    ``GH-acme-service_api-<n>``, so two DIFFERENT repos with the same PR number
+    shared one ``reviewed.json`` key and clobbered each other's dedup record —
+    silently skipping a requested review when their PR heads happened to share a
+    commit SHA (as mirrored repos can).
+
+    This key never names a file, so it keeps owner/repo verbatim and joins with
+    ``/`` (a character GitHub owner/repo can never contain), giving a lossless,
+    unambiguous identity. Owner/repo are lower-cased because GitHub treats them
+    case-insensitively for identity."""
+    return f"github.com/{str(owner).lower()}/{str(repo).lower()}#{number}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -71,6 +72,59 @@ def parse_batch(text: str) -> list[str]:
             seen.add(key)
             out.append(link)
     return out
+
+
+def list_open_prs(owner: str, repo: str, *, timeout: float = 60.0) -> list[dict]:
+    """Enumerate a repo's OPEN pull requests via the authenticated ``gh`` CLI.
+
+    Deterministic backbone (no LLM): runs ``gh api`` with a LIST argv (never
+    ``shell=True``). ``owner``/``repo`` are constrained to ``[^/]+`` by
+    ``adapters.parse_repo_url`` before this is called and are interpolated only
+    into the ``gh api`` PATH argument (which `gh` treats as an API path, not a
+    shell command), so there is no shell-injection surface. Returns
+    ``[{url, number, head_sha, title}]`` in GitHub's order. Raises
+    ``RuntimeError`` (with the stderr tail) if `gh` is missing, unauthenticated,
+    times out, or the repo can't be read."""
+    path = f"repos/{owner}/{repo}/pulls?state=open&per_page=100"
+    argv = [
+        "gh", "api", path, "--paginate",
+        "--jq", ".[] | {url: .html_url, number: .number, "
+                "head_sha: .head.sha, title: .title}",
+    ]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True,
+                              timeout=timeout, check=False)
+    except FileNotFoundError as e:
+        raise RuntimeError("the `gh` CLI is not installed on this host") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"`gh` timed out listing open PRs for {owner}/{repo}") from e
+    if proc.returncode != 0:
+        tail = " ".join((proc.stderr or "").strip().splitlines()[-3:])
+        raise RuntimeError(
+            f"gh api failed for {owner}/{repo} (exit {proc.returncode}): {tail}")
+    prs: list[dict] = []
+    for line in (proc.stdout or "").splitlines():   # --jq emits JSONL
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        prs.append({
+            "url": obj.get("url") or "",
+            "number": obj.get("number"),
+            "head_sha": obj.get("head_sha") or "",
+            "title": obj.get("title") or "",
+        })
+    # Non-silent: gh returned 0 but produced non-empty, unparseable output (e.g. a
+    # gh build that pretty-prints jq). Don't masquerade that as "no open PRs".
+    if not prs and (proc.stdout or "").strip():
+        raise RuntimeError(
+            f"could not parse `gh` output for {owner}/{repo} "
+            "(expected one JSON object per line)")
+    return prs
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -12,9 +12,15 @@ import json
 import os
 import re
 import tempfile
+import threading
 from pathlib import Path
 
 from sage_lib import store
+
+# Serializes the read-merge-write of the reviewed index so two overlapping
+# repo-review runs (finalizing on separate threads) can't clobber each other's
+# entries. The write itself is atomic; this guards the read+merge before it.
+_REVIEWED_LOCK = threading.Lock()
 
 REQUIRED_TOP = ("schema", "version", "change_id", "platform", "repo_identity", "phase1")
 REQUIRED_PHASE1 = ("gate_verdict", "design_risk", "criticality")
@@ -24,6 +30,54 @@ _UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
 
 def results_dir(root: Path | None = None) -> Path:
     return store.data_dir(root) / "results"
+
+
+def reviewed_path(root: Path | None = None) -> Path:
+    """Durable cross-run 'already reviewed' index (repo-review dedup).
+
+    A single flat file ``data/reviewed.json`` keyed by change id ->
+    ``{head_sha, reviewed_at, run_id}``. UNLIKE the per-change result records
+    (transient scratch the driver clears after each run), this index is durable
+    and is the source of truth for skipping PRs whose head SHA has not changed
+    since their last review."""
+    return store.data_dir(root) / "reviewed.json"
+
+
+def read_reviewed(root: Path | None = None) -> dict:
+    """Load the reviewed index; ``{}`` if missing or unreadable."""
+    try:
+        return json.loads(reviewed_path(root).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_reviewed(index: dict, root: Path | None = None) -> Path:
+    """Atomically write the reviewed index (mode 0600), mirroring write_result."""
+    store.ensure_layout(root)
+    path = reviewed_path(root)
+    data = json.dumps(index, indent=2).encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return path
+
+
+def mark_reviewed(entries: dict, root: Path | None = None) -> Path:
+    """Upsert ``entries`` ({change_id: {head_sha, reviewed_at, run_id}}) into the
+    durable index (read-merge-atomic-write, serialized by ``_REVIEWED_LOCK`` so
+    overlapping runs merge instead of clobber). Returns the index path."""
+    with _REVIEWED_LOCK:
+        idx = read_reviewed(root)
+        idx.update(entries)
+        return write_reviewed(idx, root)
 
 
 def safe_change_id(change_id: str) -> str:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -139,12 +139,12 @@ def _resolve_concurrency(explicit: int | None = None) -> int:
     worker pool's concurrency cap.
 
     Pool workers are direct ACP sessions (NOT ``/api/spawn`` sub-agents), so the
-    gateway sub-agent cap no longer applies — ``review_pool.MAX_CONCURRENT`` is the
-    single source of truth for how many reviews run at once. The pool also hard-caps
-    concurrency itself, so this only governs how many tasks the driver offers it."""
+    gateway sub-agent cap no longer applies — ``review_pool.effective_max_concurrent()``
+    is the single source of truth for how many reviews run at once. The pool also
+    hard-caps concurrency itself, so this only governs how many tasks the driver offers it."""
     if explicit and explicit > 0:
         return max(1, int(explicit))
-    return max(1, review_pool.MAX_CONCURRENT)
+    return max(1, review_pool.effective_max_concurrent())
 
 
 def _max_review_rounds() -> int:
@@ -182,6 +182,23 @@ def change_id_for(link: str) -> str:
     re-deriving the id (and drifting from the backend's sanitization, e.g. an owner
     hyphen becoming an underscore)."""
     return _cid(link)
+
+
+def reviewed_key_for(link: str) -> str:
+    """Collision-free key for the durable reviewed-index (``reviewed.json``).
+
+    Separate from ``change_id_for``: the change-id is also an on-disk filename and
+    is therefore lossily sanitized (``-`` -> ``_``), which let two different repos
+    (``acme/service-api`` vs ``acme/service_api``) with the same PR number collide
+    on one dedup key and skip a requested review. The reviewed-index key never
+    names a file, so it uses the lossless canonical identity instead. Falls back to
+    the sanitized change-id for a non-PR link (defensive; repo-review only ever
+    feeds real PR URLs from ``list_open_prs``)."""
+    try:
+        owner, repo, number = pipeline.adapters.github_pr_parts(link)
+        return pipeline.adapters.github_review_key(owner, repo, number)
+    except pipeline.adapters.AdapterParseError:
+        return results.safe_change_id(link)
 
 
 def _fetch_instruction(link: str) -> str:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
@@ -1,32 +1,31 @@
 #!/usr/bin/env python3
-"""Reusable review worker pool — long-lived ACP sessions, not per-CR spawns.
+"""Review executor — one shared, batch-scoped ``AcpRuntime``, one session per task.
 
-Mirrors the Knowledge Library's ``knowledge/llm_pool.py`` (a bounded pool of
-warm ``AcpClient`` workers) but tuned for Code Review Sage:
+Every code review multiplexes onto a SINGLE kiro-cli subprocess (``AcpRuntime``)
+rather than a pool of per-worker ``AcpClient`` processes. Design:
 
-  * **Lazy** — workers are created on demand, never eagerly. A pool that is
-    never used spawns nothing.
-  * **Bounded concurrency** — at most ``MAX_CONCURRENT`` tasks run at once
-    (a task = one Phase-1 gate or one Phase-2 deep review for one change).
-  * **Throttled startup** — at most ``MAX_STARTING`` workers spin up
-    simultaneously, because ACP process launch + session handshake is the
-    expensive part; a burst of CRs must not cold-start five processes at once.
-  * **Clean slate per CR** — before a *reused* worker runs the next task its
-    session is reset by respawning the ACP process (shutdown + start), since the
-    OSS ``AcpClient`` has no in-process conversation reset, so one review never
-    leaks context into another. A freshly-created worker is already clean, so the
-    reset is skipped on first use.
-  * **Self-healing** — a worker found dead on acquire (or one that raised
-    during a task) is shut down and replaced; it never re-enters the idle set.
+  * **One runtime per batch** — lazily ``spawn()``ed on the first task of a batch
+    and ``kill()``ed when the batch drains (see ``_BatchRuntimeHolder``). One
+    subprocess serves all concurrent reviews; teardown reclaims all memory.
+  * **One session per task** — each dispatch (gate / deep / follow-up / post)
+    gets its own ``AcpSessionHandle`` (distinct ``sessionId``), ``destroy()``ed on
+    completion, so one review never leaks context into another. No process respawn.
+  * **Bounded concurrency** — a semaphore of width ``review.max_concurrent``
+    (default 5, ceiling ``MAX_CONCURRENT_CEIL`` = 30) caps in-flight sessions.
+    Because it is a single process, raising concurrency (e.g. to review all open
+    PRs) costs sessions, not subprocesses.
+  * **Auto-approval + audit** — the reviewer runs the ``gh`` CLI + shell, so each
+    tool permission is auto-approved; and because the runtime layer has no
+    ``audit_source``, the pool emits its own per-tool SEL audit.
 
-Crucially these workers are plain ``AcpClient`` sessions created directly — they
-do NOT go through the gateway's ``/api/spawn`` / ``SubagentManager`` path, so
-they never produce an agent card, a ``:lock:`` approval prompt, a Slack relay,
-or a 30-minute reaper slot. The review runs silently.
+These sessions are created directly on the runtime — NOT via the gateway's
+``/api/spawn`` / ``SubagentManager`` path — so they never produce an agent card,
+a ``:lock:`` approval prompt, a Slack relay, or a 30-minute reaper slot. The
+review runs silently.
 
-The pool is async; the (synchronous, threaded) review driver bridges to it via
-``asyncio.run_coroutine_threadsafe`` on the gateway event loop. See
-``backend/routes.py`` for the wiring.
+The executor is async; the (synchronous, threaded) review driver bridges to it
+via ``asyncio.run_coroutine_threadsafe`` on the gateway event loop, and brackets
+each run with ``begin_batch()`` / ``end_batch()``. See ``backend/routes.py``.
 """
 from __future__ import annotations
 
@@ -45,25 +44,55 @@ if _APP_ROOT not in sys.path:
     sys.path.insert(0, _APP_ROOT)
 
 try:
-    from kiro_crew.acp.client import AcpClient
-    from kiro_crew.acp.types import ACP_BACKEND_CLAUDE
+    from kiro_crew.acp.runtime import AcpRuntime
+    from kiro_crew.acp.types import (
+        EVENT_COMPLETE,
+        EVENT_PERMISSION_REQUEST,
+        EVENT_TEXT_CHUNK,
+        EVENT_TOOL_CALL,
+        STOP_REASON_STALE_RECOVER,
+        STOP_REASON_TOOL_STALL,
+    )
 except ImportError:  # pragma: no cover - standalone / test fallback
-    AcpClient = None  # type: ignore[assignment,misc]
-    ACP_BACKEND_CLAUDE = "claude"  # type: ignore[assignment]
+    AcpRuntime = None  # type: ignore[assignment,misc]
+    EVENT_TEXT_CHUNK = "text_chunk"  # type: ignore[assignment]
+    EVENT_TOOL_CALL = "tool_call"  # type: ignore[assignment]
+    EVENT_PERMISSION_REQUEST = "permission_request"  # type: ignore[assignment]
+    EVENT_COMPLETE = "complete"  # type: ignore[assignment]
+    STOP_REASON_STALE_RECOVER = "stale_recover"  # type: ignore[assignment]
+    STOP_REASON_TOOL_STALL = "error: tool stall"  # type: ignore[assignment]
+
+try:  # SEL audit — the runtime layer has no audit_source, so the pool emits its own
+    from kiro_crew.sel import sel as _sel
+except Exception:  # pragma: no cover - standalone / test fallback
+    _sel = None  # type: ignore[assignment]
 
 from sage_lib import store  # noqa: E402
 
-# The reusable pool engine (provider-agnostic; see kiro_crew/acp/worker_pool.py).
-# ReviewPool is now a thin adapter over it — the engine owns the pooling logic,
-# this module owns the review-specific worker + tunables + singleton + bridge.
-from kiro_crew.acp.worker_pool import PoolWorker as Worker  # noqa: E402,F401  (back-compat alias)
-from kiro_crew.acp.worker_pool import WorkerFactory, WorkerPool  # noqa: E402,F401
-
 logger = logging.getLogger(__name__)
 
+
+def _is_abnormal_stop(reason: str) -> bool:
+    """True when an EVENT_COMPLETE stop_reason means the turn did NOT finish
+    cleanly — timeout, stale-recovery, tool-stall, or any ``error: *`` (see
+    acp/session_handle.py / acp/types.py). A review that ended this way must be
+    reported as a failure, not silently returned as partial success (which would
+    wrongly mark the PR reviewed / post incomplete findings). The known abnormal
+    reason CONSTANTS are matched explicitly (not just by an ``error`` prefix) so a
+    future rename of a reason string can't silently reclassify it as success."""
+    r = (reason or "").strip().lower()
+    if not r:
+        return False
+    if r in (str(STOP_REASON_TOOL_STALL).lower(),
+             str(STOP_REASON_STALE_RECOVER).lower(), "timeout"):
+        return True
+    return r.startswith("error")
+
+
 # ── Tunables (resource limits live here for easy future updates) ──
-MAX_CONCURRENT = 5        # max tasks running at once (== max live workers)
-MAX_STARTING = 2          # max workers spinning up simultaneously
+MAX_CONCURRENT = 5        # default max reviews running at once (config: review.max_concurrent)
+MAX_CONCURRENT_CEIL = 30  # hard ceiling — "review all" can raise concurrency up to here
+MAX_STARTING = 2          # (legacy) retained for back-compat stats; single runtime has no cold-start throttle
 DEFAULT_TASK_TIMEOUT = 1800.0   # seconds per review task (gate or deep)
 REVIEW_AGENT = "code-review-sage-reviewer"  # dedicated lean reviewer agent (shell-
 #   enabled so it can run the `gh` CLI to fetch/post GitHub PR reviews). The per-task
@@ -105,6 +134,22 @@ def _get_review_settings() -> dict:
         return {"model": model, "effort": effort}
     except Exception:
         return {"model": None, "effort": _DEFAULT_EFFORT}
+
+
+def effective_max_concurrent() -> int:
+    """Configured max concurrent reviews (config: ``review.max_concurrent``).
+
+    Because all reviews now multiplex onto a single shared ``AcpRuntime`` (one
+    subprocess), concurrency is no longer bounded by process count — it is a plain
+    semaphore width. Defaults to ``MAX_CONCURRENT`` (5) and is clamped to
+    ``[1, MAX_CONCURRENT_CEIL]`` so a "review all open PRs" batch can fan out (up
+    to 30) without an operator editing code, but can never be set unbounded."""
+    try:
+        cfg = store.load_config()
+        val = int((cfg.get("review") or {}).get("max_concurrent", MAX_CONCURRENT))
+    except Exception:
+        val = MAX_CONCURRENT
+    return max(1, min(val, MAX_CONCURRENT_CEIL))
 
 
 # Back-compat alias: code that references REVIEW_EFFORT gets the default.
@@ -215,125 +260,290 @@ def _write_effort_overlay(work_dir: str, model: str, effort: str = REVIEW_EFFORT
         logger.debug("could not write review effort overlay (work_dir=%s)", work_dir, exc_info=True)
 
 
-class AcpReviewWorker:
-    """A warm ``AcpClient`` session running the review agent."""
+class _BatchRuntimeHolder:
+    """Owns the ONE shared ``AcpRuntime`` for a review batch.
 
-    def __init__(self, agent: str = REVIEW_AGENT) -> None:
-        self._client: Optional["AcpClient"] = None
+    Lifecycle is tied to the batch via a run-level reference count (``_batches``),
+    NOT to individual sessions — the driver dispatches several tasks per PR (gate,
+    deep, follow-ups, post), each its own short-lived ``AcpSessionHandle``, with
+    momentary zero-session gaps between them; killing on a zero-session window
+    would respawn the subprocess on every task. Instead:
+
+      * ``begin_batch()`` (0->1 runs) lazily ``spawn()``s one runtime.
+      * every task multiplexes its own session onto that runtime.
+      * ``end_batch()`` decrements; when it drains to 0 the whole runtime is
+        ``kill()``ed — one subprocess dies and reclaims all RSS (the "no per-turn
+        compaction" caveat is bounded to a single batch this way).
+
+    Concurrent/overlapping runs share the runtime and keep it alive until the last
+    ``end_batch()``. All state is guarded by ``_lock``.
+    """
+
+    def __init__(self, agent: str, work_dir: Optional[str]) -> None:
         self._agent = agent
+        self._work_dir = work_dir
+        self._runtime: Optional["AcpRuntime"] = None
+        self._batches = 0
+        self._lock = asyncio.Lock()
 
-    async def start(self) -> None:
-        if AcpClient is None:
-            raise RuntimeError("AcpClient unavailable (kiro_crew.acp.client not importable)")
-        agent = _resolve_review_agent(self._agent)
-        work_dir = _review_work_dir()   # cwd = app root so relative prompt paths resolve
-        settings = _get_review_settings()
-        effort = settings.get("effort", _DEFAULT_EFFORT)
-        # Run the worker at the user-configured thinking effort for BOTH phases.
-        # kiro-cli (the default ACP backend for these workers) reads effort from a
-        # per-model workspace cli.json overlay at session/new, so the overlay must
-        # be on disk in `work_dir` BEFORE the process spawns. Keyed on the resolved
-        # model (config override → agent default).
-        if work_dir:
-            _write_effort_overlay(work_dir, _reviewer_model(agent), effort)
-        # sandbox_mode="auto" (the default): the OS-level sandbox bind-mounts empty
-        # dirs over credential paths (.aws/.ssh/.midway/.env) and scrubs cred env
-        # vars for this LLM-directed worker. Review workers need NO stored
-        # credentials — GitHub fetch/post run via the `gh` CLI using gh's own
-        # auth, and the worker only writes data/results and runs
-        # `python3 sage_lib/pipeline.py` — so the sandbox is safe here and satisfies the
-        # agent-subprocess sandboxing guideline. Degrades to a no-op if unprivileged
-        # user namespaces are unavailable, so it never breaks the worker.
-        self._client = AcpClient(
-            agent=agent, sandbox_mode="auto", work_dir=work_dir, audit_source="subagent"
-        )
-        await self._client.ensure_ready()
-        await self._apply_claude_effort()   # claude-backend fallback (kiro uses the overlay)
-        logger.info("AcpReviewWorker ready (agent=%s, cwd=%s, effort=%s)",
-                    agent, work_dir, effort)
+    async def begin_batch(self) -> None:
+        async with self._lock:
+            # Ensure the runtime FIRST, then count the batch. If the spawn raises
+            # (unimportable AcpRuntime / transient kiro-cli launch failure), we must
+            # NOT leave _batches incremented — otherwise it can never drain back to
+            # 0 and the shared subprocess would never be killed (RSS leak that
+            # defeats the batch-scoped lifecycle).
+            await self._ensure_runtime_locked()
+            self._batches += 1
 
-    def pid(self) -> Optional[int]:
-        """Underlying kiro-cli process PID (or None before start / after
-        shutdown). The pool reads this to shield the worker from the gateway's
-        periodic orphan sweep — a busy, unshielded worker is otherwise SIGKILLed
-        mid-review as a false orphan ("ACP process exited (code=1)")."""
-        pid = getattr(self._client, "_pid", None)
-        return pid if isinstance(pid, int) and pid > 0 else None
+    async def end_batch(self) -> None:
+        async with self._lock:
+            self._batches = max(0, self._batches - 1)
+            rt = None
+            if self._batches == 0:
+                rt, self._runtime = self._runtime, None
+        if rt is not None:          # kill outside the lock (SIGTERM->SIGKILL can block)
+            await self._kill(rt)
 
-    async def _apply_claude_effort(self) -> None:
-        """Push the configured effort live on the CLAUDE backend only.
+    async def acquire(self) -> "AcpRuntime":
+        """Return the live shared runtime, spawning/self-healing if needed."""
+        async with self._lock:
+            return await self._ensure_runtime_locked()
 
-        The kiro-cli backend gets effort from the cli.json overlay written before
-        spawn; pushing ``session/set_config_option`` on kiro would spam errors and
-        reset the session. This branch only fires if a future build runs the pool on
-        claude-agent-acp. Guarded + best-effort: a no-op when the backend exposes no
-        ``effort`` selector, and never raises (effort is a quality knob, not a
-        worker breaker)."""
-        client = self._client
-        if client is None:
-            return
-        effort = _get_review_settings().get("effort", _DEFAULT_EFFORT)
-        try:
-            if getattr(client, "backend", "") != ACP_BACKEND_CLAUDE:
-                return
-            if not client.supports_config_option("effort"):
-                return
-            await client.set_config_option("effort", effort)
-        except Exception:
-            logger.debug("could not push claude effort=%s", effort, exc_info=True)
+    async def force_shutdown(self) -> None:
+        """Tear the runtime down regardless of batch count (app disable / standalone)."""
+        async with self._lock:
+            self._batches = 0
+            rt, self._runtime = self._runtime, None
+        if rt is not None:
+            await self._kill(rt)
 
-    async def send_message(self, prompt: str, timeout: float = DEFAULT_TASK_TIMEOUT) -> str:
-        if self._client is None or not self._client.is_ready:
-            await self.start()
-        assert self._client is not None
-        return await self._client.send_message(prompt, timeout=timeout)
-
-    async def reset(self) -> None:
-        """Clean slate for the next change — guarantee per-change session
-        isolation (the reviewer's core invariant). The OSS ``AcpClient`` exposes
-        no in-process conversation reset, so tear the worker's client down and
-        start a fresh one; ``start()`` re-writes the effort overlay and re-runs
-        ``ensure_ready``, so the new session is fully re-initialized."""
-        await self.shutdown()
-        await self.start()
-
-    async def shutdown(self) -> None:
-        if self._client is not None:
+    async def _ensure_runtime_locked(self) -> "AcpRuntime":
+        rt = self._runtime
+        if rt is not None and rt.is_alive():
+            return rt
+        if rt is not None:                          # reap a dead one first
+            await self._kill(rt)
+        if AcpRuntime is None:
+            raise RuntimeError("AcpRuntime unavailable (kiro_crew.acp.runtime not importable)")
+        # Effort overlay is read by kiro-cli at each session/new, so it must be on
+        # disk before spawn. Keyed on the resolved model (config override -> agent
+        # default). Best-effort — a bad overlay never blocks the review.
+        if self._work_dir:
             try:
-                await self._client.shutdown()
+                _write_effort_overlay(
+                    self._work_dir, _reviewer_model(self._agent),
+                    _get_review_settings().get("effort", _DEFAULT_EFFORT))
             except Exception:
-                logger.debug("AcpReviewWorker shutdown error", exc_info=True)
-            self._client = None
+                logger.debug("could not write review effort overlay", exc_info=True)
+        # work_dir + sandbox_mode="auto" mirror the old AcpClient worker: the
+        # OS sandbox scrubs credential paths/env for this LLM-directed subprocess
+        # (GitHub fetch/post run via the `gh` CLI's own auth; the worker only
+        # writes data/results and runs `python3 sage_lib/pipeline.py`).
+        rt = AcpRuntime(agent=self._agent, work_dir=self._work_dir, sandbox_mode="auto")
+        await rt.spawn()
+        self._runtime = rt
+        logger.info("code-review-sage runtime spawned (agent=%s, cwd=%s)",
+                    self._agent, self._work_dir)
+        return rt
 
-    def is_alive(self) -> bool:
-        return self._client is not None and self._client.is_process_alive()
+    async def _kill(self, rt: "AcpRuntime") -> None:
+        try:
+            await rt.kill()
+        except Exception:
+            logger.debug("code-review-sage runtime kill error", exc_info=True)
+
+    def stats(self) -> dict:
+        rt = self._runtime
+        alive = bool(rt is not None and rt.is_alive())
+        active = 0
+        if rt is not None:
+            try:
+                active = len(getattr(rt, "_session_queues", {}) or {})
+            except Exception:
+                active = 0
+        return {"runtime_alive": alive, "active_sessions": active, "batches": self._batches}
 
 
-class ReviewPool(WorkerPool):
-    """Code Review Sage's worker pool — a thin adapter over the reusable
-    :class:`kiro_crew.acp.worker_pool.WorkerPool` engine. The engine owns the
-    pooling guarantees (lazy, bounded concurrency, startup throttle, self-healing,
-    clean-slate reset on reuse); this subclass only supplies the review-specific
-    defaults: an ``AcpReviewWorker`` factory and the review tunables.
+class ReviewPool:
+    """Code Review Sage's review executor — **one shared, batch-scoped
+    ``AcpRuntime``** multiplexing one ``AcpSessionHandle`` per task.
 
-    These workers are plain ``AcpClient`` sessions created directly — NOT
-    ``/api/spawn`` sub-agents — so they produce no agent card, ``:lock:`` prompt,
-    Slack relay, or reaper slot, and (via ``AcpReviewWorker``) are sweep-protected.
+    Replaces the former pool of ``AcpClient`` subprocesses (one process per
+    worker + a full process respawn between CRs). Now a single kiro-cli subprocess
+    serves every concurrent review; per-task isolation is a distinct ``sessionId``
+    (created + ``destroy()``ed per task, so no context leaks between reviews), and
+    the whole runtime is torn down when the batch drains (see ``_BatchRuntimeHolder``).
+
+    Concurrency is a plain semaphore over session-handles (``review.max_concurrent``,
+    default 5, ceiling 30) — independent of subprocess count. These sessions are
+    created directly on the runtime, NOT via ``/api/spawn``, so they produce no
+    agent card, ``:lock:`` prompt, Slack relay, or reaper slot; the review runs
+    silently. The runtime layer has no ``audit_source``, so this class emits the
+    per-tool SEL audit itself (parity with the old ``AcpClient`` worker).
     """
 
     def __init__(
         self,
-        max_workers: int = MAX_CONCURRENT,
-        max_starting: int = MAX_STARTING,
-        worker_factory: Optional[WorkerFactory] = None,
+        max_workers: Optional[int] = None,
+        agent: Optional[str] = None,
+        work_dir: Optional[str] = None,
+        # accepted-and-ignored for back-compat with older callers/tests:
+        max_starting: Optional[int] = None,
+        worker_factory: Optional[object] = None,
     ) -> None:
-        super().__init__(
-            worker_factory or (lambda: AcpReviewWorker()),
-            max_workers=max_workers,
-            max_starting=max_starting,
-            default_timeout=DEFAULT_TASK_TIMEOUT,
-            name="ReviewPool",
-        )
+        self._agent = _resolve_review_agent(agent or REVIEW_AGENT)
+        self._work_dir = work_dir if work_dir is not None else _review_work_dir()
+        # Auto mode = no explicit max_workers -> the semaphore tracks the live
+        # review.max_concurrent config (resized per batch). An explicit value
+        # (tests / standalone) is honored verbatim and never resized.
+        self._auto_max = not max_workers
+        self._max = int(max_workers) if max_workers else effective_max_concurrent()
+        self._max = max(1, min(self._max, MAX_CONCURRENT_CEIL))
+        self._sema = asyncio.Semaphore(self._max)
+        self._holder = _BatchRuntimeHolder(self._agent, self._work_dir)
+        self._closed = False
+
+    async def begin_batch(self) -> None:
+        """Open a review batch — lazily spawns the shared runtime (0->1 runs)."""
+        if self._closed:
+            raise RuntimeError("ReviewPool is shut down")
+        # Pick up a changed review.max_concurrent for the NEW batch. In-flight
+        # sends keep the semaphore object they already entered; new sends use the
+        # resized one. This makes a settings change take effect without a restart.
+        # Only in auto mode — an explicit max_workers is honored verbatim.
+        if self._auto_max:
+            eff = effective_max_concurrent()
+            if eff != self._max:
+                self._max = eff
+                self._sema = asyncio.Semaphore(eff)
+        await self._holder.begin_batch()
+
+    async def end_batch(self) -> None:
+        """Close a review batch — kills the runtime once the last batch drains."""
+        await self._holder.end_batch()
+
+    async def send(self, task: str, timeout: float = DEFAULT_TASK_TIMEOUT) -> str:
+        """Run one review task on its own session of the shared runtime and return
+        the final assistant text. Auto-approves every tool permission (the reviewer
+        runs the `gh` CLI + shell) and emits a per-tool SEL audit. The session is
+        always ``destroy()``ed on completion so its context never leaks."""
+        if self._closed:
+            raise RuntimeError("ReviewPool is shut down")
+        async with self._sema:
+            runtime = await self._holder.acquire()
+            handle = None
+            try:
+                # agent=None -> inherit the runtime's agent (spawned with --agent);
+                # cwd=app root so relative prompt paths + the effort overlay resolve.
+                handle = await runtime.create_session(cwd=self._work_dir, agent=None)
+                gen = handle.prompt(task, timeout=timeout)
+                parts: list[str] = []
+                stop_reason = ""
+                try:
+                    async for ev in gen:
+                        kind = getattr(ev, "kind", None)
+                        if kind == EVENT_TEXT_CHUNK:
+                            parts.append(getattr(ev, "text", "") or "")
+                        elif kind == EVENT_TOOL_CALL:
+                            await self._audit_tool(handle, ev)
+                        elif kind == EVENT_PERMISSION_REQUEST:
+                            # Auto-approve (the reviewer needs `gh` + shell) AND record
+                            # the permission DECISION in the security ledger, tagged with
+                            # its request id. The blocking backend-security-controls rule
+                            # requires every permission decision to emit an SEL event, and
+                            # the EVENT_TOOL_CALL audit carries no decision/request id.
+                            req_id = getattr(ev, "request_id", "")
+                            try:
+                                await handle.approve_tool(req_id)
+                            except Exception:
+                                logger.debug("tool approve failed", exc_info=True)
+                            else:
+                                await self._audit_tool(
+                                    handle, ev, request_id=req_id,
+                                    outcome="auto_approved")
+                        elif kind == EVENT_COMPLETE:
+                            stop_reason = getattr(ev, "stop_reason", "") or ""
+                            break
+                finally:
+                    # Deterministically close the async generator instead of leaving
+                    # it suspended-until-GC after the EVENT_COMPLETE break. prompt()
+                    # is typed AsyncIterator (no aclose in the protocol) but is an
+                    # async generator at runtime — close it if it supports it.
+                    aclose = getattr(gen, "aclose", None)
+                    if aclose is not None:
+                        await aclose()
+                # An abnormal completion (timeout / tool-stall / stale-recovery /
+                # error:*) means the review did NOT finish — surface it as a failure
+                # so make_sync_dispatch reports ok=False and the driver never marks
+                # the PR reviewed or posts on partial output.
+                if _is_abnormal_stop(stop_reason):
+                    raise RuntimeError(
+                        f"review turn ended abnormally (stop_reason={stop_reason!r})")
+                return "".join(parts)
+            finally:
+                if handle is not None:
+                    try:
+                        await handle.destroy()
+                    except Exception:
+                        logger.debug("session destroy error", exc_info=True)
+
+    async def _audit_tool(self, handle: object, ev: object, *,
+                          request_id: object = None,
+                          outcome: str = "auto_approved") -> None:
+        """Emit a per-tool SEL audit (the runtime layer has no ``audit_source``,
+        so without this the reviewer's tool calls would never reach the security log
+        — parity with ``AcpClient._maybe_audit_tool_call``). Best-effort + bounded:
+        offloaded to a thread with a timeout so a hung SEL backend can never stall a
+        review turn, and a failure never breaks tool dispatch.
+
+        Called on two events:
+          * ``EVENT_TOOL_CALL`` — records the observed tool invocation.
+          * ``EVENT_PERMISSION_REQUEST`` — records the permission DECISION itself
+            (the approve, tagged with its ``request_id``). The blocking
+            ``backend-security-controls`` rule requires EVERY permission decision to
+            emit an SEL event, and the tool_call audit carries no decision/request id.
+        """
+        if _sel is None:
+            return
+        rid = "" if request_id is None else str(request_id)
+        try:
+            loop = asyncio.get_running_loop()
+            await asyncio.wait_for(
+                loop.run_in_executor(
+                    None,
+                    lambda: _sel().log_tool_invocation(
+                        session_key=getattr(handle, "session_id", "") or "",
+                        agent=self._agent,
+                        source="subagent",
+                        tool_name=getattr(ev, "title", None) or "unknown",
+                        tool_kind=getattr(ev, "tool_kind", None) or "",
+                        outcome=outcome,
+                        request_id=rid,
+                    ),
+                ),
+                timeout=5.0,
+            )
+        except Exception:
+            logger.warning("code-review-sage SEL audit failed", exc_info=True)
+
+    def stats(self) -> dict:
+        """Live occupancy for the dashboard. Keeps the legacy key names
+        (``workers``/``idle``/``busy``/``max``/``starting_max``) so the existing UI
+        keeps working, and adds the runtime-model keys."""
+        h = self._holder.stats()
+        active = h["active_sessions"]
+        return {
+            "workers": active, "idle": 0, "busy": active,
+            "max": self._max, "starting_max": MAX_STARTING,
+            "runtime_alive": h["runtime_alive"], "active_sessions": active,
+            "batches": h["batches"],
+        }
+
+    async def shutdown(self) -> None:
+        """Force-tear-down the runtime (app disable / gateway shutdown / standalone)."""
+        self._closed = True
+        await self._holder.force_shutdown()
 
 
 # ── Process-wide singleton (owned by the gateway backend) ──
@@ -343,7 +553,7 @@ _POOL: Optional[ReviewPool] = None
 def get_pool() -> ReviewPool:
     """Lazily create and return the process-wide review pool."""
     global _POOL
-    if _POOL is None:
+    if _POOL is None or _POOL._closed:
         _POOL = ReviewPool()
     return _POOL
 
@@ -357,11 +567,15 @@ async def shutdown_pool() -> None:
 
 
 def pool_stats() -> dict:
-    """Live worker-pool occupancy for the dashboard. Safe to call from a status
-    handler — returns zeros (no lazy creation) when the pool hasn't started yet."""
+    """Live occupancy for the dashboard. Safe to call from a status handler —
+    returns zeros (no lazy creation) when the pool hasn't started yet."""
     if _POOL is None:
+        # No pool yet (before the first review) — report the static default cap.
+        # Avoid effective_max_concurrent() here: it reads config.json, and this
+        # runs synchronously on the gateway event loop from the /runs handler.
         return {"workers": 0, "idle": 0, "busy": 0,
-                "max": MAX_CONCURRENT, "starting_max": MAX_STARTING}
+                "max": MAX_CONCURRENT, "starting_max": MAX_STARTING,
+                "runtime_alive": False, "active_sessions": 0, "batches": 0}
     return _POOL.stats()
 
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -66,6 +66,8 @@ DEFAULT_CONFIG: dict[str, object] = {
         "max_review_rounds": 3,  # Phase-2 convergence rounds per change; re-review
                                  # until a round adds no new findings or this cap is
                                  # hit. Maximizes first-pass recall (>=1).
+        "max_concurrent": 5,     # max reviews running at once on the shared runtime
+                                 # (clamped to [1, 30]); "review all" can raise it.
     },
     "sensitive_globs": DEFAULT_SENSITIVE_GLOBS,
     "rule_packs": DEFAULT_RULE_PACKS,

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock
 from pathlib import Path
 
 _APP_ROOT = Path(__file__).resolve().parent.parent
@@ -69,6 +70,106 @@ class TestRunsPersistence(unittest.TestCase):
         self.mod._RUNS = [{"run_id": "c3", "status": "done"}]
         self.mod._save_runs()
         self.assertEqual(oct(self.mod._runs_file().stat().st_mode)[-3:], "600")
+
+
+class TestRecordReviewedDelivery(unittest.TestCase):
+    """Regression for the reviewed-index write path:
+      * Finding 2 (HIGH): a PR is indexed as reviewed ONLY when the poster
+        actually delivered (posted_comments >= posting_expected), not merely when
+        the poster turn completed (post_ok). A failed gh post must not strand it.
+      * The entry is keyed by the collision-free reviewed key (github.com/o/r#n),
+        NOT the lossy change-id."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._old_home = os.environ.get("KIROCREW_HOME")
+        os.environ["KIROCREW_HOME"] = self.tmp
+        self.mod = _load_routes_module()
+
+    def tearDown(self):
+        if self._old_home is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._old_home
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, *, posted, expected):
+        url = "https://github.com/acme/repo/pull/1"
+        cid = self.mod.review_driver.change_id_for(url)
+        return {
+            "run_id": "R1",
+            "changes": [url],
+            "head_shas": {self.mod.review_driver.reviewed_key_for(url): "sha1"},
+            "summary": {"per_change": [{
+                "change_id": cid, "deep_reviewed": True, "post_ok": True,
+                "posted_comments": posted, "posting_expected": expected,
+            }]},
+        }
+
+    def test_delivered_is_indexed_under_collision_free_key(self):
+        captured = {}
+        with unittest.mock.patch.object(
+                self.mod.results, "mark_reviewed",
+                side_effect=lambda entries, *a, **k: captured.update(entries)):
+            self.mod._record_reviewed(self._run(posted=2, expected=2))
+        self.assertEqual(list(captured), ["github.com/acme/repo#1"])
+        self.assertEqual(captured["github.com/acme/repo#1"]["head_sha"], "sha1")
+
+    def test_failed_post_is_not_indexed(self):
+        called = []
+        with unittest.mock.patch.object(
+                self.mod.results, "mark_reviewed",
+                side_effect=lambda entries, *a, **k: called.append(entries)):
+            # post_ok True (turn ended) but nothing actually posted -> not reviewed.
+            self.mod._record_reviewed(self._run(posted=0, expected=2))
+        self.assertEqual(called, [])
+
+
+class TestUnderLockRededup(unittest.TestCase):
+    """Regression for Codex Finding 2 (TOCTOU): a repo-review re-checks the reviewed
+    index under _RUN_LOCK, so a PR a concurrent run just recorded is not re-reviewed."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._old_home = os.environ.get("KIROCREW_HOME")
+        os.environ["KIROCREW_HOME"] = self.tmp
+        self.mod = _load_routes_module()
+        store.ensure_layout()
+
+    def tearDown(self):
+        if self._old_home is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._old_home
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, force=False):
+        url = "https://github.com/acme/repo/pull/1"
+        rkey = self.mod.review_driver.reviewed_key_for(url)
+        run = {
+            "changes": [url], "force": force,
+            "head_shas": {rkey: "sha1"},
+            "change_ids": [self.mod.review_driver.change_id_for(url)],
+        }
+        return url, rkey, run
+
+    def test_drops_pr_reviewed_by_concurrent_run(self):
+        url, rkey, run = self._run()
+        self.mod.results.mark_reviewed({rkey: {"head_sha": "sha1"}})  # concurrent run
+        kept = self.mod._dedup_changes_under_lock(run, [url])
+        self.assertEqual(kept, [])
+        self.assertEqual(run["changes"], [])
+        self.assertEqual(run["head_shas"], {})
+
+    def test_keeps_when_head_differs(self):
+        url, rkey, run = self._run()
+        self.mod.results.mark_reviewed({rkey: {"head_sha": "OLDSHA"}})  # head moved on
+        self.assertEqual(self.mod._dedup_changes_under_lock(run, [url]), [url])
+
+    def test_force_bypasses_dedup(self):
+        url, rkey, run = self._run(force=True)
+        self.mod.results.mark_reviewed({rkey: {"head_sha": "sha1"}})
+        self.assertEqual(self.mod._dedup_changes_under_lock(run, [url]), [url])
 
     def test_load_missing_file_is_noop(self):
         self.mod._RUNS = [{"run_id": "keep", "status": "done"}]

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_namespaces.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_namespaces.py
@@ -190,7 +190,10 @@ class TestConfigDrivenSettings(unittest.TestCase):
             cfg["review"]["effort"] = "ludicrous"
             cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
             with patch.object(store, "app_root", return_value=root):
-                self.assertEqual(review_pool._get_review_settings()["effort"], "max")
+                # An invalid stored effort is sanitized back to the default
+                # (_DEFAULT_EFFORT = "" = inherit the model/provider default).
+                self.assertEqual(review_pool._get_review_settings()["effort"],
+                                 review_pool._DEFAULT_EFFORT)
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_repo_review.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_repo_review.py
@@ -1,0 +1,186 @@
+"""Tests for the repo-review feature: repo-URL parsing, open-PR enumeration
+(gh CLI, mocked), and the durable reviewed-index dedup store."""
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from sage_lib import adapters, pipeline, results, review_driver, store
+
+
+class TestParseRepoUrl(unittest.TestCase):
+    def test_plain_repo_url(self):
+        self.assertEqual(adapters.parse_repo_url("https://github.com/octo/hello"),
+                         ("octo", "hello"))
+
+    def test_trailing_git_and_slash(self):
+        self.assertEqual(adapters.parse_repo_url("https://github.com/octo/hello.git"),
+                         ("octo", "hello"))
+        self.assertEqual(adapters.parse_repo_url("https://github.com/octo/hello/"),
+                         ("octo", "hello"))
+
+    def test_www_host_allowed(self):
+        self.assertEqual(adapters.parse_repo_url("https://www.github.com/o/r"),
+                         ("o", "r"))
+
+    def test_rejects_non_github_host(self):
+        # github.com in the PATH (not the host) must be rejected (SSRF/allowlist).
+        with self.assertRaises(adapters.UnsupportedPlatform):
+            adapters.parse_repo_url("https://evil.example/github.com/o/r")
+
+    def test_rejects_missing_repo_segment(self):
+        with self.assertRaises(adapters.AdapterParseError):
+            adapters.parse_repo_url("https://github.com/octo")
+
+    def test_rejects_empty(self):
+        with self.assertRaises(adapters.UnsupportedPlatform):
+            adapters.parse_repo_url("")
+
+    def test_rejects_pr_url(self):
+        # A PR URL is not a repo URL — route the user to the paste flow.
+        with self.assertRaises(adapters.AdapterParseError):
+            adapters.parse_repo_url("https://github.com/o/r/pull/5")
+
+    def test_rejects_bad_segment_chars(self):
+        with self.assertRaises(adapters.AdapterParseError):
+            adapters.parse_repo_url("https://github.com/../r")
+
+
+class TestListOpenPrs(unittest.TestCase):
+    def _cp(self, returncode=0, stdout="", stderr=""):
+        return subprocess.CompletedProcess(
+            args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def test_parses_jsonl(self):
+        jsonl = "\n".join([
+            json.dumps({"url": "https://github.com/o/r/pull/1", "number": 1,
+                        "head_sha": "abc", "title": "one"}),
+            json.dumps({"url": "https://github.com/o/r/pull/2", "number": 2,
+                        "head_sha": "def", "title": "two"}),
+            "",  # trailing blank line tolerated
+        ])
+        with patch.object(pipeline.subprocess, "run", return_value=self._cp(stdout=jsonl)):
+            prs = pipeline.list_open_prs("o", "r")
+        self.assertEqual(len(prs), 2)
+        self.assertEqual(prs[0], {"url": "https://github.com/o/r/pull/1", "number": 1,
+                                  "head_sha": "abc", "title": "one"})
+
+    def test_uses_list_argv_no_shell(self):
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            captured["kw"] = kw
+            return self._cp(stdout="")
+        with patch.object(pipeline.subprocess, "run", side_effect=fake_run):
+            pipeline.list_open_prs("o", "r")
+        self.assertIsInstance(captured["argv"], list)     # never a shell string
+        self.assertNotIn("shell", captured["kw"])         # never shell=True
+        self.assertEqual(captured["argv"][:3], ["gh", "api", "repos/o/r/pulls?state=open&per_page=100"])
+
+    def test_nonzero_exit_raises(self):
+        with patch.object(pipeline.subprocess, "run",
+                          return_value=self._cp(returncode=1, stderr="gh: not logged in")):
+            with self.assertRaises(RuntimeError) as ctx:
+                pipeline.list_open_prs("o", "r")
+        self.assertIn("not logged in", str(ctx.exception))
+
+    def test_missing_gh_raises(self):
+        with patch.object(pipeline.subprocess, "run", side_effect=FileNotFoundError()):
+            with self.assertRaises(RuntimeError):
+                pipeline.list_open_prs("o", "r")
+
+    def test_timeout_raises(self):
+        with patch.object(pipeline.subprocess, "run",
+                          side_effect=subprocess.TimeoutExpired("gh", 60)):
+            with self.assertRaises(RuntimeError):
+                pipeline.list_open_prs("o", "r")
+
+    def test_unparseable_nonempty_output_raises(self):
+        # gh exit 0 but non-empty, non-JSONL output must NOT masquerade as "no PRs".
+        with patch.object(pipeline.subprocess, "run",
+                          return_value=self._cp(stdout="{\n  \"url\": \"x\"\n}\n")):
+            with self.assertRaises(RuntimeError):
+                pipeline.list_open_prs("o", "r")
+
+    def test_truly_empty_output_returns_empty(self):
+        with patch.object(pipeline.subprocess, "run", return_value=self._cp(stdout="")):
+            self.assertEqual(pipeline.list_open_prs("o", "r"), [])
+
+
+class TestReviewedIndex(unittest.TestCase):
+    def test_roundtrip_and_merge(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "apps" / "code-review-sage"
+            store.ensure_layout(root)
+            self.assertEqual(results.read_reviewed(root), {})   # missing -> {}
+
+            results.write_reviewed(
+                {"GH-o-r-1": {"head_sha": "abc", "reviewed_at": "t0", "run_id": "R1"}}, root)
+            idx = results.read_reviewed(root)
+            self.assertEqual(idx["GH-o-r-1"]["head_sha"], "abc")
+
+            # mark_reviewed upserts without clobbering existing keys
+            results.mark_reviewed(
+                {"GH-o-r-2": {"head_sha": "def", "reviewed_at": "t1", "run_id": "R2"}}, root)
+            idx = results.read_reviewed(root)
+            self.assertEqual(set(idx), {"GH-o-r-1", "GH-o-r-2"})
+
+            # updating an existing key overwrites it (re-review at a new head)
+            results.mark_reviewed(
+                {"GH-o-r-1": {"head_sha": "xyz", "reviewed_at": "t2", "run_id": "R3"}}, root)
+            idx = results.read_reviewed(root)
+            self.assertEqual(idx["GH-o-r-1"]["head_sha"], "xyz")
+
+    def test_index_file_is_0600(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "apps" / "code-review-sage"
+            store.ensure_layout(root)
+            p = results.write_reviewed({"GH-o-r-1": {"head_sha": "abc"}}, root)
+            self.assertEqual(p.stat().st_mode & 0o777, 0o600)
+
+    def test_corrupt_index_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "apps" / "code-review-sage"
+            store.ensure_layout(root)
+            results.reviewed_path(root).write_text("{not json", encoding="utf-8")
+            self.assertEqual(results.read_reviewed(root), {})
+
+
+class TestReviewedKeyCollision(unittest.TestCase):
+    """HIGH regression: two repos differing only by '-' vs '_' with the same PR
+    number must NOT share one durable reviewed-index key. The filesystem-safe
+    change-id sanitizes '-'->'_' (so it CAN collide); the reviewed key must not."""
+
+    def test_change_id_collides_but_reviewed_key_does_not(self):
+        u1 = "https://github.com/acme/service-api/pull/5"
+        u2 = "https://github.com/acme/service_api/pull/5"
+        # Lossy change-id (also a filename) collapses '-'->'_': the two collide.
+        self.assertEqual(review_driver.change_id_for(u1),
+                         review_driver.change_id_for(u2))
+        # Collision-free reviewed key keeps distinct repos distinct.
+        self.assertNotEqual(review_driver.reviewed_key_for(u1),
+                            review_driver.reviewed_key_for(u2))
+
+    def test_reviewed_key_case_insensitive_canonical(self):
+        self.assertEqual(
+            review_driver.reviewed_key_for("https://github.com/Acme/Repo/pull/7"),
+            review_driver.reviewed_key_for("https://github.com/acme/repo/pull/7"),
+        )
+
+    def test_reviewed_key_format(self):
+        self.assertEqual(
+            adapters.github_review_key("Octo", "Hello-World", 42),
+            "github.com/octo/hello-world#42",
+        )
+
+
+class TestMaxConcurrentDefault(unittest.TestCase):
+    def test_default_config_has_max_concurrent(self):
+        self.assertEqual(store.DEFAULT_CONFIG["review"]["max_concurrent"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
@@ -1,7 +1,8 @@
-"""Unit tests for the reusable review worker pool (lazy, bounded, isolated).
+"""Unit tests for the single-runtime review executor (batch-scoped, isolated).
 
-Workers are faked so the pool's concurrency/lifecycle logic is exercised without
-spawning real ACP processes.
+The ``AcpRuntime``/``AcpSessionHandle`` layer is faked so the executor's
+concurrency, batch lifecycle, per-task session isolation, tool auto-approval,
+and SEL audit are exercised without spawning a real kiro-cli process.
 """
 import asyncio
 import json
@@ -10,16 +11,19 @@ import threading
 import unittest
 from pathlib import Path
 
+from sage_lib import review_pool as rp
 from sage_lib.review_pool import (
+    _DEFAULT_EFFORT,
     _DEFAULT_REVIEW_MODEL,
     MAX_CONCURRENT,
-    MAX_STARTING,
+    MAX_CONCURRENT_CEIL,
     REVIEW_EFFORT,
     ReviewPool,
     _resolve_review_agent,
     _review_work_dir,
     _reviewer_model,
     _write_effort_overlay,
+    effective_max_concurrent,
     make_sync_dispatch,
     pool_stats,
     reviewer_info,
@@ -27,200 +31,330 @@ from sage_lib.review_pool import (
 )
 
 
-class FakeWorker:
-    """A trivial worker: records start/reset/send/shutdown and stays alive."""
-
-    def __init__(self) -> None:
-        self.started = 0
-        self.resets = 0
-        self.sends: list[str] = []
-        self.shutdowns = 0
-        self.live = False
-
-    async def start(self) -> None:
-        self.started += 1
-        self.live = True
-
-    async def send_message(self, prompt: str, timeout: float = 0) -> str:
-        self.sends.append(prompt)
-        return "ok:" + prompt
-
-    async def reset(self) -> None:
-        self.resets += 1
-
-    async def shutdown(self) -> None:
-        self.shutdowns += 1
-        self.live = False
-
-    def is_alive(self) -> bool:
-        return self.live
+# ── Fakes for the ACP runtime/handle layer ──────────────────────────────────
+def _ev(kind, **kw):
+    """Build a fake AcpEvent-like object with a .kind and any extra attrs."""
+    return type("Ev", (), {"kind": kind, **kw})()
 
 
-class FailingWorker(FakeWorker):
-    async def send_message(self, prompt: str, timeout: float = 0) -> str:
-        raise RuntimeError("boom")
+class FakeHandle:
+    """A fake session handle. ``prompt`` replays a scripted list of events."""
 
-
-class GateWorker(FakeWorker):
-    """send_message blocks on a shared event — used to observe concurrency."""
-
-    def __init__(self, gate: asyncio.Event) -> None:
-        super().__init__()
+    def __init__(self, runtime, session_id, script=None, gate=None):
+        self._runtime = runtime
+        self.session_id = session_id
+        self._script = script or []
         self._gate = gate
+        self.approvals: list = []
+        self.destroyed = False
 
-    async def send_message(self, prompt: str, timeout: float = 0) -> str:
-        self.sends.append(prompt)
-        await self._gate.wait()
-        return "ok:" + prompt
+    async def prompt(self, message, timeout=0):
+        if self._gate is not None:
+            await self._gate.wait()
+        for ev in self._script:
+            yield ev
+        yield _ev(rp.EVENT_COMPLETE, stop_reason="end_turn")
 
+    async def approve_tool(self, request_id, option_id=None):
+        self.approvals.append(request_id)
 
-class StartGateWorker(FakeWorker):
-    """start() blocks on a shared event and tracks simultaneous startups."""
-
-    def __init__(self, gate: asyncio.Event, counter: dict) -> None:
-        super().__init__()
-        self._gate = gate
-        self._counter = counter
-
-    async def start(self) -> None:
-        self._counter["now"] += 1
-        self._counter["max"] = max(self._counter["max"], self._counter["now"])
-        await self._gate.wait()
-        self._counter["now"] -= 1
-        self.started += 1
-        self.live = True
+    async def destroy(self):
+        self.destroyed = True
+        self._runtime.active -= 1
+        self._runtime.sessions.pop(self.session_id, None)
 
 
-def _mk(lst, worker):
-    """Factory helper: record the created worker and return it. Avoids the
-    ``lst.append(x) or worker`` idiom, which mypy rejects (append returns None)."""
-    lst.append(worker)
-    return worker
+class FakeRuntime:
+    """A fake AcpRuntime: tracks spawn/kill and active sessions."""
+
+    instances: list = []
+
+    def __init__(self, agent=None, work_dir=None, sandbox_mode="auto", **kw):
+        self.agent = agent
+        self.work_dir = work_dir
+        self.spawned = False
+        self.killed = False
+        self.sessions: dict = {}
+        self._session_queues: dict = {}   # read by holder.stats()
+        self.active = 0
+        self.max_active = 0
+        self._seq = 0
+        self.script = []
+        self.gate = None
+        FakeRuntime.instances.append(self)
+
+    def is_alive(self):
+        return self.spawned and not self.killed
+
+    async def spawn(self):
+        self.spawned = True
+
+    async def kill(self):
+        self.killed = True
+
+    async def create_session(self, cwd=None, agent=None):
+        self._seq += 1
+        sid = f"s{self._seq}"
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        h = FakeHandle(self, sid, script=list(self.script), gate=self.gate)
+        self.sessions[sid] = h
+        self._session_queues[sid] = object()
+        # mirror the handle destroy -> pop from _session_queues too
+        _orig = h.destroy
+
+        async def _destroy():
+            self._session_queues.pop(sid, None)
+            await _orig()
+        h.destroy = _destroy  # type: ignore[method-assign]
+        return h
 
 
-def _count(lst, worker):
-    """Factory helper: record one creation (append a marker) and return the worker."""
-    lst.append(1)
-    return worker
+def _install_fake_runtime(test, script=None, gate=None):
+    """Patch review_pool.AcpRuntime with FakeRuntime for the duration of a test."""
+    FakeRuntime.instances = []
+
+    def factory(agent=None, work_dir=None, sandbox_mode="auto", **kw):
+        r = FakeRuntime(agent=agent, work_dir=work_dir, sandbox_mode=sandbox_mode)
+        r.script = script or []
+        r.gate = gate
+        return r
+    orig = rp.AcpRuntime
+    rp.AcpRuntime = factory  # type: ignore[assignment]
+    test.addCleanup(lambda: setattr(rp, "AcpRuntime", orig))
 
 
-class TestReviewPool(unittest.IsolatedAsyncioTestCase):
-    async def test_lazy_no_workers_until_used(self):
-        made: list = []
-        pool = ReviewPool(worker_factory=lambda: _count(made, FakeWorker()))
-        self.assertEqual(pool.created_count, 0)
-        self.assertEqual(pool.idle_count, 0)
-        self.assertEqual(made, [])
+# ── Batch lifecycle + isolation ─────────────────────────────────────────────
+class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
+    async def test_lazy_no_runtime_until_used(self):
+        _install_fake_runtime(self)
+        ReviewPool(work_dir="/tmp/x")
+        self.assertEqual(FakeRuntime.instances, [])   # nothing spawned on construction
 
-    async def test_reuse_and_reset_only_on_reuse(self):
-        worker = FakeWorker()
-        calls: list = []
-        pool = ReviewPool(worker_factory=lambda: _count(calls, worker))
-
+    async def test_begin_batch_spawns_one_runtime_shared_across_sends(self):
+        _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="hi")])
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        self.assertEqual(len(FakeRuntime.instances), 1)
+        self.assertTrue(FakeRuntime.instances[0].is_alive())
         out1 = await pool.send("a")
-        self.assertEqual(out1, "ok:a")
-        self.assertEqual(worker.resets, 0)        # fresh worker -> no reset on first use
-        self.assertEqual(pool.idle_count, 1)
-
         out2 = await pool.send("b")
-        self.assertEqual(out2, "ok:b")
-        self.assertEqual(worker.resets, 1)        # reused -> clean slate before the next CR
-        self.assertEqual(len(calls), 1)           # same worker reused, not recreated
+        self.assertEqual(out1, "hi")
+        self.assertEqual(out2, "hi")
+        # both sends multiplexed onto the ONE runtime (no respawn per task)
+        self.assertEqual(len(FakeRuntime.instances), 1)
+        await pool.end_batch()
 
-    async def test_max_concurrent_cap(self):
+    async def test_end_batch_kills_runtime_only_when_drained(self):
+        _install_fake_runtime(self)
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()          # batches 0->1 spawns
+        await pool.begin_batch()          # batches 1->2 (overlapping run)
+        rt = FakeRuntime.instances[0]
+        await pool.end_batch()            # batches 2->1: NOT killed
+        self.assertFalse(rt.killed)
+        await pool.end_batch()            # batches 1->0: killed
+        self.assertTrue(rt.killed)
+
+    async def test_new_batch_after_drain_spawns_fresh_runtime(self):
+        _install_fake_runtime(self)
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        await pool.end_batch()
+        await pool.begin_batch()
+        self.assertEqual(len(FakeRuntime.instances), 2)   # a fresh runtime per batch
+        await pool.end_batch()
+
+    async def test_session_created_and_destroyed_per_task(self):
+        _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="x")])
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        await pool.send("task")
+        rt = FakeRuntime.instances[0]
+        # exactly one session was created, and it was destroyed (no leak)
+        self.assertEqual(rt._seq, 1)
+        self.assertEqual(rt._session_queues, {})          # destroyed -> unregistered
+        await pool.end_batch()
+
+    async def test_standalone_send_lazily_spawns(self):
+        # No begin_batch (standalone CLI path) -> acquire() spawns on first send.
+        _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="y")])
+        pool = ReviewPool(work_dir="/tmp/x")
+        out = await pool.send("z")
+        self.assertEqual(out, "y")
+        self.assertEqual(len(FakeRuntime.instances), 1)
+        await pool.shutdown()
+        self.assertTrue(FakeRuntime.instances[0].killed)
+
+    async def test_abnormal_stop_reason_raises_and_still_destroys(self):
+        # A timeout/stale/error completion must surface as a failure (so dispatch
+        # reports ok=False and the driver never marks the PR reviewed), and the
+        # session must still be destroyed.
+        _install_fake_runtime(self, script=[_ev(rp.EVENT_COMPLETE, stop_reason="timeout")])
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        with self.assertRaises(RuntimeError):
+            await pool.send("t")
+        rt = FakeRuntime.instances[0]
+        self.assertEqual(rt._session_queues, {})   # session destroyed despite the raise
+        await pool.end_batch()
+
+    async def test_tool_stall_stop_reason_is_abnormal(self):
+        # STOP_REASON_TOOL_STALL ("error: tool stall") must be classified abnormal
+        # and surface as a failure (matched explicitly, not just by prefix).
+        _install_fake_runtime(
+            self, script=[_ev(rp.EVENT_COMPLETE, stop_reason=rp.STOP_REASON_TOOL_STALL)])
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        with self.assertRaises(RuntimeError):
+            await pool.send("t")
+        await pool.end_batch()
+
+    async def test_spawn_failure_does_not_leak_batch_count(self):
+        # If the runtime spawn raises, _batches must NOT be incremented — otherwise
+        # it could never drain to 0 and the subprocess would never be killed.
+        calls = {"n": 0}
+
+        def factory(agent=None, work_dir=None, sandbox_mode="auto", **kw):
+            r = FakeRuntime(agent=agent, work_dir=work_dir)
+            calls["n"] += 1
+            if calls["n"] == 1:
+                async def _boom():
+                    raise RuntimeError("spawn boom")
+                r.spawn = _boom  # type: ignore[method-assign]
+            return r
+        orig = rp.AcpRuntime
+        rp.AcpRuntime = factory  # type: ignore[assignment]
+        self.addCleanup(lambda: setattr(rp, "AcpRuntime", orig))
+        FakeRuntime.instances = []
+        pool = ReviewPool(work_dir="/tmp/x")
+        with self.assertRaises(RuntimeError):
+            await pool.begin_batch()                 # spawn fails
+        self.assertEqual(pool._holder._batches, 0)   # counter not leaked
+        # a subsequent batch spawns cleanly and drains to 0 (runtime killed)
+        await pool.begin_batch()
+        await pool.end_batch()
+        self.assertTrue(FakeRuntime.instances[-1].killed)
+
+
+# ── Concurrency ─────────────────────────────────────────────────────────────
+class TestConcurrency(unittest.IsolatedAsyncioTestCase):
+    async def test_semaphore_caps_concurrent_sessions(self):
         gate = asyncio.Event()
-        made: list[GateWorker] = []
-        pool = ReviewPool(
-            max_workers=2, max_starting=2,
-            worker_factory=lambda: _mk(made, GateWorker(gate)),
-        )
+        _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="q")], gate=gate)
+        pool = ReviewPool(max_workers=2, work_dir="/tmp/x")
+        await pool.begin_batch()
         tasks = [asyncio.create_task(pool.send(f"t{i}")) for i in range(4)]
         await asyncio.sleep(0.05)
-        # only 2 tasks may run at once -> only 2 workers ever created
-        self.assertEqual(pool.created_count, 2)
-        self.assertEqual(len(made), 2)
+        rt = FakeRuntime.instances[0]
+        self.assertEqual(rt.active, 2)             # only 2 in flight at once
+        self.assertLessEqual(rt.max_active, 2)
         gate.set()
         await asyncio.gather(*tasks)
-        self.assertEqual(len(made), 2)            # remaining tasks reused the 2 workers
+        self.assertLessEqual(rt.max_active, 2)     # never exceeded the cap
+        await pool.end_batch()
 
-    async def test_startup_throttled_to_max_starting(self):
-        gate = asyncio.Event()
-        counter = {"now": 0, "max": 0}
-        pool = ReviewPool(
-            max_workers=5, max_starting=2,
-            worker_factory=lambda: StartGateWorker(gate, counter),
-        )
-        tasks = [asyncio.create_task(pool.send(f"t{i}")) for i in range(5)]
-        await asyncio.sleep(0.05)
-        self.assertEqual(counter["now"], 2)       # exactly 2 cold-starting at once
-        self.assertLessEqual(counter["max"], 2)
-        gate.set()
-        await asyncio.gather(*tasks)
-        self.assertLessEqual(counter["max"], 2)   # never exceeded the start cap
+    async def test_effective_max_concurrent_clamped(self):
+        pool = ReviewPool(max_workers=999, work_dir="/tmp/x")
+        self.assertEqual(pool._max, MAX_CONCURRENT_CEIL)
 
-    async def test_dead_idle_worker_replaced(self):
-        made: list[FakeWorker] = []
-        pool = ReviewPool(worker_factory=lambda: _mk(made, FakeWorker()))
-        await pool.send("a")
-        self.assertEqual(len(made), 1)
-        made[0].live = False                      # worker dies while idle
-        await pool.send("b")
-        self.assertEqual(len(made), 2)            # dead idle worker replaced
-        self.assertGreaterEqual(made[0].shutdowns, 1)
-        self.assertEqual(pool.created_count, 1)   # exactly one live worker
 
-    async def test_failed_task_retires_worker(self):
-        made: list[FailingWorker] = []
-        pool = ReviewPool(worker_factory=lambda: _mk(made, FailingWorker()))
-        with self.assertRaises(RuntimeError):
-            await pool.send("x")
-        self.assertEqual(pool.created_count, 0)   # poisoned worker retired, not idled
-        self.assertEqual(pool.idle_count, 0)
-        self.assertEqual(made[0].shutdowns, 1)
+# ── Tool approval + SEL audit (parity with the old AcpClient worker) ─────────
+class TestApprovalAndAudit(unittest.IsolatedAsyncioTestCase):
+    async def test_permission_events_are_auto_approved(self):
+        script = [
+            _ev(rp.EVENT_PERMISSION_REQUEST, request_id="r1"),
+            _ev(rp.EVENT_TEXT_CHUNK, text="done"),
+        ]
+        _install_fake_runtime(self, script=script)
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        out = await pool.send("t")
+        self.assertEqual(out, "done")
+        rt = FakeRuntime.instances[0]
+        # the (now-destroyed) handle recorded the approval
+        # find it via the runtime's last created session id
+        self.assertEqual(rt._seq, 1)
+        await pool.end_batch()
 
-    async def test_shutdown_retires_idle_workers(self):
-        made: list[FakeWorker] = []
-        pool = ReviewPool(worker_factory=lambda: _mk(made, FakeWorker()))
-        await pool.send("a")
-        self.assertEqual(pool.idle_count, 1)
-        await pool.shutdown()
-        self.assertEqual(pool.idle_count, 0)
-        self.assertEqual(made[0].shutdowns, 1)
+    async def test_tool_call_emits_sel_audit(self):
+        calls: list = []
 
-    async def test_pool_stats_reports_occupancy(self):
-        await shutdown_pool()                   # ensure no singleton from other tests
+        class _FakeSel:
+            def log_tool_invocation(self, **kw):
+                calls.append(kw)
+
+        script = [_ev(rp.EVENT_TOOL_CALL, title="shell", tool_kind="execute"),
+                  _ev(rp.EVENT_TEXT_CHUNK, text="ok")]
+        _install_fake_runtime(self, script=script)
+        orig_sel = rp._sel
+        rp._sel = lambda: _FakeSel()          # type: ignore[assignment]
+        self.addCleanup(lambda: setattr(rp, "_sel", orig_sel))
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        await pool.send("t")
+        await pool.end_batch()
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["tool_name"], "shell")
+        self.assertEqual(calls[0]["source"], "subagent")
+        self.assertEqual(calls[0]["outcome"], "auto_approved")
+
+    async def test_permission_decision_emits_sel_audit(self):
+        # Codex Finding 1 (backend-security-controls): the permission DECISION must
+        # emit an SEL event carrying its request id — not only the tool_call.
+        calls: list = []
+
+        class _FakeSel:
+            def log_tool_invocation(self, **kw):
+                calls.append(kw)
+
+        script = [_ev(rp.EVENT_PERMISSION_REQUEST, request_id="r1",
+                      title="shell", tool_kind="execute"),
+                  _ev(rp.EVENT_TEXT_CHUNK, text="ok")]
+        _install_fake_runtime(self, script=script)
+        orig_sel = rp._sel
+        rp._sel = lambda: _FakeSel()          # type: ignore[assignment]
+        self.addCleanup(lambda: setattr(rp, "_sel", orig_sel))
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        await pool.send("t")
+        await pool.end_batch()
+        # exactly one audit — the permission decision — carrying the request id
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["request_id"], "r1")
+        self.assertEqual(calls[0]["outcome"], "auto_approved")
+        self.assertEqual(calls[0]["source"], "subagent")
+
+
+# ── Stats + config ──────────────────────────────────────────────────────────
+class TestStatsAndConfig(unittest.IsolatedAsyncioTestCase):
+    async def test_pool_stats_zeros_when_no_singleton(self):
+        await shutdown_pool()
         st = pool_stats()
-        self.assertEqual(st["max"], MAX_CONCURRENT)
-        self.assertEqual(st["starting_max"], MAX_STARTING)
         self.assertEqual(st["workers"], 0)
         self.assertEqual(st["busy"], 0)
         self.assertEqual(st["idle"], 0)
+        self.assertFalse(st["runtime_alive"])
+        self.assertIn("max", st)
 
-    async def test_acquire_after_shutdown_raises(self):
-        pool = ReviewPool(worker_factory=lambda: FakeWorker())
-        await pool.shutdown()
-        with self.assertRaises(RuntimeError):
-            await pool.acquire()
+    async def test_effective_max_concurrent_default(self):
+        # No config override -> MAX_CONCURRENT (5), clamped into [1, ceil].
+        self.assertEqual(effective_max_concurrent(), MAX_CONCURRENT)
+        self.assertEqual(MAX_CONCURRENT, 5)
 
-    async def test_cold_start_failure_releases_permit_and_slot(self):
-        calls = {"n": 0}
-
-        def factory():
-            calls["n"] += 1
-            if calls["n"] == 1:
-                raise RuntimeError("spawn boom")    # first cold-start fails
-            return FakeWorker()
-        pool = ReviewPool(max_workers=1, worker_factory=factory)
-        with self.assertRaises(RuntimeError):
-            await pool.send("a")
-        # The failed create must not leak the concurrency permit or the slot.
-        self.assertEqual(pool.created_count, 0)
-        out = await pool.send("b")                  # pool still usable
-        self.assertEqual(out, "ok:b")
+    async def test_stats_reflect_alive_runtime(self):
+        _install_fake_runtime(self)
+        pool = ReviewPool(work_dir="/tmp/x")
+        await pool.begin_batch()
+        st = pool.stats()
+        self.assertTrue(st["runtime_alive"])
+        self.assertEqual(st["max"], pool._max)
+        await pool.end_batch()
 
 
+# ── Sync dispatch bridge ─────────────────────────────────────────────────────
 class TestSyncDispatchBridge(unittest.TestCase):
-    """make_sync_dispatch bridges the threaded driver to the async pool."""
+    """make_sync_dispatch bridges the threaded driver to the async executor."""
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
@@ -234,49 +368,69 @@ class TestSyncDispatchBridge(unittest.TestCase):
         asyncio.run_coroutine_threadsafe(pool.shutdown(), self.loop).result(timeout=5)
 
     def test_dispatch_ok(self):
-        pool = ReviewPool(worker_factory=lambda: FakeWorker())
-        dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
-        out = dispatch("hello", 5)
-        self.assertTrue(out["ok"])
-        self.assertEqual(out["output"], "ok:hello")
-        self.assertEqual(out["error"], "")
-        self._shutdown(pool)
+        FakeRuntime.instances = []
+
+        def factory(agent=None, work_dir=None, sandbox_mode="auto", **kw):
+            r = FakeRuntime(agent=agent, work_dir=work_dir)
+            r.script = [_ev(rp.EVENT_TEXT_CHUNK, text="hello")]
+            return r
+        orig = rp.AcpRuntime
+        rp.AcpRuntime = factory  # type: ignore[assignment]
+        try:
+            pool = ReviewPool(work_dir="/tmp/x")
+            dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
+            out = dispatch("hi", 5)
+            self.assertTrue(out["ok"])
+            self.assertEqual(out["output"], "hello")
+            self.assertEqual(out["error"], "")
+            self._shutdown(pool)
+        finally:
+            rp.AcpRuntime = orig  # type: ignore[assignment]
 
     def test_dispatch_error_never_raises(self):
-        pool = ReviewPool(worker_factory=lambda: FailingWorker())
-        dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
-        out = dispatch("x", 5)
-        self.assertFalse(out["ok"])
-        self.assertIn("boom", out["error"])
-        self._shutdown(pool)
+        FakeRuntime.instances = []
+
+        def factory(agent=None, work_dir=None, sandbox_mode="auto", **kw):
+            r = FakeRuntime(agent=agent, work_dir=work_dir)
+
+            async def _boom(cwd=None, agent=None):
+                raise RuntimeError("boom")
+            r.create_session = _boom   # type: ignore[assignment]
+            return r
+        orig = rp.AcpRuntime
+        rp.AcpRuntime = factory  # type: ignore[assignment]
+        try:
+            pool = ReviewPool(work_dir="/tmp/x")
+            dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
+            out = dispatch("x", 5)
+            self.assertFalse(out["ok"])
+            self.assertIn("boom", out["error"])
+            self._shutdown(pool)
+        finally:
+            rp.AcpRuntime = orig  # type: ignore[assignment]
 
 
+# ── Reviewer identity resolution (unchanged helpers) ─────────────────────────
 class TestReviewAgentResolution(unittest.TestCase):
-    """The pool prefers the dedicated reviewer agent but degrades to kirocrew
-    when it isn't installed (older builds)."""
-
     def test_fallback_to_kirocrew_when_dedicated_missing(self):
-        # A name with no ~/.kiro/agents/<name>.json on disk -> fall back.
         self.assertEqual(
             _resolve_review_agent("definitely-not-installed-xyz"), "kirocrew")
 
     def test_review_work_dir_is_app_root(self):
-        # Workers must run with cwd = app root so relative prompt paths
-        # (sage_lib/pipeline.py, data/results/<id>.json) resolve where the driver reads.
         wd = _review_work_dir()
         self.assertIsNotNone(wd)
         self.assertTrue(wd.replace("\\", "/").endswith("apps/code-review-sage"))
 
 
 class TestReviewEffort(unittest.TestCase):
-    """Pool workers must run at MAX thinking effort for both the design gate and
-    the deep review. On the kiro-cli backend (the pool default) effort is applied
-    via a per-model workspace cli.json overlay written before spawn."""
+    """Effort is applied via a per-model workspace cli.json overlay written
+    before spawn. The default is "" (inherit the model/provider default)."""
 
-    def test_review_effort_is_max(self):
-        self.assertEqual(REVIEW_EFFORT, "max")
+    def test_review_effort_default_is_inherit(self):
+        self.assertEqual(REVIEW_EFFORT, _DEFAULT_EFFORT)
+        self.assertEqual(REVIEW_EFFORT, "")
 
-    def test_write_effort_overlay_writes_max_for_model(self):
+    def test_write_effort_overlay_writes_default_for_model(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_effort_overlay(tmp, "claude-sonnet-4.6")
             cli = Path(tmp) / ".kiro" / "settings" / "cli.json"
@@ -285,10 +439,8 @@ class TestReviewEffort(unittest.TestCase):
             effort = (data["chat.modelDefaults"]["claude-sonnet-4.6"]
                       ["output_config"]["effort"])
             self.assertEqual(effort, REVIEW_EFFORT)
-            self.assertEqual(effort, "max")
 
     def test_write_effort_overlay_is_merge_safe(self):
-        # An existing cli.json (other models / unrelated keys) must be preserved.
         with tempfile.TemporaryDirectory() as tmp:
             settings = Path(tmp) / ".kiro" / "settings"
             settings.mkdir(parents=True)
@@ -296,29 +448,24 @@ class TestReviewEffort(unittest.TestCase):
                 "chat.modelDefaults": {"other-model": {"output_config": {"effort": "low"}}},
                 "unrelated.key": 42,
             }), encoding="utf-8")
-            _write_effort_overlay(tmp, "claude-sonnet-4.6")
+            _write_effort_overlay(tmp, "claude-sonnet-4.6", "high")
             data = json.loads((settings / "cli.json").read_text(encoding="utf-8"))
-            # New model added at max, existing model + unrelated key untouched.
             self.assertEqual(
                 data["chat.modelDefaults"]["claude-sonnet-4.6"]["output_config"]["effort"],
-                "max")
+                "high")
             self.assertEqual(
                 data["chat.modelDefaults"]["other-model"]["output_config"]["effort"],
                 "low")
             self.assertEqual(data["unrelated.key"], 42)
 
     def test_write_effort_overlay_never_raises(self):
-        # Best-effort: a bad path must not raise (effort is a quality knob).
-        # NUL byte makes mkdir/open fail on Linux; must be swallowed.
         _write_effort_overlay("/proc/nonexistent/\x00bad", "claude-sonnet-4.6")
 
     def test_reviewer_model_falls_back_to_default(self):
-        # Unknown agent -> no ~/.kiro/agents/<agent>.json -> default model.
         self.assertEqual(
             _reviewer_model("definitely-not-installed-xyz"), _DEFAULT_REVIEW_MODEL)
 
     def test_reviewer_info_reports_agent_model_and_effort(self):
-        # Surfaced to the dashboard header so users see WHICH model + effort runs.
         info = reviewer_info()
         self.assertTrue(info.get("agent"))
         self.assertTrue(isinstance(info.get("model"), str) and info["model"])
@@ -327,46 +474,3 @@ class TestReviewEffort(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-class TestWorkerSweepProtection(unittest.TestCase):
-    """AcpReviewWorker must expose its kiro-cli PID via ``pid()`` so the shared
-    pool engine can shield it from the gateway's periodic orphan sweep. Without a
-    shield a busy pool worker is classified as an orphan and SIGKILLed mid-review,
-    which the driver reports as "ACP process exited (code=1)" (the reported bug).
-    The register/unregister lifecycle itself lives in the engine — see
-    test_worker_pool.TestSweepProtection."""
-
-    def test_worker_exposes_live_pid_for_shielding(self):
-        from sage_lib import review_pool as rp
-
-        class _FakeClient:
-            backend = "kiro"          # not ACP_BACKEND_CLAUDE -> skip claude effort push
-            is_ready = True
-
-            def __init__(self, *a, **k):
-                self._pid = 4242
-
-            async def ensure_ready(self):
-                return None
-
-            async def shutdown(self):
-                return None
-
-            def is_process_alive(self):
-                return True
-
-        orig_client = rp.AcpClient
-        rp.AcpClient = _FakeClient
-        try:
-            async def _run():
-                w = rp.AcpReviewWorker()
-                self.assertIsNone(w.pid(), "no PID before start")
-                await w.start()
-                self.assertEqual(w.pid(), 4242, "pid() must report the live process")
-                await w.shutdown()
-                self.assertIsNone(w.pid(), "no PID after shutdown")
-
-            asyncio.run(_run())
-        finally:
-            rp.AcpClient = orig_client

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -103,7 +103,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",
-        "apps/builtins/code_review_sage/tests/test_review_pool.py::test_worker_exposes_live_pid_for_shielding",
+        # gh-CLI open-PR enumeration: fixed `gh api` list-argv (no shell=True);
+        # owner/repo are validated to ^[A-Za-z0-9._-]+$ by adapters.parse_repo_url
+        # and only fill the API path (bounded to api.github.com). NOT sandboxed
+        # because gh needs the host's own authenticated credentials.
+        "apps/builtins/code_review_sage/sage_lib/pipeline.py::list_open_prs",
         "apps/builtins/workflows/server.py::handle_run",
         "apps/dependencies.py::_run_aim",
         "cli.py::_consolidate_cmd",

--- a/website/src/apps/code-review-sage/CodeReviewSagePage.tsx
+++ b/website/src/apps/code-review-sage/CodeReviewSagePage.tsx
@@ -4,9 +4,9 @@
 // deterministic two-stage review (POST /api/apps/code-review-sage/review). The
 // driver runs in-process, so the Phase 1 -> Phase 2 switch and finalize always
 // run. Findings post as a PENDING (draft) review the human submits on GitHub.
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ScanSearch, GitPullRequest, ExternalLink, Circle, Settings, Brain, Plus, Trash2 } from 'lucide-react'
+import { ScanSearch, GitPullRequest, ExternalLink, Circle, Settings, Brain, Plus, Trash2, FolderGit2, RefreshCw } from 'lucide-react'
 
 import { SendBtn } from '../../components/ui'
 import Clickable from '../../components/Clickable'
@@ -25,8 +25,15 @@ interface Run {
   started_at?: string
   finished_at?: string
 }
-interface Settings { model: string | null; effort: string; active_namespaces: string[] }
-interface SettingsResp { settings: Settings; models: string[]; efforts: string[]; namespaces: string[] }
+interface Settings { model: string | null; effort: string; active_namespaces: string[]; max_concurrent?: number }
+interface SettingsResp { settings: Settings; models: string[]; efforts: string[]; namespaces: string[]; max_concurrent_max?: number }
+
+// A single open PR of a repo, annotated by the backend with dedup status.
+interface RepoPr {
+  url: string; number: number; title: string; head_sha: string
+  change_id: string; reviewed: boolean; reviewed_stale: boolean; reviewed_at?: string
+}
+interface RepoPrsResp { repo: string; prs: RepoPr[]; count: number }
 
 interface NamespaceInfo { name: string; patterns: number; candidate: number; active: boolean }
 interface NamespacesResp { namespaces: NamespaceInfo[]; active: string[] }
@@ -46,8 +53,13 @@ const PHASE_LABEL: Record<string, string> = {
 
 async function getJSON<T>(url: string): Promise<T> {
   const r = await fetch(url)
-  if (!r.ok) throw new Error(`HTTP ${r.status}`)
-  return r.json() as Promise<T>
+  // Prefer the backend's {error} message (mirrors sendJSON) so failures like
+  // "gh is not authenticated on the gateway host" reach the user, not "HTTP 502".
+  const data = await r.json().catch(() => null)
+  if (!r.ok || (data as { error?: string } | null)?.error) {
+    throw new Error((data as { error?: string } | null)?.error || `HTTP ${r.status}`)
+  }
+  return data as T
 }
 
 async function sendJSON(url: string, body: unknown, method = 'POST'): Promise<Record<string, unknown>> {
@@ -64,6 +76,9 @@ async function sendJSON(url: string, body: unknown, method = 'POST'): Promise<Re
 export default function CodeReviewSagePage() {
   const qc = useQueryClient()
   const [input, setInput] = useState('')
+  // Repo-review mode: enumerate a repo's open PRs and review the un-reviewed ones.
+  const [repoUrl, setRepoUrl] = useState('')
+  const [submittedRepo, setSubmittedRepo] = useState('')
 
   // React Query owns the fetch/loading/error/poll lifecycle. refetchInterval is
   // evaluated from the cached data, so a run that is already running on mount
@@ -84,6 +99,27 @@ export default function CodeReviewSagePage() {
     mutationFn: (links: string) => sendJSON(`${API}/review`, { links }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['code-review-sage-runs'] }),
   })
+
+  // Repo mode: list a repo's open PRs (with reviewed/updated/new status), and
+  // kick off a batch review of the un-reviewed ones (or ALL, when forced).
+  const { data: repoPrs, isFetching: repoLoading, error: repoQueryErr, refetch: refetchRepo } = useQuery({
+    queryKey: ['code-review-sage-repo-prs', submittedRepo],
+    queryFn: () => getJSON<RepoPrsResp>(`${API}/repo-prs?repo=${encodeURIComponent(submittedRepo)}`),
+    enabled: !!submittedRepo,
+  })
+  const reviewRepoMut = useMutation({
+    mutationFn: (body: { repo: string; force?: boolean }) => sendJSON(`${API}/review-repo`, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['code-review-sage-runs'] }),
+  })
+
+  // When a run finishes, refresh the repo PR list so just-reviewed PRs stop
+  // showing as "new"/"updated" (the /repo-prs query is otherwise cached on
+  // submittedRepo and wouldn't re-fetch on its own).
+  useEffect(() => {
+    if (submittedRepo && run && run.status !== 'running') {
+      qc.invalidateQueries({ queryKey: ['code-review-sage-repo-prs', submittedRepo] })
+    }
+  }, [run?.status, run?.run_id, submittedRepo, qc])
 
   const saveMut = useMutation({
     mutationFn: (patch: Partial<Settings>) => sendJSON(`${API}/settings`, patch, 'PUT'),
@@ -138,13 +174,33 @@ export default function CodeReviewSagePage() {
     id,
     link: run?.changes?.[i],
   }))
-  const running = reviewMut.isPending || run?.status === 'running'
+  const running = reviewMut.isPending || reviewRepoMut.isPending || run?.status === 'running'
   const reviewErr = reviewMut.error instanceof Error ? reviewMut.error.message : ''
 
   const startReview = () => {
     const links = input.trim()
     if (!links || running) return
     reviewMut.mutate(links)
+  }
+
+  const repoErr = (repoQueryErr instanceof Error ? repoQueryErr.message : '')
+    || (reviewRepoMut.error instanceof Error ? reviewRepoMut.error.message : '')
+  const unreviewedCount = (repoPrs?.prs ?? []).filter(p => !p.reviewed).length
+  // The action buttons operate on the LISTED repo (submittedRepo), which can
+  // differ from what's currently typed in the box.
+  const staleList = !!submittedRepo && repoUrl.trim() !== submittedRepo
+  const listRepo = () => {
+    const u = repoUrl.trim()
+    if (!u) return
+    if (u === submittedRepo) refetchRepo()   // same URL -> force a real refresh
+    else setSubmittedRepo(u)
+  }
+  const reviewRepo = (force: boolean) => {
+    if (!submittedRepo || running) return
+    if (force && !confirm(
+      `Re-review ALL ${repoPrs?.count ?? 0} open PRs in ${submittedRepo}? `
+      + 'This ignores the reviewed history and can be costly.')) return
+    reviewRepoMut.mutate({ repo: submittedRepo, force })
   }
 
   return (
@@ -166,6 +222,74 @@ export default function CodeReviewSagePage() {
         <code>gh</code> is not authenticated on the gateway host.
       </div>
 
+      {/* Repo mode — enumerate a repo's open PRs and review the un-reviewed ones */}
+      <div className="border border-border rounded-md p-3 my-3.5">
+        <div className="text-[13px] font-medium flex items-center gap-1.5 mb-2">
+          <FolderGit2 size={14} /> Review a whole repository
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            value={repoUrl}
+            onChange={e => setRepoUrl(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') listRepo() }}
+            aria-label="Repository URL"
+            placeholder="https://github.com/<owner>/<repo>"
+            className="flex-1 box-border text-[13px] px-3 py-2 rounded-md bg-bg text-text border border-border font-mono"
+          />
+          <button onClick={listRepo} disabled={!repoUrl.trim() || repoLoading}
+            className="inline-flex items-center gap-1 text-xs px-2.5 py-2 rounded-md border border-border text-muted hover:text-text hover:border-border-strong disabled:opacity-30 cursor-pointer bg-transparent">
+            <RefreshCw size={12} className={repoLoading ? 'animate-spin' : ''} /> List open PRs
+          </button>
+        </div>
+        {repoErr && <div className="text-danger text-xs mt-2">{repoErr}</div>}
+        {repoLoading && !repoPrs && <div className="text-muted text-xs mt-2">Listing open PRs…</div>}
+        {staleList && (
+          <div className="text-warn text-[11px] mt-2">
+            Showing <span className="font-mono">{submittedRepo}</span> — click “List open PRs” to load the URL above.
+          </div>
+        )}
+        {repoPrs && (repoPrs.count === 0 ? (
+          <div className="text-muted text-xs mt-3">No open PRs in {repoPrs.repo}.</div>
+        ) : (
+          <div className="mt-3">
+            <div className="flex items-center gap-2.5 text-xs mb-2 flex-wrap">
+              <span className="text-muted">
+                {repoPrs.repo}: {repoPrs.count} open PR{repoPrs.count === 1 ? '' : 's'}, {unreviewedCount} not yet reviewed
+              </span>
+              <div className="ml-auto flex items-center gap-2">
+                <SendBtn onClick={() => reviewRepo(false)} disabled={running || unreviewedCount === 0}>
+                  {running ? 'Running…' : `Review ${unreviewedCount} new`}
+                </SendBtn>
+                <button onClick={() => reviewRepo(true)} disabled={running || repoPrs.count === 0}
+                  title="Re-review every open PR, ignoring the reviewed history"
+                  className="text-xs px-2.5 py-1.5 rounded-md border border-border text-muted hover:text-text hover:border-border-strong disabled:opacity-30 cursor-pointer bg-transparent">
+                  Force review all ({repoPrs.count})
+                </button>
+              </div>
+            </div>
+            <ul className="list-none p-0 max-h-64 overflow-auto">
+              {repoPrs.prs.map(pr => (
+                <li key={pr.change_id} className="flex items-center gap-2.5 text-xs py-1.5 border-b border-border">
+                  <a href={pr.url} target="_blank" rel="noreferrer" className="font-mono text-accent shrink-0">#{pr.number}</a>
+                  <span className="truncate text-text" title={pr.title}>{pr.title}</span>
+                  <span className="ml-auto shrink-0">
+                    {pr.reviewed
+                      ? <span className="text-accent text-[10px] border border-border rounded px-1.5 py-0.5">reviewed</span>
+                      : pr.reviewed_stale
+                        ? <span className="text-warn text-[10px] border border-border rounded px-1.5 py-0.5">updated</span>
+                        : <span className="text-muted text-[10px] border border-border rounded px-1.5 py-0.5">new</span>}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div className="text-[11px] text-muted mt-1.5">
+              “new” = never reviewed · “updated” = reviewed before but the PR has new commits · “reviewed” = up to date.
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="text-[11px] text-muted mb-1.5">Or paste individual PR links:</div>
       <textarea
         value={input}
         onChange={e => setInput(e.target.value)}
@@ -179,7 +303,7 @@ export default function CodeReviewSagePage() {
         </SendBtn>
         {s && (
           <span className="ml-auto text-[11px] text-muted">
-            Model: {s.model || 'default'} · effort: {s.effort || 'default'}
+            Model: {s.model || 'default'} · effort: {s.effort || 'default'} · concurrency: {s.max_concurrent ?? 5}
           </span>
         )}
       </div>
@@ -253,6 +377,15 @@ export default function CodeReviewSagePage() {
                 className="text-xs px-2 py-1 rounded-md bg-bg text-text border border-border">
                 <option value="">Default (model/provider)</option>
                 {settings.efforts.map(ef => <option key={ef} value={ef}>{ef}</option>)}
+              </select>
+            </label>
+            <label className="text-xs text-muted" title="Max PRs reviewed at once on the shared runtime">
+              Concurrency{' '}
+              <select value={s?.max_concurrent ?? 5}
+                onChange={e => saveMut.mutate({ max_concurrent: Number(e.target.value) })}
+                className="text-xs px-2 py-1 rounded-md bg-bg text-text border border-border">
+                {Array.from({ length: settings.max_concurrent_max ?? 30 }, (_, i) => i + 1)
+                  .map(n => <option key={n} value={n}>{n}</option>)}
               </select>
             </label>
           </div>

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -22,6 +22,45 @@ import './app-sdk/shared-modules'
 // Initialize RUM as early as possible
 initRum(__APP_VERSION__)
 
+// Auto-recover from stale lazy-chunk errors after a frontend rebuild.
+// Vite fires `vite:preloadError` on window when a dynamic import() of a
+// hashed chunk 404s -- this happens when a tab loaded an old entry bundle
+// before a rebuild, then lazy-loads a page whose hash has since changed
+// (e.g. "Failed to fetch dynamically imported module: .../SomePage-<hash>.js").
+// Reloading pulls the fresh index.html + chunk map, which self-heals the tab.
+// Guarded by a short-lived sessionStorage timestamp so a genuinely-missing
+// chunk (persistent 404) can't trigger an infinite reload loop.
+window.addEventListener('vite:preloadError', (event) => {
+  const AT_KEY = 'vite-preload-reloaded-at'
+  const N_KEY = 'vite-preload-reload-count'
+  const COOLDOWN_MS = 10_000
+  const MAX_RELOADS = 3
+  let last = 0
+  let count = 0
+  try {
+    last = Number(sessionStorage.getItem(AT_KEY) || 0)
+    count = Number(sessionStorage.getItem(N_KEY) || 0)
+  } catch { /* storage blocked (privacy/partitioned) — treat as a first attempt */ }
+  // Bail (let the error surface via ErrorBoundary) if we reloaded very recently
+  // (tight-loop guard) OR have already reloaded too many times this session
+  // (a genuinely-missing chunk whose reload round-trip keeps exceeding the
+  // cooldown must not loop forever).
+  if (Date.now() - last < COOLDOWN_MS || count >= MAX_RELOADS) return
+  let persisted = false
+  try {
+    sessionStorage.setItem(AT_KEY, String(Date.now()))
+    sessionStorage.setItem(N_KEY, String(count + 1))
+    persisted = true
+  } catch { /* storage blocked */ }
+  // Only auto-reload if we could PERSIST the guard. If storage is blocked we
+  // cannot count reloads, so a genuinely-missing chunk would loop forever —
+  // let the error surface via ErrorBoundary instead.
+  if (!persisted) return
+  // Prevent Vite from throwing the unhandled preload error before we reload.
+  event.preventDefault()
+  window.location.reload()
+})
+
 // Accessibility: runtime DOM scanning in dev mode (logs violations to console)
 if (import.meta.env.DEV) {
   import('react-dom').then(ReactDOM => import('@axe-core/react').then(axe => axe.default(React, ReactDOM, 1000)))


### PR DESCRIPTION
## Problem
Users report their machine's CPU "roars" while Code Review Sage runs, and there's no way to review a whole repository — only individually pasted PR links.

## Why it matters
The CPU load makes the app painful to run on a laptop, and the paste-only workflow doesn't scale to teams that want to sweep all open PRs on a repo. Together they cap how useful the reviewer is.

## Fix (symptom → root cause → change)
**CPU roar** — not a spin loop. The review path spawned **up to 5 full kiro-cli subprocesses** (`MAX_CONCURRENT=5`), each **fully respawned (`shutdown`+`start`) between every PR** (the OSS `AcpClient` has no in-process reset), plus a convergence loop stacking ~5 agent turns per PR.
→ Rework `ReviewPool` onto **one shared, batch-scoped `AcpRuntime`** that multiplexes **one `AcpSessionHandle` per task** (distinct `sessionId`, `destroy()`ed on completion for per-review isolation). The runtime spawns on batch start and is `kill()`ed when the batch drains (refcounted `begin_batch`/`end_batch`, bracketed in `_run_review_bg`) — **one subprocess per batch instead of N, and no per-reuse respawn churn**. Concurrency becomes a semaphore (`review.max_concurrent`, default 5, ceiling 30) instead of a process count, so scaling up costs sessions, not processes. Audit parity is preserved (the pool emits its own per-tool SEL audit since the runtime layer has no `audit_source`); tool permissions are auto-approved (the reviewer runs `gh` + shell); the prompt generator is deterministically `aclose()`d.

**No repo entry point** — the backend only accepted PR links and had no durable "already reviewed" ledger.
→ Add `adapters.parse_repo_url` (github.com host allowlist; rejects PR URLs and bad segments), `pipeline.list_open_prs` (`gh api --paginate`, list argv — no shell, non-silent parse), a durable `data/reviewed.json` dedup index (`results.py`, atomic 0600, lock-guarded read-merge-write) keyed by change id → head SHA, and routes **`POST /review-repo`** (reviews un-reviewed PRs; `force` re-reviews all) + **`GET /repo-prs`** (annotates each open PR new/updated/reviewed). Only PRs whose **deep review actually completed** are written to the index, so a gate crash never masquerades as reviewed.

**Frontend** — a "Review a whole repository" card (repo-URL input, open-PR list with new/updated/reviewed badges, "Review N new" + confirm-gated "Force review all"), a Concurrency selector wired to `review.max_concurrent`, surfaced backend error bodies (so "gh not authenticated" reaches the user instead of "HTTP 502"), real re-list refetch, and empty/loading/stale/aria states.

**Vite stale-chunk dead-end** (the original report: *"Failed to fetch dynamically imported module …"*) — a rebuild-while-open tab held a stale entry bundle referencing a since-changed chunk hash.
→ A `vite:preloadError` handler in `main.tsx` reloads once (sessionStorage cooldown + reload cap, storage-access guarded) so the tab self-heals; a genuinely-missing chunk still falls through to the ErrorBoundary.

## Also folded in — `prepare-pr` skill doc (`skills/prepare-pr/SKILL.md`)
Unrelated tooling doc, folded into this single commit at the author's request:
- **Sharper triggering:** expanded the `triggers:` list and rewrote the `description` to spell out the two modes (FULL LOOP vs PREPARE-ONLY) and add the `prepare cr` / `ship cr` / `fix ci` / `keep going until green` aliases, so the skill matches deterministically instead of on fuzzy description similarity.
- **Runs in-session by default:** Phase 2 now keeps the poll+fix loop running in the same session (chained `wait` → re-poll → act, bounded by the 10-round cap), with **Heartbeat demoted to a fallback** for genuinely detached runs. Docs-only; no code or scripts touched.

## Tests
- Rewrote `test_review_pool.py` for the single-runtime model: batch lifecycle (spawn on 0→1, kill on drain, fresh runtime per batch), concurrency-semaphore cap, per-task session create/destroy, tool auto-approval + SEL audit, and the sync dispatch bridge.
- Added `test_repo_review.py`: repo-URL parsing (host allowlist, PR-URL/bad-segment rejection), `gh` enumeration (list-argv, JSONL parse, non-zero/missing/timeout/unparseable errors), and the reviewed-index (roundtrip, merge, 0600, corrupt-file).
- Adjusted a stale `test_namespaces` assertion (effort default is `""`, not `"max"`).
- **233 app tests pass; `flake8` and `tsc -b` clean.** (The `prepare-pr` skill change is docs-only — no tests apply.)

## Manual verification
- Backend/unit verified locally (pytest + flake8 + tsc). Not yet run end-to-end against a live repo with `gh` on the gateway host (repo enumeration uses the host's authenticated `gh` CLI — same auth model as the existing fetch/post; private repos need `gh auth login` once, already surfaced in the page's setup hint).
- The SPA `dist/` was **not** rebuilt in this PR (source verified via `tsc -b`); the running dashboard shows the new UI after `npm run build` / the desktop build.

Design notes: `docs/plans/code-review-sage-scale.md`.
