### PR TITLE
feat(ci): reinstate the first-install DMG with a Developer ID signature

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,8 +97,9 @@ jobs:
 
   # Caller job for the reusable sign-and-notarize workflow: a workflow_call
   # callee can never exceed the caller job's permissions, so the caller must
-  # grant id-token explicitly. attestations:write is for the sign job's
-  # wheel/sdist/AppImage provenance attestation.
+  # grant id-token explicitly. attestations:write covers the sign job's
+  # wheel/sdist/AppImage provenance and the notarize job's shipping-DMG
+  # attestation (signed + stapled bytes).
   sign-and-notarize:
     name: Sign + Notarize macOS
     needs: [version, build-wheel, build-desktop]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,11 +130,12 @@ jobs:
         with:
           path: artifacts
 
-      # Assemble release assets: everything built, with the macOS zip
-      # replaced by the notarized one from the notarize job. No DMG ships:
-      # the unsigned electron-builder DMG wraps an unsigned app, and even a
-      # notarized hdiutil DMG is adhoc-signed, which Gatekeeper rejects as
-      # "damaged" (see sign-and-notarize.yml header note).
+      # Assemble release assets: everything built, with the macOS zip and DMG
+      # replaced by the notarized ones from the notarize job. The unsigned
+      # electron-builder DMG (built before signing) must never ship; the
+      # shipping DMG is Developer ID signed + notarized + stapled inside
+      # sign-and-notarize.yml (see its header note for the adhoc-DMG
+      # incident that made the signature mandatory).
       - name: Flatten artifacts (notarized macOS assets win)
         run: |
           mkdir -p release
@@ -144,6 +145,10 @@ jobs:
             cp "$NOTARIZED" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64-mac.zip"
           else
             find artifacts -type f -name "*arm64*.zip" -exec cp {} release/ \;
+          fi
+          NOTARIZED_DMG=$(find artifacts -path "*KiroCrew-notarized-*" -name "*.dmg" | head -1)
+          if [ -n "$NOTARIZED_DMG" ]; then
+            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-arm64.dmg"
           fi
           ls -la release/
 

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -23,14 +23,16 @@ name: Sign and Notarize macOS (reusable)
 #                submissions, and so the expensive macOS runner never burns
 #                minutes on S3 uploads.
 #
-# NOTE (2026-07-21): the first-install DMG was withdrawn from this pipeline.
-# hdiutil-created DMGs carry an ADHOC signature; the Apple notary service
-# Accepts them, but Gatekeeper treats adhoc as "no usable signature" and
-# shows "app is damaged" when a user drags the app out of the quarantined
-# mount -- even though the stapled app inside passes every check
-# (syspolicy_check confirms: app passes, DMG fails). Reintroduce the DMG
-# only when it can be Developer ID signed (CDSigner DMG-type support under
-# investigation). Until then the notarized zip is the install artifact.
+# DMG history (2026-07-21): the DMG was briefly withdrawn after a field
+# defect -- hdiutil-created DMGs carry an ADHOC signature, which the Apple
+# notary service Accepts but Gatekeeper treats as "no usable signature",
+# showing "app is damaged" when a user drags the app out of the quarantined
+# mount (syspolicy_check: app passed, DMG failed). It is reinstated with a
+# proper Developer ID signature: a SECOND CDSigner task (manifest type:
+# dmg, see packaging/signing/sign-dmg.sh) signs the rebuilt DMG before its
+# notarization -- which also makes the DMG STAPLE-able (stapler fails with
+# Error 73 on unsigned DMGs), so first-install verification now works
+# fully offline. A fail-closed spctl gate below enforces the end state.
 #
 # Key properties:
 #   - The signed_zip_key handoff is internal (sign job output -> notarize
@@ -187,10 +189,12 @@ jobs:
     # (fork / repo without CDSigner secrets) -- there is nothing to notarize.
     if: needs.sign.outputs.signed_zip_key != ''
     runs-on: macos-14
-    # One notarytool submission, --wait up to 30m, plus staple/upload
-    # overhead -- the job budget must exceed the worst case or GitHub
-    # cancels mid-run.
-    timeout-minutes: 45
+    # Worst-case wait budget: two notarytool submissions (app, then DMG)
+    # at up to 30m each, plus the CDSigner DMG sign task poll at up to 15m
+    # = 75m of pure waiting. The budget must also cover checkout, installs,
+    # downloads, DMG build, staple, attestation, and uploads, or GitHub
+    # cancels the job mid-publication on a legitimately slow day.
+    timeout-minutes: 90
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
     # environment switches the subject to environment:prod, which it does.
