### PR TITLE
feat(deploy): docs, live pricing, reaper alarm, operator remediation (follow-up batch)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -452,6 +452,18 @@ Persistent, versioned artifacts for chat-rendered widgets, code files, and docum
 - **Auto-dedup** — atomic dedup on `source_path` at API layer (200=bumped existing vs 201=created new)
 - **CLI** — `kirocrew artifact list/show/save/update/delete/versions`
 
+### Artifact Deploy
+
+One-click deploy of webapp artifacts into the user's own AWS account with a global public HTTPS link (Vercel-like), default TTL, and promote-to-persistent.
+
+- **Own-account model** — KiroCrew orchestrates via a named AWS profile; resources (S3 + CloudFront, optional Lambda/DynamoDB) live in the user's account
+- **TTL + reaper** — finite-TTL deploys require the in-account reaper stack; tag-gated cleanup that can only touch `kirocrew:managed` resources
+- **Live preview cards** — browser-framed artifact cards render the app's local copy through a sandboxed, token-gated gateway channel; deployed sites embed the remote page when provably framable
+- **Deploy console** — sidebar surface for AWS profiles (register/verify), fleet view, cost estimates (labelled *not a bill*), and teardown
+- **IAM keystone** — KiroCrew never writes IAM; policies are generated for the operator to apply
+
+See [artifact-deploy.md](artifact-deploy.md) for the full guide.
+
 ### Snapshot & Restore
 
 Portable backup and restore of KiroCrew state for migration between machines.

--- a/docs/artifact-deploy.md
+++ b/docs/artifact-deploy.md
@@ -1,0 +1,87 @@
+# Artifact Deploy
+
+Deploy a webapp artifact from your library into **your own AWS account** and get
+a global public HTTPS link — Vercel-like, with a default TTL, automatic cleanup,
+and a promote-to-persistent path. KiroCrew orchestrates; your account pays only
+for what the site actually serves.
+
+## Quick Start
+
+1. Enable the **Artifact Deploy** app (App Store → Artifact Deploy), open it
+   from the sidebar, and register an AWS profile (a named profile from
+   `~/.aws/config`). Click **Verify** to confirm access.
+2. Ask the agent to build something — apps saved with `kind="webapp"` appear in
+   the Artifacts gallery with a live local preview.
+3. Click **Deploy** on the artifact card. A deploy session opens, the agent
+   proposes the plan (resources, region, cost estimate), and you confirm in the
+   console.
+4. You get a CloudFront URL. The card flips to **Live** with the link, TTL
+   countdown, architecture summary, and a **Tear down** button.
+
+## What gets deployed
+
+| Tier | Resources in your account | Example |
+|------|---------------------------|---------|
+| Static | S3 (per-site prefix) + shared CloudFront distribution | landing page, three.js demo |
+| Fullstack | + Lambda Function URL behind `/api/*` | API-backed demo |
+| Stateful | + DynamoDB table | app with persistence |
+
+The first deploy in an account creates a shared **base stack**
+(`kirocrew-deploy-base`: bucket + CloudFront, ~5–15 min while CloudFront
+propagates globally). Every later deploy reuses it and completes in seconds.
+
+## TTL and the reaper
+
+| Mode | Behavior |
+|------|----------|
+| Finite TTL (default 72h) | Requires the **reaper stack** (`install-reaper.sh`) — an in-account Lambda that removes expired deployments. Without it, finite-TTL deploys are refused (409). |
+| Persistent (`ttl_hours=0`) | No reaper required. Tear down manually from the card or console. |
+
+The reaper only ever touches resources that carry the `kirocrew:site` +
+`kirocrew:managed` tags and match the managed naming scheme — it cannot delete
+anything else in your account.
+
+## The artifact card
+
+- **Live preview** — the card renders your app inside a browser-framed preview.
+  It prefers the **local copy** (served through a token-gated gateway channel,
+  sandboxed, works even before deploying); deployed sites can also render the
+  remote CloudFront page when the gateway confirms the site is framable.
+- **States** — Not deployed (Deploy button + profile picker), Deploying,
+  Live (URL, TTL countdown, architecture rows, cost pills, Tear down),
+  Expired (tombstone + **Redeploy**).
+- **Cost pills** — what-if traffic scenarios (e.g. `1,000 views · $0.05`).
+  These are **estimates, not a bill**; you pay only for actual usage.
+
+## The Artifact Deploy console
+
+Sidebar → Artifact Deploy. One console for everything deployed:
+
+| Section | What it does |
+|---------|--------------|
+| Profiles | Register/create AWS profiles, set the default, **Verify** access (an STS read — KiroCrew never stores credentials) |
+| Stats | Profiles, active deployments, ready-to-deploy artifacts, estimated cost (labelled *not a bill*) |
+| Fleet | Every active deployment: URL, TTL, profile, health, tear down / persist |
+| Setup | IAM policy generator + reaper install guidance |
+
+## Security model
+
+- **KiroCrew never writes IAM.** The deploy policy and permissions boundary are
+  generated for you but *you* apply them in your own account. Any error that
+  needs an operator action fails loudly with the exact command to run.
+- Deploy actions are tag-gated: mutations only apply to resources tagged
+  `kirocrew:managed=true`.
+- The local preview channel is deny-by-default: token-gated, sandboxed to an
+  opaque origin, path-traversal/symlink hardened, and every response is scanned
+  so credential-bearing files are refused rather than served.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Finite-TTL deploy returns 409 | Reaper stack missing — run `install-reaper.sh` for that profile/region, or use `ttl_hours=0`. |
+| Blank remote preview on the card | The deployed site's headers pre-date the current base stack. Any next deploy updates the stack in place; until then the card shows the status fallback with a plain link. |
+| Card stuck on "Not deployed" after a script deploy | Script-path deploys don't auto-update the artifact yet — ask the agent to back-fill the deploy metadata (the audited API path does this automatically). |
+| Old `meshclaw-deploy-*` stacks in the account | Pre-rename leftovers — see `src/kiro_crew/deploy/skills/artifact-deploy/MIGRATION.md`. |
+
+Design doc: Pippin project `9iRV03PF7Ptb`.

