### PR TITLE
feat(updates): publish notarized builds publicly + working desktop auto-update

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+# Single-flight nightly runs. cancel-in-progress also protects the channel
+# feed (feed/nightly/latest-mac.json, last-writer-wins): an overlapping
+# older run is cancelled rather than finishing last and rolling the feed
+# back to an older build for every client.
 concurrency:
   group: nightly-build
   cancel-in-progress: true
@@ -147,6 +151,13 @@ jobs:
           echo "NIGHTLY_VERSION=${NIGHTLY}" >> "$GITHUB_ENV"
           sed -i.bak "s/__version__ = \".*\"/__version__ = \"${NIGHTLY}\"/" src/kiro_crew/__init__.py
           rm -f src/kiro_crew/__init__.py.bak
+          # Stamp the Electron app too: app.getVersion() (from the bundle's
+          # Info.plist, which electron-builder fills from package.json) must
+          # equal the feed version, or the auto-updater's client-side compare
+          # would see a permanent mismatch and re-download the same build on
+          # every check.
+          export STAMP_VERSION="${NIGHTLY}"
+          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
           echo "Building nightly: ${NIGHTLY}"
 
       - name: Build desktop app

--- a/.github/workflows/notarize-macos.yml
+++ b/.github/workflows/notarize-macos.yml
@@ -148,23 +148,68 @@ jobs:
           echo "NOTARIZED_KEY=${KEY}" >> "$GITHUB_ENV"
           echo "Notarized artifact: s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
 
-      # Feed points at the NOTARIZED artifact -- written only after the
-      # spctl gate above passed.
-      - name: Write update feed
-        if: env.HAS_SIGNING_SECRETS && inputs.write_feed
+      # Public distribution: copy the notarized zip to the public update
+      # bucket (CloudFront + OAC) and write the channel feed there. The
+      # signing bucket stays private and single-purpose (signing material
+      # only) -- clients download exclusively through the CDN.
+      #
+      # The versioned zip key is immutable-cached by CloudFront, so it must
+      # never be republished with different bytes (same class as the cli/*
+      # wheel keys). --if-none-match makes the write conditional; on a 412
+      # (job re-run after a later-step failure) the existing object is a
+      # notarized artifact that already passed the spctl gate on the earlier
+      # attempt, so it is KEPT and the step continues idempotently.
+      - name: Publish notarized artifact to distribution bucket
+        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
         run: |
