### PR TITLE
fix(session): compact kiro-cli sessions in place so work continues after auto-compaction

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -12,11 +12,18 @@ lightweight background work (cron, heartbeat, lesson extraction).  It
 stays alive between uses, serialized by the per-session semaphore.
 
 At >= ``cfg.session.autocompact_pct`` context usage, fires a background
-compaction task. Two backends, two strategies:
+compaction task. Both backends compact **in place** so the session — and
+any queued or agentic work on it — continues without a user nudge:
 
-* **kiro-cli:** kill the session and let the next user message re-seed
-  context via ``build_session_context()``. The session_map entry is
-  dropped to avoid false-resume from stale state.
+* **kiro-cli:** run ``/compact`` in place under the session semaphore
+  (native command execute + ``_kiro.dev/compaction/status`` wait). The
+  process and session ID survive; the conversation is summarized in
+  place. If the in-place compact fails or times out, fall back to the
+  legacy **recycle**: kill the session and let the next user message
+  re-seed context via ``build_session_context()`` (the session_map entry
+  is dropped to avoid false-resume from stale state). A recycle is never
+  forced through a live turn — if the turn semaphore cannot be acquired,
+  the attempt is skipped and re-triggered at the next turn end.
 * **claude-agent-acp:** run ``/compact`` in place under the session
   semaphore. The SDK preserves the same session ID across the
   compact_boundary; the session keeps its summary and continues without
@@ -278,6 +285,11 @@ _CONTEXT_COMPACT_PCT = 80.0
 # compact would otherwise block all concurrent gets on the same session.
 _COMPACT_TIMEOUT_SECS = 300.0
 
+# How long the kiro-cli in-place path waits for the async
+# ``_kiro.dev/compaction/status`` result after issuing /compact. Matches the
+# budget the dashboard's manual /compact and Slack's !compact already use.
+_COMPACT_RESULT_WAIT_SECS = 120.0
+
 # After a failed compact, suppress auto-compaction for this many seconds so a
 # broken /compact does not fire on every subsequent turn.
 _COMPACT_FAILURE_COOLDOWN_SECS = 60.0
@@ -494,6 +506,11 @@ class SessionManager:
         self._start_sem = asyncio.Semaphore(4)  # max 4 concurrent cold-starts
         self._cleanup_task: asyncio.Task | None = None
         self._compacting: set[str] = set()
+        # Keys whose session entry is being torn down by the recycle FALLBACK
+        # (pop from _sessions + provider SIGKILL). Distinct from _compacting:
+        # an in-place compact keeps the entry healthy and reusable, so
+        # get_or_create must only skip reuse for keys in THIS set.
+        self._recycling: set[str] = set()
         self._compact_cooldown_until: dict[str, float] = {}
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         self._on_compacted: _CompactCallback | None = None
@@ -1622,18 +1639,16 @@ class SessionManager:
         _claimed: "tuple[_Session, bool] | None" = None
         try:
             async with self._lock:
-                # Skip the live-session branch only when a *recycle-style*
-                # compact is in flight (kiro path drops the entry from
-                # _sessions). Claude in-place compact keeps the entry healthy,
-                # so concurrent get_or_create must reuse it instead of
-                # cold-starting a duplicate provider that would later overwrite
-                # _sessions[key] and leak the original process.
+                # Skip the live-session branch only while the recycle FALLBACK
+                # is tearing this key down (it pops the entry from _sessions
+                # and SIGKILLs the provider). In-place compaction — both the
+                # kiro-cli and claude paths — keeps the entry healthy, so
+                # concurrent get_or_create must reuse it (queueing on the
+                # session semaphore behind the compact) instead of
+                # cold-starting a duplicate provider that would later
+                # overwrite _sessions[key] and leak the original process.
                 _existing = self._sessions.get(key)
-                _is_recycling = (
-                    key in self._compacting
-                    and _existing is not None
-                    and not _is_claude_backend(_existing.provider)
-                )
+                _is_recycling = key in self._recycling
                 if _existing is not None and not _is_recycling:
                     sess = _existing
                     # If the provider's process died (crash, SIGKILL, etc.),
@@ -1940,16 +1955,15 @@ class SessionManager:
 
             async with self._lock:
                 # Re-check: another coroutine may have created this key while we
-                # were starting the provider (race on same key). Claude in-place
-                # compact leaves the existing entry healthy, so reuse it even
-                # when _compacting is set; only kiro recycle (which drops the
-                # entry from _sessions) should fall through to register us.
+                # were starting the provider (race on same key). In-place
+                # compaction (kiro-cli and claude) leaves the existing entry
+                # healthy, so reuse it even when _compacting is set; only the
+                # recycle FALLBACK (which drops the entry from _sessions)
+                # should fall through to register us. The recycle path pops by
+                # object identity, so even if we register over a
+                # being-recycled entry, only the old session object is killed.
                 _existing = self._sessions.get(key)
