### PR TITLE
fix: run app-install copytree off the event loop and stop following symlinks

### DIFF
--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -87,6 +87,21 @@ Before submitting to the registry:
 - [ ] README.md explains what the app does and how to use it
 - [ ] If you have `setup.onInstall`, test it on a clean machine
 
+### What gets copied at install time
+
+When KiroCrew installs or updates your app, it copies the source tree into
+`~/.kirocrew/apps/{name}/` with two safeguards:
+
+- **Symlinks are never followed.** A symlink whose target resolves inside
+  your app source tree is preserved as a symlink; a symlink resolving
+  outside the source tree is omitted from the installed copy entirely.
+  Committed runtime artifacts must be real files (or in-tree relative
+  links), never reachable only through an external symlink.
+- **Build-input and VCS directories are excluded**: `node_modules`, `.git`,
+  `__pycache__`, and `.venv` (at any depth) are dropped from the installed
+  copy. Serve your UI from the committed `ui/dist/` bundle — nothing your app
+  needs at runtime may live under those names.
+
 ### Repository structure
 
 Your app should live in its own Git repo (or a subdirectory of an existing repo):

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -9,8 +9,10 @@ registration (agents, skills, crons) to bridge functions.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -261,6 +263,114 @@ def _check_path_safety(path: str) -> bool:
     return ".." not in path and "/" not in path and "\\" not in path
 
 
+# Build-input / VCS directories never needed at runtime.  The app-kit runtime
+# layout is ``app.json`` + backend code + ``ui/dist/`` — ``node_modules`` is
+# npm build input and ``.git`` comes from cloned registry sources.
+# ``shutil.ignore_patterns`` matches by basename at every depth, so both
+# ``node_modules`` and ``ui/node_modules`` are dropped.  ``build`` is
+# deliberately NOT listed: the manifest may reference runtime paths anywhere
+# under the app root, and silently dropping a manifest-referenced directory
+# would record a successful install with missing files.  A ``build`` symlink
+# into a huge build tree is already neutralized by ``symlinks=True``.
+_COPY_IGNORE = ("node_modules", ".git", "__pycache__", ".venv")
+
+
+def _copy_app_tree(source: Path, dest: Path) -> None:
+    """Copy an app source tree for install/update.
+
+    - Symlinks are never followed. A symlink whose resolved target stays
+      inside ``source`` is preserved as a symlink (e.g. an in-tree relative
+      link); a symlink resolving OUTSIDE the source root is omitted
+      entirely.  This makes the historic failure mode (a ``build`` symlink
+      into a multi-GB build tree walked on copy) structurally impossible,
+      and it prevents a link like ``ui -> ~/.docker`` from either copying
+      or later serving sensitive files through the app UI route (same
+      intent as ``snapshot._copytree_safe``).
+    - ``ignore``: drop build-input/VCS dirs never needed at runtime.
+
+    Callers on the asyncio event loop must run this off-loop (executor /
+    ``asyncio.to_thread``) — a large copy is blocking filesystem I/O.
+    """
+    src_root = os.path.realpath(source)
+    # os.path.isjunction: Python 3.12+ (always False off-Windows). Windows
+    # directory junctions are reparse points NOT reported by islink(), and
+    # copytree would descend into them despite symlinks=True — omit them.
+    _isjunction = getattr(os.path, "isjunction", None)
+
+    def _ignore(dir_path: str, names: list[str]) -> set[str]:
+        skip = {n for n in names if n in _COPY_IGNORE}
+        for n in names:
+            if n in skip:
+                continue
+            p = os.path.join(dir_path, n)
+            if _isjunction is not None and _isjunction(p):
+                # Junctions cannot be preserved as links by copytree; never
+                # copy through one (it may point at a sensitive location).
+                logger.warning("Omitting directory junction in app source: %s", p)
+                skip.add(n)
+                continue
+            if os.path.islink(p):
+                try:
+                    target = os.path.realpath(p)
+                    escapes = os.path.commonpath([src_root, target]) != src_root
+                except ValueError:
+                    # commonpath raises for paths on different drives
+                    # (Windows) or mixed abs/rel — treat as escaping.
+                    escapes = True
+                if escapes:
+                    logger.warning(
+                        "Omitting symlink escaping app source root: %s", p
+                    )
+                    skip.add(n)
+        return skip
+
+    shutil.copytree(
+        source,
+        dest,
+        dirs_exist_ok=True,
+        symlinks=True,
+        ignore=_ignore,
+    )
+
+    # Rewrite preserved ABSOLUTE in-tree symlinks to relative form: an
+    # absolute link copied verbatim still points into the *source* tree, so
+    # the installed copy would silently depend on (and break with) the local
+    # source directory. Relative in-tree links are already correct as-is.
+    for root, dirs, files in os.walk(dest):
+        for n in dirs + files:
+            p = os.path.join(root, n)
+            if not os.path.islink(p):
+                continue
+            raw = os.readlink(p)
+            if not os.path.isabs(raw):
+                continue
+            rel_to_src = os.path.relpath(os.path.realpath(p), src_root)
+            os.remove(p)
+            os.symlink(
+                os.path.relpath(os.path.join(dest, rel_to_src), os.path.dirname(p)), p
+            )
+
+
+# Per-app lifecycle locks, shared by every async entry point (registry
+# install, dashboard install/update/uninstall routes).  Once the blocking
+# copy runs off-loop, two concurrent operations on the same app could
+# otherwise race the installed-check against the copy — and update/uninstall
+# use shared move-aside names (``.{name}-data-tmp``), so an interleaving can
+# destroy preserved user data.  Different apps proceed in parallel.
+_LIFECYCLE_LOCKS: dict[str, "asyncio.Lock"] = {}
+
+
+def app_lifecycle_lock(name: str) -> "asyncio.Lock":
+    """Return the per-app asyncio lock guarding install/update/uninstall.
+
+    Must be called from (and the lock used on) the event loop thread; the
+    guarded blocking work itself runs off-loop via executor/``to_thread``.
+    """
+    if name not in _LIFECYCLE_LOCKS:
+        _LIFECYCLE_LOCKS[name] = asyncio.Lock()
+    return _LIFECYCLE_LOCKS[name]
+
+
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------
@@ -387,8 +497,12 @@ def install_app(source: str | Path) -> AppResult:
             pass
 
         if dest.exists():
+            # No installed metadata for this app (checked above), yet the
+            # dest dir exists — an orphaned partial copy from a prior crash
+            # (e.g. hard kill mid-install). Remove and re-copy fresh.
+            logger.warning("Removing orphaned partial install at %s", dest)
             shutil.rmtree(dest)
-        shutil.copytree(source, dest, dirs_exist_ok=True)
+        _copy_app_tree(source, dest)
 
         # Restore preserved data/ (overwrite empty data/ from source package)
         if tmp_data.is_dir():
@@ -396,7 +510,7 @@ def install_app(source: str | Path) -> AppResult:
             if restored.exists():
                 shutil.rmtree(restored)
             shutil.move(str(tmp_data), str(restored))
-    except OSError as exc:
+    except (OSError, shutil.Error, ValueError) as exc:
         # Clean up partial install first
         if dest.exists():
             shutil.rmtree(dest, ignore_errors=True)
@@ -458,13 +572,17 @@ def install_app(source: str | Path) -> AppResult:
 # ---------------------------------------------------------------------------
 
 
-def update_app(source: str | Path) -> AppResult:
+def update_app(source: str | Path, *, expected_name: str | None = None) -> AppResult:
     """Update an already-installed app from a local directory path.
 
     1. Validate new manifest
     2. Preserve ``data/`` directory
     3. Replace app files
     4. Update ``installed.json``
+
+    ``expected_name``: when given, reject the update unless the source
+    manifest's ``name`` matches — callers that lock/route by app name must
+    not let a mismatched source mutate a different app.
     """
     source = Path(source).expanduser().resolve()
     if not source.is_dir():
