### PR TITLE
fix(signing): dynamic Electron entries, layout tripwire, seconds-stamped nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Compute version
         id: stamp
         run: |
-          DATE=$(date -u +%Y%m%d)
           # Wheel stamp includes HHMM so re-running a nightly on the same UTC date can
           # never republish an existing version key with different bytes. CloudFront
           # caches cli/* as immutable (CACHING_OPTIMIZED); a republished key leaves
@@ -46,14 +45,19 @@ jobs:
           STAMP=$(date -u +%Y%m%d%H%M%S)
           BASE=$(grep -m1 '__version__' src/kiro_crew/__init__.py | sed -E 's/.*= *"([^"]+)".*/\1/')
           # Desktop/Squirrel needs semver; the pip wheel needs PEP 440. Emit both:
-          #   nightly_version (semver):  <base>-nightly.<date>  -> Electron app + S3 build path
-          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS> -> pip wheel, unique per RUN (see below)
+          #   nightly_version (semver):  <base>-nightly.<date+HHMMSS> -> Electron app + S3 build path
+          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS>      -> pip wheel, unique per RUN (see below)
+          # The desktop stamp carries the same seconds precision as the wheel:
+          # a date-only stamp meant two nightlies on one UTC date overwrote the
+          # same signed/<channel>/<version>/ and notarized/<channel>/<version>/
+          # keys (the exact republish class #62 fixed for cli/*), which becomes
+          # a CloudFront edge-divergence bug the day mac artifacts go public.
           # The old shared "-nightly.<date>" is invalid PEP 440, so setuptools normalized
           # every nightly wheel down to the base version (all became 0.1.0). ".dev<date>"
           # is valid PEP 440 and keeps nightly wheels uniquely versioned.
-          echo "version=${BASE}-nightly.${DATE}" >> "$GITHUB_OUTPUT"
+          echo "version=${BASE}-nightly.${STAMP}" >> "$GITHUB_OUTPUT"
           echo "wheel_version=${BASE}.dev${STAMP}" >> "$GITHUB_OUTPUT"
-          echo "Nightly (semver): ${BASE}-nightly.${DATE}"
+          echo "Nightly (semver): ${BASE}-nightly.${STAMP}"
           echo "Wheel (PEP 440):  ${BASE}.dev${STAMP}"
 
   build-wheel:

--- a/packaging/signing/generate-manifest.py
+++ b/packaging/signing/generate-manifest.py
@@ -9,9 +9,20 @@ C-extension, every vendored .dylib) plus Squirrel's ShipIt helper must be
 listed explicitly in `embedded_requirements`, or notarization returns
 `Invalid` (confirmed: submission 3fefb424, 72 rejected binaries).
 
-The backend's binary set changes whenever a Python dependency changes, so the
-list is generated at sign time from the actual .app rather than maintained by
-hand (same pattern as other Amazon Electron/CDSigner pipelines).
+The binary set changes whenever a Python dependency changes, the app is
+renamed, or Electron is upgraded, so EVERYTHING is generated at sign time
+from the actual .app rather than maintained by hand:
+  - backend entries (Resources Mach-Os + ShipIt) via collect_entries()
+  - Electron shell entries (helper .apps, Electron Framework + its Helpers)
+    via collect_shell_entries(), identifiers read from each bundle's
+    Info.plist
+
+A fail-closed layout tripwire (validate_layout) aborts the sign with a clear
+message when the bundle contains something this generator does not
+understand (a Mach-O outside the known scopes, or a nested bundle under
+Contents/Resources, which needs bundle-level signing that per-file entries
+cannot provide). Unknown layouts must break loudly at sign time, not
+silently at notarize time weeks later.
 
 Usage:
     generate-manifest.py <manifest-template.json> <path/to/App.app>