-                _is_recycling = (
-                    key in self._compacting
-                    and _existing is not None
-                    and not _is_claude_backend(_existing.provider)
-                )
+                _is_recycling = key in self._recycling
                 if _existing is not None and not _is_recycling:
                     # Another task won the race — use theirs and shut down our
                     # duplicate provider below, after the lock is released
@@ -2285,14 +2299,17 @@ class SessionManager:
     async def _compact_session(self, key: str, pct: float) -> None:
         """Compact a session that hit the context threshold.
 
-        For kiro-cli we recycle: kill the session and let the next user
-        message re-seed context via build_session_context(). The session_map
-        entry is dropped so we don't false-resume from stale state.
+        Both backends compact **in place** first, so the kiro-cli process (or
+        claude SDK session) survives and any queued or agentic work continues
+        automatically — the fix for "session stops after auto-compaction".
 
-        For claude-agent-acp we run /compact in place. The SDK summarises
-        the conversation into a fresh, smaller context — no recycle needed,
-        and the session keeps its history (the compaction summary) instead
-        of starting from scratch.
+        kiro-cli only: if the in-place ``/compact`` fails or times out, fall
+        back to the legacy recycle — kill the session and let the next user
+        message re-seed context via build_session_context(). The session_map
+        entry is dropped so we don't false-resume from stale state. A recycle
+        is never forced through a live turn: if the turn semaphore cannot be
+        acquired within the budget, the attempt is skipped and the next
+        turn-end ``check_context_usage`` re-triggers it.
         """
         try:
             session = self._sessions.get(key)
@@ -2330,36 +2347,118 @@ class SessionManager:
                 await self._fire_compact_callback(key, pct, success=True)
                 return
 
