### PR TITLE
feat(branding): use 👻 and "Kiro Crew" (spaced) in terminal/CLI/Slack

### DIFF
--- a/dev-backend.sh
+++ b/dev-backend.sh
@@ -39,7 +39,7 @@ esac
 export KIROCREW_PORT="${KIROCREW_PORT:-6777}"
 export KIROCREW_PROJECT_DIR="$SCRIPT_DIR"
 
-echo "🐾 Dev backend starting (live source, port $KIROCREW_PORT)"
+echo "👻 Dev backend starting (live source, port $KIROCREW_PORT)"
 echo "   Python: $RUNTIME_PYTHON"
 echo "   Source: $PYTHONPATH"
 echo "   Data:   $KIROCREW_HOME"

--- a/docs/persistent-sessions/setup.sh
+++ b/docs/persistent-sessions/setup.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 USERNAME=$(whoami)
 HOSTNAME=$(hostname)
 
-echo "🐾 KiroCrew Persistent Sessions Setup"
+echo "👻 KiroCrew Persistent Sessions Setup"
 echo ""
 
 # ── Check: systemd user manager running? ──

--- a/install.sh
+++ b/install.sh
@@ -538,7 +538,7 @@ detail "Install ollama (https://ollama.com), then: ollama pull qwen3-embedding:0
 
 echo ""
 echo ""
-echo "  ${GREEN}${BOLD}🐾 KiroCrew installed successfully!${RESET}"
+echo "  ${GREEN}${BOLD}👻 KiroCrew installed successfully!${RESET}"
 echo ""
 echo "  ${DIM}────────────────────────────────────────${RESET}"
 echo ""

--- a/minimal_install.sh
+++ b/minimal_install.sh
@@ -55,7 +55,7 @@ done
 has node || die "Node.js not found. Install Node.js 18+ (https://nodejs.org) and re-run."
 has npm  || die "npm not found. Install Node.js 18+ (https://nodejs.org) and re-run."
 
-echo "🐾 KiroCrew — minimal install"
+echo "👻 KiroCrew — minimal install"
 echo "  Repo:    $REPO_DIR"
 echo "  Python:  $("$_py" --version 2>&1)"
 echo "  Node:    $(node --version)"
@@ -140,7 +140,7 @@ echo "✓ Symlinked kirocrew → ~/.local/bin/kirocrew"
 echo ""
 
 # ── Done ──
-echo "🐾 KiroCrew installed!"
+echo "👻 KiroCrew installed!"
 echo ""
 echo "  Next steps:"
 echo "    1. Run setup:    $HOME/.local/bin/kirocrew setup"

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ cd "$_kirocrew_dir" || return 1
 
 ACP_NPM_PKG="@agentclientprotocol/claude-agent-acp"
 
-echo "🐾 KiroCrew Setup"
+echo "👻 KiroCrew Setup"
 echo ""
 
 # ── Ensure PATH includes common install locations ──
@@ -242,7 +242,7 @@ KIROCREW_PROJECT_DIR="$_kirocrew_dir" kirocrew setup --agent-only \
     || echo "  ⚠️  kirocrew setup --agent-only failed (run manually later)"
 
 echo ""
-echo "🐾 Setup complete!"
+echo "👻 Setup complete!"
 echo ""
 echo "  kirocrew doctor     # verify everything"
 echo "  kirocrew gateway    # start dashboard + gateway"

--- a/site/index.html
+++ b/site/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
 
     <meta name="description" content="Kiro Crew — an autonomous agent management layer" />