+          set -euo pipefail
+          DESKTOP_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.zip"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${DESKTOP_KEY}" \
+            --body work/notarized.zip \
+            --if-none-match '*' \
+            --content-type application/zip \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              echo "Key already published (job re-run) -- keeping existing notarized bytes: ${DESKTOP_KEY}"
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
+          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+
+      # Feed points at the NOTARIZED artifact on the CDN -- written only
+      # after the spctl gate above passed, and only after the artifact
+      # itself is publicly downloadable (feed-before-artifact would hand
+      # clients a 403/404). The feed key is mutable and served no-cache by
+      # the feed/* CloudFront behavior, so overwriting is safe. Out-of-order
+      # overwrites (older run finishing last -> channel rollback) are
+      # prevented by the CALLER workflows' concurrency groups, which
+      # serialize runs per channel -- not by version comparison here, which
+      # would itself be a read-then-write race.
+      - name: Write update feed
+        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
+        run: |
+          set -euo pipefail
           cat > /tmp/latest-mac.json <<EOF
           {
             "version": "${VERSION}",
-            "url": "https://${{ secrets.AWS_SIGNING_BUCKET }}.s3.us-west-2.amazonaws.com/${NOTARIZED_KEY}",
+            "url": "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}",
             "name": "${VERSION}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
           aws s3 cp /tmp/latest-mac.json \
-            "s3://${{ secrets.AWS_SIGNING_BUCKET }}/feed/${CHANNEL}/latest-mac.json" \
+            "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-mac.json" \
             --content-type application/json
-          echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${NOTARIZED_KEY}"
+          echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
       - name: Attach notarized artifact to workflow run
         if: env.HAS_SIGNING_SECRETS
@@ -182,4 +227,7 @@ jobs:
             echo "- Version: ${VERSION}"
             echo "- Input: \`${SIGNED_ZIP_KEY}\`"
             echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
+            if [ -n "${DESKTOP_KEY:-}" ]; then
+              echo "- Public: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags: ["v*"]
 
+# Serialize release runs: insider/stable feed writes are last-writer-wins;
+# two tags pushed close together must publish in order or the channel feed
+# can roll back to the older release (see nightly.yml for the full note).
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -70,6 +77,20 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      # Stamp the Electron app with the tag-derived version so
+      # app.getVersion() equals the feed version (the auto-updater's
+      # client-side compare depends on this; a mismatch means a permanent
+      # "update available" loop). Same derivation as the release job:
+      # v1.2.3-insider.1 -> 1.2.3-insider.1.
+      - name: Stamp release version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          export STAMP_VERSION="${VERSION}"
+          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" src/kiro_crew/__init__.py
+          rm -f src/kiro_crew/__init__.py.bak
+          echo "Building release: ${VERSION}"
 
       - name: Build desktop app (PBS + uv venv)
         run: make desktop

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -14,18 +14,25 @@
  * stays testable without an Electron runtime.
  */
 
-// Default update feed host. The feed compares the client's current version
-// against latest.json for this channel+platform and returns 200 (Squirrel JSON)
-// or 204 (no update). See kirocrew-publish-lambda-spec.md for the contract.
-const DEFAULT_FEED_BASE = "https://updates.kirocrew.dev/feed"; // placeholder host
+// Default update feed host: the public distribution CDN (CloudFront + OAC
+// over the kirocrew-updates bucket). The feed is a STATIC JSON file at
+// <base>/<channel>/latest-mac.json written by CI after notarization; the
+// artifact it points at lives under desktop/<channel>/<version>/ on the
+// same CDN. There is no 200/204 server endpoint: safeCheck() fetches the
+// feed itself and compares versions CLIENT-SIDE, engaging Squirrel.Mac only
+// when the feed version differs from the running app. (Squirrel treats any
+// 200 feed response as "update available", so gating on the client compare
+// is what prevents a re-download loop against a static file.)
+const DEFAULT_FEED_BASE = "https://d28nxu9if70cmc.cloudfront.net/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
+const FEED_TIMEOUT_MS = 15 * 1000;
+const FEED_MAX_BYTES = 64 * 1024;
 
 /**
- * Map the build flavor ("beta" | "stable") to an update channel.
- * Beta builds track the fast "insider" channel (nightlies + internal testers);
- * stable builds track "stable". The public KiroCrew ships a single "stable"
- * flavor, so getFlavor is wired to a constant "stable" at the call site.
+ * Map the build flavor ("beta" | "stable") to an update channel. Retained
+ * for the internal beta flavor and as the fallback when the running version
+ * carries no channel marker.
  * @param {"beta"|"stable"} flavor
  * @returns {"insider"|"stable"}
  */
@@ -34,14 +41,82 @@ function channelForFlavor(flavor) {
 }
 
 /**
- * Build the Squirrel.Mac feed URL. Pure + testable.
- * @param {{base:string, platform:string, channel:string, version:string}} o
+ * Derive the update channel from the running version. CI stamps the app
+ * version per channel (nightly.yml: <base>-nightly.<stamp>; release.yml:
+ * tag-derived), so the version itself says which feed this build must
+ * track. MUST mirror release.yml's tag-to-channel rule: "-nightly." is
+ * nightly, any OTHER prerelease suffix (-insider.N, -rc.N, ...) is
+ * insider, bare semver is stable. Without this, a nightly/insider build
+ * would check the stable feed, see a differing version, and silently
+ * migrate the user onto stable.
+ * @param {string} version
+ * @returns {"nightly"|"insider"|"stable"|null} null when unstamped (dev)
+ */
+function channelForVersion(version) {
+  if (!version || typeof version !== "string") return null;
+  if (version.includes("-nightly.")) return "nightly";
+  if (version.includes("-")) return "insider";
+  return "stable";
+}
+
+/**
+ * Build the static feed URL for a channel. Pure + testable.
+ * @param {{base:string, channel:string}} o
  * @returns {string}
  */
-function buildFeedUrl({ base, platform, channel, version }) {
+function buildFeedUrl({ base, channel }) {
   const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
-  const q = new URLSearchParams({ platform, channel, version });
-  return `${b}?${q.toString()}`;
+  return `${b}/${encodeURIComponent(channel)}/latest-mac.json`;
+}
+
+/**
+ * Default feed fetcher: GET the static feed JSON. Injectable via
+ * deps.fetchFeed for tests. Bounded body size + timeout; rejects on any
+ * non-200 so callers surface a single error path. HTTPS everywhere;
+ * plain HTTP is permitted ONLY for loopback hosts so the local update
+ * harness (KIROCREW_UPDATE_FEED=http://127.0.0.1:PORT/...) works --
+ * cleartext update metadata over a real network stays rejected.
+ * @param {string} url
+ * @returns {Promise<{version:string, url:string}>}
+ */
+function fetchFeedHttps(url) {
+  return new Promise((resolve, reject) => {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const isLoopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
+    let mod;
+    if (parsed.protocol === "https:") {
+      mod = require("https");
+    } else if (parsed.protocol === "http:" && isLoopback) {
+      mod = require("http");
+    } else {
+      reject(new Error(`feed URL must be https (or http on loopback): ${parsed.protocol}//${parsed.hostname}`));
+      return;
+    }
+    const req = mod.get(url, { headers: { "cache-control": "no-cache" } }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`feed HTTP ${res.statusCode}`));
+        return;
+      }
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+        if (body.length > FEED_MAX_BYTES) req.destroy(new Error("feed response too large"));
+      });
+      res.on("end", () => {
+        try { resolve(JSON.parse(body)); } catch (err) { reject(err); }
+      });
+    });
+    req.on("error", reject);
+    req.setTimeout(FEED_TIMEOUT_MS, () => req.destroy(new Error("feed request timed out")));
+  });
 }
 
 /**
@@ -73,6 +148,7 @@ function initAutoUpdate(deps) {
     stopGateway,
     platform = "darwin-arm64",
     feedBase = process.env.KIROCREW_UPDATE_FEED || DEFAULT_FEED_BASE,
+    fetchFeed = fetchFeedHttps,
     onUpdateState = null,
     log = console,
   } = deps;
@@ -80,16 +156,21 @@ function initAutoUpdate(deps) {
   // When the in-app UI is wired (onUpdateState provided), it owns the prompt;
   // the native dialog stays as the fallback for headless / no-renderer cases.
   const uiDriven = typeof onUpdateState === "function";
+  // Single channel resolver used for the feed AND everything reported to
+  // the UI: stamped version wins, flavor is the unstamped-dev fallback.
+  function currentChannel() {
+    return channelForVersion(app.getVersion()) || channelForFlavor(getFlavor());
+  }
   function emit(state, extra = {}) {
     if (!uiDriven) return;
     try {
-      onUpdateState({ state, channel: channelForFlavor(getFlavor()), version: app.getVersion(), ...extra });
+      onUpdateState({ state, channel: currentChannel(), version: app.getVersion(), ...extra });
     } catch (err) {
       log.error("[update] onUpdateState threw", err);
     }
   }
   function getInfo() {
-    return { version: app.getVersion(), channel: channelForFlavor(getFlavor()), platform, packaged: !!app.isPackaged };
+    return { version: app.getVersion(), channel: currentChannel(), platform, packaged: !!app.isPackaged };
   }
 
   // Squirrel is unavailable for unsigned / not-installed dev builds.
@@ -107,24 +188,40 @@ function initAutoUpdate(deps) {
   let quitHandled = false;
 
   function configureFeed() {
-    const channel = channelForFlavor(getFlavor());
-    const url = buildFeedUrl({
-      base: feedBase,
-      platform,
-      channel,
-      version: app.getVersion(),
-    });
+    const channel = currentChannel();
+    const url = buildFeedUrl({ base: feedBase, channel });
     autoUpdater.setFeedURL({ url });
     log.info(`[update] feed: ${url}`);
+    return url;
   }
 
-  function safeCheck() {
+  let checking = false;
+  async function safeCheck() {
+    if (checking || updateReady) return;
+    checking = true;
     try {
-      configureFeed(); // re-read flavor/channel each check
+      // CLIENT-SIDE version gate (see DEFAULT_FEED_BASE note): fetch the
+      // static feed and only hand off to Squirrel when the version differs.
+      // Squirrel would otherwise re-download on every check forever, since a
+      // static 200 feed always reads as "update available" to it.
+      const url = configureFeed(); // re-read flavor/channel each check
+      emit("checking");
+      const feed = await fetchFeed(url);
+      if (!feed || typeof feed.version !== "string" || typeof feed.url !== "string") {
+        throw new Error("feed missing version/url");
+      }
+      if (feed.version === app.getVersion()) {
+        log.info(`[update] up to date (${feed.version})`);
+        emit("not-available");
+        return;
+      }
+      log.info(`[update] feed has ${feed.version} (running ${app.getVersion()}) — engaging Squirrel`);
       autoUpdater.checkForUpdates();
     } catch (err) {
-      log.error("[update] checkForUpdates threw", err);
+      log.error("[update] check failed", err);
       emit("error", { message: String(err && err.message || err) });
+    } finally {
+      checking = false;
     }
   }
 
@@ -200,16 +297,19 @@ function initAutoUpdate(deps) {
   });
 
   configureFeed();
-  setTimeout(safeCheck, LAUNCH_CHECK_DELAY_MS);
-  setInterval(() => { if (!updateReady) safeCheck(); }, CHECK_INTERVAL_MS);
+  const launchTimer = setTimeout(safeCheck, LAUNCH_CHECK_DELAY_MS);
+  const pollTimer = setInterval(() => { if (!updateReady) safeCheck(); }, CHECK_INTERVAL_MS);
+  // Timers must never hold the process open (Electron quit, tests).
+  if (typeof launchTimer.unref === "function") launchTimer.unref();
+  if (typeof pollTimer.unref === "function") pollTimer.unref();
 
   // Renderer-callable triggers (wired to ipcMain in main.js).
   return {
-    check: () => { emit("checking"); safeCheck(); },
+    check: () => safeCheck(),
     install: () => applyUpdateAndRestart(),
     getInfo,
     isReady: () => updateReady,
   };
 }
 
-module.exports = { initAutoUpdate, channelForFlavor, buildFeedUrl };
+module.exports = { initAutoUpdate, channelForFlavor, channelForVersion, buildFeedUrl, fetchFeedHttps };

--- a/website/electron/scripts/local-feed-server.js
+++ b/website/electron/scripts/local-feed-server.js
@@ -1,18 +1,22 @@
 #!/usr/bin/env node
 /**
- * Local Squirrel.Mac update feed for Stage 3 auto-update testing.
+ * Local static update feed for Stage 3 auto-update testing.
  *
- * Binds 127.0.0.1 ONLY. Implements the Squirrel.Mac contract the app's
- * autoUpdater expects:
- *   GET /<anything>?version=X  -> 200 {url,name,notes,pub_date}  if X < latest
- *                              -> 204 (no content)               if X >= latest
- *   GET /download              -> streams the update .zip
+ * Binds 127.0.0.1 ONLY. Mirrors the production static-feed contract
+ * (CloudFront serving files CI wrote): the feed is a plain JSON document
+ * and the APP does the version compare client-side, engaging Squirrel only
+ * when the feed version differs from the running app. This server never
+ * returns 204 -- that behavior lives in the app now.
  *
- * The app's buildFeedUrl() appends ?platform=&channel=&version= ; this server
- * only reads `version` and compares against the served latest version.
+ *   GET /feed/<channel>/latest-mac.json -> 200 {version,url,name,pub_date}
+ *   GET /download                       -> streams the update .zip
  *
  * Usage:
- *   node local-feed-server.js --port 8799 --zip /path/Kiro-1.0.1-mac.zip --version 1.0.1
+ *   node local-feed-server.js --port 8799 --zip /path/KiroCrew.zip --version 0.1.0-nightly.20260722000000
+ *   KIROCREW_UPDATE_FEED=http://127.0.0.1:8799/feed <app binary>
+ *
+ * The app permits plain http for loopback hosts only (fetchFeedHttps), so
+ * this harness needs no TLS.
  */
 const http = require("http");
 const fs = require("fs");
