### PR TITLE
fix(dashboard): render md file-change chips like other files + hide internal synthesis prompt

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4334,7 +4334,9 @@ async def _run_chat(
             ):
                 slot._pending_synthesis = False
                 _syn = SUBAGENT_SYNTHESIS_PROMPT
-                slot.append("inject", _syn, "msg msg-inject")
+                # Do NOT echo the internal synthesis prompt into the transcript —
+                # it is an internal continuation, not user-facing text. Only its
+                # assistant reply (the consolidated summary) should be visible.
                 task = asyncio.create_task(
                     asyncio.wait_for(_run_chat(state, slot, _syn), timeout=CHAT_TURN_TIMEOUT)
                 )

--- a/website/src/components/FileChangeChips.tsx
+++ b/website/src/components/FileChangeChips.tsx
@@ -1,5 +1,4 @@
-import { memo, useState } from 'react'
-import { Star } from 'lucide-react'
+import { memo } from 'react'
 import type { FileChipStyle } from '../pages/chat/ChatSettings'
 import { colorForExt, fileIcon } from '../utils/fileIcons'
 
@@ -94,84 +93,6 @@ function MinimalChip({ fc, onClick }: { fc: FileChangeEntry; onClick: () => void
   )
 }
 
-/**
- * Pull light-weight structure out of a markdown doc's *new* content so the
- * DocChip can show something more useful than a bare filename:
- *   - `title`    → first `# ` H1 heading, if any
- *   - `sections` → the `## ` level-2 headings, in order (fenced code skipped)
- */
-export function extractMdInfo(after: string): { title: string | null; sections: string[] } {
-  let title: string | null = null
-  const sections: string[] = []
-  let inFence = false
-  for (const raw of after.split('\n')) {
-    const line = raw.trim()
-    if (line.startsWith('```')) { inFence = !inFence; continue }
-    if (inFence) continue
-    if (!title) {
-      const h1 = line.match(/^#\s+(.+)/)
-      if (h1) { title = h1[1].trim(); continue }
-    }
-    const h2 = line.match(/^##\s+(.+)/)
-    if (h2) sections.push(h2[1].trim())
-  }
-  return { title, sections }
-}
-
-/* ── Markdown docs: a larger card with icon, filename, status + section list ── */
-const DOC_MAX_SECTIONS = 3
-function DocChip({ fc, onClick, onSaveDoc }: { fc: FileChangeEntry; onClick: () => void; onSaveDoc?: (path: string) => void }) {
-  const [saved, setSaved] = useState(false)
-  const { added, removed } = countLines(fc.before, fc.after)
-  const isNew = fc.before === ''
-  const Icon = fileIcon(fc.path)
-  const { title, sections } = extractMdInfo(fc.after)
-  const shown = sections.slice(0, DOC_MAX_SECTIONS)
-  const extra = sections.length - shown.length
-  const sectionText = shown.length
-    ? shown.join(' • ') + (extra > 0 ? ` +${extra} more` : '')
-    : (title || 'Markdown document')
-  const status = isNew ? 'New document' : 'Updated'
-  return (
-    // A div (not a button) so the Save control can nest without invalid DOM.
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } }}
-      className="glass-surface file-chip flex items-start gap-3 w-full max-w-[440px] rounded-xl px-3.5 py-3 text-left cursor-pointer text-text"
-      aria-label={fc.path}
-    >
-      <span className="shrink-0 mt-0.5 flex items-center justify-center w-9 h-9 rounded-lg bg-bg-hover border border-border">
-        <Icon size={18} className={colorForExt(fc.path)} />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex items-center gap-2">
-          <span className="truncate font-semibold text-[13px]">{basename(fc.path)}</span>
-          <span className="shrink-0 ml-auto text-[11px]"><Stats added={added} removed={removed} /></span>
-        </span>
-        <span className="mt-0.5 block truncate text-[11.5px] text-muted">
-          {status} · {sectionText}
-        </span>
-      </span>
-      {onSaveDoc && (
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); if (saved) return; setSaved(true); Promise.resolve(onSaveDoc(fc.path)).catch(() => setSaved(false)) }}
-          className={`shrink-0 mt-0.5 p-1 rounded-md transition-colors bg-transparent border-none cursor-pointer ${saved ? 'text-accent' : 'text-muted/50 hover:text-accent'}`}
-          title={saved ? 'Starred' : 'Star'}
-          aria-label={saved ? 'Starred in library' : 'Star document'}
-        >
-          {saved ? <Star size={14} className="fill-current" /> : <Star size={14} />}
-        </button>
-      )}
-    </div>
-  )
-}
-
-const MD_RE = /\.(md|markdown|mdx)$/i
-
 const RENDERERS = { expanded: ExpandedChip, minimal: MinimalChip } as const
 
 /**
@@ -179,11 +100,9 @@ const RENDERERS = { expanded: ExpandedChip, minimal: MinimalChip } as const
  * Each chip shows the modified file's basename + line stats, and on
  * click opens the Monaco diff panel via `onOpenDiff(path, after, before)`.
  */
-const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, onSaveDoc, style = 'expanded' }: {
+const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, style = 'expanded' }: {
   fileChanges: FileChangeEntry[]
   onOpenDiff?: (path: string, modified: string, original: string) => void
-  /** Save a document chip into the artifact library (materialize + pin). */
-  onSaveDoc?: (path: string) => void
   style?: FileChipStyle
 }) {
   if (!fileChanges?.length) return null
@@ -191,11 +110,7 @@ const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff,
   return (
     <div className="ft-block-reveal flex flex-wrap items-center gap-1.5 mt-2 mb-1.5">
       {fileChanges.map(fc => (
-        // Markdown docs get the larger info card (with a Save action);
-        // everything else keeps the compact pill from the user's setting.
-        MD_RE.test(fc.path)
-          ? <DocChip key={fc.path} fc={fc} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} onSaveDoc={onSaveDoc} />
-          : <Chip key={fc.path} fc={fc} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} />
+        <Chip key={fc.path} fc={fc} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} />
       ))}
     </div>
   )

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1278,18 +1278,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabsCtl, dispatch, search.close, handleFileOpen])
 
