### PR TITLE
fix(dashboard): exempt /vendor/ from token auth so widget iframes load the Tailwind runtime

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -346,7 +346,14 @@ _state: TokenStateManager = TokenStateManager(max_concurrent_nonces=MAX_CONCURRE
 # HMAC path token minted by the authed /api/artifacts/{slug}/app-preview
 # endpoint (sandboxed preview iframes carry no cookies). See
 # dashboard/handlers/webapp_preview.py for the full security model.
-_BYPASS_PREFIXES = ("/assets/", "/static/", "/fonts/", "/artifact-app/")
+# /vendor/ holds same-origin vendored JS (the Tailwind v4 browser runtime at
+# /vendor/tailwindcss-browser.js plus app import-map shims) that sandboxed
+# widget/artifact iframes load via <script src>. Those iframes are null-origin
+# srcdoc sandboxes (widgetSrcdoc.ts), so the request carries no auth cookie;
+# without the exemption the middleware 403s the runtime and every <mcwidget>
+# renders unstyled (Tailwind classes silently ignored, inline styles only).
+# Same exposure class as /assets/: static non-secret files.
+_BYPASS_PREFIXES = ("/assets/", "/static/", "/fonts/", "/vendor/", "/artifact-app/")
 _BYPASS_EXACT = {
     "/logo.png",
     "/manifest.json",

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -395,6 +395,7 @@ async def test_cookie_server_port_name_denied_when_host_differs() -> None:
         "/assets/style.css",
         "/static/app.js",
         "/fonts/AWSDiatype-Regular.woff2",
+        "/vendor/tailwindcss-browser.js",
         "/logo.png",
         "/manifest.json",
         "/sw.js",


### PR DESCRIPTION
## Problem

Every `<mcwidget>` and HTML artifact renders **unstyled** — Tailwind utility classes are silently ignored, only inline styles survive.

## Root cause

The widget iframe is a null-origin srcdoc sandbox (`widgetSrcdoc.ts`), so its `<script src>` request for the same-origin Tailwind v4 runtime (`/vendor/tailwindcss-browser.js`, the Mesh-2518 replacement for the public CDN) carries **no auth cookie**. The token middleware bypass list covers `/assets/`, `/static/`, `/fonts/`, `/artifact-app/` — but not `/vendor/` — so the runtime request gets a 403 and Tailwind never initializes inside the iframe.

Verified live against a running gateway:
```
GET /vendor/tailwindcss-browser.js -> 403 (auth middleware, no cookie)
```

Note: `vendorPaths.ts` guards the three *path* consumers against drift ('or the runtime silently 404s and every widget renders unstyled') but the auth middleware was a fourth consumer nobody accounted for — same symptom via 403 instead of 404.

## Fix

Add `/vendor/` to `_BYPASS_PREFIXES` with a rationale comment. Same exposure class as `/assets/`: static, non-secret vendored JS (Tailwind runtime + import-map shims). The comment block directly above already articulates the exact reasoning ('sandboxed preview iframes carry no cookies') for `/artifact-app/`.

## Testing

- `test/test_token_auth.py` bypass property test extended with `/vendor/tailwindcss-browser.js` — 191/191 pass.
- Live repro confirmed before fix (403 on running gateway; widget screenshot showed Tailwind classes not applying).