@@ -30,17 +34,6 @@ if (!ZIP || !fs.existsSync(ZIP)) {
   process.exit(1);
 }
 
-// Minimal 3-part semver compare (ignores prerelease/build for the test).
-function cmpSemver(a, b) {
-  const pa = String(a).split(".").map((n) => parseInt(n, 10) || 0);
-  const pb = String(b).split(".").map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < 3; i++) {
-    const d = (pa[i] || 0) - (pb[i] || 0);
-    if (d !== 0) return d;
-  }
-  return 0;
-}
-
 const server = http.createServer((req, res) => {
   const u = new URL(req.url, `http://127.0.0.1:${PORT}`);
 
@@ -52,25 +45,26 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  const reqVersion = u.searchParams.get("version") || "0.0.0";
-  if (cmpSemver(reqVersion, LATEST) < 0) {
+  if (u.pathname.endsWith("/latest-mac.json")) {
     const body = JSON.stringify({
+      version: LATEST,
       url: `http://127.0.0.1:${PORT}/download`,
       name: LATEST,
-      notes: `Stage 3 local test update to ${LATEST}`,
       pub_date: new Date().toISOString(),
     });
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(body);
-    console.log(`[feed] version ${reqVersion} < ${LATEST} -> 200 update available`);
-  } else {
-    res.writeHead(204);
-    res.end();
-    console.log(`[feed] version ${reqVersion} >= ${LATEST} -> 204 up to date`);
+    console.log(`[feed] ${u.pathname} -> 200 latest=${LATEST} (app compares client-side)`);
+    return;
   }
+
+  res.writeHead(404);
+  res.end();
+  console.log(`[feed] ${u.pathname} -> 404 (expected /feed/<channel>/latest-mac.json or /download)`);
 });
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`[feed] listening on http://127.0.0.1:${PORT}`);
   console.log(`[feed] serving latest=${LATEST} from ${ZIP}`);