@@ -211,6 +215,18 @@ jobs:
       VERSION: ${{ inputs.version }}
       SIGNED_ZIP_KEY: ${{ needs.sign.outputs.signed_zip_key }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: packaging/signing
+
+      # Install the CDSigner SigV4 client BEFORE AWS credentials are
+      # configured (same supply-chain ordering as the sign job). macOS
+      # --user installs land under `python3 -m site --user-base`/bin.
+      - name: Install awscurl (SigV4 client for CDSigner)
+        run: |
+          python3 -m pip install --user --quiet "awscurl==0.44"
+          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
+
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -294,6 +310,89 @@ jobs:
           echo "NOTARIZED_KEY=${KEY}" >> "$GITHUB_ENV"
           echo "Notarized artifact: s3://${{ secrets.AWS_SIGNING_BUCKET }}/${KEY}"
 
+      # First-install DMG, rebuilt from the STAPLED app (the electron-builder
+      # DMG from the build job wraps the unsigned app and must never ship).
+      - name: Build DMG from stapled app
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          rm -rf work/dmg-staging && mkdir -p work/dmg-staging
+          cp -R "work/stapled/${APP_NAME}.app" work/dmg-staging/
+          ln -s /Applications work/dmg-staging/Applications
+          hdiutil create -volname "${APP_NAME}" -srcfolder work/dmg-staging \
+            -ov -format UDZO -quiet "work/${APP_NAME}.dmg"
+          ls -lh "work/${APP_NAME}.dmg"
+
+      # Developer ID sign the DMG itself via a second CDSigner task (type:
+      # dmg). Without this, the DMG carries hdiutil's adhoc signature, which
+      # Gatekeeper rejects as "app is damaged" on drag-out -- and an unsigned
+      # DMG cannot be stapled (stapler Error 73). Fail-closed: the script
+      # verifies a Developer ID Application authority on the result.
+      - name: Sign DMG with CDSigner
+        if: env.HAS_SIGNING_SECRETS
+        env:
+          AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+          AWS_SIGNER_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
+          CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
+        run: bash packaging/signing/sign-dmg.sh "work/${APP_NAME}.dmg" "$CHANNEL" "$VERSION"
+
+      - name: Notarize DMG
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id kirocrew/signing/apple-notary \
+            --query SecretString --output text)
+          APPLE_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['apple_id'])")
+          APPLE_PW=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['password'])")
+          TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
+          echo "::add-mask::$APPLE_PW"
+          unset SECRET_JSON
+
+          echo "Submitting DMG to Apple notary service..."
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "work/${APP_NAME}.dmg" \
+            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
+            --wait --timeout 30m 2>&1)
+          RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
+
+          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
+            echo "DMG notarization was not Accepted. Fetching the itemized Apple log..."
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
+            fi
+            exit 1
+          fi
+          echo "DMG notarization Accepted: $SUBMISSION_ID"
+
+      # Staple the ticket INTO the DMG (possible now that it is signed) and
+      # hold it to the same fail-closed Gatekeeper standard as the app. This
+      # gate is exactly the check that would have caught the adhoc defect.
+      - name: Staple and gate DMG
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          xcrun stapler staple "work/${APP_NAME}.dmg"
+          xcrun stapler validate "work/${APP_NAME}.dmg"
+          ASSESS=$(spctl --assess --type install --verbose "work/${APP_NAME}.dmg" 2>&1)
+          echo "$ASSESS"
+          echo "$ASSESS" | grep -q "Notarized Developer ID" || {
+            echo "Gatekeeper assessment did not report 'Notarized Developer ID' -- failing closed."
+            exit 1
+          }
+
+      # Attest the DMG that actually ships -- AFTER staple, because stapling
+      # embeds the ticket into the DMG file (the final released bytes).
+      - name: Attest DMG provenance
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: work/*.dmg
+
       # The GATED artifact: attached only after the spctl gate above. This
       # is the sole input of the publish job (and of release.yml's
       # github-release job), so un-notarized bytes have no path downstream.
@@ -302,7 +401,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
-          path: work/notarized.zip
+          path: |
+            work/notarized.zip
+            work/*.dmg
           if-no-files-found: error
           retention-days: 14
 
@@ -314,6 +415,7 @@ jobs:
             echo "- Version: ${VERSION}"
             echo "- Input: \`${SIGNED_ZIP_KEY}\`"
             echo "- Output: \`${NOTARIZED_KEY}\` (stapled, Gatekeeper-verified)"
+            echo "- DMG: \`${APP_NAME}.dmg\` (Developer ID signed, notarized, stapled)"
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
@@ -357,6 +459,7 @@ jobs:
           set -euo pipefail
           ls -la work/
           [ -f "work/notarized.zip" ] || { echo "notarized.zip missing from gated artifact"; exit 1; }
+          [ -f "work/${APP_NAME}.dmg" ] || { echo "${APP_NAME}.dmg missing from gated artifact"; exit 1; }
 
       # The versioned zip key is immutable-cached by CloudFront, so it must
       # never be republished with different bytes (same class as the cli/*
@@ -390,6 +493,34 @@ jobs:
           echo "DESKTOP_KEY=${DESKTOP_KEY}" >> "$GITHUB_ENV"
           echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
+      # Same never-republish discipline as the zip: conditional write,
+      # 412 on a job re-run keeps the existing bytes.
+      - name: Publish DMG to distribution bucket
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          DMG_KEY="desktop/${CHANNEL}/${VERSION}/${APP_NAME}.dmg"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${DMG_KEY}" \
+            --body "work/${APP_NAME}.dmg" \
+            --if-none-match '*' \
+            --content-type application/x-apple-diskimage \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              echo "DMG key already published (job re-run) -- keeping existing bytes: ${DMG_KEY}"
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "DMG_KEY=${DMG_KEY}" >> "$GITHUB_ENV"
+          echo "Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
+
       # Feed points at the NOTARIZED artifact on the CDN -- written only
       # after the spctl gate passed (this job's sole input is the gated
       # artifact) and only after the artifact is publicly downloadable
@@ -408,6 +539,7 @@ jobs:
           {
             "version": "${VERSION}",
             "url": "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}",
+            "dmg": "${{ vars.CLI_CDN_BASE }}/${DMG_KEY}",
             "name": "${VERSION}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -424,5 +556,6 @@ jobs:
             echo "## Publish (${CHANNEL})"
             echo "- Version: ${VERSION}"
             echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+            echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
             echo "- Feed: \`feed/${CHANNEL}/latest-mac.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/packaging/signing/sign-dmg.sh
+++ b/packaging/signing/sign-dmg.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# sign-dmg.sh -- Developer ID sign a DMG via CDSigner (second signing task).
+#
+# hdiutil-created DMGs carry an adhoc signature, which the Apple notary
+# service Accepts but Gatekeeper rejects ("app is damaged" when dragging
+# the app out of a quarantined mount). A Developer ID signature on the DMG
+# itself fixes that -- and additionally makes the DMG staple-able, so
+# first-install verification works fully offline (stapler fails with
+# Error 73 on unsigned DMGs).
+#
+# Mirrors sign.sh's proven flow (package -> upload -> submit -> poll ->
+# download) with a `type: dmg` manifest instead of the app manifest.
+# Manifest syntax per StoreGenVector docs/DMG_IMPLEMENTATION_PLAN.md and
+# the CDSigner API guide; flow per AIWQuilloWord code-signing-guide.md.
+#
+# Usage: sign-dmg.sh <dmg-path> <channel> <version>
+#
+# Env: AWS_SIGNING_BUCKET, AWS_SIGNER_ROLE_ARN, CDSIGNER_API_ENDPOINT
+# (same contract as sign.sh). Requires awscurl on PATH and AWS credentials
+# in the environment (OIDC role).
+#
+# On success the signed DMG REPLACES the file at <dmg-path>.
+
+set -euo pipefail
+
+DMG_PATH="${1:-}"
+CHANNEL="${2:-}"
+VERSION="${3:-}"
+DMG_IDENTIFIER="${DMG_IDENTIFIER:-com.amazon.kiro.crew.dmg}"
+
+if [ -z "$DMG_PATH" ] || [ -z "$CHANNEL" ] || [ -z "$VERSION" ]; then
+  echo "Usage: $0 <dmg-path> <channel> <version>" >&2
+  exit 1
+fi
+
+if [ ! -f "$DMG_PATH" ]; then
+  echo "ERROR: DMG not found at $DMG_PATH" >&2
+  exit 1
+fi
+
+# ── Env ─────────────────────────────────────────────────────────────────────
+: "${AWS_SIGNING_BUCKET:?Set AWS_SIGNING_BUCKET}"
+: "${AWS_SIGNER_ROLE_ARN:?Set AWS_SIGNER_ROLE_ARN}"
+: "${CDSIGNER_API_ENDPOINT:?Set CDSIGNER_API_ENDPOINT}"
+
+DMG_NAME="$(basename "$DMG_PATH")"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+INPUT_KEY="pre-signed/${CHANNEL}/${VERSION}/${DMG_NAME}.tar.gz"
+OUTPUT_KEY="signed/${CHANNEL}/${VERSION}/${DMG_NAME}"
+
+log() { printf '\033[1;36m▶ %s\033[0m\n' "$*"; }
+
+# ── 1. Package ──────────────────────────────────────────────────────────────
+# Same metadata-clean tar recipe as sign.sh: on macOS, suppress AppleDouble
+# (._*) entries and xattr/ACL/flag metadata -- bsdtar embeds them by default
+# and CDSigner's artifact security scan rejects archives containing them.
+TAR_PATH="$WORK_DIR/${DMG_NAME}.tar.gz"
+TAR_FLAGS=()
+if [ "$(uname)" = "Darwin" ]; then
+  TAR_FLAGS=(--no-xattrs --no-mac-metadata --no-acls --no-fflags)
+fi
+( cd "$(dirname "$DMG_PATH")" && COPYFILE_DISABLE=1 tar "${TAR_FLAGS[@]+"${TAR_FLAGS[@]}"}" -czf "$TAR_PATH" "$DMG_NAME" )
+
+# ── 2. Upload ───────────────────────────────────────────────────────────────
+log "Uploading to s3://${AWS_SIGNING_BUCKET}/${INPUT_KEY}..."
+aws s3 cp "$TAR_PATH" "s3://${AWS_SIGNING_BUCKET}/${INPUT_KEY}" --quiet || {
+  echo "ERROR: upload failed" >&2
+  exit 3
+}
+
+# ── 3. Submit signing request ───────────────────────────────────────────────
+log "Submitting CDSigner DMG sign task..."
+
+REQUEST=$(python3 - "$DMG_NAME" "$DMG_IDENTIFIER" "$AWS_SIGNER_ROLE_ARN" "$AWS_SIGNING_BUCKET" "$INPUT_KEY" "$OUTPUT_KEY" <<'PYEOF'
+import json, sys
+name, identifier, role, bucket, in_key, out_key = sys.argv[1:7]
+print(json.dumps({
+    "manifest": {
+        "type": "dmg",
+        "os": "osx",
+        "name": name,
+        "outputs": [{"label": "macos-dmg", "path": name}],
+        "dmg": {
+            "identifier": identifier,
+            "signing_requirements": {
+                "certificate_type": "developerIDAppDistribution",
+                "team_id": "94KV3E626L",
+            },
+        },
+    },
+    "s3ArtifactLocations": {
+        "bucketAccessRole": role,
+        "bucket": bucket,
+        "inputKey": in_key,
+        "outputKey": out_key,
+    },
+}))
+PYEOF
+)
+
+if ! command -v awscurl >/dev/null 2>&1; then
+  echo "ERROR: awscurl not found (required for CDSigner SigV4 signing)" >&2
+  exit 4
+fi
+
+RESPONSE=$(awscurl --service signer-builder-tools --region us-west-2 \
+  -X POST -H "Content-Type: application/json" -d "$REQUEST" \
+  "${CDSIGNER_API_ENDPOINT}/v2/sign-tasks" 2>&1) || {
+  echo "ERROR: CDSigner DMG sign-task submission failed" >&2
+  echo "$RESPONSE" >&2
+  exit 4
+}
+
+SIGN_TASK_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['signTaskId'])" 2>/dev/null) || {
+  echo "ERROR: CDSigner submission returned no signTaskId:" >&2
+  echo "$RESPONSE" >&2
+  exit 4
+}
+
+log "Sign task submitted: ${SIGN_TASK_ID}"
+
+# ── 4. Poll for completion ──────────────────────────────────────────────────
+log "Polling for completion (timeout: 15 min)..."
+
+MAX_WAIT="${SIGN_DMG_MAX_WAIT:-900}"
+POLL_INTERVAL="${SIGN_DMG_POLL_INTERVAL:-30}"
+ELAPSED=0
+SIGNED_OK=0
+
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  sleep "$POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+
+  STATUS_RESPONSE=$(awscurl --service signer-builder-tools --region us-west-2 \
+    -X GET "${CDSIGNER_API_ENDPOINT}/v2/sign-tasks/${SIGN_TASK_ID}" \
+    2>/dev/null) || continue
+
+  STATUS=$(echo "$STATUS_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+
+  case "$STATUS" in
+    success)
+      log "DMG signing completed! (${ELAPSED}s)"
+      SIGNED_OK=1
+      break
+      ;;
+    failure)
+      echo "ERROR: DMG signing failed" >&2
+      echo "$STATUS_RESPONSE" >&2
+      exit 4
+      ;;
+    *)
+      printf "  [%ds] status: %s\n" "$ELAPSED" "${STATUS:-<none>}"
+      ;;
+  esac
+done
+
+# Gate on the explicit success flag, not elapsed time: success arriving
+# exactly on the final poll tick must not be misread as a timeout.
+if [ "$SIGNED_OK" -ne 1 ]; then
+  echo "ERROR: DMG signing timed out after ${MAX_WAIT}s (sign task: ${SIGN_TASK_ID})" >&2
+  exit 5
+fi
+
+# ── 5. Download signed DMG ──────────────────────────────────────────────────
+log "Downloading signed DMG..."
+
+SIGNED_PATH="$WORK_DIR/${DMG_NAME}.signed"
+aws s3 cp "s3://${AWS_SIGNING_BUCKET}/${OUTPUT_KEY}" "$SIGNED_PATH" --quiet || {
+  echo "ERROR: Failed to download signed DMG" >&2
+  exit 3
+}
+
+# CDSigner returns the app task's output re-packaged as a zip; the dmg task
+# output format is expected to be the DMG itself, but tolerate a zip wrapper
+# (first live run confirms which). Fail closed on anything else.
+FILE_TYPE=$(file -b "$SIGNED_PATH")
+case "$FILE_TYPE" in
+  *"Zip archive"*)
+    log "Output is a zip wrapper -- extracting the DMG..."
+    unzip -q -o "$SIGNED_PATH" -d "$WORK_DIR/unwrapped"
+    INNER=$(find "$WORK_DIR/unwrapped" -name "*.dmg" | head -1)
+    [ -n "$INNER" ] || { echo "ERROR: no .dmg inside signed output zip" >&2; exit 3; }
+    mv "$INNER" "$SIGNED_PATH"
+    ;;
+  *) : ;;  # assume raw DMG; the codesign gate below fails closed if not
+esac
+
+# ── 6. Fail-closed signature gate ───────────────────────────────────────────
+# The whole point: the DMG must now carry a VALID Developer ID signature (an
+# adhoc or missing signature reproduces the "app is damaged" defect).
+# NOTE: Authority lines are only emitted at -dvvv verbosity; plain -dv omits
+# them entirely, which would make this gate reject every valid DMG.
+if ! codesign --verify --strict "$SIGNED_PATH" 2>&1; then
+  echo "ERROR: signed DMG failed codesign verification -- failing closed." >&2
+  exit 6
+fi
+AUTHORITY=$(codesign -dvvv "$SIGNED_PATH" 2>&1 | grep "^Authority=" | head -1 || true)
+log "DMG signature: ${AUTHORITY:-<none>}"
+if ! echo "$AUTHORITY" | grep -q "Developer ID Application"; then
+  echo "ERROR: signed DMG does not carry a Developer ID signature -- failing closed." >&2
+  codesign -dvvv "$SIGNED_PATH" 2>&1 | head -8 >&2 || true
+  exit 6
+fi
+
+mv "$SIGNED_PATH" "$DMG_PATH"
+log "Signed DMG in place: ${DMG_PATH} ($(du -h "$DMG_PATH" | cut -f1))"

--- a/packaging/signing/sign.sh
+++ b/packaging/signing/sign.sh
@@ -159,6 +159,7 @@ log "Polling for completion (timeout: 15 min)..."
 MAX_WAIT=900  # 15 minutes
 POLL_INTERVAL=30
 ELAPSED=0
+SIGNED_OK=0
 
 while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
   sleep "$POLL_INTERVAL"
@@ -173,6 +174,7 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
   case "$STATUS" in
     success)
       log "Signing completed! (${ELAPSED}s)"
+      SIGNED_OK=1
       break
       ;;
     failure)
@@ -189,7 +191,9 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
   esac
 done
 
-if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+# Gate on the explicit success flag, not elapsed time: success arriving
+# exactly on the final poll tick must not be misread as a timeout.
+if [ "$SIGNED_OK" -ne 1 ]; then
   echo "ERROR: Signing timed out after ${MAX_WAIT}s (sign task: ${SIGN_TASK_ID})" >&2
   exit 5
 fi

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -73,7 +73,8 @@ class TestNightlyPermissions:
         # Caller job for the reusable sign-and-notarize workflow: a
         # workflow_call callee can never exceed the caller job's permissions,
         # so the caller must grant id-token explicitly. attestations:write
-        # is for the sign job's wheel/sdist/AppImage provenance attestation.
+        # covers the sign job's wheel/sdist/AppImage provenance and the
+        # notarize job's shipping-DMG attestation.
         assert _permission_block(lines, "  sign-and-notarize:") == {
             "id-token": "write",
             "contents": "read",


### PR DESCRIPTION
Follow-up to #137 (now merged), which withdrew the DMG after the field defect: hdiutil DMGs are **adhoc-signed** -- Apple's notary Accepts them but Gatekeeper rejects them ("app is damaged" on drag-out from a quarantined mount). Investigation confirmed CDSigner supports DMG signing as a first-class manifest type (syntax per StoreGenVector's DMG implementation plan, flow per Quillo's code-signing guide; production precedents: NoSQLWorkbench, ElectronCodeSigningAutomation).

## What

- **`packaging/signing/sign-dmg.sh`** (new): second CDSigner task with a `type: dmg` manifest, mirroring `sign.sh`'s proven package -> upload -> submit -> poll -> download mechanics. Tolerates a zip wrapper on the output. **Fails closed** unless the result carries a `Developer ID Application` authority.
- **`sign-and-notarize.yml` notarize job**: build DMG from stapled app -> **CDSigner sign** -> notarize -> **staple the DMG** (possible once signed -- kills the Error 73 limitation; first-install verification works fully offline) -> **fail-closed `spctl --assess --type install` gate** (exactly the check that would have caught the adhoc defect) -> attest **after** staple (stapling embeds the ticket into the released bytes). awscurl installed before AWS credentials; timeout back to 75m.
- **publish job**: DMG publication, feed `dmg` field, gated-artifact verification restored. **`release.yml`**: DMG release asset restored.

## End state vs the withdrawn #108 design

| Property | #108 (withdrawn) | This PR |
|---|---|---|
| DMG signature | adhoc (hdiutil default) | **Developer ID (CDSigner)** |
| Gatekeeper drag-out | "app is damaged" | accepted |
| DMG staple | impossible (Error 73) | **stapled -- offline verification** |
| CI gate on DMG | notary Accepted only | **spctl --type install, fail-closed** |

## Tested locally (shim harness + real defect artifact)

- **TEST A (flow)**: full run through PATH-shimmed awscurl/aws -- captured request JSON matches the documented CDSigner shape exactly; poll loop, download, in-place replacement all verified.
- **TEST B (fail-closed gate)**: fed the gate **the actual adhoc DMG from today's field defect** (real `codesign`, live CDN bytes) -- rejected with exit 6, original input left untouched. This test also caught and fixed a pipefail exit-code bug in the diagnostic path.
- **TEST C (output tolerance)**: zip-wrapped signed output is unwrapped correctly.
- Plus: `bash -n`, YAML + duplicate-key gates, 5/5 permission tests.

## Remaining live-run unknowns (fail loudly, never silently)

CDSigner's `dmg` task in *this repo's onboarding scope* and the exact output format are confirmed by the first nightly. Every new step fails closed -- a contract mismatch is a red job, not a broken artifact. Post-merge verification: download the CDN DMG, `syspolicy_check distribution` must pass it, quarantined drag-out must show no "damaged" dialog.