### PR TITLE
feat(dev-fleet): surface per-worktree context — PR/issue/ticket links + purpose one-liner

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -798,9 +798,13 @@ async def _get_owner_repo() -> str | None:
 
 
 async def _pr_query_one(owner_repo: str, branch: str) -> dict | None:
+    # `title` is a display field carried into the payload; `body` is fetched in
+    # the SAME query (no extra gh call, so no added rate cost per refresh) and
+    # kept INTERNAL (moved to `_body`) — it feeds issue-ref parsing but is
+    # dropped from the payload by _redact_pr (which skips `_`-prefixed keys).
     rc, stdout, _ = await _run_cmd(
         ["gh", "pr", "list", "--repo", owner_repo, "--head", branch,
-         "--json", "number,state,url,isDraft", "--state", "all", "--limit", "1"],
+         "--json", "number,state,url,isDraft,title,body", "--state", "all", "--limit", "1"],
         timeout=15,
     )
     if rc != 0:
@@ -812,6 +816,8 @@ async def _pr_query_one(owner_repo: str, branch: str) -> dict | None:
         return None
     if pr is not None:
         pr["_repo"] = owner_repo
+        if "body" in pr:
+            pr["_body"] = pr.pop("body") or ""
     return pr
 
 
@@ -896,6 +902,219 @@ async def _pr_status_cached(branch: str) -> dict | None:
 
 def _is_pr_merged(pr: dict | None) -> bool:
     return (pr or {}).get("state") == "MERGED"
