### PR TITLE
fix(website): remove orphaned activityOpen declaration breaking main

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -708,7 +708,6 @@ export default function App() {
     refetchInterval: 30_000,
   })
   const approvalCount = pendingApprovals.filter((a: { id?: string }) => a.id?.startsWith('task-gate-')).length
-  const activityOpen = useAppSelector(s => s.chat.activityOpen)
   const { data: terminalConfig } = useQuery({
     queryKey: ['terminal-enabled'],
     queryFn: async () => {


### PR DESCRIPTION
**Main is red** (Build Wheel + both Build Desktop jobs on the last 3 commits): `src/App.tsx(711,9): error TS6133: 'activityOpen' is declared but its value is never read.`

## Root cause: semantic conflict between two individually-green PRs

- #145 removed the last JSX consumer of `activityOpen` (the chat-page activity toggle button).
- #143 — branched before #145 — deleted the *other* consumer (the `navLayoutPulse` transition gate) but kept the declaration, which was still legitimately used on its own base at the time.

Each PR passed CI on its own base; merged together the declaration became dead and `tsc -b` fails main. Classic stale-base semantic conflict — no behavior change involved, the state lives on in `chat.activityOpen` for its remaining selectors.

## Fix

Delete the one dead line. Verified locally with the exact CI command: `npx tsc -b` exits 0.

Unblocks #154 (and every other PR currently inheriting these failures).