### PR TITLE
fix(ci): tag releases cannot assume the signing role -- add environment:prod

### DIFF
--- a/.github/workflows/notarize-macos.yml
+++ b/.github/workflows/notarize-macos.yml
@@ -49,6 +49,18 @@ jobs:
     name: Notarize + staple (${{ inputs.channel }})
     runs-on: macos-14
     timeout-minutes: 45
+    # OIDC subject alignment: tag-triggered callers (release.yml) present
+    # ref:refs/tags/<tag>, which the signing role does not trust. The prod
+    # environment switches the subject to environment:prod, which it does.
+    # The prod environment is protected by GitHub-side ref restrictions
+    # rather than required reviewers (which would stall the unattended
+    # scheduled nightly): a deployment branch/tag policy limits the
+    # environment to main and v* tags, and the release-tags-admin-only
+    # repository ruleset restricts v* tag creation/update/deletion to
+    # repository admins. An unmerged commit can therefore only reach this
+    # environment if an admin deliberately tags it -- the same principal
+    # who could merge it to main.
+    environment: prod
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
       CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,13 @@ jobs:
     name: Sign for Release
     needs: [build-wheel, build-desktop]
     runs-on: ubuntu-latest
+    # Tag pushes present OIDC subject ref:refs/tags/<tag>, which the signing
+    # role does NOT trust. Declaring the prod environment switches the subject
+    # to environment:prod, which the trust policy accepts. The environment is
+    # gated by ref restrictions (main + v* tags only) and the
+    # release-tags-admin-only ruleset (v* tag creation is admin-only); see
+    # notarize-macos.yml for the full rationale.
+    environment: prod
     outputs:
       version: ${{ steps.channel.outputs.version }}
       channel: ${{ steps.channel.outputs.channel }}


### PR DESCRIPTION
## Problem

Tag-triggered runs (`release.yml`, the insider/stable path shipped in #80) present OIDC subject `ref:refs/tags/<tag>`. The `kirocrew-signing-invoker` trust policy (verified live) trusts only:

- `repo:kirodotdev/KiroCrew:ref:refs/heads/main`
- `repo:kirodotdev/KiroCrew:environment:prod`

So the first real insider/stable tag push would fail at `configure-aws-credentials` -- fail-closed (no unsigned artifacts leak; downstream jobs skip), but the release never happens. The path has never been exercised: only the nightly (which runs on `main` and matches the ref subject) has run since #80 merged.

## Fix

Declare `environment: prod` on the two credential-bearing jobs:

- `release.yml` -> `release` (Sign for Release) job
- `notarize-macos.yml` -> `notarize` job (reusable, called by both nightly and release)

With an environment declared, the OIDC subject becomes `environment:prod` regardless of ref -- already trusted. Zero IAM changes.

## Nightly impact

None in trust terms: nightly's publish job still matches `refs/heads/main`; its notarize leg now matches `environment:prod` -- both subjects are in the trust policy. First post-merge nightly will confirm.

## Constraint (documented in the workflow comment)

The `prod` environment (created, no protection rules) must stay free of required-reviewer rules -- the shared notarize job runs from the scheduled nightly and must not stall on human approval. If a human gate for stable releases is wanted later, it needs a separate environment name added to the role trust (CDK change).

## Validation plan

After merge: push a throwaway `v0.1.0-insider.1` tag and watch the full sign -> notarize -> GitHub Release chain execute once end-to-end (tag must point at a post-merge commit, since the workflow file is read from the tagged ref).