+  console.log(`[feed] point the app at it: KIROCREW_UPDATE_FEED=http://127.0.0.1:${PORT}/feed`);
 });

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -1,6 +1,27 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { channelForFlavor, buildFeedUrl } = require("../auto-update");
+const { channelForFlavor, channelForVersion, buildFeedUrl, fetchFeedHttps, initAutoUpdate } = require("../auto-update");
+
+test("channelForVersion: nightly stamp -> nightly feed", () => {
+  assert.strictEqual(channelForVersion("0.1.0-nightly.20260721042000"), "nightly");
+});
+
+test("channelForVersion mirrors release.yml: any non-nightly prerelease -> insider", () => {
+  assert.strictEqual(channelForVersion("0.1.0-insider.1"), "insider");
+  assert.strictEqual(channelForVersion("1.2.3-rc.1"), "insider");
+});
+
+test("channelForVersion: bare semver -> stable, unstamped/missing -> null", () => {
+  assert.strictEqual(channelForVersion("1.2.3"), "stable");
+  assert.strictEqual(channelForVersion(undefined), null);
+});
+
+test("fetchFeedHttps rejects http on non-loopback hosts", async () => {
+  await assert.rejects(
+    () => fetchFeedHttps("http://cdn.example.dev/feed/stable/latest-mac.json"),
+    /must be https/,
+  );
+});
 
 test("channelForFlavor maps beta -> insider", () => {
   assert.strictEqual(channelForFlavor("beta"), "insider");
@@ -15,37 +36,146 @@ test("channelForFlavor defaults non-beta to stable", () => {
   assert.strictEqual(channelForFlavor("anything"), "stable");
 });
 
-test("buildFeedUrl assembles platform/channel/version query", () => {
-  const url = buildFeedUrl({
-    base: "https://updates.example.dev/feed",
-    platform: "darwin-arm64",
-    channel: "insider",
-    version: "1.2.3",
-  });
-  const u = new URL(url);
-  assert.strictEqual(u.origin + u.pathname, "https://updates.example.dev/feed");
-  assert.strictEqual(u.searchParams.get("platform"), "darwin-arm64");
-  assert.strictEqual(u.searchParams.get("channel"), "insider");
-  assert.strictEqual(u.searchParams.get("version"), "1.2.3");
+test("buildFeedUrl points at the channel's static latest-mac.json", () => {
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "insider" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/insider/latest-mac.json");
 });
 
 test("buildFeedUrl strips trailing slashes from base", () => {
-  const url = buildFeedUrl({
-    base: "https://updates.example.dev/feed///",
-    platform: "darwin-arm64",
-    channel: "stable",
-    version: "2.0.0",
-  });
-  assert.ok(url.startsWith("https://updates.example.dev/feed?"));
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed///", channel: "stable" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/stable/latest-mac.json");
 });
 
-test("buildFeedUrl url-encodes version values", () => {
-  const url = buildFeedUrl({
-    base: "https://u.dev/feed",
-    platform: "darwin-arm64",
-    channel: "stable",
-    version: "1.2.3-beta+build.5",
+test("buildFeedUrl url-encodes the channel segment", () => {
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "a b" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/a%20b/latest-mac.json");
+});
+
+// ---------------------------------------------------------------------------
+// Client-side compare gate: Squirrel must only be engaged when the static
+// feed's version differs from the running app (a static 200 feed would
+// otherwise read as "update available" on every check, forever).
+// ---------------------------------------------------------------------------
+
+function makeDeps({ appVersion, feed, fetchErr }) {
+  const calls = { checkForUpdates: 0, setFeedURL: [], states: [] };
+  const handlers = {};
+  const deps = {
+    app: {
+      isPackaged: true,
+      getVersion: () => appVersion,
+      once: () => {},
+      removeListener: () => {},
+    },
+    autoUpdater: {
+      setFeedURL: (o) => calls.setFeedURL.push(o.url),
+      checkForUpdates: () => { calls.checkForUpdates += 1; },
+      on: (ev, fn) => { handlers[ev] = fn; },
+      quitAndInstall: () => {},
+    },
+    dialog: { showMessageBox: async () => ({ response: 1 }) },
+    Notification: function () { return { show: () => {} }; },
+    getFlavor: () => "beta",
+    stopGateway: async () => {},
+    feedBase: "https://cdn.example.dev/feed",
+    fetchFeed: async () => {
+      if (fetchErr) throw fetchErr;
+      return feed;
+    },
+    onUpdateState: (s) => calls.states.push(s.state),
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+  return { deps, calls, handlers };
+}
+
+// Force darwin so initAutoUpdate does not bail on non-mac test runners.
+function withDarwin(fn) {
+  const orig = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "darwin" });
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => Object.defineProperty(process, "platform", orig));
+}
+
+test("same feed version does NOT engage Squirrel (loop guard)", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      feed: { version: "1.0.0", url: "https://cdn.example.dev/desktop/insider/1.0.0/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    // allow the async safeCheck to settle
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(calls.states.includes("not-available"));
+  }));
+
+test("different feed version engages Squirrel with the static feed URL", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+    // Bare-semver running version resolves to the STABLE channel -- the
+    // version-derived channel wins over the fixture's "beta" flavor.
+    assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/stable/latest-mac.json"));
+  }));
+
+test("malformed feed surfaces error and does not engage Squirrel", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      feed: { name: "no version or url" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(calls.states.includes("error"));
+  }));
+
+test("feed fetch failure surfaces error and does not engage Squirrel", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      fetchErr: new Error("feed HTTP 403"),
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(calls.states.includes("error"));
+  }));
+
+test("stamped nightly build tracks the NIGHTLY feed, not stable (no channel migration)", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "0.1.0-nightly.20260721042000",
+      feed: { version: "0.1.0-nightly.20260722042000", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/nightly/latest-mac.json"));
+    assert.strictEqual(calls.checkForUpdates, 1);
+  }));
+
+test("fetchFeedHttps accepts plain http on loopback (local update harness)", async () => {
+  const http = require("http");
+  const srv = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ version: "9.9.9", url: "http://127.0.0.1/z.zip" }));
   });
