### PR TITLE
refactor(ci): split publish out of the notarize job

### DIFF
--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -1,33 +1,47 @@
 name: Sign and Notarize macOS (reusable)
 
-# Reusable workflow: CDSigner-sign the macOS app, then notarize + staple +
+# Reusable workflow: CDSigner-sign the macOS app, notarize + staple it, then
 # publish it. Called by nightly.yml (channel: nightly) and release.yml
 # (channel: insider | stable). See docs/signing-runbook.md for the full
 # chain and the credential rotation procedure.
 #
-# Two jobs:
+# Three jobs, chained:
 #   sign      -- flatten build artifacts, attest provenance, upload unsigned
 #                artifacts to pre-signed/ in the PRIVATE signing bucket,
 #                submit the .app to CDSigner. Nothing here is public-facing.
 #                (This job was historically duplicated in nightly.yml and
 #                release.yml under the misleading name "publish".)
-#   notarize  -- consume the signed zip, notarize + staple + spctl gate,
-#                rebuild + notarize the first-install DMG, publish to the
-#                distribution bucket, write the channel feed.
+#   notarize  -- everything macOS-bound: Apple notarization, staple, the
+#                spctl fail-closed gate, DMG rebuild + DMG notarization.
+#                The Apple credential is confined to this job. Ends by
+#                attaching the GATED artifact (notarized zip + DMG) to the
+#                workflow run.
+#   publish   -- everything S3-bound: copy the gated artifact to the public
+#                distribution bucket and write the channel feed, dead last.
+#                Separate from notarize so a transient publish failure
+#                retries as a ~2-minute ubuntu job ("Re-run failed jobs")
+#                instead of repeating two ~30-minute-budget Apple
+#                submissions, and so the expensive macOS runner never burns
+#                minutes on S3 uploads.
 #
 # Key properties:
 #   - The signed_zip_key handoff is internal (sign job output -> notarize
 #     job), no longer plumbed through every caller.
 #   - The Apple credential is fetched from AWS Secrets Manager at runtime
 #     (kirocrew/signing/apple-notary) via the same OIDC role used for
-#     signing. The password is masked and scoped to a single step; it is
-#     never persisted to GITHUB_ENV, files, or logs.
+#     signing. The password is masked and scoped to single steps in the
+#     notarize job only; it is never persisted to GITHUB_ENV, files, or
+#     logs, and the publish job never touches it.
 #   - Fails closed: Gatekeeper assessment (spctl) must report
-#     "Notarized Developer ID" or the job fails. On an Invalid notarization
-#     the itemized Apple log is printed for diagnosis.
-#   - Writes the update feed AFTER stapling. Un-notarized artifacts must
-#     never appear in the update feed for the same reason unsigned ones
-#     must not: clients would auto-update to a build Gatekeeper blocks.
+#     "Notarized Developer ID" or the notarize job fails and publish never
+#     runs. On an Invalid notarization the itemized Apple log is printed.
+#   - The publish job consumes only the artifact the notarize job attached
+#     AFTER the gate, in the same run -- un-notarized bytes have no path to
+#     the distribution bucket or the feed.
+#   - Writes the update feed AFTER both artifacts are publicly
+#     downloadable. Un-notarized artifacts must never appear in the update
+#     feed for the same reason unsigned ones must not: clients would
+#     auto-update to a build Gatekeeper blocks.
 
 on:
   workflow_call:
@@ -41,7 +55,7 @@ on:
         required: true
         type: string
       write_feed:
-        description: "Write feed/<channel>/latest-mac.json pointing at the notarized artifact"
+        description: "Publish to the distribution bucket and write feed/<channel>/latest-mac.json"
         required: false
         type: boolean
         default: true
@@ -167,8 +181,8 @@ jobs:
     if: needs.sign.outputs.signed_zip_key != ''
     runs-on: macos-14
     # Two notarytool submissions (app, then DMG), each --wait up to 30m,
-    # plus build/staple/upload overhead -- the job budget must exceed their
-    # combined worst case or GitHub cancels mid-publish.
+    # plus staple/DMG-build overhead -- the job budget must exceed their
+    # combined worst case or GitHub cancels mid-run.
     timeout-minutes: 75
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
@@ -182,6 +196,8 @@ jobs:
     # environment if an admin deliberately tags it -- the same principal
     # who could merge it to main.
     environment: prod
+    outputs:
+      app_name: ${{ steps.staple.outputs.app_name }}
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
       CHANNEL: ${{ inputs.channel }}
@@ -239,6 +255,7 @@ jobs:
           echo "Notarization Accepted: $SUBMISSION_ID"
 
       - name: Staple and verify
+        id: staple
         if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
@@ -260,6 +277,7 @@ jobs:
           # ditto preserves the resource fork carrying the stapled ticket.
           /usr/bin/ditto -c -k --keepParent "$APP" ../notarized.zip
           echo "APP_NAME=$(basename "$APP" .app)" >> "$GITHUB_ENV"
