### PR TITLE
fix(dashboard): actionable setup guidance when gh/glab is untrusted

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -242,11 +242,22 @@ def _resolve_provider_executable(executable: str) -> str:
         except ValueError:
             continue
     provider = "GitHub" if executable == "gh" else "GitLab"
+    managed_dir = os.path.dirname(_PROVIDER_EXECUTABLE_CANDIDATES[executable][0])
     raise SourceProviderError(
-        f"The {provider} CLI ({executable}) was not found in an agent-unwritable "
-        "system location. Install a root-owned, canonical copy whose entire path "
-        f"is not writable by the gateway user, authenticate it with `{executable} "
-        f"auth login`, or set {override_name} to that trusted absolute path."
+        f"The {provider} CLI ({executable}) could not be found in a location this "
+        f"panel trusts. This panel runs {executable} unattended with your "
+        f"{provider} credentials, so -- unlike chat or your terminal -- it only "
+        f"accepts a root-owned {executable} whose full path your user cannot write "
+        "(a Homebrew or otherwise user-owned copy is intentionally refused here, "
+        "even though it works elsewhere). If it is already installed, promote it "
+        "to a trusted location (needs sudo), then reload this panel:\n"
+        f"  sudo mkdir -p {managed_dir}\n"
+        f'  sudo cp "$(command -v {executable})" {managed_dir}/{executable}\n'
+        f"  sudo chown -R root {managed_dir}\n"
+        f"  sudo chmod 755 {managed_dir}/{executable}\n"
+        f"Your existing `{executable} auth login` credentials are reused "
+        f"automatically. Alternatively, set {override_name} to an already-trusted "
+        "absolute path."
     )
 
 

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -68,6 +68,32 @@ def test_provider_executable_ignores_workspace_path(monkeypatch, tmp_path) -> No
     assert str(malicious) not in seen
 
 
+def test_provider_executable_not_found_gives_setup_guidance(monkeypatch) -> None:
+    monkeypatch.delenv("KIROCREW_GH_BIN", raising=False)
+    monkeypatch.setattr(
+        source,
+        "_PROVIDER_EXECUTABLE_CANDIDATES",
+        {"gh": ("/usr/local/libexec/kirocrew/gh",), "glab": ("/usr/local/libexec/kirocrew/glab",)},
+    )
+
+    def reject(_candidate: str) -> str:
+        raise ValueError("path does not exist")
+
+    monkeypatch.setattr(source, "_validate_provider_executable", reject)
+
+    with pytest.raises(source.SourceProviderError) as excinfo:
+        source._resolve_provider_executable("gh")
+
+    message = str(excinfo.value)
+    # Names the managed target dir and gives copy/paste sudo setup steps.
+    assert "/usr/local/libexec/kirocrew" in message
+    assert 'sudo cp "$(command -v gh)" /usr/local/libexec/kirocrew/gh' in message
+    assert "sudo chown -R root /usr/local/libexec/kirocrew" in message
+    # Points at the override and reassures auth carries over.
+    assert "KIROCREW_GH_BIN" in message
+    assert "gh auth login" in message
+
+
 def test_provider_executable_rejects_relative_override(monkeypatch) -> None:
     monkeypatch.setenv("KIROCREW_GH_BIN", "workspace/bin/gh")
 


### PR DESCRIPTION
## Problem
Opening a PR/MR in the dashboard sidebar fails with a terse, non-actionable error when `gh`/`glab` is a Homebrew (user-owned) install:

```
{"error": "The GitHub CLI (gh) was not found in an agent-unwritable system location. Install a root-owned, canonical copy whose entire path is not writable by the gateway user, authenticate it with `gh auth login`, or set KIROCREW_GH_BIN to that trusted absolute path."}
```

Users are confused because the same `gh` works fine in chat and their terminal, so the message reads like `gh` is broken rather than "it's installed but not in a location this credential-handling panel trusts."

## Why it matters
The sidebar source-provider feature is the primary way to view PRs/MRs in the dashboard. A dead-end error with no concrete remediation blocks that workflow for the very common case of a Homebrew-installed `gh` (user-owned `/opt/homebrew`, symlinked into the Cellar), and invites the wrong fix (weakening the security check) instead of the right one (a trusted copy).

## Fix (symptom → root cause → change)
- Symptom: cryptic error; user can't tell what to do or why chat differs from the panel.
- Root cause: `_resolve_provider_executable` intentionally refuses any `gh`/`glab` that isn't a canonical, root-owned, non-writable executable (it runs unattended with the user's provider credentials, unlike an interactive shell). The error text described the *requirement* but gave no *setup steps* and didn't explain the chat-vs-panel asymmetry.
- Change: rewrite only the not-found error message to (1) explain why the panel is stricter than chat/terminal, (2) provide copy-pasteable `sudo` steps that promote the existing binary into the first managed candidate directory (derived from `_PROVIDER_EXECUTABLE_CANDIDATES`, so it stays correct for both `gh` and `glab`), (3) reassure that existing `gh auth login` credentials are reused, and (4) point at the `KIROCREW_GH_BIN` override.

No change to resolution, validation, sandboxing, or the trust boundary — this is purely the failure-path message. Security posture is unchanged.

## Tests
- `test_provider_executable_not_found_gives_setup_guidance` (new): asserts the not-found error names the managed target directory, includes the `sudo cp "$(command -v gh)" …` / `sudo chown -R root …` setup steps, references `KIROCREW_GH_BIN`, and mentions `gh auth login`. Locks the message in as actionable and credential-free.
- Full `test/test_source_providers.py` suite passes (106 passed), confirming no regression in resolution/validation behavior.

## Manual verification
On a Mac with a Homebrew `gh` (user-owned `/opt/homebrew/bin/gh` → Cellar symlink), opening a PR in the sidebar now returns the guided message with the exact promote-to-`/usr/local/libexec/kirocrew` commands; running those steps and reloading the panel resolves the error. (The sidebar still renders the raw `{"error": …}` JSON, so the `\n`-separated steps display on one line pending a separate frontend rendering improvement.)
