### PR TITLE
feat(dashboard): Select-to-Ask — selection popup Ask button routes to isolated /side conversation

### DIFF
--- a/website/src/components/SelectionToolbar.tsx
+++ b/website/src/components/SelectionToolbar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { MessageSquareQuote, Copy, Check } from 'lucide-react'
+import { MessageSquareQuote, MessageCircleQuestion, Copy, Check } from 'lucide-react'
 import { copyToClipboard } from '../utils/clipboard'
 
 export interface SelectionAction {
@@ -233,7 +233,10 @@ export default function SelectionToolbar({ containerRef, actions, externalSelect
 }
 
 /** Pre-built actions for common use cases */
-export function useSelectionActions(onQuote?: (text: string, rect: DOMRect) => void): SelectionAction[] {
+export function useSelectionActions(
+  onQuote?: (text: string, rect: DOMRect) => void,
+  onAsk?: (text: string, rect: DOMRect) => void,
+): SelectionAction[] {
   const actions: SelectionAction[] = []
 
   if (onQuote) {
@@ -242,6 +245,18 @@ export function useSelectionActions(onQuote?: (text: string, rect: DOMRect) => v
       icon: <MessageSquareQuote size={12} />,
       label: 'Quote',
       onClick: onQuote,
+    })
+  }
+
+  // "Ask" opens the isolated /side conversation seeded with the selection so
+  // the user can ask a scoped follow-up WITHOUT polluting the main chat
+  // context (unlike Quote, which injects into the main composer).
+  if (onAsk) {
+    actions.push({
+      id: 'ask',
+      icon: <MessageCircleQuestion size={12} />,
+      label: 'Ask',
+      onClick: onAsk,
     })
   }
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -15,7 +15,7 @@ import {
   setSlotRunning, startLocalTurn, syncSlotRunningFromServer, setPendingInput, resolveByApprovalId, clearPendingPermissions, cancelQueuedMessage, editQueuedMessage,
   selectComposerBusy,
   setVoiceAudio,
-  toggleActivity, openActivityPanel,
+  toggleActivity, openActivityPanel, openActivityToTab,
   setActiveSlot, truncateAfterIndex, replaceMessages,
   requestStop, clearQuestionCard,
 } from '../store/chatSlice'
@@ -2391,6 +2391,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus())
   }, [])
 
