### PR TITLE
fix(sidebar): remove stale sidebar-toggle tip banner

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1378,7 +1378,6 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 @media (max-width: 767px) {
   .mobile-sessions-overlay .sidebar-inner { width: 100% !important; }
   .mobile-sessions-overlay .sidebar-resize-handle { display: none !important; }
-  .mobile-sessions-overlay .sidebar-toggle-tip { display: none !important; }
 }
 
 /* ── Diff panel header: theme-conditional bg/border to match Monaco vs/vs-dark ── */

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -552,7 +552,6 @@ function ChatSidebar({
 
   // Sidebar-only state
   const [slotFilter, setSlotFilter] = useState('')
-  const [tipDismissed, setTipDismissed] = useState(() => !!localStorage.getItem('mc-sidebar-tip-dismissed'))
   const [historyFilter, setHistoryFilter] = useState('')
   const historySearchResults = useDebouncedSessionSearch(historyFilter, s => s)
   // Which folder groups are collapsed in the grouped search-results view.
@@ -2722,12 +2721,6 @@ function ChatSidebar({
           </div>
         )}
       </LayoutGroup>
-
-      {/* Sidebar-hide tip */}
-      {!tipDismissed && <div className="sidebar-toggle-tip mx-2 mb-1 mt-1 px-3 py-2 rounded-lg bg-bg-elevated border text-[12px] text-text leading-relaxed flex items-start gap-2 animate-rise" style={{ borderColor: 'color-mix(in srgb, var(--accent) 40%, transparent)' }}>
-        <span className="flex-1">You can now toggle this sidebar<br/>Enable in <strong className="text-text-strong">Settings → Chat → Sidebar</strong>.</span>
-        <Btn aria-label="Dismiss sidebar tip" className="shrink-0 text-muted hover:text-text cursor-pointer bg-transparent border-none text-[14px] leading-none p-0" onClick={() => { safeSetItem('mc-sidebar-tip-dismissed', '1'); setTipDismissed(true) }}><X className="lucide-inline" /></Btn>
-      </div>}
 
       {/* When expanded: doubles as the resize handle (accent on hover, drag to resize, dbl-click to collapse).
           When collapsed: just a static 1px divider between sessions and the Older Sessions footer. */}


### PR DESCRIPTION
## Summary
The dismissible tip at the bottom of the chat sidebar told users:

> You can now toggle this sidebar — Enable in **Settings → Chat → Sidebar**.

That settings section no longer exists (no `Sidebar` entry anywhere under Settings), so the tip is a dead pointer. This removes:
- the banner JSX and its `tipDismissed` state / `mc-sidebar-tip-dismissed` localStorage flag in `website/src/pages/ChatSidebar.tsx`
- the orphaned `.sidebar-toggle-tip` mobile CSS rule in `website/src/index.css`

## Testing
- `tsc --noEmit` passes clean
- Verified `safeSetItem`, `Btn`, and `X` are still used elsewhere in the file (no dead imports)