### PR TITLE
refactor(lessons): run contradiction sweep on the _bg runtime with haiku

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -18,7 +18,12 @@ from kiro_crew.dashboard.cron_inject import (
     inject_cron_result_to_dashboard,
 )
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.llm_helpers import stream_and_collect
+from kiro_crew.providers.base import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import (
     _MODEL_NAME_RE,
@@ -58,44 +63,106 @@ _CONTRADICTION_PROMPT = (
     "Respond with exactly one word: CONTRADICTORY, COMPLEMENTARY, or UNRELATED."
 )
 
-_CONTRADICTION_SESSION_KEY = "background:contradiction-check"
 _CONTRADICTION_MODEL = "claude-haiku-4.5"
+# Per-candidate cap on the background contradiction verdict. The sweep runs
+# fire-and-forget after the lesson is already persisted, so this bounds a hung
+# model call rather than gating the write path.
+_CONTRADICTION_TIMEOUT = 60.0
+
+
+async def _classify_contradiction(state: DashboardState, prompt: str) -> str:
+    """Run one contradiction classification on the shared ``_bg`` runtime.
+
+    Mirrors the lightweight background path used by title/suggestion generation
+    (``chat_title`` / ``suggestions``): acquire an ephemeral ``_bg`` session
+    handle via ``get_bg_session``, best-effort pin it to the cheap model, stream
+    to completion while rejecting any tool call (the classification is
+    tool-free), then always ``destroy()`` the handle. A fresh handle per call
+    keeps each verdict a clean binary classification — no cross-candidate turn
+    history — and avoids the unbounded context growth of a single long-lived
+    session reused across every ``learn_add``. Bounded by
+    ``_CONTRADICTION_TIMEOUT``. Returns the first upper-cased token of the
+    model's reply (e.g. ``"CONTRADICTORY"``), or ``""`` on empty output.
+    """
+    session = await state.sessions.get_bg_session()
+    text = ""
+    try:
+        # Contradiction check is a trivial binary classification — run on the
+        # cheapest model. Best-effort: fall through on the session's default
+        # model if the backend can't switch.
+        _set_model = getattr(session, "set_model", None)
+        if _set_model is not None:
+            try:
+                await _set_model(_CONTRADICTION_MODEL)
+            except Exception:
+                pass
+
+        async def _stream() -> None:
+            nonlocal text
+            async for event in session.prompt(prompt):
+                if event.kind == EVENT_TEXT_CHUNK:
+                    text += event.text
+                elif event.kind == EVENT_TOOL_CALL:
+                    # A tool-free classification should never dispatch a tool,
+                    # but an auto-approved tool arrives here WITHOUT a preceding
+                    # permission request (nothing to reject). Audit it so no
+                    # invocation escapes the SEL log (backend-security-controls
+                    # rule: every tool invocation emits a SEL event).
+                    _sel().log_tool_invocation(
+                        session_key="_bg",
+                        tool_name=getattr(event, "title", "unknown"),
+                        outcome="allowed",
+                        source="contradiction_check",
+                    )
+                elif event.kind == EVENT_PERMISSION_REQUEST:
+                    # The classification is tool-free; deny any tool the model
+                    # tries to call. Audit the denial (security-controls rule:
+                    # every permission decision emits a SEL event) before
+                    # rejecting, mirroring the suggestions bg path.
+                    _sel().log_tool_invocation(
+                        session_key="_bg",
+                        tool_name=getattr(event, "title", "unknown"),
+                        outcome="denied",
+                        source="contradiction_check",
+                    )
+                    await session.reject_tool(event.request_id)
+                elif event.kind == EVENT_COMPLETE:
+                    break
+
+        await asyncio.wait_for(_stream(), timeout=_CONTRADICTION_TIMEOUT)
+    finally:
+        await session.destroy()
+    stripped = text.strip()
+    return stripped.upper().split()[0] if stripped else ""
 
 
 async def _resolve_contradictions(
     state: DashboardState, new_rule: str, candidates: list[dict]
 ) -> list[str]:
-    """Use LLM to identify which candidate lessons contradict the new rule."""
+    """Use an LLM to identify which candidate lessons contradict the new rule.
+
+    Each candidate is classified independently on a fresh ``_bg`` runtime
+    session (see ``_classify_contradiction``). A per-candidate failure/timeout
+    is swallowed so one bad verdict never aborts the sweep — the lesson is
+    already persisted, and a missed verdict self-heals on the next ``learn_add``
+    touching the topic.
+    """
     to_delete: list[str] = []
     for candidate in candidates:
         prompt = _CONTRADICTION_PROMPT.format(
             old_rule=candidate["rule"], new_rule=new_rule
         )
         try:
-            provider, _new, _resumed = await state.sessions.get_or_create(
-                _CONTRADICTION_SESSION_KEY, agent="kirocrew-lite",
-            )
-            try:
-                # Contradiction check is a trivial binary classification —
-                # run on the cheapest model.
-                _set_model = getattr(provider, "set_model", None)
-                if _set_model is not None:
-                    try:
-                        await _set_model(_CONTRADICTION_MODEL)
-                    except Exception:
-                        pass
-                response = await stream_and_collect(provider, prompt)
-            finally:
-                state.sessions.release(_CONTRADICTION_SESSION_KEY)
-            verdict = response.strip().upper().split()[0] if response else ""
-            if verdict == "CONTRADICTORY":
-                logger.info(
-                    "Contradiction: new %r supersedes %r (sim=%.2f)",
-                    new_rule[:60], candidate["rule"][:60], candidate["similarity"],
-                )
-                to_delete.append(candidate["key"])
+            verdict = await _classify_contradiction(state, prompt)
         except Exception:
             logger.debug("Contradiction check failed for %r", candidate["key"], exc_info=True)
+            continue
+        if verdict == "CONTRADICTORY":
+            logger.info(
+                "Contradiction: new %r supersedes %r (sim=%.2f)",
+                new_rule[:60], candidate["rule"][:60], candidate["similarity"],
+            )
+            to_delete.append(candidate["key"])
     return to_delete
 
 

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -2,11 +2,50 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.providers.base import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+)
 from kiro_crew.vector_memory import VectorMemoryStore
