### PR TITLE
fix(subagent): probe available memory on macOS so auto-sizing scales past 3

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -27,6 +27,28 @@ Priority (highest wins): **per-spawn `max_turns`** → **config `agent.subagent_
 
 A value of `0` means "not set" and falls through to the next level. Implemented as `info.max_turns or self._default_turn_limit or _TURN_LIMIT` in `_run_subagent()`.
 
+### Concurrency Auto-Sizing — Memory Probe (per platform)
+
+When `agent.max_subagents == 0`, `compute_max_subagents()` sizes the cap from
+host memory and CPU, clamped to `[3, agent.subagent_auto_max]`. The
+available-memory term is read by `_available_memory_gb()`, which is dispatched
+per operating system (see `dynamic-subagent-sizing.md`):
+
+- **Linux** — `/proc/meminfo` `MemAvailable`, then clamped by cgroup headroom.
+- **macOS** — reclaimable memory (free + inactive + speculative + purgeable
+  pages) via the Mach `host_statistics64` syscall through `ctypes`/`libSystem`
+  (`_macos_vm_reclaimable_pages`), combined with the `os.sysconf` page size.
+  This is **in-process, non-blocking, no subprocess** — required because the
+  probe runs on the gateway event loop at startup and the spawn-audit guard
+  rejects unrouted subprocess spawns.
+- **Other (e.g. Windows)** — no probe yet; returns `-1.0` and the cap fails
+  open to the legacy floor of 3.
+
+Limitation: the per-spawn `spawn_min_memory_gb` admission gate
+(`check_memory_available`) still reads `/proc/meminfo` and so remains inert
+(fails open) on non-Linux hosts. Auto-sizing and the runtime gate are
+independent guards; unifying them is out of scope for the sizing probe.
+
 ## APIs
 
 ### `SubagentManager.__init__(sessions, ctx_builder, on_done, max_concurrent)`

--- a/src/kiro_crew/docs/dynamic-subagent-sizing.md
+++ b/src/kiro_crew/docs/dynamic-subagent-sizing.md
@@ -116,9 +116,16 @@ memory floor. They are independent guards.
 
 ## Notes
 
-- Stdlib only — reads `/proc/meminfo`, `/proc/<pid>/stat`, and cgroup limits.
-  No new dependencies.
-- On non-Linux hosts the readers fail open (the cap falls back to the configured
-  value), so behavior is unchanged there.
+- Stdlib only — no new dependencies. Memory/CPU are read per platform:
+  Linux reads `/proc/meminfo`, `/proc/<pid>/stat`, and cgroup limits; macOS
+  reads *available* memory in-process via the Mach `host_statistics64` syscall
+  through `ctypes`/`libSystem` (free + inactive + speculative + purgeable
+  pages × page size) — no subprocess, so it is safe on the gateway event loop
+  and passes the spawn-audit guard.
+- On platforms with no probe yet (e.g. Windows) the readers fail open and the
+  cap falls back to the configured value.
+  NOTE: the per-spawn `spawn_min_memory_gb` admission gate still reads
+  `/proc/meminfo` and therefore remains inert (fails open) on non-Linux hosts —
+  auto-sizing and the runtime gate are independent guards.
 - Design rationale and worked examples:
   `~/.kirocrew/workspace/dynamic-subagent-sizing.md`.

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 IS_WINDOWS: bool = sys.platform == "win32"
 IS_POSIX: bool = not IS_WINDOWS
 IS_LINUX: bool = sys.platform == "linux"
+IS_MACOS: bool = sys.platform == "darwin"
 
 # Portable signal constants — signal.SIGKILL is undefined on Windows.
 SIGKILL: int = getattr(signal, "SIGKILL", 9)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -10,6 +10,7 @@ No spawn recursion: subagents cannot spawn other subagents.
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import logging
 import math
 import os
@@ -322,19 +323,149 @@ _LEGACY_DEFAULT_MAX = 3
 
 
 def _available_memory_gb() -> float:
-    """Effective available memory (GB) = ``min(MemAvailable, cgroup headroom)``.
+    """Effective available memory (GB), dispatched per operating system.
 
-    Returns -1.0 when host memory is unreadable (non-Linux / read error) so the
-    caller fails open to the legacy default. The cgroup clamp is a no-op on
-    unconstrained hosts (no controller / unlimited).
+    Each OS reports "available" memory through a different, non-portable
+    interface, so the probe is a small per-platform branch. Every branch
+    returns a best-effort available-GB figure, or ``-1.0`` when this platform
+    has no probe yet / the read failed — in which case the caller
+    (``compute_max_subagents``) fails open to the legacy default cap.
+
+        • Linux  — ``/proc/meminfo`` ``MemAvailable`` (via ``check_memory_available``),
+                   then clamped by cgroup headroom so a container's limit binds.
+        • macOS  — reclaimable memory via Mach ``host_statistics64`` (ctypes,
+                   in-process, no subprocess); see ``_macos_available_memory_gb``.
+                   No cgroups.
+        • other  — no probe yet → ``-1.0`` (fail open).
+
+    NOTE (adding a new OS): implement a ``_<os>_available_memory_gb()`` helper
+    returning GB or -1.0, add an ``IS_<OS>`` flag to ``platform_compat``, and
+    wire one branch below. Keep the -1.0 fail-open contract so an unmeasurable
+    host degrades to the safe legacy default rather than over-spawning.
     """
-    _ok, host_gb = check_memory_available(min_gb=0.0)
-    if host_gb <= 0:
-        return host_gb  # unreadable → caller fails open
-    cg_gb = _cgroup_available_gb()
-    if cg_gb < 0:
-        return host_gb  # no cgroup cap (unconstrained / non-Linux)
-    return min(host_gb, cg_gb)
+    if platform_compat.IS_LINUX:
+        _ok, host_gb = check_memory_available(min_gb=0.0)
+        if host_gb <= 0:
+            return host_gb  # unreadable → caller fails open
+        cg_gb = _cgroup_available_gb()
+        if cg_gb < 0:
+            return host_gb  # no cgroup cap (unconstrained)
+        return min(host_gb, cg_gb)
+    if platform_compat.IS_MACOS:
+        return _macos_available_memory_gb()
+    # Unsupported platform (e.g. Windows): no probe yet → fail open.
+    return -1.0
+
+
+def _macos_vm_reclaimable_pages() -> Optional[int]:  # pragma: no cover
+    """Reclaimable memory in **pages** via Mach ``host_statistics64``, or ``None``.
+
+    macOS-only. Excluded from coverage because the Linux CI fleet cannot execute
+    the Mach path; validated live against ``vm_stat`` on Apple silicon (matches
+    within live-fluctuation noise). Reads in-process through ``ctypes`` /
+    ``libSystem`` — **no subprocess** — so it is safe on the gateway event loop
+    and passes the spawn-audit guard.
+
+    Reclaimable ≈ ``free + inactive + speculative + purgeable`` page classes:
+    memory that can back a new allocation without swapping (the closest analogue
+    to Linux ``MemAvailable``). Wired/active/compressed pages are excluded.
+    Returns ``None`` on any failure (non-macOS ``libSystem`` absent, non-zero
+    ``kern_return_t``) so the caller falls back to the legacy default.
+    """
+    try:
+        libc = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
+    except OSError:
+        return None  # not macOS / libSystem unavailable
+
+    natural_t = ctypes.c_uint  # natural_t is 32-bit on macOS
+    u64 = ctypes.c_uint64
+
+    # Leading fields of vm_statistics64_data_t (<mach/vm_statistics.h>) in
+    # declaration order, so the byte layout matches what the kernel fills. Only
+    # free/inactive/speculative/purgeable are read, but the full struct is
+    # declared so the element count handed to host_statistics64 is exact.
+    class _VMStatistics64(ctypes.Structure):
+        _fields_ = [
+            ("free_count", natural_t),
+            ("active_count", natural_t),
+            ("inactive_count", natural_t),
+            ("wire_count", natural_t),
+            ("zero_fill_count", u64),
+            ("reactivations", u64),
+            ("pageins", u64),
+            ("pageouts", u64),
+            ("faults", u64),
+            ("cow_faults", u64),
+            ("lookups", u64),
+            ("hits", u64),
+            ("purges", u64),
+            ("purgeable_count", natural_t),
+            ("speculative_count", natural_t),
+            ("decompressions", u64),
+            ("compressions", u64),
+            ("swapins", u64),
+            ("swapouts", u64),
+            ("compressor_page_count", natural_t),
+            ("throttled_count", natural_t),
+            ("external_page_count", natural_t),
+            ("internal_page_count", natural_t),
+            ("total_uncompressed_pages_in_compressor", u64),
+        ]
+
+    HOST_VM_INFO64 = 4  # flavor selector for host_statistics64
+
+    try:
+        libc.mach_host_self.restype = ctypes.c_uint
+        libc.host_statistics64.restype = ctypes.c_int
+        libc.host_statistics64.argtypes = [
+            ctypes.c_uint,
+            ctypes.c_int,
+            ctypes.POINTER(_VMStatistics64),
+            ctypes.POINTER(ctypes.c_uint),
+        ]
+        stats = _VMStatistics64()
+        count = ctypes.c_uint(ctypes.sizeof(_VMStatistics64) // ctypes.sizeof(ctypes.c_int))
+        kern_return = libc.host_statistics64(
+            libc.mach_host_self(),
+            HOST_VM_INFO64,
+            ctypes.byref(stats),
+            ctypes.byref(count),
+        )
+    except (AttributeError, OSError, ValueError):
+        return None
+    if kern_return != 0:  # non-zero kern_return_t → failure
+        return None
+
+    return (
+        stats.free_count
+        + stats.inactive_count
+        + stats.speculative_count
+        + stats.purgeable_count
+    )
+
+
+def _macos_available_memory_gb() -> float:
+    """macOS available-memory probe (GB), or ``-1.0`` on failure.
+
+    Combines the in-process Mach reclaimable-page count
+    (``_macos_vm_reclaimable_pages``) with the page size from ``os.sysconf``.
+    macOS has no ``/proc/meminfo`` and ``os.sysconf`` exposes only *total*
+    physical pages (no ``SC_AVPHYS_PAGES``), so the Mach VM statistics are the
+    only cheap, non-blocking source of *available* memory — which the sizing
+    formula needs so a memory-pressured Mac is not handed an inflated cap. Any
+    read failure returns -1.0 so the caller falls back to the legacy default.
+    """
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError):
+        return -1.0
+    if page_size <= 0:
+        return -1.0
+    pages = _macos_vm_reclaimable_pages()
+    if pages is None or pages <= 0:
+        return -1.0
+    avail_gb = pages * page_size / (1024 ** 3)
+    return round(avail_gb, 2) if avail_gb > 0 else -1.0
 
 
 # Values at/above this are the kernel's "no limit" sentinel (PAGE_COUNTER_MAX).

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -494,6 +494,9 @@ class TestAvailableMemoryClamp:
     def test_clamps_to_cgroup_when_smaller(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
+        # Force the Linux branch so the clamp logic runs regardless of test host.
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
         monkeypatch.setattr(sub, "check_memory_available", lambda **k: (True, 100.0))
         monkeypatch.setattr(sub, "_cgroup_available_gb", lambda: 14.0)
         assert sub._available_memory_gb() == pytest.approx(14.0, abs=0.01)
@@ -501,13 +504,17 @@ class TestAvailableMemoryClamp:
     def test_unconstrained_uses_host(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
         monkeypatch.setattr(sub, "check_memory_available", lambda **k: (True, 100.0))
         monkeypatch.setattr(sub, "_cgroup_available_gb", lambda: -1.0)
         assert sub._available_memory_gb() == pytest.approx(100.0, abs=0.01)
 
-    def test_non_linux_fails_open(self, monkeypatch) -> None:
+    def test_linux_unreadable_fails_open(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
         monkeypatch.setattr(sub, "check_memory_available", lambda **k: (True, -1.0))
         # cgroup not even consulted when host is unreadable
         assert sub._available_memory_gb() == -1.0
@@ -516,6 +523,8 @@ class TestAvailableMemoryClamp:
         """End-to-end: a 6 GB cgroup cap on a big host caps the count via memory."""
         import kiro_crew.subagent as sub
 
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
         monkeypatch.setattr(sub, "check_memory_available", lambda **k: (True, 174.7))
         monkeypatch.setattr(sub, "_cgroup_available_gb", lambda: 4.0)  # headroom 4 GB
         monkeypatch.setattr(sub.os, "cpu_count", lambda: 48)
@@ -523,10 +532,79 @@ class TestAvailableMemoryClamp:
         # mem_term = floor(4*0.8/0.315)=10 ; cpu_term=48 → min 10, clamp(10,3,16)=10
         assert compute_max_subagents(cfg) == 10
 
+    # --- platform dispatch -------------------------------------------------
+
+    def test_macos_branch_uses_macos_probe(self, monkeypatch) -> None:
+        """On macOS, dispatch delegates to the vm_stat probe (not /proc)."""
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", False)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", True)
+        monkeypatch.setattr(sub, "_macos_available_memory_gb", lambda: 42.0)
+        assert sub._available_memory_gb() == 42.0
+
+    def test_unsupported_platform_fails_open(self, monkeypatch) -> None:
+        """A platform with no probe yet (e.g. Windows) fails open to -1.0."""
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", False)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
+        assert sub._available_memory_gb() == -1.0
+
 
 # ---------------------------------------------------------------------------
 # Queued-spawn parameter preservation + reap-drains-queue (round-2 bugfix)
 # ---------------------------------------------------------------------------
+
+
+class TestMacosMemoryProbe:
+    """macOS available-memory calc, exercised via the mockable page-count seam.
+
+    The Mach ``host_statistics64`` reader itself is macOS-only (pragma: no
+    cover, validated live against vm_stat); these tests drive the surrounding
+    GB math + failure handling deterministically on any host.
+    """
+
+    def test_computes_available_gb_from_pages(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)  # 16 KiB pages
+        monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: 200000)
+        expected = round(200000 * 16384 / (1024 ** 3), 2)
+        assert sub._macos_available_memory_gb() == pytest.approx(expected, abs=0.01)
+
+    def test_none_page_count_fails_open(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)
+        monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: None)
+        assert sub._macos_available_memory_gb() == -1.0
+
+    def test_zero_page_count_fails_open(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)
+        monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: 0)
+        assert sub._macos_available_memory_gb() == -1.0
+
+    def test_sysconf_error_fails_open(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        def _boom(_n):
+            raise ValueError("SC_PAGE_SIZE unavailable")
+
+        monkeypatch.setattr(sub.os, "sysconf", _boom)
+        assert sub._macos_available_memory_gb() == -1.0
+
+    def test_nonpositive_page_size_fails_open(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 0)
+        # _macos_vm_reclaimable_pages must not even be consulted
+        monkeypatch.setattr(
+            sub, "_macos_vm_reclaimable_pages", lambda: pytest.fail("should not run")
+        )
+        assert sub._macos_available_memory_gb() == -1.0
 
 
 class TestQueuedSpawnParamsPreserved:


### PR DESCRIPTION
## Problem
On macOS, sub-agent auto-sizing (`agent.max_subagents=0`) never scales with host resources — it stays floored at a fixed low value regardless of RAM/cores — and separately the auto-size ceiling (`subagent_auto_max`) could be configured as low as 1, dropping the auto-computed cap below the intended minimum of 3. A real user on a 48 GB M5 Pro reported the auto scale sitting at 1.

## Why it matters
Auto-sizing is the default path. On macOS it was effectively disabled (always fail-open to the legacy default), so fan-out work ran 3–4× slower than the hardware allows. And because `subagent_auto_max` only enforced a floor of 1, the auto cap could silently drop below 3 — the spec claims "never below the legacy default (3)" but the code did not guarantee it.

## Fix (symptoms → root cause → change)
- Symptom: auto cap stuck low on macOS; auto ceiling settable below 3.
- Root cause: `_available_memory_gb()` measured memory only via Linux `/proc/meminfo`; on macOS the read fails and returns -1.0, so `compute_max_subagents()` fails open to `_LEGACY_DEFAULT_MAX`. Separately the load-time security clamp allowed `subagent_auto_max` as low as 1, so the auto floor `min(3, hard_cap)` could drop below 3.
- Change:
  1. **Platform-dispatch `_available_memory_gb()`**: Linux `/proc/meminfo` + cgroup (unchanged); macOS reads real *available* memory in-process via the Mach `host_statistics64` syscall through `ctypes`/`libSystem` (`_macos_vm_reclaimable_pages` = free + inactive + speculative + purgeable pages) — no subprocess, so it is safe on the gateway event loop and passes the spawn-audit guard; other platforms fail open. Adds `IS_MACOS` to `platform_compat`.
  2. **Hard floor of 3 for auto-sizing**: `subagent_auto_max` load-time security bound raised from min 1 to min 3 (clamped UP with a WARNING + `config_bounds_clamped` SEL event, mirroring the >64 ceiling clamp); the dashboard config API rejects `subagent_auto_max < 3`; `compute_max_subagents` floors at 3 as defense-in-depth.

Scope: the floor applies ONLY to auto-sizing (`subagent_auto_max` is used only when `max_subagents=0`). An explicit `max_subagents` pin (auto-sizing disabled) is unchanged — any value 0(auto)..64 is accepted, so operators can still pin a lower fixed cap.

## Tests
- `test_subagent_sizing.py`: `TestAvailableMemoryClamp` pins `IS_LINUX`/`IS_MACOS` (renamed `test_non_linux_fails_open` → `test_linux_unreadable_fails_open`); added dispatch tests + `TestMacosMemoryProbe` (GB calc via the mockable `_macos_vm_reclaimable_pages` seam; Mach reader is macOS-only `# pragma: no cover`, validated live). Updated `test_hard_cap_below_floor_*` to assert the new hard floor of 3.
- `test_config_loader.py`: `test_subagent_auto_max_floored_to_min` (value 1 → clamped to 3).
- `test_api_server.py`: `test_put_rejects_subagent_auto_max_below_floor` (PUT auto_max=1 → 400).

## Manual verification
Live on Apple silicon (14 cores, 48 GB): the Mach probe returns real available memory matching `vm_stat` (14.51 vs 14.44 GB); `compute_max_subagents` yields 11 with the default ceiling and 3 for `subagent_auto_max ∈ {0,1,2,3}`; loader clamps auto_max 1→3, 2→3, 100→64, preserves `max_subagents=0`. Local: `test_subagent_sizing.py` + `TestSecurityBoundClamping` + `test_api_server.py` = 96 passed; flake8/isort clean.
