### PR TITLE
fix(dashboard): surface sub-agent spawn approvals in the composer

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -6,7 +6,7 @@ import { createPortal } from 'react-dom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useBranding } from '../hooks/useBranding'
 import { useAppSelector, useAppDispatch } from '../store'
-import { resolveByApprovalId, openActivityToTool, selectSlotPendingApproval } from '../store/chatSlice'
+import { resolveByApprovalId, openActivityToTool, openActivityToTab, selectSlotPendingApproval, selectSlotPendingSpawnApprovals } from '../store/chatSlice'
 import { useSlotId } from '../providers/SlotContext'
 import { useToolPillVisible } from '../store/toolPillRegistry'
 import { ToolDetails } from '../pages/chat/ToolDetails'
@@ -462,6 +462,15 @@ function ChatInput({
       api.resolveApproval(approvalId, toApiDecision(decision)).then(finish).catch(fail)
     }
   }, [approvalId, activeSlot, dispatch])
+
+  // Pending sub-agent SPAWN approvals for this slot (blocked on user approval).
+  // Surfaced as a top-level REMINDER only — the banner does not resolve
+  // approvals itself. Doing so would duplicate the side panel's per-sub-agent
+  // Approve/Reject and let the user submit conflicting decisions through two
+  // controls for the same id. Clicking the banner opens the Subagents panel
+  // where each sub-agent is approved individually.
+  const pendingSpawnApprovals = useAppSelector(s => selectSlotPendingSpawnApprovals(s, slotId), shallowEqual)
+  const reviewSpawnApprovals = useCallback(() => { dispatch(openActivityToTab('subagents')) }, [dispatch])
 
   const approvalBtnClass = 'inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border text-text text-[12px] cursor-pointer font-body hover:bg-[color-mix(in_srgb,var(--warn)_25%,transparent)] hover:text-text hover:border-border-strong transition-colors disabled:opacity-50'
 
@@ -1585,6 +1594,40 @@ function ChatInput({
       >
         <div className="w-12 h-[3px] rounded-full bg-border group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-all duration-200 opacity-0 group-hover/drag:opacity-100" />
       </div>}
+
+      {/* Sub-agent spawn-approval reminder — a top-level signal that one or more
+       *  sub-agents are queued awaiting the user's approval to run. Reminder-only:
+       *  the whole banner is a button that opens the Subagents panel, where each
+       *  sub-agent is approved individually. We deliberately do NOT render
+       *  Approve/Reject here to avoid duplicating the panel's controls. */}
+      <AnimatePresence>
+        {pendingSpawnApprovals.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300, mass: 0.8 }}
+          >
+            <button
+              type="button"
+              onClick={reviewSpawnApprovals}
+              className="w-full text-left bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border rounded-2xl mb-2 approval-glow cursor-pointer hover:border-border-strong transition-colors"
+            >
+              <div className="flex items-center gap-1.5 px-3.5 py-2.5 select-none">
+                <Bot size={13} className="text-warn shrink-0" />
+                <span className="text-[13px] font-body text-muted flex-1 min-w-0">
+                  {pendingSpawnApprovals.length === 1
+                    ? '1 sub-agent is awaiting your approval to run'
+                    : `${pendingSpawnApprovals.length} sub-agents are awaiting your approval to run`}
+                </span>
+                <span className="inline-flex items-center gap-1 text-[11px] text-muted shrink-0">
+                  <Target size={11} className="shrink-0" />Review in panel
+                </span>
+              </div>
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Approval bar — always-visible button row, with a "ghost pill"
        *  detail mirror that grows in when the inline pill scrolls out of

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -613,6 +613,30 @@ export const selectSlotSubagentsActive = (state: RootState, slot: string): boole
   return false
 }
 