+
+
+class _FakeBgSession:
+    """Stand-in for a ``get_bg_session()`` handle.
+
+    ``prompt()`` replays a scripted event stream; ``set_model`` / ``reject_tool``
+    / ``destroy`` are AsyncMocks so tests can assert the model was pinned, tool
+    calls were rejected, and the handle was always destroyed.
+    """
+
+    def __init__(
+        self,
+        reply: str = "",
+        *,
+        emit_permission: bool = False,
+        emit_tool_call: bool = False,
+    ):
+        self._reply = reply
+        self._emit_permission = emit_permission
+        self._emit_tool_call = emit_tool_call
+        self.set_model = AsyncMock()
+        self.reject_tool = AsyncMock()
+        self.destroy = AsyncMock()
+
+    async def prompt(self, _prompt):  # noqa: ANN001 - test double
+        if self._emit_tool_call:
+            yield SimpleNamespace(kind=EVENT_TOOL_CALL, title="fs_read")
+        if self._emit_permission:
+            yield SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="req-1")
+        if self._reply:
+            yield SimpleNamespace(kind=EVENT_TEXT_CHUNK, text=self._reply)
+        yield SimpleNamespace(kind=EVENT_COMPLETE)
 
 
 class TestFindContradictionCandidates:
@@ -67,53 +106,115 @@ class TestFindContradictionCandidates:
 
 @pytest.mark.asyncio
 class TestResolveContradictions:
-    """Tests for _resolve_contradictions async helper."""
+    """Tests for _resolve_contradictions async helper (runs on the _bg runtime)."""
 
     async def test_contradictory_verdict_returns_key(self):
         from kiro_crew.dashboard.handlers.cron import _resolve_contradictions
 
         state = MagicMock()
-        mock_provider = AsyncMock()
-        state.sessions.get_or_create = AsyncMock(return_value=(mock_provider, True, False))
-        state.sessions.release = MagicMock()
+        session = _FakeBgSession("CONTRADICTORY")
+        state.sessions.get_bg_session = AsyncMock(return_value=session)
 
         candidates = [{"key": "lesson.old", "rule": "Use X format", "similarity": 0.65}]
