### PR TITLE
fix(ci): withdraw unshippable DMG + mark unsigned intermediate artifacts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -33,9 +33,14 @@ jobs:
       matrix:
         include:
           - os: macos-14
-            artifact-name: desktop-darwin-arm64
+            # 'unsigned-' prefix: this artifact is an inter-job handoff to the
+            # sign job, NOT an installable deliverable. Humans should download
+            # only the KiroCrew-notarized-* artifact. GitHub shows all uploaded
+            # artifacts on the run page with equal prominence, so the name is
+            # the only place to signal that.
+            artifact-name: unsigned-build-darwin-arm64
           - os: ubuntu-22.04
-            artifact-name: desktop-linux-x64
+            artifact-name: build-linux-x64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,10 +97,8 @@ jobs:
 
   # Caller job for the reusable sign-and-notarize workflow: a workflow_call
   # callee can never exceed the caller job's permissions, so the caller must
-  # grant id-token explicitly. attestations:write covers both the sign job's
-  # wheel/sdist/AppImage provenance and the notarize job's shipping-DMG
-  # attestation (the DMG is rebuilt there from the stapled app; the build-job
-  # DMG never ships and is attested nowhere).
+  # grant id-token explicitly. attestations:write is for the sign job's
+  # wheel/sdist/AppImage provenance attestation.
   sign-and-notarize:
     name: Sign + Notarize macOS
     needs: [version, build-wheel, build-desktop]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,10 +130,11 @@ jobs:
         with:
           path: artifacts
 
-      # Assemble release assets: everything built, with the macOS zip and DMG
-      # replaced by the notarized ones from the notarize job. The unsigned
-      # electron-builder DMG (built before signing) must never ship -- it
-      # wraps an unsigned app and hits the Gatekeeper scare dialog.
+      # Assemble release assets: everything built, with the macOS zip
+      # replaced by the notarized one from the notarize job. No DMG ships:
+      # the unsigned electron-builder DMG wraps an unsigned app, and even a
+      # notarized hdiutil DMG is adhoc-signed, which Gatekeeper rejects as
+      # "damaged" (see sign-and-notarize.yml header note).
       - name: Flatten artifacts (notarized macOS assets win)
         run: |
           mkdir -p release
@@ -143,10 +144,6 @@ jobs:
             cp "$NOTARIZED" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64-mac.zip"
           else
             find artifacts -type f -name "*arm64*.zip" -exec cp {} release/ \;
-          fi
-          NOTARIZED_DMG=$(find artifacts -path "*KiroCrew-notarized-*" -name "*.dmg" | head -1)
-          if [ -n "$NOTARIZED_DMG" ]; then
-            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64.dmg"
           fi
           ls -la release/
 

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -12,10 +12,9 @@ name: Sign and Notarize macOS (reusable)
 #                (This job was historically duplicated in nightly.yml and
 #                release.yml under the misleading name "publish".)
 #   notarize  -- everything macOS-bound: Apple notarization, staple, the
-#                spctl fail-closed gate, DMG rebuild + DMG notarization.
-#                The Apple credential is confined to this job. Ends by
-#                attaching the GATED artifact (notarized zip + DMG) to the
-#                workflow run.
+#                spctl fail-closed gate. The Apple credential is confined
+#                to this job. Ends by attaching the GATED artifact
+#                (notarized zip) to the workflow run.
 #   publish   -- everything S3-bound: copy the gated artifact to the public
 #                distribution bucket and write the channel feed, dead last.
 #                Separate from notarize so a transient publish failure
@@ -23,6 +22,15 @@ name: Sign and Notarize macOS (reusable)
 #                instead of repeating two ~30-minute-budget Apple
 #                submissions, and so the expensive macOS runner never burns
 #                minutes on S3 uploads.
+#
+# NOTE (2026-07-21): the first-install DMG was withdrawn from this pipeline.
+# hdiutil-created DMGs carry an ADHOC signature; the Apple notary service
+# Accepts them, but Gatekeeper treats adhoc as "no usable signature" and
+# shows "app is damaged" when a user drags the app out of the quarantined
+# mount -- even though the stapled app inside passes every check
+# (syspolicy_check confirms: app passes, DMG fails). Reintroduce the DMG
+# only when it can be Developer ID signed (CDSigner DMG-type support under
+# investigation). Until then the notarized zip is the install artifact.
 #
 # Key properties:
 #   - The signed_zip_key handoff is internal (sign job output -> notarize
@@ -105,9 +113,8 @@ jobs:
           # Attest only artifacts whose bytes are final here. The macOS .zip is
           # re-signed + notarized downstream, so a pre-notarization attestation
           # would bind a digest that never ships -- omit *.zip. Same for *.dmg:
