### PR TITLE
feat: refine dashboard header and panel transitions

### DIFF
--- a/website/integration/ChatSidebar.integration.test.tsx
+++ b/website/integration/ChatSidebar.integration.test.tsx
@@ -89,6 +89,13 @@ describe('ChatSidebar Folder Grouping', () => {
     expect(screen.queryByText('UNGROUPED')).not.toBeInTheDocument()
   })
 
+  it('shortens the primary create action label to New', () => {
+    renderWithProviders(<ChatSidebar {...defaultProps} />)
+    const createButton = screen.getByRole('button', { name: 'New chat session' })
+    expect(createButton).toHaveTextContent('New')
+    expect(createButton).not.toHaveTextContent('New chat')
+  })
+
   it('shows new folder action in the create menu', async () => {
     const user = userEvent.setup()
     renderWithProviders(<ChatSidebar {...defaultProps} />)

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -129,6 +129,14 @@ export function metricColor(pct: number): string {
 }
 export const memColorClass = metricColor
 
+const TOPBAR_SEARCH_GAP = 12
+const TOPBAR_SEARCH_MIN_WIDTH = 240
+
+export function calculateTopbarSearchLayout(brandWidth: number, actionsWidth: number, viewportWidth: number) {
+  const gutter = Math.ceil(Math.max(brandWidth, actionsWidth)) + TOPBAR_SEARCH_GAP
+  return { gutter, visible: viewportWidth - (gutter * 2) >= TOPBAR_SEARCH_MIN_WIDTH }
+}
+
 // Icon mapping for builtin apps (manifest icon name → React element)
 const BUILTIN_ICONS: Record<string, React.ReactElement> = {
   Users: <Users size={16} />,
@@ -761,6 +769,9 @@ export default function App() {
   useRumPageView()
   useNotificationSound()
   const [navCollapsed, setNavCollapsed] = useState(() => localStorage.getItem('mc-nav') === '1')
+  const [navLayoutPulse, setNavLayoutPulse] = useState(false)
+  const navLayoutPulseTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  useEffect(() => () => { if (navLayoutPulseTimer.current) clearTimeout(navLayoutPulseTimer.current) }, [])
   const isMobile = useIsMobile()
   // Multi-instance: which instance fills the pane below the tab bar. null = Local
   // (the native dashboard); a non-null id means a remote instance's embedded
@@ -1247,13 +1258,43 @@ export default function App() {
 
   const toggleNav = () => {
     if (isMobile) { setMobileNavOpen(p => !p) }
-    else { setNavCollapsed(prev => { const next = !prev; safeSetItem('mc-nav', next ? '1' : '0'); return next }) }
+    else {
+      if (navLayoutPulseTimer.current) clearTimeout(navLayoutPulseTimer.current)
+      setNavLayoutPulse(true)
+      navLayoutPulseTimer.current = setTimeout(() => setNavLayoutPulse(false), 180)
+      setNavCollapsed(prev => { const next = !prev; safeSetItem('mc-nav', next ? '1' : '0'); return next })
+    }
   }
   // Close mobile nav on route change
   useEffect(() => { if (isMobile) setMobileNavOpen(false) }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
   // Reset mobile nav state when leaving mobile viewport
   useEffect(() => { if (!isMobile) setMobileNavOpen(false) }, [isMobile])
   const effectiveCollapsed = navCollapsed && !isMobile
+  const topbarBrandRef = useRef<HTMLDivElement>(null)
+  const topbarActionsRef = useRef<HTMLDivElement>(null)
+  const [topbarSearchLayout, setTopbarSearchLayout] = useState({ gutter: 360, visible: true })
+  useEffect(() => {
+    if (isMobile) return
+    const brand = topbarBrandRef.current
+    const actions = topbarActionsRef.current
+    if (!brand || !actions) return
+    const update = () => {
+      const brandWidth = brand.getBoundingClientRect().width
+      const actionsWidth = actions.getBoundingClientRect().width
+      if (brandWidth <= 0 || actionsWidth <= 0) return
+      const next = calculateTopbarSearchLayout(brandWidth, actionsWidth, window.innerWidth)
+      setTopbarSearchLayout(current => current.gutter === next.gutter && current.visible === next.visible ? current : next)
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(brand)
+    observer.observe(actions)
+    window.addEventListener('resize', update)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [isMobile])
   const closeMobileNav = isMobile ? () => setMobileNavOpen(false) : undefined
   const activePath = location.pathname
   const isChat = activePath === '/chat' || activePath.startsWith('/chat/') || activePath === '/'
@@ -1295,8 +1336,19 @@ export default function App() {
       {/* Local pane: the native dashboard. Hidden (not unmounted) while a remote
           instance tab is active, so local state/websocket survive the switch. */}
       <div className="absolute inset-0" style={{ display: activeInstanceId === null ? 'block' : 'none' }}>
-    <div className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[52px_minmax(0,1fr)]' : 'grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[52px_minmax(0,1fr)]'}`}
-      style={{ gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar actbar" "nav content actbar"' }}>
+    <div
+      data-testid="dashboard-shell"
+      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[52px_minmax(0,1fr)]' : 'grid-rows-[52px_minmax(0,1fr)]'}`}
+      style={{
+        gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar actbar" "nav content actbar"',
+        ...(!isMobile && {
+          gridTemplateColumns: `${effectiveCollapsed ? 74 : 236}px minmax(0,1fr) auto`,
+          transition: navLayoutPulse && !activityOpen
+            ? 'grid-template-columns 150ms cubic-bezier(0.2, 0, 0, 1)'
+            : 'none',
+        }),
+      }}
+    >
 
       {/* Full-height activity bar slot: ChatPage portals its
           Activity panel here on desktop so it spans the window top-to-bottom
@@ -1308,21 +1360,48 @@ export default function App() {
       <a href="#main-content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent focus:text-accent-fg focus:text-sm focus:font-medium">Skip to content</a>
 
       {/* Topbar */}
-      <header className={`topbar-glass flex justify-between items-center ${isMobile ? 'pl-2 pr-2' : 'pl-5 pr-3'} z-[45]`} style={{ gridArea: 'topbar' }}>
-        <div className="flex items-center gap-3">
+      <header className="topbar-glass relative flex items-center pr-3 z-[45]" style={{ gridArea: 'topbar' }}>
+        {/* Brand + collapse, aligned to the nav card's outer width. */}
+        <div
+          ref={topbarBrandRef}
+          className={`relative flex items-center h-full shrink-0 ${isMobile ? 'px-2 gap-3' : `${effectiveCollapsed ? 'justify-start px-0 gap-2' : 'px-5 gap-2'}`}`}
+          style={isMobile ? undefined : effectiveCollapsed ? { minWidth: 74 } : { minWidth: 236 }}
+        >
           {isMobile && (
-            <button className="p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text" onClick={toggleNav} aria-label="Open menu">
+            <button className="p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text shrink-0" onClick={toggleNav} aria-label="Open menu">
               <Menu size={20} />
             </button>
           )}
-          {/* w-auto (not the old fixed w-40): the hairline + Request a Feature
-              ghost should hug the wordmark, not float 160px out. */}
-          <div className="flex items-center gap-2.5 opacity-100 w-auto transition-all duration-300 ease-in-out">
-            <img src={avatar} alt={botName} className={`${isLumon ? 'w-auto h-6' : 'w-7 h-7'} rounded-sm shrink-0 hover:rotate-[-8deg] hover:scale-110 transition-transform duration-300 object-contain`} style={{ filter: 'drop-shadow(0 2px 8px var(--accent-glow))' }} />
-            <span className="text-sm font-bold tracking-[.08em] text-text-strong whitespace-nowrap">{botName.toUpperCase()}</span>
-          </div>
-          {/* Hairline + borderless Request a Feature ghost (Lightbulb) --
-              lives beside the wordmark per the pooled-top-bar design. */}
+          {!isMobile && effectiveCollapsed ? (
+            <button
+              type="button"
+              className="group flex items-center justify-center w-[74px] h-full cursor-pointer bg-transparent border-none p-0 shrink-0"
+              onClick={toggleNav}
+              title="Expand sidebar"
+              aria-label="Expand sidebar"
+            >
+              <img src={avatar} alt={botName} className={`${isLumon ? 'w-auto h-7' : 'w-9 h-9'} rounded-sm shrink-0 group-hover:scale-110 transition-transform duration-300 object-contain`} style={{ filter: 'drop-shadow(0 2px 8px var(--accent-glow))' }} />
+              <span className="sr-only">{botName}</span>
+            </button>
+          ) : (
+            <>
+              <div className="flex items-center gap-2.5 min-w-0 opacity-100">
+                <img src={avatar} alt={botName} className={`${isLumon ? 'w-auto h-7' : 'w-9 h-9'} rounded-sm shrink-0 hover:rotate-[-8deg] hover:scale-110 transition-transform duration-300 object-contain`} style={{ filter: 'drop-shadow(0 2px 8px var(--accent-glow))' }} />
+                <span className="text-sm font-bold tracking-[.08em] text-text-strong whitespace-nowrap">{botName}</span>
+              </div>
+              {!isMobile && (
+                <button
+                  className="p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover transition-colors shrink-0"
+                  onClick={toggleNav}
+                  title="Collapse sidebar"
+                  aria-label="Collapse sidebar"
+                >
+                  <Menu size={16} />
+                </button>
+              )}
+            </>
+          )}
+          {/* Keep Request a Feature visible beside the brand in both desktop sidebar states. */}
           {!isMobile && <>
             <span className="w-px h-4 bg-border shrink-0" aria-hidden="true" />
             <button
@@ -1333,7 +1412,20 @@ export default function App() {
             </button>
           </>}
         </div>
-        <div className="flex items-center gap-1.5 relative">
+        {!isMobile && topbarSearchLayout.visible && (
+          <button
+            type="button"
+            data-topbar-overlay
+            onClick={commandPalette.openPalette}
+            className="absolute w-auto max-w-[34rem] h-9 px-4 rounded-lg border border-border bg-card text-muted hover:text-text hover:border-border-hover transition-colors flex items-center justify-center gap-2 cursor-pointer shadow-none"
+            style={{ left: topbarSearchLayout.gutter, right: topbarSearchLayout.gutter, marginInline: 'auto' }}
+            aria-label="Search sessions, files, and commands"
+            title="Search everywhere (⌘K)"
+          >
+            <span className="text-[13px]">⌘K — Search for anything…</span>
+          </button>
+        )}
+        <div ref={topbarActionsRef} className="flex items-center gap-1.5 relative ml-auto">
           {/* Unified readout capsule — connection dot . system metrics .
               kiro-credits usage pooled into one bordered pill. Offline: the
               whole capsule tints danger (red border + subtle red bg + red
@@ -1542,11 +1634,11 @@ export default function App() {
       {(!isMobile || mobileNavOpen) && (
       <motion.nav
         initial={isMobile ? { x: -240 } : false}
-        animate={{ width: isMobile ? 220 : effectiveCollapsed ? 58 : 220, x: 0 }}
+        animate={isMobile ? { width: 220, x: 0 } : { x: 0 }}
         exit={{ x: -240 }}
-        transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+        transition={isMobile ? { duration: 0.25, ease: [0.32, 0.72, 0, 1] } : undefined}
         className={`bg-bg-elevated border border-border rounded-xl flex flex-col m-2 shadow-sm z-50 overflow-hidden ${isMobile ? 'fixed top-0 left-0 bottom-0' : ''}`}
-        style={isMobile ? undefined : { gridArea: 'nav' }}
+        style={isMobile ? undefined : { gridArea: 'nav', width: 'auto' }}
         role="navigation"
         aria-label="Main navigation"
       >
@@ -1557,13 +1649,7 @@ export default function App() {
          *  bounce when scrolling past the ends. scrollbar-none + scrollbarWidth
          *  hide the scrollbar here (where scrolling actually happens) across
          *  Firefox, modern WebKit, and older Safari (<16). */}
-        <div className="flex flex-col h-full px-2 pb-4 overflow-y-auto overflow-x-hidden overscroll-y-none scrollbar-none" style={{ scrollbarWidth: 'none' }}>
-        {!isMobile && (
-        <button className="flex items-center w-full mt-2 py-2.5 pl-3 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover transition-colors mb-1 shrink-0" onClick={toggleNav} title={effectiveCollapsed ? 'Expand sidebar' : 'Collapse sidebar'} aria-label={effectiveCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}>
-          <Menu size={16} />
-        </button>
-        )}
-
+        <div className="flex flex-col h-full px-2 pt-2 pb-4 overflow-y-auto overflow-x-hidden overscroll-y-none scrollbar-none" style={{ scrollbarWidth: 'none' }}>
         {(['Main', 'Platform', 'Apps'] as const).map(group => (
           <motion.div
             className="grid gap-0.5"
@@ -1572,7 +1658,7 @@ export default function App() {
             transition={{ duration: 0.2 }}
           >
             <AnimatePresence initial={false}>
-              {!effectiveCollapsed && (
+              {!effectiveCollapsed && group !== 'Main' && (
                 <motion.div
                   key={`header-${group}`}
                   initial={{ opacity: 0, height: 0 }}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1233,7 +1233,6 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
   backdrop-filter:blur(18px) saturate(1.8);
   -webkit-backdrop-filter:blur(18px) saturate(1.8);
   box-shadow: inset 0 1px 0 rgba(255,255,255,.10);
-  border-bottom:1px solid var(--border);
   transition:background-color .25s ease}
 
 /* ── Frameless Electron window (macOS) ──

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3568,11 +3568,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
           {activityOpen && !search.isOpen && (
             <motion.div
               key="side-panel"
-              initial={{ width: 0 }}
-              animate={{ width: 'auto' }}
-              exit={{ width: 0 }}
-              transition={{ duration: 0.4, ease: [0.32, 0.72, 0, 1] }}
-              className="h-full overflow-hidden flex justify-end"
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 'auto', opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={{ duration: 0.18, ease: [0.2, 0, 0, 1] }}
+              className="h-full overflow-visible flex justify-end"
             >
               <SidePanel
                 tabsCtl={tabsCtl}

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2002,7 +2002,7 @@ function ChatSidebar({
               disabled={creatingSlot}
               className={`flex items-center h-7 cursor-pointer bg-transparent border-none text-accent-fg hover:bg-accent-hover active:scale-95 transition-all disabled:opacity-70 disabled:cursor-wait disabled:active:scale-100 ${compactHeader ? 'justify-center w-7' : 'gap-1.5 pl-2 pr-2.5 text-[12px] font-semibold'}`}
               onClick={() => { createChatMutation.mutate() }}
-              title="New chat" aria-label="New chat session" aria-busy={creatingSlot}>{creatingSlot ? <Loader2 size={15} className="animate-spin" /> : <Plus size={15} />}{!compactHeader && <span className="whitespace-nowrap">{creatingSlot ? 'Creating…' : 'New chat'}</span>}</button>
+              title="New chat" aria-label="New chat session" aria-busy={creatingSlot}>{creatingSlot ? <Loader2 size={15} className="animate-spin" /> : <Plus size={15} />}{!compactHeader && <span className="whitespace-nowrap">{creatingSlot ? 'Creating…' : 'New'}</span>}</button>
             <span className="w-px h-4 bg-accent-fg opacity-30" aria-hidden="true" />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -86,7 +86,9 @@ export const SIDE_PANEL_RESERVED_W = 560
 export function measureSidePanelReservedW(): number {
   const header = document.querySelector('header.topbar-glass')
   if (!header) return SIDE_PANEL_RESERVED_W
-  const clusters = Array.from(header.children).filter(c => c.tagName !== 'A') as HTMLElement[]
+  const clusters = Array.from(header.children).filter(
+    c => c.tagName !== 'A' && !c.hasAttribute('data-topbar-overlay'),
+  ) as HTMLElement[]
   const content = clusters.reduce((sum, c) => sum + c.getBoundingClientRect().width, 0)
   const cs = getComputedStyle(header as HTMLElement)
   const pad = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0)
@@ -171,7 +173,9 @@ export default function SidePanel({
     // the panel's own width, so this can't feed back into itself).
     const header = document.querySelector('header.topbar-glass')
     const ro = new ResizeObserver(recalc)
-    if (header) Array.from(header.children).forEach(c => ro.observe(c))
+    if (header) Array.from(header.children)
+      .filter(c => !c.hasAttribute('data-topbar-overlay'))
+      .forEach(c => ro.observe(c))
     return () => { window.removeEventListener('resize', recalc); ro.disconnect() }
   }, [])
   const effectiveWidth = isMobile ? '100%' : Math.max(MIN_W, Math.min(width, maxW))

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, act, fireEvent, waitFor, within } from '@testing-library/react'
 import { renderWithProviders, createTestStore } from './helpers'
-import App from '../App'
+import App, { calculateTopbarSearchLayout } from '../App'
 import { sseConnected, sseDisconnected } from '../store/dashboardSlice'
 import SegmentedControl from '../components/SegmentedControl'
+import { safeSetItem } from '../utils/safeStorage'
 
 // Mock all page components to isolate routing
 vi.mock('../pages/ChatPage', () => ({ default: () => <div data-testid="chat-page">ChatPage</div> }))
@@ -318,9 +319,76 @@ describe('App routing', () => {
     fireEvent.keyDown(rows[0], { key: 'Enter' })
   })
 
-  it('renders KIRO CREW branding', () => {
+  it('renders Kiro Crew branding', () => {
     renderWithProviders(<App />, { route: '/chat' })
-    expect(screen.getAllByText('KIRO CREW').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Kiro Crew').length).toBeGreaterThan(0)
+  })
+
+  it('opens Search Everywhere from the theme-aware shadowless header trigger', () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    const trigger = screen.getByRole('button', { name: 'Search sessions, files, and commands' })
+    expect(trigger).toHaveClass('rounded-lg', 'border-border', 'bg-card', 'shadow-none')
+    expect(trigger).not.toHaveClass('rounded-full')
+    fireEvent.click(trigger)
+    expect(screen.getByRole('dialog', { name: 'Search everywhere' })).toBeInTheDocument()
+  })
+
+  it('reserves the larger topbar cluster before showing the centered search', () => {
+    expect(calculateTopbarSearchLayout(330, 180, 1200)).toEqual({ gutter: 342, visible: true })
+    expect(calculateTopbarSearchLayout(180, 505, 1570)).toEqual({ gutter: 517, visible: true })
+    expect(calculateTopbarSearchLayout(330, 180, 900)).toEqual({ gutter: 342, visible: false })
+  })
+
+  it('resizes the sidebar and main body together with a quick shell transition', () => {
+    localStorage.removeItem('mc-nav')
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const shell = screen.getByTestId('dashboard-shell')
+    expect(shell).toHaveStyle({
+      gridTemplateColumns: '236px minmax(0,1fr) auto',
+      transition: 'none',
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+    expect(shell).toHaveStyle({
+      gridTemplateColumns: '74px minmax(0,1fr) auto',
+      transition: 'grid-template-columns 150ms cubic-bezier(0.2, 0, 0, 1)',
+    })
+    localStorage.removeItem('mc-nav')
+  })
+
+  it('keeps the collapse control beside the brand and hides the Main group heading', () => {
+    localStorage.removeItem('mc-nav')
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const brand = screen.getByText('Kiro Crew')
+    const logo = screen.getByAltText('Kiro Crew')
+    const collapse = screen.getByRole('button', { name: 'Collapse sidebar' })
+    expect(brand.parentElement?.parentElement).toContainElement(collapse)
+    expect(logo).toHaveClass('w-9', 'h-9')
+
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' })
+    expect(within(nav).queryByText('Main')).not.toBeInTheDocument()
+
+    fireEvent.click(collapse)
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+    expect(localStorage.getItem('mc-nav')).toBe('1')
+    localStorage.removeItem('mc-nav')
+  })
+
+  it('keeps Request a Feature visible beside the collapsed brand icon', () => {
+    safeSetItem('mc-nav', '1')
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const expand = screen.getByRole('button', { name: 'Expand sidebar' })
+    const requestFeature = screen.getByRole('button', { name: 'Request a Feature' })
+    expect(expand.parentElement).toContainElement(requestFeature)
+
+    fireEvent.click(expand)
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Request a Feature' })).toBeInTheDocument()
+    expect(localStorage.getItem('mc-nav')).toBe('0')
+    localStorage.removeItem('mc-nav')
   })
 
   it('renders connection status', () => {

--- a/website/src/test/ChatPage.responsivePanel.test.tsx
+++ b/website/src/test/ChatPage.responsivePanel.test.tsx
@@ -201,6 +201,8 @@ describe('ChatPage — activity slot self-healing', () => {
     await waitFor(() => {
       const panel = screen.getByTestId('side-panel')
       expect(slot.contains(panel)).toBe(true)
+      expect(panel.parentElement).toHaveClass('overflow-visible')
+      expect(panel.parentElement).not.toHaveClass('overflow-hidden')
     })
   })
 })

--- a/website/src/test/sidePanelReserve.test.ts
+++ b/website/src/test/sidePanelReserve.test.ts
@@ -51,6 +51,16 @@ describe('measureSidePanelReservedW', () => {
     expect(measureSidePanelReservedW()).toBe(756)
   })
 
+  it('excludes absolute topbar overlays so panel width does not feed back through search width', () => {
+    const header = mountHeader([300, 400])
+    const search = document.createElement('button')
+    search.setAttribute('data-topbar-overlay', '')
+    search.getBoundingClientRect = () => ({ width: 500, height: 36, top: 0, left: 0, right: 500, bottom: 36, x: 0, y: 0, toJSON: () => ({}) } as DOMRect)
+    header.appendChild(search)
+    // The absolute search does not consume flow space and must not inflate the reserve.
+    expect(measureSidePanelReservedW()).toBe(756)
+  })
+
   it('rounds up (Math.ceil) fractional cluster widths', () => {
     mountHeader([300.4, 400.3]) // 700.7+32+24 = 756.7 -> 757
     expect(measureSidePanelReservedW()).toBe(757)


### PR DESCRIPTION
## Problem
The dashboard header lacked a centered command-search entry point, while sidebar controls and labels consumed space inefficiently. Sidebar resizing and the right-side panel also revealed content in multiple phases, which made the interface feel slow and unstable.

## Why it matters
Search and navigation are primary dashboard actions. Overlapping header controls, sluggish body resizing, and a two-stage panel reveal make routine navigation harder to understand and reduce the perceived responsiveness of the product.

## Fix
The header now places a responsive, theme-aware Search Everywhere trigger between measured left and right control clusters. It keeps Request a Feature visible in both sidebar states, moves collapse and expansion into the brand area, preserves configured brand casing, enlarges the logo, removes the header divider and search shadow, hides the redundant Main heading, and shortens the create action to New.

The desktop shell now animates one explicit grid track only during sidebar toggles, so the sidebar and body move together. The right panel fades and expands as one unit. Its width reservation excludes the absolutely positioned search overlay, preventing the measurement feedback loop that caused a second expansion phase.

## Tests
- Added App coverage for responsive search spacing, theme styling, brand casing, logo size, sidebar controls, Request a Feature visibility, hidden Main heading, and coordinated shell transition.
- Added ChatSidebar coverage for the New label.
- Added side-panel coverage for an unclipped portal and exclusion of header overlays from width reservation.
- Complete website suite: 337 files passed, 3,776 tests passed, 3 skipped.
- Electron suite: 170 tests passed.
- Production build passed.
- Changed source files have zero ESLint errors.

## Manual verification
Visually verified in an isolated gateway in light and dark modes. Confirmed header spacing in expanded and collapsed states, sidebar body motion, and a single-phase right-panel reveal.


https://github.com/user-attachments/assets/2f0cc6b4-1fb0-4044-abbb-5ad9c7c46108

