### PR TITLE
fix(subagent): hard-floor sub-agent concurrency minimum at 3

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -298,7 +298,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Max SubAgents",
-      "help": "Maximum amount of subagents at one time. 0 = auto-size the cap at startup from host memory/CPU and a learned per-agent cost (see dynamic-subagent-sizing docs). Default; set a positive integer to pin a fixed cap.",
+      "help": "Maximum amount of subagents at one time. 0 = auto-size the cap at startup from host memory/CPU and a learned per-agent cost (see dynamic-subagent-sizing docs). Default; set a fixed cap by pinning an integer >= 3 (values of 1 or 2 are raised to 3 — a pin below 3 would disable auto-sizing and run under the default).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 0

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -178,8 +178,8 @@ class AgentConfig:
     enforce_denied_commands: str = "all"  # "all" or "kirocrew"
     soft_stop_budget_secs: float = 10.0  # seconds to wait for cooperative cancel before hard kill [0.5, 60.0]
     yolo: bool = False             # permanent YOLO mode (skip tool approval); tracked via _yolo_from_config flag
-    max_subagents: int = 3         # concurrent subagent cap; 0 = auto-size from host memory/CPU. Load-time clamped to [0, 64]
-    subagent_auto_max: int = 16    # ceiling on the auto-sized cap (max_subagents=0 only). Load-time clamped to [1, 64]
+    max_subagents: int = 3         # concurrent subagent cap; 0 = auto-size from host memory/CPU. Load-time: 0 (auto) or [3, 64] — a fixed pin of 1/2 is raised to 3
+    subagent_auto_max: int = 16    # ceiling on the auto-sized cap (max_subagents=0 only). Load-time clamped to [3, 64]
     subagent_max_turns: int = 100  # default per-subagent tool-call budget. Load-time clamped to [1, 200]
     subagent_result_ttl_secs: int = 3600  # seconds a delivered subagent's result.txt is retained before the reaper prunes it
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -44,6 +44,12 @@ per operating system (see `dynamic-subagent-sizing.md`):
 - **Other (e.g. Windows)** — no probe yet; returns `-1.0` and the cap fails
   open to the legacy floor of 3.
 
+Hard floor: the auto-sized cap is always ≥ 3 — `compute_max_subagents` clamps to
+`[3, hard_cap]` and the config loader clamps `subagent_auto_max` UP to 3 (with a
+warning + `config_bounds_clamped` SEL event, mirroring the > 64 ceiling clamp).
+Applies only to auto-sizing (`max_subagents=0`); an explicit `max_subagents` pin
+is unrestricted (any 0..64).
+
 Limitation: the per-spawn `spawn_min_memory_gb` admission gate
 (`check_memory_available`) still reads `/proc/meminfo` and so remains inert
 (fails open) on non-Linux hosts. Auto-sizing and the runtime gate are

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -528,8 +528,9 @@ class AgentConfig:
             "Max SubAgents",
             "Maximum amount of subagents at one time. 0 = auto-size the cap at "
             "startup from host memory/CPU and a learned per-agent cost "
