### PR TITLE
refactor(ci): consolidate nightly and release pipelines into reusable workflows

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,84 @@
+name: Build Desktop (reusable)
+
+# Reusable workflow: build the unsigned Electron desktop app for every
+# supported platform, stamped so app.getVersion() equals the update-feed
+# version (the auto-updater's client-side compare depends on this; a
+# mismatch means a permanent "update available" loop). Called by
+# nightly.yml and release.yml so the build recipe and the platform matrix
+# exist exactly once.
+#
+# Platform matrix (expand as support lands):
+#   - macOS arm64:  shipped (desktop app)
+#   - Linux x64:    shipped (AppImage)
+#   - Linux arm64:  TODO (Graviton, Raspberry Pi)
+#   - Windows x64:  TODO (blocked on kiro-cli Windows support)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Semver version to stamp (electron package.json + __init__.py)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-desktop:
+    name: Build Desktop (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            artifact-name: desktop-darwin-arm64
+          - os: ubuntu-22.04
+            artifact-name: desktop-linux-x64
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Stamp version
+        env:
+          STAMP_VERSION: ${{ inputs.version }}
+        run: |
+          # BSD-sed-compatible -i.bak form: this step runs on macos-14 too.
+          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${STAMP_VERSION}\"/" src/kiro_crew/__init__.py
+          rm -f src/kiro_crew/__init__.py.bak
+          # Stamp the Electron app: app.getVersion() (from the bundle's
+          # Info.plist, which electron-builder fills from package.json) must
+          # equal the feed version for the auto-updater's compare gate.
+          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+          echo "Building desktop: ${STAMP_VERSION}"
+
+      - name: Build desktop app
+        run: make desktop
+        env:
+          # Unsigned here by design: CDSigner signs the .app downstream in
+          # sign-and-notarize.yml. Local certificate discovery must stay off.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: |
+            website/electron/dist/*.dmg
+            website/electron/dist/*.zip
+            website/electron/dist/*.AppImage
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,75 @@
+name: Build Wheel (reusable)
+
+# Reusable workflow: build the kirocrew pip wheel + sdist with the frontend
+# staged in, stamped to an exact PEP 440 version. Called by nightly.yml and
+# release.yml so the build recipe exists exactly once -- the callers differ
+# only in how they derive the version (date stamp vs tag).
+#
+# Uploads artifact "cli-wheel" containing dist/* (wheel + sdist). The wheel
+# is what publish-cli.yml ships; the sdist rides along for GitHub Releases.
+
+on:
+  workflow_call:
+    inputs:
+      wheel_version:
+        description: "Exact PEP 440 version to stamp (pyproject.toml + __init__.py)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-wheel:
+    name: Build Wheel (CLI)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Stamp wheel version (PEP 440)
+        env:
+          WHEEL_VERSION: ${{ inputs.wheel_version }}
+        run: |
+          # The wheel version is sourced from pyproject.toml [project].version
+          # (static), NOT src/kiro_crew/__init__.py -- so stamp pyproject to make
+          # the built wheel carry the exact version. Keep __init__.py in sync for
+          # the runtime --version string.
+          sed -i -E "s/^version = \".*\"/version = \"${WHEEL_VERSION}\"/" pyproject.toml
+          sed -i "s/__version__ = \".*\"/__version__ = \"${WHEEL_VERSION}\"/" src/kiro_crew/__init__.py
+          echo "Building wheel: ${WHEEL_VERSION}"
+
+      - name: Build frontend
+        working-directory: website
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Stage frontend into package
+        run: |
+          rm -rf src/kiro_crew/static/dist
+          mkdir -p src/kiro_crew/static
+          cp -R website/dist src/kiro_crew/static/dist
+
+      - name: Build wheel + sdist
+        run: |
+          pip install --upgrade build
+          python -m build
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-wheel
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,12 +5,11 @@ on:
     - cron: "0 6 * * *" # 06:00 UTC = 11pm PDT
   workflow_dispatch: {} # manual trigger for testing
 
-# Platform matrix (expand as support lands):
-#   - macOS arm64:  ✅ shipped (desktop app)
-#   - Linux x64:    ✅ shipped (desktop app)
-#   - Linux arm64:  TODO (Graviton, Raspberry Pi)
-#   - Windows x64:  TODO (blocked on kiro-cli Windows support)
-#   - pip wheel:    ✅ shipped (CLI users on any platform)
+# All build/sign/notarize/publish logic lives in reusable workflows shared
+# with release.yml (build-wheel.yml, build-desktop.yml, publish-cli.yml,
+# sign-and-notarize.yml). This file owns only what is genuinely
+# nightly-specific: the trigger, the concurrency group, and the
+# date-stamped version derivation.
 
 permissions:
   contents: read
@@ -50,7 +49,7 @@ jobs:
           BASE=$(grep -m1 '__version__' src/kiro_crew/__init__.py | sed -E 's/.*= *"([^"]+)".*/\1/')
           # Desktop/Squirrel needs semver; the pip wheel needs PEP 440. Emit both:
           #   nightly_version (semver):  <base>-nightly.<date+HHMMSS> -> Electron app + S3 build path
-          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS>      -> pip wheel, unique per RUN (see below)
+          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS>      -> pip wheel, unique per RUN
           # The desktop stamp carries the same seconds precision as the wheel:
           # a date-only stamp meant two nightlies on one UTC date overwrote the
           # same signed/<channel>/<version>/ and notarized/<channel>/<version>/
@@ -65,230 +64,18 @@ jobs:
           echo "Wheel (PEP 440):  ${BASE}.dev${STAMP}"
 
   build-wheel:
-    name: Build Wheel (CLI)
+    name: Build Wheel
     needs: version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: website/package-lock.json
-
-      - name: Stamp wheel version (PEP 440)
-        run: |
-          # The wheel version is sourced from pyproject.toml [project].version
-          # (static), NOT src/kiro_crew/__init__.py — so stamp pyproject to make
-          # the built wheel uniquely versioned. Keep __init__.py in sync for the
-          # runtime --version string.
-          sed -i -E "s/^version = \".*\"/version = \"${{ needs.version.outputs.wheel_version }}\"/" pyproject.toml
-          sed -i "s/__version__ = \".*\"/__version__ = \"${{ needs.version.outputs.wheel_version }}\"/" src/kiro_crew/__init__.py
-
-      - name: Build frontend
-        working-directory: website
-        run: |
-          npm ci --no-audit --no-fund
-          npm run build
-
-      - name: Stage frontend into package
-        run: |
-          rm -rf src/kiro_crew/static/dist
-          mkdir -p src/kiro_crew/static
-          cp -R website/dist src/kiro_crew/static/dist
-
-      - name: Build wheel
-        run: |
-          pip install --upgrade build
-          python -m build --wheel
-
-      - name: Upload wheel
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: nightly-wheel
-          path: dist/*.whl
-          retention-days: 14
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      wheel_version: ${{ needs.version.outputs.wheel_version }}
 
   build-desktop:
-    name: Build Desktop (${{ matrix.os }})
+    name: Build Desktop
     needs: version
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-14
-            platform: darwin-arm64
-            artifact-name: nightly-macos-arm64
-          - os: ubuntu-22.04
-            platform: linux-x64
-            artifact-name: nightly-linux-x64
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: website/package-lock.json
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - name: Stamp nightly version
-        run: |
-          NIGHTLY="${{ needs.version.outputs.nightly_version }}"
-          echo "NIGHTLY_VERSION=${NIGHTLY}" >> "$GITHUB_ENV"
-          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${NIGHTLY}\"/" src/kiro_crew/__init__.py
-          rm -f src/kiro_crew/__init__.py.bak
-          # Stamp the Electron app too: app.getVersion() (from the bundle's
-          # Info.plist, which electron-builder fills from package.json) must
-          # equal the feed version, or the auto-updater's client-side compare
-          # would see a permanent mismatch and re-download the same build on
-          # every check.
-          export STAMP_VERSION="${NIGHTLY}"
-          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
-          echo "Building nightly: ${NIGHTLY}"
-
-      - name: Build desktop app
-        run: make desktop
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: |
-            website/electron/dist/*.dmg
-            website/electron/dist/*.zip
-            website/electron/dist/*.AppImage
-          if-no-files-found: error
-          retention-days: 14
-
-  publish:
-    name: Publish Nightly
-    needs: [version, build-wheel, build-desktop]
-    runs-on: ubuntu-latest
-    outputs:
-      signed_zip_key: ${{ steps.sign.outputs.signed_zip_key }}
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
-    env:
-      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
-      HAS_CDSIGNER: ${{ secrets.CDSIGNER_API_ENDPOINT != '' && 'true' || '' }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          sparse-checkout: packaging/signing
-
-      - name: Set version
-        run: echo "VERSION=${{ needs.version.outputs.nightly_version }}" >> "$GITHUB_ENV"
-
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          path: artifacts
-
-      - name: Flatten artifacts
-        run: |
-          mkdir -p release
-          find artifacts -type f \( -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.whl" \) -exec cp {} release/ \;
-          ls -la release/
-
-      - name: Attest build provenance
-        # Signed SLSA provenance for the nightly wheel + desktop artifacts
-        # (CWE-1104). Runs right after flatten, before anything leaves the runner.
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
-        with:
-          # Omit *.zip: the macOS zip is re-signed + notarized downstream, so a
-          # pre-notarization attestation would bind a digest that never ships.
-          # Omit *.dmg too: the electron-builder DMG wraps the unsigned app
-          # and never ships; the DMG that ships is rebuilt from the stapled
-          # app and attested inside notarize-macos.yml.
-          subject-path: |
-            release/*.whl
-            release/*.AppImage
-
-      # Install the CDSigner SigV4 client (awscurl) BEFORE AWS credentials are
-      # configured, so a compromised or version-drifted release can never observe
-      # the signing-role credentials at install time. Pinned for the same reason.
-      - name: Install awscurl (SigV4 client for CDSigner)
-        if: env.HAS_CDSIGNER
-        run: |
-          python3 -m pip install --user --quiet "awscurl==0.44"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Configure AWS credentials
-        if: env.HAS_SIGNING_SECRETS
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
-        with:
-          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
-          aws-region: us-west-2
-
-      - name: Upload unsigned artifacts to S3
-        if: env.HAS_SIGNING_SECRETS
-        run: |
-          CHANNEL="nightly"
-          for f in release/*; do
-            [ -f "$f" ] || continue
-            KEY="pre-signed/${CHANNEL}/${VERSION}/$(basename "$f")"
-            echo "Uploading $f → s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
-            aws s3 cp "$f" "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
-          done
-
-      # ── CDSigner: sign + notarize the macOS .app ──────────────────────────
-      # This step extracts the .app from the unsigned .zip, submits it to
-      # CDSigner, polls until signed, and outputs the signed .zip.
-      # Only runs when CDSIGNER_API_ENDPOINT is configured.
-
-      - name: Extract .app from zip for signing
-        if: env.HAS_CDSIGNER
-        run: |
-          mkdir -p unsigned-app
-          MAC_ZIP=$(find release -name "*arm64*.zip" | head -1)
-          if [ -n "$MAC_ZIP" ]; then
-            unzip -q "$MAC_ZIP" -d unsigned-app/
-            echo "APP_PATH=$(find unsigned-app -name '*.app' -maxdepth 1 | head -1)" >> "$GITHUB_ENV"
-          else
-            echo "No macOS zip found — skipping signing"
-            echo "APP_PATH=" >> "$GITHUB_ENV"
-          fi
-
-      - name: Sign with CDSigner
-        id: sign
-        if: env.HAS_CDSIGNER && env.APP_PATH != ''
-        env:
-          AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
-          AWS_SIGNER_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
-          CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
-        run: |
-          bash packaging/signing/sign.sh "$APP_PATH" nightly "$VERSION"
-          echo "SIGNED_ZIP=signed/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_ENV"
-          echo "signed_zip_key=signed/nightly/${VERSION}/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_OUTPUT"
-
-      # The update feed is written by the notarize job (notarize-macos.yml)
-      # AFTER stapling. Un-notarized artifacts must never appear in the feed --
-      # clients would auto-update to a build macOS Gatekeeper blocks.
-
-      - name: Summary
-        run: |
-          echo "## Nightly Build Published" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Signed:** ${{ env.HAS_CDSIGNER && env.APP_PATH != '' && 'Yes' || 'No (CDSigner not configured)' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Artifacts:**" >> "$GITHUB_STEP_SUMMARY"
-          ls release/ | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/build-desktop.yml
+    with:
+      version: ${{ needs.version.outputs.nightly_version }}
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the built wheel to the nightly CLI channel (cli/ + latest-cli.json).
@@ -305,21 +92,25 @@ jobs:
     with:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
-      wheel_artifact: nightly-wheel
+      wheel_artifact: cli-wheel
     secrets: inherit
 
-  notarize:
-    name: Notarize macOS
-    needs: [version, publish]
-    if: needs.publish.outputs.signed_zip_key != ''
+  # Caller job for the reusable sign-and-notarize workflow: a workflow_call
+  # callee can never exceed the caller job's permissions, so the caller must
+  # grant id-token explicitly. attestations:write covers both the sign job's
+  # wheel/sdist/AppImage provenance and the notarize job's shipping-DMG
+  # attestation (the DMG is rebuilt there from the stapled app; the build-job
+  # DMG never ships and is attested nowhere).
+  sign-and-notarize:
+    name: Sign + Notarize macOS
+    needs: [version, build-wheel, build-desktop]
     permissions:
       id-token: write
       contents: read
       attestations: write
-    uses: ./.github/workflows/notarize-macos.yml
+    uses: ./.github/workflows/sign-and-notarize.yml
     secrets: inherit
     with:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
-      signed_zip_key: ${{ needs.publish.outputs.signed_zip_key }}
       write_feed: true

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,8 +1,8 @@
 name: Publish CLI (reusable)
 
 # Reusable workflow: publish an already-built CLI wheel to a release channel.
-# Called by nightly.yml today (and by beta-cut.yml / promote-stable.yml once
-# those exist). See docs/RELEASE_AUTOMATION.md -> "CLI (Linux / EC2) Distribution".
+# Called by nightly.yml (channel: nightly) and release.yml (channel:
+# insider | stable). See docs/RELEASE_AUTOMATION.md -> "CLI (Linux / EC2) Distribution".
 #
 # Key properties:
 #   - CI-direct feed: writes feed/<channel>/latest-cli.json straight from CI.
@@ -15,7 +15,7 @@ on:
   workflow_call:
     inputs:
       channel:
-        description: "Release channel: nightly | beta | stable"
+        description: "Release channel: nightly | insider | stable"
         required: true
         type: string
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags: ["v*"]
 
+# All build/sign/notarize/publish logic lives in reusable workflows shared
+# with nightly.yml (build-wheel.yml, build-desktop.yml, publish-cli.yml,
+# sign-and-notarize.yml). This file owns only what is genuinely
+# release-specific: the tag trigger, the tag -> version/channel derivation,
+# and the GitHub Release job.
+
 # Serialize release runs: insider/stable feed writes are last-writer-wins;
 # two tags pushed close together must publish in order or the channel feed
 # can roll back to the older release (see nightly.yml for the full note).
@@ -15,241 +21,107 @@ permissions:
   contents: read
 
 jobs:
-  build-wheel:
-    name: Build Wheel
+  # Channel from the tag: pre-release tags (v1.2.3-insider.1, -rc.1, etc.)
+  # release on the insider channel; bare semver tags are stable.
+  version:
+    name: Derive Version + Channel
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: website/package-lock.json
-
-      - name: Build frontend
-        working-directory: website
-        run: |
-          npm ci --no-audit --no-fund
-          npm run build
-
-      - name: Stage frontend
-        run: |
-          rm -rf src/kiro_crew/static/dist
-          mkdir -p src/kiro_crew/static
-          cp -R website/dist src/kiro_crew/static/dist
-
-      - name: Build wheel + sdist
-        run: |
-          pip install --upgrade build
-          python -m build
-
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheel
-          path: dist/*
-
-  build-desktop:
-    name: Build Desktop (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-14
-            artifact-name: KiroCrew-macOS-arm64
-          - os: ubuntu-22.04
-            artifact-name: KiroCrew-Linux-x64
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: website/package-lock.json
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      # Stamp the Electron app with the tag-derived version so
-      # app.getVersion() equals the feed version (the auto-updater's
-      # client-side compare depends on this; a mismatch means a permanent
-      # "update available" loop). Same derivation as the release job:
-      # v1.2.3-insider.1 -> 1.2.3-insider.1.
-      - name: Stamp release version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          export STAMP_VERSION="${VERSION}"
-          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
-          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" src/kiro_crew/__init__.py
-          rm -f src/kiro_crew/__init__.py.bak
-          echo "Building release: ${VERSION}"
-
-      - name: Build desktop app (PBS + uv venv)
-        run: make desktop
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: |
-            website/electron/dist/*.dmg
-            website/electron/dist/*.zip
-            website/electron/dist/*.AppImage
-          if-no-files-found: warn
-
-  release:
-    name: Sign for Release
-    needs: [build-wheel, build-desktop]
-    runs-on: ubuntu-latest
-    # Tag pushes present OIDC subject ref:refs/tags/<tag>, which the signing
-    # role does NOT trust. Declaring the prod environment switches the subject
-    # to environment:prod, which the trust policy accepts. The environment is
-    # gated by ref restrictions (main + v* tags only) and the
-    # release-tags-admin-only ruleset (v* tag creation is admin-only); see
-    # notarize-macos.yml for the full rationale.
-    environment: prod
     outputs:
       version: ${{ steps.channel.outputs.version }}
       channel: ${{ steps.channel.outputs.channel }}
-      signed_zip_key: ${{ steps.sign.outputs.signed_zip_key }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    env:
-      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
-      HAS_CDSIGNER: ${{ secrets.CDSIGNER_API_ENDPOINT != '' && 'true' || '' }}
+      wheel_version: ${{ steps.channel.outputs.wheel_version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          sparse-checkout: packaging/signing
-
-      # Channel from the tag: pre-release tags (v1.2.3-insider.1, -rc.1, etc.)
-      # release on the insider channel; bare semver tags are stable.
       - name: Derive version + channel from tag
         id: channel
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           case "$VERSION" in
-            *-*) CHANNEL="insider" ;;
-            *)   CHANNEL="stable" ;;
+            *-*)
+              CHANNEL="insider"
+              # The pip wheel needs a valid PEP 440 version; semver prerelease
+              # labels ("-insider.4", "-rc.2") are not one, and setuptools
+              # would silently normalize an invalid stamp down to the base
+              # version -- making two insider releases collide on the same
+              # immutable cli/<channel>/<version>/ key. Map any prerelease to
+              # rcN using its trailing number: 1.2.3-insider.4 -> 1.2.3rc4.
+              # (Corollary: do not tag both v1.2.3-insider.N and v1.2.3-rc.N
+              # -- they map to the same wheel version, and publish-cli's
+              # conditional write would fail the second as a republish.)
+              BASE="${VERSION%%-*}"
+              PRE="${VERSION#*-}"
+              N="${PRE##*.}"
+              case "$N" in
+                ''|*[!0-9]*) N=0 ;;
+              esac
+              WHEEL_VERSION="${BASE}rc${N}"
+              ;;
+            *)
+              CHANNEL="stable"
+              WHEEL_VERSION="$VERSION"
+              ;;
           esac
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          echo "CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
-          echo "Releasing $VERSION on channel $CHANNEL"
+          echo "wheel_version=$WHEEL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION on channel $CHANNEL (wheel: $WHEEL_VERSION)"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          path: artifacts
+  build-wheel:
+    name: Build Wheel
+    needs: version
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      wheel_version: ${{ needs.version.outputs.wheel_version }}
 
-      - name: Flatten artifacts
-        run: |
-          mkdir -p release
-          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" \) -exec cp {} release/ \;
-          ls -la release/
+  build-desktop:
+    name: Build Desktop
+    needs: version
+    uses: ./.github/workflows/build-desktop.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
 
-      - name: Attest build provenance
-        # Signed SLSA build-provenance for the built artifacts
-        # (wheel/sdist/AppImage) — CWE-1104 / P475357136. Placed in the
-        # `release` job because it already holds id-token (OIDC); per the
-        # least-privilege split enforced by test_workflow_permissions.py the
-        # id-token job must never also hold contents:write (that lives only in
-        # the separate github-release job). The macOS .zip is attested here in
-        # its pre-notarized form (notarize/staple runs in a later job); the
-        # wheel/sdist/AppImage digests are identical to what is published.
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
-        with:
-          # Attest only artifacts whose bytes are final here. The macOS .zip is
-          # re-signed + notarized in a later job, so attesting it pre-notarization
-          # binds a digest that never ships (Codex review). Omit *.zip. Same for
-          # *.dmg: the electron-builder DMG wraps the unsigned app and never
-          # ships; the shipping DMG is rebuilt from the stapled app and attested
-          # inside notarize-macos.yml.
-          subject-path: |
-            release/*.whl
-            release/*.tar.gz
-            release/*.AppImage
+  # ── CLI channel publish ───────────────────────────────────────────────
+  # Publishes the release wheel to the insider/stable CLI channel (cli/ +
+  # latest-cli.json + PEP 503 index) -- previously release wheels only
+  # reached GitHub Releases, so pip/cli.sh users could never track insider
+  # or stable. Depends only on the wheel (not build-desktop or CDSigner),
+  # so a macOS signing failure never blocks the CLI release.
+  publish-cli:
+    name: Publish CLI (${{ needs.version.outputs.channel }} channel)
+    needs: [version, build-wheel]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-cli.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.version }}
+      wheel_artifact: cli-wheel
+    secrets: inherit
 
-      # Install the CDSigner SigV4 client BEFORE AWS credentials are configured
-      # (same supply-chain ordering as nightly.yml).
-      - name: Install awscurl (SigV4 client for CDSigner)
-        if: env.HAS_CDSIGNER
-        run: |
-          python3 -m pip install --user --quiet "awscurl==0.44"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Configure AWS credentials
-        if: env.HAS_SIGNING_SECRETS
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
-        with:
-          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
-          aws-region: us-west-2
-
-      - name: Upload unsigned artifacts to S3
-        if: env.HAS_SIGNING_SECRETS
-        run: |
-          for f in release/*; do
-            [ -f "$f" ] || continue
-            KEY="pre-signed/${CHANNEL}/${VERSION}/$(basename "$f")"
-            echo "Uploading $f → s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
-            aws s3 cp "$f" "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
-          done
-
-      - name: Extract .app from zip for signing
-        if: env.HAS_CDSIGNER
-        run: |
-          mkdir -p unsigned-app
-          MAC_ZIP=$(find release -name "*arm64*.zip" | head -1)
-          if [ -n "$MAC_ZIP" ]; then
-            unzip -q "$MAC_ZIP" -d unsigned-app/
-            echo "APP_PATH=$(find unsigned-app -name '*.app' -maxdepth 1 | head -1)" >> "$GITHUB_ENV"
-          else
-            echo "No macOS zip found — skipping signing"
-            echo "APP_PATH=" >> "$GITHUB_ENV"
-          fi
-
-      - name: Sign with CDSigner
-        id: sign
-        if: env.HAS_CDSIGNER && env.APP_PATH != ''
-        env:
-          AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
-          AWS_SIGNER_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
-          CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
-        run: |
-          bash packaging/signing/sign.sh "$APP_PATH" "$CHANNEL" "$VERSION"
-          echo "signed_zip_key=signed/${CHANNEL}/${VERSION}/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_OUTPUT"
-
-  notarize:
-    name: Notarize macOS
-    needs: [release]
-    if: needs.release.outputs.signed_zip_key != ''
+  # Caller job for the reusable sign-and-notarize workflow: a workflow_call
+  # callee can never exceed the caller job's permissions, so the caller must
+  # grant id-token explicitly. The signing job holds AWS creds (id-token)
+  # but never contents:write -- that lives only in the separate
+  # github-release job below (least-privilege split enforced by
+  # test_workflow_permissions.py).
+  sign-and-notarize:
+    name: Sign + Notarize macOS
+    needs: [version, build-wheel, build-desktop]
     permissions:
       id-token: write
       contents: read
       attestations: write
-    uses: ./.github/workflows/notarize-macos.yml
+    uses: ./.github/workflows/sign-and-notarize.yml
     secrets: inherit
     with:
-      channel: ${{ needs.release.outputs.channel }}
-      version: ${{ needs.release.outputs.version }}
-      signed_zip_key: ${{ needs.release.outputs.signed_zip_key }}
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.version }}
       write_feed: true
 
   github-release:
     name: Create GitHub Release
-    needs: [release, notarize]
+    needs: [version, sign-and-notarize]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -268,13 +140,13 @@ jobs:
           find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" \) -exec cp {} release/ \;
           NOTARIZED=$(find artifacts -path "*KiroCrew-notarized-*" -name "notarized.zip" | head -1)
           if [ -n "$NOTARIZED" ]; then
-            cp "$NOTARIZED" "release/KiroCrew-${{ needs.release.outputs.version }}-arm64-mac.zip"
+            cp "$NOTARIZED" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64-mac.zip"
           else
             find artifacts -type f -name "*arm64*.zip" -exec cp {} release/ \;
           fi
           NOTARIZED_DMG=$(find artifacts -path "*KiroCrew-notarized-*" -name "*.dmg" | head -1)
           if [ -n "$NOTARIZED_DMG" ]; then
-            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.release.outputs.version }}-arm64.dmg"
+            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64.dmg"
           fi
           ls -la release/
 
@@ -282,5 +154,5 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
-          prerelease: ${{ needs.release.outputs.channel == 'insider' }}
+          prerelease: ${{ needs.version.outputs.channel == 'insider' }}
           files: release/*

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -1,13 +1,23 @@
-name: Notarize macOS (reusable)
+name: Sign and Notarize macOS (reusable)
 
-# Reusable workflow: notarize + staple an already-CDSigner-signed macOS app.
-# Called by nightly.yml (channel: nightly) and release.yml (channel:
-# insider | stable). See docs/signing-runbook.md for the full chain and the
-# credential rotation procedure.
+# Reusable workflow: CDSigner-sign the macOS app, then notarize + staple +
+# publish it. Called by nightly.yml (channel: nightly) and release.yml
+# (channel: insider | stable). See docs/signing-runbook.md for the full
+# chain and the credential rotation procedure.
+#
+# Two jobs:
+#   sign      -- flatten build artifacts, attest provenance, upload unsigned
+#                artifacts to pre-signed/ in the PRIVATE signing bucket,
+#                submit the .app to CDSigner. Nothing here is public-facing.
+#                (This job was historically duplicated in nightly.yml and
+#                release.yml under the misleading name "publish".)
+#   notarize  -- consume the signed zip, notarize + staple + spctl gate,
+#                rebuild + notarize the first-install DMG, publish to the
+#                distribution bucket, write the channel feed.
 #
 # Key properties:
-#   - Consumes the signed zip CDSigner wrote to signed/<...>; never touches
-#     unsigned artifacts.
+#   - The signed_zip_key handoff is internal (sign job output -> notarize
+#     job), no longer plumbed through every caller.
 #   - The Apple credential is fetched from AWS Secrets Manager at runtime
 #     (kirocrew/signing/apple-notary) via the same OIDC role used for
 #     signing. The password is masked and scoped to a single step; it is
@@ -30,10 +40,6 @@ on:
         description: "Version label used in S3 keys and the feed"
         required: true
         type: string
-      signed_zip_key:
-        description: "S3 key of the CDSigner-signed zip (signed/<channel>/<version>/<App>.zip)"
-        required: true
-        type: string
       write_feed:
         description: "Write feed/<channel>/latest-mac.json pointing at the notarized artifact"
         required: false
@@ -46,8 +52,119 @@ permissions:
   attestations: write
 
 jobs:
+  sign:
+    name: Sign with CDSigner (${{ inputs.channel }})
+    runs-on: ubuntu-latest
+    # OIDC subject alignment: tag-triggered callers (release.yml) present
+    # ref:refs/tags/<tag>, which the signing role does not trust. The prod
+    # environment switches the subject to environment:prod, which it does.
+    # (Nightly runs on main present either trusted form.) See the notarize
+    # job below for the full environment-protection rationale.
+    environment: prod
+    outputs:
+      signed_zip_key: ${{ steps.sign.outputs.signed_zip_key }}
+    env:
+      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      HAS_CDSIGNER: ${{ secrets.CDSIGNER_API_ENDPOINT != '' && 'true' || '' }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: packaging/signing
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" \) -exec cp {} release/ \;
+          ls -la release/
+
+      - name: Attest build provenance
+        # Signed SLSA provenance for the wheel/sdist/AppImage (CWE-1104).
+        # Runs right after flatten, before anything leaves the runner.
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          # Attest only artifacts whose bytes are final here. The macOS .zip is
+          # re-signed + notarized downstream, so a pre-notarization attestation
+          # would bind a digest that never ships -- omit *.zip. Same for *.dmg:
+          # the electron-builder DMG wraps the unsigned app and never ships;
+          # the shipping DMG is rebuilt from the stapled app and attested in
+          # the notarize job below.
+          subject-path: |
+            release/*.whl
+            release/*.tar.gz
+            release/*.AppImage
+
+      # Install the CDSigner SigV4 client (awscurl) BEFORE AWS credentials are
+      # configured, so a compromised or version-drifted release can never observe
+      # the signing-role credentials at install time. Pinned for the same reason.
+      - name: Install awscurl (SigV4 client for CDSigner)
+        if: env.HAS_CDSIGNER
+        run: |
+          python3 -m pip install --user --quiet "awscurl==0.44"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure AWS credentials
+        if: env.HAS_SIGNING_SECRETS
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Upload unsigned artifacts to S3
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          for f in release/*; do
+            [ -f "$f" ] || continue
+            KEY="pre-signed/${CHANNEL}/${VERSION}/$(basename "$f")"
+            echo "Uploading $f -> s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
+            aws s3 cp "$f" "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
+          done
+
+      - name: Extract .app from zip for signing
+        if: env.HAS_CDSIGNER
+        run: |
+          mkdir -p unsigned-app
+          MAC_ZIP=$(find release -name "*arm64*.zip" | head -1)
+          if [ -n "$MAC_ZIP" ]; then
+            unzip -q "$MAC_ZIP" -d unsigned-app/
+            echo "APP_PATH=$(find unsigned-app -name '*.app' -maxdepth 1 | head -1)" >> "$GITHUB_ENV"
+          else
+            echo "No macOS zip found -- skipping signing"
+            echo "APP_PATH=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Sign with CDSigner
+        id: sign
+        if: env.HAS_CDSIGNER && env.APP_PATH != ''
+        env:
+          AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+          AWS_SIGNER_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
+          CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
+        run: |
+          bash packaging/signing/sign.sh "$APP_PATH" "$CHANNEL" "$VERSION"
+          echo "signed_zip_key=signed/${CHANNEL}/${VERSION}/$(basename "$APP_PATH" .app).zip" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Sign (${CHANNEL})"
+            echo "- Version: ${VERSION}"
+            echo "- Signed: ${{ env.HAS_CDSIGNER && env.APP_PATH != '' && 'Yes' || 'No (CDSigner not configured)' }}"
+            echo "- Artifacts:"
+            ls release/ | sed 's/^/  - /'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   notarize:
     name: Notarize + staple (${{ inputs.channel }})
+    needs: sign
+    # Skip cleanly (rather than fail) when signing is not configured
+    # (fork / repo without CDSigner secrets) -- there is nothing to notarize.
+    if: needs.sign.outputs.signed_zip_key != ''
     runs-on: macos-14
     # Two notarytool submissions (app, then DMG), each --wait up to 30m,
     # plus build/staple/upload overhead -- the job budget must exceed their
@@ -69,7 +186,7 @@ jobs:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
-      SIGNED_ZIP_KEY: ${{ inputs.signed_zip_key }}
+      SIGNED_ZIP_KEY: ${{ needs.sign.outputs.signed_zip_key }}
     steps:
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -32,7 +32,7 @@ overwritten.
   `https://d28nxu9if70cmc.cloudfront.net` (`updates.kirocrew.dev` is not
   yet provisioned)
 
-**Feed (as built) — static file, no Lambda:** `notarize-macos.yml` writes
+**Feed (as built) — static file, no Lambda:** `sign-and-notarize.yml` writes
 `feed/{channel}/latest-mac.json` directly after the spctl gate. There is no
 Feed Lambda, no S3-event trigger, no 200/204 endpoint, and no CloudFront
 Function query routing: the client (`auto-update.js`) fetches the static
@@ -52,7 +52,7 @@ delta. Schema:
 `url` is the Squirrel auto-update payload (zip, mandatory). `dmg` is the
 first-install disk image for humans/website links; Squirrel ignores it.
 
-**macOS artifact flow (as built), all channels via `notarize-macos.yml`:**
+**macOS artifact flow (as built), all channels via `sign-and-notarize.yml`** (which folds the CDSigner sign job and the notarize job into one reusable workflow shared by `nightly.yml` and `release.yml`; the trigger files carry only version derivation and `uses:` calls)**:**
 
 1. CDSigner signs the .app (dynamic manifest covering every nested Mach-O)
 2. `notarytool` submit (app) → staple → `spctl` fail-closed gate

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -56,30 +56,28 @@ def _workflow_permissions(name: str) -> dict[str, str]:
 
 
 class TestNightlyPermissions:
-    def test_only_publish_jobs_can_mint_oidc_tokens(self) -> None:
+    def test_only_publish_callers_can_mint_oidc_tokens(self) -> None:
         lines = _lines("nightly.yml")
 
         assert _workflow_permissions("nightly.yml") == {"contents": "read"}
         assert _permission_block(lines, "  version:") is None
+        # Build callers inherit the workflow-level contents:read only; the
+        # reusable build workflows request nothing more.
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
-        assert _permission_block(lines, "  publish:") == {
-            "id-token": "write",
-            "contents": "read",
-            "attestations": "write",
-        }
         assert _permission_block(lines, "  publish-cli:") == {
             "contents": "read",
             "id-token": "write",
             "attestations": "write",
         }
-        # Caller job for the reusable notarize workflow: a workflow_call
-        # callee can never exceed the caller job's permissions, so the
-        # caller must grant id-token explicitly. attestations:write is for
-        # the shipping-DMG provenance attestation inside notarize-macos.yml
-        # (the DMG is rebuilt there from the stapled app; the build-job DMG
-        # never ships and is attested nowhere).
-        assert _permission_block(lines, "  notarize:") == {
+        # Caller job for the reusable sign-and-notarize workflow: a
+        # workflow_call callee can never exceed the caller job's permissions,
+        # so the caller must grant id-token explicitly. attestations:write
+        # covers the sign job's wheel/sdist/AppImage provenance and the
+        # notarize job's shipping-DMG attestation (the DMG is rebuilt there
+        # from the stapled app; the build-job DMG never ships and is attested
+        # nowhere).
+        assert _permission_block(lines, "  sign-and-notarize:") == {
             "id-token": "write",
             "contents": "read",
             "attestations": "write",
@@ -88,7 +86,7 @@ class TestNightlyPermissions:
 
 class TestReleasePermissions:
     def test_release_jobs_follow_least_privilege_split(self) -> None:
-        """The signing job holds AWS creds (id-token) but must not hold
+        """The signing caller holds AWS creds (id-token) but must not hold
         contents:write; the GitHub-Release job holds contents:write but must
         not hold AWS creds. Keeping the two capabilities in separate jobs
         means a compromise of either job cannot both exfiltrate via AWS and
@@ -96,13 +94,46 @@ class TestReleasePermissions:
         lines = _lines("release.yml")
 
         assert _workflow_permissions("release.yml") == {"contents": "read"}
+        assert _permission_block(lines, "  version:") is None
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
-        assert _permission_block(lines, "  release:") == {
+        assert _permission_block(lines, "  publish-cli:") == {
             "contents": "read",
             "id-token": "write",
             "attestations": "write",
         }
+        assert _permission_block(lines, "  sign-and-notarize:") == {
+            "id-token": "write",
+            "contents": "read",
+            "attestations": "write",
+        }
         assert _permission_block(lines, "  github-release:") == {
             "contents": "write",
+        }
+
+
+class TestReusableWorkflowPermissions:
+    def test_build_workflows_are_read_only(self) -> None:
+        """The shared build workflows compile source into artifacts; they
+        must never hold OIDC or write capabilities."""
+        assert _workflow_permissions("build-wheel.yml") == {"contents": "read"}
+        assert _workflow_permissions("build-desktop.yml") == {"contents": "read"}
+
+    def test_sign_and_notarize_declares_exact_capabilities(self) -> None:
+        """The shared sign/notarize workflow needs OIDC (AWS signing role)
+        and attestations (provenance for the artifacts + shipping DMG) --
+        and nothing else. contents:write in particular must never appear
+        here (least-privilege split: the GitHub-Release job in release.yml
+        is the only writer)."""
+        assert _workflow_permissions("sign-and-notarize.yml") == {
+            "contents": "read",
+            "id-token": "write",
+            "attestations": "write",
+        }
+
+    def test_publish_cli_declares_exact_capabilities(self) -> None:
+        assert _workflow_permissions("publish-cli.yml") == {
+            "contents": "read",
+            "id-token": "write",
+            "attestations": "write",
         }


### PR DESCRIPTION
## Why

nightly.yml and release.yml ran near-verbatim copies of four blocks: the 7-step CDSigner sign sequence, the desktop build job, the wheel build job, and the version stamp application. The divergence tax was paid twice: release shipped unsigned artifacts for weeks because signing was added only to nightly (#80), and #98 wrote the electron version stamp twice.

## What

**Same logic, flags in** -- shared blocks extracted into reusable workflows, trigger files reduced to trigger + concurrency + version derivation + `uses:` calls:

| File | Role |
|---|---|
| `build-wheel.yml` (new, reusable) | stamp + frontend + wheel/sdist, uploads `cli-wheel` |
| `build-desktop.yml` (new, reusable) | stamp + unsigned electron-builder matrix |
| `sign-and-notarize.yml` (renamed from `notarize-macos.yml`) | **sign job folded in** (the block formerly duplicated in both trigger files under the misleading name `publish` -- it never published anything public); `signed_zip_key` handoff now internal |
| `nightly.yml` / `release.yml` | trigger + version derivation + 4 `uses:` calls (+ `github-release`, release-only by nature) |

## Gaps fixed en route

1. **Insider/stable CLI publish**: release.yml now calls `publish-cli.yml` -- previously tag-release wheels only reached GitHub Releases; pip/cli.sh users could never track insider or stable.
2. **Release wheel version stamp (latent collision)**: release.yml never stamped the wheel version, so every tag release built a wheel labeled with the committed pyproject version. Harmless while release wheels were GitHub-Release-only; fatal once CLI publish is wired (two insider tags collide on the same immutable `cli/` key). Tags now map to PEP 440: `v1.2.3-insider.4` -> `1.2.3rc4`, bare semver passes through. (Corollary documented in-file: don't tag both `-insider.N` and `-rc.N` for the same base -- publish-cli's conditional write fails the second as a republish.)

## Invariants preserved (deliberately)

- `publish-cli` depends **only** on the wheel build -- a macOS signing failure never blocks a CLI release (this is why there are two build reusables, not one `build-artifacts.yml`).
- Feed written only after the spctl fail-closed gate; concurrency groups still serialize per-trigger runs.
- Least-privilege split: the sign/notarize path holds `id-token` but never `contents:write`; `github-release` holds `contents:write` but no AWS creds.
- `environment: prod` on both sign and notarize jobs (OIDC subject alignment for tag refs; nightly on main is trusted under either subject form).
- Attestation split unchanged: wheel/sdist/AppImage attested at sign time, the shipping DMG attested after rebuild from the stapled app, macOS zips never attested pre-notarization.

## Tests

- `test_workflow_permissions.py` learns the new topology and now also pins the reusable workflows' own permission blocks (5/5 pass).
- YAML parse + duplicate-key gate on all six workflows.
- Tag derivation unit-tested: `v1.2.3`->stable/1.2.3, `v0.2.0-insider.1`->insider/0.2.0rc1, `v1.2.3-rc.2`->insider/1.2.3rc2, `v2.0.0-insider.10`->insider/2.0.0rc10.

## Post-merge validation plan

1. Trigger a manual nightly -- exercises build-wheel + build-desktop + publish-cli + sign-and-notarize through the nightly caller.
2. Push a test insider tag -- exercises the same shared logic through the release caller, including the first-ever insider CLI publish.

Renamed artifact names (`cli-wheel`, `desktop-darwin-arm64`, `desktop-linux-x64`) and job names are internal to the run; grep confirmed zero external references.