+
+
+# --- per-worktree context: issue/ticket links + purpose one-liner (issue #147) ---
+#
+# Best-effort and TTL-cached per branch exactly like the PR-state cache. Every
+# field degrades to empty/None on any git/gh failure so context resolution can
+# never break the fleet payload.
+
+# GitHub issue references: keyworded (Fixes/Closes/Resolves #N) OR bare #N. The
+# bare form is a superset, so a single "#<digits>" match — guarded by a
+# trailing non-alphanumeric lookahead that rejects colour hexes (#1a2b, #fff)
+# and version-ish tokens — covers both; dedup collapses the keyworded overlap.
+_ISSUE_REF_RE = re.compile(r"#(\d{1,7})(?![0-9A-Za-z])")
+# Ticket IDs (JIRA / Taskei style): PROJECT-1234. Pattern fixed by issue #147.
+_TICKET_ID_RE = re.compile(r"\b[A-Z][A-Za-z]{1,15}-\d{1,6}\b")
+# Subjects that are pure version bumps — skipped when picking the one-liner.
+_VERSION_BUMP_RE = re.compile(
+    r"^\s*(?:chore(?:\([^)]*\))?:\s*)?"
+    r"(?:bump\b|release\b|bump version\b|version bump\b|v?\d+\.\d+\.\d+\s*$)",
+    re.IGNORECASE,
+)
+# Payload growth caps (keep fleet rows modest).
+_CTX_MAX_ISSUES = 8
+_CTX_MAX_TICKETS = 5
+
+
+def _extract_issue_refs(text: str) -> list[int]:
+    """Ordered-unique GitHub issue numbers referenced in *text*."""
+    seen: list[int] = []
+    for m in _ISSUE_REF_RE.finditer(text or ""):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.append(n)
+    return seen
+
+
+def _extract_ticket_ids(text: str) -> list[str]:
+    """Ordered-unique ticket IDs (PROJECT-1234) referenced in *text*."""
+    seen: list[str] = []
+    for m in _TICKET_ID_RE.finditer(text or ""):
+        t = m.group(0)
+        if t not in seen:
+            seen.append(t)
+    return seen
+
+
+def _render_ticket_url(template: str, tid: str) -> str | None:
+    """Render a ticket URL from *template* ({id} placeholder). Returns None
+    when the template is empty or has no {id} — chips then render unlinked."""
+    if not template or "{id}" not in template:
+        return None
+    return template.replace("{id}", tid)
+
+
+def _is_version_bump(subject: str) -> bool:
+    return bool(_VERSION_BUMP_RE.match(subject or ""))
+
+
+def _pick_summary(subjects: list[str]) -> str | None:
+    """Latest non-merge commit subject, skipping trivial version bumps; falls
+    back to the latest subject when every candidate is a bump."""
+    for s in subjects:
+        if s and not _is_version_bump(s):
+            return s
+    return subjects[0] if subjects else None
+
+
+def _issue_url(base: str | None, n: int) -> str | None:
+    return f"{base}/issues/{n}" if base else None
+
+
+def _parse_html_repo_base(remote_url: str) -> str | None:
+    """Derive the repo's browser (html) base URL from a git remote URL,
+    normalising scp-style and scheme URLs to https. None when unparseable."""
+    url = (remote_url or "").strip()
+    if not url:
+        return None
+    # scp-like: [user@]host:owner/repo(.git)  — (?!/) rejects a scheme "://".
+    m = re.match(r"^(?:[^@/]+@)?([\w.\-]+):(?!/)(.+?)(?:\.git)?/?$", url)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    # scheme://[user@]host[:port]/owner/repo(.git)
+    m = re.match(
+        r"^[A-Za-z][\w+.\-]*://(?:[^@/]+@)?([\w.\-]+)(?::\d+)?/(.+?)(?:\.git)?/?$",
+        url,
+    )
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    return None
+
+
+_HTML_BASE: str | None = None
+
+
+async def _html_repo_base() -> str | None:
+    """Cached browser base URL of the upstream repo (for issue links). Derived
+    from the remote URL; falls back to github.com/<owner/repo> (PR resolution
+    is gh/github-only anyway)."""
+    global _HTML_BASE
+    if _HTML_BASE:
+        return _HTML_BASE
+    remote = await _upstream_remote()
+    rc, out, _ = await _run_cmd(
+        ["git", "-C", MAIN_REPO, "remote", "get-url", remote], timeout=5
+    )
+    if rc == 0:
+        base = _parse_html_repo_base(out.strip())
+        if base:
+            _HTML_BASE = base
+            return base
+    owner_repo = await _get_owner_repo()
+    if owner_repo:
+        _HTML_BASE = f"https://github.com/{owner_repo}"
+    return _HTML_BASE
+
+
+def _load_dev_fleet_cfg() -> dict:
+    """Read the ``dev_fleet`` config section (config.json + local overlay),
+    lazily and best-effort. Never raises; a missing file/section -> {}. Read
+    directly rather than through KiroCrewConfig (a separate process owns the
+    validated loader) so a purely cosmetic template needs no schema dependency
+    and can never break the fleet payload."""
+    section: dict = {}
+    try:
+        from kiro_crew.config.loader import config_dir
+        base = config_dir()
+    except Exception:  # noqa: BLE001
+        return section
+    for fname in ("config.json", "config.local.json"):
+        p = base / fname
+        try:
+            if not p.is_file():
+                continue
+            raw = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(raw, dict) and isinstance(raw.get("dev_fleet"), dict):
+            section.update(raw["dev_fleet"])
+    return section
+
+
+# per-branch context cache (mirrors _PR_CACHE / _PR_TTL)
+_CTX_CACHE: dict[str, dict] = {}
+_CTX_TTL = 55
+
+
+async def _resolve_context(
+    branch: str | None, subjects: list[str], bodies: list[str], pr_body: str | None
+) -> dict:
+    """Assemble {issues, tickets, summary} from pre-extracted text. The html
+    base is resolved ONLY when issue refs exist and the ticket template ONLY
+    when ticket IDs exist — so a refless worktree triggers no extra lookup (and
+    no owner/repo cache write), keeping callers side-effect-free."""
+    issue_nums = _extract_issue_refs("\n".join([pr_body or "", *subjects, *bodies]))
+    ticket_ids = _extract_ticket_ids("\n".join([branch or "", *subjects]))
+    html_base = await _html_repo_base() if issue_nums else None
+    tpl = str(_load_dev_fleet_cfg().get("ticket_url_template") or "") if ticket_ids else ""
+    summary = _pick_summary(subjects)
+    return {
+        "issues": [
+            {"number": n, "url": _issue_url(html_base, n)}
+            for n in issue_nums[:_CTX_MAX_ISSUES]
+        ],
+        "tickets": [
+            {"id": t, "url": _render_ticket_url(tpl, t)}
+            for t in ticket_ids[:_CTX_MAX_TICKETS]
+        ],
+        "summary": _redact(summary) if summary else None,
+    }
+
+
+async def _build_context(branch: str, path: str, pr: dict | None) -> dict:
+    """Resolve {issues, tickets, summary} for a worktree branch. Best-effort:
+    the PR body comes from the already-cached PR dict (no NEW gh call) and the
+    commit subjects/bodies from a local `git log`; any failure yields empties."""
+    remote = await _upstream_remote()
+    subjects: list[str] = []
+    bodies: list[str] = []
+    # Subject + body of the last ~10 non-merge commits, record-separated by
+    # 0x1e (bodies contain newlines, so newline can't delimit records).
+    log = await _git(
+        path, "log", f"{remote}/{BASE_BRANCH}..HEAD", "--no-merges", "-10",
+        "--format=%s%x1f%b%x1e", timeout=12,
+    )
+    if log:
+        for rec in log.split("\x1e"):
+            rec = rec.strip("\n")
+            if not rec.strip():
+                continue
+            subj, _sep, body = rec.partition("\x1f")
+            subj = subj.strip()
+            if subj:
+                subjects.append(subj)
+            if body.strip():
+                bodies.append(body)
+    return await _resolve_context(branch, subjects, bodies, (pr or {}).get("_body"))
+
+
+async def _context_cached(branch: str | None, path: str, pr: dict | None) -> dict:
+    """TTL-cached per-branch context (same approach as _pr_status_cached)."""
+    empty: dict = {"issues": [], "tickets": [], "summary": None}
+    if not branch or branch == BASE_BRANCH:
+        return empty
+    now = time.time()
+    ent = _CTX_CACHE.get(branch)
+    if ent and (now - ent["ts"]) < _CTX_TTL:
+        return ent["data"]
+    try:
+        data = await _build_context(branch, path, pr)
+    except Exception:  # noqa: BLE001 — context is best-effort, never break fleet
+        data = empty
+    _CTX_CACHE[branch] = {"data": data, "ts": time.time()}
+    return data
 
 
 # --- worktree discovery via git worktree list --porcelain ---
