### PR TITLE
feat(platform): add companion-edition CPP seams (v1, no CONTRACT_VERSION bump)

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1150,7 +1150,9 @@
         "max_ingest_file_mb": 100.0,
         "embed_timeout_secs": 10.0,
         "embed_content_budget": 0,
-        "pool_idle_ttl_secs": 300
+        "pool_idle_ttl_secs": 300,
+        "auto_ingest_doc_links": false,
+        "doc_ingest_hosts": []
       }
     },
     {
@@ -1255,6 +1257,48 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 300
+    },
+    {
+      "path": "knowledge.auto_ingest_doc_links",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Auto-Ingest Doc Links",
+      "help": "Automatically ingest documents referenced by links pasted into chat whose host is in the doc-ingest allowlist. Off by default. An edition that supplies a doc-link scanner (via the dashboard on_user_message seam) uses this + the host allowlist below; inert in the public build unless a link scanner is wired.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "knowledge.doc_ingest_hosts",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Doc-Ingest Host Allowlist",
+      "help": "Exact hostnames whose links may be auto-ingested when auto_ingest_doc_links is on. Empty = ingest nothing (SSRF-safe deny-by-default): a link is only fetched if its host is an exact member of this list. Prevents a pasted link to an internal metadata endpoint or arbitrary host from being fetched.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": []
+    },
+    {
+      "path": "knowledge.doc_ingest_hosts.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
     },
     {
       "path": "skills",
@@ -2765,6 +2809,7 @@
         },
         "default_project": "",
         "theme_mode": "",
+        "mwinit_flags": "",
         "theme_color": "",
         "recent_tint_count": 0,
         "onboarded": false,
@@ -2994,6 +3039,20 @@
         "light",
         "system"
       ],
+      "defaultValue": ""
+    },
+    {
+      "path": "dashboard.mwinit_flags",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "mwinit Flags",
+      "help": "Flags passed to the SSO login command by an edition that supplies a real login handler (DashboardContributor.mwinit_handler). Empty = the edition default. Inert in the public build (the core /api/mwinit is a no-op stub); the companion validates the token allowlist when it uses them.",
+      "hasChildren": false,
+      "enumValues": null,
       "defaultValue": ""
     },
     {
@@ -3257,20 +3316,6 @@
       "tags": [],
       "label": "Agent",
       "help": "Agent override for this channel (empty = default).",
-      "hasChildren": false,
-      "enumValues": null,
-      "defaultValue": ""
-    },
-    {
-      "path": "slack_channels.*.project_path",
-      "kind": "core",
-      "type": "string",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "label": "Project Path",
-      "help": "Project directory for project-scoped agent (empty = global agent).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": ""

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -466,10 +466,53 @@ delegates to that same global. Wired sites:
   `sandbox.prewarm_backend()` before companion composition so the cache is warm
   by the time a jail backend probes it.
 
+
+### Amazon-edition seam additions (v1, no `CONTRACT_VERSION` bump)
+
+Existing-Protocol methods added / wired so the Amazon companion can re-introduce
+dropped MeshClaw behavior without the core importing it. All are v1 additions (a
+`Default*` no-op reproduces today's OSS behavior exactly — a standalone process
+is byte-identical) with no `CONTRACT_VERSION` bump.
+
+- `SlackEnterpriseGate.heartbeat_safe_tools() -> frozenset[str]` — unioned into
+  `slack/gateway.py::_is_heartbeat_safe_tool` after the core `HEARTBEAT_SAFE_TOOLS`
+  exact-match. Default `frozenset()`. ADD-only; never sourced from config.
+- `AppsLoader.registry_rows() -> List[Dict]` — ADD-only merged by
+  `apps/registry.py::_load_registry_file` after bundled `app-registry.json`
+  (same-`name` core row wins). Default `[]`.
+- `DashboardContributor.on_user_message(app, message)` — fired once per user
+  message by `dashboard/chat_handlers.py::api_chat` before the turn, inside a
+  fail-safe `safe_context_call`. OBSERVER only. Default no-op.
+- `McpToolingProvider.extra_skills()` — now WIRED: `SkillsLoader.__init__`
+  appends returned paths as lowest-precedence extra skill roots (sensitivity- +
+  existence-checked). Default `[]`.
+- `browser/auth.py::register_browser_auth_provider(provider)` — module-level
+  registration hook (twin of `register_acp_backends`); every `browser/auth`
+  helper delegates to it when present, else the OSS default. `browser/cli.py`
+  auth subcommands now delegate through the helpers.
+- `hooks.register_internal_read_path(read_id, rel_path)` — guarded seam adding a
+  fixed-path entry to `_INTERNAL_READ_ALLOWLIST` (rejects `..`/absolute/
+  non-sensitive/repoint).
+- `security._SENSITIVE_HOME_DIRS` gains `.midway` (live SSO bearer cookie;
+  inert on a host without `~/.midway`).
+- `config.dashboard.mwinit_flags` (str) + `_EDITABLE_CONFIG` PATCH entry.
+- `config.knowledge.auto_ingest_doc_links` (bool) + `doc_ingest_hosts` (list) —
+  SSRF-safe, empty allowlist = deny-by-default.
+- `KiroCrewConfig._extra_sections` (private) — unknown top-level config.json
+  sections captured at `load()`, re-emitted by `to_dict()`, so an edition
+  section is not dropped on `save()`/PATCH. Excluded from the JSON schema
+  (`build_json_schema` skips leading-underscore fields). Data-preservation half
+  of the eventual `ConfigSchemaContributor`; Settings-visibility half is TODO.
+- ACP claude seam (all inside the dormant `_is_claude` path, inert on kiro-cli):
+  `AcpClient._claude_session_mcp_servers()` (Default `[]`) feeds both
+  `session/new` + `session/load` `mcpServers`; `_spawn` calls the
+  companion-attached `_write_claude_local_settings()` (via `getattr`) on the
+  PRIMARY spawn path; `AcpClient`/`AcpProvider` take a `permission_mode` kwarg
+  (Default `None`); `acp/types.py` adds `CC_PERMISSION_MODE_DEFAULT` /
+  `CC_PERMISSION_MODE_AUTO`.
+
 ### Deferred / non-mapping sites
 
-- `agent.py` — `mcp_tooling.extra_skills()` (skill catalog) is **not** wired:
-  skill discovery lives in `SkillsLoader`, not the agent config (TODO).
 - `cli_doctor.py` — `package_manager` is **not** wired: the ollama-install
   diagnostic is inline step-by-step logic, not a single plan-resolution site
   (TODO; Default `install_plan` returns `[]` = today's inline behavior).

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1190,12 +1190,18 @@ class AcpClient:
         mcp_gateway_overlay: str | Path | None = None,
         mcp_gateway_settings_mcp_json: str | Path | None = None,
         mcp_gateway_socket: str | Path | None = None,
+        permission_mode: str | None = None,
     ):
         self._work_dir = Path(work_dir) if work_dir else Path.home() / ".kirocrew" / "workspace"
         self._model = model or DEFAULT_MODEL
         self._agent = agent
         self._sandbox_mode = sandbox_mode
         self._acp_backend = acp_backend
+        # Claude Code permission mode (Auto-mode / permission-UI parity). Inert
+        # on the kiro-cli path and unused by the public core; a companion that
+        # drives the _is_claude seam reads/writes it and wires the permission-mode
+        # method set + settings.local.json defaultMode. None = the backend default.
+        self._permission_mode = permission_mode
         self._session_key = session_key
         # When set, this client emits a per-tool-call SEL audit from the ACP
         # dispatch loop. Used by app/worker-pool clients (e.g. code-review-sage,
@@ -1330,6 +1336,19 @@ class AcpClient:
     @property
     def _is_claude(self) -> bool:
         return self.backend == ACP_BACKEND_CLAUDE
+
+    def _claude_session_mcp_servers(self) -> list:
+        """MCP server array passed to a claude ``session/new`` / ``session/load``.
+
+        Overridable seam for the dormant ``_is_claude`` backend. The Default is
+        ``[]`` so the public core (kiro-cli only, which gets its servers via
+        ``--agent``) is byte-identical. An internal companion that re-registers
+        Claude Code over the ``ACP_BACKEND_CLAUDE`` seam overrides this to inject
+        the kirocrew-core/cron + user MCP servers — the claude adapter does not
+        read ``kirocrew.mcp.json`` on its own, so without this a claude session
+        would have zero MCP tools.
+        """
+        return []
 
     @property
     def is_ready(self) -> bool:
@@ -1557,6 +1576,22 @@ class AcpClient:
             # ~/.claude registration glue (settings.local.json, the MCP-registry
             # reader) lived in the deleted cc_agent module and is re-added by the
             # internal companion, not the public core.
+            #
+            # Per-session settings seed: a companion attaches
+            # _write_claude_local_settings (permissions.defaultMode + the
+            # availableModels allowlist that unlocks the 1M-token window). It
+            # MUST run on the PRIMARY spawn path — not only the rare
+            # model-substitution retry at _new_session_following_substitution —
+            # or a claude session collapses to the 200K default. Guarded via
+            # getattr so the public core (no such method) is byte-identical.
+            _seed = getattr(self, "_write_claude_local_settings", None)
+            if callable(_seed):
+                try:
+                    _seed()
+                except (OSError, ValueError, TypeError):
+                    logger.warning(
+                        "initial seed of settings.local.json failed", exc_info=True
+                    )
             global _claude_acp_argv_cache  # noqa: PLW0603
             if _claude_acp_argv_cache is _UNRESOLVED:
                 _claude_acp_argv_cache = await asyncio.to_thread(_resolve_claude_acp_bin)
@@ -1962,8 +1997,11 @@ class AcpClient:
         new_params: dict = {
             "cwd": str(self._work_dir),
             # kiro-cli loads servers from --agent; claude-agent-acp must be
-            # told here -- it does not read kirocrew.mcp.json on its own.
-            "mcpServers": [],
+            # told here -- it does not read kirocrew.mcp.json on its own. The
+            # Default hook returns [] (kiro-cli path unchanged); an internal
+            # companion that drives the _is_claude seam overrides
+            # _claude_session_mcp_servers() to populate the claude MCP array.
+            "mcpServers": self._claude_session_mcp_servers(),
         }
         if self._is_claude:
             new_params["_meta"] = {"claudeCode": {"options": {}}}
@@ -2068,8 +2106,10 @@ class AcpClient:
                         "cwd": str(self._work_dir),
                         # kiro-cli gets its servers via --agent; the claude
                         # backend must receive them here (it does not read
-                        # kirocrew.mcp.json itself).
-                        "mcpServers": [],
+                        # kirocrew.mcp.json itself). Default [] leaves kiro-cli
+                        # unchanged; a companion overrides the hook (see
+                        # session/new above).
+                        "mcpServers": self._claude_session_mcp_servers(),
                     }
                     if self._is_claude:
                         load_params["_meta"] = {"claudeCode": {"options": {}}}

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -60,6 +60,16 @@ METHOD_SET_CONFIG_OPTION = "session/set_config_option"
 
 ACP_BACKEND_CLAUDE = "claude"
 