+// Stable empty result so the selector is referentially stable (with shallowEqual)
+// when a slot has no pending spawn approvals — avoids needless re-renders.
+const _EMPTY_PENDING_SPAWNS: SubagentActivity[] = []
+
+/**
+ * Pending sub-agent SPAWN approvals for a slot — sub-agents queued to run but
+ * blocked on the user's approval (status 'pending' + an approval_id).
+ *
+ * The backend broadcasts a spawn approval as a WS `approval` event with
+ * id `spawn:<agent_id>`; useWebSocket routes it into `sseSubagentPending`, so
+ * it only ever renders as a pending card in the side panel's Subagents tab —
+ * there is NO inline chat prompt and NO notification. This selector lets the
+ * composer surface a top-level "awaiting approval" banner so the user knows an
+ * action is required without hunting through the side panel. Use with
+ * `shallowEqual`.
+ */
+export const selectSlotPendingSpawnApprovals = (state: RootState, slot: string | null): SubagentActivity[] => {
+  if (!slot) return _EMPTY_PENDING_SPAWNS
+  const subs = getSlotSubs(state.chat, slot)
+  if (!subs) return _EMPTY_PENDING_SPAWNS
+  const out = Object.values(subs).filter(a => a.status === 'pending' && !!a.approval_id)
+  return out.length ? out : _EMPTY_PENDING_SPAWNS
+}
+
 /**
  * Single source of truth for "is this slot's composer busy" — the signal that
  * queues the next message (busy affordance) and skips the optimistic user

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -266,3 +266,63 @@ describe('ChatInput approval flow', () => {
     expect(buttons.some(b => b.textContent?.includes('commands'))).toBe(false)
   })
 })
+
+function stateWithPendingSpawn(count = 1): Partial<RootState> {
+  const subagents: Record<string, unknown> = {}
+  for (let i = 1; i <= count; i++) {
+    subagents[`a${i}`] = {
+      id: `a${i}`, task: `task ${i}`, agent: '', status: 'pending',
+      streaming: '', lastTool: '', startedAt: Date.now(), elapsed: 0,
+      approval_id: `spawn:a${i}`,
+    }
+  }
+  return {
+    chat: {
+      activeSlot: 'slot-1',
+      messages: [{ role: 'user', content: 'go' }],
+      toolLog: [],
+      subagents,
+      slotActivity: {},
+      slotStatusDetail: {},
+    } as unknown as RootState['chat'],
+    dashboard: {
+      slots: [{ key: 'slot-1', messages: 1, running: false, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+      approvalMode: 'normal', connected: true, channelTrusted: false,
+      refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+    } as unknown as RootState['dashboard'],
+  }
+}
+
+describe('ChatInput sub-agent spawn-approval reminder', () => {
+  it('surfaces a top-level reminder when a sub-agent awaits approval', () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getByText(/1 sub-agent is awaiting your approval to run/)).toBeInTheDocument()
+    expect(screen.getByText('Review in panel')).toBeInTheDocument()
+    // Reminder-only: no inline Approve/Reject (would duplicate the side panel's controls)
+    expect(screen.queryByText('Approve')).not.toBeInTheDocument()
+    expect(screen.queryByText('Approve all')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reject')).not.toBeInTheDocument()
+  })
+
+  it('pluralizes for multiple pending spawns', () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getByText(/3 sub-agents are awaiting your approval to run/)).toBeInTheDocument()
+  })
+
+  it('clicking the reminder opens the Subagents panel and resolves nothing', () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /awaiting your approval to run/i }))
+    expect(store.getState().chat.activityTab).toBe('subagents')
+    expect(store.getState().chat.activityOpen).toBe(true)
+    expect(api.resolveApproval).not.toHaveBeenCalled()
+  })
+
+  it('does not render the reminder when there are no pending spawns', () => {
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.queryByText(/awaiting your approval to run/)).not.toBeInTheDocument()
+  })
+})

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -37,6 +37,7 @@ import reducer, {
   editQueuedMessage,
   cancelQueuedMessage,
   selectSlotSubagentsActive,
+  selectSlotPendingSpawnApprovals,
   selectComposerBusy,
 } from '../store/chatSlice'
 import './mockApiClient'
@@ -1827,5 +1828,46 @@ describe('createSlot.fulfilled switched-away guard (Mesh-2908)', () => {
     const state = reducer(busy, fulfilled('new-slot', null))
     expect(state.activeSlot).toBe('slot-b')
     expect(state.creatingSlot).toBe(false)
+  })
+})
+
+describe('selectSlotPendingSpawnApprovals', () => {
+  const initial = reducer(undefined, { type: '@@INIT' })
+  const withSlot = { ...initial, activeSlot: 'slot-1' }
+  const wrap = (chat: typeof initial) => ({ chat }) as any
+
+  it('returns pending spawn approvals for the active slot', () => {
+    const state = reducer(withSlot, sseSubagentPending({ slot: 'slot-1', id: 'a1', task: 'do stuff', approval_id: 'spawn:a1' }))
+    const pending = selectSlotPendingSpawnApprovals(wrap(state), 'slot-1')
+    expect(pending).toHaveLength(1)
+    expect(pending[0].id).toBe('a1')
+    expect(pending[0].approval_id).toBe('spawn:a1')
+  })
+
+  it('is empty (stable ref) when the slot has no pending spawns', () => {
+    const a = selectSlotPendingSpawnApprovals(wrap(withSlot), 'slot-1')
+    const b = selectSlotPendingSpawnApprovals(wrap(withSlot), 'slot-1')
+    expect(a).toHaveLength(0)
+    expect(a).toBe(b) // referentially stable so shallowEqual short-circuits re-renders
+  })
+
+  it('returns empty for a null slot', () => {
+    expect(selectSlotPendingSpawnApprovals(wrap(withSlot), null)).toHaveLength(0)
+  })
+
+  it('drops the approval once the sub-agent starts running', () => {
+    let state = reducer(withSlot, sseSubagentPending({ slot: 'slot-1', id: 'a1', task: 't', approval_id: 'spawn:a1' }))
+    expect(selectSlotPendingSpawnApprovals(wrap(state), 'slot-1')).toHaveLength(1)
+    state = reducer(state, sseSubagentSpawn({ slot: 'slot-1', id: 'a1', task: 't', agent: 'kirocrew' }))
+    expect(selectSlotPendingSpawnApprovals(wrap(state), 'slot-1')).toHaveLength(0)
+  })
+
+  it('surfaces pending spawns parked under a background (non-active) slot', () => {
+    // Pending card for a slot the user is NOT currently viewing lands in
+    // slotActivity[slot]; the selector must still find it when queried by slot.
+    const state = reducer(withSlot, sseSubagentPending({ slot: 'bg-slot', id: 'a2', task: 't', approval_id: 'spawn:a2' }))
+    const pending = selectSlotPendingSpawnApprovals(wrap(state), 'bg-slot')
+    expect(pending).toHaveLength(1)
+    expect(pending[0].id).toBe('a2')
   })
 })


### PR DESCRIPTION
## Problem

When a spawned sub-agent blocks on approval, the request only appears as a
pending card in the side panel's **Subagents** tab. No top-level signal appears
above the composer, so the main chat looks idle while a sub-agent silently waits
for the user to approve it. Confirmed with a user: *"I only find the sub-agent
approval request at the side panel, so no approval chip appeared."*

## Why it matters

A spawned sub-agent stalls indefinitely (up to the 2h human-approval window)
with no top-level signal that action is required — turns appear hung and the user
has no way to know they need to act unless they happen to open the side panel.

## Fix (symptom → root cause → change)

- **Symptom:** spawn approval visible only in the side-panel Subagents tab.
- **Root cause:** sub-agent approvals are delivered as a *state-level* request
  (`dashboard/state.py:request_approval`, id `spawn:<agent_id>` from
  `subagent.py:1986`) and, on the frontend, a `spawn:` id is routed by
  `useWebSocket.ts` into `sseSubagentPending`, which renders **only** the
  side-panel card — no reliable top-level surface. (The deeper backend
  state-level-vs-slot-level divergence is tracked as a follow-up: #198.)
- **Change (frontend-only):** add `selectSlotPendingSpawnApprovals(state, slot)`
  over the pending-spawn state that already exists in the store (a sub-agent with
  `status:'pending'` and an `approval_id`), and render a **reminder** banner above
  the composer in `ChatInput` when a slot has pending spawn approvals. The banner
  is a single button showing a count + "Review in panel"; clicking it opens the
  Subagents panel where each sub-agent is approved individually.
- **Reminder-only by design:** the banner does **not** render its own
  Approve/Reject. An earlier revision did, but the WS handler can also surface the
  same approval as a standard `permission` control, so inline resolve buttons here
  would be a duplicate, independently-actionable control for the same id (Codex
  MEDIUM). Making it reminder-only removes that risk and keeps a single
  per-sub-agent resolve path (the side panel).

## Tests

- `website/src/test/chatSlice.test.ts` (+5): `selectSlotPendingSpawnApprovals`
  returns pending spawns for the active slot, is referentially stable when empty
  (so `shallowEqual` short-circuits re-renders), returns empty for a null slot,
  drops the approval once the sub-agent transitions to running, and finds spawns
  parked under a background (non-active) slot.
- `website/src/test/ChatInput.approval.test.tsx` (+4): the reminder renders with a
  count + "Review in panel" and **no** inline Approve/Reject, pluralizes for
  multiple pending spawns, clicking it opens the Subagents panel
  (`activityTab==='subagents'`, `activityOpen===true`) and resolves nothing
  (`api.resolveApproval` not called), and it is absent when there are no pending
  spawns.
- `npx tsc -b` clean; `chatSlice.test.ts` 174 pass, `ChatInput.approval.test.tsx`
  25 pass.

## Manual verification

Static + unit coverage; live UI not exercised in CI. Recommended manual check:
spawn a sub-agent from a dashboard chat and confirm the "N sub-agent(s) awaiting
your approval to run" reminder appears above the composer and clicking it opens
the Subagents panel to approve.

## Scope / follow-ups (not in this PR)

- **#198** — unify the sub-agent approval path with main-session approvals
  (state-level vs slot-level divergence; the parent slot's `pending_approval`
  "Needs Approval" lane flag is never set for a sub-agent approval).
- Reminder shows in the composer of the slot that spawned the sub-agent (the
  observed case); no cross-slot signal yet when viewing a *different* chat.
- Rare edge case (folded into #198): in a background split pane, the reminder's
  open-panel action targets the global active slot rather than the pane's slot.