-            # kiro-cli recycle SIGKILLs the provider; drain the in-flight turn
-            # via the session semaphore first so we don't kill mid-cleanup.
-            drain = self._sessions.get(key)
-            sem = drain.semaphore if drain else None
-            sem_held = False
-            if sem is not None:
-                try:
-                    await asyncio.wait_for(sem.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
-                    sem_held = True
-                except asyncio.TimeoutError:
+            # ── kiro-cli: in-place /compact first ──
+            if session is not None:
+                outcome = await self._compact_in_place(key, session, pct)
+                if outcome == "ok":
+                    return
+                if outcome == "busy":
+                    # A turn is still running. NEVER kill a live turn for
+                    # compaction — the old force-recycle here SIGKILLed
+                    # kiro-cli mid-turn, losing all in-flight work. The next
+                    # turn-end check_context_usage re-triggers compaction
+                    # when the semaphore is free. No cooldown / no failure
+                    # callback: this is a deferral, not a failure.
                     logger.warning(
-                        "Session %s recycle: turn still active after %.0fs, forcing recycle",
+                        "Session %s compaction deferred — turn still active after %.0fs",
                         key,
                         _COMPACT_TIMEOUT_SECS,
                     )
+                    return
+                # outcome == "failed" → fall through to the recycle fallback.
+
+            # ── kiro-cli recycle fallback ──
+            # SIGKILLs the provider; drain the in-flight turn via the session
+            # semaphore first so we don't kill mid-turn. Operates strictly on
+            # the *session object captured above*: pop-by-identity means a
+            # fresh session registered by a racing cold-start is never popped
+            # or killed by mistake.
+            if session is None:
+                return
+            sem = session.semaphore
+            try:
+                await asyncio.wait_for(sem.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Session %s recycle skipped — turn still active after %.0fs",
+                    key,
+                    _COMPACT_TIMEOUT_SECS,
+                )
+                return
+            self._recycling.add(key)
             try:
                 async with self._lock:
-                    session = self._sessions.pop(key, None)
-                if session:
-                    self._session_map.delete(key)
+                    popped = None
+                    if self._sessions.get(key) is session:
+                        popped = self._sessions.pop(key, None)
+                if popped is None:
+                    # A racing cold-start already replaced the entry — the map
+                    # now points at a fresh, healthy session. Reap OUR old
+                    # provider (its process would otherwise leak) but leave the
+                    # replacement and its session_map entry untouched.
                     await session.provider.shutdown()
+                    logger.info(
+                        "Recycled session %s (context overflow; entry already replaced)", key
+                    )
+                else:
+                    self._session_map.delete(key)
+                    await popped.provider.shutdown()
                     logger.info("Recycled session %s (context overflow)", key)
-                    await self._fire_compact_callback(key, pct, success=True)
+                await self._fire_compact_callback(key, pct, success=True)
             finally:
-                if sem_held and sem is not None:
-                    sem.release()
+                self._recycling.discard(key)
+                sem.release()
         except Exception:
             logger.exception("Session recycle failed for %s", key)
         finally:
             self._compacting.discard(key)
+
+    async def _compact_in_place(self, key: str, session: "_Session", pct: float) -> str:
+        """Attempt a native in-place ``/compact`` on a kiro-cli session.
+
+        Returns:
+        - ``"ok"``: compaction completed; session (and its process) survives.
+          The success callback has been fired and the cooldown cleared.
+        - ``"busy"``: the turn semaphore could not be acquired within
+          ``_COMPACT_TIMEOUT_SECS`` — a turn is still running. Nothing was
+          attempted; the caller must NOT recycle (no mid-turn kill).
+        - ``"failed"``: the compact was attempted but failed, timed out, or
+          the provider does not support it (base ``wait_for_compaction``
+          returns ``{"type": "timeout"}``). The caller falls back to recycle.
+
+        Holds the session semaphore for the duration so a queued turn waits
+        behind the compaction (and then continues on the compacted session)
+        instead of interleaving with it.
+        """
+        try:
+            await asyncio.wait_for(session.semaphore.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
+        except asyncio.TimeoutError:
+            return "busy"
+        try:
+
+            async def _run() -> None:
+                await session.provider.compact()
+                result = await session.provider.wait_for_compaction(
+                    timeout=_COMPACT_RESULT_WAIT_SECS
+                )
+                rtype = result.get("type") if isinstance(result, dict) else None
+                if rtype != "completed":
+                    raise RuntimeError(f"compaction reported {rtype or 'no result'}")
+
+            await asyncio.wait_for(_run(), timeout=_COMPACT_TIMEOUT_SECS)
+        except (Exception, asyncio.TimeoutError):
+            logger.warning(
+                "Session %s in-place /compact failed — falling back to recycle",
+                key,
+                exc_info=True,
+            )
+            return "failed"
+        finally:
+            session.semaphore.release()
+        self._compact_cooldown_until.pop(key, None)
+        logger.info("Compacted session %s in place (context overflow)", key)
+        await self._fire_compact_callback(key, pct, success=True)
+        return "ok"
 
     async def _fire_compact_callback(self, key: str, pct: float, *, success: bool) -> None:
         """Invoke ``_on_compacted`` if registered, swallowing exceptions."""

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1026,22 +1026,29 @@ class TestCompactCallback:
         await mgr.close_all()
 
     @pytest.mark.asyncio
-    async def test_compact_session_force_recycles_after_timeout(self, cfg, caplog, monkeypatch):
-        """A stuck turn (semaphore never released) must force-recycle after
-        _COMPACT_TIMEOUT_SECS so context still clears."""
+    async def test_compact_session_defers_when_turn_never_drains(self, cfg, caplog, monkeypatch):
+        """A still-running turn (semaphore held) must NEVER be killed for
+        compaction: after _COMPACT_TIMEOUT_SECS the attempt is deferred —
+        session intact, no callback — and re-triggered at the next turn end."""
         monkeypatch.setattr("kiro_crew.session._COMPACT_TIMEOUT_SECS", 0.1)
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
-        # Hold the semaphore and never release -> simulates a stuck turn.
-        await mgr.get_or_create("dashboard:chat-1")
+        # Hold the semaphore and never release -> simulates a long-running turn.
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
         cb = AsyncMock()
         mgr.set_compact_callback(cb)
 
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session"):
             await asyncio.wait_for(mgr._compact_session("dashboard:chat-1", 92.0), timeout=2)
 
-        assert "dashboard:chat-1" not in mgr._sessions
-        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
-        assert any("forcing recycle" in r.message for r in caplog.records)
+        # Session survives, the live turn was not killed, and nothing was
+        # reported to the user (a deferral is not a failure).
+        assert "dashboard:chat-1" in mgr._sessions
+        provider.shutdown.assert_not_awaited()
+        cb.assert_not_awaited()
+        assert any("compaction deferred" in r.message for r in caplog.records)
+        # _compacting cleared so the next turn-end check can re-trigger.
+        assert "dashboard:chat-1" not in mgr._compacting
+        mgr.release("dashboard:chat-1")
         await mgr.close_all()
 
     @pytest.mark.asyncio
@@ -2409,25 +2416,42 @@ class TestClaudeBackendCompaction:
         await mgr.close_all()
 
     @pytest.mark.asyncio
-    async def test_get_or_create_during_kiro_recycle_cold_starts(self, cfg):
-        """Kiro path drops the entry from _sessions; if a stale entry is still
-        present we must fall through to cold-start (preserves the recycle
-        semantics that predate the claude in-place branch)."""
+    async def test_get_or_create_during_recycle_teardown_cold_starts(self, cfg):
+        """While the recycle fallback is tearing the entry down (_recycling),
+        get_or_create must not reuse the doomed entry — fall through to
+        cold-start."""
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         provider, _, _ = await mgr.get_or_create("k1")
         mgr.release("k1")
 
-        with patch("kiro_crew.session._is_claude_backend", return_value=False):
-            mgr._compacting.add("k1")
-            try:
-                provider2, is_new, _ = await mgr.get_or_create("k1")
-            finally:
-                mgr._compacting.discard("k1")
+        mgr._recycling.add("k1")
+        try:
+            provider2, is_new, _ = await mgr.get_or_create("k1")
+        finally:
+            mgr._recycling.discard("k1")
 
-        # New provider, original kept (cold-start path replaces _sessions[key]
-        # via the post-start lock, but for the test we just check we did not
-        # short-circuit to the existing entry).
+        # New provider: we did not short-circuit to the doomed entry.
         assert provider2 is not provider
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_during_inplace_compact_reuses_session(self, cfg):
+        """An in-place compact (kiro or claude) keeps the entry healthy:
+        concurrent get_or_create must reuse it — queueing on the session
+        semaphore — instead of cold-starting a duplicate provider."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+
+        mgr._compacting.add("k1")  # in-place compact in flight; NOT recycling
+        try:
+            provider2, is_new, _ = await mgr.get_or_create("k1")
+        finally:
+            mgr._compacting.discard("k1")
+
+        assert provider2 is provider
+        assert is_new is False
         mgr.release("k1")
         await mgr.close_all()
 
@@ -2446,6 +2470,175 @@ class TestClaudeBackendCompaction:
         assert is_new is True
         assert provider is not None
         mgr.release("k1")
+        await mgr.close_all()
+
+
+class TestKiroInPlaceCompaction:
+    """kiro-cli auto-compaction runs /compact IN PLACE first, so the session
+    (and any queued/agentic work) continues automatically — recycle is only
+    the fallback. Fix for 'session stops after auto-compaction'."""
+
+    @staticmethod
+    def _inplace_provider_factory(result: dict):
+        """Provider whose native compaction reports *result*."""
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+            m.compact = AsyncMock()
+            m.wait_for_compaction = AsyncMock(return_value=result)
+            return m
+
+        return factory
+
+    @pytest.mark.asyncio
+    async def test_inplace_success_keeps_session_and_process(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "completed"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # Session survives in place: same entry, same provider, no SIGKILL.
+        assert "dashboard:chat-1" in mgr._sessions
+        assert mgr._sessions["dashboard:chat-1"].provider is provider
+        provider.compact.assert_awaited_once()
+        provider.shutdown.assert_not_awaited()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        # Semaphore released: the next turn can proceed immediately.
+        assert not mgr._sessions["dashboard:chat-1"].semaphore.locked()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_failed_result_falls_back_to_recycle(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "failed"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # Fallback recycle: entry dropped, process killed, context guaranteed
+        # to clear on the next (re-seeded) message.
+        assert "dashboard:chat-1" not in mgr._sessions
+        provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        assert "dashboard:chat-1" not in mgr._recycling
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_no_native_support_falls_back_to_recycle(self, cfg):
+        """Base LLMProvider.wait_for_compaction returns {'type': 'timeout'} —
+        providers without native compaction must keep today's recycle path."""
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "timeout"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert "dashboard:chat-1" not in mgr._sessions
+        provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_success_clears_failure_cooldown(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "completed"})
+        )
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_cooldown_until["dashboard:chat-1"] = time.monotonic() + 999
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_holds_semaphore_so_queued_turns_wait(self, cfg):
+        """While the in-place compact runs, the session semaphore is held —
+        a queued turn waits behind it and then continues on the compacted
+        session instead of interleaving with the compaction."""
+        gate = asyncio.Event()
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+            m.compact = AsyncMock()
+
+            async def _wait(timeout=120.0):
+                await gate.wait()
+                return {"type": "completed"}
+
+            m.wait_for_compaction = _wait
+            return m
+
+        mgr = SessionManager(cfg, provider_factory=factory)
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        sess = mgr._sessions["dashboard:chat-1"]
+
+        task = asyncio.create_task(mgr._compact_session("dashboard:chat-1", 92.0))
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        assert sess.semaphore.locked()  # queued turn would wait here
+
+        gate.set()
+        await asyncio.wait_for(task, timeout=2)
+        assert "dashboard:chat-1" in mgr._sessions
+        assert not sess.semaphore.locked()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_recycle_pop_by_identity_spares_replacement(self, cfg):
+        """If a racing cold-start replaced the entry while the recycle
+        fallback waited on the old turn semaphore, only the OLD session is
+        killed; the fresh replacement (and its session_map entry) survives."""
+        from kiro_crew.session import _Session
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        old_provider, _, _ = await mgr.get_or_create("k1")
+        old_sess = mgr._sessions["k1"]
+        # Keep the old turn semaphore held so the recycle blocks on acquire.
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+        # Skip the in-place attempt: force the fallback path directly.
+        mgr._compact_in_place = AsyncMock(return_value="failed")  # type: ignore[method-assign]
+
+        task = asyncio.create_task(mgr._compact_session("k1", 92.0))
+        await asyncio.sleep(0.05)
+        assert not task.done()
+
+        # A racing cold-start replaces the entry with a fresh session.
+        new_provider = AsyncMock()
+        new_provider.shutdown = AsyncMock()
+        mgr._sessions["k1"] = _Session(provider=new_provider, is_new=False)
+
+        # Old turn ends -> recycle proceeds, pops by identity.
+        old_sess.semaphore.release()
+        await asyncio.wait_for(task, timeout=2)
+
+        # Replacement untouched; old provider reaped.
+        assert mgr._sessions["k1"].provider is new_provider
+        new_provider.shutdown.assert_not_awaited()
+        old_provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("k1", 92.0, success=True)
         await mgr.close_all()
 
 