@@ -476,6 +594,12 @@ def update_app(source: str | Path) -> AppResult:
 
     manifest = AppManifest.from_json_file(source / APP_MANIFEST_FILENAME)
     name = manifest.name
+    if expected_name is not None and name != expected_name:
+        return AppResult(
+            ok=False,
+            name=expected_name,
+            error=f"source manifest name {name!r} does not match app {expected_name!r}",
+        )
     dest = app_dir(name)
 
     # Guard against path traversal in manifest name
@@ -521,7 +645,7 @@ def update_app(source: str | Path) -> AppResult:
 
         # Replace app files
         shutil.rmtree(dest)
-        shutil.copytree(source, dest, dirs_exist_ok=True)
+        _copy_app_tree(source, dest)
 
         # Restore data
         if tmp_data.is_dir():
@@ -532,7 +656,7 @@ def update_app(source: str | Path) -> AppResult:
         # Restore secret
         if tmp_secret.is_file():
             shutil.move(str(tmp_secret), str(dest / ".app_secret"))
-    except OSError as exc:
+    except (OSError, shutil.Error, ValueError) as exc:
         # Attempt to restore on failure — each step independently wrapped
         try:
             if tmp_data.is_dir() and not data_dir.is_dir():

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1037,7 +1037,6 @@ def app_source_dir(name: str) -> Path:
 # ---------------------------------------------------------------------------
 
 _BUILD_TIMEOUT = 600  # 10 minutes — frontend bundlers / packagers can be slow
-_APP_LOCKS: dict[str, asyncio.Lock] = {}  # per-app serialization
 _KILL_GRACE_PERIOD = 5  # seconds to wait after SIGTERM before SIGKILL
 
 
