### PR TITLE
fix(ui): render row-actions dropdown in a portal so Card overflow can't clip it

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -3,6 +3,7 @@
  * Manages git worktrees, pod instances, syncing, pruning, and rebasing.
  */
 import { useState, useRef, useCallback, useEffect, type CSSProperties, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Card, CardTitle, Btn, Checkbox, StatCard, EmptyState, ContentSkeleton, PageHeader, SearchInput, Badge, Select } from '../components/ui'
 import InfoTip from '../components/InfoTip'
@@ -95,32 +96,97 @@ function iconLabel(icon: ReactNode, label: string) {
 
 /* ─── Sub-components ─── */
 interface MenuItemDef { label: string; icon?: ReactNode; onClick: () => void; disabled?: boolean; danger?: boolean; title?: string }
+// Row-actions dropdown geometry. The menu is portaled to <body> so a row's
+// <Card overflow> can't clip it (issue #146); these drive fixed positioning.
+const MENU_GAP = 6        // gap between trigger and menu (was `calc(100% + 6px)`)
+const MENU_MARGIN = 8     // min gap from the viewport edge
+const MENU_ITEM_H = 32    // estimated per-item height for the flip decision
+const MENU_PAD = 8        // container vertical padding (4px top + 4px bottom)
 function MenuBtn({ items }: { items: (MenuItemDef | null)[] }) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLSpanElement>(null)
-  const close = useCallback((e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false) }, [])
-  useEffect(() => { document.addEventListener('mousedown', close); return () => document.removeEventListener('mousedown', close) }, [close])
+  // Trigger rect captured on open; drives the portaled menu's fixed position.
+  const [rect, setRect] = useState<DOMRect | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const visible = items.filter(Boolean) as MenuItemDef[]
+
+  useEffect(() => {
+    if (!open) return
+    // The menu is portaled to <body>, so it is no longer a DOM descendant of
+    // the trigger — the outside-click guard must exclude BOTH the trigger and
+    // the menu (a plain trigger.contains() check would close on every menu
+    // click). Escape closes and returns focus to the trigger.
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (!triggerRef.current?.contains(t) && !menuRef.current?.contains(t)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { setOpen(false); triggerRef.current?.focus() } }
+    // position:fixed desyncs from any scrolling ancestor — close on scroll
+    // (capture phase catches nested scrollers) and on resize.
+    const onScrollOrResize = () => setOpen(false)
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', onScrollOrResize, true)
+    window.addEventListener('resize', onScrollOrResize)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('scroll', onScrollOrResize, true)
+      window.removeEventListener('resize', onScrollOrResize)
+    }
+  }, [open])
+
+  const toggle = () => {
+    if (!open && triggerRef.current) setRect(triggerRef.current.getBoundingClientRect())
+    setOpen((o) => !o)
+  }
+
+  // Right-align the menu's right edge to the trigger (as before), clamped so it
+  // never sits flush against the viewport edge. Open downward by default; flip
+  // up when there isn't room below for the estimated height and there's more
+  // room above. Either `top` or `bottom` is set (never both) + maxHeight so the
+  // menu is always clamped inside the viewport.
+  const estH = visible.length * MENU_ITEM_H + MENU_PAD
+  const spaceBelow = rect ? window.innerHeight - rect.bottom - MENU_GAP : 0
+  const spaceAbove = rect ? rect.top - MENU_GAP : 0
+  const openUp = !!rect && spaceBelow < estH + MENU_MARGIN && spaceAbove > spaceBelow
+  const avail = Math.max(80, (openUp ? spaceAbove : spaceBelow) - MENU_MARGIN)
+  const posStyle: CSSProperties = rect
+    ? {
+        position: 'fixed',
+        right: Math.max(MENU_MARGIN, window.innerWidth - rect.right),
+        ...(openUp
+          ? { bottom: window.innerHeight - rect.top + MENU_GAP }
+          : { top: rect.bottom + MENU_GAP }),
+        maxHeight: avail,
+      }
+    : { position: 'fixed' }
+
   return (
-    <span ref={ref} style={{ position: 'relative', display: 'inline-flex' } as CSSProperties}>
-      <Btn onClick={() => setOpen(!open)} title="More actions" aria-label="More actions">
+    <span style={{ display: 'inline-flex' } as CSSProperties}>
+      <Btn ref={triggerRef} onClick={toggle} title="More actions" aria-label="More actions" aria-haspopup="menu" aria-expanded={open}>
         <Ellipsis size={15} className="lucide-inline" />
       </Btn>
-      {open && (
-        <div style={{ position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 1200, background: 'var(--card, #16161a)', border: '1px solid var(--border)', borderRadius: 10, padding: 4, minWidth: 168, boxShadow: '0 8px 24px rgba(0,0,0,0.45)' } as CSSProperties}>
-          {items.filter(Boolean).map((it, i) => {
-            const item = it!
-            return (
-              <Clickable
-                key={'mi' + i}
-                onClick={() => { setOpen(false); item.onClick() }}
-                disabled={!!item.disabled}
-                style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%', textAlign: 'left' as const, background: 'none', border: 'none', borderRadius: 7, padding: '7px 10px', fontSize: 12, color: item.danger ? 'var(--danger)' : 'var(--text)', cursor: item.disabled ? 'default' : 'pointer', opacity: item.disabled ? 0.5 : 1 } as CSSProperties}
-              >
-                {item.icon || null}{item.label}
-              </Clickable>
-            )
-          })}
-        </div>
+      {open && rect && createPortal(
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="More actions"
+          data-placement={openUp ? 'up' : 'down'}
+          style={{ ...posStyle, zIndex: 4000, overflowY: 'auto', background: 'var(--card, #16161a)', border: '1px solid var(--border)', borderRadius: 10, padding: 4, minWidth: 168, boxShadow: '0 8px 24px rgba(0,0,0,0.45)' } as CSSProperties}
+        >
+          {visible.map((item, i) => (
+            <Clickable
+              key={'mi' + i}
+              onClick={() => { setOpen(false); item.onClick() }}
+              disabled={!!item.disabled}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%', textAlign: 'left' as const, background: 'none', border: 'none', borderRadius: 7, padding: '7px 10px', fontSize: 12, color: item.danger ? 'var(--danger)' : 'var(--text)', cursor: item.disabled ? 'default' : 'pointer', opacity: item.disabled ? 0.5 : 1 } as CSSProperties}
+            >
+              {item.icon || null}{item.label}
+            </Clickable>
+          ))}
+        </div>,
+        document.body,
       )}
     </span>
   )

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -455,4 +455,100 @@ describe('DevFleetPage', () => {
     // The purpose one-liner renders in the drill-in.
     expect(screen.getByText('feat: add pagination to users API')).toBeInTheDocument()
   })
+
+  /* ─── Row-actions dropdown: portal + flip (issue #146) ─── */
+  // A worktree row whose "More actions" menu has items: non-main, not live,
+  // has_dist & not running → Spin up pod / Rebase onto main / Make live.
+  const FLEET_MENU = {
+    worktrees: [
+      { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+      { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0, path: '/wt/feature-x' },
+    ],
+  }
+  function mockFleet(data: unknown) {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(data), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+  }
+
+  it('renders the row-actions dropdown in a portal on document.body (escapes Card overflow)', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    // Portaled: the menu is a direct child of <body>, not nested inside the SPA
+    // container / row Card — this is what lets it escape Card overflow clipping.
+    expect(menu.parentElement).toBe(document.body)
+    // Items render inside the portaled menu and are reachable.
+    expect(screen.getByText('Rebase onto main')).toBeInTheDocument()
+    expect(screen.getByText('Make live')).toBeInTheDocument()
+  })
+
+  it('portaled row-actions items are clickable (opens the Make live dialog)', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    fireEvent.click(await screen.findByText('Make live'))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(screen.getByText('Make "feature-x" live?')).toBeInTheDocument()
+  })
+
+  it('outside-click closes the portaled row-actions menu', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    // A click on <body> is outside both the trigger and the portaled menu.
+    fireEvent.mouseDown(document.body)
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  })
+
+  it('Escape closes the portaled row-actions menu', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  })
+
+  it('row-actions menu opens downward when there is room below', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    const trigger = screen.getByLabelText('More actions')
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      top: 100, bottom: 120, left: 400, right: 440, width: 40, height: 20, x: 400, y: 100, toJSON: () => ({}),
+    } as DOMRect)
+    fireEvent.click(trigger)
+    const menu = await screen.findByRole('menu') as HTMLElement
+    expect(menu.getAttribute('data-placement')).toBe('down')
+    // Downward placement anchors via `top`, not `bottom`.
+    expect(menu.style.top).not.toBe('')
+    expect(menu.style.bottom).toBe('')
+  })
+
+  it('row-actions menu flips upward when near the viewport bottom', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    const trigger = screen.getByLabelText('More actions')
+    // Trigger a few px above the bottom edge → no room below → flip up.
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      top: window.innerHeight - 8, bottom: window.innerHeight - 4, left: 400, right: 440, width: 40, height: 20, x: 400, y: window.innerHeight - 8, toJSON: () => ({}),
+    } as DOMRect)
+    fireEvent.click(trigger)
+    const menu = await screen.findByRole('menu') as HTMLElement
+    expect(menu.getAttribute('data-placement')).toBe('up')
+    // Upward placement anchors via `bottom`, not `top`.
+    expect(menu.style.bottom).not.toBe('')
+    expect(menu.style.top).toBe('')
+  })
 })


