### PR TITLE
feat(code-review-sage): single-pass review to cut timeout exposure

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -72,8 +72,10 @@ def _redact(text: str) -> str:
     return redact_credentials(redact_exfiltration_urls(text)[0])[0]
 
 
-DEFAULT_TASK_TIMEOUT = 1800      # seconds per review task (gate or deep)
-DEFAULT_MAX_REVIEW_ROUNDS = 3    # Phase-2 convergence rounds per change (config override)
+DEFAULT_TASK_TIMEOUT = 5400      # 90 min per review turn (the governing cap — passed
+#   through run_review -> _one -> dispatch -> pool.send -> handle.prompt). One heavier
+#   single-pass turn replaces up to 5 old turns; the old 30-min cap force-killed
+#   working large-PR reviews. Stays under the runtime's 2h prompt default.
 _REPORT_ARTIFACT_TAG = "sage-report"   # tags every per-run report artifact
 DEFAULT_REPORT_RETENTION = 20    # keep the N most-recent report artifacts; prune older
 
@@ -147,20 +149,6 @@ def _resolve_concurrency(explicit: int | None = None) -> int:
     return max(1, review_pool.effective_max_concurrent())
 
 
-def _max_review_rounds() -> int:
-    """Max Phase-2 convergence rounds per change (config: ``review.max_review_rounds``,
-    default 3). The driver re-runs the deep review — feeding prior findings forward —
-    until a round adds no new findings or this cap is hit, maximizing first-pass
-    recall so issues don't drip out across later revisions. Clamped to >= 1 so at
-    least one deep review always runs."""
-    try:
-        cfg = store.load_config()
-        val = int((cfg.get("review") or {}).get("max_review_rounds", DEFAULT_MAX_REVIEW_ROUNDS))
-    except Exception:  # pragma: no cover - defensive (bad/missing config)
-        val = DEFAULT_MAX_REVIEW_ROUNDS
-    return max(1, val)
-
-
 def _cid(link: str) -> str:
     """Derive the change id from a GitHub PR link — filesystem-safe. A PR URL ->
     ``GH-<owner>-<repo>-<n>`` (matching the id ``adapters.parse_github_payload``
@@ -210,133 +198,98 @@ def _fetch_instruction(link: str) -> str:
     return pipeline.fetch_spec(platform)
 
 
-def build_gate_task(change_link: str) -> str:
-    """Stage 1 prompt: Phase-1 design gate ONLY. The isolated session fetches the
-    change, runs the gate, writes a GATE-ONLY result record (phase1 +
-    blast_radius, deep_reviewed=false), and STOPS. It never runs Phase 2 — the
-    driver reads the recorded verdict and decides whether Phase 2 happens."""
+def build_review_task(change_link: str) -> str:
+    """Single-pass review prompt: ONE isolated session does the WHOLE review —
+    design reasoning AND every code-level dimension — in a single turn, and writes
+    the complete result record (phase1 design fields + findings + counts +
+    ship_summary + a coverage signal). Design is one dimension of the review, not a
+    separate gated stage; the driver runs neither a gate turn nor a convergence
+    loop. The session RECORDS findings only — it never posts (the driver builds the
+    Python-redacted bodies and a separate poster publishes them verbatim)."""
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
-        "Run ONLY the Phase 1 design gate for EXACTLY ONE change: " + change_link + ".\n"
-        "Load the `sage-review` skill and follow its per-change review ruleset:\n"
-        "  1. Self-heal the store; load patterns from active namespaces "
-        "(`python3 sage_lib/learning.py list-for-review`).\n"
-        "  2. Resolve the per-repo rule pack (if any).\n"
-        "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
-        "normalize via `python3 sage_lib/pipeline.py prepare --link " + change_link
-        + " --payload-file <file>`.\n"
-        "  4. Run the Phase 1 design gate ONLY -> gate_verdict (PASS|CONCERNS|BLOCK) "
-        "+ design_risk + criticality. THINK DEEPLY and deliberately — this is the "
-        "highest-leverage step and you are running at maximum thinking effort. Work the "
-        "change through the skill's `Deep design reasoning` lenses (architectural fit, "
-        "contract/data evolution, alternatives & proportionality, failure modes, "
-        "root-cause vs symptom), each as a consequence chain, BEFORE settling on a "
-        "verdict; the weakest applicable lens sets design_risk. BLOCK is ONLY for a "
-        "genuine DESIGN defect (no real "
-        "problem, wrong/over-engineered fix, or a clearly better alternative ignored); a "
-        "large blast radius / high criticality is NEVER on its own a BLOCK — it means PASS "
-        "or CONCERNS and review more deeply in Phase 2. Capture the design reasoning as a "
-        "CHAIN OF "
-        "THOUGHT in structured fields. design_headline: a STRAIGHTFORWARD, DIRECT "
-        "description of the design issue AND the recommended direction — this is what "
-        "the author actually reads, so get straight to the point with no preamble or "
-        "hedging. Keep it tight (one or a few sentences — as long as the issue needs, "
-        "not artificially capped), self-contained and actionable. Set it "
-        "ONLY on a CONCERNS or BLOCK verdict; leave it empty on PASS. problem: the "
-        "customer/system problem "
-        "in one sentence. why_it_matters: one or two SHORT lines (who is hurt, how "
-        "often/badly). solution_assessment: a few SHORT facets on SEPARATE LINES "
-        "(NOT one paragraph — the report renders each line on its own so it must be "
-        "scannable), each a 'Label: text' point, e.g. 'Resolution: does it fix the "
-        "root cause?' / 'Mechanism: cause -> mechanism -> consequence' / 'Tradeoffs: "
-        "side effects or sub-optimal choices' / 'Alternatives: a clearly better option "
-        "ignored?'. Put a REAL newline between facets and omit any facet that does "
-        "not apply.\n"
-        "  5. Write a GATE-ONLY result record to data/results/<id>.json: phase1 "
-        "(gate_verdict, design_risk, criticality, design_headline, problem, why_it_matters, "
-        "solution_assessment) + blast_radius, deep_reviewed=false, empty findings, "
-        "counts {red:0,yellow:0} (findings contract). Always review — do NOT skip on "
-        "any prior result; re-reviewing the same change is expected.\n"
-        "STOP after writing the gate record. Do NOT run Phase 2, do NOT post comments, "
-        "do NOT spawn further subagents. Execute; do not ask questions."
-    )
-
-
-def build_deep_review_task(change_link: str) -> str:
-    """Stage 2 prompt: Phase-2 deep review. Spawned by the driver ONLY when the
-    recorded gate verdict is not BLOCK. The session RECORDS findings into the gate
-    record — it does NOT post anything. The driver then builds Python-redacted
-    comment bodies and a separate poster publishes them (security-controls: LLM
-    output is redacted in Python before it can reach the CR surface)."""
-    return (
-        "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
-        "The Phase 1 design gate for this change has ALREADY RUN and its verdict "
-        "(PASS, CONCERNS, or BLOCK) is recorded. Run the Phase 2 deep review "
-        "REGARDLESS of that verdict — a design BLOCK informs the ship decision but "
-        "does NOT skip the code review. Review EXACTLY ONE change: " + change_link + ".\n"
+        "Do the COMPLETE review of EXACTLY ONE change in a SINGLE thorough pass: "
+        + change_link + ". There is NO separate gate and NO follow-up round — cover "
+        "everything now, carefully, at maximum thinking effort.\n"
         "Load the `sage-review` skill and follow its per-change review ruleset:\n"
         "  1. Self-heal the store; load patterns from active namespaces "
         "(`python3 sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
         "normalize via `python3 sage_lib/pipeline.py prepare --link " + change_link
-        + " --payload-file <file>`. Read the existing gate record and "
-        "PRESERVE its phase1 verdict / criticality / rationale.\n"
-        "  4. Phase 2: the 9 code-level dimensions + self-critique "
-        "(Filter/Merge/Sharpen/Stabilize) -> surviving 🔴/🟡 findings. Assign "
-        "severity per the three-tier rule: 🔴 must-fix = breaks now OR a latent "
-        "issue with high probability AND high impact of failing soon (a 'have-to-fix' "
-        "— do NOT downgrade it to 🟡 just because it works today); 🟡 should-fix = "
-        "real but non-blocking; drop nice-to-haves. Keep these first-class: STRICT "
-        "bidirectional description<->diff fidelity (no phantom claims, no undocumented "
-        "change), and an explicit threat chain on every security finding (entry point "
-        "-> trust boundary -> exploit -> impact).\n"
-        "  5. RECORD ONLY — do NOT post any comments. Update the result record "
-        "data/results/<id>.json: keep the gate's phase1 block; add `findings` (each "
-        "with file, line, severity 🔴/🟡, dimension, observation, consequence, "
-        "suggestion, snippet, lang); set `counts` {red,yellow}; set `ship_summary` to "
-        "ONE straightforward line (good to ship + reason when there are no 🔴, or "
-        "not-ready + the must-fix reason when there is a 🔴 or a design BLOCK); set "
-        "deep_reviewed=true. The driver builds the redacted comment bodies and a "
-        "separate poster publishes them — you MUST NOT call any comment tool.\n"
-        "  6. If this change is itself a FIX (is_fix), run INLINE miss-analysis "
-        "(learn-from-sage): trace the introducing change, ask which dimension was blind, "
-        "and STAGE the learning into the candidate file "
-        "(`python3 sage_lib/learning.py stage --file <pattern.json> --source fix_introduce`). "
-        "It is NOT applied to the live ruleset until a human triggers consolidation.\n"
+        + " --payload-file <file>`.\n"
+        "  4. DESIGN dimension (THINK DEEPLY — highest leverage): work the change "
+        "through the skill's `Deep design reasoning` lenses (architectural fit, "
+        "contract/data evolution, alternatives & proportionality, failure modes, "
+        "root-cause vs symptom) as consequence chains; the weakest applicable lens "
+        "sets design_risk. Produce gate_verdict (PASS|CONCERNS|BLOCK — BLOCK is ONLY "
+        "for a genuine DESIGN defect: no real problem, wrong/over-engineered fix, or a "
+        "clearly better alternative ignored; a large blast radius / high criticality "
+        "is NEVER on its own a BLOCK), design_risk, criticality, and — ONLY on "
+        "CONCERNS/BLOCK — a straightforward, direct design_headline (issue + "
+        "recommended direction, no hedging; empty on PASS), plus problem (one "
+        "sentence), why_it_matters (one or two SHORT lines), and solution_assessment "
+        "(a few 'Label: text' facets on SEPARATE LINES).\n"
+        "  5. CODE dimensions: walk EVERY changed hunk against ALL 9 code-level "
+        "dimensions + self-critique (Filter/Merge/Sharpen/Stabilize) -> surviving "
+        "🔴/🟡 findings. Severity three-tier: 🔴 must-fix (breaks now OR a latent "
+        "high-probability/high-impact 'have-to-fix' — do NOT downgrade to 🟡 just "
+        "because it works today); 🟡 should-fix; drop nice-to-haves. Keep first-class: "
+        "STRICT bidirectional description<->diff fidelity (no phantom claims, no "
+        "undocumented change) and an explicit threat chain on every security finding "
+        "(entry point -> trust boundary -> exploit -> impact). A design CONCERNS/BLOCK "
+        "is ALSO expressed as a finding so it reaches the author.\n"
+        "  6. COVERAGE self-check (the driver relies on this): before emitting, "
+        "enumerate every changed FILE and confirm you reviewed each against all "
+        "dimensions. Set `files_covered` to the list of changed file paths you "
+        "actually reviewed, and `coverage_complete` to true ONLY if that list covers "
+        "every changed file — otherwise set it false (the driver will run ONE "
+        "targeted follow-up on the remainder). Do not pad the list; report honestly.\n"
+        "  7. RECORD ONLY — do NOT post any comments. Write data/results/<id>.json: "
+        "phase1 (gate_verdict, design_risk, criticality, design_headline, problem, "
+        "why_it_matters, solution_assessment) + blast_radius; `findings` (each with "
+        "file, line, severity 🔴/🟡, dimension, observation, consequence, suggestion, "
+        "snippet, lang); `counts` {red,yellow}; `ship_summary` (ONE straightforward "
+        "line: good-to-ship + reason when there are no 🔴, or not-ready + the "
+        "must-fix/design reason otherwise); `files_covered`; `coverage_complete`; "
+        "deep_reviewed=true. The driver builds the redacted bodies and a separate "
+        "poster publishes them — you MUST NOT call any comment tool.\n"
+        "  8. If this change is itself a FIX (is_fix), run INLINE miss-analysis "
+        "(learn-from-sage): trace the introducing change, ask which dimension was "
+        "blind, and STAGE the learning "
+        "(`python3 sage_lib/learning.py stage --file <pattern.json> --source fix_introduce`) "
+        "— NOT applied to the live ruleset until a human consolidates.\n"
         "Do NOT spawn further subagents. Execute; do not ask questions."
     )
 
 
-def build_deep_followup_task(change_link: str) -> str:
-    """Follow-up deep-review round (convergence loop). A prior round already
-    RECORDED findings into the result record; this round hunts for ADDITIONAL
-    issues the earlier round missed and APPENDS only net-new findings — it never
-    repeats, rewords, or removes existing ones. The driver stops looping when a
-    round adds nothing new (or hits the configured cap), maximizing first-pass
-    recall so issues don't drip out across later revisions."""
+def build_review_followup_task(change_link: str) -> str:
+    """Bounded coverage backstop — dispatched AT MOST ONCE, and only when the single
+    review reported ``coverage_complete=false``. It reviews the STILL-UNCOVERED
+    changed files and APPENDS only net-new findings (never repeats/removes existing
+    ones), then marks coverage complete. This is NOT the old convergence loop: it
+    runs at most one targeted pass, signal-driven, not count-delta-driven."""
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
-        "This is a FOLLOW-UP review round for EXACTLY ONE change: " + change_link + ". "
-        "A previous round already recorded findings into data/results/<id>.json.\n"
+        "A prior pass reviewed EXACTLY ONE change: " + change_link + " but reported "
+        "INCOMPLETE file coverage (coverage_complete=false) in data/results/<id>.json.\n"
         "Load the `sage-review` skill and follow its per-change review ruleset:\n"
