### PR TITLE
fix(skills): keep path slashes in skills.sh download URL

### DIFF
--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -156,10 +156,20 @@ class SkillsShProvider:
         Returns a list of (relative_path, content) tuples, or None on failure.
         Uses GET /api/download/{id} which returns all skill files.
         """
-        # Percent-encode the id (safe="") so a crafted value can't smuggle
-        # path segments or a query string into the URL — same treatment
-        # search() gives its query parameter.
-        url = f"{self._config.api_base}/download/{urllib.parse.quote(skill_id, safe='')}"
+        # The skills.sh id is an "owner/repo/skill" path whose slashes are real
+        # path segments. The download route is /api/download/{owner}/{repo}/{skill},
+        # so the slashes MUST survive into the URL (safe="/"). Encoding them
+        # (safe="") collapses the id into a single segment, misses the API route,
+        # and skills.sh returns its HTML SPA page instead of the JSON bundle, so
+        # the install surfaces as "not found or empty on skillsh". We still block
+        # traversal and smuggling: reject any empty, "." or ".." segment (which
+        # also covers a leading, trailing, or doubled slash), and quote() keeps
+        # encoding "?", "#", space, and similar so a query string cannot be
+        # smuggled in.
+        if not skill_id or any(seg in ("", ".", "..") for seg in skill_id.split("/")):
+            logger.debug("Rejecting malformed skill_id for download: %r", skill_id)
+            return None
+        url = f"{self._config.api_base}/download/{urllib.parse.quote(skill_id, safe='/')}"
         data = await _fetch_json(url)
         if data is None:
             return None

--- a/test/test_skill_providers.py
+++ b/test/test_skill_providers.py
@@ -299,3 +299,76 @@ class TestSkillsShTagsCoercion:
         with patch("kiro_crew.skill_providers.skillsh._sync_fetch_json", return_value=payload):
             results = await SkillsShProvider().search("g")
         assert results[0].tags == ["docker", "ci"]
+
+
+class TestSkillsShDownloadUrl:
+    """A skills.sh id is an owner/repo/skill PATH; its slashes are real path
+    segments that must reach the /api/download/{owner}/{repo}/{skill} route.
+    Percent-encoding them (safe="") collapsed the id into a single segment,
+    missed the API route, and skills.sh returned its HTML SPA page instead of
+    the JSON bundle, so a skill install surfaced as "not found or empty on
+    skillsh". fetch_skill_bundle() now keeps the slashes (safe="/") while still
+    rejecting traversal and encoding query/fragment metacharacters."""
+
+    @pytest.mark.asyncio
+    async def test_download_url_preserves_path_slashes(self):
+        captured = {}
+
+        def fake_fetch(url):
+            captured["url"] = url
+            return {"files": [{"path": "SKILL.md", "contents": "# ok"}]}
+
+        with patch(
+            "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+            side_effect=fake_fetch,
+        ):
+            bundle = await SkillsShProvider().fetch_skill_bundle(
+                "vercel-labs/agent-skills/vercel-react-best-practices"
+            )
+
+        assert bundle == [("SKILL.md", "# ok")]
+        assert captured["url"] == (
+            "https://skills.sh/api/download/"
+            "vercel-labs/agent-skills/vercel-react-best-practices"
+        )
+        assert "%2F" not in captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_download_url_still_encodes_query_and_fragment(self):
+        captured = {}
+
+        def fake_fetch(url):
+            captured["url"] = url
+            return {"files": [{"path": "SKILL.md", "contents": "# ok"}]}
+
+        with patch(
+            "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+            side_effect=fake_fetch,
+        ):
+            await SkillsShProvider().fetch_skill_bundle("owner/repo/a b?x=1#f")
+
+        # Legit path slashes survive; smuggling metacharacters are encoded.
+        assert "/download/owner/repo/" in captured["url"]
+        assert "%20" in captured["url"]  # space
+        assert "%3F" in captured["url"]  # ?
+        assert "%23" in captured["url"]  # #
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_traversal_ids(self):
+        calls = {"n": 0}
+
+        def fake_fetch(url):
+            calls["n"] += 1
+            return {"files": [{"path": "SKILL.md", "contents": "x"}]}
+
+        with patch(
+            "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+            side_effect=fake_fetch,
+        ):
+            p = SkillsShProvider()
+            assert await p.fetch_skill_bundle("../../etc/passwd") is None
+            assert await p.fetch_skill_bundle("/abs/path") is None
+            assert await p.fetch_skill_bundle("owner//repo") is None
+            assert await p.fetch_skill_bundle("") is None
+
+        assert calls["n"] == 0  # malformed ids never reach the network


### PR DESCRIPTION
## Summary
`SkillsShProvider.fetch_skill_bundle` built the download URL with
`urllib.parse.quote(skill_id, safe='')`, which percent-encodes the `/` in an
`owner/repo/skill` id to `%2F`. skills.sh serves bundles from
`/api/download/{owner}/{repo}/{skill}` (three real path segments), so the
single-segment `%2F` URL misses the API route, falls through to the site's page
catch-all, and returns the HTML SPA shell instead of the JSON bundle.
`json.loads(<html>)` then fails, `fetch_skill_bundle` returns `None`, and the
install handler emits `{"error": "Skill '<id>' not found or empty on skillsh"}`
(discover.py, HTTP 404). Only slash-containing ids broke; single-token ids were
unchanged by `quote()`.

This regressed the desktop skill browser: any `owner/repo/skill` install (e.g.
`vercel-labs/agent-skills/vercel-react-best-practices`) failed with "not found
or empty on skillsh", while the older MeshClaw build (raw `{skill_id}`, no
quoting) still worked.

## Fix
- Use `quote(skill_id, safe='/')` so legitimate path slashes reach the URL.
- Add a guard rejecting empty / "." / ".." segments (covers leading, trailing,
  and doubled slashes), preserving the original anti-smuggling intent of the
  `safe=''` hardening. `?`, `#`, space, and similar still get encoded, so a
  query string cannot be smuggled in, and the host stays skills.sh.

## Evidence (live, same id, both URL forms)
```
GET /api/download/vercel-labs/agent-skills/vercel-react-best-practices
  -> 200 application/json  {"files":[...]}   (raw slashes, matches route)
GET /api/download/vercel-labs%2Fagent-skills%2F...
  -> 200 text/html  (SPA page)               (%2F, misses route)
```

## Testing
Added 3 regression tests in `test/test_skill_providers.py`:
- download URL preserves path slashes (no `%2F`)
- non-slash metacharacters (`?`, `#`, space) still percent-encoded
- traversal ids (`../..`, leading `/`, doubled `//`, empty) rejected without a network call

`pytest test/test_skill_providers.py` -> 35 passed (32 existing + 3 new).
