### PR TITLE
fix(desktop): keep CPython bytecode caches out of the signed bundle

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -210,7 +210,21 @@ function startGateway() {
         const child = spawn(bin, ["gateway", "--no-open"], {
           stdio: ["ignore", childOut, childOut],
           detached: false,
-          env: { ...cleanEnv, KIROCREW_PROJECT_DIR: path.resolve(__dirname, "..") },
+          env: {
+            ...cleanEnv,
+            KIROCREW_PROJECT_DIR: path.resolve(__dirname, ".."),
+            // Keep CPython bytecode caches OUT of the signed app bundle.
+            // Without this, the embedded interpreter writes __pycache__/*.pyc
+            // next to the bundled sources on first import, breaking the
+            // codesign seal ("a sealed resource is missing or invalid") --
+            // Gatekeeper then fails the installed app, and Squirrel's
+            // installer can trip over the corrupted target during updates.
+            // CPython creates the directory tree on demand (PEP 3147 /
+            // sys.pycache_prefix). Inherited by every Python child the
+            // gateway spawns (app servers run on the same interpreter), so
+            // the whole process tree stays out of the bundle.
+            PYTHONPYCACHEPREFIX: path.join(kirocrewDir, "cache", "pycache"),
+          },
         });
         gatewayProcess = child;
         // The child inherits its own dup of the fd; close our copy so it doesn't leak.


### PR DESCRIPTION
## Problem

The embedded CPython writes `__pycache__/*.pyc` next to the bundled sources on first import, breaking the installed app's codesign seal -- verified on a live install: `codesign --verify --deep --strict /Applications/KiroCrew.app` -> **"a sealed resource is missing or invalid"**.

Consequences of a seal-broken install:
- Gatekeeper assessment of the installed app fails (bad hygiene at minimum)
- Probable trigger for the Squirrel installer errors observed during real update attempts today (`errSecCS -67062` "code object is not signed at all" / `-67028` "bundle format unrecognized" while installing over the corrupted target -- ShipIt log evidence; the staged update itself verified clean)

## Fix

Set `PYTHONPYCACHEPREFIX` on the gateway spawn env, pointing at `$KIROCREW_HOME/cache/pycache`:
- CPython creates the directory tree on demand (PEP 3147 / `sys.pycache_prefix`) -- no pre-create needed
- Inherited by every Python child the gateway spawns (app servers run on the bundle's interpreter -- e.g. `backend-dist/kirocrew-backend/bin/python3.12 ~/.kirocrew/apps/*/backend/server.py`), so the whole process tree stays out of the bundle
- CLI-launched gateways (pip install) are unaffected in behavior that matters: their site-packages aren't a signed bundle

Existing installs remain seal-broken until the next OTA swap replaces the bundle; new installs stay clean from first launch.

## Validation

Electron test suite green (node --test). Single-seam change at the spawn site in `website/electron/main.js`.