-        "  1. Self-heal the store; load patterns from active namespaces "
+        "  1. Self-heal the store; load patterns "
         "(`python3 sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
         "normalize via `python3 sage_lib/pipeline.py prepare --link " + change_link
-        + " --payload-file <file>`. READ the existing result record and "
-        "its current `findings` list.\n"
-        "  4. Hunt for ADDITIONAL issues the earlier round MISSED: per the skill's "
-        "Coverage mandate, walk EVERY changed hunk against ALL 9 dimensions. Apply the "
-        "same three-tier severity rule (🔴 must-fix incl. latent 'have-to-fix', 🟡 "
-        "should-fix, drop nice-to-haves) and the STRICT description<->diff fidelity + "
+        + " --payload-file <file>`. READ the existing record: its `findings` and "
+        "`files_covered`.\n"
+        "  4. Review ONLY the changed files NOT already in `files_covered`, against "
+        "ALL 9 code dimensions AND the design lenses, with the same three-tier "
+        "severity (🔴/🟡, drop nice-to-haves) and the description<->diff fidelity + "
         "security threat-chain checks.\n"
-        "  5. RECORD ONLY — do NOT post any comments. APPEND only NET-NEW findings to "
-        "the existing `findings` (do NOT repeat, reword, or remove any already-recorded "
-        "finding); recompute `counts` {red,yellow} over the FULL list; refresh "
-        "`ship_summary`; keep deep_reviewed=true and PRESERVE the phase1 block. You "
-        "MUST NOT call any comment tool.\n"
+        "  5. RECORD ONLY — APPEND only NET-NEW findings (do NOT repeat, reword, or "
+        "remove any already-recorded finding); recompute `counts` {red,yellow} over "
+        "the FULL list; refresh `ship_summary`; extend `files_covered` to include "
+        "every changed file and set `coverage_complete=true`; keep deep_reviewed=true "
+        "and PRESERVE the phase1 block. You MUST NOT call any comment tool.\n"
         "Do NOT spawn further subagents. Execute; do not ask questions."
     )
 