+          echo "app_name=$(basename "$APP" .app)" >> "$GITHUB_OUTPUT"
 
       - name: Upload notarized artifact to S3
         if: env.HAS_SIGNING_SECRETS
@@ -268,43 +286,6 @@ jobs:
           aws s3 cp work/notarized.zip "s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}" --only-show-errors
           echo "NOTARIZED_KEY=${KEY}" >> "$GITHUB_ENV"
           echo "Notarized artifact: s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
-
-      # Public distribution: copy the notarized zip to the public update
-      # bucket (CloudFront + OAC) and write the channel feed there. The
-      # signing bucket stays private and single-purpose (signing material
-      # only) -- clients download exclusively through the CDN.
-      #
-      # The versioned zip key is immutable-cached by CloudFront, so it must
-      # never be republished with different bytes (same class as the cli/*
-      # wheel keys). --if-none-match makes the write conditional; on a 412
-      # (job re-run after a later-step failure) the existing object is a
-      # notarized artifact that already passed the spctl gate on the earlier
-      # attempt, so it is KEPT and the step continues idempotently.
-      - name: Publish notarized artifact to distribution bucket
-        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
-        run: |
-          set -euo pipefail
-          DESKTOP_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.zip"
-          set +e
-          PUT_OUT=$(aws s3api put-object \
-            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
-            --key "${DESKTOP_KEY}" \
-            --body work/notarized.zip \
-            --if-none-match '*' \
-            --content-type application/zip \
-            --cache-control "public, max-age=31536000, immutable" 2>&1)
-          RC=$?
-          set -e
-          if [ $RC -ne 0 ]; then
-            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
-              echo "Key already published (job re-run) -- keeping existing notarized bytes: ${DESKTOP_KEY}"
-            else
-              echo "$PUT_OUT"
-              exit $RC
-            fi
-          fi
-          echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
-          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
       # First-install DMG, rebuilt from the STAPLED app (the electron-builder
       # DMG from the build job wraps the unsigned app and must never ship).
@@ -370,10 +351,111 @@ jobs:
           fi
           echo "DMG notarization Accepted: $SUBMISSION_ID"
 
