### PR TITLE
feat(dev-fleet): Make Live — switch the live gateway to another worktree

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -1,6 +1,6 @@
 # Dev Fleet Module
 
-Last Updated: 2026-07-20
+Last Updated: 2026-07-22
 
 ## Overview
 
@@ -21,6 +21,8 @@ Gateway session auth (token/cookie) gates the proxy entrance as with all builtin
 4. **Prune** — safely remove merged/empty worktrees with PR-shipped verification
 5. **Rebase** — rebase feature branches onto main with conflict detection + abort
 6. **GitHub PR status** — TTL-cached `gh pr list` queries for merge state
+7. **Make Live** — repoint the live gateway at another worktree via a systemd
+   `--user` drop-in (never edits the shipped unit file)
 
 ## Routes
 
@@ -53,6 +55,8 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/pod/token` | `{name}` | Mint a dashboard token for the pod |
 | `/apps/dev-fleet/api/pod/provision` | `{name}` | Start async venv+dist build (returns `{run_id}`) |
 | `/apps/dev-fleet/api/rebase` | `{name}` | Rebase worktree onto origin/main |
+| `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway in place (detached `systemd-run`) |
+| `/apps/dev-fleet/api/make-live` | `{path, dry_run?}` | Repoint the live gateway at another worktree (see Make Live) |
 
 ## Authorization
 
@@ -108,6 +112,152 @@ Long-running operations (sync, provision) are tracked via `_RUNS` dict with:
 
 Clients poll `/apps/dev-fleet/api/run?id=<run_id>` for progress.
 
+## Make Live
+
+`POST /apps/dev-fleet/api/make-live` repoints the live gateway at a different
+worktree. `_restart_gateway` only bounces the live unit *in place* — the
+shipped unit file hardcodes `WorkingDirectory`/`ExecStart`/`PATH`, so it cannot
+point the gateway at another checkout. Make Live closes that gap with a systemd
+`--user` **drop-in** that overrides those three fields; the shipped unit file is
+never edited.
+
+### Request / Response
+
+Request body: `{path, dry_run?}` — `path` is a worktree path (validated against
+the discovered set, never an arbitrary path); `dry_run` (bool, default false)
+returns the plan without touching systemd.
+
+- **dry_run success:** `{ok: true, dry_run: true, plan: {unit, dropin_path,
+  dropin_content, target}}`
+- **cutover success:** `{ok: true, cutover: true, target, plan}`
+- **refusal:** `{ok: false, code, error}` — `code` is one of the values below.
+
+The handler additionally returns HTTP 400 for a missing/non-string `path` or a
+non-boolean `dry_run`.
+
+### Error codes
+
+| Code | Meaning |
+|------|---------|
+| `unknown_path` | `path` is not a discovered worktree |
+| `missing_path` | the worktree path no longer exists on disk |
+| `pod` | called from inside a pod — a throwaway test instance must never repoint the live gateway |
+| `pod_indeterminate` | pod status could not be resolved (config home unresolvable) — **fail-closed**, never treated as "not a pod" |
+| `no_systemd` | not Linux / `systemctl` absent — Make Live requires systemd `--user` |
+| `no_user_unit` | `systemctl` present but the live gateway is **not** a loaded `--user` unit (e.g. a `kirocrew service install` SYSTEM unit) — the `--user` drop-in + restart would be a silent no-op |
+| `already_live` | the target is already the live gateway |
+| `missing_venv` | the worktree has no `.venv/bin/kirocrew` (Provision it first) |
+| `venv_not_executable` | the worktree's `.venv/bin/kirocrew` exists but is **not executable** (`chmod +x` it or re-Provision) — a non-executable binary would stop the live gateway but could not start the replacement, leaving no gateway running |
+| `missing_dist` | the worktree has no built `src/kiro_crew/static/dist/index.html` (Pull+Build first) — a cutover without a built dist serves a broken dashboard |
+| `unsafe_path` | the worktree path contains a newline, NUL, or other control character and cannot be safely written into a systemd directive (paths with spaces / `%` / quotes are *escaped*, not rejected) |
+| `write_failed` | writing the drop-in file failed |
+| `reload_failed` | `systemctl --user daemon-reload` failed — the drop-in is rolled back to its prior state before returning (response carries `rolled_back`) |
+| `restart_failed` | the detached `systemd-run` restart failed to launch — the drop-in is rolled back before returning (response carries `rolled_back`) |
+| `busy` | another make-live cutover is already in progress — the mutation sequence is single-flighted, so a concurrent request is refused immediately (no queueing) rather than racing the in-flight cutover's drop-in write/rollback |
+| `restart_pending` | a cutover has already been **successfully scheduled** in this gateway process — `systemd-run` only *schedules* the restart and returns immediately, so a process-local latch refuses every further request (cutover **and** `dry_run`) until the pending restart replaces the process. The fresh gateway starts with the latch clear |
+
+On a `reload_failed` / `restart_failed` refusal the response includes
+`rolled_back: true|false` — whether the pre-cutover drop-in state (prior
+content, or absence) was successfully restored on disk.
+
+### Concurrency
+
+The cutover mutation (prior-state snapshot → atomic drop-in write →
+`daemon-reload` → detached `systemd-run` restart → any rollback) runs under a
+single module-level `asyncio.Lock`. Two concurrent cutovers would otherwise
+race on the shared drop-in file — one request's failure rollback could
+restore or delete the other's successful override, restarting the gateway into
+the wrong worktree. A second request that arrives while the lock is held is
+refused immediately with `busy` (fail-fast, **not** queued): serializing the
+queue could apply a stale target after the winner already restarted the
+gateway. The `dry_run` validation path mutates nothing and runs outside the
+lock.
+
+**Committed latch.** `systemd-run` only *schedules* the detached restart and
+returns immediately, so the lock is released while the restart is still
+pending. A process-local `_MAKE_LIVE_COMMITTED` flag is set to `True` — before
+returning success, inside the lock — the moment a cutover is scheduled. It is
+checked both at function entry and again after the lock is acquired (closing
+the entry-check-vs-acquire race), so any further request — a second cutover for
+a different target, or even a `dry_run` — is refused with `restart_pending`
+instead of mutating the drop-in while the pending restart tears the backend
+down. The latch is never persisted: the fresh gateway the restart spawns starts
+clear. Failure paths **before** successful scheduling (write / `daemon-reload`
+/ `systemd-run` launch) never set it, so a rolled-back cutover leaves the
+process free to retry.
+
+### Validation order
+
+Every check runs for `dry_run` too, in this order (first failure wins):
+
+`path` (exists as a known worktree) → **pod guard** (fail-closed on
+indeterminate) → **user-unit check** (loaded systemd `--user` unit) →
+`already_live` → `missing_venv` → `venv_not_executable` → `missing_dist`.
+
+The pod guard and user-unit check precede the venv/dist checks so an operator on
+an ineligible install gets an actionable refusal before any per-worktree state
+matters.
+
+### Drop-in mechanism
+
+The drop-in is written to
+`$XDG_CONFIG_HOME/systemd/user/kirocrew-gateway.service.d/make-live.conf`
+(falls back to `~/.config`). Its body overrides exactly three fields:
+
+```ini
+[Service]
+WorkingDirectory=<worktree>
+ExecStart=
+ExecStart=<worktree>/.venv/bin/kirocrew gateway --no-open
+Environment=PATH=<worktree>/.venv/bin:~/.local/bin:/usr/local/bin:/usr/bin:/bin
+```
+
+The lone empty `ExecStart=` line **resets** the unit's `ExecStart` before the
+replacement — systemd otherwise *appends*, and a `Type=simple` service with two
+`ExecStart` values is a fatal unit error. `~` is not expanded inside
+`Environment=`, so the operator bin dir is materialised to an absolute path.
+
+**Value escaping.** All three directives undergo systemd specifier expansion,
+so every interpolated value is serialised through `_sd_value`, which:
+
+- **rejects** (→ `unsafe_path`) any value containing a newline, NUL, or other
+  control character — such a value would split/truncate the drop-in, and the
+  persisted-but-invalid override would then block every subsequent restart;
+- doubles a literal `%` to `%%` (defeating specifier expansion);
+- double-quotes the value — escaping `\` → `\\` and `"` → `\"` per systemd's
+  command-line C-style quoting — **only** when it contains whitespace or a
+  systemd metacharacter. A clean path is emitted verbatim (unquoted), so an
+  ordinary worktree renders byte-for-byte as before. This makes a worktree path
+  with spaces, `%`, or quotes cut over correctly instead of corrupting the
+  unit.
+
+### Detached restart
+
+A real cutover writes the drop-in **atomically** (a temp file in the same
+directory + `os.replace`, so a partial write never leaves a truncated unit),
+runs `systemctl --user daemon-reload`, then issues the restart via `systemd-run
+--user --collect systemctl --user restart kirocrew-gateway.service`. Because
+the restart tears down this backend along with the gateway, the restart is
+detached (same pattern as `restart-gateway`) so it survives our own death. The
+`_LIVE_WORKTREE` cache is then invalidated so the next fleet poll re-resolves
+the live checkout.
+
+**Failure rollback.** Before writing, the prior drop-in state is snapshotted
+(existing `make-live.conf` content, or absence). If `daemon-reload` or the
+`systemd-run` launch fails, the drop-in is restored to that prior state
+(rewrite the old content, or delete the file when there was none) and
+`daemon-reload` is re-run best-effort so the loaded config matches disk. Without
+this, a persisted override from a failed cutover would silently activate on the
+NEXT unrelated restart. The refusal response carries `rolled_back: true|false`.
+
+### Platform limitation
+
+Make Live is **Linux + systemd `--user` only**. A `kirocrew service install`
+SYSTEM unit (`/etc/systemd/system/kirocrew.service`) is not controllable via
+`systemctl --user` and is refused up-front with `no_user_unit`; non-systemd
+hosts are refused with `no_systemd`. Cutover from inside a pod is always
+refused (`pod` / `pod_indeterminate`).
+
 ## Output Redaction
 
 All user-visible output passes through `redact_credentials()` and
