### PR TITLE
feat(update): macOS-style consent flow — update card, explicit download, robust checks

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -26,6 +26,7 @@
 const DEFAULT_FEED_BASE = "https://d28nxu9if70cmc.cloudfront.net/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
+const FORCE_EXIT_AFTER_MS = 5 * 1000; // failsafe: guarantee exit after quitAndInstall
 const FEED_TIMEOUT_MS = 15 * 1000;
 const FEED_MAX_BYTES = 64 * 1024;
 
@@ -184,6 +185,9 @@ function initAutoUpdate(deps) {
   }
 
   let updateReady = false;
+  let downloading = false; // Squirrel download/extract in flight
+  let stagedVersion = null; // version name Squirrel has downloaded + staged
+  let stagedNotes = "";
   let installing = false;
   let quitHandled = false;
 
@@ -196,14 +200,26 @@ function initAutoUpdate(deps) {
   }
 
   let checking = false;
+  let foundFeed = null; // last feed entry surfaced to the user, awaiting consent
   async function safeCheck() {
-    if (checking || updateReady) return;
+    // NOTE: no updateReady short-circuit here. A check ALWAYS consults the
+    // feed and reports state (macOS Software Update semantics) — the silent
+    // `return` this replaces made the Check-for-updates button a dead no-op
+    // once a download had been staged.
+    if (checking) return;
+    if (downloading) {
+      // Squirrel is mid-download/extract. Re-engaging checkForUpdates() now
+      // restarts its update flow and tears down the temp staging dir under
+      // the in-flight extraction (observed in the field as
+      // "ditto: Could not lstat .../update.XXXX/...: No such file or
+      // directory"). Report progress instead; update-downloaded/error will
+      // clear the flag and the next check proceeds normally.
+      log.info("[update] check requested while download in flight — reporting progress");
+      emit("downloading");
+      return;
+    }
     checking = true;
     try {
-      // CLIENT-SIDE version gate (see DEFAULT_FEED_BASE note): fetch the
-      // static feed and only hand off to Squirrel when the version differs.
-      // Squirrel would otherwise re-download on every check forever, since a
-      // static 200 feed always reads as "update available" to it.
       const url = configureFeed(); // re-read flavor/channel each check
       emit("checking");
       const feed = await fetchFeed(url);
@@ -212,17 +228,72 @@ function initAutoUpdate(deps) {
       }
       if (feed.version === app.getVersion()) {
         log.info(`[update] up to date (${feed.version})`);
+        foundFeed = null;
         emit("not-available");
         return;
       }
-      log.info(`[update] feed has ${feed.version} (running ${app.getVersion()}) — engaging Squirrel`);
-      autoUpdater.checkForUpdates();
+      if (updateReady && stagedVersion === feed.version) {
+        // Latest is already downloaded + staged: re-surface the install
+        // prompt instead of doing nothing (and instead of re-downloading).
+        log.info(`[update] ${stagedVersion} already downloaded — awaiting install`);
+        emit("downloaded", { version: stagedVersion, notes: stagedNotes });
+        return;
+      }
+      // CONSENT GATE (macOS Software Update semantics): discovery never
+      // downloads. Surface what was found — version, notes, publish date —
+      // and wait for an explicit download() before engaging Squirrel.
+      foundFeed = feed;
+      log.info(`[update] found ${feed.version} (running ${app.getVersion()}) — awaiting user consent`);
+      emit("found", {
+        version: feed.version,
+        notes: typeof feed.notes === "string" ? feed.notes : "",
+        pubDate: typeof feed.pub_date === "string" ? feed.pub_date : "",
+      });
     } catch (err) {
       log.error("[update] check failed", err);
       emit("error", { message: String(err && err.message || err) });
     } finally {
       checking = false;
     }
+  }
+
+  /**
+   * Explicit user consent: engage Squirrel to download (and stage) the
+   * version last surfaced by safeCheck. Never called automatically.
+   */
+  async function startDownload() {
+    if (downloading) { emit("downloading"); return; }
+    if (updateReady && foundFeed && stagedVersion === foundFeed.version) {
+      emit("downloaded", { version: stagedVersion, notes: stagedNotes });
+      return;
+    }
+    if (updateReady) {
+      // A previously staged bundle was superseded by a newer find: drop the
+      // stale stage so Squirrel re-downloads the newest instead of installing
+      // an already-old build.
+      log.info(`[update] staged ${stagedVersion} superseded — re-downloading`);
+      updateReady = false;
+      stagedVersion = null;
+      stagedNotes = "";
+    }
+    configureFeed();
+    log.info("[update] user consented — engaging Squirrel download");
+    downloading = true;
+    emit("downloading");
+    autoUpdater.checkForUpdates();
+  }
+
+  // ShipIt aborts the bundle swap with "App Still Running Error" (Code=-9)
+  // if ANY instance of the app is alive during its ~25s install window — and
+  // the user silently relaunches into the OLD version. If anything blocks the
+  // Electron quit (a renderer beforeunload, a lingering child holding the
+  // process open), force-exit so this instance is guaranteed gone.
+  function forceExitFailsafe(reason) {
+    const t = setTimeout(() => {
+      log.error(`[update] process still alive ${FORCE_EXIT_AFTER_MS}ms after quitAndInstall (${reason}) — forcing exit so ShipIt can swap`);
+      try { app.exit(0); } catch { process.exit(0); }
+    }, FORCE_EXIT_AFTER_MS);
+    if (typeof t.unref === "function") t.unref();
   }
 
   async function applyUpdateAndRestart() {
@@ -239,6 +310,7 @@ function initAutoUpdate(deps) {
     app.removeListener("before-quit", deferredInstallOnQuit);
     log.info("[update] gateway down — quitAndInstall");
     autoUpdater.quitAndInstall();
+    forceExitFailsafe("manual install");
   }
 
   // If the user chose "Later", install on the natural quit. before-quit can't
@@ -251,6 +323,7 @@ function initAutoUpdate(deps) {
       log.info("[update] deferred install on quit");
       try { await stopGateway(); } catch (err) { log.error("[update] stop on quit errored", err); }
       autoUpdater.quitAndInstall();
+      forceExitFailsafe("deferred install on quit");
     })();
   }
 