+# ── Claude Code permission modes ──
+# Values an edition writes into a per-session settings.local.json
+# ``permissions.defaultMode`` when it drives the dormant ``ACP_BACKEND_CLAUDE``
+# seam. ``default`` = per-tool approval; ``auto`` = the SDK auto-accept mode
+# (Auto-mode / permission-UI parity). Inert in the public core (kiro-cli only);
+# defined here so the client's ``permission_mode`` kwarg and a companion share
+# one canonical vocabulary rather than duplicating string literals.
+CC_PERMISSION_MODE_DEFAULT = "default"
+CC_PERMISSION_MODE_AUTO = "auto"
+
 # ── ACP Session Update Types ──
 
 UPDATE_USER_MESSAGE_CHUNK = "user_message_chunk"

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1818,7 +1818,16 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # On existing configs, don't touch tools/allowedTools — user controls those.
     if fresh_install:
         added_refs: list[str] = []
-        for mcp_name in _MANAGED_MCP_SERVERS:
+        # Managed servers + edition-contributed servers both get their @ref
+        # registered so their tools are callable. Edition servers are injected
+        # into config['mcpServers'] via _extra_mcp_servers() above but were
+        # previously never added to config['tools'], so kiro-cli exposed the
+        # server but not its tools. The public edition contributes none, so this
+        # is a no-op there.
+        _register_names = list(_MANAGED_MCP_SERVERS) + [
+            n for n in _extra_mcp_servers() if n not in _MANAGED_MCP_SERVERS
+        ]
+        for mcp_name in _register_names:
             ref = f"@{mcp_name}"
             if mcp_name in valid_servers:
                 if ref not in config.get("tools", []):

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -298,20 +298,49 @@ def _context_clone_sandbox_mode(git_url: str) -> str:
         return _clone_sandbox_mode(git_url, _configured_registry_hosts())
 
 
+def _edition_registry_rows() -> list[dict[str, Any]]:
+    """Edition-contributed App-Store rows (CPP seam), fail-closed to []."""
+    from kiro_crew.platform.context import safe_context_call
+
+    def _read() -> list[dict[str, Any]]:
+        rows = current_context().apps_loader.registry_rows()
+        return [r for r in rows if isinstance(r, dict) and isinstance(r.get("name"), str)]
+
+    return safe_context_call(
+        _read,
+        fallback_factory=list,
+        log_message="edition registry_rows lookup failed; using bundled only",
+    )
+
+
 def _load_registry_file() -> list[dict[str, Any]]:
-    """Load and parse the bundled app-registry.json."""
+    """Load and parse the bundled app-registry.json, then merge edition rows.
+
+    Edition rows (from the CPP ``AppsLoader.registry_rows`` seam) are appended
+    ADD-only: a bundled core row wins over a same-``name`` edition row, so a
+    companion can only add catalog entries, never repoint a core one. The public
+    edition contributes none, so the merged list equals the bundled file.
+    """
+    rows: list[dict[str, Any]] = []
     if not _REGISTRY_FILE.is_file():
         logger.warning("Registry file not found: %s", _REGISTRY_FILE)
