### PR TITLE
feat: consolidate top header and restructure left nav

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -26,13 +26,12 @@ import { ZoomProvider } from './hooks/ZoomProvider'
 import { api, isAuthBannerShown } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
-import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, PanelRight, PanelLeftClose, Globe, LayoutGrid, Lightbulb, ExternalLink } from 'lucide-react'
+import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, ArrowLeftToLine, Globe, LayoutGrid, Lightbulb, ExternalLink } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import OnboardingFlow from './components/OnboardingFlow'
 import { motion, AnimatePresence } from 'framer-motion'
 import { usePersistedBool } from './hooks/usePersistedBool'
 import { isMacElectron } from './lib/electron'
-import { SIDE_PANEL_MIN_W, measureSidePanelReservedW } from './pages/chat/SidePanel'
 import { DndContext, closestCenter, MouseSensor, TouchSensor, useSensor, useSensors, DragOverlay, type DragStartEvent, type DragEndEvent } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -1099,16 +1098,6 @@ export default function App() {
     capsulePulseTimer.current = setTimeout(() => setCapsuleLayoutPulse(false), 350)
   }, [])
   useEffect(() => () => clearTimeout(capsulePulseTimer.current), [])
-  // Whether the window currently has room for the activity panel beside the
-  // chat's reserved minimum. When it doesn't (the panel would be
-  // force-collapsed anyway), the toggle button is disabled.
-  const [actSpace, setActSpace] = useState(true)
-  useEffect(() => {
-    const check = () => setActSpace(window.innerWidth >= SIDE_PANEL_MIN_W + measureSidePanelReservedW())
-    check()
-    window.addEventListener('resize', check)
-    return () => window.removeEventListener('resize', check)
-  }, [])
   // macOS fullscreen hides the native traffic lights, so the header's 84px
   // clearance inset drops while fullscreen (mac-fullscreen class on the root).
   const [macFullscreen, setMacFullscreen] = useState(false)
@@ -1117,12 +1106,14 @@ export default function App() {
     const api = (window as { electronAPI?: { onFullScreenChanged?: (cb: (fs: boolean) => void) => () => void } }).electronAPI
     return api?.onFullScreenChanged?.(setMacFullscreen)
   }, [])
-  // True when the instance tab bar is the topmost strip on macOS and the native
-  // traffic lights therefore sit over it (not the header). Drives the
-  // .mac-instancebar-inset root class that relocates the 84px clearance.
+  // True when the standalone instance tab-bar STRIP is the topmost strip on
+  // macOS (only while a remote pane is active — on the local pane the tabs live
+  // inline in the consolidated header, which keeps its own 84px clearance). The
+  // native traffic lights then sit over the strip, so relocate the inset to it.
   const macInstanceBarInset =
     isMacElectron &&
     !macFullscreen &&
+    activeInstanceId !== null &&
     visibleInstanceTabs(instancesData?.instances ?? [], instanceWarm).length > 0
   // Tell the Electron main process which strip is topmost so it can center the
   // native traffic lights against the 32px instance bar (when shown) instead of
