### PR TITLE
feat(terminal): app-wide bottom terminal panel + transferable tabs

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -26,7 +26,7 @@ import { ZoomProvider } from './hooks/ZoomProvider'
 import { api, isAuthBannerShown } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
-import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, ArrowLeftToLine, Globe, LayoutGrid, Lightbulb, ExternalLink } from 'lucide-react'
+import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, ArrowLeftToLine, Globe, LayoutGrid, Lightbulb, ExternalLink, SquareTerminal } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import OnboardingFlow from './components/OnboardingFlow'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -65,6 +65,8 @@ import SchedulePage from './pages/SchedulePage'
 import { useUpdateSubscription } from './hooks/useUpdateSubscription'
 import UpdateModal from './components/UpdateModal'
 import BrowserLiveView from './components/BrowserLiveView'
+import BottomTerminalPanel from './components/BottomTerminalPanel'
+import { useBottomTerminalOpen, toggleBottomTerminal } from './hooks/useBottomTerminal'
 import { setTerminalEnabledFlag } from './utils/terminalRegistry'
 import AppsPage from './pages/AppsPage'
 import AppPage from './pages/AppPage'
@@ -726,6 +728,7 @@ export default function App() {
   // so there is no hidden-until-fetch-resolves flash.
   const terminalEnabled = terminalConfig?.enabled !== false
   useEffect(() => { setTerminalEnabledFlag(terminalEnabled) }, [terminalEnabled])
+  const bottomTerminalOpen = useBottomTerminalOpen()
   const navigate = useNavigate()
 
   // Main-dashboard role for the artifact popout nav-intent handshake: perform
@@ -1800,6 +1803,17 @@ export default function App() {
                 />
                 )
               })()}
+              {terminalEnabled && (
+                <NavItem
+                  path="#"
+                  label="Terminal"
+                  icon={<SquareTerminal size={16} />}
+                  active={bottomTerminalOpen}
+                  collapsed={effectiveCollapsed}
+                  onClick={closeMobileNav}
+                  onClickOverride={() => toggleBottomTerminal()}
+                />
+              )}
               <NavItem
                 path={s.path}
                 label={s.label}