-        return []
-    try:
-        data = json.loads(_REGISTRY_FILE.read_text(encoding="utf-8"))
-        if not isinstance(data, list):
-            logger.warning("Registry file is not a JSON array")
-            return []
-        return data
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Failed to load registry: %s", exc)
-        return []
+    else:
+        try:
+            data = json.loads(_REGISTRY_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                rows = data
+            else:
+                logger.warning("Registry file is not a JSON array")
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load registry: %s", exc)
+
+    seen = {r.get("name") for r in rows if isinstance(r, dict)}
+    for row in _edition_registry_rows():
+        if row.get("name") in seen:
+            continue
+        rows.append(row)
+        seen.add(row.get("name"))
+    return rows
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/browser/auth.py
+++ b/src/kiro_crew/browser/auth.py
@@ -1,4 +1,4 @@
-"""Browser authentication helpers for Playwright MCP browsing (OSS stub).
+"""Browser authentication helpers for Playwright MCP browsing.
 
 In the open-source build there is no bundled enterprise SSO integration, so the
 SSO/cookie-refresh helpers below are inert stubs that report "not available in
@@ -7,12 +7,26 @@ browser cookie file a user wants to inject into Playwright.
 
 All public symbols are preserved so that ``browser/setup.py``, ``browser/cli.py``
 and the dashboard handlers continue to import and call them safely.
+
+**Edition seam.** A companion edition supplies its real enterprise SSO/cookie
+flow by registering a provider via
+:func:`register_browser_auth_provider` at boot — the structural twin of
+``register_acp_backends`` / ``register_publish_providers`` /
+``embeddings.register_embedding_backend``. Every helper below delegates to the
+registered provider when one is present and otherwise returns today's OSS
+"not available" default, so the standalone build is byte-identical. A provider
+only needs to implement the subset of methods it supports; a missing method
+falls back to the OSS default for that helper (``getattr`` duck-typing keeps the
+companion free of an import-inherit dependency on this module).
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 # Path of a Netscape cookie jar, if the user maintains one. Kept generic; the
 # default location matches the historic name but nothing requires it to exist.
@@ -21,8 +35,70 @@ MIDWAY_COOKIE_PATH = Path.home() / ".midway" / "cookie"
 _NOT_AVAILABLE = {"available": False, "reason": "not available in OSS"}
 
 
+@runtime_checkable
+class BrowserAuthProvider(Protocol):
+    """The edition-supplied browser-auth flow (all methods optional).
+
+    A companion registers an instance via :func:`register_browser_auth_provider`.
+    Each method mirrors the module-level helper of the same name; a provider that
+    omits a method leaves that helper at its OSS default. Structural (``Protocol``)
+    so the companion need not import-inherit this class.
+    """
+
+    def cookie_path(self) -> Path: ...
+
+    def has_mcscli(self) -> bool: ...
+
+    def mcs_keys_process_running(self) -> bool: ...
+
+    def refresh_cookie_via_mcs(self) -> bool: ...
+
+    def refresh_aea(self) -> bool: ...
+
+    def has_kerberos_ticket(self) -> bool: ...
+
+    def health(self) -> dict[str, Any]: ...
+
+    def ensure(self) -> dict[str, Any]: ...
+
+    def federate_auth(self, target_url: str) -> dict[str, Any]: ...
+
+
+# Module-level provider slot. ``None`` → the OSS stubs below apply unchanged.
+_provider: Optional[BrowserAuthProvider] = None
+
+
+def register_browser_auth_provider(provider: Optional[BrowserAuthProvider]) -> None:
+    """Register (or clear, with ``None``) the edition browser-auth provider.
+
+    Called once from an edition's boot composition with a hardcoded provider
+    instance — never from an agent-reachable path. Idempotent; a later call
+    replaces the previous provider (tests pass ``None`` to reset).
+    """
+    global _provider
+    _provider = provider
+
+
+def _delegate(method: str, default: Callable[[], Any]) -> Any:
+    """Call ``provider.<method>()`` if a provider supplies it, else ``default()``.
+
+    A provider exception is logged and degrades to the OSS default rather than
+    propagating — a broken edition helper must not crash a browse/dashboard path.
+    """
+    prov = _provider
+    if prov is not None:
+        fn = getattr(prov, method, None)
+        if callable(fn):
+            try:
+                return fn()
+            except Exception:
+                logger.warning("browser-auth provider %s() failed; using default", method,
+                               exc_info=True)
+    return default()
+
+
 def cookie_path() -> Path:
-    return MIDWAY_COOKIE_PATH
+    return _delegate("cookie_path", lambda: MIDWAY_COOKIE_PATH)
 
 
 def parse_netscape_cookies(path: Path) -> list[dict[str, Any]]:
@@ -60,44 +136,54 @@ def parse_netscape_cookies(path: Path) -> list[dict[str, Any]]:
 
 
 def has_mcscli() -> bool:
-    """No enterprise credential helper in the OSS build."""
-    return False
+    """No enterprise credential helper in the OSS build (edition may override)."""
+    return _delegate("has_mcscli", lambda: False)
 
 
 def mcs_keys_process_running() -> bool:
-    """No enterprise credential helper in the OSS build."""
-    return False
+    """No enterprise credential helper in the OSS build (edition may override)."""
+    return _delegate("mcs_keys_process_running", lambda: False)
 
 
 def refresh_cookie_via_mcs() -> bool:
-    """Cookie refresh via an enterprise helper is not available in OSS."""
-    return False
+    """Cookie refresh via an enterprise helper (edition may override)."""
+    return _delegate("refresh_cookie_via_mcs", lambda: False)
 
 
 def refresh_aea() -> bool:
-    """Device-posture refresh is not available in OSS."""
-    return False
+    """Device-posture refresh (edition may override)."""
+    return _delegate("refresh_aea", lambda: False)
 
 
 def has_kerberos_ticket() -> bool:
-    """Kerberos/SPNEGO is not wired up in the OSS build."""
-    return False
+    """Kerberos/SPNEGO ticket presence (edition may override)."""
+    return _delegate("has_kerberos_ticket", lambda: False)
 
 
 def health() -> dict[str, Any]:
-    """Report auth health. The OSS build ships no bundled SSO integration."""
-    return dict(_NOT_AVAILABLE)
+    """Report auth health. OSS default: no bundled SSO (edition may override)."""
+    return _delegate("health", lambda: dict(_NOT_AVAILABLE))
 
 
 def ensure() -> dict[str, Any]:
-    """One-stop auth check. No-op in OSS: nothing to refresh."""
-    return dict(_NOT_AVAILABLE)
+    """One-stop auth check. OSS default: nothing to refresh (edition may override)."""
+    return _delegate("ensure", lambda: dict(_NOT_AVAILABLE))
 
 
 def federate_auth(target_url: str) -> dict[str, Any]:
-    """Enterprise federate SSO flow — not available in the OSS build.
+    """Enterprise federate SSO flow (edition may override).
 
-    Returns a result dict with ``ok=False`` so callers degrade gracefully and
-    simply navigate without injected SSO cookies.
+    OSS default returns ``ok=False`` so callers degrade gracefully and simply
+    navigate without injected SSO cookies. When a companion provider is present
+    its ``federate_auth(target_url)`` is called with the target URL.
     """
+    prov = _provider
+    if prov is not None:
+        fn = getattr(prov, "federate_auth", None)
+        if callable(fn):
+            try:
+                return fn(target_url)
+            except Exception:
+                logger.warning("browser-auth provider federate_auth() failed; using default",
+                               exc_info=True)
     return {"ok": False, "error": "not available in OSS", "cookies": []}

--- a/src/kiro_crew/browser/cli.py
+++ b/src/kiro_crew/browser/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -146,24 +147,51 @@ def _patch_mcp_config_headless() -> None:
 
 
 def _cmd_auth_health() -> None:
-    """Browser auth health check is not available in the open-source build."""
+    """Browser auth health check — delegates to the auth layer.
+
+    In the OSS build the auth layer reports "not available in OSS"; an edition
+    that registered a ``BrowserAuthProvider`` surfaces its real health here.
+    """
+    from kiro_crew.browser import auth as _auth
+
+    result = _auth.health()
+    if result.get("available"):
+        print(json.dumps(result, indent=2))
+        return
     print("browser auth health: not available in OSS")
     sys.exit(1)
 
 
 def _cmd_auth_inject() -> None:
-    """Cookie injection is not available in the open-source build."""
+    """Cookie injection — delegates to the auth layer (OSS: not available)."""
+    from kiro_crew.browser import auth as _auth
+
+    result = _auth.ensure()
+    if result.get("available"):
+        print(json.dumps(result, indent=2))
+        return
     print("browser auth inject: not available in OSS")
     sys.exit(1)
 
 
 def _cmd_auth_refresh() -> None:
-    """Storage-state refresh is not available in the open-source build."""
+    """Storage-state refresh — delegates to the auth layer (OSS: not available)."""
+    from kiro_crew.browser import auth as _auth
+
+    if _auth.refresh_cookie_via_mcs():
+        print("browser auth refresh: ok")
+        return
     print("browser auth refresh: not available in OSS")
     sys.exit(1)
 
 
 def _cmd_auth_federate(url: str) -> None:
-    """Federated SSO is not available in the open-source build."""
+    """Federated SSO — delegates to the auth layer (OSS: not available)."""
+    from kiro_crew.browser import auth as _auth
+
+    result = _auth.federate_auth(url)
+    if result.get("ok"):
+        print(json.dumps({k: v for k, v in result.items() if k != "cookies"}, indent=2))
+        return
     print("browser auth federate: not available in OSS")
     sys.exit(1)

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -82,6 +82,54 @@ from kiro_crew.mcp_gateway.rewriter import default_overlay_dir, default_socket_p
 
 logger = logging.getLogger(__name__)
 
+# Top-level config.json sections this core models AND round-trips through
+# to_dict(). Any other top-level key found at load() is captured into
+# KiroCrewConfig._extra_sections and re-emitted by to_dict() so an
+# edition-contributed section (written by a companion) survives the save()/PATCH
+# round-trip instead of being silently dropped.
+#
+# INVARIANT: this set must equal the top-level keys to_dict() emits (guarded by
+# test_config_extra_sections_roundtrip's parity test). It is the *emitted* set,
+# not merely the *parsed* set: a section this core parses into a field must ALSO
+# be emitted by to_dict() to be listed here — otherwise it would be excluded
+# from _extra_sections capture yet dropped by to_dict(), losing it on save().
+_KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
+    {
+        "agent",
+        "session",
+        "memory",
+        "slack",
+        "publish",
+        "telegram",
+        "discord",
+        "dashboard",
+        "tunnel",
+        "hooks",
+        "agents",
+        "default_agent",
+        "workspaces",
+        "default_workspace",
+        "memory_stores",
+        "default_memory_store",
+        "stt",
+        "instances",
+        "mcp_gateway",
+        "taskrunner",
+        "orchestrator",
+        "watchdog",
+        "messaging",
+        "cron_history",
+        "knowledge",
+        "heartbeat",
+        "skills",
+        "telemetry",
+        "snapshot_dir",
+        "timezone",
+        "auto_update",
+        "registries",
+    }
+)
+
 # Credential keys loaded from .env / environment
 CRED_SLACK_APP_TOKEN = "SLACK_APP_TOKEN"
 CRED_SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN"
@@ -1007,6 +1055,28 @@ class KnowledgeConfig:
             "0 keeps the workers warm indefinitely.",
         ),
     )
+    auto_ingest_doc_links: bool = field(
+        default=False,
+        metadata=_meta(
+            "Auto-Ingest Doc Links",
+            "Automatically ingest documents referenced by links pasted into chat "
+            "whose host is in the doc-ingest allowlist. Off by default. An edition "
+            "that supplies a doc-link scanner (via the dashboard on_user_message "
+            "seam) uses this + the host allowlist below; inert in the public build "
+            "unless a link scanner is wired.",
+        ),
+    )
+    doc_ingest_hosts: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Doc-Ingest Host Allowlist",
+            "Exact hostnames whose links may be auto-ingested when "
+            "auto_ingest_doc_links is on. Empty = ingest nothing (SSRF-safe "
+            "deny-by-default): a link is only fetched if its host is an exact "
+            "member of this list. Prevents a pasted link to an internal metadata "
+            "endpoint or arbitrary host from being fetched.",
+        ),
+    )
 
 
 @dataclass
@@ -1270,6 +1340,17 @@ class DashboardConfig:
             "Dashboard color mode preference: 'dark', 'light', or 'system'. "
             "Empty = unset (frontend falls back to localStorage or 'system').",
             enum=["", "dark", "light", "system"],
+        ),
+    )
+    mwinit_flags: str = field(
+        default="",
+        metadata=_meta(
+            "mwinit Flags",
+            "Flags passed to the SSO login command by an edition that supplies a "
+            "real login handler (DashboardContributor.mwinit_handler). Empty = the "
+            "edition default. Inert in the public build (the core /api/mwinit is a "
+            "no-op stub); the companion validates the token allowlist when it uses "
+            "them.",
         ),
     )
     theme_color: str = field(
@@ -2665,6 +2746,15 @@ class KiroCrewConfig:
             "External app registries (org-owned repos). " "Each entry: {name, repo, branch}.",
         ),
     )
+    # Unknown top-level config.json sections captured verbatim at load() and
+    # re-emitted by to_dict() so a section this core does not model (e.g. an
+    # edition-contributed section written by a companion) is NOT silently
+    # dropped on the first save()/PATCH round-trip. Excluded from the JSON
+    # schema by the leading underscore (build_json_schema skips private fields);
+    # populated only from disk. This is the data-preservation half of the
+    # ConfigSchemaContributor seam — a companion writes its section, the core
+    # round-trips it untouched.
+    _extra_sections: dict = field(default_factory=dict)
 
     def channel_config(self, channel_id: str) -> ChannelConfig:
         """Return the config for *channel_id*, falling back to defaults.
@@ -2888,6 +2978,15 @@ class KiroCrewConfig:
         if not isinstance(default_memory_store_val, str):
             default_memory_store_val = "default"
 
+        # Capture unknown top-level sections verbatim so a section this core does
+        # not model (e.g. an edition-contributed section written by a companion)
+        # survives the load()->to_dict()->save() round-trip instead of being
+        # silently dropped. ``meta`` is stamped by save() itself, so it is never
+        # treated as an unknown section to preserve.
+        extra_sections = {
+            k: v for k, v in data.items() if k not in _KNOWN_CONFIG_SECTIONS and k != "meta"
+        }
+
         cfg = cls(
             agent=AgentConfig(
                 approval_mode=agent_data.get("approval_mode", "auto"),
@@ -3046,6 +3145,14 @@ class KiroCrewConfig:
                     and ttl >= 0
                     else 300
                 ),
+                auto_ingest_doc_links=bool(
+                    knowledge_data.get("auto_ingest_doc_links", False)
+                ),
+                doc_ingest_hosts=[
+                    str(h)
+                    for h in knowledge_data.get("doc_ingest_hosts", [])
+                    if isinstance(h, str) and h.strip()
+                ],
             ),
             telegram=TelegramConfig(
                 enabled=bool(telegram_data.get("enabled", False)),
@@ -3138,6 +3245,7 @@ class KiroCrewConfig:
                 terminal=dashboard_data.get("terminal", {"enabled": True}),
                 default_project=dashboard_data.get("default_project", ""),
                 theme_mode=dashboard_data.get("theme_mode", ""),
+                mwinit_flags=str(dashboard_data.get("mwinit_flags", "")),
                 theme_color=dashboard_data.get("theme_color", ""),
                 recent_tint_count=_safe_int(dashboard_data.get("recent_tint_count", 0), 0),
                 onboarded=bool(dashboard_data.get("onboarded", False)),
@@ -3255,6 +3363,7 @@ class KiroCrewConfig:
             observe_ttl_hours=max(
                 0.0, float(data.get("slack", {}).get("observe_ttl_hours", 168.0))
             ),
+            _extra_sections=extra_sections,
         )
 
         # Write-back migration: if the on-disk config has legacy format
@@ -3315,6 +3424,7 @@ class KiroCrewConfig:
             "slack": asdict(self.slack),
             "publish": asdict(self.publish),
             "telegram": asdict(self.telegram),
+            "discord": asdict(self.discord),
             "dashboard": asdict(self.dashboard),
             "tunnel": asdict(self.tunnel),
             "hooks": self.hooks,
@@ -3342,6 +3452,13 @@ class KiroCrewConfig:
         }
         # External registries (always serialized so save() round-trips the field)
         d["registries"] = [asdict(r) for r in self.registries]
