### PR TITLE
feat(themes): install Level-0 themes from a local folder or GitHub

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -98,6 +98,7 @@ from kiro_crew.dashboard.handlers.agents import (  # noqa: E402, F401
     api_theme_detail,
     api_themes,
     api_themes_create,
+    api_themes_install,
 )
 from kiro_crew.dashboard.handlers.cron import (  # noqa: E402, F401
     api_cron_ack,

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -10,6 +10,8 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
+import urllib.parse
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -223,6 +225,196 @@ def _slugify_theme_name(name: str) -> str:
     return slug[:_THEME_SLUG_MAX_LEN] or "custom"
 
 
+def _safe_theme_slug(slug: str) -> str | None:
+    """Return the slug if it is filesystem-safe (no traversal), else None.
+
+    Mirrors the inline guard in ``api_theme_detail`` so install/remove share
+    one path-traversal check.
+    """
+    if not isinstance(slug, str) or not slug:
+        return None
+    cleaned = re.sub(r"[^a-z0-9\-]", "", slug)
+    if not cleaned or cleaned != slug:
+        return None
+    return cleaned
+
+
+# ── Installed theme directories (Level 0) ──
+#
+# Editor-created custom themes are flat ``<slug>.json`` files under
+# ``_themes_dir()``.  *Installed* themes (from a local folder or GitHub) are
+# directories ``_themes_dir()/<slug>/`` holding a ``theme.json`` manifest plus
+# a ``variables.json`` (top-level or under ``styles/``).  A file ``<slug>.json``
+# and a directory ``<slug>/`` never collide, so the two stores sit side by side.
+#
+# Level 0 (Color) only: the installer accepts colour variables and rejects any
+# Level 1/2 payload (branding, fonts, overrides.css, overlays, topbar, audio,
+# persona) — the declared ``level`` must be 0 AND no higher-tier asset may be
+# present.  Validation is defensive by construction: bounded entry count, a
+# per-file and total size cap, a filename allowlist, symlink rejection, and a
+# containment check so nothing resolves outside the theme directory.
+
+_THEME_MANIFEST_NAME = "theme.json"
+# variables.json may live at the top level or under styles/ (relative POSIX).
+_THEME_VARIABLES_REL = ("variables.json", "styles/variables.json")
+# Files/dirs (lowercased relative POSIX paths) allowed in a Level-0 theme dir.
+_THEME_L0_ALLOWED = frozenset(
+    {"theme.json", "variables.json", "styles", "styles/variables.json", "readme.md"}
+)
+# Higher-tier (L1/L2) top-level assets whose presence disqualifies a L0 install.
+_THEME_HIGHER_TIER = frozenset(
+    {"overlays", "topbar", "audio", "persona.md", "branding", "fonts", "overrides.css"}
+)
+# VCS/meta files tolerated (not counted, not rejected, not copied into the store)
+# so a cloned repo or a folder carrying LICENSE validates cleanly.
+_THEME_META_IGNORE = frozenset(
+    {".git", ".github", ".gitignore", ".ds_store", "license", "license.md", "license.txt"}
+)
+_THEME_MAX_ENTRIES = 32
+_THEME_MAX_FILE_BYTES = 64 * 1024
+_THEME_MAX_TOTAL_BYTES = 256 * 1024
+# GitHub install: https-only, host allowlist, argv (no shell), bounded time.
+_THEME_GITHUB_HOSTS = frozenset({"github.com", "www.github.com"})
+_THEME_CLONE_TIMEOUT_SEC = 30
+
+
+def _installed_theme_dir(slug: str) -> Path:
+    """Directory for an *installed* theme: ``_themes_dir()/<slug>/``."""
+    return _themes_dir() / slug
+
+
+def _read_json_file(path: Path, max_bytes: int) -> tuple[Any, str | None]:
+    """Read + parse a JSON file with a byte cap. Returns ``(data, error)``."""
+    try:
+        raw = path.read_bytes()
+    except OSError as e:
+        return None, f"cannot read {path.name}: {e}"
+    if len(raw) > max_bytes:
+        return None, f"{path.name} too large (max {max_bytes} bytes)"
+    try:
+        return json.loads(raw.decode("utf-8")), None
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        return None, f"{path.name} is not valid JSON: {e}"
+
+
+def _validate_theme_dir(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate an installed **Level-0 theme directory** (structure + data).
+
+    On success returns ``(summary, None)`` where ``summary`` is the record to
+    register (``slug``/``name``/``emoji``/``level``/``source``/``dark``/
+    ``light``); on any failure returns ``(None, error)`` and nothing should be
+    registered. Reuses ``_validate_theme_data`` for the colour values so the
+    43-var allowlist and per-value CSS sanitisation are enforced identically to
+    editor-created themes.
+    """
+    if not path.is_dir() or path.is_symlink():
+        return None, "theme path is not a directory"
+
+    root = path.resolve()
+
+    # Walk the tree: bound entry count, reject symlinks / escaping paths,
+    # enforce the filename allowlist + higher-tier denylist, and sum sizes.
+    total = 0
+    entries = 0
+    for entry in sorted(path.rglob("*")):
+        rel = entry.relative_to(path).as_posix().lower()
+        top = rel.split("/", 1)[0]
+        if top in _THEME_META_IGNORE or rel in _THEME_META_IGNORE:
+            continue
+        entries += 1
+        if entries > _THEME_MAX_ENTRIES:
+            return None, f"too many files in theme (max {_THEME_MAX_ENTRIES})"
+        if entry.is_symlink():
+            return None, f"symlinks are not allowed: {entry.name}"
+        try:
+            entry.resolve().relative_to(root)
+        except (OSError, ValueError):
+            return None, "path escapes theme directory"
+        if top in _THEME_HIGHER_TIER or rel in _THEME_HIGHER_TIER:
+            return None, (
+                f"'{rel}' is a Level 1/2 asset; only Level 0 (color) themes "
+                "can be installed yet"
+            )
+        if entry.is_dir():
+            if rel not in _THEME_L0_ALLOWED:
+                return None, f"unexpected directory in theme: '{rel}'"
+            continue
+        if rel not in _THEME_L0_ALLOWED:
+            return None, f"unexpected file in theme: '{rel}'"
+        try:
+            sz = entry.stat().st_size
+        except OSError:
+            return None, f"cannot stat '{rel}'"
+        if sz > _THEME_MAX_FILE_BYTES:
+            return None, f"'{rel}' too large (max {_THEME_MAX_FILE_BYTES} bytes)"
+        total += sz
+    if total > _THEME_MAX_TOTAL_BYTES:
+        return None, f"theme too large (max {_THEME_MAX_TOTAL_BYTES} bytes total)"
+
+    # Manifest (theme.json): must declare level 0 and a name.
+    manifest_path = path / _THEME_MANIFEST_NAME
+    if not manifest_path.is_file():
+        return None, "missing theme.json manifest"
+    manifest, err = _read_json_file(manifest_path, _THEME_MAX_FILE_BYTES)
+    if err:
+        return None, err
+    if not isinstance(manifest, dict):
+        return None, "theme.json must be a JSON object"
+    level = manifest.get("level", 0)
+    if not isinstance(level, int) or isinstance(level, bool) or level != 0:
+        return None, (
+            "only Level 0 (color) themes are supported; "
+            f"theme.json declares level {level!r}"
+        )
+    name = manifest.get("name", "")
+    if not isinstance(name, str) or not name.strip():
+        return None, "theme.json 'name' is required"
+    emoji = manifest.get("emoji", _THEME_DEFAULT_EMOJI)
+    if not isinstance(emoji, str):
+        return None, "theme.json 'emoji' must be a string"
+
+    # Variables (variables.json | styles/variables.json).
+    var_path: Path | None = None
+    for rel in _THEME_VARIABLES_REL:
+        cand = path / rel
+        if cand.is_file():
+            var_path = cand
+            break
+    if var_path is None:
+        return None, "missing variables.json (top-level or under styles/)"
+    variables, err = _read_json_file(var_path, _THEME_MAX_FILE_BYTES)
+    if err:
+        return None, err
+    if not isinstance(variables, dict):
+        return None, "variables.json must be a JSON object"
+
+    # Reuse the colour-data validator (43-var allowlist + CSS sanitisation).
+    theme_data = {
+        "name": name.strip()[:_THEME_NAME_MAX_LEN],
+        "emoji": emoji,
+        "dark": variables.get("dark", {}),
+        "light": variables.get("light", {}),
+    }
+    data_err = _validate_theme_data(theme_data)
+    if data_err:
+        return None, data_err
+
+    raw_slug = manifest.get("slug")
+    slug = _slugify_theme_name(
+        raw_slug if isinstance(raw_slug, str) and raw_slug.strip() else name
+    )
+    summary = {
+        "slug": slug,
+        "name": theme_data["name"],
+        "emoji": emoji.strip()[:_THEME_EMOJI_MAX_LEN] or _THEME_DEFAULT_EMOJI,
+        "level": 0,
+        "source": "installed",
+        "dark": _strip_to_allowed_vars(variables.get("dark", {})),
+        "light": _strip_to_allowed_vars(variables.get("light", {})),
+    }
+    return summary, None
+
+
 async def api_themes(request: web.Request) -> web.Response:
     """GET /api/themes — list all custom themes, sorted by creation date."""
     themes_path = _themes_dir()
@@ -241,6 +433,27 @@ async def api_themes(request: web.Request) -> web.Response:
                 )
             except (json.JSONDecodeError, OSError):
                 continue
+        # Installed themes are directories (<slug>/) carrying a theme.json.
+        for d in sorted(
+            p for p in themes_path.iterdir() if p.is_dir() and not p.is_symlink()
+        ):
+            mpath = d / "theme.json"
+            if not mpath.is_file():
+                continue
+            try:
+                m = json.loads(mpath.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            result.append(
+                {
+                    "slug": d.name,
+                    "name": m.get("name", d.name),
+                    "emoji": m.get("emoji", _THEME_DEFAULT_EMOJI),
+                    "created_at": m.get("created_at", ""),
+                    "source": "installed",
+                    "level": 0,
+                }
+            )
     # Sort by created_at (oldest first), falling back to name
     result.sort(key=lambda t: t.get("created_at") or "9999")
     return web.json_response({"themes": result})
@@ -282,6 +495,126 @@ async def api_themes_create(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "slug": slug, "theme": theme_data})
 
 
+def _resolve_local_source(path_str: str) -> tuple[Path | None, str | None]:
+    """Resolve a user-supplied local folder path to an existing directory."""
+    if not isinstance(path_str, str) or not path_str.strip():
+        return None, "local 'path' is required"
+    p = Path(path_str).expanduser()
+    if p.is_symlink():
+        return None, "local path must not be a symlink"
+    if not p.is_dir():
+        return None, f"not a directory: {path_str}"
+    return p.resolve(), None
+
+
+def _clone_github(url: str, dest: Path) -> str | None:
+    """Shallow-clone an https github.com repo into ``dest``. Error or None.
+
+    https-only + host allowlist, argv (never shell) so the URL can't inject a
+    command, and a bounded timeout.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return "github 'url' is required"
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() not in _THEME_GITHUB_HOSTS:
+        return "only https github.com URLs are allowed"
+    try:
+        proc = subprocess.run(
+            ["git", "clone", "--depth", "1", "--quiet", "--", url, str(dest)],
+            capture_output=True,
+            text=True,
+            timeout=_THEME_CLONE_TIMEOUT_SEC,
+        )
+    except FileNotFoundError:
+        return "git is not available on the server"
+    except subprocess.TimeoutExpired:
+        return "git clone timed out"
+    if proc.returncode != 0:
+        return f"git clone failed: {proc.stderr.strip()[:200]}"
+    return None
+
+
+def _copy_installed_theme(src: Path, dst: Path) -> None:
+    """Copy only the recognized L0 files from a validated ``src`` into ``dst``.
+
+    Meta/VCS files are intentionally left behind so the installed store holds
+    only ``theme.json`` + the variables file.
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src / _THEME_MANIFEST_NAME, dst / _THEME_MANIFEST_NAME)
+    top = src / "variables.json"
+    styled = src / "styles" / "variables.json"
+    if top.is_file():
+        shutil.copyfile(top, dst / "variables.json")
+    elif styled.is_file():
+        (dst / "styles").mkdir(exist_ok=True)
+        shutil.copyfile(styled, dst / "styles" / "variables.json")
+
+
+async def api_themes_install(request: web.Request) -> web.Response:
+    """POST /api/themes/install — install a Level-0 theme directory.
+
+    Body: ``{"source": {"type": "local", "path": "..."}}`` or
+    ``{"source": {"type": "github", "url": "https://github.com/..."}}``.
+    Fetch/move -> validate (data + structure) -> register as
+    ``_themes_dir()/<slug>/``.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON"}, status=400)
+    source = body.get("source") if isinstance(body, dict) else None
+    if not isinstance(source, dict):
+        return web.json_response({"error": "missing 'source' object"}, status=400)
+    stype = source.get("type")
+
+    tmp_root = Path(tempfile.mkdtemp(prefix="theme-install-"))
+    try:
+        if stype == "local":
+            src, err = _resolve_local_source(source.get("path", ""))
+        elif stype == "github":
+            src = tmp_root / "clone"
+            err = _clone_github(source.get("url", ""), src)
+        else:
+            return web.json_response(
+                {"error": "source.type must be 'local' or 'github'"}, status=400
+            )
+        if err:
+            return web.json_response({"error": err}, status=400)
+
+        summary, err = _validate_theme_dir(src)
+        if err:
+            return web.json_response({"error": err}, status=400)
+
+        slug = summary["slug"]
+        # Collision guard across BOTH stores (installed dir + custom record).
+        if _installed_theme_dir(slug).exists() or (_themes_dir() / f"{slug}.json").exists():
+            return web.json_response(
+                {"error": f"theme '{slug}' already exists"}, status=409
+            )
+
+        staged = tmp_root / "staged"
+        _copy_installed_theme(src, staged)
+        _themes_dir().mkdir(parents=True, exist_ok=True)
+        shutil.move(str(staged), str(_installed_theme_dir(slug)))
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+    return web.json_response(
+        {
+            "ok": True,
+            "slug": slug,
+            "theme": {
+                "slug": slug,
+                "name": summary["name"],
+                "emoji": summary["emoji"],
+                "level": 0,
+                "source": stype,
+            },
+        }
+    )
+
+
 async def api_theme_detail(request: web.Request) -> web.Response:
     """GET/PUT/DELETE /api/themes/{slug} — get, update, or delete a custom theme."""
     slug = request.match_info["slug"]
@@ -291,14 +624,23 @@ async def api_theme_detail(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid theme slug"}, status=400)
 
     target = _themes_dir() / f"{safe_slug}.json"
+    dir_target = _installed_theme_dir(safe_slug)
 
     if request.method == "DELETE":
-        if not target.exists():
-            return web.json_response({"error": "not found"}, status=404)
-        target.unlink()
-        return web.json_response({"ok": True})
+        if target.exists():
+            target.unlink()
+            return web.json_response({"ok": True})
+        if dir_target.is_dir():
+            shutil.rmtree(dir_target, ignore_errors=True)
+            return web.json_response({"ok": True})
+        return web.json_response({"error": "not found"}, status=404)
 
     if request.method == "PUT":
+        if dir_target.is_dir() and not target.exists():
+            return web.json_response(
+                {"error": "installed themes are read-only; reinstall to update"},
+                status=400,
+            )
         if not target.exists():
             return web.json_response({"error": "not found"}, status=404)
         try:
@@ -330,13 +672,30 @@ async def api_theme_detail(request: web.Request) -> web.Response:
         return web.json_response({"ok": True, "theme": theme_data})
 
     # GET
-    if not target.exists():
-        return web.json_response({"error": "not found"}, status=404)
-    try:
-        data = json.loads(target.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return web.json_response({"error": "failed to read theme"}, status=500)
-    return web.json_response(data)
+    if target.exists():
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return web.json_response({"error": "failed to read theme"}, status=500)
+        return web.json_response(data)
+    if dir_target.is_dir():
+        summary, err = _validate_theme_dir(dir_target)
+        if err:
+            return web.json_response(
+                {"error": f"invalid installed theme: {err}"}, status=500
+            )
+        return web.json_response(
+            {
+                "slug": safe_slug,
+                "name": summary["name"],
+                "emoji": summary["emoji"],
+                "level": 0,
+                "source": "installed",
+                "dark": summary["dark"],
+                "light": summary["light"],
+            }
+        )
+    return web.json_response({"error": "not found"}, status=404)
 
 
 # ── Agent Config ──

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1163,6 +1163,7 @@ async def start_dashboard(
     # Custom Themes (CRUD)
     app.router.add_get("/api/themes", handlers.api_themes)
     app.router.add_post("/api/themes", handlers.api_themes_create)
+    app.router.add_post("/api/themes/install", handlers.api_themes_install)
     app.router.add_get("/api/themes/{slug}", handlers.api_theme_detail)
     app.router.add_put("/api/themes/{slug}", handlers.api_theme_detail)
     app.router.add_delete("/api/themes/{slug}", handlers.api_theme_detail)

--- a/test/test_theme_install.py
+++ b/test/test_theme_install.py
@@ -1,0 +1,223 @@
+"""Tests for Level-0 theme install (directory store + structure validation).
+
+Exercises the pure helpers in ``kiro_crew.dashboard.handlers.agents`` directly
+— the validator is where the real structure/security logic lives, so no aiohttp
+app is needed. Covers: valid installs (top-level + styles/), missing/invalid
+manifest, level bounds (L0 declaring-but-shipping-L2), stray files, VCS/meta
+tolerance, symlink rejection, oversize, bad CSS values, the GitHub URL guard,
+recognized-file staging, and an install→list→remove round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard.handlers.agents import (
+    _clone_github,
+    _copy_installed_theme,
+    _installed_theme_dir,
+    _safe_theme_slug,
+    _validate_theme_dir,
+)
+
+# _validate_theme_data only *requires* --bg/--text/--accent and rejects unknown
+# keys, so a 3-var map per mode is a complete, valid Level-0 theme.
+_VALID_VARS = {
+    "dark": {"--bg": "#000000", "--text": "#ffffff", "--accent": "#3366ff"},
+    "light": {"--bg": "#ffffff", "--text": "#000000", "--accent": "#0033cc"},
+}
+
+
+def _write(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _make_theme(
+    root: Path,
+    *,
+    level: int = 0,
+    name: str = "LCARS",
+    styled: bool = False,
+    variables: dict | None = None,
+) -> Path:
+    """Build a theme directory under ``root`` and return its path."""
+    d = root / "theme"
+    d.mkdir(parents=True, exist_ok=True)
+    _write(d / "theme.json", {"slug": "lcars", "name": name, "emoji": "🖖", "level": level})
+    varobj = _VALID_VARS if variables is None else variables
+    _write(d / ("styles/variables.json" if styled else "variables.json"), varobj)
+    return d
+
+
+class TestValidateThemeDir:
+    def test_valid_toplevel(self, tmp_path: Path) -> None:
+        summary, err = _validate_theme_dir(_make_theme(tmp_path))
+        assert err is None, err
+        assert summary is not None
+        assert summary["slug"] == "lcars"
+        assert summary["name"] == "LCARS"
+        assert summary["emoji"] == "🖖"
+        assert summary["level"] == 0
+        assert summary["source"] == "installed"
+        assert summary["dark"]["--bg"] == "#000000"
+        assert summary["light"]["--text"] == "#000000"
+
+    def test_valid_styles_subdir(self, tmp_path: Path) -> None:
+        summary, err = _validate_theme_dir(_make_theme(tmp_path, styled=True))
+        assert err is None, err
+        assert summary is not None and summary["slug"] == "lcars"
+
+    def test_missing_manifest(self, tmp_path: Path) -> None:
+        d = tmp_path / "t"
+        _write(d / "variables.json", _VALID_VARS)
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "theme.json" in err
+
+    def test_missing_variables(self, tmp_path: Path) -> None:
+        d = tmp_path / "t"
+        _write(d / "theme.json", {"slug": "x", "name": "X", "level": 0})
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "variables.json" in err
+
+    def test_level_nonzero_rejected(self, tmp_path: Path) -> None:
+        summary, err = _validate_theme_dir(_make_theme(tmp_path, level=2))
+        assert summary is None
+        assert err is not None and "Level 0" in err
+
+    def test_l2_overlay_asset_rejected(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)  # declares level 0 but ships an overlay
+        (d / "overlays").mkdir()
+        (d / "overlays" / "scanner.html").write_text("<b>x</b>", encoding="utf-8")
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "Level 1/2" in err
+
+    def test_persona_asset_rejected(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)
+        (d / "persona.md").write_text("# persona", encoding="utf-8")
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "Level 1/2" in err
+
+    def test_stray_file_rejected(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)
+        (d / "evil.txt").write_text("x", encoding="utf-8")
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "unexpected file" in err
+
+    def test_meta_files_tolerated(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)
+        (d / ".gitignore").write_text("x", encoding="utf-8")
+        (d / "LICENSE").write_text("MIT", encoding="utf-8")
+        gitdir = d / ".git"
+        gitdir.mkdir()
+        (gitdir / "config").write_text("[core]", encoding="utf-8")
+        summary, err = _validate_theme_dir(d)
+        assert err is None, err
+        assert summary is not None and summary["slug"] == "lcars"
+
+    def test_symlink_rejected(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)
+        outside = tmp_path / "outside.json"
+        outside.write_text("{}", encoding="utf-8")
+        try:
+            (d / "readme.md").symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported on this platform")
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "symlink" in err.lower()
+
+    def test_bad_css_value_rejected(self, tmp_path: Path) -> None:
+        bad = {
+            "dark": {"--bg": "red; }", "--text": "#fff", "--accent": "#00f"},
+            "light": {"--bg": "#fff", "--text": "#000", "--accent": "#00c"},
+        }
+        summary, err = _validate_theme_dir(_make_theme(tmp_path, variables=bad))
+        assert summary is None
+        assert err is not None  # rejected by _validate_theme_data
+
+    def test_oversize_variables_rejected(self, tmp_path: Path) -> None:
+        d = tmp_path / "t"
+        _write(d / "theme.json", {"slug": "x", "name": "X", "level": 0})
+        padded = dict(_VALID_VARS)
+        padded["_pad"] = "x" * (70 * 1024)  # push variables.json past 64KB
+        _write(d / "variables.json", padded)
+        summary, err = _validate_theme_dir(d)
+        assert summary is None
+        assert err is not None and "too large" in err
+
+
+class TestSafeThemeSlug:
+    def test_valid_slug(self) -> None:
+        assert _safe_theme_slug("lcars-01") == "lcars-01"
+
+    @pytest.mark.parametrize("bad", ["../etc", "a/b", "", "Foo", "a.b", "x y"])
+    def test_unsafe_rejected(self, bad: str) -> None:
+        assert _safe_theme_slug(bad) is None
+
+
+class TestCloneGithubGuard:
+    """The URL guard runs before any subprocess — no network/git required."""
+
+    def test_non_https_rejected(self, tmp_path: Path) -> None:
+        err = _clone_github("http://github.com/u/r", tmp_path / "c")
+        assert err is not None and "https" in err
+
+    def test_non_github_host_rejected(self, tmp_path: Path) -> None:
+        err = _clone_github("https://evil.example.com/u/r", tmp_path / "c")
+        assert err is not None and "github.com" in err
+
+    def test_empty_url_rejected(self, tmp_path: Path) -> None:
+        assert _clone_github("", tmp_path / "c") is not None
+
+
+class TestCopyInstalledTheme:
+    def test_copies_only_recognized_files(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path)
+        (d / "LICENSE").write_text("MIT", encoding="utf-8")
+        dst = tmp_path / "dst"
+        _copy_installed_theme(d, dst)
+        assert (dst / "theme.json").is_file()
+        assert (dst / "variables.json").is_file()
+        assert not (dst / "LICENSE").exists()
+
+    def test_preserves_styles_location(self, tmp_path: Path) -> None:
+        dst = tmp_path / "dst"
+        _copy_installed_theme(_make_theme(tmp_path, styled=True), dst)
+        assert (dst / "styles" / "variables.json").is_file()
+
+
+class TestInstalledStore:
+    def test_dir_under_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import kiro_crew.dashboard.handlers.agents as agents_mod
+
+        monkeypatch.setattr(agents_mod, "config_dir", lambda: tmp_path)
+        assert _installed_theme_dir("lcars") == tmp_path / "themes" / "lcars"
+
+    def test_install_copy_and_remove_roundtrip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import kiro_crew.dashboard.handlers.agents as agents_mod
+
+        monkeypatch.setattr(agents_mod, "config_dir", lambda: tmp_path)
+        src = _make_theme(tmp_path)
+        summary, err = _validate_theme_dir(src)
+        assert err is None and summary is not None
+
+        dest = _installed_theme_dir(summary["slug"])
+        _copy_installed_theme(src, dest)
+        assert (dest / "theme.json").is_file()
+        assert dest.is_dir()
+
+        # Remove de-registers (matches the DELETE handler's rmtree path).
+        shutil.rmtree(dest)
+        assert not dest.exists()

--- a/website/docs/theming-contract.md
+++ b/website/docs/theming-contract.md
@@ -1,0 +1,62 @@
+# Theming / Customization Contract
+
+The dashboard is fully themable. A **theme** ranges from a color palette
+(Level 0) up to a full experience pack; a color theme is the degenerate case of
+a pack. Themes are a **standalone subsystem built on `useTheme`** — not apps.
+Design of record: *Pluggable Theme Packs* (Pippin architect
+`J5yAarkBafXI` / artifact `2kHOjwOSKy00`).
+
+## The rule for contributors
+
+**Every new UI element MUST be themable at least at the color layer.** Style it
+with the theme CSS custom properties or Tailwind classes mapped to them —
+**never** a hardcoded `#hex` / `rgb(...)` / `rgba(...)` literal.
+
+```tsx
+// ❌ don't
+<div style={{ background: '#16213e', color: '#fff' }} />
+<div className="bg-gray-900 text-white" />
+
+// ✅ do
+<div style={{ background: 'var(--card)', color: 'var(--card-fg)' }} />
+<div className="bg-[var(--card)] text-[var(--card-fg)]" />
+```
+
+The 43 CSS variables are the single source of truth for color. They are the
+customization surface a theme (built-in, custom, or installed) can set.
+
+## Adding a new color role
+
+When you genuinely need a new color role, add the variable to **both** sides in
+parity (a parity test guards drift), then define it in **every** built-in theme:
+
+- Frontend: `ALLOWED_CSS_VARS` in `src/hooks/useTheme.tsx`
+- Backend: `_THEME_CSS_VARS_SET` in `src/kiro_crew/dashboard/handlers/agents.py`
+
+Never introduce a one-off literal instead of a variable.
+
+## What is / isn't customizable
+
+| Tier | Surface |
+|---|---|
+| **L0 Color** | the 43 CSS vars (dark + light) |
+| **L1 Brand** | logo, favicon, wordmark, botName, fonts, scoped `overrides.css` |
+| **L2 Experience** | sandboxed overlays, topbar, audio, persona |
+
+Out of contract: app structure/routing, functional-control behavior, security
+chrome, and anything outside the CSS-var set + the `overrides.css` selector
+allowlist.
+
+## Checker (advisory)
+
+```bash
+npm run lint:theme-colors          # report raw literals in src/ (exit 0)
+node scripts/check-theme-colors.mjs --strict   # exit 1 if any (future ratchet)
+```
+
+The checker excludes the theme-definition files (`useTheme.tsx`,
+`themeEditor.tsx`, `index.css`, `cssSanitize.ts`, `sessionColors.ts`), tests,
+and generated code. It is **advisory** today (the existing tree has legitimate
+literals in themes/icons/palettes) and is **not** wired into the blocking CI
+gate — enabling `--strict` in CI is a follow-up once the baseline is burned
+down.

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "check": "npm run typecheck && npm run lint && npm run test",
     "jscpd": "jscpd .",
     "gen:settings": "node scripts/gen-settings-registry.mjs",
+    "lint:theme-colors": "node scripts/check-theme-colors.mjs",
     "pretest": "npm run jscpd"
   },
   "files": [

--- a/website/scripts/check-theme-colors.mjs
+++ b/website/scripts/check-theme-colors.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Theme customization-contract guardrail (ADVISORY).
+ *
+ * Flags raw color literals (`#rrggbb`, `rgb(...)`, `rgba(...)`) in
+ * `website/src/**` outside the theme-definition files. Per the Customization
+ * Contract, new UI must be themable at the color layer — style with the theme
+ * CSS custom properties (`var(--bg)`, `var(--text)`, `var(--accent)`, …) or
+ * Tailwind classes mapped to them, never a hardcoded literal.
+ *
+ * This is intentionally ADVISORY: the existing codebase (23 built-in themes,
+ * SVG icons, session palettes, test mocks) contains many legitimate literals,
+ * so the checker exits 0 by default and only reports. Pass `--strict` to exit
+ * non-zero (for a future ratchet once the baseline is burned down). It is NOT
+ * wired into the blocking CI gate yet — see docs/theming-contract.md.
+ *
+ * Usage:
+ *   node scripts/check-theme-colors.mjs           # report, exit 0
+ *   node scripts/check-theme-colors.mjs --strict  # report, exit 1 if any found
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+const SRC = join(ROOT, 'src')
+
+// Files where raw color literals are legitimate (theme definitions, sanitizer,
+// palette data, generated code, and tests).
+const EXCLUDE_SUBSTR = [
+  'src/hooks/useTheme.tsx',
+  'src/components/themeEditor.tsx',
+  'src/index.css',
+  'src/lib/cssSanitize.ts',
+  'src/utils/sessionColors.ts',
+]
+const EXCLUDE_RE = [/\.test\.tsx?$/, /\/test\//, /\.gen\.ts$/, /\.d\.ts$/]
+
+const SCAN_EXT = /\.(tsx?|css)$/
+// #rgb / #rrggbb / #rrggbbaa, and rgb()/rgba()
+const COLOR_RE = /#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3}(?:[0-9a-fA-F]{2})?)?\b|\brgba?\s*\(/
+
+function walk(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    const st = statSync(p)
+    if (st.isDirectory()) out.push(...walk(p))
+    else out.push(p)
+  }
+  return out
+}
+
+function excluded(rel) {
+  if (EXCLUDE_SUBSTR.some((s) => rel.includes(s))) return true
+  return EXCLUDE_RE.some((re) => re.test(rel))
+}
+
+const offenders = []
+for (const file of walk(SRC)) {
+  if (!SCAN_EXT.test(file)) continue
+  const rel = relative(ROOT, file)
+  if (excluded(rel)) continue
+  const lines = readFileSync(file, 'utf8').split('\n')
+  const hits = []
+  lines.forEach((line, i) => {
+    if (COLOR_RE.test(line)) hits.push(i + 1)
+  })
+  if (hits.length) offenders.push({ rel, count: hits.length, lines: hits })
+}
+
+const total = offenders.reduce((n, o) => n + o.count, 0)
+const strict = process.argv.includes('--strict')
+
+if (total === 0) {
+  console.log('✅ theme-colors: no raw color literals found in scanned files.')
+  process.exit(0)
+}
+
+offenders.sort((a, b) => b.count - a.count)
+console.log(
+  `theme-colors: ${total} raw color literal(s) across ${offenders.length} file(s) ` +
+    `(advisory — see docs/theming-contract.md).`
+)
+for (const o of offenders.slice(0, 20)) {
+  console.log(`  ${o.rel}: ${o.count}  [lines: ${o.lines.slice(0, 10).join(', ')}${o.lines.length > 10 ? ', …' : ''}]`)
+}
+if (offenders.length > 20) console.log(`  … and ${offenders.length - 20} more file(s)`)
+console.log(
+  '\nNew UI should use theme CSS vars (var(--bg)/--text/--accent, …), not literals. ' +
+    'A new color role goes into BOTH ALLOWED_CSS_VARS (useTheme.tsx) and ' +
+    '_THEME_CSS_VARS_SET (backend) in parity.'
+)
+
+process.exit(strict ? 1 : 0)

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -722,6 +722,8 @@ export const api = {
   dashboardConfig: () => fetch('/api/dashboard/config').then(j),
   updateDashboardConfig: (body: object) => put('/api/dashboard/config', body).then(j),
   createTheme: (body: object) => post('/api/themes', body).then(j),
+  installTheme: (source: { type: 'local'; path: string } | { type: 'github'; url: string }) =>
+    post('/api/themes/install', { source }).then(j),
   updateTheme: (slug: string, body: object) => put('/api/themes/' + encodeURIComponent(slug), body).then(j),
   deleteTheme: (slug: string) => del('/api/themes/' + encodeURIComponent(slug)).then(j),
   themeDetail: (slug: string) => fetch('/api/themes/' + encodeURIComponent(slug)).then(j),

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -19,6 +19,8 @@ export interface ThemeEntry {
   value: string
   label: string
   custom?: boolean
+  /** True for themes installed from a folder/GitHub (read-only), vs editor-created customs. */
+  installed?: boolean
 }
 
 export interface CustomThemeData {
@@ -223,11 +225,14 @@ function useThemeState(): ThemeContextValue {
   const loadCustomThemes = useCallback(async () => {
     try {
       const res = await api.themes()
-      const themes: ThemeEntry[] = (res.themes || []).map((t: { slug: string; name: string; emoji: string }) => ({
-        value: `custom-${t.slug}`,
-        label: `${t.emoji} ${t.name}`,
-        custom: true,
-      }))
+      const themes: ThemeEntry[] = (res.themes || []).map(
+        (t: { slug: string; name: string; emoji: string; source?: string }) => ({
+          value: `custom-${t.slug}`,
+          label: `${t.emoji} ${t.name}`,
+          custom: true,
+          installed: t.source === 'installed',
+        })
+      )
       setCustomThemes(themes)
 
       // Fetch all theme details in parallel to avoid serial waterfall

--- a/website/src/pages/settings/DisplayPanel.tsx
+++ b/website/src/pages/settings/DisplayPanel.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react'
+import { useState } from 'react'
 import { useZoomCtx } from '../../hooks/ZoomProvider'
 import { useTheme } from '../../hooks/useTheme'
 import type { ColorTheme } from '../../hooks/useTheme'
@@ -17,7 +18,7 @@ import { clampTintCount, RECENT_TINT_COUNT } from '../../utils/recencyTint'
 
 export function DisplayPanel() {
   const { zoom, zoomIn, zoomOut, reset, fontScale, fontScaleUp, fontScaleDown, fontScaleReset, family, setFontFamily } = useZoomCtx()
-  const { preference, setTheme, colorTheme, setColorTheme, allThemes } = useTheme()
+  const { preference, setTheme, colorTheme, setColorTheme, allThemes, loadCustomThemes } = useTheme()
   const { uiMode, setUIMode } = useUIMode()
   const editor = useThemeEditor()
 
@@ -49,6 +50,37 @@ export function DisplayPanel() {
   })
   const setTintCount = (n: number) => tintMut.mutate(clampTintCount(n))
 
+  // ── Install theme (Level 0) from a local folder or a GitHub repo ──
+  const [installType, setInstallType] = useState<'github' | 'local'>('github')
+  const [installValue, setInstallValue] = useState('')
+  const [installBusy, setInstallBusy] = useState(false)
+  const [installError, setInstallError] = useState<string | null>(null)
+
+  const handleInstall = async () => {
+    const v = installValue.trim()
+    if (!v || installBusy) return
+    setInstallBusy(true)
+    setInstallError(null)
+    try {
+      const source =
+        installType === 'github'
+          ? ({ type: 'github', url: v } as const)
+          : ({ type: 'local', path: v } as const)
+      const res = await api.installTheme(source)
+      if (!res?.ok) {
+        setInstallError(res?.error || 'Install failed')
+        return
+      }
+      await loadCustomThemes()
+      if (res.slug) setColorTheme(`custom-${res.slug}` as ColorTheme)
+      setInstallValue('')
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : 'Install failed')
+    } finally {
+      setInstallBusy(false)
+    }
+  }
+
   return (
     <>
       <SettingsSection title="View">
@@ -72,9 +104,9 @@ export function DisplayPanel() {
         </SettingsCard>
       </SettingsSection>
 
-      <SettingsSection title="Color Theme">
+      <SettingsSection title="Theme">
         <SettingsCard>
-          <SettingsSelect label="Color Theme" description="Select a color palette for the dashboard" value={colorTheme}
+          <SettingsSelect label="Theme" description="Select a theme for the dashboard" value={colorTheme}
             options={allThemes.map(t => t.value)} optionLabels={allThemes.map(t => t.label)}
             onChange={v => setColorTheme(v as ColorTheme)} />
           <SettingsButtonGroup label="Mode" description="Light or dark appearance for the dashboard" value={preference}
@@ -87,12 +119,14 @@ export function DisplayPanel() {
 
           {allThemes.filter(t => t.custom).length > 0 && (
             <div className="flex flex-col gap-1.5 pt-2">
-              <span className="text-[12px] text-muted font-medium uppercase tracking-[.04em]">Custom Themes</span>
+              <span className="text-[12px] text-muted font-medium uppercase tracking-[.04em]">Custom & Installed Themes</span>
               {allThemes.filter(t => t.custom).map(t => (
                 <div key={t.value} className="flex items-center justify-between px-3 py-2 rounded-md bg-bg-elevated border border-border">
                   <span className="text-[13px] text-text font-medium">{t.label}</span>
                   <div className="flex items-center gap-2">
-                    <button className="text-[13px] text-muted hover:text-text cursor-pointer bg-transparent border-none transition-colors" onClick={() => editor.openEditTheme(t.value.replace('custom-', ''))}>Edit</button>
+                    {!t.installed && (
+                      <button className="text-[13px] text-muted hover:text-text cursor-pointer bg-transparent border-none transition-colors" onClick={() => editor.openEditTheme(t.value.replace('custom-', ''))}>Edit</button>
+                    )}
                     <button className="text-[13px] text-muted hover:text-danger cursor-pointer bg-transparent border-none transition-colors" onClick={() => editor.handleDelete(t.value.replace('custom-', ''))}>Delete</button>
                   </div>
                 </div>
@@ -101,6 +135,28 @@ export function DisplayPanel() {
           )}
           <div className="pt-1">
             <button className="px-2.5 py-1 rounded-md text-[13px] font-medium border border-dashed border-border-strong text-muted hover:text-accent hover:border-accent cursor-pointer transition-all bg-transparent" onClick={editor.openNewTheme}>+ New Theme</button>
+          </div>
+
+          <div className="flex flex-col gap-1.5 pt-2">
+            <span className="text-[12px] text-muted font-medium uppercase tracking-[.04em]">Install Theme</span>
+            <div className="flex items-center gap-2">
+              <select aria-label="Theme source" value={installType}
+                onChange={e => setInstallType(e.target.value as 'github' | 'local')}
+                className="text-[13px] px-2 py-1.5 rounded-md bg-bg border border-border text-text cursor-pointer">
+                <option value="github">GitHub</option>
+                <option value="local">Local folder</option>
+              </select>
+              <input aria-label="Theme source location" value={installValue}
+                onChange={e => setInstallValue(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') handleInstall() }}
+                placeholder={installType === 'github' ? 'https://github.com/user/theme' : '/path/to/theme'}
+                className="flex-1 min-w-0 text-[13px] px-2.5 py-1.5 rounded-md bg-bg border border-border text-text" />
+              <button onClick={handleInstall} disabled={installBusy || !installValue.trim()}
+                className="text-[13px] px-3 py-1.5 rounded-md border border-border-strong text-muted hover:text-accent hover:border-accent cursor-pointer transition-all bg-transparent disabled:opacity-50 disabled:cursor-not-allowed">
+                {installBusy ? 'Installing…' : 'Install'}
+              </button>
+            </div>
+            {installError && <span className="text-[12px] text-danger">{installError}</span>}
           </div>
         </SettingsCard>
       </SettingsSection>

--- a/website/src/test/DisplayPanel.test.tsx
+++ b/website/src/test/DisplayPanel.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DisplayPanel } from '../pages/settings/DisplayPanel'
 import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
 
 // Mock useZoomCtx — DisplayPanel uses it for zoom/font controls
 vi.mock('../hooks/ZoomProvider', () => ({
@@ -154,5 +155,41 @@ describe('DisplayPanel – ThemeEditorPanel overlay', () => {
     // Sidebar Colors section should still be visible and interactive
     expect(screen.getByText('Sidebar Colors')).toBeInTheDocument()
     expect(screen.getByText('Palette')).toBeInTheDocument()
+  })
+})
+
+
+describe('DisplayPanel – theme install', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the renamed "Theme" section with an Install control', () => {
+    renderWithProviders(<DisplayPanel />)
+    expect(screen.getByText('Install Theme')).toBeInTheDocument()
+    expect(screen.getByLabelText('Theme source')).toBeInTheDocument()
+    expect(screen.getByLabelText('Theme source location')).toBeInTheDocument()
+  })
+
+  it('installs a theme from a GitHub URL via api.installTheme', async () => {
+    const user = userEvent.setup()
+    const spy = vi
+      .spyOn(api, 'installTheme')
+      .mockResolvedValue({ ok: true, slug: 'lcars' })
+    renderWithProviders(<DisplayPanel />)
+
+    await user.type(
+      screen.getByLabelText('Theme source location'),
+      'https://github.com/u/lcars'
+    )
+    await user.click(screen.getByText('Install'))
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        type: 'github',
+        url: 'https://github.com/u/lcars',
+      })
+    })
+    spy.mockRestore()
   })
 })


### PR DESCRIPTION
## Problem
There is no way to share or install a dashboard color theme. Users can only pick built-in themes or hand-build one in the editor — a palette can't be distributed (e.g. from a GitHub repo) and dropped into another install.

## Why it matters
Themes are the most-requested personalization surface. A shareable, installable color theme (the Level-0 case of the "Pluggable Theme Packs" design) lets users publish palettes and adopt others' with one action, without any new install mechanism or security surface beyond the existing, vetted color pipeline.

## Fix (symptom → root cause → change)
Symptom: no install/select path for external themes. Root cause: the theme system only knew about compiled built-ins and editor-created `<slug>.json` records. Change: add a **standalone theme-install subsystem** (not a MeshClaw app) that stores installed themes as **directories** under `config_dir()/themes/<slug>/`, coexisting with the flat `<slug>.json` custom records, and surfaces them through the *same* `/api/themes` list + detail endpoints so the existing `useTheme` → `injectCustomThemeCSS` path lists/applies them unchanged.

- **Backend** (`agents.py`, `server.py`, `handlers/__init__.py`): `_validate_theme_dir` (structure + data: filename allowlist, per-file/total size caps, entry cap, symlink rejection, path containment, **level-bounds-payload** so a theme declaring `level:0` but shipping overlays/topbar/audio/persona/branding/fonts/overrides.css is rejected; reuses `_validate_theme_data`). `POST /api/themes/install` — local (move/copy) or GitHub (**https-only + host allowlist**, `git clone --depth 1 --` via argv/no-shell, 30s timeout) → validate → copy only recognized files → move into store; **409** on slug collision across both stores. `GET /api/themes` lists installed dirs; `GET/DELETE /api/themes/{slug}` serve/remove installed dirs; `PUT` rejects installed themes as read-only. Route registered before `/api/themes/{slug}` so `install` isn't captured as a slug.
- **Frontend** (`useTheme.tsx`, `DisplayPanel.tsx`, `api/client.ts`): rename the "Color Theme" section → **"Theme"**; installed themes flow through the existing list with their own emoji+name (`ThemeEntry.installed` flag); an **Install form** (source select + location input, Enter/click submits) calls `api.installTheme`; **Edit hidden** for read-only installed themes (Delete reuses the existing endpoint).
- **Guardrail**: advisory `lint:theme-colors` checker + `docs/theming-contract.md` (the color-themability contract). All new UI uses theme CSS vars — no hardcoded hex.

Scope is **Level 0 (color)** only; **L1 (branding/fonts) and L2 (overlays/audio/persona) are deferred** per the design.

## Tests
- `test/test_theme_install.py` — 18 tests over the pure helpers: `_validate_theme_dir` happy paths (top-level + `styles/`) and every rejection branch (missing/invalid manifest, `level != 0`, L0-declares-but-ships-L2 for overlays and persona, stray file, symlink, oversize, bad CSS), VCS/meta tolerance; `_safe_theme_slug` traversal guard; `_clone_github` URL guard (no network); `_copy_installed_theme` staging; and an install-copy→remove round-trip.
- `website/src/test/DisplayPanel.test.tsx` — 2 new tests: renders the "Install Theme" control; typing a GitHub URL + Install calls `api.installTheme({type:'github', url})`. (5/5 pass locally.)

## Manual verification
Local gates green: **flake8** (backend, `--jobs=1`), **eslint** + **tsc -b** (frontend), **vitest** `DisplayPanel.test.tsx` 5/5. Backend `pytest` was not runnable locally (sandbox `python3` is 3.9, below the repo's 3.10+ floor) → relies on CI's 3.10/3.12 matrix. `vite build` relies on CI (sandbox EMFILE).

Design of record: https://pippin.amazon.dev/architect/J5yAarkBafXI/pluggable-theme-packs?artifact=2kHOjwOSKy00