--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -30,6 +30,7 @@ from aiohttp import web
 from kiro_crew.config.paths import config_dir
 from kiro_crew.deploy import engine
 from kiro_crew.deploy import iam as iam_mod
+from kiro_crew.deploy import pricing as pricing_mod
 from kiro_crew.deploy import profiles as profiles_mod
 from kiro_crew.deploy.render import render_standalone
 from kiro_crew.deploy.scan import Finding, is_credential_finding, scan_content, summarize
@@ -169,6 +170,21 @@ DATA_DIR = _data_dir()
 CONFIG_PATH = DATA_DIR / "config.json"
 DEFAULT_REGION = engine.DEFAULT_REGION
 _SITE_ID_MAX = 64
+
+
+def _reaper_remediation(profile: str, region: str) -> str:
+    """Exact operator command for the finite-TTL reaper precondition (FU-1).
+
+    Rendered with the request's real profile/region so the 409 payload is
+    directly actionable. Installing the reaper is an operator step by design
+    (the stack creates an IAM role, which KiroCrew never does itself).
+    """
+    parts = ["install-reaper.sh"]
+    if profile:
+        parts += ["--profile", profile]
+    if region:
+        parts += ["--region", region]
+    return " ".join(parts)
 
 
 def _audit(action: str, site_id: str, outcome: str, *, error: str = "") -> None:
@@ -965,11 +981,17 @@ async def _do_deploy(params: dict[str, Any]) -> tuple[int, dict[str, Any]]:
             pass
 
         if not manifest_bucket and ttl_hours != 0:
-            return 409, {"error": (
-                "Finite-TTL deploys require the reaper base stack "
-                "(kirocrew-deploy-base). Use ttl_hours=0 for persistent "
-                "or install the reaper (install-reaper.sh)."
-            )}
+            # FU-1: precondition failures render the EXACT operator command
+            # with the request's real profile/region so remediation is
+            # copy-paste, not archaeology.
+            return 409, {
+                "error": (
+                    "Finite-TTL deploys require the reaper base stack "
+                    "(kirocrew-deploy-base). Use ttl_hours=0 for persistent "
+                    "or install the reaper (install-reaper.sh)."
+                ),
+                "remediation": _reaper_remediation(profile, region),
+            }
 
         # F3: Finite-TTL also requires the reaper Lambda stack (separate from base)
         if ttl_hours != 0:
@@ -985,11 +1007,14 @@ async def _do_deploy(params: dict[str, Any]) -> tuple[int, dict[str, Any]]:
             except Exception:  # noqa: BLE001
                 reaper_rc = 1
             if reaper_rc != 0:
-                return 409, {"error": (
-                    "Finite-TTL deploys require the reaper stack "
-                    "(kirocrew-deploy-reaper). Install the reaper "
-                    "(install-reaper.sh) or use ttl_hours=0 for persistent."
-                )}
+                return 409, {
+                    "error": (
+                        "Finite-TTL deploys require the reaper stack "
+                        "(kirocrew-deploy-reaper). Install the reaper "
+                        "(install-reaper.sh) or use ttl_hours=0 for persistent."
+                    ),
+                    "remediation": _reaper_remediation(profile, region),
+                }
 
         result = await asyncio.to_thread(engine.deploy, site_id, src_dir, profile, region)
         _audit("deploy", site_id, "ok")
