### PR TITLE
fix(signing): DMG manifest uses documented type:app shape + onboarded identifier

### DIFF
--- a/packaging/signing/sign-dmg.sh
+++ b/packaging/signing/sign-dmg.sh
@@ -26,7 +26,11 @@ set -euo pipefail
 DMG_PATH="${1:-}"
 CHANNEL="${2:-}"
 VERSION="${3:-}"
-DMG_IDENTIFIER="${DMG_IDENTIFIER:-com.amazon.kiro.crew.dmg}"
+# Default to the ONBOARDED app identifier: CDSigner authz is per-identifier
+# (Bindle-backed) -- an unfamiliar identifier (e.g. com.amazon.kiro.crew.dmg)
+# is rejected with a Bindle ownership-transfer demand. Proven by live probe:
+# com.amazon.kiro.crew signs successfully (task eb171910, 2026-07-21).
+DMG_IDENTIFIER="${DMG_IDENTIFIER:-com.amazon.kiro.crew}"
 
 if [ -z "$DMG_PATH" ] || [ -z "$CHANNEL" ] || [ -z "$VERSION" ]; then
   echo "Usage: $0 <dmg-path> <channel> <version>" >&2
@@ -73,16 +77,22 @@ aws s3 cp "$TAR_PATH" "s3://${AWS_SIGNING_BUCKET}/${INPUT_KEY}" --quiet || {
 # ── 3. Submit signing request ───────────────────────────────────────────────
 log "Submitting CDSigner DMG sign task..."
 
+# Manifest shape per the OFFICIAL CDSigner API guide ("macOS application
+# (.app, .pkg and .dmg) signing"): DMGs sign as type "app" with the DMG as
+# the output path -- the live API enumerates valid types and "dmg" is NOT
+# one (a "type: dmg" submission is rejected with a 400; proven by nightly
+# run 29884088951). The DMG must already be read-only UDZO, which the
+# build step guarantees (hdiutil create -format UDZO).
 REQUEST=$(python3 - "$DMG_NAME" "$DMG_IDENTIFIER" "$AWS_SIGNER_ROLE_ARN" "$AWS_SIGNING_BUCKET" "$INPUT_KEY" "$OUTPUT_KEY" <<'PYEOF'
 import json, sys
 name, identifier, role, bucket, in_key, out_key = sys.argv[1:7]
 print(json.dumps({
     "manifest": {
-        "type": "dmg",
+        "type": "app",
         "os": "osx",
         "name": name,
-        "outputs": [{"label": "macos-dmg", "path": name}],
-        "dmg": {
+        "outputs": [{"label": "macos", "path": name}],
+        "app": {
             "identifier": identifier,
             "signing_requirements": {
                 "certificate_type": "developerIDAppDistribution",


### PR DESCRIPTION
Nightly [29884088951](https://github.com/kirodotdev/KiroCrew/actions/runs/29884088951) failed at `Sign DMG with CDSigner`: the live API rejects `type: dmg` -- its valid types are `app | app_extension | bundle | framework | static_lib | xcframework | generic | xcarchive`. The [official CDSigner API guide](https://docs.hub.amazon.dev/docs/cd-signer/api-guide/getting-started/) section **"macOS application (.app, .pkg and .dmg) signing"** signs DMGs as `type: app` with the DMG as the output path. The `type: dmg` syntax in #139 came from another team's unshipped design doc; my error was trusting it without a live probe.

## Fully tested against production before this push (per review feedback)

Ran the fixed `sign-dmg.sh` end-to-end from a workstation against the real CDSigner API + Apple notary, using the real defect DMG (UDZO, fully signed+stapled app inside):

| Stage | Result |
|---|---|
| CDSigner sign task (`type: app`, onboarded identifier) | success in 60s (task `eb171910`) |
| Output handling | zip-wrapper path exercised **in production**, DMG extracted |
| Signature gate | `Authority=Developer ID Application: AMZN Mobile LLC (94KV3E626L)` |
| Apple notarization of the signed DMG | **Accepted** (`93dee966`) |
| `stapler staple` on the DMG | **worked** -- Error 73 gone, offline verification closed |
| `spctl --assess --type install` | accepted, `source=Notarized Developer ID` |
| `syspolicy_check distribution` (the check the adhoc defect failed) | **"ready for distribution"** |

## Second gate found by the probe (would have been the NEXT CI failure)

CDSigner authz is per-identifier (Bindle-backed): the unfamiliar `com.amazon.kiro.crew.dmg` identifier is rejected with a Bindle ownership-transfer demand (resource `amzn1.bindle.resource.dfwyxpiejh5j7vbrrq2a` was auto-created by the probe -- harmless orphan, claimable later if a distinct DMG identifier is ever wanted). Default flipped to the onboarded `com.amazon.kiro.crew`.

Two-line diff to `packaging/signing/sign-dmg.sh` (manifest shape + identifier default); workflow YAML untouched. Harness regression re-run: manifest-shape assertion updated and green.