### PR TITLE
fix(sources): detect PR URLs wrapped in markdown emphasis

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1119,7 +1119,12 @@ class _ChatSlot:
                 end = idx
                 while end < len(content) and content[end] not in stop_chars:
                     end += 1
-                candidate = content[idx:end].rstrip(".,!?;:")
+                # Also strip markdown emphasis (**bold**, *italic*, `code`,
+                # _underscore_, ~~strike~~): agent messages routinely wrap PR
+                # URLs in emphasis and a trailing "**" fails the numeric tail
+                # check. Valid PR/MR URLs end in a number, so these chars can
+                # never belong to a legitimate link tail.
+                candidate = content[idx:end].rstrip(".,!?;:*_~`")
                 idx = end
                 if "/pull/" not in candidate and "/merge_requests/" not in candidate:
                     continue

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -111,6 +111,19 @@ class TestChatSlot:
         assert payload["source_links_total"] == 1
         assert payload["source_links"][0]["url"] == url
 
+    def test_pr_source_links_detect_markdown_wrapped_urls(self):
+        """Regression: '**url**' left a trailing '**' on the candidate, so the
+        numeric tail check failed and the link was silently dropped."""
+        slot = _ChatSlot("s1")
+        url = "https://github.com/acme/widgets/pull/166"
+        for i, wrapped in enumerate(
+            (f"**{url}**", f"*{url}*", f"`{url}`", f"__{url}__", f"~~{url}~~")
+        ):
+            slot.append("assistant", f"PR is up: {wrapped} — fix(tips)", ts=f"t{i}")
+        payload = slot.to_dict()
+        assert payload["source_links_total"] == 1
+        assert payload["source_links"][0]["url"] == url
+
     @pytest.mark.parametrize(
         "role", ["chunk", "done", "streaming", "queued", "permission"]
     )

--- a/website/src/test/pullRequestLinks.test.ts
+++ b/website/src/test/pullRequestLinks.test.ts
@@ -37,6 +37,21 @@ describe('extractPullRequestLinks', () => {
     ))).toEqual([])
   })
 
+  it('detects URLs wrapped in markdown emphasis (regression: trailing ** broke the numeric tail)', () => {
+    const url = 'https://github.com/acme/widgets/pull/166'
+    for (const wrapped of [`**${url}**`, `*${url}*`, `\`${url}\``, `__${url}__`, `~~${url}~~`]) {
+      expect(extractPullRequestLinks(messages(`PR is up: ${wrapped} — fix(tips)`))).toEqual([
+        { url, provider: 'github', number: 166, repo: 'widgets' },
+      ])
+    }
+    // GitLab MRs get the same trim
+    expect(extractPullRequestLinks(messages(
+      'MR: **https://gitlab.com/acme/platform/-/merge_requests/42**',
+    ))).toEqual([
+      { url: 'https://gitlab.com/acme/platform/-/merge_requests/42', provider: 'gitlab', number: 42, repo: 'platform' },
+    ])
+  })
+
   it.each([
     ['streaming', 'assistant'],
     ['chunk', 'user'],

--- a/website/src/utils/pullRequestLinks.ts
+++ b/website/src/utils/pullRequestLinks.ts
@@ -25,8 +25,13 @@ const MAX_PERSISTED_SLOT_LENGTH = 512
 const URL_CANDIDATE_RE = /https:\/\/[^\s<>()[\]{}"']+/g
 
 function parseCandidate(raw: string): PullRequestLink | null {
-  // Trim trailing punctuation that the candidate scan may have swallowed.
-  const cleaned = raw.replace(/[.,!?;:]+$/, '')
+  // Trim trailing punctuation and markdown emphasis (**bold**, *italic*,
+  // `code`, _underscore_, ~~strike~~) that the candidate scan may have
+  // swallowed — agent messages routinely wrap PR URLs in emphasis, and a
+  // trailing "**" makes the numeric tail check fail silently. Safe for
+  // this parser: a valid PR/MR URL always ends in a numeric component, so
+  // these characters can never be part of a legitimate link tail.
+  const cleaned = raw.replace(/[.,!?;:*_~`]+$/, '')
   let url: URL
   try {
     url = new URL(cleaned)


### PR DESCRIPTION
## Problem
The "Changes" view never appears for a chat session even when a PR URL is plainly visible in the transcript — e.g. an agent message containing `**https://github.com/kirodotdev/KiroCrew/pull/166**`. The link is silently dropped, so the side panel's + menu hides the Changes entry and the backend reports zero source links.

## Why it matters
Agent-generated messages are the primary way PR URLs enter a chat, and agents routinely wrap URLs in markdown emphasis (bold/code). The per-PR sources feature (#84) is invisible exactly where it should trigger most, and the failure gives no feedback.

## Fix (symptoms → root cause → change)
Both link scanners treat `*`, `` ` ``, `_`, `~` as URL characters: the candidate scan swallows a trailing `**`, the trailing-punctuation trim only strips `.,!?;:`, and the PR-number tail (`166**`) then fails the numeric check — silently. Fixed by extending the trailing trim to also strip markdown emphasis characters in the two twin parsers:
- frontend: `website/src/utils/pullRequestLinks.ts` (`parseCandidate`)
- backend: `src/kiro_crew/dashboard/state.py` (source-links scanner)

Safe by construction: a valid GitHub PR / GitLab MR URL always ends in a numeric component, so these characters can never terminate a legitimate link.

## Tests
- `website/src/test/pullRequestLinks.test.ts`: new case covering `**url**`, `*url*`, `` `url` ``, `__url__`, `~~url~~` for GitHub plus a bold GitLab MR; asserts the canonical URL is extracted.
- `test/test_dashboard_chat.py::test_pr_source_links_detect_markdown_wrapped_urls`: same five wrappers through `_ChatSlot`, asserts one deduplicated source link.
- Gates: tsc clean, vitest 3918 passed (full suite), backend `test_dashboard_chat.py` + `test_dashboard_state_ws.py` 465 passed, flake8 clean (`-j 1`, host constraint).

## Manual verification
Reproduced the original failure with the exact production message text before the fix (candidate `...pull/166**` fails `^\d+$`); the new unit tests encode that reproduction. N/A beyond that — unit coverage sufficient.