@@ -1269,7 +1294,7 @@ def _is_internal_secret_request(request: web.Request) -> bool:
 # F1: default-deny allowlist for internal-secret callers.
 # Only these handler operations are reachable via MCP tool path (X-Internal-Secret).
 # ANY new handler added to register_routes is DENIED unless explicitly listed here.
-_INTERNAL_ALLOWED_HANDLERS: frozenset[str] = frozenset({"deploy", "list"})
+_INTERNAL_ALLOWED_HANDLERS: frozenset[str] = frozenset({"deploy", "list", "pricing"})
 
 _INTERNAL_DENIED_ATTR = "_internal_denied"
 
@@ -1430,6 +1455,31 @@ async def _handle_verify(request: web.Request) -> web.Response:
         # like every other registry mutation in this file.
         _audit("profile_verify", profile, "allowed")
     return web.json_response(_sanitize_response({**result, "profile": profile}))  # R26 F2
+
+
+async def _handle_pricing(request: web.Request) -> web.Response:
+    """Live unit prices for cost estimates (NEW-1, Joe R1 follow-up).
+
+    Read-only: queries the AWS Pricing API through the resolved profile and
+    returns per-unit USD prices with a ``source`` marker (``live`` vs
+    ``fallback``). Estimate consumers (skill contract, cost surfaces) use
+    these instead of the hardcoded MVP table when available. Failures of any
+    kind degrade to the fallback table -- an estimate must never 500.
+    """
+    denied = _deny_restricted(request, "pricing")
+    if denied:
+        return denied
+    query = dict(request.rel_url.query)
+    try:
+        profile, region = await _resolve_profile(query)
+    except _ProfileResolveError as e:
+        return web.json_response(e.payload, status=400)
+    prices = await asyncio.to_thread(pricing_mod.get_unit_prices, profile, region)
+    _audit("pricing", profile, "allowed")
+    return web.json_response(_sanitize_response({
+        "region": region,
+        "prices": prices.to_dict(),
+    }))
 
 
 # --- profile control plane (§ multi-profile) --------------------------------
@@ -2178,6 +2228,7 @@ def register_routes(app: web.Application) -> None:
     r.add_delete("/api/deploy/profiles/{name}", _handle_profiles_delete)
     r.add_get("/api/deploy/iam-policy", _handle_iam_policy)
     r.add_post("/api/deploy/verify", _handle_verify)
+    r.add_get("/api/deploy/pricing", _handle_pricing)
     r.add_post("/api/deploy/deploy", _handle_deploy)
     r.add_post("/api/deploy/recall", _handle_recall)
     r.add_post("/api/deploy/destroy", _handle_destroy)
@@ -2208,6 +2259,7 @@ def register_routes(app: web.Application) -> None:
         "pending_list": _handle_pending_list,
         "pending_confirm": _handle_pending_confirm,
         "pending_dismiss": _handle_pending_dismiss,
+        "pricing": _handle_pricing,
     }
     for op_name, handler in _REGISTERED_HANDLERS.items():
         if op_name in _INTERNAL_ALLOWED_HANDLERS:

