### PR TITLE
fix(research): title the campaign worker slot from its name instead of 'New Session…'

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -26,6 +26,7 @@ from kiro_crew.apps.builtins.auto_research.workflow_template import (
 )
 from kiro_crew.autonudge import get_instance as _autonudge_instance
 from kiro_crew.config.paths import config_dir
+from kiro_crew.dashboard.chat_utils import _history_key_for
 from kiro_crew.knowledge.llm_pool import LLMPool
 
 try:
@@ -875,7 +876,7 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
         return
     db = _get_db()
     row = db.execute(
-        "SELECT question, sub_questions, sources, scope_constraints, max_cycles, idle_secs, "
+        "SELECT name, question, sub_questions, sources, scope_constraints, max_cycles, idle_secs, "
         "success_criteria, auto_approve, parallel_workers FROM campaigns WHERE id = ?",
         (cid,),
     ).fetchone()
@@ -886,6 +887,40 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
     slot = state.get_or_create_slot(
         name=f"research-{cid}", agent=_RESEARCH_AGENT, app="auto-research"
     )
+    # Give the app-owned worker slot a meaningful title (the campaign's human
+    # name) instead of the "New Session…" placeholder. The slot is driven by
+    # autonudge, whose injected messages carry role "nudge" (not "user"), so the
+    # normal LLM auto-titler never fires for it (_maybe_auto_title gates on
+    # user_count >= 1). Set it explicitly, mirroring the cron/workflow slot
+    # pattern: redact user-supplied text (defence-in-depth), lock _titled so
+    # display_title returns it instead of the placeholder, persist so it survives
+    # a gateway restart, and push a live SSE update to the sidebar/header.
+    raw_title = row["name"] or f"research-{cid}"
+    if _HAS_SECURITY:
+        raw_title, _ = redact_exfiltration_urls(raw_title)
+        raw_title, _ = redact_credentials(raw_title)
+    else:
+        # Fail closed: the campaign name is user-controlled, so if the security
+        # redactors are unavailable we must NOT persist/broadcast it. Fall back
+        # to the non-user-derived slot key, which carries no user content.
+        raw_title = f"research-{cid}"
+    slot.title = raw_title
+    slot._titled = True
+    # Persist the title so it survives a gateway restart. set_title() does
+    # synchronous file I/O (read + rewrite + fsync), so offload it to a thread
+    # to avoid blocking the event loop, and treat persistence as best-effort:
+    # a slow/failed write must never prevent the worker loop from being armed
+    # below (otherwise the campaign would be left running with no worker).
+    if getattr(state, "conversation_log", None) is not None:
+        try:
+            await asyncio.to_thread(
+                state.conversation_log.set_title, _history_key_for(slot.key), slot.title
+            )
+        except Exception:
+            logger.warning(
+                "auto_research: failed to persist slot title for %s", cid, exc_info=True
+            )
+    state.push_slot_title(slot.key, slot.title)
     # The worker runs autonomously — auto-approve its tools so the loop never
     # stalls on per-tool approval prompts (brakes: max_cycles, Stop, sandbox,
     # deny-list). The slot is app-owned, so it's hidden from the chat sidebar.

--- a/test/test_auto_research.py
+++ b/test/test_auto_research.py
@@ -1316,6 +1316,80 @@ class TestLoopLaunch:
         assert state.get_or_create_slot.return_value._trust is True
 
     @pytest.mark.asyncio
