### PR TITLE
feat(migrations): one-time MeshClaw data import at first boot

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1001,6 +1001,22 @@ async def _gateway(
     test_mode: bool = False,
 ) -> None:
     """Load config and start the Slack Socket Mode gateway."""
+    # ── Legacy ~/.meshclaw -> ~/.kirocrew one-time import (Phase 2) ──
+    # MUST run before any store is opened by run_gateway() below: the import
+    # replaces memory.db (old-wins) and the workspace knowledge.db in place and
+    # finally renames the legacy dir, so an open SQLite connection would be
+    # clobbered underneath or block the rename. If the onboarding step wrote an
+    # intent marker on a previous boot, this performs the import now, then
+    # clears the intent + writes the done marker. Microsecond no-op otherwise.
+    try:
+        from kiro_crew.migrations.meshclaw_import import run_pending_meshclaw_import
+
+        run_pending_meshclaw_import()
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "meshclaw->kirocrew import runner failed (continuing boot)", exc_info=True
+        )
+
     # Activate mise once at gateway start so every subprocess we
     # later spawn — MCP servers, script crons, kiro-cli — inherits the user's
     # mise-managed toolchain. Without this, Node-based MCP servers spawn against

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -489,6 +489,8 @@ from kiro_crew.dashboard.handlers.core import (  # noqa: E402, F401
     api_live,
     api_logout,
     api_ready,
+    api_meshclaw_import_start,
+    api_meshclaw_import_status,
     api_security_stats,
     api_sel_events,
     api_sel_verify,

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1597,3 +1597,107 @@ async def api_app_token(request: web.Request) -> web.Response:
         source="app_auth",
     )
     return web.json_response({"token": token})
