### PR TITLE
feat(ci): stable latest-DMG permalink per channel

### DIFF
--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -16,7 +16,9 @@ name: Sign and Notarize macOS (reusable)
 #                to this job. Ends by attaching the GATED artifact
 #                (notarized zip) to the workflow run.
 #   publish   -- everything S3-bound: copy the gated artifact to the public
-#                distribution bucket and write the channel feed, dead last.
+#                distribution bucket and write the channel feed, dead last
+#                among the go-live pointers (a convenience latest-DMG alias
+#                mirroring the feed's dmg field trails it deliberately).
 #                Separate from notarize so a transient publish failure
 #                retries as a ~2-minute ubuntu job ("Re-run failed jobs")
 #                instead of repeating two ~30-minute-budget Apple
@@ -566,6 +568,36 @@ jobs:
             --content-type application/json
           echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
 
+      # Human-clickable permalink to the current DMG:
+      #   <CDN>/desktop/<channel>/latest/KiroCrew.dmg
+      # The feed remains the canonical pointer for machines; this alias is a
+      # convenience mirror of the feed's dmg field for download buttons and
+      # docs, so it is written AFTER the feed (never points ahead of the
+      # go-live switch). Unlike the versioned keys it is MUTABLE by design
+      # (same class as the feed): plain overwrite, no --if-none-match, and a
+      # short max-age instead of immutable. desktop/* rides the default
+      # CloudFront behavior (CACHING_OPTIMIZED), which honors per-object
+      # Cache-Control -- versioned keys cache for a year only because we
+      # stamp them immutable; max-age=300 here means edges roll over to a
+      # new nightly within minutes, no invalidation needed. Worst case is
+      # standard latest-link semantics: a download in that window gets the
+      # previous build, which is still fully signed+notarized+stapled.
+      # Uploads the local body (not an S3 copy): the publish role's
+      # desktop/* grant is Put-only.
+      - name: Update latest DMG alias
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          LATEST_DMG_KEY="desktop/${CHANNEL}/latest/${APP_NAME}.dmg"
+          aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${LATEST_DMG_KEY}" \
+            --body "work/${APP_NAME}.dmg" \
+            --content-type application/x-apple-diskimage \
+            --cache-control "public, max-age=300" > /dev/null
+          echo "LATEST_DMG_KEY=${LATEST_DMG_KEY}" >> "$GITHUB_ENV"
+          echo "Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_DMG_KEY}"
+
       - name: Summary
         if: env.HAS_SIGNING_SECRETS
         run: |
@@ -574,5 +606,6 @@ jobs:
             echo "- Version: ${VERSION}"
             echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
             echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
+            echo "- Latest DMG alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_DMG_KEY}"
             echo "- Feed: \`feed/${CHANNEL}/latest-mac.json\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

One always-current, human-clickable DMG link per channel:

```
https://d28nxu9if70cmc.cloudfront.net/desktop/nightly/latest/KiroCrew.dmg
```

(and `desktop/insider/latest/…`, `desktop/stable/latest/…` for free — the publish job is channel-parameterized.)

## Why

Today the only stable pointer is the feed JSON (`feed/<channel>/latest-mac.json`), whose `dmg` field requires indirection — fine for the app's updater and a JS download button, not a link a human can click or paste into docs.

## Design

- **Written AFTER the feed** — the alias never points ahead of the canonical go-live switch.
- **Mutable by design** (same class as the feed): plain overwrite, no `--if-none-match`, `Cache-Control: public, max-age=300`. The never-republish discipline stays intact for versioned keys — those are long-cached only because we stamp them `immutable`.
- **No CDK change**: `desktop/*` rides the default CloudFront behavior (`CACHING_OPTIMIZED`, min TTL 1s), which honors per-object `Cache-Control` — verified in `distribution-stack.ts`. Edges roll over within ~5 minutes of a new publish, no invalidation.
- **Put-only IAM respected**: uploads the local gated-artifact body instead of an S3 server-side copy, because the publish role's `desktop/*` grant is `grantPut` only (no `GetObject`).
- **Worst case** is standard latest-link semantics: a download started inside the 5-minute edge window gets the previous build — still fully signed, notarized, and stapled.

## Failure semantics

The alias step runs after the feed write; if it fails, the run goes red and "Re-run failed jobs" retries the 2-minute publish job alone (the #133 split's whole point). The feed — the pointer clients actually consume — has already advanced correctly.

## Validation

- YAML parse + duplicate-key check clean; step ordering asserted programmatically (`feed -> alias -> summary`).
- 6/6 workflow permission/security tests pass.
- The `put-object` call is byte-identical to the DMG publish step already running green in production nightlies, minus the conditional-write flag and with the short cache header.

Follow-up (separate, if wanted): point the landing page's Download button at the stable alias once the stable channel ships.