--- a/src/kiro_crew/deploy/pricing.py
+++ b/src/kiro_crew/deploy/pricing.py
@@ -1,0 +1,167 @@
+"""Live AWS unit prices for deploy cost estimates (NEW-1, Joe R1 follow-up).
+
+The what-if cost buckets shown on artifact cards and the deploy console were
+computed from a hardcoded price table (public us-west-2 rates circa the MVP).
+This module upgrades them to LIVE unit prices from the AWS Pricing API when
+the deploy profile can reach it, while keeping the hardcoded table as a
+fail-open fallback -- an estimate labelled "not a bill" must never block on a
+pricing lookup.
+
+Design constraints:
+- The Pricing API is only served from us-east-1/eu-central-1/ap-south-1; we
+  always query us-east-1 regardless of the deploy region (prices are filtered
+  by the deploy region's location name).
+- Responses are large stringified JSON documents; every extraction step is
+  wrapped so a shape drift degrades to the fallback price, never a 500.
+- Results are cached per (profile, region) for 24h -- unit prices change on
+  the order of months.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+
+from kiro_crew.deploy import engine
+
+logger = logging.getLogger(__name__)
+
+_PRICING_API_REGION = "us-east-1"
+_CACHE_TTL_SECS = 24 * 3600
+_CACHE: dict[tuple[str, str], tuple[float, "UnitPrices"]] = {}
+_CACHE_MAX = 64
+
+_REGION_LOCATIONS = {
+    "us-east-1": "US East (N. Virginia)",
+    "us-east-2": "US East (Ohio)",
+    "us-west-1": "US West (N. California)",
+    "us-west-2": "US West (Oregon)",
+    "eu-west-1": "EU (Ireland)",
+    "eu-central-1": "EU (Frankfurt)",
+    "ap-southeast-1": "Asia Pacific (Singapore)",
+    "ap-southeast-2": "Asia Pacific (Sydney)",
+    "ap-northeast-1": "Asia Pacific (Tokyo)",
+    "ap-south-1": "Asia Pacific (Mumbai)",
+}
+
+
+@dataclass(frozen=True)
+class UnitPrices:
+    """USD unit prices used by the what-if estimate buckets."""
+
+    s3_gb_month: float = 0.023
+    cf_per_10k_requests: float = 0.0075
+    cf_gb_egress: float = 0.085
+    lambda_per_request: float = 0.0000002
+    lambda_gb_second: float = 0.0000166667
+    source: str = "fallback"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+_FALLBACK = UnitPrices()
+
+
+def _first_on_demand_usd(price_list_entry: str) -> float | None:
+    """Extract the first OnDemand USD price from one PriceList document."""
+    doc = json.loads(price_list_entry)
+    terms = doc["terms"]["OnDemand"]
+    term = next(iter(terms.values()))
+    dim = next(iter(term["priceDimensions"].values()))
+    usd = dim["pricePerUnit"]["USD"]
+    value = float(usd)
+    return value if value > 0 else None
+
+
+def _query_price(profile: str, service_code: str, filters: list[tuple[str, str]]) -> float | None:
+    """One Pricing API lookup -> first positive OnDemand USD price, or None."""
+    args = [
+        "pricing", "get-products",
+        "--service-code", service_code,
+        "--region", _PRICING_API_REGION,
+        "--max-results", "1",
+        "--output", "json",
+    ]
+    for field, value in filters:
+        args += ["--filters", f"Type=TERM_MATCH,Field={field},Value={value}"]
+    try:
+        rc, out, _ = engine.run_aws(args, profile, 20)
+        if rc != 0 or not out:
+            return None
+        entries = json.loads(out).get("PriceList") or []
+        if not entries:
+            return None
+        return _first_on_demand_usd(entries[0])
+    except Exception:  # noqa: BLE001 -- any shape drift degrades to fallback
+        logger.debug("pricing lookup failed for %s", service_code, exc_info=True)
+        return None
+
+
+def get_unit_prices(profile: str, region: str) -> UnitPrices:
+    """Live unit prices for the deploy region, falling back per-field.
+
+    Every field that the Pricing API cannot supply keeps its fallback value;
+    ``source`` is ``live`` only when at least one live price was obtained.
+    """
+    key = (profile or "", region or "")
+    now = time.time()
+    cached = _CACHE.get(key)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    location = _REGION_LOCATIONS.get(region, "")
+    values = _FALLBACK.to_dict()
+    values.pop("source")
+    live = 0
+
+    if location:
+        s3 = _query_price(profile, "AmazonS3", [
+            ("location", location),
+            ("storageClass", "General Purpose"),
+            ("volumeType", "Standard"),
+        ])
+        if s3 is not None:
+            values["s3_gb_month"] = s3
+            live += 1
+
+        lam_req = _query_price(profile, "AWSLambda", [
+            ("location", location),
+            ("group", "AWS-Lambda-Requests"),
+        ])
+        if lam_req is not None:
+            values["lambda_per_request"] = lam_req
+            live += 1
+
+        lam_gbs = _query_price(profile, "AWSLambda", [
+            ("location", location),
+            ("group", "AWS-Lambda-Duration"),
+        ])
+        if lam_gbs is not None:
+            values["lambda_gb_second"] = lam_gbs
+            live += 1
+
+    # CloudFront prices by geographic zone, not AWS region.
+    cf_req = _query_price(profile, "AmazonCloudFront", [
+        ("productFamily", "Request"),
+        ("location", "United States"),
+        ("requestType", "HTTPS"),
+    ])
+    if cf_req is not None:
+        values["cf_per_10k_requests"] = cf_req * 10000
+        live += 1
+
+    cf_gb = _query_price(profile, "AmazonCloudFront", [
+        ("productFamily", "Data Transfer"),
+        ("location", "United States"),
+    ])
+    if cf_gb is not None:
+        values["cf_gb_egress"] = cf_gb
+        live += 1
+
+    prices = UnitPrices(**values, source="live" if live else "fallback")
+    if len(_CACHE) >= _CACHE_MAX:
+        _CACHE.clear()
+    _CACHE[key] = (now + _CACHE_TTL_SECS, prices)
+    return prices

--- a/src/kiro_crew/deploy/skills/artifact-deploy/MIGRATION.md
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/MIGRATION.md
@@ -1,0 +1,64 @@
+# Migrating from legacy `meshclaw-deploy-*` stacks
+
+Accounts that used the pre-rename deploy tooling carry `meshclaw-deploy-base`
+and `meshclaw-deploy-reaper` stacks. Current code only recognizes the
+`kirocrew-` prefix, so a first deploy with the new tooling creates a second,
+parallel base stack — two CloudFront distributions and two buckets coexist
+until the old set is removed.
+
+Stack-name prefixes are deliberately NOT configurable: the reaper's identity
+gates (OAC name fullmatch, `kirocrew:site` tag checks, bucket-prefix
+cross-validation) are written against the fixed prefix. Making the prefix an
+environment override would reopen the spoofing surface those gates close.
+
+## 1. Identify legacy resources
+
+```bash
+aws cloudformation describe-stacks --stack-name meshclaw-deploy-base \
+  --profile <P> --region <R> --query 'Stacks[0].StackStatus'
+aws cloudformation describe-stacks --stack-name meshclaw-deploy-reaper \
+  --profile <P> --region <R> --query 'Stacks[0].StackStatus'
+```
+
+A `ValidationError` ("does not exist") for both means nothing to migrate.
+
+## 2. Move any live sites first
+
+Legacy deployments keep serving from the old distribution. Redeploy each one
+with the new tooling (the artifact card's Deploy button, or `deploy.sh`) so it
+lands behind the `kirocrew-deploy-base` distribution, then verify the new URL
+before tearing the old set down.
+
+## 3. Tear down the legacy set (operator step)
+
+Empty the old bucket first — CloudFormation cannot delete a non-empty bucket:
+
+```bash
+OLD_BUCKET=$(aws cloudformation describe-stacks --stack-name meshclaw-deploy-base \
+  --profile <P> --region <R> \
+  --query "Stacks[0].Outputs[?OutputKey=='BucketName'].OutputValue" --output text)
+aws s3 rm "s3://${OLD_BUCKET}" --recursive --profile <P> --region <R>
+
+aws cloudformation delete-stack --stack-name meshclaw-deploy-reaper \
+  --profile <P> --region <R>
+aws cloudformation delete-stack --stack-name meshclaw-deploy-base \
+  --profile <P> --region <R>
+```
+
+Base-stack deletion takes several minutes (CloudFront disable + removal).
+Confirm with:
+
+```bash
+aws cloudformation describe-stacks --stack-name meshclaw-deploy-base \
+  --profile <P> --region <R> 2>&1 | grep -q 'does not exist' && echo CLEAN
+```
+
+## 4. Leftovers outside the stacks
+
+Per-site buckets created by very old versions are named `meshclaw-web-*`.
+List and remove any that remain after their sites were migrated:
+
+```bash
+aws s3api list-buckets --profile <P> \
+  --query "Buckets[?starts_with(Name, 'meshclaw-web-')].Name" --output text
+```

--- a/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
@@ -62,7 +62,13 @@ create the artifact immediately (before any deploy) via
 `artifact_save(name, content=<one-line human summary>, kind="webapp", webapp_metadata=…)`.
 For a not-yet-deployed app: fill `architecture` (intended tiers) + `cost`
 (projected from the model), set `lifecycle.status="draft"`, and leave
-`deploy_target.public_url` empty — the card then shows the Deploy button. (The
+`deploy_target.public_url` empty — the card then shows the Deploy button.
+Filling `cost.estimates` is REQUIRED (empty estimates render a blank cost area
+on the card; `artifact_save` warns when you skip it). For the unit prices, GET
+`/api/deploy/pricing?profile=<name>` on the gateway — it returns live AWS
+Pricing API rates for the profile's region (`source: "live"`) or the fallback
+table when the API is unreachable; multiply into per-bucket what-if totals
+(e.g. 1,000 / 100,000 / 1,000,000 views). (The
 MCP `artifact_save` tool accepts `kind="webapp"` + `webapp_metadata`.) Deploy — via this
 skill or the card's Deploy button — fills in the rest.
 

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/install-reaper.sh
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/install-reaper.sh
@@ -4,7 +4,7 @@
 # non-persistent deploys. Reliable: runs in-account on a timer, no local creds.
 #
 # Usage:
-#   install-reaper.sh [--rate 'rate(1 hour)'] [--profile P] [--region R]
+#   install-reaper.sh [--rate 'rate(1 hour)'] [--profile P] [--region R] [--alarm-email you@example.com]
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$DIR/_common.sh"
@@ -16,6 +16,7 @@ while [[ $# -gt 0 ]]; do case "$1" in
   --rate)    RATE="$2"; shift 2;;
   --profile) PROFILE="$2"; shift 2;;
   --region)  REGION="$2"; shift 2;;
+  --alarm-email) ALARM_EMAIL="$2"; shift 2;;
   -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
   *) echo "unknown arg: $1" >&2; exit 2;;
 esac; done
@@ -72,8 +73,13 @@ aws_cli cloudformation deploy \
   --template-file "$TEMPLATE" \
   --capabilities CAPABILITY_NAMED_IAM \
   --no-fail-on-empty-changeset \
-  --parameter-overrides Bucket="$BUCKET" DistributionId="$DIST_ID" CodeBucket="$BUCKET" CodeKey="$key" ScheduleRate="$RATE"
+  --parameter-overrides Bucket="$BUCKET" DistributionId="$DIST_ID" CodeBucket="$BUCKET" CodeKey="$key" ScheduleRate="$RATE" AlarmEmail="${ALARM_EMAIL:-}"
 
 echo ""
 echo "✅ reaper installed: Lambda kirocrew-deploy-reaper runs $RATE in-account."
+if [[ -n "${ALARM_EMAIL:-}" ]]; then
+  echo "   Errors alarm wired to $ALARM_EMAIL (confirm the SNS subscription email)."
+else
+  echo "   TIP: rerun with --alarm-email you@example.com to get notified if the reaper starts failing silently."
+fi
 echo "   Test one run:  aws lambda invoke --function-name kirocrew-deploy-reaper /tmp/reap.json --profile <p> --region <r> && cat /tmp/reap.json"

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/reaper.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/reaper.yaml
@@ -17,6 +17,16 @@ Parameters:
   ScheduleRate:
     Type: String
     Default: 'rate(1 hour)'
+  AlarmEmail:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional. When set, a CloudWatch alarm on reaper Lambda errors notifies
+      this address via SNS. A reaper that fires on schedule but throws every
+      run otherwise fails SILENTLY while expired deployments leak forever.
+
+Conditions:
+  HasAlarmEmail: !Not [!Equals [!Ref AlarmEmail, '']]
 
 Resources:
 
@@ -181,6 +191,38 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt Schedule.Arn
+
+  AlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: HasAlarmEmail
+    Properties:
+      Subscription:
+        - Endpoint: !Ref AlarmEmail
+          Protocol: email
+      Tags:
+        - Key: 'kirocrew:managed'
+          Value: 'true'
+
+  ReaperErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasAlarmEmail
+    Properties:
+      AlarmDescription: >-
+        Reaper Lambda is throwing. Expired kirocrew deployments are NOT being
+        cleaned up; investigate the function logs.
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ReaperFn
+      Statistic: Sum
+      Period: 3600
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlarmTopic
 
 Outputs:
   ReaperFunctionName:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -3420,6 +3420,24 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         version = d.get("version", 1)
         name = d.get("name", args.get("name", ""))
         kind = d.get("kind", args.get("kind", "widget"))
+        # FU-3: the artifact-deploy skill requires webapp producers to fill
+        # projected cost estimates at save time, but nothing enforced it —
+        # field-tested agents skipped it and the card's cost area rendered
+        # blank until deploy. Attach a soft warning hint (never a hard
+        # reject: existing flows must keep working) so the agent
+        # self-corrects on the next turn.
+        cost_hint = ""
+        wm = args.get("webapp_metadata")
+        if kind == "webapp" and isinstance(wm, dict):
+            cost = wm.get("cost") or {}
+            if not (isinstance(cost, dict) and cost.get("estimates")):
+                cost_hint = (
+                    "\n\n⚠️  webapp_metadata.cost.estimates is empty — the "
+                    "artifact card's cost area will render blank. Call "
+                    "`artifact_update` with projected what-if estimates "
+                    "(e.g. views buckets with usd amounts) per the "
+                    "artifact-deploy skill contract."
+                )
         # Widgets re-surface via the re-emit tag; only non-widgets need the link.
         ref_link = "" if kind == "widget" else f"{_artifact_ref_link(slug, name)}\n\n"
         return (
@@ -3427,6 +3445,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"{ref_link}"
             f"{_artifact_reemit_hint(slug, name, kind)}"
             f"{dedup_hint}"
+            f"{cost_hint}"
         )
 
     if name == "artifact_get":

--- a/test/test_deploy_followup.py
+++ b/test/test_deploy_followup.py
@@ -1,0 +1,130 @@
+"""Follow-up batch regression tests (FU-1/FU-3, NEW-1 pricing, NEW-3 alarm)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.deploy import handlers as h
+from kiro_crew.deploy import pricing
+
+_TPL_DIR = Path(h.__file__).parent / "skills" / "artifact-deploy" / "templates"
+
+
+class TestFU1ReaperRemediation:
+    def test_renders_exact_operator_command(self):
+        cmd = h._reaper_remediation("personal", "us-west-2")
+        assert cmd == "install-reaper.sh --profile personal --region us-west-2"
+
+    def test_omits_empty_parts(self):
+        assert h._reaper_remediation("", "") == "install-reaper.sh"
+
+    def test_both_409_sites_attach_remediation(self):
+        src = Path(h.__file__).read_text()
+        assert src.count('"remediation": _reaper_remediation(profile, region)') == 2
+
+
+class TestFU3EmptyCostHint:
+    def test_save_response_warns_on_empty_estimates(self):
+        from kiro_crew import mcp_core
+        src = Path(mcp_core.__file__.replace(".pyc", ".py")).read_text()
+        assert "webapp_metadata.cost.estimates is empty" in src
+
+    def test_hint_condition_requires_webapp_kind(self):
+        from kiro_crew import mcp_core
+        src = Path(mcp_core.__file__.replace(".pyc", ".py")).read_text()
+        gate = src.split("cost_hint = \"\"")[1].split("cost_hint = (")[0]
+        assert 'kind == "webapp"' in gate
+
+
+def _price_doc(usd: str) -> str:
+    return json.dumps({
+        "product": {"attributes": {}},
+        "terms": {"OnDemand": {"t1": {"priceDimensions": {
+            "d1": {"unit": "Requests", "pricePerUnit": {"USD": usd}},
+        }}}},
+    })
+
+
+class TestNew1Pricing:
+    def setup_method(self):
+        pricing._CACHE.clear()
+
+    def test_live_prices_extracted(self, monkeypatch):
+        def fake_run_aws(args, profile, timeout):
+            return 0, json.dumps({"PriceList": [_price_doc("0.0000012")]}), ""
+        monkeypatch.setattr(pricing.engine, "run_aws", fake_run_aws)
+        prices = pricing.get_unit_prices("p1", "us-west-2")
+        assert prices.source == "live"
+        assert prices.s3_gb_month == pytest.approx(0.0000012)
+        assert prices.cf_per_10k_requests == pytest.approx(0.0000012 * 10000)
+
+    def test_fallback_on_api_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing.engine, "run_aws", lambda a, p, t: (1, "", "denied"))
+        prices = pricing.get_unit_prices("p1", "us-west-2")
+        assert prices.source == "fallback"
+        assert prices.s3_gb_month == pricing._FALLBACK.s3_gb_month
+
+    def test_fallback_on_shape_drift(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing.engine, "run_aws",
+            lambda a, p, t: (0, '{"PriceList": ["not-json"]}', ""))
+        prices = pricing.get_unit_prices("p1", "us-west-2")
+        assert prices.source == "fallback"
+
+    def test_zero_price_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing.engine, "run_aws",
+            lambda a, p, t: (0, json.dumps({"PriceList": [_price_doc("0")]}), ""))
+        prices = pricing.get_unit_prices("p1", "us-west-2")
+        assert prices.source == "fallback"
+
+    def test_cache_prevents_repeat_lookups(self, monkeypatch):
+        calls = []
+
+        def fake_run_aws(args, profile, timeout):
+            calls.append(args)
+            return 0, json.dumps({"PriceList": [_price_doc("0.001")]}), ""
+        monkeypatch.setattr(pricing.engine, "run_aws", fake_run_aws)
+        pricing.get_unit_prices("p1", "us-west-2")
+        first = len(calls)
+        pricing.get_unit_prices("p1", "us-west-2")
+        assert len(calls) == first
+
+    def test_pricing_api_always_queried_in_us_east_1(self, monkeypatch):
+        seen = []
+
+        def fake_run_aws(args, profile, timeout):
+            seen.append(args)
+            return 1, "", ""
+        monkeypatch.setattr(pricing.engine, "run_aws", fake_run_aws)
+        pricing.get_unit_prices("p1", "ap-southeast-2")
+        for args in seen:
+            region = args[args.index("--region") + 1]
+            assert region == "us-east-1"
+
+    def test_route_registered(self):
+        src = Path(h.__file__).read_text()
+        assert 'r.add_get("/api/deploy/pricing", _handle_pricing)' in src
+
+
+class TestNew3ReaperAlarm:
+    def test_alarm_resources_are_conditional(self):
+        tpl = (_TPL_DIR / "reaper.yaml").read_text()
+        assert "AlarmEmail:" in tpl
+        assert "HasAlarmEmail: !Not [!Equals [!Ref AlarmEmail, '']]" in tpl
+        assert tpl.count("Condition: HasAlarmEmail") == 2
+
+    def test_alarm_watches_reaper_errors_with_action(self):
+        tpl = (_TPL_DIR / "reaper.yaml").read_text()
+        assert "MetricName: Errors" in tpl
+        assert "AlarmActions:" in tpl
+        assert "TreatMissingData: notBreaching" in tpl
+
+    def test_install_script_wires_alarm_email(self):
+        script = (
+            _TPL_DIR.parent / "scripts" / "install-reaper.sh").read_text()
+        assert "--alarm-email" in script
+        assert 'AlarmEmail="${ALARM_EMAIL:-}"' in script

