### PR TITLE
feat(worlds): true agent state, live thread popovers, and Kiro Haunt scene

### DIFF
--- a/website/src/hooks/sceneText.ts
+++ b/website/src/hooks/sceneText.ts
@@ -14,10 +14,10 @@ type TextRole = 'title' | 'name' | 'status' | 'detail' | 'label' | 'spell'
 const ROLE_SCALE: Record<TextRole, number> = {
   title: 1.1,
   spell: 0.85,
-  name: 0.65,
-  status: 0.55,
-  detail: 0.48,
-  label: 0.43,
+  name: 0.8,
+  status: 0.66,
+  detail: 0.58,
+  label: 0.5,
 }
 
 /** Get a font string for a given role and optional weight */
@@ -29,6 +29,45 @@ export function sceneFont(role: TextRole, weight: '' | 'bold' = ''): string {
 /** Get the computed font size for a role */
 export function sceneFontSize(role: TextRole): number {
   return BASE_SIZE * ROLE_SCALE[role]
+}
+
+/** Vertical advance between wrapped lines for a role, in canvas px */
+export function sceneLineHeight(role: TextRole): number {
+  return sceneFontSize(role) * 1.3
+}
+
+/** Word-wrap text to fit maxWidth using the current canvas font. Hard-breaks over-long words. */
+function wrapText(T: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  if (T.measureText(text).width <= maxWidth) return [text]
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let line = ''
+  const push = () => { if (line) { lines.push(line); line = '' } }
+  for (const word of words) {
+    const candidate = line ? line + ' ' + word : word
+    if (T.measureText(candidate).width <= maxWidth) {
+      line = candidate
+      continue
+    }
+    push()
+    if (T.measureText(word).width <= maxWidth) {
+      line = word
+      continue
+    }
+    // Hard-break a single word longer than the line
+    let chunk = ''
+    for (const ch of word) {
+      if (T.measureText(chunk + ch).width > maxWidth && chunk) {
+        lines.push(chunk)
+        chunk = ch
+      } else {
+        chunk += ch
+      }
+    }
+    line = chunk
+  }
+  push()
+  return lines.length ? lines : [text]
 }
 
 /**
@@ -51,6 +90,8 @@ export function initTextCanvas(canvas: HTMLCanvasElement, w: number, h: number, 
 /**
  * Draw text with an optional auto-sized background box.
  * Both background and text are drawn on the text canvas (T) for correct DPI alignment.
+ * When `maxWidth` (canvas px) is provided, text word-wraps into multiple lines.
+ * Returns the number of lines drawn so callers can offset content below.
  */
 export function drawLabel(
   T: CanvasRenderingContext2D,
@@ -65,28 +106,127 @@ export function drawLabel(
     padX?: number
     padY?: number
     scale: number
+    maxWidth?: number
   },
-) {
-  const { role, weight = '', color, bgColor, align = 'start', padX = 3, padY = 2, scale: S } = opts
+): number {
+  const { role, weight = '', color, bgColor, align = 'start', padX = 3, padY = 2, scale: S, maxWidth } = opts
   T.font = sceneFont(role, weight)
   T.fillStyle = color
   T.textAlign = align
   T.textBaseline = 'middle'
 
-  if (bgColor) {
-    const metrics = T.measureText(text)
-    const tw = metrics.width
-    const fontSize = sceneFontSize(role)
-    const bh = fontSize + padY * 2 * S
-    let bx = x
-    if (align === 'center') bx = x - tw / 2
-    else if (align === 'end') bx = x - tw
-    T.fillStyle = bgColor
-    T.fillRect(bx - padX * S, y - bh / 2, tw + padX * 2 * S, bh)
-    T.fillStyle = color
-  }
+  const lines = maxWidth ? wrapText(T, text, maxWidth) : [text]
+  const lineH = sceneLineHeight(role)
 
-  T.fillText(text, x, y)
+  lines.forEach((line, i) => {
+    const ly = y + i * lineH
+    if (bgColor) {
+      const tw = T.measureText(line).width
+      const fontSize = sceneFontSize(role)
+      const bh = fontSize + padY * 2 * S
+      let bx = x
+      if (align === 'center') bx = x - tw / 2
+      else if (align === 'end') bx = x - tw
+      T.fillStyle = bgColor
+      T.fillRect(bx - padX * S, ly - bh / 2, tw + padX * 2 * S, bh)
+      T.fillStyle = color
+    }
+    T.fillText(line, x, ly)
+  })
+
+  T.textAlign = 'start'
+  T.textBaseline = 'alphabetic'
+  return lines.length
+}
+
+/** How long a fresh message bubble stays visible, in ms */
+export const SPEECH_BUBBLE_MS = 7000
+
+/** Kiro ghost bitmap, 24×28 — traced from the reference art. Shared by the
+ *  Ghost scene sprite and the mini agent avatar in the thread popover. */
+export const KIRO_GHOST_PIXELS = [
+  '..........#######.......',
+  '.......#############....',
+  '......##############....',
+  '......###############...',
+  '.....#################..',
+  '....##################..',
+  '....###################.',
+  '....###################.',
+  '....####################',
+  '...#####################',
+  '...#####################',
+  '...#####################',
+  '...#####################',
+  '...#####################',
+  '..######################',
+  '..######################',
+  '.#######################',
+  '.######################.',
+  '#######################.',
+  '######################..',
+  '.#####################..',
+  '.###.#################..',
+  '....#################...',
+  '....#################...',
+  '....########.#######....',
+  '....#######..######.....',
+  '....#######...####......',
+  '......###...............',
+]
+
+/**
+ * Draw a speech bubble with wrapped text above an agent.
+ * (bx, by) is the bubble tail anchor in canvas px (the agent's head).
+ * Text is clamped to `maxLines` with an ellipsis on the last line.
+ */
+export function drawSpeechBubble(
+  T: CanvasRenderingContext2D,
+  text: string,
+  bx: number, by: number,
+  opts: { scale: number; maxWidth?: number; maxLines?: number; alpha?: number },
+) {
+  const { scale: S, maxWidth = 82 * S, maxLines = 3, alpha = 1 } = opts
+  const role = 'detail'
+  T.font = sceneFont(role)
+  const flat = text.replace(/\s+/g, ' ').trim()
+  if (!flat) return
+  let lines = wrapText(T, flat, maxWidth)
+  if (lines.length > maxLines) {
+    lines = lines.slice(0, maxLines)
+    lines[maxLines - 1] = lines[maxLines - 1].replace(/.{2}$/, '') + '…'
+  }
+  const lineH = sceneLineHeight(role)
+  const padX = 4 * S, padY = 3 * S
+  const widest = Math.max(...lines.map(l => T.measureText(l).width))
+  const bw = widest + padX * 2
+  const bh = lines.length * lineH + padY * 2
+  const left = bx - bw / 2
+  const top = by - bh - 6 * S
+
+  T.save()
+  T.globalAlpha = alpha
+  // Bubble body
+  T.fillStyle = 'rgba(255,255,255,0.94)'
+  T.beginPath()
+  const r = 4 * S
+  T.roundRect(left, top, bw, bh, r)
+  T.fill()
+  // Tail
+  T.beginPath()
+  T.moveTo(bx - 3 * S, top + bh)
+  T.lineTo(bx, top + bh + 5 * S)
+  T.lineTo(bx + 3 * S, top + bh)
+  T.closePath()
+  T.fill()
+  // Text
+  T.fillStyle = '#222'
+  T.textAlign = 'left'
+  T.textBaseline = 'middle'
+  lines.forEach((line, i) => {
+    T.fillText(line, left + padX, top + padY + lineH * i + lineH / 2)
+  })
+  T.restore()
   T.textAlign = 'start'
   T.textBaseline = 'alphabetic'
 }

--- a/website/src/hooks/useAgentSync.ts
+++ b/website/src/hooks/useAgentSync.ts
@@ -11,13 +11,19 @@ export interface AgentSource {
   kind: 'slot' | 'cron' | 'spawn'
   running: boolean
   detail: string
+  /** Real latest message preview for chat slots (empty for crons/spawns) */
+  lastMessage?: string
+  /** True when the session is waiting for user input */
+  waitingForInput?: boolean
+  /** Pending tool approval blocking the session, if any */
+  pendingApproval?: { tool: string; requestId: string } | null
 }
 
 const MAX_AGENTS = 8
 const CRON_POLL_MS = 5000
 const SPAWN_POLL_MS = 3000
 
-function shortName(s: string, max = 10): string {
+function shortName(s: string, max = 45): string {
   if (s.length <= max) return s
   return s.slice(0, max - 1) + '…'
 }
@@ -30,6 +36,11 @@ export function useAgentSync() {
     id: 'slot-' + sl.key, name: shortName(sl.title || sl.key),
     label: sl.agent || 'default', kind: 'slot' as const,
     running: sl.running, detail: sl.messages + ' msgs',
+    lastMessage: sl.last_message || '',
+    waitingForInput: !!sl.waiting_for_input,
+    pendingApproval: sl.pending_approval_info
+      ? { tool: sl.pending_approval_info.tool, requestId: sl.pending_approval_info.request_id }
+      : null,
   })), [slots])
 
   useEffect(() => {
@@ -57,7 +68,7 @@ export function useAgentSync() {
       try {
         const spawnData = await api.spawnList() as SubagentInfo[]
         spawnResult = spawnData.filter(s => !s.done).slice(0, 3).map(sp => ({
-          id: 'spawn-' + sp.id, name: shortName(sp.task, 8),
+          id: 'spawn-' + sp.id, name: shortName(sp.task, 45),
           label: 'spawn', kind: 'spawn' as const,
           running: !sp.done, detail: sp.done ? 'done' : 'running',
         }))

--- a/website/src/hooks/useSceneInteraction.tsx
+++ b/website/src/hooks/useSceneInteraction.tsx
@@ -1,12 +1,37 @@
-import React, { useState, useCallback, type RefObject } from 'react'
+import React, { useState, useCallback, useEffect, useRef, type RefObject } from 'react'
+import { Circle, Pause, MessageSquare, X, Check } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../store'
 import { switchSlot } from '../store/chatSlice'
+import { api } from '../api/client'
+import type { AgentSource } from './useAgentSync'
+import { KIRO_GHOST_PIXELS } from './sceneText'
 
 /** Minimal agent shape for hit-testing — all scene agent types satisfy this */
 export interface SceneAgent {
   id: string; name: string; x: number; y: number; running: boolean; detail: string
   kind: 'slot' | 'cron' | 'spawn'
+  /** Scene accent color for this agent, used by the popover mini avatar */
+  color?: string
+}
+
+/** Tiny pixel Kiro ghost used as the popover's agent identity marker */
+function MiniGhost({ color }: { color: string }) {
+  const ref = useRef<HTMLCanvasElement>(null)
+  useEffect(() => {
+    const cv = ref.current
+    const ctx = cv?.getContext('2d')
+    if (!cv || !ctx) return
+    ctx.clearRect(0, 0, 24, 28)
+    ctx.fillStyle = color
+    KIRO_GHOST_PIXELS.forEach((row, y) => {
+      for (let x = 0; x < row.length; x++) if (row[x] === '#') ctx.fillRect(x, y, 1, 1)
+    })
+    ctx.fillStyle = '#14141e'
+    ctx.fillRect(11, 8, 3, 4)
+    ctx.fillRect(17, 8, 3, 4)
+  }, [color])
+  return <canvas ref={ref} width={24} height={28} style={{ width: 18, height: 21, imageRendering: 'pixelated', flexShrink: 0 }} aria-hidden />
 }
 
 export interface SceneTooltipTheme {
@@ -18,14 +43,66 @@ interface TooltipState {
   x: number; y: number; agent: SceneAgent
 }
 
+interface ThreadMessage { role: string; content: string }
+
+interface ThreadViewState {
+  x: number; y: number; agent: SceneAgent
+  loading: boolean
+  messages: ThreadMessage[]
+  error: boolean
+}
+
+/** Derive the agent's true state line from its kind, running flag, and detail. */
+export function agentStatusLine(agent: SceneAgent): string {
+  const detail = agent.detail ? ` · ${agent.detail}` : ''
+  switch (agent.kind) {
+    case 'cron':
+      return agent.running ? `Cron · running` : `Cron${detail}`
+    case 'spawn':
+      return `Subagent${detail}`
+    default:
+      return (agent.running ? 'Working' : 'Idle') + detail
+  }
+}
+
+/** Truncate a message preview to a single tooltip-friendly line. */
+export function messagePreview(text: string, max = 64): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  if (flat.length <= max) return flat
+  return flat.slice(0, max - 1) + '…'
+}
+
+const THREAD_VIEW_MESSAGES = 8
+
+/** Streaming-bookkeeping roles the main chat filters out of history */
+const THREAD_SKIP_ROLES = new Set(['chunk', 'done'])
+
+/** Clean raw slot history for the mini thread: drop streaming roles and
+ *  collapse consecutive duplicates (a streamed chunk + its persisted final). */
+function cleanThread(msgs: ThreadMessage[]): ThreadMessage[] {
+  const out: ThreadMessage[] = []
+  for (const m of msgs) {
+    if (THREAD_SKIP_ROLES.has(m.role)) continue
+    const prev = out[out.length - 1]
+    if (prev && prev.role === m.role && prev.content === m.content) continue
+    out.push(m)
+  }
+  return out.slice(-THREAD_VIEW_MESSAGES)
+}
+
 /**
- * Shared click-to-chat + tooltip for all Worlds scenes.
+ * Shared tooltip + mini thread view for all Worlds scenes.
+ * Hover shows true state (+ real last message when sources are provided).
+ * Clicking a chat-slot agent opens a mini thread popover with recent messages
+ * and an "Open chat" action.
  * @param canvasRef - ref to the pixel canvas element
  * @param agentsRef - ref to the scene's agent array
  * @param W - scene width in logical pixels
  * @param H - scene height in logical pixels
  * @param theme - scene-specific tooltip messages
  * @param hitRadius - hit-test radius in logical pixels (default 10)
+ * @param extraLine - optional scene-specific tooltip line
+ * @param sources - live AgentSource list (enables last-message tooltip line)
  */
 export function useSceneInteraction(
   canvasRef: RefObject<HTMLCanvasElement | null>,
@@ -34,10 +111,15 @@ export function useSceneInteraction(
   theme: SceneTooltipTheme,
   hitRadius = 10,
   extraLine?: (agent: SceneAgent) => React.ReactNode,
+  sources?: AgentSource[],
 ) {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const [threadView, setThreadView] = useState<ThreadViewState | null>(null)
+  const sourcesRef = useRef<AgentSource[] | undefined>(sources)
+  sourcesRef.current = sources
+  const popoverRef = useRef<HTMLDivElement | null>(null)
 
   const getAgentAt = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const cv = canvasRef.current
@@ -61,25 +143,332 @@ export function useSceneInteraction(
 
   const onMouseLeave = useCallback(() => setTooltip(null), [])
 
+  const openChat = useCallback((agent: SceneAgent) => {
+    const slotKey = agent.id.replace(/^slot-/, '')
+    dispatch(switchSlot(slotKey))
+    navigate('/chat')
+  }, [dispatch, navigate])
+
   const onClick = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const a = getAgentAt(e)
-    if (a && a.kind === 'slot') {
-      const slotKey = a.id.replace(/^slot-/, '')
-      dispatch(switchSlot(slotKey))
-      navigate('/chat')
+    if (!a || a.kind !== 'slot') {
+      setThreadView(null)
+      return
     }
-  }, [getAgentAt, dispatch, navigate])
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    // Toggle off when clicking the same agent
+    if (threadView && threadView.agent.id === a.id) {
+      setThreadView(null)
+      return
+    }
+    const px = Math.min(e.clientX - rect.left + 12, rect.width - 280)
+    const py = Math.min(Math.max(e.clientY - rect.top - 60, 8), rect.height - 200)
+    setTooltip(null)
+    setThreadView({ x: Math.max(8, px), y: py, agent: a, loading: true, messages: [], error: false })
+    const slotKey = a.id.replace(/^slot-/, '')
+    api.chatSlotDetail(slotKey, THREAD_VIEW_MESSAGES * 3)
+      .then((d: { messages?: ThreadMessage[] }) => {
+        setThreadView(tv => tv && tv.agent.id === a.id
+          ? { ...tv, loading: false, messages: cleanThread(d.messages || []) }
+          : tv)
+      })
+      .catch(() => {
+        setThreadView(tv => tv && tv.agent.id === a.id ? { ...tv, loading: false, error: true } : tv)
+      })
+  }, [getAgentAt, canvasRef, threadView])
 
-  const tooltipEl = tooltip ? (
-    <div style={{ position: 'absolute', left: tooltip.x, top: tooltip.y, background: '#111', border: '1px solid #555', borderRadius: 4, padding: '4px 8px', fontSize: 11, color: '#ccc', pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 10 }}>
-      <div style={{ color: '#f90', fontWeight: 'bold' }}>{tooltip.agent.name}</div>
-      <div>{tooltip.agent.running ? `🟢 ${theme.active}` : `🟡 ${theme.idle}`}</div>
+  // Dismiss the thread view on outside click or Escape
+  useEffect(() => {
+    if (!threadView) return
+    const onPointerDown = (ev: PointerEvent) => {
+      const el = popoverRef.current
+      if (el && ev.target instanceof Node && !el.contains(ev.target) && ev.target !== canvasRef.current) {
+        setThreadView(null)
+      }
+    }
+    const onKey = (ev: KeyboardEvent) => { if (ev.key === 'Escape') setThreadView(null) }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [threadView, canvasRef])
+
+  // Live refresh: poll the thread while the popover is open so agent
+  // responses appear without reopening. Recently-sent messages that the
+  // server hasn't persisted yet are re-appended to avoid flicker.
+  const threadAgentId = threadView?.agent.id
+  const lastSentRef = useRef<{ slotKey: string; content: string; at: number } | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!threadAgentId || !threadAgentId.startsWith('slot-')) return
+    const slotKey = threadAgentId.replace(/^slot-/, '')
+    const refresh = () => {
+      api.chatSlotDetail(slotKey, THREAD_VIEW_MESSAGES * 3)
+        .then((d: { messages?: ThreadMessage[] }) => {
+          setThreadView(tv => {
+            if (!tv || tv.agent.id !== threadAgentId) return tv
+            let msgs = cleanThread(d.messages || [])
+            const sent = lastSentRef.current
+            if (sent && sent.slotKey === slotKey && Date.now() - sent.at < 8000 && !msgs.some(m => m.role === 'user' && m.content === sent.content)) {
+              msgs = [...msgs, { role: 'user', content: sent.content }].slice(-THREAD_VIEW_MESSAGES)
+            }
+            return { ...tv, loading: false, messages: msgs }
+          })
+        })
+        .catch(() => {})
+    }
+    const timer = setInterval(refresh, 2000)
+    return () => clearInterval(timer)
+  }, [threadAgentId])
+
+  // Keep the mini thread pinned to the newest message
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [threadView?.messages.length, threadView?.loading])
+
+  const sourceFor = (agent: SceneAgent): AgentSource | undefined =>
+    sourcesRef.current?.find(s => s.id === agent.id)
+
+  const [draft, setDraft] = useState('')
+  const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent' | 'failed'>('idle')
+  const [approvalState, setApprovalState] = useState<'idle' | 'resolving' | 'failed'>('idle')
+
+  // Reset composer state when the popover target changes
+  useEffect(() => {
+    setDraft(''); setSendState('idle'); setApprovalState('idle')
+  }, [threadView?.agent.id])
+
+  // Draggable popover: dragPos overrides the anchored position once the user
+  // grabs the header. Resets when the popover retargets.
+  const [dragPos, setDragPos] = useState<{ x: number; y: number } | null>(null)
+  useEffect(() => { setDragPos(null) }, [threadView?.agent.id])
+
+  const onHeaderPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!threadView) return
+    // Buttons in the header keep their click behavior
+    if (e.target instanceof Element && e.target.closest('button')) return
+    e.preventDefault()
+    const startX = e.clientX, startY = e.clientY
+    const base = dragPos ?? { x: threadView.x, y: threadView.y }
+    const parent = popoverRef.current?.offsetParent as HTMLElement | null
+    const bounds = parent ? { w: parent.clientWidth, h: parent.clientHeight } : null
+    const onMove = (ev: PointerEvent) => {
+      let nx = base.x + (ev.clientX - startX)
+      let ny = base.y + (ev.clientY - startY)
+      if (bounds) {
+        nx = Math.min(Math.max(nx, -180), bounds.w - 90)
+        ny = Math.min(Math.max(ny, 0), bounds.h - 40)
+      }
+      setDragPos({ x: nx, y: ny })
+    }
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }, [threadView, dragPos])
+
+  const sendToAgent = useCallback(async (agent: SceneAgent, text: string) => {
+    const msg = text.trim()
+    if (!msg) return
+    const slotKey = agent.id.replace(/^slot-/, '')
+    setSendState('sending')
+    try {
+      const src = sourceFor(agent)
+      if (src?.running) {
+        // Mid-turn: steer the running turn (backend queues if steer unavailable)
+        await api.steerChat(msg, slotKey)
+      } else {
+        // Idle or waiting for input: start/continue the turn.
+        // sendChat streams SSE — fire it and swallow the stream; the scene's
+        // live slot state reflects the turn via the normal WS updates.
+        await api.sendChat(msg, slotKey).then(r => { r.body?.cancel().catch(() => {}) })
+      }
+      setDraft('')
+      setSendState('sent')
+      setTimeout(() => setSendState('idle'), 1500)
+      lastSentRef.current = { slotKey, content: msg, at: Date.now() }
+      // Optimistically append to the mini thread
+      setThreadView(tv => tv && tv.agent.id === agent.id
+        ? { ...tv, messages: [...tv.messages, { role: 'user', content: msg }].slice(-THREAD_VIEW_MESSAGES) }
+        : tv)
+    } catch {
+      setSendState('failed')
+    }
+  }, [])
+
+  const resolvePendingApproval = useCallback(async (agent: SceneAgent, action: 'approve' | 'reject') => {
+    const src = sourceFor(agent)
+    if (!src?.pendingApproval) return
+    setApprovalState('resolving')
+    try {
+      await api.resolveApproval(src.pendingApproval.requestId, action)
+      setApprovalState('idle')
+    } catch {
+      setApprovalState('failed')
+    }
+  }, [])
+
+  const tooltipSource = tooltip ? sourceFor(tooltip.agent) : undefined
+
+  // In-world "New session" sign — creates a chat slot; the new agent enters
+  // the scene through the live slot state. Rendered only when sources are wired.
+  const [creating, setCreating] = useState(false)
+  const createSession = useCallback(async () => {
+    setCreating(true)
+    try {
+      await api.createChatSlot()
+    } catch { /* button re-enables; slot list unchanged */ }
+    setCreating(false)
+  }, [])
+  // Mirrors MAX_AGENTS in useAgentSync (kept local so tests can mock that module)
+  const WORLD_CAPACITY = 8
+  const worldFull = (sourcesRef.current?.length ?? 0) >= WORLD_CAPACITY
+  const spawnEl = sources ? (
+    <button
+      onClick={createSession}
+      disabled={creating || worldFull}
+      title={worldFull ? 'All slots are occupied' : 'Create a new chat session — a new agent joins this world'}
+      style={{
+        position: 'absolute', right: 10, bottom: 10, zIndex: 8,
+        background: 'rgba(10,10,20,0.72)', border: '1.5px solid var(--accent, #f90)',
+        borderRadius: 6, color: 'var(--accent, #f90)', fontSize: 11, fontWeight: 'bold',
+        padding: '4px 10px', cursor: worldFull ? 'default' : 'pointer',
+        opacity: creating || worldFull ? 0.45 : 0.9,
+        fontFamily: 'var(--font-body, inherit)',
+      }}
+    >
+      {creating ? 'summoning…' : '+ New session'}
+    </button>
+  ) : null
+
+  const tooltipEl = tooltip && !threadView ? (
+    <div style={{ position: 'absolute', left: tooltip.x, top: tooltip.y, background: '#111', border: '1px solid #555', borderRadius: 4, padding: '4px 8px', fontSize: 11, color: '#ccc', pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 10, maxWidth: 300 }}>
+      <div style={{ color: '#f90', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis' }}>{tooltip.agent.name}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}><Circle size={8} fill={tooltip.agent.running ? '#4f4' : '#ccc'} color={tooltip.agent.running ? '#4f4' : '#ccc'} aria-hidden /> {agentStatusLine(tooltip.agent)}</div>
+      {tooltipSource?.pendingApproval ? (
+        <div style={{ color: '#fb0', display: 'flex', alignItems: 'center', gap: 4 }}><Pause size={10} aria-hidden /> needs approval: {tooltipSource.pendingApproval.tool}</div>
+      ) : null}
+      {tooltipSource?.lastMessage ? (
+        <div style={{ color: '#aab', overflow: 'hidden', textOverflow: 'ellipsis', display: 'flex', alignItems: 'center', gap: 4 }}><MessageSquare size={10} style={{ flexShrink: 0 }} aria-hidden /> <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{messagePreview(tooltipSource.lastMessage)}</span></div>
+      ) : null}
+      <div style={{ color: '#777', fontStyle: 'italic' }}>{tooltip.agent.running ? theme.active : theme.idle}</div>
       {extraLine && extraLine(tooltip.agent)}
+      {tooltip.agent.kind === 'slot' ? (
+        <div style={{ color: '#666', marginTop: 2 }}>click for thread</div>
+      ) : null}
+    </div>
+  ) : null
+
+  const threadViewEl = threadView ? (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label={`Recent messages for ${threadView.agent.name}`}
+      style={{ position: 'absolute', left: (dragPos ?? threadView).x, top: (dragPos ?? threadView).y, width: 272, background: '#15151f', border: '1px solid #555', borderRadius: 6, fontSize: 11, color: '#ccc', zIndex: 20, boxShadow: '0 4px 16px rgba(0,0,0,0.5)', overflow: 'hidden' }}
+    >
+      <div
+        onPointerDown={onHeaderPointerDown}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 8px', borderBottom: '1px solid #333', cursor: 'grab', touchAction: 'none', userSelect: 'none' }}
+      >
+        <MiniGhost color={threadView.agent.color || '#e8ecf4'} />
+        <span style={{ color: '#f90', fontWeight: 'bold', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{threadView.agent.name}</span>
+        <button
+          onClick={() => openChat(threadView.agent)}
+          style={{ background: '#2a2a3a', border: '1px solid #555', borderRadius: 4, color: '#ddd', fontSize: 10, padding: '2px 8px', cursor: 'pointer' }}
+        >
+          Open chat
+        </button>
+        <button
+          onClick={() => setThreadView(null)}
+          aria-label="Close thread view"
+          style={{ background: 'transparent', border: 'none', color: '#888', fontSize: 12, cursor: 'pointer', padding: '0 2px', lineHeight: 1 }}
+        >
+          <X size={12} aria-hidden />
+        </button>
+      </div>
+      <div style={{ maxHeight: 180, overflowY: 'auto', padding: '6px 8px', display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {threadView.loading ? (
+          <div style={{ color: '#777', fontStyle: 'italic' }}>Loading thread…</div>
+        ) : threadView.error ? (
+          <div style={{ color: '#c66' }}>Couldn't load messages</div>
+        ) : threadView.messages.length === 0 ? (
+          <div style={{ color: '#777', fontStyle: 'italic' }}>No messages yet</div>
+        ) : (
+          threadView.messages.map((m, i) => (
+            <div key={i} style={{ display: 'flex', gap: 5, alignItems: 'baseline' }}>
+              <span style={{ color: m.role === 'user' ? '#f90' : '#7a8', flexShrink: 0, fontWeight: 'bold' }}>
+                {m.role === 'user' ? 'you' : 'kiro'}
+              </span>
+              <span style={{ color: '#bbb', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+                {messagePreview(m.content, 200)}
+              </span>
+            </div>
+          ))
+        )}
+        {sourceFor(threadView.agent)?.running ? (
+          <div style={{ color: '#7a8', fontStyle: 'italic' }}>kiro is working…</div>
+        ) : null}
+        <div ref={messagesEndRef} />
+      </div>
+      {(() => {
+        const src = sourceFor(threadView.agent)
+        return src?.pendingApproval ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 8px', borderTop: '1px solid #333', background: '#241d10' }}>
+            <span style={{ color: '#fb0', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Pause size={10} style={{ flexShrink: 0 }} aria-hidden /> Waiting on approval: {src.pendingApproval.tool}
+            </span>
+            <button
+              onClick={() => resolvePendingApproval(threadView.agent, 'approve')}
+              disabled={approvalState === 'resolving'}
+              style={{ background: '#1e4620', border: '1px solid #3a7a3d', borderRadius: 4, color: '#8f8', fontSize: 10, padding: '2px 8px', cursor: 'pointer' }}
+            >
+              Approve
+            </button>
+            <button
+              onClick={() => resolvePendingApproval(threadView.agent, 'reject')}
+              disabled={approvalState === 'resolving'}
+              style={{ background: '#46201e', border: '1px solid #7a3d3a', borderRadius: 4, color: '#f88', fontSize: 10, padding: '2px 8px', cursor: 'pointer' }}
+            >
+              Deny
+            </button>
+            {approvalState === 'failed' ? <span style={{ color: '#c66' }}>failed</span> : null}
+          </div>
+        ) : null
+      })()}
+      <div style={{ display: 'flex', gap: 6, padding: '6px 8px', borderTop: '1px solid #333' }}>
+        <input
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendToAgent(threadView.agent, draft) } }}
+          placeholder={sourceFor(threadView.agent)?.running ? 'Steer this agent…' : 'Message this agent…'}
+          aria-label={`Message ${threadView.agent.name}`}
+          style={{ flex: 1, background: '#0d0d15', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11, padding: '4px 7px', outline: 'none' }}
+        />
+        <button
+          onClick={() => sendToAgent(threadView.agent, draft)}
+          disabled={sendState === 'sending' || !draft.trim()}
+          aria-label={sendState === 'sending' ? 'Sending message' : sendState === 'sent' ? 'Message sent' : sendState === 'failed' ? 'Retry sending message' : 'Send message'}
+          style={{ background: '#2a2a3a', border: '1px solid #555', borderRadius: 4, color: sendState === 'failed' ? '#f88' : '#ddd', fontSize: 10, padding: '2px 9px', cursor: 'pointer', opacity: draft.trim() ? 1 : 0.5 }}
+        >
+          {sendState === 'sending' ? '…' : sendState === 'sent' ? <Check size={12} aria-hidden /> : sendState === 'failed' ? 'Retry' : 'Send'}
+        </button>
+      </div>
     </div>
   ) : null
 
   return {
     canvasProps: { onMouseMove, onMouseLeave, onClick, style: { cursor: tooltip?.agent.kind === 'slot' ? 'pointer' : 'default' } },
-    tooltipEl,
+    tooltipEl: (
+      <>
+        {tooltipEl}
+        {threadViewEl}
+        {spawnEl}
+      </>
+    ),
   }
 }

--- a/website/src/pages/scenes/GhostScene.tsx
+++ b/website/src/pages/scenes/GhostScene.tsx
@@ -1,0 +1,414 @@
+import { SCENE_SCALE } from './config'
+import { useEffect, useRef } from 'react'
+import type { AgentSource } from '../../hooks/useAgentSync'
+import { isKnownAgent, markAgentsKnown, pruneAgents } from '../../hooks/sceneStateCache'
+import { sceneFont, drawLabel, sceneLineHeight, drawSpeechBubble, SPEECH_BUBBLE_MS, KIRO_GHOST_PIXELS, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
+import { initSceneCanvases, runSceneLoop, useVisibleSync } from '../../hooks/sceneCanvas'
+import { useSceneInteraction, type SceneTooltipTheme } from '../../hooks/useSceneInteraction'
+
+const GHOST_THEME: SceneTooltipTheme = { active: 'Haunting the codebase', idle: 'Drifting through walls' }
+
+/* ── Types ── */
+interface Ghost {
+  id: string; name: string; kind: 'slot' | 'cron' | 'spawn'
+  x: number; y: number; tx: number; ty: number
+  running: boolean; color: string; detail: string
+  phase: number; blinkTimer: number; enterProgress: number
+  dir: number; outfit: Outfit
+  lastMessage: string; msgAt: number
+}
+interface Star { x: number; y: number; size: number; twinkle: number; speed: number }
+interface Wisp { x: number; y: number; drift: number; speed: number; alpha: number }
+interface ShootingStar { x: number; y: number; vx: number; vy: number; life: number; maxLife: number }
+interface Firefly { x: number; y: number; drift: number; speed: number; blink: number }
+
+/* ── Constants ── */
+const W = 440, H = 300, S = SCENE_SCALE
+// All ghosts stay classic Kiro white — hats, glasses, and capes differentiate them
+const GHOST_COLOR = '#e8ecf4'
+const EYE_COLOR = '#14141e'
+
+/* ── Accessories: each ghost gets a distinct look ── */
+type Hat = 'witch' | 'top' | 'party' | 'beanie' | 'crown' | 'none'
+type Glasses = 'round' | 'shades' | 'none'
+interface Outfit { hat: Hat; glasses: Glasses; cape: boolean; capeColor: string }
+const OUTFITS: Outfit[] = [
+  { hat: 'none', glasses: 'round', cape: false, capeColor: '' },
+  { hat: 'witch', glasses: 'none', cape: false, capeColor: '' },
+  { hat: 'none', glasses: 'none', cape: true, capeColor: '#c0392b' },
+  { hat: 'top', glasses: 'none', cape: false, capeColor: '' },
+  { hat: 'none', glasses: 'shades', cape: true, capeColor: '#27408b' },
+  { hat: 'beanie', glasses: 'none', cape: false, capeColor: '' },
+  { hat: 'party', glasses: 'round', cape: false, capeColor: '' },
+  { hat: 'crown', glasses: 'none', cape: true, capeColor: '#5b2c6f' },
+]
+
+/** Anchor positions for up to 8 ghosts — a loose two-row haunt */
+const GHOST_SPOTS = [
+  { x: 70, y: 120 }, { x: 170, y: 105 }, { x: 270, y: 125 }, { x: 360, y: 108 },
+  { x: 115, y: 205 }, { x: 220, y: 195 }, { x: 320, y: 210 }, { x: 400, y: 190 },
+]
+
+interface Props {
+  agents: AgentSource[]
+  visible?: boolean
+}
+
+export default function GhostScene({ agents, visible = true }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const textRef = useRef<HTMLCanvasElement>(null)
+  const tickRef = useRef(0)
+  const ghostsRef = useRef<Ghost[]>([])
+  const visibleRef = useRef(visible)
+  const starsRef = useRef<Star[]>([])
+  const wispsRef = useRef<Wisp[]>([])
+  const shootingRef = useRef<ShootingStar[]>([])
+  const firefliesRef = useRef<Firefly[]>([])
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, ghostsRef, W, H, GHOST_THEME, 14, undefined, agents)
+
+  /* ── Init background elements ── */
+  useEffect(() => {
+    const stars: Star[] = []
+    for (let i = 0; i < 70; i++) {
+      stars.push({
+        x: Math.random() * W, y: Math.random() * H * 0.55,
+        size: Math.random() < 0.2 ? 1.5 : 0.8,
+        twinkle: Math.random() * Math.PI * 2,
+        speed: 0.01 + Math.random() * 0.03,
+      })
+    }
+    starsRef.current = stars
+
+    const wisps: Wisp[] = []
+    for (let i = 0; i < 10; i++) {
+      wisps.push({
+        x: Math.random() * W, y: H * 0.6 + Math.random() * H * 0.35,
+        drift: Math.random() * Math.PI * 2,
+        speed: 0.004 + Math.random() * 0.008,
+        alpha: 0.04 + Math.random() * 0.06,
+      })
+    }
+    wispsRef.current = wisps
+
+    const fireflies: Firefly[] = []
+    for (let i = 0; i < 12; i++) {
+      fireflies.push({
+        x: Math.random() * W, y: H * 0.45 + Math.random() * H * 0.45,
+        drift: Math.random() * Math.PI * 2,
+        speed: 0.006 + Math.random() * 0.012,
+        blink: Math.random() * Math.PI * 2,
+      })
+    }
+    firefliesRef.current = fireflies
+  }, [])
+
+  /* ── Sync agents → ghosts ── */
+  useEffect(() => {
+    const existing = ghostsRef.current
+    const newGhosts: Ghost[] = []
+
+    agents.slice(0, GHOST_SPOTS.length).forEach((src, i) => {
+      const prev = existing.find(g => g.id === src.id)
+      const spot = GHOST_SPOTS[i]
+
+      if (prev) {
+        prev.name = src.name; prev.running = src.running; prev.detail = src.detail
+        prev.tx = spot.x; prev.ty = spot.y; prev.kind = src.kind
+        if ((src.lastMessage || '') !== prev.lastMessage) { prev.lastMessage = src.lastMessage || ''; prev.msgAt = Date.now() }
+        newGhosts.push(prev)
+      } else {
+        const known = isKnownAgent('ghost', src.id)
+        newGhosts.push({
+          id: src.id, name: src.name, kind: src.kind,
+          x: spot.x, y: known ? spot.y : H + 30,
+          tx: spot.x, ty: spot.y,
+          running: src.running, color: GHOST_COLOR,
+          detail: src.detail, phase: Math.random() * Math.PI * 2,
+          blinkTimer: 120 + Math.random() * 300,
+          enterProgress: known ? 1 : 0, dir: 1,
+          outfit: OUTFITS[i % OUTFITS.length],
+          lastMessage: src.lastMessage || '', msgAt: 0,
+        })
+        markAgentsKnown('ghost', [src.id])
+      }
+    })
+    ghostsRef.current = newGhosts
+    pruneAgents('ghost', newGhosts.map(g => g.id))
+  }, [agents])
+
+  /* ── Canvas render loop ── */
+  useEffect(() => {
+    const { X, T, d } = initSceneCanvases(canvasRef.current!, textRef.current!, W, H, S)
+
+    /** Kiro ghost bitmap, 24×28 — shared trace from the reference art (eye holes filled; eyes drawn as overlay) */
+    const GHOST_PIXELS = KIRO_GHOST_PIXELS
+
+    /** Draw one Kiro ghost, 24×28, anchored at top-left (gx, gy) */
+    const drawGhost = (gx: number, gy: number, color: string, g: Ghost, t: number) => {
+      const o = g.outfit
+      // Cape — drawn behind the body, fluttering with time
+      if (o.cape) {
+        const flutter = Math.sin(t * 0.08 + g.phase) * 1.5
+        const back = g.dir > 0 ? gx - 3 : gx + 23
+        d(back, gy + 6, 4, 14 + flutter, o.capeColor)
+        d(back + (g.dir > 0 ? -1 : 1), gy + 9, 2, 9 + flutter, o.capeColor)
+        // Collar over the shoulders
+        d(gx + 4, gy + 6, 17, 1.8, o.capeColor)
+      }
+      // Body from bitmap
+      X.fillStyle = color
+      GHOST_PIXELS.forEach((row, ry) => {
+        let run = -1
+        for (let cx = 0; cx <= row.length; cx++) {
+          const on = cx < row.length && row[cx] === '#'
+          if (on && run < 0) run = cx
+          else if (!on && run >= 0) {
+            X.fillRect((gx + run) * S, (gy + ry) * S, (cx - run) * S, 1 * S)
+            run = -1
+          }
+        }
+      })
+      // Eyes — tall rounded ovals right of center (traced from the reference); blink to 1px
+      const eyeShift = g.dir > 0 ? 0.5 : -0.5
+      const blinking = g.blinkTimer < 6
+      if (blinking) {
+        d(gx + 11 + eyeShift, gy + 9, 3, 1, EYE_COLOR)
+        d(gx + 17 + eyeShift, gy + 9, 3, 1, EYE_COLOR)
+      } else {
+        // Rounded: 1px-narrower top and bottom caps
+        d(gx + 11.5 + eyeShift, gy + 7, 2, 1, EYE_COLOR)
+        d(gx + 11 + eyeShift, gy + 8, 3, 3, EYE_COLOR)
+        d(gx + 11.5 + eyeShift, gy + 11, 2, 1, EYE_COLOR)
+        d(gx + 17.5 + eyeShift, gy + 7, 2, 1, EYE_COLOR)
+        d(gx + 17 + eyeShift, gy + 8, 3, 3, EYE_COLOR)
+        d(gx + 17.5 + eyeShift, gy + 11, 2, 1, EYE_COLOR)
+      }
+      // Glasses
+      if (o.glasses === 'round') {
+        d(gx + 10 + eyeShift, gy + 6.2, 5, 0.9, '#3a3a4a')
+        d(gx + 16 + eyeShift, gy + 6.2, 5, 0.9, '#3a3a4a')
+        d(gx + 10 + eyeShift, gy + 6.2, 0.9, 6.5, '#3a3a4a')
+        d(gx + 14.1 + eyeShift, gy + 6.2, 0.9, 6.5, '#3a3a4a')
+        d(gx + 20.1 + eyeShift, gy + 6.2, 0.9, 6.5, '#3a3a4a')
+        d(gx + 10 + eyeShift, gy + 11.8, 5, 0.9, '#3a3a4a')
+        d(gx + 16 + eyeShift, gy + 11.8, 5, 0.9, '#3a3a4a')
+        d(gx + 14.9 + eyeShift, gy + 7.5, 1.2, 0.9, '#3a3a4a')
+      } else if (o.glasses === 'shades') {
+        d(gx + 10 + eyeShift, gy + 6.8, 4.6, 4.4, '#111')
+        d(gx + 15.6 + eyeShift, gy + 6.8, 4.6, 4.4, '#111')
+        d(gx + 14.4 + eyeShift, gy + 7.4, 1.4, 1, '#111')
+        // Lens glint
+        d(gx + 10.8 + eyeShift, gy + 7.5, 1.2, 0.9, '#8fa8ff')
+        d(gx + 16.4 + eyeShift, gy + 7.5, 1.2, 0.9, '#8fa8ff')
+      }
+      // Hats — perched on the dome (apex ~cols 10-16)
+      if (o.hat === 'witch') {
+        d(gx + 6, gy - 1, 16, 1.8, '#2d1b4e')
+        d(gx + 10, gy - 4.5, 7, 3.5, '#2d1b4e')
+        d(gx + 11.8, gy - 7.5, 3.4, 3.4, '#2d1b4e')
+        d(gx + 10, gy - 2, 7, 1.1, '#8e44ad')
+      } else if (o.hat === 'top') {
+        d(gx + 7, gy - 1, 13, 1.4, '#181820')
+        d(gx + 9, gy - 7, 9, 6, '#181820')
+        d(gx + 9, gy - 2.2, 9, 1.2, '#b03a2e')
+      } else if (o.hat === 'party') {
+        d(gx + 11, gy - 2.4, 4.6, 2.4, '#f39c12')
+        d(gx + 12, gy - 4.8, 2.7, 2.4, '#e74c3c')
+        d(gx + 12.7, gy - 6.4, 1.2, 1.6, '#f1c40f')
+      } else if (o.hat === 'beanie') {
+        d(gx + 8, gy - 1.2, 11, 2.8, '#16a085')
+        d(gx + 8, gy + 0.6, 11, 1, '#0e6655')
+        d(gx + 12.7, gy - 2.8, 1.8, 1.8, '#f4d03f')
+      } else if (o.hat === 'crown') {
+        d(gx + 9.5, gy - 2.4, 7.5, 2.4, '#f1c40f')
+        d(gx + 9.5, gy - 4, 1.7, 1.9, '#f1c40f')
+        d(gx + 12.4, gy - 4, 1.7, 1.9, '#f1c40f')
+        d(gx + 15.3, gy - 4, 1.7, 1.9, '#f1c40f')
+        d(gx + 12.8, gy - 1.6, 1.1, 1.1, '#e74c3c')
+      }
+      // Blush when active
+      if (g.running && !blinking) {
+        X.globalAlpha = 0.35
+        d(gx + 8 + eyeShift, gy + 12.5, 2, 1.1, '#ff8899')
+        d(gx + 21 + eyeShift, gy + 12.5, 2, 1.1, '#ff8899')
+        X.globalAlpha = 1
+      }
+    }
+
+    const drawBackground = (t: number) => {
+      // Friendly twilight gradient — cozy, only sort of spooky
+      const grad = X.createLinearGradient(0, 0, 0, H * S)
+      grad.addColorStop(0, '#171232')
+      grad.addColorStop(0.6, '#251c48')
+      grad.addColorStop(1, '#332757')
+      X.fillStyle = grad
+      X.fillRect(0, 0, W * S, H * S)
+
+      // Stars
+      starsRef.current.forEach(star => {
+        const alpha = 0.25 + Math.sin(t * star.speed + star.twinkle) * 0.32
+        X.globalAlpha = Math.max(0.06, alpha)
+        X.fillStyle = '#dbe2f7'
+        X.fillRect(star.x * S, star.y * S, star.size * S, star.size * S)
+      })
+      X.globalAlpha = 1
+
+      // Shooting stars — spawn occasionally, streak across the sky
+      if (t % 140 === 0 && Math.random() < 0.5 && shootingRef.current.length < 3) {
+        const fromLeft = Math.random() < 0.5
+        shootingRef.current.push({
+          x: fromLeft ? -5 : W + 5, y: 10 + Math.random() * H * 0.35,
+          vx: (fromLeft ? 1 : -1) * (2.2 + Math.random() * 2),
+          vy: 0.4 + Math.random() * 0.9,
+          life: 0, maxLife: 45 + Math.random() * 30,
+        })
+      }
+      shootingRef.current.forEach(ss => {
+        ss.x += ss.vx; ss.y += ss.vy; ss.life++
+        const alpha = 1 - ss.life / ss.maxLife
+        for (let i = 0; i < 7; i++) {
+          const ta = alpha * (1 - i * 0.14)
+          X.fillStyle = `rgba(255,240,200,${Math.max(0, ta)})`
+          X.fillRect((ss.x - ss.vx * i * 0.6) * S, (ss.y - ss.vy * i * 0.6) * S, 2 * S, 1 * S)
+        }
+        X.fillStyle = `rgba(255,255,255,${alpha})`
+        X.fillRect(ss.x * S, ss.y * S, 2 * S, 2 * S)
+      })
+      shootingRef.current = shootingRef.current.filter(ss => ss.life < ss.maxLife)
+
+      // Moon with glow + craters
+      const mx = W - 62, my = 46
+      const glow = X.createRadialGradient(mx * S, my * S, 0, mx * S, my * S, 40 * S)
+      glow.addColorStop(0, 'rgba(240,238,220,0.16)')
+      glow.addColorStop(1, 'transparent')
+      X.fillStyle = glow
+      X.fillRect((mx - 40) * S, (my - 40) * S, 80 * S, 80 * S)
+      X.fillStyle = '#efe9d4'
+      X.beginPath(); X.arc(mx * S, my * S, 17 * S, 0, Math.PI * 2); X.fill()
+      X.fillStyle = '#ddd5bc'
+      X.beginPath(); X.arc((mx - 5) * S, (my - 4) * S, 3.4 * S, 0, Math.PI * 2); X.fill()
+      X.beginPath(); X.arc((mx + 6) * S, (my + 5) * S, 2.4 * S, 0, Math.PI * 2); X.fill()
+      X.beginPath(); X.arc((mx + 2) * S, (my - 8) * S, 1.6 * S, 0, Math.PI * 2); X.fill()
+
+      // Distant hills
+      X.fillStyle = '#1e1740'
+      X.beginPath()
+      X.moveTo(0, H * 0.82 * S)
+      X.quadraticCurveTo(W * 0.25 * S, H * 0.72 * S, W * 0.5 * S, H * 0.8 * S)
+      X.quadraticCurveTo(W * 0.75 * S, H * 0.88 * S, W * S, H * 0.78 * S)
+      X.lineTo(W * S, H * S); X.lineTo(0, H * S)
+      X.fill()
+
+      // Fireflies — warm blinking dots drifting near the ground
+      firefliesRef.current.forEach(ff => {
+        const fx = ff.x + Math.sin(t * ff.speed + ff.drift) * 18
+        const fy = ff.y + Math.cos(t * ff.speed * 0.8 + ff.drift) * 8
+        const glow = Math.max(0, Math.sin(t * 0.03 + ff.blink))
+        if (glow > 0.15) {
+          X.globalAlpha = glow * 0.8
+          X.fillStyle = '#ffe08a'
+          X.fillRect(fx * S, fy * S, 1.2 * S, 1.2 * S)
+          X.globalAlpha = glow * 0.25
+          X.fillRect((fx - 1) * S, (fy - 1) * S, 3.2 * S, 3.2 * S)
+        }
+      })
+      X.globalAlpha = 1
+
+      // Ground fog wisps
+      wispsRef.current.forEach(wp => {
+        const wx = wp.x + Math.sin(t * wp.speed + wp.drift) * 24
+        X.globalAlpha = wp.alpha + Math.sin(t * wp.speed * 1.4 + wp.drift) * 0.02
+        X.fillStyle = '#a9b4d8'
+        X.beginPath(); X.ellipse(wx * S, wp.y * S, 34 * S, 6 * S, 0, 0, Math.PI * 2); X.fill()
+      })
+      X.globalAlpha = 1
+
+      // Title
+      T.fillStyle = '#a89ee0'; T.font = sceneFont('title', 'bold')
+      T.fillText('Kiro Haunt', (W / 2 - 22) * S, 26 * S)
+      T.fillStyle = '#7a70ad'; T.font = sceneFont('detail')
+      T.fillText('friendly hauntings only', (W / 2 - 20) * S, 34 * S)
+    }
+
+    /* ── Update ── */
+    const update = (t: number) => {
+      ghostsRef.current.forEach(g => {
+        if (g.enterProgress < 1) g.enterProgress = Math.min(1, g.enterProgress + 0.02)
+        const ddx = g.tx - g.x, ddy = g.ty - g.y
+        if (Math.abs(ddx) > 0.5) { g.x += ddx * 0.04; g.dir = ddx > 0 ? 1 : -1 }
+        if (Math.abs(ddy) > 0.5) g.y += ddy * 0.04
+        g.blinkTimer -= 1
+        if (g.blinkTimer <= 0) g.blinkTimer = 140 + Math.random() * 320
+        void t
+      })
+    }
+
+    /* ── Main draw ── */
+    const draw = (t: number) => {
+      T.clearRect(0, 0, W * S, H * S)
+      drawBackground(t)
+
+      const sorted = [...ghostsRef.current].sort((a, b) => a.y - b.y)
+      sorted.forEach(g => {
+        const bobAmp = g.running ? 2.6 : 1.1
+        const bobSpeed = g.running ? 0.055 : 0.022
+        const bob = Math.sin(t * bobSpeed + g.phase) * bobAmp
+        const gx = g.x - 12
+        const gy = g.y - 14 + bob
+
+        X.globalAlpha = g.enterProgress * (g.running ? 1 : 0.72)
+
+        // Spectral glow under active ghosts
+        if (g.running) {
+          const glow = X.createRadialGradient(g.x * S, (g.y + bob) * S, 0, g.x * S, (g.y + bob) * S, 24 * S)
+          glow.addColorStop(0, g.color + '30')
+          glow.addColorStop(1, 'transparent')
+          X.fillStyle = glow
+          X.fillRect((g.x - 24) * S, (g.y + bob - 24) * S, 48 * S, 48 * S)
+        }
+
+        // Faint shadow on the ground
+        X.globalAlpha = g.enterProgress * 0.18
+        X.fillStyle = '#000'
+        X.beginPath(); X.ellipse(g.x * S, (g.y + 17) * S, (8.5 - bob * 0.6) * S, 2.2 * S, 0, 0, Math.PI * 2); X.fill()
+        X.globalAlpha = g.enterProgress * (g.running ? 1 : 0.72)
+
+        drawGhost(gx, gy, g.color, g, t)
+        X.globalAlpha = 1
+
+        // Status label above
+        drawLabel(T, g.running ? 'haunting' : 'idle', g.x * S, (gy - 11) * S, { role: 'status', color: g.running ? '#4f4' : '#888', bgColor: 'rgba(0,0,0,0.5)', align: 'center', scale: S })
+      // Real-message speech bubble — appears when the session's latest message changes
+      if (g.lastMessage && Date.now() - g.msgAt < SPEECH_BUBBLE_MS) {
+        const msgAge = Date.now() - g.msgAt
+        const msgAlpha = msgAge > SPEECH_BUBBLE_MS - 1000 ? (SPEECH_BUBBLE_MS - msgAge) / 1000 : 1
+        drawSpeechBubble(T, g.lastMessage, g.x * S, (gy - 15) * S, { scale: S, alpha: msgAlpha })
+      }
+
+
+        // Name (wraps up to ~45 chars) + detail below
+        const nameLines = drawLabel(T, g.name, g.x * S, (g.y + 21) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S, maxWidth: 64 * S })
+        if (g.detail) {
+          drawLabel(T, g.detail, g.x * S, (g.y + 26) * S + (nameLines - 1) * sceneLineHeight('name'), { role: 'detail', color: '#8f86c9', align: 'center', scale: S })
+        }
+      })
+
+      // Counter
+      T.fillStyle = '#4c4670'
+      T.font = sceneFont('label')
+      T.fillText(`kiro haunt · ${ghostsRef.current.length} ghosts`, 4 * S, (H - 4) * S)
+    }
+
+    return runSceneLoop(visibleRef, tickRef, update, draw)
+  }, [])
+
+  useVisibleSync(visibleRef, visible)
+
+  return (
+    <div style={SCENE_CONTAINER_STYLE(W, H)}>
+      <canvas ref={canvasRef} aria-label="Kiro ghost haunt animation" style={{ ...PIXEL_CANVAS_STYLE, ...canvasProps.style }} onMouseMove={canvasProps.onMouseMove} onMouseLeave={canvasProps.onMouseLeave} onClick={canvasProps.onClick} />
+      <canvas ref={textRef} aria-label="Kiro ghost haunt text overlay" style={TEXT_CANVAS_STYLE} />
+      {tooltipEl}
+    </div>
+  )
+}

--- a/website/src/pages/scenes/NeuralConstellationScene.tsx
+++ b/website/src/pages/scenes/NeuralConstellationScene.tsx
@@ -49,7 +49,7 @@ export default function NeuralConstellationScene({ agents, visible = true }: Pro
   const nebulaeRef = useRef<Nebula[]>([])
   const wavesRef = useRef<EnergyWave[]>([])
   const shootingRef = useRef<ShootingStar[]>([])
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, nodesRef, W, H, NEURAL_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, nodesRef, W, H, NEURAL_THEME, 10, undefined, agents)
 
   /* ── Init background elements ── */
   useEffect(() => {

--- a/website/src/pages/scenes/OfficeScene.tsx
+++ b/website/src/pages/scenes/OfficeScene.tsx
@@ -2,7 +2,7 @@ import { SCENE_SCALE } from './config'
 import { useEffect, useRef, useState } from 'react'
 import type { AgentSource } from '../../hooks/useAgentSync'
 import { isKnownAgent, markAgentsKnown, pruneAgents } from '../../hooks/sceneStateCache'
-import { sceneFont, drawLabel, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
+import { sceneFont, drawLabel, sceneLineHeight, drawSpeechBubble, SPEECH_BUBBLE_MS, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
 import { initSceneCanvases, runSceneLoop, useVisibleSync } from '../../hooks/sceneCanvas'
 import { useSceneInteraction, type SceneTooltipTheme } from '../../hooks/useSceneInteraction'
 
@@ -15,6 +15,7 @@ interface OfficeAgent {
   deskIdx: number; color: string; status: string; detail: string
   dir: number; activity: string; enterProgress: number
   running: boolean; actTimer: number
+  lastMessage: string; msgAt: number
 }
 interface Desk {
   x: number; y: number; occupied: boolean
@@ -95,7 +96,7 @@ export default function OfficeScene({ agents, visible = true }: { agents: AgentS
   const kanbanRef = useRef<string[]>([])
   const [_agentCount, setAgentCount] = useState(0)
   const visibleRef = useRef(visible)
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, agentsRef, W, H, OFFICE_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, agentsRef, W, H, OFFICE_THEME, 10, undefined, agents)
 
   useVisibleSync(visibleRef, visible)
 
@@ -115,6 +116,7 @@ export default function OfficeScene({ agents, visible = true }: { agents: AgentS
       if (prev) {
         prev.name = src.name; prev.detail = src.detail
         prev.running = src.running
+        if ((src.lastMessage || '') !== prev.lastMessage) { prev.lastMessage = src.lastMessage || ''; prev.msgAt = Date.now() }
         prev.status = src.running ? 'working' : 'idle'
         if (prev.deskIdx >= 0) desks[prev.deskIdx].occupied = true
         newAgents.push(prev)
@@ -134,6 +136,7 @@ export default function OfficeScene({ agents, visible = true }: { agents: AgentS
           detail: src.detail, dir: 1,
           activity: known ? 'desk' : 'entering',
           enterProgress: known ? 1 : 0, running: src.running, actTimer: 0,
+          lastMessage: src.lastMessage || '', msgAt: 0,
         })
         markAgentsKnown('office', [src.id])
       }
@@ -462,13 +465,20 @@ export default function OfficeScene({ agents, visible = true }: { agents: AgentS
 
       // Status label
       drawLabel(T, a.running ? 'active' : 'idle', (bx + 4) * S, (by - 10 + bob) * S, { role: 'status', color: a.running ? '#4f4' : '#888', bgColor: 'rgba(0,0,0,0.5)', align: 'center', scale: S })
+      // Real-message speech bubble — appears when the session's latest message changes
+      if (a.lastMessage && Date.now() - a.msgAt < SPEECH_BUBBLE_MS) {
+        const msgAge = Date.now() - a.msgAt
+        const msgAlpha = msgAge > SPEECH_BUBBLE_MS - 1000 ? (SPEECH_BUBBLE_MS - msgAge) / 1000 : 1
+        drawSpeechBubble(T, a.lastMessage, (bx + 4) * S, (by - 14 + bob) * S, { scale: S, alpha: msgAlpha })
+      }
 
-      // Name
-      drawLabel(T, a.name, (bx + 4) * S, (by + 14) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S })
+
+      // Name (wraps up to ~45 chars)
+      const nameLines = drawLabel(T, a.name, (bx + 4) * S, (by + 14) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S, maxWidth: 64 * S })
 
       // Detail
       if (a.detail) {
-        drawLabel(T, a.detail, (bx - 2) * S, (by + 18) * S, { role: 'detail', color: '#999', scale: S })
+        drawLabel(T, a.detail, (bx - 2) * S, (by + 18) * S + (nameLines - 1) * sceneLineHeight('name'), { role: 'detail', color: '#999', scale: S })
       }
 
       // Nameplate on cubicle

--- a/website/src/pages/scenes/PandaOfficeScene.tsx
+++ b/website/src/pages/scenes/PandaOfficeScene.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { AgentSource } from '../../hooks/useAgentSync'
 import { isKnownAgent, markAgentsKnown, pruneAgents } from '../../hooks/sceneStateCache'
-import { sceneFont, drawLabel, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
+import { sceneFont, drawLabel, sceneLineHeight, drawSpeechBubble, SPEECH_BUBBLE_MS, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
 import { initSceneCanvases, runSceneLoop, useVisibleSync } from '../../hooks/sceneCanvas'
 import { useSceneInteraction, type SceneTooltipTheme } from '../../hooks/useSceneInteraction'
 
@@ -18,6 +18,7 @@ interface OfficeAgent {
   deskIdx: number; color: string; detail: string
   dir: number; activity: AgentActivity
   running: boolean
+  lastMessage: string; msgAt: number
 }
 interface Desk {
   x: number; y: number; occupied: boolean
@@ -110,7 +111,7 @@ export default function PandaOfficeScene({ agents, visible = true }: { agents: A
   const kanbanRef = useRef<string[]>([])
   const [_agentCount, setAgentCount] = useState(0)
   const visibleRef = useRef(visible)
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, agentsRef, W, H, OFFICE_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, agentsRef, W, H, OFFICE_THEME, 10, undefined, agents)
 
   useVisibleSync(visibleRef, visible)
 
@@ -133,6 +134,7 @@ export default function PandaOfficeScene({ agents, visible = true }: { agents: A
       if (prev) {
         prev.name = src.name; prev.label = src.label; prev.detail = src.detail
         prev.running = src.running; prev.kind = src.kind
+        if ((src.lastMessage || '') !== prev.lastMessage) { prev.lastMessage = src.lastMessage || ''; prev.msgAt = Date.now() }
         if (prev.deskIdx >= 0) desks[prev.deskIdx].occupied = true
         newAgents.push(prev)
       } else {
@@ -154,6 +156,7 @@ export default function PandaOfficeScene({ agents, visible = true }: { agents: A
         detail: src.detail, dir: 1,
         activity: known ? 'desk' : 'entering',
         running: src.running,
+        lastMessage: src.lastMessage || '', msgAt: 0,
       })
       markAgentsKnown('panda-office', [src.id])
     })
@@ -546,13 +549,20 @@ export default function PandaOfficeScene({ agents, visible = true }: { agents: A
 
       // Status label
       drawLabel(T, a.running ? 'active' : 'idle', (bx + 4) * S, (by - 11 + bob) * S, { role: 'status', color: a.running ? '#4f4' : '#888', bgColor: 'rgba(0,0,0,0.5)', align: 'center', scale: S })
+      // Real-message speech bubble — appears when the session's latest message changes
+      if (a.lastMessage && Date.now() - a.msgAt < SPEECH_BUBBLE_MS) {
+        const msgAge = Date.now() - a.msgAt
+        const msgAlpha = msgAge > SPEECH_BUBBLE_MS - 1000 ? (SPEECH_BUBBLE_MS - msgAge) / 1000 : 1
+        drawSpeechBubble(T, a.lastMessage, (bx + 4) * S, (by - 15 + bob) * S, { scale: S, alpha: msgAlpha })
+      }
 
-      // Name
-      drawLabel(T, a.name, (bx + 4) * S, (by + 14) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S })
+
+      // Name (wraps up to ~45 chars)
+      const nameLines = drawLabel(T, a.name, (bx + 4) * S, (by + 14) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S, maxWidth: 64 * S })
 
       // Detail
       if (a.detail) {
-        drawLabel(T, a.detail, (bx - 2) * S, (by + 18) * S, { role: 'detail', color: '#999', scale: S })
+        drawLabel(T, a.detail, (bx - 2) * S, (by + 18) * S + (nameLines - 1) * sceneLineHeight('name'), { role: 'detail', color: '#999', scale: S })
       }
 
       // Nameplate on cubicle

--- a/website/src/pages/scenes/UnderwaterLabScene.tsx
+++ b/website/src/pages/scenes/UnderwaterLabScene.tsx
@@ -64,7 +64,7 @@ export default function UnderwaterLabScene({ agents, visible = true }: Props) {
   const jellyRef = useRef<Jelly[]>([])
   const sonarMsgRef = useRef('')
   const visibleRef = useRef(visible)
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, diversRef, W, H, UNDERWATER_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, diversRef, W, H, UNDERWATER_THEME, 10, undefined, agents)
 
   /* ── Init sea life ── */
   useEffect(() => {

--- a/website/src/pages/scenes/WateringHoleScene.tsx
+++ b/website/src/pages/scenes/WateringHoleScene.tsx
@@ -15,7 +15,7 @@ import { SCENE_SCALE } from './config'
 import { useEffect, useRef } from 'react'
 import type { AgentSource } from '../../hooks/useAgentSync'
 import { isKnownAgent, markAgentsKnown, pruneAgents } from '../../hooks/sceneStateCache'
-import { sceneFont, drawLabel, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
+import { sceneFont, drawLabel, sceneLineHeight, drawSpeechBubble, SPEECH_BUBBLE_MS, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
 import { initSceneCanvases, runSceneLoop, useVisibleSync } from '../../hooks/sceneCanvas'
 import { useSceneInteraction, type SceneTooltipTheme } from '../../hooks/useSceneInteraction'
 
@@ -37,6 +37,7 @@ interface Animal {
   homeX: number; homeY: number
   x: number; y: number; tx: number; ty: number
   running: boolean; detail: string
+  lastMessage: string; msgAt: number
   facing: 'right' | 'left'
   activity: Activity
   actTimer: number; actLimit: number
@@ -126,7 +127,7 @@ export default function WateringHoleScene({ agents, visible = true }: Props) {
   const animalsRef = useRef<Animal[]>([])
   const ripplesRef = useRef<{ x: number; y: number; r: number; life: number }[]>([])
   const visibleRef = useRef(visible)
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, animalsRef, W, H, SERENGETI_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, animalsRef, W, H, SERENGETI_THEME, 10, undefined, agents)
 
   /* ── Sync agents → animals ── */
   useEffect(() => {
@@ -142,6 +143,7 @@ export default function WateringHoleScene({ agents, visible = true }: Props) {
       if (!prev) return
       prev.name = src.name
       prev.detail = src.detail
+      if ((src.lastMessage || '') !== prev.lastMessage) { prev.lastMessage = src.lastMessage || ''; prev.msgAt = Date.now() }
       // If kind flipped (rare), just reset activity to idle so we don't get
       // an animal stuck mid-activity. Species stays fixed (hashed from id).
       if (prev.kind !== src.kind) {
@@ -176,6 +178,7 @@ export default function WateringHoleScene({ agents, visible = true }: Props) {
         y: known ? home.y : home.y,
         tx: home.x, ty: home.y,
         running: src.running, detail: src.detail,
+          lastMessage: src.lastMessage || '', msgAt: 0,
         facing: home.x < HOLE.cx ? 'right' : 'left',
         activity: 'idle',
         // A new agent that arrives already running should start wandering on
@@ -640,13 +643,20 @@ export default function WateringHoleScene({ agents, visible = true }: Props) {
         role: 'status', color: a.running ? '#7fbb3d' : '#aaa', align: 'center', scale: S,
       })
 
-      // Name + detail below the animal
+      // Real-message speech bubble — appears when the session's latest message changes
+      if (a.lastMessage && Date.now() - a.msgAt < SPEECH_BUBBLE_MS) {
+        const msgAge = Date.now() - a.msgAt
+        const msgAlpha = msgAge > SPEECH_BUBBLE_MS - 1000 ? (SPEECH_BUBBLE_MS - msgAge) / 1000 : 1
+        drawSpeechBubble(T, a.lastMessage, (a.x + 9) * S, (labelY - 4) * S, { scale: S, alpha: msgAlpha })
+      }
+
+      // Name + detail below the animal (name wraps up to ~45 chars)
       const nameY = a.y + 32
-      drawLabel(T, a.name, (a.x + 9) * S, nameY * S, {
-        role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S,
+      const nameLines = drawLabel(T, a.name, (a.x + 9) * S, nameY * S, {
+        role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S, maxWidth: 64 * S,
       })
       if (a.detail) {
-        drawLabel(T, a.detail, (a.x + 9) * S, (nameY + 6) * S, {
+        drawLabel(T, a.detail, (a.x + 9) * S, (nameY + 6) * S + (nameLines - 1) * sceneLineHeight('name'), {
           role: 'detail', color: '#dcd2b8', align: 'center', scale: S,
         })
       }

--- a/website/src/pages/scenes/WizardTowerScene.tsx
+++ b/website/src/pages/scenes/WizardTowerScene.tsx
@@ -2,7 +2,7 @@ import { SCENE_SCALE } from './config'
 import { useEffect, useRef } from 'react'
 import type { AgentSource } from '../../hooks/useAgentSync'
 import { isKnownAgent, markAgentsKnown, pruneAgents } from '../../hooks/sceneStateCache'
-import { sceneFont, drawLabel, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
+import { sceneFont, drawLabel, sceneLineHeight, drawSpeechBubble, SPEECH_BUBBLE_MS, TEXT_CANVAS_STYLE, SCENE_CONTAINER_STYLE, PIXEL_CANVAS_STYLE } from '../../hooks/sceneText'
 import { initSceneCanvases, runSceneLoop, useVisibleSync } from '../../hooks/sceneCanvas'
 import { useSceneInteraction, type SceneTooltipTheme } from '../../hooks/useSceneInteraction'
 
@@ -15,6 +15,7 @@ interface Wizard {
   benchIdx: number; color: string; robeColor: string
   running: boolean; detail: string
   hatBob: number; castTimer: number; activity: 'entering' | 'bench' | 'circle' | 'shelf'
+  lastMessage: string; msgAt: number
 }
 interface MagicParticle {
   x: number; y: number; vx: number; vy: number
@@ -66,7 +67,7 @@ export default function WizardTowerScene({ agents, visible = true }: Props) {
   const particlesRef = useRef<MagicParticle[]>([])
   const spellRef = useRef<{ text: string; x: number; y: number; life: number } | null>(null)
   const visibleRef = useRef(visible)
-  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, wizardsRef, W, H, WIZARD_THEME)
+  const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, wizardsRef, W, H, WIZARD_THEME, 10, undefined, agents)
 
   /* ── Sync agents → wizards ── */
   useEffect(() => {
@@ -77,6 +78,7 @@ export default function WizardTowerScene({ agents, visible = true }: Props) {
       const prev = existing.find(w => w.id === src.id)
       if (prev) {
         prev.name = src.name; prev.running = src.running; prev.detail = src.detail; prev.kind = src.kind
+        if ((src.lastMessage || '') !== prev.lastMessage) { prev.lastMessage = src.lastMessage || ''; prev.msgAt = Date.now() }
         newWizards.push(prev)
       } else {
         const benchIdx = BENCH_POSITIONS.findIndex((_, bi) => !existing.some(w => w.benchIdx === bi) && !newWizards.some(w => w.benchIdx === bi))
@@ -91,6 +93,7 @@ export default function WizardTowerScene({ agents, visible = true }: Props) {
           benchIdx, color: ROBE_COLORS[i % ROBE_COLORS.length],
           robeColor: HAT_COLORS[i % HAT_COLORS.length],
           running: src.running, detail: src.detail,
+          lastMessage: src.lastMessage || '', msgAt: 0,
           hatBob: Math.random() * Math.PI * 2, castTimer: 0,
           activity: known ? 'bench' : 'entering',
         })
@@ -404,13 +407,20 @@ export default function WizardTowerScene({ agents, visible = true }: Props) {
 
       // Status
       drawLabel(T, w.running ? 'casting' : 'resting', (bx + 4) * S, (by - 18 + bob) * S, { role: 'status', color: w.running ? '#4f4' : '#888', bgColor: 'rgba(0,0,0,0.5)', align: 'center', scale: S })
+      // Real-message speech bubble — appears when the session's latest message changes
+      if (w.lastMessage && Date.now() - w.msgAt < SPEECH_BUBBLE_MS) {
+        const msgAge = Date.now() - w.msgAt
+        const msgAlpha = msgAge > SPEECH_BUBBLE_MS - 1000 ? (SPEECH_BUBBLE_MS - msgAge) / 1000 : 1
+        drawSpeechBubble(T, w.lastMessage, (bx + 4) * S, (by - 22 + bob) * S, { scale: S, alpha: msgAlpha })
+      }
 
-      // Name
-      drawLabel(T, w.name, (bx + 4) * S, (by + 16) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S })
+
+      // Name (wraps up to ~45 chars)
+      const nameLines = drawLabel(T, w.name, (bx + 4) * S, (by + 16) * S, { role: 'name', weight: 'bold', color: '#fff', align: 'center', scale: S, maxWidth: 64 * S })
 
       // Detail
       if (w.detail) {
-        drawLabel(T, w.detail, (bx - 2) * S, (by + 20) * S, { role: 'detail', color: '#999', scale: S })
+        drawLabel(T, w.detail, (bx - 2) * S, (by + 20) * S + (nameLines - 1) * sceneLineHeight('name'), { role: 'detail', color: '#999', scale: S })
       }
     }
 

--- a/website/src/pages/scenes/components.ts
+++ b/website/src/pages/scenes/components.ts
@@ -7,9 +7,10 @@ import WizardTowerScene from './WizardTowerScene'
 import UnderwaterLabScene from './UnderwaterLabScene'
 import MissionControlScene from './mission-control/MissionControlScene'
 import WateringHoleScene from './WateringHoleScene'
+import GhostScene from './GhostScene'
 
 export const SCENE_COMPONENTS: Record<SceneKey, React.ComponentType<{ agents: AgentSource[]; visible?: boolean }>> = {
   office: OfficeScene, panda: PandaOfficeScene, neural: NeuralConstellationScene, wizard: WizardTowerScene,
   underwater: UnderwaterLabScene, mission: MissionControlScene,
-  serengeti: WateringHoleScene,
+  serengeti: WateringHoleScene, ghost: GhostScene,
 }

--- a/website/src/pages/scenes/config.tsx
+++ b/website/src/pages/scenes/config.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
-import { Building2, Brain, Wand2, Waves, Rocket, Sparkles, TreePine } from 'lucide-react'
+import { Building2, Brain, Wand2, Waves, Rocket, Sparkles, TreePine, Ghost } from 'lucide-react'
 
-export type SceneKey = 'office' | 'panda' | 'neural' | 'wizard' | 'underwater' | 'mission' | 'serengeti'
+export type SceneKey = 'office' | 'panda' | 'neural' | 'wizard' | 'underwater' | 'mission' | 'serengeti' | 'ghost'
 
 export interface SceneMeta {
   key: SceneKey
@@ -18,6 +18,7 @@ export const SCENES: SceneMeta[] = [
   { key: 'underwater', label: 'Deep Lab', icon: <Waves className="lucide-inline" />, desc: 'Underwater station' },
   { key: 'mission', label: 'Mission Control', icon: <Rocket className="lucide-inline" />, desc: 'NASA ops center' },
   { key: 'serengeti', label: 'Watering Hole', icon: <TreePine className="lucide-inline" />, desc: 'Serengeti savanna with giraffes, warthogs, and elephants' },
+  { key: 'ghost', label: 'Kiro Haunt', icon: <Ghost className="lucide-inline" />, desc: 'Kiro ghosts in hats, glasses, and capes' },
 ]
 
 export const SCENE_STORAGE_KEY = 'mc-agent-scene'

--- a/website/src/pages/scenes/mission-control/MissionControlScene.tsx
+++ b/website/src/pages/scenes/mission-control/MissionControlScene.tsx
@@ -19,7 +19,8 @@ export default function MissionControlScene({ agents, visible = true }: { agents
   const winUpdateRef = useRef(0)
   const [, setCount] = useState(0)
   const { canvasProps, tooltipEl } = useSceneInteraction(canvasRef, agentsRef, W, H, MC_THEME, 10,
-    (a) => { const { level, title } = getLevel(parseInt(a.detail || '0') || 0); return <div style={{ color: '#888' }}>Lv.{level} {title}</div> }
+    (a) => { const { level, title } = getLevel(parseInt(a.detail || '0') || 0); return <div style={{ color: '#888' }}>Lv.{level} {title}</div> },
+    agents,
   )
 
   useEffect(() => { visibleRef.current = visible }, [visible])

--- a/website/src/test/agentStatusLine.test.ts
+++ b/website/src/test/agentStatusLine.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { agentStatusLine, type SceneAgent } from '../hooks/useSceneInteraction'
+
+const base = { id: 'x', name: 'x', x: 0, y: 0 }
+
+function agent(kind: SceneAgent['kind'], running: boolean, detail: string): SceneAgent {
+  return { ...base, kind, running, detail }
+}
+
+describe('agentStatusLine', () => {
+  it('shows Working with detail for a running chat slot', () => {
+    expect(agentStatusLine(agent('slot', true, '12 msgs'))).toBe('Working · 12 msgs')
+  })
+
+  it('shows Idle with detail for an idle chat slot', () => {
+    expect(agentStatusLine(agent('slot', false, '3 msgs'))).toBe('Idle · 3 msgs')
+  })
+
+  it('omits the detail separator when detail is empty', () => {
+    expect(agentStatusLine(agent('slot', false, ''))).toBe('Idle')
+  })
+
+  it('shows the schedule for an idle cron', () => {
+    expect(agentStatusLine(agent('cron', false, 'every 15m'))).toBe('Cron · every 15m')
+  })
+
+  it('shows running for an active cron', () => {
+    expect(agentStatusLine(agent('cron', true, 'every 15m'))).toBe('Cron · running')
+  })
+
+  it('shows subagent state for spawns', () => {
+    expect(agentStatusLine(agent('spawn', true, 'running'))).toBe('Subagent · running')
+  })
+})


### PR DESCRIPTION
## Problem

Agent Worlds showed hardcoded flavor text ("Waiting for CR approval") on hover instead of an agent's real state, truncated session names at 10 characters ("New Sessi..."), and the scenes were view-only: no way to read a session's messages, reply, or unblock a stuck approval without leaving the page.

## Why it matters

The Worlds page is meant to be a live monitoring surface for running agents. When every idle agent claims to be "waiting for CR approval", the view actively misinforms. Making agents inspectable and steerable from the scene turns it from a screensaver into a usable control surface.

## Fix (symptoms -> root cause -> change)

- **False status text**: `useSceneInteraction.tsx` rendered only per-scene theme strings, ignoring the agent's `kind`/`running`/`detail`. Added `agentStatusLine()` showing true state (Working/Idle + msgs for slots, schedule for crons, status for subagents); flavor text demoted to a muted secondary line; idle indicator is a white circle.
- **Truncated names**: `shortName()` capped at 10 chars and canvas labels had no wrapping. Cap raised to 45; `drawLabel()` gained `maxWidth` word-wrap and returns the line count so detail rows shift below wrapped names; label font scales increased.
- **View-only scenes**: added a shared interactive layer in `useSceneInteraction` — hover tooltips include the session's real last message; clicking opens a draggable mini thread popover (last 8 messages, cleaned of `chunk`/`done` streaming roles with consecutive duplicates collapsed, 2s live refresh, auto-scroll) with a composer (steers running turns via `steerChat`, starts idle ones via `sendChat`), Approve/Deny wired to the approvals API for blocked sessions, a tinted mini Kiro ghost avatar for tracking while dragged, and an Open chat handoff. Real-message speech bubbles appear above agents for 7s when their latest message changes. An in-world "+ New session" sign creates a slot via the existing API.
- **New scene**: "Kiro Haunt" — white Kiro ghosts (24×28 bitmap traced from the logo art) differentiated by hats/glasses/capes, with blink/blush/glow, moon, stars, shooting stars, fireflies, and fog.

The optimistic-send merge is slot-scoped (prevents a sent message briefly appearing in another agent's popover), and the thread cleaner mirrors the main chat's `SKIP_ROLES` filtering (prevents doubled assistant messages from raw history).

## Tests

- New `agentStatusLine.test.ts`: 6 unit tests covering slot/cron/spawn state lines and empty-detail handling.
- All existing scene/worlds tests pass (44); full frontend suite 3877 pass, 3 skipped.
- tsc, ESLint (touched files), and production build clean.

## Manual verification

Verified on isolated test gateways across ~15 review rounds with the requester: tooltips show true state, names wrap, bubbles fire on new messages, popover chat send/steer works with live response refresh, Approve/Deny unblocks a pending approval, popover drags with bounds clamping, New session spawns an agent into the scene, and Kiro Haunt renders the traced ghost with outfits.

https://github.com/user-attachments/assets/21892628-7677-4f80-848d-d6c890911696