-  const u = new URL(url);
-  assert.strictEqual(u.searchParams.get("version"), "1.2.3-beta+build.5");
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  try {
+    const feed = await fetchFeedHttps(`http://127.0.0.1:${srv.address().port}/feed/stable/latest-mac.json`);
+    assert.strictEqual(feed.version, "9.9.9");
+  } finally {
+    srv.close();
+  }
 });


### PR DESCRIPTION
Closes the three desktop auto-update gaps identified after the notarization work: artifacts only reachable in the private signing bucket (HTTP 403), placeholder feed host, no feed endpoint.

## CI — notarize-macos.yml
- After the spctl gate: copy the notarized zip to the **public distribution bucket** at `desktop/<channel>/<version>/` (CloudFront + OAC). The signing bucket stays private and single-purpose — clients download exclusively through the CDN.
- Versioned keys are immutable-cached, so the write is conditional (`--if-none-match`) with idempotent 412 handling for job re-runs (an existing key already passed the gate on the earlier attempt; it is kept, never overwritten — same never-republish discipline as `cli/*`).
- The channel feed `feed/<channel>/latest-mac.json` moves to the distribution bucket and points at the CDN URL. Reuses the existing no-cache `feed/*` behavior and PutObject grant. Written only after the artifact is publicly downloadable (feed-before-artifact would hand clients a 403).