@@ -545,89 +498,76 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     def _one(link: str) -> dict:
         change_id = _cid(link)
 
-        # --- Stage 1: Phase-1 design gate (cheap) ---
-        progress(change_id, "gating", {})           # worker is running Phase 1 now
-        gate_spawn = dispatch(build_gate_task(link), timeout)
-        gate_rec = results.read_result(change_id, root)
-        verdict = str(((gate_rec or {}).get("phase1") or {}).get("gate_verdict", "")).upper()
+        # --- Single thorough review pass (design is ONE dimension, not a gate) ---
+        # No separate gate turn and no convergence loop: ONE dispatch does the whole
+        # review (design reasoning + all code dimensions) and writes the complete
+        # record. This cuts per-change turns from up to 5 (gate + deep + follow-ups +
+        # post) down to review + post, sharply reducing exposure to the per-turn
+        # timeout / backend-generation failures that killed the old multi-turn flow.
+        progress(change_id, "reviewing", {})
+        review_spawn = dispatch(build_review_task(link), timeout)
+        rev_rec = results.read_result(change_id, root)
+        verdict = str(((rev_rec or {}).get("phase1") or {}).get("gate_verdict", "")).upper()
 
+        # The gate_*/deep_* keys are retained for downstream compatibility — the run
+        # summary, _record_reviewed, and the dashboard still read them; with the
+        # single-pass model they simply reflect the ONE review dispatch (there is no
+        # longer a distinct gate).
         rec: dict = {
             "change": link, "change_id": change_id,
-            "gate_spawn_ok": gate_spawn.get("ok", False),
-            "gate_error": gate_spawn.get("error", ""),
+            "gate_spawn_ok": review_spawn.get("ok", False),
+            "gate_error": review_spawn.get("error", ""),
             "gate_verdict": verdict or "UNKNOWN",
-            "phase2_ran": False,
-            "deep_spawn_ok": None,
-            "deep_error": "",
-            "deep_reviewed": False,
-            "result_recorded": gate_rec is not None,
+            "phase2_ran": review_spawn.get("ok", False),
+            "deep_spawn_ok": review_spawn.get("ok", False),
+            "deep_error": review_spawn.get("error", ""),
+            "deep_reviewed": bool((rev_rec or {}).get("deep_reviewed")),
+            "result_recorded": rev_rec is not None,
+            "design_block": (verdict == "BLOCK"),
+            "deep_rounds": 1,
         }
 
-        # --- Gate outcome check (Python decides, not the LLM) ---
-        if not gate_spawn.get("ok", False):
-            rec["skipped_reason"] = "gate_spawn_failed"
-            progress(change_id, "failed", {"error": gate_spawn.get("error", "gate failed")})
+        # Fail only when the turn failed OR nothing usable was recorded — never
+        # discard a record that DID land (the old ok-before-recorded ordering
+        # discarded already-written verdicts/findings on a trailing abnormal stop).
+        if not review_spawn.get("ok", False):
+            rec["skipped_reason"] = "review_failed"
+            progress(change_id, "failed", {"error": review_spawn.get("error", "review failed")})
             return rec
-        if verdict not in ("PASS", "CONCERNS", "BLOCK"):
-            rec["skipped_reason"] = "no_gate_verdict"  # gate left no usable verdict
-            progress(change_id, "failed", {"error": "gate produced no verdict"})
+        if not rec["deep_reviewed"]:
+            rec["skipped_reason"] = "no_review_recorded"  # turn completed but wrote no review
+            progress(change_id, "failed", {"error": "review produced no result record"})
             return rec
-        # A BLOCK verdict NO LONGER skips Phase 2. A genuine design defect informs
-        # the ship decision (and still posts a design comment), but the author wants
-        # the whole code review in one pass — so every usable verdict runs Phase 2.
-        rec["design_block"] = (verdict == "BLOCK")
 
-        # --- Stage 2: Phase-2 deep review with a bounded convergence loop ---
-        # Re-review — feeding prior findings forward — until a round adds no new
-        # findings or we hit the configured cap. This maximizes first-pass recall
-        # so issues don't drip out across later revisions (the author's pain point).
-        progress(change_id, "deep", {"verdict": verdict})   # worker is running Phase 2
-        max_rounds = _max_review_rounds()
-        deep_spawn = dispatch(build_deep_review_task(link), timeout)
-        deep_rec = results.read_result(change_id, root)
-        rec["phase2_ran"] = True
-        rec["deep_spawn_ok"] = deep_spawn.get("ok", False)
-        rec["deep_error"] = deep_spawn.get("error", "")
-        rec["deep_reviewed"] = bool((deep_rec or {}).get("deep_reviewed"))
-        rec["result_recorded"] = deep_rec is not None
-        rounds = 1
-        if deep_spawn.get("ok", False):
-            # Confirmatory follow-up rounds: each appends only NET-NEW findings.
-            # Stop as soon as a round grows the finding set by nothing (converged),
-            # or when the round cap is reached.
-            prev_count = len((deep_rec or {}).get("findings") or [])
-            while rounds < max_rounds:
-                followup = dispatch(build_deep_followup_task(link), timeout)
-                if not followup.get("ok", False):
-                    break   # a failed follow-up never discards the findings we have
-                rounds += 1
-                deep_rec = results.read_result(change_id, root)
-                cur_count = len((deep_rec or {}).get("findings") or [])
-                if cur_count <= prev_count:
-                    break   # converged: this round surfaced nothing new
-                prev_count = cur_count
-        rec["deep_rounds"] = rounds
-        if not deep_spawn.get("ok", False):
-            progress(change_id, "failed", {"error": deep_spawn.get("error", "deep review failed")})
-        else:
-            counts = (deep_rec or {}).get("counts") or {}
-            red, yellow = counts.get("red", 0), counts.get("yellow", 0)
-            # Deep review only RECORDS findings. The driver now builds the
-            # Python-redacted comment bodies (the surviving 🔴/🟡 findings plus the
-            # always-on ship-readiness comment) and a verbatim poster publishes them
-            # — so no LLM free-text reaches the CR (security-controls).
-            post = _post_pending(change_id, link)
-            posted = post["posted_comments"]
-            expected = red + yellow + 1   # inline findings + the always-on ship-readiness comment
-            rec["posted_comments"] = posted
-            rec["posting_expected"] = expected
-            rec["post_ok"] = post["post_ok"]
-            rec["design_comment_posted"] = post["design_comment_posted"]
-            progress(change_id, "done", {
-                "counts": {"red": red, "yellow": yellow},
-                "design_block": rec.get("design_block", False),
-                "posted": posted, "expected": expected,
-            })
+        # --- Bounded coverage backstop: AT MOST ONE targeted follow-up, and only
+        # when the review self-reported incomplete file coverage. This replaces the
+        # blanket 3-round convergence loop with a single, signal-driven pass; a
+        # failed follow-up keeps whatever the first pass recorded.
+        if (rev_rec or {}).get("coverage_complete") is False:
+            progress(change_id, "reviewing", {"coverage": "followup"})
+            followup = dispatch(build_review_followup_task(link), timeout)
+            if followup.get("ok", False):
+                rev_rec = results.read_result(change_id, root) or rev_rec
+                rec["deep_rounds"] = 2
+                rec["deep_reviewed"] = bool((rev_rec or {}).get("deep_reviewed"))
+
+        counts = (rev_rec or {}).get("counts") or {}
+        red, yellow = counts.get("red", 0), counts.get("yellow", 0)
+        # The review only RECORDS findings; the driver builds the Python-redacted
+        # comment bodies and a separate poster publishes them verbatim — no LLM
+        # free-text reaches the CR (security control, unchanged).
+        post = _post_pending(change_id, link)
+        posted = post["posted_comments"]
+        expected = red + yellow + 1   # inline findings + the always-on ship-readiness comment
+        rec["posted_comments"] = posted
+        rec["posting_expected"] = expected
+        rec["post_ok"] = post["post_ok"]
+        rec["design_comment_posted"] = post["design_comment_posted"]
+        progress(change_id, "done", {
+            "counts": {"red": red, "yellow": yellow},
+            "design_block": rec.get("design_block", False),
+            "posted": posted, "expected": expected,
+        })
         return rec
 
     with ThreadPoolExecutor(max_workers=concurrency) as pool:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
