### PR TITLE
fix(tips): sentence-safe truncation, markdown body, doc link, easy opt-out

### DIFF
--- a/scripts/generate_tips_catalog.py
+++ b/scripts/generate_tips_catalog.py
@@ -25,6 +25,7 @@ _DOCS_DIR = _REPO_ROOT / "src" / "kiro_crew" / "docs"
 # tips_allowlist is dependency-free, so importing it never pulls the runtime.
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST  # noqa: E402
+from kiro_crew.tips_text import truncate_summary  # noqa: E402
 
 
 def _get_git_mtime(filepath: Path) -> float:
@@ -82,7 +83,7 @@ def _scan_docs_catalog() -> list[dict]:
         entries.append({
             "feature": title,
             "title": title,
-            "summary": para[:300],
+            "summary": truncate_summary(para),
             "doc": md.name,
             "mtime": mtime,
         })

--- a/src/kiro_crew/data/tips_catalog.json
+++ b/src/kiro_crew/data/tips_catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-21T06:17:55.194009+00:00",
+  "generated_at": "2026-07-22T12:59:41.704579+00:00",
   "entries": [
     {
       "feature": "Agents & Configuration",
@@ -27,7 +27,7 @@
       "title": "Web Dashboard",
       "summary": "The dashboard is a React SPA at `http://localhost:5476` (or your configured URL). It provides chat, memory management, cron jobs, skills, agents, and system monitoring.",
       "doc": "dashboard.md",
-      "mtime": 1784265640.0
+      "mtime": 1784650591.0
     },
     {
       "feature": "Artifact Deploy (deploy-web)",
@@ -37,18 +37,25 @@
       "mtime": 1784517233.0
     },
     {
+      "feature": "Discord Integration",
+      "title": "Discord Integration",
+      "summary": "Talk to your agent from Discord DMs. The channel connects outbound over Discord's Gateway WebSocket, so it works behind NAT and firewalls with no webhook or public address.",
+      "doc": "discord-integration.md",
+      "mtime": 1784663052.0
+    },
+    {
       "feature": "Dynamic Sub-Agent Max Count",
       "title": "Dynamic Sub-Agent Max Count",
-      "summary": "KiroCrew sizes the concurrent sub-agent cap **automatically** by default (`agent.max_subagents = 0`): at gateway startup it computes a sensible cap from the host's actual memory and CPU, plus a per-agent cost KiroCrew *learns* from past runs. A fixed number is wrong in both directions \u2014 it wastes ca",
+      "summary": "KiroCrew sizes the concurrent sub-agent cap **automatically** by default (`agent.max_subagents = 0`): at gateway startup it computes a sensible cap from the host's actual memory and CPU, plus a per-agent cost KiroCrew *learns* from past runs.",
       "doc": "dynamic-subagent-sizing.md",
-      "mtime": 1784265640.0
+      "mtime": 1784706744.0
     },
     {
       "feature": "Feature Tips",
       "title": "Feature Tips",
       "summary": "KiroCrew occasionally surfaces a small tip above the chat composer while the agent is working, pointing at a feature you have not used yet. Tips are personalized: a background session reads your recent activity and memory context to pick features that fit how you actually work.",
       "doc": "feature-tips.md",
-      "mtime": 1784614606.3223891
+      "mtime": 1784615857.0
     },
     {
       "feature": "Getting Started with KiroCrew",
@@ -74,7 +81,7 @@
     {
       "feature": "Research Lab",
       "title": "Research Lab",
-      "summary": "Research Lab (the `auto-research` builtin app) runs autonomous, multi-cycle campaigns: you define a research question, a **grill tree** interactively clarifies scope and sub-questions, then the system investigates cycle-by-cycle until it satisfies a success criterion or exhausts its cycle budget. Ea",
+      "summary": "Research Lab (the `auto-research` builtin app) runs autonomous, multi-cycle campaigns: you define a research question, a **grill tree** interactively clarifies scope and sub-questions, then the system investigates cycle-by-cycle until it satisfies a success criterion or exhausts its cycle budget.",
       "doc": "research-lab.md",
       "mtime": 1784265640.0
     },

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -28,6 +28,7 @@ from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, E
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
+from kiro_crew.tips_text import truncate_summary
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import DashboardState
@@ -139,7 +140,7 @@ def _scan_docs_catalog() -> list[CatalogEntry]:
                 break
         if not para:
             continue
-        entries.append(CatalogEntry(feature=title, summary=para[:300], doc=md.name, mtime=mtime))
+        entries.append(CatalogEntry(feature=title, summary=truncate_summary(para), doc=md.name, mtime=mtime))
     return entries
 
 
@@ -347,7 +348,7 @@ def _load_bundled_catalog() -> list[CatalogEntry] | None:
                     mtime = 0.0
                 if not math.isfinite(mtime):
                     mtime = 0.0
-                entries.append(CatalogEntry(feature=feature, summary=summary[:300], doc=doc, mtime=mtime))
+                entries.append(CatalogEntry(feature=feature, summary=truncate_summary(summary), doc=doc, mtime=mtime))
         return entries if entries else None
     except (OSError, ValueError, TypeError, AttributeError, OverflowError):
         # ValueError covers json.JSONDecodeError; the rest are defense-in-depth

--- a/src/kiro_crew/tips_text.py
+++ b/src/kiro_crew/tips_text.py
@@ -1,0 +1,48 @@
+"""Dependency-free text helpers shared by the tips runtime (``kiro_crew.tips``)
+and the release-time catalog generator (``scripts/generate_tips_catalog.py``).
+
+Kept import-light on purpose: the generator script runs outside the installed
+package (``sys.path`` insert) and must not pull the aiohttp runtime.
+"""
+
+from __future__ import annotations
+
+# Cap for catalog summaries (user-visible tip bodies in the fallback path).
+SUMMARY_MAX_CHARS = 300
+
+_SENTENCE_ENDINGS = (". ", "! ", "? ")
+
+
+def truncate_summary(text: str, limit: int = SUMMARY_MAX_CHARS) -> str:
+    """Truncate *text* to at most *limit* chars without cutting mid-word.
+
+    A plain ``text[:limit]`` slice chops mid-word ("… its cycle budget. Ea"),
+    and the fallback tips path serves that string verbatim to the user.
+    Instead:
+
+    1. If the text already fits, return it unchanged.
+    2. Prefer cutting after the last complete sentence that fits.
+    3. Otherwise cut at the last word boundary and append an ellipsis.
+    """
+    if len(text) <= limit:
+        return text
+    # Look one char past the limit so a sentence ending exactly at the edge
+    # (period at index limit-1, space at index limit) still counts as a hit.
+    window = text[: limit + 1]
+    best = -1
+    for sep in _SENTENCE_ENDINGS:
+        idx = window.rfind(sep)
+        if idx > best:
+            best = idx
+    if best != -1:
+        return window[: best + 1]
+    # No full sentence fits: cut the partial last word, append an ellipsis.
+    window = text[:limit]
+    if " " in window:
+        words = window.rsplit(" ", 1)[0].rstrip()
+    else:
+        # Single unbroken token longer than the limit: hard cut is all we have.
+        words = window[: limit - 1]
+    if not words:
+        words = window[: limit - 1]
+    return words + "\u2026"

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -25,6 +25,7 @@ from kiro_crew.tips import (
     _select_tip,
     _validate_tip_fields,
 )
+from kiro_crew.tips_text import truncate_summary
 
 
 class TestCatalogParsing:
@@ -1311,3 +1312,57 @@ class TestOptOutState:
         ok = isinstance(tip_id, str) and isinstance(action, str) and len(tip_id) <= 100
         assert ok is True
         assert action in ("ack", "dismiss", "snooze", "helpful", "optout", "optin")
+
+
+class TestTruncateSummary:
+    """Sentence-safe truncation (kiro_crew.tips_text.truncate_summary)."""
+
+    def test_short_text_unchanged(self) -> None:
+        assert truncate_summary("A short summary.") == "A short summary."
+
+    def test_exact_limit_unchanged(self) -> None:
+        text = "x" * 300
+        assert truncate_summary(text) == text
+
+    def test_cuts_at_sentence_boundary(self) -> None:
+        first = "First sentence ends here."
+        text = first + " " + "Second sentence that pushes the total well past the limit " * 10
+        result = truncate_summary(text, limit=60)
+        assert result == first
+
+    def test_sentence_ending_exactly_at_limit_kept(self) -> None:
+        # Period at index limit-1, space at index limit: the full sentence fits.
+        first = "A" * 58 + "."
+        text = first + " trailing words beyond the limit"
+        assert truncate_summary(text, limit=59) == first
+
+    def test_word_boundary_fallback_appends_ellipsis(self) -> None:
+        text = "no sentence punctuation here just many words " * 5
+        result = truncate_summary(text, limit=60)
+        assert len(result) <= 61
+        assert result.endswith("\u2026")
+        # Never a mid-word cut: everything before the ellipsis is whole words.
+        assert text.startswith(result[:-1])
+        assert text[len(result) - 1] == " "
+
+    def test_never_cuts_mid_word_like_old_slice(self) -> None:
+        """Regression: the old text[:300] slice produced '... cycle budget. Ea'."""
+        text = (
+            "Research Lab runs autonomous campaigns until it satisfies a success "
+            "criterion or exhausts its cycle budget. Each cycle produces a report."
+        )
+        result = truncate_summary(text, limit=110)
+        assert result == (
+            "Research Lab runs autonomous campaigns until it satisfies a success "
+            "criterion or exhausts its cycle budget."
+        )
+
+    def test_single_unbroken_token_hard_cut(self) -> None:
+        text = "a" * 400
+        result = truncate_summary(text, limit=50)
+        assert len(result) == 50
+        assert result.endswith("\u2026")
+
+    def test_bang_and_question_boundaries(self) -> None:
+        assert truncate_summary("Stop! Then more words follow here.", limit=10) == "Stop!"
+        assert truncate_summary("Why? Then more words follow here.", limit=10) == "Why?"

--- a/website/src/components/TipCard.tsx
+++ b/website/src/components/TipCard.tsx
@@ -1,9 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Lightbulb, X } from 'lucide-react'
+import { ExternalLink, Lightbulb, Settings, X } from 'lucide-react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
 import { api } from '../api/client'
 import { safeGetItem, safeSetItem } from '../utils/safeStorage'
+import MarkdownRenderer from './MarkdownRenderer'
+
+// The Feature Tips toggle lives in Settings → Chat.
+export const TIPS_SETTINGS_PATH = '/settings?tab=chat'
+
+// Tip docs live in the repo at src/kiro_crew/docs/ (same base the Security and
+// Discord settings panels link to).
+const DOCS_BASE = 'https://github.com/kirodotdev/KiroCrew/blob/main/src/kiro_crew/docs'
+// Tips can be LLM-generated: only link a doc value shaped like a plain
+// markdown filename so an invented value can't produce a weird URL.
+const DOC_FILENAME_RE = /^[a-z0-9][a-z0-9._-]*\.md$/i
+
+export function tipDocHref(doc: string | undefined): string | null {
+  if (!doc || !DOC_FILENAME_RE.test(doc)) return null
+  return `${DOCS_BASE}/${doc}`
+}
 
 export interface Tip {
   id: string
@@ -36,7 +53,25 @@ export function TipCard({ tip, onDismiss }: TipCardProps) {
     feedbackMutation.mutate({ id: tip.id, action: 'dismiss' })
   }, [tip.id, feedbackMutation])
 
+  // Permanent opt-out (same action the Settings → Chat toggle uses). The
+  // backend accepts an empty id for optout; on success the toggle's cached
+  // status is refreshed so Settings reflects the change immediately.
+  const optOutMutation = useMutation({
+    mutationFn: () => api.tipsFeedback('', 'optout'),
+    onSuccess: () => {
+      queryClient.setQueryData(['tips-next'], null)
+      queryClient.invalidateQueries({ queryKey: ['tipsStatus'] })
+      onDismiss()
+    },
+  })
+
+  const handleOptOut = useCallback(() => {
+    if (optOutMutation.isPending) return
+    optOutMutation.mutate()
+  }, [optOutMutation])
+
   const tooltipText = tip.why ? `${tip.title} — ${tip.why}` : tip.title
+  const docHref = tipDocHref(tip.doc)
 
   return (
     <motion.div
@@ -55,15 +90,57 @@ export function TipCard({ tip, onDismiss }: TipCardProps) {
     >
       <Lightbulb size={14} className="shrink-0 mt-0.5" aria-hidden="true" style={{ color: 'var(--accent)' }} />
 
-      <span className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1">
         <span className="block font-medium text-[12px] leading-tight" style={{ color: 'var(--text)' }}>{tip.title}</span>
         {/* Full multi-line body — no truncation (maintainer feedback: "it can
             be multiple lines, don't cut off"). A viewport-relative max-height
             with scroll (Codex round-23) keeps a very long body from pushing
             the bottom-anchored card past the viewport on narrow screens —
-            every character stays reachable, nothing is clipped away. */}
-        <span className="block text-[12px] leading-snug mt-0.5 break-words overflow-y-auto max-h-[30vh]" style={{ color: 'var(--muted)' }}>{tip.body}</span>
-      </span>
+            every character stays reachable, nothing is clipped away.
+            Rendered through the sanitized markdown pipeline so inline
+            `code` / **bold** in generated bodies display styled instead of
+            as literal asterisks and backticks; the arbitrary variants strip
+            block margins to keep the strip compact. */}
+        <div
+          data-testid="tip-body"
+          className="text-[12px] leading-snug mt-0.5 break-words overflow-y-auto max-h-[30vh] [&_p]:m-0 [&_pre]:my-1 [&_ul]:my-0 [&_ol]:my-0"
+          style={{ color: 'var(--muted)' }}
+        >
+          <MarkdownRenderer content={tip.body} />
+        </div>
+        <div className="flex items-center gap-3 mt-1">
+          {docHref && (
+            <a
+              href={docHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[11px] hover:underline"
+              style={{ color: 'var(--accent)' }}
+            >
+              <ExternalLink size={10} aria-hidden="true" />
+              Learn more
+            </a>
+          )}
+          <button
+            onClick={handleOptOut}
+            disabled={optOutMutation.isPending}
+            className="text-[11px] hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ color: 'var(--muted)' }}
+            aria-label="Turn off tips"
+          >
+            Turn off tips
+          </button>
+          <Link
+            to={TIPS_SETTINGS_PATH}
+            className="inline-flex items-center gap-1 text-[11px] hover:underline"
+            style={{ color: 'var(--muted)' }}
+            aria-label="Tip settings"
+          >
+            <Settings size={10} aria-hidden="true" />
+            Settings
+          </Link>
+        </div>
+      </div>
 
       <div className="flex items-center shrink-0 ml-auto">
         <button

--- a/website/src/test/TipCard.test.tsx
+++ b/website/src/test/TipCard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import { TipCard, useTipTrigger } from '../components/TipCard'
 
 const mockTip = {
@@ -30,7 +31,11 @@ vi.mock('framer-motion', () => ({
 
 function renderWithQuery(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+    </MemoryRouter>,
+  )
 }
 
 describe('TipCard (single-line strip)', () => {
@@ -50,9 +55,9 @@ describe('TipCard (single-line strip)', () => {
 
     const title = screen.getByText('Schedule recurring tasks')
     expect(title).toBeInTheDocument()
-    const body = screen.getByText(/Use cron_add/)
-    expect(body).toBeInTheDocument()
+    expect(screen.getByText(/Use cron_add/)).toBeInTheDocument()
     // Maintainer feedback: body may wrap to multiple lines, never cut off
+    const body = screen.getByTestId('tip-body')
     expect(body.className).not.toContain('line-clamp')
     expect(body.className).not.toContain('truncate')
     // Long bodies scroll within a viewport-relative cap instead of pushing
@@ -65,6 +70,69 @@ describe('TipCard (single-line strip)', () => {
     // Lucide lightbulb SVG present
     const icon = root.querySelector('svg[aria-hidden="true"]')
     expect(icon).not.toBeNull()
+  })
+
+  it('renders inline markdown in the body (code + bold) instead of literal syntax', () => {
+    renderWithQuery(
+      <TipCard
+        tip={{ ...mockTip, body: 'The `auto-research` app uses a **grill tree** to clarify scope.' }}
+        onDismiss={onDismiss}
+      />,
+    )
+    const body = screen.getByTestId('tip-body')
+    const code = body.querySelector('code')
+    expect(code?.textContent).toBe('auto-research')
+    const strong = body.querySelector('strong')
+    expect(strong?.textContent).toBe('grill tree')
+    // Raw markdown syntax must not leak through as literal text
+    expect(body.textContent).not.toContain('`')
+    expect(body.textContent).not.toContain('**')
+  })
+
+  it('renders a Learn more link to the doc on GitHub', () => {
+    renderWithQuery(
+      <TipCard tip={mockTip} onDismiss={onDismiss} />,
+    )
+    const link = screen.getByRole('link', { name: /learn more/i }) as HTMLAnchorElement
+    expect(link.href).toBe(
+      'https://github.com/kirodotdev/KiroCrew/blob/main/src/kiro_crew/docs/cron-and-scheduling.md',
+    )
+    expect(link.target).toBe('_blank')
+    expect(link.rel).toContain('noopener')
+    expect(link.rel).toContain('noreferrer')
+  })
+
+  it('omits the Learn more link when doc is empty or not a plain .md filename', () => {
+    // Path traversal / invented values must not produce a URL
+    for (const doc of ['', '../secrets/keys.md', 'https://evil.example/x.md']) {
+      const { unmount } = renderWithQuery(
+        <TipCard tip={{ ...mockTip, doc }} onDismiss={onDismiss} />,
+      )
+      expect(screen.queryByRole('link', { name: /learn more/i })).toBeNull()
+      unmount()
+    }
+  })
+
+  it('"Turn off tips" opts out permanently (same action as the Settings toggle) and hides the card', async () => {
+    const { api: mockApi } = await import('../api/client')
+    renderWithQuery(
+      <TipCard tip={mockTip} onDismiss={onDismiss} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /turn off tips/i }))
+    await waitFor(() => {
+      expect(mockApi.tipsFeedback).toHaveBeenCalledWith('', 'optout')
+    })
+    await waitFor(() => {
+      expect(onDismiss).toHaveBeenCalled()
+    })
+  })
+
+  it('renders a Settings link pointing at the Feature Tips toggle (Settings → Chat)', () => {
+    renderWithQuery(
+      <TipCard tip={mockTip} onDismiss={onDismiss} />,
+    )
+    const link = screen.getByRole('link', { name: /tip settings/i }) as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('/settings?tab=chat')
   })
 
   it('dismiss calls tipsFeedback(id, "dismiss") and hides on success', async () => {


### PR DESCRIPTION
## Problem
The feature-tip strip above the composer has four UX defects (see screenshot in review): the body text is cut mid-word ("…exhausts its cycle budget. Ea"), inline markdown renders as literal `` ` `` and `**` characters, there is no link to the underlying doc, and there is no quick way to turn tips off from the tip itself.

## Why it matters
Tips are the product's self-discovery surface — a truncated, unstyled tip with no path to the doc (or to the off switch) reads as broken and erodes trust in the feature it's advertising.

## Fix (symptoms → root cause → change)
- **Mid-word cut** → `tips.py` and `scripts/generate_tips_catalog.py` truncated doc summaries with a hard `[:300]` slice, and `_fallback_tips` serves that string verbatim as the tip body → new dependency-free helper `kiro_crew/tips_text.py::truncate_summary()` keeps whole sentences up to 300 chars (word-boundary + ellipsis fallback), used at all three slice sites; bundled `data/tips_catalog.json` regenerated (all 19 entries now end at sentence boundaries).
- **Literal markdown** → `TipCard.tsx` rendered `tip.body` as a plain string → body now renders through the existing sanitized `MarkdownRenderer` pipeline with compact margin overrides.
- **No doc link** → tips always carry a `doc` field but the card never used it → "Learn more" link to `blob/main/src/kiro_crew/docs/<doc>` (same base as the Security/Discord panels), gated by a strict filename regex so LLM-invented doc values can't form odd URLs.
- **Hard to disable** → no in-card affordance → footer adds "Turn off tips" (posts the same `optout` feedback action the Settings toggle uses, refreshes cached `tipsStatus`) and a "Settings" link to `/settings?tab=chat`.

## Tests
- `test/test_tips.py`: 8 new `TestTruncateSummary` cases (sentence boundary, boundary-at-limit, word-boundary ellipsis, unbroken-token, regression for the exact "…budget. Ea" cut). 107 tips tests pass.
- `website/src/test/TipCard.test.tsx`: markdown body (code/bold, no literal syntax), Learn more href/target/rel, link omitted for empty/traversal/URL doc values, Turn off tips → `tipsFeedback('', 'optout')` + card hides, Settings link href. 20 pass.
- Full gates: tsc clean, vitest 3916 passed (346 files), pytest 15156 passed (two known-environmental host failures excluded: `test_approval_threading.py`, multiprocessing-SemLock subagent suite — both fail identically on clean main), flake8 clean.

## Manual verification
N/A — unit coverage exercises all four behaviors; the regenerated catalog was inspected entry-by-entry (all 19 summaries end at sentence boundaries).
