### PR TITLE
style(website): update Kiro theme with design system

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -125,7 +125,7 @@ const NAV_ITEMS = getBuiltinSurfaces().map(s => ({
 
 /** Usage color class: green (<70%), yellow (70-90%), red (>90%). */
 export function metricColor(pct: number): string {
-  return pct > 0.9 ? 'text-danger' : pct > 0.7 ? 'text-warn' : 'text-accent'
+  return pct > 0.9 ? 'text-danger' : pct > 0.7 ? 'text-warn' : 'text-muted'
 }
 export const memColorClass = metricColor
 
@@ -389,7 +389,7 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
       whileHover={collapsed ? undefined : { scale: 1.02 }}
       whileTap={{ scale: 0.97 }}
       transition={{ duration: 0.15 }}
-      className={`group/nav relative flex items-center rounded-md cursor-pointer text-sm font-medium whitespace-nowrap gap-2.5 py-2 pl-3 pr-3 transition-colors duration-200 ${collapsed ? '' : 'overflow-hidden'} ${active ? 'text-text-strong bg-accent-subtle' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
+      className={`nav-item group/nav relative flex items-center rounded-md cursor-pointer text-sm font-medium whitespace-nowrap gap-2.5 py-2 pl-3 pr-3 transition-colors duration-200 ${collapsed ? '' : 'overflow-hidden'} ${active ? 'nav-active text-text-strong bg-accent-subtle' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
       onClick={activate}
       onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate() } }}
       onMouseEnter={showTip}
@@ -1667,7 +1667,7 @@ export default function App() {
                   transition={{ duration: 0.15 }}
                   className="overflow-hidden"
                 >
-                  <div className="flex items-center gap-2 px-2.5 py-1.5 text-[13px] font-medium text-muted">{group}</div>
+                  <div className="nav-section flex items-center gap-2 px-2.5 py-1.5 text-[13px] font-medium text-muted">{group}</div>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/website/src/components/AgentDropdownList.tsx
+++ b/website/src/components/AgentDropdownList.tsx
@@ -95,7 +95,7 @@ function AgentButton({ a, active, isDefault, activeRef, onSelect, activeProjectP
         title={isNotFound ? 'Project path not found. Rescan to restore.' : isOtherProject ? `Switch to ${folderName} to use this agent` : undefined}
         className={`w-full text-left px-2.5 py-2 flex flex-col gap-0.5 rounded-md transition-all
           ${isNotFound || isOtherProject ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-          ${active ? 'bg-accent-subtle' : (!isNotFound && !isOtherProject) ? 'hover:bg-bg-hover' : ''}
+          ${active ? 'list-selected bg-accent-subtle' : (!isNotFound && !isOtherProject) ? 'hover:bg-bg-hover' : ''}
         `}
         onClick={handleClick}
       >

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1727,7 +1727,7 @@ function ChatInput({
       <div
         data-testid="input-wrapper"
         ref={wrapperRef}
-        className={`${hasApproval ? 'rounded-b-2xl rounded-t-none' : 'rounded-2xl'} relative transition-colors overflow-hidden ${manualHeight !== null ? 'flex flex-col min-h-0' : ''} ${(cleanMode || memoryMode === 'incognito' || memoryMode === 'temporary') ? 'border-2' : 'border'} ${dragOver ? 'border-accent bg-accent-subtle' : cleanMode ? 'border-accent bg-bg-elevated' : memoryMode === 'temporary' ? 'border-aim bg-bg-elevated' : memoryMode === 'incognito' ? 'border-warn bg-bg-elevated' : 'border-border bg-bg-elevated focus-within:border-accent/50'}`}
+        className={`${hasApproval ? 'rounded-b-2xl rounded-t-none' : 'rounded-2xl'} relative transition-colors overflow-hidden ${manualHeight !== null ? 'flex flex-col min-h-0' : ''} ${(cleanMode || memoryMode === 'incognito' || memoryMode === 'temporary') ? 'border-2' : 'border'} ${dragOver ? 'border-accent bg-accent/10' : cleanMode ? 'border-accent bg-bg-elevated' : memoryMode === 'temporary' ? 'border-aim bg-bg-elevated' : memoryMode === 'incognito' ? 'border-warn bg-bg-elevated' : 'border-border bg-bg-elevated focus-within:border-accent/50'}`}
 
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}

--- a/website/src/components/DetailPanel.tsx
+++ b/website/src/components/DetailPanel.tsx
@@ -179,7 +179,7 @@ export default function DetailPanel({ title, onClose, footer, headerActions, sec
             keyboard gesture for a 6px handle); role="separator" is the correct
             ARIA role. */
         <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-20 group/drag" style={{ touchAction: 'none' }} {...drag}>
-          <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent" />
+          <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
         </div>
       )}
       {customHeader ?? (<>

--- a/website/src/components/McpRegistryCard.tsx
+++ b/website/src/components/McpRegistryCard.tsx
@@ -110,7 +110,7 @@ export default function McpRegistryCard() {
           }</>
         : install.isPending && install.variables === s.id
           ? <span className="text-[12px] text-accent animate-pulse">Installing…</span>
-          : <button className="px-3 py-1 rounded-md text-[12px] font-semibold bg-accent/10 text-accent border border-accent/30 hover:bg-accent hover:text-accent-fg transition-all cursor-pointer" disabled={install.isPending} onClick={e => { e.stopPropagation(); install.mutate(s.id) }}>Install</button>
+          : <Btn disabled={install.isPending} onClick={e => { e.stopPropagation(); install.mutate(s.id) }}>Install</Btn>
       }
       </div>
     </div>
@@ -140,7 +140,7 @@ export default function McpRegistryCard() {
               <div className="h-3 w-5/6 rounded-md animate-pulse" style={{ background: 'var(--border)', opacity: 0.5, animationDelay: `${i * 80 + 300}ms` }} />
               <div className="h-3 w-2/3 rounded-md animate-pulse" style={{ background: 'var(--border)', opacity: 0.4, animationDelay: `${i * 80 + 400}ms` }} />
             </div>
-            <div className="mt-2.5 pt-2 border-t border-border/50"><div className="h-7 w-16 rounded-md animate-pulse" style={{ background: 'var(--border)', animationDelay: `${i * 80 + 500}ms` }} /></div>
+            <div className="mt-2.5 pt-2 border-t border-border"><div className="h-7 w-16 rounded-md animate-pulse" style={{ background: 'var(--border)', animationDelay: `${i * 80 + 500}ms` }} /></div>
           </div>
         ))}</div> : filtered.length === 0 ? (
           <div className="text-[13px] text-muted py-2">{servers.length === 0 ? 'No servers in registry' : 'No matches'}</div>
@@ -153,7 +153,7 @@ export default function McpRegistryCard() {
                 <div className="text-[13px] font-semibold text-text leading-tight">{s.title || s.id}</div>
                 <div className="text-[11px] text-muted font-mono mt-0.5">{s.id}</div>
               </div>
-              {s.tier === 'Recommended' && <span className="px-1.5 py-[1px] rounded-full text-[11px] font-bold bg-accent/15 text-accent border border-accent/30 shrink-0 whitespace-nowrap"><Star className="lucide-inline" /> recommended</span>}
+              {s.tier === 'Recommended' && <span className="px-1.5 py-[1px] rounded-full text-[11px] font-bold bg-bg-elevated text-muted border border-border shrink-0 whitespace-nowrap"><Star className="lucide-inline" /> recommended</span>}
               {s.tier === 'Supported' && <span className="px-1.5 py-[1px] rounded-full text-[11px] font-bold bg-muted/15 text-muted border border-muted/30 shrink-0">supported</span>}
             </div>
             {s.description && (
@@ -161,7 +161,7 @@ export default function McpRegistryCard() {
                 {summaryFromDescription(s.description)}
               </div>
             )}
-            <div className="mt-2.5 pt-2 border-t border-border/50">
+            <div className="mt-2.5 pt-2 border-t border-border">
               {renderActions(s)}
             </div>
           </motion.div>

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -210,7 +210,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, fuseBelow = 
                 }}
                 exit={{ y: y + 40, zIndex: 50, borderBottomWidth: 1, borderBottomLeftRadius: 12, borderBottomRightRadius: 12, transition: SPRING }}
                 transition={SPRING}
-                className="absolute top-0 left-0 right-0 bg-warn border border-warn/20 px-3 py-2 text-[13px] text-warn-fg"
+                className="queue-card absolute top-0 left-0 right-0 bg-warn/15 border border-warn/40 px-3 py-2 text-[13px] text-warn"
                 style={{ transformOrigin: 'bottom center', height: CARD_H, zIndex }}
               >
                 <span className="flex items-center gap-1.5 h-full">

--- a/website/src/components/SkillBrowserModal.tsx
+++ b/website/src/components/SkillBrowserModal.tsx
@@ -467,7 +467,7 @@ function SkillDetailPanel({
       </div>
 
       {phase?.step === 'error' && (
-        <div className="mb-3 p-2 rounded bg-red-500/10 border border-red-500/30 text-xs text-red-400">
+        <div className="mb-3 p-2 rounded bg-danger-subtle border border-danger/30 text-xs text-danger">
           {phase.message}
         </div>
       )}

--- a/website/src/components/SourceBadge.tsx
+++ b/website/src/components/SourceBadge.tsx
@@ -1,6 +1,6 @@
 const sourceColorMap: Record<string, string> = {
   aim: 'bg-aim/15 text-aim',
-  kirocrew: 'bg-accent/15 text-accent',
+  kirocrew: 'bg-bg-elevated text-muted border border-border',
   project: 'text-ok',
 }
 const defaultColor = 'bg-muted/10 text-muted'
@@ -12,7 +12,7 @@ export function SourceBadge({ source, children, className }: {
 }) {
   const colorClass = sourceColorMap[source ?? ''] ?? defaultColor
   return (
-    <span className={`px-1.5 py-[1px] rounded text-[12px] font-medium ${colorClass} ${className ?? ''}`}>
+    <span className={`px-1.5 py-[1px] rounded-full text-[12px] font-medium ${colorClass} ${className ?? ''}`}>
       {children ?? source}
     </span>
   )

--- a/website/src/components/settings.tsx
+++ b/website/src/components/settings.tsx
@@ -235,16 +235,16 @@ interface SettingsButtonGroupProps {
 export function SettingsButtonGroup({ label, description, hint, value, options, onChange, disabled }: SettingsButtonGroupProps) {
   return (
     <SettingsField label={label} description={description} hint={hint}>
-      <div className="flex items-center gap-1.5">
+      <div className="inline-flex items-center gap-1 p-1 rounded-md bg-bg-elevated w-fit">
         {options.map(o => (
           <button
             key={o.value}
             type="button"
             disabled={disabled}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium cursor-pointer border transition-all ${
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-[13px] font-medium cursor-pointer border-none transition-colors ${
               value === o.value
-                ? 'bg-accent-subtle text-accent border-accent'
-                : 'bg-transparent text-muted border-border hover:border-border-strong hover:text-text'
+                ? 'bg-bg-hover text-accent'
+                : 'bg-transparent text-muted hover:text-text'
             } disabled:opacity-40 disabled:cursor-not-allowed`}
             onClick={() => !disabled && onChange(o.value)}
           >

--- a/website/src/components/ui.tsx
+++ b/website/src/components/ui.tsx
@@ -132,7 +132,7 @@ export function Badge({ variant, children, className, ...rest }: { variant: 'ok'
 export function AimBadge({ source }: { source: string }) {
   const cls =
     source === 'aim' ? 'bg-aim-subtle text-aim border-aim/30'
-    : source === 'kirocrew' ? 'bg-accent-subtle text-accent border-accent/30'
+    : source === 'kirocrew' ? 'bg-bg-elevated text-muted border-border'
     : source === 'project' ? 'text-ok border-ok/30'
     : 'bg-bg-elevated text-muted border-border'
   return <span className={`px-1.5 py-[2px] rounded-full text-[11px] font-bold border shrink-0 ${cls}`}>{source}</span>

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -134,7 +134,7 @@ export const THEMES: ThemeEntry[] = [
   { value: 'gruvbox', label: '🍦 Gruvbox' },
   { value: 'ice', label: '🧊 Ice' },
   { value: 'amoled', label: '🖤 AMOLED' },
-  { value: 'kiro', label: '🔮 Kiro' },
+  { value: 'kiro', label: '👻 Kiro' },
   { value: 'intellij', label: '😶‍🌫️ IntelliJ' },
   { value: 'highcontrast', label: '🔆 High Contrast' },
   { value: 'lumon', label: '🛗 Lumon' },

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -632,53 +632,53 @@
 }
 
 [data-theme="kiro-dark"]{
-  --bg:#0a0a0c;--bg-accent:#0d0d10;--bg-elevated:#141418;--bg-hover:#1e1e24;
-  --card:#111114;--card-fg:#f4f4f5;--card-hl:rgba(255,255,255,.04);
-  --panel:#0a0a0c;--panel-strong:#141418;
-  --chrome:rgba(10,10,12,.95);
-  --text:#e4e4e7;--text-strong:#fafafa;--muted:#71717a;--muted-strong:#52525b;
-  --border:#1e1e24;--border-strong:#2e2e36;--border-hover:#3f3f4a;
-  --accent:#8b7ec8;--accent-hover:#a599d4;--accent-subtle:rgba(139,126,200,.15);
-  --accent-glow:rgba(139,126,200,.3);--ring:#7c6fba;
-  --ok:#22c55e;--ok-subtle:rgba(34,197,94,.12);
-  --warn:#eab308;--warn-subtle:rgba(234,179,8,.12);
-  --danger:#ef4444;--danger-subtle:rgba(239,68,68,.12);
-  --info:#a78bfa;
-  --aim:#c084fc;--aim-subtle:rgba(192,132,252,.15);
-  --clarify:#eab308;--clarify-subtle:rgba(234,179,8,.08);
+  --bg:#19161d;--bg-accent:#1c1922;--bg-elevated:#211d25;--bg-hover:#28242e;
+  --card:#211d25;--card-fg:#f2f1f4;--card-hl:rgba(255,255,255,.04);
+  --panel:#211d25;--panel-strong:#28242e;
+  --chrome:rgba(25,22,29,.95);
+  --text:#dcdadf;--text-strong:#f2f1f4;--muted:#938f9b;--muted-strong:#5e5966;
+  --border:#352f3d;--border-strong:#4a464f;--border-hover:#5e5966;
+  --accent:#8e48ff;--accent-fg:#ffffff;--accent-hover:#9f63ff;--accent-subtle:rgba(178,127,255,.18);
+  --accent-glow:rgba(142,72,255,.3);--ring:#8e48ff;
+  --ok:#008543;--ok-subtle:rgba(0,133,67,.15);
+  --warn:#e0b94d;--warn-subtle:rgba(224,185,77,.12);
+  --danger:#f94359;--danger-subtle:rgba(249,67,89,.12);
+  --info:#6f9ae0;
+  --aim:#c19aff;--aim-subtle:rgba(193,154,255,.15);
+  --clarify:#e0b94d;--clarify-subtle:rgba(224,185,77,.08);
   --diff-add:rgba(46,160,67,.15);--diff-add-text:#7ee787;
-  --diff-del:rgba(248,81,73,.15);--diff-del-text:#ffa198;
-  --diff-hunk:rgba(139,126,200,.15);--diff-hunk-text:#a599d4;
+  --diff-del:rgba(249,67,89,.15);--diff-del-text:#ffa198;
+  --diff-hunk:rgba(159,99,255,.15);--diff-hunk-text:#b07fff;
   --diff-meta-text:#e6edf3;
   --shadow-sm:0 1px 2px rgba(0,0,0,.3);
   --shadow-md:0 4px 12px rgba(0,0,0,.35),0 0 0 1px rgba(255,255,255,.02);
   --shadow-lg:0 12px 28px rgba(0,0,0,.45);
-  --json-key:#a599d4;--json-str:#7ee787;--json-num:#c084fc;--json-bool:#ef4444;
+  --json-key:#b07fff;--json-str:#7ee787;--json-num:#c19aff;--json-bool:#f94359;
   color-scheme:dark;
 }
 [data-theme="kiro-light"]{
   --bg:#f5f3f7;--bg-accent:#ece8f0;--bg-elevated:#ffffff;--bg-hover:#e4dfe9;
-  --card:#ffffff;--card-fg:#1a1625;--card-hl:rgba(0,0,0,.03);
+  --card:#ffffff;--card-fg:#19161d;--card-hl:rgba(0,0,0,.03);
   --panel:#f5f3f7;--panel-strong:#ece8f0;
   --chrome:rgba(245,243,247,.95);
-  --text:#4a4458;--text-strong:#1a1625;--muted:#8a839a;--muted-strong:#6b6480;
+  --text:#4a464f;--text-strong:#19161d;--muted:#5e5966;--muted-strong:#4a464f;
   --border:#d8d2e0;--border-strong:#c4bcd0;--border-hover:#a99fc0;
-  --accent:#6b5ba8;--accent-hover:#7d6fba;--accent-subtle:rgba(107,91,168,.12);
-  --accent-glow:rgba(107,91,168,.15);--ring:#6b5ba8;
-  --ok:#16a34a;--ok-subtle:rgba(22,163,74,.1);
-  --warn:#a16207;--warn-subtle:rgba(161,98,7,.1);
-  --danger:#e11d48;--danger-subtle:rgba(225,29,72,.1);
-  --info:#7c3aed;
-  --aim:#9333ea;--aim-subtle:rgba(147,51,234,.12);
-  --clarify:#a16207;--clarify-subtle:rgba(161,98,7,.06);
+  --accent:#8e48ff;--accent-fg:#ffffff;--accent-hover:#7a35e0;--accent-subtle:rgba(142,72,255,.12);
+  --accent-glow:rgba(142,72,255,.15);--ring:#8e48ff;
+  --ok:#008543;--ok-subtle:rgba(0,133,67,.12);
+  --warn:#a38a00;--warn-subtle:rgba(163,138,0,.1);
+  --danger:#d92544;--danger-subtle:rgba(217,37,68,.1);
+  --info:#285092;
+  --aim:#8041e6;--aim-subtle:rgba(128,65,230,.12);
+  --clarify:#a38a00;--clarify-subtle:rgba(163,138,0,.06);
   --diff-add:rgba(22,163,74,.12);--diff-add-text:#15803d;
-  --diff-del:rgba(225,29,72,.12);--diff-del-text:#be123c;
-  --diff-hunk:rgba(107,91,168,.12);--diff-hunk-text:#6b5ba8;
-  --diff-meta-text:#1a1625;
+  --diff-del:rgba(217,37,68,.12);--diff-del-text:#be123c;
+  --diff-hunk:rgba(128,65,230,.12);--diff-hunk-text:#723acc;
+  --diff-meta-text:#19161d;
   --shadow-sm:0 1px 2px rgba(0,0,0,.06);
   --shadow-md:0 4px 12px rgba(0,0,0,.08),0 0 0 1px rgba(0,0,0,.04);
   --shadow-lg:0 12px 28px rgba(0,0,0,.12);
-  --json-key:#6b5ba8;--json-str:#16a34a;--json-num:#7c3aed;--json-bool:#e11d48;
+  --json-key:#723acc;--json-str:#16a34a;--json-num:#8041e6;--json-bool:#d92544;
   color-scheme:light;
 }
 
@@ -1162,6 +1162,41 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 .msg-content code{font-family:var(--mono);font-size:.9em}
 .msg-content :not(pre)>code{background:rgba(0,0,0,.15);padding:.15em .4em;border-radius:4px;overflow-wrap:break-word;word-break:break-all}
 [data-mode="light"] .msg-content :not(pre)>code{background:rgba(0,0,0,.06)}
+/* Kiro theme: inline code = neutral elevated surface (Prey/750) + light-purple text (Figma 3906:185658) */
+[data-theme="kiro-dark"] .msg-content :not(pre)>code{background:#28242e;color:#c19aff}
+[data-theme="kiro-light"] .msg-content :not(pre)>code{background:var(--bg-hover);color:#723acc}
+/* Kiro dark: brighten message links — #8e48ff (=accent, same as the button fill) reads dull as thin
+   text on the dark bg, so step up to Purple/300 for equal perceived vibrancy. Scoped to Kiro. */
+[data-theme="kiro-dark"] .msg-content a{color:#b07fff;text-decoration-color:rgba(176,127,255,.45)}
+/* Kiro dark: accent FOREGROUND (icons, spinners, accent text) reads dull/blue as thin strokes at
+   #8e48ff, so brighten the text-accent utility to Purple/300. Fills (bg-accent, e.g. buttons) are a
+   separate utility and stay #8e48ff. More-specific rules (e.g. .nav-active .text-accent) still win. */
+[data-theme="kiro-dark"] .text-accent{color:#b07fff}
+/* Kiro theme: selected nav item + session row = neutral surface (Prey/700) with purple text/icon,
+   not a purple-tinted fill (Figma SessionTitle 2010:46988). Hover stays --bg-hover (Prey/750). */
+[data-theme="kiro-dark"] .nav-active,[data-theme="kiro-dark"] .session-row.session-active,[data-theme="kiro-dark"] .list-selected{background:#352f3d;color:#c19aff;border-color:#4a464f}
+[data-theme="kiro-dark"] .nav-active .text-accent{color:#c19aff}
+[data-theme="kiro-light"] .nav-active,[data-theme="kiro-light"] .session-row.session-active,[data-theme="kiro-light"] .list-selected{background:#d8d2e0;color:#723acc;border-color:#c4bcd0}
+[data-theme="kiro-light"] .nav-active .text-accent{color:#723acc}
+/* Kiro theme: lift unselected nav labels + section headers to Prey/300 (#c1bec6, ~9.8:1) per the
+   Figma settings-panel guideline (was Prey/400 #938f9b ~5.7:1). Inactive icons inherit this color
+   (they only carry opacity-70), lifting them from ~3.4:1 to ~5.6:1. Active items keep .nav-active. */
+[data-theme="kiro-dark"] .nav-item:not(.nav-active),[data-theme="kiro-dark"] .nav-section{color:#c1bec6}
+/* Kiro theme: lift the chat-header session title and the "Sessions" panel title from muted grey to
+   primary text (var(--text) = Prey/200 #dcdadf in dark) — titles were dim at ~5.7:1; now ~9-10:1. */
+[data-theme="kiro-dark"] .session-header-title,[data-theme="kiro-light"] .session-header-title,
+[data-theme="kiro-dark"] .sessions-panel-title,[data-theme="kiro-light"] .sessions-panel-title{color:var(--text)}
+/* Kiro dark: panel resize-handle highlight is a thin line, so match it to the brightened thin-accent
+   (#B07FFF) rather than the #8E48FF fill it inherits from bg-accent. Only applies while dragging-hover. */
+[data-theme="kiro-dark"] .group\/drag:hover .resize-accent{background-color:#b07fff}
+/* Kiro dark: queued-message bar matches the Figma "Waiting for input" snackbar (1793:25695) —
+   semi-transparent olive bg + Yellow/800 border + Yellow/100 text. */
+[data-theme="kiro-dark"] .queue-card{background-color:#2a2810;border-color:#5c5500;color:#fff7cc}
+/* Kiro theme: session agent-label ("default") gets a purple tint matching the accent foreground
+   (#B07FFF). The last-message subtitle is intentionally NOT tinted here — it keeps its default grey
+   and only turns purple (text-accent → #B07FFF) while the session is running, so both share one tint. */
+[data-theme="kiro-dark"] .session-agent-label{color:#b07fff}
+[data-theme="kiro-light"] .session-agent-label{color:#8e48ff}
 .msg-content pre{background:rgba(0,0,0,.15);border-radius:var(--radius-sm);padding:10px 12px;overflow-x:auto;margin:4px 0;font-size:0.8125rem;font-family:var(--mono);line-height:1.5}
 [data-mode="light"] .msg-content pre{background:rgba(0,0,0,.04)}
 /* Reset pre inside new code/diff block components */

--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -241,7 +241,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                     const key = a.package || a.name; (g[key] ||= []).push(a); return g
                   }, {})
                   const renderAgent = (a: typeof installed[0], showDelete?: boolean) => (
-                    <Clickable key={`${a.name}-${a.project_path || ''}`} className={`flex items-center gap-2 px-3 py-2.5 rounded-md border transition-all cursor-pointer mb-1 ${selectedAgent?.name === a.name ? 'bg-accent-subtle border-accent/40' : 'bg-bg-elevated border-transparent hover:border-border-strong'}`} onClick={async () => { try { const d = await api.agentDetail(a.name, a.project_path); setSelectedAgent(d) } catch { setSelectedAgent(a) } }}>
+                    <Clickable key={`${a.name}-${a.project_path || ''}`} className={`flex items-center gap-2 px-3 py-2.5 rounded-md border transition-all cursor-pointer mb-1 ${selectedAgent?.name === a.name ? 'list-selected bg-accent-subtle border-accent/40' : 'bg-bg-elevated border-transparent hover:bg-bg-hover hover:border-border-strong'}`} onClick={async () => { try { const d = await api.agentDetail(a.name, a.project_path); setSelectedAgent(d) } catch { setSelectedAgent(a) } }}>
                       <span
                         role="button"
                         tabIndex={a.source === 'project' ? -1 : 0}
@@ -263,7 +263,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                           <span className="text-[11px] text-muted font-mono">{a.model}</span>
                         </div>
                       </div>
-                      {showDelete && <button className="text-[10px] text-danger/50 hover:text-danger-fg hover:bg-danger px-1 py-0.5 rounded border border-danger/20 hover:border-danger/30 transition-all shrink-0" title={`Delete ${a.name}`} aria-label={`Delete ${a.name}`} onClick={e => { e.stopPropagation(); if (confirm(`Delete agent "${a.name}"? This removes the config file.`)) deleteAgentMut.mutate(a.name) }}><X className="lucide-inline" /></button>}
+                      {showDelete && <button className="text-[10px] text-muted hover:text-danger-fg hover:bg-danger px-1 py-0.5 rounded border border-border hover:border-danger/40 transition-all shrink-0" title={`Delete ${a.name}`} aria-label={`Delete ${a.name}`} onClick={e => { e.stopPropagation(); if (confirm(`Delete agent "${a.name}"? This removes the config file.`)) deleteAgentMut.mutate(a.name) }}><X className="lucide-inline" /></button>}
                     </Clickable>
                   )
                   return (<>

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2960,7 +2960,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
           </div>
         )}
         {uploadNotice && (
-          <div className="mx-4 mt-2 mb-0 bg-bg-elevated border rounded-lg p-3 flex items-center gap-3 animate-rise" style={{ borderColor: 'color-mix(in srgb, var(--info) 45%, transparent)' }}>
+          <div className="mx-4 mt-2 mb-0 bg-bg-elevated border rounded-lg p-3 flex items-center gap-3 animate-rise" style={{ borderColor: 'color-mix(in srgb, var(--accent) 45%, transparent)' }}>
             <span className="text-sm text-text flex-1">{uploadNotice}</span>
             <button onClick={() => setUploadNotice('')} aria-label="Dismiss notice" className="text-muted hover:text-text text-lg leading-none">&times;</button>
           </div>
@@ -3020,7 +3020,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                   <Clickable className="flex items-center gap-1" onClick={() => { if (activeSlot && generatingTitleSlots.has(activeSlot)) return; setEditingTitle(true); setTitleDraft(title) }}>
                     {currentSlot?.memory_mode === 'incognito' && <span title="Incognito — memory writes disabled"><EyeOff size={13} className="shrink-0 text-warn" /></span>}
                     {currentSlot?.memory_mode === 'temporary' && <span title="Temporary — no memory reads or writes"><VenetianMask size={13} className="shrink-0 text-aim" /></span>}
-                    <TypewriterText text={title} className="text-sm font-semibold text-muted font-mono truncate max-w-[40vw]" />
+                    <TypewriterText text={title} className="session-header-title text-sm font-semibold text-muted font-mono truncate max-w-[40vw]" />
                     <Pen size={13} className="shrink-0 text-muted opacity-0 group-hover/header:opacity-60 transition-opacity" />
                   </Clickable>
                   {activeSlot && (generatingTitleSlots.has(activeSlot) ? <Loader size={16} className="shrink-0 text-accent animate-spin" /> : <Btn aria-label="Regenerate title with LLM" className="shrink-0 text-muted opacity-0 group-hover/header:opacity-40 hover:!opacity-100 hover:text-accent transition-all cursor-pointer bg-transparent border-none p-0" title="Regenerate title with LLM" onClick={e => { e.stopPropagation(); if (!activeSlot || generatingTitleSlots.has(activeSlot)) return; const slot = activeSlot; setGeneratingTitleSlots(prev => new Set(prev).add(slot)); api.generateTitle(slot).then(r => { /* title is redacted server-side via redact_exfiltration_urls + redact_credentials */ if (r.title) dispatch(sseSlotTitle({ key: slot, title: r.title })) }).catch(e => {

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1580,7 +1580,7 @@ function ChatSidebar({
     const agentMeta = installedAgents.find(a => a.name === agentName)
     const isAim = agentMeta?.source === 'aim'
     const isBuiltin = agentMeta?.source === 'builtin'
-    const agentColor = isAim ? 'text-[var(--aim)]' : isBuiltin ? 'text-muted' : 'text-accent'
+    const agentColor = isAim ? 'text-[var(--aim)]' : isBuiltin ? 'text-muted' : 'text-muted'
     const isActive = activeSlot === s.key
     const isOut = poppedOut.has(s.key)
     const recent = recentRank.get(s.key)
@@ -1672,7 +1672,7 @@ function ChatSidebar({
             <span className="absolute right-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full pointer-events-none" style={{ background: 'var(--info)' }} title="Agent finished — your turn" />
           )}
           <div className="flex-1 min-w-0 overflow-hidden">
-            <div className={`text-[11px] font-semibold truncate leading-tight flex items-center gap-1 ${agentColor}`}>
+            <div className={`session-agent-label text-[11px] font-semibold truncate leading-tight flex items-center gap-1 ${agentColor}`}>
               {pinned.has(s.key) && <span className="shrink-0" title="Pinned"><Pin size={10} className="text-accent" /></span>}
               <AnimatePresence mode="wait">
                 <motion.span key={agentName || 'empty'} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }} className="truncate">{agentName || '\u00A0'}</motion.span>
@@ -1995,7 +1995,7 @@ function ChatSidebar({
       {/* Header */}
       <div className="flex justify-between items-center px-2 h-12">
         <div className={`flex items-center gap-1.5 min-w-0 flex-1 ${collapsible && !isMobile ? 'pl-8' : ''}`}>
-          {!tinyHeader && <span className="text-[13px] font-medium text-muted uppercase tracking-[.04em] truncate">Sessions</span>}
+          {!tinyHeader && <span className="sessions-panel-title text-[13px] font-medium text-muted uppercase tracking-[.04em] truncate">Sessions</span>}
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <DropdownMenu>
@@ -2818,7 +2818,7 @@ function ChatSidebar({
                   const meta = installedAgents.find(a => a.name === agentName)
                   if (meta?.source === 'aim') return 'text-[var(--aim)]'
                   if (meta?.source === 'builtin') return 'text-muted'
-                  return 'text-accent'
+                  return 'text-muted'
                 }
                 const historyRow = (s: (typeof sortedHistory)[number]) => {
                   const displayDate = fmtRelativeTime(s.modified ?? s.created)
@@ -2855,7 +2855,7 @@ function ChatSidebar({
                         }
                       </span>
                       <div className="flex-1 min-w-0 overflow-hidden">
-                        <div className={`text-[11px] font-semibold truncate leading-tight flex items-center gap-1 ${agentColor}`}>
+                        <div className={`session-agent-label text-[11px] font-semibold truncate leading-tight flex items-center gap-1 ${agentColor}`}>
                           <span className="truncate">{agentName || '\u00A0'}</span>
                           {s.clean_mode
                             ? <span className="text-accent" title="Clean — agent-only, no KiroCrew context or MCP"><Droplet size={10} /></span>

--- a/website/src/pages/aidlc/DagView.tsx
+++ b/website/src/pages/aidlc/DagView.tsx
@@ -13,7 +13,7 @@ const STATUS_DOT: Record<string, { color: string; label: ReactNode; key: string 
   in_progress: { color: '#f59e32', label: <><StatusDot color="#f59e32" /> Running</>, key: 'in_progress' },
   reviewing: { color: '#f59e32', label: <><StatusDot color="#f59e32" /> Reviewing</>, key: 'reviewing' },
   passed: { color: '#22c55e', label: <><StatusDot color="#22c55e" /> Done</>, key: 'passed' },
-  failed: { color: '#ef4444', label: <><StatusDot color="#ef4444" /> Failed</>, key: 'failed' },
+  failed: { color: 'var(--danger)', label: <><StatusDot color="var(--danger)" /> Failed</>, key: 'failed' },
   skipped: { color: '#9ca3af', label: <><SkipForward className="lucide-inline" /> Skipped</>, key: 'skipped' },
   cancelled: { color: '#9ca3af', label: <><Square className="lucide-inline" /> Cancelled</>, key: 'cancelled' },
   cancelling: { color: '#f59e32', label: <><Hourglass className="lucide-inline" /> Cancelling</>, key: 'cancelling' },
@@ -136,7 +136,7 @@ export default function DagView({ nodes, edges, onNodeClick, selectedId, pending
                 <foreignObject x={n.x} y={n.y + NODE_H + 4} width={NODE_W} height={24}>
                   <div style={{ display: 'flex', gap: 4, justifyContent: 'center' }}>
                     <button onClick={e => { e.stopPropagation(); onApprove(Number(n.id), 'approve'); }} style={{ padding: '2px 10px', fontSize: 10, fontWeight: 600, background: '#22c55e', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 2 }}><Check size={10} /> Approve</button>
-                    <button onClick={e => { e.stopPropagation(); onApprove(Number(n.id), 'reject'); }} style={{ padding: '2px 10px', fontSize: 10, fontWeight: 600, background: '#ef4444', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 2 }}><X size={10} /> Deny</button>
+                    <button onClick={e => { e.stopPropagation(); onApprove(Number(n.id), 'reject'); }} style={{ padding: '2px 10px', fontSize: 10, fontWeight: 600, background: 'var(--danger)', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 2 }}><X size={10} /> Deny</button>
                   </div>
                 </foreignObject>
               )}

--- a/website/src/pages/aidlc/PhasedView.tsx
+++ b/website/src/pages/aidlc/PhasedView.tsx
@@ -49,7 +49,7 @@ function TaskGroup({ icon, label, items, onTaskClick, color, opacity, showError,
           <span>{icon}</span>
           <span style={{ flex: 1, fontSize: 13, opacity: opacity ?? 1 }}>Task {t.index}: {t.title}</span>
           {pendingEditIndexes?.has(t.index) && <span style={{ width: 8, height: 8, borderRadius: '50%', background: '#f59e32', flexShrink: 0 }} />}
-          {showError && t.error && <span style={{ fontSize: 11, color: '#ef4444', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.error}</span>}
+          {showError && t.error && <span style={{ fontSize: 11, color: 'var(--danger)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.error}</span>}
         </div>
       ))}
     </div>

--- a/website/src/pages/chat/ChatNavPanel.tsx
+++ b/website/src/pages/chat/ChatNavPanel.tsx
@@ -14,7 +14,7 @@ const TYPE_COLORS: Record<string, string> = {
   taskei: 'bg-blue-500/15 text-blue-400',
   quip: 'bg-purple-500/15 text-purple-400',
   tt: 'bg-orange-500/15 text-orange-400',
-  mcm: 'bg-red-500/15 text-red-400',
+  mcm: 'bg-danger/15 text-danger',
   wiki: 'bg-green-500/15 text-green-400',
   sim: 'bg-yellow-500/15 text-yellow-400',
   cr: 'bg-cyan-500/15 text-cyan-400',

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -223,7 +223,7 @@ export default function SidePanel({
     <div className="h-full shrink-0 flex flex-col bg-bg border-l border-border overflow-hidden relative" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
       {/* Left-edge resize handle */}
       <div className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" onMouseDown={onDragStart}>
-        <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent" />
+        <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
       </div>
       {/* Tab strip — drag chips horizontally to reorder (framer Reorder).
           h-[52px] matches the app header row so the two bars align.

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -487,7 +487,7 @@ export default function KnowledgePage() {
       <div className="flex gap-1 px-6 border-b border-border">
         {TABS.map(t => (
           <button key={t} onClick={() => { setTab(t); setSelectedId(null); setSelectedItems(new Set()) }}
-            className={`flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium border-b-2 transition-all bg-transparent cursor-pointer ${tab === t ? 'border-accent text-accent' : 'border-transparent text-muted hover:text-text'}`}>
+            className={`flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium border-b-2 transition-all bg-transparent cursor-pointer ${tab === t ? 'border-accent text-text font-semibold' : 'border-transparent text-muted hover:text-text'}`}>
             {TAB_META[t].icon} {TAB_META[t].label}
           </button>
         ))}

--- a/website/src/pages/overview/MemoryTab.tsx
+++ b/website/src/pages/overview/MemoryTab.tsx
@@ -70,9 +70,9 @@ export default function MemoryTab({ refreshTrigger }: { refreshTrigger: number }
     scheduleClear(() => setConsolidateMsg(''), 4000)
   }
   return (<>
-    <div className="flex items-center gap-2 mb-4">
-      <Btn onClick={() => setView('table')} className={view === 'table' ? '!border-accent !text-accent' : ''}><ClipboardList className="lucide-inline" /> Table</Btn>
-      <Btn onClick={() => setView('graph')} className={view === 'graph' ? '!border-accent !text-accent' : ''}><Network className="lucide-inline" /> Graph</Btn>
+    <div className="inline-flex items-center gap-1 p-1 rounded-md bg-bg-elevated mb-4 w-fit">
+      <button onClick={() => setView('table')} className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[13px] font-medium cursor-pointer border-none transition-colors ${view === 'table' ? 'bg-bg-hover text-accent' : 'bg-transparent text-muted hover:text-text'}`}><ClipboardList className="lucide-inline" /> Table</button>
+      <button onClick={() => setView('graph')} className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[13px] font-medium cursor-pointer border-none transition-colors ${view === 'graph' ? 'bg-bg-hover text-accent' : 'bg-transparent text-muted hover:text-text'}`}><Network className="lucide-inline" /> Graph</button>
     </div>
     {view === 'graph' ? <MemoryGraphTab /> : <>
     <Card><CardTitle>Memory Settings <InfoTip text="Controls how conversation history is consolidated into memory." /></CardTitle>

--- a/website/src/pages/overview/SkillsTab.tsx
+++ b/website/src/pages/overview/SkillsTab.tsx
@@ -135,7 +135,7 @@ export default function SkillsTab() {
         onClick={() => selectSkill(s)}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSkill(s) } }}
         className={`flex flex-col gap-0.5 px-3 py-2.5 rounded-md cursor-pointer mb-1 transition-colors ${
-          isSel ? 'bg-accent-subtle' : 'bg-bg-elevated hover:bg-bg-hover'
+          isSel ? 'list-selected bg-accent-subtle' : 'bg-bg-elevated hover:bg-bg-hover'
         }`}
       >
         <div className="flex items-center gap-1.5 min-w-0">

--- a/website/src/pages/overview/VectorMemoryCard.tsx
+++ b/website/src/pages/overview/VectorMemoryCard.tsx
@@ -351,13 +351,15 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
               </div>
             </div>
           </div>
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-2 flex-wrap items-center">
+            <div className="inline-flex items-center gap-1 p-1 rounded-md bg-bg-elevated w-fit">
             {(['semantic','episodic','audit','inspector'] as const).map(v => (
-              <Btn key={v} onClick={() => { setView(v); if (v === 'episodic') loadEpisodic(); if (v === 'audit') loadEvents(); if (v === 'inspector') loadPreview() }}
-                className={view === v ? '!border-accent !text-accent' : ''}>{
+              <button key={v} onClick={() => { setView(v); if (v === 'episodic') loadEpisodic(); if (v === 'audit') loadEvents(); if (v === 'inspector') loadPreview() }}
+                className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[13px] font-medium cursor-pointer border-none transition-colors ${view === v ? 'bg-bg-hover text-accent' : 'bg-transparent text-muted hover:text-text'}`}>{
                   v === 'inspector' ? <><Search className="lucide-inline" /> Inspector</> : v[0].toUpperCase() + v.slice(1)
-                }</Btn>
+                }</button>
             ))}
+            </div>
             <div className="flex gap-2 ml-auto">
               {!stats?.migrated && stats?.has_legacy_memory && !migrateResult?.semantic && (
                 <Btn disabled={migrating} onClick={async () => { setMigrating(true); setMigrateResult(null); const r = await api.vectorMigrate().catch(() => ({ error: 'Migration failed' })); setMigrateResult(r); setMigrating(false); await load() }}>

--- a/website/src/test/memColorClass.test.ts
+++ b/website/src/test/memColorClass.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { memColorClass } from '../App'
 
 describe('memColorClass', () => {
-  it('returns text-accent (green) for usage below 70%', () => {
-    expect(memColorClass(0)).toBe('text-accent')
-    expect(memColorClass(0.5)).toBe('text-accent')
-    expect(memColorClass(0.69)).toBe('text-accent')
-    expect(memColorClass(0.7)).toBe('text-accent')
+  it('returns text-muted for normal usage at or below 70%', () => {
+    expect(memColorClass(0)).toBe('text-muted')
+    expect(memColorClass(0.5)).toBe('text-muted')
+    expect(memColorClass(0.69)).toBe('text-muted')
+    expect(memColorClass(0.7)).toBe('text-muted')
   })
 
   it('returns text-warn (yellow) for usage between 70-90%', () => {


### PR DESCRIPTION
## Problem
The built-in **Kiro** theme and a number of dashboard components didn't match the "Kiro on the Web" Figma design system. Concretely: the palette was off (legacy muted-lavender vs. the Figma Prey/Purple ramps), thin accent strokes read dull/blue, selection states used a muddy purple-tint fill, tabs/badges/toggles/code-chips each had one-off styling, a few blue/green tints clashed, the queued-message banner was semi-transparent (revealed stacked cards behind it), and several reds were hardcoded off-palette.

## Why it matters
The Kiro theme is the fork's signature look; these inconsistencies made it feel off-brand and, in a couple of spots (dim nav text/titles, low-contrast icons), sat right at the WCAG AA floor. Unifying to the Figma tokens makes the theme cohesive and nudges the borderline contrast well clear of AA.

## Fix (symptom → root cause → change)
- **Symptom:** colors/components drifted from the Figma. **Root cause:** the `kiro-*` theme variables and many components used ad-hoc/legacy values instead of the design tokens. **Change:** retuned the `kiro-dark`/`kiro-light` CSS-variable blocks to the Figma ramps and normalized component styling. All component-level changes are **Kiro-scoped** via `[data-theme="kiro-*"]` rules + inert marker classes (`nav-active`, `list-selected`, `session-agent-label`, `queue-card`, `resize-accent`), so other themes are untouched.
  - Palette: bg `#19161D`, surfaces `#211D25`/`#28242E`, border `#352F3D`, Prey text ramp, purple accent `#8E48FF` + ring `#723ACC`; success `#008543`; danger Red/400 `#F94359`.
  - Accent **foreground** (icons/links/spinners) brightened to Purple/300 `#B07FFF` in dark (thin strokes read dull at `#8E48FF`); solid fills (buttons) stay `#8E48FF`.
  - Selection unified across nav / session list / agent + skill lists to a neutral `#352F3D` surface + purple text (was `bg-accent-subtle`).
  - Inline code chips → neutral `#28242E` + Purple/200 text; tabs → bold text + accent underline; source/tier badges → neutral pill; segmented controls (settings groups, Memory table/graph, Vector Memory views) → filled selected segment on an elevated track.
  - Queued-message bar matches the Figma "waiting for input" snackbar (opaque olive `#2A2810` + `#5C5500` border + `#FFF7CC` text) and no longer shows content behind it.
  - Panel resize handle + upload-notice border use accent purple (was blue `--info`).
  - Hardcoded reds (`#ef4444`, `red-500/400`) routed through the `danger` token so all reds resolve to Red/400 in Kiro.
  - Kiro theme label emoji `🔮` → `👻` (ghost branding, matches the Figma logo).

## Tests
No automated tests added — the change is purely visual (theme CSS variables + Tailwind class/`data-theme` styling) with no new logic branches to unit-test. The existing suite is unaffected (no behavioral code paths changed).

## Manual verification
- `npm run build` (vite + tsc) run after every change — exit 0, including after rebasing onto latest `main`.
- Previewed each surface in the Kiro theme against the referenced Figma nodes: side nav + section headers, session list (default/hover/selected), chat header title, MCP registry cards (divider + secondary button + recommended badge), Agent Templates (tags + delete button), Skills list, Vector Memory + Memory toggles, Settings toggles, Knowledge tabs, queued-message stacking, panel resize handle, and the danger/stop/badge reds.
- Spot-checked WCAG AA contrast on nav text (`#C1BEC6` ≈ 9.8:1), titles (`var(--text)` ≈ 9–10:1), and neutral-surface selected text (`#C19AFF` on `#352F3D` ≈ 5.7:1).
- Confirmed non-Kiro themes are unchanged (component edits are `[data-theme="kiro-*"]`-scoped or token-based).
