### PR TITLE
feat(taskrunner): add per-run auto-approve (trust) toggle

### DIFF
--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -172,6 +172,8 @@ class Project:
     commit_hashes: list[str]  # per-step commit SHAs
     worktree_path: str     # git worktree path (empty if git init)
     repo_root: str         # original repo root (for worktree cleanup)
+    auto_approve: bool = False  # per-run trust: auto-approve tool permission requests
+                                # (deny-lists + force_approval gates still apply)
 ```
 
 ## Concurrent Tasks
@@ -415,6 +417,86 @@ Two-layer approval during step execution:
    - 2-hour timeout on interactive approval (auto-reject)
    - YOLO mode: auto-approves all
    - Trust mode: auto-approves when all slots trusted
+
+### Per-run auto-approve (trust) toggle
+
+`Project.auto_approve` is a per-run trust flag (default `False`). It is opt-in
+at execute time via the dashboard (`auto_approve` in the execute/start request
+body) and threaded through `execute_plan()`, `run()`, and `start_background()`.
+
+- **Default off** → current interactive behavior (tool permission requests
+  prompt via `on_tool_approval`, or deny-by-default when headless).
+- **On** → the run's tool permission requests are auto-approved WITHOUT the
+  interactive prompt, and the SEL tool-invocation audit records the approval
+  with reason `run_auto_approve` (vs `hook_auto_approve` for an explicit hook
+  trust).
+
+Two guardrails remain intact for a trusted run:
+
+- **Hook deny-lists / sensitive-path blocks** are evaluated BEFORE the
+  auto-approve check, so a `TOOL_DENY` still rejects the tool.
+- **`force_approval` / `requires_approval` task gates** are a separate
+  task-level path (top of `execute_single_task`) and are unaffected — they
+  still block/prompt regardless of `auto_approve`.
+
+The mid-stream context-overflow check still runs before final approval.
+
+Hardening measures scope the trust tightly. It is not the global `SafetyOverride`
+singleton (which would leak trust to every session), but the authoritative grant
+IS held by `SafetyOverride` — as a **task-scoped grant** — so per-run trust is
+audited and expires through the same primitive the `backend-security-controls`
+rule mandates, with no independent approval state living on the run:
+
+- **SafetyOverride scoped grant (audited, TTL-bounded, slide-renewed)** — enabling
+  `auto_approve` calls `safety_override().activate_scoped("taskrunner:{task_id}:autoapprove",
+  source="dashboard")`, which fail-closed audits the activation to the SEL BEFORE
+  committing and stamps a TTL (dashboard window, 6h, under the 24h hard ceiling).
+  The permission branch authorizes via `is_scope_active(scope)` before EVERY
+  approval; when the grant lapses (or is absent, e.g. after a gateway restart) the
+  run's intent is revoked (`auto_approve` cleared, SEL `task.auto_approve_expired`)
+  and the tool falls through to interactive / deny-by-default. To avoid a long but
+  *actively-progressing* run losing trust mid-flight at the base TTL, each
+  auto-approved tool call slides the grant forward via `renew_scoped()` — capped at
+  the 24h hard ceiling from first activation, so an abandoned (idle) run still lapses
+  after the base window. `scope_remaining_secs()` is surfaced in `build_status`
+  (`auto_approve_remaining_secs`) so the dashboard can warn before expiry.
+  `Project.auto_approve` is only the persisted UI-intent flag; the live authorization
+  is the scoped grant. Setting/clearing both sides is owned by a single
+  `TaskRunner._grant_run_trust(run, enabled)` so the intent flag and grant cannot
+  diverge; grants are revoked at run teardown (`_release_run_runtime`).
+- **Deny-by-default parsing** — the API reads `auto_approve` as `body.get(...)
+  is True`, so only a literal JSON `true` enables trust; truthy non-booleans
+  (`"false"`, `"0"`, `[]`, `{}`) do NOT.
+- **Provenance gated at the boundary (label-based, shared by every launch endpoint)**
+  — a single `_gate_auto_approve()` helper is applied by BOTH `api_taskrunner_start`
+  AND `api_taskrunner_execute_plan` (and any future launch surface), so the gate can't
+  drift between routes. It honors `auto_approve` only when the request is not
+  app/proxy-embedded (`request["app"] == ""`, set by `token_auth_middleware` for the
+  dashboard itself) — blocking an embedded app/proxy from minting trust even while
+  claiming `source: "dashboard"` — and, on `start` (which carries a source claim),
+  only when the caller EXPLICITLY declared `source == "dashboard"` (checked on the raw
+  claimed value, so an omitted/unknown source cannot inherit trust via coercion). The
+  decision is SEL-audited (`auto_approve_grant` with endpoint + claimed-vs-resolved
+  source + `request["app"]`). Residual: a raw token-holder is indistinguishable from
+  the dashboard UI (the gateway's trust model is "token == user"), so this remains a
+  declared-label gate; a sub-principal auth model would be a platform-level follow-up.
+- **Reset on crash-recovery + affirmative re-grant on resume** — a run recovered from
+  an active state (`running`/`pausing`/`cancelling`) on gateway restart has
+  `auto_approve` forced `False` and its scoped grant deactivated in `_load_runs()`;
+  and because a grant is torn down at run teardown, the dashboard toggle re-syncs from
+  the *live* grant (`auto_approve_remaining_secs > 0`), not stale persisted intent —
+  so resuming a paused/planned run shows the toggle UNCHECKED and requires an
+  affirmative re-grant rather than a click on a pre-checked box.
+
+### Scope limitation (cron / MCP unattended runs)
+
+Per-run trust is intentionally reachable **only** from the dashboard toggle, so
+cron-scheduled and MCP/chat-launched runs — which are headless by construction —
+cannot carry it and still hit the `headless_no_authorization` deny-by-default
+branch. Auto-granting recurring trust to a cron is a deliberately larger risk, so
+that surface is **not** covered by this feature and continues to rely on the
+operator's existing global controls. Extending unattended trust to recurring runs
+is a possible follow-up, not a current goal.
 
 ## Watchdog
 

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -23,6 +23,45 @@ def _sel():
     return _pkg.sel()
 
 
+def _gate_auto_approve(
+    request: web.Request, requested: bool, claimed_source, endpoint: str
+) -> bool:
+    """Provenance gate for per-run auto-approve, shared by every launch endpoint.
+
+    Per-run trust is a human-at-the-dashboard decision, so it is honored ONLY for a
+    dashboard-context request — ``request["app"] == ""`` (set by
+    ``token_auth_middleware`` for the dashboard itself), which blocks an
+    app/proxy-embedded caller from minting trust even while claiming
+    ``source: "dashboard"``. When a caller declares a ``source`` (the start
+    endpoint), it must be the literal ``"dashboard"`` (checked on the raw claimed
+    value so an omitted/unknown source cannot inherit trust via coercion). The
+    grant decision is SEL-audited (claimed-vs-resolved source + request app), so a
+    machine grant cannot masquerade as a human one without a trace. Residual: a raw
+    token-holder is indistinguishable from the dashboard UI (gateway trust model is
+    "token == user"); a sub-principal auth model is a platform-level follow-up.
+
+    ``claimed_source=None`` means the endpoint carries no source claim (e.g.
+    ``/execute`` operates on an existing run) — only the app-context check applies.
+    """
+    request_app = request.get("app", "")
+    granted = requested
+    if requested and (request_app != "" or (claimed_source is not None and claimed_source != "dashboard")):
+        granted = False
+    if requested:
+        _sel().log_tool_invocation(
+            session_key="dashboard",
+            source="taskrunner",
+            tool_name="auto_approve_grant",
+            outcome="granted" if granted else "denied",
+            metadata={
+                "endpoint": endpoint,
+                "claimed_source": str(claimed_source),
+                "request_app": str(request_app),
+            },
+        )
+    return granted
+
+
 # ── Task Runner ──
 
 
@@ -101,11 +140,15 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         task_name = body.get("name", "")
         workspace_dir = body.get("workspace_dir", "")
         allowed_sources = {"dashboard", "text", "spec", "file", "chat", "mcp", "cron", "yaml"}
-        source = body.get("source", "dashboard")
-        if source not in allowed_sources:
-            source = "dashboard"
+        claimed_source = body.get("source")
+        source = claimed_source if claimed_source in allowed_sources else "dashboard"
+        # Deny-by-default (`is True`) + shared provenance gate (dashboard-context only).
+        auto_approve = _gate_auto_approve(
+            request, body.get("auto_approve") is True, claimed_source, endpoint="start"
+        )
         task_id = state.task_runner.start_background(
-            spec_path, agent=agent, name=task_name, source=source, workspace_dir=workspace_dir
+            spec_path, agent=agent, name=task_name, source=source, workspace_dir=workspace_dir,
+            auto_approve=auto_approve,
         )
     except Exception as exc:
         return web.json_response({"error": str(exc)}, status=400)
@@ -517,8 +560,14 @@ async def api_taskrunner_execute_plan(request: web.Request) -> web.Response:
     agent = body.get("agent", "")
     fresh = body.get("fresh", False)
     workspace_dir = body.get("workspace_dir", "")
+    # Same provenance gate as /start: an app/proxy-embedded caller cannot mint
+    # trust on the resume/execute path either (no source claim here — the run
+    # already exists — so only the dashboard-context check applies).
+    auto_approve = _gate_auto_approve(
+        request, body.get("auto_approve") is True, None, endpoint="execute"
+    )
     try:
-        state.task_runner.execute_plan(task_id, agent=agent, fresh=fresh, workspace_dir=workspace_dir)
+        state.task_runner.execute_plan(task_id, agent=agent, fresh=fresh, workspace_dir=workspace_dir, auto_approve=auto_approve)
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response({"ok": True, "task_id": task_id})

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -112,6 +112,12 @@ class SafetyOverride:
         self._last_renewed_by: str = ""
         self._on_expired: Optional[Callable[[str], None]] = None
         self._on_activated: Optional[Callable[[str, int], None]] = None
+        # Task-scoped auto-approve grants: scope key -> (activated_at, expires_at)
+        # monotonic. Independent of the global override; each grant is TTL-bounded,
+        # audited on activation, and slide-renewable up to a 24h ceiling from first
+        # activation, so a caller (e.g. the task runner) can hold a narrow, expiring
+        # grant without flipping the session-wide override.
+        self._scoped: dict[str, tuple[float, float]] = {}
 
     def __getattr__(self, name: str) -> object:
         # Provide a fallback _lock for instances created with object.__new__()
@@ -120,6 +126,10 @@ class SafetyOverride:
             lock = threading.Lock()
             object.__setattr__(self, "_lock", lock)
             return lock
+        if name == "_scoped":
+            scoped: dict[str, tuple[float, float]] = {}
+            object.__setattr__(self, "_scoped", scoped)
+            return scoped
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     # ── Callback properties ──────────────────────────────────────────────────
@@ -274,6 +284,126 @@ class SafetyOverride:
             outcome="disabled",
             resources=f"source:{source}",
         )
+
+    # ── Task-scoped grants ───────────────────────────────────────────────────
+
+    def activate_scoped(
+        self, scope: str, source: str, ttl: Optional[int] = None
+    ) -> ActivationResult:
+        """Activate a narrow, TTL-bounded auto-approve grant for ``scope``.
+
+        Unlike ``activate()`` this does NOT flip the session-wide override; it
+        records an expiring grant for a single scope key (e.g. one task run).
+        The activation is audited fail-closed to the SEL BEFORE it is committed,
+        exactly like the global ``activate()``, so no grant exists without an
+        audit trail. TTL defaults to the source's default and is capped at the
+        24h hard ceiling.
+        """
+        if ttl is None:
+            ttl = self._SOURCE_TTLS.get(source, self._SLACK_TTL)
+        ttl = min(ttl, self._MAX_TTL)
+        now_mono = time.monotonic()
+        activated_at_iso = datetime.now(tz=timezone.utc).isoformat()
+
+        # Fail-closed audit before commit — no grant without a trace.
+        try:
+            self._log_sel(
+                caller="safety_override",
+                operation="safety_override:activate_scoped",
+                outcome="enabled",
+                resources=f"scope:{scope}, source:{source}, ttl:{ttl}s",
+                critical=True,
+            )
+        except Exception:
+            logger.error(
+                "SEL audit failed; refusing scoped safety override activation", exc_info=True
+            )
+            return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
+
+        with self._lock:
+            self._scoped[scope] = (now_mono, now_mono + ttl)
+
+        return ActivationResult(
+            active=True, ttl=ttl, source=source, activated_at_iso=activated_at_iso
+        )
+
+    def renew_scoped(
+        self, scope: str, source: str, ttl: Optional[int] = None
+    ) -> RenewResult:
+        """Slide a scoped grant's expiry forward on activity, capped at the ceiling.
+
+        Extends the grant to ``min(now + ttl, activated_at + _MAX_TTL)`` so an
+        actively-progressing run does not lose trust at the base TTL, while the
+        absolute 24h hard ceiling from first activation is still honored (an
+        abandoned run with no activity simply lapses). No-op / not-renewed if the
+        grant is absent or the ceiling is already reached. Intentionally NOT
+        SEL-logged per call — it extends an already-audited grant within its
+        audited ceiling, and per-tool-call logging would flood the SEL.
+        """
+        if ttl is None:
+            ttl = self._SOURCE_TTLS.get(source, self._SLACK_TTL)
+        ttl = min(ttl, self._MAX_TTL)
+        now_mono = time.monotonic()
+        with self._lock:
+            entry = self._scoped.get(scope)
+            if entry is None:
+                return RenewResult(renewed=False, ttl=0, source=source, reason="not_active")
+            activated_at, _ = entry
+            ceiling = activated_at + self._MAX_TTL
+            if now_mono >= ceiling:
+                return RenewResult(renewed=False, ttl=0, source=source, reason="ceiling_reached")
+            new_expiry = min(now_mono + ttl, ceiling)
+            self._scoped[scope] = (activated_at, new_expiry)
+            remaining = max(0, int(new_expiry - now_mono))
+        return RenewResult(renewed=True, ttl=remaining, source=source)
+
+    def is_scope_active(self, scope: str) -> bool:
+        """Return True if ``scope`` has a live (unexpired) grant.
+
+        Expires the grant and logs a SEL event when its TTL has lapsed.
+        """
+        now_mono = time.monotonic()
+        with self._lock:
+            entry = self._scoped.get(scope)
+            if entry is None:
+                return False
+            if now_mono < entry[1]:
+                return True
+            del self._scoped[scope]
+
+        self._log_sel(
+            caller="safety_override",
+            operation="safety_override:scope_expired",
+            outcome="expired",
+            resources=f"scope:{scope}",
+        )
+        return False
+
+    def deactivate_scope(self, scope: str) -> None:
+        """Revoke a scoped grant immediately. No-op if absent."""
+        with self._lock:
+            existed = self._scoped.pop(scope, None) is not None
+        if existed:
+            self._log_sel(
+                caller="safety_override",
+                operation="safety_override:deactivate_scope",
+                outcome="disabled",
+                resources=f"scope:{scope}",
+            )
+
+    def scope_remaining_secs(self, scope: str) -> int:
+        """Return seconds remaining on a scoped grant, 0 if absent/expired.
+
+        Pure read — does NOT expire or SEL-log a lapsed grant (that is the
+        enforcement path's job via ``is_scope_active``), so a status/UI poll can
+        never emit a ``scope_expired`` event or mutate state.
+        """
+        now_mono = time.monotonic()
+        with self._lock:
+            entry = self._scoped.get(scope)
+            if entry is None:
+                return 0
+            return max(0, int(entry[1] - now_mono))
 
     def is_active(self) -> bool:
         """Return True if the override is currently active.

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -24,6 +24,7 @@ from kiro_crew.providers.base import (
     EVENT_TEXT_CHUNK,
     EVENT_TOOL_CALL,
 )
+from kiro_crew.safety_override import safety_override
 from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -355,6 +356,7 @@ async def execute_task(
                     # interactive prompt — the task runner previously handled only
                     # TOOL_DENY and always prompted, ignoring explicit trust.
                     _auto_approved = False
+                    _auto_reason = ""
                     if ctx:
                         tool_result = ctx.hooks.on_tool_call(
                             event.title,
@@ -380,6 +382,49 @@ async def execute_task(
                             continue
                         if tool_result.action == TOOL_AUTO_APPROVE:
                             _auto_approved = True
+                            _auto_reason = "hook_auto_approve"
+
+                    # Per-run trust toggle: the user explicitly opted THIS run into
+                    # unattended execution via the dashboard. It is NOT the global
+                    # SafetyOverride singleton (which would leak trust to every
+                    # session); instead the authoritative grant is a task-scoped
+                    # SafetyOverride grant (scope `taskrunner:{task_id}:autoapprove`)
+                    # activated through the singleton's fail-closed audited
+                    # `activate_scoped()` and TTL-bounded there (dashboard window,
+                    # ≤24h ceiling) — so no independent approval state lives on the
+                    # run, and it satisfies the backend-security-controls expiry rule.
+                    # `run.auto_approve` is only the UI intent flag; the live decision
+                    # is `is_scope_active()`, re-checked before EVERY approval and
+                    # revoked the moment the grant lapses. It is deny-by-default (only a
+                    # literal `true` enables it), dashboard source-gated, SEL-audited as
+                    # `run_auto_approve`, and reset on crash-recovery. Compensating
+                    # controls stay intact: hook deny-lists / sensitive-path blocks
+                    # (handled above) still reject, and force_approval / requires_approval
+                    # task gates (separate task-level path) still pause for approval.
+                    if not _auto_approved and getattr(run, "auto_approve", False):
+                        _scope = f"{SESSION_PREFIX}:{run.task_id}:autoapprove"
+                        if safety_override().is_scope_active(_scope):
+                            _auto_approved = True
+                            _auto_reason = "run_auto_approve"
+                            # Slide the grant forward on activity so an actively
+                            # progressing run does not lose trust at the base TTL;
+                            # still hard-capped at the 24h ceiling from first grant,
+                            # so an abandoned (idle) run lapses as intended.
+                            safety_override().renew_scoped(_scope, source="dashboard")
+                        else:
+                            # Grant lapsed / absent — clear BOTH trust representations
+                            # together (intent flag + scoped grant, idempotent) and fall
+                            # through to interactive / deny-by-default. Bounds unattended
+                            # tool execution to the grant window.
+                            run.auto_approve = False
+                            safety_override().deactivate_scope(_scope)
+                            sel().log_api_access(
+                                caller="taskrunner",
+                                operation="task.auto_approve_expired",
+                                outcome="expired",
+                                source="taskrunner",
+                                resources=f"task-{task.index}",
+                            )
 
                     # Mid-stream context check runs BEFORE authorization resolution:
                     # context management is orthogonal to approval and must fire even
@@ -400,7 +445,7 @@ async def execute_task(
                     # Positive-authorization resolution (deny-by-default shape):
                     # each path is explicit — no falsy-guard fall-through.
                     if _auto_approved:
-                        approve_reason = "hook_auto_approve"
+                        approve_reason = _auto_reason or "hook_auto_approve"
                     elif on_tool_approval:
                         run.last_task_time = _time.time()
                         approved = await on_tool_approval(event)
@@ -443,6 +488,9 @@ async def execute_task(
                             "task": task.index,
                             "task_id": run.task_id,
                             "reason": approve_reason,
+                            # Trust provenance: which launch surface granted this run.
+                            # run_auto_approve is dashboard-gated at the API boundary.
+                            "source": run.source,
                         },
                     )
                 elif event.kind == EVENT_TOOL_CALL:

--- a/src/kiro_crew/task_models.py
+++ b/src/kiro_crew/task_models.py
@@ -122,6 +122,7 @@ class Project:
     mode: str = "quick"  # "quick" (text only) | "spec" (has spec file/content)
     source_spec: str = ""  # original input text or spec content
     skip_planning: bool = False  # true = plan + execute immediately
+    auto_approve: bool = False  # per-run trust intent (UI flag); the live, expiring, audited grant is held in SafetyOverride (scope taskrunner:{task_id}:autoapprove)
 
 
 # Callback for notifications: (title, body, task_id) -> None

--- a/src/kiro_crew/task_reporter.py
+++ b/src/kiro_crew/task_reporter.py
@@ -7,9 +7,11 @@ import re
 import time
 from pathlib import Path
 
+from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact_exfiltration_urls
 from kiro_crew.task_models import (
     PROGRESS_FILE,
+    SESSION_PREFIX,
     NotifyCallback,
     Project,
     Task,
@@ -154,6 +156,14 @@ def build_status(
                 "error": run.error,
                 "tokens_used": run.tokens_used,
                 "replan_count": run.replan_count,
+                "auto_approve": getattr(run, "auto_approve", False),
+                "auto_approve_remaining_secs": (
+                    safety_override().scope_remaining_secs(
+                        f"{SESSION_PREFIX}:{run.task_id}:autoapprove"
+                    )
+                    if getattr(run, "auto_approve", False)
+                    else 0
+                ),
                 "original_input": run.original_input[:2000],
                 "source": run.source,
                 "task_details": [

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -17,6 +17,7 @@ from kiro_crew import git_coord, shutdown_event
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.llm_helpers import stream_and_collect_json
+from kiro_crew.safety_override import safety_override
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session import BACKGROUND_KEY
@@ -93,6 +94,16 @@ _DEFAULT_TOKEN_BUDGET = DEFAULT_TOKEN_BUDGET
 _HEARTBEAT_INTERVAL = 30  # watchdog checks process liveness every 30s
 _DEAD_THRESHOLD = 2  # consecutive dead checks before fail-fast reset
 _RESULT_MEM_CAP = 4000  # truncate task.result in memory after step completes
+
+
+def _auto_approve_scope(task_id: str) -> str:
+    """SafetyOverride scope key holding a run's per-run auto-approve grant.
+
+    The live, TTL-bounded, audited grant lives in the SafetyOverride singleton
+    (see ``activate_scoped``); ``Project.auto_approve`` is only the UI intent
+    flag. Enforcement reads ``safety_override().is_scope_active(scope)``.
+    """
+    return f"{_SESSION_PREFIX}:{task_id}:autoapprove"
 
 
 def _resolve_workspace_dir(raw: str) -> str:
@@ -386,7 +397,7 @@ class TaskRunner:
         self._persist_runs()
         return {"index": task.index, "title": task.title, "description": task.description, "depends_on": task.depends_on, "requires_approval": task.requires_approval, "force_approval": task.force_approval}
 
-    def execute_plan(self, task_id: str, agent: str = "", fresh: bool = False, workspace_dir: str = "") -> str:
+    def execute_plan(self, task_id: str, agent: str = "", fresh: bool = False, workspace_dir: str = "", auto_approve: bool = False) -> str:
         run = self._runs.get(task_id)
         if not run:
             raise ValueError(f"Run {task_id} not found")
@@ -422,6 +433,9 @@ class TaskRunner:
             run.replan_count = 0
             run.status = "planned"
             self._persist_runs()
+
+        self._grant_run_trust(run, bool(auto_approve))
+        self._persist_runs()
 
         self._agent = agent
         history_key = f"taskrunner:run:{task_id}"
@@ -496,7 +510,7 @@ class TaskRunner:
 
     async def run(
         self, spec_path: str | Path, task_id: str = "", name: str = "", source: str = "",
-        workspace_dir: str = "",
+        workspace_dir: str = "", auto_approve: bool = False,
     ) -> Project:
         spec_path = Path(spec_path)
         if not spec_path.exists():
@@ -521,6 +535,7 @@ class TaskRunner:
         run.task_id = task_id
         run.name = name or auto_name(spec_content, str(spec_path))
         run.work_dir = str(task_dir)
+        self._grant_run_trust(run, bool(auto_approve))
         self._runs[task_id] = run
         self._persist_runs()  # persist immediately so crash recovery works
         watchdog_task: asyncio.Task | None = None  # type: ignore[type-arg]
@@ -826,7 +841,7 @@ class TaskRunner:
 
     def start_background(
         self, spec_path: str | Path, agent: str = "", name: str = "", source: str = "",
-        workspace_dir: str = "",
+        workspace_dir: str = "", auto_approve: bool = False,
     ) -> str:
         # Validate the per-run workspace override synchronously so the caller
         # (HTTP handler) surfaces a bad/sensitive path immediately, not inside
@@ -872,12 +887,13 @@ class TaskRunner:
             status="planning",
             started_at=time.time(),
             source=source,
+            auto_approve=bool(auto_approve),
         )
         self._persist_runs()  # persist planning state for crash recovery
 
         async def _wrapped() -> None:
             try:
-                await self.run(spec_path, task_id=task_id, name=name, source=source, workspace_dir=workspace_dir)
+                await self.run(spec_path, task_id=task_id, name=name, source=source, workspace_dir=workspace_dir, auto_approve=auto_approve)
             except Exception as exc:
                 logger.exception("start_background task %s failed", task_id)
                 placeholder = self._runs.get(task_id)
@@ -938,6 +954,19 @@ class TaskRunner:
         # down (one kiro-cli process for the whole run).
         await self._release_run_runtime(run)
 
+    def _grant_run_trust(self, run: Project, enabled: bool) -> None:
+        """Single owner of per-run trust — sets the persisted UI intent flag AND
+        the authoritative SafetyOverride scoped grant together, so the two
+        representations can never diverge at a call site. Enable activates an
+        audited, TTL-bounded scoped grant; disable revokes it.
+        """
+        run.auto_approve = bool(enabled)
+        scope = _auto_approve_scope(run.task_id)
+        if run.auto_approve:
+            safety_override().activate_scoped(scope, source="dashboard")
+        else:
+            safety_override().deactivate_scope(scope)
+
     async def _release_run_runtime(self, run: Project) -> None:
         """Kill the run's shared AcpRuntime once (idempotent) at run teardown.
 
@@ -952,6 +981,11 @@ class TaskRunner:
             )
         except Exception:
             logger.debug("release run runtime failed for %s", run.task_id, exc_info=True)
+        # Revoke the per-run auto-approve grant so trust never outlives the run.
+        try:
+            safety_override().deactivate_scope(_auto_approve_scope(run.task_id))
+        except Exception:
+            logger.debug("deactivate auto-approve scope failed for %s", run.task_id, exc_info=True)
 
     def delete_run(self, task_id: str) -> bool:
         run = self._runs.get(task_id)
@@ -1287,6 +1321,7 @@ class TaskRunner:
                         "original_input": run.original_input,
                         "source": run.source,
                         "spec_content": run.spec_content,
+                        "auto_approve": run.auto_approve,
                         "task_details": [
                             {
                                 "index": t.index,
@@ -1345,8 +1380,17 @@ class TaskRunner:
                     original_input=item.get("original_input", ""),
                     source=item.get("source", ""),
                     tasks=tasks,
+                    auto_approve=item.get("auto_approve", False),
                 )
                 self._runs[run.task_id] = run
+                # Compensating control: never let per-run trust silently survive a
+                # gateway restart. A run recovered from an active state had its
+                # auto-approve granted for a live, attended launch; after a crash the
+                # user must re-affirm trust on resume (execute_plan re-applies it from
+                # the dashboard toggle).
+                if run.status in ("running", "pausing", "cancelling"):
+                    run.auto_approve = False
+                    safety_override().deactivate_scope(_auto_approve_scope(run.task_id))
                 # Crash recovery: if gateway died mid-execution, mark as resumable
                 if run.status in ("running", "pausing"):
                     if not run.tasks:

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -1,0 +1,494 @@
+"""Tests for the per-run auto-approve (trust) toggle.
+
+Covers:
+- Project.auto_approve default (False)
+- execute_plan()/run() set run.auto_approve
+- _persist_runs()/_load_runs() round-trip the flag
+- execute_task: run.auto_approve=True → tool auto-approved WITHOUT on_tool_approval
+- execute_task: run.auto_approve=True + hook TOOL_DENY → tool STILL rejected
+- force_approval task gate still triggers on_approval regardless of run.auto_approve
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.dashboard.handlers.taskrunner import (
+    api_taskrunner_execute_plan,
+    api_taskrunner_start,
+)
+from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
+from kiro_crew.providers.base import LLMEvent
+from kiro_crew.safety_override import reset_singleton, safety_override
+from kiro_crew.task_models import Project
+from kiro_crew.taskrunner import Step, StepStatus, TaskRun, TaskRunner, _auto_approve_scope
+
+
+@pytest.fixture(autouse=True)
+def _reset_safety_override():
+    """Isolate the SafetyOverride singleton (per-run grants) between tests."""
+    reset_singleton()
+    yield
+    reset_singleton()
+
+
+# ── Helpers ──
+
+
+def _mock_sessions() -> MagicMock:
+    s = MagicMock()
+    s._lock = asyncio.Lock()
+    s._sessions = {}
+    s.get_or_create = AsyncMock()
+
+    async def _open_task_session(_pk, session_key, *, agent=None, cwd=None, approval_policy=""):
+        return await s.get_or_create(session_key, agent=agent, cwd=cwd)
+
+    s.open_task_session = _open_task_session
+    s.release_subagent_runtime = AsyncMock()
+    s.release = MagicMock()
+    s.reset = AsyncMock()
+    s.record_success = MagicMock()
+    s.record_failure = AsyncMock()
+    s.check_context_usage = MagicMock()
+    return s
+
+
+def _perm_then_done_provider():
+    """Provider that emits one permission_request, then text + complete."""
+    provider = MagicMock()
+
+    async def _stream(msg: str):
+        yield LLMEvent(
+            kind="permission_request",
+            title="write_file",
+            text="",
+            request_id="req-1",
+            tool_kind="tool",
+        )
+        yield LLMEvent(kind="text_chunk", text="done")
+        yield LLMEvent(kind="complete")
+
+    provider.stream = _stream
+    provider.approve_tool = AsyncMock()
+    provider.reject_tool = AsyncMock()
+    provider.context_usage_pct = MagicMock(return_value=0.0)
+    return provider
+
+
+def _plain_provider(text: str = "done"):
+    provider = MagicMock()
+
+    async def _stream(msg: str):
+        yield LLMEvent(kind="text_chunk", text=text)
+        yield LLMEvent(kind="complete")
+
+    provider.stream = _stream
+    provider.approve_tool = AsyncMock()
+    provider.reject_tool = AsyncMock()
+    provider.context_usage_pct = MagicMock(return_value=0.0)
+    return provider
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (i) default
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAutoApproveDefault:
+    def test_project_auto_approve_defaults_false(self) -> None:
+        run = Project(spec_path="s.md", spec_content="s")
+        assert run.auto_approve is False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (ii) execute_plan / run set it
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestSettersSetAutoApprove:
+    def test_execute_plan_sets_auto_approve(self, tmp_path: Path) -> None:
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        run = TaskRun(spec_path="s.md", spec_content="s", status="planned", task_id="t1")
+        run.tasks = [Step(index=1, title="A", description="d")]
+        runner._runs = {"t1": run}
+        # Prevent the background _execute task from actually running.
+        with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
+            runner.execute_plan("t1", auto_approve=True)
+        assert run.auto_approve is True
+        assert safety_override().is_scope_active(_auto_approve_scope("t1")) is True
+
+    def test_execute_plan_defaults_false(self, tmp_path: Path) -> None:
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        run = TaskRun(spec_path="s.md", spec_content="s", status="planned", task_id="t1")
+        run.tasks = [Step(index=1, title="A", description="d")]
+        runner._runs = {"t1": run}
+        with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
+            runner.execute_plan("t1")
+        assert run.auto_approve is False
+        assert safety_override().is_scope_active(_auto_approve_scope("t1")) is False
+
+    @pytest.mark.asyncio
+    async def test_run_sets_auto_approve(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Task: Trust run\n## Steps\n1. Do thing", encoding="utf-8")
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        runner._decompose = AsyncMock(return_value=[Step(index=1, title="s", description="d")])
+        with patch.object(runner, "_execute_tasks", new_callable=AsyncMock, return_value=True):
+            run = await runner.run(spec, auto_approve=True)
+        assert run.auto_approve is True
+        # NOTE: run() completes its full lifecycle here, whose teardown
+        # (_release_run_runtime) deactivates the scoped grant by design — so we
+        # assert the persisted intent flag; live-grant activation is covered by
+        # test_execute_plan_sets_auto_approve and the execution tests.
+
+    @pytest.mark.asyncio
+    async def test_start_background_sets_auto_approve(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Bg\n## Steps\n1. Do thing", encoding="utf-8")
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        with patch.object(runner, "run", new_callable=AsyncMock) as mock_run:
+            task_id = runner.start_background(spec, auto_approve=True)
+            await asyncio.sleep(0)  # let the wrapper task run
+        # Placeholder Project carries the flag immediately …
+        assert runner._runs[task_id].auto_approve is True
+        # … and it is threaded through into run().
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs.get("auto_approve") is True
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (iii) persist / load round-trip
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAutoApprovePersistence:
+    def test_persist_and_load_round_trip(self, tmp_path: Path) -> None:
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        run = TaskRun(
+            spec_path=str(tmp_path / "s.md"),
+            spec_content="s",
+            status="paused",
+            task_id="t1",
+        )
+        run.work_dir = str(tmp_path)
+        run.auto_approve = True
+        run.tasks = [Step(index=1, title="A", description="d")]
+        runner._runs = {"t1": run}
+        runner._persist_runs()
+
+        # Fresh runner loads from the same runs.json on __init__.
+        runner2 = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        loaded = runner2._runs["t1"]
+        assert loaded.auto_approve is True
+
+    def test_trust_reset_on_crash_recovery(self, tmp_path: Path) -> None:
+        """A run recovered from an active state must not silently retain trust."""
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        run = TaskRun(
+            spec_path=str(tmp_path / "s.md"),
+            spec_content="s",
+            status="running",  # gateway "crashed" mid-execution
+            task_id="t1",
+        )
+        run.work_dir = str(tmp_path)
+        run.auto_approve = True
+        run.tasks = [Step(index=1, title="A", description="d")]
+        runner._runs = {"t1": run}
+        runner._persist_runs()
+
+        # Fresh runner recovers the crashed run on __init__.
+        runner2 = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        recovered = runner2._runs["t1"]
+        assert recovered.status == "paused"  # recovered as resumable
+        assert recovered.auto_approve is False  # trust dropped — must re-affirm on resume
+
+    def test_load_defaults_false_when_absent(self, tmp_path: Path) -> None:
+        runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        run = TaskRun(
+            spec_path=str(tmp_path / "s.md"),
+            spec_content="s",
+            status="paused",
+            task_id="t1",
+        )
+        run.work_dir = str(tmp_path)
+        run.tasks = [Step(index=1, title="A", description="d")]
+        runner._runs = {"t1": run}
+        runner._persist_runs()
+        runner2 = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
+        assert runner2._runs["t1"].auto_approve is False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (iv) auto-approve without interactive handler
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAutoApproveExecution:
+    @pytest.mark.asyncio
+    async def test_auto_approve_skips_interactive_handler(self, tmp_path: Path) -> None:
+        sessions = _mock_sessions()
+        provider = _perm_then_done_provider()
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        on_tool_approval = AsyncMock(return_value=True)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
+        runner._on_tool_approval = on_tool_approval
+
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running", task_id="t1")
+        run.auto_approve = True
+        safety_override().activate_scoped(_auto_approve_scope("t1"), source="dashboard")  # live grant
+        step = Step(index=1, title="Write", description="d")
+        run.tasks = [step]
+
+        with patch("kiro_crew.task_executor.self_review", return_value=True):
+            success = await runner._execute_single_task(run, step)
+
+        assert success is True
+        assert step.status == StepStatus.PASSED
+        # Auto-approved WITHOUT prompting the interactive handler.
+        provider.approve_tool.assert_awaited_once_with("req-1")
+        on_tool_approval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_expired_trust_is_revoked_and_not_auto_approved(self, tmp_path: Path) -> None:
+        """No live scoped grant → trust is not honored: no auto-approve, intent cleared."""
+        sessions = _mock_sessions()
+        provider = _perm_then_done_provider()
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
+        # No interactive handler → after trust lapses, deny-by-default applies.
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running", task_id="t1")
+        run.auto_approve = True  # intent set, but NO active SafetyOverride grant (expired/absent)
+        step = Step(index=1, title="Write", description="d")
+        run.tasks = [step]
+
+        with patch("kiro_crew.task_executor.self_review", return_value=True):
+            await runner._execute_single_task(run, step)
+
+        # Trust lapsed → not auto-approved (rejected via deny-by-default) and revoked.
+        provider.approve_tool.assert_not_called()
+        provider.reject_tool.assert_awaited_with("req-1")
+        assert run.auto_approve is False
+
+    @pytest.mark.asyncio
+    async def test_without_auto_approve_headless_rejects(self, tmp_path: Path) -> None:
+        """Quick check: with auto_approve off and no handler, the tool is denied."""
+        sessions = _mock_sessions()
+        provider = _perm_then_done_provider()
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
+        # No on_tool_approval handler configured, auto_approve off.
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running")
+        step = Step(index=1, title="Write", description="d")
+        run.tasks = [step]
+
+        with patch("kiro_crew.task_executor.self_review", return_value=True):
+            await runner._execute_single_task(run, step)
+
+        provider.reject_tool.assert_awaited_with("req-1")
+        provider.approve_tool.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (v) hook deny-list still blocks a trusted run
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAutoApproveRespectsHookDeny:
+    @pytest.mark.asyncio
+    async def test_hook_deny_still_rejects_when_auto_approve(self, tmp_path: Path) -> None:
+        sessions = _mock_sessions()
+        provider = _perm_then_done_provider()
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        # ctx.hooks.on_tool_call returns TOOL_DENY (deny-list / sensitive-path block).
+        ctx = MagicMock()
+        ctx.build_message = MagicMock(return_value=("prompt", {}))
+        ctx.hooks.on_tool_call = MagicMock(return_value=MagicMock(action=TOOL_DENY))
+
+        runner = TaskRunner(
+            sessions=sessions, context_builder=ctx, auto_test=False, work_dir=tmp_path
+        )
+        runner._on_tool_approval = AsyncMock(return_value=True)
+
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running")
+        run.auto_approve = True
+        step = Step(index=1, title="Delete", description="d")
+        run.tasks = [step]
+
+        with patch("kiro_crew.task_executor.self_review", return_value=True):
+            await runner._execute_single_task(run, step)
+
+        # Deny-list is evaluated BEFORE auto-approve, so the tool is rejected
+        # even though the run is trusted.
+        provider.reject_tool.assert_awaited_with("req-1")
+        provider.approve_tool.assert_not_called()
+        runner._on_tool_approval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hook_auto_approve_reason_preserved(self, tmp_path: Path) -> None:
+        """An explicit hook TOOL_AUTO_APPROVE keeps its own reason, not run's."""
+        sessions = _mock_sessions()
+        provider = _perm_then_done_provider()
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        ctx = MagicMock()
+        ctx.build_message = MagicMock(return_value=("prompt", {}))
+        ctx.hooks.on_tool_call = MagicMock(return_value=MagicMock(action=TOOL_AUTO_APPROVE))
+
+        runner = TaskRunner(
+            sessions=sessions, context_builder=ctx, auto_test=False, work_dir=tmp_path
+        )
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running")
+        run.auto_approve = False  # only the hook trusts it
+        step = Step(index=1, title="Read", description="d")
+        run.tasks = [step]
+
+        with patch("kiro_crew.task_executor.self_review", return_value=True), patch(
+            "kiro_crew.task_executor.sel"
+        ) as mock_sel:
+            await runner._execute_single_task(run, step)
+
+        provider.approve_tool.assert_awaited_once_with("req-1")
+        # The approval audit records reason=hook_auto_approve.
+        reasons = [
+            c.kwargs.get("metadata", {}).get("reason")
+            for c in mock_sel().log_tool_invocation.call_args_list
+            if c.kwargs.get("outcome") == "approved"
+        ]
+        assert "hook_auto_approve" in reasons
+
+
+# ══════════════════════════════════════════════════════════════════════
+# (vi) force_approval task gate unaffected by auto_approve
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestForceApprovalGateUnaffected:
+    @pytest.mark.asyncio
+    async def test_force_approval_still_prompts_when_auto_approve(self, tmp_path: Path) -> None:
+        sessions = _mock_sessions()
+        provider = _plain_provider("done")
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        on_approval = AsyncMock(return_value=True)
+        runner = TaskRunner(
+            sessions=sessions, auto_test=False, work_dir=tmp_path, on_approval=on_approval
+        )
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running")
+        run.auto_approve = True  # trusted run — must NOT bypass the task gate
+        step = Step(
+            index=1, title="Deploy", description="d", requires_approval=True, force_approval=True
+        )
+        run.tasks = [step]
+
+        with patch.object(runner, "self_review", return_value=True):
+            success = await runner._execute_single_task(run, step, "hk")
+
+        # The task-level force_approval gate still fired despite auto_approve.
+        on_approval.assert_awaited_once()
+        assert success is True
+        assert step.status == StepStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_force_approval_denied_pauses_even_when_auto_approve(self, tmp_path: Path) -> None:
+        sessions = _mock_sessions()
+        runner = TaskRunner(
+            sessions=sessions,
+            auto_test=False,
+            work_dir=tmp_path,
+            on_approval=AsyncMock(return_value=False),
+        )
+        run = TaskRun(spec_path=str(tmp_path / "t.md"), spec_content="s", status="running")
+        run.auto_approve = True
+        step = Step(
+            index=1, title="Deploy", description="d", requires_approval=True, force_approval=True
+        )
+        run.tasks = [step]
+
+        result = await runner._execute_single_task(run, step, "hk")
+        assert result is False
+        assert step.status == StepStatus.PENDING
+        assert run.status == "paused"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Design-review #1: trust provenance enforced at the API boundary
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAutoApproveProvenanceGating:
+    """`auto_approve` is honored only for dashboard-launched runs.
+
+    Cron/MCP/chat/file callers cannot mint a self-trusted run even if they
+    send ``auto_approve: true`` — the SEL ``run_auto_approve`` signal stays a
+    human-at-the-dashboard signal.
+    """
+
+    async def _auto_approve_passed(self, tmp_path: Path, source: str, auto_approve: bool, request_app: str = ""):
+        runner = MagicMock()
+        runner._work_dir = tmp_path
+        runner.start_background = MagicMock(return_value="tid")
+        app = web.Application()
+        app["state"] = SimpleNamespace(task_runner=runner)
+        req = make_mocked_request("POST", "/api/taskrunner", app=app)
+        req["app"] = request_app  # set by token_auth_middleware; "" == dashboard itself
+        req.json = AsyncMock(
+            return_value={
+                "spec": "__inline__:# t\n## Steps\n1. do",
+                "source": source,
+                "auto_approve": auto_approve,
+            }
+        )
+        await api_taskrunner_start(req)
+        return runner.start_background.call_args.kwargs["auto_approve"]
+
+    @pytest.mark.asyncio
+    async def test_app_embedded_caller_ignored(self, tmp_path: Path) -> None:
+        # Even with source="dashboard", an app/proxy-embedded caller cannot self-trust.
+        assert await self._auto_approve_passed(tmp_path, "dashboard", True, request_app="someapp") is False
+
+    @pytest.mark.asyncio
+    async def test_dashboard_source_allows_trust(self, tmp_path: Path) -> None:
+        assert await self._auto_approve_passed(tmp_path, "dashboard", True) is True
+
+    @pytest.mark.asyncio
+    async def test_cron_source_ignores_trust(self, tmp_path: Path) -> None:
+        assert await self._auto_approve_passed(tmp_path, "cron", True) is False
+
+    @pytest.mark.asyncio
+    async def test_mcp_source_ignores_trust(self, tmp_path: Path) -> None:
+        assert await self._auto_approve_passed(tmp_path, "mcp", True) is False
+
+    async def _execute_auto_approve_passed(self, request_app: str, auto_approve: bool = True):
+        runner = MagicMock()
+        runner.execute_plan = MagicMock(return_value=None)
+        app = web.Application()
+        app["state"] = SimpleNamespace(task_runner=runner)
+        req = make_mocked_request(
+            "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
+            headers={"Content-Length": "32"},
+        )
+        req["app"] = request_app
+        req.json = AsyncMock(return_value={"auto_approve": auto_approve})
+        await api_taskrunner_execute_plan(req)
+        return runner.execute_plan.call_args.kwargs["auto_approve"]
+
+    @pytest.mark.asyncio
+    async def test_execute_dashboard_context_allows_trust(self) -> None:
+        assert await self._execute_auto_approve_passed(request_app="") is True
+
+    @pytest.mark.asyncio
+    async def test_execute_app_embedded_ignored(self) -> None:
+        # The /execute endpoint must enforce the SAME gate as /start.
+        assert await self._execute_auto_approve_passed(request_app="someapp") is False

--- a/test/test_safety_override.py
+++ b/test/test_safety_override.py
@@ -451,3 +451,91 @@ class TestSourceTtls:
         # Should not crash; use slack TTL as fallback
         assert result.active is True
         assert result.ttl == SafetyOverride._SLACK_TTL
+
+
+# ─── Task-scoped grants ───────────────────────────────────────────────────────
+
+
+class TestScopedGrants:
+    def test_activate_scoped_uses_source_ttl(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            result = override.activate_scoped("taskrunner:t1:autoapprove", source="dashboard")
+        assert result.active is True
+        assert result.ttl == SafetyOverride._DASHBOARD_TTL
+        assert override.is_scope_active("taskrunner:t1:autoapprove") is True
+
+    def test_ttl_capped_at_ceiling(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            result = override.activate_scoped("s", source="dashboard", ttl=999999)
+        assert result.ttl == SafetyOverride._MAX_TTL
+
+    def test_unknown_scope_is_inactive(self, override: SafetyOverride) -> None:
+        assert override.is_scope_active("never-granted") is False
+
+    def test_scope_expires_and_is_purged(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate_scoped("s", source="dashboard", ttl=60)
+            # Fast-forward past the TTL.
+            with patch("kiro_crew.safety_override.time.monotonic", return_value=time.monotonic() + 120):
+                assert override.is_scope_active("s") is False
+        # Purged from the internal map after expiry.
+        assert "s" not in override._scoped
+
+    def test_deactivate_scope_revokes(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate_scoped("s", source="dashboard")
+            assert override.is_scope_active("s") is True
+            override.deactivate_scope("s")
+        assert override.is_scope_active("s") is False
+
+    def test_scoped_grant_does_not_flip_global(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate_scoped("s", source="dashboard")
+        # A scoped grant must NOT activate the session-wide override.
+        assert override.is_active() is False
+
+    def test_activate_scoped_fails_closed_on_audit_error(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value.log_api_access.side_effect = RuntimeError("sel down")
+            result = override.activate_scoped("s", source="dashboard")
+        # No grant is committed when the fail-closed audit raises.
+        assert result.active is False
+        assert override.is_scope_active("s") is False
+
+    def test_renew_scoped_extends_expiry(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            base = time.monotonic()
+            with patch("kiro_crew.safety_override.time.monotonic", return_value=base):
+                override.activate_scoped("s", source="dashboard", ttl=100)
+            # 90s later a tool call renews it — expiry slides forward.
+            with patch("kiro_crew.safety_override.time.monotonic", return_value=base + 90):
+                r = override.renew_scoped("s", source="dashboard", ttl=100)
+                assert r.renewed is True
+                # Now ~100s of remaining window, not the ~10s left before renewal.
+                assert override.scope_remaining_secs("s") > 50
+
+    def test_renew_capped_at_ceiling(self, override: SafetyOverride) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            base = time.monotonic()
+            with patch("kiro_crew.safety_override.time.monotonic", return_value=base):
+                override.activate_scoped("s", source="dashboard", ttl=100)
+            # Past the 24h ceiling from first activation → cannot renew further.
+            with patch(
+                "kiro_crew.safety_override.time.monotonic",
+                return_value=base + SafetyOverride._MAX_TTL + 10,
+            ):
+                r = override.renew_scoped("s", source="dashboard", ttl=100)
+                assert r.renewed is False
+                assert r.reason == "ceiling_reached"
+
+    def test_renew_absent_scope(self, override: SafetyOverride) -> None:
+        r = override.renew_scoped("never", source="dashboard")
+        assert r.renewed is False
+        assert r.reason == "not_active"

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -733,8 +733,8 @@ export const api = {
   cancelPlan: () => post('/api/taskrunner/plan/cancel').then(j),
   updatePlan: (taskId: string, steps: PlanStepInput[]) =>
     put('/api/taskrunner/' + encodeURIComponent(taskId) + '/plan', { steps }).then(j),
-  executePlan: (taskId: string, agent?: string) =>
-    post('/api/taskrunner/' + encodeURIComponent(taskId) + '/execute', { agent: agent || '' }).then(j),
+  executePlan: (taskId: string, agent?: string, autoApprove?: boolean) =>
+    post('/api/taskrunner/' + encodeURIComponent(taskId) + '/execute', { agent: agent || '', auto_approve: !!autoApprove }).then(j),
   planFromChat: (steps: PlanStepInput[], taskId?: string, originalInput?: string) =>
     post('/api/taskrunner/from-chat', { steps, task_id: taskId || '', original_input: originalInput || '' }).then(j),
   planContext: (taskId: string) =>

--- a/website/src/pages/ProjectsPage.tsx
+++ b/website/src/pages/ProjectsPage.tsx
@@ -5,7 +5,7 @@ import { useAppSelector, useAppDispatch } from '../store'
 import { setPendingInput, switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
 import type { TaskRunnerStatus, ProjectRun } from '../types'
-import { Card, PageHeader, SendBtn, Btn } from '../components/ui'
+import { Card, PageHeader, SendBtn, Btn, Checkbox } from '../components/ui'
 import AgentSelector from '../components/AgentSelector'
 import type { KiroCrewAgent } from '../components/AgentSelector'
 import ProjectDetailPage from './ProjectDetailPage'
@@ -51,6 +51,7 @@ export default function ProjectsPage() {
   const [editingName, setEditingName] = useState(false)
   const [editNameValue, setEditNameValue] = useState('')
   const [refined, setRefined] = useState('')
+  const [autoApprove, setAutoApprove] = useState(false)
   const [refineStatus, setRefineStatus] = useState<string>('idle')
   const [refineError, setRefineError] = useState('')
   const mountedRef = useRef(true)
@@ -129,8 +130,18 @@ export default function ProjectsPage() {
     const id = autoRunRef.current
     if (!id || !selectedRun || selectedRun.task_id !== id || selectedRun.status !== 'planned') return
     autoRunRef.current = null
-    api.executePlan(selectedRun.task_id, agent).then(r => { if (r.ok) load() })
+    // Auto-run is a programmatic launch, NOT an affirmative per-run trust grant for
+    // THIS run — always pass false. (Per-run trust requires an explicit dashboard
+    // toggle + manual Execute.) Passing the component-wide `autoApprove` here would
+    // also race the sync effect below and could leak a stale `true` from a
+    // previously-selected run onto this one.
+    api.executePlan(selectedRun.task_id, agent, false).then(r => { if (r.ok) load() })
   }, [selectedRun, agent, load])
+  // Sync the per-run auto-approve toggle from the selected run (default false).
+  // Reflect only a LIVE trust grant (not stale persisted intent), so resuming a
+  // paused/planned run — whose grant was torn down — shows unchecked and requires an
+  // affirmative re-grant rather than a single click on a pre-checked box.
+  useEffect(() => { setAutoApprove((selectedRun?.auto_approve_remaining_secs ?? 0) > 0) }, [selectedRun?.task_id, selectedRun?.auto_approve_remaining_secs])
   useEffect(() => { sessionStorage.setItem('tr-input', userInput) }, [userInput])
   useEffect(() => { sessionStorage.setItem('tr-spec', specText) }, [specText])
   useEffect(() => { sessionStorage.setItem('tr-yaml', yamlText) }, [yamlText])
@@ -323,7 +334,11 @@ export default function ProjectsPage() {
               <span className="text-[12px] text-muted">{selectedRun.status === 'planning' ? <><Hourglass className="lucide-inline" /> Planning…</> : selectedRun.running ? <><RefreshCw className="lucide-inline" /> Running</> : selectedRun.status}</span>
               <div className="flex-1" />
               {selectedRun.status === 'planned' && <>
-                <button className="btn-sweep bg-accent text-accent-fg border-none rounded-lg px-4 h-8 text-[13px] font-semibold cursor-pointer hover:bg-accent-hover transition-all" onClick={async () => { const r = await api.executePlan(selectedRun.task_id, agent); if (r.ok) load() }}><Play className="lucide-inline" /> Execute</button>
+                <label className="flex items-center gap-1.5 text-[12px] text-muted cursor-pointer select-none" title="Run unattended: auto-approve this run's tool calls. Deny-listed tools and force_approval gates still block.">
+                  <Checkbox checked={autoApprove} onChange={e => setAutoApprove(e.target.checked)} />
+                  Auto-approve tool calls
+                </label>
+                <button className="btn-sweep bg-accent text-accent-fg border-none rounded-lg px-4 h-8 text-[13px] font-semibold cursor-pointer hover:bg-accent-hover transition-all" onClick={async () => { const r = await api.executePlan(selectedRun.task_id, agent, autoApprove); if (r.ok) load() }}><Play className="lucide-inline" /> Execute</button>
                 <button className="px-3 h-8 rounded-md border border-border text-muted text-[13px] cursor-pointer hover:text-accent hover:border-accent transition-all" onClick={async () => { const res = await api.planContext(selectedRun.task_id); if (res.ok && res.context) { dispatch(setPendingInput("Let's optimize this plan:\n\n" + res.context)); navigate('/chat?autoSend=1&newSession=1') } }}><MessageSquare className="lucide-inline" /> Chat</button>
                 <button className="px-3 h-8 rounded-md border border-border text-muted text-[13px] cursor-pointer hover:text-danger hover:border-danger transition-all" onClick={async () => { await api.deleteTaskRun(selectedRun.task_id); setSelectedRun(null); load() }}><X className="lucide-inline" /> Discard</button>
               </>}
@@ -332,7 +347,13 @@ export default function ProjectsPage() {
               {selectedRun.running && <button className="px-3 h-8 rounded-md border border-border text-muted text-[13px] cursor-pointer hover:text-danger hover:border-danger transition-all" onClick={async () => { await api.cancelTaskRunner(selectedRun.task_id); load() }}><Square className="lucide-inline" /> Cancel</button>}
               {!selectedRun.running && selectedRun.status !== 'planned' && selectedRun.status !== 'planning' && <>
                 {selectedRun.status === 'paused' && (
-                  <button className="btn-sweep bg-accent text-accent-fg border-none rounded-lg px-4 h-8 text-[13px] font-semibold cursor-pointer hover:bg-accent-hover transition-all" onClick={async () => { const r = await api.executePlan(selectedRun.task_id, agent); if (r.ok) load() }}><Play className="lucide-inline" /> Resume</button>
+                  <>
+                    <label className="flex items-center gap-1.5 text-[12px] text-muted cursor-pointer select-none" title="Run unattended: auto-approve this run's tool calls. Deny-listed tools and force_approval gates still block.">
+                      <Checkbox checked={autoApprove} onChange={e => setAutoApprove(e.target.checked)} />
+                      Auto-approve tool calls
+                    </label>
+                    <button className="btn-sweep bg-accent text-accent-fg border-none rounded-lg px-4 h-8 text-[13px] font-semibold cursor-pointer hover:bg-accent-hover transition-all" onClick={async () => { const r = await api.executePlan(selectedRun.task_id, agent, autoApprove); if (r.ok) load() }}><Play className="lucide-inline" /> Resume</button>
+                  </>
                 )}
                 {(selectedRun.status === 'completed' || selectedRun.status === 'cancelled') && (
                   <button className="px-3 h-8 rounded-md border border-accent bg-transparent text-accent text-[13px] font-semibold cursor-pointer hover:bg-accent hover:text-accent-fg transition-all" onClick={async () => {

--- a/website/src/test/ProjectsPage.test.tsx
+++ b/website/src/test/ProjectsPage.test.tsx
@@ -160,6 +160,30 @@ describe('ProjectsPage', () => {
     expect(mockApi.retryTaskRun).toHaveBeenCalledWith('run-4', 1)
   })
 
+  it('toggling auto-approve then Execute calls executePlan with autoApprove=true', async () => {
+    const plannedRun: ProjectRun = {
+      task_id: 'run-plan', name: 'Plan Me', running: false, status: 'planned',
+      steps: 1, completed: 0, failed: 0, skipped: 0, current_step: 0,
+      spec: '', spec_name: '', error: '', tokens_used: 0, replan_count: 0,
+      task_details: [], started_at: 0, finished_at: 0,
+      work_dir: '', branch_name: '', spec_content: 'spec', lessons_learned: [],
+      commits: 0, original_input: '', source: 'text', groups: [],
+    }
+    const { api: mockApi } = await import('../api/client')
+    vi.mocked(mockApi.taskRunnerStatus).mockResolvedValue({ running: false, available: true, runs: [plannedRun] })
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByText('Plan Me')
+    fireEvent.click(screen.getByText('Plan Me'))
+    // Toggle defaults OFF
+    const toggle = screen.getByLabelText('Auto-approve tool calls') as HTMLInputElement
+    expect(toggle.checked).toBe(false)
+    fireEvent.click(toggle)
+    expect(toggle.checked).toBe(true)
+    // Click Execute
+    fireEvent.click(screen.getByRole('button', { name: /Execute/ }))
+    expect(mockApi.executePlan).toHaveBeenCalledWith('run-plan', '', true)
+  })
+
   it('schedule calls createCron with project spec', async () => {
     const completedRun: ProjectRun = {
       task_id: 'run-5', name: 'Cron Me', running: false, status: 'completed',

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -298,6 +298,10 @@ export interface ProjectRun {
   work_dir: string; branch_name: string
   spec_content: string; lessons_learned: string[]; commits: number
   original_input: string; source: string; groups: number[][]
+  /** Whether this run should auto-approve tool calls (per-run trust toggle).
+   * Reflects the last chosen value; deny-lists and force_approval gates still block. */
+  auto_approve?: boolean
+  auto_approve_remaining_secs?: number
 }
 export interface TaskRunnerStatus {
   running: boolean; available: boolean; runs: ProjectRun[]


### PR DESCRIPTION
## Problem
Running a task under the task runner prompts for approval on every tool call. To run a task unattended the user had to enable a global YOLO / `SafetyOverride`, which is coarse (every session and tool) and time-limited. There was no way to say "I trust *this* run, execute it without prompting."

## Why it matters
Autonomous task runs are the point of the task runner, but with per-tool prompting an unattended run stalls waiting for clicks and, if nobody is watching, tool calls time out and get rejected — the run fails. Forcing global YOLO over-grants trust and expires, so it is both unsafe and inconvenient.

## Fix (symptom → root cause → change)
- Symptom: task runs pause on each tool call, or fail unattended.
- Root cause: the task runner's only auto-approval paths were global; there was no per-run trust signal, so the default fell through to the interactive prompt.
- Change: a per-run trust intent flag `Project.auto_approve` (default `False`), set from the dashboard at run start, persisted in `runs.json`, surfaced in status, read from the `/start` + `/execute` bodies. The **authoritative grant** is a task-scoped `SafetyOverride` grant (below). `execute_task` authorizes via `SafetyOverride.is_scope_active(...)` after the deny-hook check and before the context-overflow check, SEL reason `run_auto_approve`.
- Frontend: an "Auto-approve tool calls" checkbox next to Execute/Resume, default off, that reflects the run's LIVE grant; passed on every `executePlan` call.

### Security model
Per-run trust is not the global `SafetyOverride` singleton (that would leak trust to every session) — the authoritative grant is held BY `SafetyOverride` as a task-scoped grant, so activation is audited and expiry is centralized, with no independent approval state on `Project`:
- **Scoped grant, audited + TTL-bounded + slide-renewed** — enabling trust calls `activate_scoped("taskrunner:{task_id}:autoapprove", source="dashboard")` (fail-closed SEL audit before commit; dashboard TTL 6h under a 24h hard ceiling). Authorized via `is_scope_active` before every approval; each auto-approved tool call `renew_scoped()`s the grant (sliding window) so an actively-progressing run doesn't lose trust mid-flight, still hard-capped at 24h from first activation, so an idle/abandoned run lapses after the base window. On lapse both trust reps clear together and the tool falls through to interactive / deny-by-default. `scope_remaining_secs()` (a pure read) is surfaced in `build_status` as `auto_approve_remaining_secs`. New API: `activate_scoped` / `is_scope_active` / `renew_scoped` / `deactivate_scope` / `scope_remaining_secs`.
- **Single owner** — `TaskRunner._grant_run_trust(run, enabled)` sets the intent flag AND the grant together, so the two representations can't diverge.
- **Deny-by-default parsing** — `body.get("auto_approve") is True`; only a literal JSON `true` enables it.
- **Provenance gate shared by every launch endpoint** — one `_gate_auto_approve()` helper is applied by BOTH `api_taskrunner_start` and `api_taskrunner_execute_plan`, so the gate can't drift between routes. It honors `auto_approve` only for a dashboard-context request (`request["app"] == ""`, set by `token_auth_middleware`) — blocking app/proxy-embedded callers from minting trust even while claiming `source:"dashboard"` — and, on `/start`, only when the raw claimed `source == "dashboard"`. SEL-audited (`auto_approve_grant`: endpoint + claimed-vs-resolved source + `request["app"]`). Residual (documented): a raw token-holder is indistinguishable from the dashboard UI (gateway model is "token == user"); a sub-principal auth model is a platform-level follow-up.
- **Crash-recovery reset + affirmative re-grant** — a recovered active-state run has `auto_approve` forced `False` and its grant deactivated in `_load_runs()`; grants are also torn down at run teardown, and the toggle re-syncs from the live grant (`auto_approve_remaining_secs`), so resuming shows it UNCHECKED — re-affirmation is affirmative, not a pre-checked box.
- **Guardrails intact** — hook deny-lists / sensitive-path blocks (checked first) still reject; `force_approval` / `requires_approval` task gates (separate task-level path) still pause for approval.

### Scope limitation (deliberate)
Per-run trust is reachable only from the dashboard toggle; cron- and MCP/chat-launched runs (headless) cannot carry it and still hit `headless_no_authorization` deny-by-default — they rely on existing global controls. Recurring auto-trust is a deliberately larger risk and a possible follow-up. Documented in `docs/system-specs/modules/taskrunner.md`.

## Tests
- `test/test_safety_override.py::TestScopedGrants`: source-TTL, 24h cap, unknown-scope inactive, expiry-purge, deactivate, does-not-flip-global, fail-closed-on-audit-error, slide-renew extends, renew capped at ceiling, renew-absent.
- `test/test_auto_approve.py`: defaults; setters set intent + activate grant; persist/load round-trip; live-grant run auto-approves without `on_tool_approval`; no-live-grant → not approved + intent revoked; `TOOL_DENY` still rejects; `force_approval` gate still prompts; crash-recovery resets; provenance gating on `/start` (dashboard vs cron/mcp, app-embedded ignored) AND `/execute` (dashboard-context vs app-embedded).
- `website/src/test/ProjectsPage.test.tsx`: toggle → Execute passes `auto_approve`.

## Manual verification
Local: `pytest test/test_auto_approve.py test/test_safety_override.py test/test_taskrunner.py test/test_approval_and_update_task.py test/test_project_alias.py` → 262 pass; `tsc --noEmit` clean; `vitest run src/test/ProjectsPage.test.tsx` 25 pass; flake8 + isort clean. Recommended live check: run one task with the toggle on (proceeds unattended) and one with a `force_approval` step (still pauses).
