### PR TITLE
fix(chat): snap to bottom on open instead of smooth-paging through history

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -538,9 +538,31 @@ export function useVirtualChat<T>(
   useLayoutEffect(() => {
     const el = scrollerRef.current
     if (!el) return
-    const grew = itemCount > prevItemCountRef.current
+    const growth = itemCount - prevItemCountRef.current
     prevItemCountRef.current = itemCount
-    if (!grew) return
+    if (growth <= 0) return
+    // BULK growth while followed is history hydration, not streaming: the
+    // slot-detail fetch resolving and REPLACING a thin optimistic list (e.g.
+    // a lone WS streaming bubble that landed before the fetch — it consumed
+    // the slot-entry one-shot pin) with the full conversation. Routing that
+    // through pinAuto smooth-glides from the top across hundreds of
+    // virtualized rows, visibly "paging" through the conversation and often
+    // landing short while heights are still estimates. Treat it like slot
+    // entry instead: remount the tail window and force-pin instantly.
+    // Gated on stick so a "load older" prepend while the user reads history
+    // is never yanked to the bottom.
+    if (growth > overscan + 1 && stickRef.current) {
+      setWindowRange({ start: Math.max(0, itemCount - (overscan + 1)), end: itemCount })
+      forcePin()
+      const id = requestAnimationFrame(() => {
+        // Recheck stick: the user can scroll up between the synchronous pin
+        // and this frame — the scroll handler releases stick, and an
+        // unconditional forcePin here would yank them back and re-arm follow.
+        if (!el.isConnected || !stickRef.current) return
+        forcePin()
+      })
+      return () => cancelAnimationFrame(id)
+    }
     // Pin synchronously (pre-paint) so a new message appears at the bottom
     // without a flicker, then once more next frame after its real height is
     // known. Both go through the race-proof pinAuto.
@@ -550,7 +572,7 @@ export function useVirtualChat<T>(
       pinAuto()
     })
     return () => cancelAnimationFrame(id)
-  }, [itemCount, pinAuto, scrollerRef])
+  }, [itemCount, overscan, pinAuto, forcePin, scrollerRef])
 
   // ---- Slot entry: force the scroller to the true bottom ----
   // Runs after the new session's tail window has committed (windowRange reset

--- a/website/src/test/useVirtualChat.integration.test.tsx
+++ b/website/src/test/useVirtualChat.integration.test.tsx
@@ -195,4 +195,105 @@ describe('useVirtualChat integration: follow / pin wiring', () => {
 
     expect(el.scrollTop).toBe(400)
   })