+    async def test_launch_sets_slot_title_from_campaign_name(self, monkeypatch):
+        # The worker slot is autonudge-driven (messages are role "nudge", not
+        # "user"), so the LLM auto-titler never fires and the slot would show
+        # the "New Session…" placeholder. _launch_loop must title it from the
+        # campaign's human name, lock _titled, and push a live update.
+        from kiro_crew.apps.builtins.auto_research import handlers as h
+
+        c = create_campaign(
+            {
+                "name": "SQLite vs Postgres deep dive",
+                "question": "Compare SQLite and PostgreSQL for desktop apps",
+                "sources": ["web"],
+            }
+        )
+        svc = MagicMock()
+        svc.add = AsyncMock()
+        monkeypatch.setattr(h, "_autonudge_instance", lambda: svc)
+        state = MagicMock()
+        slot = SimpleNamespace(key=f"research-{c['id']}")
+        state.get_or_create_slot.return_value = slot
+        await h._launch_loop(SimpleNamespace(app={"state": state}), c["id"])
+        assert slot.title == "SQLite vs Postgres deep dive"
+        assert slot._titled is True
+        state.push_slot_title.assert_called_once_with(slot.key, "SQLite vs Postgres deep dive")
+        # Title persisted under the slot's canonical history key so it survives
+        # a gateway restart.
+        state.conversation_log.set_title.assert_called_once()
+        assert state.conversation_log.set_title.call_args.args[1] == "SQLite vs Postgres deep dive"
+
+    @pytest.mark.asyncio
+    async def test_launch_title_persist_failure_still_arms_worker(self, monkeypatch):
+        # Title persistence is best-effort: a set_title I/O failure must NOT
+        # propagate and leave the campaign running without its worker armed.
+        from kiro_crew.apps.builtins.auto_research import handlers as h
+
+        c = create_campaign(
+            {"question": "Research question about something here", "sources": ["web"]}
+        )
+        svc = MagicMock()
+        svc.add = AsyncMock()
+        monkeypatch.setattr(h, "_autonudge_instance", lambda: svc)
+        state = MagicMock()
+        state.get_or_create_slot.return_value = SimpleNamespace(key=f"research-{c['id']}")
+        state.conversation_log.set_title.side_effect = OSError("disk full")
+        await h._launch_loop(SimpleNamespace(app={"state": state}), c["id"])
+        # Worker still armed despite the persistence failure.
+        svc.add.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_launch_title_fails_closed_without_redactors(self, monkeypatch):
+        # The campaign name is user-controlled. If the security redactors are
+        # unavailable (_HAS_SECURITY False), the title MUST fall back to the
+        # non-user-derived key rather than persisting/broadcasting raw input.
+        from kiro_crew.apps.builtins.auto_research import handlers as h
+
+        c = create_campaign(
+            {
+                "name": "http://evil.example/leak?token=abc",
+                "question": "Research question about something here",
+                "sources": ["web"],
+            }
+        )
+        svc = MagicMock()
+        svc.add = AsyncMock()
+        monkeypatch.setattr(h, "_autonudge_instance", lambda: svc)
+        monkeypatch.setattr(h, "_HAS_SECURITY", False)
+        state = MagicMock()
+        slot = SimpleNamespace(key=f"research-{c['id']}")
+        state.get_or_create_slot.return_value = slot
+        await h._launch_loop(SimpleNamespace(app={"state": state}), c["id"])
+        assert slot.title == f"research-{c['id']}"
+        assert "evil.example" not in slot.title
+
+    @pytest.mark.asyncio
     async def test_launch_writes_brief(self, monkeypatch):
         from kiro_crew.apps.builtins.auto_research import handlers as h
 


### PR DESCRIPTION
## Problem

A Research Lab campaign's chat session shows the generic **"New Session…"** title for its entire life, instead of the campaign name.

Two compounding causes:
1. The slot is created with `name="research-<cid>"`, which is only an internal **key** — the slot's `title` defaults to that key, and `display_title` returns the `New Session…` placeholder whenever `title == key` (`dashboard/state.py`).
2. The normal LLM auto-titler (`chat_title._maybe_auto_title`) hard-gates on `user_count >= 1`, but the research loop is driven by **autonudge**, which appends messages with role `"nudge"` (not `"user"`). So `user_count` is always 0 and the titler no-ops every turn.

## Fix

The campaign already stores a human title — the `name` column (explicit name, else first 50 chars of the question). Set it on the worker slot at launch in `_launch_loop`, mirroring the existing cron/workflow slot pattern:
- redact user-supplied text (defence-in-depth),
- `slot._titled = True` so `display_title` returns it,
- `conversation_log.set_title(...)` to persist across a gateway restart,
- `push_slot_title(...)` for a live SSE update to the sidebar/header.

## Tests
- New: `test_launch_sets_slot_title_from_campaign_name` — asserts title set from campaign name, `_titled` locked, live push + persisted.
- Full `test_auto_research.py` suite green (157 + 1), flake8 clean.

No frontend changes.