### PR TITLE
fix(session): compact kiro-cli sessions in place so work continues after auto-compaction

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -72,9 +72,17 @@ check (`dashboard/handlers/cron.py`).
 
 ## Key Behaviors
 
-- **Context compaction**: at ≥ configured threshold (`session.autocompact_pct`, default 90%, valid 5–90), fires `/compact` to kiro-cli. Context re-injected via
-  `build_session_context()` on next message. Blind fallback after 40
-  prompts if metadata never reports %.
+- **Context compaction**: at ≥ configured threshold (`session.autocompact_pct`, default 90%, valid 5–90), compacts **in place** on both
+  backends: kiro-cli via native `/compact` (command execute +
+  `_kiro.dev/compaction/status` wait), claude via SDK `/compact`. The
+  process and session ID survive, so queued/agentic work continues
+  automatically. kiro-cli only: if the in-place compact fails, times out,
+  or the provider lacks native support, falls back to the legacy
+  **recycle** (kill session; context re-injected via
+  `build_session_context()` on next message). A recycle is never forced
+  through a live turn — if the turn semaphore cannot be acquired within
+  the budget, the attempt is deferred to the next turn-end check. Blind
+  fallback after 40 prompts if metadata never reports %.
 - **Circuit breaker**: force-resets session after 5 consecutive failures.
 - **Dead provider detection**: `get_or_create()` checks `provider.is_alive()`
   on the fast path. If the backing process died (crash, SIGKILL, orphan
@@ -546,6 +554,17 @@ exceeds 85% of available cores.
 
 ## Compaction Race Handling
 
-If user sends message during compaction: `get_or_create()` sees key in
-`_compacting` → creates fresh session. Background task finishes → checks
-provider identity → only shuts down old provider.
+In-place compaction (both backends) keeps the `_sessions` entry healthy:
+a concurrent `get_or_create()` reuses it, queueing on the session
+semaphore behind the compact, then continues on the compacted session.
+
+Only the kiro-cli recycle fallback tears the entry down. It records the
+exact session object under teardown in `_recycling` (distinct from
+`_compacting`, which is just the trigger dedup gate): `get_or_create()`
+skips reuse only when the map still holds that exact object, then
+cold-starts fresh — a healthy replacement registered under the same key
+during the teardown is reused normally, never overwritten. The recycle
+pops by object identity — if a racing cold-start already replaced the
+entry, only the old session object is shut down; the fresh replacement
+and its session_map entry survive (the old provider is still reaped so
+its process never leaks).

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -12,11 +12,18 @@ lightweight background work (cron, heartbeat, lesson extraction).  It
 stays alive between uses, serialized by the per-session semaphore.
 
 At >= ``cfg.session.autocompact_pct`` context usage, fires a background
-compaction task. Two backends, two strategies:
+compaction task. Both backends compact **in place** so the session — and
+any queued or agentic work on it — continues without a user nudge:
 
-* **kiro-cli:** kill the session and let the next user message re-seed
-  context via ``build_session_context()``. The session_map entry is
-  dropped to avoid false-resume from stale state.
+* **kiro-cli:** run ``/compact`` in place under the session semaphore
+  (native command execute + ``_kiro.dev/compaction/status`` wait). The
+  process and session ID survive; the conversation is summarized in
+  place. If the in-place compact fails or times out, fall back to the
+  legacy **recycle**: kill the session and let the next user message
+  re-seed context via ``build_session_context()`` (the session_map entry
+  is dropped to avoid false-resume from stale state). A recycle is never
+  forced through a live turn — if the turn semaphore cannot be acquired,
+  the attempt is skipped and re-triggered at the next turn end.
 * **claude-agent-acp:** run ``/compact`` in place under the session
   semaphore. The SDK preserves the same session ID across the
   compact_boundary; the session keeps its summary and continues without
@@ -278,6 +285,11 @@ _CONTEXT_COMPACT_PCT = 80.0
 # compact would otherwise block all concurrent gets on the same session.
 _COMPACT_TIMEOUT_SECS = 300.0
 
+# How long the kiro-cli in-place path waits for the async
+# ``_kiro.dev/compaction/status`` result after issuing /compact. Matches the
+# budget the dashboard's manual /compact and Slack's !compact already use.
+_COMPACT_RESULT_WAIT_SECS = 120.0
+
 # After a failed compact, suppress auto-compaction for this many seconds so a
 # broken /compact does not fire on every subsequent turn.
 _COMPACT_FAILURE_COOLDOWN_SECS = 60.0
@@ -494,6 +506,14 @@ class SessionManager:
         self._start_sem = asyncio.Semaphore(4)  # max 4 concurrent cold-starts
         self._cleanup_task: asyncio.Task | None = None
         self._compacting: set[str] = set()
+        # key -> the EXACT _Session object being torn down by the recycle
+        # FALLBACK (pop from _sessions + provider SIGKILL). Distinct from
+        # _compacting: an in-place compact keeps the entry healthy and
+        # reusable. get_or_create skips reuse only when the map still holds
+        # THIS object — a healthy replacement registered under the same key
+        # is reused normally (never overwritten/leaked by a duplicate
+        # cold-start).
+        self._recycling: dict[str, "_Session"] = {}
         self._compact_cooldown_until: dict[str, float] = {}
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         self._on_compacted: _CompactCallback | None = None
@@ -1622,17 +1642,19 @@ class SessionManager:
         _claimed: "tuple[_Session, bool] | None" = None
         try:
             async with self._lock:
-                # Skip the live-session branch only when a *recycle-style*
-                # compact is in flight (kiro path drops the entry from
-                # _sessions). Claude in-place compact keeps the entry healthy,
-                # so concurrent get_or_create must reuse it instead of
-                # cold-starting a duplicate provider that would later overwrite
-                # _sessions[key] and leak the original process.
+                # Skip the live-session branch only while the recycle FALLBACK
+                # is tearing down the EXACT session object still in the map.
+                # In-place compaction — both the kiro-cli and claude paths —
+                # keeps the entry healthy, so concurrent get_or_create must
+                # reuse it (queueing on the session semaphore behind the
+                # compact). A healthy REPLACEMENT registered under the same
+                # key during a recycle is likewise reused — the object match
+                # keeps the guard from exiling it and cold-starting a
+                # duplicate provider that would overwrite _sessions[key] and
+                # leak the replacement's process.
                 _existing = self._sessions.get(key)
                 _is_recycling = (
-                    key in self._compacting
-                    and _existing is not None
-                    and not _is_claude_backend(_existing.provider)
+                    _existing is not None and self._recycling.get(key) is _existing
                 )
                 if _existing is not None and not _is_recycling:
                     sess = _existing
@@ -1940,15 +1962,18 @@ class SessionManager:
 
             async with self._lock:
                 # Re-check: another coroutine may have created this key while we
-                # were starting the provider (race on same key). Claude in-place
-                # compact leaves the existing entry healthy, so reuse it even
-                # when _compacting is set; only kiro recycle (which drops the
-                # entry from _sessions) should fall through to register us.
+                # were starting the provider (race on same key). In-place
+                # compaction (kiro-cli and claude) leaves the existing entry
+                # healthy, so reuse it even when _compacting is set; only an
+                # entry that IS the exact object the recycle FALLBACK is
+                # tearing down should fall through to register us — a healthy
+                # replacement under the same key must be reused, never
+                # overwritten. The recycle path also pops by object identity,
+                # so even if we do register over a being-recycled entry, only
+                # the old session object is killed.
                 _existing = self._sessions.get(key)
                 _is_recycling = (
-                    key in self._compacting
-                    and _existing is not None
-                    and not _is_claude_backend(_existing.provider)
+                    _existing is not None and self._recycling.get(key) is _existing
                 )
                 if _existing is not None and not _is_recycling:
                     # Another task won the race — use theirs and shut down our
@@ -2285,14 +2310,17 @@ class SessionManager:
     async def _compact_session(self, key: str, pct: float) -> None:
         """Compact a session that hit the context threshold.
 
-        For kiro-cli we recycle: kill the session and let the next user
-        message re-seed context via build_session_context(). The session_map
-        entry is dropped so we don't false-resume from stale state.
+        Both backends compact **in place** first, so the kiro-cli process (or
+        claude SDK session) survives and any queued or agentic work continues
+        automatically — the fix for "session stops after auto-compaction".
 
-        For claude-agent-acp we run /compact in place. The SDK summarises
-        the conversation into a fresh, smaller context — no recycle needed,
-        and the session keeps its history (the compaction summary) instead
-        of starting from scratch.
+        kiro-cli only: if the in-place ``/compact`` fails or times out, fall
+        back to the legacy recycle — kill the session and let the next user
+        message re-seed context via build_session_context(). The session_map
+        entry is dropped so we don't false-resume from stale state. A recycle
+        is never forced through a live turn: if the turn semaphore cannot be
+        acquired within the budget, the attempt is skipped and the next
+        turn-end ``check_context_usage`` re-triggers it.
         """
         try:
             session = self._sessions.get(key)
@@ -2330,36 +2358,119 @@ class SessionManager:
                 await self._fire_compact_callback(key, pct, success=True)
                 return
 
-            # kiro-cli recycle SIGKILLs the provider; drain the in-flight turn
-            # via the session semaphore first so we don't kill mid-cleanup.
-            drain = self._sessions.get(key)
-            sem = drain.semaphore if drain else None
-            sem_held = False
-            if sem is not None:
-                try:
-                    await asyncio.wait_for(sem.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
-                    sem_held = True
-                except asyncio.TimeoutError:
+            # ── kiro-cli: in-place /compact first ──
+            if session is not None:
+                outcome = await self._compact_in_place(key, session, pct)
+                if outcome == "ok":
+                    return
+                if outcome == "busy":
+                    # A turn is still running. NEVER kill a live turn for
+                    # compaction — the old force-recycle here SIGKILLed
+                    # kiro-cli mid-turn, losing all in-flight work. The next
+                    # turn-end check_context_usage re-triggers compaction
+                    # when the semaphore is free. No cooldown / no failure
+                    # callback: this is a deferral, not a failure.
                     logger.warning(
-                        "Session %s recycle: turn still active after %.0fs, forcing recycle",
+                        "Session %s compaction deferred — turn still active after %.0fs",
                         key,
                         _COMPACT_TIMEOUT_SECS,
                     )
+                    return
+                # outcome == "failed" → fall through to the recycle fallback.
+
+            # ── kiro-cli recycle fallback ──
+            # SIGKILLs the provider; drain the in-flight turn via the session
+            # semaphore first so we don't kill mid-turn. Operates strictly on
+            # the *session object captured above*: pop-by-identity means a
+            # fresh session registered by a racing cold-start is never popped
+            # or killed by mistake.
+            if session is None:
+                return
+            sem = session.semaphore
+            try:
+                await asyncio.wait_for(sem.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Session %s recycle skipped — turn still active after %.0fs",
+                    key,
+                    _COMPACT_TIMEOUT_SECS,
+                )
+                return
+            self._recycling[key] = session
             try:
                 async with self._lock:
-                    session = self._sessions.pop(key, None)
-                if session:
-                    self._session_map.delete(key)
+                    popped = None
+                    if self._sessions.get(key) is session:
+                        popped = self._sessions.pop(key, None)
+                if popped is None:
+                    # A racing cold-start already replaced the entry — the map
+                    # now points at a fresh, healthy session. Reap OUR old
+                    # provider (its process would otherwise leak) but leave the
+                    # replacement and its session_map entry untouched.
                     await session.provider.shutdown()
+                    logger.info(
+                        "Recycled session %s (context overflow; entry already replaced)", key
+                    )
+                else:
+                    self._session_map.delete(key)
+                    await popped.provider.shutdown()
                     logger.info("Recycled session %s (context overflow)", key)
-                    await self._fire_compact_callback(key, pct, success=True)
+                await self._fire_compact_callback(key, pct, success=True)
             finally:
-                if sem_held and sem is not None:
-                    sem.release()
+                if self._recycling.get(key) is session:
+                    self._recycling.pop(key, None)
+                sem.release()
         except Exception:
             logger.exception("Session recycle failed for %s", key)
         finally:
             self._compacting.discard(key)
+
+    async def _compact_in_place(self, key: str, session: "_Session", pct: float) -> str:
+        """Attempt a native in-place ``/compact`` on a kiro-cli session.
+
+        Returns:
+        - ``"ok"``: compaction completed; session (and its process) survives.
+          The success callback has been fired and the cooldown cleared.
+        - ``"busy"``: the turn semaphore could not be acquired within
+          ``_COMPACT_TIMEOUT_SECS`` — a turn is still running. Nothing was
+          attempted; the caller must NOT recycle (no mid-turn kill).
+        - ``"failed"``: the compact was attempted but failed, timed out, or
+          the provider does not support it (base ``wait_for_compaction``
+          returns ``{"type": "timeout"}``). The caller falls back to recycle.
+
+        Holds the session semaphore for the duration so a queued turn waits
+        behind the compaction (and then continues on the compacted session)
+        instead of interleaving with it.
+        """
+        try:
+            await asyncio.wait_for(session.semaphore.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
+        except asyncio.TimeoutError:
+            return "busy"
+        try:
+
+            async def _run() -> None:
+                await session.provider.compact()
+                result = await session.provider.wait_for_compaction(
+                    timeout=_COMPACT_RESULT_WAIT_SECS
+                )
+                rtype = result.get("type") if isinstance(result, dict) else None
+                if rtype != "completed":
+                    raise RuntimeError(f"compaction reported {rtype or 'no result'}")
+
+            await asyncio.wait_for(_run(), timeout=_COMPACT_TIMEOUT_SECS)
+        except (Exception, asyncio.TimeoutError):
+            logger.warning(
+                "Session %s in-place /compact failed — falling back to recycle",
+                key,
+                exc_info=True,
+            )
+            return "failed"
+        finally:
+            session.semaphore.release()
+        self._compact_cooldown_until.pop(key, None)
+        logger.info("Compacted session %s in place (context overflow)", key)
+        await self._fire_compact_callback(key, pct, success=True)
+        return "ok"
 
     async def _fire_compact_callback(self, key: str, pct: float, *, success: bool) -> None:
         """Invoke ``_on_compacted`` if registered, swallowing exceptions."""

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1026,22 +1026,29 @@ class TestCompactCallback:
         await mgr.close_all()
 
     @pytest.mark.asyncio
-    async def test_compact_session_force_recycles_after_timeout(self, cfg, caplog, monkeypatch):
-        """A stuck turn (semaphore never released) must force-recycle after
-        _COMPACT_TIMEOUT_SECS so context still clears."""
+    async def test_compact_session_defers_when_turn_never_drains(self, cfg, caplog, monkeypatch):
+        """A still-running turn (semaphore held) must NEVER be killed for
+        compaction: after _COMPACT_TIMEOUT_SECS the attempt is deferred —
+        session intact, no callback — and re-triggered at the next turn end."""
         monkeypatch.setattr("kiro_crew.session._COMPACT_TIMEOUT_SECS", 0.1)
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
-        # Hold the semaphore and never release -> simulates a stuck turn.
-        await mgr.get_or_create("dashboard:chat-1")
+        # Hold the semaphore and never release -> simulates a long-running turn.
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
         cb = AsyncMock()
         mgr.set_compact_callback(cb)
 
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session"):
             await asyncio.wait_for(mgr._compact_session("dashboard:chat-1", 92.0), timeout=2)
 
-        assert "dashboard:chat-1" not in mgr._sessions
-        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
-        assert any("forcing recycle" in r.message for r in caplog.records)
+        # Session survives, the live turn was not killed, and nothing was
+        # reported to the user (a deferral is not a failure).
+        assert "dashboard:chat-1" in mgr._sessions
+        provider.shutdown.assert_not_awaited()
+        cb.assert_not_awaited()
+        assert any("compaction deferred" in r.message for r in caplog.records)
+        # _compacting cleared so the next turn-end check can re-trigger.
+        assert "dashboard:chat-1" not in mgr._compacting
+        mgr.release("dashboard:chat-1")
         await mgr.close_all()
 
     @pytest.mark.asyncio
@@ -2409,25 +2416,73 @@ class TestClaudeBackendCompaction:
         await mgr.close_all()
 
     @pytest.mark.asyncio
-    async def test_get_or_create_during_kiro_recycle_cold_starts(self, cfg):
-        """Kiro path drops the entry from _sessions; if a stale entry is still
-        present we must fall through to cold-start (preserves the recycle
-        semantics that predate the claude in-place branch)."""
+    async def test_get_or_create_during_recycle_teardown_cold_starts(self, cfg):
+        """While the recycle fallback is tearing the entry down (_recycling
+        holds the exact object still in the map), get_or_create must not
+        reuse the doomed entry — fall through to cold-start."""
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         provider, _, _ = await mgr.get_or_create("k1")
         mgr.release("k1")
 
-        with patch("kiro_crew.session._is_claude_backend", return_value=False):
-            mgr._compacting.add("k1")
-            try:
-                provider2, is_new, _ = await mgr.get_or_create("k1")
-            finally:
-                mgr._compacting.discard("k1")
+        mgr._recycling["k1"] = mgr._sessions["k1"]
+        try:
+            provider2, is_new, _ = await mgr.get_or_create("k1")
+        finally:
+            mgr._recycling.pop("k1", None)
 
-        # New provider, original kept (cold-start path replaces _sessions[key]
-        # via the post-start lock, but for the test we just check we did not
-        # short-circuit to the existing entry).
+        # New provider: we did not short-circuit to the doomed entry.
         assert provider2 is not provider
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_reuses_healthy_replacement_during_recycle(self, cfg):
+        """The _recycling marker is object-aware: when the map already holds a
+        healthy REPLACEMENT for a key whose OLD session is still being torn
+        down, get_or_create must reuse the replacement — not exile it and
+        cold-start a duplicate provider that would overwrite and leak it."""
+        from kiro_crew.session import _Session
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        old_provider, _, _ = await mgr.get_or_create("k1")
+        old_sess = mgr._sessions["k1"]
+        mgr.release("k1")
+
+        # Recycle of the OLD object is in flight; a racing cold-start has
+        # already registered a fresh replacement under the same key.
+        replacement_provider = AsyncMock()
+        replacement_provider.shutdown = AsyncMock()
+        replacement = _Session(provider=replacement_provider, is_new=False)
+        mgr._sessions["k1"] = replacement
+        mgr._recycling["k1"] = old_sess
+        try:
+            provider2, is_new, _ = await mgr.get_or_create("k1")
+        finally:
+            mgr._recycling.pop("k1", None)
+
+        assert provider2 is replacement_provider
+        assert is_new is False
+        assert mgr._sessions["k1"] is replacement
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_during_inplace_compact_reuses_session(self, cfg):
+        """An in-place compact (kiro or claude) keeps the entry healthy:
+        concurrent get_or_create must reuse it — queueing on the session
+        semaphore — instead of cold-starting a duplicate provider."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+
+        mgr._compacting.add("k1")  # in-place compact in flight; NOT recycling
+        try:
+            provider2, is_new, _ = await mgr.get_or_create("k1")
+        finally:
+            mgr._compacting.discard("k1")
+
+        assert provider2 is provider
+        assert is_new is False
         mgr.release("k1")
         await mgr.close_all()
 
@@ -2446,6 +2501,175 @@ class TestClaudeBackendCompaction:
         assert is_new is True
         assert provider is not None
         mgr.release("k1")
+        await mgr.close_all()
+
+
+class TestKiroInPlaceCompaction:
+    """kiro-cli auto-compaction runs /compact IN PLACE first, so the session
+    (and any queued/agentic work) continues automatically — recycle is only
+    the fallback. Fix for 'session stops after auto-compaction'."""
+
+    @staticmethod
+    def _inplace_provider_factory(result: dict):
+        """Provider whose native compaction reports *result*."""
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+            m.compact = AsyncMock()
+            m.wait_for_compaction = AsyncMock(return_value=result)
+            return m
+
+        return factory
+
+    @pytest.mark.asyncio
+    async def test_inplace_success_keeps_session_and_process(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "completed"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # Session survives in place: same entry, same provider, no SIGKILL.
+        assert "dashboard:chat-1" in mgr._sessions
+        assert mgr._sessions["dashboard:chat-1"].provider is provider
+        provider.compact.assert_awaited_once()
+        provider.shutdown.assert_not_awaited()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        # Semaphore released: the next turn can proceed immediately.
+        assert not mgr._sessions["dashboard:chat-1"].semaphore.locked()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_failed_result_falls_back_to_recycle(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "failed"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # Fallback recycle: entry dropped, process killed, context guaranteed
+        # to clear on the next (re-seeded) message.
+        assert "dashboard:chat-1" not in mgr._sessions
+        provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        assert "dashboard:chat-1" not in mgr._recycling
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_no_native_support_falls_back_to_recycle(self, cfg):
+        """Base LLMProvider.wait_for_compaction returns {'type': 'timeout'} —
+        providers without native compaction must keep today's recycle path."""
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "timeout"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert "dashboard:chat-1" not in mgr._sessions
+        provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_success_clears_failure_cooldown(self, cfg):
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "completed"})
+        )
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_cooldown_until["dashboard:chat-1"] = time.monotonic() + 999
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_holds_semaphore_so_queued_turns_wait(self, cfg):
+        """While the in-place compact runs, the session semaphore is held —
+        a queued turn waits behind it and then continues on the compacted
+        session instead of interleaving with the compaction."""
+        gate = asyncio.Event()
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+            m.compact = AsyncMock()
+
+            async def _wait(timeout=120.0):
+                await gate.wait()
+                return {"type": "completed"}
+
+            m.wait_for_compaction = _wait
+            return m
+
+        mgr = SessionManager(cfg, provider_factory=factory)
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        sess = mgr._sessions["dashboard:chat-1"]
+
+        task = asyncio.create_task(mgr._compact_session("dashboard:chat-1", 92.0))
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        assert sess.semaphore.locked()  # queued turn would wait here
+
+        gate.set()
+        await asyncio.wait_for(task, timeout=2)
+        assert "dashboard:chat-1" in mgr._sessions
+        assert not sess.semaphore.locked()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_recycle_pop_by_identity_spares_replacement(self, cfg):
+        """If a racing cold-start replaced the entry while the recycle
+        fallback waited on the old turn semaphore, only the OLD session is
+        killed; the fresh replacement (and its session_map entry) survives."""
+        from kiro_crew.session import _Session
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        old_provider, _, _ = await mgr.get_or_create("k1")
+        old_sess = mgr._sessions["k1"]
+        # Keep the old turn semaphore held so the recycle blocks on acquire.
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+        # Skip the in-place attempt: force the fallback path directly.
+        mgr._compact_in_place = AsyncMock(return_value="failed")  # type: ignore[method-assign]
+
+        task = asyncio.create_task(mgr._compact_session("k1", 92.0))
+        await asyncio.sleep(0.05)
+        assert not task.done()
+
+        # A racing cold-start replaces the entry with a fresh session.
+        new_provider = AsyncMock()
+        new_provider.shutdown = AsyncMock()
+        mgr._sessions["k1"] = _Session(provider=new_provider, is_new=False)
+
+        # Old turn ends -> recycle proceeds, pops by identity.
+        old_sess.semaphore.release()
+        await asyncio.wait_for(task, timeout=2)
+
+        # Replacement untouched; old provider reaped.
+        assert mgr._sessions["k1"].provider is new_provider
+        new_provider.shutdown.assert_not_awaited()
+        old_provider.shutdown.assert_awaited_once()
+        cb.assert_awaited_once_with("k1", 92.0, success=True)
         await mgr.close_all()
 
 


