### PR TITLE
fix(website): sidebar expand/collapse width animation snaps instead of animating

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -769,9 +769,6 @@ export default function App() {
   useRumPageView()
   useNotificationSound()
   const [navCollapsed, setNavCollapsed] = useState(() => localStorage.getItem('mc-nav') === '1')
-  const [navLayoutPulse, setNavLayoutPulse] = useState(false)
-  const navLayoutPulseTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
-  useEffect(() => () => { if (navLayoutPulseTimer.current) clearTimeout(navLayoutPulseTimer.current) }, [])
   const isMobile = useIsMobile()
   // Multi-instance: which instance fills the pane below the tab bar. null = Local
   // (the native dashboard); a non-null id means a remote instance's embedded
@@ -1259,9 +1256,6 @@ export default function App() {
   const toggleNav = () => {
     if (isMobile) { setMobileNavOpen(p => !p) }
     else {
-      if (navLayoutPulseTimer.current) clearTimeout(navLayoutPulseTimer.current)
-      setNavLayoutPulse(true)
-      navLayoutPulseTimer.current = setTimeout(() => setNavLayoutPulse(false), 180)
       setNavCollapsed(prev => { const next = !prev; safeSetItem('mc-nav', next ? '1' : '0'); return next })
     }
   }
@@ -1360,9 +1354,11 @@ export default function App() {
         gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar actbar" "nav content actbar"',
         ...(!isMobile && {
           gridTemplateColumns: `${effectiveCollapsed ? 74 : 236}px minmax(0,1fr) auto`,
-          transition: navLayoutPulse && !activityOpen
-            ? 'grid-template-columns 150ms cubic-bezier(0.2, 0, 0, 1)'
-            : 'none',
+          // Transition fires only when the template string itself changes (the
+          // collapse toggle) — content-driven resizes of the auto track (e.g.
+          // the Activity panel opening) don't alter the value, so keeping this
+          // unconditional is safe and avoids the gated-pulse snap regression.
+          transition: 'grid-template-columns 150ms cubic-bezier(0.2, 0, 0, 1)',
         }),
       }}
     >

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act, fireEvent, waitFor, within } from '@testing-librar
 import { renderWithProviders, createTestStore } from './helpers'
 import App, { calculateTopbarSearchLayout } from '../App'
 import { sseConnected, sseDisconnected } from '../store/dashboardSlice'
+import { openActivityPanel } from '../store/chatSlice'
 import SegmentedControl from '../components/SegmentedControl'
 import { safeSetItem } from '../utils/safeStorage'
 
@@ -349,12 +350,18 @@ describe('App routing', () => {
 
   it('resizes the sidebar and main body together with a quick shell transition', () => {
     localStorage.removeItem('mc-nav')
-    renderWithProviders(<App />, { route: '/chat' })
+    // Regression (PR #94): the width transition was gated on a 180ms pulse AND
+    // the Activity panel being closed, so the sidebar snapped instead of
+    // animating whenever Activity was open (or a slow frame ate the pulse).
+    // The transition must now be unconditional — including with Activity open.
+    const store = createTestStore()
+    store.dispatch(openActivityPanel())
+    renderWithProviders(<App />, { route: '/chat', store })
 
     const shell = screen.getByTestId('dashboard-shell')
     expect(shell).toHaveStyle({
       gridTemplateColumns: '236px minmax(0,1fr) auto',
-      transition: 'none',
+      transition: 'grid-template-columns 150ms cubic-bezier(0.2, 0, 0, 1)',
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }))


### PR DESCRIPTION
## Problem
Since #94, toggling the sidebar snaps between 74px and 236px instead of animating whenever the chat Activity panel is open. Even with the panel closed, the animation is intermittently cut short.

## Root cause
#94 replaced the always-on framer-motion width animation on the nav rail with a `grid-template-columns` transition on the dashboard shell, gated behind `navLayoutPulse && !activityOpen`:

- `!activityOpen`: any toggle while the Activity panel is open gets `transition: 'none'` and hard-snaps. This is the common case in chat.
- `navLayoutPulse`: the 150ms transition races a 180ms pulse window; one slow frame (the grid resize reflows ChatPage at that exact moment) re-applies `transition: 'none'` mid-flight.

## Fix
Make the shell transition unconditional and delete the pulse machinery. This is safe because a CSS transition on `grid-template-columns` only fires when the computed template string changes — and the string only changes when `effectiveCollapsed` flips. Activity panel open/close resizes the `auto` track's content without altering the template, so it cannot trigger the transition. #94's goal (sidebar and body move together as one grid track) is preserved; only the gating is removed.

## Tests
- Extended the shell-transition test in `App.test.tsx` to render with the Activity panel open (the regression case) and assert the transition is present at rest and during toggle.
- Full website suite: 346 files, 3890 passed, 3 skipped.
- `tsc -b` clean.