### PR TITLE
fix(chat): separate file-change diff pills from the steered chip

### DIFF
--- a/website/src/components/FileChangeChips.tsx
+++ b/website/src/components/FileChangeChips.tsx
@@ -189,7 +189,7 @@ const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff,
   if (!fileChanges?.length) return null
   const Chip = RENDERERS[style] ?? ExpandedChip
   return (
-    <div className="ft-block-reveal flex flex-wrap items-center gap-1.5 mb-1.5">
+    <div className="ft-block-reveal flex flex-wrap items-center gap-1.5 mt-2 mb-1.5">
       {fileChanges.map(fc => (
         // Markdown docs get the larger info card (with a Save action);
         // everything else keeps the compact pill from the user's setting.


### PR DESCRIPTION
## Problem
When the agent acknowledges a mid-turn steer, a "Steered" ack chip renders at the end of the assistant message. If that message also has file changes, the file-change diff pills (e.g. `GhostScene.tsx +145 -79`) sit almost flush against the steered bubble, with no visual breathing room between the two.

## Why it matters
The two elements read as one cramped cluster, making the diff pills look attached to the steered bubble rather than being a distinct affordance. It looks like a layout bug.

## Fix (symptom -> root cause -> change)
The `SteerAckChip` is the last element inside the `.msg-content` container, and `FileChangeChips` renders as an immediate sibling right after it. `FileChangeChips`'s root container had only a bottom margin (`mb-1.5`, for spacing to the footer) and no top margin, so the pills butted directly against whatever preceded them. Added `mt-2` to the `FileChangeChips` container so the pills always get consistent top separation from the preceding content, whether that's a steered chip or plain prose.

`FileChangeChips` only renders inside `AssistantMessage`, so the blast radius is limited to assistant-message diff pills.

## Tests
No behavioral change (a Tailwind spacing utility), so no new tests. Existing suites confirm no regression:
- `FileChangeChips.test.tsx` (18 tests) pass
- `AssistantMessage.test.tsx` (37 tests) pass
- `tsc --noEmit` clean

## Manual verification
Rendered an assistant message with both a steered ack chip and file-change pills; the pills now sit with a clear gap below the steered bubble instead of hugging it.