@@ -117,5 +267,7 @@ All user-visible output passes through `redact_credentials()` and
 
 - **Linux only** — pod integration requires systemd (systemctl, journalctl)
 - **macOS** — worktree management works; pod operations degrade (import fails gracefully)
+- **Make Live** — Linux + systemd `--user` only; refuses on non-systemd hosts
+  (`no_systemd`) and on SYSTEM-unit installs (`no_user_unit`)
 - **git** and **gh** CLI required for full functionality; missing binaries produce
   graceful degradation via OSError catch in `_run_cmd`

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -23,6 +23,7 @@ Routes (as seen by the backend after prefix stripping by gateway):
   POST /api/pod/token {name}
   POST /api/pod/provision {name}  -> start async build, returns {run_id}
   POST /api/rebase  {name}
+  POST /api/make-live {path, dry_run?}  -> repoint the live gateway at a worktree
   GET  /health                -> {"status": "ok"}
 """
 
@@ -303,18 +304,36 @@ async def _live_worktree_path() -> str | None:
     if sys.platform != "linux" or not shutil.which("systemctl"):
         _LIVE_WORKTREE = None
         return None
+    # Prefer WorkingDirectory: make-live always writes it alongside ExecStart,
+    # and the baseline unit sets it too. ``--value`` prints the bare path with
+    # no ``WorkingDirectory=`` prefix and, crucially, NO truncation at spaces —
+    # so a checkout path containing a space resolves correctly. The old
+    # ExecStart ``path=([^ ;]+)`` regex truncates at the first space, which
+    # (now that make-live escapes space paths into the drop-in) would leave
+    # is_live / already_live perpetually unmatched for such a worktree and
+    # drive pointless repeat restarts.
+    path = None
     rc, out, _err = await _run_cmd(
-        ["systemctl", "--user", "show", _LIVE_GATEWAY_UNIT, "-p", "ExecStart"],
+        ["systemctl", "--user", "show", _LIVE_GATEWAY_UNIT,
+         "--property=WorkingDirectory", "--value"],
         timeout=5,
     )
-    path = None
-    if rc == 0 and out:
-        m = re.search(r"path=([^ ;]+)", out)
-        if m:
-            exe = Path(m.group(1))
-            # <checkout>/.venv/bin/kirocrew -> <checkout>
-            if ".venv" in exe.parts:
-                path = str(exe.parents[2])
+    if rc == 0 and out.strip():
+        path = out.strip()
+    else:
+        # Fallback: parse ExecStart's ``path=`` when WorkingDirectory is empty
+        # (an older unit that predates the WorkingDirectory= directive).
+        rc, out, _err = await _run_cmd(
+            ["systemctl", "--user", "show", _LIVE_GATEWAY_UNIT, "-p", "ExecStart"],
+            timeout=5,
+        )
+        if rc == 0 and out:
+            m = re.search(r"path=([^ ;]+)", out)
+            if m:
+                exe = Path(m.group(1))
+                # <checkout>/.venv/bin/kirocrew -> <checkout>
+                if ".venv" in exe.parts:
+                    path = str(exe.parents[2])
     try:
         _LIVE_WORKTREE = str(Path(path).resolve()) if path else None
     except OSError:
@@ -1973,7 +1992,7 @@ def _audited(tool_name: str):
                     try:
                         parsed = json.loads(raw)
                         if isinstance(parsed, dict):
-                            t = parsed.get("name") or parsed.get("names")
+                            t = parsed.get("name") or parsed.get("names") or parsed.get("path")
                             if isinstance(t, str):
                                 target = t
                             elif isinstance(t, list):
@@ -2254,6 +2273,29 @@ _GATEWAY_SERVICE_CHECK_AT: float = 0.0
 _GATEWAY_SERVICE_TTL = 30.0
 _LIVE_GATEWAY_UNIT = "kirocrew-gateway.service"
 
+# Single-flights the make-live cutover. Two concurrent cutovers would race on
+# the shared drop-in (snapshot -> atomic-write -> daemon-reload -> systemd-run
+# -> rollback): one request's failure rollback could restore/delete the OTHER
+# request's successful override, restarting the gateway into the wrong
+# worktree. The mutation sequence in ``_make_live`` runs under this lock; a
+# second concurrent request fails fast with ``busy`` rather than queueing (a
+# queued cutover could apply a stale target after the winner already restarted
+# the gateway out from under us).
+_MAKE_LIVE_LOCK = asyncio.Lock()
+
+# Process-local "cutover committed" latch. ``systemd-run --collect ... restart``
+# only SCHEDULES the restart and returns immediately, so ``_MAKE_LIVE_LOCK`` is
+# released while the restart is still pending. Without this latch a second
+# cutover could then acquire the lock and mutate the drop-in for target B while
+# target A's already-scheduled restart tears this backend down mid-write —
+# leaving the loaded unit and the persisted drop-in disagreeing. Once a cutover
+# is successfully scheduled we set this True (BEFORE returning) and refuse every
+# further request for the rest of THIS process's life with ``restart_pending``.
+# It is deliberately process-local and never persisted: the fresh gateway the
+# restart spawns starts with it clear. Failure paths BEFORE successful
+# scheduling never set it, and ``dry_run`` never sets it.
+_MAKE_LIVE_COMMITTED = False
+
 
 def _gateway_unit_name() -> str:
     """Resolve the systemd unit of the gateway THIS backend belongs to.