### PR DESCRIPTION
## Problem

Whenever auto-compaction fires (`session.autocompact_pct`, default 90%), a kiro-cli-backed session **stops and never continues automatically**. Reproduced live on a dashboard session:

```
00:30:01 WARNING kiro_crew.session: Session dashboard:chat-2-… compacting — context at 93%
00:30:01 WARNING kiro_crew.acp.runtime: AcpRuntime dead (PID 15048): killed
```

Root cause: `_compact_session()` treated the two backends differently. claude-agent-acp compacts in place, but **kiro-cli recycled**: SIGKILL the process, drop the session_map entry, and — per the code comment — *"let the next user message re-seed context"*. By design it waited for a human. Two failure modes:

1. **End-of-turn recycle**: process killed, "Auto-compacted at N%" banner posted, then silence. Queued/agentic work never resumes.
2. **Mid-turn force-kill**: if a turn was still running after the 300s drain budget, recycle was *forced* — SIGKILLing kiro-cli mid-turn and losing all in-flight work.

## Fix

- **In-place `/compact` first** for kiro-cli, via the same proven plumbing the dashboard's manual `/compact` and Slack's `!compact` already use (`provider.compact()` → `wait_for_compaction()` on `_kiro.dev/compaction/status`). The process and session ID survive; a queued turn waits on the session semaphore behind the compaction and then just continues.
- **Recycle demoted to fallback** — only when the in-place compact fails, times out, or the provider has no native support (`wait_for_compaction` → `{type: timeout}`). Keeps the guaranteed context-clear safety net and existing cooldown machinery.
- **Never kill a live turn**: if the turn semaphore can't be acquired within the budget, the attempt is deferred (no cooldown, no failure banner) and re-triggered at the next turn-end `check_context_usage`.
- **Recycle hardening**: pop-by-identity so a racing cold-start's fresh session is never popped/killed by mistake (old provider still reaped); new `_recycling` set replaces the `_compacting`+backend heuristic in the `get_or_create` reuse guards, so a healthy in-place-compacting session is reused instead of cold-starting a duplicate provider (which leaked the original process).

## Testing

- `test/test_session.py`: **216/216 pass** — 6 new tests in `TestKiroInPlaceCompaction` (in-place success keeps session/process, failed/timeout results fall back to recycle, semaphore held during compact, cooldown cleared, pop-by-identity spares a racing replacement), 2 rewritten for the new contract (no-mid-turn-kill deferral; `_recycling`-based guard).
- `test/test_dashboard_chat.py` compaction selection: 9/9 pass.
- flake8 + mypy clean on changed files.

## Notes for reviewers

- The dashboard compact banner path is unchanged: `_fire_compact_callback(success=True)` fires on both in-place success and fallback recycle.
- Slack/Telegram/WeChat share `SessionManager`, so their auto-compaction also becomes in-place-first — strictly better (thread context preserved), with identical fallback semantics to today.