### PR TITLE
feat(desktop): notarized first-install DMG published to the CDN

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,9 +214,11 @@ jobs:
         with:
           # Omit *.zip: the macOS zip is re-signed + notarized downstream, so a
           # pre-notarization attestation would bind a digest that never ships.
+          # Omit *.dmg too: the electron-builder DMG wraps the unsigned app
+          # and never ships; the DMG that ships is rebuilt from the stapled
+          # app and attested inside notarize-macos.yml.
           subject-path: |
             release/*.whl
-            release/*.dmg
             release/*.AppImage
 
       # Install the CDSigner SigV4 client (awscurl) BEFORE AWS credentials are
@@ -313,6 +315,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
     uses: ./.github/workflows/notarize-macos.yml
     secrets: inherit
     with:

--- a/.github/workflows/notarize-macos.yml
+++ b/.github/workflows/notarize-macos.yml
@@ -43,12 +43,16 @@ on:
 permissions:
   contents: read
   id-token: write
+  attestations: write
 
 jobs:
   notarize:
     name: Notarize + staple (${{ inputs.channel }})
     runs-on: macos-14
-    timeout-minutes: 45
+    # Two notarytool submissions (app, then DMG), each --wait up to 30m,
+    # plus build/staple/upload overhead -- the job budget must exceed their
+    # combined worst case or GitHub cancels mid-publish.
+    timeout-minutes: 75
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
     # environment switches the subject to environment:prod, which it does.
@@ -185,6 +189,98 @@ jobs:
           echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
           echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
+      # First-install DMG, rebuilt from the STAPLED app (the electron-builder
+      # DMG from the build job wraps the unsigned app and must never ship).
+      # The DMG itself is not code-signed (the Developer ID cert lives inside
+      # CDSigner, which signs .app bundles): Apple ACCEPTS notarization of an
+      # unsigned DMG whose contents are fully signed+stapled (proven:
+      # submission 1c29ae3d), and Gatekeeper verifies the DMG via the online
+      # ticket lookup. Stapling the DMG is impossible without a signature
+      # (stapler Error 73), so it is deliberately skipped -- the app INSIDE
+      # is stapled, which covers the offline launch check that matters.
+      - name: Build DMG from stapled app
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          rm -rf work/dmg-staging && mkdir -p work/dmg-staging
+          cp -R "work/stapled/${APP_NAME}.app" work/dmg-staging/
+          ln -s /Applications work/dmg-staging/Applications
+          hdiutil create -volname "${APP_NAME}" -srcfolder work/dmg-staging \
+            -ov -format UDZO -quiet "work/${APP_NAME}.dmg"
+          ls -lh "work/${APP_NAME}.dmg"
+
+      # Attest the DMG that actually ships: the electron-builder DMG from the
+      # build job is attested nowhere (it wraps the unsigned app and never
+      # publishes); THIS rebuilt DMG is the released artifact, so provenance
+      # must bind these bytes. Runs before notarization/publication so nothing
+      # leaves the runner unattested.
+      - name: Attest DMG provenance
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: work/*.dmg
+
+      - name: Notarize DMG
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id kirocrew/signing/apple-notary \
+            --query SecretString --output text)
+          APPLE_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['apple_id'])")
+          APPLE_PW=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['password'])")
+          TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
+          echo "::add-mask::$APPLE_PW"
+          unset SECRET_JSON
+
+          echo "Submitting DMG to Apple notary service..."
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "work/${APP_NAME}.dmg" \
+            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
+            --wait --timeout 30m 2>&1)
+          RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
+
+          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
+            echo "DMG notarization was not Accepted. Fetching the itemized Apple log..."
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
+            fi
+            exit 1
+          fi
+          echo "DMG notarization Accepted: $SUBMISSION_ID"
+
+      # Same never-republish discipline as the zip: conditional write,
+      # 412 on a job re-run keeps the existing notarized bytes.
+      - name: Publish DMG to distribution bucket
+        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
+        run: |
+          set -euo pipefail
+          DMG_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.dmg"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${DMG_KEY}" \
+            --body "work/${APP_NAME}.dmg" \
+            --if-none-match '*' \
+            --content-type application/x-apple-diskimage \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              echo "DMG key already published (job re-run) -- keeping existing bytes: ${DMG_KEY}"
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "DMG_KEY=${DMG_KEY}" >> "$GITHUB_ENV"
+          echo "Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
+
       # Feed points at the NOTARIZED artifact on the CDN -- written only
       # after the spctl gate above passed, and only after the artifact
       # itself is publicly downloadable (feed-before-artifact would hand
@@ -202,6 +298,7 @@ jobs:
           {
             "version": "${VERSION}",
             "url": "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}",
+            "dmg": "${{ vars.CLI_CDN_BASE }}/${DMG_KEY}",
             "name": "${VERSION}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -216,7 +313,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
-          path: work/notarized.zip
+          path: |
+            work/notarized.zip
+            work/*.dmg
           retention-days: 14
 
       - name: Summary
@@ -228,6 +327,9 @@ jobs:
             echo "- Input: \`${SIGNED_ZIP_KEY}\`"
             echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
             if [ -n "${DESKTOP_KEY:-}" ]; then
-              echo "- Public: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+              echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+            fi
+            if [ -n "${DMG_KEY:-}" ]; then
+              echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,22 +162,24 @@ jobs:
 
       - name: Attest build provenance
         # Signed SLSA build-provenance for the built artifacts
-        # (wheel/sdist/DMG/AppImage) — CWE-1104 / P475357136. Placed in the
+        # (wheel/sdist/AppImage) — CWE-1104 / P475357136. Placed in the
         # `release` job because it already holds id-token (OIDC); per the
         # least-privilege split enforced by test_workflow_permissions.py the
         # id-token job must never also hold contents:write (that lives only in
         # the separate github-release job). The macOS .zip is attested here in
         # its pre-notarized form (notarize/staple runs in a later job); the
-        # wheel/sdist/dmg/AppImage digests are identical to what is published.
+        # wheel/sdist/AppImage digests are identical to what is published.
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           # Attest only artifacts whose bytes are final here. The macOS .zip is
           # re-signed + notarized in a later job, so attesting it pre-notarization
-          # binds a digest that never ships (Codex review). Omit *.zip.
+          # binds a digest that never ships (Codex review). Omit *.zip. Same for
+          # *.dmg: the electron-builder DMG wraps the unsigned app and never
+          # ships; the shipping DMG is rebuilt from the stapled app and attested
+          # inside notarize-macos.yml.
           subject-path: |
             release/*.whl
             release/*.tar.gz
-            release/*.dmg
             release/*.AppImage
 
       # Install the CDSigner SigV4 client BEFORE AWS credentials are configured
@@ -236,6 +238,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
     uses: ./.github/workflows/notarize-macos.yml
     secrets: inherit
     with:
@@ -255,17 +258,23 @@ jobs:
         with:
           path: artifacts
 
-      # Assemble release assets: everything built, with the macOS zip
-      # replaced by the notarized + stapled one from the notarize job.
-      - name: Flatten artifacts (notarized macOS zip wins)
+      # Assemble release assets: everything built, with the macOS zip and DMG
+      # replaced by the notarized ones from the notarize job. The unsigned
+      # electron-builder DMG (built before signing) must never ship -- it
+      # wraps an unsigned app and hits the Gatekeeper scare dialog.
+      - name: Flatten artifacts (notarized macOS assets win)
         run: |
           mkdir -p release
-          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.dmg" -o -name "*.AppImage" \) -exec cp {} release/ \;
+          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" \) -exec cp {} release/ \;
           NOTARIZED=$(find artifacts -path "*KiroCrew-notarized-*" -name "notarized.zip" | head -1)
           if [ -n "$NOTARIZED" ]; then
             cp "$NOTARIZED" "release/KiroCrew-${{ needs.release.outputs.version }}-arm64-mac.zip"
           else
             find artifacts -type f -name "*arm64*.zip" -exec cp {} release/ \;
+          fi
+          NOTARIZED_DMG=$(find artifacts -path "*KiroCrew-notarized-*" -name "*.dmg" | head -1)
+          if [ -n "$NOTARIZED_DMG" ]; then
+            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.release.outputs.version }}-arm64.dmg"
           fi
           ls -la release/
 

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -2,6 +2,90 @@
 
 Design for the three-channel release pipeline: Nightly → Beta → Stable.
 
+## As built (authoritative, 2026-07-21)
+
+The sections below this one are the original design; the implementation
+deliberately diverged in several places. Where they disagree, THIS section
+is the contract.
+
+**Channels and triggers (as built):**
+
+| Channel | Trigger | Workflow |
+|---------|---------|----------|
+| nightly | schedule (06:00 UTC) + manual dispatch on `main` | `nightly.yml` |
+| insider | push of a prerelease tag (`v0.2.0-insider.1`, `-rc.N`, …) | `release.yml` |
+| stable  | push of a bare semver tag (`v0.2.0`) | `release.yml` |
+
+There is no release-branch / beta-cut / promote model and no
+`beta-hotfix.yml`, `promote-stable.yml`, or `rollback.yml`. Channel is
+derived from the tag; versions are stamped with seconds precision on
+nightly (`0.1.0-nightly.YYYYMMDDHHMMSS`) so no published key is ever
+overwritten.
+
+**Buckets (as built) — two, not one:**
+
+- `kirocrew-signing-artifacts-…` (PRIVATE, signing trust domain only):
+  `pre-signed/` → `signed/` (CDSigner output) → `notarized/` (archive)
+- `kirocrew-updates-…` (private + CloudFront OAC, public trust domain):
+  `cli/{channel}/{version}/`, `desktop/{channel}/{version}/`,
+  `feed/{channel}/latest-mac.json`, served at
+  `https://d28nxu9if70cmc.cloudfront.net` (`updates.kirocrew.dev` is not
+  yet provisioned)
+
+**Feed (as built) — static file, no Lambda:** `notarize-macos.yml` writes
+`feed/{channel}/latest-mac.json` directly after the spctl gate. There is no
+Feed Lambda, no S3-event trigger, no 200/204 endpoint, and no CloudFront
+Function query routing: the client (`auto-update.js`) fetches the static
+JSON and compares versions CLIENT-SIDE, engaging Squirrel only on a version
+delta. Schema:
+
+```json
+{
+  "version": "0.1.0-nightly.20260721061155",
+  "url": "https://d28nxu9if70cmc.cloudfront.net/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip",
+  "dmg": "https://d28nxu9if70cmc.cloudfront.net/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.dmg",
+  "name": "0.1.0-nightly.20260721061155",
+  "pub_date": "2026-07-21T06:22:13Z"
+}
+```
+
+`url` is the Squirrel auto-update payload (zip, mandatory). `dmg` is the
+first-install disk image for humans/website links; Squirrel ignores it.
+
+**macOS artifact flow (as built), all channels via `notarize-macos.yml`:**
+
+1. CDSigner signs the .app (dynamic manifest covering every nested Mach-O)
+2. `notarytool` submit (app) → staple → `spctl` fail-closed gate
+3. Notarized zip → `notarized/` (signing bucket) + `desktop/{channel}/{version}/`
+   (distribution bucket, conditional write, immutable cache)
+4. **DMG rebuilt from the STAPLED app** (`hdiutil`, /Applications symlink) —
+   the electron-builder DMG wraps the unsigned app and never ships anywhere.
+   The rebuilt DMG is provenance-attested, then notarized (Apple accepts an
+   unsigned DMG whose contents are signed+stapled; stapling the DMG itself
+   requires a code signature and is skipped — the DMG passes Gatekeeper via
+   the online ticket lookup, and the stapled app inside covers the offline
+   launch check), then published to `desktop/{channel}/{version}/…dmg`
+5. Feed written last, only after both artifacts are publicly downloadable
+6. Build/attest/notarize of the DMG run whenever signing is configured;
+   only CDN publication and the feed write additionally require the
+   distribution bucket to be configured. `release.yml` attaches the
+   notarized zip + notarized DMG to the GitHub Release (never the unsigned
+   electron-builder DMG)
+
+**Feed-ordering protection (as built):** workflow-level `concurrency`
+groups (nightly: `cancel-in-progress: true`; release: queued) prevent an
+older run finishing last from rolling a channel feed backward. There is no
+`blocked-versions.json` and no rollback workflow yet; rollback is a manual
+feed overwrite.
+
+**CLI channel (as built):** `publish-cli.yml` publishes the wheel +
+SHA256SUMS + PEP 503 index to `cli/nightly/` from `nightly.yml` only;
+insider/stable CLI channel publication is not yet wired (wheels ship as
+GitHub Release assets). The signing trust domain for the wheel
+(minisign/cosign detached signatures) remains an open item.
+
+---
+
 ## Channels
 
 | Channel | Cadence | Source | Who uses it |

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -75,10 +75,14 @@ class TestNightlyPermissions:
         }
         # Caller job for the reusable notarize workflow: a workflow_call
         # callee can never exceed the caller job's permissions, so the
-        # caller must grant id-token explicitly.
+        # caller must grant id-token explicitly. attestations:write is for
+        # the shipping-DMG provenance attestation inside notarize-macos.yml
+        # (the DMG is rebuilt there from the stapled app; the build-job DMG
+        # never ships and is attested nowhere).
         assert _permission_block(lines, "  notarize:") == {
             "id-token": "write",
             "contents": "read",
+            "attestations": "write",
         }
 
 


### PR DESCRIPTION
Ships the proper first-install artifact: a DMG rebuilt from the **stapled** app inside the notarize job, notarized, and published to the CDN + GitHub Releases. The electron-builder DMG (built before signing, wraps the unsigned app) no longer ships anywhere.

## What the notarize job now does after the spctl gate
1. **Build DMG** from the stapled .app (hdiutil UDZO, /Applications symlink for drag-install)
2. **Notarize the DMG** -- same masked single-step Secrets Manager credential pattern as the app submission. Empirically proven before wiring: Apple `Accepted` an unsigned DMG whose contents are fully signed+stapled (submission `1c29ae3d`, run locally against the live nightly artifact).
3. **Deliberately skip stapling the DMG**: stapler requires a code signature to anchor the ticket (Error 73 on unsigned DMGs) and our Developer ID cert lives inside CDSigner, which signs .app bundles. Consequence documented in-file: the DMG's own Gatekeeper check uses the online ticket lookup; the app inside is stapled, so the launch check works fully offline. (Future polish: if CDSigner grows DMG artifact support, sign+staple the DMG too.)
4. **Publish** to `desktop/<channel>/<version>/<App>.dmg` -- conditional write, 412-keep on job re-runs, immutable cache (keys are unique per the seconds stamp)
5. Feed gains a `dmg` field (website can link the latest installer; Squirrel ignores extra fields); workflow artifact + step summary include the DMG

## release.yml
GitHub Releases attach the **notarized** DMG (`KiroCrew-<version>-arm64.dmg`) and stop shipping the unsigned electron-builder DMG. AppImage (Linux, no Gatekeeper) unchanged.

## End state per channel
**DMG for the first install, zip feed for every update after** -- the DMG-installed app auto-updates via the Squirrel chain shipped in #98.

## Validation
- Local end-to-end probe with the live nightly artifact: DMG built from stapled app, Apple `Accepted`, mount + drag verified
- YAML parses; no duplicate top-level keys (checked explicitly)
- Post-merge: next nightly publishes the first CI DMG; URL appears in the step summary as `Public DMG: ...`