## CI — nightly.yml / release.yml
- Stamp `website/electron/package.json` with the channel version before building, so `app.getVersion()` equals the feed version. The built app previously reported the static `0.1.0` — the client-side compare would otherwise re-download the same build every 4 hours forever. (Bonus: release artifacts stop being named `KiroCrew-0.1.0-*` regardless of tag.)

## App — auto-update.js
- `DEFAULT_FEED_BASE` → the CloudFront distribution (env override `KIROCREW_UPDATE_FEED` unchanged; vanity domain can swap in later without code changes).
- **Client-side version gate**: the feed is a static file, so `safeCheck()` fetches it and compares versions itself, engaging Squirrel.Mac only when the feed version differs. Squirrel treats any 200 feed response as 'update available' — this gate is what makes a static feed correct, eliminating the need for a 200/204 server endpoint (the Lambda from the old spec becomes optional polish).
- Bounded feed fetches (15s timeout, 64KB cap), injectable `fetchFeed` for tests, unref'd timers.

## Tests
174/174 electron suite. 4 new compare-gate cases: same-version loop guard, differing-version engages Squirrel with the static feed URL, malformed feed → error (no Squirrel), fetch failure → error (no Squirrel).

## Dependency
Needs the `desktop/*` PutObject grant on the distribution bucket — CDK change in KiroCrewPublishCDK, raised as a separate CR (same shipped-then-merged flow as the cli/* grants). Until it deploys, the new publish step fails with AccessDenied — merge order: deploy grant first.

## Validation plan post-merge
Trigger a nightly: confirm public zip + feed on the CDN, then install the previous nightly, launch with default feed, and watch the first real over-the-air update (download → gateway stop → ShipIt swap → relaunch).