### PR TITLE
fix(chat): surface + auto-continue unexpected mid-run cancels

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -77,6 +77,7 @@ from kiro_crew.dashboard.handlers import (
 )
 from kiro_crew.dashboard.handlers.usage import persist_token_record_async
 from kiro_crew.dashboard.state import (
+    CANCEL_RECOVERY_PREFIX,
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
     REFUSAL_RECOVERY_PREFIX,
@@ -87,6 +88,7 @@ from kiro_crew.dashboard.state import (
     TOOL_STALL_RECOVERY_PREFIX,
     DashboardState,
     _ChatSlot,
+    build_cancel_recovery_prompt,
     build_refusal_recovery_prompt,
     build_stale_recovery_prompt,
     build_tool_stall_recovery_prompt,
@@ -1759,6 +1761,15 @@ async def _run_chat(
     # this reset is a no-op for them and a later real turn can still recover.
     if message != _POSTTOKEN_RECOVER_MSG:
         slot._posttoken_retry_used = False
+    # Refresh the one-shot unexpected-cancel recovery allowance at the START of a
+    # GENUINE new user turn (mirrors _posttoken_retry_used above). The synthetic
+    # cancel-recovery continuation — detected by the CANCEL_RECOVERY_PREFIX — must
+    # NOT refresh the allowance: if that continuation is itself cancelled, the
+    # inherited True flag makes the re-cancel marker-only, so recovery can never
+    # loop. Suppressed/nested cancels never set the flag, so this reset is a
+    # no-op for them and a later real turn can still recover once.
+    if not message.startswith(CANCEL_RECOVERY_PREFIX):
+        slot._cancel_recover_used = False
     _pending_tools: dict[str, str] = {}  # tool_call_id -> tool_name
     # session_id -> {started, done, agent, task} for native kiro-cli subagents,
     # reconciled from `_kiro.dev/subagent/list_update` (one card per sub-agent).
@@ -1786,7 +1797,9 @@ async def _run_chat(
     _refusal_reasons: list[tuple[str, str]] = []
     # True when this turn IS an automatic refusal-recovery continuation. Used to
     # keep the synthetic prompt out of the linked-Slack user-message mirror.
-    _is_recovery = message.startswith(REFUSAL_RECOVERY_PREFIX)
+    _is_recovery = message.startswith(REFUSAL_RECOVERY_PREFIX) or message.startswith(
+        CANCEL_RECOVERY_PREFIX
+    )
     # The post-fan-out synthesis prompt is a synthetic continuation too: never
     # mirror it to linked surfaces (Slack/Telegram) as if the user typed it —
     # only its assistant reply is delivered.
@@ -2119,6 +2132,25 @@ async def _run_chat(
         # context_builder would hit UnboundLocalError at the mirror legs.
         _user_msg_for_mirror = message
 
+        # Consume the one-shot cancelled-turn flag at the start of every real
+        # (non-slash) turn, regardless of context_builder — a stale flag would
+        # otherwise leak into the cancel-attribution race guard at this turn's
+        # completion and misclassify an unexpected cancel as a user Stop.
+        # Preamble injection below still requires a conversation log; slash
+        # turns never reach the LLM, so they leave the flag for the next real
+        # turn.
+        _prev_turn_cancelled = False
+        if not is_slash:
+            try:
+                _ptc_session = getattr(state.sessions, "_sessions", {}).get(session_key)
+                if _ptc_session is not None and (
+                    getattr(_ptc_session, "prev_turn_cancelled", False) is True
+                ):
+                    _prev_turn_cancelled = True
+                    _ptc_session.prev_turn_cancelled = False
+            except Exception:
+                pass
+
         if is_slash:
             full_message = message
             sel().log_tool_invocation(
@@ -2173,11 +2205,9 @@ async def _run_chat(
             # Re-inject just the cancelled turn (user prompt + partial assistant)
             # as a preamble so the LLM remembers what was interrupted, without
             # duplicating older history. Flag lives on the session (set by
-            # SessionManager.stop_turn), consumed one-shot here. Use getattr
-            # for prev_turn_cancelled so test doubles don't raise on access.
-            _session = getattr(state.sessions, "_sessions", {}).get(session_key)
-            if _session is not None and getattr(_session, "prev_turn_cancelled", False):
-                _session.prev_turn_cancelled = False
+            # SessionManager.stop_turn), consumed one-shot ABOVE (before the
+            # context_builder gate, so it can never go stale).
+            if _prev_turn_cancelled:
                 if state.context_builder and state.context_builder.conversation_log:
                     from kiro_crew.context import (
                         build_cancelled_turn_preamble,  # circular: context -> dashboard.chat -> chat_runner (can't top-level: context imports chat at module load); circular: context -> chat -> chat_runner; circular: context -> chat
@@ -3809,7 +3839,74 @@ async def _run_chat(
             # post-token 5xx during recovery re-queue forever (finding #3).
 
         if _stop_reason == STOP_REASON_CANCELLED:
-            logger.info("Turn cancelled by user for slot %s", slot.key)
+            # Two flavors of cancel arrive here:
+            #  • USER Stop — intentional; ``_should_suppress_requeue(slot)`` is
+            #    True (slot._stop_state != "idle"). Stay silent (log only), never
+            #    re-queue — the user asked for it.
+            #  • UNEXPECTED cancel — an internal/task-layer cancellation
+            #    interrupted the turn while the slot was idle. Left as-is it is
+            #    silent and the turn dangles half-finished with no explanation.
+            #    Surface a visible marker and (one-shot, top-level only)
+            #    auto-continue on the SAME live session with a CONTINUE nudge so
+            #    the turn finishes in place. Modeled on the STALE_RECOVER path.
+            logger.info("Turn cancelled for slot %s", slot.key)
+            # RACE GUARD: a dashboard Stop's soft-ack callback (_on_soft) resets
+            # slot._stop_state to "idle" as soon as kiro-cli ACKs session/cancel
+            # — which can happen BEFORE this completion is consumed, so
+            # _should_suppress_requeue alone can misclassify a user Stop as an
+            # unexpected cancel and resume a task the user killed. stop_turn()
+            # sets session.prev_turn_cancelled = True synchronously BEFORE
+            # invoking on_soft, so a True flag here means "a user soft-stop was
+            # ACKed for this session" regardless of _stop_state timing. Treat
+            # either signal as a user cancellation.
+            _user_cancelled = _should_suppress_requeue(slot)
+            if not _user_cancelled:
+                try:
+                    _sess = getattr(state.sessions, "_sessions", {}).get(session_key)
+                    # Strict identity check: the flag is a real bool in
+                    # production; duck-typed stores/mocks must not classify.
+                    _user_cancelled = (
+                        getattr(_sess, "prev_turn_cancelled", False) is True
+                    )
+                except Exception:
+                    pass
+            if not _user_cancelled and _prompt_depth == 0:
+                def _emit_cancel(msg: str) -> None:
+                    slot.append("error", msg, "msg msg-err")
+                    state.broadcast_ws(
+                        "chat_message",
+                        {"slot": slot.key, "role": "error", "content": msg},
+                    )
+
+                if not slot._cancel_recover_used:
+                    # Consume the one-shot allowance ONLY on an actual enqueue
+                    # (mirrors the post-token finding #3 accounting), then
+                    # re-queue the CONTINUE nudge (NOT the original prompt) onto
+                    # the same live session — the finally-block dequeue
+                    # re-dispatches it against the still-loaded context.
+                    # kiro-cli discards cancelled turns from its own log, so
+                    # also flag prev_turn_cancelled: the recovery turn then
+                    # re-injects the interrupted user prompt + partial reply
+                    # via build_cancelled_turn_preamble (consumed one-shot at
+                    # turn start), giving the CONTINUE nudge its context.
+                    slot._cancel_recover_used = True
+                    try:
+                        _sess = getattr(state.sessions, "_sessions", {}).get(session_key)
+                        if _sess is not None:
+                            _sess.prev_turn_cancelled = True
+                    except Exception:
+                        logger.debug(
+                            "Could not flag prev_turn_cancelled for recovery", exc_info=True
+                        )
+                    slot.queue_insert(
+                        0, f"{CANCEL_RECOVERY_PREFIX}\n{build_cancel_recovery_prompt()}"
+                    )
+                    _emit_cancel("⟳ Interrupted — resuming…")
+                else:
+                    # Allowance already spent this user turn: marker only, no
+                    # re-queue — loop-proof (a cancelled recovery can't recover
+                    # again until a genuine new user turn refreshes the flag).
+                    _emit_cancel("⟳ Interrupted — please retry.")
         elif not _retrying_empty:
             _maybe_consolidate(state, slot)
         state.sessions.check_context_usage(session_key, client)
@@ -3901,6 +3998,20 @@ async def _run_chat(
                 redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
                 "msg msg-a",
             )
+        # Hard cancel (task cancelled at the asyncio layer — e.g. a gateway
+        # shutdown/restart kills the in-flight turn). Best-effort flag the
+        # session so the NEXT turn after restart re-injects the interrupted
+        # context via build_cancelled_turn_preamble (consumed one-shot in the
+        # session-load path). Do NOT re-queue here — the process is going down;
+        # the queue would not survive, and on restart the preamble is the
+        # recovery signal. Guarded: session_key/_sessions may be unbound if the
+        # cancel fired before session acquisition.
+        try:
+            _sess = getattr(state.sessions, "_sessions", {}).get(session_key)
+            if _sess is not None:
+                _sess.prev_turn_cancelled = True
+        except Exception:
+            logger.debug("Could not flag prev_turn_cancelled on cancel", exc_info=True)
     except AcpProcessDied as exc:
         logger.warning("ACP process died in slot %s: %s — resetting session", slot.key, exc)
         needs_session_reset = True
@@ -4290,6 +4401,7 @@ async def _run_chat(
                 next_msg.startswith(REFUSAL_RECOVERY_PREFIX)
                 or next_msg.startswith(STALE_RECOVERY_PREFIX)
                 or next_msg.startswith(TOOL_STALL_RECOVERY_PREFIX)
+                or next_msg.startswith(CANCEL_RECOVERY_PREFIX)
             )
             # User took over: a plain user message draining cancels any armed
             # post-fan-out synthesis (the user has redirected the conversation).

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -380,6 +380,15 @@ STALE_RECOVERY_PREFIX = "[Stalled turn — automatic recovery]"
 # partial results and continue. Rendered as an "inject" message (not a user
 # bubble) and never mirrored to a linked Slack thread as user input.
 TOOL_STALL_RECOVERY_PREFIX = "[Tool stall — automatic recovery]"
+# Synthetic continuation injected after a turn was cancelled WITHOUT the user
+# asking for it (an unattributed/unexpected cancel — e.g. an internal task
+# cancellation that left ``slot._stop_state`` idle). Unlike a user Stop (which
+# is intentional and must stay silent), an unexpected cancel would otherwise
+# leave the turn half-finished with no explanation. This nudge tells the model
+# its previous turn was interrupted by the system — NOT the user — and to
+# resume from its last committed step. Rendered as an "inject" message (not a
+# user bubble) and never mirrored to a linked Slack thread as user input.
+CANCEL_RECOVERY_PREFIX = "[Interrupted turn — automatic recovery]"
 
 
 def should_queue_refusal_recovery(
@@ -531,6 +540,28 @@ def build_tool_stall_recovery_prompt(
     return "\n".join(lines)
 
 
+def build_cancel_recovery_prompt() -> str:
+    """Body of the continuation injected after an UNEXPECTED (unattributed) cancel.
+
+    A previous turn was cancelled but NOT by the user pressing Stop
+    (``slot._stop_state`` was idle when the ``cancelled`` stop reason arrived) —
+    e.g. an internal/task-layer cancellation interrupted the turn mid-flight.
+    The work already committed to the conversation is preserved on the same live
+    session; this nudge tells the model to CONTINUE from that last committed step
+    rather than restart. The caller prepends :data:`CANCEL_RECOVERY_PREFIX`.
+    Framed as a system interruption — NOT a user cancellation — so the agent
+    doesn't stop. Modeled on ``chat_runner._POSTTOKEN_RECOVER_MSG``.
+    """
+    return (
+        "Your previous response was interrupted partway through — this was NOT a "
+        "user action, so do not treat it as a cancellation or a request to stop. "
+        "The work already done above (including any completed tool results) is "
+        "preserved in the conversation. Continue from where it stopped to finish "
+        "the original request — do NOT restart from scratch and do NOT re-run "
+        "steps or tools that already completed successfully."
+    )
+
+
 # Anchor the closing ']' to end-of-line so the non-greedy body expands past a
 # literal ']' inside option text (e.g. "Fix [x] logging") instead of truncating
 # at the first inner bracket. Mirrors slack/format.py's _OPTIONS_RE so both the
@@ -671,6 +702,7 @@ class _ChatSlot:
         "_tool_stall_retries",
         "_transient_5xx_retries",
         "_posttoken_retry_used",
+        "_cancel_recover_used",
         "_empty_response_retries",
         "_batch_rejected",
         "_compaction_fail_streak",
@@ -808,6 +840,13 @@ class _ChatSlot:
         # ONCE on a transient 5xx (and only when no tool call fired). Reset on a
         # completed turn alongside _transient_5xx_retries (Mesh-2150).
         self._posttoken_retry_used: bool = False
+        # One-shot guard for unexpected-cancel auto-continue: a turn ended by an
+        # unattributed ``cancelled`` stop reason (NOT a user Stop) may be
+        # auto-continued at most ONCE. Consumed only when a continue-nudge is
+        # actually enqueued; refreshed at the start of a genuine new user turn
+        # (mirrors ``_posttoken_retry_used`` semantics) so a recovery that
+        # itself gets cancelled cannot loop forever.
+        self._cancel_recover_used: bool = False
         self._empty_response_retries: int = 0
         self._batch_rejected: bool = False
         # Per-turn compaction-status failure tracking (Mesh compaction-spam

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -8259,6 +8259,226 @@ class TestStopReasonCancelled:
         assert any("partial output here" in m["content"] for m in assistant_msgs)
 
 
+class TestUnexpectedCancelRecovery:
+    """Auto-continue + visibility for an UNEXPECTED (unattributed) cancel.
+
+    A ``cancelled`` stop reason arriving while the slot is idle (``_stop_state``
+    == "idle") is NOT a user Stop — it is an internal/task-layer cancellation
+    that left the turn dangling. The CANCELLED branch surfaces a visible marker
+    and, one-shot at top level, re-queues a CONTINUE nudge so the turn finishes
+    in place. A user Stop (``_stop_state`` != "idle") stays silent and never
+    re-queues. Mirrors the STALE_RECOVER + post-token one-shot precedents.
+    """
+
+    @staticmethod
+    def _make_state(tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.push_refresh = MagicMock()
+        state.context_builder = None
+        state.consolidator = None
+        state._hook_store = None
+        state._yolo = False
+        return state
+
+    @staticmethod
+    def _wire_sessions(state, client):
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        state.sessions.get_pid = MagicMock(return_value=None)
+        state.sessions.check_context_usage = MagicMock()
+        state.sessions.record_success = MagicMock()
+        state.sessions.record_failure = AsyncMock()
+        state.sessions.release = MagicMock()
+        state.sessions.reset = AsyncMock()
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+
+    @staticmethod
+    def _client(stream):
+        client = AsyncMock()
+        client.context_usage_pct = MagicMock(return_value=0.0)
+        client.stream = stream
+        client.stream_command = stream
+        return client
+
+    @staticmethod
+    async def _drain_bg(state, limit=30):
+        for _ in range(limit):
+            pending = [t for t in list(state._background_tasks) if not t.done()]
+            if not pending:
+                return
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def _err_texts(self, slot):
+        return [m["content"] for m in slot.messages if m.get("role") == "error"]
+
+    @pytest.mark.asyncio
+    async def test_user_stop_cancel_no_requeue_no_marker(self, tmp_path, monkeypatch):
+        """(a) A user Stop (slot._stop_state != 'idle') + cancelled → log only:
+        no continue-nudge re-queued, no '⟳ Interrupted' marker, allowance intact."""
+        from kiro_crew.acp.types import STOP_REASON_CANCELLED
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        calls: list = []
+
+        async def _stream(msg):
+            calls.append(msg)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_CANCELLED)
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+        slot._stopping = True  # user Stop in progress → _stop_state != "idle"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        assert calls == ["hello"]  # no recovery re-dispatch
+        assert not any("Interrupted" in t for t in self._err_texts(slot))
+        assert slot._cancel_recover_used is False
+
+    @pytest.mark.asyncio
+    async def test_soft_ack_race_treated_as_user_stop(self, tmp_path, monkeypatch):
+        """RACE GUARD (Codex #1): the dashboard Stop's soft-ack callback resets
+        slot._stop_state to 'idle' BEFORE the cancelled completion is consumed.
+        stop_turn() sets session.prev_turn_cancelled synchronously before that
+        reset, so a True flag must classify the cancel as a USER stop: no
+        marker, no re-queue, allowance intact."""
+        from types import SimpleNamespace
+
+        from kiro_crew.acp.types import STOP_REASON_CANCELLED
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        calls: list = []
+        sess = SimpleNamespace(prev_turn_cancelled=False)
+
+        async def _stream(msg):
+            calls.append(msg)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")
+            # Mid-turn: user presses Stop → stop_turn() sets the flag
+            # synchronously, THEN _on_soft resets slot._stop_state to "idle" —
+            # both before this cancelled completion is consumed below.
+            sess.prev_turn_cancelled = True
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_CANCELLED)
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+        # _stop_state stays "idle" (soft-ack already fired) but the session
+        # carries the synchronous user-stop flag set by stop_turn().
+        state.sessions._sessions = {"dashboard:s1": sess}
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        assert calls == ["hello"]  # classified as user stop → no re-dispatch
+        assert not any("Interrupted" in t for t in self._err_texts(slot))
+        assert slot._cancel_recover_used is False
+
+    @pytest.mark.asyncio
+    async def test_unattributed_cancel_marker_and_single_requeue(self, tmp_path, monkeypatch):
+        """(b) An idle-slot cancelled → visible marker + EXACTLY ONE continue
+        re-queue. A second cancel during that recovery (no intervening real user
+        turn) → marker only, no further re-queue (loop-proof)."""
+        from kiro_crew.acp.types import STOP_REASON_CANCELLED
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.dashboard.state import CANCEL_RECOVERY_PREFIX
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        calls: list = []
+
+        async def _stream(msg):
+            calls.append(msg)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_CANCELLED)
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        # Exactly two stream calls: the original + ONE continue re-dispatch.
+        assert len(calls) == 2
+        assert calls[0] == "hello"
+        # The re-dispatched message carries the continue nudge (it may be wrapped
+        # with a reset-history preamble, so match on substring not prefix).
+        assert CANCEL_RECOVERY_PREFIX in calls[1]
+        # One "resuming" marker (first turn) + one "please retry" marker (second).
+        errs = self._err_texts(slot)
+        assert sum("⟳ Interrupted — resuming…" in t for t in errs) == 1
+        assert sum("⟳ Interrupted — please retry." in t for t in errs) == 1
+        assert slot._cancel_recover_used is True
+
+    @pytest.mark.asyncio
+    async def test_allowance_refreshes_after_genuine_user_turn(self, tmp_path, monkeypatch):
+        """(c) A genuine new user turn resets the one-shot allowance so a later
+        unexpected cancel can recover again."""
+        from kiro_crew.acp.types import STOP_REASON_END_TURN
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        async def _stream(msg):
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="done")
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN)
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+        slot._cancel_recover_used = True  # spent on a prior turn
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "a genuine new question")
+            await self._drain_bg(state)
+
+        assert slot._cancel_recover_used is False
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_sets_prev_turn_cancelled(self, tmp_path, monkeypatch):
+        """(d) A hard asyncio.CancelledError best-effort flags the session's
+        prev_turn_cancelled so the next post-restart turn re-injects context."""
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.providers.base import EVENT_TEXT_CHUNK, LLMEvent
+
+        async def _stream(msg):
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")
+            raise asyncio.CancelledError()
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+
+        class _FakeSession:
+            prev_turn_cancelled = False
+
+        fake = _FakeSession()
+        # session_key for slot 's1' == 'dashboard:s1' (see _history_key_for).
+        state.sessions._sessions = {"dashboard:s1": fake}
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        # The handler swallows CancelledError (runs finally, returns normally).
+        await _run_chat(state, slot, "hello")
+
+        assert fake.prev_turn_cancelled is True
+
+
 # ── Phase 5: Soft-stop dashboard backend tests ──
 
 


### PR DESCRIPTION
## Problem

When a running turn is cancelled **without the user pressing Stop** (an unattributed `STOP_REASON_CANCELLED` — e.g. an internal/task-layer cancellation), the user sees nothing: the streamed partial text silently freezes into a normal assistant bubble with no explanation, and the interrupted work never resumes. Separately, a hard cancel (`asyncio.CancelledError`, e.g. a gateway restart mid-turn) preserves the partial text but never flags the session, so the interrupted-context re-injection (`build_cancelled_turn_preamble`) doesn't fire on the next turn.

Git archaeology confirmed this is a gap-from-birth, not a regression: the `STOP_REASON_CANCELLED` branch has been log-only since the fork's earliest commit. The stop-experience work only ever added coverage around it — `5018772` (#59) carved watchdog-probe cancels into `STALE_RECOVER`/`TOOL_STALL` auto-recovery, and `cc1f24e` (#91) added the post-token transient-5xx recover-once. Unattributed cancels were the remaining silent hole.

## Why it matters

Long autonomous runs (research campaigns, CI loops, multi-step tasks) die silently mid-flight. The user has no signal that anything went wrong and no automatic continuation — the session just looks like the agent stopped for no reason, and unattended work is lost until a human notices and types "continue".

## Fix (symptoms → root cause → change)

Symptom: silent freeze + no resume. Root cause: the `CANCELLED` completion branch in `chat_runner.py` treats **every** cancel as a user Stop (log-only, deliberately no re-queue), but only user Stops set `slot._stop_state != "idle"`. Change — reuse exactly that distinction:

- **`chat_runner.py` (CANCELLED branch):** when `_should_suppress_requeue(slot)` is False (no user Stop in progress) and `_prompt_depth == 0`, append a visible `⟳ Interrupted — resuming…` error-marker and re-queue a CONTINUE nudge onto the same live session (the still-loaded context finishes in place). Modeled on the `STALE_RECOVER` path. **User Stop behavior is byte-identical** (log-only, never re-queued).
- **Loop-proofing:** one-shot `slot._cancel_recover_used`, consumed only on an actual enqueue (mirrors the post-token finding-#3 accounting), refreshed only at the start of a *genuine* new user turn — the synthetic `CANCEL_RECOVERY_PREFIX` continuation cannot refresh its own allowance, so a cancelled recovery degrades to a marker-only `⟳ Interrupted — please retry.` and can never loop.
- **`chat_runner.py` (`except asyncio.CancelledError`):** best-effort set `session.prev_turn_cancelled = True` so the first turn after a gateway restart re-injects the interrupted context via `build_cancelled_turn_preamble` (which degrades gracefully without a `stop_event` marker). No re-queue there — the process is going down.
- **`state.py`:** `CANCEL_RECOVERY_PREFIX` + `build_cancel_recovery_prompt()` (framed as a *system* interruption, not a user cancellation, instructing the model to continue without re-running completed tools), and the `_cancel_recover_used` slot flag. The recovery message is intentionally visible in the transcript, consistent with the existing recovery paths.

## Tests

`test/test_dashboard_chat.py` — `TestStopReasonCancelled` + `TestUnexpectedCancelRecovery` (8 tests):
- User Stop (`_stop_state != "idle"`) + CANCELLED → no re-queue, no marker (existing behavior locked in).
- Unattributed CANCELLED → marker appended + exactly one `queue_insert` carrying `CANCEL_RECOVERY_PREFIX`; allowance consumed.
- Second unattributed cancel with the allowance spent → marker-only, no second re-queue (loop-proof).
- Allowance refreshes on a genuine new user turn; the synthetic recovery continuation does NOT refresh it.
- Nested (`_prompt_depth != 0`) cancels stay log-only.

Full file: 438/438 pass; flake8 clean on touched files.

## Manual verification

N/A — unit coverage exercises both branches and the one-shot accounting directly; the marker rendering reuses the existing error-message path (no new frontend surface).