-
-        with patch(
-            "kiro_crew.dashboard.handlers.cron.stream_and_collect",
-            new=AsyncMock(return_value="CONTRADICTORY"),
-        ):
-            result = await _resolve_contradictions(state, "Do NOT use X format", candidates)
+        result = await _resolve_contradictions(state, "Do NOT use X format", candidates)
 
         assert result == ["lesson.old"]
+        # Model was pinned to the cheap contradiction model and the ephemeral
+        # handle was destroyed.
+        session.set_model.assert_awaited_once_with("claude-haiku-4.5")
+        session.destroy.assert_awaited_once()
 
     async def test_complementary_verdict_keeps_lesson(self):
         from kiro_crew.dashboard.handlers.cron import _resolve_contradictions
 
         state = MagicMock()
-        mock_provider = AsyncMock()
-        state.sessions.get_or_create = AsyncMock(return_value=(mock_provider, True, False))
-        state.sessions.release = MagicMock()
+        session = _FakeBgSession("COMPLEMENTARY")
+        state.sessions.get_bg_session = AsyncMock(return_value=session)
 
         candidates = [{"key": "lesson.keep", "rule": "Add CR links", "similarity": 0.55}]
-
-        with patch(
-            "kiro_crew.dashboard.handlers.cron.stream_and_collect",
-            new=AsyncMock(return_value="COMPLEMENTARY"),
-        ):
-            result = await _resolve_contradictions(state, "Add stakeholder quotes", candidates)
+        result = await _resolve_contradictions(state, "Add stakeholder quotes", candidates)
 
         assert result == []
+        session.destroy.assert_awaited_once()
 
     async def test_llm_failure_skips_gracefully(self):
         from kiro_crew.dashboard.handlers.cron import _resolve_contradictions
 
         state = MagicMock()
-        state.sessions.get_or_create = AsyncMock(side_effect=RuntimeError("no provider"))
+        state.sessions.get_bg_session = AsyncMock(side_effect=RuntimeError("no bg runtime"))
 
         candidates = [{"key": "lesson.err", "rule": "Some rule", "similarity": 0.5}]
         result = await _resolve_contradictions(state, "New rule", candidates)
         assert result == []
+
+    async def test_rejects_tool_calls_and_still_classifies(self):
+        """A tool-permission event mid-stream is rejected + SEL-audited; the
+        verdict still lands."""
+        from kiro_crew.dashboard.handlers import cron
+
+        state = MagicMock()
+        session = _FakeBgSession("CONTRADICTORY", emit_permission=True)
+        state.sessions.get_bg_session = AsyncMock(return_value=session)
+
+        candidates = [{"key": "lesson.old", "rule": "Use X", "similarity": 0.6}]
+        with patch.object(cron, "_sel") as mock_sel:
+            result = await cron._resolve_contradictions(state, "Do NOT use X", candidates)
+
+        assert result == ["lesson.old"]
+        session.reject_tool.assert_awaited_once_with("req-1")
+        # Denied tool invocation is audited (security-controls rule).
+        mock_sel.return_value.log_tool_invocation.assert_called_once()
+        _, kwargs = mock_sel.return_value.log_tool_invocation.call_args
+        assert kwargs["outcome"] == "denied"
+        assert kwargs["source"] == "contradiction_check"
+        session.destroy.assert_awaited_once()
+
+    async def test_auto_approved_tool_call_is_audited(self):
+        """An auto-approved EVENT_TOOL_CALL (no permission request to reject) is
+        still SEL-audited so no invocation escapes the log."""
+        from kiro_crew.dashboard.handlers import cron
+
+        state = MagicMock()
+        session = _FakeBgSession("UNRELATED", emit_tool_call=True)
+        state.sessions.get_bg_session = AsyncMock(return_value=session)
+
+        candidates = [{"key": "lesson.x", "rule": "r", "similarity": 0.6}]
+        with patch.object(cron, "_sel") as mock_sel:
+            result = await cron._resolve_contradictions(state, "new", candidates)
+
+        assert result == []  # UNRELATED verdict keeps the lesson
+        mock_sel.return_value.log_tool_invocation.assert_called_once()
+        _, kwargs = mock_sel.return_value.log_tool_invocation.call_args
+        assert kwargs["outcome"] == "allowed"
+        assert kwargs["source"] == "contradiction_check"
+        assert kwargs["tool_name"] == "fs_read"
+        session.destroy.assert_awaited_once()
+
+    async def test_timeout_is_swallowed_and_handle_destroyed(self):
+        """A hung classification times out per-candidate without aborting; the
+        bg handle is still destroyed in the finally."""
+        from kiro_crew.dashboard.handlers import cron
+
+        state = MagicMock()
+        destroyed = AsyncMock()
+
+        class _HangSession:
+            def __init__(self):
+                self.set_model = AsyncMock()
+                self.reject_tool = AsyncMock()
+                self.destroy = destroyed
+
+            async def prompt(self, _prompt):  # noqa: ANN001 - test double
+                import asyncio
+                await asyncio.sleep(10)
+                yield SimpleNamespace(kind=EVENT_COMPLETE)  # pragma: no cover
+
+        state.sessions.get_bg_session = AsyncMock(return_value=_HangSession())
+        candidates = [{"key": "lesson.hang", "rule": "r", "similarity": 0.6}]
+        with patch.object(cron, "_CONTRADICTION_TIMEOUT", 0.01):
+            result = await cron._resolve_contradictions(state, "new", candidates)
+        assert result == []
+        destroyed.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The `learn_add` contradiction sweep classified each candidate lesson on a
**long-lived named session** — `background:contradiction-check` (agent
`kirocrew-lite`), acquired via `get_or_create` + `stream_and_collect`. That
session was reused for the entire process lifetime, so its ACP turn history
grew **unbounded** across every `learn_add` (each classification carried all
prior ones as context), and the per-candidate LLM call had **no timeout**.