### PR DESCRIPTION
Fixes #146

## Problem
The worktree row "…" (More actions) dropdown renders `position: absolute` inside the worktrees `<Card>`, which clips overflow. For rows near the card bottom the menu is cut off — items like **Make live** are half-visible or unreachable (clicks land on nothing). Worst when the list is filtered to few rows (short card). Reproduced during PR #120 QA and again by the user on latest main.

## Why it matters
Make Live (#120) put the primary cutover action inside this menu — a clipped menu means bottom-row worktrees can't be made live from the UI at all.

## Fix (symptom → root cause → change)
Clipped menu → absolutely-positioned dropdown inside an overflow-clipping ancestor → render the open menu via `ReactDOM.createPortal` to `document.body` with `position: fixed` coordinates from the trigger's `getBoundingClientRect()`. No ancestor overflow/stacking context can clip it. Flip upward when space below the viewport is insufficient (viewport-clamped with margin). Outside-click detection updated to check both trigger and portaled-menu refs (portal breaks DOM-descendant checks). Menu closes on scroll (capture) and resize to avoid fixed-position desync. Escape/ARIA/danger/disabled behaviors preserved. Fix lives in the shared menu component — all consumers benefit.

## Tests
- vitest: menu portals into `document.body`, items clickable, outside-click + Escape close, flip-up near viewport bottom (mocked rects). All green (tsc + vitest 0 failures).
- Backend full suite `-n auto`: 15165 passed, zero new failures (5 known unshare-EPERM env failures only). flake8 clean.

## Manual verification
QA on isolated pod (:7985): DOM-verified portal + viewport containment for bottom-row menus incl. filtered short-card worst case; flip-up confirmed; outside-click/Escape/scroll-close regression-checked; 30s demo video recorded showing before-broken scenarios now fully visible.