+
+  it('jumps instantly (no smooth glide) when bulk history hydration replaces a thin list', () => {
+    // The in-progress-conversation race: slot switches (sessionId flips), the
+    // history fetch is in flight, and a live WS streaming chunk lands FIRST —
+    // the list goes 0 → 1 and the slot-entry one-shot pin is consumed against
+    // that lone streaming bubble.
+    const { el, state, view } = render(
+      { scrollTop: 0, scrollHeight: 0, clientHeight: 400 },
+      [],
+      'bulk-hydration',
+    )
+    act(() => {
+      state.scrollHeight = 120
+      view.rerender({ items: mkItems(1), sessionId: 'bulk-hydration', getKey, externalScrollerRef: { current: el } })
+    })
+    expect(el.scrollTop).toBe(0) // content shorter than viewport
+
+    // Track HOW the scroller is driven from here: a smooth scrollTo is the
+    // "awkward paging" bug; the fix must land via an instant write.
+    let smoothCalls = 0
+    ;(el as unknown as { scrollTo: (o: { top: number; behavior?: string }) => void }).scrollTo = (o) => {
+      if (o.behavior === 'smooth') smoothCalls++
+      state.scrollTop = o.top
+    }
+
+    // The fetch resolves: the full conversation replaces the thin list
+    // (1 → 200 items, way past the overscan+1 bulk threshold).
+    act(() => {
+      state.scrollHeight = 24000
+      view.rerender({ items: mkItems(200), sessionId: 'bulk-hydration', getKey, externalScrollerRef: { current: el } })
+    })
+
+    // Instant force-pin to the true bottom — not a smooth glide.
+    expect(el.scrollTop).toBe(23600)
+    expect(smoothCalls).toBe(0)
+  })
+
+  it('bulk growth does NOT yank a user who scrolled up while history loads', () => {
+    const { el, state, view } = render(
+      { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 },
+      mkItems(8),
+      'bulk-no-yank',
+    )
+    expect(el.scrollTop).toBe(1600)
+
+    // User scrolls up to read — the scroll handler releases stick.
+    act(() => { state.scrollTop = 300; el.dispatchEvent(new Event('scroll')) })
+
+    // A bulk prepend lands (load-older page). Stick is released, so neither
+    // the bulk force-pin nor pinAuto may move the viewport.
+    act(() => {
+      state.scrollHeight = 12000
+      view.rerender({ items: mkItems(108), sessionId: 'bulk-no-yank', getKey, externalScrollerRef: { current: el } })
+    })
+
+    expect(el.scrollTop).toBe(300)
+  })
+
+  it('does NOT yank when the user scrolls up between the bulk pin and its settle frame', () => {
+    // rAF is queued by the bulk path's settle pin — capture it so the test
+    // controls exactly when the frame fires.
+    const frames: FrameRequestCallback[] = []
+    const origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof requestAnimationFrame
+    try {
+      const { el, state, view } = render(
+        { scrollTop: 0, scrollHeight: 0, clientHeight: 400 },
+        [],
+        'bulk-settle-scrollup',
+      )
+      // The settle frame guards on el.isConnected — attach the scroller so
+      // the frame actually runs (other tests use a detached element because
+      // they only exercise synchronous pins).
+      document.body.appendChild(el)
+      act(() => {
+        state.scrollHeight = 120
+        view.rerender({ items: mkItems(1), sessionId: 'bulk-settle-scrollup', getKey, externalScrollerRef: { current: el } })
+      })
+      frames.length = 0 // drop entry-pin frames; only the bulk settle matters below
+
+      // Bulk hydration lands: synchronous force-pin to the bottom.
+      act(() => {
+        state.scrollHeight = 24000
+        view.rerender({ items: mkItems(200), sessionId: 'bulk-settle-scrollup', getKey, externalScrollerRef: { current: el } })
+      })
+      expect(el.scrollTop).toBe(23600)
+
+      // User scrolls up BEFORE the settle frame fires — stick is released.
+      act(() => { state.scrollTop = 5000; el.dispatchEvent(new Event('scroll')) })
+
+      // The settle frame must respect the released stick and not yank back.
+      act(() => { frames.forEach(cb => cb(0)); frames.length = 0 })
+      expect(el.scrollTop).toBe(5000)
+      el.remove()
+    } finally {
+      globalThis.requestAnimationFrame = origRaf
+    }
+  })
 })


### PR DESCRIPTION
## Problem

Opening a conversation — especially one with a turn in progress — sometimes doesn't land at the bottom. Instead the viewport visibly "pages" down through the history, scrolling stepwise from the top, and can stop short of the latest message.

## Why it matters

Snapping to the latest message is the core contract of opening a chat. The paging glide makes every switch to a busy session feel broken and slow, and landing short hides the in-flight response the user came to check.

## Fix (symptom → root cause → change)

Opening an in-progress conversation races the history HTTP fetch against the live WebSocket stream. A streaming chunk can land first (the chunk handler appends into `state.messages` even while the slot detail fetch is pending), so the virtualizer's one-shot slot-entry pin fires against that lone streaming bubble and is consumed. When the fetch then resolves and replaces the thin list with the full conversation, that bulk growth goes through `pinAuto`, which uses `scrollTo({ behavior: 'smooth' })` (introduced with smooth text streaming). The smooth glide travels from the top across hundreds of virtualized rows, mounting windows along the way — the visible paging — and can land short while unmounted row heights are still estimates. The same shape hits previously-visited chats whose cached snapshot is thinner than the fetched history.

The change (in `useVirtualChat`'s append effect): bulk growth — more than `overscan + 1` items in one commit while follow is armed — is history hydration, not streaming. Treat it like slot entry: remount the tail window and force-pin instantly. Streaming appends (1–3 items) keep the smooth follow, and the bulk path is gated on the stick flag so a load-older prepend never yanks a user who scrolled up to read.

## Tests

Two integration tests added to `useVirtualChat.integration.test.tsx`:
- `jumps instantly (no smooth glide) when bulk history hydration replaces a thin list` — reproduces the exact race (entry pin consumed by one streaming bubble, then 1 → 200 hydration) and asserts the pin lands at the true bottom with zero smooth `scrollTo` calls. Fails on main, passes with the fix.
- `bulk growth does NOT yank a user who scrolled up while history loads` — asserts the stick gate: a bulk prepend while the user reads history leaves the viewport untouched.

Full suite: 344 files / 3874 tests pass. TypeScript and ESLint clean. Production build passes.

## Manual verification

Verified on an isolated test gateway: started a session generating a long response, switched away, switched back mid-stream — the view snaps straight to the bottom instead of paging in. Load-older-on-scroll-up still preserves position.