@@ -279,12 +352,15 @@ function initAutoUpdate(deps) {
     }
   }
 
-  autoUpdater.on("error", (err) => { log.error("[update] error", err); emit("error", { message: String(err && err.message || err) }); });
+  autoUpdater.on("error", (err) => { downloading = false; log.error("[update] error", err); emit("error", { message: String(err && err.message || err) }); });
   autoUpdater.on("checking-for-update", () => { log.info("[update] checking…"); emit("checking"); });
-  autoUpdater.on("update-not-available", () => { log.info("[update] up to date"); emit("not-available"); });
-  autoUpdater.on("update-available", () => { log.info("[update] available — downloading…"); emit("available"); });
+  autoUpdater.on("update-not-available", () => { downloading = false; log.info("[update] up to date"); emit("not-available"); });
+  autoUpdater.on("update-available", () => { downloading = true; log.info("[update] downloading…"); emit("downloading"); });
   autoUpdater.on("update-downloaded", (_e, notes, name) => {
     updateReady = true;
+    downloading = false;
+    stagedVersion = name || null;
+    stagedNotes = notes || "";
     log.info(`[update] downloaded ${name} — ${uiDriven ? "notifying UI" : "prompting"}`);
     emit("downloaded", { version: name || app.getVersion(), notes: notes || "" });
     if (uiDriven) {
@@ -303,9 +379,12 @@ function initAutoUpdate(deps) {
   if (typeof launchTimer.unref === "function") launchTimer.unref();
   if (typeof pollTimer.unref === "function") pollTimer.unref();
 
-  // Renderer-callable triggers (wired to ipcMain in main.js).
+  // Renderer-callable triggers (wired to ipcMain in main.js). Background
+  // timers only ever DISCOVER (safeCheck emits "found") — downloading
+  // requires the explicit download() consent call.
   return {
     check: () => safeCheck(),
+    download: () => startDownload(),
     install: () => applyUpdateAndRestart(),
     getInfo,
     isReady: () => updateReady,

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1524,6 +1524,7 @@ app.whenReady().then(async () => {
   // Renderer-callable bridges for Settings > About + the UpdateModal.
   ipcMain.handle("update:get-info", () => updater.getInfo());
   ipcMain.handle("update:check", () => { updater.check(); return { ok: true }; });
+  ipcMain.handle("update:download", () => { updater.download(); return { ok: true }; });
   ipcMain.handle("update:install", async () => { await updater.install(); return { ok: true }; });
 
   app.on("activate", () => {

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld("updateAPI", {
     return () => ipcRenderer.removeListener("update-state", handler);
   },
   check: () => ipcRenderer.invoke("update:check"),
+  download: () => ipcRenderer.invoke("update:download"),
   install: () => ipcRenderer.invoke("update:install"),
   getInfo: () => ipcRenderer.invoke("update:get-info"),
 });

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -111,19 +111,26 @@ test("same feed version does NOT engage Squirrel (loop guard)", () =>
     assert.ok(calls.states.includes("not-available"));
   }));
 
-test("different feed version engages Squirrel with the static feed URL", () =>
+test("newer feed version surfaces 'found' and does NOT download until consent", () =>
   withDarwin(async () => {
     const { deps, calls } = makeDeps({
       appVersion: "1.0.0",
-      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip" },
+      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip", notes: "Fixes things", pub_date: "2026-07-21T18:40:21Z" },
     });
     const u = initAutoUpdate(deps);
     await u.check();
     await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 1);
+    // Discovery only: no Squirrel engagement, card metadata surfaced.
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(calls.states.includes("found"));
     // Bare-semver running version resolves to the STABLE channel -- the
     // version-derived channel wins over the fixture's "beta" flavor.
     assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/stable/latest-mac.json"));
+    // Explicit consent engages Squirrel.
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+    assert.ok(calls.states.includes("downloading"));
   }));
 
 test("malformed feed surfaces error and does not engage Squirrel", () =>
@@ -162,7 +169,9 @@ test("stamped nightly build tracks the NIGHTLY feed, not stable (no channel migr
     await u.check();
     await new Promise((r) => setImmediate(r));
     assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/nightly/latest-mac.json"));
-    assert.strictEqual(calls.checkForUpdates, 1);
+    // Discovery never downloads (consent gate).
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(calls.states.includes("found"));
   }));
 
 test("fetchFeedHttps accepts plain http on loopback (local update harness)", async () => {
@@ -179,3 +188,123 @@ test("fetchFeedHttps accepts plain http on loopback (local update harness)", asy
     srv.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Manual re-check semantics (macOS Software Update style): a check must never
+// be a silent no-op. Regression for the dead Check-for-updates button (silent
+// `if (updateReady) return`) and the stale-staged-bundle install.
+// ---------------------------------------------------------------------------
+
+test("re-check with the staged version still latest RE-SURFACES the downloaded state (no dead button)", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260721061155",
+      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    // Simulate Squirrel having downloaded + staged the feed version.
+    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721082353");
+    calls.states.length = 0;
+    calls.checkForUpdates = 0;
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    // Must not silently no-op, must not re-download; must re-surface install.
+    assert.ok(calls.states.includes("checking"));
+    assert.ok(calls.states.includes("downloaded"));
+    assert.strictEqual(calls.checkForUpdates, 0);
+  }));
+
+test("stale staged bundle: check surfaces the newer version; consented download supersedes the stage", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260721042000",
+      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    // An OLDER version was staged earlier in the day.
+    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721061155");
+    calls.states.length = 0;
+    calls.checkForUpdates = 0;
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    // The check must NOT re-surface the stale stage as installable, and must
+    // not download on its own: it surfaces the newest version for consent.
+    assert.strictEqual(calls.checkForUpdates, 0);
+    assert.ok(!calls.states.includes("downloaded"));
+    assert.ok(calls.states.includes("found"));
+    // Consent: the stale stage is dropped and Squirrel re-downloads.
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+  }));
+
+test("re-check when already up to date reports not-available even with a stale updateReady flag", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260721082353",
+      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721082353");
+    calls.states.length = 0;
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.states.includes("not-available"));
+    assert.strictEqual(calls.checkForUpdates, 0);
+  }));
+
+test("install path arms a force-exit failsafe after quitAndInstall (ShipIt App-Still-Running guard)", () =>
+  withDarwin(async () => {
+    const { deps } = makeDeps({
+      appVersion: "1.0.0",
+      feed: { version: "2.0.0", url: "https://cdn.example.dev/desktop/stable/2.0.0/KiroCrew.zip" },
+    });
+    const events = [];
+    deps.app.exit = (code) => events.push(`exit:${code}`);
+    deps.autoUpdater.quitAndInstall = () => events.push("quitAndInstall");
+    // Capture the failsafe timer instead of waiting 5s of wall clock.
+    const realSetTimeout = global.setTimeout;
+    let failsafe = null;
+    global.setTimeout = (fn, ms, ...rest) => {
+      if (ms === 5000) { failsafe = fn; return { unref: () => {} }; }
+      return realSetTimeout(fn, ms, ...rest);
+    };
+    try {
+      const u = initAutoUpdate(deps);
+      await u.install();
+    } finally {
+      global.setTimeout = realSetTimeout;
+    }
+    assert.deepStrictEqual(events, ["quitAndInstall"]);
+    assert.ok(failsafe, "failsafe timer must be armed");
+    failsafe(); // simulate the app still being alive 5s later
+    assert.deepStrictEqual(events, ["quitAndInstall", "exit:0"]);
+  }));
+
+test("re-check while a download is in flight does NOT re-engage Squirrel (staging-dir race guard)", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260721082353",
+      feed: { version: "0.1.0-nightly.20260721182718", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    // Discovery, then explicit consent starts the download.
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+    handlers["update-available"]();
+    calls.states.length = 0;
+    // Impatient re-check AND re-click mid-download: must NOT restart
+    // Squirrel's flow (that rips the update.XXXX staging dir out from under
+    // ditto) -- both report progress instead.
+    await u.check();
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+    assert.ok(calls.states.includes("downloading"));
+    // Download completes -> flag clears -> ready to install.
+    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721182718");
+    assert.ok(calls.states.includes("downloaded"));
+  }));

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -10,9 +10,10 @@ import { api, ApiError } from '../../api/client'
 import { sanitize } from '../../api/helpers'
 
 type UpdateState = {
-  state: 'checking' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error'
+  state: 'checking' | 'found' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error'
   version?: string
   notes?: string
+  pubDate?: string
   channel?: string
   message?: string
 }