-  // Save a document chip from chat into the artifact library (materialize +
-  // pin). Fire-and-forget; the artifact library refetches on its own.
-  const handleSaveDoc = useCallback((path: string) => {
-    // Return the promise (and rethrow) so the DocChip can revert its optimistic
-    // "Starred" state if the materialize fails, rather than claiming success.
-    return api.materializeArtifact(path, activeSlotRef.current ?? undefined).catch((e) => {
-      // eslint-disable-next-line no-console -- surface save failures to the dev console
-      console.warn('save document to library failed', e)
-      throw e
-    })
-  }, [])
-
   // Auto-surface files modified by the agent (carried in m.meta.file_changes)
   // into the activity Files tab so the user sees a unified list. Skip files
   // referenced by messages older than the last 'tool' watermark — once the
@@ -2782,7 +2770,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
             })()
           ) : (
             <div className="flex flex-col gap-0">
-              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} onOpenDiff={handleOpenDiff} onSaveDoc={handleSaveDoc} fileChipStyle={chatConfig.fileChipStyle} showFooter={(() => {
+              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} showFooter={(() => {
                 // Show footer on the last assistant message of each completed turn
                 if (isStreaming) return false
                 // Find next message after this one that's assistant, user, or streaming
@@ -2814,7 +2802,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // apply-plan handler, so it belongs here for correctness. approve/send/
     // dismissApproval are NOT referenced in this renderer (user/approval rows go
     // through renderUserContentCb), so they are omitted to keep it stable.
-  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handleSaveDoc, handlePlanFromHere, navigate, planTaskId])
+  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId])
 
   const [mobileSessions, setMobileSessions] = useState(false)
   // Close mobile sessions panel when a session is selected

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -77,7 +77,7 @@ function SteerAckChip({ summary }: { summary: string }) {
   )
 }
 
-const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, onSaveDoc, fileChipStyle }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; onSaveDoc?: (path: string) => void; fileChipStyle?: FileChipStyle }) {
+const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle }) {
   const [applied, setApplied] = useState(false)
   const [copied, setCopied] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
@@ -190,7 +190,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
       {!isStreaming && selectionActions.length > 0 && <SelectionToolbar containerRef={contentRef} actions={selectionActions} />}
     </div>
     {fileChanges && fileChanges.length > 0 && !isStreaming && (
-      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} onSaveDoc={onSaveDoc} style={fileChipStyle} />
+      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} style={fileChipStyle} />
     )}
     {!isStreaming && showFooter && (
       <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300">


### PR DESCRIPTION
## Problem
Two dashboard UX issues:
1. **Markdown file-change chips look different from every other file.** `.md/.markdown/.mdx` diffs rendered as a large `DocChip` with a heading "summary" line and a **Star** (save-to-library) button, while all other file types rendered as the compact `Chip`. This inconsistency was confusing.
2. **The internal sub-agent synthesis prompt was shown as a chat bubble.** After a fan-out completes, the one-shot synthesis turn echoed its *entire internal prompt* (`SUBAGENT_SYNTHESIS_PROMPT`) into the transcript as an `inject` bubble — the user saw raw "[SYSTEM] Sub-agent synthesis: …" guidance instead of just the result.

## Why it matters
Consistent chip rendering keeps the diff UI predictable; the special markdown card + star added surface area and visual noise the user did not want. Showing the internal synthesis prompt leaks implementation detail into the conversation and clutters the transcript, while adding no value (the synthesis reply itself is what matters).

## Fix (symptoms → root cause → change)
1. **md chips** — root cause: a `MD_RE`-based ternary in `FileChangeChips.tsx` routed markdown to `DocChip` (summary + star) instead of `Chip`. Change: the `.map` now always renders `Chip`; removed the dead `DocChip`, `extractMdInfo`, `DOC_MAX_SECTIONS`, `MD_RE`, the `Star` import, and the `onSaveDoc` plumbing end-to-end (`FileChangeChips` → `AssistantMessage` → `ChatPage.handleSaveDoc` + its `useMemo` dep). `api.materializeArtifact` is **kept** (still used by `ArtifactsPage` and `ActivityViewer`).
2. **synthesis bubble** — root cause: `chat_runner.py` did `slot.append("inject", _syn, "msg msg-inject")` before dispatching the synthesis turn, echoing the internal prompt. Change: removed that append. The synthesis turn still fires (`_run_chat(state, slot, _syn)` is unchanged), so the consolidated assistant reply still appears — only the internal prompt bubble is gone.

## Tests
- Frontend `tsc --noEmit`: clean (0 errors) after removing the plumbing.
- `src/test/FileChangeChips.test.tsx`: **18 passed** (the suite uses `.ts/.py/.rs/.log` paths — no markdown branch was ever asserted, so removal is non-breaking).
- Backend `py_compile` on `chat_runner.py`: OK.

## Manual verification
The synthesis behavior is verified by construction: the only change is dropping the transcript echo; the dispatch (`_run_chat`) and the `_pending_synthesis`/inflight gating are untouched, so the synthesis turn still runs after all sub-agents complete — the user simply no longer sees the internal prompt. md-chip change is visual-only and type-checked; recommend a quick dashboard glance that a `.md` change now shows the same compact pill as a `.ts` change.