-          # the electron-builder DMG wraps the unsigned app and never ships;
-          # the shipping DMG is rebuilt from the stapled app and attested in
-          # the notarize job below.
+          # the electron-builder DMG wraps the unsigned app and never ships
+          # (no DMG ships at all -- see the header note).
           subject-path: |
             release/*.whl
             release/*.tar.gz
@@ -180,10 +187,10 @@ jobs:
     # (fork / repo without CDSigner secrets) -- there is nothing to notarize.
     if: needs.sign.outputs.signed_zip_key != ''
     runs-on: macos-14
-    # Two notarytool submissions (app, then DMG), each --wait up to 30m,
-    # plus staple/DMG-build overhead -- the job budget must exceed their
-    # combined worst case or GitHub cancels mid-run.
-    timeout-minutes: 75
+    # One notarytool submission, --wait up to 30m, plus staple/upload
+    # overhead -- the job budget must exceed the worst case or GitHub
+    # cancels mid-run.
+    timeout-minutes: 45
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
     # environment switches the subject to environment:prod, which it does.
@@ -287,82 +294,15 @@ jobs:
           echo "NOTARIZED_KEY=${KEY}" >> "$GITHUB_ENV"
           echo "Notarized artifact: s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
 
-      # First-install DMG, rebuilt from the STAPLED app (the electron-builder
-      # DMG from the build job wraps the unsigned app and must never ship).
-      # The DMG itself is not code-signed (the Developer ID cert lives inside
-      # CDSigner, which signs .app bundles): Apple ACCEPTS notarization of an
-      # unsigned DMG whose contents are fully signed+stapled (proven:
-      # submission 1c29ae3d), and Gatekeeper verifies the DMG via the online
-      # ticket lookup. Stapling the DMG is impossible without a signature
-      # (stapler Error 73), so it is deliberately skipped -- the app INSIDE
-      # is stapled, which covers the offline launch check that matters.
-      - name: Build DMG from stapled app
-        if: env.HAS_SIGNING_SECRETS
-        run: |
-          set -euo pipefail
-          rm -rf work/dmg-staging && mkdir -p work/dmg-staging
-          cp -R "work/stapled/${APP_NAME}.app" work/dmg-staging/
-          ln -s /Applications work/dmg-staging/Applications
-          hdiutil create -volname "${APP_NAME}" -srcfolder work/dmg-staging \
-            -ov -format UDZO -quiet "work/${APP_NAME}.dmg"
-          ls -lh "work/${APP_NAME}.dmg"
-
-      # Attest the DMG that actually ships: the electron-builder DMG from the
-      # build job is attested nowhere (it wraps the unsigned app and never
-      # publishes); THIS rebuilt DMG is the released artifact, so provenance
-      # must bind these bytes. Runs before notarization/publication so nothing
-      # leaves the runner unattested.
-      - name: Attest DMG provenance
-        if: env.HAS_SIGNING_SECRETS
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
-        with:
-          subject-path: work/*.dmg
-
-      - name: Notarize DMG
-        if: env.HAS_SIGNING_SECRETS
-        run: |
-          set -euo pipefail
-          SECRET_JSON=$(aws secretsmanager get-secret-value \
-            --secret-id kirocrew/signing/apple-notary \
-            --query SecretString --output text)
-          APPLE_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['apple_id'])")
-          APPLE_PW=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['password'])")
-          TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
-          echo "::add-mask::$APPLE_PW"
-          unset SECRET_JSON
-
-          echo "Submitting DMG to Apple notary service..."
-          set +e
-          SUBMIT_OUT=$(xcrun notarytool submit "work/${APP_NAME}.dmg" \
-            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
-            --wait --timeout 30m 2>&1)
-          RC=$?
-          set -e
-          echo "$SUBMIT_OUT"
-          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
-
-          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
-            echo "DMG notarization was not Accepted. Fetching the itemized Apple log..."
-            if [ -n "$SUBMISSION_ID" ]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
-            fi
-            exit 1
-          fi
-          echo "DMG notarization Accepted: $SUBMISSION_ID"
-
-      # The GATED artifact: attached only after the spctl gate and both
-      # Apple acceptances above. This is the sole input of the publish job
-      # (and of release.yml's github-release job), so un-notarized bytes
-      # have no path downstream.
+      # The GATED artifact: attached only after the spctl gate above. This
+      # is the sole input of the publish job (and of release.yml's
+      # github-release job), so un-notarized bytes have no path downstream.
       - name: Attach notarized artifact to workflow run
         if: env.HAS_SIGNING_SECRETS
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
-          path: |
-            work/notarized.zip
-            work/*.dmg
+          path: work/notarized.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -374,7 +314,6 @@ jobs:
             echo "- Version: ${VERSION}"
             echo "- Input: \`${SIGNED_ZIP_KEY}\`"
             echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
-            echo "- DMG: \`${APP_NAME}.dmg\` (rebuilt from stapled app, notarized)"
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
@@ -418,7 +357,6 @@ jobs:
           set -euo pipefail
           ls -la work/
           [ -f "work/notarized.zip" ] || { echo "notarized.zip missing from gated artifact"; exit 1; }
-          [ -f "work/${APP_NAME}.dmg" ] || { echo "${APP_NAME}.dmg missing from gated artifact"; exit 1; }
 
       # The versioned zip key is immutable-cached by CloudFront, so it must
       # never be republished with different bytes (same class as the cli/*
@@ -452,37 +390,9 @@ jobs:
           echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
           echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
-      # Same never-republish discipline as the zip: conditional write,
-      # 412 on a job re-run keeps the existing notarized bytes.
-      - name: Publish DMG to distribution bucket
-        if: env.HAS_SIGNING_SECRETS
-        run: |
-          set -euo pipefail
-          DMG_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.dmg"
-          set +e
-          PUT_OUT=$(aws s3api put-object \
-            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
-            --key "${DMG_KEY}" \
-            --body "work/${APP_NAME}.dmg" \
-            --if-none-match '*' \
-            --content-type application/x-apple-diskimage \
-            --cache-control "public, max-age=31536000, immutable" 2>&1)
-          RC=$?
-          set -e
-          if [ $RC -ne 0 ]; then
-            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
-              echo "DMG key already published (job re-run) -- keeping existing bytes: ${DMG_KEY}"
-            else
-              echo "$PUT_OUT"
-              exit $RC
-            fi
-          fi
-          echo "DMG_KEY=${DMG_KEY}" >> "$GITHUB_ENV"
-          echo "Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
-
       # Feed points at the NOTARIZED artifact on the CDN -- written only
       # after the spctl gate passed (this job's sole input is the gated
-      # artifact) and only after both artifacts are publicly downloadable
+      # artifact) and only after the artifact is publicly downloadable
       # (feed-before-artifact would hand clients a 403/404). The feed key is
       # mutable and served no-cache by the feed/* CloudFront behavior, so
       # overwriting is safe. Out-of-order overwrites (older run finishing
@@ -498,7 +408,6 @@ jobs:
           {
             "version": "${VERSION}",
             "url": "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}",
-            "dmg": "${{ vars.CLI_CDN_BASE }}/${DMG_KEY}",
             "name": "${VERSION}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -515,6 +424,5 @@ jobs:
             echo "## Publish (${CHANNEL})"
             echo "- Version: ${VERSION}"
             echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
-            echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
             echo "- Feed: \`feed/${CHANNEL}/latest-mac.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -73,10 +73,7 @@ class TestNightlyPermissions:
         # Caller job for the reusable sign-and-notarize workflow: a
         # workflow_call callee can never exceed the caller job's permissions,
         # so the caller must grant id-token explicitly. attestations:write
-        # covers the sign job's wheel/sdist/AppImage provenance and the
-        # notarize job's shipping-DMG attestation (the DMG is rebuilt there
-        # from the stapled app; the build-job DMG never ships and is attested
-        # nowhere).
+        # is for the sign job's wheel/sdist/AppImage provenance attestation.
         assert _permission_block(lines, "  sign-and-notarize:") == {
             "id-token": "write",
             "contents": "read",


### PR DESCRIPTION
## The bug (user-reported, verified on a real machine)

The first-install DMG shipped by #108 is **Gatekeeper-broken for end users**: `hdiutil` gives DMGs an **adhoc signature** by default. Apple's notary service Accepts adhoc DMGs, but Gatekeeper treats adhoc as *no usable signature* -- dragging the app out of a quarantined mount shows **"KiroCrew is damaged"**, even though the stapled app inside is perfect.

Verification (on the live CDN bytes for `0.1.0-nightly.20260721182718`):
- app inside DMG: `codesign --deep --strict` valid, `stapler validate` OK, `spctl: Notarized Developer ID`, `syspolicy_check`: **passes** distribution checks
- the DMG itself: `syspolicy_check distribution`: **FAILS** -- "Adhoc Signed App ... not suitable for distribution"

The original probe (submission `1c29ae3d`) validated the notary layer only and never tested the quarantined drag-out flow -- that conclusion was wrong.

## Changes

1. **Withdraw the DMG from every public surface** until it can be Developer ID signed (CDSigner DMG-type support under investigation, tracked follow-up): DMG build/attest/notarize/publish steps removed from `sign-and-notarize.yml`; feed drops the `dmg` field (grep confirms no client consumes it); the gated workflow artifact is the notarized zip only; notarize timeout back to 45m (one Apple submission). `release.yml` stops attaching the DMG as a release asset.
2. **Rename inter-job handoff artifacts** so run-page visitors stop mistaking them for deliverables (this run confusion was the second half of the user report): `desktop-darwin-arm64` -> `unsigned-build-darwin-arm64` (every app in it is unsigned by design and always fails Gatekeeper), `desktop-linux-x64` -> `build-linux-x64` (its AppImage IS consumed downstream, stays neutral). Downstream jobs discover files by pattern, not artifact name -- only the matrix values change.

## Path back for the DMG

Reintroduce only with a Developer ID signature on the DMG itself (then `stapler` also works on it, fixing offline verification): either CDSigner DMG artifact-type support, or an alternative signing path. Documented in the workflow header.

## Validation

YAML + duplicate-key gates on all four changed workflows; 5/5 permission tests (comment-only test change); leftover-reference sweep clean (remaining `dmg` mentions are the sign job's attest-exclusion comment and the flatten pattern for the never-shipping electron-builder DMG, both still correct).