### PR TITLE
fix(pr-panel): surface a clear CTA in the provider-not-found error

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -245,20 +245,28 @@ def _resolve_provider_executable(executable: str) -> str:
     provider = "GitHub" if executable == "gh" else "GitLab"
     managed_dir = os.path.dirname(_PROVIDER_EXECUTABLE_CANDIDATES[executable][0])
     raise SourceProviderError(
-        f"The {provider} CLI ({executable}) could not be found in a location this "
-        f"panel trusts. This panel runs {executable} unattended with your "
-        f"{provider} credentials, so -- unlike chat or your terminal -- it only "
-        f"accepts a root-owned {executable} whose full path your user cannot write "
-        "(a Homebrew or otherwise user-owned copy is intentionally refused here, "
-        "even though it works elsewhere). If it is already installed, promote it "
-        "to a trusted location (needs sudo), then reload this panel:\n"
+        f"Can't load pull requests: the {provider} CLI ({executable}) isn't "
+        f"installed in a location this panel trusts.\n"
+        "\n"
+        f"To fix this, copy your existing {executable} into a trusted location "
+        "(needs sudo), then click Retry:\n"
+        "\n"
         f"  sudo mkdir -p {managed_dir}\n"
         f'  sudo cp "$(command -v {executable})" {managed_dir}/{executable}\n'
         f"  sudo chown -R root {managed_dir}\n"
         f"  sudo chmod 755 {managed_dir}/{executable}\n"
-        f"Your existing `{executable} auth login` credentials are reused "
-        f"automatically. Alternatively, set {override_name} to an already-trusted "
-        "absolute path."
+        "\n"
+        f"You won't have to sign in again -- your existing "
+        f"`{executable} auth login` credentials are reused automatically.\n"
+        "\n"
+        f"Why sudo? This panel runs {executable} unattended with your "
+        f"{provider} credentials, so -- unlike chat or your terminal -- it only "
+        f"accepts a root-owned {executable} your user cannot write. A Homebrew "
+        "or otherwise user-owned copy is intentionally refused here, even "
+        "though it works elsewhere.\n"
+        "\n"
+        f"Alternative: point {override_name} at an already-trusted, absolute "
+        f"{executable} path."
     )
 
 


### PR DESCRIPTION
## Problem
When the PR/MR panel can't find a trusted `gh`/`glab` CLI, it shows a dense
paragraph titled "Could not load this pull request". The security rationale
leads, and the actionable fix (the `sudo` commands, or the `KIROCREW_GH_BIN`
override) is buried mid-prose after "reload this panel". Users see a wall of
text and don't immediately know what to do.

## Why it matters
This error is the one thing standing between the user and a working PR panel.
Burying the call-to-action makes a recoverable setup step feel like a dead end,
and "reload this panel" doesn't match the panel's actual **Retry** button.

## Fix (symptom → root cause → change)
- Symptom: the fix steps are hard to find inside the explanation.
- Root cause: the message was ordered explanation-first, action-last, with the
  commands embedded in a single run-on paragraph.
- Change: reorder the message in `_resolve_provider_executable` so it now
  (1) states the failure in one line, (2) leads with a clearly labelled
  **"To fix this … then click Retry:"** block containing the copy-paste
  commands, (3) reassures that existing `gh auth login` credentials are reused,
  (4) demotes the security rationale to a short **"Why sudo?"** footnote, and
  (5) keeps the `KIROCREW_*_BIN` override as the final alternative. "reload this
  panel" is replaced with "click Retry" to match the button the user sees.

No behavioral/security logic changed — only the human-facing error string.

## Tests
Covered by the existing `test/test_source_providers.py` suite, which asserts the
message still names the managed target dir, emits the copy-paste `sudo`
setup steps, points at `KIROCREW_GH_BIN`, and reassures that
`` `gh auth login` credentials are reused automatically`` — all preserved by
the new wording. 110 passed locally; `flake8` clean on the changed file.

## Manual verification
N/A — the change is a static string and the assertions above lock in the
substrings the UI depends on. Rendering is unchanged (the panel already shows
the message as monospace text with indented command lines highlighted).