@@ -1345,19 +1336,20 @@ export default function App() {
       </div>
     ) : (
     <div className={`h-screen w-screen flex flex-col overflow-hidden bg-bg ${macInstanceBarInset ? 'mac-instancebar-inset' : ''}`}>
-      {/* Thin instance tab bar — renders null unless >=1 remote is connected, so
-          the single-instance experience is unchanged. Everything below it is the
-          switchable window: the Local dashboard, or a remote's embedded one. */}
-      <InstanceTabBar />
+      {/* Standalone instance tab bar — shown ONLY while a remote pane is active
+          (the local pane below is hidden then, so its inline in-header tabs are
+          not visible; this strip is what lets you switch back to Local). On the
+          local pane the tabs render inline inside the consolidated header. */}
+      {activeInstanceId !== null && <InstanceTabBar />}
       <div className="flex-1 min-h-0 relative">
       {/* Local pane: the native dashboard. Hidden (not unmounted) while a remote
           instance tab is active, so local state/websocket survive the switch. */}
       <div className="absolute inset-0" style={{ display: activeInstanceId === null ? 'block' : 'none' }}>
     <div
       data-testid="dashboard-shell"
-      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[52px_minmax(0,1fr)]' : 'grid-rows-[52px_minmax(0,1fr)]'}`}
+      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[42px_minmax(0,1fr)]' : 'grid-rows-[42px_minmax(0,1fr)]'}`}
       style={{
-        gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar actbar" "nav content actbar"',
+        gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar topbar" "nav content actbar"',
         ...(!isMobile && {
           gridTemplateColumns: `${effectiveCollapsed ? 74 : 236}px minmax(0,1fr) auto`,
           transition: navLayoutPulse && !activityOpen
@@ -1377,51 +1369,34 @@ export default function App() {
       <a href="#main-content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent focus:text-accent-fg focus:text-sm focus:font-medium">Skip to content</a>
 
       {/* Topbar */}
-      <header className="topbar-glass relative flex items-center pr-3 z-[45]" style={{ gridArea: 'topbar' }}>
-        {/* Brand + collapse, aligned to the nav card's outer width. */}
+      <header className="topbar-glass relative flex items-center pl-3 pr-3 z-[45]" style={{ gridArea: 'topbar' }}>
+        {/* Left: mobile menu toggle + inline instance selector. The brand now
+            lives in the sidebar (item 1.1). The selector reuses InstanceTabBar's
+            visibility rule — it renders nothing unless >=1 remote instance
+            exists, so the common single-instance header-left is empty (only the
+            macOS traffic-light clearance remains). */}
         <div
           ref={topbarBrandRef}
-          className={`relative flex items-center h-full shrink-0 ${isMobile ? 'px-2 gap-3' : `${effectiveCollapsed ? 'justify-start px-0 gap-2' : 'px-5 gap-2'}`}`}
-          style={isMobile ? undefined : effectiveCollapsed ? { minWidth: 74 } : { minWidth: 236 }}
+          className={`relative flex items-center h-full shrink-0 gap-2 ${isMobile ? 'px-2' : ''}`}
         >
           {isMobile && (
             <button className="p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text shrink-0" onClick={toggleNav} aria-label="Open menu">
               <Menu size={20} />
             </button>
           )}
-          {!isMobile && effectiveCollapsed ? (
-            <div className="flex items-center justify-center w-[74px] h-full shrink-0">
-              <img src={avatar} alt={botName} className={`${isLumon ? 'w-auto h-7' : 'w-9 h-9'} rounded-sm shrink-0 hover:scale-110 transition-transform duration-300 object-contain`} style={{ filter: 'drop-shadow(0 2px 8px var(--accent-glow))' }} />
-              <span className="sr-only">{botName}</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-2.5 min-w-0 opacity-100">
-              <img src={avatar} alt={botName} className={`${isLumon ? 'w-auto h-7' : 'w-9 h-9'} rounded-sm shrink-0 hover:rotate-[-8deg] hover:scale-110 transition-transform duration-300 object-contain`} style={{ filter: 'drop-shadow(0 2px 8px var(--accent-glow))' }} />
-              <span className="text-sm font-bold tracking-[.08em] text-text-strong whitespace-nowrap">{botName}</span>
-            </div>
-          )}
-          {/* Keep Request a Feature visible beside the brand in both desktop sidebar states. */}
-          {!isMobile && <>
-            <span className="w-px h-4 bg-border shrink-0" aria-hidden="true" />
-            <button
-              className="flex items-center gap-1.5 px-2 -ml-2 py-1 rounded-md bg-transparent border-none cursor-pointer text-[12px] text-muted hover:text-text hover:bg-bg-hover transition-colors whitespace-nowrap"
-              onClick={requestFeature}
-            >
-              <Lightbulb size={13} /> Request a Feature
-            </button>
-          </>}
+          {!isMobile && <InstanceTabBar variant="inline" />}
         </div>
         {!isMobile && topbarSearchLayout.visible && (
           <button
             type="button"
             data-topbar-overlay
             onClick={commandPalette.openPalette}
-            className="absolute w-auto max-w-[34rem] h-9 px-4 rounded-lg border border-border bg-card text-muted hover:text-text hover:border-border-hover transition-colors flex items-center justify-center gap-2 cursor-pointer shadow-none"
-            style={{ left: topbarSearchLayout.gutter, right: topbarSearchLayout.gutter, marginInline: 'auto' }}
+            className="absolute h-7 px-3 rounded-md border border-border bg-card text-muted hover:text-text hover:border-border-hover transition-colors flex items-center justify-center gap-2 cursor-pointer shadow-none"
+            style={{ left: '50vw', transform: 'translateX(-50%)', width: 'calc(33.3333vw - 40px)', minWidth: TOPBAR_SEARCH_MIN_WIDTH }}
             aria-label="Search sessions, files, and commands"
             title="Search everywhere (⌘K)"
           >
-            <span className="text-[13px]">⌘K — Search for anything…</span>
+            <span className="text-[13px] truncate">⌘K — Search for anything…</span>
           </button>
         )}
         <div ref={topbarActionsRef} className="flex items-center gap-1.5 relative ml-auto">
@@ -1506,34 +1481,28 @@ export default function App() {
               <motion.div
                 layout
                 transition={{ layout: { duration: capsuleLayoutPulse ? 0.25 : 0, ease: 'easeOut' } }}
-                className={`flex items-center gap-2 h-7 px-2.5 rounded-full border transition-colors duration-300 ${offline ? 'border-danger bg-danger-subtle' : 'border-border bg-card'}`}
+                className={`flex items-center gap-2 h-7 px-2.5 rounded-xl transition-colors duration-300 ${offline ? 'bg-danger-subtle' : 'bg-card'}`}
               >
                 {segments.flatMap((s, i) => (i === 0 ? [s] : [<span key={`sep-${i}`} className="w-px h-3.5 bg-border shrink-0" aria-hidden="true" />, s]))}
               </motion.div>
             )
           })()}
-          {/* Notifications bell — rightmost regular button (borderless icon,
-              matching the activity toggle's style). The activity toggle stays
-              at the absolute edge: its -mr-1.5 window-edge overlap with the
-              panel's close button is positional, and it hides when the panel
-              opens — leaving the bell as the visible far-right icon. */}
+          {/* Request a Feature — its own bordered pill (28px tall, 12px radius),
+              separated from the readout capsule (item 2.3). */}
+          {!isMobile && (
+            <button
+              className="flex items-center gap-1.5 h-7 px-2.5 rounded-xl bg-card text-muted hover:text-text transition-colors cursor-pointer text-[12px] whitespace-nowrap shrink-0"
+              onClick={requestFeature}
+              title="Request a feature"
+            >
+              <Lightbulb size={13} /> Request a Feature
+            </button>
+          )}
+          {/* Notifications bell — borderless icon button, rightmost control.
+              (The activity-panel open toggle now lives in the session header,
+              beside the pop-out control — see ChatPage — so opening the panel
+              no longer narrows this full-width header.) */}
           <NotificationsBellButton />
-          {/* Activity panel toggle — rightmost icon, adjacent to
-              the panel it opens. Hidden while the panel is open: the panel's
-              own header close button takes over (no duplicate affordance).
-              Styled + positioned to mirror that close button exactly (w-7
-              borderless icon; -mr-1.5 pulls it from the header's pr-3 to 6px
-              off the window edge, matching the strip's pr-1.5) so open/close
-              icons overlap and the toggle feels like one button flipping. */}
-          {!isMobile && activePath.startsWith('/chat') && !activityOpen && <button
-            className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 -mr-1.5 ${actSpace ? 'text-muted hover:text-text hover:bg-bg-hover cursor-pointer' : 'text-muted opacity-40 cursor-not-allowed'}`}
-            onClick={() => window.dispatchEvent(new CustomEvent('toggle-activity-panel'))}
-            disabled={!actSpace}
-            title={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
-            aria-label={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
-          >
-            <PanelRight size={15} />
-          </button>}
         </div>
       </header>
 
@@ -1644,26 +1613,62 @@ export default function App() {
         {/* Top-fixed: menu row + primary destinations + Apps section header.
             The sidebar toggle lives HERE (menu row), not in the topbar. */}
         <div className="shrink-0 flex flex-col gap-0.5 px-2 pt-2">
-          <div className={`flex items-center py-2 pl-3 pr-3 ${effectiveCollapsed ? '' : 'justify-between'}`}>
+          <div className={`flex items-center p-1 ${effectiveCollapsed ? 'justify-start' : ''}`}>
+            {/* One persistent click target that toggles the rail. The logo
+                never unmounts, so it stays perfectly still across collapse/
+                expand (no swap, no shift). Only the brand text + collapse arrow
+                animate — fading in on expand and out on collapse via
+                AnimatePresence. No hover tint on the row; on hover only the
+                logo rotates (group-hover). */}
             <button
-              className="flex items-center justify-center p-1.5 -m-1.5 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover transition-colors shrink-0"
+              type="button"
+              className="group relative flex items-center gap-2 w-full p-0 bg-transparent border-none cursor-pointer text-left overflow-hidden"
               onClick={toggleNav}
               title={effectiveCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              aria-label={effectiveCollapsed ? 'Expand sidebar' : 'Toggle sidebar'}
+              aria-label={effectiveCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               aria-expanded={!effectiveCollapsed}
             >
-              <Menu size={16} />
+              <span className="flex items-center gap-2.5 min-w-0">
+                {/* Glow via box-shadow, NOT filter: drop-shadow. A drop-shadow
+                    filter re-rasterizes for a frame when the sidebar width
+                    transition starts on expand (a visible "blink"); box-shadow
+                    composites without that re-raster. The logo is a rounded-md
+                    square, so the rounded-rect box-shadow reads the same. */}
+                <img src={avatar} alt="" aria-hidden="true" className={`${isLumon ? 'w-auto h-8' : 'w-8 h-8'} rounded-md shrink-0 object-contain transition-transform duration-300 group-hover:rotate-[-8deg]`} style={{ boxShadow: '0 2px 8px var(--accent-glow)' }} />
+                <AnimatePresence initial={false}>
+                  {!effectiveCollapsed && (
+                    <motion.span
+                      key="brand-text"
+                      initial={{ opacity: 0, x: -6 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -6, transition: { duration: 0.12, ease: 'easeIn' } }}
+                      transition={{ duration: 0.2, ease: 'easeOut' }}
+                      className="text-sm font-bold tracking-[.08em] text-text-strong whitespace-nowrap truncate"
+                    >{botName}</motion.span>
+                  )}
+                </AnimatePresence>
+              </span>
+              {/* Arrow is ABSOLUTE (out of flex flow), pinned to the right.
+                  If it were a flex child it would reserve ~16px on the right
+                  from frame 1 of expand — but the rail is still at collapsed
+                  width (74px) for that frame, so logo + gap + arrow overflowed
+                  and the logo got crammed/clipped against the arrow (the
+                  "blink"). Absolute-positioning removes that reserved space, so
+                  the logo stays put and the arrow just fades in at the edge. */}
+              <AnimatePresence initial={false}>
+                {!effectiveCollapsed && (
+                  <motion.span
+                    key="collapse-arrow"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1, transition: { duration: 0.18, ease: 'easeOut', delay: 0.12 } }}
+                    exit={{ opacity: 0, transition: { duration: 0.12, ease: 'easeIn' } }}
+                    className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center text-muted pointer-events-none"
+                  >
+                    <ArrowLeftToLine size={16} />
+                  </motion.span>
+                )}
+              </AnimatePresence>
             </button>
-            {!effectiveCollapsed && (
-              <button
-                className="flex items-center justify-center p-1.5 -m-1.5 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover transition-colors shrink-0"
-                onClick={toggleNav}
-                title="Collapse sidebar"
-                aria-label="Collapse sidebar"
-              >
-                <PanelLeftClose size={16} />
-              </button>
-            )}
           </div>
           {NAV_ITEMS.filter(n => n.group === 'Main').map(n => <div key={n.id}>{renderNavRow(n)}</div>)}
           {/* Apps section header. "Explore" (the App Store) rides the header
@@ -1686,6 +1691,7 @@ export default function App() {
             </div>
           ) : (
             <motion.div
+              className="mt-4"
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}

--- a/website/src/components/BrandIcon.tsx
+++ b/website/src/components/BrandIcon.tsx
@@ -16,8 +16,13 @@ function BrandGlyph({ url, size }: { url: string; size: number }) {
         width: size,
         height: size,
         backgroundColor: 'currentColor',
-        WebkitMaskImage: `url(${url})`,
-        maskImage: `url(${url})`,
+        // Quote the URL: in the production build these small SVGs are inlined
+        // by Vite as `data:` URIs, whose commas/`#`/parens break an UNQUOTED
+        // `url(...)` token (the mask silently fails and the span renders as a
+        // solid currentColor box). Dev serves them as clean file paths, so the
+        // bug only shows in the packaged app. Matches GithubLogo/GitlabLogo.
+        WebkitMaskImage: `url("${url}")`,
+        maskImage: `url("${url}")`,
         WebkitMaskRepeat: 'no-repeat',
         maskRepeat: 'no-repeat',
         WebkitMaskSize: 'contain',

--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -61,7 +61,7 @@ function fmtDuration(secs: number): string {
   return h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`
 }
 
-export default function InstanceTabBar() {
+export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip' | 'inline' } = {}) {
   const dispatch = useAppDispatch()
   const activeId = useAppSelector(s => s.instances.activeId)
   const warm = useAppSelector(s => s.instances.warm)
@@ -120,10 +120,10 @@ export default function InstanceTabBar() {
   if (embedded || disabled || tabInstances.length === 0) return null
 
   const tabCls = (active: boolean) =>
-    'flex items-center gap-1.5 h-6 px-2.5 rounded-md text-[12px] font-medium whitespace-nowrap transition-colors border shrink-0 ' +
+    'flex items-center gap-1.5 h-6 px-2.5 rounded-md text-[12px] whitespace-nowrap transition-colors border shrink-0 ' +
     (active
-      ? 'bg-accent-subtle text-accent border-accent/40'
-      : 'bg-transparent text-muted border-transparent hover:text-text hover:bg-bg-hover')
+      ? 'bg-accent-subtle text-accent border-accent/40 font-bold'
+      : 'bg-transparent text-muted border-transparent font-medium hover:text-text hover:bg-bg-hover')
 
   // Right-aligned tunnel-status cluster: the ACTIVE remote pane's connection
   // state + countdown to the next token auto-refresh. On the Local tab there is
@@ -159,11 +159,15 @@ export default function InstanceTabBar() {
 
   return (
     <div
-      className="topbar-glass instance-tab-bar flex items-center gap-2 h-8 px-2 border-b border-border shrink-0 z-[46]"
+      className={
+        variant === 'inline'
+          ? 'instance-tab-bar-inline flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar'
+          : 'topbar-glass instance-tab-bar flex items-center gap-2 h-8 px-2 border-b border-border shrink-0 z-[46]'
+      }
       role="tablist"
       aria-label="Instances"
     >
-      <div className="flex items-center gap-1 flex-1 min-w-0 overflow-x-auto no-scrollbar">
+      <div className={`flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar ${variant === 'strip' ? 'flex-1' : ''}`}>
         <button
           type="button"
           role="tab"
@@ -225,7 +229,7 @@ export default function InstanceTabBar() {
           )
         })}
       </div>
-      {activeInst && (
+      {variant === 'strip' && activeInst && (
         <div className="flex items-center gap-1.5 shrink-0 pl-2 pr-1" title={tunnelTitle}>
           <span className={`w-2 h-2 rounded-full ${tunnelDotCls}`} aria-hidden />
           <span className="text-[11px] text-[var(--muted)] hidden sm:inline">{tunnelLabel}</span>

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -109,7 +109,7 @@ import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { ShieldCheck, BookOpen, Handshake, Rocket, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Check, Columns2, ExternalLink } from 'lucide-react'
+import { ShieldCheck, BookOpen, Handshake, Rocket, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Check, Columns2, ExternalLink, PanelRight } from 'lucide-react'
 
 import InfoTip from '../components/InfoTip'
 import { FileCard } from '../components/FileCard'
@@ -2376,6 +2376,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     window.addEventListener('toggle-activity-panel', h)
     return () => window.removeEventListener('toggle-activity-panel', h)
   }, [toggleAct])
+  // Whether the window has room for the activity panel beside the chat's
+  // reserved minimum. When it doesn't (the panel would be force-collapsed
+  // anyway) the session-header activity toggle is disabled. Mirrors the
+  // crossing-based threshold used by the auto-collapse effect above.
+  const [actSpace, setActSpace] = useState(true)
+  useEffect(() => {
+    const check = () => setActSpace(window.innerWidth >= SIDE_PANEL_MIN_W + measureSidePanelReservedW())
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
   // Bridge explicit view requests (e.g. the /side slash command dispatches
   // openActivityToTab('side')) into the tab model.
   const activityTab = useAppSelector(s => s.chat.activityTab)
@@ -2953,7 +2964,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
           />
         </div>
       ) : (
-      <OverlayDrawer open={sidebarOpen} width={isMobile ? window.innerWidth : sidebarWidth} dragging={sidebarDragging} morph={!isMobile} className={isMobile ? 'mobile-sessions-overlay fixed top-[52px] bottom-0 left-0 z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
+      <OverlayDrawer open={sidebarOpen} width={isMobile ? window.innerWidth : sidebarWidth} dragging={sidebarDragging} morph={!isMobile} className={isMobile ? 'mobile-sessions-overlay fixed top-[42px] bottom-0 left-0 z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
         <ChatSidebar
           slots={filteredSlots}
           activeSlot={activeSlot}
@@ -3008,7 +3019,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
           </div>
         )}
         {isMobile && !sidebarOpen && !(activeSlot && (messages.length > 0 || slotRunning)) && (
-          <div className="fixed top-[52px] left-2 z-10">
+          <div className="fixed top-[42px] left-2 z-10">
             <button className="p-2 rounded-lg text-muted hover:text-text bg-bg-elevated border border-border shadow-sm cursor-pointer" onClick={() => setMobileSessions(true)} aria-label="Toggle sessions">
               {effectiveMode === 'orchestrator' ? <MessageSquareDot size={18} /> : <MessageSquare size={18} />}
             </button>
@@ -3070,7 +3081,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               {/* Trailing controls grouped under a single ml-auto so multiple
                   right-aligned items don't each absorb free space (two ml-auto
                   siblings split the gap, parking the split icon mid-header). */}
-              <div className="ml-auto flex items-center gap-2 pointer-events-none">
+              <div className="ml-auto flex items-center gap-1.5 pr-1.5 pointer-events-none">
               {/* Pop-out control, promoted to the title bar (menu items remain for
                   sidebar parity). Mirrors the split-view pattern to its left: a
                   dimmed icon to act, an accent chip when the state is active.
@@ -3084,10 +3095,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                   <ExternalLink size={13} /> Popped out
                 </Clickable>
               ) : (
-                <Clickable className="flex items-center opacity-40 hover:opacity-100 transition-opacity cursor-pointer pointer-events-auto" onClick={() => openActivePopout(activeSlot, currentSlot?.title)} title="Pop out to window" aria-label="Pop out session to its own window">
-                  <ExternalLink size={14} />
+                <Clickable className="flex items-center justify-center w-7 h-7 rounded-md hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0 text-muted hover:text-text pointer-events-auto" onClick={() => openActivePopout(activeSlot, currentSlot?.title)} title="Pop out to window" aria-label="Pop out session to its own window">
+                  <ExternalLink size={15} />
                 </Clickable>
               ))}
+              {/* Activity panel open toggle — relocated here from the top bar
+                  (item 2.4) so opening the panel no longer narrows the now
+                  full-width header. Shown only while the panel is closed; the
+                  panel's own header carries the close button. Disabled when the
+                  window is too narrow (the panel would be force-collapsed). */}
+              {!embedMode && !isMobile && !popout && !activityOpen && (
+                <Clickable
+                  className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto ${actSpace ? 'text-muted hover:text-text hover:bg-bg-hover cursor-pointer' : 'text-muted opacity-40 !cursor-not-allowed'}`}
+                  onClick={() => { if (actSpace) toggleAct() }}
+                  title={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
+                  aria-label={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
+                >
+                  <PanelRight size={15} />
+                </Clickable>
+              )}
               {!embedMode && splitFeatureEnabled && (splitAnchorForActive && !activeIsSplitAnchor ? (
                 <Clickable className="flex items-center gap-1 text-accent bg-accent/10 hover:bg-accent/20 transition-colors cursor-pointer pointer-events-auto text-[11px] font-medium px-1.5 py-0.5 rounded" onClick={() => enterSplit(splitAnchorForActive)} title="This session is open in a split — return to it" aria-label="Return to split view">
                 <Columns2 size={13} /> In split

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -226,12 +226,12 @@ export default function SidePanel({
         <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
       </div>
       {/* Tab strip — drag chips horizontally to reorder (framer Reorder).
-          h-[52px] matches the app header row so the two bars align.
+          h-[42px] matches the app header row so the two bars align.
           side-panel-strip punches the strip out of the Electron window-drag
           region (see index.css) so chips receive pointer events. */}
       {/* border-b gives the strip a tab-bar baseline; chips stay centered
           pills (bordered when active) floating above it. */}
-      <div className="side-panel-strip flex items-center gap-1.5 h-[52px] shrink-0 pl-2 pr-1.5 border-b border-border">
+      <div className="side-panel-strip flex items-center gap-1.5 h-[42px] shrink-0 pl-2 pr-1.5 border-b border-border">
         <Reorder.Group
           axis="x"
           values={tabs}

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -328,14 +328,17 @@ describe('App routing', () => {
   })
 
   it('renders Kiro Crew branding', () => {
+    localStorage.removeItem('mc-nav') // expanded sidebar shows the brand text
     renderWithProviders(<App />, { route: '/chat' })
+    // Brand (logo + name) moved from the top bar into the sidebar menu row.
     expect(screen.getAllByText('Kiro Crew').length).toBeGreaterThan(0)
+    localStorage.removeItem('mc-nav')
   })
 
   it('opens Search Everywhere from the theme-aware shadowless header trigger', () => {
     renderWithProviders(<App />, { route: '/chat' })
     const trigger = screen.getByRole('button', { name: 'Search sessions, files, and commands' })
-    expect(trigger).toHaveClass('rounded-lg', 'border-border', 'bg-card', 'shadow-none')
+    expect(trigger).toHaveClass('rounded-md', 'border-border', 'bg-card', 'shadow-none')
     expect(trigger).not.toHaveClass('rounded-full')
     fireEvent.click(trigger)
     expect(screen.getByRole('dialog', { name: 'Search everywhere' })).toBeInTheDocument()
@@ -369,19 +372,18 @@ describe('App routing', () => {
     localStorage.removeItem('mc-nav')
     renderWithProviders(<App />, { route: '/chat' })
 
-    const logo = screen.getByAltText('Kiro Crew')
-    expect(logo).toHaveClass('w-9', 'h-9')
-
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })
-    // The sidebar toggle moved from the topbar into the rail's menu row:
-    // a hamburger plus (expanded only) a panel-left-close collapse control.
+    // Brand (logo + name) now lives in the rail's menu row, replacing the old
+    // hamburger; the collapse control is an arrow-left-to-line button.
+    expect(within(nav).getByText('Kiro Crew')).toBeInTheDocument()
     const collapse = within(nav).getByRole('button', { name: 'Collapse sidebar' })
-    expect(within(nav).getByRole('button', { name: 'Toggle sidebar' })).toBeInTheDocument()
+    expect(within(nav).queryByRole('button', { name: 'Toggle sidebar' })).not.toBeInTheDocument()
     expect(within(nav).queryByText('Main')).not.toBeInTheDocument()
 
     fireEvent.click(collapse)
+    // Collapsed: the brand shrinks to a clickable logo that expands the rail;
+    // the collapse control unmounts.
     expect(within(nav).getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
-    // Collapsed: the panel-left-close control unmounts, only the hamburger stays.
     expect(within(nav).queryByRole('button', { name: 'Collapse sidebar' })).not.toBeInTheDocument()
     expect(localStorage.getItem('mc-nav')).toBe('1')
     localStorage.removeItem('mc-nav')
@@ -401,11 +403,13 @@ describe('App routing', () => {
     localStorage.removeItem('mc-nav')
   })
 
-  it('keeps Request a Feature visible beside the collapsed brand icon', () => {
+  it('keeps Request a Feature visible in the header actions cluster in both sidebar states', () => {
     safeSetItem('mc-nav', '1')
     renderWithProviders(<App />, { route: '/chat' })
 
-    // Collapsed: brand shrinks to the icon but Request a Feature stays.
+    // Request a Feature moved out of the brand region into its own pill in the
+    // header's right-side actions cluster; it stays visible regardless of the
+    // sidebar's collapsed/expanded state.
     expect(screen.getByRole('button', { name: 'Request a Feature' })).toBeInTheDocument()
 
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })

--- a/website/src/test/App.topbarCapsule.test.tsx
+++ b/website/src/test/App.topbarCapsule.test.tsx
@@ -1,15 +1,15 @@
 /**
  * Tests for the top-bar surfaces added in the electron shell redesign commits:
  * - readout capsule collapse/expand via the connection dot (persisted)
- * - activity panel toggle: present on /chat, disabled when the window is too
- *   narrow to fit the panel beside the chat's reserved minimum
  * - macOS fullscreen: 'mac-fullscreen' class driven by the electron
  *   fullscreen-changed bridge (drops the 84px traffic-light inset via CSS)
+ *
+ * (The activity-panel open toggle moved out of the top bar into the ChatPage
+ * session header — see ChatPage.responsivePanel.test.tsx for its coverage.)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, screen, fireEvent } from '@testing-library/react'
-import { renderWithProviders, createTestStore } from './helpers'
-import { toggleActivity } from '../store/chatSlice'
+import { renderWithProviders } from './helpers'
 import { safeSetItem } from '../utils/safeStorage'
 
 vi.mock('../pages/ChatPage', () => ({ default: () => <div data-testid="chat-page">ChatPage</div> }))
@@ -99,53 +99,6 @@ describe('App top bar — readout capsule collapse', () => {
     const dot = await screen.findByLabelText('Gateway connected')
     expect(dot.getAttribute('aria-expanded')).toBe('false')
     expect(screen.queryByLabelText('System metrics')).toBeNull()
-  })
-})
-
-describe('App top bar — activity panel toggle', () => {
-  beforeEach(() => {
-    localStorage.clear()
-    setWindowWidth(1400)
-    // App derives activePath from the GLOBAL location (not useLocation), so
-    // the toggle's /chat gate reads jsdom's URL — align it with the route.
-    window.history.pushState({}, '', '/chat')
-  })
-
-  it('is enabled on /chat when the window has room for the panel', async () => {
-    renderWithProviders(<App />, { route: '/chat' })
-    const btn = await screen.findByLabelText('Open activity panel')
-    expect((btn as HTMLButtonElement).disabled).toBe(false)
-  })
-
-  it('disables with an explanatory label when the window is too narrow, re-enables when widened', async () => {
-    renderWithProviders(<App />, { route: '/chat' })
-    await screen.findByLabelText('Open activity panel')
-
-    // Shrink below SIDE_PANEL_MIN_W (320) + reserve (>=560) = 880.
-    act(() => {
-      setWindowWidth(800)
-      window.dispatchEvent(new Event('resize'))
-    })
-    const disabled = screen.getByLabelText('Window too narrow for the activity panel')
-    expect((disabled as HTMLButtonElement).disabled).toBe(true)
-
-    // Widen back: enabled again.
-    act(() => {
-      setWindowWidth(1400)
-      window.dispatchEvent(new Event('resize'))
-    })
-    const enabled = screen.getByLabelText('Open activity panel')
-    expect((enabled as HTMLButtonElement).disabled).toBe(false)
-  })
-
-  it('hides while the activity panel is open (panel close button takes over)', async () => {
-    // renderWithProviders ignores a preloadedState option — build the store
-    // explicitly and open the panel through the real reducer.
-    const store = createTestStore()
-    store.dispatch(toggleActivity())
-    renderWithProviders(<App />, { route: '/chat', store })
-    await screen.findByTestId('chat-page')
-    expect(screen.queryByLabelText(/activity panel/i)).toBeNull()
   })
 })
 

--- a/website/src/test/ChatPage.responsivePanel.test.tsx
+++ b/website/src/test/ChatPage.responsivePanel.test.tsx
@@ -9,7 +9,7 @@
  *   (fixes the mobile->desktop race that stranded the panel inline).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, renderHook, act, waitFor, screen } from '@testing-library/react'
+import { render, renderHook, act, waitFor, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
@@ -246,5 +246,38 @@ describe('ChatPage — activity slot self-healing', () => {
       expect(panel.parentElement).toHaveClass('overflow-visible')
       expect(panel.parentElement).not.toHaveClass('overflow-hidden')
     })
+  })
+})
+
+describe('ChatPage — session-header activity toggle (relocated from the top bar)', () => {
+  beforeEach(() => { setWindowWidth(1400); localStorage.clear() })
+  afterEach(() => { document.getElementById('activity-bar-slot')?.remove() })
+
+  function renderWithSlot() {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch(switchSlot.pending('req-toggle', 'slot-toggle'))
+      store.dispatch(switchSlot.fulfilled({
+        key: 'slot-toggle',
+        messages: [{ role: 'assistant', content: 'hi', cls: '' }],
+        running: false, hasMore: false, total: 1, queue: [],
+      }, 'req-toggle', 'slot-toggle'))
+    })
+    return renderChat(store)
+  }
+
+  it('opens the activity panel from the session-header toggle', async () => {
+    const { store } = renderWithSlot()
+    const btn = await screen.findByLabelText('Open activity panel')
+    expect(store.getState().chat.activityOpen).toBe(false)
+    fireEvent.click(btn)
+    expect(store.getState().chat.activityOpen).toBe(true)
+  })
+
+  it('disables the toggle with an explanatory label when the window is too narrow', async () => {
+    renderWithSlot()
+    await screen.findByLabelText('Open activity panel')
+    resizeTo(800) // below the 880 space threshold (320 + 560)
+    expect(await screen.findByLabelText('Window too narrow for the activity panel')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Consolidates the two stacked top bars into a single header and restructures the left nav to match the new IA design. Also fixes the GitHub/Discord icons rendering as solid boxes in the packaged build.

### Left nav
- Logo + **Kiro Crew** moved into the sidebar menu row, replacing the hamburger. When expanded the whole row (logo + text + collapse arrow) is one click target that collapses the rail; on hover only the logo rotates. The logo is a single persistent element, so it stays put across collapse/expand.
- Collapse icon `PanelLeftClose` → `ArrowLeftToLine`.
- 16px gap between the main nav and the Apps section when collapsed.

### Header (two bars → one)
- Instance selector rendered inline via `InstanceTabBar variant="inline"` (selected instance in accent + bold). The standalone strip now shows **only on a remote pane**, so the local pane never shows two bars. macOS traffic-light clearance retuned to key off remote-pane-active.
- Slim, viewport-centered search (28px tall).
- Right cluster: readout capsule (status / heartbeat / credits) + a separate **Request a Feature** pill + notification bell. No terminal button (kept in the SidePanel).
- Header now spans all three grid columns so it stays full width when the activity panel opens; the activity-panel toggle moved into the session header beside **Pop out to window**.

### Fix
- Quote the CSS mask `url("…")` in `BrandIcon` so the GitHub/Discord SVGs survive Vite `data:` URI inlining in the production build (they rendered as solid `currentColor` boxes before; dev served file paths so it only showed in the packaged app).

## Testing
- `npm run typecheck` — clean
- `npm run lint` — no new errors on changed files
- `npm run build` — succeeds
- `npm run jscpd` — 0 clones
- Website vitest suite — all affected suites green; updated `App.test.tsx` / `ChatPage.responsivePanel.test.tsx` for the new header/nav contract and moved the activity-toggle coverage out of `App.topbarCapsule.test.tsx`.

## Notes
- Single commit, rebased on latest `main`.
- `dev-preview.sh` intentionally excluded (untracked local tooling).