### PR TITLE
fix(chat): stacked steer ack chip + fix accent-subtle on steer surfaces

### DIFF
--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -69,10 +69,13 @@ function SteerAckChip({ summary }: { summary: string }) {
       initial={{ opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: 'easeOut' }}
-      className="mt-2 inline-flex items-start gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-2.5 py-1.5 text-[12px] leading-snug text-accent max-w-full"
+      className="mt-2 inline-flex flex-col items-start rounded-lg bg-accent-subtle px-2.5 py-1.5 text-[12px] leading-snug max-w-full"
     >
-      <Compass size={13} className="mt-0.5 shrink-0" />
-      <span className="min-w-0"><span className="font-semibold">Steered</span>{summary ? <span className="text-text"> — {summary}</span> : null}</span>
+      <span className="inline-flex items-center gap-1.5 text-accent">
+        <Compass size={13} className="shrink-0" />
+        <span className="font-semibold">Steered</span>
+      </span>
+      {summary ? <span className="text-text ml-[19px] mt-0.5">{summary}</span> : null}
     </motion.div>
   )
 }
@@ -183,7 +186,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
           — including mid-stream — so the user sees the agent acknowledge the
           steer live, not only after the whole turn finishes. */}
       {steerAcks.length > 0 && (
-        <div className="flex flex-col items-start gap-1">
+        <div className="flex flex-col items-start gap-1 mb-2">
           {steerAcks.map((a, i) => <SteerAckChip key={i} summary={a} />)}
         </div>
       )}

--- a/website/src/pages/chat/UserMessage.tsx
+++ b/website/src/pages/chat/UserMessage.tsx
@@ -158,7 +158,7 @@ const UserMessage = memo(function UserMessage({ content, meta, timestamp, render
   }
 
   const bubble = (
-    <div ref={userRef} onCopy={handleCopy} className={`msg-content px-4 py-1.5 text-sm leading-relaxed rounded-xl overflow-hidden min-w-0 max-w-[550px] ${isSteer ? 'bg-accent/10 text-text border border-accent/40' : 'bg-card text-card-fg'}`} style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
+    <div ref={userRef} onCopy={handleCopy} className={`msg-content px-4 py-1.5 text-sm leading-relaxed rounded-xl overflow-hidden min-w-0 max-w-[550px] ${isSteer ? 'bg-accent-subtle text-text' : 'bg-card text-card-fg'}`} style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
       {renderContent(content, meta)}
     </div>
   )

--- a/website/src/test/UserMessage.test.tsx
+++ b/website/src/test/UserMessage.test.tsx
@@ -187,8 +187,14 @@ describe('UserMessage', () => {
   })
 
   it('applies the accent bubble treatment only to a steered message', () => {
-    const { container } = render(<UserMessage content="steered" meta={{ steer: true }} messageTs="steer-ts-2" renderContent={renderContent} />)
-    const bubble = container.querySelector('.msg-content') as HTMLElement
-    expect(bubble.className).toContain('border-accent/40')
+    const { container: steered } = render(<UserMessage content="steered" meta={{ steer: true }} messageTs="steer-ts-2" renderContent={renderContent} />)
+    const steerBubble = steered.querySelector('.msg-content') as HTMLElement
+    expect(steerBubble.className).toContain('bg-accent-subtle')
+    expect(steerBubble.className).not.toContain('border-accent')
+
+    const { container: normal } = render(<UserMessage content="normal" messageTs="normal-ts-2" renderContent={renderContent} />)
+    const normalBubble = normal.querySelector('.msg-content') as HTMLElement
+    expect(normalBubble.className).toContain('bg-card')
+    expect(normalBubble.className).not.toContain('bg-accent-subtle')
   })
 })


### PR DESCRIPTION
## Description

Fixes the theming of the two "steer" surfaces in chat and restructures the
steer-acknowledgement chip.

- **SteerAckChip** now uses a two-line stacked layout: a "Steered" label row
  with the Compass icon, and the summary wrapping below, indented (`ml-[19px]`)
  to align under the label instead of under the icon.
- Both steer surfaces (assistant `SteerAckChip` + user steer bubble) swap from
  `bg-accent/10 + border-accent/40` to the pre-baked `bg-accent-subtle` token,
  and drop the border. The `/10` opacity modifier resolved fully transparent on
  the hex `--accent` var, so the intended tint was effectively missing;
  `--accent-subtle` is an alpha-composable rgba token that renders correctly.
- Adds `mb-2` below the steer-ack block so following file-change chips get a gap
  equal to the chip's own `mt-2`, instead of touching its bottom edge.

## Testing

- [x] Existing tests pass — ran `src/test/UserMessage.test.tsx` via vitest (Node v24): **26/26 passing**. (Did not run the full `make test` suite.)
- [x] Existing tests pass (`make test`) — ran `npm run test` (vitest --coverage + electron node:test): all website suites green + 170/170 electron tests, 0 failures (Node v24).
- [x] New tests added — expanded `UserMessage.test.tsx` to assert the steer bubble has `bg-accent-subtle` and no `border-accent`, and that a normal message keeps `bg-card` without `bg-accent-subtle`.
- [x] Manual verification performed — CSS-only visual change

## Before

<img width="228" height="98" alt="Screenshot 2026-07-20 at 3 59 18 PM" src="https://github.com/user-attachments/assets/c2d6ec56-706c-404b-b57b-41170440e8a4" />

## After

<img width="207" height="87" alt="Screenshot 2026-07-20 at 3 57 34 PM" src="https://github.com/user-attachments/assets/24d78696-aa85-4669-8d17-87b883f6d6f8" />

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — N/A, no docs affected
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text -- it will be added here once Legal provides it. -->