### PR TITLE
docs(tips): Feature Tips doc + tone-tuned generation prompt

### DIFF
--- a/src/kiro_crew/data/tips_catalog.json
+++ b/src/kiro_crew/data/tips_catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-20T04:11:37.659839+00:00",
+  "generated_at": "2026-07-21T06:17:55.194009+00:00",
   "entries": [
     {
       "feature": "Agents & Configuration",
@@ -13,7 +13,7 @@
       "title": "Configuration Reference",
       "summary": "`~/.kirocrew/config.json` \u2014 main configuration file. Created automatically on first `kirocrew gateway` run.",
       "doc": "configuration.md",
-      "mtime": 1784265640.0
+      "mtime": 1784575659.0
     },
     {
       "feature": "Cron Jobs & Scheduling",
@@ -44,6 +44,13 @@
       "mtime": 1784265640.0
     },
     {
+      "feature": "Feature Tips",
+      "title": "Feature Tips",
+      "summary": "KiroCrew occasionally surfaces a small tip above the chat composer while the agent is working, pointing at a feature you have not used yet. Tips are personalized: a background session reads your recent activity and memory context to pick features that fit how you actually work.",
+      "doc": "feature-tips.md",
+      "mtime": 1784614606.3223891
+    },
+    {
       "feature": "Getting Started with KiroCrew",
       "title": "Getting Started with KiroCrew",
       "summary": "KiroCrew is an autonomous AI agent layer that runs on top of the kiro-cli (KiroACP) backend. It adds persistent memory, scheduled jobs, background subagents, self-learning, and multi-session orchestration. You interact with it via Slack DMs or a web dashboard.",
@@ -55,14 +62,14 @@
       "title": "Knowledge Library \u2014 How the Graph Works",
       "summary": "The Knowledge Library builds a graph from documents without embeddings. It uses LLM extraction to identify entities and their relationships, then connects them through shared entity names across chunks.",
       "doc": "knowledge-library-how-it-works.md",
-      "mtime": 1784265640.0
+      "mtime": 1784575659.0
     },
     {
       "feature": "Memory & Learning",
       "title": "Memory & Learning",
       "summary": "KiroCrew has persistent memory that survives across sessions. It remembers your preferences, project context, daily activity, and corrections you teach it.",
       "doc": "memory-and-learning.md",
-      "mtime": 1784265640.0
+      "mtime": 1784575659.0
     },
     {
       "feature": "Research Lab",

--- a/src/kiro_crew/docs/feature-tips.md
+++ b/src/kiro_crew/docs/feature-tips.md
@@ -1,0 +1,51 @@
+# Feature Tips
+
+KiroCrew occasionally surfaces a small tip above the chat composer while the
+agent is working, pointing at a feature you have not used yet. Tips are
+personalized: a background session reads your recent activity and memory
+context to pick features that fit how you actually work.
+
+## How It Works
+
+- Tips appear only during a running turn, about 10 seconds in, as a single
+  strip above the input box. They never cover chat content — the strip takes
+  real layout space and pushes the conversation up.
+- At most one tip is shown per turn, and after a tip is shown the next one
+  waits for the cadence window (6 hours by default).
+- Candidates come from a catalog built from these feature docs. A background
+  model call ranks them against your recent activity; a small share of tips is
+  picked at random so less obvious features still get a chance to surface.
+- Tips never appear in temporary sessions, split view, or embedded
+  composer-less views.
+
+## Controls
+
+Three layers, from one tip to everything:
+
+| Action | Effect |
+|--------|--------|
+| Click the X on a tip | Permanently dismisses that tip (the feature, not just the wording) |
+| Settings -> Chat -> Feature Tips | Per-user toggle; turns all tips off or back on |
+| `dashboard.tips_enabled: false` in config | Instance-wide kill switch |
+
+When the instance config disables tips, the Settings toggle is grayed out with
+a note saying so.
+
+## Privacy
+
+Tip personalization uses the same memory context that a normal chat turn
+already receives, sent to the same model you configured — no new data leaves
+your machine beyond what a regular turn sends. The local tips state file is
+written with owner-only permissions. Temporary sessions (which promise no
+memory reads) never show tips.
+
+## Configuration
+
+```yaml
+dashboard:
+  tips_enabled: true        # instance-wide switch
+  tips_cadence_hours: 6     # minimum gap between tips
+  tips_max_count: 5         # tips generated per refresh
+```
+
+See [Configuration Reference](configuration.md) for the full list.

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -55,6 +55,7 @@ agent backend and Slack credentials.
 | Cooperative Stop | Soft-stop with cancel ack before hard kill (preserves session state) |
 | Streaming STT | Live speech-to-text partials in dashboard input (Whisper local; AWS Transcribe optional) |
 | Memory Modes | Per-session persistent, incognito, or temporary memory |
+| [Feature Tips](feature-tips.md) | Occasional personalized tips above the composer pointing at features you have not used yet |
 | TUI | Terminal UI with Ink (React for CLI) — alternative to web dashboard |
 | [Queued-Message Editing](dashboard.md) | Edit, reorder, or cancel a chat message waiting in the queue before it runs |
 

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -54,12 +54,29 @@ work with cron jobs daily, tip about cron features first.
 3. BUT note some features are context-independent (theme, split view, keyboard shortcuts) \
 and may be suggested regardless of recent activity.
 
+TONE — this is the most important rule. The reader is a developer mid-task; write \
+like the product documentation, not like marketing:
+- State plainly what the feature does and when it is useful. Nothing else.
+- NO superlatives or hype ("powerful", "amazing", "supercharge", "game-changing", \
+"effortlessly", "unlock", "transform", "revolutionize").
+- NO exclamation marks. NO emoji. NO rhetorical questions ("Did you know...?", \
+"Tired of...?").
+- Do not oversell outcomes. "Runs independent tasks in parallel" is right; \
+"Get results 10x faster" is wrong.
+- Model the register on these real doc one-liners:
+  "Schedule recurring tasks — 'every weekday at 9am give me a pipeline briefing'"
+  "Spawn parallel background workers for fan-out research and multi-package work"
+  "Persistent preferences, project context, and learned corrections across sessions"
+
 Each tip must have:
 - id: a short kebab-case identifier (e.g. "cron-scheduling-tip")
+- title: the feature's plain name or its core action, under 60 chars \
+(e.g. "Schedule recurring reports", not "Never miss a beat with cron!")
 - feature: the feature name from the catalog
-- title: attention-grabbing title (under 60 chars)
-- body: 1-2 sentence explanation of what it does
-- why: 1 sentence explaining why THIS user specifically would benefit (reference their actual workflow)
+- body: 1-2 sentences stating what it does, ideally with one concrete usage example
+- why: 1 factual sentence connecting it to THIS user's actual recent workflow \
+(name the specific activity; if the connection is weak, pick a different feature \
+rather than inventing one)
 - doc: the doc filename from the catalog
 - cta_prompt: a ready-to-send chat message demonstrating the feature
 

--- a/src/kiro_crew/tips_allowlist.py
+++ b/src/kiro_crew/tips_allowlist.py
@@ -24,6 +24,7 @@ TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "dashboard.md",
         "deploy-web.md",
         "dynamic-subagent-sizing.md",
+        "feature-tips.md",
         "getting-started.md",
         "knowledge-library-how-it-works.md",
         "memory-and-learning.md",


### PR DESCRIPTION
Follow-up to #47 (merged this morning).

## 1. Feature doc for the tips feature itself

Tips had no entry on the docs page. New `src/kiro_crew/docs/feature-tips.md` covers how it works (in-flow strip, one per turn, cadence, exploration blend, surface gating), the three control layers (per-tip X / Settings toggle / instance config), privacy semantics (same memory context as a normal turn, owner-only state file, never in temporary sessions), and config keys. Listed in `index.md` and the catalog allowlist; bundled catalog regenerated (17 -> 18 entries).

## 2. Tone-tune the background generation prompt

Generated tips read like marketing copy. Root cause: the prompt asked for an *attention-grabbing title* with no tone constraints. Rewritten with an explicit tone contract modeled on the docs' own one-liners:

- plain statement of what the feature does and when it is useful
- banned: superlatives/hype words, exclamation marks, emoji, rhetorical questions, oversold outcomes (with concrete right/wrong examples)
- register examples quoted from real `index.md` one-liners
- `why` must name an actual recent activity; weak connection -> pick a different feature instead of inventing relevance

## Gate

- 99/99 `test/test_tips.py` (catalog subset/allowlist/existence tests cover the new doc)
- flake8 + isort clean, no CJK in any artifact