+        # Re-emit unknown/edition-contributed top-level sections captured at
+        # load() so save()/PATCH does not silently drop them. A known section
+        # never appears here (only keys absent from d are restored), so this can
+        # never clobber a core section with a stale captured copy.
+        for _k, _v in self._extra_sections.items():
+            if _k not in d:
+                d[_k] = _v
         # Preserve per-channel activation settings on round-trip
         slack_section = d.setdefault("slack", {})
         if self.slack_channels:

--- a/src/kiro_crew/config/schema.py
+++ b/src/kiro_crew/config/schema.py
@@ -247,6 +247,12 @@ def _build_object_schema(cls: type) -> dict:
 
     props: dict = {}
     for f in fields(cls):
+        # Private fields (leading underscore) are internal bookkeeping, not
+        # user-facing config — e.g. KiroCrewConfig._extra_sections, which
+        # round-trips unknown/edition-contributed top-level sections. They are
+        # not part of the JSON schema or the flattened ConfigEntry baseline.
+        if f.name.startswith("_"):
+            continue
         props[f.name] = _build_field_schema(f, hints.get(f.name))
 
     return {

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -472,6 +472,21 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         state._background_tasks.add(_tt)
         _tt.add_done_callback(state._background_tasks.discard)
 
+    # Edition message observer (CPP seam). Fire-and-forget, fail-safe: a
+    # companion uses this to auto-ingest doc links pasted into chat. The public
+    # Default is a no-op. Guarded so an observer error never blocks the turn;
+    # deferred context read via the sel.py pattern (no platform import at load).
+    try:
+        from kiro_crew.platform.context import current_context, safe_context_call
+
+        safe_context_call(
+            lambda: current_context().dashboard.on_user_message(request.app, message),
+            fallback=None,
+            log_message="dashboard.on_user_message observer failed",
+        )
+    except Exception:
+        logger.debug("on_user_message observer raised; ignoring", exc_info=True)
+
     task = asyncio.create_task(
         asyncio.wait_for(_run_chat(state, slot, message), timeout=CHAT_TURN_TIMEOUT)
     )

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -63,6 +63,18 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
 
     masked = copy.deepcopy(cfg.to_dict())
 
+    # Drop unknown/edition-contributed top-level sections (KiroCrewConfig.
+    # _extra_sections) from the API response entirely. They exist ONLY for the
+    # save() round-trip; the core does not model them, so they are absent from
+    # the schema and the sensitivity walk below (which is schema-driven) cannot
+    # know which of their values are secrets. Returning them verbatim to the
+    # dashboard would leak any credential an edition stored in its own section.
+    # to_dict()/save() still carry them — only this browser-facing view omits
+    # them. (An edition that needs to surface its config in the dashboard does
+    # so through its own masked route, not this core endpoint.)
+    for _extra_key in getattr(cfg, "_extra_sections", {}):
+        masked.pop(_extra_key, None)
+
     def _walk(node: object, prefix: str) -> None:
         if isinstance(node, dict):
             for key, val in list(node.items()):
@@ -990,6 +1002,11 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "auto_update": {"type": "bool"},
     "dashboard.mcp_probe_timeout_secs": {"type": "int", "min": 5, "max": 120},
     "dashboard.recent_tint_count": {"type": "int", "min": 0, "max": 10},
+    # SSO login flags for an edition that supplies a real mwinit_handler. Bounded
+    # to a short string here; the companion login handler re-validates each token
+    # against its own flag allowlist before spawning the login PTY (defense in
+    # depth — this gate only stores the value). Inert in the public build.
+    "dashboard.mwinit_flags": {"type": "str", "max_len": 256},
     # Instances (multi-instance management). Toggling enabled needs a gateway
     # restart to take effect (the SSH manager + CSP relaxation init at startup),
     # so the Instances settings panel surfaces a "restart required" hint.

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -850,6 +850,57 @@ _INTERNAL_READ_ALLOWLIST: dict[str, str] = {
 }
 
 
+def register_internal_read_path(read_id: str, rel_path: str) -> None:
+    """Register an edition-contributed fixed-path internal-read carve-out.
+
+    The composition-time seam an edition companion uses to add its own trusted
+    fixed-path reads (e.g. an SSO cookie jar for the usage-upload path) to
+    ``_INTERNAL_READ_ALLOWLIST`` — the exact structural twin of the boot-time
+    ``register_acp_backends`` / ``register_publish_providers`` seams.  This is
+    NOT an agent-reachable API: it is called once, from the companion's boot
+    composition, with HARDCODED constant arguments.  It never widens what
+    ``safe_read_file_internal`` will read at call time — that function still
+    re-verifies the resolved path is sensitive, opens O_NOFOLLOW, and SEL-audits
+    every outcome — this only lets an edition contribute an entry to the same
+    guarded table the core ships.
+
+    Guards (fail-closed, so a mis-registration cannot open a hole):
+
+    * ``read_id`` must be a non-empty string; re-registering an existing key with
+      a DIFFERENT path raises (a companion cannot silently repoint a core entry
+      such as ``kiro_usage_api.sso_token_cli`` at an attacker file).  Re-
+      registering the same key with the same path is idempotent.
+    * ``rel_path`` must be a relative path with no ``..`` component and no
+      absolute/anchor part, so the resolved target can only ever live under
+      ``~`` (the read still resolves under ``Path.home()`` at call time).
+    * the resolved ``~/<rel_path>`` must already be classified sensitive by
+      :func:`kiro_crew.security.is_sensitive_path` — the carve-out is only valid
+      for a path the shared file gate otherwise blocks; registering a
+      non-sensitive path is a configuration error and raises.
+    """
+    if not isinstance(read_id, str) or not read_id:
+        raise ValueError("register_internal_read_path: read_id must be a non-empty string")
+    existing = _INTERNAL_READ_ALLOWLIST.get(read_id)
+    if existing is not None and existing != rel_path:
+        raise ValueError(
+            f"register_internal_read_path: {read_id!r} already registered to a "
+            f"different path {existing!r}; refusing to repoint",
+        )
+    p = Path(rel_path)
+    if p.is_absolute() or p.anchor or ".." in p.parts:
+        raise ValueError(
+            f"register_internal_read_path: rel_path must be relative with no '..' "
+            f"(got {rel_path!r})",
+        )
+    resolved = str((Path.home() / p).expanduser())
+    if not is_sensitive_path(resolved):
+        raise ValueError(
+            f"register_internal_read_path: {rel_path!r} resolves to a non-sensitive "
+            f"path; the carve-out is only valid for a sensitive path",
+        )
+    _INTERNAL_READ_ALLOWLIST[read_id] = rel_path
+
+
 def safe_read_file_internal(read_id: str) -> bytes | None:
     """Read a sensitive path on behalf of an authorized internal caller.
 

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -130,6 +130,12 @@ class DefaultSlackEnterpriseGate:
 
         return enterprise.check_message_origin(event_team_id)
 
+    def heartbeat_safe_tools(self) -> "frozenset[str]":
+        # The public edition adds no tools to the heartbeat allowlist — the set
+        # stays exactly the core HEARTBEAT_SAFE_TOOLS. The companion returns its
+        # internal read-only tool names.
+        return frozenset()
+
 
 class DefaultIdentityProvider:
     """No-SSO local identity — the ``midway.py`` no-op stubs."""
@@ -227,6 +233,11 @@ class DefaultAppsLoader:
     def manifest_sources(self) -> List[Path]:
         return []
 
+    def registry_rows(self) -> List[Dict[str, Any]]:
+        # The public edition bundles no extra App-Store rows beyond
+        # apps/app-registry.json. A companion returns its internal catalog rows.
+        return []
+
 
 class DefaultPackageManager:
     """Public brew/curl/pip install strategy (delegated to cli_doctor logic)."""
@@ -302,6 +313,11 @@ class DefaultDashboardContributor:
 
     def mwinit_handler(self) -> Optional[Callable[..., Any]]:
         # None → the dashboard keeps its built-in /api/mwinit stub handler.
+        return None
+
+    def on_user_message(self, app: Any, message: str) -> None:
+        # The public edition observes no chat messages. A companion uses this to
+        # e.g. auto-ingest doc links pasted into chat.
         return None
 
 

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -172,6 +172,33 @@ class SlackEnterpriseGate(Protocol):
 
     def check_message_origin(self, event_team_id: str) -> bool: ...
 
+    def heartbeat_safe_tools(self) -> "frozenset[str]":
+        """Extra tool names an edition allows during unattended heartbeat polling.
+
+        WIRED: ``slack/gateway.py::_is_heartbeat_safe_tool`` checks this set after
+        the core ``HEARTBEAT_SAFE_TOOLS`` exact-name match. The public default is
+        ``frozenset()`` (no additions — the heartbeat allowlist is byte-identical
+        to today). A companion returns its own read-only tool names so its
+        heartbeat polls can auto-approve them.
+
+        **Entries MUST be server-qualified ``"@server/Tool"``.** An entry is
+        honored ONLY when it matches that qualified identity; a bare tool name
+        never matches (and a tool-call title with no resolvable server is never
+        auto-approved from this set). This is deliberate: a bare-name allowlist
+        entry would let a *different* (or compromised) MCP server expose a
+        destructive tool with the same bare name as an allowlisted read-only one
+        and get it auto-approved during an unattended heartbeat — a hole in the
+        deny-by-default boundary. Pin the exact server (e.g.
+        ``"@builder-mcp/ReadInternalWebsites"``).
+
+        ADD-only by construction: this can only widen the allowlist with names
+        the companion vouches for; it can never remove a core entry or relax the
+        exact-match discipline. NEVER sourced from config — an agent-writable set
+        would defeat the deny-by-default heartbeat gate, so the companion adapter
+        is the only supplier. v1 method addition (no ``CONTRACT_VERSION`` bump).
+        """
+        ...
+
 
 class IdentityProvider(Protocol):
     """SSO/identity resolution.
@@ -246,8 +273,14 @@ class McpToolingProvider(Protocol):
     def extra_mcp_servers(self) -> Dict[str, dict]: ...
 
     def extra_skills(self) -> List[Path]:
-        """NOT YET WIRED: the core does not yet load edition-contributed skill
-        paths; only ``extra_mcp_servers`` is consumed. Staged for later.
+        """Extra SKILL.md source roots the edition contributes.
+
+        WIRED: ``SkillsLoader.__init__`` appends these as lowest-precedence extra
+        skill paths (after local + AIM), each sensitivity- and existence-checked
+        like a configured ``skills.extra_paths`` entry, so an edition's SKILL.md
+        catalog (e.g. a PromptFarm-synced tree, an internal recommendation-engine
+        skill) is discoverable by trigger matching and the ``$skill`` picker. The
+        public Default returns ``[]`` (no extra paths — discovery is unchanged).
         """
         ...
 
@@ -277,6 +310,21 @@ class AppsLoader(Protocol):
     def bundled_app_names(self) -> List[str]: ...
 
     def manifest_sources(self) -> List[Path]: ...
+
+    def registry_rows(self) -> List[Dict[str, Any]]:
+        """Extra App-Store registry rows the edition bundles (ADD-only merge).
+
+        WIRED: ``apps/registry.py::_load_registry_file`` appends these to the
+        rows parsed from the bundled ``app-registry.json``, de-duplicated by the
+        row ``name`` (a bundled core row wins over a same-named edition row, so a
+        companion can only ADD catalog entries, never silently repoint a core
+        one). The public Default returns ``[]`` (catalog unchanged). A companion
+        returns its internal App-Store rows (e.g. dev-fleet, pipeline-health)
+        pointing at internal git hosts — which its ``AppRegistryPolicy`` already
+        trusts. Each row is the same dict shape as an ``app-registry.json`` entry.
+        v1 method addition (no ``CONTRACT_VERSION`` bump).
+        """
+        ...
 
 
 class KnowledgeProvider(Protocol):
@@ -424,6 +472,20 @@ class DashboardContributor(Protocol):
 
     def mwinit_handler(self) -> Optional[Callable]:
         """Return the SSO-login WS handler, or ``None`` to keep the core stub."""
+        ...
+
+    def on_user_message(self, app: "web.Application", message: str) -> None:
+        """Observe an inbound user chat message (Default: no-op).
+
+        WIRED: ``dashboard/chat_handlers.py::api_chat`` calls this once per user
+        message, just before the turn is scheduled, inside a fail-safe guard so
+        an observer error never blocks the chat.  Fire-and-forget by contract:
+        the observer must not block (schedule its own task if it needs to do
+        work).  The public Default is a no-op; a companion uses it e.g. to
+        auto-ingest document links pasted into chat.  It is an
+        OBSERVER — its return value is ignored and it MUST NOT mutate the message
+        or the turn.
+        """
         ...
 
 

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -222,6 +222,7 @@ class AcpProvider(LLMProvider):
         mcp_gateway_overlay: str | Path | None = None,
         mcp_gateway_settings_mcp_json: str | Path | None = None,
         mcp_gateway_socket: str | Path | None = None,
+        permission_mode: str | None = None,
     ) -> None:
         kwargs: dict[str, Any] = {
             "work_dir": work_dir,
@@ -234,6 +235,9 @@ class AcpProvider(LLMProvider):
             "mcp_gateway_overlay": mcp_gateway_overlay,
             "mcp_gateway_settings_mcp_json": mcp_gateway_settings_mcp_json,
             "mcp_gateway_socket": mcp_gateway_socket,
+            # Claude permission mode (Auto-mode/permission-UI parity). None on the
+            # kiro-cli path — fully inert; a companion CC provider threads it.
+            "permission_mode": permission_mode,
         }
         if agent:
             kwargs["agent"] = agent

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -527,6 +527,16 @@ _SENSITIVE_HOME_DIRS: list[str] = [
     ".pypirc",
     ".netrc",
     ".git-credentials",
+    # Enterprise SSO cookie store. The public core ships no bundled SSO
+    # integration, but the browser-auth layer already references this cookie
+    # path (browser/auth.py), an edition CredentialPolicy redacts its session
+    # token, and a companion IdentityProvider watches it for rotation. The cookie
+    # is a live bearer credential: an agent that could fs_read it could
+    # impersonate the user against every SSO-gated service. Classify the whole
+    # directory so the cookie and its sidecars are covered. Generic and inert on
+    # a host that does not have it — legitimate readers (the companion cookie
+    # jar) open it directly + SEL-audited, not through this shared gate.
+    ".midway",
     # kiro-cli / amazon-q auth stores hold the live SSO bearer token, read by
     # the dashboard credit pill via the audited kiro_usage_api._token_from_sqlite
     # helper. Classify the WHOLE data directories (not just data.sqlite3) so the

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -347,6 +347,31 @@ class SkillsLoader:
         ):
             self._extra_paths.append(aim_skills_root)
 
+        # Edition-contributed skill paths (CPP seam). A companion returns extra
+        # SKILL.md source roots via McpToolingProvider.extra_skills(); the public
+        # Default returns [] so this is a no-op for the standalone edition.
+        # Lowest precedence (appended last, after local + AIM), sensitivity- and
+        # existence-checked exactly like the configured extra_paths. Deferred
+        # context read via the sel.py pattern so skills.py never imports the
+        # platform package at module load; fails closed to no extra paths.
+        from kiro_crew.platform.context import current_context, safe_context_call
+
+        edition_skill_paths: list[Path] = safe_context_call(
+            lambda: list(current_context().mcp_tooling.extra_skills()),
+            fallback_factory=list,
+            log_message="extra_skills lookup failed; using none",
+        )
+        for edition_path in edition_skill_paths:
+            resolved = Path(edition_path).expanduser().resolve()
+            if resolved in self._extra_paths:
+                continue
+            if is_sensitive_path(str(resolved)):
+                logger.warning("Skipping sensitive edition skill path: %s", edition_path)
+            elif resolved.is_dir():
+                self._extra_paths.append(resolved)
+            else:
+                logger.debug("Edition skill path does not exist: %s", edition_path)
+
         # Persistent usage ledger for hotness-ranked lazy skill injection.
         # Co-located with the skills root's parent (the KiroCrew home) so it
         # travels with runtime state. Best-effort: a failure here must not break

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -356,6 +356,17 @@ def _is_heartbeat_safe_tool(event_title: str) -> bool:
         if name.startswith(prefix):
             name = name[len(prefix):]
             break
+    # Preserve the server-QUALIFIED form (before the prefix is stripped) so the
+    # edition allowlist can match on the full identity and avoid bare-name
+    # collisions — normalized to the "@server/Tool" spelling regardless of which
+    # wire form arrived ("mcp__server__Tool" or "@server/Tool").
+    qualified = ""
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            qualified = f"@{parts[1]}/{parts[2]}"
+    elif name.startswith("@") and "/" in name:
+        qualified = name
     # Strip MCP server prefix: "mcp__builder-mcp__ToolName" → "ToolName"
     if name.startswith("mcp__"):
         parts = name.split("__", 2)
@@ -364,7 +375,31 @@ def _is_heartbeat_safe_tool(event_title: str) -> bool:
     # Strip @server/Tool prefix: "@builder-mcp/ReadInternalWebsites" → "ReadInternalWebsites"
     if name.startswith("@") and "/" in name:
         name = name.rsplit("/", 1)[-1]
-    return name in HEARTBEAT_SAFE_TOOLS
+    if name in HEARTBEAT_SAFE_TOOLS:
+        return True
+    # Edition-contributed additions. Deferred context read via the sel.py pattern
+    # so this module never imports the platform package at load time; fails closed
+    # to the core set on any error.
+    #
+    # SECURITY — match ONLY the server-qualified "@server/Tool" identity, never a
+    # bare tool name: a bare-name allowlist entry would let a DIFFERENT (or
+    # compromised) MCP server expose a destructive tool with the same bare name
+    # as an allowlisted read-only one, and an injected heartbeat could get it
+    # auto-approved. So a title with no resolvable server (``qualified == ""``)
+    # can never match an edition entry, and an edition entry that is itself a
+    # bare name simply never matches any qualified title. This keeps the
+    # deny-by-default boundary intact; the companion MUST pin "@server/Tool".
+    if not qualified:
+        return False
+    from kiro_crew.platform.context import current_context, safe_context_call
+
+    empty: frozenset[str] = frozenset()
+    extra: frozenset[str] = safe_context_call(
+        lambda: current_context().slack_gate.heartbeat_safe_tools(),
+        fallback=empty,
+        log_message="heartbeat_safe_tools lookup failed; using core set only",
+    )
+    return qualified in extra
 
 
 # Prepended to every heartbeat task_text before ``ctx_builder.build_message``.

--- a/test/test_config_extra_sections.py
+++ b/test/test_config_extra_sections.py
@@ -1,0 +1,83 @@
+"""Round-trip preservation of unknown top-level config.json sections.
+
+An edition-contributed top-level section (written by a companion) must survive
+the ``load()`` -> ``to_dict()`` -> ``save()`` round-trip instead of being
+silently dropped. See ``KiroCrewConfig._extra_sections`` /
+``_KNOWN_CONFIG_SECTIONS`` in ``config/loader.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import _KNOWN_CONFIG_SECTIONS, KiroCrewConfig
+
+
+def test_known_sections_equals_emitted_sections():
+    """INVARIANT: _KNOWN_CONFIG_SECTIONS must equal the keys to_dict() emits.
+
+    A section in _KNOWN but NOT emitted would be excluded from _extra_sections
+    capture yet dropped by to_dict() (lost on save()). A section emitted but NOT
+    in _KNOWN would be captured as "unknown" and could round-trip a stale copy.
+    """
+    emitted = set(KiroCrewConfig().to_dict().keys())
+    # to_dict() also stamps slack sub-keys / meta at save() time; compare only
+    # the top-level section names it writes from to_dict() itself.
+    assert emitted == set(_KNOWN_CONFIG_SECTIONS), (
+        "drift between to_dict() output and _KNOWN_CONFIG_SECTIONS: "
+        f"emitted-only={emitted - set(_KNOWN_CONFIG_SECTIONS)}, "
+        f"known-only={set(_KNOWN_CONFIG_SECTIONS) - emitted}"
+    )
+
+
+def test_unknown_section_round_trips(tmp_path, monkeypatch):
+    cfgp = tmp_path / "config.json"
+    cfgp.write_text(
+        json.dumps({"agent": {"provider": "acp"}, "amazon": {"midway_flags": "-o -s", "n": [1, 2]}})
+    )
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_sections.get("amazon") == {"midway_flags": "-o -s", "n": [1, 2]}
+    assert cfg.to_dict().get("amazon") == {"midway_flags": "-o -s", "n": [1, 2]}
+
+
+def test_extra_sections_never_clobbers_a_known_section():
+    """A stale/hostile capture of a known key must not overwrite the real one."""
+    c = KiroCrewConfig()
+    c._extra_sections = {"agent": {"MALICIOUS": True}, "amazon": {"ok": 1}}
+    d = c.to_dict()
+    assert "MALICIOUS" not in d["agent"]
+    assert d["amazon"] == {"ok": 1}
+
+
+def test_extra_sections_excluded_from_json_schema():
+    from kiro_crew.config import schema
+
+    assert not any("_extra_sections" in e.path for e in schema.SCHEMA_REGISTRY)
+
+
+def test_api_config_response_omits_extra_sections():
+    """The masked GET /api/config response must NOT expose unknown sections.
+
+    `_masked_config_dict` masks only schema-declared sensitive paths; an edition
+    section is absent from the schema, so returning it verbatim would leak any
+    credential it holds. The masked view must drop `_extra_sections` entirely,
+    while `to_dict()` (the save() path) still carries them.
+    """
+    from kiro_crew.dashboard.handlers.core import _masked_config_dict
+
+    cfg = KiroCrewConfig()
+    cfg._extra_sections = {"amazon": {"api_token": "SECRET-should-not-leak", "flag": True}}
+
+    # save()/round-trip path keeps it
+    assert cfg.to_dict().get("amazon", {}).get("api_token") == "SECRET-should-not-leak"
+
+    # browser-facing API view drops the whole unknown section
+    masked = _masked_config_dict(cfg)
+    assert "amazon" not in masked
+    # confirm the secret string appears nowhere in the serialized response
+    assert "SECRET-should-not-leak" not in json.dumps(masked)

--- a/test/test_config_schema.py
+++ b/test/test_config_schema.py
@@ -54,9 +54,19 @@ def _all_fields_recursive(
     cls: type,
     prefix: str = "",
 ) -> list[tuple[str, dataclasses.Field]]:  # type: ignore[type-arg]
-    """Yield (dot_path, field) for every field in the dataclass hierarchy."""
+    """Yield (dot_path, field) for every field in the dataclass hierarchy.
+
+    Private fields (leading underscore) are internal bookkeeping, not
+    user-facing config — e.g. ``KiroCrewConfig._extra_sections``, which
+    round-trips unknown/edition-contributed top-level sections. They are
+    excluded from the JSON schema (``schema.build_json_schema`` skips them), so
+    they carry no label/help metadata and never appear in SCHEMA_REGISTRY; skip
+    them here for the same reason the builder does.
+    """
     result: list[tuple[str, dataclasses.Field]] = []  # type: ignore[type-arg]
     for f in dataclasses.fields(cls):
+        if f.name.startswith("_"):
+            continue
         path = f"{prefix}.{f.name}" if prefix else f.name
         result.append((path, f))
         tp = f.type

--- a/test/test_heartbeat_safe_tools.py
+++ b/test/test_heartbeat_safe_tools.py
@@ -153,6 +153,93 @@ class TestIsHeartbeatSafeTool:
         assert not _is_heartbeat_safe_tool("@kirocrew-core/cron_add")
 
 
+class TestEditionHeartbeatAllowlist:
+    """The CPP ``SlackEnterpriseGate.heartbeat_safe_tools()`` seam.
+
+    A companion may ADD tool names; the public Default is empty (byte-identical).
+    A qualified ``@server/Tool`` entry must match ONLY that server's tool, not a
+    same-bare-name tool from a different (or compromised) server.
+    """
+
+    def _install_gate_extra(self, monkeypatch, extra):
+        """Install a platform context whose slack_gate returns *extra*."""
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.platform import build_default_context
+        from kiro_crew.platform.context import set_context
+
+        base = build_default_context(KiroCrewConfig())
+
+        class _Gate:
+            def validate_enterprise(self, *a, **k):
+                return True
+
+            def check_message_origin(self, *a, **k):
+                return True
+
+            def heartbeat_safe_tools(self):
+                return frozenset(extra)
+
+        import dataclasses
+
+        ctx = dataclasses.replace(base, slack_gate=_Gate())
+        set_context(ctx)
+        monkeypatch.setattr(
+            "kiro_crew.platform.bootstrap._BOOTED", True, raising=False
+        )
+
+    @pytest.fixture(autouse=True)
+    def _reset_ctx(self):
+        from kiro_crew.platform.context import set_context
+
+        yield
+        set_context(None)
+
+    def test_default_edition_set_is_empty(self, monkeypatch) -> None:
+        """No companion → the allowlist is byte-identical to the core set."""
+        self._install_gate_extra(monkeypatch, [])
+        assert not _is_heartbeat_safe_tool("@builder-mcp/ReadInternalWebsites")
+
+    def test_qualified_entry_matches_only_its_server(self, monkeypatch) -> None:
+        """A pinned ``@server/Tool`` entry auto-approves that exact identity…"""
+        self._install_gate_extra(monkeypatch, ["@builder-mcp/ReadInternalWebsites"])
+        assert _is_heartbeat_safe_tool("@builder-mcp/ReadInternalWebsites")
+        assert _is_heartbeat_safe_tool("Running: @builder-mcp/ReadInternalWebsites")
+        assert _is_heartbeat_safe_tool("mcp__builder-mcp__ReadInternalWebsites")
+
+    def test_qualified_entry_rejects_same_bare_name_other_server(self, monkeypatch) -> None:
+        """…but a DIFFERENT server exposing the same bare tool name is denied.
+
+        This is the collision guard: pinning ``@builder-mcp/ReadInternalWebsites``
+        must NOT auto-approve ``@evil-mcp/ReadInternalWebsites``.
+        """
+        self._install_gate_extra(monkeypatch, ["@builder-mcp/ReadInternalWebsites"])
+        assert not _is_heartbeat_safe_tool("@evil-mcp/ReadInternalWebsites")
+        assert not _is_heartbeat_safe_tool("Running: @evil-mcp/ReadInternalWebsites")
+        assert not _is_heartbeat_safe_tool("mcp__evil-mcp__ReadInternalWebsites")
+        # And the bare name alone is not auto-approved when only a qualified
+        # entry was allowlisted.
+        assert not _is_heartbeat_safe_tool("ReadInternalWebsites")
+
+    def test_bare_edition_entry_never_matches(self, monkeypatch) -> None:
+        """A BARE edition entry must NOT auto-approve anything (deny-by-default).
+
+        Entries MUST be server-qualified; a bare name would carry the collision
+        risk (a different server's same-named destructive tool auto-approved), so
+        the gate ignores it entirely — neither a qualified nor a bare title match.
+        """
+        self._install_gate_extra(monkeypatch, ["ReadInternalWebsites"])
+        assert not _is_heartbeat_safe_tool("@builder-mcp/ReadInternalWebsites")
+        assert not _is_heartbeat_safe_tool("ReadInternalWebsites")
+        assert not _is_heartbeat_safe_tool("Running: @builder-mcp/ReadInternalWebsites")
+
+    def test_unqualified_title_never_matches_edition_set(self, monkeypatch) -> None:
+        """A bare tool-call title (no resolvable server) never matches the edition
+        set even when a qualified entry is allowlisted."""
+        self._install_gate_extra(monkeypatch, ["@builder-mcp/ReadInternalWebsites"])
+        assert not _is_heartbeat_safe_tool("ReadInternalWebsites")
+        assert not _is_heartbeat_safe_tool("Running: ReadInternalWebsites")
+
+
 # ── HEARTBEAT_KEEP injection text ──
 
 


### PR DESCRIPTION
## Summary

Adds Composed Platform Providers (CPP) extension-point seams so an out-of-repo companion edition can plug in enterprise behavior **without the core ever importing companion code**. Every addition is a v1 EXTRACT: it ships a `Default*` no-op that reproduces today's open-source behavior exactly (a standalone process is byte-identical), and `CONTRACT_VERSION` stays **1**.

The seams themselves are generic — a Protocol method plus a no-op default. All edition-specific logic lives in the companion; the core only exposes the plug points.

## What's in it

**Identity / auth**
- `browser/auth.py::register_browser_auth_provider()` — module-level registration hook (the twin of `register_acp_backends` / `register_publish_providers`); every `browser/auth` helper delegates to the registered provider when present, else the OSS "not available" default. `browser/cli.py` auth subcommands delegate through the helpers.
- `hooks.register_internal_read_path()` — guarded seam to ADD a fixed-path entry to `_INTERNAL_READ_ALLOWLIST` (rejects `..`/absolute/non-sensitive/repoint of a core entry).
- `config.dashboard.mwinit_flags` (str) + its `_EDITABLE_CONFIG` PATCH entry; inert in the public build.

**MCP / agent / knowledge**
- `agent.py` fresh-install registers edition `extra_mcp_servers` `@ref`s into `tools` so their tools are callable.
- `McpToolingProvider.extra_skills()` now WIRED into `SkillsLoader` (lowest-precedence, sensitivity-checked).
- `config.knowledge.auto_ingest_doc_links` + `doc_ingest_hosts` (SSRF-safe, empty allowlist = deny-by-default).
- `DashboardContributor.on_user_message()` observer, fired from `api_chat` inside a fail-safe guard.

**Slack / registry**
- `SlackEnterpriseGate.heartbeat_safe_tools()` unioned into the heartbeat allowlist (ADD-only, fail-closed).
- `AppsLoader.registry_rows()` ADD-only merged into the App Store registry (same-name core row wins).

**ACP claude backend** (all inside the dormant backend path, inert on kiro-cli)
- `AcpClient._claude_session_mcp_servers()` feeds `session/new` + `session/load`.
- `_spawn` calls a companion-attached settings writer on the primary path.
- `AcpClient`/`AcpProvider` accept a `permission_mode` kwarg; `acp/types.py` adds the permission-mode constants.

**Config robustness**
- `KiroCrewConfig._extra_sections` round-trips unknown top-level config.json sections through `load()`->`to_dict()` so an edition section isn't dropped on `save()`/PATCH. Private fields excluded from the JSON schema.
- Fixes a latent pre-existing bug: the `discord` section was never emitted by `to_dict()` and was silently dropped on save; now emitted, guarded by a `_KNOWN == emitted` parity test.

## Invariants preserved

- `CONTRACT_VERSION` stays **1** — new methods on existing Protocols + `Default*` no-ops only; no new Protocols, no `PlatformContext` field-shape change.
- Security floor is ADD-only; governance keystone files stay on the sensitive-path floor.
- Core never imports a companion; every new module-level read goes through `current_context()` + `safe_context_call` (re-raises `PlatformCompositionError`, degrades other errors to a fallback).

## Spec + tests

- `docs/system-specs/modules/platform-context.md` updated in the same commit (new v1 seam-additions section).
- `config-baseline.json` regenerated; new `test/test_config_extra_sections.py`.
- Touched-module suites green; the only failures are pre-existing (`test_artifact_materialize.py`, `test_cpp_wiring_standalone.py::test_boot_standalone_no_signals`) and reproduce on clean `main`.

🤖 Generated with [Claude Code](https://claude.ai/code)
