### PR TITLE
feat: auto-migrate legacy memory to embeddings on boot

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -124,7 +124,7 @@ Embeddings run in-process via the vendored llama-cpp-python 0.3.34 runtime (`kir
 - `status` dict (`step`: `idle`/`downloading`/`verifying`/`waiting_retry`/`ready`/`failed`, plus `error` and `attempt`) is readable at any time by the dashboard status endpoint
 
 **Dashboard Enable Flow** (non-blocking, retryable):
-- `POST /api/memory/enable-embeddings` — never blocks on the download: if the model is absent it kicks (or adopts an already-in-flight) background download with `DOWNLOAD_ATTEMPTS_INTERACTIVE` (3) attempts and returns immediately (`{"ok": true, "status": "downloading"}`); the frontend polls `embedding-status` for progress. When the model is present it installs faiss-cpu if missing, wires the embed function, and persists config
+- `POST /api/memory/enable-embeddings` — never blocks on the download: if the model is absent it kicks (or adopts an already-in-flight) background download with `DOWNLOAD_ATTEMPTS_INTERACTIVE` (3) attempts and returns immediately (`{"ok": true, "status": "downloading"}`); the frontend polls `embedding-status` for progress. When the model is present it installs faiss-cpu if missing, wires the embed function, and persists config. The dashboard no longer surfaces a proactive "Start Embedding Engine" button (embeddings auto-start at boot) — this endpoint now backs only the error-state **Retry** affordance
 - On failure: status resets to `idle` with error message, frontend shows error + Retry button
 - Prevents concurrent setup attempts (409 if already in progress)
 - `can_retry` flag in status response for frontend retry button
@@ -204,9 +204,14 @@ Parses legacy markdown files into structured memory:
 - `preferences.md`: bullet points with `key: value` → semantic entries (confidence 0.85, source "migration"). Bare prefix keys get `.default` suffix.
 - `projects.md`: project names → `project.name` semantic entries, details → episodic
 - `history/*.md`: daily summaries → episodic entries (importance 0.4)
-- **Embedding during migration**: when the model file is present, the dashboard handler sets `store.embed_fn` before calling migration. Each episodic entry is embedded in-process and stored with its FAISS vector, enabling vector search immediately after migration.
+- **Embedding during migration**: when the model file is present, the caller sets `store.embed_fn` before calling migration. Each episodic entry is embedded in-process and stored with its FAISS vector, enabling vector search immediately after migration.
 - Idempotent: re-running skips existing semantic entries (conflict resolution), episodic dedup via FAISS when available
-- Dashboard: "📦 Migrate from Markdown" button shown when `migrated=false` and legacy files exist
+
+**Automatic migration (boot-time, `GatewayOrchestrator._auto_migrate_memory`)**: migration is fully automatic — there is **no dashboard "Migrate" button**. Right after `_start_embeddings()`, the gateway schedules a fire-and-forget background task (retained in `_background_tasks`, cancelled on shutdown) that runs two idempotent phases, all blocking work offloaded to the maintenance executor so boot is never blocked:
+1. **Migrate** (gated on `memory.migrated == False`): detects legacy content via the shared `memory.legacy_memory_present()` helper (also used by `/api/memory/stats`), runs `migrate_from_markdown()`, then flips `memory.migrated=True` for **everyone** — fresh installs with zero legacy entries included, so all users land in vector-only mode. Syncs the live `consolidator._migrated`, and **acknowledges** with a `migration` audit event (`memory_events`, visible in the dashboard Audit tab, `source="auto"`, counts in `new_value`) plus a `logger.info` line. On error: logs and leaves `migrated=False` so the next boot retries.
+2. **Re-embed sweep** (gated on model readiness, independent of the migrated flag): once the model file is present (awaits the background download task if still in flight — safe, we are our own task), `VectorMemory.backfill_missing_embeddings()` embeds any episodic rows written with a NULL vector (migrated before the model landed) and rebuilds the FAISS index. Self-healing across boots and across a download that failed then later succeeded.
+
+The backend `POST /api/memory/migrate` endpoint and the `kirocrew memory migrate` CLI remain as a manual escape hatch, but the dashboard no longer calls them.
 
 ### Cross-Platform
 

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -9,7 +9,6 @@ import logging
 import math
 import os
 import sys
-from pathlib import Path
 from typing import Any
 
 from aiohttp import web
@@ -265,12 +264,27 @@ _migrate_lock: asyncio.Lock | None = None
 
 
 async def _set_migrated(value: bool) -> None:
-    """Set memory.migrated in config.json."""
+    """Set memory.migrated in config.json.
+
+    If an existing config.json can't be parsed, do NOT write — overwriting it
+    with only the migration flag would destroy every other recoverable setting
+    (provider, Slack, dashboard, ...). Boot-time auto-migration calls this on
+    every startup while migrated is false, so a malformed config must fail
+    closed (skip the flag, keep the file) and let a later boot retry once the
+    user has repaired it, rather than silently clobbering their config.
+    """
     async with _get_config_lock():
         path = config_path()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-        except Exception:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                logger.warning(
+                    "config.json is unparseable; skipping memory.migrated write to "
+                    "avoid clobbering other settings — will retry next boot"
+                )
+                return
+        else:
             data = {}
         data.setdefault("memory", {})["migrated"] = value
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -624,25 +638,10 @@ async def api_memory_stats(request: web.Request) -> web.Response:
     cfg = KiroCrewConfig.load()
     stats["embedding_provider"] = cfg.memory.embedding_provider
     stats["migrated"] = cfg.memory.migrated
-    # Check if legacy markdown memory has real content (for showing Migrate button)
-    from kiro_crew.memory import memory_dir  # noqa: F811
+    # Legacy markdown presence (diagnostics; migration is automatic at boot).
+    from kiro_crew.memory import legacy_memory_present  # noqa: F811
 
-    md = memory_dir()
-    has_legacy = False
-    for f in [md / "preferences.md", md / "projects.md"]:
-        if f.is_file():
-            has_legacy = any(
-                line.strip().startswith("- ") for line in f.read_text(encoding="utf-8", errors="replace").splitlines()
-            )
-            if has_legacy:
-                break
-    if not has_legacy and (md / "history").is_dir():
-        has_legacy = any((md / "history").glob("*.md"))
-    # Also check lessons.jsonl
-    lessons_path = Path.home() / ".kirocrew" / "lessons.jsonl"
-    if not has_legacy and lessons_path.is_file() and lessons_path.stat().st_size > 5:
-        has_legacy = True
-    stats["has_legacy_memory"] = has_legacy
+    stats["has_legacy_memory"] = legacy_memory_present()
     return web.json_response(stats)
 
 

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -60,6 +60,31 @@ def memory_file() -> Path:
     return memory_dir() / PREFERENCES_FILE
 
 
+def legacy_memory_present() -> bool:
+    """True when legacy markdown memory has real content worth migrating.
+
+    Shared by the /api/memory/stats handler and the gateway's boot-time
+    auto-migration so both agree on what "there is something to migrate" means:
+    any ``- `` bullet in preferences.md/projects.md, any ``history/*.md`` file,
+    or a non-trivial ``lessons.jsonl``.
+    """
+    md = memory_dir()
+    for name in (PREFERENCES_FILE, PROJECTS_FILE):
+        f = md / name
+        if f.is_file() and any(
+            line.strip().startswith("- ")
+            for line in f.read_text(encoding="utf-8", errors="replace").splitlines()
+        ):
+            return True
+    history = md / HISTORY_DIR_NAME
+    if history.is_dir() and any(history.glob("*.md")):
+        return True
+    lessons_path = config_dir() / "lessons.jsonl"
+    if lessons_path.is_file() and lessons_path.stat().st_size > 5:
+        return True
+    return False
+
+
 # ── MemoryStore ──
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -85,6 +85,7 @@ from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
 from kiro_crew.embeddings import (
+    get_shared_embedder,
     make_sync_embed_fn,
     model_file_present,
     start_background_model_download,
@@ -532,6 +533,7 @@ class GatewayOrchestrator:
         self._socket_client: WSSocketModeClient | None = None
         self._wecom_client: "WeComClient | None" = None  # set by maybe_start_wecom
         self._model_download_task: "asyncio.Task[bool] | None" = None
+        self._auto_migrate_task: "asyncio.Task[None] | None" = None
         self._mcp_gateway_manager: GatewayManager | None = None
 
     def _count_in_flight_work(self) -> int:
@@ -3394,6 +3396,112 @@ class GatewayOrchestrator:
             )
         self._model_download_task = start_background_model_download()
 
+    async def _auto_migrate_memory(self) -> None:
+        """Migrate legacy markdown memory into the vector store, then backfill.
+
+        Runs once at boot as a fire-and-forget background task. Two idempotent
+        phases, all blocking work offloaded to the maintenance executor so the
+        event loop is never stalled:
+
+          1. Migrate (gated on ``memory.migrated`` being False): parse legacy
+             markdown/lessons via ``migrate_from_markdown``, flip
+             ``memory.migrated`` to True (even for a fresh install with zero
+             legacy entries, so everyone lands in vector-only mode), sync the
+             live consolidator, and acknowledge via an audit event + log line.
+          2. Re-embed sweep (gated on model readiness, independent of phase 1):
+             once the model file is present, embed any episodic rows written
+             without a vector (migrated before the model landed) and rebuild the
+             FAISS index. Self-healing across boots.
+
+        Never raises: any failure is logged and leaves ``migrated`` unchanged so
+        the next boot retries. Boot survives regardless.
+        """
+        from kiro_crew.memory import legacy_memory_present
+
+        store = self.vector_memory
+        loop = asyncio.get_running_loop()
+        try:
+            # ── Phase 1: migrate ──
+            if not self._cfg.memory.migrated:
+                # Bind embed_fn so migration writes real vectors when the model
+                # is already present; otherwise rows are written NULL and the
+                # sweep below (or a later boot) backfills them.
+                if store.embed_fn is None and model_file_present():
+                    store.embed_fn = make_sync_embed_fn()
+
+                had_legacy = await loop.run_in_executor(
+                    maintenance_executor(), legacy_memory_present
+                )
+                counts = {"semantic": 0, "episodic": 0, "skipped": 0}
+                if had_legacy:
+                    counts = await loop.run_in_executor(
+                        maintenance_executor(), store.migrate_from_markdown
+                    )
+                # Flip the flag for everyone (fresh installs included) so the
+                # app enters vector-only mode and stops writing markdown.
+                await self._set_memory_migrated(True)
+                self._cfg.memory.migrated = True
+                if self.consolidator is not None:
+                    self.consolidator._migrated = True
+                summary = (
+                    f"semantic={counts['semantic']} episodic={counts['episodic']} "
+                    f"skipped={counts['skipped']}"
+                )
+                try:
+                    store._log_event(
+                        "migration", "system", "auto_migrate", None, summary, "auto"
+                    )
+                except Exception:
+                    logger.debug("auto-migrate audit log failed", exc_info=True)
+                logger.info("Auto-migrated legacy memory: %s", summary)
+
+            # ── Phase 2: re-embed sweep ──
+            # Wait (non-blocking to boot — we are our own task) for the model, so
+            # rows written NULL during phase 1 get vectors.
+            if not model_file_present() and self._model_download_task is not None:
+                try:
+                    await self._model_download_task
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.debug("model download task errored", exc_info=True)
+            if model_file_present():
+                if store.embed_fn is None:
+                    store.embed_fn = make_sync_embed_fn()
+
+                # model_file_present() only means the GGUF is on disk — the
+                # in-memory load is async and the first embed returns None while
+                # it warms up. Block (in the worker thread) until the model is
+                # actually loaded, else backfill_missing_embeddings would embed
+                # zero rows and no later sweep is scheduled. On timeout, skip and
+                # let a later boot's sweep backfill.
+                def _wait_then_backfill() -> int:
+                    embedder = get_shared_embedder()
+                    # wait_ready() is on the llama.cpp backend but not the
+                    # EmbeddingBackend ABC (a swapped-in backend may not support
+                    # blocking-wait); fall back to is_ready() when absent.
+                    wait_ready = getattr(embedder, "wait_ready", None)
+                    ready = wait_ready(timeout=120) if callable(wait_ready) else embedder.is_ready()
+                    if not ready:
+                        logger.info(
+                            "Embedding model not ready within timeout; deferring "
+                            "re-embed sweep to a later boot"
+                        )
+                        return 0
+                    return store.backfill_missing_embeddings()
+
+                await loop.run_in_executor(maintenance_executor(), _wait_then_backfill)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Auto-migration failed; will retry next boot", exc_info=True)
+
+    async def _set_memory_migrated(self, value: bool) -> None:
+        """Persist ``memory.migrated`` to config.json (config-lock guarded)."""
+        from kiro_crew.dashboard.handlers.memory import _set_migrated
+
+        await _set_migrated(value)
+
     # ------------------------------------------------------------------
     # MCP Gateway
     # ------------------------------------------------------------------
@@ -3588,6 +3696,9 @@ class GatewayOrchestrator:
         # Cancel background model download if still in flight
         if self._model_download_task is not None and not self._model_download_task.done():
             self._model_download_task.cancel()
+        # Cancel background auto-migration if still in flight
+        if self._auto_migrate_task is not None and not self._auto_migrate_task.done():
+            self._auto_migrate_task.cancel()
 
         if cleanup_tasks:
             await asyncio.gather(*cleanup_tasks, return_exceptions=True)
@@ -3917,6 +4028,14 @@ class GatewayOrchestrator:
 
         # Wire in-process embeddings (always-on) and kick background model download
         await self._start_embeddings()
+
+        # Auto-migrate legacy markdown memory to the vector store in the
+        # background (fire-and-forget) — never blocks boot. Idempotent: gated on
+        # memory.migrated for the migrate phase; the re-embed sweep is cheap when
+        # nothing is pending.
+        self._auto_migrate_task = asyncio.create_task(self._auto_migrate_memory())
+        self._background_tasks.add(self._auto_migrate_task)
+        self._auto_migrate_task.add_done_callback(self._background_tasks.discard)
 
         # Start MCP gateway sidecar before any ACP session can spawn.  The
         # rewriter writes the agent-JSON overlay first so kiro-cli picks up

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1663,13 +1663,78 @@ class VectorMemoryStore:
                 return None
         return None
 
+    def backfill_missing_embeddings(self) -> int:
+        """Compute embeddings for episodic rows that have none, then rebuild FAISS.
+
+        Entries written while the embedding model was still downloading (first
+        boot, or a migration that ran before the model landed) are stored with a
+        NULL ``embedding`` and are keyword-searchable only. Once the model is
+        present and ``embed_fn`` is bound, this sweep embeds those rows and
+        rebuilds the vector index so they become semantically searchable.
+
+        Idempotent and cheap in steady state: a no-op (returns 0) when there is
+        no ``embed_fn``, faiss/numpy are missing, or no NULL-embedding rows
+        remain. Synchronous + blocking (runs model inference) — call from a
+        worker thread / executor, never directly on the event loop.
+        """
+        if self.embed_fn is None or not _HAS_FAISS or not _HAS_NUMPY:
+            return 0
+        with self._db_lock:
+            rows = self.db.execute(
+                "SELECT id, text FROM episodic_memories "
+                "WHERE is_deleted = 0 AND embedding IS NULL"
+            ).fetchall()
+        if not rows:
+            return 0
+        embedded = 0
+        for row in rows:
+            vec = self._try_embed(row["text"])
+            if not vec:
+                continue
+            arr = np.asarray(vec, dtype=np.float32)
+            # Validate dimension before storing: a wrong-dim vector is skipped by
+            # build_faiss_index() but would be written non-NULL, so a later sweep
+            # would never retry it. Leave it NULL instead so it stays a candidate.
+            if arr.shape != (self._embedding_dim,):
+                logger.warning(
+                    "Backfill embed dim mismatch for %s (got %s, expected %d) — leaving NULL",
+                    row["id"],
+                    arr.shape,
+                    self._embedding_dim,
+                )
+                continue
+            # L2-normalize to match write_episodic(): the FAISS IndexFlatIP scores
+            # inner product, which only equals cosine similarity on unit vectors.
+            norm = float(np.linalg.norm(arr))
+            if norm > 0:
+                arr = arr / norm
+            blob = arr.tobytes()
+            with self._db_lock:
+                self.db.execute(
+                    "UPDATE episodic_memories SET embedding = ? WHERE id = ?",
+                    (blob, row["id"]),
+                )
+                self.db.commit()
+            embedded += 1
+        if embedded:
+            with self._db_lock:
+                self.build_faiss_index()
+                self.save_faiss_index()
+            logger.info("Backfilled embeddings for %d episodic entries", embedded)
+        return embedded
+
     def migrate_from_markdown(self) -> dict[str, int]:
         """Migrate legacy markdown memory files and lessons.jsonl into vector memory."""
-        base = Path.home() / ".kirocrew" / "workspace" / "memory"
+        # Honor KIROCREW_HOME via config_dir() so the source directory matches
+        # what legacy_memory_present() detects — hardcoding Path.home() would
+        # migrate a different dir than was detected under a custom home, then
+        # flip migrated=True having imported nothing (silent data loss).
+        home = config_dir()
+        base = home / "workspace" / "memory"
         counts = {"semantic": 0, "episodic": 0, "skipped": 0}
 
         # ── Lessons ──
-        lessons_path = Path.home() / ".kirocrew" / "lessons.jsonl"
+        lessons_path = home / "lessons.jsonl"
         if lessons_path.is_file():
             for line in lessons_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()

--- a/test/test_enable_embeddings_faiss.py
+++ b/test/test_enable_embeddings_faiss.py
@@ -428,3 +428,44 @@ class TestEnsurePipBootstrap:
 
         assert mem_mod._embedding_setup_status["step"] == "idle"
         assert "pip bootstrap" in str(mem_mod._embedding_setup_status["error"])
+
+
+class TestSetMigratedFailClosed:
+    """_set_migrated must not clobber an unparseable config.json.
+
+    Boot-time auto-migration calls _set_migrated(True) on every startup while
+    memory.migrated is false, so a malformed config must fail closed (skip the
+    write, preserve the file) rather than overwrite it with only the flag.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_config_is_not_overwritten(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{ this is not valid json ", encoding="utf-8")
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._set_migrated(True)
+        # File is left byte-for-byte intact (no destructive rewrite).
+        assert cfg_path.read_text(encoding="utf-8") == "{ this is not valid json "
+
+    @pytest.mark.asyncio
+    async def test_valid_config_preserves_other_sections(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(
+            json.dumps({"agent": {"provider": "acp"}, "slack": {"command": "/kc"}}),
+            encoding="utf-8",
+        )
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._set_migrated(True)
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert data["memory"]["migrated"] is True
+        # Other sections survive the write.
+        assert data["agent"]["provider"] == "acp"
+        assert data["slack"]["command"] == "/kc"
+
+    @pytest.mark.asyncio
+    async def test_missing_config_writes_fresh(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"  # does not exist
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._set_migrated(True)
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert data["memory"]["migrated"] is True

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2639,6 +2639,158 @@ class TestStartEmbeddings:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Tests: _auto_migrate_memory (boot-time auto-migration + re-embed sweep)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAutoMigrateMemory:
+    """Background auto-migration of legacy markdown + re-embed sweep at boot."""
+
+    def _orch_with_store(self, *, migrated: bool):
+        orch = _make_orchestrator()
+        orch._cfg.memory.migrated = migrated
+        store = MagicMock()
+        store.embed_fn = None
+        store.migrate_from_markdown = MagicMock(
+            return_value={"semantic": 3, "episodic": 5, "skipped": 1}
+        )
+        store.backfill_missing_embeddings = MagicMock(return_value=0)
+        store._log_event = MagicMock()
+        orch.vector_memory = store
+        orch.consolidator = MagicMock(_migrated=False)
+        return orch, store
+
+    @staticmethod
+    def _ready_embedder():
+        """A shared embedder whose model is loaded (wait_ready -> True)."""
+        return MagicMock(wait_ready=MagicMock(return_value=True), is_ready=MagicMock(return_value=True))
+
+    @pytest.mark.asyncio
+    async def test_migrates_when_not_migrated_and_legacy_present(self):
+        orch, store = self._orch_with_store(migrated=False)
+        set_migrated = AsyncMock()
+        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=True
+        ), patch.object(
+            orch, "_set_memory_migrated", set_migrated
+        ):
+            await orch._auto_migrate_memory()
+        store.migrate_from_markdown.assert_called_once()
+        set_migrated.assert_awaited_once_with(True)
+        assert orch._cfg.memory.migrated is True
+        assert orch.consolidator._migrated is True
+        # Ack: audit event with counts summary.
+        store._log_event.assert_called_once()
+        assert store._log_event.call_args[0][0] == "migration"
+        # Model present + loaded → re-embed sweep runs.
+        store.backfill_missing_embeddings.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_migrate_when_already_migrated(self):
+        orch, store = self._orch_with_store(migrated=True)
+        set_migrated = AsyncMock()
+        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=True
+        ), patch.object(
+            orch, "_set_memory_migrated", set_migrated
+        ):
+            await orch._auto_migrate_memory()
+        store.migrate_from_markdown.assert_not_called()
+        set_migrated.assert_not_awaited()
+        # Phase 2 sweep still runs (independent of the migrated flag).
+        store.backfill_missing_embeddings.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sweep_deferred_when_model_not_ready(self):
+        # GGUF present on disk but the in-memory load hasn't finished:
+        # wait_ready() -> False, so the sweep is deferred (not run with a cold
+        # model that would embed zero rows).
+        orch, store = self._orch_with_store(migrated=True)
+        not_ready = MagicMock(
+            wait_ready=MagicMock(return_value=False), is_ready=MagicMock(return_value=False)
+        )
+        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.slack.gateway.get_shared_embedder", return_value=not_ready
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=True
+        ), patch.object(
+            orch, "_set_memory_migrated", AsyncMock()
+        ):
+            await orch._auto_migrate_memory()
+        not_ready.wait_ready.assert_called_once()
+        store.backfill_missing_embeddings.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_no_legacy_still_flips_migrated(self):
+        orch, store = self._orch_with_store(migrated=False)
+        set_migrated = AsyncMock()
+        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=False
+        ), patch.object(
+            orch, "_set_memory_migrated", set_migrated
+        ):
+            await orch._auto_migrate_memory()
+        # No legacy → don't parse markdown, but still flip the flag + ack (0 counts).
+        store.migrate_from_markdown.assert_not_called()
+        set_migrated.assert_awaited_once_with(True)
+        assert orch._cfg.memory.migrated is True
+        store._log_event.assert_called_once()
+        assert "semantic=0 episodic=0 skipped=0" in store._log_event.call_args[0][4]
+
+    @pytest.mark.asyncio
+    async def test_model_absent_awaits_download_then_sweeps(self):
+        orch, store = self._orch_with_store(migrated=False)
+        # Model absent at migrate time, present after the download task resolves.
+        presence = iter([False, False, True, True])
+        orch._model_download_task = asyncio.ensure_future(asyncio.sleep(0))
+        with patch(
+            "kiro_crew.slack.gateway.model_file_present",
+            side_effect=lambda: next(presence, True),
+        ), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=True
+        ), patch.object(
+            orch, "_set_memory_migrated", AsyncMock()
+        ):
+            await orch._auto_migrate_memory()
+        # Migrated even though the model was absent; sweep ran after the wait.
+        store.migrate_from_markdown.assert_called_once()
+        store.backfill_missing_embeddings.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_migrate_error_leaves_flag_false_and_survives(self):
+        orch, store = self._orch_with_store(migrated=False)
+        store.migrate_from_markdown.side_effect = RuntimeError("boom")
+        set_migrated = AsyncMock()
+        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
+            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
+        ), patch(
+            "kiro_crew.memory.legacy_memory_present", return_value=True
+        ), patch.object(
+            orch, "_set_memory_migrated", set_migrated
+        ):
+            # Must not raise — boot survives.
+            await orch._auto_migrate_memory()
+        set_migrated.assert_not_awaited()
+        assert orch._cfg.memory.migrated is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Tests: _auto_apply_update discards local edits before staging frontend
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -1526,3 +1526,73 @@ class TestEpisodicGhostVectorDedup:
             if e["event_type"] == "conflict_skip" and e.get("memory_key") == ghost_id
         ]
         assert conflicts == []
+
+
+@pytest.mark.skipif(
+    not (_HAS_FAISS and _HAS_NUMPY), reason="faiss/numpy not available"
+)
+class TestBackfillMissingEmbeddings:
+    """Re-embed sweep: embed episodic rows written without a vector."""
+
+    def test_backfills_null_rows_and_rebuilds_index(self, tmp_path: Path) -> None:
+        # Write episodic entries with NO embed_fn → embedding stored as NULL.
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        assert store.write_episodic("User standardized on Postgres for storage")
+        assert store.write_episodic("User prefers pytest over unittest for tests")
+        null_before = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE embedding IS NULL"
+        ).fetchone()[0]
+        assert null_before == 2
+
+        # Bind an embed_fn returning a NON-unit vector and sweep.
+        store.embed_fn = lambda text: [0.1] * store._embedding_dim
+        embedded = store.backfill_missing_embeddings()
+        assert embedded == 2
+        null_after = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE embedding IS NULL"
+        ).fetchone()[0]
+        assert null_after == 0
+        # Index rebuilt to include the freshly-embedded rows.
+        assert store._faiss_index is not None
+        assert store._faiss_index.ntotal == 2  # type: ignore[attr-defined]
+        # Stored vectors must be L2-normalized (IndexFlatIP scores IP == cosine
+        # only on unit vectors) — matching write_episodic().
+        import numpy as _np
+
+        blob = store.db.execute(
+            "SELECT embedding FROM episodic_memories WHERE is_deleted=0 LIMIT 1"
+        ).fetchone()[0]
+        stored = _np.frombuffer(blob, dtype=_np.float32)
+        assert abs(float(_np.linalg.norm(stored)) - 1.0) < 1e-5
+
+    def test_dim_mismatch_left_null_for_retry(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        assert store.write_episodic("A memory that will get a bad-dim embedding")
+        # embed_fn returns the WRONG dimension → row must stay NULL (not stored
+        # non-NULL, which would block every future backfill retry).
+        store.embed_fn = lambda text: [0.1] * (store._embedding_dim + 3)
+        assert store.backfill_missing_embeddings() == 0
+        null_count = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE embedding IS NULL"
+        ).fetchone()[0]
+        assert null_count == 1
+
+    def test_noop_without_embed_fn(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.write_episodic("Some memory without any embedding attached")
+        # No embed_fn bound → sweep is a no-op, rows stay NULL.
+        assert store.backfill_missing_embeddings() == 0
+        null_count = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE embedding IS NULL"
+        ).fetchone()[0]
+        assert null_count == 1
+
+    def test_noop_when_nothing_pending(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.embed_fn = lambda text: [0.1] * store._embedding_dim
+        # No episodic rows at all → returns 0.
+        assert store.backfill_missing_embeddings() == 0

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -442,7 +442,6 @@ export const api = {
   vectorEmbeddingStatus: () => fetch('/api/memory/embedding-status').then(j),
   vectorEnableEmbeddings: () => post('/api/memory/enable-embeddings').then(j),
   vectorDisableEmbeddings: () => post('/api/memory/disable-embeddings').then(j),
-  vectorMigrate: () => post('/api/memory/migrate').then(j),
   vectorImport: (data: object) => post('/api/memory/import', data).then(j),
   vectorContextPreview: (query?: string) => fetch('/api/memory/context-preview' + (query ? '?q=' + encodeURIComponent(query) : '')).then(j),
   memoryGraph: () => fetch('/api/memory/graph').then(j),

--- a/website/src/pages/overview/VectorMemoryCard.tsx
+++ b/website/src/pages/overview/VectorMemoryCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Brain, Zap, Hourglass, Package, CheckCircle, XCircle, RefreshCw, Search, AlertTriangle, Check, X } from 'lucide-react'
+import { Brain, Hourglass, CheckCircle, XCircle, RefreshCw, Search, AlertTriangle, Check, X } from 'lucide-react'
 import { api } from '../../api/client'
 import { Card, CardTitle, Btn, SendBtn, Input, Badge } from '../../components/ui'
 import InfoTip from '../../components/InfoTip'
@@ -64,13 +64,6 @@ interface AuditEvent {
   created_at?: string
 }
 
-interface MigrateResult {
-  error?: string
-  semantic?: number
-  episodic?: number
-  skipped?: number
-}
-
 interface ContextPreview {
   semantic_context?: string
   episodic_context?: string
@@ -120,7 +113,6 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
   const [eventFilter, setEventFilter] = useState<string>('all')
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [evHasMore, setEvHasMore] = useState(false)
-  const [migrating, setMigrating] = useState(false); const [migrateResult, setMigrateResult] = useState<MigrateResult | null>(null)
   const [inspectorQuery, setInspectorQuery] = useState(''); const [preview, setPreview] = useState<ContextPreview | null>(null)
   const [writeError, setWriteError] = useState('')
   const [semFilter, setSemFilter] = useState('')
@@ -172,7 +164,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
       setEmbStatus(s)
       if (s.setup_step === 'done' || s.setup_step === 'error' || (s.setup_step === 'idle' && s.setup_error)) {
         if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
-        if (s.setup_error) setMigrateResult({ error: s.setup_error })
+        // setup_error surfaces directly from embStatus in the error state.
         load().then(() => setEnabling(false))
       }
     }, 2000)
@@ -228,7 +220,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
   if (stats === null) return <Card><CardTitle><Brain className="lucide-inline" /> Vector Memory</CardTitle><p className="text-muted text-sm">Loading…</p></Card>
 
   const startEmbeddings = async () => {
-    setEnabling(true); setMigrateResult(null)
+    setEnabling(true)
     api.vectorEnableEmbeddings().catch(() => {})
     pollEmbeddingStatus()
   }
@@ -268,27 +260,17 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
       <CardTitle><Brain className="lucide-inline" /> Vector Memory <InfoTip text="Structured semantic (key-value) + episodic (conversation fragments) memory with vector search. Embeddings are always-on — the model downloads automatically in the background." /></CardTitle>
       {!active && !enabling && (
         <div className="flex flex-col gap-3 items-start">
-          {embStatus?.model_available
-            ? <p className="text-sm text-muted">Model loaded. Embedding engine is starting up.</p>
-            : <p className="text-sm text-muted">Vector memory is initializing. The embedding model (~610MB) downloads automatically in the background.</p>
+          {embStatus?.setup_error
+            ? (
+              <div className="flex items-center gap-2">
+                <p className="text-sm text-danger"><XCircle className="lucide-inline" /> {embStatus.setup_error}</p>
+                <Btn onClick={startEmbeddings}><RefreshCw className="lucide-inline" /> Retry</Btn>
+              </div>
+            )
+            : embStatus?.model_available
+              ? <p className="text-sm text-muted">Model loaded. Embedding engine is starting up.</p>
+              : <p className="text-sm text-muted">Vector memory is initializing. The embedding model (~610MB) downloads automatically in the background, and legacy memory migrates on its own — no action needed.</p>
           }
-          <div className="flex gap-2 flex-wrap">
-            <SendBtn onClick={startEmbeddings}>{ embStatus?.model_available ? <><Zap className="lucide-inline" /> Start Embedding Engine</> : <><Brain className="lucide-inline" /> Retry Download</>}</SendBtn>
-            {!stats?.migrated && stats?.has_legacy_memory && !migrateResult?.semantic && (
-              <Btn disabled={migrating} onClick={async () => { setMigrating(true); setMigrateResult(null); const r = await api.vectorMigrate().catch(() => ({ error: 'Migration failed' })); setMigrateResult(r); setMigrating(false); await load() }}>
-                {migrating ? <><Hourglass className="lucide-inline" /> Migrating…</> : <><Package className="lucide-inline" /> Migrate from Markdown</>}
-              </Btn>
-            )}
-          </div>
-          {migrateResult && !migrateResult.error && (
-            <p className="text-sm text-ok"><CheckCircle className="lucide-inline" /> Migrated {migrateResult.semantic} semantic + {migrateResult.episodic} episodic entries ({migrateResult.skipped} skipped)</p>
-          )}
-          {migrateResult?.error && (
-            <div className="flex items-center gap-2">
-              <p className="text-sm text-danger"><XCircle className="lucide-inline" /> {migrateResult.error}</p>
-              <Btn onClick={startEmbeddings}><RefreshCw className="lucide-inline" /> Retry</Btn>
-            </div>
-          )}
         </div>
       )}
       {enabling && (() => {
@@ -360,17 +342,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
                 }</button>
             ))}
             </div>
-            <div className="flex gap-2 ml-auto">
-              {!stats?.migrated && stats?.has_legacy_memory && !migrateResult?.semantic && (
-                <Btn disabled={migrating} onClick={async () => { setMigrating(true); setMigrateResult(null); const r = await api.vectorMigrate().catch(() => ({ error: 'Migration failed' })); setMigrateResult(r); setMigrating(false); await load() }}>
-                  {migrating ? <><Hourglass className="lucide-inline" />…</> : <><Package className="lucide-inline" /> Migrate</>}
-                </Btn>
-              )}
-            </div>
           </div>
-          {migrateResult && !migrateResult.error && (
-            <p className="text-sm text-ok"><CheckCircle className="lucide-inline" /> Migrated {migrateResult.semantic} semantic + {migrateResult.episodic} episodic ({migrateResult.skipped} skipped)</p>
-          )}
         </div>
       )}
     </Card>

--- a/website/src/test/VectorMemoryCard.autoMigrate.test.tsx
+++ b/website/src/test/VectorMemoryCard.autoMigrate.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import VectorMemoryCard from '../pages/overview/VectorMemoryCard'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+
+// Migration is automatic + background at gateway boot, so the Vector Memory
+// card no longer exposes any manual "Migrate" / "Migrate from Markdown" button
+// or a proactive "Start Embedding Engine" button. Only a Retry affordance
+// survives, and only in the genuine download-error state.
+
+vi.mock('../api/client', () => ({
+  api: {
+    vectorStats: vi.fn(async () => ({})),
+    vectorEmbeddingStatus: vi.fn(async () => ({})),
+    vectorSemantic: vi.fn(async () => ({ entries: [] })),
+    vectorSemanticWrite: vi.fn(async () => undefined),
+    vectorSemanticDelete: vi.fn(async () => undefined),
+    vectorEpisodic: vi.fn(async () => ({ entries: [] })),
+    vectorEvents: vi.fn(async () => ({ events: [] })),
+    vectorContextPreview: vi.fn(async () => null),
+    vectorEnableEmbeddings: vi.fn(async () => ({ ok: true })),
+  },
+}))
+
+describe('VectorMemoryCard — automatic migration (no manual buttons)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('has legacy memory but is NOT migrated → shows no Migrate button', async () => {
+    // The exact state that used to render "Migrate from Markdown".
+    vi.mocked(api.vectorStats).mockResolvedValue({
+      semantic_active: 0, episodic_active: 0, embedded_count: 0,
+      migrated: false, has_legacy_memory: true,
+    })
+    vi.mocked(api.vectorEmbeddingStatus).mockResolvedValue({
+      provider: 'none', setup_step: 'idle', model_available: false,
+    })
+    renderWithProviders(<VectorMemoryCard />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/downloads automatically in the background/i)).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/Migrate from Markdown/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Migrate$/i })).not.toBeInTheDocument()
+    // Proactive start button is gone too.
+    expect(screen.queryByText(/Start Embedding Engine/i)).not.toBeInTheDocument()
+  })
+
+  it('active + not-migrated with legacy → no Migrate button in the active view', async () => {
+    vi.mocked(api.vectorStats).mockResolvedValue({
+      semantic_active: 5, episodic_active: 3, embedded_count: 3,
+      migrated: false, has_legacy_memory: true,
+    })
+    vi.mocked(api.vectorEmbeddingStatus).mockResolvedValue({
+      provider: 'llama_cpp', setup_step: 'done', model_available: true,
+    })
+    renderWithProviders(<VectorMemoryCard />)
+
+    // Active view renders (the Inspector tab button is unique to it).
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Inspector/i })).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/Migrate/i)).not.toBeInTheDocument()
+  })
+
+  it('download error state → shows a Retry button', async () => {
+    vi.mocked(api.vectorStats).mockResolvedValue({
+      semantic_active: 0, episodic_active: 0, embedded_count: 0,
+      migrated: true, has_legacy_memory: false,
+    })
+    vi.mocked(api.vectorEmbeddingStatus).mockResolvedValue({
+      provider: 'none', setup_step: 'idle', model_available: false,
+      setup_error: 'Download failed',
+    })
+    renderWithProviders(<VectorMemoryCard />)
+
+    await waitFor(() => expect(screen.getByText(/Download failed/i)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

Embeddings are documented as always-on, but legacy markdown memory only migrated on a **manual dashboard button click**, and the Vector Memory card still shipped "Migrate" / "Start Embedding Engine" buttons. New users stayed in markdown mode indefinitely — contradicting the "always-on" promise.

**Problem.** Migration was opt-in and manual; nothing moved legacy `preferences.md` / `projects.md` / `history/*.md` / `lessons.jsonl` into the vector store unless the user clicked.

**Why it matters.** Users never got semantic memory unless they discovered and pressed a button. The intended behavior is: everything migrates to embeddings automatically in the background on startup, and the system acknowledges it — no user action.

**Fix (symptom → root cause → change).** The gateway already kicked the background model download at boot (`_start_embeddings`), so *background embedding* existed; the gap was auto-migration and the leftover manual buttons. This PR:

- **`GatewayOrchestrator._auto_migrate_memory()`** — a fire-and-forget task scheduled right after `_start_embeddings()`. Two idempotent phases, all blocking work offloaded to the maintenance executor so boot never blocks:
  1. **Migrate** (gated on `memory.migrated`): parse legacy markdown via `migrate_from_markdown()`, flip `memory.migrated=True` for everyone (fresh installs land in vector-only mode too), sync the live consolidator, and **acknowledge** with a `migration` audit event (visible in the Audit tab) + a log line.
  2. **Re-embed sweep** (gated on model readiness): once the model is actually loaded, embed any episodic rows written with a NULL vector (migrated before the model landed) and rebuild the FAISS index. Self-healing across boots.
  - Never raises — any failure is logged and leaves `migrated=False` so the next boot retries. Cancelled on shutdown.
- **`VectorMemory.backfill_missing_embeddings()`** — embeds NULL-vector episodic rows and rebuilds FAISS; idempotent no-op when nothing is pending. Mirrors `write_episodic()`: **L2-normalizes** each vector (the FAISS `IndexFlatIP` scores inner product, which equals cosine only on unit vectors) and **validates `shape == (embedding_dim,)`**, leaving the row NULL on mismatch so a later sweep retries instead of storing a non-NULL vector that the index silently skips forever.
- **`memory.legacy_memory_present()`** — shared legacy-detection helper used by both the boot migration and the `/api/memory/stats` handler.
- **Frontend** — remove the migrate + "Start Embedding Engine" buttons and their state; keep only an error-state **Retry**. Drop the unused `vectorMigrate` client method. The card is now passive.

**Correctness hardening (from review):**
- `migrate_from_markdown()` now derives source paths from `config_dir()` so it honors `KIROCREW_HOME` and reads the **same** directory `legacy_memory_present()` detects — previously a custom home could detect legacy content in one dir, migrate an empty other dir, then permanently set `migrated=True` having imported nothing.
- The re-embed sweep blocks on the embedder's `wait_ready()` (falling back to `is_ready()` for backends without it) **before** backfilling: model-file presence only means the GGUF is on disk, and the first embed kicks an async load that returns `None` — without the wait the sweep would embed zero rows and never reschedule.
- `_set_migrated()` **fails closed** on an unparseable `config.json`: it logs and returns without writing, instead of substituting `{}` and clobbering every other section (provider, Slack, dashboard). Since auto-migration calls it on every boot while `migrated=false`, a malformed config is preserved for repair and the flag flip retries later.

The `/api/memory/migrate` endpoint and `kirocrew memory migrate` CLI remain as a manual escape hatch; the dashboard just stops calling them.

## Related Issues

<!-- none -->

## Testing

- [x] Existing tests pass — full `test_slack_gateway.py` (172) and `test_memory.py` + `test_enable_embeddings_faiss.py` (41), no regressions
- [x] New tests added for new functionality:
  - `TestAutoMigrateMemory` — migrate / skip-when-migrated / fresh-install / model-absent-then-sweep / **model-not-ready-defers** / error-survives
  - `TestBackfillMissingEmbeddings` — embeds + rebuilds index, **L2-normalization asserted**, **dim-mismatch left NULL for retry**, no-op paths (verified against real faiss+numpy)
  - `TestSetMigratedFailClosed` — malformed config left untouched / valid config preserves other sections / missing config writes fresh
  - Frontend `VectorMemoryCard.autoMigrate` — the manual buttons are gone and Retry survives on error
- [x] Manual verification performed — backend blocking gates green (isort, flake8, mypy); frontend `tsc -b` + vite build succeed and the full vitest suite passes

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated — `docs/system-specs/modules/memory-skills-hooks.md` (Migration + enable-flow) in the same change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. -->