@@ -93,7 +93,11 @@ def _is_abnormal_stop(reason: str) -> bool:
 MAX_CONCURRENT = 5        # default max reviews running at once (config: review.max_concurrent)
 MAX_CONCURRENT_CEIL = 30  # hard ceiling — "review all" can raise concurrency up to here
 MAX_STARTING = 2          # (legacy) retained for back-compat stats; single runtime has no cold-start throttle
-DEFAULT_TASK_TIMEOUT = 1800.0   # seconds per review task (gate or deep)
+DEFAULT_TASK_TIMEOUT = 5400.0   # 90 min per review turn. The single-pass review
+#   is ONE heavier turn (design + all code dimensions) that replaces up to 5 old
+#   turns, so the old 30-min cap force-killed legitimately-working large-PR reviews
+#   (stop_reason='timeout'). 90 min gives real headroom while staying well under the
+#   runtime's 2h (_DEFAULT_PROMPT_TIMEOUT) default that chat/subagent turns use.
 REVIEW_AGENT = "code-review-sage-reviewer"  # dedicated lean reviewer agent (shell-
 #   enabled so it can run the `gh` CLI to fetch/post GitHub PR reviews). The per-task
 #   prompt loads the `sage-review` skill on top of it.

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -63,9 +63,6 @@ DEFAULT_CONFIG: dict[str, object] = {
         "model": None,         # None = inherit the system/agent default model
         "effort": "",          # "" = inherit the model/provider default effort
         "active_namespaces": ["default"],  # which namespaces to load during review
-        "max_review_rounds": 3,  # Phase-2 convergence rounds per change; re-review
-                                 # until a round adds no new findings or this cap is
-                                 # hit. Maximizes first-pass recall (>=1).
         "max_concurrent": 5,     # max reviews running at once on the shared runtime
                                  # (clamped to [1, 30]); "review all" can raise it.
     },

--- a/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: sage-review
-description: Deep, platform-neutral code review for PRs and CRs. Phase 1 design gate (Problem Worth Solving & Solution Fit) then 9 code-level dimensions with chain-of-consequences, self-critique, and draft-only comments. The single app-owned source of truth.
+description: Deep, platform-neutral code review for PRs and CRs in ONE thorough single pass — design reasoning (Problem Worth Solving & Solution Fit) as one dimension alongside the 9 code-level dimensions, with chain-of-consequences, self-critique, and draft-only comments. The single app-owned source of truth.
 version: 1.0.0
-tags: [code-review, security, quality, design-gate, platform-neutral]
+tags: [code-review, security, quality, design, platform-neutral]
 ---
 
 # Code Review Sage — Review Ruleset
@@ -63,11 +63,12 @@ the finding.
 
 ---
 
-## Phase 1 — Design gate: Problem Worth Solving & Solution Fit
+## Design dimension — Problem Worth Solving & Solution Fit
 
-Runs **before** any code-level dimension and acts as a **gate** (a bad design
-short-circuits the review). The senior-engineer "should we even build this, and
-is this the best way?" lens. Answer each with a consequence chain:
+Reviewed **together with** the code dimensions in the SAME single pass — it is
+**one dimension** of the review, not a gate that runs before or short-circuits
+the code review. The senior-engineer "should we even build this, and is this the
+best way?" lens. Answer each with a consequence chain:
 
 - **What is the problem?** One sentence, from the user's/system's perspective.
 - **Does it matter, and to whom?** Who is hurt, how often, how badly? If the
@@ -81,11 +82,11 @@ is this the best way?" lens. Answer each with a consequence chain:
   high-stakes — impact, not size, is the signal. Blast radius governs **how
   deeply to review** (it raises `criticality`), NOT **whether** to review: a
   large or high-impact blast radius is **never, on its own, a `BLOCK`** — it
-  means proceed to Phase 2 with *more* scrutiny.
+  means review the code dimensions with *more* scrutiny.
 
 ### Deep design reasoning (think hard — this is the highest-leverage step)
 
-The design gate is **unified with the design review**: there is no separate
+The design dimension is **unified with the design review**: there is no separate
 "deep dive" stage — *this is it*. A design defect costs far more than any
 line-level bug and is the hardest to see, so reason **deliberately and deeply**
 here. Do not pattern-match a verdict. Spend real thinking budget (these workers
@@ -102,7 +103,7 @@ its own consequence chain, and only then settle on a verdict.
   public contracts, APIs, schemas, or persisted data *safely*? Is there a
   migration / compatibility story for existing callers and existing data? A
   design that silently breaks or strands either is a defect (this is the
-  design-level twin of the Phase-2 backward-compat check).
+  design-level twin of the code-level backward-compat check).
 - **Alternatives & proportionality.** Name the 1–2 strongest alternative
   designs and say why this one wins. Is the solution proportionate to the
   problem, or over-/under-engineered? "No alternative considered" on a
@@ -155,29 +156,34 @@ treat any divergence as a finding:
 
 ### Gate verdict
 
+The `gate_verdict` field is **still recorded** (the result schema requires it),
+but it is a **design assessment, not a Python gate**: a `BLOCK` is emitted as a
+🔴 design finding and `CONCERNS` as a 🟡. It never skips or short-circuits the
+code review — the review continues across ALL code dimensions in the SAME pass.
+
 | Verdict | Meaning | Effect |
 |---------|---------|--------|
-| `PASS` | Real problem, sound and proportionate solution | Proceed to Phase 2 |
-| `CONCERNS` | Acceptable but notable design risk | Record findings, still proceed to Phase 2 |
-| `BLOCK` | No real problem, wrong/over-engineered fix, or better alternative ignored | Record the design finding; **still proceed to Phase 2**. Marks the change not-ready-to-ship, but never skips the code review |
+| `PASS` | Real problem, sound and proportionate solution | No design finding; the review continues across all code dimensions in the same pass |
+| `CONCERNS` | Acceptable but notable design risk | Recorded as a 🟡 design finding; the review continues across all code dimensions in the same pass |
+| `BLOCK` | No real problem, wrong/over-engineered fix, or better alternative ignored | Recorded as a 🔴 not-ready-to-ship design finding; the review continues across all code dimensions in the same pass |
 
 **`BLOCK` is reserved for a genuine *design* defect** — the change solves no real
 problem, applies the wrong or over-engineered fix, ignores a clearly better
 alternative, or (for a posture-bearing change) has a missing/unreviewed design
 chain. A large blast radius, high `criticality`, or high `design_risk` is **NOT**
