### PR TITLE
fix(ci): PEP 668-safe awscurl install (venv) in sign-and-notarize

### DIFF
--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -128,8 +128,16 @@ jobs:
       - name: Install awscurl (SigV4 client for CDSigner)
         if: env.HAS_CDSIGNER
         run: |
-          python3 -m pip install --user --quiet "awscurl==0.44"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # Dedicated venv: `pip install --user` is refused by PEP 668
+          # (externally-managed-environment) on Homebrew/Deadsnakes-managed
+          # runner Pythons -- macos-14 enforces it today, ubuntu images will.
+          # Symlink only the awscurl binary onto PATH so the venv's python
+          # never shadows the system python3 used by later steps.
+          python3 -m venv "$RUNNER_TEMP/awscurl-venv"
+          "$RUNNER_TEMP/awscurl-venv/bin/pip" install --quiet "awscurl==0.44"
+          mkdir -p "$RUNNER_TEMP/tool-bin"
+          ln -sf "$RUNNER_TEMP/awscurl-venv/bin/awscurl" "$RUNNER_TEMP/tool-bin/awscurl"
+          echo "$RUNNER_TEMP/tool-bin" >> "$GITHUB_PATH"
 
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS
@@ -220,12 +228,16 @@ jobs:
           sparse-checkout: packaging/signing
 
       # Install the CDSigner SigV4 client BEFORE AWS credentials are
-      # configured (same supply-chain ordering as the sign job). macOS
-      # --user installs land under `python3 -m site --user-base`/bin.
+      # configured (same supply-chain ordering as the sign job). Same
+      # PEP 668-safe venv recipe: macos-14's Homebrew python3 refuses
+      # `pip install --user` with externally-managed-environment.
       - name: Install awscurl (SigV4 client for CDSigner)
         run: |
-          python3 -m pip install --user --quiet "awscurl==0.44"
-          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
+          python3 -m venv "$RUNNER_TEMP/awscurl-venv"
+          "$RUNNER_TEMP/awscurl-venv/bin/pip" install --quiet "awscurl==0.44"
+          mkdir -p "$RUNNER_TEMP/tool-bin"
+          ln -sf "$RUNNER_TEMP/awscurl-venv/bin/awscurl" "$RUNNER_TEMP/tool-bin/awscurl"
+          echo "$RUNNER_TEMP/tool-bin" >> "$GITHUB_PATH"
 
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS


### PR DESCRIPTION
First nightly after #139 ([run 29883419878](https://github.com/kirodotdev/KiroCrew/actions/runs/29883419878)) failed at the notarize job's new `Install awscurl` step: macos-14's Homebrew-managed python3 refuses `pip install --user` with **externally-managed-environment (PEP 668)**.

Fix: dedicated venv + symlink **only the awscurl binary** onto PATH (`$RUNNER_TEMP/tool-bin`) so the venv's python never shadows the system `python3` that later steps use for Secrets Manager JSON parsing. Applied to **both** install steps -- the ubuntu sign job tolerates `--user` today but is the same landmine when its image starts enforcing PEP 668.

Verified locally on a PEP 668-enforcing Homebrew python (same failure mode as the runner): the venv install succeeds and `awscurl --help` resolves via the symlink. Supply-chain ordering unchanged (install still precedes credential configuration); version still pinned.

Failure-mode note: the step failed before any credentials were configured and before any artifact was produced -- fail-closed as designed, nothing published.