@@ -1087,6 +1306,14 @@ async def _build_fleet() -> dict:
             and not is_main
         )
 
+        # Per-worktree context (issue/ticket links + purpose one-liner). Skipped
+        # for the main checkout (no feature context). Best-effort: never raises.
+        ctx = (
+            await _context_cached(branch, path, pr)
+            if branch and not is_main
+            else {"issues": [], "tickets": [], "summary": None}
+        )
+
         wts.append({
             # "name" doubles as the opaque identifier for follow-up actions
             # (validated against the discovered set on every call); display
@@ -1098,6 +1325,8 @@ async def _build_fleet() -> dict:
             "branch": _redact(g["branch"] or branch or ""), "head": g["head"] or wt.get("head", "")[:7],
             "dirty": g["dirty"], "behind": g["behind"],
             "pr": _redact_pr(pr), "shipped": shipped,
+            "issues": ctx["issues"], "tickets": ctx["tickets"],
+            "summary": ctx["summary"],
             "legacy": bool(legacy_prefixes) and not is_main
             and name.lower().startswith(legacy_prefixes),
             "last_updated_at": g["last_updated_at"],
@@ -1209,12 +1438,23 @@ async def _worktree_detail(name: str) -> dict:
         except Exception:
             pass
 
+    # Context (issue/ticket links + purpose one-liner) assembled from the
+    # commits already fetched above (their subjects) + the PR body — no extra
+    # git log, so the detail endpoint keeps to a single own-commits log call.
+    ctx = (
+        await _resolve_context(branch, [c["subject"] for c in commits], [],
+                               (pr or {}).get("_body"))
+        if branch and not is_main
+        else {"issues": [], "tickets": [], "summary": None}
+    )
     return {
         "name": name, "path": _redact(path),
         "branch": _redact(g["branch"] or branch or ""), "head": g["head"],
         "dirty": g["dirty"], "own_commits": own_commits,
         "real_dirty": await _real_dirty(path),
         "pr": _redact_pr(pr), "pr_merged": _is_pr_merged(pr),
+        "issues": ctx["issues"], "tickets": ctx["tickets"],
+        "summary": ctx["summary"],
         "commits": commits, "design_docs": design_docs,
         "disk_mb": disk_mb,
         "behind": g["behind"],

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -2919,3 +2919,198 @@ async def test_head_contained_equal_oids_no_spawn(monkeypatch):
     monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
     assert await mod._head_contained_in_pr("/wt", "same", "same") is True
     assert not called
+
+
+# =============================================================================
+# Per-worktree context: issue/ticket links + purpose one-liner (issue #147)
+# =============================================================================
+
+# --- issue-ref extraction ---
+def test_extract_issue_refs_keyworded_and_bare_with_dedup():
+    txt = "Fixes #12, Closes #34 and Resolves #56. See also #12 and bare #78."
+    assert mod._extract_issue_refs(txt) == [12, 34, 56, 78]
+
+
+def test_extract_issue_refs_rejects_hex_and_alnum_and_empty():
+    # #fff / #1a2b (colours) and #12abc must NOT be parsed as issue refs.
+    assert mod._extract_issue_refs("colour #fff border #1a2b tag #12abc") == []
+    assert mod._extract_issue_refs("") == []
+    assert mod._extract_issue_refs(None) == []  # type: ignore[arg-type]
+
+
+def test_extract_issue_refs_boundaries():
+    # Trailing punctuation / parens still yield the number.
+    assert mod._extract_issue_refs("bump (#120) then #7.") == [120, 7]
+
+
+# --- ticket-id extraction ---
+def test_extract_ticket_ids_matches_and_dedups():
+    txt = "TT-123 blocked by JIRA-4567; TT-123 again; PROJECT-9"
+    assert mod._extract_ticket_ids(txt) == ["TT-123", "JIRA-4567", "PROJECT-9"]
+
+
+def test_extract_ticket_ids_none_present():
+    assert mod._extract_ticket_ids("no tickets here, just words") == []
+    assert mod._extract_ticket_ids("") == []
+
+
+# --- ticket-url template rendering ---
+def test_render_ticket_url_with_template():
+    assert mod._render_ticket_url("https://t.corp/{id}", "TT-9") == "https://t.corp/TT-9"
+
+
+def test_render_ticket_url_empty_or_no_placeholder_returns_none():
+    assert mod._render_ticket_url("", "TT-9") is None
+    assert mod._render_ticket_url("https://t.corp/browse", "TT-9") is None
+
+
+# --- version-bump detection + summary pick ---
+def test_is_version_bump():
+    assert mod._is_version_bump("chore: bump version to 1.2.3") is True
+    assert mod._is_version_bump("Bump version") is True
+    assert mod._is_version_bump("1.2.3") is True
+    assert mod._is_version_bump("release 2.0.0") is True
+    assert mod._is_version_bump("feat: add pagination") is False
+
+
+def test_pick_summary_skips_version_bumps():
+    subjects = ["chore: bump version 1.2.3", "feat: add real feature", "wip"]
+    assert mod._pick_summary(subjects) == "feat: add real feature"
+
+
+def test_pick_summary_falls_back_to_latest_when_all_bumps():
+    subjects = ["chore: bump version 1.2.3", "release 1.2.2"]
+    assert mod._pick_summary(subjects) == "chore: bump version 1.2.3"
+    assert mod._pick_summary([]) is None
+
+
+# --- html origin parsing (issue link base) ---
+def test_parse_html_repo_base_variants():
+    p = mod._parse_html_repo_base
+    assert p("git@github.com:kirodotdev/KiroCrew.git") == "https://github.com/kirodotdev/KiroCrew"
+    assert p("https://github.com/kirodotdev/KiroCrew.git") == "https://github.com/kirodotdev/KiroCrew"
+    assert p("https://github.com/kirodotdev/KiroCrew") == "https://github.com/kirodotdev/KiroCrew"
+    assert p("ssh://git@github.com/kirodotdev/KiroCrew.git") == "https://github.com/kirodotdev/KiroCrew"
+    assert p("") is None
+    assert p("not a url") is None
+
+
+# --- _pr_query_one carries title, hides body, and _redact_pr drops internals ---
+@pytest.mark.asyncio
+async def test_pr_query_one_carries_title_and_hides_body():
+    payload = json.dumps([{
+        "number": 42, "state": "OPEN",
+        "url": "https://github.com/o/r/pull/42", "isDraft": False,
+        "title": "My PR title", "body": "Fixes #7",
+    }])
+    with patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, payload, "")):
+        pr = await mod._pr_query_one("o/r", "feat/x")
+    assert pr is not None
+    assert pr["title"] == "My PR title"
+    assert pr["_body"] == "Fixes #7"
+    assert "body" not in pr  # moved to internal _body
+    redacted = mod._redact_pr(pr)
+    assert redacted["title"] == "My PR title"
+    assert redacted["number"] == 42
+    assert "_body" not in redacted  # internal fields dropped from payload
+    assert "_repo" not in redacted
+
+
+# --- _build_context: parses PR body + commits, builds links ---
+@pytest.mark.asyncio
+async def test_build_context_parses_pr_body_and_commits():
+    log = (
+        "feat(dev-fleet): surface context\x1fFixes #147\nrelated #99\x1e"
+        "wip TT-5 progress\x1f\x1e"
+    )
+    with patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"), \
+         patch.object(mod, "_git", new_callable=AsyncMock, return_value=log), \
+         patch.object(mod, "_html_repo_base", new_callable=AsyncMock,
+                      return_value="https://github.com/kirodotdev/KiroCrew"), \
+         patch.object(mod, "_load_dev_fleet_cfg",
+                      return_value={"ticket_url_template": "https://t.corp/{id}"}):
+        ctx = await mod._build_context("feat/thing", "/wt/thing", {"_body": "Closes #147\nsee #12"})
+    # ordered-unique across pr body + commit subjects + commit bodies
+    assert [i["number"] for i in ctx["issues"]] == [147, 12, 99]
+    assert ctx["issues"][0]["url"] == "https://github.com/kirodotdev/KiroCrew/issues/147"
+    assert [t["id"] for t in ctx["tickets"]] == ["TT-5"]
+    assert ctx["tickets"][0]["url"] == "https://t.corp/TT-5"
+    assert ctx["summary"] == "feat(dev-fleet): surface context"
+
+
+@pytest.mark.asyncio
+async def test_build_context_graceful_when_git_fails():
+    # git log fails (returns None) and there is no PR — issues empty, but a
+    # ticket in the BRANCH NAME still resolves; never raises.
+    with patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"), \
+         patch.object(mod, "_git", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_html_repo_base", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_load_dev_fleet_cfg", return_value={}):
+        ctx = await mod._build_context("TT-42-fix-thing", "/wt/x", None)
+    assert ctx["issues"] == []
+    assert [t["id"] for t in ctx["tickets"]] == ["TT-42"]
+    assert ctx["tickets"][0]["url"] is None  # no template configured
+    assert ctx["summary"] is None
+
+
+@pytest.mark.asyncio
+async def test_context_cached_skips_main_and_base():
+    empty = {"issues": [], "tickets": [], "summary": None}
+    assert await mod._context_cached(None, "/wt", None) == empty
+    assert await mod._context_cached(mod.BASE_BRANCH, "/wt", None) == empty
+
+
+@pytest.mark.asyncio
+async def test_context_cached_serves_from_cache(monkeypatch):
+    calls = []
+
+    async def fake_build(branch, path, pr):
+        calls.append(branch)
+        return {"issues": [{"number": 1, "url": None}], "tickets": [], "summary": "s"}
+
+    monkeypatch.setattr(mod, "_build_context", fake_build)
+    mod._CTX_CACHE.pop("feat/cache-me", None)
+    try:
+        a = await mod._context_cached("feat/cache-me", "/wt", None)
+        b = await mod._context_cached("feat/cache-me", "/wt", None)
+        assert a == b
+        assert len(calls) == 1  # second call served from cache
+    finally:
+        mod._CTX_CACHE.pop("feat/cache-me", None)
+
+
+# --- fleet payload carries the new context fields per worktree ---
+@pytest.mark.asyncio
+async def test_build_fleet_payload_has_context_fields():
+    sentinel = {
+        "issues": [{"number": 147, "url": "https://github.com/o/r/issues/147"}],
+        "tickets": [{"id": "TT-5", "url": None}],
+        "summary": "feat: do the thing",
+    }
+    worktrees = [
+        {"path": "/repo", "branch": "main", "is_main": True},
+        {"path": "/repo-wt-x", "branch": "feat/x", "is_main": False},
+    ]
+    ginfo = {
+        "branch": "feat/x", "head": "abc1234", "dirty": False,
+        "ahead": 0, "behind": 0, "last_updated_at": 111,
+    }
+    pr = {"number": 9, "state": "OPEN", "url": "u", "title": "T"}
+    with patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_discover_worktrees", new_callable=AsyncMock, return_value=worktrees), \
+         patch.object(mod, "_load_cfg", return_value=None), \
+         patch.object(mod, "_git_info", new_callable=AsyncMock, return_value=ginfo), \
+         patch.object(mod, "_pr_status_cached", new_callable=AsyncMock, return_value=pr), \
+         patch.object(mod, "_git_ahead", new_callable=AsyncMock, return_value=0), \
+         patch.object(mod, "_context_cached", new_callable=AsyncMock, return_value=sentinel), \
+         patch.object(mod, "_gateway_service_active", new_callable=AsyncMock, return_value=False):
+        fleet = await mod._build_fleet()
+    rows = {w["name"]: w for w in fleet["worktrees"]}
+    feat = rows["repo-wt-x"]
+    assert feat["issues"] == sentinel["issues"]
+    assert feat["tickets"] == sentinel["tickets"]
+    assert feat["summary"] == "feat: do the thing"
+    assert feat["pr"]["title"] == "T"  # title carried into the payload
+    # main row still present and carries empty context (no crash)
+    assert rows["main"]["summary"] is None
+    assert rows["main"]["issues"] == []

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -148,12 +148,15 @@ function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: Con
 }
 
 /* ─── Types ─── */