+
+
+# ── Legacy ~/.meshclaw -> ~/.kirocrew one-time import (onboarding) ──
+
+
+async def api_meshclaw_import_status(request: web.Request) -> web.Response:
+    """GET /api/onboarding/meshclaw-import/status — is a legacy import available?
+
+    Returns availability plus lightweight metadata (source path, byte-size
+    estimate, session count). Read-only; safe to poll.
+    """
+    from kiro_crew.migrations.meshclaw_import import detect_meshclaw_import_available
+
+    info = await asyncio.to_thread(detect_meshclaw_import_available)
+    return web.json_response(info)
+
+
+async def api_meshclaw_import_start(request: web.Request) -> web.Response:
+    """POST /api/onboarding/meshclaw-import/start — request the import + restart.
+
+    Writes the Phase-1 intent marker and restarts the gateway using the same
+    in-process exec-restart the update flow exposes. On the next boot, the
+    early runner (before any store opens) performs the import, renames
+    ``~/.meshclaw`` -> ``~/.meshclaw.bak``, and writes the done marker.
+    """
+    from kiro_crew.migrations.meshclaw_import import (
+        clear_import_intent,
+        detect_meshclaw_import_available,
+        write_import_intent,
+    )
+
+    caller = request.get("user", "dashboard")
+    state: DashboardState = request.app["state"]
+
+    # Double-restart guard: the flag is checked-and-set with no await in
+    # between, so two concurrent POSTs cannot both schedule a restart — the
+    # second gets a 409.
+    if state.meshclaw_import_restart_inflight:
+        _sel().log_api_access(
+            caller=caller,
+            operation="meshclaw_import.start",
+            outcome="denied",
+            error="restart already in flight",
+        )
+        return web.json_response({"error": "restart already in flight"}, status=409)
+    state.meshclaw_import_restart_inflight = True
+
+    try:
+        info = await asyncio.to_thread(detect_meshclaw_import_available)
+        if not info.get("available"):
+            state.meshclaw_import_restart_inflight = False
+            _sel().log_api_access(
+                caller=caller,
+                operation="meshclaw_import.start",
+                outcome="denied",
+                error="import not available",
+            )
+            return web.json_response(
+                {"error": "meshclaw import not available", **info}, status=409
+            )
+
+        await asyncio.to_thread(write_import_intent)
+    except BaseException:
+        # Nothing was scheduled — release the guard so a later request works.
+        state.meshclaw_import_restart_inflight = False
+        raise
+    _sel().log_api_access(
+        caller=caller,
+        operation="meshclaw_import.start",
+        outcome="allowed",
+        resources=str(info.get("sourcePath", "~/.meshclaw")),
+    )
+
+    # Restart via the same mechanism the update flow exposes (save state,
+    # close sessions, os.execv the same process). Scheduled as a tracked
+    # background task so this response flushes before the exec.
+    from kiro_crew.dashboard.handlers.updates import _restart_gateway
+
+    task = asyncio.create_task(_restart_gateway(state))
+    state._background_tasks.add(task)
+
+    def _on_restart_done(t: "asyncio.Task[None]") -> None:
+        state._background_tasks.discard(t)
+        # Reaching this callback at all means no exec happened (a successful
+        # restart exec()s the process and never returns here), so release
+        # the guard UNCONDITIONALLY — covering the invalid-executable early
+        # return, exceptions, and cancellation — so a non-exec restart can
+        # never leave the flag stuck True and permanently 409 the endpoint.
+        state.meshclaw_import_restart_inflight = False
+        if not t.cancelled() and t.exception() is not None:
+            logger.warning(
+                "meshclaw import: gateway restart failed: %s", t.exception()
+            )
+        # The restart this intent was written for is not coming, so the
+        # consent must not linger for an unrelated later restart to consume.
+        # A genuine re-request simply rewrites the marker. File IO — run it
+        # off the event loop, tracked like other background work.
+        cleanup = asyncio.create_task(asyncio.to_thread(clear_import_intent))
+        state._background_tasks.add(cleanup)
+        cleanup.add_done_callback(state._background_tasks.discard)
+
+    task.add_done_callback(_on_restart_done)
+
+    return web.json_response({"status": "restarting"})

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1366,6 +1366,8 @@ async def start_dashboard(
     app.router.add_get("/api/stream", handlers.api_stream)
     app.router.add_get("/api/sso-ttl", handlers.api_sso_ttl)
     app.router.add_get("/api/dashboard/branding", handlers.api_branding)
+    app.router.add_get("/api/onboarding/meshclaw-import/status", handlers.api_meshclaw_import_status)
+    app.router.add_post("/api/onboarding/meshclaw-import/start", handlers.api_meshclaw_import_start)
     app.router.add_get("/api/health", handlers.api_health)
     app.router.add_get("/api/live", handlers.api_live)
     app.router.add_get("/api/ready", handlers.api_ready)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1604,6 +1604,10 @@ class DashboardState:
         # Sidebar columns — flat list of {id, name, tag_ids, mode, order, include_untagged}
         self._tag_boards: list[dict[str, Any]] = []
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
+        # True once a meshclaw-import restart has been scheduled; a second
+        # concurrent POST /api/onboarding/meshclaw-import/start gets a 409
+        # instead of scheduling a second _restart_gateway.
+        self.meshclaw_import_restart_inflight: bool = False
         self.no_crons: bool = False  # --no-crons flag: cron execution disabled
         self._hook_store: Any = None  # Lazy-init ScriptHookStore
         # Task refine state (background LLM spec generation)

--- a/src/kiro_crew/migrations/__init__.py
+++ b/src/kiro_crew/migrations/__init__.py
@@ -1,0 +1,7 @@
+"""One-time data migrations that run before the gateway opens its stores.
+
+Modules here follow the ``~/.kirocrew/.migrations/<marker>`` guarded
+one-shot pattern: a migration checks for a per-migration marker file, runs
+at most once, and writes the marker on success so subsequent boots are a
+cheap no-op.
+"""

--- a/src/kiro_crew/migrations/meshclaw_import.py
+++ b/src/kiro_crew/migrations/meshclaw_import.py
@@ -1,0 +1,1476 @@
+"""One-time import of a legacy ``~/.meshclaw`` data dir into the current
+KiroCrew home (``~/.kirocrew``), followed by a reversible rename of the
+legacy dir to ``~/.meshclaw.bak``.
+
+Why this exists
+---------------
+KiroCrew is the renamed successor to MeshClaw. When a MeshClaw user first
+launches KiroCrew, their old data lives in ``~/.meshclaw`` while the new
+app reads/writes ``~/.kirocrew`` (the running app sets ``KIROCREW_HOME`` to
+its own home, so :func:`config_dir` resolves to the *destination*). This
+module offers a one-time, consent-gated import that mirrors the manual
+``meshclaw-to-kirocrew-migrate.sh`` selective-merge script exactly.
+
+Design (two-phase, boot-safe)
+-----------------------------
+The import replaces ``memory.db`` and ``workspace/knowledge/knowledge.db``
+in place and finally *renames* the legacy dir, so it MUST NOT run while any
+of those SQLite stores are open. It therefore runs in two phases:
+
+* Phase 1 (onboarding, UI-driven): the dashboard ``.../start`` endpoint
+  writes an *intent* marker and restarts the gateway.
+* Phase 2 (early boot): :func:`run_pending_meshclaw_import` runs from
+  ``cli_server._gateway()`` **before** ``run_gateway()`` opens any store —
+  if the intent marker is present it performs the import, renames the
+  legacy dir, writes the *done* marker, and clears the intent.
+
+Most copy steps are additive, but the old-wins/merge steps (``memory.db``,
+``preferences.md``/``projects.md``, ``knowledge.db``, the session-map /
+folders / crons merges) overwrite destination files in place, so the copy
+phase is ALL-OR-NOTHING: a fail-closed, write-once backup of exactly those
+targets (dbs together with their ``-wal``/``-shm`` sidecars) is taken under
+``.migrations/meshclaw_import_dest_backup/`` BEFORE anything is overwritten
+(each backup file is written atomically; a backup failure aborts before any
+overwrite, so nothing needs undoing). During the copy every additive path
+the run creates in the destination is journaled, and on ANY failure —
+including an unexpected exception — the run rolls back completely: the
+overwrite targets are restored from the backup, the journaled additive
+files/dirs are deleted, and the backup dir plus ALL run markers (including
+the intent) are cleared. The destination is back to its fresh pre-import
+state, boot proceeds normally, and the consent-gated import offer simply
+becomes available again. There is NO retained retry state.
+
+The on-disk backup dir doubles as a durable crash record: a later boot that
+finds a dest backup with no *copied* marker (the prior run was killed
+mid-copy — SIGKILL/power loss — before it could either commit or roll back)
+restores the overwrite targets from it, consumes the backup, clears the
+intent, and does NOT import (re-running the copy needs fresh consent).
+Additive residue from the crashed run cannot be enumerated (the journal is
+memory-only); if it keeps the destination looking non-fresh the import
+offer simply stays withdrawn. A backup missing its completion marker (the
+crash hit the backup phase itself, before any overwrite) is discarded
+untrusted rather than restored from.
+
+Freshness is re-validated at execution time with no bypass: if no fully
+successful copy is recorded and the destination no longer looks fresh, the
+run bails (the user accrued real data since consenting). The intent marker
+has a simple max-age TTL — a stale intent is dropped, not honored.
+
+A *copied* marker records a fully successful copy phase, after which only
+the final rename remains: a later boot re-attempts just the rename and
+never re-copies (which could clobber post-import changes in the
+destination). The rename retry is bounded by an attempt counter in the
+copied marker; after the cap the run gives up — the completed import stays
+in place (the destination is whole), the intent is cleared, and a prominent
+log tells the user to move ``~/.meshclaw`` aside manually. The rename
+itself is ``os.rename`` only and reversible (``~/.meshclaw.bak`` is never
+deleted). Do not run the import while a separate legacy MeshClaw app is
+actively writing ``~/.meshclaw`` — the WAL sidecars are snapshotted
+best-effort and the ``.bak`` rename preserves the originals.
+
+Manifest parity
+---------------
+The copy manifest is a faithful Python port of
+``meshclaw-to-kirocrew-migrate.sh``:
+
+* sessions/ additive; session_map.json + folders.json union-merge (new wins)
+* memory.db old-wins together with its ``-wal``/``-shm`` sidecars when the
+  source has them (consistent snapshot; stale dest sidecars dropped
+  otherwise); ``memory_index.db`` always dropped so the embedding index
+  rebuilds on launch
+* workspace docs additive; workspace ``memory/`` (preferences.md/projects.md
+  old-wins, ``history/`` additive); workspace ``knowledge/knowledge.db``
+  old-wins with its ``-wal``/``-shm`` snapshot (stale dest sidecars dropped
+  otherwise). Overwritten dest files are first backed up under
+  ``.migrations/meshclaw_import_dest_backup/``
+* apps: 10 meshclaw-only apps copied in full; 7 shared apps get ``data/``
+  only (additive); the ~2900 stub app dirs (no ``installed.json``) are
+  never touched because only these explicit lists are copied
+* skills: copy each dir not already present and not a built-in ``meshclaw-*``
+* artifacts/ + uploads/ additive
+* crons.json MERGED into any existing dest file (dest jobs kept, dest wins
+  on id collision) with every imported legacy job ``enabled=false`` AND
+  ``user_paused=true``; legacy dict/list forms both accepted; crons/ +
+  cron-history/ additive
+* mcp.json copied only if absent (else parked at ``mcp.json.from-meshclaw``);
+  mcp-servers/ additive
+* .env copied only if absent (in-product self-migration of the app's own
+  data dir)
+* misc user state (lessons/tags/secretary/mochi files absent-only; plan_memory,
+  tasks, live_views, review-requests, workspace-oncall, writing_review,
+  agent-metadata dirs additive)
+* config.json is NEVER copied
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from kiro_crew.config.paths import config_dir
+
+logger = logging.getLogger(__name__)
+
+# ── Names ────────────────────────────────────────────────────────────────
+LEGACY_DIR_NAME = ".meshclaw"
+BACKUP_DIR_NAME = ".meshclaw.bak"
+MARKER_DIR_NAME = ".migrations"
+DONE_MARKER = "meshclaw_import_done"
+INTENT_MARKER = "meshclaw_import_requested"
+COPIED_MARKER = "meshclaw_import_copied"
+DEST_BACKUP_DIR = "meshclaw_import_dest_backup"
+# Written inside the dest-backup dir once EVERY target has been copied. Its
+# absence marks a backup the copy phase never started from: a crash during
+# the backup phase leaves the destination untouched, so such a partial
+# backup must be discarded, never restored from (it may be missing targets
+# that DID exist pre-import, and a restore would delete them).
+_BACKUP_COMPLETE_MARKER = ".backup-complete"
+# Written inside the dest-backup dir when a restore attempt could not put
+# every target back; the backup dir is then RETAINED for the next attempt
+# (and for manual recovery) instead of being deleted.
+_RESTORE_INCOMPLETE_MARKER = ".restore-incomplete"
+
+# Dest files that the old-wins/merge steps overwrite; backed up (when they
+# exist) into ``.migrations/meshclaw_import_dest_backup/`` before the copy
+# and restored from there if the copy phase fails. The SQLite dbs are
+# backed up together with their ``-wal``/``-shm`` sidecars so the backup is
+# WAL-consistent; session_map.json / folders.json are included because the
+# union merges rewrite them in place.
+_DEST_BACKUP_TARGETS = (
+    "memory.db",
+    "memory.db-wal",
+    "memory.db-shm",
+    "session_map.json",
+    "folders.json",
+    "workspace/memory/preferences.md",
+    "workspace/memory/projects.md",
+    "workspace/knowledge/knowledge.db",
+    "workspace/knowledge/knowledge.db-wal",
+    "workspace/knowledge/knowledge.db-shm",
+    "crons.json",
+)
+
+# SQLite dbs restored as a family SET in a safe order: the destination's
+# ``-wal``/``-shm`` sidecars are strictly dropped BEFORE the db file is
+# swapped in (a foreign sidecar beside a replaced db would corrupt it on
+# open), then the backed-up sidecars (if any) are restored after it.
+_SQLITE_FAMILY_DBS = ("memory.db", "workspace/knowledge/knowledge.db")
+
+# The final rename is retried across boots at most this many times (bounds
+# e.g. an EXDEV loop where os.rename can never succeed). After the cap the
+# run gives up: the completed import stays in place and the intent is
+# cleared (the destination is whole, so this is safe).
+_MAX_RENAME_ATTEMPTS = 3
+# An intent marker older than this with no committed copy is stale consent
+# (e.g. the restart never happened) and is dropped, not honored.
+_INTENT_MAX_AGE_SECONDS = 15 * 60
+
+# A fresh-init destination memory.db is tiny; anything larger means the
+# user has real data in the new home and the import offer is withdrawn.
+_FRESH_MEMORY_DB_MAX_BYTES = 1024 * 1024
+
+# Apps copied in FULL (meshclaw-only apps, not present in a fresh KiroCrew).
+APPS_FULL = (
+    "auto-improvement", "board", "code-reviewer", "deploy-web", "mimir",
+    "oncall-radar", "secretary", "taskkeeper", "team-manager", "writing-review",
+)
+# Shared apps: only their ``data/`` subdir is imported (additive).
+APPS_SHARED = (
+    "agent-worlds", "auto-research", "channels", "code-review-sage",
+    "file-explorer", "projects", "workflows",
+)
+
+# workspace/ top-level names handled explicitly (excluded from the additive
+# docs copy).
+_WORKSPACE_EXCLUDE = frozenset({"memory", "knowledge", ".kiro", "HEARTBEAT.md"})
+
+# Absent-only single files under the data-dir root.
+_MISC_FILES = (
+    "lessons.jsonl", "lessons.md", "tags.json", "tag_boards.json",
+    "secretary.json", "secretary_state.json", "notifications.jsonl",
+    "mochi-queue.json", "mochi-activity.json", "mochi-watchlist.json",
+    "mochi-chat-history.json", "mochi-prompt.md", "mochi-prompt-bg.md",
+)
+# Additive directories under the data-dir root.
+_MISC_DIRS = (
+    "plan_memory", "tasks", "live_views", "review-requests",
+    "workspace-oncall", "writing_review", "agent-metadata",
+)
+
+# Top-level source dirs excluded from the size estimate (huge / ephemeral and
+# not part of the migrated footprint), mirroring the backup exclude in the
+# reference script.
+_SIZE_SKIP_TOP = frozenset({"models", "run"})
+# Individual files never part of the migrated footprint.
+_SIZE_SKIP_FILES = frozenset({"security_events.jsonl", "config.json"})
+# Memoized size estimates keyed by root path so /status polls don't re-walk.
+_size_estimate_cache: dict[str, int] = {}
+
+
+# ── Path seams (monkeypatched in tests) ────────────────────────────────────
+def _home() -> Path:
+    return Path.home()
+
+
+def _legacy_source() -> Path:
+    return _home() / LEGACY_DIR_NAME
+
+
+def _legacy_backup() -> Path:
+    return _home() / BACKUP_DIR_NAME
+
+
+def _marker_dir() -> Path:
+    return config_dir() / MARKER_DIR_NAME
+
+
+def _done_marker_path() -> Path:
+    return _marker_dir() / DONE_MARKER
+
+
+def _intent_marker_path() -> Path:
+    return _marker_dir() / INTENT_MARKER
+
+
+def _copied_marker_path() -> Path:
+    return _marker_dir() / COPIED_MARKER
+
+
+def _dest_backup_dir() -> Path:
+    return _marker_dir() / DEST_BACKUP_DIR
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    try:
+        return a.resolve() == b.resolve()
+    except OSError:
+        return str(a) == str(b)
+
+
+def _nested_paths(a: Path, b: Path) -> bool:
+    """True iff one path is nested under the other (after resolving).
+
+    A nested source/destination would make the copy recurse into itself and
+    the final rename destroy live data, so both :func:`detect...` and
+    :func:`run_meshclaw_import` bail when this holds.
+    """
+    try:
+        ra, rb = a.resolve(), b.resolve()
+    except OSError:
+        return False
+    if ra == rb:
+        return False
+    return ra.is_relative_to(rb) or rb.is_relative_to(ra)
+
+
+# ── Run journal (all-or-nothing copy phase) ─────────────────────────────────
+class _RunJournal:
+    """Records every path the running copy phase newly creates in the
+    destination, so a failed copy can delete its additive residue and leave
+    the destination exactly as it was pre-import."""
+
+    def __init__(self) -> None:
+        self.files: list[Path] = []
+        self.dirs: list[Path] = []
+
+
+# Active journal for the in-flight copy phase (None outside of it). The copy
+# runs single-threaded at early boot, so a module global is safe and spares
+# threading a context object through every helper.
+_journal = None  # type: _RunJournal | None
+
+
+def _record_new_file(p: Path) -> None:
+    """Journal a destination file/symlink this run is about to create."""
+    if _journal is not None:
+        _journal.files.append(p)
+
+
+def _mkdirs(p: Path) -> None:
+    """``mkdir -p`` that journals every directory it actually creates."""
+    if p.exists():
+        return
+    missing: list[Path] = []
+    q = p
+    while not q.exists():
+        missing.append(q)
+        q = q.parent
+    p.mkdir(parents=True, exist_ok=True)
+    if _journal is not None:
+        _journal.dirs.extend(missing)
+
+
+# ── Low-level copy helpers (pure-Python; no rsync dependency) ───────────────
+def _unlink(p: Path) -> None:
+    """Best-effort unlink (marker cleanup etc.); never raises."""
+    try:
+        if p.is_symlink() or p.exists():
+            p.unlink()
+    except OSError:
+        logger.debug("could not unlink %s", p, exc_info=True)
+
+
+def _unlink_strict(p: Path) -> None:
+    """Unlink that RAISES on failure.
+
+    Used on overwrite paths: silently keeping a surviving destination entry
+    (e.g. a symlink) and then copying *through* it would write outside the
+    destination tree, so a failed unlink must fail the step.
+    """
+    if p.is_symlink() or p.exists():
+        p.unlink()
+
+
+def _fsync_path(p: Path) -> None:
+    """fsync a file by path (durability before an ``os.replace``)."""
+    fd = os.open(p, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(p: Path) -> None:
+    """Best-effort fsync of a directory (durability of a rename/replace)."""
+    try:
+        fd = os.open(p, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _raise_walk_error(exc: OSError) -> None:
+    """``os.walk(onerror=...)`` hook: an unreadable subtree fails the step
+    instead of being silently skipped (which would look like success)."""
+    raise exc
+
+
+def _copy_entry(s: Path, d: Path) -> None:
+    """Copy a single file or symlink ``s`` -> ``d`` (parent created).
+
+    Symlinks are preserved as symlinks (matching ``rsync -a`` / ``cp -a``);
+    regular files are copied with metadata via ``copy2``. Callers are
+    responsible for journaling ``d`` when it is newly created.
+    """
+    _mkdirs(d.parent)
+    if s.is_symlink():
+        try:
+            os.symlink(os.readlink(s), d)
+        except OSError:
+            logger.debug("could not recreate symlink %s", d, exc_info=True)
+        return
+    shutil.copy2(s, d)
+
+
+def _atomic_write_text(p: Path, text: str) -> None:
+    """Atomically write ``text`` to ``p`` (temp file + fsync + ``os.replace``)."""
+    _mkdirs(p.parent)
+    new = not (p.is_symlink() or p.exists())
+    tmp = p.with_name(p.name + ".tmp-import")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+        _fsync_dir(p.parent)
+    finally:
+        _unlink(tmp)
+    if new:
+        _record_new_file(p)
+
+
+def _split_symlink_dirs(root_p: Path, dirs: list) -> tuple[list, list]:
+    """Partition ``dirs`` into (regular, symlinked) directory names."""
+    regular: list = []
+    linked: list = []
+    for dn in dirs:
+        (linked if (root_p / dn).is_symlink() else regular).append(dn)
+    return regular, linked
+
+
+def _copytree_additive(src: Path, dst: Path, *, exclude: frozenset[str] = frozenset()) -> None:
+    """Additive recursive copy (``rsync -a --ignore-existing``).
+
+    Never overwrites an existing destination entry. ``exclude`` names are
+    pruned at the *top level* of ``src`` only. Symlinked directories are
+    recreated as symlinks (never followed/expanded).
+    """
+    if not src.is_dir():
+        return
+    for root, dirs, files in os.walk(src, onerror=_raise_walk_error):
+        root_p = Path(root)
+        rel = root_p.relative_to(src)
+        if rel == Path("."):
+            dirs[:] = [x for x in dirs if x not in exclude]
+            files = [x for x in files if x not in exclude]
+        target_dir = dst / rel
+        _mkdirs(target_dir)
+        # Recreate symlinked dirs as symlinks; prune them from recursion.
+        regular, linked = _split_symlink_dirs(root_p, dirs)
+        dirs[:] = regular
+        for dn in linked:
+            d = target_dir / dn
+            if d.is_symlink() or d.exists():
+                continue
+            try:
+                os.symlink(os.readlink(root_p / dn), d)
+                _record_new_file(d)
+            except OSError:
+                logger.debug("could not recreate dir symlink %s", d, exc_info=True)
+        for fn in files:
+            s = root_p / fn
+            d = target_dir / fn
+            if d.is_symlink() or d.exists():
+                continue
+            # Journal BEFORE copying so a partially-written file is still
+            # cleaned up by the rollback.
+            _record_new_file(d)
+            _copy_entry(s, d)
+
+
+def _copytree_overwrite(src: Path, dst: Path) -> None:
+    """Recursive copy (``rsync -a``): overwrites existing destination files.
+
+    Symlinked directories in the *source* are recreated as symlinks (never
+    followed). A destination DIRECTORY position occupied by a symlink is
+    strictly unlinked (raise on failure) and replaced with a real directory —
+    never written *through*, which would land files outside the destination
+    tree. An existing *real* directory at the destination is left in place.
+    """
+    if not src.is_dir():
+        return
+    for root, dirs, files in os.walk(src, onerror=_raise_walk_error):
+        root_p = Path(root)
+        rel = root_p.relative_to(src)
+        target_dir = dst / rel
+        if target_dir.is_symlink():
+            # Never write through a dest dir symlink into an outside tree.
+            _unlink_strict(target_dir)
+        _mkdirs(target_dir)
+        # Recreate symlinked dirs as symlinks; prune them from recursion.
+        regular, linked = _split_symlink_dirs(root_p, dirs)
+        dirs[:] = regular
+        for dn in linked:
+            d = target_dir / dn
+            new = not (d.is_symlink() or d.exists())
+            if d.is_symlink() or d.is_file():
+                _unlink_strict(d)
+            if d.exists():  # a real dir: don't destroy it to plant a link
+                continue
+            try:
+                os.symlink(os.readlink(root_p / dn), d)
+                if new:
+                    _record_new_file(d)
+            except OSError:
+                logger.debug("could not recreate dir symlink %s", d, exc_info=True)
+        for fn in files:
+            s = root_p / fn
+            d = target_dir / fn
+            new = not (d.is_symlink() or d.exists())
+            if not new:
+                _unlink_strict(d)
+            else:
+                # Journal BEFORE copying so a partially-written file is
+                # still cleaned up by the rollback.
+                _record_new_file(d)
+            _copy_entry(s, d)
+
+
+def _copy_file_overwrite(s: Path, d: Path) -> None:
+    """``cp -a`` a single file, overwriting the destination (old-wins).
+
+    Regular files are copied to a temp file in the destination directory,
+    fsynced, and swapped in with ``os.replace`` (atomic — a crash mid-copy
+    can never leave a torn destination file, and a symlink at the
+    destination is replaced, never followed). Symlink sources are strictly
+    unlinked-then-recreated.
+    """
+    if not s.is_file():
+        return
+    _mkdirs(d.parent)
+    new = not (d.is_symlink() or d.exists())
+    if s.is_symlink():
+        _unlink_strict(d)
+        if new:
+            _record_new_file(d)
+        _copy_entry(s, d)
+        return
+    tmp = d.with_name(d.name + ".tmp-import")
+    try:
+        shutil.copy2(s, tmp)
+        _fsync_path(tmp)
+        os.replace(tmp, d)
+        _fsync_dir(d.parent)
+    finally:
+        _unlink(tmp)
+    if new:
+        _record_new_file(d)
+
+
+def _copy_file_if_absent(s: Path, d: Path) -> None:
+    """Copy a single file only if the destination does not already exist."""
+    if not s.is_file():
+        return
+    if d.is_symlink() or d.exists():
+        return
+    _record_new_file(d)
+    _copy_entry(s, d)
+
+
+# ── JSON merges ─────────────────────────────────────────────────────────────
+def _load_json(p: Path, default):
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def _merge_session_map(src: Path, dst: Path) -> None:
+    """Union-merge session_map.json (new/dest wins on key collisions)."""
+    sp = src / "session_map.json"
+    dp = dst / "session_map.json"
+    if not sp.is_file() and not dp.is_file():
+        return  # nothing to merge — don't materialize an empty {}
+    old = _load_json(sp, {})
+    new = _load_json(dp, {})
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        return
+    merged = dict(old)
+    merged.update(new)  # new wins
+    _atomic_write_text(dp, json.dumps(merged, indent=2))
+
+
+def _merge_folders(src: Path, dst: Path) -> None:
+    """Union-merge folders.json (new/dest wins), dedup by ``id`` (or value)."""
+    sp = src / "folders.json"
+    dp = dst / "folders.json"
+    if not sp.is_file() and not dp.is_file():
+        return  # nothing to merge — don't materialize an empty []
+    old = _load_json(sp, [])
+    new = _load_json(dp, [])
+    if not isinstance(old, list) or not isinstance(new, list):
+        return
+
+    def key(x):
+        if isinstance(x, dict) and x.get("id") is not None:
+            return x.get("id")
+        return json.dumps(x, sort_keys=True)
+
+    seen: set = set()
+    out: list = []
+    for x in list(new) + list(old):  # new first -> new wins
+        k = key(x)
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(x)
+    _atomic_write_text(dst / "folders.json", json.dumps(out, indent=2))
+
+
+def _normalize_legacy_cron_jobs(data) -> list:
+    """Normalize a legacy crons.json payload to a list of job dicts.
+
+    Accepts both the dict form (``{"jobs": [...]}``) and the older
+    top-level-list form.
+    """
+    if isinstance(data, dict):
+        jobs = data.get("jobs", [])
+    elif isinstance(data, list):
+        jobs = data
+    else:
+        return []
+    return [j for j in jobs if isinstance(j, dict)]
+
+
+def _import_crons(src: Path, dst: Path) -> None:
+    """MERGE legacy crons.json into any existing dest crons.json.
+
+    Every legacy job is imported ``enabled=false`` + ``user_paused=true``.
+    If the destination file exists, all destination jobs are kept and legacy
+    jobs are appended only when their ``id`` is absent (dest wins on
+    collision). If the destination is absent, the paused legacy set is
+    written as ``{"jobs": [...]}``. The write is atomic.
+    """
+    p = src / "crons.json"
+    if not p.is_file():
+        return
+    legacy = _normalize_legacy_cron_jobs(_load_json(p, None))
+    if not legacy:
+        return
+    for j in legacy:
+        j["enabled"] = False
+        j["user_paused"] = True
+
+    dest_p = dst / "crons.json"
+    if dest_p.is_file():
+        dest_data = _load_json(dest_p, None)
+        if isinstance(dest_data, dict):
+            container: dict | None = dict(dest_data)
+            dest_jobs = [j for j in dest_data.get("jobs", []) if isinstance(j, dict)]
+        elif isinstance(dest_data, list):
+            container = None
+            dest_jobs = [j for j in dest_data if isinstance(j, dict)]
+        else:
+            container = None
+            dest_jobs = []
+        dest_ids = {j.get("id") for j in dest_jobs if j.get("id") is not None}
+        merged = list(dest_jobs) + [j for j in legacy if j.get("id") not in dest_ids]
+        if container is not None:
+            container["jobs"] = merged
+            out = container
+        else:
+            out = {"jobs": merged}
+    else:
+        out = {"jobs": legacy}
+    _atomic_write_text(dest_p, json.dumps(out, indent=2))
+
+
+# ── Metadata (status endpoint) ──────────────────────────────────────────────
+def _estimate_size_bytes(root: Path) -> int:
+    """Best-effort byte size of the *migrated* footprint (memoized).
+
+    Counts only what the manifest would actually copy: skips ``models/`` and
+    ``run/``, ``*.log`` / ``*.log.*`` files, ``security_events.jsonl``,
+    ``config.json``, and app dirs without an ``installed.json``. The result
+    is cached per root so repeated /status polls don't re-walk the tree.
+    """
+    key = str(root)
+    cached = _size_estimate_cache.get(key)
+    if cached is not None:
+        return cached
+    total = 0
+    apps_dir = root / "apps"
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dp = Path(dirpath)
+            if dp == root:
+                dirnames[:] = [d for d in dirnames if d not in _SIZE_SKIP_TOP]
+            elif dp == apps_dir:
+                dirnames[:] = [
+                    d for d in dirnames if (apps_dir / d / "installed.json").is_file()
+                ]
+            for fn in filenames:
+                if fn in _SIZE_SKIP_FILES or fn.endswith(".log") or ".log." in fn:
+                    continue
+                fp = os.path.join(dirpath, fn)
+                try:
+                    if not os.path.islink(fp):
+                        total += os.path.getsize(fp)
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    _size_estimate_cache[key] = total
+    return total
+
+
+def _count_sessions(root: Path) -> int:
+    """Count session transcripts in ``sessions/`` (layout-agnostic)."""
+    sdir = root / "sessions"
+    if not sdir.is_dir():
+        return 0
+    try:
+        jsonl = list(sdir.glob("*.jsonl"))
+        if jsonl:
+            return len(jsonl)
+        return sum(1 for _ in sdir.iterdir())
+    except OSError:
+        return 0
+
+
+# ── Markers / intent ────────────────────────────────────────────────────────
+def _ensure_marker_dir() -> Path:
+    d = _marker_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_done_marker(reason: str = "") -> None:
+    _ensure_marker_dir()
+    payload = {
+        "done_at": _now_iso(),
+        "reason": reason,
+        "source": str(_legacy_source()),
+        "backup": str(_legacy_backup()),
+    }
+    _done_marker_path().write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_copied_marker() -> None:
+    """Record that the copy phase completed with ZERO step failures.
+
+    Present + no done marker means only the final rename is outstanding; a
+    retry must skip the copy phase entirely (re-copying could clobber
+    post-import changes in the destination). Also carries the
+    ``rename_attempts`` counter that bounds the cross-boot rename retry.
+    """
+    _ensure_marker_dir()
+    _atomic_write_text(
+        _copied_marker_path(),
+        json.dumps({"copied_at": _now_iso(), "rename_attempts": 0}, indent=2),
+    )
+
+
+def _bump_rename_attempts() -> int:
+    """Increment and persist the rename attempt counter in the copied marker."""
+    p = _copied_marker_path()
+    data = _load_json(p, {})
+    if not isinstance(data, dict):
+        data = {}
+    attempts = int(data.get("rename_attempts", 0) or 0) + 1
+    data.setdefault("copied_at", _now_iso())
+    data["rename_attempts"] = attempts
+    _ensure_marker_dir()
+    _atomic_write_text(p, json.dumps(data, indent=2))
+    return attempts
+
+
+def write_import_intent() -> Path:
+    """Record intent (Phase 1) so the next boot performs the import."""
+    _ensure_marker_dir()
+    # NOTE: no rename_attempts reset here. A re-request while a copied
+    # marker is pending is effectively unreachable through the product
+    # path: after a successful copy the destination holds the imported
+    # data, so the /start endpoint's availability check (freshness) refuses
+    # to re-request. In the corner where a tiny import leaves the dest
+    # still looking fresh, a re-request after ``rename_gave_up`` simply
+    # hits the exhausted rename cap and gives up again — acceptable, since
+    # the destination is whole either way.
+    p = _intent_marker_path()
+    _atomic_write_text(p, json.dumps({"requested_at": _now_iso()}, indent=2))
+    return p
+
+
+def clear_import_intent() -> None:
+    """Remove the Phase-1 intent marker (public seam for the /start handler).
+
+    Used when the scheduled restart task completes WITHOUT exec'ing: the
+    consent it recorded must not linger for an unrelated later restart to
+    consume. A genuine re-request simply rewrites the marker.
+    """
+    _clear_intent()
+
+
+def _intent_is_stale() -> bool:
+    """True iff the intent marker is older than ``_INTENT_MAX_AGE_SECONDS``.
+
+    Phase 1 restarts the gateway immediately after writing the intent, so a
+    boot seeing an old intent is acting on stale consent — e.g. the restart
+    never happened and the user kept using the app — and must not import.
+    """
+    p = _intent_marker_path()
+    data = _load_json(p, {})
+    ts = data.get("requested_at") if isinstance(data, dict) else None
+    if isinstance(ts, str):
+        try:
+            req = datetime.fromisoformat(ts)
+            if req.tzinfo is None:
+                req = req.replace(tzinfo=timezone.utc)
+            age = (datetime.now(timezone.utc) - req).total_seconds()
+            return age > _INTENT_MAX_AGE_SECONDS
+        except ValueError:
+            pass
+    try:
+        age = datetime.now(timezone.utc).timestamp() - p.stat().st_mtime
+        return age > _INTENT_MAX_AGE_SECONDS
+    except OSError:
+        return True
+
+
+def _clear_intent() -> None:
+    _unlink(_intent_marker_path())
+
+
+# ── Public API ────────────────────────────────────────────────────────────
+def _dest_is_fresh(dest: Path) -> bool:
+    """True iff the destination home looks like a fresh install.
+
+    Not fresh (import offer withdrawn) when the dest ``memory.db`` exceeds a
+    fresh-init size threshold, there are any ``sessions/*.jsonl``
+    transcripts, or any of the meshclaw-only ``APPS_FULL`` app dirs already
+    exists non-empty — any of these means the user already has real data in
+    the new home that an old-wins/full-overwrite import could damage.
+    """
+    try:
+        mdb = dest / "memory.db"
+        if mdb.is_file() and mdb.stat().st_size > _FRESH_MEMORY_DB_MAX_BYTES:
+            return False
+        sdir = dest / "sessions"
+        if sdir.is_dir() and any(sdir.glob("*.jsonl")):
+            return False
+        apps = dest / "apps"
+        for a in APPS_FULL:
+            d = apps / a
+            if d.is_dir() and any(d.iterdir()):
+                return False
+    except OSError:
+        return False
+    return True
+
+
+def detect_meshclaw_import_available() -> dict:
+    """Return whether a legacy import can be offered, plus metadata.
+
+    Available only if ``~/.meshclaw`` exists, is a *different* dir than the
+    current KiroCrew home (so running as legacy MeshClaw is a no-op), neither
+    dir is nested inside the other, ``~/.meshclaw.bak`` is absent, the done
+    marker is absent, and the destination still looks like a fresh install
+    (see :func:`_dest_is_fresh`).
+    """
+    src = _legacy_source()
+    dest = config_dir()
+    try:
+        available = (
+            src.is_dir()
+            and not _same_path(src, dest)
+            and not _nested_paths(src, dest)
+            and not _legacy_backup().exists()
+            and not _done_marker_path().exists()
+            and _dest_is_fresh(dest)
+        )
+    except OSError:
+        available = False
+
+    size = _estimate_size_bytes(src) if available else 0
+    sessions = _count_sessions(src) if available else 0
+    return {
+        "available": bool(available),
+        "sourcePath": "~/.meshclaw",
+        "sizeEstimateBytes": int(size),
+        "sessionCount": int(sessions),
+    }
+
+
+def _run_guarded(steps: list, name: str, fn) -> None:
+    """Run one manifest step, recording ok/fail; never raises."""
+    try:
+        fn()
+        steps.append({"step": name, "ok": True})
+    except Exception as exc:  # noqa: BLE001 — a single step must not abort the import
+        logger.warning("meshclaw import step %r failed: %s", name, exc, exc_info=True)
+        steps.append({"step": name, "ok": False, "error": str(exc)})
+
+
+def _backup_dest_targets(dest: Path) -> None:
+    """Back up the exact dest files the overwrite steps will replace.
+
+    Copies each existing ``_DEST_BACKUP_TARGETS`` entry (preserving its
+    relative path) into ``.migrations/meshclaw_import_dest_backup/``.
+    WRITE-ONCE: an entry already present in the backup is never overwritten.
+    Each backup file is written via a tmp sibling + fsync + ``os.replace``
+    so a crash mid-backup can never leave a truncated file at the final
+    backup path (which the restore would then trust). The backup dir is
+    ALWAYS created (even when zero targets exist) and a completion marker
+    is stamped inside it LAST: the dir is the durable on-disk record a
+    later boot uses to detect a run that crashed mid-copy, and the marker
+    distinguishes a complete, restorable backup from one the crash
+    interrupted mid-backup (which must be discarded, never restored from).
+    This runs as a fail-closed precondition — a failure here aborts the
+    copy phase before anything is overwritten.
+    """
+    bdir = _dest_backup_dir()
+    bdir.mkdir(parents=True, exist_ok=True)
+    for rel in _DEST_BACKUP_TARGETS:
+        p = dest / rel
+        if p.is_file():
+            b = bdir / rel
+            if b.exists():
+                continue  # write-once: keep the pristine first backup
+            b.parent.mkdir(parents=True, exist_ok=True)
+            tmp = b.with_name(b.name + ".tmp-import")
+            try:
+                shutil.copy2(p, tmp)
+                _fsync_path(tmp)
+                os.replace(tmp, b)
+            finally:
+                _unlink(tmp)
+    marker = bdir / _BACKUP_COMPLETE_MARKER
+    mtmp = marker.with_name(marker.name + ".tmp-import")
+    try:
+        mtmp.write_text(json.dumps({"completed_at": _now_iso()}), encoding="utf-8")
+        _fsync_path(mtmp)
+        os.replace(mtmp, marker)
+    finally:
+        _unlink(mtmp)
+    _fsync_dir(bdir)
+
+
+def _restore_dest_targets(dest: Path) -> list[str]:
+    """Roll the overwrite targets back to their pre-import state.
+
+    For each ``_DEST_BACKUP_TARGETS`` entry: restore it from the write-once
+    backup when a backup copy exists, otherwise remove it (no backup means
+    the file did not exist pre-import, so anything there was written by the
+    failed run). SQLite dbs are restored as a family SET in a safe order:
+    the destination's ``-wal``/``-shm`` sidecars are strictly removed
+    FIRST (a foreign sidecar beside a replaced db would corrupt it on
+    open), then the db file is swapped in atomically, then the backed-up
+    sidecars (if any) are restored. If a family's sidecar cannot be
+    removed, the db swap is skipped for that family — fail-closed beats a
+    db/WAL mismatch.
+
+    Best-effort per target — a single failure must not stop the remaining
+    targets from being rolled back — but NEVER silent: every target that
+    could not be restored is returned so the caller can refuse to report a
+    clean rollback (and keep the backup dir).
+    """
+    bdir = _dest_backup_dir()
+    failures: list[str] = []
+
+    def _restore_one(rel: str) -> bool:
+        d = dest / rel
+        b = bdir / rel
+        try:
+            if b.is_file():
+                _copy_file_overwrite(b, d)
+            else:
+                _unlink_strict(d)
+            return True
+        except OSError:
+            failures.append(rel)
+            logger.warning(
+                "meshclaw import rollback: could not restore %s", rel, exc_info=True
+            )
+            return False
+
+    handled: set[str] = set()
+    for db_rel in _SQLITE_FAMILY_DBS:
+        wal_rel, shm_rel = db_rel + "-wal", db_rel + "-shm"
+        handled.update({db_rel, wal_rel, shm_rel})
+        # (1) strictly drop the dest sidecars before touching the db
+        sidecar_failed = False
+        for rel in (wal_rel, shm_rel):
+            try:
+                _unlink_strict(dest / rel)
+            except OSError:
+                sidecar_failed = True
+                failures.append(rel)
+                logger.warning(
+                    "meshclaw import rollback: could not remove %s", rel,
+                    exc_info=True,
+                )
+        if sidecar_failed:
+            # Swapping the db in under a sidecar we could not remove would
+            # hand SQLite a mismatched WAL — leave the family untouched.
+            failures.append(db_rel)
+            continue
+        # (2) restore the db itself (tmp sibling + os.replace, atomic)
+        if not _restore_one(db_rel):
+            continue  # don't lay backed-up sidecars beside a failed db
+        # (3) restore the backed-up sidecars, if the pre-import dest had any
+        for rel in (wal_rel, shm_rel):
+            if (bdir / rel).is_file():
+                _restore_one(rel)
+    for rel in _DEST_BACKUP_TARGETS:
+        if rel in handled:
+            continue
+        _restore_one(rel)
+    return failures
+
+
+def _remove_backup_dir() -> None:
+    """Best-effort removal of the dest-backup dir (rollback / abort paths)."""
+    try:
+        shutil.rmtree(_dest_backup_dir())
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.warning(
+            "meshclaw import: could not remove dest backup dir", exc_info=True
+        )
+
+
+def _write_restore_incomplete_marker(failures: list[str]) -> None:
+    """Note inside the (retained) backup dir that a restore attempt failed.
+
+    Purely informational for the next attempt / manual recovery — detection
+    of an unconsumed backup keys off the dir itself, not this marker.
+    """
+    try:
+        (_dest_backup_dir() / _RESTORE_INCOMPLETE_MARKER).write_text(
+            json.dumps(
+                {"at": _now_iso(), "failed_targets": failures}, indent=2
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        logger.warning(
+            "meshclaw import: could not write restore-incomplete marker",
+            exc_info=True,
+        )
+
+
+def _rollback_copy_phase(dest: Path, journal: _RunJournal) -> bool:
+    """Undo a failed copy phase completely: the destination goes back to its
+    exact pre-import state and NO retry state is retained.
+
+    Order matters: (1) delete every additive file this run created (from the
+    journal), pruning now-empty directories it created; (2) restore the
+    overwrite targets from the write-once backup (recreating any target the
+    journal deletion removed); (3) remove the backup dir ONLY if every
+    target was restored — on any restore failure the backup dir is KEPT
+    (with a restore-incomplete note) so the data needed to finish the
+    rollback is never destroyed; (4) clear the intent and all run markers.
+    Each item is best-effort — one failure must not stop the rest of the
+    rollback. Returns True iff every overwrite target was restored (the
+    caller must NOT report a clean rollback otherwise).
+    """
+    for f in reversed(journal.files):
+        try:
+            if f.is_symlink() or f.exists():
+                f.unlink()
+        except OSError:
+            logger.warning(
+                "meshclaw import rollback: could not delete %s", f, exc_info=True
+            )
+    for d in sorted(journal.dirs, key=lambda p: len(p.parts), reverse=True):
+        try:
+            d.rmdir()  # only succeeds on (our own, now-empty) dirs
+        except OSError:
+            pass
+    failures = _restore_dest_targets(dest)
+    if failures:
+        _write_restore_incomplete_marker(failures)
+        logger.error(
+            "meshclaw import rollback INCOMPLETE: could not restore %d "
+            "target(s) (%s). The pre-import backup is KEPT at %s — restore "
+            "these files from it manually or let the next boot retry.",
+            len(failures), ", ".join(failures), _dest_backup_dir(),
+        )
+    else:
+        _remove_backup_dir()
+    _unlink(_copied_marker_path())
+    _clear_intent()
+    return not failures
+
+
+def _recover_crashed_run(dest: Path) -> dict:
+    """Recover from a prior run that was killed mid-copy (X1).
+
+    Detection (by the callers): the on-disk dest backup dir exists but the
+    *copied* marker does not — the run died after starting its copy phase
+    but before it could either commit (copied marker) or roll back (which
+    consumes the backup dir). The in-memory journal died with the process,
+    so the backup dir is the only durable record: restore the overwrite
+    targets from it, consume it, clear the intent, and do NOT import —
+    re-running the copy needs fresh consent via the normal offer.
+
+    Additive residue (sessions/apps files the crashed run copied) cannot be
+    enumerated without the journal; that is acceptable — the backup targets
+    are restored, and if the residue keeps the destination looking
+    non-fresh the import offer simply stays withdrawn.
+
+    A backup missing its completion marker means the crash hit the backup
+    phase itself, BEFORE any overwrite: the destination is untouched and
+    the partial backup must not be trusted for a restore (it may be missing
+    targets that did exist pre-import, and restoring would delete them) —
+    it is simply discarded.
+
+    Fail-closed like the rollback path: the backup dir is deleted only when
+    every target was restored; otherwise it is kept (with a
+    restore-incomplete note) and the distinct ``recovery_incomplete``
+    status is returned — never a clean report.
+    """
+    bdir = _dest_backup_dir()
+    if not (bdir / _BACKUP_COMPLETE_MARKER).is_file():
+        logger.warning(
+            "meshclaw import: discarding a partial dest backup left by a "
+            "run that crashed during its backup phase (the destination was "
+            "never modified, so there is nothing to restore)"
+        )
+        _remove_backup_dir()
+        _clear_intent()
+        return {"status": "recovered_crashed_run", "renamed": False, "steps": []}
+    logger.warning(
+        "meshclaw import: found a dest backup from a prior run that crashed "
+        "mid-copy — restoring the overwrite targets from it. Additive files "
+        "the crashed run copied (e.g. sessions/apps) cannot be enumerated "
+        "and are left in place; if they keep the destination looking "
+        "non-fresh, the import offer stays withdrawn."
+    )
+    failures = _restore_dest_targets(dest)
+    if failures:
+        _write_restore_incomplete_marker(failures)
+        logger.error(
+            "meshclaw import crash recovery INCOMPLETE: could not restore "
+            "%d target(s) (%s). The pre-import backup is KEPT at %s — "
+            "restore these files from it manually or let the next boot "
+            "retry.",
+            len(failures), ", ".join(failures), bdir,
+        )
+        _clear_intent()
+        return {
+            "status": "recovery_incomplete",
+            "renamed": False,
+            "steps": [],
+            "restore_failures": failures,
+        }
+    _remove_backup_dir()
+    _clear_intent()
+    return {"status": "recovered_crashed_run", "renamed": False, "steps": []}
+
+
+def _snapshot_sqlite_sidecars(src_db: Path, dst_db: Path) -> None:
+    """Copy ``-wal``/``-shm`` sidecars from source when present (consistent
+    snapshot); otherwise drop any stale destination sidecar. A failed drop
+    raises — a stale WAL left beside a replaced db would corrupt it."""
+    for suf in ("-wal", "-shm"):
+        s = src_db.with_name(src_db.name + suf)
+        d = dst_db.with_name(dst_db.name + suf)
+        if s.is_file():
+            _copy_file_overwrite(s, d)
+        else:
+            _unlink_strict(d)
+
+
+def _copy_manifest(src: Path, dest: Path, steps: list) -> None:
+    """Perform the full copy manifest (everything except the final rename).
+
+    The fail-closed dest backup (:func:`_backup_dest_targets`) MUST have
+    already succeeded before this is called — every guarded step below may
+    overwrite a backup target and relies on
+    :func:`_rollback_copy_phase` for recovery.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # 1. sessions/ (additive)
+    _run_guarded(steps, "sessions", lambda: _copytree_additive(src / "sessions", dest / "sessions"))
+    # 2. session_map.json + folders.json (union merge, new wins)
+    _run_guarded(steps, "session_map", lambda: _merge_session_map(src, dest))
+    _run_guarded(steps, "folders", lambda: _merge_folders(src, dest))
+
+    # 3. memory.db (old wins) + WAL snapshot; drop index so it re-embeds
+    def _memory_db() -> None:
+        _copy_file_overwrite(src / "memory.db", dest / "memory.db")
+        if (src / "memory.db").is_file():
+            _snapshot_sqlite_sidecars(src / "memory.db", dest / "memory.db")
+            _unlink_strict(dest / "memory_index.db")
+    _run_guarded(steps, "memory.db", _memory_db)
+
+    # 4. workspace/: docs additive; memory/knowledge old-wins
+    def _workspace() -> None:
+        _copytree_additive(src / "workspace", dest / "workspace", exclude=_WORKSPACE_EXCLUDE)
+        _copy_file_overwrite(
+            src / "workspace" / "memory" / "preferences.md",
+            dest / "workspace" / "memory" / "preferences.md",
+        )
+        _copy_file_overwrite(
+            src / "workspace" / "memory" / "projects.md",
+            dest / "workspace" / "memory" / "projects.md",
+        )
+        _copytree_additive(
+            src / "workspace" / "memory" / "history",
+            dest / "workspace" / "memory" / "history",
+        )
+        kdb_src = src / "workspace" / "knowledge" / "knowledge.db"
+        if kdb_src.is_file():
+            kdb_dst = dest / "workspace" / "knowledge" / "knowledge.db"
+            _copy_file_overwrite(kdb_src, kdb_dst)
+            _snapshot_sqlite_sidecars(kdb_src, kdb_dst)
+        _copytree_additive(src / "workspace" / ".kiro", dest / "workspace" / ".kiro")
+    _run_guarded(steps, "workspace", _workspace)
+
+    # 5. apps: 10 full; 7 shared -> data/ only
+    def _apps() -> None:
+        for a in APPS_FULL:
+            _copytree_overwrite(src / "apps" / a, dest / "apps" / a)
+        for a in APPS_SHARED:
+            _copytree_additive(src / "apps" / a / "data", dest / "apps" / a / "data")
+    _run_guarded(steps, "apps", _apps)
+
+    # 6. skills: custom only (skip meshclaw-* and already-present)
+    def _skills() -> None:
+        sk = src / "skills"
+        if not sk.is_dir():
+            return
+        for d in sorted(sk.iterdir()):
+            if not d.is_dir():
+                continue
+            if d.name.startswith("meshclaw-"):
+                continue
+            if (dest / "skills" / d.name).exists():
+                continue
+            _copytree_overwrite(d, dest / "skills" / d.name)
+    _run_guarded(steps, "skills", _skills)
+
+    # 7. artifacts/ + uploads/ (additive)
+    _run_guarded(steps, "artifacts", lambda: _copytree_additive(src / "artifacts", dest / "artifacts"))
+    _run_guarded(steps, "uploads", lambda: _copytree_additive(src / "uploads", dest / "uploads"))
+
+    # 8. crons.json (paused) + crons/ + cron-history/
+    _run_guarded(steps, "crons.json", lambda: _import_crons(src, dest))
+    _run_guarded(steps, "crons", lambda: _copytree_additive(src / "crons", dest / "crons"))
+    _run_guarded(steps, "cron-history", lambda: _copytree_additive(src / "cron-history", dest / "cron-history"))
+
+    # 9. mcp.json (absent-only, else parked) + mcp-servers/
+    def _mcp() -> None:
+        mj_src = src / "mcp.json"
+        mj_dst = dest / "mcp.json"
+        if mj_src.is_file():
+            if mj_dst.is_file():
+                _copy_file_overwrite(mj_src, mj_dst.with_name("mcp.json.from-meshclaw"))
+            else:
+                _record_new_file(mj_dst)
+                _copy_entry(mj_src, mj_dst)
+        _copytree_additive(src / "mcp-servers", dest / "mcp-servers")
+    _run_guarded(steps, "mcp", _mcp)
+
+    # .env (absent-only; in-product self-migration of the app's own data dir)
+    _run_guarded(steps, ".env", lambda: _copy_file_if_absent(src / ".env", dest / ".env"))
+
+    # 10. misc user state
+    def _misc() -> None:
+        for fn in _MISC_FILES:
+            _copy_file_if_absent(src / fn, dest / fn)
+        for dn in _MISC_DIRS:
+            _copytree_additive(src / dn, dest / dn)
+    _run_guarded(steps, "misc", _misc)
+
+    # config.json is NEVER copied — the fresh install's config is authoritative.
+
+
+def run_meshclaw_import() -> dict:
+    """Copy-then-rename import: all-or-nothing copy phase, bounded rename retry.
+
+    Guards / outcomes:
+
+    * no-op statuses: ``already_done`` / ``already_done_backup`` /
+      ``no_source`` / ``source_is_dest`` / ``nested_paths``;
+    * ``recovered_crashed_run`` / ``recovery_incomplete``: an on-disk dest
+      backup with no copied marker means a prior run was killed mid-copy
+      before it could commit or roll back. The overwrite targets are
+      restored from the durable backup (a backup missing its completion
+      marker is discarded untrusted — the crash hit the backup phase, so
+      the destination was never modified), the backup is consumed, the
+      intent is cleared, and NOTHING is imported — a retry needs fresh
+      consent. If any target cannot be restored the backup is KEPT and the
+      distinct incomplete status is returned;
+    * ``dest_not_fresh``: unless a prior copy already fully succeeded
+      (copied marker), a destination that no longer looks fresh means the
+      user accrued real data since consenting — the intent is cleared and
+      nothing is copied. No bypass;
+    * ``backup_failed``: the fail-closed write-once dest backup is a hard
+      precondition. If it fails, nothing has been touched — the partial
+      backup dir and the intent are cleared and the run bails terminally;
+    * ``rolled_back``: the copy phase is all-or-nothing. Every additive
+      path the run creates is journaled; on ANY failure — a failed manifest
+      step or an unexpected exception (e.g. a marker-write OSError) — the
+      overwrite targets are restored from the backup, the journaled
+      additive files/dirs are deleted, and the backup dir plus all markers
+      (including the intent) are cleared. The destination is back to its
+      pre-import state and the consent-gated import offer simply becomes
+      available again. ``rollback_incomplete`` is the fail-closed variant:
+      if any overwrite target could not be restored, the backup dir is KEPT
+      (with a restore-incomplete note) and the run never reports a clean
+      rollback. ``KeyboardInterrupt`` / ``SystemExit`` also trigger the
+      full rollback and are re-raised once it completes;
+    * ``ok`` / ``copied_no_rename`` / ``rename_gave_up``: after a fully
+      successful copy the *copied* marker commits the import; only the
+      ``os.rename`` of ``~/.meshclaw`` -> ``~/.meshclaw.bak`` remains
+      (``os.rename`` only — no move fallback, so a partial ``.bak`` can
+      never be created) and is retried across boots without ever
+      re-copying, bounded by an attempt counter in the copied marker. After
+      the cap the run gives up: the completed import stays in place (the
+      destination is whole), the intent is cleared, and a prominent log
+      tells the user to move ``~/.meshclaw`` aside manually;
+    * the done marker is written only after a successful rename; the copied
+      marker is cleaned up at that point.
+    """
+    global _journal
+    dest = config_dir()
+    src = _legacy_source()
+    backup = _legacy_backup()
+
+    if _done_marker_path().exists():
+        return {"status": "already_done", "renamed": False, "steps": []}
+    # Crash recovery (X1): an on-disk dest backup with no copied marker
+    # means a prior consented run was killed mid-copy (SIGKILL/power loss)
+    # before it could commit or roll back. Recover from the durable backup
+    # and bail WITHOUT importing — re-running the copy needs fresh consent.
+    # This also guarantees a fresh consented run never sees a leftover
+    # backup: the write-once backup below only ever trusts THIS run's files.
+    if _dest_backup_dir().is_dir() and not _copied_marker_path().exists():
+        return _recover_crashed_run(dest)
+    if backup.exists():
+        _write_done_marker(reason="backup_present")
+        return {"status": "already_done_backup", "renamed": False, "steps": []}
+    if not src.is_dir():
+        return {"status": "no_source", "renamed": False, "steps": []}
+    if _same_path(src, dest):
+        # Running as legacy MeshClaw itself (source == destination) — nothing
+        # to import and renaming would destroy the live home.
+        return {"status": "source_is_dest", "renamed": False, "steps": []}
+    if _nested_paths(src, dest):
+        # One dir inside the other: the copy would recurse into itself and
+        # the rename would destroy live data.
+        return {"status": "nested_paths", "renamed": False, "steps": []}
+
+    steps: list = []
+    if not _copied_marker_path().exists():
+        # Execution-time freshness re-check: consent was given against a
+        # fresh destination. If it is no longer fresh, the user accrued real
+        # data — do NOT import. No bypass.
+        if not _dest_is_fresh(dest):
+            _clear_intent()
+            return {"status": "dest_not_fresh", "renamed": False, "steps": []}
+
+        # Fail-closed, write-once backup BEFORE any overwrite step.
+        try:
+            _backup_dest_targets(dest)
+        except Exception as exc:  # noqa: BLE001 — must abort the copy phase, not boot
+            logger.warning("meshclaw import: dest backup failed: %s", exc, exc_info=True)
+            steps.append({"step": "dest_backup", "ok": False, "error": str(exc)})
+            # Nothing was overwritten: discard the partial backup and the
+            # intent — a future attempt is just the normal consent-gated
+            # offer again.
+            _remove_backup_dir()
+            _clear_intent()
+            return {"status": "backup_failed", "renamed": False, "steps": steps}
+        steps.append({"step": "dest_backup", "ok": True})
+
+        # All-or-nothing copy: journal every additive path created, and on
+        # ANY failure (step failure or unexpected exception) roll back
+        # completely and clear all state.
+        journal = _RunJournal()
+        _journal = journal
+        failed = False
+        reraise: BaseException | None = None
+        try:
+            _copy_manifest(src, dest, steps)
+            failed = any(not s.get("ok") for s in steps)
+            if not failed:
+                _write_copied_marker()
+        except BaseException as exc:  # noqa: BLE001 — uncaught-exception seam (S7/X2)
+            # BaseException, not Exception: KeyboardInterrupt / SystemExit
+            # mid-copy must also trigger the full rollback (a half-imported
+            # dest is never acceptable) — but they are RE-RAISED after the
+            # rollback completes rather than swallowed.
+            logger.error(
+                "meshclaw import: unexpected copy-phase failure: %s", exc, exc_info=True
+            )
+            steps.append({"step": "unexpected", "ok": False, "error": str(exc)})
+            failed = True
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                reraise = exc
+        finally:
+            _journal = None
+        if failed:
+            clean = _rollback_copy_phase(dest, journal)
+            if reraise is not None:
+                raise reraise
+            return {
+                "status": "rolled_back" if clean else "rollback_incomplete",
+                "renamed": False,
+                "steps": steps,
+            }
+    # else: prior copy phase already succeeded — only the rename remains.
+
+    # Final (reversible) step: rename legacy dir. os.rename only — never a
+    # copy-based move, which could leave a partial ``.bak`` on failure. The
+    # cross-boot retry is bounded so an os.rename that can never succeed
+    # (e.g. EXDEV) does not loop forever.
+    try:
+        rename_attempts = _bump_rename_attempts()
+    except OSError:
+        # Can't persist the counter; still attempt the rename this boot —
+        # it may well succeed and finish the import.
+        logger.warning(
+            "meshclaw import: could not persist rename attempt count", exc_info=True
+        )
+        rename_attempts = 1
+    if rename_attempts > _MAX_RENAME_ATTEMPTS:
+        logger.error(
+            "meshclaw import: giving up on renaming %s -> %s after %d failed "
+            "attempts. The import itself is COMPLETE — your data is in %s. "
+            "Move or delete %s manually to silence this.",
+            src, backup, rename_attempts - 1, dest, src,
+        )
+        _clear_intent()
+        return {
+            "status": "rename_gave_up",
+            "renamed": False,
+            "steps": steps,
+            "rename_attempts": rename_attempts,
+        }
+    renamed = False
+    try:
+        os.rename(src, backup)
+        renamed = True
+    except OSError:
+        logger.warning("meshclaw import: could not rename %s -> %s", src, backup, exc_info=True)
+
+    if renamed:
+        try:
+            _write_done_marker(reason="import_complete")
+        except OSError:
+            # Self-healing: with ``.bak`` present, the next run takes the
+            # already_done_backup path and re-writes the done marker.
+            logger.warning("meshclaw import: could not write done marker", exc_info=True)
+        _unlink(_copied_marker_path())
+
+    return {
+        "status": "ok" if renamed else "copied_no_rename",
+        "renamed": renamed,
+        "steps": steps,
+    }
+
+
+# The single retryable status: a successful copy whose final rename failed
+# (under its bounded attempt cap). Every other status is terminal for the
+# intent — a failed copy is fully rolled back and must be re-requested.
+_RETRYABLE_STATUSES = frozenset({"copied_no_rename"})
+
+
+def run_pending_meshclaw_import() -> dict:
+    """Phase-2 early-boot runner: import iff an intent marker is pending.
+
+    MUST be called from ``cli_server._gateway()`` before ``run_gateway()``
+    opens ``memory.db`` / ``knowledge.db``. Cheap no-op on every boot where
+    no import was requested or the import already completed.
+    """
+    if _done_marker_path().exists():
+        if _intent_marker_path().exists():
+            _clear_intent()
+        return {"ran": False, "reason": "already_done"}
+    # Crash recovery (X1) runs BEFORE the intent gates: after a SIGKILL /
+    # power loss mid-copy the next boot may be arbitrarily late (stale
+    # intent) or the intent may be gone entirely — the on-disk backup dir
+    # alone is the durable record and must be honored regardless.
+    if _dest_backup_dir().is_dir() and not _copied_marker_path().exists():
+        return {"ran": True, **_recover_crashed_run(config_dir())}
+    if not _intent_marker_path().exists():
+        return {"ran": False, "reason": "no_intent"}
+
+    # Stale consent: Phase 1 restarts the gateway immediately after writing
+    # the intent, so an old intent means the restart never happened (and the
+    # user kept using the app). Drop it. The TTL guards *consent for the
+    # destructive copy* only — once the copied marker shows the copy is
+    # committed, the only remaining work is the consent-insensitive rename,
+    # which must still complete on boots arbitrarily far in the future.
+    if _intent_is_stale() and not _copied_marker_path().exists():
+        _clear_intent()
+        return {"ran": False, "reason": "stale_intent"}
+
+    result = run_meshclaw_import()
+    # Retain the intent only for the single retryable outcome (successful
+    # copy awaiting its rename). Every other status is terminal: success /
+    # already-done write the done marker, a failed copy is fully rolled back
+    # (offer becomes available again), and the remaining no-op outcomes
+    # would repeat identically on every boot.
+    if result.get("status") not in _RETRYABLE_STATUSES:
+        _clear_intent()
+    return {"ran": True, **result}

--- a/test/test_meshclaw_import.py
+++ b/test/test_meshclaw_import.py
@@ -1,0 +1,1071 @@
+"""Tests for the legacy ~/.meshclaw -> ~/.kirocrew one-time import migration.
+
+All tests operate against throwaway tmp HOME dirs via monkeypatched seams
+(``_home`` and ``config_dir``); the real ``~/.meshclaw`` is NEVER touched.
+
+Covers: detect true/false cases + metadata, idempotency (done marker /
+backup-present guards), additive never-clobber, old-wins overwrites, crons
+imported paused, manifest parity (apps full vs shared-data vs stub-skip,
+skills skip rules, json merges, mcp/.env absent-only, config.json never
+copied), the reversible rename, the two-phase intent flow, and the
+all-or-nothing copy phase (fail-closed atomic backup, journaled additive
+residue, full rollback, bounded rename retry, uncaught-exception seam).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import kiro_crew.migrations.meshclaw_import as mod
+
+
+def _write(p: Path, text: str = "x") -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _raise_oserror(*_a, **_k):
+    raise OSError("simulated rename failure")
+
+
+def _raise_runtimeerror(*_a, **_k):
+    raise RuntimeError("simulated step failure")
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    src = home / ".meshclaw"
+    dest = home / ".kirocrew"
+    src.mkdir(parents=True)
+    dest.mkdir(parents=True)
+    monkeypatch.setattr(mod, "_home", lambda: home)
+    monkeypatch.setattr(mod, "config_dir", lambda: dest)
+    mod._size_estimate_cache.clear()
+    return SimpleNamespace(home=home, src=src, dest=dest)
+
+
+def _seed_full_source(env) -> None:
+    """A realistic legacy source tree exercising every manifest branch."""
+    s = env.src
+    _write(s / "sessions" / "old-a.jsonl", '{"a":1}\n')
+    _write(s / "session_map.json", json.dumps({"dup": "OLD", "k1": "v1"}))
+    _write(s / "folders.json", json.dumps([{"id": "f_old"}, {"id": "f_dup"}]))
+    _write(s / "memory.db", "OLD_MEMORY")
+    _write(s / "workspace" / "notes.md", "note")
+    _write(s / "workspace" / "memory" / "preferences.md", "OLD_PREFS")
+    _write(s / "workspace" / "memory" / "history" / "h1.md", "hist1")
+    _write(s / "workspace" / "knowledge" / "knowledge.db", "OLD_KDB")
+    _write(s / "workspace" / ".kiro" / "steering.md", "steer")
+    # apps: one FULL, one SHARED (data-only), one stub (no installed.json)
+    _write(s / "apps" / "board" / "installed.json", "{}")
+    _write(s / "apps" / "board" / "state" / "b.json", "board-state")
+    _write(s / "apps" / "projects" / "data" / "p.json", "proj-data")
+    _write(s / "apps" / "projects" / "code.py", "should-not-copy")
+    _write(s / "apps" / "zzz-stub" / "manifest.json", "stub")  # no installed.json
+    # skills: custom (copy), builtin (skip), name colliding with dest (skip)
+    _write(s / "skills" / "custom-skill" / "SKILL.md", "custom")
+    _write(s / "skills" / "meshclaw-builtin" / "SKILL.md", "builtin")
+    _write(s / "skills" / "existing-skill" / "SKILL.md", "SRC_EXISTING")
+    _write(s / "artifacts" / "art1.txt", "a1")
+    _write(s / "uploads" / "u1.txt", "u1")
+    _write(s / "crons.json", json.dumps({"jobs": [
+        {"id": "j1", "enabled": True, "name": "one"},
+        {"id": "j2", "enabled": True, "user_paused": False},
+    ]}))
+    _write(s / "crons" / "log.json", "cronlog")
+    _write(s / "cron-history" / "h.json", "chist")
+    _write(s / "mcp.json", "SRC_MCP")
+    _write(s / "mcp-servers" / "srv.json", "srv")
+    _write(s / ".env", "SECRET=old")
+    _write(s / "lessons.jsonl", "lesson")
+    _write(s / "plan_memory" / "pm.json", "plan")
+    _write(s / "config.json", "SRC_CONFIG")
+
+
+# ── detect ────────────────────────────────────────────────────────────────
+class TestDetect:
+    def test_available_true(self, env):
+        _write(env.src / "sessions" / "a.jsonl", "{}\n")
+        _write(env.src / "sessions" / "b.jsonl", "{}\n")
+        info = mod.detect_meshclaw_import_available()
+        assert info["available"] is True
+        assert info["sourcePath"] == "~/.meshclaw"
+        assert info["sessionCount"] == 2
+        assert info["sizeEstimateBytes"] > 0
+
+    def test_false_when_source_missing(self, env, monkeypatch):
+        monkeypatch.setattr(mod, "_home", lambda: env.home / "nope")
+        info = mod.detect_meshclaw_import_available()
+        assert info["available"] is False
+        assert info["sizeEstimateBytes"] == 0 and info["sessionCount"] == 0
+
+    def test_false_when_backup_exists(self, env):
+        (env.home / ".meshclaw.bak").mkdir()
+        assert mod.detect_meshclaw_import_available()["available"] is False
+
+    def test_false_when_done_marker_present(self, env):
+        mod._write_done_marker(reason="test")
+        assert mod.detect_meshclaw_import_available()["available"] is False
+
+    def test_false_when_source_is_dest(self, env, monkeypatch):
+        # Running as legacy MeshClaw itself: config_dir == source.
+        monkeypatch.setattr(mod, "config_dir", lambda: env.src)
+        assert mod.detect_meshclaw_import_available()["available"] is False
+
+    def test_size_estimate_skips_models_dir(self, env):
+        _write(env.src / "memory.db", "abc")
+        _write(env.src / "models" / "big.bin", "x" * 100000)
+        info = mod.detect_meshclaw_import_available()
+        assert 0 < info["sizeEstimateBytes"] < 100000
+
+    def test_size_estimate_manifest_scope_and_memo(self, env):
+        _write(env.src / "memory.db", "abc")
+        _write(env.src / "gateway.log", "x" * 5000)
+        _write(env.src / "gateway.log.1", "x" * 5000)
+        _write(env.src / "security_events.jsonl", "x" * 5000)
+        _write(env.src / "config.json", "x" * 5000)
+        _write(env.src / "apps" / "stub-app" / "manifest.json", "x" * 5000)  # no installed.json
+        _write(env.src / "apps" / "real-app" / "installed.json", "{}")
+        size = mod._estimate_size_bytes(env.src)
+        assert size == 3 + 2  # memory.db + real-app/installed.json only
+        # memoized: a second call does not re-walk (new files invisible)
+        _write(env.src / "memory2.db", "x" * 999)
+        assert mod._estimate_size_bytes(env.src) == size
+
+    def test_false_when_dest_has_sessions(self, env):
+        _write(env.src / "memory.db", "x")
+        _write(env.dest / "sessions" / "live.jsonl", "{}\n")
+        assert mod.detect_meshclaw_import_available()["available"] is False
+
+    def test_false_when_dest_memory_db_not_fresh(self, env):
+        _write(env.src / "memory.db", "x")
+        _write(env.dest / "memory.db", "x" * (mod._FRESH_MEMORY_DB_MAX_BYTES + 1))
+        assert mod.detect_meshclaw_import_available()["available"] is False
+
+    def test_true_when_dest_memory_db_small(self, env):
+        _write(env.src / "memory.db", "x")
+        _write(env.dest / "memory.db", "tiny-fresh-init")
+        assert mod.detect_meshclaw_import_available()["available"] is True
+
+
+# ── idempotency / guards ────────────────────────────────────────────────────
+class TestGuards:
+    def test_noop_when_done_marker_present(self, env):
+        _seed_full_source(env)
+        mod._write_done_marker(reason="prior")
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "already_done" and res["renamed"] is False
+        # Nothing copied, source left intact.
+        assert env.src.is_dir()
+        assert not (env.dest / "sessions" / "old-a.jsonl").exists()
+
+    def test_backup_exists_guard(self, env):
+        _seed_full_source(env)
+        (env.home / ".meshclaw.bak").mkdir()
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "already_done_backup" and res["renamed"] is False
+        assert mod._done_marker_path().exists()
+        # Source untouched, no copy performed.
+        assert env.src.is_dir()
+        assert not (env.dest / "sessions" / "old-a.jsonl").exists()
+
+    def test_no_source_guard(self, env, monkeypatch):
+        monkeypatch.setattr(mod, "_home", lambda: env.home / "gone")
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "no_source" and res["renamed"] is False
+
+    def test_source_is_dest_guard(self, env, monkeypatch):
+        monkeypatch.setattr(mod, "config_dir", lambda: env.src)
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "source_is_dest" and res["renamed"] is False
+        assert env.src.is_dir()
+
+    def test_double_run_is_noop(self, env):
+        _seed_full_source(env)
+        first = mod.run_meshclaw_import()
+        assert first["renamed"] is True
+        second = mod.run_meshclaw_import()
+        assert second["status"] == "already_done" and second["renamed"] is False
+
+
+# ── rename (reversible) + crash-safe retry semantics ────────────────────────
+class TestRename:
+    def test_rename_occurs_and_done_marker_written(self, env):
+        _seed_full_source(env)
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "ok" and res["renamed"] is True
+        assert not env.src.exists()
+        assert (env.home / ".meshclaw.bak").is_dir()
+        assert mod._done_marker_path().exists()
+        # Backup is a faithful copy (reversible): legacy data still present.
+        assert (env.home / ".meshclaw.bak" / "config.json").read_text() == "SRC_CONFIG"
+
+    def test_failed_rename_returns_copied_no_rename(self, env, monkeypatch):
+        _seed_full_source(env)
+        monkeypatch.setattr(mod.os, "rename", _raise_oserror)
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "copied_no_rename" and res["renamed"] is False
+        # no partial .bak (os.rename only, no move fallback)
+        assert not (env.home / ".meshclaw.bak").exists()
+        assert env.src.is_dir()
+        assert mod._copied_marker_path().exists()
+        assert not mod._done_marker_path().exists()
+
+    def test_retry_after_failed_rename_does_not_recopy(self, env, monkeypatch):
+        _seed_full_source(env)
+        real_rename = os.rename
+        monkeypatch.setattr(mod.os, "rename", _raise_oserror)
+        first = mod.run_meshclaw_import()
+        assert first["status"] == "copied_no_rename"
+        # Post-import: user works in the new home; source also changes.
+        (env.dest / "memory.db").write_text("POST_IMPORT_EDIT", encoding="utf-8")
+        (env.src / "memory.db").write_text("CHANGED_SRC", encoding="utf-8")
+        monkeypatch.setattr(mod.os, "rename", real_rename)
+        second = mod.run_meshclaw_import()
+        assert second["status"] == "ok" and second["renamed"] is True
+        assert second["steps"] == []  # copy phase skipped entirely
+        # retry did NOT re-copy / clobber the post-import dest change
+        assert (env.dest / "memory.db").read_text() == "POST_IMPORT_EDIT"
+        assert not env.src.exists()
+        assert mod._done_marker_path().exists()
+
+    def test_copy_failure_rolls_back_and_skips_rename(self, env, monkeypatch):
+        _seed_full_source(env)
+        monkeypatch.setattr(mod, "_merge_session_map", _raise_runtimeerror)
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "rolled_back" and res["renamed"] is False
+        assert any(s["step"] == "session_map" and not s["ok"] for s in res["steps"])
+        # source untouched, no markers written, no rename
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+        assert not mod._done_marker_path().exists()
+        assert not mod._copied_marker_path().exists()
+
+    def test_rename_gave_up_after_cap(self, env, monkeypatch):
+        _seed_full_source(env)
+        mod.write_import_intent()
+        monkeypatch.setattr(mod.os, "rename", _raise_oserror)
+        for _ in range(mod._MAX_RENAME_ATTEMPTS):
+            res = mod.run_pending_meshclaw_import()
+            assert res["status"] == "copied_no_rename"
+            assert mod._intent_marker_path().exists()  # retryable: retained
+            # Age the intent past the TTL: the staleness gate guards consent
+            # for the COPY only — a committed copy's rename must still be
+            # retried on boots arbitrarily far in the future.
+            old = datetime.now(timezone.utc) - timedelta(
+                seconds=mod._INTENT_MAX_AGE_SECONDS + 60
+            )
+            mod._intent_marker_path().write_text(
+                json.dumps({"requested_at": old.isoformat()}), encoding="utf-8"
+            )
+        final = mod.run_pending_meshclaw_import()
+        assert final["status"] == "rename_gave_up"
+        assert not mod._intent_marker_path().exists()  # gave up: cleared
+        # dest keeps the COMPLETE import; source untouched; no done marker
+        assert (env.dest / "memory.db").read_text() == "OLD_MEMORY"
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+        assert not mod._done_marker_path().exists()
+        # subsequent boots are silent no-ops (intent gone)
+        assert mod.run_pending_meshclaw_import() == {"ran": False, "reason": "no_intent"}
+
+
+# ── additive / old-wins semantics ───────────────────────────────────────────
+class TestCopySemantics:
+    def test_sessions_additive_never_clobber(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "sessions" / "old-a.jsonl", "DEST_KEEP")  # collision
+        _write(env.dest / "sessions" / "dest-only.jsonl", "keep2")
+        mod.run_meshclaw_import()
+        # existing dest file preserved (additive), source's copy skipped
+        assert (env.dest / "sessions" / "old-a.jsonl").read_text() == "DEST_KEEP"
+        assert (env.dest / "sessions" / "dest-only.jsonl").read_text() == "keep2"
+
+    def test_artifacts_and_uploads_additive(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "artifacts" / "art1.txt", "DEST_ART")
+        mod.run_meshclaw_import()
+        assert (env.dest / "artifacts" / "art1.txt").read_text() == "DEST_ART"
+        assert (env.dest / "uploads" / "u1.txt").read_text() == "u1"  # new file added
+
+    def test_memory_db_old_wins_and_index_dropped(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        _write(env.dest / "memory.db-wal", "wal")
+        _write(env.dest / "memory.db-shm", "shm")
+        _write(env.dest / "memory_index.db", "idx")
+        mod.run_meshclaw_import()
+        assert (env.dest / "memory.db").read_text() == "OLD_MEMORY"  # old wins
+        assert not (env.dest / "memory.db-wal").exists()
+        assert not (env.dest / "memory.db-shm").exists()
+        assert not (env.dest / "memory_index.db").exists()
+
+    def test_workspace_prefs_old_wins_history_additive(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "workspace" / "memory" / "preferences.md", "FRESH_PREFS")
+        _write(env.dest / "workspace" / "memory" / "history" / "dest.md", "dkeep")
+        mod.run_meshclaw_import()
+        assert (env.dest / "workspace" / "memory" / "preferences.md").read_text() == "OLD_PREFS"
+        assert (env.dest / "workspace" / "memory" / "history" / "dest.md").read_text() == "dkeep"
+        assert (env.dest / "workspace" / "memory" / "history" / "h1.md").read_text() == "hist1"
+        assert (env.dest / "workspace" / "notes.md").read_text() == "note"  # docs additive
+
+    def test_knowledge_db_old_wins_with_dest_backup(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "workspace" / "knowledge" / "knowledge.db", "FRESH_KDB")
+        _write(env.dest / "workspace" / "knowledge" / "knowledge.db-wal", "w")
+        mod.run_meshclaw_import()
+        kdir = env.dest / "workspace" / "knowledge"
+        assert (kdir / "knowledge.db").read_text() == "OLD_KDB"
+        # stale dest -wal dropped (source has none)
+        assert not (kdir / "knowledge.db-wal").exists()
+        # pre-overwrite backup of the fresh install's db lives in the
+        # dedicated dest-backup dir (replaces the old .new-backup file)
+        bdir = mod._dest_backup_dir()
+        assert (bdir / "workspace" / "knowledge" / "knowledge.db").read_text() == "FRESH_KDB"
+        assert not (kdir / "knowledge.db.new-backup").exists()
+
+    def test_source_wal_copied_for_consistent_snapshot(self, env):
+        _seed_full_source(env)
+        _write(env.src / "memory.db-wal", "SRC_WAL")
+        _write(env.dest / "memory.db-shm", "STALE_SHM")
+        _write(env.dest / "memory_index.db", "idx")
+        mod.run_meshclaw_import()
+        assert (env.dest / "memory.db-wal").read_text() == "SRC_WAL"  # snapshot
+        assert not (env.dest / "memory.db-shm").exists()  # stale dest dropped
+        assert not (env.dest / "memory_index.db").exists()  # always dropped
+
+    def test_pre_overwrite_dest_backup_made(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        _write(env.dest / "workspace" / "memory" / "preferences.md", "FRESH_PREFS")
+        mod.run_meshclaw_import()
+        bdir = mod._dest_backup_dir()
+        assert (bdir / "memory.db").read_text() == "FRESH_MEMORY"
+        assert (bdir / "workspace" / "memory" / "preferences.md").read_text() == "FRESH_PREFS"
+        # only targets that existed in dest are backed up
+        assert not (bdir / "crons.json").exists()
+        assert not (bdir / "workspace" / "memory" / "projects.md").exists()
+        # atomic backup writes: no tmp residue at the backup paths
+        assert not list(bdir.rglob("*.tmp-import"))
+
+    def test_dir_symlink_preserved_as_symlink(self, env):
+        _seed_full_source(env)
+        real = env.src / "artifacts" / "real-dir"
+        _write(real / "f.txt", "rf")
+        link = env.src / "artifacts" / "linked"
+        link.symlink_to(real, target_is_directory=True)
+        target = os.readlink(link)
+        mod.run_meshclaw_import()
+        d = env.dest / "artifacts" / "linked"
+        assert d.is_symlink()
+        assert os.readlink(d) == target
+        # the real dir is still copied as a dir
+        assert (env.dest / "artifacts" / "real-dir" / "f.txt").read_text() == "rf"
+
+
+# ── apps / skills manifest parity ───────────────────────────────────────────
+class TestAppsAndSkills:
+    def test_apps_full_shared_and_stub_skip(self, env):
+        _seed_full_source(env)
+        mod.run_meshclaw_import()
+        # FULL app copied entirely
+        assert (env.dest / "apps" / "board" / "installed.json").exists()
+        assert (env.dest / "apps" / "board" / "state" / "b.json").read_text() == "board-state"
+        # SHARED app: only data/ imported
+        assert (env.dest / "apps" / "projects" / "data" / "p.json").read_text() == "proj-data"
+        assert not (env.dest / "apps" / "projects" / "code.py").exists()
+        # stub app (no installed.json, not in either list) never touched
+        assert not (env.dest / "apps" / "zzz-stub").exists()
+
+    def test_skills_skip_builtin_and_existing(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "skills" / "existing-skill" / "SKILL.md", "DEST_EXISTING")
+        mod.run_meshclaw_import()
+        assert (env.dest / "skills" / "custom-skill" / "SKILL.md").read_text() == "custom"
+        assert not (env.dest / "skills" / "meshclaw-builtin").exists()
+        # pre-existing skill dir untouched (not clobbered by src)
+        assert (env.dest / "skills" / "existing-skill" / "SKILL.md").read_text() == "DEST_EXISTING"
+
+
+# ── json merges ─────────────────────────────────────────────────────────────
+class TestJsonMerges:
+    def test_session_map_union_new_wins(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "session_map.json", json.dumps({"dup": "NEW", "k2": "v2"}))
+        mod.run_meshclaw_import()
+        merged = json.loads((env.dest / "session_map.json").read_text())
+        assert merged == {"dup": "NEW", "k1": "v1", "k2": "v2"}  # new wins on collision
+
+    def test_folders_union_new_wins(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "folders.json", json.dumps([{"id": "f_dup"}, {"id": "f_new"}]))
+        mod.run_meshclaw_import()
+        ids = [f["id"] for f in json.loads((env.dest / "folders.json").read_text())]
+        assert set(ids) == {"f_dup", "f_new", "f_old"}
+        assert ids.index("f_new") < ids.index("f_old")  # new listed first
+
+
+# ── crons imported paused / merged ──────────────────────────────────────────
+class TestCrons:
+    def test_crons_imported_paused(self, env):
+        _seed_full_source(env)
+        mod.run_meshclaw_import()
+        data = json.loads((env.dest / "crons.json").read_text())
+        assert data["jobs"] and all(
+            j["enabled"] is False and j["user_paused"] is True for j in data["jobs"]
+        )
+        assert (env.dest / "crons" / "log.json").exists()
+        assert (env.dest / "cron-history" / "h.json").exists()
+
+    def test_crons_merge_keeps_dest_jobs_dest_wins(self, env):
+        _seed_full_source(env)  # legacy has j1, j2
+        _write(env.dest / "crons.json", json.dumps({"jobs": [
+            {"id": "j1", "enabled": True, "name": "dest-one"},
+            {"id": "d9", "enabled": True},
+        ], "schema": 2}))
+        mod.run_meshclaw_import()
+        data = json.loads((env.dest / "crons.json").read_text())
+        by_id = {j["id"]: j for j in data["jobs"]}
+        # dest wins on id collision: j1 stays enabled with dest's name
+        assert by_id["j1"]["enabled"] is True and by_id["j1"]["name"] == "dest-one"
+        # dest-only job kept untouched
+        assert by_id["d9"]["enabled"] is True
+        # legacy-only job appended, paused
+        assert by_id["j2"]["enabled"] is False and by_id["j2"]["user_paused"] is True
+        # other dest top-level keys preserved
+        assert data["schema"] == 2
+
+    def test_crons_legacy_list_form_normalized_and_disabled(self, env):
+        _write(env.src / "memory.db", "m")
+        _write(env.src / "crons.json", json.dumps([
+            {"id": "L1", "enabled": True},
+            {"id": "L2", "enabled": True, "user_paused": False},
+        ]))
+        mod.run_meshclaw_import()
+        data = json.loads((env.dest / "crons.json").read_text())
+        assert isinstance(data, dict)
+        assert {j["id"] for j in data["jobs"]} == {"L1", "L2"}
+        assert all(j["enabled"] is False and j["user_paused"] is True for j in data["jobs"])
+
+
+# ── mcp.json / .env / config.json ───────────────────────────────────────────
+class TestSensitiveFiles:
+    def test_mcp_json_copied_when_absent(self, env):
+        _seed_full_source(env)
+        mod.run_meshclaw_import()
+        assert (env.dest / "mcp.json").read_text() == "SRC_MCP"
+        assert (env.dest / "mcp-servers" / "srv.json").exists()
+
+    def test_mcp_json_parked_when_present(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "mcp.json", "DEST_MCP")
+        mod.run_meshclaw_import()
+        assert (env.dest / "mcp.json").read_text() == "DEST_MCP"  # new preserved
+        assert (env.dest / "mcp.json.from-meshclaw").read_text() == "SRC_MCP"
+
+    def test_env_absent_only(self, env):
+        _seed_full_source(env)
+        mod.run_meshclaw_import()
+        assert (env.dest / ".env").read_text() == "SECRET=old"
+
+    def test_env_not_overwritten_when_present(self, env):
+        _seed_full_source(env)
+        _write(env.dest / ".env", "SECRET=new")
+        mod.run_meshclaw_import()
+        assert (env.dest / ".env").read_text() == "SECRET=new"
+
+    def test_config_json_never_copied(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "config.json", "DEST_CONFIG")
+        mod.run_meshclaw_import()
+        assert (env.dest / "config.json").read_text() == "DEST_CONFIG"
+
+    def test_misc_state_additive(self, env):
+        _seed_full_source(env)
+        mod.run_meshclaw_import()
+        assert (env.dest / "lessons.jsonl").read_text() == "lesson"
+        assert (env.dest / "plan_memory" / "pm.json").read_text() == "plan"
+
+
+# ── two-phase intent flow ───────────────────────────────────────────────────
+class TestTwoPhase:
+    def test_run_pending_noop_without_intent(self, env):
+        _seed_full_source(env)
+        res = mod.run_pending_meshclaw_import()
+        assert res == {"ran": False, "reason": "no_intent"}
+        assert env.src.is_dir()  # untouched
+        assert not (env.dest / "sessions" / "old-a.jsonl").exists()
+
+    def test_intent_then_run_pending_performs_import(self, env):
+        _seed_full_source(env)
+        p = mod.write_import_intent()
+        assert p.exists() and mod._intent_marker_path().exists()
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["renamed"] is True
+        assert not env.src.exists()
+        assert (env.home / ".meshclaw.bak").is_dir()
+        assert mod._done_marker_path().exists()
+        # intent cleared once complete
+        assert not mod._intent_marker_path().exists()
+
+    def test_run_pending_noop_when_done(self, env):
+        mod._write_done_marker(reason="prior")
+        mod.write_import_intent()  # stale intent
+        res = mod.run_pending_meshclaw_import()
+        assert res == {"ran": False, "reason": "already_done"}
+        # stale intent cleaned up
+        assert not mod._intent_marker_path().exists()
+
+    def test_write_import_intent_creates_marker_dir(self, env):
+        assert not mod._marker_dir().exists()
+        mod.write_import_intent()
+        assert mod._marker_dir().is_dir()
+        assert mod._intent_marker_path().exists()
+
+    def test_intent_cleared_on_no_source(self, env, monkeypatch):
+        mod.write_import_intent()
+        monkeypatch.setattr(mod, "_home", lambda: env.home / "gone")
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "no_source"
+        # terminal no-op: intent cleared so it doesn't repeat every boot
+        assert not mod._intent_marker_path().exists()
+
+    def test_intent_cleared_on_rolled_back_copy(self, env, monkeypatch):
+        _seed_full_source(env)
+        mod.write_import_intent()
+        monkeypatch.setattr(mod, "_merge_session_map", _raise_runtimeerror)
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "rolled_back"
+        # NO retained retry state: a failed copy is fully rolled back and
+        # the intent is cleared — a future attempt is a fresh consent-gated
+        # offer, not an automatic retry.
+        assert not mod._intent_marker_path().exists()
+        assert not mod._copied_marker_path().exists()
+
+    def test_intent_retained_on_copied_no_rename(self, env, monkeypatch):
+        _seed_full_source(env)
+        mod.write_import_intent()
+        monkeypatch.setattr(mod.os, "rename", _raise_oserror)
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "copied_no_rename"
+        # rename retried on next boot: intent must survive
+        assert mod._intent_marker_path().exists()
+
+
+# ── all-or-nothing copy phase (backup / journal / rollback) ─────────────────
+class TestTransactional:
+    def test_backup_failure_aborts_before_any_overwrite(self, env, monkeypatch):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+
+        def _boom(*_a, **_k):
+            raise OSError("simulated backup copy failure")
+
+        monkeypatch.setattr(mod.shutil, "copy2", _boom)
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "backup_failed" and res["renamed"] is False
+        # fail-closed: the ONLY step recorded is the failed backup — no
+        # manifest step ran, so nothing in dest was overwritten
+        assert res["steps"] == [
+            {"step": "dest_backup", "ok": False, "error": "simulated backup copy failure"}
+        ]
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        assert not (env.dest / "sessions").exists()
+        assert env.src.is_dir()
+        # terminal: partial backup dir and intent are cleared — a future
+        # attempt is the normal consent-gated offer again
+        assert not mod._dest_backup_dir().exists()
+        assert not mod._intent_marker_path().exists()
+        assert mod.detect_meshclaw_import_available()["available"] is True
+
+    def test_torn_backup_never_at_final_path(self, env, monkeypatch):
+        _write(env.dest / "memory.db", "PRISTINE")
+        captured = []
+
+        def _torn(s, d, **_k):
+            # simulate a crash mid-copy that leaves a partial file at ``d``
+            captured.append(str(d))
+            Path(d).write_text("PARTIAL", encoding="utf-8")
+            raise OSError("crash mid-backup")
+
+        monkeypatch.setattr(mod.shutil, "copy2", _torn)
+        with pytest.raises(OSError):
+            mod._backup_dest_targets(env.dest)
+        # the write went to a tmp sibling, never the final backup path...
+        assert captured and all(p.endswith(".tmp-import") for p in captured)
+        b = mod._dest_backup_dir() / "memory.db"
+        assert not b.exists()  # no truncated file the restore would trust
+        # ...and the tmp itself was cleaned up
+        assert not list(mod._dest_backup_dir().rglob("*.tmp-import"))
+
+    def test_midmanifest_failure_full_rollback(self, env, monkeypatch):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+        state = {"fail": True}
+        real_import_crons = mod._import_crons
+
+        def _flaky(src, dst):
+            if state["fail"]:
+                raise RuntimeError("simulated crons failure")
+            return real_import_crons(src, dst)
+
+        monkeypatch.setattr(mod, "_import_crons", _flaky)
+        first = mod.run_meshclaw_import()
+        assert first["status"] == "rolled_back"
+        # crons.json fails AFTER memory.db + workspace were overwritten:
+        # rollback must restore memory.db from the backup...
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        # ...remove overwrite targets that did not exist pre-import...
+        assert not (env.dest / "workspace" / "memory" / "preferences.md").exists()
+        assert not (env.dest / "crons.json").exists()
+        assert not (env.dest / "session_map.json").exists()
+        # ...and delete ALL additive residue this run created
+        assert not (env.dest / "sessions").exists()
+        assert not (env.dest / "apps").exists()
+        assert not (env.dest / "skills").exists()
+        assert not (env.dest / "artifacts").exists()
+        assert not (env.dest / "uploads").exists()
+        assert not (env.dest / "mcp.json").exists()
+        assert not (env.dest / ".env").exists()
+        assert not (env.dest / "lessons.jsonl").exists()
+        assert not (env.dest / "workspace").exists()
+        # all state cleared: no markers, no backup dir, no intent
+        assert not mod._copied_marker_path().exists()
+        assert not mod._intent_marker_path().exists()
+        assert not mod._dest_backup_dir().exists()
+        # source never touched
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+        # dest is back to fresh: the import offer is available again
+        assert mod.detect_meshclaw_import_available()["available"] is True
+
+        # a fresh consent-gated attempt then succeeds normally
+        state["fail"] = False
+        mod.write_import_intent()
+        second = mod.run_pending_meshclaw_import()
+        assert second["status"] == "ok" and second["renamed"] is True
+        assert (env.dest / "memory.db").read_text() == "OLD_MEMORY"
+        assert (env.dest / "workspace" / "memory" / "preferences.md").read_text() == "OLD_PREFS"
+        assert mod._done_marker_path().exists()
+        assert not env.src.exists()
+
+    def test_uncaught_exception_rolls_back(self, env, monkeypatch):
+        # S7 seam: an exception ESCAPING the guarded manifest (e.g. the
+        # copied-marker write failing with OSError) must trigger the same
+        # full rollback instead of leaving intent + partial state behind.
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+        monkeypatch.setattr(
+            mod, "_write_copied_marker", _raise_oserror
+        )
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "rolled_back" and res["renamed"] is False
+        assert any(s["step"] == "unexpected" and not s["ok"] for s in res["steps"])
+        # full rollback despite the copy itself having succeeded
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        assert not (env.dest / "sessions").exists()
+        assert not (env.dest / "workspace").exists()
+        assert not mod._copied_marker_path().exists()
+        assert not mod._intent_marker_path().exists()
+        assert not mod._dest_backup_dir().exists()
+        assert env.src.is_dir()
+        assert mod.detect_meshclaw_import_available()["available"] is True
+
+    def test_freshness_recheck_bails_and_clears_intent(self, env):
+        _seed_full_source(env)
+        mod.write_import_intent()
+        # dest accrued real data since consent (a session transcript)
+        _write(env.dest / "sessions" / "accrued.jsonl", "DEST_DATA")
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "dest_not_fresh" and res["steps"] == []
+        assert not (env.dest / "memory.db").exists()  # nothing copied
+        assert (env.dest / "sessions" / "accrued.jsonl").read_text() == "DEST_DATA"
+        assert env.src.is_dir()
+        assert not mod._done_marker_path().exists()
+        # simple clear+bail: no bypass, no retained retry state
+        assert not mod._intent_marker_path().exists()
+
+    def test_stale_intent_ttl_expiry_bails(self, env):
+        _seed_full_source(env)
+        p = mod.write_import_intent()
+        # age the intent past the TTL by rewriting its requested_at
+        old = datetime.now(timezone.utc) - timedelta(
+            seconds=mod._INTENT_MAX_AGE_SECONDS + 60
+        )
+        p.write_text(
+            json.dumps({"requested_at": old.isoformat()}), encoding="utf-8"
+        )
+        res = mod.run_pending_meshclaw_import()
+        assert res == {"ran": False, "reason": "stale_intent"}
+        assert not mod._intent_marker_path().exists()  # dropped, not honored
+        assert not (env.dest / "memory.db").exists()  # nothing imported
+        assert env.src.is_dir()
+
+    def test_nesting_guard_refuses(self, env, monkeypatch):
+        _seed_full_source(env)
+        nested_dest = env.src / "nested-home"
+        nested_dest.mkdir(parents=True)
+        monkeypatch.setattr(mod, "config_dir", lambda: nested_dest)
+        assert mod.detect_meshclaw_import_available()["available"] is False
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "nested_paths" and res["renamed"] is False
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+
+    def test_unlink_failure_raises_not_write_through_symlink(self, env, tmp_path):
+        outside = tmp_path / "outside.txt"
+        _write(outside, "SAFE")
+        srcdir = env.src / "adir"
+        _write(srcdir / "f.txt", "NEW")
+        dstdir = env.dest / "adir"
+        dstdir.mkdir(parents=True)
+        (dstdir / "f.txt").symlink_to(outside)
+        os.chmod(dstdir, 0o500)  # unlink in this dir now fails
+        try:
+            with pytest.raises(OSError):
+                mod._copytree_overwrite(srcdir, dstdir)
+            # the failure surfaced instead of writing through the symlink
+            assert outside.read_text() == "SAFE"
+            assert (dstdir / "f.txt").is_symlink()
+        finally:
+            os.chmod(dstdir, 0o755)
+
+    def test_dest_dir_symlink_replaced_not_written_through(self, env, tmp_path):
+        # S4: a dest DIRECTORY position occupied by a symlink must be
+        # strictly unlinked and replaced with a real dir — never written
+        # through into the outside tree.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        srcdir = env.src / "apps" / "board"
+        _write(srcdir / "sub" / "f.txt", "NEW")
+        dstdir = env.dest / "apps" / "board"
+        dstdir.mkdir(parents=True)
+        (dstdir / "sub").symlink_to(outside, target_is_directory=True)
+        mod._copytree_overwrite(srcdir, dstdir)
+        assert not (dstdir / "sub").is_symlink()  # replaced with a real dir
+        assert (dstdir / "sub" / "f.txt").read_text() == "NEW"
+        assert not (outside / "f.txt").exists()  # outside tree untouched
+
+    def test_dest_dir_symlink_unlink_failure_raises(self, env, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        srcdir = env.src / "apps" / "board"
+        _write(srcdir / "sub" / "f.txt", "NEW")
+        dstdir = env.dest / "apps" / "board"
+        dstdir.mkdir(parents=True)
+        (dstdir / "sub").symlink_to(outside, target_is_directory=True)
+        os.chmod(dstdir, 0o500)  # unlinking the dir symlink now fails
+        try:
+            with pytest.raises(OSError):
+                mod._copytree_overwrite(srcdir, dstdir)
+            assert (dstdir / "sub").is_symlink()  # strict: kept, not followed
+            assert not (outside / "f.txt").exists()
+        finally:
+            os.chmod(dstdir, 0o755)
+
+
+# ── crash recovery (durable on-disk backup record) ─────────────────────────
+class TestCrashRecovery:
+    def test_crashed_run_recovered_without_import(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        _write(env.dest / "workspace" / "memory" / "preferences.md", "FRESH_PREFS")
+        # simulate the durable state a SIGKILL mid-copy leaves behind: a
+        # COMPLETE dest backup, overwritten targets, no copied marker.
+        mod._backup_dest_targets(env.dest)
+        _write(env.dest / "memory.db", "IMPORTED_OLD")
+        _write(env.dest / "workspace" / "memory" / "preferences.md", "OLD_PREFS")
+        _write(env.dest / "crons.json", "{}")  # crashed run created it (no backup)
+        mod.write_import_intent()
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "recovered_crashed_run"
+        # overwrite targets restored from the backup...
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        assert (
+            env.dest / "workspace" / "memory" / "preferences.md"
+        ).read_text() == "FRESH_PREFS"
+        # ...a target with no backup entry did not exist pre-import: removed
+        assert not (env.dest / "crons.json").exists()
+        # backup consumed, intent cleared, and NOTHING was imported
+        assert not mod._dest_backup_dir().exists()
+        assert not mod._intent_marker_path().exists()
+        assert not mod._copied_marker_path().exists()
+        assert not (env.dest / "sessions").exists()
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+        # a leftover backup can never poison a later consented run: a fresh
+        # re-consent starts with no backup dir at all
+        mod.write_import_intent()
+        second = mod.run_pending_meshclaw_import()
+        assert second["status"] == "ok" and second["renamed"] is True
+        assert (env.dest / "memory.db").read_text() == "OLD_MEMORY"
+
+    def test_crashed_run_recovered_even_without_intent(self, env):
+        # SIGKILL + a much later boot: the intent is stale or gone entirely —
+        # the on-disk backup alone must trigger recovery.
+        _write(env.src / "memory.db", "OLD")
+        _write(env.dest / "memory.db", "FRESH")
+        mod._backup_dest_targets(env.dest)
+        _write(env.dest / "memory.db", "IMPORTED")
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "recovered_crashed_run"
+        assert (env.dest / "memory.db").read_text() == "FRESH"
+        assert not mod._dest_backup_dir().exists()
+
+    def test_crashed_backup_phase_discards_partial_backup(self, env):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        _write(env.dest / "session_map.json", "{}")
+        # a crash DURING the backup phase: one target copied, but the
+        # completion marker never written — and dest never modified.
+        # (session_map.json existed pre-import but was NOT yet backed up.)
+        _write(mod._dest_backup_dir() / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+        res = mod.run_pending_meshclaw_import()
+        assert res["status"] == "recovered_crashed_run"
+        # the partial backup is discarded WITHOUT restoring from it — a
+        # restore would have DELETED session_map.json (no backup entry)
+        assert not mod._dest_backup_dir().exists()
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        assert (env.dest / "session_map.json").read_text() == "{}"
+        assert not mod._intent_marker_path().exists()
+        assert not (env.dest / "sessions").exists()
+
+    def test_recovery_incomplete_keeps_backup(self, env, monkeypatch):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod._backup_dest_targets(env.dest)
+        _write(env.dest / "memory.db", "IMPORTED")
+        monkeypatch.setattr(mod, "_restore_dest_targets", lambda dest: ["memory.db"])
+        mod.write_import_intent()
+        res = mod.run_pending_meshclaw_import()
+        assert res["ran"] is True and res["status"] == "recovery_incomplete"
+        assert res["restore_failures"] == ["memory.db"]
+        # never reports clean: the backup is KEPT with an incomplete note
+        assert mod._dest_backup_dir().is_dir()
+        assert (
+            mod._dest_backup_dir() / mod._RESTORE_INCOMPLETE_MARKER
+        ).is_file()
+        assert not mod._intent_marker_path().exists()
+        # and nothing was imported
+        assert not (env.dest / "sessions").exists()
+        assert env.src.is_dir()
+
+    def test_copied_marker_present_is_not_a_crash(self, env, monkeypatch):
+        # backup dir + copied marker = the committed rename-retry path, not
+        # a crash — recovery must NOT fire and clobber the completed import.
+        _seed_full_source(env)
+        mod.write_import_intent()
+        real_rename = os.rename
+        state = {"fail": True}
+
+        def _maybe_rename(srcp, dstp):
+            if state["fail"]:
+                raise OSError("simulated rename failure")
+            return real_rename(srcp, dstp)
+
+        monkeypatch.setattr(mod.os, "rename", _maybe_rename)
+        first = mod.run_pending_meshclaw_import()
+        assert first["status"] == "copied_no_rename"
+        assert mod._dest_backup_dir().is_dir()  # backup dir still on disk
+        state["fail"] = False
+        second = mod.run_pending_meshclaw_import()
+        assert second["status"] == "ok" and second["renamed"] is True
+        assert (env.dest / "memory.db").read_text() == "OLD_MEMORY"
+
+    def test_keyboard_interrupt_rolls_back_and_reraises(self, env, monkeypatch):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+
+        def _ki(*_a, **_k):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(mod, "_import_crons", _ki)
+        with pytest.raises(KeyboardInterrupt):
+            mod.run_meshclaw_import()
+        # the full rollback happened BEFORE the re-raise
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEMORY"
+        assert not (env.dest / "sessions").exists()
+        assert not (env.dest / "workspace").exists()
+        assert not mod._dest_backup_dir().exists()
+        assert not mod._copied_marker_path().exists()
+        assert not mod._intent_marker_path().exists()
+        assert env.src.is_dir()
+        assert not (env.home / ".meshclaw.bak").exists()
+
+
+# ── fail-closed restore (WAL-set ordering, failure collection) ──────────────
+class TestFailClosedRestore:
+    def test_rollback_incomplete_keeps_backup(self, env, monkeypatch):
+        _seed_full_source(env)
+        _write(env.dest / "memory.db", "FRESH_MEMORY")
+        mod.write_import_intent()
+        monkeypatch.setattr(mod, "_import_crons", _raise_runtimeerror)
+        monkeypatch.setattr(mod, "_restore_dest_targets", lambda dest: ["memory.db"])
+        res = mod.run_meshclaw_import()
+        assert res["status"] == "rollback_incomplete" and res["renamed"] is False
+        # never reports clean: backup KEPT with an incomplete note
+        assert mod._dest_backup_dir().is_dir()
+        assert (
+            mod._dest_backup_dir() / mod._RESTORE_INCOMPLETE_MARKER
+        ).is_file()
+        # run state still cleared; no rename attempted
+        assert not mod._copied_marker_path().exists()
+        assert not mod._intent_marker_path().exists()
+        assert not (env.home / ".meshclaw.bak").exists()
+        assert env.src.is_dir()
+
+    def test_wal_removed_before_db_replace(self, env, monkeypatch):
+        _write(env.dest / "memory.db", "FRESH")
+        mod._backup_dest_targets(env.dest)
+        # simulate the failed run's overwrite: replaced db + foreign WAL
+        _write(env.dest / "memory.db", "IMPORTED")
+        _write(env.dest / "memory.db-wal", "FOREIGN_WAL")
+        real_replace = os.replace
+        seen = {}
+
+        def _watch(srcp, dstp):
+            if str(dstp).endswith("memory.db"):
+                seen["wal_gone_at_replace"] = not (
+                    env.dest / "memory.db-wal"
+                ).exists()
+            return real_replace(srcp, dstp)
+
+        monkeypatch.setattr(mod.os, "replace", _watch)
+        failures = mod._restore_dest_targets(env.dest)
+        assert failures == []
+        assert (env.dest / "memory.db").read_text() == "FRESH"
+        assert not (env.dest / "memory.db-wal").exists()
+        # the foreign WAL was gone BEFORE the db was swapped in
+        assert seen.get("wal_gone_at_replace") is True
+
+    def test_backed_up_sidecars_restored_with_db(self, env):
+        _write(env.dest / "memory.db", "FRESH")
+        _write(env.dest / "memory.db-wal", "FRESH_WAL")
+        mod._backup_dest_targets(env.dest)
+        _write(env.dest / "memory.db", "IMPORTED")
+        _write(env.dest / "memory.db-wal", "IMPORTED_WAL")
+        failures = mod._restore_dest_targets(env.dest)
+        assert failures == []
+        assert (env.dest / "memory.db").read_text() == "FRESH"
+        assert (env.dest / "memory.db-wal").read_text() == "FRESH_WAL"
+
+    def test_restore_collects_failures_best_effort(self, env):
+        _write(env.dest / "memory.db", "FRESH_MEM")
+        _write(env.dest / "workspace" / "memory" / "preferences.md", "FRESH_PREFS")
+        mod._backup_dest_targets(env.dest)
+        _write(env.dest / "memory.db", "IMPORTED")
+        (env.dest / "workspace" / "memory" / "preferences.md").write_text(
+            "IMPORTED_PREFS", encoding="utf-8"
+        )
+        os.chmod(env.dest / "workspace" / "memory", 0o500)  # prefs restore fails
+        try:
+            failures = mod._restore_dest_targets(env.dest)
+        finally:
+            os.chmod(env.dest / "workspace" / "memory", 0o755)
+        # NOT silent: the failed target is reported...
+        assert failures == ["workspace/memory/preferences.md"]
+        # ...and the other targets were still restored (best effort goes on)
+        assert (env.dest / "memory.db").read_text() == "FRESH_MEM"
+
+
+# ── onboarding /start restart guard (dashboard handler) ─────────────────────
+class TestRestartInflightFlag:
+    @staticmethod
+    def _make_request(state):
+        from aiohttp import web
+        from aiohttp.test_utils import make_mocked_request
+
+        app = web.Application()
+        app["state"] = state
+        return make_mocked_request(
+            "POST", "/api/onboarding/meshclaw-import/start", app=app
+        )
+
+    @staticmethod
+    def _state():
+        return SimpleNamespace(
+            meshclaw_import_restart_inflight=False,
+            _background_tasks=set(),
+        )
+
+    @staticmethod
+    async def _settle(state):
+        # Drain until quiescent: done-callbacks (scheduled via call_soon)
+        # may spawn follow-up tasks (e.g. the intent-cleanup to_thread task).
+        for _ in range(10):
+            tasks = list(state._background_tasks)
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            for _ in range(3):
+                await asyncio.sleep(0)
+            if not state._background_tasks:
+                break
+
+    @pytest.mark.asyncio
+    async def test_flag_released_when_restart_returns_without_exec(
+        self, env, monkeypatch
+    ):
+        import kiro_crew.dashboard.handlers.core as core_mod
+        import kiro_crew.dashboard.handlers.updates as updates_mod
+
+        _seed_full_source(env)
+        monkeypatch.setattr(
+            core_mod, "_sel",
+            lambda: SimpleNamespace(log_api_access=lambda **_kw: None),
+        )
+
+        async def _no_exec_restart(_state):
+            # e.g. the invalid-executable early return: the task completes
+            # normally but NO exec happened — the process keeps running.
+            return None
+
+        monkeypatch.setattr(updates_mod, "_restart_gateway", _no_exec_restart)
+        state = self._state()
+        resp = await core_mod.api_meshclaw_import_start(self._make_request(state))
+        assert resp.status == 200
+        await self._settle(state)
+        # reaching the done-callback means no exec happened: the guard MUST
+        # be released so the endpoint doesn't 409 forever
+        assert state.meshclaw_import_restart_inflight is False
+        assert not state._background_tasks
+        # the restart this intent was written for never happened — the
+        # intent must NOT linger for an unrelated later restart to consume
+        assert not mod._intent_marker_path().exists()
+
+    @pytest.mark.asyncio
+    async def test_flag_released_when_restart_raises(self, env, monkeypatch):
+        import kiro_crew.dashboard.handlers.core as core_mod
+        import kiro_crew.dashboard.handlers.updates as updates_mod
+
+        _seed_full_source(env)
+        monkeypatch.setattr(
+            core_mod, "_sel",
+            lambda: SimpleNamespace(log_api_access=lambda **_kw: None),
+        )
+
+        async def _boom(_state):
+            raise RuntimeError("restart failed")
+
+        monkeypatch.setattr(updates_mod, "_restart_gateway", _boom)
+        state = self._state()
+        resp = await core_mod.api_meshclaw_import_start(self._make_request(state))
+        assert resp.status == 200
+        await self._settle(state)
+        assert state.meshclaw_import_restart_inflight is False
+        assert not state._background_tasks
+        # a failed restart is equally a no-exec outcome: intent cleared
+        assert not mod._intent_marker_path().exists()

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -70,6 +70,7 @@ import { useUpdateSubscription } from './hooks/useUpdateSubscription'
 import UpdateModal from './components/UpdateModal'
 import BottomTerminalPanel from './components/BottomTerminalPanel'
 import { toggleBottomTerminal } from './hooks/useBottomTerminal'
+import { MeshclawImportCard } from './components/MeshclawImportCard'
 import { setTerminalEnabledFlag } from './utils/terminalRegistry'
 import AppsPage from './pages/AppsPage'
 import AppPage from './pages/AppPage'
@@ -1696,6 +1697,11 @@ export default function App() {
         initialOpen={showOnboarding}
         onComplete={() => { markOnboarded(); setShowOnboarding(false) }}
       />
+
+      {/* First-run legacy MeshClaw data import. Self-gates on backend
+          availability; suppressed while the onboarding flow is still open so
+          the two first-run overlays never stack. */}
+      <MeshclawImportCard suppressed={showOnboarding || showAgentImport} />
 
       {/* Mobile backdrop */}
       <AnimatePresence>

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -646,6 +646,16 @@ export interface AgentImportApplyResponse {
   summary: AgentImportSummary
 }
 