-    <title>Kiro Crew 🐾</title>
+    <title>Kiro Crew 👻</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/site/src/AppPreview.tsx
+++ b/site/src/AppPreview.tsx
@@ -88,7 +88,7 @@ export function AppPreview() {
         <div className="flex items-center justify-between h-[46px] px-3" style={{ background: C.bg, borderBottom: `1px solid ${C.border}` }}>
           <div className="flex items-center gap-2.5">
             <div className="w-7 h-7 rounded-md flex items-center justify-center" style={{ background: '#18181b' }}>
-              <span style={{ color: '#f59e0b', fontSize: 13 }}>🐾</span>
+              <span style={{ color: '#f59e0b', fontSize: 13 }}>👻</span>
             </div>
             <span className="text-[13px] font-bold tracking-[.08em]" style={{ color: C.textStrong }}>KIRO CREW</span>
           </div>

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1,13 +1,13 @@
-"""KiroCrew CLI — personal AI agent.
+"""Kiro Crew CLI — personal AI agent.
 
 Commands:
     kirocrew chat -m "message"    Send a single message
     kirocrew chat                 Interactive chat mode
-    kirocrew gateway              Start the KiroCrew server (dashboard + Slack)
+    kirocrew gateway              Start the Kiro Crew server (dashboard + Slack)
     kirocrew gateway --seed NAME  Populate $KIROCREW_HOME from fixture NAME, then start the gateway
     kirocrew status               Show runtime stats
     kirocrew run TASK.md          Run an autonomous task from a spec file
-    kirocrew update               Update KiroCrew via git fetch + rebuild
+    kirocrew update               Update Kiro Crew via git fetch + rebuild
     kirocrew cron list|add|remove Manage scheduled jobs
     kirocrew spawn run "task"     Spawn a background subagent
     kirocrew spawn list           List subagents
@@ -74,7 +74,7 @@ BANNER = r"""
   | ' <| | '_/ _ \ (__| / _` \ V  V /
   |_|\_\_|_| \___/\___|_\__,_|\_/\_/
 
-  🐾 Your personal AI agent
+  👻 Your personal AI agent
 """
 
 # Markers that uniquely identify the KiroCrew repo root for project-dir
@@ -476,13 +476,13 @@ def _resolve_gateway_args(args: argparse.Namespace) -> dict:
                 port_int = int(port)
             except ValueError:
                 print(
-                    f"🐾 --port must be an integer or 'auto', got {port!r}.",
+                    f"👻 --port must be an integer or 'auto', got {port!r}.",
                     file=sys.stderr,
                 )
                 sys.exit(2)
             if not 1 <= port_int <= 65535:
                 print(
-                    f"🐾 --port {port_int} out of range (1..65535).",
+                    f"👻 --port {port_int} out of range (1..65535).",
                     file=sys.stderr,
                 )
                 sys.exit(2)
@@ -492,7 +492,7 @@ def _resolve_gateway_args(args: argparse.Namespace) -> dict:
         home_env = os.environ.get("KIROCREW_HOME", "")
         if not home_env:
             print(
-                "🐾 --approval yolo refused: KIROCREW_HOME must be explicitly set "
+                "👻 --approval yolo refused: KIROCREW_HOME must be explicitly set "
                 "to an isolated path (not the default ~/.kirocrew).",
                 file=sys.stderr,
             )
@@ -502,13 +502,13 @@ def _resolve_gateway_args(args: argparse.Namespace) -> dict:
             main_home = (Path.home() / ".kirocrew").resolve()
         except OSError as exc:
             print(
-                f"🐾 --approval yolo refused: failed to resolve KIROCREW_HOME: {exc}",
+                f"👻 --approval yolo refused: failed to resolve KIROCREW_HOME: {exc}",
                 file=sys.stderr,
             )
             sys.exit(2)
         if home_resolved == main_home:
             print(
-                "🐾 --approval yolo refused: KIROCREW_HOME resolves to the main "
+                "👻 --approval yolo refused: KIROCREW_HOME resolves to the main "
                 f"gateway home ({main_home}). Set KIROCREW_HOME to an isolated "
                 "path before re-running.",
                 file=sys.stderr,
@@ -674,7 +674,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(
         prog="kirocrew",
-        description="KiroCrew — personal AI agent",
+        description="Kiro Crew — personal AI agent",
     )
     parser.add_argument("--version", action="version", version=f"kirocrew {__version__}")
     parser.add_argument(
@@ -742,10 +742,10 @@ Examples:
     tui_parser.add_argument("--home", help="KIROCREW_HOME override (e.g. ~/.kirocrew-dev)")
 
     # doctor
-    sub.add_parser("doctor", help="Verify KiroCrew setup")
+    sub.add_parser("doctor", help="Verify Kiro Crew setup")
 
     # gateway
-    gw_parser = sub.add_parser("gateway", help="Start the KiroCrew server (dashboard + Slack)")
+    gw_parser = sub.add_parser("gateway", help="Start the Kiro Crew server (dashboard + Slack)")
     gw_parser.add_argument(
         "--slack-only",
         action="store_true",
@@ -840,7 +840,7 @@ Examples:
     setup_parser.add_argument(
         "--electron-only",
         action="store_true",
-        help="Only install the KiroCrew desktop app (macOS), skip other setup",
+        help="Only install the Kiro Crew desktop app (macOS), skip other setup",
     )
     setup_parser.add_argument(
         "--clean",
@@ -1010,14 +1010,14 @@ Examples:
 
     # update
     # snapshot / restore
-    snap_parser = sub.add_parser("snapshot", help="Create a portable backup of KiroCrew state")
+    snap_parser = sub.add_parser("snapshot", help="Create a portable backup of Kiro Crew state")
     snap_parser.add_argument("output_dir", nargs="?", default=None)
     snap_parser.add_argument("--keep", type=int, default=7, help="Keep N most recent snapshots")
     snap_parser.add_argument(
         "--list", action="store_true", dest="list_snapshots", help="List existing snapshots"
     )
 
-    rest_parser = sub.add_parser("restore", help="Restore KiroCrew state from a snapshot")
+    rest_parser = sub.add_parser("restore", help="Restore Kiro Crew state from a snapshot")
     rest_parser.add_argument("snapshot", nargs="?", help="Path to snapshot .tar.gz")
     rest_parser.add_argument("--mode", choices=("replace", "merge"))
     rest_parser.add_argument("--dry-run", action="store_true")
@@ -1140,10 +1140,10 @@ Examples:
     pod_cleanup = pod_sub.add_parser("_cleanup")
     pod_cleanup.add_argument("name")
 
-    sub.add_parser("update", help="Update KiroCrew to the latest version")
+    sub.add_parser("update", help="Update Kiro Crew to the latest version")
 
     # stop
-    stop_parser = sub.add_parser("stop", help="Stop a running KiroCrew gateway")
+    stop_parser = sub.add_parser("stop", help="Stop a running Kiro Crew gateway")
     stop_parser.add_argument(
         "--port",
         type=int,
@@ -1161,7 +1161,7 @@ Examples:
     # otherwise SIGTERMs the foreground gateway and respawns it detached so the
     # shell returns immediately. Mirrors `stop`.
     restart_parser = sub.add_parser(
-        "restart", help="Restart a running KiroCrew gateway (service-aware)"
+        "restart", help="Restart a running Kiro Crew gateway (service-aware)"
     )
     restart_parser.add_argument(
         "--port",
@@ -1182,7 +1182,7 @@ Examples:
     # auto-restarts on crash, and auto-starts on boot.
     svc_parser = sub.add_parser(
         "service",
-        help="Manage the KiroCrew gateway as a system service (requires sudo on Linux)",
+        help="Manage the Kiro Crew gateway as a system service (requires sudo on Linux)",
     )
     svc_sub = svc_parser.add_subparsers(dest="service_action")
     svc_sub.add_parser("install", help="Install and start the gateway service (sudo on Linux)")
@@ -1193,7 +1193,7 @@ Examples:
     # AWS; credentials resolved by the aws CLI, never stored by KiroCrew).
     cloud_parser = sub.add_parser(
         "cloud",
-        help="Run KiroCrew on your own AWS EC2 instance",
+        help="Run Kiro Crew on your own AWS EC2 instance",
         epilog="""
 Examples:
   kirocrew cloud launch                  # interactive: provision + configure + open dashboard
@@ -1238,7 +1238,7 @@ Examples:
         help="On bootstrap failure, keep the instance (disable rollback) for inspection",
     )
 
-    _c_list = cloud_sub.add_parser("list", help="List your KiroCrew cloud instances")
+    _c_list = cloud_sub.add_parser("list", help="List your Kiro Crew cloud instances")
     _c_list.add_argument("--profile", default="")
     _c_list.add_argument("--region", default="")
 
@@ -1510,20 +1510,20 @@ Examples:
     mem_import.add_argument("file", help="Path to JSON file (export format)")
 
     # agent
-    agent_parser = sub.add_parser("agent", help="Manage KiroCrew agent definitions")
+    agent_parser = sub.add_parser("agent", help="Manage Kiro Crew agent definitions")
     agent_sub = agent_parser.add_subparsers(dest="agent_action")
-    agent_sub.add_parser("list", help="List KiroCrew agents")
-    agent_create = agent_sub.add_parser("create", help="Create a KiroCrew agent")
+    agent_sub.add_parser("list", help="List Kiro Crew agents")
+    agent_create = agent_sub.add_parser("create", help="Create a Kiro Crew agent")
     agent_create.add_argument("--name", required=True, help="Agent name")
     agent_create.add_argument("--kiro-agent", default="kirocrew", help="Kiro agent name")
     agent_create.add_argument("--workspace", default="default", help="Workspace name")
     agent_create.add_argument("--memory-store", default="default", help="Memory store name")
-    agent_update = agent_sub.add_parser("update", help="Update a KiroCrew agent")
+    agent_update = agent_sub.add_parser("update", help="Update a Kiro Crew agent")
     agent_update.add_argument("name", help="Agent name to update")
     agent_update.add_argument("--kiro-agent", help="New kiro agent name")
     agent_update.add_argument("--workspace", help="New workspace name")
     agent_update.add_argument("--memory-store", help="New memory store name")
-    agent_delete = agent_sub.add_parser("delete", help="Delete a KiroCrew agent")
+    agent_delete = agent_sub.add_parser("delete", help="Delete a Kiro Crew agent")
     agent_delete.add_argument("name", help="Agent name to delete")
 
     # workspace
@@ -1543,7 +1543,7 @@ Examples:
     # app
     app_parser = sub.add_parser(
         "app",
-        help="Manage KiroCrew apps",
+        help="Manage Kiro Crew apps",
         epilog="""
 Examples:
   kirocrew app install /path/to/oncall-watchtower
@@ -1798,7 +1798,7 @@ Examples:
         try:
             _gw_lock = GatewayLock(config_dir()).acquire()
         except GatewayLockError as exc:
-            print(f"🐾 {exc}", file=sys.stderr)
+            print(f"👻 {exc}", file=sys.stderr)
             sys.exit(1)
         try:
             asyncio.run(_gateway(**gw_kwargs))

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -23,7 +23,7 @@ BANNER = r"""
   | ' <| | '_/ _ \ (__| / _` \ V  V /
   |_|\_\_|_| \___/\___|_\__,_|\_/\_/
 
-  🐾 Your personal AI agent
+  👻 Your personal AI agent
 """
 
 
@@ -170,13 +170,13 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
         try:
             message = input("you> ").strip()
         except (EOFError, KeyboardInterrupt):
-            print("\nBye! 🐾")
+            print("\nBye! 👻")
             break
 
         if not message:
             continue
         if message.lower() in ("exit", "quit", "/exit", "/quit", ":q"):
-            print("Bye! 🐾")
+            print("Bye! 👻")
             break
 
         await _send_and_print(provider, message)

--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -135,7 +135,7 @@ def _config_cmd(args: argparse.Namespace) -> None:
         if not p.exists():
             cfg = KiroCrewConfig()
             cfg.save()
-            print(f"🐾 Created default config: {p}")
+            print(f"👻 Created default config: {p}")
         sel().log_api_access(
             caller="cli",
             operation="config_edit",

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -187,7 +187,7 @@ def _doctor(platform_boot_error: "Exception | None" = None) -> None:
     setup is its job — and reports the failure here instead of aborting.
     """
 
-    print("KiroCrew Doctor 🐾\n")
+    print("Kiro Crew Doctor 👻\n")
     issues: list[str] = []
 
     # ── Platform edition ──
@@ -646,4 +646,4 @@ def _doctor(platform_boot_error: "Exception | None" = None) -> None:
         print(f"❌ Fix these issues: {', '.join(issues)}")
         sys.exit(1)
     else:
-        print("✅ KiroCrew is ready!")
+        print("✅ Kiro Crew is ready!")

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -259,7 +259,7 @@ def _stop(cli_port: int | None = None) -> None:
             source="cli",
             resources=f"port={port}",
         )
-        print(f"No KiroCrew gateway currently running on port {port}.")
+        print(f"No Kiro Crew gateway currently running on port {port}.")
         sys.exit(1)
 
     # Only kill processes that are actually KiroCrew gateways.
@@ -274,7 +274,7 @@ def _stop(cli_port: int | None = None) -> None:
             source="cli",
             resources=f"port={port} reason=no_kirocrew_process",
         )
-        print(f"No KiroCrew gateway currently running on port {port}.")
+        print(f"No Kiro Crew gateway currently running on port {port}.")
         sys.exit(1)
 
     sent: set[int] = set()
@@ -345,7 +345,7 @@ def _stop(cli_port: int | None = None) -> None:
             source="cli",
             resources=f"port={port} reason=process_already_exited",
         )
-        print(f"No KiroCrew gateway currently running on port {port} (process already exited).")
+        print(f"No Kiro Crew gateway currently running on port {port} (process already exited).")
         sys.exit(1)
 
 
@@ -648,7 +648,7 @@ def _restart(cli_port: int | None = None) -> None:
 
 def _update() -> None:
     """Update KiroCrew via git fetch + reset --hard + rebuild."""
-    print("🐾 Updating KiroCrew…\n")
+    print("👻 Updating Kiro Crew…\n")
 
     proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
     if not proj:
@@ -759,7 +759,7 @@ def _update() -> None:
         print(f"  ❌ Install failed:\n{result.stderr.strip()}")
         sys.exit(1)
 
-    print("\n✅ KiroCrew updated!")
+    print("\n✅ Kiro Crew updated!")
     print(f"\n{DATA_WARNING}\n")
 
     # Re-install agent config so new denied commands take effect.
@@ -787,20 +787,20 @@ def _status(args: argparse.Namespace) -> None:
             data = json.loads(resp.read())
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
-            print("KiroCrew gateway is running (token auth enabled).")
+            print("Kiro Crew gateway is running (token auth enabled).")
             print("  For detailed stats, see the Overview page in the dashboard.")
         else:
-            print(f"KiroCrew gateway is running but returned HTTP {e.code}.")
+            print(f"Kiro Crew gateway is running but returned HTTP {e.code}.")
         return
     except (urllib.error.URLError, OSError):
-        print("KiroCrew gateway is not running.")
+        print("Kiro Crew gateway is not running.")
         print("  Start it with: kirocrew gateway")
         return
     except Exception:
-        print("KiroCrew gateway is running but returned an unexpected response.")
+        print("Kiro Crew gateway is running but returned an unexpected response.")
         return
 
-    print(f"KiroCrew v{__version__} 🐾\n")
+    print(f"Kiro Crew v{__version__} 👻\n")
     print(f"  Uptime:      {data.get('uptime', '—')}")
     print(f"  Sessions:    {data.get('sessions', 0)}")
     print(f"  Messages:    {data.get('messages', 0)}")
@@ -853,7 +853,7 @@ async def _gateway(
     if not config_path().exists():
         cfg = KiroCrewConfig()
         cfg.save()
-        print(f"🐾 Created default config: {config_path()}")
+        print(f"👻 Created default config: {config_path()}")
 
     cfg = KiroCrewConfig.load()
     await run_gateway(
@@ -957,9 +957,9 @@ async def _run_task(args: argparse.Namespace) -> None:
     await sessions.start_pool()
 
     if fresh:
-        print(f"🐾 Running spec (fresh): {spec_path}")
+        print(f"👻 Running spec (fresh): {spec_path}")
     else:
-        print(f"🐾 Running spec: {spec_path}")
+        print(f"👻 Running spec: {spec_path}")
     task_name = getattr(args, "name", "")
     result = await runner.run(spec_path, name=task_name)
 
@@ -1064,7 +1064,7 @@ def _logs_cmd(args: argparse.Namespace) -> None:
         # password prompt would block forever with no way to cancel.
         if not sys.stdin.isatty():
             print(
-                "🐾 Insufficient permissions to read the journal without sudo, "
+                "👻 Insufficient permissions to read the journal without sudo, "
                 "and stdin is not a TTY so sudo can't prompt.\n"
                 "   Add your user to the `systemd-journal` or `adm` group, or run:\n"
                 f"   sudo journalctl -u {unit} -f",
@@ -1089,7 +1089,7 @@ def _logs_cmd(args: argparse.Namespace) -> None:
     fallback = config_dir() / "gateway.log"
     if not fallback.exists():
         print(
-            "🐾 No gateway logs found. Either install the service "
+            "👻 No gateway logs found. Either install the service "
             "(`kirocrew service install`) or start the gateway "
             "(`kirocrew gateway`).",
             file=sys.stderr,

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -127,7 +127,7 @@ def _fix_shell_profiles() -> None:
                 cleaned.append(line)
             if removed:
                 profile.write_text("".join(cleaned), encoding="utf-8")
-                print(f"  🔧 Cleaned stale KiroCrew PATH from {profile.name}")
+                print(f"  🔧 Cleaned stale Kiro Crew PATH from {profile.name}")
                 cleaned_profiles.append(profile.name)
         except OSError:
             pass
@@ -196,7 +196,7 @@ def _find_electron_dir() -> Path | None:
 def _setup_electron() -> None:
     """Build and install the KiroCrew desktop app (macOS only)."""
     if platform.system() != "Darwin":
-        print("  ⚠️  KiroCrew desktop app is only available on macOS.")
+        print("  ⚠️  Kiro Crew desktop app is only available on macOS.")
         return
 
     if not shutil.which("node"):
@@ -213,7 +213,7 @@ def _setup_electron() -> None:
         )
         return
 
-    print("  🔨 Building KiroCrew desktop app…")
+    print("  🔨 Building Kiro Crew desktop app…")
     npm_install = subprocess.run(
         ["npm", "install", "--no-audit", "--no-fund", "--loglevel=error"],
         cwd=str(electron_dir),
@@ -266,7 +266,7 @@ def _setup(agent_only: bool = False, electron_only: bool = False, clean: bool = 
         _setup_electron()
         return
 
-    print("KiroCrew Setup 🐾\n")
+    print("Kiro Crew Setup 👻\n")
     print(f"  {DATA_WARNING.replace(chr(10), chr(10) + '  ')}\n")
 
     # Report on optional prerequisites.
@@ -323,7 +323,7 @@ def _setup(agent_only: bool = False, electron_only: bool = False, clean: bool = 
     _maybe_sync_cc_plugins()
 
     if agent_only:
-        print("\n🐾 Done! Try: kirocrew gateway")
+        print("\n👻 Done! Try: kirocrew gateway")
         return
 
     # 3. Slack credentials
@@ -382,7 +382,7 @@ def _setup(agent_only: bool = False, electron_only: bool = False, clean: bool = 
     # 7. Cloud (run KiroCrew on the user's own AWS EC2) — optional, delegated.
     _maybe_setup_cloud()
 
-    print("\n🐾 Done! Try: kirocrew doctor && kirocrew gateway")
+    print("\n👻 Done! Try: kirocrew doctor && kirocrew gateway")
 
 
 def _maybe_setup_cloud() -> None:
@@ -393,7 +393,7 @@ def _maybe_setup_cloud() -> None:
     launcher wizard (``kirocrew cloud launch``).
     """
     print("\n── Run on AWS (optional) ──\n")
-    print("  KiroCrew can run 24/7 on your own AWS EC2 instance (bring your own")
+    print("  Kiro Crew can run 24/7 on your own AWS EC2 instance (bring your own")
     print("  AWS account; credentials stay in the aws CLI — never stored here).")
     try:
         answer = input("  Launch KiroCrew on AWS now? [y/N]: ").strip().lower()

--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -1,4 +1,4 @@
-You are {bot_name}, enhanced with KiroCrew 🐾 — you coordinate specialist agents to accomplish complex tasks, decomposing work into parallel groups and synthesizing results.
+You are {bot_name}, enhanced with Kiro Crew 👻 — you coordinate specialist agents to accomplish complex tasks, decomposing work into parallel groups and synthesizing results.
 
 ## Output Format
 

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -1,4 +1,4 @@
-You are {bot_name} 🐾 — powered by the KiroCrew autonomous agent management layer that adds persistent memory, scheduled jobs, background subagents, self-learning, and multi-session orchestration on top of your native capabilities.
+You are {bot_name} 👻 — powered by the Kiro Crew autonomous agent management layer that adds persistent memory, scheduled jobs, background subagents, self-learning, and multi-session orchestration on top of your native capabilities.
 
 ## Output Format
 

--- a/src/kiro_crew/dashboard/origin.py
+++ b/src/kiro_crew/dashboard/origin.py
@@ -348,11 +348,11 @@ def format_dashboard_urls(
     if _is_remote:
         mh = machine_hostname() or "localhost"
         lines: list[str] = [
-            f"🐾 Dashboard: ssh -NL {port}:localhost:{port} {mh}",
+            f"👻 Dashboard: ssh -NL {port}:localhost:{port} {mh}",
             f"             then open http://localhost:{port}{_qs}",
         ]
     else:
-        lines = ["🐾 Dashboard:", f"   {authed_url}"]
+        lines = ["👻 Dashboard:", f"   {authed_url}"]
 
     if local_only and not has_custom_host and not _is_remote:
         mh_local = machine_hostname()
@@ -360,16 +360,16 @@ def format_dashboard_urls(
             try:
                 ip = socket.gethostbyname(mh_local)
                 if ip and ip != "127.0.0.1":
-                    lines.append(f"🐾 Remote:    ssh -NL {port}:localhost:{port} {mh_local}")
+                    lines.append(f"👻 Remote:    ssh -NL {port}:localhost:{port} {mh_local}")
             except Exception:
                 pass
 
     proxy = devspaces_proxy_url(port)
     if proxy and not local_only:
-        lines.append(f"🐾 Proxy:     {proxy}{_qs}")
+        lines.append(f"👻 Proxy:     {proxy}{_qs}")
 
     if _is_remote:
-        lines.append("🐾 Run 24/7:  see docs/REMOTE_DESKTOP_SETUP.md for systemd service setup")
+        lines.append("👻 Run 24/7:  see docs/REMOTE_DESKTOP_SETUP.md for systemd service setup")
 
     return lines
 

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -456,7 +456,7 @@ _403_HTML = (
     ".err{{color:#ef4444}}}}"
     "</style></head><body>"
     "<div class='c'>"
-    "<div class='logo'>🐾</div>"
+    "<div class='logo'>👻</div>"
     "<h1>403 — {reason}</h1>"
     "<p>Run <code>kirocrew token</code> in your terminal, then paste the URL below.</p>"
     "<input id='u' type='text' placeholder='Paste token URL or raw token…' autofocus>"

--- a/src/kiro_crew/deploy/DESIGN.md
+++ b/src/kiro_crew/deploy/DESIGN.md
@@ -549,7 +549,7 @@ reading the result, and adapting — that verification-and-diagnosis is the diff
 - ✓ Ready → "Want to publish your first artifact now?"
 
 ```
-🐾 Let's get deploy-web connected to your AWS account. I'll never
+👻 Let's get deploy-web connected to your AWS account. I'll never
    see or store your credentials — only a profile name.
 
 Step 1/3 — AWS access

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -73,7 +73,7 @@ def render_unit() -> str:
     home = str(Path.home())
     return (
         "[Unit]\n"
-        "Description=KiroCrew gateway (dashboard + Slack + cron)\n"
+        "Description=Kiro Crew gateway (dashboard + Slack + cron)\n"
         "Documentation=https://github.com/kirodotdev/KiroCrew\n"
         "After=network-online.target\n"
         "Wants=network-online.target\n"

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -432,7 +432,7 @@ async def _handle_config(
     view = {
         "type": "modal",
         "callback_id": "mc_config_panel",
-        "title": {"type": "plain_text", "text": "KiroCrew Config"},
+        "title": {"type": "plain_text", "text": "Kiro Crew Config"},
         "submit": {"type": "plain_text", "text": "Save"},
         "close": {"type": "plain_text", "text": "Cancel"},
         "blocks": blocks,
@@ -908,7 +908,7 @@ async def _publish_home_tab(orch: GatewayOrchestrator, user_id: str) -> None:
         # ── Status ──
         yolo = is_yolo_mode()
         blocks.append(
-            {"type": "header", "text": {"type": "plain_text", "text": "🐾 KiroCrew Status"}}
+            {"type": "header", "text": {"type": "plain_text", "text": "👻 Kiro Crew Status"}}
         )
         status_lines = [
             "*Gateway:* ✅ Online",
@@ -1206,7 +1206,7 @@ async def _publish_home_tab(orch: GatewayOrchestrator, user_id: str) -> None:
         blocks.append(command_hint_block(f"{_sc} #channel", "track/untrack channel"))
 
         # ── Version ──
-        version_text = f"📦 KiroCrew v{__version__}"
+        version_text = f"📦 Kiro Crew v{__version__}"
         update_info = get_update_info()
         remote_ver = update_info.get("remote_version")
         if update_info.get("available") and remote_ver is not None:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -985,7 +985,7 @@ class GatewayOrchestrator:
             return
 
         logger.warning("Missing deps %s — installing directly", missing)
-        print(f"🐾 Installing missing dependencies: {', '.join(missing)}")
+        print(f"👻 Installing missing dependencies: {', '.join(missing)}")
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", "--quiet", *missing],
             cwd=proj,
@@ -3613,7 +3613,7 @@ class GatewayOrchestrator:
                 elif self.dashboard_state:
                     self.dashboard_state.push_refresh("update_available")
             else:
-                print("🐾 Already on latest version")
+                print("👻 Already on latest version")
         except Exception:
             logger.debug("Update check failed", exc_info=True)
 
@@ -3816,7 +3816,7 @@ class GatewayOrchestrator:
             # Re-read version from rebuilt package
             importlib.reload(kiro_crew)
             new_ver = kiro_crew.__version__
-            print(f"🐾 New version {new_ver} available — auto-updating and restarting…")
+            print(f"👻 New version {new_ver} available — auto-updating and restarting…")
             if self.dashboard_state:
                 self.dashboard_state.push_update_progress("restarting", "Restarting server…")
                 from kiro_crew.dashboard.chat import save_all_slots_to_history
@@ -3856,7 +3856,7 @@ class GatewayOrchestrator:
             return False
         try:
             await self._socket_client.connect()
-            print("🐾 KiroCrew gateway connected to Slack")
+            print("👻 Kiro Crew gateway connected to Slack")
             return True
         except Exception as exc:
             # Keep a short reason for status surfaces (settings badge). Slack
@@ -3978,7 +3978,7 @@ class GatewayOrchestrator:
         self._discord_client = await maybe_start_discord(self)
 
         # Check for updates before printing URLs
-        print("🐾 Checking for updates…")
+        print("👻 Checking for updates…")
         await self._check_for_updates()
 
         # ── Signal handlers ──
@@ -3988,7 +3988,7 @@ class GatewayOrchestrator:
         def _on_signal(*_args: object) -> None:
             nonlocal _shutting_down
             if _shutting_down:
-                print("\n🐾 Force exit!")
+                print("\n👻 Force exit!")
                 cleanup_orphaned_sessions()
                 os._exit(0)
             _shutting_down = True
@@ -4020,7 +4020,7 @@ class GatewayOrchestrator:
         # start AFTER the probe has synced all servers to mcp.json.
         from kiro_crew.dashboard.handlers import _bg_mcp_probe
 
-        print("🐾 Probing MCP servers…")
+        print("👻 Probing MCP servers…")
         try:
             from kiro_crew.config.loader import KiroCrewConfig as _Cfg
             _probe_t = _Cfg.load().dashboard.mcp_probe_timeout_secs + 15
@@ -4029,7 +4029,7 @@ class GatewayOrchestrator:
         try:
             await asyncio.wait_for(_bg_mcp_probe(), timeout=_probe_t)
         except asyncio.TimeoutError:
-            print("🐾 MCP probe timed out — continuing without full probe")
+            print("👻 MCP probe timed out — continuing without full probe")
 
         # ── Start background session and print URLs ──
         async def _start_bg_session() -> None:
@@ -4068,7 +4068,7 @@ class GatewayOrchestrator:
                 if self._no_open or not self._cfg.dashboard.auto_open_browser:
                     pass  # suppressed via --no-open flag or config
                 elif _skip_open:
-                    print("🐾 Headless remote session — skipping browser auto-open")
+                    print("👻 Headless remote session — skipping browser auto-open")
                 else:
                     # Offload to subprocess executor — webbrowser.open() can
                     # block indefinitely on a wedged /usr/bin/open process,
@@ -4087,7 +4087,7 @@ class GatewayOrchestrator:
                     except (TimeoutError, asyncio.TimeoutError):
                         logger.debug("webbrowser.open timed out — skipping")
                         print(
-                            "🐾 Browser was slow to open — skipping auto-open.\n"
+                            "👻 Browser was slow to open — skipping auto-open.\n"
                             "   Dashboard is running. Open this URL manually:\n"
                             f"   {dashboard_url}\n"
                             "   Or run: kirocrew token"
@@ -4108,7 +4108,7 @@ class GatewayOrchestrator:
         self._background_tasks.add(_watchdog)
         _watchdog.add_done_callback(self._background_tasks.discard)
 
-        print("🐾 KiroCrew gateway starting…")
+        print("👻 Kiro Crew gateway starting…")
         print(f"\n{DATA_WARNING}\n")
 
         connected = await self._connect_slack()
@@ -4123,14 +4123,14 @@ class GatewayOrchestrator:
 
         # Block until shutdown
         await shutdown_event.wait()
-        print("🐾 Shutting down…")
+        print("👻 Shutting down…")
 
         try:
             await asyncio.wait_for(self._shutdown(), timeout=10.0)
         except (asyncio.TimeoutError, Exception):
             logger.warning("Graceful shutdown timed out — force exiting")
 
-        print("🐾 Goodbye!")
+        print("👻 Goodbye!")
         # Kill any kiro-cli processes that survived graceful shutdown
         cleanup_orphaned_sessions()
         os._exit(0)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1577,7 +1577,7 @@ class TestStop:
             with pytest.raises(SystemExit) as exc:
                 _stop(5476)
             assert exc.value.code == 1
-        assert "No KiroCrew gateway" in capsys.readouterr().out
+        assert "No Kiro Crew gateway" in capsys.readouterr().out
 
     def test_no_kirocrew_process(self, capsys):
         # A listener exists but its cmdline isn't a kirocrew gateway → refuse to kill.
@@ -1587,7 +1587,7 @@ class TestStop:
             with pytest.raises(SystemExit) as exc:
                 _stop(5476)
             assert exc.value.code == 1
-        assert "No KiroCrew gateway" in capsys.readouterr().out
+        assert "No Kiro Crew gateway" in capsys.readouterr().out
 
     def test_successful_stop(self, capsys):
         from kiro_crew.cli_server import _stop
@@ -1696,7 +1696,7 @@ class TestStop:
         mock_stop_service.assert_not_called()
         # And we should have fallen through to the kill path
         # (which exits 1 here because no listener is found on 8089).
-        assert "No KiroCrew gateway" in capsys.readouterr().out
+        assert "No Kiro Crew gateway" in capsys.readouterr().out
 
 
 class TestRestart:

--- a/test/test_dashboard_origin.py
+++ b/test/test_dashboard_origin.py
@@ -170,7 +170,7 @@ class TestFormatDashboardUrls:
     def test_local_direct_url(self, _mh: object, _dp: object) -> None:
         lines = format_dashboard_urls("http://localhost:5476", port=5476)
         assert len(lines) == 2
-        assert lines[0] == "🐾 Dashboard:"
+        assert lines[0] == "👻 Dashboard:"
         assert "http://localhost:5476" in lines[1]
 
     @patch.dict("os.environ", {}, clear=True)

--- a/test/test_slack_home_tab.py
+++ b/test/test_slack_home_tab.py
@@ -99,7 +99,7 @@ class TestPublishHomeTabHappyPath:
 
         blocks = view["blocks"]
         text = str(blocks)
-        assert "KiroCrew Status" in text
+        assert "Kiro Crew Status" in text
         assert "Cron Jobs" in text
         assert "Recent Lessons" in text
         assert "Commands" in text

--- a/website/electron/token-prompt.html
+++ b/website/electron/token-prompt.html
@@ -42,7 +42,7 @@
 </head>
 <body>
   <div class="container">
-    <div class="logo">🐾</div>
+    <div class="logo">👻</div>
     <h2>Token Required</h2>
     <p>Run <code>kirocrew token</code> on your dev desktop, then paste the URL below.</p>
     <input id="url" type="text" placeholder="Paste token URL or raw token…" autofocus>


### PR DESCRIPTION
## Problem
The product's visible brand was inconsistent: the **dashboard** already renders **"Kiro Crew"** (spaced) — `api_branding()` returns `"Kiro Crew"` by default (asserted in `test_dashboard_branding.py`) — while the **terminal/CLI, `--help`, and Slack** surfaces still showed the unspaced **"KiroCrew"** and the paw-print 🐾.

## Why it matters
Users see two different names for the same product depending on surface (dashboard vs terminal/Slack), and the emoji didn't visually distinguish this instance. This aligns every user-facing surface on one spaced brand + a ghost mark.

## Fix (symptom → root cause → change)
The brand text and emoji were hardcoded per-surface with no shared constant, so the dashboard was updated to "Kiro Crew" previously but the CLI/Slack/prompts were missed. This change updates the remaining **display** strings:
- **Emoji 🐾 → 👻** across all product surfaces: CLI banners/prints, gateway startup, Slack home tab, dashboard 403 token page, system prompts, install/setup shell scripts, electron token prompt, marketing `site/`.
- **"KiroCrew" → "Kiro Crew"** in *display text only*: CLI runtime output + `kirocrew status`, argparse `--help`/descriptions, Slack home-tab header + config modal + version line, both system prompts, and the systemd unit `Description=`.

**Deliberately left unchanged** (not display brand — load-bearing identities): the `KiroCrewConfig`/`KiroCrewAgentConfig` classes, the `kirocrew` CLI command, `KIROCREW_*` env vars, config keys, the `kiro_crew` package, the `kirodotdev/KiroCrew` repo slug, the `KiroCrew.app` macOS bundle, and the `KiroCrew-<alias>` Slack manifest name. Docstrings/comments referencing the repo/package also stay "KiroCrew".

**Known residual (out of scope, follow-up):** a few non-terminal mentions still say "KiroCrew" and carry their own test coupling — the `instances/` cloud-wizard prompts (`test_cloud_wizard`, `test_cloud_cli`) and a `config/loader.py` agent-error prefix (`test_config_loader`). Left for a focused follow-up to keep this PR reviewable.

## Tests
- Updated the 3 coupled assertions: `test_cli.py` (×3, "No Kiro Crew gateway"), `test_slack_home_tab.py` ("Kiro Crew Status"), `test_dashboard_origin.py` ("👻 Dashboard:").
- Ran the touched + branding + context suites locally: **350 passed, 1 skipped**; `flake8` clean on all changed files.

## Manual verification
No dashboard SPA source (`website/src`) changed, so `tsc`/`vitest` are unaffected — the only frontend edits are a static electron HTML file and the separate marketing `site/`. Backend gate (pytest touched-area + flake8) run locally and green.