@@ -28,6 +29,8 @@ type UpdateInfo = {
 type UpdateAPI = {
   onState: (cb: (payload: UpdateState) => void) => (() => void)
   check: () => Promise<unknown>
+  download: () => Promise<unknown>
+  install: () => Promise<unknown>
   getInfo: () => Promise<UpdateInfo>
 }
 
@@ -90,25 +93,68 @@ export function AboutPanel() {
     mutationFn: () => desktopApi!.check(),
     onMutate: () => queryClient.setQueryData(['update-state'], null),
   })
+  // Explicit consent actions (macOS Software Update semantics): downloading
+  // and installing each happen only when the user clicks.
+  const downloadMutation = useMutation({ mutationFn: () => desktopApi!.download() })
+  const installMutation = useMutation({ mutationFn: () => desktopApi!.install() })
 
   const version = info?.version || gatewayVersion || '—'
   const channel = info?.channel
   const updatesDisabled = info?.disabled
   const checking = checkMutation.isPending || updateState?.state === 'checking'
 
-  // Desktop status line under the Check button.
+  // Desktop status line under the Check button (simple states only — the
+  // found/downloading/downloaded lifecycle renders as the update card below).
   let status: React.ReactNode = null
   if (checking) {
     status = <span className="text-muted flex items-center gap-1.5"><RefreshCw size={13} className="lucide-inline animate-spin" /> Checking for updates...</span>
   } else if (updateState?.state === 'not-available') {
     status = <span className="text-ok flex items-center gap-1.5"><CheckCircle2 size={13} className="lucide-inline" /> You are on the latest version.</span>
-  } else if (updateState?.state === 'available' || updateState?.state === 'downloading') {
-    status = <span className="text-accent flex items-center gap-1.5"><RefreshCw size={13} className="lucide-inline animate-spin" /> Update found — downloading...</span>
-  } else if (updateState?.state === 'downloaded') {
-    status = <span className="text-accent flex items-center gap-1.5"><CheckCircle2 size={13} className="lucide-inline" /> Update {updateState.version || ''} ready — see the install prompt.</span>
   } else if (updateState?.state === 'error') {
     status = <span className="text-danger flex items-center gap-1.5"><AlertCircle size={13} className="lucide-inline" /> Couldn't check for updates{updateState.message ? `: ${updateState.message}` : ''}.</span>
   }