+/** GET /api/onboarding/meshclaw-import/status — legacy ~/.meshclaw data dir
+ *  discovery for the first-run import onboarding card. `available` is false on
+ *  fresh installs with no legacy dir, so the card never renders for them. */
+export interface MeshclawImportStatus {
+  available: boolean
+  sourcePath: string
+  sizeEstimateBytes: number
+  sessionCount: number
+}
+
 export const api = {
   status: () => fetch('/api/status').then(j),
   tunnelStatus: () => fetch('/api/tunnel/status').then(j) as Promise<TunnelStatus>,
@@ -1445,6 +1455,14 @@ export const api = {
     const errText = await r.text()
     throw new ApiError(r.status, errText || `HTTP ${r.status}`)
   },
+
+  // Onboarding: legacy MeshClaw data import (first-run migration card).
+  // start() triggers a gateway restart that performs the import; the UI shows a
+  // reconnecting state and the existing socket-reconnect logic re-establishes.
+  meshclawImportStatus: () =>
+    get('/api/onboarding/meshclaw-import/status').then(j) as Promise<MeshclawImportStatus>,
+  meshclawImportStart: () =>
+    post('/api/onboarding/meshclaw-import/start').then(j) as Promise<{ status: string }>,
 
   // Tips
   tipsNext: () => get('/api/tips/next').then(jNullable) as Promise<{ tip: { id: string; feature: string; title: string; body: string; why: string; doc: string; cta_prompt: string; action?: { kind: 'route'; label: string; route: string } | null } | null; glow: boolean } | null>,

--- a/website/src/components/MeshclawImportCard.tsx
+++ b/website/src/components/MeshclawImportCard.tsx
@@ -1,0 +1,373 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { Package, Download, Loader2, RefreshCw, X } from 'lucide-react'
+import { api } from '../api/client'
+
+// Persist a skip so the card does not nag on every reconnect within this
+// browser (mirrors the `mc-onboarded` theme-onboarding flag). A successful
+// import renames ~/.meshclaw -> ~/.meshclaw.bak server-side, so after the
+// restart the status query reports available:false and the card stays gone
+// regardless of this flag.
+const DISMISS_KEY = 'mc-meshclaw-import-dismissed'
+
+/** Human-readable byte size, e.g. 1536 -> "1.5 KB", 0 -> "0 B". */
+export function formatBytes(n: number): string {
+  if (!n || n <= 0 || !Number.isFinite(n)) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let v = n
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  const rounded = i === 0 || v >= 10 ? Math.round(v).toString() : v.toFixed(1)
+  return `${rounded} ${units[i]}`
+}
+
+/**
+ * True when the start-mutation failure is a real HTTP error (ApiError carries
+ * a numeric `.status`). Duck-typed on `.status` — same convention as
+ * api/queryClient.ts — so it needs no import of the ApiError class itself.
+ *
+ * A network-level rejection (fetch TypeError, no HTTP status) is NOT a
+ * confirmed failure here: POST /start triggers a gateway restart that can
+ * drop the socket before the response flushes, so the import may well be
+ * running even though the fetch rejected.
+ */
+const isHttpError = (err: unknown): boolean =>
+  typeof (err as { status?: unknown } | null)?.status === 'number'
+
+/** Elements the Tab trap cycles between. Disabled controls are skipped. */
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+/**
+ * A11y: hide everything OUTSIDE `el` from assistive tech and the tab order
+ * while a modal overlay is open. Walks up to <body>, marking each ancestor's
+ * siblings `aria-hidden` + `inert` (the same "hide others" approach Radix
+ * uses), and returns an undo function that restores the previous attribute
+ * values. Used together with the keyboard Tab trap below: `inert` keeps
+ * pointer/sequential focus out of the background, the trap keeps Tab cycling
+ * inside the dialog.
+ */
+function hideOutside(el: HTMLElement): () => void {
+  const undos: Array<() => void> = []
+  let node: HTMLElement | null = el
+  while (node && node !== document.body) {
+    const parent: HTMLElement | null = node.parentElement
+    if (!parent) break
+    for (const sib of Array.from(parent.children)) {
+      if (sib === node || !(sib instanceof HTMLElement)) continue
+      const prevAria = sib.getAttribute('aria-hidden')
+      const hadInert = sib.hasAttribute('inert')
+      sib.setAttribute('aria-hidden', 'true')
+      sib.setAttribute('inert', '')
+      undos.push(() => {
+        if (prevAria === null) sib.removeAttribute('aria-hidden')
+        else sib.setAttribute('aria-hidden', prevAria)
+        if (!hadInert) sib.removeAttribute('inert')
+      })
+    }
+    node = parent
+  }
+  return () => undos.forEach((undo) => undo())
+}
+
+interface MeshclawImportCardProps {
+  /** When true (e.g. the theme picker is still open), render nothing so the
+   *  two first-run overlays never stack. */
+  suppressed?: boolean
+  /** How long the restarting overlay waits before offering a manual reload
+   *  escape hatch (a dropped POST that never restarts the gateway would
+   *  otherwise leave a permanent spinner). Overridable for tests. */
+  stalledAfterMs?: number
+}
+
+/**
+ * First-run onboarding step: if the backend reports an importable legacy
+ * MeshClaw data dir, offer a one-click import. Import triggers a gateway
+ * restart on the backend; the card then shows a reconnecting state and the
+ * app's existing socket-reconnect logic re-establishes the session.
+ *
+ * Gated on `status.available === true`, so it NEVER renders for fresh installs
+ * with no legacy data.
+ */
+export function MeshclawImportCard({
+  suppressed = false,
+  stalledAfterMs = 30_000,
+}: MeshclawImportCardProps) {
+  // `dismissed` hides the card for this mount. Only the explicit Skip button
+  // persists the choice to localStorage; Escape sets the transient state, so
+  // the offer returns on the next launch.
+  const [dismissed, setDismissed] = useState(() => !!localStorage.getItem(DISMISS_KEY))
+  const [importing, setImporting] = useState(false)
+  const [stalled, setStalled] = useState(false)
+
+  const { data } = useQuery({
+    queryKey: ['meshclaw-import-status'],
+    queryFn: () => api.meshclawImportStatus(),
+    staleTime: Infinity,
+    retry: false,
+    enabled: !dismissed && !suppressed,
+  })
+
+  const startMutation = useMutation({
+    mutationFn: () => api.meshclawImportStart(),
+    onSuccess: () => setImporting(true),
+    onError: (err) => {
+      // Lost-response race: the restart can kill the connection before the
+      // 200 arrives. Treat a network-level failure as "import started" and
+      // show the reconnecting overlay; only a confirmed HTTP error (e.g. 409
+      // not-available) keeps the card up with the error message.
+      if (!isHttpError(err)) setImporting(true)
+    },
+  })
+
+  const starting = startMutation.isPending
+  const startFailed = startMutation.isError && isHttpError(startMutation.error)
+
+  const handleSkip = useCallback(() => {
+    localStorage.setItem(DISMISS_KEY, '1')
+    setDismissed(true)
+  }, [])
+
+  const cardVisible = !importing && !dismissed && !suppressed && !!data?.available
+
+  const cardDialogRef = useRef<HTMLDivElement>(null)
+  const importingDialogRef = useRef<HTMLDivElement>(null)
+  // Outer fixed wrapper of whichever overlay is currently rendered — the
+  // background-inert effect hides everything outside this subtree.
+  const overlayRootRef = useRef<HTMLDivElement>(null)
+  const importButtonRef = useRef<HTMLButtonElement>(null)
+
+  // A11y: Escape closes the offer card TRANSIENTLY (card returns on next
+  // launch); the permanent, localStorage-backed skip is reserved for the
+  // explicit Skip button. Not wired while a start request is in flight, and
+  // never for the importing overlay (nothing to cancel).
+  useEffect(() => {
+    if (!cardVisible || starting) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return
+      // Only act when this card is the top-most open dialog: a dialog stacked
+      // above (e.g. UpdateModal) owns Escape. Modals mount when they open, so
+      // document order is a faithful proxy for stacking order.
+      const dialogs = document.querySelectorAll('[role="dialog"][aria-modal="true"]')
+      if (dialogs[dialogs.length - 1] !== cardDialogRef.current) return
+      setDismissed(true)
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [cardVisible, starting])
+
+  // A11y: initial focus. The offer card focuses its primary action; the
+  // importing overlay focuses the dialog container itself.
+  useEffect(() => {
+    if (cardVisible) importButtonRef.current?.focus()
+  }, [cardVisible])
+
+  useEffect(() => {
+    if (importing) importingDialogRef.current?.focus()
+  }, [importing])
+
+  // A11y: on an HTTP failure the pending (disabled) button ejected focus to
+  // <body>; return it to the re-enabled Import button so keyboard users can
+  // retry, pairing the role=alert announcement with a sane focus point.
+  useEffect(() => {
+    if (startFailed) importButtonRef.current?.focus()
+  }, [startFailed])
+
+  // A11y: while either overlay is open, everything behind it is aria-hidden +
+  // inert so screen readers and sequential focus cannot reach the background.
+  useEffect(() => {
+    if (!importing && !cardVisible) return
+    const root = overlayRootRef.current
+    if (!root) return
+    return hideOutside(root)
+  }, [importing, cardVisible])
+
+  // Stuck-spinner watchdog: if the gateway restart never comes back (the
+  // POST was dropped before the backend acted), surface a manual reload so
+  // the overlay is not a dead end.
+  useEffect(() => {
+    if (!importing) return
+    const t = window.setTimeout(() => setStalled(true), stalledAfterMs)
+    return () => window.clearTimeout(t)
+  }, [importing, stalledAfterMs])
+
+  // A11y: keyboard half of the focus trap — Tab/Shift-Tab wrap within the
+  // dialog. With zero focusables (importing overlay before the reload
+  // affordance appears) focus is parked on the container itself.
+  const trapTabKey = useCallback((e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return
+    const container = e.currentTarget
+    const focusables = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    if (focusables.length === 0) {
+      e.preventDefault()
+      container.focus()
+      return
+    }
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement
+    if (e.shiftKey) {
+      if (active === first || !container.contains(active)) {
+        e.preventDefault()
+        last.focus()
+      }
+    } else if (active === last || !container.contains(active)) {
+      e.preventDefault()
+      first.focus()
+    }
+  }, [])
+
+  // Restarting state: the gateway is performing the import and will drop the
+  // socket. Keep this overlay up (even if `suppressed` flips or the card was
+  // dismissed mid-flight); the reconnect logic reloads the app.
+  if (importing) {
+    return (
+      <div
+        ref={overlayRootRef}
+        className="fixed inset-0 z-[100] flex items-center justify-center bg-bg/80 backdrop-blur-sm animate-rise"
+      >
+        <div
+          ref={importingDialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="mc-import-restarting-title"
+          tabIndex={-1}
+          onKeyDown={trapTabKey}
+          className="bg-card border border-border rounded-xl p-8 max-w-md w-full mx-4 shadow-xl text-center outline-none"
+        >
+          <div className="flex justify-center mb-4">
+            <Loader2 aria-hidden="true" className="lucide-inline animate-spin" size={32} />
+          </div>
+          <div id="mc-import-restarting-title" className="text-lg font-bold text-text-strong mb-2">
+            Importing your data…
+          </div>
+          <div className="text-sm text-muted mb-1">
+            KiroCrew is restarting to import your previous MeshClaw data.
+          </div>
+          <div className="text-[13px] text-muted">This page will reconnect shortly…</div>
+          {stalled && (
+            <div className="mt-5 pt-4 border-t border-border">
+              <div className="text-[13px] text-muted mb-2">
+                Taking longer than expected. If this screen does not reconnect, reload the page.
+              </div>
+              <button
+                className="px-3.5 py-1.5 rounded-lg text-[13px] font-medium cursor-pointer bg-transparent border border-border text-text hover:bg-bg-hover transition-colors inline-flex items-center gap-1.5"
+                onClick={() => window.location.reload()}
+              >
+                <RefreshCw aria-hidden="true" className="lucide-inline" size={14} /> Reload
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (dismissed || suppressed) return null
+
+  // Gate: never render for fresh installs (available !== true) or while status
+  // is still loading.
+  if (!data?.available) return null
+
+  return (
+    <div
+      ref={overlayRootRef}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-bg/80 backdrop-blur-sm animate-rise"
+    >
+      <div
+        ref={cardDialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mc-import-card-title"
+        onKeyDown={trapTabKey}
+        className="bg-card border border-border rounded-xl p-6 max-w-md w-full mx-4 shadow-xl"
+      >
+        <div className="flex items-start gap-3 mb-4">
+          <div className="shrink-0 mt-0.5 text-accent">
+            <Package aria-hidden="true" className="lucide-inline" size={22} />
+          </div>
+          <div className="min-w-0">
+            <div id="mc-import-card-title" className="text-lg font-bold text-text-strong">
+              We found data from a previous MeshClaw install
+            </div>
+            <div className="text-[13px] text-muted mt-1">
+              Import your sessions, memory, workspace, and settings into KiroCrew. Your original
+              data is preserved and renamed as a backup.
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-bg/40 p-3 mb-4 text-[13px]">
+          <div className="flex justify-between gap-3 py-0.5">
+            <span className="text-muted">Sessions</span>
+            <span className="text-text font-medium tabular-nums">{data.sessionCount}</span>
+          </div>
+          <div className="flex justify-between gap-3 py-0.5">
+            <span className="text-muted">Size</span>
+            <span className="text-text font-medium tabular-nums">
+              {formatBytes(data.sizeEstimateBytes)}
+            </span>
+          </div>
+          {data.sourcePath && (
+            <div className="flex justify-between gap-3 py-0.5">
+              <span className="text-muted shrink-0">Source</span>
+              <span className="text-text/80 font-mono text-[11px] truncate" title={data.sourcePath}>
+                {data.sourcePath}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {startFailed && (
+          <div role="alert" className="text-[13px] text-danger mb-3">
+            Import failed to start: {(startMutation.error as Error)?.message || 'Unknown error'}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            className="px-3.5 py-1.5 rounded-lg text-[13px] font-medium cursor-pointer bg-transparent border border-border text-muted hover:text-text hover:bg-bg-hover transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={handleSkip}
+            disabled={starting}
+          >
+            <X aria-hidden="true" className="lucide-inline" size={14} /> Skip
+          </button>
+          <button
+            ref={importButtonRef}
+            className="px-4 py-1.5 rounded-lg text-[13px] font-medium cursor-pointer bg-accent text-accent-fg border-none hover:opacity-90 transition-opacity flex items-center gap-1.5 disabled:opacity-60 disabled:cursor-not-allowed"
+            onClick={() => startMutation.mutate()}
+            disabled={starting}
+          >
+            {starting ? (
+              <>
+                <Loader2 aria-hidden="true" className="lucide-inline animate-spin" size={14} />{' '}
+                Starting…
+              </>
+            ) : (
+              <>
+                <Download aria-hidden="true" className="lucide-inline" size={14} /> Import
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MeshclawImportCard

--- a/website/src/test/MeshclawImportCard.test.tsx
+++ b/website/src/test/MeshclawImportCard.test.tsx
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/* ── Mocks: must run before importing the component ── */
+const mockApi = vi.hoisted(() => ({
+  meshclawImportStatus: vi.fn(),
+  meshclawImportStart: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import { MeshclawImportCard, formatBytes } from '../components/MeshclawImportCard'
+
+function renderCard(props: { suppressed?: boolean; stalledAfterMs?: number } = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MeshclawImportCard {...props} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  mockApi.meshclawImportStatus.mockReset()
+  mockApi.meshclawImportStart.mockReset()
+})
+
+describe('formatBytes', () => {
+  it('formats byte sizes with units', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1572864)).toBe('1.5 MB')
+  })
+})
+
+describe('MeshclawImportCard', () => {
+  it('renders nothing for a fresh install (available: false)', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: false,
+      sourcePath: '',
+      sizeEstimateBytes: 0,
+      sessionCount: 0,
+    })
+    renderCard()
+    // Give the query a tick to resolve, then confirm the card never appears.
+    await waitFor(() => expect(mockApi.meshclawImportStatus).toHaveBeenCalled())
+    expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull()
+  })
+
+  it('does not fetch or render while suppressed (theme picker open)', () => {
+    renderCard({ suppressed: true })
+    expect(mockApi.meshclawImportStatus).not.toHaveBeenCalled()
+    expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull()
+  })
+
+  it('shows size + session count and switches to the restarting state on Import', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 1572864, // 1.5 MB
+      sessionCount: 42,
+    })
+    mockApi.meshclawImportStart.mockResolvedValue({ status: 'restarting' })
+    renderCard()
+
+    expect(await screen.findByText(/found data from a previous MeshClaw install/i)).toBeTruthy()
+    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByText('1.5 MB')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /import/i }))
+
+    await waitFor(() => expect(mockApi.meshclawImportStart).toHaveBeenCalledTimes(1))
+    // Restarting / reconnecting state replaces the card.
+    expect(await screen.findByText(/This page will reconnect shortly/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /import/i })).toBeNull()
+  })
+
+  it('Skip dismisses the card and persists the choice', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    renderCard()
+
+    await screen.findByText(/found data from a previous MeshClaw install/i)
+    fireEvent.click(screen.getByRole('button', { name: /skip/i }))
+
+    await waitFor(() =>
+      expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull(),
+    )
+    expect(localStorage.getItem('mc-meshclaw-import-dismissed')).toBe('1')
+    expect(mockApi.meshclawImportStart).not.toHaveBeenCalled()
+  })
+
+  it('treats a network-level start failure as importing (restart drops the socket)', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    // fetch rejects with a TypeError (no HTTP status) when the gateway kills
+    // the connection before the response flushes -- the import still runs.
+    mockApi.meshclawImportStart.mockRejectedValue(new TypeError('Failed to fetch'))
+    renderCard()
+
+    fireEvent.click(await screen.findByRole('button', { name: /import/i }))
+
+    expect(await screen.findByText(/This page will reconnect shortly/i)).toBeTruthy()
+    expect(screen.queryByText(/Import failed to start/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: /import/i })).toBeNull()
+  })
+
+  it('shows the error and re-enables Import on a real HTTP failure (409)', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    // Shape of api/client.ts ApiError: an Error carrying a numeric .status.
+    mockApi.meshclawImportStart.mockRejectedValue(
+      Object.assign(new Error('import not available'), { status: 409 }),
+    )
+    renderCard()
+
+    fireEvent.click(await screen.findByRole('button', { name: /import/i }))
+
+    expect(await screen.findByText(/Import failed to start: import not available/i)).toBeTruthy()
+    // Card stays up (no restarting overlay) and Import is clickable again.
+    expect(screen.queryByText(/This page will reconnect shortly/i)).toBeNull()
+    const importBtn = screen.getByRole('button', { name: /import/i }) as HTMLButtonElement
+    expect(importBtn.disabled).toBe(false)
+    // A11y: the error is announced as an alert...
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toContain('import not available')
+    // ...and focus returns to the Import button (the disabled pending button
+    // had ejected focus to <body>).
+    await waitFor(() => expect(document.activeElement).toBe(importBtn))
+  })
+
+  it('renders nothing while the status query is still in flight', () => {
+    mockApi.meshclawImportStatus.mockReturnValue(new Promise(() => {}))
+    renderCard()
+    expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('fires the status query once unsuppressed', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <MeshclawImportCard suppressed />
+      </QueryClientProvider>,
+    )
+    expect(mockApi.meshclawImportStatus).not.toHaveBeenCalled()
+
+    rerender(
+      <QueryClientProvider client={qc}>
+        <MeshclawImportCard suppressed={false} />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(mockApi.meshclawImportStatus).toHaveBeenCalled())
+    expect(await screen.findByText(/found data from a previous MeshClaw install/i)).toBeTruthy()
+  })
+
+  it('Escape transiently closes the card without persisting the skip', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    renderCard()
+    await screen.findByText(/found data from a previous MeshClaw install/i)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() =>
+      expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull(),
+    )
+    // Transient close only: the permanent skip flag is reserved for the
+    // explicit Skip button, so the offer returns on the next launch.
+    expect(localStorage.getItem('mc-meshclaw-import-dismissed')).toBeNull()
+  })
+
+  it('ignores Escape that another handler already consumed (defaultPrevented)', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    renderCard()
+    await screen.findByText(/found data from a previous MeshClaw install/i)
+
+    // A document-level listener (running before the card's window listener on
+    // the bubble path) preventDefaults, as a stacked component would.
+    const consume = (e: Event) => e.preventDefault()
+    document.addEventListener('keydown', consume)
+    try {
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+    } finally {
+      document.removeEventListener('keydown', consume)
+    }
+
+    expect(screen.getByText(/found data from a previous MeshClaw install/i)).toBeTruthy()
+    expect(localStorage.getItem('mc-meshclaw-import-dismissed')).toBeNull()
+  })
+
+  it('does not steal Escape from a dialog stacked above the card', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    renderCard()
+    await screen.findByText(/found data from a previous MeshClaw install/i)
+
+    // Simulate a modal (e.g. UpdateModal) mounted after — and therefore
+    // stacked above — the card.
+    const stacked = document.createElement('div')
+    stacked.setAttribute('role', 'dialog')
+    stacked.setAttribute('aria-modal', 'true')
+    document.body.appendChild(stacked)
+    try {
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(screen.getByText(/found data from a previous MeshClaw install/i)).toBeTruthy()
+    } finally {
+      stacked.remove()
+    }
+
+    // With the stacked dialog gone, Escape reaches the card again.
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByText(/found data from a previous MeshClaw install/i)).toBeNull(),
+    )
+    expect(localStorage.getItem('mc-meshclaw-import-dismissed')).toBeNull()
+  })
+
+  it('traps Tab focus inside the dialog', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    renderCard()
+    await screen.findByText(/found data from a previous MeshClaw install/i)
+
+    const dialog = screen.getByRole('dialog')
+    const skipBtn = screen.getByRole('button', { name: /skip/i })
+    const importBtn = screen.getByRole('button', { name: /import/i })
+
+    // Initial focus lands on Import (the last focusable); Tab wraps to Skip.
+    await waitFor(() => expect(document.activeElement).toBe(importBtn))
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(skipBtn)
+    // Shift-Tab from the first focusable wraps back to the last.
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(importBtn)
+  })
+
+  it('marks background content inert/aria-hidden while the overlay is open', async () => {
+    const bystander = document.createElement('div')
+    document.body.appendChild(bystander)
+    try {
+      mockApi.meshclawImportStatus.mockResolvedValue({
+        available: true,
+        sourcePath: '/Users/tester/.meshclaw',
+        sizeEstimateBytes: 2048,
+        sessionCount: 3,
+      })
+      renderCard()
+      await screen.findByText(/found data from a previous MeshClaw install/i)
+
+      expect(bystander.getAttribute('aria-hidden')).toBe('true')
+      expect(bystander.hasAttribute('inert')).toBe(true)
+
+      // Closing the overlay restores the background.
+      fireEvent.click(screen.getByRole('button', { name: /skip/i }))
+      await waitFor(() => expect(bystander.hasAttribute('inert')).toBe(false))
+      expect(bystander.getAttribute('aria-hidden')).toBeNull()
+    } finally {
+      bystander.remove()
+    }
+  })
+
+  it('offers a reload escape hatch when the restart takes too long', async () => {
+    mockApi.meshclawImportStatus.mockResolvedValue({
+      available: true,
+      sourcePath: '/Users/tester/.meshclaw',
+      sizeEstimateBytes: 2048,
+      sessionCount: 3,
+    })
+    mockApi.meshclawImportStart.mockResolvedValue({ status: 'restarting' })
+    renderCard({ stalledAfterMs: 25 })
+
+    fireEvent.click(await screen.findByRole('button', { name: /import/i }))
+    await screen.findByText(/This page will reconnect shortly/i)
+
+    expect(await screen.findByRole('button', { name: /reload/i })).toBeTruthy()
+    expect(screen.getByText(/Taking longer than expected/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What

One-time, consent-gated import of a legacy `~/.meshclaw` data dir (MeshClaw, the pre-rename product) into the KiroCrew home at first boot, then a reversible rename to `~/.meshclaw.bak`. Offered via a first-run onboarding card; executed at early boot before any SQLite store opens, via a two-phase intent-marker + gateway-restart flow.

## Design

- Manifest: sessions/artifacts/uploads/skills/apps additive; `memory.db`, workspace memory + `knowledge.db` old-wins; crons imported disabled+paused (merged, dest wins); `mcp.json`/`.env` absent-only; `config.json` never copied.
- Transactional copy: fail-closed write-once atomically-written backup of the dest overwrite targets; journaled additive paths; full rollback on any failure (`BaseException` seam, re-raises KeyboardInterrupt/SystemExit); crash recovery on the next boot driven by the durable on-disk backup; fail-closed WAL-family restore (backup kept unless every target restored).
- Freshness gate (dest must have no accrued data) enforced at offer AND execution time, no bypass; intent TTL. The only retained retry state is the rename-only retry after a fully committed copy (bounded).
- Endpoints `GET/POST /api/onboarding/meshclaw-import/{status,start}` behind the full auth+CSRF chain, SEL-audited on start; restart-in-flight 409 guard released unconditionally; intent cleared if the restart never execs.
- Frontend: gated onboarding card (never renders for fresh installs), network-failure-on-start treated as the restarting state, dialog a11y (focus trap, scoped Escape, role=alert on errors), stalled-restart reload affordance.

## Review

Hardened via a 5-round blind multi-lens adversarial review (Logic / Filesystem / Concurrency / Frontend): 47 findings, 38 fixed, 3 documented trade-offs (boot-block duration deferred to a follow-up; `GET /status` not SEL-audited by design, read-only; a concurrently-running legacy MeshClaw app is out of scope, `.bak` preserves originals). Round 1 removed a structural data-loss path; rounds 2-5 hardened to crash-durable, fail-closed semantics.

## Testing

- Backend: 70 hermetic tests (tmp-HOME fixtures; a real `~/.meshclaw` is never touched) via this repo's pytest.
- Frontend: 15 component tests; `tsc --noEmit` clean.
- Manual test plan: on a machine with a legacy `~/.meshclaw`, launch KiroCrew fresh -> onboarding card appears -> Import -> gateway restarts -> data present, `~/.meshclaw.bak` created; verify the card never appears on a fresh install or once the dest has accrued data.
