### PR TITLE
fix(dashboard): allow local dashboard session to view PRs when no owner is configured

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -1162,7 +1162,7 @@ async def fetch_pull_request(raw_url: str, *, refresh: bool = False) -> dict[str
 
 async def api_pull_request_source(request: web.Request) -> web.Response:
     """Owner-only POST ``/api/source/pull-request`` with ``{url, refresh?}``."""
-    denied = _authorize_owner_request(request, "source.pull_request.read")
+    denied = _authorize_owner_request(request, "source.pull_request.read", allow_local_no_owner=True)
     if denied is not None:
         return denied
     try:
@@ -1193,7 +1193,7 @@ async def api_pull_request_source(request: web.Request) -> web.Response:
 
 async def api_pull_request_checks(request: web.Request) -> web.Response:
     """Owner-only POST ``/api/source/pull-request/checks`` with ``{url}``."""
-    denied = _authorize_owner_request(request, "source.pull_request.checks")
+    denied = _authorize_owner_request(request, "source.pull_request.checks", allow_local_no_owner=True)
     if denied is not None:
         return denied
     try:
@@ -1319,12 +1319,28 @@ def _audit_source_api(
         logger.debug("SEL source API audit failed", exc_info=True)
 
 
-def _authorize_owner_request(request: web.Request, operation: str) -> web.Response | None:
-    """Require an explicit dashboard-user claim matching the configured owner."""
+def _authorize_owner_request(
+    request: web.Request, operation: str, *, allow_local_no_owner: bool = False
+) -> web.Response | None:
+    """Require an explicit dashboard-user claim matching the configured owner.
+
+    When no owner is configured, the deployment is a local single-user install
+    (``owner_id`` is only set during Slack/owner setup). For **read-only**
+    operations (``allow_local_no_owner=True``), the endpoint is already gated by
+    ``token_auth`` and the local dashboard token carries subject ``local-app``
+    with an empty ``app`` claim — allow *that* local session so viewing a PR diff
+    does not require Slack setup; app tokens and any other subject still fail
+    closed. Mutations (e.g. resolving a review thread) pass the default
+    ``allow_local_no_owner=False`` and stay owner-only. Once an owner IS
+    configured (shared / Slack / multi-user), the strict owner match applies to
+    every operation.
+    """
     state = request.app["state"]
     owner_id = str(getattr(state, "owner_id", "") or "")
     caller = str(request.get("user") or "")
     if not owner_id:
+        if allow_local_no_owner and request.get("app") == "" and caller == "local-app":
+            return None
         _audit_source_api(request, operation, "denied", "owner_not_configured")
         return web.json_response({"error": "forbidden"}, status=403)
     if "app" not in request or request["app"] != "":

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -1572,6 +1572,68 @@ async def test_read_handlers_require_explicit_owner_dashboard_claims(
     assert secret not in str(call)
 
 
+@pytest.mark.asyncio
+async def test_read_handler_allows_local_token_when_no_owner_configured(
+    monkeypatch, _mock_source_sel
+) -> None:
+    """Local single-user install (no owner): the local dashboard token
+    (subject ``local-app``, empty app claim) may use the credential-backed
+    provider so viewing a PR diff does not require Slack/owner setup."""
+    fetch = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(source, "fetch_pull_request", fetch)
+    url = "https://github.com/acme/repo/pull/1"
+
+    async with TestClient(
+        TestServer(_app(owner_id="", user="local-app", app_name=""))
+    ) as client:
+        response = await client.post("/api/source/pull-request", json={"url": url})
+        assert response.status == 200
+        assert (await response.json()) == {"ok": True}
+
+    fetch.assert_awaited_once_with(url, refresh=False)
+
+
+@pytest.mark.asyncio
+async def test_read_handler_denies_non_local_subject_when_no_owner(
+    monkeypatch, _mock_source_sel
+) -> None:
+    """No owner + a non ``local-app`` subject (e.g. a stale owner-minted token)
+    still fails closed — the fallback is scoped to the genuine local token."""
+    fetch = AsyncMock()
+    monkeypatch.setattr(source, "fetch_pull_request", fetch)
+
+    async with TestClient(
+        TestServer(_app(owner_id="", user="U_OWNER", app_name=""))
+    ) as client:
+        response = await client.post(
+            "/api/source/pull-request", json={"url": "https://github.com/acme/repo/pull/1"}
+        )
+        assert response.status == 403
+        assert (await response.json()) == {"error": "forbidden"}
+
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_handler_denies_local_token_when_no_owner(monkeypatch, _mock_source_sel) -> None:
+    """The local no-owner fallback is scoped to reads: the resolve *mutation*
+    stays owner-only, so a local-app token with no owner still fails closed."""
+    resolve = AsyncMock()
+    monkeypatch.setattr(source, "resolve_pull_request_thread", resolve)
+
+    async with TestClient(
+        TestServer(_app(owner_id="", user="local-app", app_name=""))
+    ) as client:
+        response = await client.post(
+            "/api/source/pull-request/resolve",
+            json={"url": "https://github.com/acme/repo/pull/1", "threadId": "PRRT_1"},
+        )
+        assert response.status == 403
+        assert (await response.json()) == {"error": "forbidden"}
+
+    resolve.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     ("handler", "fetch_name", "operation"),
     [


### PR DESCRIPTION
## Problem
On a local single-user KiroCrew install, the PR **Changes** panel always failed with `Could not load this pull request {"error":"forbidden"}`. Viewing a PR diff required configuring a Slack owner — which is unrelated to viewing code.

## Why it matters
The PR-diff/review feature is unusable out-of-the-box for anyone who runs the dashboard locally without Slack (the common case). It forces unrelated Slack/owner setup just to read a diff, and the error ("forbidden") gives no hint that owner configuration is the cause.

## Fix (symptoms → root cause → change)
- **Symptom:** `POST /api/source/pull-request` → 403 `{"error":"forbidden"}`, before any GitHub access.
- **Root cause:** the endpoint is guarded by `_authorize_owner_request()` (`src/kiro_crew/dashboard/handlers/source_providers.py`), which **fails closed** when `owner_id` is empty (`owner_id` is only populated during Slack/owner setup). The gate exists to stop a *non-owner on a network-exposed/shared deployment* from riding the owner's GitHub credentials — but that risk doesn't exist for the **read** path of a purely local session, which is already gated by `token_auth` and whose only caller is the local browser token (subject `local-app`, empty `app` claim).
- **Change:** added an opt-in `allow_local_no_owner` flag to `_authorize_owner_request`. When no owner is configured **and** the flag is set, allow the local dashboard token (`app == ""` and subject `== "local-app"`); app tokens and any other subject still fail closed. The flag is enabled **only for the read/check endpoints** (`pull-request` read + `checks`). The **resolve mutation keeps the default (owner-only)** — a local token cannot mutate remote review threads without a configured owner. When an owner **is** configured (shared / Slack / multi-user), the strict owner match is unchanged for every operation.

## Tests
Added to `test/test_source_providers.py`:
- `test_read_handler_allows_local_token_when_no_owner_configured` — no owner + `local-app`/empty-app on the read endpoint ⇒ **200**, provider fetch awaited.
- `test_read_handler_denies_non_local_subject_when_no_owner` — no owner + a non-`local-app` subject (e.g. a stale owner-minted token) ⇒ still **403**.
- `test_resolve_handler_denies_local_token_when_no_owner` — no owner + `local-app` on the **resolve mutation** ⇒ still **403** (mutation stays owner-only; locks in the read-only scoping).
The existing owner-gate deny suite (`owner_not_configured`/`app_token_not_allowed`/`non_owner`) is unchanged. Full file: **104 passed**.

## Manual verification
On a local dashboard with no `KIROCREW_OWNER_ID` set, the Changes panel now loads the PR diff instead of `forbidden`; resolving a thread still requires a configured owner. With an owner configured, behavior is unchanged (verified by the untouched deny-suite parametrization). `py_compile` clean.