@@ -2326,6 +2368,397 @@ async def api_dev_fleet_restart_gateway(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+# --- make-live: switch the live gateway to another worktree ---
+#
+# `_restart_gateway` only bounces the live unit in place — the shipped unit
+# file hardcodes WorkingDirectory/ExecStart/PATH, so there is no way to point
+# the live gateway at a DIFFERENT worktree. Make-live closes that gap with a
+# systemd drop-in that OVERRIDES those three fields (the main unit file is
+# never edited), then a detached restart applies it.
+
+
+def _in_pod() -> bool | None:
+    """Whether THIS backend runs inside a pod (config home under
+    ``.kirocrew-pods/<name>``) — same detection as _gateway_unit_name.
+
+    Returns ``True`` (definitely a pod), ``False`` (definitely not), or
+    ``None`` when pod status cannot be resolved (config home unresolvable).
+
+    Cutting the real live gateway from a pod plane is refused: a pod is a
+    throwaway test instance and must never repoint the operator's live
+    gateway. The ambiguous ``None`` case is fail-CLOSED by the caller
+    (``_make_live`` refuses with ``pod_indeterminate``) — an unresolvable
+    home must NEVER be treated as "not a pod", which would let a pod cut the
+    operator's live gateway (the previous fail-OPEN ``False`` did exactly
+    that)."""
+    try:
+        from kiro_crew.config.loader import config_dir
+
+        return config_dir().parent.name == ".kirocrew-pods"
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dropin_path() -> Path:
+    """Absolute path of the make-live systemd drop-in for the live unit.
+
+    Honours ``$XDG_CONFIG_HOME`` (systemd --user reads units there when set)
+    and falls back to ``~/.config`` — a literal ``~/.config`` would be the
+    WRONG directory on a host that sets XDG_CONFIG_HOME, and the override
+    would silently never take effect."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else (Path.home() / ".config")
+    return base / "systemd" / "user" / f"{_LIVE_GATEWAY_UNIT}.d" / "make-live.conf"
+
+
+class _UnsafeUnitValue(ValueError):
+    """A path/value cannot be safely serialised into a systemd unit directive.
+
+    Raised for a value containing a newline, NUL, or any other control
+    character. Such a value would split or truncate the drop-in, and because
+    the broken override is PERSISTED, the failed cutover would then poison
+    every subsequent restart of the live unit (the restart stops the gateway
+    but the malformed unit refuses to start, and recovery restarts hit the
+    same wall)."""
+
+
+# Control chars (C0 range + DEL) are unrepresentable in a single directive
+# value: NUL/newline split or truncate the unit; a tab is ambiguous whitespace.
+_SD_CTRL_RE = re.compile(r"[\x00-\x1f\x7f]")
+# A value needs double-quoting only when it carries whitespace or a systemd
+# command-line / assignment metacharacter. A plain path is emitted verbatim so
+# ordinary worktrees render byte-for-byte identically to before this guard.
+_SD_NEEDS_QUOTE_RE = re.compile(r"""[\s"'\\$;`]""")
+
+
+def _sd_value(raw: str) -> str:
+    """Serialise *raw* for a systemd unit directive value.
+
+    All three directives make-live emits — ``WorkingDirectory``, ``ExecStart``
+    and ``Environment`` — undergo specifier expansion, so a literal ``%`` is
+    doubled to ``%%``. Control characters are rejected outright
+    (``_UnsafeUnitValue`` → ``unsafe_path``). Only when *raw* contains
+    whitespace or a systemd metacharacter is it wrapped in double quotes (with
+    ``\\`` and ``"`` backslash-escaped, per systemd's command-line C-style
+    quoting); a clean path is returned unquoted so existing units are
+    unchanged."""
+    if _SD_CTRL_RE.search(raw):
+        raise _UnsafeUnitValue(repr(raw))
+    escaped = raw.replace("%", "%%")
+    if _SD_NEEDS_QUOTE_RE.search(raw):
+        inner = escaped.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{inner}"'
+    return escaped
+
+
+def _dropin_content(worktree: Path, kcbin: Path) -> str:
+    """Render the drop-in that repoints the live unit at *worktree*.
+
+    The lone empty ``ExecStart=`` line RESETS the unit's ExecStart before the
+    replacement — systemd otherwise APPENDS, and a Type=simple service with
+    two ExecStart values is a fatal unit error. ``~`` is NOT expanded inside
+    ``Environment=``, so the operator bin dir is materialised to an absolute
+    path here (a literal ``~/.local/bin`` would corrupt PATH).
+
+    Every interpolated value passes through ``_sd_value`` so a worktree path
+    with spaces, ``%`` specifiers, or quotes is escaped (and a control-char
+    path rejected) rather than silently splitting/expanding the directive."""
+    venv_bin = worktree / ".venv" / "bin"
+    local_bin = Path.home() / ".local" / "bin"
+    path_env = ":".join(
+        [str(venv_bin), str(local_bin), "/usr/local/bin", "/usr/bin", "/bin"]
+    )
+    return (
+        "[Service]\n"
+        f"WorkingDirectory={_sd_value(str(worktree))}\n"
+        "ExecStart=\n"
+        f"ExecStart={_sd_value(str(kcbin))} gateway --no-open\n"
+        f"Environment={_sd_value('PATH=' + path_env)}\n"
+    )
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically: a temp file in the same directory
+    then ``os.replace`` (an atomic same-filesystem rename), so a crash or
+    partial write never leaves a half-written unit drop-in that systemd would
+    fail to parse."""
+    tmp = path.parent / f".{path.name}.tmp-{uuid.uuid4().hex}"
+    try:
+        tmp.write_text(content)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _restore_dropin(dropin: Path, prior: str | None) -> bool:
+    """Restore the drop-in to its pre-cutover state after a failed cutover:
+    rewrite *prior* content, or delete the file when there was none. Returns
+    ``True`` when the on-disk state was restored; best-effort, returning
+    ``False`` on any OSError so the caller can report ``rolled_back: false``."""
+    try:
+        if prior is None:
+            dropin.unlink(missing_ok=True)
+        else:
+            _atomic_write_text(dropin, prior)
+        return True
+    except OSError:
+        return False
+
+
+async def _find_worktree_by_path(path: str) -> tuple[dict | None, str | None]:
+    """Resolve a discovered worktree by filesystem path.
+
+    Reuses the same ``git worktree list`` enumeration the fleet listing uses,
+    so the caller-supplied path is only ever a SELECTOR validated against the
+    server's authoritative set — an arbitrary path can never be made live."""
+    if not path:
+        return None, "'path' must be a non-empty string"
+    try:
+        want = Path(path).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return None, f"invalid path: {path!r}"
+    for w in await _discover_worktrees():
+        try:
+            if Path(w["path"]).resolve() == want:
+                return w, None
+        except OSError:
+            continue
+    return None, f"path is not a known worktree: {path!r}"
+
+
+async def _live_user_unit_status() -> str:
+    """Classify the live gateway unit for make-live eligibility.
+
+    make-live writes a ``systemctl --user`` drop-in and restarts the --user
+    unit. A ``kirocrew service install`` SYSTEM unit
+    (``/etc/systemd/system/kirocrew.service``) is NOT controllable that way:
+    the drop-in would be written and the cutover would "succeed" while the
+    detached ``--user restart`` bounces nothing (a silent false success).
+    Gate on the unit actually being known to the --user manager
+    (``systemctl --user cat`` rc==0, same plane ``_restart_gateway`` acts on).
+
+    Returns:
+      ``"no_systemd"``   — not Linux / systemctl absent (make-live needs --user systemd);
+      ``"no_user_unit"`` — systemctl present but the live unit is not a loaded
+                           --user unit (a system-unit install, or not installed);
+      ``"ok"``           — the live unit is known to the --user manager.
+    """
+    if sys.platform != "linux" or not shutil.which("systemctl"):
+        return "no_systemd"
+    rc, _out, _err = await _run_cmd(
+        ["systemctl", "--user", "cat", _LIVE_GATEWAY_UNIT], timeout=5,
+    )
+    return "ok" if rc == 0 else "no_user_unit"
+
+
+async def _make_live(path: str, dry_run: bool = False) -> dict:
+    """Repoint the live gateway unit at *path* via a systemd drop-in.
+
+    Validation order (all enforced for ``dry_run`` too): the path is a known,
+    existing worktree (``unknown_path`` / ``missing_path``); NOT inside a pod,
+    fail-CLOSED on indeterminate pod status (``pod`` / ``pod_indeterminate``);
+    the live gateway is a loaded systemd ``--user`` unit (``no_systemd`` /
+    ``no_user_unit`` — a ``kirocrew service install`` SYSTEM unit cannot be
+    repointed this way); not already live (``already_live``); the worktree has
+    its own executable ``.venv/bin/kirocrew`` (else Provision -> ``missing_venv``
+    when absent, ``venv_not_executable`` when present but not +x) and a
+    built SPA ``dist/index.html`` (else Pull+Build -> ``missing_dist``). A real
+    cutover writes the drop-in, ``daemon-reload``s, then issues a DETACHED
+    restart (survives our death, mirroring ``_restart_gateway``) and
+    invalidates the live-worktree cache.
+    """
+    global _MAKE_LIVE_COMMITTED
+    # A cutover already scheduled in THIS process. systemd-run has returned but
+    # the restart is still pending, so refuse up-front (before any validation or
+    # dry_run plan) — any further mutation would race the pending restart.
+    if _MAKE_LIVE_COMMITTED:
+        return {"ok": False, "code": "restart_pending", "error": (
+            "a cutover has been scheduled; the gateway is restarting — "
+            "retry after it comes back"
+        )}
+    target, err = await _find_worktree_by_path(path)
+    if target is None:
+        return {"ok": False, "code": "unknown_path", "error": err}
+    real = Path(target["path"])
+    if not real.exists():
+        return {"ok": False, "code": "missing_path",
+                "error": f"worktree path no longer exists: {real}"}
+
+    pod = _in_pod()
+    if pod is None:
+        return {"ok": False, "code": "pod_indeterminate", "error": (
+            "cannot determine whether this backend runs inside a pod (config "
+            "home unresolvable) — refusing make-live to avoid repointing the "
+            "live gateway from an unattributable plane"
+        )}
+    if pod:
+        return {"ok": False, "code": "pod", "error": (
+            "refusing make-live from inside a pod — a pod is a throwaway test "
+            "instance and must never repoint the real live gateway "
+            "(run this from the live dashboard)"
+        )}
+
+    # The live gateway must be a loaded systemd --user unit, else the --user
+    # drop-in + restart is a silent no-op false success (a `kirocrew service
+    # install` SYSTEM unit is not controllable via `systemctl --user`).
+    unit_status = await _live_user_unit_status()
+    if unit_status == "no_systemd":
+        return {"ok": False, "code": "no_systemd", "error": (
+            "make-live requires the gateway to run as a systemd --user service"
+        )}
+    if unit_status != "ok":
+        return {"ok": False, "code": "no_user_unit", "error": (
+            f"the live gateway is not running as the user service "
+            f"{_LIVE_GATEWAY_UNIT} — make-live only supports systemd --user "
+            "installs (a `kirocrew service install` system unit cannot be "
+            "repointed this way)"
+        )}
+
+    live = await _live_worktree_path()
+    if live is not None and _same_path(str(real), live):
+        return {"ok": False, "code": "already_live",
+                "error": f"{real.name} is already the live gateway"}
+
+    kcbin = real / ".venv" / "bin" / "kirocrew"
+    if not kcbin.is_file():
+        return {"ok": False, "code": "missing_venv", "error": (
+            f"{real.name} has no .venv/bin/kirocrew — Provision it first "
+            "(row menu \u2192 Provision) before making it live"
+        )}
+    # A present-but-non-executable binary is worse than a missing one: the
+    # drop-in gets written and the old gateway is stopped, but the replacement
+    # can never start (systemd ExecStart requires +x) — leaving NO gateway
+    # running. Gate on the exec bit with a DISTINCT, actionable code.
+    if not os.access(kcbin, os.X_OK):
+        return {"ok": False, "code": "venv_not_executable", "error": (
+            f"{real.name} has a non-executable .venv/bin/kirocrew — run "
+            "`chmod +x` on it or re-Provision the worktree before making it "
+            "live (a non-executable binary stops the live gateway but cannot "
+            "start the replacement, leaving no gateway running)"
+        )}
+    dist_index = real / "src" / "kiro_crew" / "static" / "dist" / "index.html"
+    if not dist_index.is_file():
+        return {"ok": False, "code": "missing_dist", "error": (
+            f"{real.name} has no built dashboard "
+            "(src/kiro_crew/static/dist/index.html) — run Pull+Build first; "
+            "cutover without a built dist serves a broken dashboard"
+        )}
+
+    unit = _LIVE_GATEWAY_UNIT
+    dropin = _dropin_path()
+    try:
+        content = _dropin_content(real, kcbin)
+    except _UnsafeUnitValue as exc:
+        return {"ok": False, "code": "unsafe_path", "error": (
+            "refusing make-live: the worktree path is not safely representable "
+            "in a systemd unit directive (contains control characters): "
+            f"{_redact(str(exc))}"
+        )}
+    plan = {
+        "unit": unit,
+        "dropin_path": str(dropin),
+        "dropin_content": content,
+        "target": str(real),
+    }
+    if dry_run:
+        return {"ok": True, "dry_run": True, "plan": plan}
+
+    # Serialize the mutation sequence: two concurrent cutovers racing on the
+    # shared drop-in (snapshot -> write -> reload -> restart -> rollback) could
+    # have one request's rollback restore/delete the OTHER's successful
+    # override, restarting into the wrong worktree. Fail fast with ``busy`` on
+    # contention rather than queueing — a queued cutover would apply a stale
+    # target after the winner already restarted the gateway. The check and the
+    # acquire are atomic here (no ``await`` between them on the single-threaded
+    # event loop), so the busy response cannot itself race the lock.
+    if _MAKE_LIVE_LOCK.locked():
+        return {"ok": False, "code": "busy", "error": (
+            "another make-live cutover is in progress"
+        )}
+    async with _MAKE_LIVE_LOCK:
+        # Re-check the committed latch now that we hold the lock. A request
+        # that passed the entry check just before the WINNING cutover latched
+        # (the entry check and the lock acquire are separated by awaits) would
+        # otherwise fall through here and mutate the drop-in a second time while
+        # the winner's restart is already tearing us down.
+        if _MAKE_LIVE_COMMITTED:
+            return {"ok": False, "code": "restart_pending", "error": (
+                "a cutover has been scheduled; the gateway is restarting — "
+                "retry after it comes back"
+            )}
+        # Snapshot the prior drop-in (content, or None when absent) BEFORE
+        # writing so a failed cutover can be rolled back — a persisted-but-
+        # uninstalled override would otherwise silently activate on the NEXT
+        # unrelated restart. Write atomically (temp file + os.replace) so a
+        # partial write can't leave a truncated, unparseable unit either.
+        try:
+            dropin.parent.mkdir(parents=True, exist_ok=True)
+            prior_content = dropin.read_text() if dropin.exists() else None
+            _atomic_write_text(dropin, content)
+        except OSError as exc:
+            return {"ok": False, "code": "write_failed",
+                    "error": f"failed to write drop-in: {_redact(str(exc))}"}
+
+        rc, _out, stderr = await _run_cmd(
+            ["systemctl", "--user", "daemon-reload"], timeout=10,
+        )
+        if rc != 0:
+            rolled_back = _restore_dropin(dropin, prior_content)
+            # Re-reload (best-effort) so the loaded config matches the restored
+            # disk state rather than the rejected override.
+            await _run_cmd(["systemctl", "--user", "daemon-reload"], timeout=10)
+            return {"ok": False, "code": "reload_failed", "rolled_back": rolled_back,
+                    "error": _redact(stderr.strip()[:200]) or "daemon-reload failed"}
+
+        # The restart tears down THIS backend with the gateway, so schedule it
+        # via `systemd-run --collect` (same pattern as _restart_gateway) so the
+        # restart survives our own death.
+        rc, _out, stderr = await _run_cmd(
+            ["systemd-run", "--user", "--collect",
+             "systemctl", "--user", "restart", unit],
+            timeout=10,
+        )
+        if rc != 0:
+            rolled_back = _restore_dropin(dropin, prior_content)
+            # Nothing has restarted yet (the detached launch failed), so reload
+            # the reverted drop-in to keep the loaded config == disk.
+            await _run_cmd(["systemctl", "--user", "daemon-reload"], timeout=10)
+            return {"ok": False, "code": "restart_failed", "rolled_back": rolled_back,
+                    "error": _redact(stderr.strip()[:200]) or "systemd-run failed"}
+
+        # COMMITTED: systemd-run has scheduled the detached restart (it returns
+        # before the restart lands). Latch process-locally BEFORE returning so
+        # no further cutover can mutate the drop-in while the restart is pending
+        # — the fresh process the restart spawns starts with this clear.
+        _MAKE_LIVE_COMMITTED = True
+
+        # Invalidate the live-worktree cache so the next fleet poll re-resolves
+        # the live checkout (the unit's ExecStart only reflects the new path
+        # once the restart lands).
+        global _LIVE_WORKTREE, _LIVE_CHECK_AT
+        _LIVE_WORKTREE = None
+        _LIVE_CHECK_AT = 0.0
+
+        return {"ok": True, "cutover": True, "target": str(real), "plan": plan}
+
+
+@_audited("dev_fleet_make_live")
+async def api_dev_fleet_make_live(request: web.Request) -> web.Response:
+    body, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert body is not None
+    path = body.get("path")
+    if not isinstance(path, str) or not path:
+        return web.json_response(
+            {"error": "'path' must be a non-empty string"}, status=400
+        )
+    dry_run = body.get("dry_run")
+    if dry_run is not None and not isinstance(dry_run, bool):
+        return web.json_response({"error": "dry_run must be a boolean"}, status=400)
+    return web.json_response(await _make_live(path, dry_run is True))
+
+
 # =============================================================================
 # Application factory and main
 # =============================================================================
@@ -2351,6 +2784,7 @@ def create_app() -> web.Application:
     app.router.add_post("/api/pod/provision", api_dev_fleet_pod_provision)
     app.router.add_post("/api/rebase", api_dev_fleet_rebase)
     app.router.add_post("/api/restart-gateway", api_dev_fleet_restart_gateway)
+    app.router.add_post("/api/make-live", api_dev_fleet_make_live)
     app.on_startup.append(dev_fleet_startup)
     app.on_cleanup.append(dev_fleet_cleanup)
     return app

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1675,6 +1675,669 @@ async def test_restart_gateway_audited():
 
 
 # =============================================================================
+# Task: make-live (switch the live gateway to another worktree)
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _reset_make_live_committed_latch():
+    """``_MAKE_LIVE_COMMITTED`` is a process-local latch: once a real cutover
+    schedules a restart it refuses all further cutovers for the process's life.
+    In-process pytest would leak that latched state into later tests, so reset
+    it around every test to mirror a fresh gateway process."""
+    mod._MAKE_LIVE_COMMITTED = False
+    yield
+    mod._MAKE_LIVE_COMMITTED = False
+
+
+def _mk_make_live_wt(tmp_path, *, venv: bool = False, dist: bool = False,
+                     venv_exec: bool = True):
+    """Build a fake worktree dir with optional .venv/bin/kirocrew and built dist.
+
+    When ``venv`` is set the fake ``.venv/bin/kirocrew`` is created **executable**
+    (``venv_exec=True``, the realistic provisioned state that passes the make-live
+    exec-bit gate); pass ``venv_exec=False`` to simulate a present-but-non-executable
+    binary (the ``venv_not_executable`` case)."""
+    wt = tmp_path / "kirocrew-wt-feat"
+    wt.mkdir(parents=True, exist_ok=True)
+    if venv:
+        vb = wt / ".venv" / "bin"
+        vb.mkdir(parents=True, exist_ok=True)
+        kcbin = vb / "kirocrew"
+        kcbin.write_text("#!/bin/sh\n")
+        kcbin.chmod(0o755 if venv_exec else 0o644)
+    if dist:
+        dd = wt / "src" / "kiro_crew" / "static" / "dist"
+        dd.mkdir(parents=True, exist_ok=True)
+        (dd / "index.html").write_text("<html></html>")
+    return wt
+
+
+def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok"):
+    """Wire the make-live seams: the path resolves to *wt*, pod/live/unit state
+    fixed. ``unit_status`` stubs _live_user_unit_status so tests never depend on
+    the host's real systemd --user state."""
+    monkeypatch.setattr(
+        mod, "_discover_worktrees",
+        AsyncMock(return_value=[{"path": str(wt), "branch": "feat", "is_main": False}]),
+    )
+    monkeypatch.setattr(mod, "_live_worktree_path", AsyncMock(return_value=live))
+    monkeypatch.setattr(mod, "_in_pod", lambda: in_pod)
+    monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value=unit_status))
+
+
+@pytest.mark.asyncio
+async def test_make_live_dry_run_plan(monkeypatch, tmp_path):
+    """dry_run returns the full plan (incl. the empty ExecStart reset line) and
+    never touches systemd."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt)
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is True and res["dry_run"] is True
+    plan = res["plan"]
+    assert plan["unit"] == "kirocrew-gateway.service"
+    assert plan["dropin_path"].endswith(
+        "kirocrew-gateway.service.d/make-live.conf"
+    )
+    assert plan["target"] == str(wt)
+    c = plan["dropin_content"]
+    # The empty ExecStart reset MUST precede the replacement command.
+    assert "\nExecStart=\n" in c
+    assert f"ExecStart={wt}/.venv/bin/kirocrew gateway --no-open" in c
+    assert f"WorkingDirectory={wt}" in c
+    assert f"Environment=PATH={wt}/.venv/bin:" in c
+    # dry-run writes/reloads/restarts nothing.
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_make_live_unknown_path(monkeypatch):
+    """A path that is not a discovered worktree is refused."""
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(return_value=[]))
+    monkeypatch.setattr(mod, "_in_pod", lambda: False)
+    res = await mod._make_live("/nope/not-a-worktree", dry_run=True)
+    assert res["ok"] is False and res["code"] == "unknown_path"
+
+
+@pytest.mark.asyncio
+async def test_make_live_refuses_in_pod(monkeypatch, tmp_path):
+    """Refuse to cut the real live gateway from inside a pod plane (even dry_run)."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt, in_pod=True)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "pod"
+
+
+@pytest.mark.asyncio
+async def test_make_live_already_live(monkeypatch, tmp_path):
+    """Refuse when the target is already the live gateway."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt, live=str(wt.resolve()))
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "already_live"
+
+
+@pytest.mark.asyncio
+async def test_make_live_missing_venv(monkeypatch, tmp_path):
+    """No .venv/bin/kirocrew -> actionable Provision error."""
+    wt = _mk_make_live_wt(tmp_path, venv=False, dist=True)
+    _stub_make_live(monkeypatch, wt)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "missing_venv"
+    assert "Provision" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_make_live_venv_not_executable(monkeypatch, tmp_path):
+    """.venv/bin/kirocrew present but NOT executable -> a distinct, actionable
+    error (missing_venv is for the not-a-file case). A non-executable binary
+    would stop the live gateway but never start the replacement, so this MUST
+    be refused before any cutover."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True, venv_exec=False)
+    _stub_make_live(monkeypatch, wt)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "venv_not_executable"
+    assert "chmod" in res["error"]
+    # An executable binary (the realistic provisioned state) passes this gate
+    # and proceeds to a valid plan — proving the check is exec-bit-specific,
+    # not a blanket rejection.
+    wt_ok = _mk_make_live_wt(tmp_path / "ok", venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt_ok)
+    res_ok = await mod._make_live(str(wt_ok), dry_run=True)
+    assert res_ok["ok"] is True and res_ok.get("dry_run") is True
+
+
+@pytest.mark.asyncio
+async def test_make_live_missing_dist(monkeypatch, tmp_path):
+    """Built venv but no dist/index.html -> actionable Pull+Build error."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=False)
+    _stub_make_live(monkeypatch, wt)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "missing_dist"
+    assert "Pull+Build" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_make_live_real_cutover_writes_dropin(monkeypatch, tmp_path):
+    """A real cutover writes the drop-in, daemon-reloads, issues a detached
+    restart, and invalidates the live-worktree cache."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+    monkeypatch.setattr(mod, "_LIVE_WORKTREE", "sentinel", raising=False)
+    monkeypatch.setattr(mod, "_LIVE_CHECK_AT", 123.0, raising=False)
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is True and res.get("cutover") is True
+    # Drop-in written with the reset + replacement ExecStart.
+    assert dropin.is_file()
+    written = dropin.read_text()
+    assert "\nExecStart=\n" in written
+    assert f"ExecStart={wt}/.venv/bin/kirocrew gateway --no-open" in written
+    # daemon-reload then a DETACHED systemd-run restart.
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert any(
+        c[:2] == ["systemd-run", "--user"] and "restart" in c for c in calls
+    )
+    # Live-worktree cache invalidated so the next poll re-resolves.
+    assert mod._LIVE_WORKTREE is None
+    assert mod._LIVE_CHECK_AT == 0.0
+
+
+@pytest.mark.asyncio
+async def test_make_live_latches_after_cutover(monkeypatch, tmp_path):
+    """A successful cutover latches _MAKE_LIVE_COMMITTED (systemd-run only
+    SCHEDULES the restart and returns immediately). A second request — cutover
+    for a DIFFERENT valid target, or even a dry_run — is then refused with
+    restart_pending, so no concurrent cutover can mutate the drop-in while the
+    scheduled restart is tearing this process down."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+
+    async def fake_run_cmd(cmd, **kw):
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    assert mod._MAKE_LIVE_COMMITTED is False
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is True and res.get("cutover") is True
+    assert mod._MAKE_LIVE_COMMITTED is True
+
+    # Second cutover for a different, otherwise-valid target -> restart_pending.
+    wt2 = _mk_make_live_wt(tmp_path / "b", venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt2)
+    res2 = await mod._make_live(str(wt2), dry_run=False)
+    assert res2["ok"] is False and res2["code"] == "restart_pending"
+    # A dry_run is refused too (the latch is checked at entry, before dry_run).
+    res3 = await mod._make_live(str(wt2), dry_run=True)
+    assert res3["ok"] is False and res3["code"] == "restart_pending"
+
+
+@pytest.mark.asyncio
+async def test_make_live_prescheduling_failure_does_not_latch(monkeypatch, tmp_path):
+    """A cutover that fails BEFORE systemd-run schedules the restart (here a
+    daemon-reload failure) must NOT latch — the restart never happened, so a
+    subsequent cutover proceeds normally."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+
+    reload_calls = {"n": 0}
+
+    async def fail_first_reload(cmd, **kw):
+        # Fail only the FIRST daemon-reload (the pre-restart one). The
+        # best-effort re-reload after rollback still succeeds, and systemd-run
+        # is never reached — so nothing gets scheduled and nothing latches.
+        if cmd[:3] == ["systemctl", "--user", "daemon-reload"]:
+            reload_calls["n"] += 1
+            if reload_calls["n"] == 1:
+                return (1, "", "reload boom")
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fail_first_reload)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is False and res["code"] == "reload_failed"
+    assert mod._MAKE_LIVE_COMMITTED is False
+
+    # With all seams green, a subsequent cutover proceeds (not latched).
+    async def ok_run(cmd, **kw):
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", ok_run)
+    res2 = await mod._make_live(str(wt), dry_run=False)
+    assert res2["ok"] is True and res2.get("cutover") is True
+    assert mod._MAKE_LIVE_COMMITTED is True
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_reads_working_directory_with_spaces(monkeypatch):
+    """_live_worktree_path resolves via `systemctl show --property=
+    WorkingDirectory --value`, which (unlike the ExecStart path= regex) is NOT
+    truncated at spaces — so a checkout path containing a space resolves whole."""
+    spacey = "/home/u/my worktrees/kirocrew-wt-feat"
+
+    async def fake_run_cmd(cmd, **kw):
+        assert "--property=WorkingDirectory" in cmd and "--value" in cmd
+        return (0, spacey + "\n", "")
+
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    monkeypatch.setattr(mod, "_LIVE_CHECK_AT", 0.0, raising=False)
+    monkeypatch.setattr(mod, "_LIVE_WORKTREE", None, raising=False)
+    got = await mod._live_worktree_path()
+    assert got == str(Path(spacey).resolve())
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_falls_back_to_execstart(monkeypatch, tmp_path):
+    """When WorkingDirectory is empty, fall back to parsing ExecStart's path=."""
+    checkout = tmp_path / "kirocrew-wt-feat"
+    (checkout / ".venv" / "bin").mkdir(parents=True)
+    exe = checkout / ".venv" / "bin" / "kirocrew"
+
+    async def fake_run_cmd(cmd, **kw):
+        if "--property=WorkingDirectory" in cmd:
+            return (0, "\n", "")  # empty -> trigger ExecStart fallback
+        if cmd[-1] == "ExecStart":
+            return (0, f"{{ path={exe} ; argv[]={exe} gateway ; ignore_errors=no }}", "")
+        raise AssertionError(f"unexpected cmd {cmd}")
+
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    monkeypatch.setattr(mod, "_LIVE_CHECK_AT", 0.0, raising=False)
+    monkeypatch.setattr(mod, "_LIVE_WORKTREE", None, raising=False)
+    got = await mod._live_worktree_path()
+    assert got == str(checkout.resolve())
+
+
+@pytest.mark.asyncio
+async def test_make_live_already_live_space_path(monkeypatch, tmp_path):
+    """already_live is detected when the live WorkingDirectory (and target)
+    contain spaces — the regression the WorkingDirectory switch fixes: the old
+    ExecStart path= regex truncated at the space, never matched, and would let
+    the same worktree be pointlessly re-cut over and over."""
+    wt = tmp_path / "my worktrees" / "kirocrew-wt-feat"
+    wt.mkdir(parents=True)
+    vb = wt / ".venv" / "bin"
+    vb.mkdir(parents=True)
+    kc = vb / "kirocrew"
+    kc.write_text("#!/bin/sh\n")
+    kc.chmod(0o755)
+    dd = wt / "src" / "kiro_crew" / "static" / "dist"
+    dd.mkdir(parents=True)
+    (dd / "index.html").write_text("<html></html>")
+    _stub_make_live(monkeypatch, wt, live=str(wt.resolve()))
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "already_live"
+
+
+def test_make_live_route_registered_and_audited():
+    """/api/make-live is wired in create_app and the handler is a coroutine."""
+    import inspect
+    app = mod.create_app()
+    paths = [getattr(r.resource, "canonical", None) for r in app.router.routes()]
+    assert "/api/make-live" in paths
+    fn = mod.api_dev_fleet_make_live
+    assert callable(fn) and inspect.iscoroutinefunction(fn)
+
+
+# --- make-live: fail-closed pod guard (Codex finding 1) ---
+def test_in_pod_tristate(monkeypatch, tmp_path):
+    """_in_pod is tri-state: True inside a pod home, False outside, and None
+    when the config home cannot be resolved (fail-closed at the source — the
+    previous fail-OPEN False would have let a pod cut the live gateway)."""
+    import kiro_crew.config.loader as cfg_loader
+
+    pod_home = tmp_path / ".kirocrew-pods" / "kirocrew-wt-x"
+    pod_home.mkdir(parents=True)
+    monkeypatch.setattr(cfg_loader, "config_dir", lambda: pod_home)
+    assert mod._in_pod() is True
+
+    live_home = tmp_path / ".kirocrew"
+    live_home.mkdir()
+    monkeypatch.setattr(cfg_loader, "config_dir", lambda: live_home)
+    assert mod._in_pod() is False
+
+    monkeypatch.setattr(
+        cfg_loader, "config_dir", MagicMock(side_effect=RuntimeError("boom"))
+    )
+    assert mod._in_pod() is None
+
+
+@pytest.mark.asyncio
+async def test_make_live_pod_indeterminate_fails_closed(monkeypatch, tmp_path):
+    """Indeterminate pod status must refuse make-live (fail-closed), never
+    proceed as if not-a-pod."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt)
+    monkeypatch.setattr(mod, "_in_pod", lambda: None)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "pod_indeterminate"
+
+
+# --- make-live: user-unit precheck (Codex finding 2) ---
+@pytest.mark.asyncio
+async def test_make_live_refuses_system_unit(monkeypatch, tmp_path):
+    """A live gateway installed as a SYSTEM unit (not systemd --user) is
+    refused up-front — even for dry_run and even with venv+dist present — so
+    the cutover never 'succeeds' by writing a --user drop-in the restart can't
+    apply. No drop-in write / reload / restart occurs."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt, unit_status="no_user_unit")
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is False and res["code"] == "no_user_unit"
+    assert "kirocrew-gateway.service" in res["error"]
+    assert calls == []  # nothing written / reloaded / restarted
+
+
+@pytest.mark.asyncio
+async def test_make_live_no_systemd(monkeypatch, tmp_path):
+    """No systemd (non-Linux / systemctl absent) refuses with no_systemd,
+    enforced during validation (dry_run included)."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt, unit_status="no_systemd")
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "no_systemd"
+
+
+@pytest.mark.asyncio
+async def test_live_user_unit_status_no_systemd(monkeypatch):
+    """Non-Linux -> no_systemd, without spawning systemctl."""
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
+    assert await mod._live_user_unit_status() == "no_systemd"
+
+
+@pytest.mark.asyncio
+async def test_live_user_unit_status_ok_and_missing(monkeypatch):
+    """`systemctl --user cat` rc==0 -> ok; rc!=0 (system unit / not installed)
+    -> no_user_unit."""
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+
+    async def cat_ok(cmd, **kw):
+        assert cmd[:2] == ["systemctl", "--user"] and "cat" in cmd
+        return (0, "# unit contents", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", cat_ok)
+    assert await mod._live_user_unit_status() == "ok"
+
+    async def cat_missing(cmd, **kw):
+        return (1, "", "No files found for kirocrew-gateway.service.")
+
+    monkeypatch.setattr(mod, "_run_cmd", cat_missing)
+    assert await mod._live_user_unit_status() == "no_user_unit"
+
+
+# --- make-live: systemd value escaping / unsafe_path (Codex round 2, Finding A) ---
+def test_sd_value_escapes_and_conditionally_quotes():
+    """A clean path is emitted verbatim; `%` specifiers double to `%%`; only
+    whitespace/metacharacters trigger double-quoting (with \\ and " escaped)."""
+    assert mod._sd_value("/clean/path-1.2/bin") == "/clean/path-1.2/bin"
+    assert mod._sd_value("/a b/c") == '"/a b/c"'          # whitespace -> quoted
+    assert mod._sd_value("/a%b") == "/a%%b"               # specifier doubled, unquoted
+    assert mod._sd_value("/a %b") == '"/a %%b"'           # both
+    assert mod._sd_value('/a"b') == '"/a\\"b"'            # embedded quote escaped
+    assert mod._sd_value("/a\\b") == '"/a\\\\b"'          # embedded backslash escaped
+
+
+def test_sd_value_rejects_control_char_paths():
+    """Newline / NUL / tab / other C0 control chars are rejected outright."""
+    for bad in ["/a\nb", "/a\x00b", "/a\tb", "/a\x1fb", "/a\x7fb", "/a\rb"]:
+        with pytest.raises(mod._UnsafeUnitValue):
+            mod._sd_value(bad)
+
+
+@pytest.mark.asyncio
+async def test_make_live_escapes_special_char_worktree(monkeypatch, tmp_path):
+    """A worktree path with a space, `%`, quote and backslash yields a plan
+    whose dropin_content escapes every directive value correctly."""
+    name = 'kirocrew-wt feat %v "q"\\z'
+    wt = tmp_path / name
+    (wt / ".venv" / "bin").mkdir(parents=True)
+    _kc = wt / ".venv" / "bin" / "kirocrew"
+    _kc.write_text("#!/bin/sh\n")
+    _kc.chmod(0o755)  # provisioned binary is executable (passes the exec-bit gate)
+    dd = wt / "src" / "kiro_crew" / "static" / "dist"
+    dd.mkdir(parents=True)
+    (dd / "index.html").write_text("<html></html>")
+    _stub_make_live(monkeypatch, wt)
+
+    async def fake_run_cmd(cmd, **kw):
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is True
+    c = res["plan"]["dropin_content"]
+
+    def enc(raw):  # spec mirror of _sd_value: %% first, then \\ and " escaped, wrap
+        pct = raw.replace("%", "%%")
+        return '"' + pct.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+    kc = str(wt / ".venv" / "bin" / "kirocrew")
+    local_bin = Path.home() / ".local" / "bin"
+    path_env = ":".join(
+        [str(wt / ".venv" / "bin"), str(local_bin),
+         "/usr/local/bin", "/usr/bin", "/bin"]
+    )
+    assert f"WorkingDirectory={enc(str(wt))}\n" in c
+    assert f"ExecStart={enc(kc)} gateway --no-open\n" in c
+    assert f"Environment={enc('PATH=' + path_env)}\n" in c
+    # The raw (unescaped, unquoted) path must NOT leak into any directive.
+    assert f"WorkingDirectory={wt}\n" not in c
+    assert "%%" in c and '\\"' in c
+
+
+@pytest.mark.asyncio
+async def test_make_live_unsafe_path_returns_code(monkeypatch, tmp_path):
+    """When rendering the drop-in raises _UnsafeUnitValue, _make_live refuses
+    with code `unsafe_path` (enforced for dry_run too) and touches nothing."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt)
+
+    def boom(*a, **k):
+        raise mod._UnsafeUnitValue("'/x\\ny'")
+
+    monkeypatch.setattr(mod, "_dropin_content", boom)
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is False and res["code"] == "unsafe_path"
+    assert calls == []
+
+
+# --- make-live: atomic write + failure rollback (Codex round 2, Finding B) ---
+def _stub_cutover_systemd(monkeypatch):
+    """Put _make_live on the real-cutover branch (linux + systemctl present)."""
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_live_rolls_back_on_reload_failure(monkeypatch, tmp_path):
+    """daemon-reload failure restores the PRIOR drop-in content, re-runs
+    daemon-reload, attempts no restart, and reports rolled_back."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    dropin.parent.mkdir(parents=True)
+    dropin.write_text("PRIOR-OVERRIDE\n")
+    _stub_make_live(monkeypatch, wt)
+    _stub_cutover_systemd(monkeypatch)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    calls: list = []
+    reloads = {"n": 0}
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        if cmd == ["systemctl", "--user", "daemon-reload"]:
+            reloads["n"] += 1
+            return (1, "", "reload boom") if reloads["n"] == 1 else (0, "", "")
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is False and res["code"] == "reload_failed"
+    assert res["rolled_back"] is True
+    assert dropin.read_text() == "PRIOR-OVERRIDE\n"   # restored to prior content
+    assert reloads["n"] == 2                            # rollback re-reload ran
+    assert not any(c[:2] == ["systemd-run", "--user"] for c in calls)  # no restart
+
+
+@pytest.mark.asyncio
+async def test_make_live_rolls_back_on_restart_failure(monkeypatch, tmp_path):
+    """systemd-run failure with NO prior drop-in deletes the freshly-written
+    override (restoring absence) and re-runs daemon-reload."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"   # absent initially
+    _stub_make_live(monkeypatch, wt)
+    _stub_cutover_systemd(monkeypatch)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    reloads = {"n": 0}
+
+    async def fake_run_cmd(cmd, **kw):
+        if cmd == ["systemctl", "--user", "daemon-reload"]:
+            reloads["n"] += 1
+            return (0, "", "")
+        if cmd[:2] == ["systemd-run", "--user"]:
+            return (1, "", "run boom")
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is False and res["code"] == "restart_failed"
+    assert res["rolled_back"] is True
+    assert not dropin.exists()          # prior was absent -> deleted on rollback
+    assert reloads["n"] == 2            # initial reload + rollback re-reload
+
+
+# --- make-live: concurrency single-flight lock (Codex round 4) ---
+@pytest.mark.asyncio
+async def test_make_live_concurrent_second_call_busy(monkeypatch, tmp_path):
+    """While one cutover holds the make-live lock, a concurrent second call is
+    refused immediately with ``busy`` (fail-fast, not queued) and the winner
+    still completes and releases the lock."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    _stub_cutover_systemd(monkeypatch)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    # Fresh lock so a leaked hold from another test can't poison this one.
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+
+    entered = asyncio.Event()   # set once the first call is inside the lock
+    release = asyncio.Event()   # test-controlled gate to hold it there
+
+    async def fake_run_cmd(cmd, **kw):
+        # The first _run_cmd (daemon-reload) runs INSIDE the critical section:
+        # signal we hold the lock, then block until the test releases us.
+        if cmd == ["systemctl", "--user", "daemon-reload"]:
+            entered.set()
+            await release.wait()
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+
+    first = asyncio.ensure_future(mod._make_live(str(wt), dry_run=False))
+    await asyncio.wait_for(entered.wait(), timeout=5)   # first now holds the lock
+    assert mod._MAKE_LIVE_LOCK.locked() is True
+
+    # Second call returns busy without waiting (would hang on wait_for if queued).
+    busy = await asyncio.wait_for(mod._make_live(str(wt), dry_run=False), timeout=5)
+    assert busy["ok"] is False and busy["code"] == "busy"
+    assert "in progress" in busy["error"]
+
+    release.set()
+    res = await asyncio.wait_for(first, timeout=5)
+    assert res["ok"] is True and res.get("cutover") is True
+    assert mod._MAKE_LIVE_LOCK.locked() is False        # released after success
+
+
+@pytest.mark.asyncio
+async def test_make_live_lock_released_after_failure_and_reusable(monkeypatch, tmp_path):
+    """The lock is released on the failure-rollback path too, so a subsequent
+    cutover proceeds (never wedged on ``busy``) — and then also releases on
+    success."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    _stub_cutover_systemd(monkeypatch)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+
+    # 1) daemon-reload fails -> rollback path; the lock MUST be released.
+    async def reload_fails(cmd, **kw):
+        if cmd == ["systemctl", "--user", "daemon-reload"]:
+            return (1, "", "reload boom")
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", reload_fails)
+    fail = await mod._make_live(str(wt), dry_run=False)
+    assert fail["ok"] is False and fail["code"] == "reload_failed"
+    assert mod._MAKE_LIVE_LOCK.locked() is False        # released on rollback
+
+    # 2) A subsequent all-green cutover proceeds (not refused as busy) and also
+    #    releases the lock on the success path.
+    async def all_ok(cmd, **kw):
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", all_ok)
+    ok = await mod._make_live(str(wt), dry_run=False)
+    assert ok["ok"] is True and ok.get("cutover") is True
+    assert mod._MAKE_LIVE_LOCK.locked() is False        # released on success
+
+
+# =============================================================================
 # Task 2b: fleet gateway_service_active
 # =============================================================================
 

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -13,7 +13,7 @@ import { addNotification } from '../store/notificationsSlice'
 import {
   Server, RefreshCw, Play, Square, ExternalLink, ChevronRight, Trash2,
   LoaderCircle, Check,
-  Ellipsis, RotateCw, FileText, GitCommit,
+  Ellipsis, RotateCw, FileText, GitCommit, Rocket,
 } from 'lucide-react'
 import * as api from './devFleetApi'
 
@@ -155,6 +155,7 @@ interface Worktree {
   last_updated_at?: number
   pr?: PrInfo | null; shipped?: boolean
   own_commits?: number; real_dirty?: boolean; is_live?: boolean; legacy?: boolean
+  path?: string
 }
 interface FleetData { worktrees: Worktree[]; error?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean }
 interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; phase: number; phaseAt?: number; lines: string[]; startedAt: number; exit?: number | null; last?: string }
@@ -546,6 +547,33 @@ export default function DevFleetPage() {
     } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false) }
   }
 
+  async function makeLive(w: Worktree) {
+    // Only the already-live row is blocked. Main is a valid target when it is
+    // NOT live (after a cutover to a feature worktree, this is the way back).
+    if (w.is_live) return
+    if (!w.path) { notify('Cannot resolve worktree path for ' + w.name, { type: 'error' }); return }
+    const ok = await askConfirm('Make "' + w.name + '" live?',
+      'Swaps the code behind the live dashboard to this worktree (same port, same data). The gateway restarts and this page reconnects automatically. Refused unless the worktree is provisioned and built.',
+      { confirmLabel: 'Make live' })
+    if (!ok) return
+    setFlag(w.name + ':makelive', true)
+    try {
+      const r = await api.post<{ ok?: boolean; error?: string }>('/make-live', { path: w.path })
+      if (!r?.ok) { notify(r?.error || 'Make live failed', { type: 'error' }); setFlag(w.name + ':makelive', false); return }
+      // Gateway is restarting into the new worktree — reuse the restart overlay,
+      // poll until it answers again, then reload into the freshly-live code.
+      setRestarting(true)
+      await sleep(3000)
+      const deadline = Date.now() + 60000
+      while (Date.now() < deadline) {
+        try { await fetch('/', { signal: AbortSignal.timeout(3000) }); window.location.reload(); return } catch { /* still restarting */ }
+        await sleep(2000)
+      }
+      setRestarting(false); setFlag(w.name + ':makelive', false)
+      notify('Gateway still restarting after 60s \u2014 reload manually', { type: 'error' })
+    } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false); setFlag(w.name + ':makelive', false) }
+  }
+
   async function loadPodLogs(name: string) {
     setPodLogsLoading((l) => ({ ...l, [name]: true }))
     try {
@@ -616,6 +644,16 @@ export default function DevFleetPage() {
             {iconLabel(<RotateCw size={13} className="lucide-inline" />, 'Restart')}
           </Btn>
         )
+        // After a cutover to a feature worktree, main is dormant (is_live=false)
+        // and this inline control is the only way back to running main live.
+        // Consistent with makeLive()'s guard: shown iff the row is NOT live.
+        if (!w.is_live) {
+          out.push(
+            <Btn key="makelive" onClick={() => makeLive(w)} disabled={!!busy[w.name + ':makelive']} title="Repoint the live gateway back at main (restarts the gateway)">
+              {iconLabel(<Rocket size={13} className="lucide-inline" />, 'Make live')}
+            </Btn>
+          )
+        }
       }
       if (fleet?.build_pending) {
         out.push(<Badge key="bp" variant="warn">build pending \u2014 restart gateway to apply (kirocrew restart)</Badge>)
@@ -637,6 +675,7 @@ export default function DevFleetPage() {
       w.has_dist && !w.running ? { label: 'Spin up pod', icon: <Play size={13} className="lucide-inline" />, onClick: () => act(w.name, 'up') } : null,
       w.running ? { label: 'Restart pod', icon: <RefreshCw size={13} className="lucide-inline" />, onClick: () => act(w.name, 'restart') } : null,
       { label: 'Rebase onto main', icon: <RefreshCw size={13} className="lucide-inline" />, onClick: () => rebaseWorktree(w.name), disabled: !!busy[w.name + ':rebase'] },
+      !w.is_live ? { label: 'Make live', icon: <Rocket size={13} className="lucide-inline" />, onClick: () => makeLive(w), disabled: !!busy[w.name + ':makelive'], title: 'Repoint the live gateway at this worktree (restarts the gateway)' } : null,
       w.running ? { label: 'Stop pod', icon: <Square size={13} className="lucide-inline" />, onClick: () => act(w.name, 'down'), danger: true } : null,
     ]} />)
     const rr = rebaseResult[w.name]

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -297,4 +297,96 @@ describe('DevFleetPage', () => {
     // Remove button
     expect(screen.getByText('Remove selected')).toBeInTheDocument()
   })
+
+  it('shows "Make live" in the row menu for a non-live worktree and opens a confirm dialog', async () => {
+    const FLEET_ONE = {
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+        { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0, path: '/wt/feature-x' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_ONE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // Only the non-main row has a "More actions" menu.
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const item = await screen.findByText('Make live')
+    fireEvent.click(item)
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(screen.getByText('Make "feature-x" live?')).toBeInTheDocument()
+  })
+
+  it('hides "Make live" for the worktree that is already live', async () => {
+    const FLEET_LIVE = {
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+        { name: 'live-wt', is_main: false, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/live' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('live-wt')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    // Menu is open (Rebase is always present) but Make live is omitted on the live row.
+    expect(await screen.findByText('Rebase onto main')).toBeInTheDocument()
+    expect(screen.queryByText('Make live')).toBeNull()
+  })
+
+  it('shows an inline "Make live" on the MAIN row when main is NOT live (switch back after cutover)', async () => {
+    // A feature worktree is live; main is dormant (is_live:false). The main
+    // row must offer Make live so the operator can cut back to main.
+    const FLEET_MAIN_DORMANT = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: false, path: '/wt/main' },
+        { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/feature-x' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_MAIN_DORMANT), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+    // The dormant main row exposes an inline Make live control (feature-x is
+    // live, so its own menu — unopened here — has no Make live to collide).
+    const btn = await screen.findByTitle('Repoint the live gateway back at main (restarts the gateway)')
+    expect(btn).toBeInTheDocument()
+    fireEvent.click(btn)
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(screen.getByText('Make "main" live?')).toBeInTheDocument()
+  })
+
+  it('hides "Make live" on the MAIN row when main IS live', async () => {
+    const FLEET_MAIN_LIVE = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/main' },
+        { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0, is_live: false, path: '/wt/feature-x' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_MAIN_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // Main is live -> no inline Make live control on the main row (feature-x's
+    // menu is closed, so its Make live is not rendered either).
+    expect(screen.queryByTitle('Repoint the live gateway back at main (restarts the gateway)')).toBeNull()
+  })
 })


### PR DESCRIPTION
Fixes #114

## Problem
Dev Fleet shows which worktree is live and offers Restart gateway, but restart only bounces `kirocrew-gateway.service` — the unit hardcodes WorkingDirectory/ExecStart/PATH, so once a feature worktree is live there is no way to switch back from the UI.

## Change
**Backend** (`src/kiro_crew/apps/builtins/dev_fleet/server.py`): new `POST /api/make-live {path, dry_run?}`
- Validates the target is a known worktree; preflights `.venv/bin/kirocrew` and a built SPA dist with actionable error codes (`missing_venv` → Provision, `missing_dist` → Pull+Build)
- **Refuses inside a pod** (`code:"pod"`, fires before everything incl. dry_run) — a throwaway pod plane must never cut the user's real gateway; verified side-effect-free (no drop-in written, live PID untouched)
- Mechanism: systemd **drop-in override** `kirocrew-gateway.service.d/make-live.conf` (WorkingDirectory + empty `ExecStart=` reset + new ExecStart + PATH) — the user's main unit file is never edited — then `daemon-reload` + detached restart via `systemd-run --collect` (survives our own death)
- `dry_run:true` returns the full `plan` (unit, dropin_path, dropin_content, target) without writing/reloading/restarting
- All subprocess via the `_run_cmd` chokepoint; `@_audited("dev_fleet_make_live")`; live-worktree cache invalidated after cutover

**Frontend** (`website/src/pages/DevFleetPage.tsx`): "Make live" row action on non-live worktrees → confirm dialog (explains the gateway restarts and the same data plane is kept) → backend errors surfaced verbatim in a toast.

## Testing
- Build gate green: dist build ✅ · tsc ✅ · vitest 3877 passed (+2) ✅ · pytest 15021 passed, zero new failures (5 pre-existing userns-EPERM env failures only) ✅ · flake8 clean ✅
- 8 new backend tests: dry_run plan (incl. the empty ExecStart reset line), pod refusal even under dry_run, unknown_path, already_live, missing_venv, missing_dist, real cutover (drop-in write + daemon-reload + detached restart + cache invalidation), route registration/audit
- QA against an isolated pod (:7940): all HTTP paths verified; tamper check confirmed the pod refusal writes nothing and the live gateway PID/start-time never changed; 29s demo video recorded (row menu → confirm dialog → pod-refusal toast)

## Notes for reviewers
- Ordering is intentional: the pod guard precedes the dry_run return, so even a dry-run preview is refused from a pod plane. Trade-off: the dashboard's dry-run preview is only available on the live plane.

## Review round 1 fixes (Codex)
Addresses all 4 findings from the first Codex pass:
- **Fail-closed pod detection** (`_in_pod`): the pod probe now treats an exception as *in a pod* (fail-closed) instead of falling open, so a probe error can no longer allow a cutover from a pod plane. Still surfaces as `code:"pod"`.
- **User-unit precheck** (`code:"no_user_unit"`): detect a missing `kirocrew-gateway.service` systemd `--user` unit up front and return a structured error, instead of letting `daemon-reload`/restart appear to succeed against a non-existent unit (late false success).
- **main-row Make Live**: the main/baseline worktree row now offers "Make live" whenever it is not the live worktree, restoring a way back to main after switching away from it (previously the main row never showed the action).
- **Spec docs** (`docs/system-specs/modules/dev-fleet.md`): documented the Make Live cutover, the drop-in override mechanism, `dry_run`, and the pod / user-unit guards.

Branch squashed to a single commit; build gate re-run green (vitest 3879 passed, pytest 15027 passed with only the 5 pre-existing userns-EPERM env failures, flake8 clean on changed files).


---

## Review round 2 fixes (Codex)

Two HIGH findings on `_make_live` / the drop-in renderer:

- **Finding A — systemd value escaping.** Drop-in values (`WorkingDirectory=`,
  `ExecStart=`, `Environment=PATH=`) were interpolated unescaped, so a worktree
  path with spaces or systemd metacharacters (`%` specifiers, quotes,
  backslashes) split/expanded wrongly — the restart would stop the gateway but
  fail to start the target, and the persisted invalid drop-in blocked recovery
  restarts. Added `_sd_value`: rejects control-char paths (`unsafe_path`),
  doubles `%`→`%%`, and double-quotes (escaping `\`→`\\`, `"`→`\"`) only when
  whitespace/metacharacters are present; a clean path renders verbatim.
- **Finding B — failed-cutover left the drop-in persisted.** On a
  `daemon-reload` or `systemd-run` failure the new drop-in stayed on disk even
  though the API reported failure, so a later unrelated restart silently
  activated the cutover. Now the prior state is snapshotted, the drop-in is
  written atomically (temp file + `os.replace`), and on failure the prior state
  is restored (rewrite old content / delete when absent) + `daemon-reload`
  re-run best-effort, with `rolled_back` in the error payload.

Tests: `_sd_value` escaping + control-char rejection; a special-char worktree
produces a correctly-escaped plan; `unsafe_path` code path; reload-failure and
systemd-run-failure each restore the prior drop-in state and re-run
daemon-reload. `test_dev_fleet_app.py` 130 passed (124 → +6). Full suite 15033
passed (only the 5 known unshare-EPERM env failures remain); `flake8 src/ test/`
clean. Docs updated (Make Live section: escaping/`unsafe_path` + rollback).

---

### Review round 3 fix (Codex)

- **HIGH — non-executable gateway binary passed validation.** Make Live checked
  `.venv/bin/kirocrew` with only `is_file()`, so a present-but-non-executable
  binary passed: the drop-in was written and the old gateway stopped, but the
  replacement could never start (systemd `ExecStart` requires `+x`), leaving
  **no gateway running**. Now the check also requires `os.access(kcbin, os.X_OK)`
  and, when the file exists but is not executable, returns a **distinct,
  actionable** code `venv_not_executable` (message suggests `chmod +x` or
  re-Provision). `missing_venv` is retained for the not-a-file case.

Tests: new `test_make_live_venv_not_executable` asserts the non-executable
binary is refused with `venv_not_executable` and that an executable binary
passes the gate to a valid plan; make-live fixtures now create the fake binary
`+x` (fixtures fixed, assertions unchanged). `test_dev_fleet_app.py` 131 passed
(+1). Full suite 15034 passed (only the 5 known unshare-EPERM env failures
remain); `flake8 --jobs=1 src/ test/` clean. Backend-only change — no frontend
build. Docs error-code table + validation order updated with `venv_not_executable`.


---

### Review round 4 fix (Codex)

- **HIGH — concurrent make-live cutovers raced on the shared drop-in.** Two
  overlapping requests each ran the `snapshot → atomic-write → daemon-reload →
  systemd-run → rollback` sequence against the same
  `make-live.conf`, so one request's failure rollback could restore or delete
  the **other** request's successful override — restarting the gateway into the
  wrong worktree (or into none). The entire mutation sequence now runs under a
  module-level `asyncio.Lock` (`_MAKE_LIVE_LOCK`), single-flighting the cutover.
  A second concurrent request **fails fast** with a new `busy` code rather than
  queueing — a queued cutover could apply a stale target after the winner
  already restarted the gateway out from under it. The lock is released on every
  exit (success, and write / reload / restart failure with rollback). The
  `dry_run` validation-only path mutates nothing and stays outside the lock; the
  `busy` check and lock acquire are atomic (no `await` between them on the
  single-threaded event loop).

Tests: `test_make_live_concurrent_second_call_busy` holds the first call inside
the critical section via an event barrier on the `_run_cmd` seam and asserts the
concurrent second call returns `busy` immediately (never queues) while the winner
still completes and releases the lock; `test_make_live_lock_released_after_failure_and_reusable`
asserts the lock is released on the failure-rollback path and a subsequent cutover
proceeds (and also releases on success). `test_dev_fleet_app.py` 133 passed (+2).
Full suite 15036 passed with only the 5 known unshare-EPERM env failures;
`flake8 --jobs=1 src/ test/` clean. Backend-only change — no frontend build. Docs
error-code table + a new Concurrency section updated with `busy`.


---

### Review round 5 fixes (Codex)

**`restart_pending` committed latch (HIGH).** `systemd-run --collect ... restart`
only **schedules** the restart and returns immediately, so `_MAKE_LIVE_LOCK` was
released while the restart was still pending — a second cutover could then
acquire the lock and mutate the drop-in for target B while target A's scheduled
restart tore this backend down mid-write, leaving the loaded unit and the
persisted drop-in disagreeing. A process-local `_MAKE_LIVE_COMMITTED` latch is
now set `True` (**before returning success, inside the lock**) the moment a
cutover is scheduled, and is checked both at function entry **and** again after
the lock is acquired (closing the entry-check-vs-acquire race). Any further
request — a second cutover or even a `dry_run` — is refused with the new
`restart_pending` code. The latch is never persisted, so the fresh gateway the
restart spawns starts clear; failure paths **before** successful scheduling
never set it, so a rolled-back cutover is free to retry.

**WorkingDirectory live-detection (MEDIUM).** `_live_worktree_path` parsed the
live checkout from `ExecStart` via `path=([^ ;]+)`, which truncates at the first
space — inconsistent with the round-2 space-path escaping, so a worktree whose
path contains a space would never register as `is_live`/`already_live` and could
be pointlessly re-cut over and over. Detection now reads
`systemctl --user show <unit> --property=WorkingDirectory --value` (make-live
always writes `WorkingDirectory=` alongside `ExecStart`, and the baseline unit
sets it too), which is not truncated at spaces, with a fallback to the old
`ExecStart` parse when `WorkingDirectory` is empty. Both routes go through
`_run_cmd`.

Tests: `test_make_live_latches_after_cutover` (second call + `dry_run` →
`restart_pending`), `test_make_live_prescheduling_failure_does_not_latch`
(reload failure does not latch; subsequent cutover proceeds),
`test_live_worktree_path_reads_working_directory_with_spaces`,
`test_live_worktree_path_falls_back_to_execstart`, and
`test_make_live_already_live_space_path`; an autouse fixture resets the
process-local latch around every test. `test_dev_fleet_app.py` 138 passed (+5).
Full suite 15041 passed with only the 5 known unshare-EPERM env failures;
`flake8 --jobs=1 src/ test/` clean. Backend-only change — no frontend build.
Docs error-code table (`restart_pending`) + Concurrency section (committed
latch) updated.