@@ -1158,13 +1157,11 @@ async def _clone_build_app(
     Returns ``{"ok": True, "pkg_dir": <Path>}`` on success or
     ``{"ok": False, "error": ...}`` on failure.
     """
-    # Per-app lock — prevents two concurrent installs of the same app from
-    # racing on clone / build. Different apps can install in parallel.
-    if app_name not in _APP_LOCKS:
-        _APP_LOCKS[app_name] = asyncio.Lock()
-
-    async with _APP_LOCKS[app_name]:
-        return await _clone_build_app_locked(git_url, app_name, log_lines, branch=branch)
+    # Lock-free: the caller (route handler) holds app_lifecycle_lock(name)
+    # across the complete lifecycle transaction — clone/build, copy,
+    # registration, and backend startup — so nested acquisition here would
+    # deadlock (asyncio.Lock is not reentrant).
+    return await _clone_build_app_locked(git_url, app_name, log_lines, branch=branch)
 
 
 async def _clone_build_app_locked(
@@ -1586,11 +1583,17 @@ async def install_from_registry(
 
         # Kirocrew-managed: copy to ~/.kirocrew/apps/ and register resources
         log_lines.append("Installing app...")
+        # Lock-free: the route handler holds app_lifecycle_lock(name) across
+        # the whole transaction (clone/build → copy → register → backend
+        # start); asyncio.Lock is not reentrant, so no acquisition here.
         existing = get_app(name)
+        # Off-loop: install_app/update_app do a blocking filesystem copy
+        # that can take minutes on large source trees — on the loop it
+        # would trip the loop-stall watchdog and kill the gateway.
         if existing:
-            result = update_app(str(app_source))
+            result = await asyncio.to_thread(update_app, str(app_source))
         else:
-            result = install_app(str(app_source))
+            result = await asyncio.to_thread(install_app, str(app_source))
         log_lines.append(result.message or result.error or "done")
 
         # Mark source as registry-installed

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -41,6 +41,7 @@ from kiro_crew.apps.builtins import BUILTIN_NAMES
 from kiro_crew.apps.dependencies import resolve_dependencies as _resolve_deps
 from kiro_crew.apps.hooks_integration import on_app_disable, on_app_enable
 from kiro_crew.apps.manager import (
+    app_lifecycle_lock,
     apps_dir,
     cleanup_migrated_builtin,
     disable_app,
@@ -411,26 +412,43 @@ async def handle_install_app(request: web.Request) -> web.Response:
     # Check minKiroCrewVersion before installing
     source_path = Path(source).expanduser().resolve()
     manifest_path = source_path / "app.json"
+    lock_name = str(source_path)  # fallback lock key when manifest is unreadable
     if manifest_path.is_file():
         try:
             manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
             ver_err = _check_min_version(manifest_data)
             if ver_err:
                 return web.json_response({"error": ver_err}, status=400)
+            raw_name = manifest_data.get("name")
+            # Only a nonempty string is a usable lock key — anything else
+            # (list, dict, number) keeps the path fallback and is rejected
+            # by manifest validation inside install_app.
+            if isinstance(raw_name, str) and raw_name:
+                lock_name = raw_name
         except (json.JSONDecodeError, OSError):
             pass
 
-    result = install_app(source)
-    if not result.ok:
-        sel().log_api_access(caller="dashboard", operation="app_install", outcome="failed", resources=source, error=result.error)
-        return web.json_response(result.to_dict(), status=400)
-    invalidate_app_secret_cache(result.name)
+    # Per-app lifecycle lock (shared with registry installs), held across
+    # the whole install transaction — copy, registration, and backend start —
+    # so a concurrent uninstall cannot deregister between our copy and our
+    # register, leaving a running backend for a removed app.
+    async with app_lifecycle_lock(lock_name):
+        # Off-loop: the copy in install_app is blocking filesystem I/O that can
+        # take minutes on large source trees — running it on the loop would trip
+        # the loop-stall watchdog and kill the gateway.
+        result = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), install_app, source
+        )
+        if not result.ok:
+            sel().log_api_access(caller="dashboard", operation="app_install", outcome="failed", resources=source, error=result.error)
+            return web.json_response(result.to_dict(), status=400)
+        invalidate_app_secret_cache(result.name)
 
-    # Auto-register resources
-    reg = register_app(result.name)
-    # Spawn the backend now so the app is reachable without a gateway reboot
-    # (see _start_backend_after_install). No-op for backend-less apps.
-    await _start_backend_after_install(result.name)
+        # Auto-register resources
+        reg = register_app(result.name)
+        # Spawn the backend now so the app is reachable without a gateway reboot
+        # (see _start_backend_after_install). No-op for backend-less apps.
+        await _start_backend_after_install(result.name)
     sel().log_api_access(caller="dashboard", operation="app_install", outcome="completed", resources=result.name)
     return web.json_response({
         **result.to_dict(),
@@ -465,17 +483,20 @@ async def handle_update_app(request: web.Request) -> web.Response:
     # to avoid leaving the app in a broken state on failure.
     if is_registry_source(source):
         registry_name = registry_name_from_source(source)
-        reg_install = await install_from_registry(registry_name)
-        if not reg_install.get("ok"):
-            sel().log_api_access(caller="dashboard", operation="app_update", outcome="failed", resources=name, error=reg_install.get("error", ""))
-            return web.json_response(reg_install, status=400)
-        # Install succeeded — now safe to swap resources
-        deregister_app(name)
-        await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
-        if info.get("enabled"):
-            reg_result = register_app(name)
-            await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
-            reg_install["registration"] = reg_result.to_dict()
+        # One lock across re-install + resource swap + backend restart
+        # (install_from_registry is lock-free internally).
+        async with app_lifecycle_lock(name):
+            reg_install = await install_from_registry(registry_name)
+            if not reg_install.get("ok"):
+                sel().log_api_access(caller="dashboard", operation="app_update", outcome="failed", resources=name, error=reg_install.get("error", ""))
+                return web.json_response(reg_install, status=400)
+            # Install succeeded — now safe to swap resources
+            deregister_app(name)
+            await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
+            if info.get("enabled"):
+                reg_result = register_app(name)
+                await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
+                reg_install["registration"] = reg_result.to_dict()
         sel().log_api_access(caller="dashboard", operation="app_update", outcome="completed", resources=name)
         return web.json_response(reg_install)
 
@@ -484,24 +505,35 @@ async def handle_update_app(request: web.Request) -> web.Response:
             {"error": "source path required (not found in installed metadata)"}, status=400,
         )
 
-    # Deregister old resources before update
-    deregister_app(name)
-    await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
+    # Per-app lifecycle lock: the deregister → stop → copy → re-register
+    # sequence must not interleave with another update/install/uninstall of
+    # the same app — update_app moves user data through a shared
+    # ``.{name}-data-tmp`` path, so an interleaving can destroy it.
+    # (The registry branch above locks inside install_from_registry.)
+    async with app_lifecycle_lock(name):
+        # Deregister old resources before update
+        deregister_app(name)
+        await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
 
-    up_result = update_app(source)
-    if not up_result.ok:
-        # Re-register old resources on failure
-        register_app(name)
+        # Off-loop: blocking filesystem copy (see handle_install_app).
+        # expected_name makes update_app itself reject a source whose
+        # manifest names a different app than the one this lock guards.
+        up_result = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), lambda: update_app(source, expected_name=name)
+        )
+        if not up_result.ok:
+            # Re-register old resources on failure
+            register_app(name)
+            if info.get("enabled"):
+                await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
+            sel().log_api_access(caller="dashboard", operation="app_update", outcome="failed", resources=name, error=up_result.error)
+            return web.json_response(up_result.to_dict(), status=400)
+
+        # Re-register with new manifest if app was enabled
+        up_reg = None
         if info.get("enabled"):
+            up_reg = register_app(name)
             await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
-        sel().log_api_access(caller="dashboard", operation="app_update", outcome="failed", resources=name, error=up_result.error)
-        return web.json_response(up_result.to_dict(), status=400)
-
-    # Re-register with new manifest if app was enabled
-    up_reg = None
-    if info.get("enabled"):
-        up_reg = register_app(name)
-        await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
 
     sel().log_api_access(caller="dashboard", operation="app_update", outcome="completed", resources=name)
     resp: dict[str, Any] = up_result.to_dict()
@@ -651,63 +683,74 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         if script_output.get("failed"):
             uninstall_log.append("onUninstall script failed (exit code non-zero)")
 
-    # Step 2: Deregister resources (gateway-managed only)
-    if resources == "gateway":
-        await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
-        # Clean up app-declared cron jobs from the scheduler before the
-        # per-app cron manifest is removed by deregister_app(). Mirrors the
-        # cleanup that on_app_disable performs on the disable path.
-        state = request.app.get("state")
-        cron_service = getattr(state, "crons", None) if state else None
-        if cron_service is not None:
-            try:
-                removed = deregister_app_crons_from_service(name, cron_service)
-                sel().log_api_access(
-                    caller="dashboard",
-                    operation="app_crons_deregister",
-                    outcome="completed",
-                    resources=f"app={name} removed={removed}",
-                )
-            except Exception as exc:
-                logger.warning("Cron cleanup failed for %s on uninstall: %s", name, exc)
-                sel().log_api_access(
-                    caller="dashboard",
-                    operation="app_crons_deregister",
-                    outcome="failed",
-                    resources=name,
-                    error=str(exc),
-                )
-        deregister_app(name)
+    # Per-app lifecycle lock, held across deregistration → dependency cleanup
+    # → file removal, so this sequence cannot interleave with a concurrent
+    # install/update of the same app (which holds the same lock across copy →
+    # registration → backend start). Without it, an install could re-register
+    # and start a backend between our deregister and our file removal.
+    async with app_lifecycle_lock(name):
+        # Step 2: Deregister resources (gateway-managed only)
+        if resources == "gateway":
+            await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
+            # Clean up app-declared cron jobs from the scheduler before the
+            # per-app cron manifest is removed by deregister_app(). Mirrors the
+            # cleanup that on_app_disable performs on the disable path.
+            state = request.app.get("state")
+            cron_service = getattr(state, "crons", None) if state else None
+            if cron_service is not None:
+                try:
+                    removed = deregister_app_crons_from_service(name, cron_service)
+                    sel().log_api_access(
+                        caller="dashboard",
+                        operation="app_crons_deregister",
+                        outcome="completed",
+                        resources=f"app={name} removed={removed}",
+                    )
+                except Exception as exc:
+                    logger.warning("Cron cleanup failed for %s on uninstall: %s", name, exc)
+                    sel().log_api_access(
+                        caller="dashboard",
+                        operation="app_crons_deregister",
+                        outcome="failed",
+                        resources=name,
+                        error=str(exc),
+                    )
+            deregister_app(name)
 
-    # Step 3: Clean dependencies (atomic classify + ledger update)
-    cleaned_deps: list[str] = []
-    if not keep_dependencies:
-        deps_data = manifest.get("dependencies", {})
-        aim_deps = deps_data.get("aim", {})
-        declared_deps: list[str] = []
-        for dep_type in ("mcp", "skills", "agents"):
-            for entry in aim_deps.get(dep_type, []):
-                dep_id = entry.get("id") if isinstance(entry, dict) else entry
-                if not dep_id:
-                    continue
-                declared_deps.append(f"aim/{dep_type}/{dep_id}")
+        # Step 3: Clean dependencies (atomic classify + ledger update)
+        cleaned_deps: list[str] = []
+        if not keep_dependencies:
+            deps_data = manifest.get("dependencies", {})
+            aim_deps = deps_data.get("aim", {})
+            declared_deps: list[str] = []
+            for dep_type in ("mcp", "skills", "agents"):
+                for entry in aim_deps.get(dep_type, []):
+                    dep_id = entry.get("id") if isinstance(entry, dict) else entry
+                    if not dep_id:
+                        continue
+                    declared_deps.append(f"aim/{dep_type}/{dep_id}")
 
-        from kiro_crew.apps.dependency_ledger import classify_and_clean_for_uninstall
-        classification = classify_and_clean_for_uninstall(
-            name, declared_deps, keep_specific=list(keep_specific),
+            from kiro_crew.apps.dependency_ledger import classify_and_clean_for_uninstall
+            classification = classify_and_clean_for_uninstall(
+                name, declared_deps, keep_specific=list(keep_specific),
+            )
+            removable = [
+                d for d in classification.get("removable", [])
+                if d.get("id") not in keep_specific
+            ]
+            if removable:
+                from kiro_crew.apps.dependencies import clean_dependencies
+                cleaned_deps = await clean_dependencies(name, removable)
+                if cleaned_deps:
+                    uninstall_log.append(f"Cleaned {len(cleaned_deps)} dependency(ies)")
+
+        # Step 4: Remove files. Off-loop: rmtree of a large installed tree is
+        # blocking filesystem I/O. (uninstall_app shares the
+        # ``.{name}-data-tmp`` move-aside path with install/update — covered
+        # by the lifecycle lock held above.)
+        result = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), lambda: uninstall_app(name, keep_data=keep_data)
         )
-        removable = [
-            d for d in classification.get("removable", [])
-            if d.get("id") not in keep_specific
-        ]
-        if removable:
-            from kiro_crew.apps.dependencies import clean_dependencies
-            cleaned_deps = await clean_dependencies(name, removable)
-            if cleaned_deps:
-                uninstall_log.append(f"Cleaned {len(cleaned_deps)} dependency(ies)")
-
-    # Step 4: Remove files
-    result = uninstall_app(name, keep_data=keep_data)
     if not result.ok:
         sel().log_api_access(caller="dashboard", operation="app_uninstall", outcome="failed", resources=name, error=result.error)
         return web.json_response(result.to_dict(), status=400)
@@ -750,116 +793,121 @@ async def handle_enable_app(request: web.Request) -> web.Response:
     on_enable = (manifest.get("setup") or {}).get("onEnable", "")
     enable_timeout = int((manifest.get("setup") or {}).get("onEnableTimeout", 30))
 
-    result = enable_app(name)
-    if not result.ok:
-        sel().log_api_access(caller="dashboard", operation="app_enable", outcome="failed", resources=name, error=result.error)
-        return web.json_response(result.to_dict(), status=400)
+    # Per-app lifecycle lock: enable mutates metadata, registers resources,
+    # and starts the backend — must not interleave with a concurrent
+    # install/update/uninstall of the same app (e.g. enabling while an
+    # off-loop uninstall is deleting the app directory).
+    async with app_lifecycle_lock(name):
+        result = enable_app(name)
+        if not result.ok:
+            sel().log_api_access(caller="dashboard", operation="app_enable", outcome="failed", resources=name, error=result.error)
+            return web.json_response(result.to_dict(), status=400)
 
-    resp: dict[str, Any] = result.to_dict()
+        resp: dict[str, Any] = result.to_dict()
 
-    # Register resources if gateway-managed
-    if resources == "gateway":
-        reg = register_app(name)
-        backend = await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
-        # MCP re-registration is HEALTH-GATED (review CR-284432051). register_app ran before
-        # the backend was up, so an HTTP MCP server with backend.port:"auto" carries the
-        # manifest's illustrative port. The backend's health-check loop calls
-        # _gate_mcp_registration once /health passes, rewriting the url to the real allocated
-        # port (and scrubbing it if the backend never becomes healthy — the dead-url shape
-        # that broke kiro-cli). EXCEPTION: an adopted already-healthy instance runs no health
-        # loop, so register it synchronously here.
-        if backend is not None and getattr(backend, "healthy", False):
-            try:
-                reregister_app_mcp_servers(name, live_port=getattr(backend, "port", None))
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("MCP re-registration after backend start failed for %s: %s", name, exc)
-        resp["registration"] = reg.to_dict()
-        if backend:
-            resp["backend"] = backend.to_dict()
+        # Register resources if gateway-managed
+        if resources == "gateway":
+            reg = register_app(name)
+            backend = await asyncio.get_running_loop().run_in_executor(subprocess_executor(), start_app_backend, name)
+            # MCP re-registration is HEALTH-GATED (review CR-284432051). register_app ran before
+            # the backend was up, so an HTTP MCP server with backend.port:"auto" carries the
+            # manifest's illustrative port. The backend's health-check loop calls
+            # _gate_mcp_registration once /health passes, rewriting the url to the real allocated
+            # port (and scrubbing it if the backend never becomes healthy — the dead-url shape
+            # that broke kiro-cli). EXCEPTION: an adopted already-healthy instance runs no health
+            # loop, so register it synchronously here.
+            if backend is not None and getattr(backend, "healthy", False):
+                try:
+                    reregister_app_mcp_servers(name, live_port=getattr(backend, "port", None))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("MCP re-registration after backend start failed for %s: %s", name, exc)
+            resp["registration"] = reg.to_dict()
+            if backend:
+                resp["backend"] = backend.to_dict()
 
-    # Resolve declared dependencies (if any)
-    deps_data = manifest.get("dependencies")
-    if deps_data and isinstance(deps_data, dict):
-        deps = Dependencies.from_dict(deps_data)
-        dep_result = await _resolve_deps(name, deps)
-        sel().log_api_access(
-            caller="dashboard",
-            operation="app_enable_resolve_deps",
-            outcome="partial_failure" if dep_result.failed else "success",
-            resources=name,
-            error=str(dep_result.failed) if dep_result.failed else "",
-        )
-        dep_info: dict[str, Any] = {}
-        if dep_result.installed:
-            dep_info["installed"] = dep_result.installed
-        if dep_result.failed:
-            dep_info["failed"] = dep_result.failed
-        if dep_result.missing:
-            dep_info["missing"] = dep_result.missing
-        if dep_info:
-            resp["dependencies"] = dep_info
+        # Resolve declared dependencies (if any)
+        deps_data = manifest.get("dependencies")
+        if deps_data and isinstance(deps_data, dict):
+            deps = Dependencies.from_dict(deps_data)
+            dep_result = await _resolve_deps(name, deps)
+            sel().log_api_access(
+                caller="dashboard",
+                operation="app_enable_resolve_deps",
+                outcome="partial_failure" if dep_result.failed else "success",
+                resources=name,
+                error=str(dep_result.failed) if dep_result.failed else "",
+            )
+            dep_info: dict[str, Any] = {}
+            if dep_result.installed:
+                dep_info["installed"] = dep_result.installed
+            if dep_result.failed:
+                dep_info["failed"] = dep_result.failed
+            if dep_result.missing:
+                dep_info["missing"] = dep_result.missing
+            if dep_info:
+                resp["dependencies"] = dep_info
 
-    # Run onEnable script
-    if on_enable:
-        script_output = await _run_lifecycle_script(name, on_enable, timeout=enable_timeout)
-        if script_output.get("failed"):
-            # Rollback: disable the app again
-            if resources == "gateway":
-                await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
-                deregister_app(name)
-            disable_app(name)
-            sel().log_api_access(caller="dashboard", operation="app_enable", outcome="failed", resources=name, error="onEnable script failed")
-            from kiro_crew.security import redact_credentials
-            cleaned, _ = redact_credentials(script_output.get("output", ""))
-            return web.json_response({
-                "ok": False, "name": name,
-                "error": "onEnable script failed — app remains disabled",
-                "script_output": cleaned,
-            }, status=400)
-        resp["onEnable"] = {
-            "output": "",
-            "failed": False,
-        }
-        if script_output.get("output"):
-            from kiro_crew.security import redact_credentials
-            cleaned, _ = redact_credentials(script_output.get("output", ""))
-            resp["onEnable"]["output"] = cleaned
-        resp["onEnable"]["failed"] = script_output.get("failed", False)
+        # Run onEnable script
+        if on_enable:
+            script_output = await _run_lifecycle_script(name, on_enable, timeout=enable_timeout)
+            if script_output.get("failed"):
+                # Rollback: disable the app again
+                if resources == "gateway":
+                    await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
+                    deregister_app(name)
+                disable_app(name)
+                sel().log_api_access(caller="dashboard", operation="app_enable", outcome="failed", resources=name, error="onEnable script failed")
+                from kiro_crew.security import redact_credentials
+                cleaned, _ = redact_credentials(script_output.get("output", ""))
+                return web.json_response({
+                    "ok": False, "name": name,
+                    "error": "onEnable script failed — app remains disabled",
+                    "script_output": cleaned,
+                }, status=400)
+            resp["onEnable"] = {
+                "output": "",
+                "failed": False,
+            }
+            if script_output.get("output"):
+                from kiro_crew.security import redact_credentials
+                cleaned, _ = redact_credentials(script_output.get("output", ""))
+                resp["onEnable"]["output"] = cleaned
+            resp["onEnable"]["failed"] = script_output.get("failed", False)
 
-    # Invoke Python lifecycle hooks (routes + on_startup) — runs AFTER shell scripts
-    try:
-        state = request.app.get("state")
-        hooks_result = await on_app_enable(
-            name, info,
-            cron_service=getattr(state, "crons", None),
-            broadcast_fn=getattr(state, "broadcast", None),
-        )
-        if hooks_result:
-            # Redact any sensitive content in health_status issues
-            if "health_status" in hooks_result:
-                hs = hooks_result["health_status"]
-                if "issues" in hs:
-                    hs["issues"] = [_redact_warning(i) for i in hs["issues"]]
-            resp["hooks"] = hooks_result
-    except Exception as exc:
-        logger.warning("Hook execution failed for %s: %s", name, exc)
-        resp.setdefault("warnings", []).append(_redact_warning(f"hooks failed: {exc}"))
-
-    # Sync config.json and start live service for builtin apps
-    origin = info.get("origin", "")
-    if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
+        # Invoke Python lifecycle hooks (routes + on_startup) — runs AFTER shell scripts
         try:
-            _sync_builtin_config(name, enabled=True)
-        except OSError as exc:
-            logger.warning("Failed to sync config.json for %s: %s", name, exc)
-            resp.setdefault("warnings", []).append(_redact_warning(f"config sync failed: {exc}"))
-        else:
-            svc_warn = await _notify_builtin_service(request, name)
-            if svc_warn:
-                resp.setdefault("warnings", []).append(_redact_warning(svc_warn))
+            state = request.app.get("state")
+            hooks_result = await on_app_enable(
+                name, info,
+                cron_service=getattr(state, "crons", None),
+                broadcast_fn=getattr(state, "broadcast", None),
+            )
+            if hooks_result:
+                # Redact any sensitive content in health_status issues
+                if "health_status" in hooks_result:
+                    hs = hooks_result["health_status"]
+                    if "issues" in hs:
+                        hs["issues"] = [_redact_warning(i) for i in hs["issues"]]
+                resp["hooks"] = hooks_result
+        except Exception as exc:
+            logger.warning("Hook execution failed for %s: %s", name, exc)
+            resp.setdefault("warnings", []).append(_redact_warning(f"hooks failed: {exc}"))
 
-    sel().log_api_access(caller="dashboard", operation="app_enable", outcome="completed", resources=name)
-    return web.json_response(resp)
+        # Sync config.json and start live service for builtin apps
+        origin = info.get("origin", "")
+        if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
+            try:
+                _sync_builtin_config(name, enabled=True)
+            except OSError as exc:
+                logger.warning("Failed to sync config.json for %s: %s", name, exc)
+                resp.setdefault("warnings", []).append(_redact_warning(f"config sync failed: {exc}"))
+            else:
+                svc_warn = await _notify_builtin_service(request, name)
+                if svc_warn:
+                    resp.setdefault("warnings", []).append(_redact_warning(svc_warn))
+
+        sel().log_api_access(caller="dashboard", operation="app_enable", outcome="completed", resources=name)
+        return web.json_response(resp)
 
 
 async def handle_disable_app(request: web.Request) -> web.Response:
@@ -881,65 +929,69 @@ async def handle_disable_app(request: web.Request) -> web.Response:
     disable_timeout = int((manifest.get("setup") or {}).get("onDisableTimeout", 30))
     warnings: list[str] = []
 
-    # Run onDisable script first
-    if on_disable:
-        script_output = await _run_lifecycle_script(name, on_disable, timeout=disable_timeout)
-        if script_output.get("failed"):
-            from kiro_crew.security import redact_credentials
-            raw_output = script_output.get("output", "")[:200]
-            cleaned, _ = redact_credentials(raw_output)
-            warnings.append(f"onDisable script failed: {cleaned}")
-            logger.warning("onDisable failed for %s, proceeding with disable", name)
+    # Per-app lifecycle lock: disable stops the backend and deregisters
+    # resources — must not interleave with a concurrent install/update/
+    # uninstall/enable of the same app.
+    async with app_lifecycle_lock(name):
+        # Run onDisable script first
+        if on_disable:
+            script_output = await _run_lifecycle_script(name, on_disable, timeout=disable_timeout)
+            if script_output.get("failed"):
+                from kiro_crew.security import redact_credentials
+                raw_output = script_output.get("output", "")[:200]
+                cleaned, _ = redact_credentials(raw_output)
+                warnings.append(f"onDisable script failed: {cleaned}")
+                logger.warning("onDisable failed for %s, proceeding with disable", name)
 
-    # Invoke Python lifecycle hooks (on_shutdown + route deregistration + cron cleanup)
-    try:
-        hooks_result = await on_app_disable(name, info)
-        if hooks_result:
-            for k, v in hooks_result.items():
-                if k == "cron_cleanup" and isinstance(v, str):
-                    warnings.append(v)
-    except Exception as exc:
-        logger.warning("Hook disable failed for %s: %s", name, exc)
-        warnings.append(_redact_warning(f"hooks disable failed: {exc}"))
-
-    # Deregister resources if gateway-managed
-    if resources == "gateway":
-        await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
-        deregister_app(name)
-
-    result = disable_app(name)
-    if not result.ok:
-        sel().log_api_access(caller="dashboard", operation="app_disable", outcome="failed", resources=name, error=result.error)
-        return web.json_response(result.to_dict(), status=400)
-
-    # Run builtin on_disable hook if available
-    if name in BUILTIN_NAMES:
+        # Invoke Python lifecycle hooks (on_shutdown + route deregistration + cron cleanup)
         try:
-            mod = importlib.import_module(f"kiro_crew.apps.builtins.{name}")
-            if hasattr(mod, "on_disable"):
-                mod.on_disable(request.app)
+            hooks_result = await on_app_disable(name, info)
+            if hooks_result:
+                for k, v in hooks_result.items():
+                    if k == "cron_cleanup" and isinstance(v, str):
+                        warnings.append(v)
         except Exception as exc:
-            logger.warning("on_disable hook for %s failed: %s", name, exc)
-            warnings.append(_redact_warning(f"on_disable hook failed: {exc}"))
+            logger.warning("Hook disable failed for %s: %s", name, exc)
+            warnings.append(_redact_warning(f"hooks disable failed: {exc}"))
 
-    # Sync config.json and stop live service for builtin apps
-    origin = info.get("origin", "")
-    if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
-        try:
-            _sync_builtin_config(name, enabled=False)
-        except OSError as exc:
-            logger.warning("Failed to sync config.json for %s: %s", name, exc)
-            warnings.append(_redact_warning(f"config sync failed: {exc}"))
-        else:
-            svc_warn = await _notify_builtin_service(request, name)
-            if svc_warn:
-                warnings.append(_redact_warning(svc_warn))
+        # Deregister resources if gateway-managed
+        if resources == "gateway":
+            await asyncio.get_running_loop().run_in_executor(subprocess_executor(), stop_app_backend, name)
+            deregister_app(name)
 
-    sel().log_api_access(caller="dashboard", operation="app_disable", outcome="completed", resources=name)
-    resp = result.to_dict()
-    if warnings:
-        resp["warnings"] = warnings
-    return web.json_response(resp)
+        result = disable_app(name)
+        if not result.ok:
+            sel().log_api_access(caller="dashboard", operation="app_disable", outcome="failed", resources=name, error=result.error)
+            return web.json_response(result.to_dict(), status=400)
+
+        # Run builtin on_disable hook if available
+        if name in BUILTIN_NAMES:
+            try:
+                mod = importlib.import_module(f"kiro_crew.apps.builtins.{name}")
+                if hasattr(mod, "on_disable"):
+                    mod.on_disable(request.app)
+            except Exception as exc:
+                logger.warning("on_disable hook for %s failed: %s", name, exc)
+                warnings.append(_redact_warning(f"on_disable hook failed: {exc}"))
+
+        # Sync config.json and stop live service for builtin apps
+        origin = info.get("origin", "")
+        if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
+            try:
+                _sync_builtin_config(name, enabled=False)
+            except OSError as exc:
+                logger.warning("Failed to sync config.json for %s: %s", name, exc)
+                warnings.append(_redact_warning(f"config sync failed: {exc}"))
+            else:
+                svc_warn = await _notify_builtin_service(request, name)
+                if svc_warn:
+                    warnings.append(_redact_warning(svc_warn))
+
+        sel().log_api_access(caller="dashboard", operation="app_disable", outcome="completed", resources=name)
+        resp = result.to_dict()
+        if warnings:
+            resp["warnings"] = warnings
+        return web.json_response(resp)
 
 
 async def handle_open_app(request: web.Request) -> web.Response:
@@ -1033,35 +1085,39 @@ async def handle_registry_install(request: web.Request) -> web.Response:
     if not name:
         return web.json_response({"error": "app name required"}, status=400)
 
-    result = await install_from_registry(name)
+    # One lock for the complete transaction: install_from_registry is
+    # lock-free internally (asyncio.Lock is not reentrant), so this is the
+    # single acquisition covering clone/build → copy → register → backend.
+    async with app_lifecycle_lock(name):
+        result = await install_from_registry(name)
 
-    # Redact install log and error before returning to client — build output
-    # may contain internal hostnames, package URLs, or credential fragments.
-    if result.get("log"):
-        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-        cleaned_log, _ = redact_exfiltration_urls(result["log"])
-        cleaned_log, _ = redact_credentials(cleaned_log)
-        result["log"] = cleaned_log
-    if result.get("error"):
-        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-        cleaned_err, _ = redact_exfiltration_urls(result["error"])
-        cleaned_err, _ = redact_credentials(cleaned_err)
-        result["error"] = cleaned_err
+        # Redact install log and error before returning to client — build output
+        # may contain internal hostnames, package URLs, or credential fragments.
+        if result.get("log"):
+            from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+            cleaned_log, _ = redact_exfiltration_urls(result["log"])
+            cleaned_log, _ = redact_credentials(cleaned_log)
+            result["log"] = cleaned_log
+        if result.get("error"):
+            from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+            cleaned_err, _ = redact_exfiltration_urls(result["error"])
+            cleaned_err, _ = redact_credentials(cleaned_err)
+            result["error"] = cleaned_err
 
-    if result.get("needsClientInstall"):
-        return web.json_response(result, status=200)
-    if not result.get("ok"):
-        sel().log_api_access(caller="dashboard", operation="app_registry_install", outcome="failed", resources=name, error=result.get("error", ""))
-        return web.json_response(result, status=400)
+        if result.get("needsClientInstall"):
+            return web.json_response(result, status=200)
+        if not result.get("ok"):
+            sel().log_api_access(caller="dashboard", operation="app_registry_install", outcome="failed", resources=name, error=result.get("error", ""))
+            return web.json_response(result, status=400)
 
-    # Auto-register resources
-    reg = register_app(result["name"])
-    # Spawn the backend now so apps with a server are reachable immediately —
-    # without this the backend only starts on the next gateway reboot (via
-    # start_enabled_app_backends), leaving the app's UI with "no reachable
-    # backend" until then. No-op for apps that declare no backend. Run in a
-    # thread because start_app_backend blocks on a health-check poll.
-    await _start_backend_after_install(result["name"])
+        # Auto-register resources
+        reg = register_app(result["name"])
+        # Spawn the backend now so apps with a server are reachable immediately —
+        # without this the backend only starts on the next gateway reboot (via
+        # start_enabled_app_backends), leaving the app's UI with "no reachable
+        # backend" until then. No-op for apps that declare no backend. Run in a
+        # thread because start_app_backend blocks on a health-check poll.
+        await _start_backend_after_install(result["name"])
     result["registration"] = reg.to_dict()
     sel().log_api_access(caller="dashboard", operation="app_registry_install", outcome="completed", resources=name)
     return web.json_response(result, status=201)
@@ -1137,10 +1193,22 @@ async def handle_registry_install_stream(request: web.Request) -> web.StreamResp
             cleaned, _ = redact_credentials(cleaned)
             await _send_sse("log", cleaned)
 
-    # Run install + drain concurrently
-    install_task = asyncio.create_task(
-        install_from_registry(name, log_lines=streaming_log)
-    )
+    # Run install + drain concurrently. The complete lifecycle transaction —
+    # install, resource registration, backend start — runs under one per-app
+    # lock (install_from_registry is lock-free internally).
+    async def _locked_install() -> dict[str, Any]:
+        async with app_lifecycle_lock(name):
+            r = await install_from_registry(name, log_lines=streaming_log)
+            if r.get("ok") and not r.get("needsClientInstall"):
+                reg = register_app(r["name"])
+                # Spawn the backend immediately (see handle_registry_install) so
+                # the app is reachable without a gateway reboot. No-op for
+                # backend-less apps.
+                await _start_backend_after_install(r["name"])
+                r["registration"] = reg.to_dict()
+            return r
+
+    install_task = asyncio.create_task(_locked_install())
     drain_task = asyncio.create_task(_drain_queue())
 
     try:
@@ -1180,12 +1248,8 @@ async def handle_registry_install_stream(request: web.Request) -> web.StreamResp
         await resp.write_eof()
         return resp
 
-    # Auto-register resources (same as non-streaming endpoint)
-    reg = register_app(result["name"])
-    # Spawn the backend immediately (see handle_registry_install) so the app is
-    # reachable without a gateway reboot. No-op for backend-less apps.
-    await _start_backend_after_install(result["name"])
-    result["registration"] = reg.to_dict()
+    # Resource registration + backend start already ran inside the locked
+    # transaction above; result carries "registration".
     sel().log_api_access(caller="dashboard", operation="app_registry_install_stream", outcome="completed", resources=name)
     await _send_sse("done", json.dumps(result))
     await resp.write_eof()

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -914,3 +914,210 @@ class TestCleanupMigratedBuiltin:
         assert "already migrated" in result.message
         # File was NOT deleted
         assert (app_path / INSTALLED_META_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# _copy_app_tree — symlink / denylist / off-loop regression tests
+# (app install used to run a raw follow-symlinks copytree on the event loop;
+# a large `build` symlink target froze the loop until the watchdog killed
+# the gateway)
+# ---------------------------------------------------------------------------
+
+class TestCopyAppTree:
+    def test_symlink_escaping_source_root_omitted(self, tmp_path, app_home):
+        """A symlink resolving outside the app source is omitted — never
+        followed (no multi-GB walk) and never preserved (nothing in the
+        installed tree can point at e.g. ~/.ssh)."""
+        src = _make_app_source(tmp_path)
+        big = tmp_path / "big-target"
+        big.mkdir()
+        for i in range(20):
+            (big / f"file{i}.bin").write_text("x" * 1024)
+        (src / "assets-link").symlink_to(big)
+
+        result = install_app(src)
+        assert result.ok, result.error
+
+        from kiro_crew.apps.manager import app_dir
+
+        dest = app_dir("test-app")
+        assert not (dest / "assets-link").exists()
+        assert not (dest / "assets-link").is_symlink()
+        # Target contents were not copied anywhere in the installed tree.
+        copied_files = [p for p in dest.rglob("*") if p.is_file() and not p.is_symlink()]
+        assert not any("file0.bin" in str(p) for p in copied_files)
+
+    def test_symlink_inside_source_root_preserved(self, tmp_path, app_home):
+        """An in-tree symlink is preserved — and an ABSOLUTE in-tree link is
+        rewritten to a relative link targeting the installed copy, so the
+        installed app never depends on the original source directory."""
+        import os
+        import shutil as _shutil
+
+        src = _make_app_source(tmp_path)
+        (src / "shared").mkdir()
+        (src / "shared" / "common.js").write_text("export {}")
+        (src / "alias").symlink_to(src / "shared")  # absolute in-tree link
+
+        result = install_app(src)
+        assert result.ok, result.error
+
+        from kiro_crew.apps.manager import app_dir
+
+        dest = app_dir("test-app")
+        link = dest / "alias"
+        assert link.is_symlink()
+        # Rewritten relative — must not embed an absolute path to the source.
+        assert not os.path.isabs(os.readlink(link))
+        # Resolves inside the installed tree and stays usable even after the
+        # original source directory is gone.
+        _shutil.rmtree(src)
+        assert (link / "common.js").is_file()
+        assert link.resolve().is_relative_to(dest.resolve())
+
+    def test_denylist_dirs_dropped_runtime_payload_kept(self, tmp_path, app_home):
+        src = _make_app_source(tmp_path)
+        (src / "ui" / "node_modules").mkdir(parents=True)
+        (src / "ui" / "node_modules" / "junk.js").write_text("junk")
+        (src / "ui" / "dist").mkdir(parents=True)
+        (src / "ui" / "dist" / "index.mjs").write_text("export {}")
+        (src / ".git").mkdir()
+        (src / ".git" / "config").write_text("[core]")
+        (src / "__pycache__").mkdir()
+        (src / "__pycache__" / "x.pyc").write_bytes(b"\x00")
+        # A real `build/` dir is NOT denylisted: the manifest may reference
+        # runtime paths anywhere under the app root, so it must survive.
+        # (A `build` *symlink* is neutralized by symlinks=True instead.)
+        (src / "build").mkdir()
+        (src / "build" / "artifact.txt").write_text("built")
+
+        result = install_app(src)
+        assert result.ok, result.error
+
+        from kiro_crew.apps.manager import app_dir
+
+        dest = app_dir("test-app")
+        assert not (dest / "ui" / "node_modules").exists()
+        assert not (dest / ".git").exists()
+        assert not (dest / "__pycache__").exists()
+        assert (dest / "build" / "artifact.txt").is_file()
+        assert (dest / "ui" / "dist" / "index.mjs").is_file()
+
+    def test_lifecycle_lock_is_per_app(self):
+        from kiro_crew.apps.manager import app_lifecycle_lock
+
+        lock_a = app_lifecycle_lock("app-a")
+        assert app_lifecycle_lock("app-a") is lock_a
+        assert app_lifecycle_lock("app-b") is not lock_a
+
+    @pytest.mark.asyncio
+    async def test_install_off_loop_does_not_block_event_loop(self, tmp_path, app_home):
+        """Heartbeat latency stays low while a many-file install runs off-loop."""
+        import asyncio
+        import time
+
+        src = _make_app_source(tmp_path, name="fat-app")
+        payload = src / "payload"
+        payload.mkdir()
+        for i in range(2000):
+            (payload / f"f{i}.txt").write_text(str(i))
+
+        gaps: list[float] = []
+
+        async def heartbeat():
+            prev = time.monotonic()
+            while True:
+                await asyncio.sleep(0.01)
+                now = time.monotonic()
+                gaps.append(now - prev)
+                prev = now
+
+        hb = asyncio.ensure_future(heartbeat())
+        try:
+            result = await asyncio.to_thread(install_app, src)
+        finally:
+            hb.cancel()
+        assert result.ok, result.error
+        # The watchdog threshold is 30s; anything close to that (or even 1s)
+        # would indicate the copy ran on the loop.
+        assert max(gaps) < 1.0
+
+    def test_orphaned_partial_install_self_heals(self, tmp_path, app_home):
+        """dest exists with junk but no installed metadata → fresh install wins."""
+        from kiro_crew.apps.manager import app_dir
+
+        orphan = app_dir("test-app")
+        orphan.mkdir(parents=True)
+        (orphan / "leftover.bin").write_text("partial copy from a crash")
+
+        src = _make_app_source(tmp_path)
+        result = install_app(src)
+        assert result.ok, result.error
+        assert not (orphan / "leftover.bin").exists()
+        assert (orphan / APP_MANIFEST_FILENAME).is_file()
+
+    def test_update_preserves_data_and_secret(self, tmp_path, app_home):
+        from kiro_crew.apps.manager import app_dir, update_app
+
+        src = _make_app_source(tmp_path)
+        assert install_app(src).ok
+        dest = app_dir("test-app")
+        (dest / "data").mkdir(exist_ok=True)
+        (dest / "data" / "state.json").write_text('{"k": 1}')
+        secret = (dest / ".app_secret")
+        secret.write_text("s3cret")
+
+        v2 = _make_app_source(tmp_path / "v2", version="2.0.0")
+        result = update_app(v2)
+        assert result.ok, result.error
+        assert (dest / "data" / "state.json").read_text() == '{"k": 1}'
+        assert secret.read_text() == "s3cret"
+
+    def test_directory_junction_omitted(self, tmp_path, app_home, monkeypatch):
+        """Windows directory junctions (reparse points not reported by
+        islink) are omitted from the copy. Simulated by monkeypatching
+        os.path.isjunction since junctions don't exist on POSIX."""
+        import os
+
+        src = _make_app_source(tmp_path)
+        (src / "junction-dir").mkdir()
+        (src / "junction-dir" / "secret.txt").write_text("sensitive")
+
+        def fake_isjunction(p):
+            return os.path.basename(str(p)) == "junction-dir"
+
+        monkeypatch.setattr(os.path, "isjunction", fake_isjunction, raising=False)
+
+        result = install_app(src)
+        assert result.ok, result.error
+
+        from kiro_crew.apps.manager import app_dir
+
+        dest = app_dir("test-app")
+        assert not (dest / "junction-dir").exists()
+
+    def test_update_rejects_mismatched_source_name(self, tmp_path, app_home):
+        """expected_name guards against updating app A from app B's source."""
+        from kiro_crew.apps.manager import update_app
+
+        src = _make_app_source(tmp_path)
+        assert install_app(src).ok
+        other = _make_app_source(tmp_path / "other", name="other-app")
+
+        result = update_app(other, expected_name="test-app")
+        assert not result.ok
+        assert "does not match" in (result.error or "")
+
+    def test_shutil_error_rolls_back_cleanly(self, tmp_path, app_home, monkeypatch):
+        """shutil.Error (copytree aggregate, not an OSError) is caught and
+        reported as a failed AppResult instead of propagating."""
+        src = _make_app_source(tmp_path)
+
+        def failing_copytree(*args, **kwargs):
+            raise shutil.Error([("a", "b", "boom")])
+
+        monkeypatch.setattr(shutil, "copytree", failing_copytree)
+        result = install_app(src)
+        assert not result.ok
+        assert "failed to copy app files" in (result.error or "")
+        assert _read_installed("test-app") is None


### PR DESCRIPTION
## Problem

Installing or updating an app runs a synchronous `shutil.copytree(source, dest, dirs_exist_ok=True)` directly on the gateway's asyncio event loop (`apps/manager.py` `install_app`/`update_app`, called without any executor wrap from `install_from_registry`, `handle_install_app`, and `handle_update_app`). The copy follows symlinks (`symlinks=False` default) and has no ignore list, so it includes `ui/node_modules`, `.git` from cloned registry sources, and the full *target* of any symlink in the source tree.

For a large source tree this freezes the event loop for minutes; the loop-stall watchdog (`dashboard/loop_watchdog.py`) then hard-kills the gateway mid-install. The user sees a network error, no installed metadata is written, and an orphaned multi-GB partial copy is left under `~/.kirocrew/apps/<name>/`. Observed in production on the upstream codebase: a `build` symlink to a 5.3 GB / 81k-file tree was followed during a registry install; the crash dump showed MainThread 20+ frames deep in `shutil.copytree` when the watchdog fired.

Fixes #99.

## Why it matters

Any registry app whose install script leaves `node_modules` behind, or any local-path install containing a big directory symlink, can hard-crash the whole gateway and leave multi-GB orphans on disk. Following symlinks also means a symlink pointing at e.g. `~/.ssh` gets its target contents copied into the apps dir (`snapshot._copytree_safe` already guards snapshots against exactly this; app install did not).

## Fix (symptoms → root cause → change)

Symptom: gateway dies mid-install on large app sources. Root cause: a blocking, symlink-following, copy-everything `copytree` on the event loop. Change, in four layers:

1. **`apps/manager.py` — `_copy_app_tree` helper** replaces both raw copytree calls: `symlinks=True` (copy links as links, never follow — makes the multi-GB walk structurally impossible and closes the symlink-target-exfil hazard) plus an ignore denylist (`node_modules`, `.git`, `__pycache__`, `.venv`; basename match at every depth). `build` is deliberately **not** denylisted: the manifest may reference runtime paths anywhere under the app root, and silently dropping a manifest-referenced directory would record a successful install with missing files — a `build` *symlink* (the observed crash trigger) is already neutralized by `symlinks=True`. Also: `except OSError` widened to `except (OSError, shutil.Error)` in both functions — `shutil.Error` (copytree's aggregate error) is not an `OSError` subclass, so partial-copy errors previously propagated uncaught past the rollback logic. A WARNING is now logged when install removes an orphaned partial dest (no installed metadata).
2. **Async call sites run the copy off-loop**, keeping `install_app`/`update_app` sync for the CLI path: `apps/routes.py` install/update handlers use `run_in_executor(subprocess_executor(), ...)` (matching the existing start/stop-backend pattern in that file); `apps/registry.py` `install_from_registry` uses `asyncio.to_thread` (matching that file's style).
3. **One shared per-app lifecycle lock across every async entry point** (`app_lifecycle_lock` in `manager.py`, replacing registry.py's local `_APP_LOCKS`): registry clone/build + install, dashboard install, the dashboard update sequence (deregister → stop → copy → re-register), and uninstall's file removal. Once the copy is off-loop, concurrent operations on the same app could otherwise interleave — and update/uninstall move user data through the shared `.{name}-data-tmp` path, so an interleaving could permanently destroy preserved `data/` and `.app_secret`. Different apps still proceed in parallel.
4. **Docs**: publishing guide now documents what is excluded from the installed copy and that symlinks are preserved, not followed.

## Tests

Seven new regression tests in `test/test_app_manager.py` (`TestCopyAppTree`):

- `test_symlink_not_followed` — a directory symlink copies as a symlink; target contents absent from the installed tree
- `test_denylist_dirs_dropped_runtime_payload_kept` — `ui/node_modules`, `.git`, `__pycache__` dropped; `ui/dist/index.mjs` **and a real `build/` dir** survive (locks in the build-not-denylisted decision)
- `test_lifecycle_lock_is_per_app` — same app returns the same lock instance; different apps get different locks
- `test_install_off_loop_does_not_block_event_loop` — heartbeat task measures loop latency while a 2000-file install runs via `to_thread`; max gap must stay under 1s (watchdog threshold is 30s)
- `test_orphaned_partial_install_self_heals` — pre-existing junk dest with no metadata is removed and reinstalled cleanly
- `test_update_preserves_data_and_secret` — `data/` and `.app_secret` survive an update through the new helper
- `test_shutil_error_rolls_back_cleanly` — `shutil.Error` is caught, reported as a failed `AppResult`, no metadata written

Locally: 189 passed across `test_app_manager.py`, `test_app_routes.py`, `test_external_registry.py`, `test_gateway_appkit_endpoints.py`. flake8 and isort clean on touched files.

## Manual verification

N/A — unit coverage sufficient: the loop-latency test exercises the exact off-loop path the routes/registry now use, and the symlink/denylist tests reproduce the production crash shape (large symlink target + node_modules) at small scale.

---

**Review-bot round 1 response** (Codex flagged two findings on `a01e537`, both addressed in `3c5f4e1`):
- HIGH (routes handlers unlocked): fixed — one shared `app_lifecycle_lock` now covers registry install, dashboard install/update, and uninstall file removal.
- MEDIUM (`build` denylist could drop manifest-referenced paths): fixed — `build` removed from the denylist; `symlinks=True` alone neutralizes the observed crash trigger, and a regression test asserts a real `build/` dir survives install.


**Review-bot round 2 response** (Codex flagged two HIGHs on `3c5f4e1`, both addressed in `ca82191`):
- Lock could guard the wrong app (route name vs. source manifest name): fixed — `handle_update_app` now parses the source manifest and rejects the request with 400 unless its `name` equals the route param, so the lock always guards the app actually mutated.
- Uninstall `rmtree` still on-loop: fixed — `uninstall_app` now runs via `run_in_executor(subprocess_executor(), ...)` under the same lifecycle lock.


**Review-bot round 3 response** (Codex flagged 2 HIGH + 1 MEDIUM on `ca82191`, plus a CodeQL alert; all addressed in `68c8bf2`):
- HIGH (preserved symlinks servable via UI route): fixed — `_copy_app_tree` now omits any symlink whose resolved target escapes the app source root (WARNING-logged); in-tree relative symlinks are still preserved. Regression tests split into escaping-omitted + in-root-preserved.
- HIGH (lock released between copy and registration): fixed — install holds the lifecycle lock through copy → register → backend start; uninstall holds it through deregister → dependency cleanup → file removal (file removal also moved off-loop via executor).
- MEDIUM (non-string manifest `name` crashes lock lookup): fixed — the lock key only uses the manifest name when it's a nonempty string; otherwise the resolved-path fallback is used and manifest validation rejects the install.
- CodeQL (user-provided value in path expression at the route's manifest read): fixed structurally — the route-level manifest read is deleted; `update_app(source, expected_name=name)` now enforces the name match itself on the already-validated source path, with a new mismatch-rejection test.


**Review-bot round 4 response** (Codex flagged 1 HIGH + 1 MEDIUM on `68c8bf2`; both addressed in `53d4398`):
- HIGH (`os.path.commonpath` ValueError escapes the rollback handler): fixed — the escape check catches `ValueError` and treats the link as escaping (omit); both rollback handlers also widened to `except (OSError, shutil.Error, ValueError)` as defense in depth.
- MEDIUM (absolute in-tree symlinks copied verbatim still point at the source dir): fixed — after the copy, absolute in-tree links are rewritten as relative links targeting the installed copy, so the installed app is self-contained. The regression test now deletes the source dir and asserts the installed link still resolves inside the installed tree.
- Build Desktop (ubuntu-22.04) failure on `68c8bf2` was an electron-builder toolchain flake (`ERR_ELECTRON_BUILDER_CANNOT_EXECUTE`) in a job this Python-only diff doesn't touch (it passed on both prior commits) — re-run requested.


**Review-bot round 5 response** (Codex flagged 1 HIGH on `53d4398`; addressed in `c7056ce`):
- HIGH (enable/disable + registry post-install not under the lock): fixed with the suggested refactor — the registry helpers (`install_from_registry`, `_clone_build_app`) are now lock-free internally, and every route-level lifecycle transaction holds exactly one `app_lifecycle_lock`: local install (copy → register → backend start), registry install + SSE streaming install (clone/build → copy → register → backend start), update (both local-path and registry branches), uninstall (deregister → dep cleanup → file removal), enable (metadata → register → backend start → deps → onEnable incl. rollback), and disable (onDisable → hooks → stop → deregister → metadata). No nested acquisition anywhere (asyncio.Lock is not reentrant). 210 tests pass across the app modules.


**Review-bot round 6 response** (Codex flagged 1 HIGH on `c7056ce`; addressed in `72675a2`):
- HIGH (Windows directory junctions bypass islink and get traversed): fixed — the ignore callback now omits any entry `os.path.isjunction()` reports (guarded via `getattr` since isjunction is Python 3.12+; always False on POSIX). Note KiroCrew is macOS/Linux-only per CONTRIBUTING prerequisites, so this is defense in depth. Regression test simulates a junction via monkeypatch (junctions don't exist on POSIX).