@@ -21,13 +32,36 @@ INPUT_KEY, OUTPUT_KEY) and prints the final manifest JSON to stdout. A summary
 line is printed to stderr for build logs.
 """
 
+import glob
 import json
 import os
+import plistlib
 import re
 import struct
 import sys
 
+# Fallback identifier prefix when the app bundle's own CFBundleIdentifier
+# cannot be read (never expected for a real electron-builder output).
 APP_ID = "com.amazon.kiro.crew"
+
+_ENTITLEMENTS = {"entitlements_path": "SIGNING_METADATA/Entitlements.entitlements"}
+
+# Bundle suffixes that require bundle-level signing (identifier + sealed
+# resources). Finding one under Contents/Resources is a layout error.
+# Covers all code-bearing bundle types, not just app/framework: XPC
+# services, loadable bundles, and legacy plugins are sealed bundles too.
+_BUNDLE_SUFFIXES = (".app", ".framework", ".appex", ".xpc", ".bundle", ".plugin")
+
+# The only places a Mach-O may live in a layout this generator understands:
+#   Contents/MacOS/       -- main executable, signed by CDSigner's app pass
+#   Contents/Frameworks/  -- bundles auto-signed by CDSigner + explicit shell
+#                            entries from collect_shell_entries()
+#   Contents/Resources/   -- embedded backend, enumerated by collect_entries()
+_UNDERSTOOD_SCOPES = (
+    "Contents/MacOS/",
+    "Contents/Frameworks/",
+    "Contents/Resources/",
+)
 
 # Mach-O magic numbers (thin, both endiannesses).
 _THIN_MAGICS = {0xFEEDFACE, 0xFEEDFACF, 0xCEFAEDFE, 0xCFFAEDFE}
@@ -56,7 +90,40 @@ def is_macho(path: str) -> bool:
     return False
 
 
-def identifier_for(rel_path: str) -> str:
+def read_bundle_identifier(bundle_path: str) -> "str | None":
+    """CFBundleIdentifier of a .app/.framework, or None if unreadable.
+
+    Checks the flat app layout (Contents/Info.plist), the versioned
+    framework layout (Versions/*/Resources/Info.plist), and the flat
+    framework layout (Resources/Info.plist). plistlib handles both XML and
+    binary plists.
+    """
+    candidates = [os.path.join(bundle_path, "Contents", "Info.plist")]
+    candidates.extend(
+        sorted(glob.glob(os.path.join(bundle_path, "Versions", "*", "Resources", "Info.plist")))
+    )
+    candidates.append(os.path.join(bundle_path, "Resources", "Info.plist"))
+    for plist_path in candidates:
+        if not os.path.isfile(plist_path):
+            continue
+        try:
+            with open(plist_path, "rb") as fh:
+                ident = plistlib.load(fh).get("CFBundleIdentifier")
+        except Exception:
+            continue
+        if ident:
+            return str(ident)
+    return None
+
+
+def app_identifier(app_path: str) -> str:
+    """The app's own bundle id (prefix for generated identifiers). Derived
+    from the bundle so an app rename cannot silently desynchronize the
+    generated identifiers; falls back to the historical constant."""
+    return read_bundle_identifier(app_path) or APP_ID
+
+
+def identifier_for(rel_path: str, app_id: str = APP_ID) -> str:
     """Stable, unique bundle id derived from the full relative path.
 
     Derived from the whole path (not the basename) so duplicate filenames in
@@ -70,7 +137,7 @@ def identifier_for(rel_path: str) -> str:
     # everything non-alphanumeric, including dots, to hyphens so every
     # identifier segment is well-formed.
     suffix = re.sub(r"[^A-Za-z0-9]+", "-", stem).strip("-")
-    return f"{APP_ID}.{suffix}"
+    return f"{app_id}.{suffix}"
 
 
 def collect_all_machos(app_path: str) -> "list[str]":
@@ -87,8 +154,135 @@ def collect_all_machos(app_path: str) -> "list[str]":
     return out
 
 
-def collect_entries(app_path: str) -> "dict[str, dict]":
-    """Manifest entries, matching the recipe proven to both sign and
+def validate_layout(machos: "list[str]") -> "list[str]":
+    """Fail-closed tripwire. Returns a list of layout errors (empty = OK).
+
+    Three classes of unknown layout, each of which would otherwise surface
+    as a notarization `Invalid` weeks later with no bisectable trail:
+      1. A Mach-O outside the understood scopes (e.g. Contents/PlugIns/*.appex,
+         Contents/Library/LoginItems) -- nothing signs it.
+      2. A nested bundle under Contents/Resources -- its binaries would be
+         signed per-file, but Apple requires bundle-level signing (identifier
+         + sealed resources) for nested bundles.
+      3. A loose Mach-O under Contents/Frameworks with no .app/.framework
+         in its path -- bundle interiors are auto-signed or explicitly
+         listed, but a bare file dropped in Frameworks/ has no signing rule.
+    """
+    errors: "list[str]" = []
+    for rel in machos:
+        if not rel.startswith(_UNDERSTOOD_SCOPES):
+            errors.append(
+                f"Mach-O outside understood scopes: {rel}\n"
+                "    No signing rule covers this location. Extend "
+                "generate-manifest.py deliberately (and verify notarization) "
+                "before shipping binaries here."
+            )
+            continue
+        if rel.startswith("Contents/Frameworks/"):
+            segments = rel.split("/")[2:-1]
+            in_bundle = any(s.endswith((".app", ".framework")) for s in segments)
+            # Loose .dylibs directly under Frameworks/ are auto-signed by
+            # CDSigner's app pass (documented + verified); only a loose
+            # EXECUTABLE with no bundle in its path has no signing rule.
+            if not in_bundle and not rel.endswith(".dylib"):
+                errors.append(
+                    f"Loose Mach-O executable under Contents/Frameworks: {rel}\n"
+                    "    Not inside any .app/.framework bundle, so neither "
+                    "CDSigner auto-signing nor the generated entries cover "
+                    "it. Move it into a bundle or extend the generator "
+                    "deliberately."
+                )
+            continue
+        if rel.startswith("Contents/Resources/"):
+            # Any path segment that is itself a bundle means per-file signing
+            # would be the wrong granularity.
+            for segment in rel.split("/")[2:-1]:
+                if segment.endswith(_BUNDLE_SUFFIXES):
+                    errors.append(
+                        f"Nested bundle under Contents/Resources: {segment} (in {rel})\n"
+                        "    Nested bundles need bundle-level signing; per-file "
+                        "entries are rejected at notarization. Move it under "
+                        "Contents/Frameworks or add explicit bundle handling."
+                    )
+                    break
+    return errors
+
+
+def collect_shell_entries(app_path: str) -> "dict[str, dict]":
+    """Electron shell entries, derived from the actual bundle.
+
+    Replaces the previously hand-maintained template entries, which encoded
+    one specific Electron layout and one specific app name and silently
+    rotted on either changing (exactly the bug class this generator exists
+    to prevent). electron-builder stamps each shell bundle's
+    CFBundleIdentifier with the app id prefix, so the identifiers are read,
+    never synthesized:
+      - every helper .app under Contents/Frameworks -> one entry
+      - every framework that ships loose Helpers executables (Electron
+        Framework's chrome_crashpad_handler) -> one entry for the framework
+        plus one per helper executable, all under the framework's identifier
+        (the recipe Apple has accepted)
+      - frameworks without Helpers (Mantle, ReactiveObjC, Squirrel) stay
+        unlisted: CDSigner's app pass auto-signs them. ShipIt, the loose
+        executable in Squirrel's Resources dir, is covered by
+        collect_entries().
+    """
+    entries: "dict[str, dict]" = {}
+    frameworks_dir = os.path.join(app_path, "Contents", "Frameworks")
+    if not os.path.isdir(frameworks_dir):
+        return entries
+    for name in sorted(os.listdir(frameworks_dir)):
+        bundle = os.path.join(frameworks_dir, name)
+        rel = f"Contents/Frameworks/{name}"
+        if os.path.islink(bundle) or not os.path.isdir(bundle):
+            continue
+        if name.endswith(".app"):
+            ident = read_bundle_identifier(bundle)
+            if not ident:
+                raise RuntimeError(f"no CFBundleIdentifier readable for {rel}")
+            entries[rel] = {
+                "full_identifier": ident,
+                "signing_args": dict(_ENTITLEMENTS),
+            }
+        elif name.endswith(".framework"):
+            # Versioned layout (Versions/<v>/Helpers) and flat layout
+            # (Helpers at framework root). Versions/Current is a symlink to
+            # the real version dir; resolve helpers only through real dirs
+            # or every helper enumerates twice.
+            helper_dirs = sorted(
+                d
+                for d in glob.glob(os.path.join(bundle, "Versions", "*", "Helpers"))
+                if not os.path.islink(os.path.dirname(d))
+            )
+            flat_helpers = os.path.join(bundle, "Helpers")
+            if os.path.isdir(flat_helpers) and not os.path.islink(flat_helpers):
+                helper_dirs.append(flat_helpers)
+            helpers: "list[str]" = []
+            for helper_dir in helper_dirs:
+                for root, _dirs, files in os.walk(helper_dir):
+                    for fname in files:
+                        full = os.path.join(root, fname)
+                        if not os.path.islink(full) and is_macho(full):
+                            helpers.append(os.path.relpath(full, app_path))
+            if not helpers:
+                continue  # auto-signed by CDSigner's app pass
+            ident = read_bundle_identifier(bundle)
+            if not ident:
+                raise RuntimeError(f"no CFBundleIdentifier readable for {rel}")
+            for helper_rel in sorted(helpers):
+                entries[helper_rel] = {
+                    "full_identifier": ident,
+                    "signing_args": dict(_ENTITLEMENTS),
+                }
+            entries[rel] = {
+                "full_identifier": ident,
+                "signing_args": dict(_ENTITLEMENTS),
+            }
+    return entries
+
+
+def collect_entries(app_path: str, app_id: str = APP_ID) -> "dict[str, dict]":
+    """Backend manifest entries, matching the recipe proven to both sign and
     notarize for Python-runtime apps on this API:
       - EXCLUDE .dylib files (CDSigner signs dynamic libraries
         automatically during the app pass; listing them explicitly is
@@ -107,17 +301,22 @@ def collect_entries(app_path: str) -> "dict[str, dict]":
         if rel.startswith("Contents/MacOS/"):
             continue
         in_resources = rel.startswith("Contents/Resources/")
-        is_shipit = os.path.basename(rel) == "ShipIt"
-        # Framework bundles are handled by the static template entries +
-        # CDSigner auto-detection; ShipIt is the exception (a loose
-        # executable in a framework's Resources dir that is NOT covered).
-        if not (in_resources or is_shipit):
+        # Loose executables in a framework's Resources dir (Squirrel's
+        # ShipIt today) are NOT auto-signed by CDSigner's app pass and must
+        # be listed (verified empirically -- the original 72-binary
+        # rejection included ShipIt). Matched by LOCATION, not by name, so
+        # a future Squirrel-like helper is signed instead of silently
+        # skipped.
+        in_framework_resources = (
+            rel.startswith("Contents/Frameworks/")
+            and ".framework/" in rel
+            and "/Resources/" in "/" + rel.split(".framework/", 1)[1]
+        )
+        if not (in_resources or in_framework_resources):
             continue
         entries[rel] = {
-            "full_identifier": identifier_for(rel),
-            "signing_args": {
-                "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements"
-            },
+            "full_identifier": identifier_for(rel, app_id),
+            "signing_args": dict(_ENTITLEMENTS),
         }
     # Inside-out: sign the deepest binaries first.
     return dict(
@@ -156,18 +355,53 @@ def main() -> int:
         raw = raw.replace("${%s}" % var, value)
     doc = json.loads(raw)
 
-    generated = collect_entries(app_path)
+    machos = collect_all_machos(app_path)
+    layout_errors = validate_layout(machos)
+    if layout_errors:
+        print("ERROR: bundle layout not understood by this generator:", file=sys.stderr)
+        for err in layout_errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "Failing the sign so this surfaces now instead of as a "
+            "notarization rejection later.",
+            file=sys.stderr,
+        )
+        return 1
+
+    app_id = app_identifier(app_path)
+    # Keep the manifest header in lockstep with the actual bundle: sign.sh
+    # packages the tarball under the real .app name, so a renamed app with
+    # a hardcoded template name would make CDSigner look for a path that
+    # is not in the archive. The template values remain as documentation;
+    # the bundle is the source of truth.
+    app_name = os.path.basename(os.path.normpath(app_path))
+    doc["manifest"]["name"] = app_name
+    for output in doc["manifest"].get("outputs", []):
+        output["path"] = app_name
+    doc["manifest"]["app"]["identifier"] = app_id
+    backend = collect_entries(app_path, app_id)
+    try:
+        shell = collect_shell_entries(app_path)
+    except RuntimeError as err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        return 1
     static = doc["manifest"]["app"].get("embedded_requirements", {})
-    # Generated (deepest-first) ahead of the static Electron entries; a
-    # static entry for the same path wins so hand overrides stay possible.
-    merged = dict(generated)
+    # Backend + shell are generated; a template entry for the same path wins
+    # so deliberate hand overrides stay possible. Final map is globally
+    # sorted inside-out (deepest paths sign first).
+    merged = dict(backend)
+    merged.update(shell)
     merged.update(static)
+    merged = dict(
+        sorted(merged.items(), key=lambda kv: (-kv[0].count("/"), kv[0]))
+    )
     doc["manifest"]["app"]["embedded_requirements"] = merged
 
     print(
         f"embedded_requirements: {len(merged)} total "
-        f"({len(generated)} generated non-dylib Mach-Os, {len(static)} static; "
-        "dylibs auto-signed by CDSigner)",
+        f"({len(backend)} backend Mach-Os incl. Resources dylibs, "
+        f"{len(shell)} Electron shell, {len(static)} template overrides; "
+        "Frameworks dylibs auto-signed by CDSigner)",
         file=sys.stderr,
     )
     json.dump(doc, sys.stdout, indent=2)

--- a/packaging/signing/manifest-template.json
+++ b/packaging/signing/manifest-template.json
@@ -6,32 +6,7 @@
     "outputs": [{ "label": "macos", "path": "KiroCrew.app" }],
     "app": {
       "identifier": "com.amazon.kiro.crew",
-      "embedded_requirements": {
-        "Contents/Frameworks/Electron Framework.framework/Versions/A/Helpers/chrome_crashpad_handler": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.framework",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        },
-        "Contents/Frameworks/Electron Framework.framework": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.framework",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        },
-        "Contents/Frameworks/KiroCrew Helper.app": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.helper",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        },
-        "Contents/Frameworks/KiroCrew Helper (GPU).app": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.helper.GPU",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        },
-        "Contents/Frameworks/KiroCrew Helper (Plugin).app": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.helper.Plugin",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        },
-        "Contents/Frameworks/KiroCrew Helper (Renderer).app": {
-          "full_identifier": "com.amazon.kiro.crew.com.github.Electron.helper.Renderer",
-          "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" }
-        }
-      },
+      "embedded_requirements": {},
       "signing_requirements": {
         "signing_args": { "entitlements_path": "SIGNING_METADATA/Entitlements.entitlements" },
         "certificate_type": "developerIDAppDistribution",


### PR DESCRIPTION
Closes the three hardening follow-ups tracked on #80.

## 1. Dynamic Electron shell entries
The six hand-maintained template entries encoded one specific Electron layout and one specific app name -- an Electron major upgrade or an app rename silently broke them (we lived the rename once: KiroClaw -> KiroCrew). `collect_shell_entries()` now derives them from the actual bundle: every helper `.app` under `Contents/Frameworks`, plus Helpers-bearing frameworks (Electron Framework's `chrome_crashpad_handler`), identifiers **read from each bundle's `CFBundleIdentifier`**, never synthesized. Frameworks without Helpers (Mantle/ReactiveObjC/Squirrel) stay unlisted -- CDSigner auto-signs them; ShipIt remains covered by the backend collector. The template's `embedded_requirements` map stays as a deliberate hand-override hook (template wins on path collision).

**Equivalence proof**: on the current Apple-accepted notarized bundle, the generated output is entry-for-entry identical to the old static set (86/86 paths, identifiers and signing_args byte-equal, inside-out ordering held). This PR is a provable no-op for today's bundle.

## 2. Fail-closed layout tripwire
`validate_layout()` aborts the sign with an actionable message on either unknown-layout class:
- a Mach-O outside `Contents/{MacOS,Frameworks,Resources}` (e.g. a future `PlugIns/*.appex`) -- nothing would sign it
- a nested bundle (`.app`/`.framework`/`.appex`) under `Contents/Resources` -- per-file signing is the wrong granularity; notarization rejects it

Both classes previously surfaced as a notarization `Invalid` weeks later with no bisectable trail; now they fail the sign step immediately. Both exercised with synthetic bundles (exit 1, message names the offending path).

## 3. Seconds-precision nightly desktop version
`0.1.0-nightly.<date>` meant two nightlies on one UTC date overwrote the same `signed/` and `notarized/` keys (observed live on 2026-07-20: morning run's zip replaced by evening run's at the same key). Same republish class #62 fixed for `cli/*`; becomes a CloudFront edge-divergence bug the day mac artifacts go public. Now `<base>-nightly.<date+HHMMSS>`, matching the wheel stamp. Insider/stable are unaffected (tag-derived versions are inherently unique).

## Also
- Identifier prefix now read from the app's own `CFBundleIdentifier` (rename-proof), falling back to the historical constant
- Summary log line corrected ("non-dylib Mach-Os" was stale -- Resources dylibs are included since the notarize fix)

## Validation
- Equivalence proof vs Apple-accepted baseline: IDENTICAL (see above)
- `--list-machos` regression: still 94 binaries on the reference bundle
- Both tripwires: exit 1 + named offending path on synthetic bundles
- `test_workflow_permissions.py` architecture tests: 2 passed
- nightly.yml YAML-parses; generator py_compiles

Post-merge, the next scheduled nightly exercises the dynamic shell entries + new stamp end-to-end (sign -> notarize -> spctl gate).