+  // "Ask" (Select-to-Ask): open the isolated /side conversation seeded with the
+  // selection, WITHOUT touching the main chat context (unlike handleQuote, which
+  // injects into the main composer). Mirrors the /side slash command's
+  // openActivityToTab('side') bridge, then hands the selection to SideChat via a
+  // `side-seed` CustomEvent (same event-bridge pattern as openActivityToTab /
+  // reveal-slot — no new prop-drilling, no backend change).
+  const handleAsk = useCallback((text: string, _rect: DOMRect) => {
+    dispatch(openActivityToTab('side'))
+    // Defer the seed one frame so the Side panel/tab has mounted its
+    // `side-seed` listener before the event fires.
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('side-seed', { detail: { text } }))
+    })
+  }, [dispatch])
+
   const handleEditResend = useCallback((index: number, ts: string, newContent: string) => {
     if (!activeSlot || slotRunning) return
     const snapshot = [...messages]
@@ -2920,7 +2935,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
             })()
           ) : (
             <div className="flex flex-col gap-0">
-              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} turnStats={chatConfig.showTurnStats ? (m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined : undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} artifactPaths={artifactPaths} showFooter={(() => {
+              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} onAsk={handleAsk} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} turnStats={chatConfig.showTurnStats ? (m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined : undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} artifactPaths={artifactPaths} showFooter={(() => {
                 // Show footer on the last assistant message of each completed turn
                 if (isStreaming) return false
                 // Find next message after this one that's assistant, user, or streaming
@@ -2952,7 +2967,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // apply-plan handler, so it belongs here for correctness. approve/send/
     // dismissApproval are NOT referenced in this renderer (user/approval rows go
     // through renderUserContentCb), so they are omitted to keep it stable.
-  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths])
+  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths])
 
   const [mobileSessions, setMobileSessions] = useState(false)
   // Close mobile sessions panel when a session is selected

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2378,6 +2378,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
   const [flyingQuote, setFlyingQuote] = useState<{ text: string; from: DOMRect } | null>(null)
   const inputAreaRef = useRef<HTMLDivElement>(null)
+  // Select-to-Ask reuses the same FlyingQuote "pluck" animation as Quote, but
+  // targets the Side panel's input (which only mounts once the panel opens).
+  const [flyingAsk, setFlyingAsk] = useState<{ text: string; from: DOMRect } | null>(null)
+  const askTargetRef = useRef<HTMLElement | null>(null)
 
   const handleQuote = useCallback((text: string, rect: DOMRect) => {
     const quoted = text.split('\n').map(line => `> ${line}`).join('\n')
@@ -2397,13 +2401,26 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // openActivityToTab('side') bridge, then hands the selection to SideChat via a
   // `side-seed` CustomEvent (same event-bridge pattern as openActivityToTab /
   // reveal-slot — no new prop-drilling, no backend change).
-  const handleAsk = useCallback((text: string, _rect: DOMRect) => {
+  const handleAsk = useCallback((text: string, rect: DOMRect) => {
     dispatch(openActivityToTab('side'))
-    // Defer the seed one frame so the Side panel/tab has mounted its
-    // `side-seed` listener before the event fires.
-    requestAnimationFrame(() => {
-      window.dispatchEvent(new CustomEvent('side-seed', { detail: { text } }))
-    })
+    // The Side input mounts asynchronously once the panel opens. Poll a few
+    // frames for it, then fire the FlyingQuote "pluck" animation toward it and
+    // seed the selection (mirrors handleQuote's simultaneous seed + animate).
+    // If it never appears (panel blocked), fall back to seeding without the
+    // animation so the feature still works.
+    const trySeed = (attempt = 0) => {
+      const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Ask a side question"]')
+      if (ta) {
+        askTargetRef.current = ta
+        setFlyingAsk({ text, from: rect })
+        window.dispatchEvent(new CustomEvent('side-seed', { detail: { text } }))
+      } else if (attempt < 20) {
+        requestAnimationFrame(() => trySeed(attempt + 1))
+      } else {
+        window.dispatchEvent(new CustomEvent('side-seed', { detail: { text } }))
+      }
+    }
+    requestAnimationFrame(() => trySeed())
   }, [dispatch])
 
   const handleEditResend = useCallback((index: number, ts: string, newContent: string) => {
@@ -3458,6 +3475,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               {!activityOpen && <WorkflowProgressBar slot={activeSlot} />}
               <QueueStack messages={queuedMessages} onCancel={handleCancelQueued} onInterrupt={handleInterruptQueued} onEdit={handleEditQueued} fuseBelow={followUpOptions.length === 0 && !knowledgeFetch.pendingKnowledge} />
               {flyingQuote && <FlyingQuote text={flyingQuote.text} from={flyingQuote.from} targetRef={inputAreaRef} onComplete={() => setFlyingQuote(null)} />}
+              {flyingAsk && <FlyingQuote text={flyingAsk.text} from={flyingAsk.from} targetRef={askTargetRef} onComplete={() => setFlyingAsk(null)} />}
               <div ref={inputAreaRef} className="relative z-10">
               {showHistorySuggestions && (
                 <div className="absolute left-0 right-0 bottom-full mb-1 mx-auto w-full max-w-[760px] border border-border rounded-lg bg-card overflow-hidden animate-scale-in z-50 shadow-lg flex flex-col max-h-[min(300px,40vh)]">

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -103,7 +103,7 @@ function SteerAckChip({ summary }: { summary: string }) {
   )
 }
 
-const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle, artifactPaths, turnStats }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle; artifactPaths?: Set<string>; turnStats?: TurnStats }) {
+const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, onAsk, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle, artifactPaths, turnStats }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; onAsk?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle; artifactPaths?: Set<string>; turnStats?: TurnStats }) {
   const [applied, setApplied] = useState(false)
   const [copied, setCopied] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
@@ -148,7 +148,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
   }, [effectiveContent, isStreaming, planTaskId])
 
   const contentRef = useRef<HTMLDivElement>(null)
-  const selectionActions = useSelectionActions(onQuote)
+  const selectionActions = useSelectionActions(onQuote, onAsk)
 
   const { term, caseSensitive } = useSearchHighlight()
   const currentOcc = useCurrentOcc()

--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Send, MessageSquare, Copy, Check, RotateCcw } from 'lucide-react'
 import { useMutation } from '@tanstack/react-query'
 import { api } from '../../api/client'
@@ -9,6 +9,8 @@ import MarkdownRenderer from '../../components/MarkdownRenderer'
 import type { SideMessage } from '../../store/chatSlice'
 
 const MAX_QUESTION_BYTES = 32_768
+// Max auto-grow height (px) for the side-question input before it scrolls.
+const MAX_INPUT_H = 240
 
 function SideMessageBubble({ msg, isStreaming }: { msg: SideMessage; isStreaming: boolean }) {
   const [copied, setCopied] = useState(false)
@@ -134,12 +136,26 @@ export default function SideChat({ slot }: { slot: string }) {
           el.focus()
           const len = el.value.length
           el.setSelectionRange(len, len)
+          // Scroll to the top so the START of a long quote is visible (focusing
+          // + caret-at-end scrolls to the bottom otherwise, hiding the quote).
+          el.scrollTop = 0
         }
       })
     }
     window.addEventListener('side-seed', onSeed)
     return () => window.removeEventListener('side-seed', onSeed)
   }, [])