-interface PrInfo { number?: number; state?: string; url?: string; isDraft?: boolean }
+interface IssueRef { number: number; url?: string | null }
+interface TicketRef { id: string; url?: string | null }
+interface PrInfo { number?: number; state?: string; url?: string; isDraft?: boolean; title?: string }
 interface Worktree {
   name: string; branch?: string; is_main?: boolean; running?: boolean
   has_dist?: boolean; dirty?: boolean; port?: number; health?: number; behind?: number
   last_updated_at?: number
   pr?: PrInfo | null; shipped?: boolean
+  issues?: IssueRef[]; tickets?: TicketRef[]; summary?: string | null
   own_commits?: number; real_dirty?: boolean; is_live?: boolean; legacy?: boolean
   path?: string
 }
@@ -172,12 +175,35 @@ function DetailPanel({ w, d, busy, onRemove, onLoadLogs, logs, logsLoading }: { 
       <div style={mutedSm}>Branch: <span style={{ ...mono, color: 'var(--text)' }}>{d.branch || '?'}</span></div>
       {d.pr ? (
         <div style={mutedSm}>
-          PR: <a href={d.pr.url || '#'} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
-            #{d.pr.number || '?'}
+          PR: <a href={d.pr.url || '#'} target="_blank" rel="noopener noreferrer" title={d.pr.title || undefined} style={{ color: 'var(--accent)' }}>
+            #{d.pr.number || '?'}{d.pr.title ? ' \u2014 ' + d.pr.title : ''}
           </a>{' '}
           <Badge variant={d.pr.state === 'MERGED' ? 'aim' : d.pr.state === 'OPEN' ? 'ok' : 'warn'}>
             {(d.pr.state || '').toLowerCase()}
           </Badge>
+        </div>
+      ) : null}
+      {d.summary ? (
+        <div style={mutedSm}>Purpose: <span style={{ color: 'var(--text)' }}>{d.summary}</span></div>
+      ) : null}
+      {d.issues?.length > 0 ? (
+        <div style={mutedSm}>
+          Issues:{' '}
+          {d.issues.map((it: IssueRef, i: number) => (
+            it.url
+              ? <a key={i} href={it.url} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', marginRight: 8 }}>#{it.number}</a>
+              : <span key={i} style={{ color: 'var(--text)', marginRight: 8 }}>#{it.number}</span>
+          ))}
+        </div>
+      ) : null}
+      {d.tickets?.length > 0 ? (
+        <div style={mutedSm}>
+          Tickets:{' '}
+          {d.tickets.map((t: TicketRef, i: number) => (
+            t.url
+              ? <a key={i} href={t.url} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', marginRight: 8 }}>{t.id}</a>
+              : <span key={i} style={{ color: 'var(--text)', marginRight: 8 }}>{t.id}</span>
+          ))}
         </div>
       ) : null}
       {d.design_docs?.length > 0 ? (
@@ -748,10 +774,11 @@ export default function DevFleetPage() {
             {w.dirty ? <span title="uncommitted changes">&bull;</span> : null}
             {w.is_main ? <span style={mut}>&middot; main</span> : null}
             {w.is_live ? <Badge variant="aim" className="text-[10px] px-1.5 py-0" title="The live gateway on this port runs from this checkout">live</Badge> : null}
+            {w.summary ? <span title={w.summary} style={{ fontSize: 11.5, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: '0 1 auto' } as CSSProperties}>{w.summary}</span> : null}
           </div>
           {isMainWithStepper ? renderSyncStepper() : (
             <>
-              {rs && prUrl ? <a href={prUrl} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}><Badge variant={rs.variant}>{rs.word}</Badge></a> : <span style={{ ...mut, opacity: 0.5 }}>&mdash;</span>}
+              {rs && prUrl ? <a href={prUrl} target="_blank" rel="noopener noreferrer" title={w.pr?.title || rs.word} style={{ textDecoration: 'none' }}><Badge variant={rs.variant}>{rs.word}</Badge></a> : <span style={{ ...mut, opacity: 0.5 }}>&mdash;</span>}
               <span style={{ ...mut, opacity: (w.behind ?? 0) > 0 ? 1 : 0.5 }} title={(w.behind ?? 0) > 0 ? w.behind + ' commits behind main' : 'up to date with main'}>{(w.behind ?? 0) > 0 ? '\u2193' + w.behind : '\u2014'}</span>
               <span style={{ ...mut, opacity: 0.85 }}>{relTime(w.last_updated_at).replace(' ago', '')}</span>
               <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end', alignItems: 'center', minWidth: 0 } as CSSProperties}>{rowButtons(w)}</div>

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -389,4 +389,70 @@ describe('DevFleetPage', () => {
     // menu is closed, so its Make live is not rendered either).
     expect(screen.queryByTitle('Repoint the live gateway back at main (restarts the gateway)')).toBeNull()
   })
+
+  it('compact row: PR badge is a link with PR title as hover title, and shows the summary one-liner', async () => {
+    const FLEET_CTX = {
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+        {
+          name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0,
+          pr: { number: 42, state: 'OPEN', url: 'https://github.com/org/repo/pull/42', title: 'Add pagination' },
+          summary: 'feat: add pagination to users API',
+        },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_CTX), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // PR badge is wrapped in an <a> whose title attribute is the PR title.
+    const link = screen.getByTitle('Add pagination')
+    expect(link.tagName.toLowerCase()).toBe('a')
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    // Purpose one-liner shows inline in the compact row.
+    expect(screen.getByText('feat: add pagination to users API')).toBeInTheDocument()
+  })
+
+  it('drill-in shows issue chips, ticket chips, and the purpose summary', async () => {
+    const FLEET_ONE = {
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+        { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0 },
+      ],
+    }
+    const DETAIL = {
+      branch: 'feat/x',
+      pr: { number: 42, state: 'OPEN', url: 'https://github.com/org/repo/pull/42', title: 'Add pagination' },
+      issues: [{ number: 147, url: 'https://github.com/org/repo/issues/147' }],
+      tickets: [{ id: 'TT-5', url: 'https://t.corp/TT-5' }],
+      summary: 'feat: add pagination to users API',
+      commits: [],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/worktree?name=')) return Promise.resolve(new Response(JSON.stringify(DETAIL), { status: 200 }))
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_ONE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // Expand feature-x (the only non-main row -> a single Expand control).
+    fireEvent.click(screen.getByLabelText('Expand'))
+    const issueLink = await screen.findByText('#147')
+    expect(issueLink.tagName.toLowerCase()).toBe('a')
+    expect(issueLink).toHaveAttribute('href', 'https://github.com/org/repo/issues/147')
+    expect(issueLink).toHaveAttribute('rel', 'noopener noreferrer')
+    const ticketLink = screen.getByText('TT-5')
+    expect(ticketLink.tagName.toLowerCase()).toBe('a')
+    expect(ticketLink).toHaveAttribute('href', 'https://t.corp/TT-5')
+    // The purpose one-liner renders in the drill-in.
+    expect(screen.getByText('feat: add pagination to users API')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Fixes #147

## Problem
Worktree rows show only a PR state badge (not even a link), behind-count, and updated time. With 10+ worktrees you cannot tell what each one is FOR without checking git manually.

## Why it matters
Dev Fleet just gained Make Live (#120) — confident switching needs at-a-glance purpose visibility. Currently the fleet page is a build-state dashboard, not a 'what is everyone working on' overview.

## Fix
**Backend** (dev_fleet server, fleet payload per worktree):
- `pr` extended to carry `{number, title, url}` (same gh query + cache as the existing state badge)
- `issues`: GitHub refs (`Fixes/Closes #N` + bare `#N`) parsed from PR body + last ~10 non-merge commit subjects/bodies, deduped, with URLs
- `tickets`: `TEAM-123`-style IDs from branch name + commit subjects; URL via new config `dev_fleet.ticket_url_template` ({id} placeholder; unset = unlinked chips)
- `summary`: latest non-merge commit subject (purpose one-liner)
- All via the `_run_cmd` chokepoint, failure-tolerant (fields absent, payload never breaks), cached with existing TTL

**Frontend** (DevFleetPage): PR badge is now an `<a>` (new tab, title tooltip = PR title); muted ellipsized one-liner after the branch name; drill-in expand shows a context block with PR title+link, issue chips, ticket chips.

## Tests
Backend: issue-ref extraction (Fixes/bare/dedup), ticket regex, template rendering, gh-failure tolerance, payload field presence (vitest 3912 / pytest 15182, zero new failures, flake8 clean). Frontend: badge-as-link, drill-in chips, summary rendering.

## Manual verification
QA on isolated pod: real-repo extraction verified — make-live branch → PR #120 (MERGED) with title+URL, issue **#114** extracted from 'Fixes #114'; ticket chip (AVP-23427) extracted from a legacy branch; rows without PRs degrade gracefully.

Note: `gh` resolution uses dev-fleet's existing trusted-bin policy — on hosts where gh lives under $HOME, the documented `KIROCREW_DEVFLEET_BIN_GH` operator override applies (pre-existing behavior, same as the state badge; the pod QA confirmed pr populates once set).