-            "(see dynamic-subagent-sizing docs). Default; set a positive integer "
-            "to pin a fixed cap.",
+            "(see dynamic-subagent-sizing docs). Default; set a fixed cap by "
+            "pinning an integer >= 3 (values of 1 or 2 are raised to 3 — a pin "
+            "below 3 would disable auto-sizing and run under the default).",
         ),
     )
     spawn_min_memory_gb: float = field(
@@ -1580,11 +1581,22 @@ SUBAGENT_AUTO_MAX_CEILING = 64  # agent.subagent_auto_max — concurrent subagen
 SUBAGENT_MAX_TURNS_CEILING = 200  # agent.subagent_max_turns — per-subagent turn budget
 POOL_SIZE_MAX = 10  # session.pool_size — pre-warmed process pool
 
+# agent.max_subagents fixed-pin floor. 0 is the "auto-size" sentinel; any other
+# (explicit) value must be >= this floor. A pin of 1 or 2 would silently DISABLE
+# auto-sizing and run below today's default of 3, so such values are normalized
+# UP to the floor at load time (see _clamp_security_bounds) and rejected by the
+# dashboard API. Mirrors ``subagent._LEGACY_DEFAULT_MAX`` (kept as a local
+# constant to avoid a config→subagent import cycle).
+MAX_SUBAGENTS_FIXED_FLOOR = 3
+
 # (section, key, min, max) for each bounded field clamped at load time. The
-# mins match the existing runtime floors (0 / 1) so a legitimate in-range value
-# is never altered — only out-of-range (tampered) values are clamped.
+# mins match the runtime floors: subagent_auto_max has a floor of 3
+# (``subagent._LEGACY_DEFAULT_MAX`` — the auto-size minimum), so a value < 3 is
+# clamped UP to 3 with a warning, mirroring the > ceiling clamp. max_subagents
+# keeps a 0 floor here (0 = auto sentinel) — its 0-or-(>=3) rule is applied as a
+# special case after the generic loop. Only out-of-range values are altered.
 _SECURITY_BOUNDED_FIELDS: tuple[tuple[str, str, int, int], ...] = (
-    ("agent", "subagent_auto_max", 1, SUBAGENT_AUTO_MAX_CEILING),
+    ("agent", "subagent_auto_max", 3, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "max_subagents", 0, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "subagent_max_turns", 1, SUBAGENT_MAX_TURNS_CEILING),
     ("session", "pool_size", 0, POOL_SIZE_MAX),
@@ -1666,6 +1678,35 @@ def _clamp_security_bounds(data: dict) -> None:
                 clamped,
             )
             _log_config_clamp_event(f"{section}.{key}", val, clamped, lo, hi)
+
+    # max_subagents special case: 0 is the auto-size sentinel; any explicit pin
+    # must be >= MAX_SUBAGENTS_FIXED_FLOOR. A stray 1/2 silently disables
+    # auto-sizing AND runs below today's default, so clamp it UP to the floor
+    # (0 is left intact). Runs after the generic [0, ceiling] range clamp above.
+    agent = data.get("agent")
+    if isinstance(agent, dict):
+        ms = agent.get("max_subagents")
+        if (
+            isinstance(ms, int)
+            and not isinstance(ms, bool)
+            and 0 < ms < MAX_SUBAGENTS_FIXED_FLOOR
+        ):
+            agent["max_subagents"] = MAX_SUBAGENTS_FIXED_FLOOR
+            logger.warning(
+                "config agent.max_subagents=%d is below the fixed-pin floor of %d "
+                "(0 = auto-size; an explicit pin must be >= %d); clamped UP to %d",
+                ms,
+                MAX_SUBAGENTS_FIXED_FLOOR,
+                MAX_SUBAGENTS_FIXED_FLOOR,
+                MAX_SUBAGENTS_FIXED_FLOOR,
+            )
+            _log_config_clamp_event(
+                "agent.max_subagents",
+                ms,
+                MAX_SUBAGENTS_FIXED_FLOOR,
+                MAX_SUBAGENTS_FIXED_FLOOR,
+                SUBAGENT_AUTO_MAX_CEILING,
+            )
 
 
 def _config_fingerprint() -> tuple:

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -23,6 +23,7 @@ from kiro_crew import platform_compat
 from kiro_crew.agent import build_agent_config
 from kiro_crew.config.loader import (
     _VALID_STT_PROVIDERS,
+    MAX_SUBAGENTS_FIXED_FLOOR,
     SUBAGENT_AUTO_MAX_CEILING,
     SUBAGENT_MAX_TURNS_CEILING,
     KiroCrewConfig,
@@ -879,7 +880,7 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
         if (
             not isinstance(persisted_hard_cap, int)
             or isinstance(persisted_hard_cap, bool)
-            or persisted_hard_cap < 1
+            or persisted_hard_cap < 3
         ):
             persisted_hard_cap = 16
         # Clamp to the absolute ceiling even when read from persisted config: a
@@ -894,22 +895,32 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
             if (
                 isinstance(val, bool)
                 or not isinstance(val, int)
-                or val < 1
+                or val < 3
                 or val > SUBAGENT_AUTO_MAX_CEILING
             ):
                 return _deny(
-                    "subagent_auto_max must be an integer between 1 and "
+                    "subagent_auto_max must be an integer between 3 and "
                     f"{SUBAGENT_AUTO_MAX_CEILING}"
                 )
             agent["subagent_auto_max"] = val
             applied.append("subagent_auto_max")
-        # max_subagents: 0 = auto-size; otherwise 1..persisted_hard_cap. The bound
-        # is the persisted ceiling captured above, never this request's value.
+        # max_subagents: 0 = auto-size; otherwise a fixed pin in
+        # [MAX_SUBAGENTS_FIXED_FLOOR, persisted_hard_cap]. The bound is the
+        # persisted ceiling captured above, never this request's value. A pin of
+        # 1 or 2 is rejected — it would disable auto-sizing and run below the
+        # default (0 is the only way to request the host-safe auto cap).
         if "max_subagents" in agent_settings:
             val = agent_settings["max_subagents"]
             hard_cap = persisted_hard_cap
-            if isinstance(val, bool) or not isinstance(val, int) or val < 0 or val > hard_cap:
-                return _deny(f"max_subagents must be an integer between 0 (auto) and {hard_cap}")
+            if (
+                isinstance(val, bool)
+                or not isinstance(val, int)
+                or (val != 0 and not (MAX_SUBAGENTS_FIXED_FLOOR <= val <= hard_cap))
+            ):
+                return _deny(
+                    f"max_subagents must be 0 (auto) or an integer between "
+                    f"{MAX_SUBAGENTS_FIXED_FLOOR} and {hard_cap}"
+                )
             agent["max_subagents"] = val
             applied.append("max_subagents")
         # Boolean toggles

--- a/src/kiro_crew/docs/dynamic-subagent-sizing.md
+++ b/src/kiro_crew/docs/dynamic-subagent-sizing.md
@@ -4,8 +4,8 @@ KiroCrew sizes the concurrent sub-agent cap **automatically** by default
 (`agent.max_subagents = 0`): at gateway startup it computes a sensible cap from
 the host's actual memory and CPU, plus a per-agent cost KiroCrew *learns* from
 past runs. A fixed number is wrong in both directions — it wastes capacity on a
-large host and over-commits a tiny one — so auto is the default; set a positive
-integer to pin an explicit cap.
+large host and over-commits a tiny one — so auto is the default; set an
+integer >= 3 to pin an explicit cap.
 
 ## Enabling It
 
@@ -16,7 +16,14 @@ kirocrew config set agent.max_subagents 8
 ```
 
 - `agent.max_subagents = 0` — **auto** (default): compute the cap at startup.
-- `agent.max_subagents > 0` — explicit fixed cap.
+- `agent.max_subagents >= 3` — explicit fixed cap.
+
+`max_subagents` accepts **0 (auto) or an integer >= 3**. A pin of 1 or 2 would
+silently disable auto-sizing *and* run below today's default of 3, so it is
+normalized UP to 3 (config loader, with a `config_bounds_clamped` SEL event) and
+rejected by the dashboard API. `resolve_max_subagents` also floors any explicit
+value at 3 as a runtime backstop. `0` is the only way to request the host-safe
+auto cap.
 
 The cap is computed once per gateway start. Restart to recompute (e.g. after the
 host's resources change).
@@ -35,8 +42,11 @@ cap      = clamp( min(mem_term, cpu_term), 3, hard_cap )
 - **CPU term** — how many fit in the core budget, using a measured per-agent
   CPU cost (agents are mostly I/O-bound, so this is generous).
 - **`min(...)`** — the tighter of memory/CPU wins.
-- **Floor of 3** — never drops below the legacy default, so enabling auto can't
-  regress a small host. The per-spawn memory gate (`agent.spawn_min_memory_gb`)
+- **Floor of 3** — the auto-sized cap never drops below the legacy default
+  (`_LEGACY_DEFAULT_MAX`), so enabling auto can't regress a small host. This is
+  a hard floor: `compute_max_subagents` clamps to `[3, hard_cap]`, and the
+  config loader clamps `subagent_auto_max` itself UP to 3 (with a warning) if a
+  file sets it lower. The per-spawn memory gate (`agent.spawn_min_memory_gb`)
   still refuses individual spawns under real memory pressure.
 - **`hard_cap`** — an absolute ceiling (see "Why a hard cap" below).
 

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -530,8 +530,12 @@ def compute_max_subagents(cfg: KiroCrewConfig) -> int:
     See ``dynamic-subagent-sizing.md`` §3.
     """
     agent = cfg.agent
-    hard_cap = max(1, agent.subagent_auto_max)
-    lo = min(_LEGACY_DEFAULT_MAX, hard_cap)  # keeps clamp well-formed if hard_cap < 3
+    # Hard floor of 3 (``_LEGACY_DEFAULT_MAX``): the auto-sized cap never drops
+    # below today's behavior even if ``subagent_auto_max`` is somehow < 3 (the
+    # config loader clamps it up to 3, but defend here too so the runtime cap is
+    # guaranteed >= 3). ``subagent_auto_max`` is the upper ceiling.
+    hard_cap = max(_LEGACY_DEFAULT_MAX, agent.subagent_auto_max)
+    lo = _LEGACY_DEFAULT_MAX
 
     avail_gb = _available_memory_gb()
     if avail_gb <= 0:
@@ -586,7 +590,12 @@ def resolve_max_subagents(cfg: KiroCrewConfig) -> int:
     except (AttributeError, TypeError, ValueError):
         configured = _LEGACY_DEFAULT_MAX
     if configured > 0:
-        return configured
+        # An explicit pin below the legacy floor (1 or 2) would silently disable
+        # auto-sizing AND run below today's default; floor it to 3. 0 stays the
+        # auto sentinel. The config loader and dashboard API also enforce this;
+        # defend here so a directly-constructed config can't drop the runtime cap
+        # below the floor.
+        return max(configured, _LEGACY_DEFAULT_MAX)
     return compute_max_subagents(cfg)
 
 

--- a/test/test_api_server.py
+++ b/test/test_api_server.py
@@ -546,6 +546,32 @@ class TestApiKirocrewConfig:
             assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_put_rejects_subagent_auto_max_below_floor(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        (tmp_path / "config.json").write_text('{"agent": {}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put("/api/config/kirocrew", json={"agent": {"subagent_auto_max": 1}})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_max_subagents_below_fixed_floor(self, tmp_path, monkeypatch):
+        # A fixed pin of 1 or 2 is rejected: 0 (auto) is the only sub-3 value
+        # allowed, and an explicit pin must be >= 3 (below that disables auto-sizing
+        # and runs under the default).
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        (tmp_path / "config.json").write_text('{"agent": {}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            for bad in (1, 2):
+                resp = await c.put("/api/config/kirocrew", json={"agent": {"max_subagents": bad}})
+                assert resp.status == 400
+            # 0 (auto) and a valid pin (>= 3) are accepted.
+            for ok in (0, 3):
+                resp = await c.put("/api/config/kirocrew", json={"agent": {"max_subagents": ok}})
+                assert resp.status == 200
+
+    @pytest.mark.asyncio
     async def test_put_auto_max_cannot_bypass_max_subagents_limit(self, tmp_path, monkeypatch):
         # Raising subagent_auto_max in the same request must NOT let max_subagents
         # exceed the absolute ceiling (64): a 9999 auto_max is rejected first, so

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2491,12 +2491,35 @@ class TestSecurityBoundClamping:
             cfg = _load_from_dict({"agent": {"subagent_auto_max": 200}})
         assert cfg.agent.subagent_auto_max == SUBAGENT_AUTO_MAX_CEILING == 64
 
+    def test_subagent_auto_max_floored_to_min(self) -> None:
+        """A value below the auto-size floor (3) is clamped UP to 3 with a
+        warning, mirroring the > ceiling clamp."""
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            cfg = _load_from_dict({"agent": {"subagent_auto_max": 1}})
+        assert cfg.agent.subagent_auto_max == 3
+
     def test_max_subagents_clamped_to_ceiling(self) -> None:
         from kiro_crew.config.loader import SUBAGENT_AUTO_MAX_CEILING
 
         with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
             cfg = _load_from_dict({"agent": {"max_subagents": 200}})
         assert cfg.agent.max_subagents == SUBAGENT_AUTO_MAX_CEILING == 64
+
+    def test_max_subagents_below_fixed_floor_raised_to_three(self) -> None:
+        """An explicit pin of 1 or 2 is normalized UP to the fixed-pin floor (3):
+        a sub-3 pin would silently disable auto-sizing and run below the default.
+        The auto sentinel (0) and in-range pins (>= 3) are left untouched."""
+        from kiro_crew.config.loader import MAX_SUBAGENTS_FIXED_FLOOR
+
+        assert MAX_SUBAGENTS_FIXED_FLOOR == 3
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            for pinned in (1, 2):
+                cfg = _load_from_dict({"agent": {"max_subagents": pinned}})
+                assert cfg.agent.max_subagents == 3
+            # 0 (auto sentinel) and a valid pin are preserved verbatim.
+            assert _load_from_dict({"agent": {"max_subagents": 0}}).agent.max_subagents == 0
+            assert _load_from_dict({"agent": {"max_subagents": 3}}).agent.max_subagents == 3
+            assert _load_from_dict({"agent": {"max_subagents": 8}}).agent.max_subagents == 8
 
     def test_subagent_max_turns_clamped_to_ceiling(self) -> None:
         from kiro_crew.config.loader import SUBAGENT_MAX_TURNS_CEILING

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -129,11 +129,13 @@ def test_floor_never_below_three(patch_host) -> None:
     assert compute_max_subagents(cfg) == 3
 
 
-def test_hard_cap_below_floor_does_not_exceed_hard_cap(patch_host) -> None:
-    # Misconfigured hard_cap < 3 must still not exceed hard_cap.
+def test_hard_cap_below_floor_is_raised_to_three(patch_host) -> None:
+    # A misconfigured subagent_auto_max < 3 no longer drops the cap below 3:
+    # compute_max_subagents enforces a hard floor of 3 (the loader also clamps
+    # subagent_auto_max up to 3, but compute defends independently).
     patch_host(174.7, 48)
     cfg = _cfg(hard_cap=2)
-    assert compute_max_subagents(cfg) == 2
+    assert compute_max_subagents(cfg) == 3
 
 
 def test_unreadable_memory_fails_open_to_legacy_default(patch_host) -> None:
@@ -155,6 +157,17 @@ def test_resolve_zero_sentinel_triggers_compute(patch_host) -> None:
     patch_host(174.7, 48)
     cfg = _cfg(max_subagents=0, mem_cost=0.315, cpu_cost=0.8, hard_cap=16)
     assert resolve_max_subagents(cfg) == 16
+
+
+def test_resolve_floors_explicit_pin_below_three(patch_host) -> None:
+    # A stray explicit pin of 1 or 2 (e.g. from a directly-constructed config
+    # that bypassed the loader/API clamps) is floored to 3 at resolve time — it
+    # must never drop the runtime cap below the legacy default. 0 stays "auto".
+    patch_host(174.7, 48)
+    assert resolve_max_subagents(_cfg(max_subagents=1)) == 3
+    assert resolve_max_subagents(_cfg(max_subagents=2)) == 3
+    # A valid explicit pin (>= 3) is returned unchanged, not auto-computed.
+    assert resolve_max_subagents(_cfg(max_subagents=5, hard_cap=16)) == 5
 
 
 # --- Gateway wiring contract (Stage 3) -------------------------------------


### PR DESCRIPTION
## Problem
The macOS available-memory probe (#124, merged) lets auto-sizing scale with host resources, but the concurrent sub-agent cap could still be driven below the intended minimum of 3 in two ways: `subagent_auto_max` (the auto-size ceiling) could be configured as low as 1, and `max_subagents` (an explicit pin) accepted 1 or 2. A user reported the auto sub-agent scale sitting at **1** on a 48 GB host.

## Why it matters
The spec says the sized cap is "never below the legacy default (3)", but neither sizing path actually guaranteed it. Running only 1–2 sub-agents silently defeats fan-out, with no signal to the user.

## Fix (symptoms → root cause → change)
Guarantee the effective cap is ≥ 3 in **all** cases, across both sizing paths.

Auto-sizing ceiling — `subagent_auto_max` (used only when `max_subagents = 0`):
- Symptom: auto cap 1–2 when `subagent_auto_max` is set below 3.
- Root cause: `_SECURITY_BOUNDED_FIELDS` bounded it at `[1, 64]`, and `compute_max_subagents` floored at `min(3, hard_cap)` — both allow < 3.
- Change: loader min `1 → 3` (a config value below 3 is clamped UP to 3 with a WARNING + `config_bounds_clamped` SEL event); the dashboard API rejects `subagent_auto_max < 3`; `compute_max_subagents` uses `hard_cap = max(3, subagent_auto_max)` and `lo = 3`, so the runtime cap is ≥ 3 even if the clamp is bypassed.

Explicit pin — `max_subagents` (auto-sizing disabled):
- Symptom: a pin of 1 or 2 ran a fixed cap below 3 (and disabled auto-sizing).
- Root cause: the loader/API/resolve accepted any `0..64`.
- Change: `max_subagents` accepts **0 (auto, the default) or an integer ≥ 3**. The loader special-cases 1/2 → 3 (0 preserved; WARNING + SEL event), the dashboard API rejects 1/2 ("must be 0 (auto) or between 3 and {hard_cap}"), and `resolve_max_subagents` floors any explicit pin at runtime. `0` remains the only way to request the host-safe auto cap.

## Tests
- `test_config_loader.py::TestSecurityBoundClamping`: `subagent_auto_max` 1 → 3; `max_subagents` 1/2 → 3 with 0/3/8 preserved.
- `test_api_server.py`: PUT `subagent_auto_max=1` → 400; PUT `max_subagents` 1/2 → 400, 0/3 → 200.
- `test_subagent_sizing.py`: `test_hard_cap_below_floor_is_raised_to_three` (`hard_cap=2` → 3); `test_resolve_floors_explicit_pin_below_three` (pin 1/2 → 3, 0 → auto, 5 → 5).

## Manual verification
Local: `test_subagent_sizing.py` + `TestSecurityBoundClamping` + `test_api_server.py` = 99 passed; isort + flake8 clean. Direct runtime checks: `compute_max_subagents` for `subagent_auto_max ∈ {0,1,2,3}` → 3 and 32 → 11; loader clamps `subagent_auto_max` 1/2 → 3, `max_subagents` 0 → 0, 1/2 → 3, 8 → 8; `resolve_max_subagents` 0 → auto, 1 → 3, 5 → 5.