+
+  // Auto-grow the input so a seeded multi-line quote (or a long typed question)
+  // is fully visible instead of being clipped to the 2-row default. Grows with
+  // content up to MAX_INPUT_H, then scrolls. The `min-h-[52px]` class floors it
+  // at ~2 rows so an empty box keeps its original size.
+  useLayoutEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, MAX_INPUT_H)}px`
+  }, [draft])
 
   const send = useCallback(() => {
     const q = draft.trim()
@@ -233,7 +249,8 @@ export default function SideChat({ slot }: { slot: string }) {
           placeholder="Ask a side question…"
           rows={2}
           disabled={sendMutation.isPending}
-          className="flex-1 resize-none rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-text focus:outline-none focus:border-accent disabled:opacity-60"
+          style={{ maxHeight: MAX_INPUT_H }}
+          className="flex-1 resize-none overflow-y-auto min-h-[52px] rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-text focus:outline-none focus:border-accent disabled:opacity-60"
         />
         <button
           onClick={() => void send()}

--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -70,6 +70,7 @@ export default function SideChat({ slot }: { slot: string }) {
   const [draft, setDraft] = useState('')
   const [localError, setLocalError] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const isNearBottomRef = useRef(true)
 
   const messages = reduxSide?.messages ?? []
@@ -113,6 +114,32 @@ export default function SideChat({ slot }: { slot: string }) {
       requestAnimationFrame(() => { el.scrollTop = el.scrollHeight })
     }
   }, [messages.length, lastMessageContent])
+
+  // Select-to-Ask seed: when the user clicks "Ask" in the selection toolbar,
+  // ChatPage opens this panel and fires a `side-seed` CustomEvent carrying the
+  // selected text. Prefill the draft with the selection as a grounding
+  // blockquote and focus the input so the user types their actual question
+  // (which then fires sideOpen → sideTurn as usual). Isolated from main context.
+  useEffect(() => {
+    const onSeed = (e: Event) => {
+      const detail = (e as CustomEvent<{ text?: string }>).detail
+      const sel = detail?.text?.trim()
+      if (!sel) return
+      const quoted = sel.split('\n').map(line => `> ${line}`).join('\n')
+      setDraft(prev => (prev.trim() ? `${prev.trimEnd()}\n\n${quoted}\n\n` : `${quoted}\n\n`))
+      // Focus + place caret at the end so the user immediately types the question.
+      requestAnimationFrame(() => {
+        const el = textareaRef.current
+        if (el) {
+          el.focus()
+          const len = el.value.length
+          el.setSelectionRange(len, len)
+        }
+      })
+    }
+    window.addEventListener('side-seed', onSeed)
+    return () => window.removeEventListener('side-seed', onSeed)
+  }, [])
 
   const send = useCallback(() => {
     const q = draft.trim()
@@ -198,6 +225,7 @@ export default function SideChat({ slot }: { slot: string }) {
       )}
       <div className="border-t border-border p-2 flex items-end gap-2 shrink-0">
         <textarea
+          ref={textareaRef}
           value={draft}
           onChange={e => setDraft(e.target.value)}
           onKeyDown={onKeyDown}

--- a/website/src/test/SelectToAsk.test.tsx
+++ b/website/src/test/SelectToAsk.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, screen } from '@testing-library/react'
+import { useRef } from 'react'
+import type { RootState } from '../store'
+import { renderWithProviders, createTestStore } from './helpers'
+import SelectionToolbar, { useSelectionActions } from '../components/SelectionToolbar'
+
+// SideChat pulls the api client — stub the side-* calls it may touch.
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop) => {
+      const fn = vi.fn().mockResolvedValue({})
+      Object.defineProperty(_t, prop, { value: fn, writable: true, configurable: true })
+      return fn
+    },
+  }),
+  SEARCH_MIN_CHARS: 2,
+}))
+
+import SideChat from '../pages/chat/SideChat'
+
+// Harness that mounts the toolbar from an external selection so the actions
+// render deterministically without simulating a real DOM range.
+function ToolbarHarness({ onAsk }: { onAsk?: (t: string, r: DOMRect) => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const actions = useSelectionActions(undefined, onAsk)
+  return (
+    <div ref={ref}>
+      <SelectionToolbar containerRef={ref} actions={actions} externalSelection={{ text: 'hi', x: 10, y: 10 }} />
+    </div>
+  )
+}
+
+describe('Select-to-Ask', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('useSelectionActions exposes an Ask action only when onAsk is provided', () => {
+    renderWithProviders(<ToolbarHarness onAsk={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument()
+  })
+
+  it('omits the Ask action when onAsk is absent', () => {
+    renderWithProviders(<ToolbarHarness />)
+    expect(screen.queryByRole('button', { name: 'Ask' })).not.toBeInTheDocument()
+  })
+
+  it('clicking Ask invokes the handler with the selected text', () => {
+    const onAsk = vi.fn()
+    renderWithProviders(<ToolbarHarness onAsk={onAsk} />)
+    act(() => { screen.getByRole('button', { name: 'Ask' }).click() })
+    expect(onAsk).toHaveBeenCalledWith('hi', expect.anything())
+  })
+
+  it('SideChat seeds the draft as a grounding quote on the side-seed event', () => {
+    const SLOT = 'seed-slot'
+    const store = createTestStore({
+      chat: {
+        activeSlot: SLOT,
+        messages: [],
+        slotSide: {},
+        slotHistory: [SLOT],
+        activityOpen: true,
+        activityTab: 'side',
+      } as unknown as RootState['chat'],
+    })
+    renderWithProviders(<SideChat slot={SLOT} />, { store })
+    const ta = screen.getByLabelText('Ask a side question') as HTMLTextAreaElement
+    expect(ta.value).toBe('')
+    act(() => {
+      window.dispatchEvent(new CustomEvent('side-seed', { detail: { text: 'line one\nline two' } }))
+    })
+    expect(ta.value).toBe('> line one\n> line two\n\n')
+  })
+})


### PR DESCRIPTION
## Summary

Implements **Mesh-3038**. Adds an **Ask** action to the text-selection popup. Unlike **Quote** — which injects a blockquote into the *main composer* and permanently pollutes the main session context — **Ask** opens the existing isolated `/side` conversation panel, seeds the selection as a grounding blockquote, and focuses the input so the user types their real question. The answer renders in the Side panel, leaving the main conversation untouched.

Design locked to **Option A (seed & focus)** per the task. Frontend-only wiring on existing `/side` primitives — **no backend change** (`/api/chat/slots/<slot>/side/*` already exists).

## Changes (4 files + 1 test)

- `website/src/components/SelectionToolbar.tsx` — `useSelectionActions(onQuote?, onAsk?)` gains an optional `onAsk` param and renders an **Ask** action (MessageCircleQuestion icon).
- `website/src/pages/chat/AssistantMessage.tsx` — new `onAsk` prop threaded into `useSelectionActions`, mirroring `onQuote`.
- `website/src/pages/ChatPage.tsx` — `handleAsk(text, rect)` opens the Side tab via the existing `openActivityToTab('side')` bridge and hands the selection to `SideChat` through a new `side-seed` CustomEvent (same event-bridge pattern as `openActivityToTab`/`reveal-slot`, no prop-drilling). Wired via `onAsk={handleAsk}`.
- `website/src/pages/chat/SideChat.tsx` — listens for `side-seed`, prefills the draft with the selection as a `> ` blockquote, and focuses the textarea (caret at end). The user then types their question, which fires `sideOpen` → `sideTurn` as today.
- `website/src/test/SelectToAsk.test.tsx` — 4 new tests: Ask action present/absent by `onAsk`, click invokes handler with selected text, and SideChat seeds the draft on `side-seed`.

## Testing

- `tsc --noEmit` — 0 errors
- `eslint` on all changed files — 0 errors
- `vitest` — existing SideChat/SelectionToolbar suites (10 tests) + 4 new tests all pass

## Notes

Distinct from **Mesh-1183** (inline comments that inject into the *main* chat); this is the isolated-answer sibling. Thin frontend micro-interaction on existing MeshClaw `/side` primitives — low overlap risk with KiroCrew orchestration/memory.