## Why it matters

Every preference/lesson write triggers this sweep. A single ever-growing
session means each contradiction check is progressively more expensive and
context-polluted, and a hung model call in the fire-and-forget sweep had
nothing bounding it. It's also inconsistent with the other lightweight
background LLM tasks (title / suggestion generation), which already use the
shared `_bg` runtime.

## Fix (symptom → root cause → change)

- **Symptom:** heavyweight, unbounded, un-timed background classification.
- **Root cause:** the sweep used a persistent named session instead of the
  ephemeral shared `_bg AcpRuntime` handle the rest of the codebase uses for
  one-shot background LLM work.
- **Change:** `_resolve_contradictions` now classifies each candidate via a new
  `_classify_contradiction` helper on a **fresh `get_bg_session()` handle** —
  the same tool-free, one-shot `_bg` path as `chat_title` / `suggestions`:
  best-effort `set_model("claude-haiku-4.5")`, stream to `EVENT_COMPLETE` while
  rejecting any tool call, bounded by a 60s `asyncio.wait_for`, and `destroy()`
  in a `finally`. A fresh handle per candidate keeps each verdict a clean binary
  classification (no cross-candidate history) and removes the unbounded growth.
  Per-candidate failures/timeouts are swallowed so one bad verdict never aborts
  the sweep. Drops the now-dead `_CONTRADICTION_SESSION_KEY`; adds
  `_CONTRADICTION_TIMEOUT`.

Note: the write path itself is unchanged and already non-blocking —
`api_lessons_create` persists the lesson first and fires the sweep
fire-and-forget (`asyncio.create_task`), so `learn_add` (and the MCP tool that
POSTs to the same endpoint) returns without waiting on the LLM. This PR only
changes the mechanism the backgrounded sweep uses.

## Tests

`test/test_lesson_contradiction.py` — `TestResolveContradictions` rewritten to
drive the `_bg` mechanism via a `_FakeBgSession` double:
- contradictory verdict returns the key; asserts model pinned to
  `claude-haiku-4.5` and the handle is destroyed;
- complementary verdict keeps the lesson;
- `get_bg_session` raising is swallowed (empty result);
- a mid-stream tool-permission event is rejected and the verdict still lands;
- a hung `prompt()` hits the per-candidate timeout, is swallowed, and the
  handle is still destroyed.

## Manual verification

N/A — unit coverage exercises the model-pin, tool-reject, timeout, and
destroy-in-finally paths against a fake bg session. `flake8` clean and the full
`test_lesson_contradiction.py` suite (14 tests) passes locally on the rebased
tree.