--- a/test/test_deploy_round30_fixes.py
+++ b/test/test_deploy_round30_fixes.py
@@ -60,9 +60,10 @@ class TestF1NolinkRead:
 
 class TestF2ReaperAccountId:
     def test_reaper_env_supplies_account_id(self):
-        doc = yaml.safe_load(
-            (TEMPLATES / "reaper.yaml").read_text().replace("!Ref ", "REF ").replace("!GetAtt ", "GETATT ").replace("!Sub ", "SUB ")
-        )
+        import re
+        raw = (TEMPLATES / "reaper.yaml").read_text()
+        sanitized = re.sub(r"!(Ref|GetAtt|Sub|Not|Equals|If|Select|Join|And|Or|Condition)\b", r"\1", raw)
+        doc = yaml.safe_load(sanitized)
         fn = doc["Resources"]["ReaperFn"]["Properties"]
         env = fn["Environment"]["Variables"]
         assert "ACCOUNT_ID" in env, "reaper Lambda must receive ACCOUNT_ID (role cannot call STS)"

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -251,8 +251,13 @@ def test_reaper_template_includes_engine_arch_permissions():
 
     class _CfnLoader(yaml.SafeLoader):
         pass
-    for tag in ("!Sub", "!Ref", "!GetAtt", "!If", "!Select", "!Join"):
-        _CfnLoader.add_constructor(tag, lambda loader, node: loader.construct_scalar(node))
+    for tag in ("!Sub", "!Ref", "!GetAtt", "!If", "!Select", "!Join",
+                "!Not", "!Equals", "!Condition", "!And", "!Or"):
+        _CfnLoader.add_constructor(
+            tag, lambda loader, node: loader.construct_sequence(node)
+            if isinstance(node, yaml.SequenceNode)
+            else loader.construct_scalar(node)
+        )
 
     template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "reaper.yaml"
     with open(template_path) as f:


### PR DESCRIPTION
Follow-up batch for the Artifact Deploy feature (post PR #6 / #61 merge), from the field-test backlog plus Joe's R1 review asks.

## What's in here

**Feature documentation (new)** — `docs/artifact-deploy.md` user guide (Quick Start, deploy tiers, TTL/reaper, card states, console, security model, troubleshooting) + an Artifact Deploy section in `docs/FEATURES.md`. The feature previously had no user-facing docs at all.

**Live cost pricing (Joe R1: "aws has an api for it")** — new `deploy/pricing.py` queries the AWS Pricing API (always via us-east-1, per-deploy-region location filters) for S3/CloudFront/Lambda unit prices, exposed at `GET /api/deploy/pricing`. Every failure mode (API unreachable, permission denied, response shape drift, zero price) degrades per-field to the previous hardcoded table with `source: "fallback"` — an estimate labelled *not a bill* never blocks or 500s. 24h cache per profile+region. The skill contract now points estimate producers at this endpoint.

**Reaper errors alarm (optional)** — `reaper.yaml` gains an `AlarmEmail` parameter; when set, a conditional SNS topic + CloudWatch alarm on the reaper Lambda's `Errors` metric fires after sustained failures. A reaper that runs on schedule but throws every run otherwise fails *silently* while expired deployments leak forever. `install-reaper.sh --alarm-email you@example.com` wires it; omitted = exactly the previous template (cfn-lint clean).

**Operator remediation on 409 (FU-1)** — the two finite-TTL reaper-precondition 409s now include a `remediation` field with the exact `install-reaper.sh --profile <P> --region <R>` command rendered from the request's real arguments. Installing the reaper stays an operator step by design (it creates an IAM role; KiroCrew never writes IAM).

**Empty-cost warning (FU-3)** — `artifact_save(kind="webapp")` with empty `cost.estimates` now appends a soft warning hint to the tool response so the agent self-corrects (never a hard reject — existing flows keep working).

**Legacy stack migration guide (FU-4)** — `MIGRATION.md` for accounts carrying pre-rename `meshclaw-deploy-*` stacks: identify, move live sites, teardown commands, leftover buckets. Stack-name prefixes stay deliberately non-configurable (the reaper's identity gates are written against the fixed prefix).

## Testing

- New `test/test_deploy_followup.py`: 15 tests (remediation rendering, both 409 sites, cost-hint gating, pricing live/fallback/shape-drift/zero-price/cache/us-east-1 pinning/route, alarm conditionality + action wiring + script flag)
- cfn-lint clean on `reaper.yaml`; `bash -n` clean on `install-reaper.sh`
- Adjacent suites green (round-40 + webapp preview: 42 passed); full-tree flake8/isort/mypy clean

## Deferred (tracked, not here)

- Script-path `--artifact-slug` back-fill (auth + port discovery chain — separate PR)
- Preview session auth for reverse-proxied dashboards (security-review heavy — separate PR)