-a design defect on its own: it *raises review depth* (more thorough Phase 2), it
-never short-circuits the review. In fact a `BLOCK` **no longer skips Phase 2 at
-all** — it flags the design as not-ready-to-ship while the full code review still
-runs, so the author gets design + code feedback in one pass. When torn between
-`BLOCK` and `CONCERNS`, choose **`CONCERNS`**; reserve `BLOCK` for a design that is
-genuinely wrong.
+a design defect on its own: it *raises review depth* (more thorough code review),
+it never short-circuits the review. A `BLOCK` is recorded as a 🔴 design finding
+that flags the change not-ready-to-ship while the full code review still runs in
+the same pass, so the author gets design + code feedback together. When torn
+between `BLOCK` and `CONCERNS`, choose **`CONCERNS`**; reserve `BLOCK` for a
+design that is genuinely wrong.
 
-**Outputs of Phase 1** — capture the design reasoning as an explicit **chain of
-thought**, not one dense paragraph:
+**Outputs of the design dimension** — capture the design reasoning as an explicit
+**chain of thought**, not one dense paragraph:
 - `gate_verdict` ∈ {PASS, CONCERNS, BLOCK}
 - `design_risk` ∈ {low, medium, high}
 - `criticality` ∈ {critical, medium, low} — an a-priori review-depth tier from
-  design-risk × blast radius. Drives which changes get the Phase 2 deep review
+  design-risk × blast radius. Drives how deeply the code dimensions are reviewed
   (the curate/select step picks tiers); it is not only about blocking.
 - `problem` — the customer/system problem in **one sentence** (the user's lens).
 - `why_it_matters` — who is hurt, how often, how badly. If you can't name a real
@@ -187,17 +193,17 @@ thought**, not one dense paragraph:
   effects / sub-optimal tradeoffs**? State it as a consequence chain
   (*cause → mechanism → consequence*). This is where the design-risk verdict is
   justified.
-- `rationale` — *(optional)* a one-line synthesis tying the three together.
+- `design_headline` — *(optional)* a one-line synthesis tying the three together.
 
 ---
 
-## Phase 2 — The 9 code-level dimensions
+## The 9 code-level dimensions
 
-Run on every usable verdict — `PASS`, `CONCERNS`, AND `BLOCK`. A design `BLOCK`
-informs the ship decision but never skips this code review: the author wants all
-issues surfaced in one pass. For each added/modified line (skip deleted lines),
-evaluate against every dimension. Each finding gets a dimension, a severity, and
-a consequence chain.
+Reviewed in the SAME single pass as the design dimension — not a separate phase.
+A design `BLOCK` informs the ship decision but never skips this code review: the
+author wants all issues surfaced in one pass. For each added/modified line (skip
+deleted lines), evaluate against every dimension. Each finding gets a dimension,
+a severity, and a consequence chain.
 
 ### Coverage mandate — review EVERY change (first-pass completeness)
 
@@ -216,9 +222,17 @@ Prevent it — be **exhaustive, not representative**:
    and finish — do not emit until every changed hunk is covered.
 
 Aim to surface the COMPLETE set of findings in THIS pass. A finding that a later
-revision would expose should have been caught here. (The driver also re-runs this
-review in a bounded convergence loop until a round adds nothing new, but that is a
-safety net — your single pass should already be exhaustive.)
+revision would expose should have been caught here.
+
+**Emit a machine coverage signal** into the result record so the driver can
+verify first-pass completeness deterministically:
+
+- `files_covered` — the list of changed file PATHS you actually reviewed against
+  all dimensions in this pass.
+- `coverage_complete` — `true` ONLY if `files_covered` covers **every** changed
+  file in the diff. If it is `false` (you could not cover every file in this
+  pass), the driver runs **ONE targeted follow-up** on the remaining files — so
+  be honest about what you did and did not cover.
 
 1. **Correctness & regression** — logic errors, edge cases, null/empty handling,
    off-by-one, behavior changed on a path the description didn't mention. Did
@@ -264,8 +278,8 @@ safety net — your single pass should already be exhaustive.)
    listeners/handles, sync work on hot paths.
 
 5. **Scope & description fidelity** — scope creep (3+ unrelated concerns in one
-   change SHOULD be split); description accuracy (covered in Phase 1, re-checked
-   against the actual diff here).
+   change SHOULD be split); description accuracy (assessed in the design
+   dimension, re-checked against the actual diff here).
 
 6. **Cross-change conflict** — does another open change touch the same files or
    ship an overlapping feature? Flag merge-order/duplication risk. (Dedup against
@@ -419,7 +433,7 @@ the durable source of truth the Focus Report reads. **Findings JSON contract**
     "problem": "one-sentence customer/system problem",
     "why_it_matters": "who is hurt, how often/badly",
     "solution_assessment": "resolves? optimal/proportionate? side effects? — cause → mechanism → consequence",
-    "rationale": "optional one-line synthesis"
+    "design_headline": "optional one-line synthesis"
   },
   "blast_radius": {
     "rating": "SMALL | MEDIUM | LARGE",
@@ -427,6 +441,8 @@ the durable source of truth the Focus Report reads. **Findings JSON contract**
                 "guard_removals": 0, "import_fanout": 0}
   },
   "deep_reviewed": true,