+
+  // Update card: shown whenever an update is found / downloading / ready.
+  const cardState = updateState?.state
+  const showUpdateCard = !checking && (cardState === 'found' || cardState === 'available' || cardState === 'downloading' || cardState === 'downloaded')
+  const cardBusy = cardState === 'available' || cardState === 'downloading'
+  const cardReady = cardState === 'downloaded'
+  const cardPubDate = updateState?.pubDate ? new Date(updateState.pubDate) : null
+  const updateCard: React.ReactNode = showUpdateCard ? (
+    <div className="p-3 bg-bg rounded-lg border border-border flex flex-col gap-2" data-testid="update-card">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[13px] font-medium text-text flex items-center gap-1.5">
+            <ArrowUp size={13} className="lucide-inline text-accent" />
+            {botName || 'Kiro Crew'} {updateState?.version || 'update'}
+          </span>
+          <span className="text-[12px] text-muted">
+            {channel ? `${channel} channel` : 'update'}
+            {cardPubDate && !isNaN(cardPubDate.getTime()) ? ` · published ${cardPubDate.toLocaleString()}` : ''}
+          </span>
+        </div>
+        <div className="shrink-0">
+          {cardReady ? (
+            <Btn primary onClick={() => installMutation.mutate()} disabled={installMutation.isPending}>
+              <RefreshCw size={13} className={`lucide-inline ${installMutation.isPending ? 'animate-spin' : ''}`} /> Restart & Update
+            </Btn>
+          ) : (
+            <Btn primary onClick={() => downloadMutation.mutate()} disabled={cardBusy || downloadMutation.isPending}>
+              {cardBusy || downloadMutation.isPending
+                ? (<><RefreshCw size={13} className="lucide-inline animate-spin" /> Downloading...</>)
+                : (<><ArrowUp size={13} className="lucide-inline" /> Download & Install</>)}
+            </Btn>
+          )}
+        </div>
+      </div>
+      {cardReady && (
+        <span className="text-[12px] text-muted">Downloaded and verified. The app restarts to finish installing; you can also quit later and it installs on exit.</span>
+      )}
+      {updateState?.notes ? (
+        <div className="p-2.5 bg-card rounded-md border border-border max-h-40 overflow-y-auto text-[12px] text-text whitespace-pre-wrap">{updateState.notes}</div>
+      ) : null}
+    </div>
+  ) : null
 
   // --- Gateway (web dashboard) update flow ---
   // The gateway exposes /api/update/check + /api/update; used when not running