+      # The GATED artifact: attached only after the spctl gate and both
+      # Apple acceptances above. This is the sole input of the publish job
+      # (and of release.yml's github-release job), so un-notarized bytes
+      # have no path downstream.
+      - name: Attach notarized artifact to workflow run
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
+          path: |
+            work/notarized.zip
+            work/*.dmg
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summary
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          {
+            echo "## Notarization (${CHANNEL})"
+            echo "- Version: ${VERSION}"
+            echo "- Input: \`${SIGNED_ZIP_KEY}\`"
+            echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
+            echo "- DMG: \`${APP_NAME}.dmg\` (rebuilt from stapled app, notarized)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish to distribution (${{ inputs.channel }})
+    needs: notarize
+    # success() is REQUIRED here: a custom job-level `if` replaces the
+    # implicit success check, and without it this job would run even after
+    # a failed or skipped notarize. The remaining conditions gate public
+    # distribution on the CDN being configured -- when it is not (fork),
+    # notarize still produced the gated artifact for github-release.
+    if: ${{ success() && inputs.write_feed && vars.CLI_DIST_BUCKET != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Same OIDC subject alignment as the jobs above (S3 writes assume the
+    # signing role). No Secrets Manager access here -- the Apple credential
+    # stays confined to the notarize job.
+    environment: prod
+    env:
+      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      APP_NAME: ${{ needs.notarize.outputs.app_name }}
+    steps:
+      - name: Configure AWS credentials
+        if: env.HAS_SIGNING_SECRETS
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Download gated artifact
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
+          path: work
+
+      - name: Verify gated artifact contents
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          ls -la work/
+          [ -f "work/notarized.zip" ] || { echo "notarized.zip missing from gated artifact"; exit 1; }
+          [ -f "work/${APP_NAME}.dmg" ] || { echo "${APP_NAME}.dmg missing from gated artifact"; exit 1; }
+
+      # The versioned zip key is immutable-cached by CloudFront, so it must
+      # never be republished with different bytes (same class as the cli/*
+      # wheel keys). --if-none-match makes the write conditional; on a 412
+      # (job re-run after a later-step failure) the existing object is a
+      # notarized artifact that already passed the spctl gate on the earlier
+      # attempt, so it is KEPT and the step continues idempotently.
+      - name: Publish notarized artifact to distribution bucket
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          DESKTOP_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.zip"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${DESKTOP_KEY}" \
+            --body work/notarized.zip \
+            --if-none-match '*' \
+            --content-type application/zip \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              echo "Key already published (job re-run) -- keeping existing notarized bytes: ${DESKTOP_KEY}"
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
+          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+
       # Same never-republish discipline as the zip: conditional write,
       # 412 on a job re-run keeps the existing notarized bytes.
       - name: Publish DMG to distribution bucket
-        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
+        if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
           DMG_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.dmg"
@@ -399,16 +481,17 @@ jobs:
           echo "Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
 
       # Feed points at the NOTARIZED artifact on the CDN -- written only
-      # after the spctl gate above passed, and only after the artifact
-      # itself is publicly downloadable (feed-before-artifact would hand
-      # clients a 403/404). The feed key is mutable and served no-cache by
-      # the feed/* CloudFront behavior, so overwriting is safe. Out-of-order
-      # overwrites (older run finishing last -> channel rollback) are
-      # prevented by the CALLER workflows' concurrency groups, which
-      # serialize runs per channel -- not by version comparison here, which
-      # would itself be a read-then-write race.
+      # after the spctl gate passed (this job's sole input is the gated
+      # artifact) and only after both artifacts are publicly downloadable
+      # (feed-before-artifact would hand clients a 403/404). The feed key is
+      # mutable and served no-cache by the feed/* CloudFront behavior, so
+      # overwriting is safe. Out-of-order overwrites (older run finishing
+      # last -> channel rollback) are prevented by the CALLER workflows'
+      # concurrency groups, which serialize runs per channel -- not by
+      # version comparison here, which would itself be a read-then-write
+      # race.
       - name: Write update feed
-        if: env.HAS_SIGNING_SECRETS && inputs.write_feed && vars.CLI_DIST_BUCKET != ''
+        if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
           cat > /tmp/latest-mac.json <<EOF
@@ -425,28 +508,13 @@ jobs:
             --content-type application/json
           echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
-      - name: Attach notarized artifact to workflow run
-        if: env.HAS_SIGNING_SECRETS
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
-          path: |
-            work/notarized.zip
-            work/*.dmg
-          retention-days: 14
-
       - name: Summary
         if: env.HAS_SIGNING_SECRETS
         run: |
           {
-            echo "## Notarization (${CHANNEL})"
+            echo "## Publish (${CHANNEL})"
             echo "- Version: ${VERSION}"
-            echo "- Input: \`${SIGNED_ZIP_KEY}\`"
-            echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
-            if [ -n "${DESKTOP_KEY:-}" ]; then
-              echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
-            fi
-            if [ -n "${DMG_KEY:-}" ]; then
-              echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
-            fi
+            echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+            echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
+            echo "- Feed: \`feed/${CHANNEL}/latest-mac.json\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Stacked on #132 (merged). The notarize job did everything after signing -- Apple notarization, staple, spctl gate, DMG rebuild + notarization, S3 publication, feed write. One 75-minute macOS job whose name undersold half its duties.

## The cut: OS boundary

| Job | Runner | Does |
|---|---|---|
| `sign` | ubuntu | (unchanged) CDSigner sequence |
| `notarize` | macos-14, 75 min | everything macOS-bound: notarytool, stapler, **spctl gate**, hdiutil DMG rebuild, DMG notarization. Apple credential confined here. Ends by attaching the **gated artifact** (`if-no-files-found: error`). |
| `publish` | ubuntu, 15 min | everything S3-bound: download gated artifact -> verify contents -> publish zip -> publish DMG -> **feed dead last** |

## Why

- **Retry economics**: a transient S3 blip after successful notarization currently forces re-running two ~30-minute-budget Apple submissions (the one non-idempotent stage -- it's Apple's queue). Split, "Re-run failed jobs" retries a 2-minute ubuntu job.
- **Runner economics**: the 10x-cost macOS runner stops spending minutes on S3 uploads.
- **Credential confinement**: the Secrets Manager Apple credential is now only ever fetched in the notarize job; the publish path never sees it.
- **Fail-closed strengthens**: publish's *sole input* is the artifact attached after the spctl gate and both Apple acceptances -- un-notarized bytes have no path to the distribution bucket or the feed. (Also the answer to "could a new version event trigger publish?" -- the `needs:` edge IS that trigger, without the feed-rollback race an externally-triggered publisher would reintroduce: ordering stays serialized by the caller concurrency groups, not by read-compare-write.)

## Semantics preserved

- Callers (nightly.yml, release.yml) unchanged -- same reusable call, same inputs.
- Immutable 412-keep conditional writes unchanged; feed written only after both artifacts are publicly downloadable.
- Fork/no-CDN case: publish skips (explicit `success() &&` guard -- a custom job-level `if` replaces the implicit success check, documented in-file), while notarize still attaches the gated artifact for github-release (#108 round-3 gate semantics).
- Least-privilege: workflow permissions unchanged (`contents:read` + `id-token:write` + `attestations:write`), pinned by test_workflow_permissions.py (5/5).

## Validation

YAML parse + duplicate-key gate; job graph asserted `sign -> notarize -> publish`; 5/5 permission tests. Post-merge: the next nightly exercises the full 3-job chain end-to-end (artifact handoff notarize -> publish is the new surface to watch).