@@ -1865,6 +1879,10 @@ export default function App() {
             <Route path="*" element={<ChatRedirect />} />
           </Routes>
         </main>
+        {/* App-wide docked terminal panel — spans every route, below <main>.
+            Toggled from the sidebar Terminal icon; hosts app-wide
+            shells. Distinct from the chat-scoped activity-bar terminal tabs. */}
+        {terminalEnabled && <BottomTerminalPanel />}
         {/* Self-managed floating panel: lifecycle-driven (hidden → small → chip),
             not a motion.* child, so it lives outside AnimatePresence. */}
         <BrowserLiveView />

--- a/website/src/components/BottomTerminalPanel.tsx
+++ b/website/src/components/BottomTerminalPanel.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { motion, AnimatePresence, Reorder } from 'framer-motion'
+import { useLocation } from 'react-router-dom'
+import { TerminalSquare, Plus, X, ChevronDown, PanelRight } from 'lucide-react'
+import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from './CliPanel'
+import { useTerminalTitle } from '../utils/terminalRegistry'
+import { usePanelTabs } from '../hooks/usePanelTabs'
+import { useAppSelector, useAppDispatch } from '../store'
+import { openActivityPanel } from '../store/chatSlice'
+import {
+  useBottomTerminal, addTab, removeTab, setActiveTab, setTabsOrder,
+  closeBottomTerminal, setBottomTerminalHeight, MAX_TERMINALS,
+  type TermTab,
+} from '../hooks/useBottomTerminal'
+
+/** Fraction of the viewport the panel may grow to via the resize grip. */
+const MAX_VH = 0.72
+
+/** Live terminal tab title — the running command / cwd basename pushed by the
+ *  backend poller; falls back to "Terminal" until the first frame arrives. */
+function TerminalTitle({ sessionId }: { sessionId: string }) {
+  const live = useTerminalTitle(sessionId)
+  return <>{live || 'Terminal'}</>
+}
+
+/** A terminal tab chip — mirrors the activity-bar SidePanel TabChip design */
+function TabChip({ tab, active, onSelect, onClose, onTransfer, canTransfer }: {
+  tab: TermTab; active: boolean; onSelect: () => void; onClose: () => void
+  onTransfer: () => void; canTransfer: boolean
+}) {
+  const transferCls = canTransfer
+    ? `shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`
+    : 'shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full bg-transparent border-none text-muted opacity-30 cursor-not-allowed'
+  return (
+    <div
+      role="tab"
+      aria-selected={active}
+      tabIndex={0}
+      onClick={onSelect}
+      // Guard on e.target so Enter/Space on the nested transfer/close buttons
+      // activates them natively instead of also selecting the tab.
+      onKeyDown={(e) => { if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect() } }}
+      onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); onClose() } }}
+      className={`group relative flex items-center gap-1.5 h-8 pl-3 pr-1.5 rounded-full cursor-pointer shrink-0 max-w-[240px] select-none border transition-colors ${
+        active ? 'bg-bg-elevated border-border text-text-strong shadow-sm' : 'bg-transparent border-transparent text-muted hover:text-text hover:bg-bg-hover'
+      }`}
+    >
+      <span className="shrink-0 opacity-80"><TerminalSquare size={13} /></span>
+      <span className="min-w-0 text-[12.5px] truncate text-left">
+        <TerminalTitle sessionId={tab.id} />
+      </span>
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          onClick={(e) => { e.stopPropagation(); if (canTransfer) onTransfer() }}
+          disabled={!canTransfer}
+          className={transferCls}
+          title={canTransfer ? 'Move to side panel' : 'Open a chat page to move this terminal there'}
+          aria-label="Move to side panel"
+        >
+          <PanelRight size={12} />
+        </button>
+        <button
+          onClick={(e) => { e.stopPropagation(); onClose() }}
+          className={`shrink-0 -ml-0.5 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+          title="Close terminal"
+          aria-label="Close terminal"
+        >
+          <X size={12} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * App-wide docked terminal panel. Toggled from the sidebar Terminal icon
+ * (App.tsx), it spans the whole app (below the routed <main>) rather than
+ * living inside a single chat's activity bar. A terminals-only tab view: each
+ * tab is a single-session CliPanel bound to a PTY in terminalRegistry — so
+ * hiding/reopening the panel, switching tabs, or navigating routes keeps every
+ * shell warm. Only closing an individual tab kills its PTY.
+ */
+export default function BottomTerminalPanel() {
+  const { open, height, tabs, activeId } = useBottomTerminal()
+  const del = useDeleteTerminalSession()
+  const [dragging, setDragging] = useState(false)
+
+  // Move-to-chat is only offered while the user is actually ON the chat page
+  // with a slot active
+  const activeSlot = useAppSelector(s => s.chat.activeSlot)
+  const chatTabs = usePanelTabs(activeSlot)
+  const dispatch = useAppDispatch()
+  const location = useLocation()
+  const canTransferToChat = activeSlot != null && location.pathname.startsWith('/chat')
+
+  /** Close a tab: kill its backend PTY (best-effort), tear down local WS +
+   *  xterm, then drop it from the store (which hides the panel if it was last). */
+  const closeTab = useCallback((id: string) => {
+    del.mutate(id)
+    disposeTerminalSession(id)
+    removeTab(id)
+  }, [del])
+
+  // Move a terminal OUT of the app-wide panel into the active chat's activity
+  // bar. Non-disposing (mirror of the chat→bottom transfer): the PTY/xterm live
+  // in terminalRegistry/termCache keyed by session id and re-attach in the
+  // chat. Open the chat's activity panel so the moved tab is visible; only drop
+  // it from the bottom panel once the chat accepts it.
+  const transferToChat = useCallback((id: string, cwd?: string) => {
+    if (!canTransferToChat) return
+    if (chatTabs.adoptTerminal(id, cwd)) {
+      dispatch(openActivityPanel())
+      removeTab(id)
+    }
+  }, [canTransferToChat, chatTabs, dispatch])
+
+  /* ── Top grip resize (drag up → taller) ── */
+  const startRef = useRef<{ y: number; h: number } | null>(null)
+  const onGripDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    startRef.current = { y: e.clientY, h: height }
+    setDragging(true)
+    const onMove = (ev: MouseEvent) => {
+      if (!startRef.current) return
+      const maxH = Math.round(window.innerHeight * MAX_VH)
+      setBottomTerminalHeight(Math.min(maxH, startRef.current.h + (startRef.current.y - ev.clientY)))
+    }
+    const onUp = () => {
+      startRef.current = null
+      setDragging(false)
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'row-resize'
+  }, [height])
+
+  // Safety: restore body styles if unmounted mid-drag.
+  useEffect(() => () => {
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }, [])
+
+  const atCap = tabs.length >= MAX_TERMINALS
+
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          key="bottom-terminal"
+          className="shrink-0 overflow-hidden border-t border-border bg-bg"
+          initial={{ height: 0 }}
+          animate={{ height }}
+          exit={{ height: 0 }}
+          transition={{ duration: dragging ? 0 : 0.22, ease: 'easeOut' }}
+          style={{ willChange: 'height' }}
+        >
+          <div className="flex flex-col" style={{ height }}>
+          <div
+            onMouseDown={onGripDown}
+            className="relative shrink-0 h-[6px] cursor-row-resize group/drag"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize terminal panel"
+          >
+            <div className={`absolute inset-x-0 top-0 h-[2px] transition-colors duration-200 ${dragging ? 'bg-accent' : 'bg-transparent group-hover/drag:bg-accent'}`} />
+          </div>
+          {/* Tab strip — same aesthetics as the activity-bar strip; drag chips
+              horizontally to reorder (framer Reorder). */}
+          <div className="flex items-center gap-1.5 h-9 shrink-0 pl-2 pr-1.5">
+            <Reorder.Group
+              axis="x"
+              values={tabs}
+              onReorder={setTabsOrder}
+              role="tablist"
+              className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none list-none m-0 p-0"
+            >
+              {tabs.map((t, i) => (
+                <Reorder.Item
+                  key={t.id}
+                  value={t}
+                  className="relative shrink-0 list-none"
+                  transition={{ type: 'spring', stiffness: 700, damping: 45 }}
+                >
+                  {/* Hairline between adjacent chips, suppressed on both edges of
+                      the active tab (its pill already delineates it). */}
+                  {i > 0 && t.id !== activeId && tabs[i - 1].id !== activeId && (
+                    <span aria-hidden="true" className="absolute -left-[4.5px] top-1/2 -translate-y-1/2 w-px h-4 bg-border" />
+                  )}
+                  <TabChip
+                    tab={t}
+                    active={t.id === activeId}
+                    onSelect={() => setActiveTab(t.id)}
+                    onClose={() => closeTab(t.id)}
+                    onTransfer={() => transferToChat(t.id, t.cwd)}
+                    canTransfer={canTransferToChat}
+                  />
+                </Reorder.Item>
+              ))}
+            </Reorder.Group>
+            {/* + opens a new terminal tab instantly (no menu). */}
+            <button
+              className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+              onClick={() => addTab()}
+              disabled={atCap}
+              title={atCap ? `Maximum ${MAX_TERMINALS} terminals` : 'New terminal'}
+              aria-label="New terminal"
+            >
+              <Plus size={15} />
+            </button>
+            <button
+              className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0 ml-auto"
+              onClick={() => closeBottomTerminal()}
+              title="Hide terminal panel"
+              aria-label="Hide terminal panel"
+            >
+              <ChevronDown size={16} />
+            </button>
+          </div>
+          {/* Body — every terminal stays mounted (hidden when inactive) so the
+              xterm session + scrollback survive tab switches. */}
+          <div className="flex-1 min-h-0 relative">
+            {tabs.map(t => (
+              <div key={t.id} className="absolute inset-0" style={{ display: t.id === activeId ? 'block' : 'none' }}>
+                <CliPanel sessionId={t.id} cwd={t.cwd} visible={t.id === activeId} />
+              </div>
+            ))}
+          </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/website/src/hooks/useBottomTerminal.ts
+++ b/website/src/hooks/useBottomTerminal.ts
@@ -1,0 +1,184 @@
+import { useSyncExternalStore } from 'react'
+import { safeSetItem } from '../utils/safeStorage'
+
+/* ── App-wide bottom terminal panel ───────────────────────────────────────
+ * A single docked terminal panel shared by the ENTIRE app (every route), as
+ * opposed to the chat-scoped activity-bar terminal tabs (usePanelTabs). It is
+ * a TAB view — terminals only — mirroring the activity-bar tab strip: each tab
+ * is its own PTY session, the active one is shown and the rest kept mounted
+ * (hidden) so their shells survive tab switches.
+ *
+ * State is MODULE-LEVEL + localStorage-persisted (mirroring usePanelTabs and
+ * terminalRegistry) rather than redux, so the panel survives route changes and
+ * full reloads; on reload each persisted tab reconnects to its still-live PTY
+ * (backend orphan-reaper window), the same way activity-bar terminal tabs do.
+ * Tab session ids are persisted; the running shell is not. */
+
+export interface TermTab {
+  /** PTY session id — one live shell per tab. */
+  id: string
+  /** Working directory the shell spawned in (undefined = server default). */
+  cwd?: string
+}
+
+interface BottomTerminalState {
+  open: boolean
+  /** Panel height in px (resizable via the top grip). */
+  height: number
+  /** Terminal tabs, left → right. */
+  tabs: TermTab[]
+  /** Active (visible) tab. */
+  activeId: string | null
+}
+
+const STORAGE_KEY = 'mc-bottom-terminal'
+/** Min panel height in px; the grip can't drag below this. */
+export const MIN_HEIGHT = 120
+/** Default panel height on first open. */
+const DEFAULT_HEIGHT = 300
+/** Max concurrent terminal tabs (each is a live PTY). */
+export const MAX_TERMINALS = 8
+
+const mintId = () => Math.random().toString(36).slice(2, 14)
+const clampHeight = (h: number) => Math.max(MIN_HEIGHT, Math.round(h))
+
+function loadPersisted(): BottomTerminalState {
+  const base: BottomTerminalState = { open: false, height: DEFAULT_HEIGHT, tabs: [], activeId: null }
+  if (typeof localStorage === 'undefined') return base
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return base
+    // `splits` is read as a fallback for the pre-tab-model dev shape.
+    const p = JSON.parse(raw) as (Partial<BottomTerminalState> & { splits?: TermTab[] }) | null
+    if (!p || typeof p !== 'object') return base
+    const rawTabs = Array.isArray(p.tabs) ? p.tabs : Array.isArray(p.splits) ? p.splits : []
+    const tabs = (rawTabs.filter(t => t && typeof (t as TermTab).id === 'string') as TermTab[]).slice(0, MAX_TERMINALS)
+    return {
+      // Only restore "open" when there were tabs to restore — a stale open flag
+      // with no tabs would render an empty panel on boot.
+      open: p.open === true && tabs.length > 0,
+      height: typeof p.height === 'number' ? clampHeight(p.height) : DEFAULT_HEIGHT,
+      tabs,
+      activeId: tabs.some(t => t.id === p.activeId) ? (p.activeId as string) : (tabs[0]?.id ?? null),
+    }
+  } catch {
+    return base
+  }
+}
+
+let state: BottomTerminalState = loadPersisted()
+const listeners = new Set<() => void>()
+
+function emit() { for (const cb of listeners) cb() }
+
+function set(next: BottomTerminalState) {
+  if (next === state) return
+  state = next
+  emit()
+  try { safeSetItem(STORAGE_KEY, JSON.stringify(state)) } catch { /* quota / locked storage */ }
+}
+
+/* ── Actions (module functions so non-React callers — e.g. keyboard handlers,
+ *    "Run in terminal" — can drive the panel too) ── */
+
+/** Open the panel, minting a first terminal tab if it has none. */
+export function openBottomTerminal(cwd?: string): void {
+  const tabs = state.tabs.length ? state.tabs : [{ id: mintId(), cwd }]
+  set({ ...state, open: true, tabs, activeId: state.activeId ?? tabs[0].id })
+}
+
+/** Hide the panel WITHOUT killing its shells — they stay warm for reopen. */
+export function closeBottomTerminal(): void {
+  if (!state.open) return
+  set({ ...state, open: false })
+}
+
+export function toggleBottomTerminal(cwd?: string): void {
+  if (state.open) closeBottomTerminal()
+  else openBottomTerminal(cwd)
+}
+
+/** Open a new terminal tab instantly (mints a fresh PTY session). At the cap,
+ *  focuses the last tab instead of spawning. Returns the new session id, or
+ *  null at the cap. */
+export function addTab(cwd?: string): string | null {
+  if (state.tabs.length >= MAX_TERMINALS) {
+    const last = state.tabs[state.tabs.length - 1]
+    if (last) set({ ...state, open: true, activeId: last.id })
+    return null
+  }
+  const id = mintId()
+  set({ ...state, open: true, tabs: [...state.tabs, { id, cwd }], activeId: id })
+  return id
+}
+
+/** Adopt an EXISTING terminal session as a bottom-panel tab (no new PTY) — used
+ *  when moving a chat's terminal into the app-wide panel. The session id is
+ *  preserved so its live shell + scrollback come along (the PTY/xterm live in
+ *  terminalRegistry/termCache keyed by session id, independent of the view).
+ *  Returns false at the cap so the caller leaves the tab in its source view. */
+export function adoptTab(id: string, cwd?: string): boolean {
+  if (state.tabs.some(t => t.id === id)) { set({ ...state, open: true, activeId: id }); return true }
+  if (state.tabs.length >= MAX_TERMINALS) return false
+  set({ ...state, open: true, tabs: [...state.tabs, { id, cwd }], activeId: id })
+  return true
+}
+
+/** Remove a tab from the store (the caller disposes the PTY/xterm first).
+ *  Closing the last tab also hides the panel. */
+export function removeTab(id: string): void {
+  const idx = state.tabs.findIndex(t => t.id === id)
+  if (idx === -1) return
+  const tabs = state.tabs.filter(t => t.id !== id)
+  // Refocus a neighbor when closing the active tab (prefer the left one).
+  const activeId = state.activeId !== id
+    ? state.activeId
+    : (tabs[idx - 1] ?? tabs[idx] ?? tabs[tabs.length - 1])?.id ?? null
+  set({ ...state, tabs, activeId, open: tabs.length > 0 ? state.open : false })
+}
+
+export function setActiveTab(id: string): void {
+  if (state.activeId === id) return
+  set({ ...state, activeId: id })
+}
+
+/** Replace the tab order wholesale (drag-to-reorder in the strip). */
+export function setTabsOrder(next: TermTab[]): void {
+  set({ ...state, tabs: next })
+}
+
+export function setBottomTerminalHeight(px: number): void {
+  const height = clampHeight(px)
+  if (height === state.height) return
+  set({ ...state, height })
+}
+
+/* ── React binding ── */
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}
+function getSnapshot(): BottomTerminalState { return state }
+
+export function useBottomTerminal(): BottomTerminalState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/** Selector for just the `open` flag. App only needs this; returning a
+ *  primitive lets useSyncExternalStore's Object.is check skip re-renders on
+ *  unrelated state changes — notably setBottomTerminalHeight firing on every
+ *  mousemove during a grip-drag. */
+function getOpenSnapshot(): boolean { return state.open }
+export function useBottomTerminalOpen(): boolean {
+  return useSyncExternalStore(subscribe, getOpenSnapshot, getOpenSnapshot)
+}
+
+/** Test-only: reset the module store and its persisted copy. */
+export function __resetBottomTerminal(): void {
+  state = { open: false, height: DEFAULT_HEIGHT, tabs: [], activeId: null }
+  emit()
+  if (typeof localStorage !== 'undefined') {
+    try { localStorage.removeItem(STORAGE_KEY) } catch { /* ignore */ }
+  }
+}

--- a/website/src/hooks/usePanelTabs.ts
+++ b/website/src/hooks/usePanelTabs.ts
@@ -285,12 +285,24 @@ export function usePanelTabs(slotKey: string | null = null) {
     return sessionId
   }, [tabs, upsert, setActive])
 
+  /** Adopt an EXISTING terminal session as a tab in THIS slot (no new PTY) —
+   *  the mirror of openTerminal, used to move a terminal from the app-wide
+   *  bottom panel back into a chat. Reuses the given session id so its live
+   *  shell + scrollback come along. Returns false at the per-chat cap. */
+  const adoptTerminal = useCallback((sessionId: string, cwd?: string): boolean => {
+    const id = `terminal:${sessionId}`
+    if (tabs.some(t => t.id === id)) { setActive(id); return true }
+    if (tabs.filter(t => t.kind === 'terminal').length >= MAX_TERMINALS_PER_CHAT) return false
+    upsert({ id, kind: 'terminal', title: cwd ? basename(cwd) : 'Terminal', sessionId, cwd })
+    return true
+  }, [tabs, upsert, setActive])
+
   const activeTab = useMemo(() => tabs.find(t => t.id === activeId) ?? null, [tabs, activeId])
 
   return useMemo(() => ({
     tabs, activeId, activeTab,
-    openView, openTerminal, openFile, openDiff, openArtifact,
+    openView, openTerminal, adoptTerminal, openFile, openDiff, openArtifact,
     patchTab, closeTab, closeAll, setActive, setOrder,
     hasTabs: tabs.length > 0,
-  }), [tabs, activeId, activeTab, openView, openTerminal, openFile, openDiff, openArtifact, patchTab, closeTab, closeAll, setActive, setOrder])
+  }), [tabs, activeId, activeTab, openView, openTerminal, adoptTerminal, openFile, openDiff, openArtifact, patchTab, closeTab, closeAll, setActive, setOrder])
 }

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { Reorder } from 'framer-motion'
-import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, PanelRightClose, Component } from 'lucide-react'
+import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, PanelRightClose, Component, PanelBottom } from 'lucide-react'
 import ActivityViewer from './ActivityViewer'
 import DiffPanel from '../../components/DiffPanel'
 import DetailPanel from '../../components/DetailPanel'
@@ -10,6 +10,7 @@ import ArtifactPanel from '../../components/ArtifactPanel'
 import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from '../../components/CliPanel'
 import { countLines } from '../../components/FileChangeChips'
 import { useTerminalEnabled, useTerminalTitle } from '../../utils/terminalRegistry'
+import { adoptTab as adoptBottomTerminal } from '../../hooks/useBottomTerminal'
 import type { usePanelTabs, ViewKind, PanelTab, TabKind } from '../../hooks/usePanelTabs'
 import { usePersistedBool } from '../../hooks/usePersistedBool'
 import { useListboxKeyboard } from '../../hooks/useListboxKeyboard'
@@ -133,6 +134,15 @@ export default function SidePanel({
     }
     closeTab(id)
   }, [tabs, closeTab, deleteTerminalSession])
+  // Move a terminal tab OUT of this chat into the app-wide bottom panel. Unlike
+  // handleCloseTab this must NOT dispose the session — the PTY + xterm live in
+  // terminalRegistry/termCache keyed by session id and simply re-attach in the
+  // bottom panel. Only drop it from this chat once the panel accepts it.
+  const handleTransferToBottom = useCallback((id: string) => {
+    const t = tabs.find(x => x.id === id)
+    if (t?.kind !== 'terminal' || !t.sessionId) return
+    if (adoptBottomTerminal(t.sessionId, t.cwd)) closeTab(id)
+  }, [tabs, closeTab])
   const [menuOpen, setMenuOpen] = useState(false)
   // Diff view preferences — persisted; 'mc-diff-split' is shared with the
   // file view's git-diff toggle so split/unified is one app-wide preference.
@@ -257,7 +267,7 @@ export default function SidePanel({
               {i > 0 && t.id !== activeId && tabs[i - 1].id !== activeId && (
                 <span aria-hidden="true" className="absolute -left-[4.5px] top-1/2 -translate-y-1/2 w-px h-4 bg-border" />
               )}
-              <TabChip tab={t} active={t.id === activeId} onSelect={() => setActive(t.id)} onClose={() => handleCloseTab(t.id)} />
+              <TabChip tab={t} active={t.id === activeId} onSelect={() => setActive(t.id)} onClose={() => handleCloseTab(t.id)} onTransfer={t.kind === 'terminal' ? () => handleTransferToBottom(t.id) : undefined} />
             </Reorder.Item>
           ))}
         </Reorder.Group>
@@ -483,12 +493,16 @@ function TerminalTabTitle({ sessionId, fallback }: { sessionId: string; fallback
   return <>{live || fallback}</>
 }
 
-function TabChip({ tab, active, onSelect, onClose }: { tab: PanelTab; active: boolean; onSelect: () => void; onClose: () => void }) {
+function TabChip({ tab, active, onSelect, onClose, onTransfer }: { tab: PanelTab; active: boolean; onSelect: () => void; onClose: () => void; onTransfer?: () => void }) {
   return (
     <div
       role="tab"
       aria-selected={active}
+      tabIndex={0}
       onClick={onSelect}
+      // Guard on e.target so Enter/Space on the nested transfer/close buttons
+      // activates them natively instead of also selecting the tab.
+      onKeyDown={(e) => { if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect() } }}
       onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); onClose() } }}
       className={`group relative flex items-center gap-1.5 h-8 pl-3 pr-1.5 rounded-full cursor-pointer shrink-0 max-w-[240px] select-none border transition-colors ${
         active ? 'bg-bg-elevated border-border text-text-strong shadow-sm' : 'bg-transparent border-transparent text-muted hover:text-text hover:bg-bg-hover'
@@ -500,14 +514,26 @@ function TabChip({ tab, active, onSelect, onClose }: { tab: PanelTab; active: bo
           ? <TerminalTabTitle sessionId={tab.sessionId} fallback={tab.title} />
           : tab.title}
       </span>
-      <button
-        onClick={(e) => { e.stopPropagation(); onClose() }}
-        className={`shrink-0 -ml-0.5 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
-        title="Close tab"
-        aria-label="Close tab"
-      >
-        <X size={12} />
-      </button>
+      <div className="flex items-center gap-0.5 shrink-0">
+        {onTransfer && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onTransfer() }}
+            className={`shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+            title="Move to bottom panel"
+            aria-label="Move to bottom panel"
+          >
+            <PanelBottom size={12} />
+          </button>
+        )}
+        <button
+          onClick={(e) => { e.stopPropagation(); onClose() }}
+          className={`shrink-0 -ml-0.5 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+          title="Close tab"
+          aria-label="Close tab"
+        >
+          <X size={12} />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Re-adds a global bottom terminal panel alongside the chat-scoped activity-bar
terminal tabs, and lets terminals move between the two views. Toggled from a
sidebar terminal icon; spans every route.

## Changes
- **useBottomTerminal**: module-level `useSyncExternalStore` + localStorage store
  (open / height / tabs / activeId) with a `useBottomTerminalOpen()` selector so
  `App` only re-renders when the open flag changes (not on every resize frame).
  Tabs persist so shells reconnect on reload via `terminalRegistry`; hiding the
  panel keeps shells warm, only per-tab close kills the PTY.
- **BottomTerminalPanel**: terminals-only tab strip matching the SidePanel pill
  design (rounded-full, border, shadow on active), instant `+`, drag-to-reorder,
  `ChevronDown` hide, standard 2px accent resize grip. A fixed-height inner
  wrapper keeps the open/close tween from resizing the xterm (which had made the
  shell reprint its prompt on every toggle).
- **App**: sidebar terminal icon toggles the panel (gated on `terminalEnabled`);
  panel docked below `<main>`.
- **Transferable tabs**: a `PanelBottom` button on chat terminal tabs moves them
  to the bottom panel; a `PanelRight` button on bottom tabs moves them to the
  active chat's side panel (only on the chat route). Both are non-disposing, so
  the live shell and scrollback re-attach in the new view. `usePanelTabs` gains
  `adoptTerminal()` as the mirror of `openTerminal`.

## Testing
- `tsc -b` clean.
- Verified toggle / split / drag-reorder / bidirectional transfer, and that
  closing+reopening no longer accumulates prompt lines.

https://github.com/user-attachments/assets/a126ec05-c3d0-4cc8-a849-3c7c847c64ad