### PR DESCRIPTION
Supersedes #160 (rebased onto current main past the #159 hotfix — force-push is policy-blocked, so fresh branch per PR Hygiene single-commit rule).

## Problem

Whenever auto-compaction fires (`session.autocompact_pct`, default 90%), a kiro-cli-backed session **stops and never continues automatically**. Reproduced live on a dashboard session (gateway.log 2026-07-22 00:30:01, context at 93%).

Root cause: `_compact_session()` treated the two backends differently. claude-agent-acp compacts in place, but **kiro-cli recycled**: SIGKILL the process, drop the session_map entry, and wait for the next USER message to re-seed context. Two failure modes:

1. **End-of-turn recycle**: process killed, banner posted, then silence — queued/agentic work never resumes.
2. **Mid-turn force-kill**: a turn still running after the 300s drain budget got force-recycled, SIGKILLing kiro-cli mid-turn and losing all in-flight work.

## Fix

- **In-place `/compact` first** for kiro-cli, via the proven plumbing the dashboard's manual `/compact` and Slack's `!compact` already use (`provider.compact()` → `wait_for_compaction()` on `_kiro.dev/compaction/status`). Process and session ID survive; a queued turn waits on the session semaphore behind the compaction and then continues.
- **Recycle demoted to fallback** — only when the in-place compact fails, times out, or the provider has no native support. Keeps the guaranteed context-clear safety net + cooldown machinery.
- **Never kill a live turn**: semaphore-busy → defer to the next turn-end `check_context_usage` (no cooldown, no failure banner).
- **Recycle hardening**: pop-by-identity spares a racing cold-start's fresh session (old provider still reaped); new `_recycling` set replaces the `_compacting`+backend heuristic in `get_or_create` reuse guards, so a healthy in-place-compacting session is reused instead of leaking a duplicate provider.
- **Spec updated** (`docs/system-specs/modules/session.md`): Context compaction bullet + Compaction Race Handling section rewritten for the new contract (addresses Codex MEDIUM on #160).

## Testing

- `test/test_session.py`: **216/216 pass** — 6 new tests in `TestKiroInPlaceCompaction`, 2 rewritten for the new contract.
- `test/test_dashboard_chat.py` compaction selection: 9/9 pass.
- flake8 + mypy clean.
- Note: #160's `Backend Tests (3.12, 2)` failure (`test_first_empty_response_requeues_message`) reproduces green locally — shard flake, unrelated. Its frontend/E2E/desktop failures were the pre-#159 `activityOpen` TS6133 main breakage, resolved by this rebase.

## Notes for reviewers

- Dashboard compact banner path unchanged: `_fire_compact_callback(success=True)` fires on both in-place success and fallback recycle.
- Slack/Telegram/WeChat share `SessionManager`, so their auto-compaction becomes in-place-first too — strictly better (thread context preserved), identical fallback semantics.