+  "files_covered": ["path/to/file/a", "path/to/file/b"],
+  "coverage_complete": true,
   "findings": [
     {"dimension": "security",
      "severity": "red | yellow",
@@ -447,10 +463,14 @@ the durable source of truth the Focus Report reads. **Findings JSON contract**
 
 > Use the `change_id` emitted by `python3 sage_lib/pipeline.py prepare` **verbatim** — do NOT invent or reformat it (it must match the driver's `_cid`, or the record write and read hit different files).
 
-A gate-only record (the gate ran but Phase 2 hasn't executed yet, or the gate
-could not produce a usable verdict) carries just the `phase1` + `blast_radius`
-fields with `deep_reviewed: false`. A `BLOCK` verdict is NOT gate-only — it now
-gets the full Phase 2 review like any other usable verdict.
+**One record, written in one pass.** Every review writes exactly ONE record with
+`deep_reviewed: true` and a fully populated `phase1` block (design dimension) —
+there is no "gate-only" record and no design-vs-code split. Two coverage fields
+make first-pass completeness machine-checkable:
+- `files_covered` — array of changed file paths you reviewed against all
+  dimensions in this pass.
+- `coverage_complete` — `true` only if `files_covered` covers every changed file;
+  `false` triggers the driver's ONE targeted follow-up on the remaining files.
 
 ---
 
@@ -472,9 +492,8 @@ orchestration.
 ```
 - [ ] Self-heal store; load common + repo learned patterns
 - [ ] Resolve per-repo rule pack (if any) and read it as additional rules
-- [ ] Phase 1 design gate → verdict + design_risk + criticality + rationale
-- [ ] Phase 2 ALWAYS runs (PASS / CONCERNS / BLOCK) → 9 dimensions, chain-of-consequences findings
-- [ ] Coverage self-check: every changed hunk reviewed against all 9 dimensions (go back if any uncovered)
+- [ ] ONE thorough pass: design dimension (verdict + design_risk + criticality + design_headline) AND the 9 code dimensions together → chain-of-consequences findings
+- [ ] Coverage self-check: every changed hunk reviewed against all dimensions; emit files_covered + coverage_complete (driver runs ONE targeted follow-up if incomplete)
 - [ ] Self-critique (Filter / Merge / Sharpen / Stabilize)
 - [ ] Post surviving findings as DRAFT comments (publish=false), each quoting the snippet
 - [ ] If the change is a fix, run INLINE miss-analysis (learn-from-sage) → STAGE the learning into the candidate file

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -23,10 +23,14 @@ class TestReviewDriver(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _fake_dispatch(self, verdict="PASS", write_records=True, max_seen=None):
-        """A dispatch fn that mimics two kinds of isolated worker session:
-        - a GATE session writes a gate-only record carrying ``verdict``;
-        - a DEEP session augments that record (deep_reviewed=true + a finding).
+    def _fake_dispatch(self, verdict="PASS", write_records=True, max_seen=None,
+                       coverage_complete=True):
+        """A dispatch fn modeling the SINGLE-PASS reviewer:
+        - a REVIEW session writes the COMPLETE record in one turn (phase1 verdict +
+          one finding + counts + deep_reviewed=true + the coverage signal);
+        - a POSTER session publishes the driver-built pending comments;
+        - a COVERAGE FOLLOW-UP session (dispatched only when the first pass set
+          coverage_complete=false) marks coverage complete.
         The pool's send() returns when the worker's turn ends; this fake models
         that by writing the record and returning synchronously.
         """
@@ -37,8 +41,8 @@ class TestReviewDriver(unittest.TestCase):
                 if max_seen is not None:
                     max_seen[0] = max(max_seen[0], self._concurrent)
             m = re.search(r"CR-\d+", task)
-            is_gate = "ONLY the Phase 1 design gate" in task
-            is_deep = "Phase 2 deep review" in task
+            is_review = "SINGLE thorough pass" in task
+            is_followup = "INCOMPLETE file coverage" in task
             is_poster = "pre-redacted DRAFT review comments" in task
             if write_records and m:
                 cid = m.group(0)
@@ -49,22 +53,23 @@ class TestReviewDriver(unittest.TestCase):
                     rec["design_comment_posted"] = any(
                         e.get("kind") == "design" for e in pending)
                     results.write_result(rec, self.root)
-                elif is_gate:
+                elif is_review:
                     results.write_result({
                         "schema": "code-review-sage-result", "version": 1, "change_id": cid,
                         "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
                         "phase1": {"gate_verdict": verdict, "design_risk": "low", "criticality": "low"},
                         "blast_radius": {"rating": "SMALL", "signals": {}},
-                        "counts": {"red": 0, "yellow": 0}, "findings": [],
-                        "deep_reviewed": False, "title": cid,
+                        "counts": {"red": 0, "yellow": 1},
+                        "findings": [{"dimension": "correctness", "severity": "yellow",
+                                      "file": "f", "line": 1, "snippet": "x",
+                                      "observation": "o", "consequence": "c", "suggestion": "s"}],
+                        "deep_reviewed": True, "title": cid,
+                        "files_covered": ["f"], "coverage_complete": coverage_complete,
                     }, self.root)
-                elif is_deep:
+                elif is_followup:
                     rec = results.read_result(cid, self.root) or {}
-                    rec["deep_reviewed"] = True   # RECORDS findings only; does NOT post
-                    rec["findings"] = [{"dimension": "correctness", "severity": "yellow",
-                                        "file": "f", "line": 1, "snippet": "x",
-                                        "observation": "o", "consequence": "c", "suggestion": "s"}]
-                    rec["counts"] = {"red": 0, "yellow": 1}
+                    rec["coverage_complete"] = True
+                    rec["deep_reviewed"] = True
                     results.write_result(rec, self.root)
             with self.lock:
                 self._concurrent -= 1
@@ -75,7 +80,7 @@ class TestReviewDriver(unittest.TestCase):
         self.archived.append(html)
         return "sage-report-test"
 
-    def test_gate_then_deep_for_passing_changes(self):
+    def test_single_pass_reviews_all_changes(self):
         out = D.run_review(["CR-1", "CR-2", "CR-3"], dispatch=self._fake_dispatch(verdict="PASS"),
                            archiver=self._archiver, root=self.root)
         self.assertEqual(out["changes"], 3)
@@ -83,9 +88,9 @@ class TestReviewDriver(unittest.TestCase):
         self.assertEqual(out["deep_spawns"], 3)
         self.assertEqual(out["deep_reviewed"], 3)
         self.assertEqual(out["design_blocked"], 0)
-        # gate + deep + 1 convergence follow-up (finds nothing new) + poster, per change
-        self.assertEqual(len(self.calls), 12)
-        self.assertEqual(out["deep_rounds"], 6)           # 2 rounds/change (round 1 + 1 confirm)
+        # ONE review pass + poster per change (coverage complete -> no follow-up)
+        self.assertEqual(len(self.calls), 6)
+        self.assertEqual(out["deep_rounds"], 3)           # one review pass per change
         self.assertEqual(out["report"]["total"], 3)
         # report archived as a per-run artifact, then records cleaned
         self.assertEqual(out["report_slug"], "sage-report-test")
@@ -120,13 +125,13 @@ class TestReviewDriver(unittest.TestCase):
         self.assertNotIn("results_cleaned", out)
         self.assertEqual(len(results.list_results(self.root)), 2)   # records preserved
 
-    def test_no_gate_verdict_skips_phase2(self):
-        # dispatch that does not write any record -> no usable verdict
+    def test_no_record_marks_failed(self):
+        # dispatch that completes but writes no record -> review produced nothing usable
         def no_record(task, timeout=0):
             return {"ok": True, "output": "", "error": ""}
         out = D.run_review(["CR-7"], dispatch=no_record, generate_report=False, root=self.root)
-        self.assertEqual(out["deep_spawns"], 0)
-        self.assertEqual(out["per_change"][0]["skipped_reason"], "no_gate_verdict")
+        self.assertEqual(out["deep_reviewed"], 0)
+        self.assertEqual(out["per_change"][0]["skipped_reason"], "no_review_recorded")
 
     def test_each_task_is_single_change(self):
         D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(), archiver=self._archiver,
@@ -141,39 +146,38 @@ class TestReviewDriver(unittest.TestCase):
                      concurrency=2, root=self.root)
         self.assertLessEqual(max_seen[0], 2)
 
-    def test_gate_spawn_failure_surfaced_and_skips_deep(self):
+    def test_review_failure_surfaced(self):
         def failing(task, timeout=0):
             return {"ok": False, "output": "", "error": "boom"}
         out = D.run_review(["CR-9"], dispatch=failing, generate_report=False, root=self.root)
         self.assertEqual(len(out["failures"]), 1)
-        self.assertEqual(out["deep_spawns"], 0)
-        self.assertEqual(out["per_change"][0]["skipped_reason"], "gate_spawn_failed")
+        self.assertEqual(out["deep_reviewed"], 0)
+        self.assertEqual(out["per_change"][0]["skipped_reason"], "review_failed")
 
     def test_empty_change_set(self):
         out = D.run_review([], dispatch=self._fake_dispatch(), root=self.root)
         self.assertFalse(out["ok"])
 
-    def test_gate_task_is_phase1_only(self):
-        task = D.build_gate_task("https://github.com/o/r/pull/7")
+    def test_review_task_covers_design_and_is_single_pass(self):
+        task = D.build_review_task("https://github.com/o/r/pull/7")
         self.assertIn("ISOLATED", task)
-        self.assertIn("ONLY the Phase 1 design gate", task)
-        self.assertIn("Do NOT run Phase 2", task)
+        self.assertIn("SINGLE thorough pass", task)
+        self.assertIn("DESIGN dimension", task)
         self.assertIn("spawn further subagents", task)
         self.assertIn("github.com/o/r/pull/7", task)
 
-    def test_deep_task_runs_phase2_and_inline_learning(self):
-        task = D.build_deep_review_task("CR-8")
+    def test_review_task_has_inline_learning(self):
+        task = D.build_review_task("CR-8")
         self.assertIn("ISOLATED", task)
-        self.assertIn("Phase 2 deep review", task)
         self.assertIn("INLINE miss-analysis", task)
         self.assertIn("is_fix", task)
         self.assertIn("Do NOT spawn further subagents", task)
         self.assertIn("CR-8", task)
 
-    def test_deep_task_keeps_code_reviewer_checks_first_class(self):
-        # Gap-closing: the code-reviewer's strong checks must be explicitly
-        # reinforced in the deep prompt, not just folded into the skill.
-        task = D.build_deep_review_task("CR-9")
+    def test_review_task_keeps_code_reviewer_checks_first_class(self):
+        # The code-reviewer's strong checks must be explicit in the single-pass
+        # prompt (the 9 dimensions + fidelity + security threat chain).
+        task = D.build_review_task("CR-9")
         self.assertIn("9 code-level dimensions", task)
         self.assertIn("description<->diff fidelity", task)
         self.assertIn("threat chain", task)
@@ -189,25 +193,25 @@ class TestReviewDriver(unittest.TestCase):
                      generate_report=False, root=self.root, progress=prog)
         phases = [p for (c, p) in seen if c == "CR-1"]
         self.assertEqual(phases[0], "queued")     # marked queued upfront
-        self.assertIn("gating", phases)           # Phase 1 in progress
-        self.assertIn("deep", phases)             # Phase 2 in progress
+        self.assertIn("reviewing", phases)        # single review pass in progress
         self.assertEqual(phases[-1], "done")      # terminal
 
-    def test_progress_block_now_runs_deep(self):
+    def test_progress_block_still_reviews(self):
         seen = []
 
         def prog(cid, phase, extra=None):
             seen.append(phase)
         D.run_review(["CR-2"], dispatch=self._fake_dispatch(verdict="BLOCK"),
                      generate_report=False, root=self.root, progress=prog)
-        self.assertIn("deep", seen)               # BLOCK now proceeds to Phase 2
-        self.assertNotIn("blocked", seen)         # no more design-block short-circuit
+        self.assertIn("reviewing", seen)          # BLOCK is still fully reviewed
+        self.assertNotIn("blocked", seen)         # no design-block short-circuit
+        self.assertNotIn("gating", seen)          # no gate phase
         self.assertEqual(seen[-1], "done")
 
-    def test_gate_task_blast_radius_never_blocks(self):
-        # The design gate must BLOCK only on genuine design defects — a large
+    def test_review_task_blast_radius_never_blocks(self):
+        # The design dimension must BLOCK only on genuine design defects — a large
         # blast radius alone is not a BLOCK (it raises review depth).
-        task = D.build_gate_task("CR-9")
+        task = D.build_review_task("CR-9")
         self.assertIn("BLOCK is ONLY for a genuine DESIGN defect", task)
         self.assertIn("NEVER on its own a BLOCK", task)
 
@@ -224,28 +228,27 @@ class TestReviewDriver(unittest.TestCase):
         self.assertEqual(out["per_change"][0]["posted_comments"], 2)
 
     def test_progress_done_flags_unposted_findings(self):
-        # A deep session that writes findings but posts nothing -> driver reports
-        # posted=0 with expected>0 so the UI can flag "findings not posted".
-        def deep_no_post(task, timeout=0):
+        # A review that records findings but whose poster posts nothing -> driver
+        # reports posted=0 with expected>0 so the UI can flag "findings not posted".
+        def review_no_post(task, timeout=0):
             m = re.search(r"CR-\d+", task)
             assert m is not None
             cid = m.group(0)
-            if "ONLY the Phase 1 design gate" in task:
+            if "SINGLE thorough pass" in task:
                 results.write_result({
                     "schema": "code-review-sage-result", "version": 1, "change_id": cid,
                     "platform": "github", "repo_identity": "x", "revision": "1",
                     "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
                     "blast_radius": {"rating": "SMALL", "signals": {}},
-                    "counts": {"red": 0, "yellow": 0}, "findings": [],
-                    "deep_reviewed": False, "title": cid,
+                    "counts": {"red": 1, "yellow": 0},
+                    "findings": [{"dimension": "correctness", "severity": "red",
+                                  "file": "f", "line": 1, "snippet": "x",
+                                  "observation": "o", "consequence": "c", "suggestion": "s"}],
+                    "deep_reviewed": True, "title": cid,
+                    "files_covered": ["f"], "coverage_complete": True,
                 }, self.root)
-            elif "Phase 2 deep review" in task:
+            elif "pre-redacted DRAFT review comments" in task:
                 rec = results.read_result(cid, self.root) or {}
-                rec["deep_reviewed"] = True
-                rec["findings"] = [{"dimension": "correctness", "severity": "red",
-                                    "file": "f", "line": 1, "snippet": "x",
-                                    "observation": "o", "consequence": "c", "suggestion": "s"}]
-                rec["counts"] = {"red": 1, "yellow": 0}
                 rec["posted_comments"] = 0   # nothing posted despite a finding
                 results.write_result(rec, self.root)
             return {"ok": True, "output": "", "error": ""}
@@ -255,7 +258,7 @@ class TestReviewDriver(unittest.TestCase):
         def prog(cid, phase, extra=None):
             if phase == "done":
                 seen[cid] = extra or {}
-        D.run_review(["CR-2"], dispatch=deep_no_post, generate_report=False,
+        D.run_review(["CR-2"], dispatch=review_no_post, generate_report=False,
                      root=self.root, progress=prog)
         self.assertEqual(seen["CR-2"]["posted"], 0)
         self.assertEqual(seen["CR-2"]["expected"], 2)     # red1 + 1 ship comment; UI flags mismatch
@@ -301,52 +304,21 @@ class TestReviewDriver(unittest.TestCase):
         self.assertEqual(D._resolve_concurrency(7), 7)
         self.assertEqual(D._resolve_concurrency(1), 1)
 
-    def _fake_dispatch_growing(self, rounds_findings):
-        """Dispatch where each deep / follow-up round sets the finding count to the
-        next value in ``rounds_findings``, modeling recall that grows across rounds
-        then converges. Gate writes a PASS record; deep + follow-up share the counter."""
-        state = {"round": 0}
-
-        def dispatch(task, timeout=0):
-            with self.lock:
-                self.calls.append(task)
-            m = re.search(r"CR-\d+", task)
-            assert m is not None
-            cid = m.group(0) if m else None
-            if cid and "ONLY the Phase 1 design gate" in task:
-                results.write_result({
-                    "schema": "code-review-sage-result", "version": 1, "change_id": cid,
-                    "platform": "github", "repo_identity": "x", "revision": "1",
-                    "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
-                    "blast_radius": {"rating": "SMALL", "signals": {}},
-                    "counts": {"red": 0, "yellow": 0}, "findings": [],
-                    "deep_reviewed": False, "title": cid,
-                }, self.root)
-            elif cid and ("Phase 2 deep review" in task or "FOLLOW-UP review round" in task):
-                total = rounds_findings[min(state["round"], len(rounds_findings) - 1)]
-                state["round"] += 1
-                rec = results.read_result(cid, self.root) or {}
-                rec["deep_reviewed"] = True
-                rec["findings"] = [{"dimension": "correctness", "severity": "yellow",
-                                    "file": "f", "line": i, "snippet": "x", "observation": "o",
-                                    "consequence": "c", "suggestion": "s"} for i in range(total)]
-                rec["counts"] = {"red": 0, "yellow": total}
-                results.write_result(rec, self.root)
-            return {"ok": True, "output": "", "error": ""}
-        return dispatch
-
-    def test_convergence_loop_stops_when_no_new_findings(self):
-        # round 1 finds 1, follow-up finds 1 (no growth) -> converged, stop at 2 rounds
-        # (well under the default cap of 3), so recall converges without wasted rounds.
-        disp = self._fake_dispatch_growing([1, 1])
+    def test_coverage_backstop_runs_one_followup(self):
+        # First pass reports incomplete coverage -> the driver runs EXACTLY ONE
+        # targeted follow-up (not a blanket loop), then posts. deep_rounds == 2.
+        disp = self._fake_dispatch(verdict="PASS", coverage_complete=False)
         out = D.run_review(["CR-1"], dispatch=disp, generate_report=False, root=self.root)
         self.assertEqual(out["per_change"][0]["deep_rounds"], 2)
+        self.assertEqual(len(self.calls), 3)   # review + one follow-up + poster
+        self.assertTrue(any("INCOMPLETE file coverage" in c for c in self.calls))
 
-    def test_convergence_loop_respects_round_cap(self):
-        # findings grow every round, but the cap (default 3) stops the loop.
-        disp = self._fake_dispatch_growing([1, 2, 3, 4, 5])
+    def test_coverage_complete_skips_followup(self):
+        disp = self._fake_dispatch(verdict="PASS", coverage_complete=True)
         out = D.run_review(["CR-1"], dispatch=disp, generate_report=False, root=self.root)
-        self.assertEqual(out["per_change"][0]["deep_rounds"], 3)
+        self.assertEqual(out["per_change"][0]["deep_rounds"], 1)
+        self.assertEqual(len(self.calls), 2)   # review + poster only
+        self.assertFalse(any("INCOMPLETE file coverage" in c for c in self.calls))
 
 
 class TestWorkerPromptScriptPaths(unittest.TestCase):
@@ -357,8 +329,8 @@ class TestWorkerPromptScriptPaths(unittest.TestCase):
 
     def test_prompts_reference_existing_script_paths(self):
         app_root = Path(__file__).resolve().parents[1]
-        prompts = [D.build_gate_task("CR-12345678"),
-                   D.build_deep_review_task("CR-12345678")]
+        prompts = [D.build_review_task("CR-12345678"),
+                   D.build_review_followup_task("CR-12345678")]
         refs = set()
         for p in prompts:
             refs.update(re.findall(r"python3 ([\w./-]+\.py)", p))
@@ -373,12 +345,12 @@ class TestDeterministicPosting(unittest.TestCase):
     never posts), the driver builds the Python-redacted bodies, and a separate
     poster publishes them verbatim — so no LLM free-text reaches the CR surface."""
 
-    def test_deep_prompt_records_only_and_never_posts(self):
-        p = D.build_deep_review_task("https://github.com/o/r/pull/12345678")
+    def test_review_prompt_records_only_and_never_posts(self):
+        p = D.build_review_task("https://github.com/o/r/pull/12345678")
         self.assertIn("RECORD ONLY", p)                  # writes findings, no posting
         self.assertIn("do NOT post", p)
         self.assertIn("MUST NOT call any comment tool", p)
-        self.assertNotIn("CRAddComment", p)              # deep worker never posts
+        self.assertNotIn("CRAddComment", p)              # reviewer never posts
 
     def test_post_task_posts_prebuilt_redacted_bodies_verbatim(self):
         p = D.build_post_task("https://github.com/o/r/pull/12345678")
@@ -414,16 +386,16 @@ class TestChangeIdAndFetch(unittest.TestCase):
         self.assertNotIn("/", cid)
         self.assertNotIn(":", cid)
 
-    def test_gate_prompt_github_fetch(self):
-        p = D.build_gate_task("https://github.com/o/r/pull/5")
+    def test_review_prompt_github_fetch(self):
+        p = D.build_review_task("https://github.com/o/r/pull/5")
         self.assertIn("gh api", p)
         self.assertIn("--payload-file", p)
         self.assertNotIn("ReadInternalWebsites", p)
 
-    def test_deep_and_followup_prompts_use_gh(self):
+    def test_review_and_followup_prompts_use_gh(self):
         gh = "https://github.com/o/r/pull/5"
-        self.assertIn("gh api", D.build_deep_review_task(gh))
-        self.assertIn("gh api", D.build_deep_followup_task(gh))
+        self.assertIn("gh api", D.build_review_task(gh))
+        self.assertIn("gh api", D.build_review_followup_task(gh))
 
 
 class TestGithubPosting(unittest.TestCase):
@@ -465,7 +437,7 @@ class TestGithubPosting(unittest.TestCase):
         cid = D._cid(link)   # GH-o-r-5
 
         def dispatch(task, timeout=0):
-            if "ONLY the Phase 1 design gate" in task:
+            if "SINGLE thorough pass" in task:
                 results.write_result({
                     "schema": "code-review-sage-result", "version": 1, "change_id": cid,
                     "platform": "github", "repo_identity": "github.com/o/r",
@@ -473,18 +445,14 @@ class TestGithubPosting(unittest.TestCase):
                     "phase1": {"gate_verdict": "PASS", "design_risk": "low",
                                "criticality": "low"},
                     "blast_radius": {"rating": "SMALL", "signals": {}},
-                    "counts": {"red": 0, "yellow": 0}, "findings": [],
-                    "deep_reviewed": False, "title": cid,
+                    "counts": {"red": 1, "yellow": 0},
+                    "findings": [{"dimension": "correctness", "severity": "red",
+                                  "file": "src/a.rs", "line": 5, "snippet": "x",
+                                  "observation": "o", "consequence": "c",
+                                  "suggestion": "s"}],
+                    "deep_reviewed": True, "title": cid,
+                    "files_covered": ["src/a.rs"], "coverage_complete": True,
                 }, self.root)
-            elif "Phase 2 deep review" in task or "FOLLOW-UP review round" in task:
-                rec = results.read_result(cid, self.root) or {}
-                rec["deep_reviewed"] = True
-                rec["findings"] = [{"dimension": "correctness", "severity": "red",
-                                    "file": "src/a.rs", "line": 5, "snippet": "x",
-                                    "observation": "o", "consequence": "c",
-                                    "suggestion": "s"}]
-                rec["counts"] = {"red": 1, "yellow": 0}
-                results.write_result(rec, self.root)
             elif "pre-redacted DRAFT review comments" in task:
                 rec = results.read_result(cid, self.root) or {}
                 pay = rec.get("github_review_payload") or {}

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_guidance.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_guidance.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from sage_lib.review_driver import build_gate_task  # noqa: E402
+from sage_lib.review_driver import build_review_task  # noqa: E402
 
 _SKILL = (Path(__file__).resolve().parents[1]
           / "skills" / "sage-review" / "SKILL.md")
@@ -76,7 +76,7 @@ class TestGateTaskPromptCarriesDesignLenses(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.prompt = build_gate_task("CR-12345678")
+        cls.prompt = build_review_task("CR-12345678")
 
     def test_prompt_instructs_deep_thinking(self):
         self.assertIn("THINK DEEPLY", self.prompt)


### PR DESCRIPTION
## Problem
A batch Code Review Sage run failed on ~7/10 PRs. Reviews on large PRs died mid-generation while equivalent chat sessions on the same shared runtime succeeded.

## Why it matters
Silent, high-rate review failures make the app untrustworthy for repo-wide runs — users can't tell a "clean" PR from one whose review simply timed out, and re-running wastes compute.

## Fix (symptom → root cause → change)
- **Symptom:** reviews time out / fail on big PRs; chat sessions don't.
- **Root cause:** the per-review hard timeout (`DEFAULT_TASK_TIMEOUT = 1800s` / 30 min) was unique to review sessions (chat gets 7200s) and too tight for large diffs. The old **5-turn-per-PR** flow (gate stage → up to 3 deep rounds → post) amplified the exposure. It was **not** shared-runtime contention.
- **Change:**
  - Collapse the flow into a **single thorough review pass**: design is now **one dimension** of the single review rather than a separate gate stage; an **optional coverage-signal follow-up** backstops completeness; then the post step. This drops each PR from ~5 turns to **2-3**.
  - Raise `DEFAULT_TASK_TIMEOUT` **1800s → 5400s** (90 min), the governing ceiling for `handle.prompt`.
  - Remove the now-dead multi-round builders and the `max_review_rounds` store config.
  - `review_pool.py` adjusted for the single-pass contract.
  - `sage-review/SKILL.md` rewritten: design-as-dimension, the 9 code dimensions, and the coverage signal.

## Tests
`test_review_driver.py` rewritten for the single-pass model (build_review_task → optional coverage follow-up → build_post_task) plus coverage-backstop cases; `test_review_guidance.py` intent-guard assertions updated (THINK DEEPLY / design lenses / BLOCK semantics). Full suite: **245 passed**, mypy + isort clean locally.

## Manual verification
N/A for live batch behavior in this PR — unit coverage exercises the driver flow, timeout wiring, and coverage backstop. A real repo-wide batch run against large PRs is the recommended post-merge smoke test to confirm the timeout/turn reduction resolves the field failures.
