### PR TITLE
fix(ci): declare environment: prod on publish-cli for tag-ref OIDC

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -37,6 +37,14 @@ jobs:
   publish-cli:
     name: Publish CLI wheel (${{ inputs.channel }})
     runs-on: ubuntu-latest
+    # REQUIRED for tag-triggered (release) runs: the signing role's OIDC
+    # trust accepts exactly two subjects -- ref:refs/heads/main and
+    # environment:prod. Nightly runs on main's ref and passes bare, which
+    # masked this gap until the first tag-triggered CLI publish
+    # (v0.1.0-insider.2, run 29943346319) failed AssumeRoleWithWebIdentity.
+    # Declaring the environment switches ANY caller's subject to
+    # environment:prod, same as every job in sign-and-notarize.yml.
+    environment: prod
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
       CHANNEL: ${{ inputs.channel }}


### PR DESCRIPTION
**First tag-triggered CLI publish ever failed** (v0.1.0-insider.2, run 29943346319): all 12 `AssumeRoleWithWebIdentity` retries rejected.

## Root cause

The signing role's OIDC trust accepts exactly two subjects: `ref:refs/heads/main` and `environment:prod` (verified live against IAM during PR #89). Every job in `sign-and-notarize.yml` declares `environment: prod` for exactly this reason -- but `publish-cli.yml` never did. Nightly calls it on main's ref, which passes bare, masking the gap for weeks. insider.1 predates #132's release-side CLI publish, so today's insider.2 was the first run to present a `ref:refs/tags/v*` subject from this job.

## Fix

One line: `environment: prod` on the publish-cli job, matching sign-and-notarize. The prod environment has no required-reviewer rule (documented in sign-and-notarize.yml), so nothing stalls.

## Validation

- YAML parse + environment assertion clean
- 5/5 workflow permission tests pass
- Live proof lands with the next tag: v0.1.0-insider.3 will be cut after merge (re-runs of insider.2 reuse the tag-pinned workflow snapshot, so the failed run cannot be healed in place).