@@ -260,6 +306,7 @@ export function AboutPanel() {
                 </Btn>
               </div>
               {status && <div className="text-[13px]">{status}</div>}
+              {updateCard}
             </div>
           )
         ) : (


### PR DESCRIPTION
## What this is

Reworks the desktop update flow to macOS Software Update semantics (explicit user consent) and fixes four field-diagnosed failures.

## Consent flow (new UX)

- A check only DISCOVERS. `safeCheck` fetches the static feed and emits a new `found` state (version, notes, pub_date). Nothing downloads automatically — background polls included.
- Settings > About renders an **update card** for `found` / `downloading` / `downloaded`: version, channel, publish date, notes (when the feed carries them), and an explicit **Download & Install** button (`update:download` IPC -> `startDownload()` engages Squirrel). Once staged, the card flips to **Restart & Update**.
- `update-available` maps to the `downloading` UI state; UpdateModal still fires on `downloaded` only.

## Robustness fixes (field-diagnosed on live nightlies, ShipIt logs)

1. **Dead button** — `safeCheck()` silently returned once a download was staged. Checks now always consult the feed and report state; a staged build re-surfaces `downloaded`.
2. **Stale stage** — consented download supersedes an older staged bundle, so a user never installs an already-old build.
3. **Silent swap abort** — ShipIt cancels the swap (`App Still Running Error`, Code=-9) if any app instance is alive in its install window, relaunching the old version. A 5s force-exit failsafe after `quitAndInstall` (both install paths) guarantees the requesting instance is gone.
4. **Staging-dir race** — checks/clicks during an in-flight download report progress instead of re-engaging `checkForUpdates()` (field error: `ditto: Could not lstat .../update.XXXX/.../bin/2to3`; the published zip was verified intact via byte-exact `ditto -xk` repro).

## Tests

Electron suite green (consent-flow cases rewritten + race/failsafe regressions). Frontend: tsc clean, vite build OK, 3884 tests pass.

## Follow-ups (out of scope)

- Feed `notes` population in CI (card renders them when present)
- Optional auto-download preference toggle
- E2E OTA swap job in CI (artifact gate + feed contract discussed separately)