### PR TITLE
feat(notifications): app producers push endpoint (RFC Phase 2)

### DIFF
--- a/docs/system-specs/features/app-notifications.md
+++ b/docs/system-specs/features/app-notifications.md
@@ -1,0 +1,72 @@
+# App Notification Producers (Push Endpoint) — Design Document
+
+Last Updated: 2026-07-22 (initial: RFC local notification bus, Phase 2)
+
+## Overview
+
+Phase 2 of the local notification bus (`docs/request-for-change/rfc-local-notification-bus.md`): installed apps become first-class notification producers. An app declares its channels in `app.json`, then pushes notifications through `POST /api/notifications/push` authenticated with its app token. The gateway resolves the producer identity server-side from the verified token (never from the request body), enforces manifest-declared channels, and applies a per-app rate limit. Delivered notes flow through the Phase 1 `NotificationBus` sink (`DashboardState._deliver_note`), which redacts, broadcasts to SSE clients, and persists.
+
+## API
+
+### POST /api/notifications/push
+
+App-token-only endpoint (dashboard-user tokens are rejected with 403: they have no app identity, and the endpoint is for producers). Registered in `server.py` `_register_mcp_routes`, so it serves both the dashboard app and the headless gateway.
+
+Request body (JSON, max 64 KB — enforced on Content-Length AND incrementally on the raw stream so chunked transfer-encoding cannot bypass it):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `channel` | string | yes | A channel id declared in the app's manifest (bare id, not the full dotted name) |
+| `title` | string | yes | Validated by `NotificationPayload.validate()` (length caps) |
+| `body` | string | yes | Length-capped |
+| `priority` | string | no | `critical` / `default` / `passive`; defaults to the channel's `defaultPriority` |
+| `group_key`, `url`, `icon`, `ttl`, `actions`, `meta` | — | no | Passed through payload validation; `url` must be a dashboard-internal path |
+
+The note's `source` is always `app:<name>` resolved from the verified token; `channel` becomes `<app-name>.<channel-id>`.
+
+Responses: `200` with `{"ok": true, "note": {...}}` where `note` is the enriched note (resolved `source`, full `channel`, effective `priority`, server timestamp `ts`); `400` (validation failure — including a corrupt on-disk manifest `defaultPriority`), `403` (no app token / app disabled or unknown / channel not declared), `413` (oversized body), `429` (rate limited), `500` (delivery or persistence failure, SEL-audited). A `200` is a durability guarantee: the handler awaits the persist job before acknowledging, so an accepted push cannot be silently lost to a disk failure. Legacy system producers remain best-effort fire-and-forget.
+
+### Request pipeline order
+
+`validate -> register-channel-once -> rate-limit token -> bus.push`, chosen so that:
+
+- Invalid payloads and corrupt-manifest 400s never consume a rate-limit token (the budget caps DELIVERED notifications).
+- Channel registration happens at most once per channel (re-registering every push would stomp future runtime priority overrides).
+- A `NotificationValidationError` escaping `bus.push` (unreachable today; safety net) refunds the token. A sink failure (e.g. disk full) deliberately does NOT refund: delivery may be partial, and throttling a producer while the gateway is failing is protective.
+
+## Manifest schema: `notifications.channels`
+
+```json
+{
+  "notifications": {
+    "channels": [
+      { "id": "sync-status", "name": "Sync status", "defaultPriority": "passive" }
+    ]
+  }
+}
+```
+
+Validation (`apps/manifest.py`): max 8 channels per app, kebab-case ids, unique ids, `defaultPriority` in the priority enum. The `notifications` block is covered by `signing_payload()` when non-empty, so channel declarations (including any `critical` default priority) are tamper-evident post-signing; manifests without channels produce a byte-identical signing payload to pre-Phase-2 manifests (backward compatible).
+
+## Authorization
+
+- **Token gate** (`token_auth.py` `app_token_path_allowed`): app tokens are deny-by-default; a single carve-out grants every app token exactly `/api/notifications/push`. Deliberately NOT `/api/notifications` — that path also serves GET (read history) and DELETE, which app tokens must not reach.
+- **Handler checks**: app must be installed AND enabled (`is_app_enabled`, a read-only accessor safe for `asyncio.to_thread` — unlike `get_app` it has no version-sync write side effect), and the channel must be declared in the manifest. Manifest reads run off-loop via `asyncio.to_thread` (TOCTOU window accepted: one final notification from a just-disabled app).
+- **Auditing**: every denial, error, and grant emits SEL `log_api_access` with the caller identity.
+
+## Rate limiting
+
+`notifications/rate_limit.py` `AppRateLimiter`: per-app token bucket, 30 notifications per 5 minutes with burst 10. State-owned (`DashboardState.notification_rate_limiter`), not a module global, so its lifecycle matches the gateway instance and tests get isolation. Buckets are never evicted; growth is bounded because only installed, enabled apps reach the limiter (unknown apps 403 earlier). `refund(app_name)` returns one token (capped at burst) for requests that consumed a token but delivered nothing.
+
+## Delivery and event-loop safety
+
+`bus.push` delivers synchronously into `DashboardState._deliver_note` (redact, append to in-memory log, SSE broadcast). Persistence (JSONL append + trim) does blocking file I/O; because the sink is externally drivable in Phase 2, ALL notification file mutations run on a dedicated single-worker executor when a loop is running: appends from the delivery sink AND whole-file rewrites from delete/ack/unack/clear. Single-worker execution means strict submission order — a rewrite submitted after an append can never be overtaken by that append, so a deleted notification cannot be resurrected by a still-queued persist. Mutation endpoints (`delete_notification`, `ack_notification`, `unack_notification`, `clear_notifications`) are async and await durability before responding; the delivery sink stays fire-and-forget (a push response does not need to wait for disk). Snapshot copies are handed to the executor so later loop-side mutation (e.g. ack flags) cannot race serialization. No locks are taken on the event loop and no file I/O runs on it. Sync callers (tests, CLI) persist inline.
+
+## Testing
+
+`test/test_notifications_push.py` (39 tests): auth bypass attempts, undeclared channels, oversized/chunked bodies, rate limit + refund semantics, falsy-but-valid fields, signing-payload coverage, register-once behavior, sink-failure 500. `test/test_dashboard.py` covers persistence, load-time redaction, and the executor-offloaded persist path.
+
+## Known follow-ups
+
+- An app named `system` could produce `full_channel == "system.<id>"`, shadowing reserved system channels (cosmetic spoofing only — `source` stays `app:system` and is SEL-audited). Follow-up: reject reserved app names at install or namespace app channels distinctly.
+- Phase 3 (per RFC): per-channel user settings and runtime priority overrides.

--- a/docs/system-specs/index.md
+++ b/docs/system-specs/index.md
@@ -48,6 +48,7 @@ Load relevant module specs before making changes to that component. Read common 
 
 | Feature | Description |
 |---------|-------------|
+| [app-notifications](features/app-notifications.md) | App notification producers: push endpoint, manifest channels, rate limiting |
 | [claude-code-provider](features/claude-code-provider.md) | Removed — KiroCrew is KiroACP/kiro-cli only; documents the dormant ACP seam that remains |
 | [code-approvers](features/code-approvers.md) | Tier-based CR reviewer routing with drift validator |
 | [dashboard-token-auth](features/dashboard-token-auth.md) | Slack-gated HMAC token authentication for dashboard |

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -966,6 +966,17 @@ def get_app_manifest(name: str) -> AppManifest | None:
         return None
 
 
+def is_app_enabled(name: str) -> bool:
+    """Read-only enablement check: True only for an installed, enabled app.
+
+    Unlike ``get_app`` this never writes (no version-sync side effect), so it
+    is safe to call from worker threads (e.g. ``asyncio.to_thread``) without
+    racing loop-side writers of ``installed.json``.
+    """
+    meta = _read_installed(name)
+    return bool(meta and meta.enabled)
+
+
 def set_app_source(name: str, source: str) -> bool:
     """Update the ``source`` field of an installed app's metadata.
 

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -582,11 +582,91 @@ class PublishProviderConfig:
 # ---------------------------------------------------------------------------
 
 # Fields that are parsed into typed dataclass attributes
+@dataclass
+class NotificationChannel:
+    """A producer-declared notification channel (RFC local notification bus, Phase 2)."""
+
+    id: str = ""  # kebab-case, unique within the app
+    name: str = ""  # human-readable display name for settings UI
+    icon: str = ""  # lucide icon name (optional)
+    defaultPriority: str = "default"  # "critical" | "default" | "passive"  # noqa: N815
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"id": self.id, "name": self.name}
+        if self.icon:
+            d["icon"] = self.icon
+        if self.defaultPriority != "default":
+            d["defaultPriority"] = self.defaultPriority
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NotificationChannel:
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            icon=str(data.get("icon", "")),
+            defaultPriority=str(data.get("defaultPriority", "default")),  # noqa: N815
+        )
+
+
+# Maximum declared channels per app (RFC "Channel registry"): keeps the
+# per-channel settings surface bounded; raising later is free, lowering after
+# apps ship with more is a breaking change.
+MAX_NOTIFICATION_CHANNELS = 8
+
+_CHANNEL_PRIORITIES = ("critical", "default", "passive")
+
+
+@dataclass
+class NotificationsConfig:
+    """Notification channel declarations for an app."""
+
+    channels: list[NotificationChannel] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        if not self.channels:
+            return {}
+        return {"channels": [c.to_dict() for c in self.channels]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NotificationsConfig:
+        raw = data.get("channels", [])
+        channels = [NotificationChannel.from_dict(c) for c in raw if isinstance(c, dict)]
+        return cls(channels=channels)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if len(self.channels) > MAX_NOTIFICATION_CHANNELS:
+            errors.append(
+                f"notifications.channels: at most {MAX_NOTIFICATION_CHANNELS} channels "
+                f"per app, got {len(self.channels)}"
+            )
+        seen: set[str] = set()
+        for ch in self.channels:
+            if not ch.id:
+                errors.append("notifications.channels: channel missing required field: id")
+                continue
+            if not KEBAB_RE.match(ch.id):
+                errors.append(f"notifications.channels: channel id must be kebab-case: {ch.id!r}")
+            if ch.id in seen:
+                errors.append(f"notifications.channels: duplicate channel id: {ch.id!r}")
+            seen.add(ch.id)
+            if not ch.name:
+                errors.append(f"notifications.channels: channel {ch.id!r} missing name")
+            if ch.defaultPriority not in _CHANNEL_PRIORITIES:
+                errors.append(
+                    f"notifications.channels: channel {ch.id!r} defaultPriority must be "
+                    f"one of {_CHANNEL_PRIORITIES}, got {ch.defaultPriority!r}"
+                )
+        return errors
+
+
 _KNOWN_FIELDS = frozenset({
     "name", "version", "displayName", "description", "author", "license",
     "minKiroCrewVersion", "signer", "signature", "agents", "skills", "sops",
     "mcpServers", "crons", "ui", "backend", "permissions", "setup", "tags",
     "jobFamilies", "platform", "dependencies", "publishProvider",
+    "notifications",
 })
 
 
@@ -641,6 +721,9 @@ class AppManifest:
 
     # --- Publish registry (Route B, §1.3) ---
     publishProvider: PublishProviderConfig = field(default_factory=PublishProviderConfig)  # noqa: N815
+
+    # --- Notifications (RFC local notification bus, Phase 2) ---
+    notifications: NotificationsConfig = field(default_factory=NotificationsConfig)
 
     # --- Discovery ---
     tags: list[str] = field(default_factory=list)
@@ -726,18 +809,29 @@ class AppManifest:
         # Backend hooks validation
         errors.extend(self.backend.hooks.validate())
 
+        # Notification channel validation (RFC Phase 2: 8-channel cap, kebab ids)
+        errors.extend(self.notifications.validate())
+
         return errors
 
     def signing_payload(self) -> bytes:
         """Canonical bytes an admission signature covers (manifest minus the
-        signature). Deterministic across field ordering so a future admission
-        verify has a stable payload over name/version/signer/permissions."""
+        signature). Dict keys are sorted for determinism; note the channels
+        list keeps its manifest order, so reordering channel declarations is
+        a signature-relevant change (intentional -- the signed bytes track
+        the manifest as written)."""
         body = {
             "name": self.name,
             "version": self.version,
             "signer": self.signer,
             "permissions": self.permissions.to_dict(),
         }
+        if self.notifications.channels:
+            # Channel declarations gate what an app may push and at which
+            # default priority -- tampering must invalidate the signature.
+            # Included only when non-empty so manifests signed before
+            # notifications existed keep producing the identical payload.
+            body["notifications"] = self.notifications.to_dict()
         return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
     # -----------------------------------------------------------------
@@ -793,6 +887,9 @@ class AppManifest:
         pp_d = self.publishProvider.to_dict()
         if pp_d:
             d["publishProvider"] = pp_d
+        notif_d = self.notifications.to_dict()
+        if notif_d:
+            d["notifications"] = notif_d
         if self.tags:
             d["tags"] = self.tags
         if self.jobFamilies:
@@ -862,6 +959,13 @@ class AppManifest:
             else PublishProviderConfig()
         )
 
+        notif_raw = data.get("notifications", {})
+        notifications = (
+            NotificationsConfig.from_dict(notif_raw)
+            if isinstance(notif_raw, dict)
+            else NotificationsConfig()
+        )
+
         return cls(
             name=str(data.get("name", "")),
             version=str(data.get("version", "")),
@@ -888,6 +992,7 @@ class AppManifest:
             dependencies=deps,
             platform=platform_cfg,
             publishProvider=publish_provider,
+            notifications=notifications,
             tags=[str(t) for t in data.get("tags", []) if t],
             jobFamilies=[str(j) for j in data.get("jobFamilies", []) if j],  # noqa: N815
             extra=extra,

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -473,6 +473,9 @@ from kiro_crew.dashboard.handlers.core import (  # noqa: E402, F401
     logo,
     pwa_file,
 )
+from kiro_crew.dashboard.handlers.notifications_push import (  # noqa: E402, F401
+    api_push_notification,
+)
 from kiro_crew.dashboard.handlers.optimizer import (  # noqa: E402, F401
     handle_optimize,
 )

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -571,7 +571,7 @@ async def api_cron_ack(request: web.Request) -> web.Response:
     notification_ts = body.get("ts", "")
     ok = state.crons.ack_job(job_id, summary)
     if notification_ts:
-        state.ack_notification(notification_ts)
+        await state.ack_notification(notification_ts)
     return web.json_response({"ok": ok})
 
 

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -29,7 +29,6 @@ from kiro_crew.dashboard.state import (
     CRON_NOTIFY_END,
     CRON_NOTIFY_PREFIX,
     DashboardState,
-    _rewrite_notifications,
 )
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.slack.format import build_options_blocks, extract_options
@@ -362,14 +361,14 @@ async def api_notification_delete(request: web.Request) -> web.Response:
     ts = body.get("ts", "")
     if not ts:
         return web.json_response({"error": "ts is required"}, status=400)
-    ok = state.delete_notification(ts)
+    ok = await state.delete_notification(ts)
     return web.json_response({"ok": ok})
 
 
 async def api_notifications_clear(request: web.Request) -> web.Response:
     """POST /api/notifications/clear — clear all notifications."""
     state: DashboardState = request.app["state"]
-    state.clear_notifications()
+    await state.clear_notifications()
     return web.json_response({"ok": True})
 
 
@@ -383,7 +382,7 @@ async def api_notification_ack(request: web.Request) -> web.Response:
     ts = body.get("ts", "")
     if not ts:
         return web.json_response({"error": "ts is required"}, status=400)
-    ok = state.ack_notification(ts)
+    ok = await state.ack_notification(ts)
     return web.json_response({"ok": ok})
 
 
@@ -402,7 +401,7 @@ async def api_notification_unack(request: web.Request) -> web.Response:
         if n.get("ts") == ts and n.get("kind") == "cron" and n.get("job_id"):
             state.crons.unack_job(n["job_id"])
             break
-    ok = state.unack_notification(ts)
+    ok = await state.unack_notification(ts)
     return web.json_response({"ok": ok})
 
 
@@ -411,7 +410,10 @@ async def api_notifications_ack_all(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     for n in state._notification_log:
         n["acked"] = True
-    _rewrite_notifications(state._notification_log)
+    # Same ordered executor as every other notification-file mutation: a
+    # rewrite submitted after a queued delivery append can never be
+    # overtaken by it, and durability is awaited before responding.
+    await state._rewrite_notifications_async()
     state.broadcast_ws("notification_ack", {"ts": "*"})
     return web.json_response({"ok": True})
 

--- a/src/kiro_crew/dashboard/handlers/notifications_push.py
+++ b/src/kiro_crew/dashboard/handlers/notifications_push.py
@@ -1,0 +1,228 @@
+"""App notification producer endpoint (RFC local notification bus, Phase 2).
+
+``POST /api/notifications/push`` lets an authenticated app backend push a
+schema-v2 notification through the bus. Security posture (RFC "Security
+considerations"):
+
+- The producer identity comes from the verified app token (``request["app"]``,
+  set by the token-auth middleware after HMAC validation) — never from the
+  request body, so an app cannot impersonate another source.
+- The channel must be declared in the app's manifest (``notifications.channels``)
+  and the app must currently be enabled; deny-by-default otherwise.
+- Pushes are rate limited per app (token bucket); violations are SEL-logged
+  and rejected with 429.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from aiohttp import web
+
+from kiro_crew.apps.manager import get_app_manifest, is_app_enabled
+from kiro_crew.notifications.bus import (
+    NotificationPayload,
+    NotificationValidationError,
+)
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY_BYTES = 64 * 1024  # generous; payload fields have their own caps
+
+
+def _resolve_app_channels(app_name: str) -> dict[str, str] | None:
+    """Return {channel_id: default_priority} for an installed, enabled app.
+
+    None when the app is unknown or disabled — callers treat that as deny.
+    Read-only by design: runs in a worker thread (asyncio.to_thread), so it
+    must never write app metadata (``get_app`` has a version-sync write side
+    effect that would race loop-side writers of ``installed.json``).
+    """
+    if not is_app_enabled(app_name):
+        return None
+    manifest = get_app_manifest(app_name)
+    if manifest is None:
+        return None
+    return {ch.id: ch.defaultPriority for ch in manifest.notifications.channels}
+
+
+async def api_push_notification(request: web.Request) -> web.Response:
+    """POST /api/notifications/push — app backends push notifications via the bus."""
+    app_name = request.get("app", "")
+    if not app_name:
+        # Dashboard-user tokens have no app identity; this endpoint is for
+        # app producers only (deny-by-default).
+        sel().log_api_access(
+            caller="unknown",
+            operation="notification_push",
+            outcome="denied",
+            source="notifications_api",
+            error="app token required",
+        )
+        return web.json_response(
+            {"error": "app token required"}, status=403
+        )
+
+    if request.content_length and request.content_length > _MAX_BODY_BYTES:
+        return web.json_response({"error": "payload too large"}, status=413)
+
+    # Enforce the cap while streaming: chunked transfer-encoding carries no
+    # Content-Length header, and buffering the whole body first
+    # (request.read()) would allocate up to the server-wide client_max_size
+    # before any check runs. Reading incrementally bounds the allocation to
+    # _MAX_BODY_BYTES + one chunk.
+    chunks: list[bytes] = []
+    received = 0
+    async for chunk in request.content.iter_chunked(8192):
+        received += len(chunk)
+        if received > _MAX_BODY_BYTES:
+            return web.json_response({"error": "payload too large"}, status=413)
+        chunks.append(chunk)
+    try:
+        body: dict[str, Any] = json.loads(b"".join(chunks))
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+    if not isinstance(body, dict):
+        return web.json_response({"error": "body must be a JSON object"}, status=400)
+
+    # get_app/get_app_manifest read installed.json + app.json from disk (and
+    # may even write a version sync) -- keep that off the event loop. The
+    # await window this opens between the enablement check and bus.push()
+    # means an app disabled mid-request can still land one final
+    # notification; that is accepted (harmless) rather than locked against.
+    channels = await asyncio.to_thread(_resolve_app_channels, app_name)
+    if channels is None:
+        sel().log_api_access(
+            caller=app_name,
+            operation="notification_push",
+            outcome="denied",
+            source="notifications_api",
+            error="app not installed or not enabled",
+        )
+        return web.json_response({"error": "app not installed or not enabled"}, status=403)
+
+    channel_id = str(body.get("channel", ""))
+    if channel_id not in channels:
+        sel().log_api_access(
+            caller=app_name,
+            operation="notification_push",
+            outcome="denied",
+            source="notifications_api",
+            error=f"undeclared channel: {channel_id!r}",
+        )
+        return web.json_response(
+            {"error": f"channel not declared in app manifest: {channel_id!r}"}, status=400
+        )
+
+    state = request.app["state"]
+    bus = state.notification_bus
+    full_channel = f"{app_name}.{channel_id}"
+
+    priority_raw = body.get("priority")
+    # ``is not None`` (not truthiness): falsy-but-valid values like
+    # ``group_key: 0`` must survive, and an explicit ``url: ""`` should fail
+    # validation loudly (400) rather than be silently dropped. Single lookup
+    # per key -- the checked value is the consumed value.
+    group_key_raw = body.get("group_key")
+    url_raw = body.get("url")
+    icon_raw = body.get("icon")
+    actions_raw = body.get("actions")
+    ttl_raw = body.get("ttl")
+    meta_raw = body.get("meta")
+    meta: dict[str, Any] = meta_raw if isinstance(meta_raw, dict) else {}
+    payload = NotificationPayload(
+        source=f"app:{app_name}",  # server-resolved; body cannot override
+        channel=full_channel,
+        title=str(body.get("title", "")),
+        body=str(body.get("body", "")),
+        priority=str(priority_raw) if priority_raw is not None else None,
+        group_key=str(group_key_raw) if group_key_raw is not None else None,
+        actions=actions_raw if isinstance(actions_raw, list) else None,
+        url=str(url_raw) if url_raw is not None else None,
+        icon=str(icon_raw) if icon_raw is not None else None,
+        ttl=ttl_raw if isinstance(ttl_raw, int) else None,
+        meta=meta,
+    )
+    try:
+        # Validate BEFORE consuming a rate-limit token: the limiter's purpose
+        # is capping delivered notifications (RFC "Rate limiting"), and
+        # invalid payloads deliver nothing -- they must not drain the budget
+        # and then 429-block legitimate retries.
+        payload.validate()
+        # Register once per channel, also before the limiter: registration is
+        # cheap and idempotent, and its only failure mode (corrupt on-disk
+        # manifest defaultPriority) is a 400 that likewise delivers nothing.
+        # Re-registering on every push would stomp any later runtime priority
+        # override (RFC Phase 3 per-channel settings); manifest priority
+        # changes take effect on gateway restart.
+        if not bus.is_registered(full_channel):
+            bus.register_channel(full_channel, channels[channel_id])
+    except NotificationValidationError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+
+    if not state.notification_rate_limiter.allow(app_name):
+        sel().log_api_access(
+            caller=app_name,
+            operation="notification_push",
+            outcome="denied",
+            source="notifications_api",
+            error="rate limit exceeded",
+        )
+        return web.json_response({"error": "rate limit exceeded"}, status=429)
+
+    try:
+        # bus.push delivers via the state sink: redact, in-memory append,
+        # SSE broadcast, and a persist job queued on the notification I/O
+        # executor (the sink stashes its future on the state).
+        note = bus.push(payload)
+    except NotificationValidationError as exc:
+        # Unreachable today (payload validated and channel registered above
+        # with no await between); kept as a safety net so a future refactor
+        # cannot turn this into an unhandled 500. Refund the token: nothing
+        # was delivered, and the budget caps delivered notifications only.
+        state.notification_rate_limiter.refund(app_name)
+        return web.json_response({"error": str(exc)}, status=400)
+    except Exception:
+        # Sink failure during delivery. Delivery may have PARTIALLY happened
+        # (broadcast precedes persist), so the token is deliberately NOT
+        # refunded -- and throttling a producer while the gateway is failing
+        # is protective, not punitive.
+        logger.exception("notification push delivery failed for %s", full_channel)
+        sel().log_api_access(
+            caller=app_name,
+            operation="notification_push",
+            outcome="error",
+            source="notifications_api",
+            error="delivery failed",
+        )
+        return web.json_response({"error": "notification delivery failed"}, status=500)
+
+    # Await durability before acknowledging: an accepted app push must not
+    # be silently lost to a disk failure (legacy system producers remain
+    # best-effort fire-and-forget). No await ran between bus.push and here,
+    # so the stashed future belongs to this note. The note WAS broadcast, so
+    # the token stays spent on failure (same rationale as the sink except).
+    persist_fut = state.last_notification_persist
+    if persist_fut is not None and not await persist_fut:
+        logger.error("notification persistence failed for %s", full_channel)
+        sel().log_api_access(
+            caller=app_name,
+            operation="notification_push",
+            outcome="error",
+            source="notifications_api",
+            error="persistence failed",
+        )
+        return web.json_response({"error": "notification persistence failed"}, status=500)
+
+    sel().log_api_access(
+        caller=app_name,
+        operation="notification_push",
+        outcome="granted",
+        source="notifications_api",
+        resources=full_channel,
+    )
+    return web.json_response({"ok": True, "note": note})

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -555,6 +555,7 @@ def _register_mcp_routes(app: web.Application) -> None:
     app.router.add_get("/api/session-tool-policy", handlers.api_session_tool_policy)
     app.router.add_post("/api/slack-profile", handlers.api_slack_profile)
     app.router.add_get("/api/notifications", handlers.api_notifications)
+    app.router.add_post("/api/notifications/push", handlers.api_push_notification)
     app.router.add_post("/api/notifications/clear", handlers.api_notifications_clear)
 
     # Auto-nudge (feature-flagged — returns 503 when KIROCREW_AUTONUDGE unset)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -29,6 +30,7 @@ from kiro_crew.notifications.bus import (
     normalize_note,
     payload_from_legacy,
 )
+from kiro_crew.notifications.rate_limit import AppRateLimiter
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -1354,6 +1356,14 @@ class DashboardState:
         # Notification bus (schema v2) — notify() adapts legacy calls onto it;
         # _deliver_note is the delivery sink (log, count, broadcast, persist).
         self.notification_bus = NotificationBus(sink=self._deliver_note)
+        # Future of the most recent delivery-sink persist job (None when the
+        # last persist ran inline). The app push handler awaits it to give a
+        # durability guarantee; legacy producers ignore it (best-effort).
+        self.last_notification_persist: asyncio.Future[bool] | None = None
+        # Per-app push rate limiter (RFC Phase 2). State-owned (not a module
+        # global) so its lifecycle matches the gateway instance and tests get
+        # isolation for free.
+        self.notification_rate_limiter = AppRateLimiter()
         self._slots: dict[str, _ChatSlot] = {}
         self._slack_to_slot: dict[str, str] = {}  # Slack session_key → slot name
         self._slot_counter = 0
@@ -1815,7 +1825,25 @@ class DashboardState:
         self._notification_log.append(note)
         self._unread_count += 1
         self._broadcast(note)
-        _persist_notification(note)
+        # Persistence does blocking file I/O (append + possible trim). The
+        # bus sink is now externally drivable (Phase 2 app producers), so on
+        # a running event loop the write is offloaded to a dedicated
+        # single-worker executor (FIFO keeps on-disk order = delivery order).
+        # A snapshot copy is handed off because the in-memory note can be
+        # mutated afterwards on the loop (e.g. ack sets note["acked"]).
+        # The future is stashed so callers that need durability (the app
+        # push endpoint) can await it and read the success bool; legacy
+        # system producers stay fire-and-forget (best-effort history).
+        # Without a running loop (unit tests, sync callers) persist inline.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            _persist_notification(note)
+            self.last_notification_persist = None
+        else:
+            self.last_notification_persist = loop.run_in_executor(
+                _notification_io_executor(), _persist_notification, dict(note)
+            )
 
     def register_sse(self) -> asyncio.Queue[dict[str, Any]]:
         """Register a new SSE client and return its dedicated queue."""
@@ -1834,45 +1862,56 @@ class DashboardState:
         """Reset unread counter (called when client opens notification panel)."""
         self._unread_count = 0
 
-    def delete_notification(self, ts: str) -> bool:
+    async def _rewrite_notifications_async(self) -> None:
+        """Rewrite the notifications file on the I/O executor and await it.
+
+        All disk mutations (appends from ``_deliver_note`` and rewrites from
+        delete/ack/clear) go through the same single-worker executor, so they
+        execute strictly in submission order — a rewrite submitted after an
+        append can never be overtaken by it (no resurrection of deleted
+        rows). Awaiting makes the mutation durable before the HTTP response
+        returns. A shallow per-row snapshot is handed off because rows are
+        mutated on the loop (e.g. ack flags).
+        """
+        snapshot = [dict(n) for n in self._notification_log]
+        await asyncio.get_running_loop().run_in_executor(
+            _notification_io_executor(), _rewrite_notifications, snapshot
+        )
+
+    async def delete_notification(self, ts: str) -> bool:
         """Remove a single notification by timestamp and persist to disk."""
         before = len(self._notification_log)
         self._notification_log = [n for n in self._notification_log if n.get("ts") != ts]
         removed = len(self._notification_log) < before
         if removed:
-            _rewrite_notifications(self._notification_log)
+            await self._rewrite_notifications_async()
         return removed
 
-    def ack_notification(self, ts: str) -> bool:
+    async def ack_notification(self, ts: str) -> bool:
         """Mark a notification as acknowledged and persist."""
         for n in self._notification_log:
             if n.get("ts") == ts:
                 n["acked"] = True
-                _rewrite_notifications(self._notification_log)
+                await self._rewrite_notifications_async()
                 self.broadcast_ws("notification_ack", {"ts": ts})
                 return True
         return False
 
-    def unack_notification(self, ts: str) -> bool:
+    async def unack_notification(self, ts: str) -> bool:
         """Mark a notification as unread and persist."""
         for n in self._notification_log:
             if n.get("ts") == ts:
                 n["acked"] = False
-                _rewrite_notifications(self._notification_log)
+                await self._rewrite_notifications_async()
                 self.broadcast_ws("notification_unack", {"ts": ts})
                 return True
         return False
 
-    def clear_notifications(self) -> None:
+    async def clear_notifications(self) -> None:
         """Remove all notifications from memory and disk."""
         self._notification_log.clear()
         self._unread_count = 0
-        path = _notifications_path()
-        try:
-            if path.exists():
-                path.write_text("", encoding="utf-8")
-        except Exception:
-            logger.debug("Failed to clear notifications file", exc_info=True)
+        await self._rewrite_notifications_async()
 
     def get_slot(self, name: str) -> _ChatSlot | None:
         """Look up a slot by name without creating it. Returns None if absent."""
@@ -2624,8 +2663,31 @@ def _load_notifications() -> list[dict[str, Any]]:
         return []
 
 
-def _persist_notification(note: dict[str, str]) -> None:
-    """Append a single notification to the JSONL file on disk."""
+# Notification file I/O runs exclusively on this single-worker executor when
+# an event loop is running: appends (from the delivery sink) and rewrites
+# (from delete/ack/clear) execute strictly in submission order, so no lock is
+# needed and the loop never blocks on file I/O.
+_notification_io_pool: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+def _notification_io_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Lazily create the single-worker executor for notification persistence."""
+    global _notification_io_pool
+    if _notification_io_pool is None:
+        _notification_io_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="notif-io"
+        )
+    return _notification_io_pool
+
+
+def _persist_notification(note: dict[str, str]) -> bool:
+    """Append a single notification to the JSONL file on disk.
+
+    Returns True on success. Failures are swallowed (legacy system producers
+    are explicitly best-effort — history is a cache, delivery is the
+    broadcast) but reported via the return value so callers that need
+    durability (the app push endpoint) can surface them.
+    """
     path = _notifications_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -2633,8 +2695,10 @@ def _persist_notification(note: dict[str, str]) -> None:
             f.write(json.dumps(note) + "\n")
         # Trim if file grows too large (keep last N lines)
         _maybe_trim_notifications(path)
+        return True
     except Exception:
         logger.debug("Failed to persist notification", exc_info=True)
+        return False
 
 
 def _rewrite_notifications(notifications: list[dict[str, str]]) -> None:

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1052,6 +1052,14 @@ def app_token_path_allowed(app_name: str, path: str) -> bool:
         return False
     if _app_owns_path(app_name, path):
         return True
+    # Notification push (RFC local notification bus, Phase 2): every app may
+    # reach this single push-only endpoint — the handler independently
+    # enforces app identity (from the verified token), manifest-declared
+    # channels, and per-app rate limits, so the grant confers no cross-app
+    # authority. Deliberately NOT /api/notifications: that path also serves
+    # GET (read history) and DELETE, which app tokens must not reach.
+    if path == "/api/notifications/push":
+        return True
     return any(_api_pattern_matches(p, path) for p in _app_api_allowlist(app_name))
 
 

--- a/src/kiro_crew/notifications/rate_limit.py
+++ b/src/kiro_crew/notifications/rate_limit.py
@@ -1,0 +1,65 @@
+"""Per-app rate limiting for notification pushes (RFC Phase 2).
+
+Token bucket per app: sustained rate of 30 notifications per 5 minutes with a
+burst of 10. Deliberately coarse — the goal is stopping a buggy loop from
+flooding the notification center, not fine-grained fairness (RFC "Rate
+limiting"). System channels never pass through this limiter.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+# 30 notifications per 5 minutes sustained, burst of 10 (RFC Phase 2).
+RATE_LIMIT_TOKENS_PER_WINDOW = 30
+RATE_LIMIT_WINDOW_SECS = 300.0
+RATE_LIMIT_BURST = 10
+
+_REFILL_RATE = RATE_LIMIT_TOKENS_PER_WINDOW / RATE_LIMIT_WINDOW_SECS  # tokens/sec
+
+
+@dataclass
+class _Bucket:
+    tokens: float = float(RATE_LIMIT_BURST)
+    last_refill: float = field(default_factory=time.monotonic)
+
+
+class AppRateLimiter:
+    """Token bucket per app name. Single-threaded (asyncio event loop) use.
+
+    Buckets are never evicted; growth is bounded because callers only pass
+    names of installed, enabled apps (the push handler denies unknown apps
+    with 403 before consulting the limiter), and each bucket is two floats.
+    Entries for later-uninstalled apps linger harmlessly for the gateway's
+    lifetime -- an accepted trade-off over eviction bookkeeping.
+    """
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+
+    def allow(self, app_name: str) -> bool:
+        """Consume one token for *app_name*; False when the budget is exhausted."""
+        now = time.monotonic()
+        bucket = self._buckets.get(app_name)
+        if bucket is None:
+            bucket = _Bucket(last_refill=now)
+            self._buckets[app_name] = bucket
+        elapsed = now - bucket.last_refill
+        bucket.tokens = min(float(RATE_LIMIT_BURST), bucket.tokens + elapsed * _REFILL_RATE)
+        bucket.last_refill = now
+        if bucket.tokens >= 1.0:
+            bucket.tokens -= 1.0
+            return True
+        return False
+
+    def refund(self, app_name: str) -> None:
+        """Return one token to *app_name*'s bucket (capped at burst).
+
+        For callers whose request consumed a token via :meth:`allow` but then
+        failed without delivering anything -- the budget caps DELIVERED
+        notifications, so non-delivering failures must not drain it.
+        """
+        bucket = self._buckets.get(app_name)
+        if bucket is not None:
+            bucket.tokens = min(float(RATE_LIMIT_BURST), bucket.tokens + 1.0)

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -1611,7 +1611,7 @@ async def _handle_cron_ack(payload: dict, action: dict, channel: str, msg_ts: st
     if _orch.dashboard_state:
         for n in _orch.dashboard_state._notification_log:
             if n.get("job_id") == job_id and not n.get("acked"):
-                _orch.dashboard_state.ack_notification(n["ts"])
+                await _orch.dashboard_state.ack_notification(n["ts"])
                 _orch.dashboard_state.broadcast_ws("notification_ack", {"ts": n["ts"]})
 
 
@@ -1622,7 +1622,7 @@ async def _handle_subagent_ack(payload: dict, action: dict, channel: str, msg_ts
         return
     for n in _orch.dashboard_state._notification_log:
         if n.get("kind") == "subagent" and subagent_id in n.get("title", "") and not n.get("acked"):
-            _orch.dashboard_state.ack_notification(n["ts"])
+            await _orch.dashboard_state.ack_notification(n["ts"])
             _orch.dashboard_state.broadcast_ws("notification_ack", {"ts": n["ts"]})
 
 

--- a/test/test_dashboard.py
+++ b/test/test_dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ from kiro_crew.dashboard.state import (
     _maybe_trim_notifications,
     _persist_notification,
 )
+from kiro_crew.notifications.bus import payload_from_legacy
 
 
 class TestDashboard:
@@ -160,6 +162,24 @@ class TestNotificationPersistence:
         assert loaded[0]["title"] == "Test Job"
         assert "ts" in loaded[0]  # timestamp added
 
+    def test_bus_sink_is_redacting_deliver_note(self, monkeypatch, tmp_path) -> None:
+        """Wiring guarantee for Phase 2 app producers: the production bus sink
+        IS the redacting _deliver_note, so an app push through
+        notification_bus.push() gets its title/body/meta redacted there --
+        producers (e.g. the push endpoint) rely on this and do not
+        pre-redact."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+        note = state.notification_bus.push(
+            payload_from_legacy("cron", "key AKIAIOSFODNN7EXAMPLE via bus", "b")
+        )
+        assert "AKIAIOSFODNN7EXAMPLE" not in note["title"]
+
     def test_deliver_note_redacts_nested_strings(self, monkeypatch, tmp_path) -> None:
         """Redaction descends into nested structures like action labels.
 
@@ -216,3 +236,134 @@ class TestNotificationPersistence:
         assert len(state._notification_log) == 2
         assert state._notification_log[0]["title"] == "Old"
         assert state._notification_log[1]["title"] == "Old2"
+
+    def test_deliver_note_offloads_persist_on_running_loop(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """On a running event loop, persistence goes through the single-worker
+        executor (never blocking the loop), rows land in delivery order, and a
+        later in-memory mutation (e.g. ack) does not leak into the snapshot
+        that was handed to the executor."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.state import _notification_io_executor
+
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+
+        async def scenario() -> None:
+            state._deliver_note({"ts": "t1", "kind": "cron", "title": "First", "body": "b"})
+            state._deliver_note({"ts": "t2", "kind": "cron", "title": "Second", "body": "b"})
+            # Mutate the in-memory note AFTER delivery (ack semantics); the
+            # executor received a snapshot, so disk must not see this flag.
+            state._notification_log[0]["acked"] = True
+            # Fence: a no-op on the same single-worker executor runs only
+            # after both pending persist jobs (FIFO) have completed.
+            await asyncio.get_running_loop().run_in_executor(
+                _notification_io_executor(), lambda: None
+            )
+
+        asyncio.run(scenario())
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "notifications.jsonl").read_text().splitlines()
+        ]
+        assert [r["title"] for r in rows] == ["First", "Second"]
+        assert "acked" not in rows[0]
+
+    def test_deliver_note_persists_inline_without_loop(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Without a running loop (sync callers), persist happens inline so
+        the row is on disk immediately after _deliver_note returns."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+        state._deliver_note({"ts": "t1", "kind": "cron", "title": "Sync", "body": "b"})
+        rows = (tmp_path / "notifications.jsonl").read_text().splitlines()
+        assert len(rows) == 1
+        assert json.loads(rows[0])["title"] == "Sync"
+
+    def test_delete_after_push_cannot_resurrect_row(self, monkeypatch, tmp_path) -> None:
+        """A delete issued immediately after a push must win on disk: both the
+        queued append and the rewrite run on the same single-worker executor
+        in submission order, so the rewrite (submitted second) lands last and
+        the deleted row cannot be resurrected by the still-queued append."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+
+        async def scenario() -> bool:
+            state._deliver_note({"ts": "t1", "kind": "cron", "title": "Doomed", "body": "b"})
+            # Delete before the queued append has necessarily run.
+            return await state.delete_notification("t1")
+
+        assert asyncio.run(scenario()) is True
+        content = (tmp_path / "notifications.jsonl").read_text()
+        assert "Doomed" not in content
+
+    def test_ack_persists_durably_before_return(self, monkeypatch, tmp_path) -> None:
+        """ack_notification awaits the executor rewrite, so the acked flag is
+        on disk by the time the coroutine returns."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+        state.broadcast_ws = MagicMock()
+
+        async def scenario() -> bool:
+            state._deliver_note({"ts": "t1", "kind": "cron", "title": "A", "body": "b"})
+            return await state.ack_notification("t1")
+
+        assert asyncio.run(scenario()) is True
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "notifications.jsonl").read_text().splitlines()
+        ]
+        assert rows[0]["acked"] is True
+
+    def test_ack_all_rewrite_not_overtaken_by_queued_append(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """ack-all's rewrite goes through the same ordered executor as the
+        delivery append: acked state on disk cannot be clobbered by a
+        still-queued unacked append snapshot."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = DashboardState(
+            sessions=MagicMock(count=0),
+            crons=MagicMock(),
+            lessons=MagicMock(),
+            start_time=0.0,
+        )
+        state.broadcast_ws = MagicMock()
+
+        async def scenario() -> None:
+            state._deliver_note({"ts": "t1", "kind": "cron", "title": "A", "body": "b"})
+            # Ack-all immediately: rewrite is submitted after the append and
+            # must land after it on disk.
+            for n in state._notification_log:
+                n["acked"] = True
+            await state._rewrite_notifications_async()
+
+        asyncio.run(scenario())
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "notifications.jsonl").read_text().splitlines()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["acked"] is True

--- a/test/test_notifications_push.py
+++ b/test/test_notifications_push.py
@@ -1,0 +1,682 @@
+"""Tests for Phase 2 of the local notification bus RFC: app producers."""
+
+import asyncio
+import contextlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.apps.manifest import (
+    MAX_NOTIFICATION_CHANNELS,
+    AppManifest,
+    NotificationChannel,
+    NotificationsConfig,
+)
+from kiro_crew.dashboard.handlers.notifications_push import api_push_notification
+from kiro_crew.dashboard.token_auth import app_token_path_allowed
+from kiro_crew.notifications.bus import NotificationBus
+from kiro_crew.notifications.rate_limit import RATE_LIMIT_BURST, AppRateLimiter
+
+# ── Manifest channel declarations ──
+
+
+class TestNotificationsManifest:
+    def _manifest(self, channels: list[NotificationChannel]) -> AppManifest:
+        return AppManifest(
+            name="test-app",
+            version="1.0.0",
+            displayName="Test App",
+            description="d",
+            notifications=NotificationsConfig(channels=channels),
+        )
+
+    def test_valid_channels_pass(self):
+        m = self._manifest(
+            [
+                NotificationChannel(id="ticket-update", name="Ticket Updates"),
+                NotificationChannel(id="alerts", name="Alerts", defaultPriority="critical"),
+            ]
+        )
+        assert m.validate() == []
+
+    def test_channel_cap_enforced(self):
+        channels = [
+            NotificationChannel(id=f"ch-{i}", name=f"Channel {i}")
+            for i in range(MAX_NOTIFICATION_CHANNELS + 1)
+        ]
+        errors = self._manifest(channels).validate()
+        assert any("at most" in e for e in errors)
+
+    def test_exactly_at_cap_passes(self):
+        channels = [
+            NotificationChannel(id=f"ch-{i}", name=f"Channel {i}")
+            for i in range(MAX_NOTIFICATION_CHANNELS)
+        ]
+        assert self._manifest(channels).validate() == []
+
+    def test_non_kebab_id_rejected(self):
+        errors = self._manifest([NotificationChannel(id="Bad_Id", name="Bad")]).validate()
+        assert any("kebab-case" in e for e in errors)
+
+    def test_duplicate_id_rejected(self):
+        errors = self._manifest(
+            [
+                NotificationChannel(id="dup", name="A"),
+                NotificationChannel(id="dup", name="B"),
+            ]
+        ).validate()
+        assert any("duplicate" in e for e in errors)
+
+    def test_bad_priority_rejected(self):
+        errors = self._manifest(
+            [NotificationChannel(id="ch", name="C", defaultPriority="urgent")]
+        ).validate()
+        assert any("defaultPriority" in e for e in errors)
+
+    def test_missing_name_rejected(self):
+        errors = self._manifest([NotificationChannel(id="ch")]).validate()
+        assert any("missing name" in e for e in errors)
+
+    def test_round_trip_through_dict(self):
+        m = self._manifest(
+            [NotificationChannel(id="ch", name="C", icon="bell", defaultPriority="passive")]
+        )
+        restored = AppManifest.from_dict(m.to_dict())
+        assert restored.notifications.channels[0].id == "ch"
+        assert restored.notifications.channels[0].icon == "bell"
+        assert restored.notifications.channels[0].defaultPriority == "passive"
+
+    def test_no_channels_serializes_empty(self):
+        m = self._manifest([])
+        assert "notifications" not in m.to_dict()
+
+
+# ── Rate limiter ──
+
+
+class TestAppRateLimiter:
+    def test_burst_allowed_then_limited(self):
+        limiter = AppRateLimiter()
+        for _ in range(RATE_LIMIT_BURST):
+            assert limiter.allow("app-a")
+        assert not limiter.allow("app-a")
+
+    def test_apps_have_independent_buckets(self):
+        limiter = AppRateLimiter()
+        for _ in range(RATE_LIMIT_BURST):
+            limiter.allow("app-a")
+        assert not limiter.allow("app-a")
+        assert limiter.allow("app-b")
+
+    def test_tokens_refill_over_time(self, monkeypatch):
+        limiter = AppRateLimiter()
+        now = [1000.0]
+        monkeypatch.setattr(
+            "kiro_crew.notifications.rate_limit.time.monotonic", lambda: now[0]
+        )
+        for _ in range(RATE_LIMIT_BURST):
+            assert limiter.allow("app-a")
+        assert not limiter.allow("app-a")
+        now[0] += 60.0  # 60s at 0.1 tokens/sec = 6 tokens
+        for _ in range(6):
+            assert limiter.allow("app-a")
+        assert not limiter.allow("app-a")
+
+    def test_refund_returns_token_capped_at_burst(self):
+        limiter = AppRateLimiter()
+        for _ in range(RATE_LIMIT_BURST):
+            assert limiter.allow("app-a")
+        assert not limiter.allow("app-a")
+        limiter.refund("app-a")
+        assert limiter.allow("app-a")  # refunded token usable
+        # Refund never exceeds burst, and refunding an unknown app is a no-op.
+        fresh = AppRateLimiter()
+        fresh.refund("never-seen")
+        for _ in range(RATE_LIMIT_BURST):
+            assert fresh.allow("never-seen")
+        assert not fresh.allow("never-seen")
+
+
+# ── Token path grant ──
+
+
+class TestAppTokenPathGrant:
+    def test_push_path_allowed_for_app_tokens(self):
+        assert app_token_path_allowed("some-app", "/api/notifications/push")
+
+    def test_notification_read_path_still_denied(self):
+        assert not app_token_path_allowed("some-app", "/api/notifications")
+
+    def test_empty_app_name_denied(self):
+        assert not app_token_path_allowed("", "/api/notifications/push")
+
+
+# ── Push handler ──
+
+
+class _FakeState:
+    def __init__(self) -> None:
+        self.delivered: list[dict] = []
+        self.notification_bus = NotificationBus(sink=self.delivered.append)
+        self.notification_rate_limiter = AppRateLimiter()
+        # None = last persist ran inline (no durability future to await),
+        # matching DashboardState's sync-context behavior.
+        self.last_notification_persist = None
+
+
+def _make_app(state: _FakeState, identity: dict) -> web.Application:
+    @web.middleware
+    async def fake_auth(request, handler):
+        if identity["app"]:
+            request["app"] = identity["app"]
+        return await handler(request)
+
+    app = web.Application(middlewares=[fake_auth])
+    app["state"] = state
+    app.router.add_post("/api/notifications/push", api_push_notification)
+    return app
+
+
+_CHANNELS = {"ticket-update": "default", "alerts": "critical"}
+
+
+def _patch_channels(channels="unset"):
+    return patch(
+        "kiro_crew.dashboard.handlers.notifications_push._resolve_app_channels",
+        return_value=dict(_CHANNELS) if channels == "unset" else channels,
+    )
+
+
+def _fresh_limiter():
+    # The limiter is state-owned (each _FakeState gets its own), so no
+    # module-global patching is needed; kept as a no-op context manager so
+    # existing test bodies read unchanged.
+    return contextlib.nullcontext()
+
+
+class TestPushHandler:
+    @pytest.mark.asyncio
+    async def test_push_delivers_with_server_resolved_source(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={
+                        "channel": "ticket-update",
+                        "title": "New Sev-2",
+                        "body": "V123 assigned",
+                        "source": "app:EVIL",  # must be ignored
+                    },
+                )
+        assert resp.status == 200
+        assert len(state.delivered) == 1
+        note = state.delivered[0]
+        assert note["source"] == "app:oncall-radar"
+        assert note["channel"] == "oncall-radar.ticket-update"
+        assert note["kind"] == "ticket-update"
+
+    @pytest.mark.asyncio
+    async def test_channel_default_priority_applied(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "alerts", "title": "t", "body": "b"},
+                )
+        assert state.delivered[0]["priority"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_channel_rejected(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "not-declared", "title": "t", "body": "b"},
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_or_unknown_app_rejected(self):
+        state = _FakeState()
+        with _patch_channels(channels=None), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 403
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_no_app_identity_rejected(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": ""}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 403
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_returns_429(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                statuses = []
+                for _ in range(RATE_LIMIT_BURST + 1):
+                    resp = await client.post(
+                        "/api/notifications/push",
+                        json={"channel": "ticket-update", "title": "t", "body": "b"},
+                    )
+                    statuses.append(resp.status)
+        assert statuses[:RATE_LIMIT_BURST] == [200] * RATE_LIMIT_BURST
+        assert statuses[-1] == 429
+        assert len(state.delivered) == RATE_LIMIT_BURST
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_rejected(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    data=b"not json",
+                    headers={"Content-Type": "application/json"},
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_field_rejected(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={
+                        "channel": "ticket-update",
+                        "title": "t",
+                        "body": "b",
+                        "url": "https://evil.example.com/",
+                    },
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_json_body_must_be_object(self):
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    data=json.dumps([1, 2]),
+                    headers={"Content-Type": "application/json"},
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_oversized_chunked_body_rejected(self):
+        # Regression: chunked transfer-encoding carries no Content-Length, so
+        # the header-based size check alone would let an oversized body
+        # through to the JSON parser.
+        state = _FakeState()
+
+        async def gen():
+            yield b'{"channel": "ticket-update", "title": "t", "body": "'
+            yield b"x" * (64 * 1024)
+            yield b'"}'
+
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    data=gen(),
+                    headers={"Content-Type": "application/json"},
+                )
+        assert resp.status == 413
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_falsy_group_key_preserved(self):
+        # Regression: group_key 0 is a valid grouping identifier -- a
+        # truthiness guard would silently drop it to None.
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b", "group_key": 0},
+                )
+        assert resp.status == 200
+        assert state.delivered[0]["group_key"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_url_rejected_not_dropped(self):
+        # Regression: url "" is a client bug -- it must fail validation with
+        # 400 rather than be silently treated as absent.
+        state = _FakeState()
+        with _patch_channels(), _fresh_limiter():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b", "url": ""},
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_rate_limiter_is_state_owned_not_module_global(self):
+        # Regression: two gateway states must not share rate-limit budgets
+        # (the limiter was previously a module-level singleton).
+        state_a = _FakeState()
+        state_b = _FakeState()
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state_a, {"app": "oncall-radar"}))) as ca:
+                for _ in range(RATE_LIMIT_BURST):
+                    resp = await ca.post(
+                        "/api/notifications/push",
+                        json={"channel": "ticket-update", "title": "t", "body": "b"},
+                    )
+                    assert resp.status == 200
+                resp = await ca.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                assert resp.status == 429
+            async with TestClient(TestServer(_make_app(state_b, {"app": "oncall-radar"}))) as cb:
+                resp = await cb.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_body_size_boundary_exact(self):
+        # Regression: prove the cap boundary is exact for chunked bodies --
+        # exactly _MAX_BODY_BYTES must pass the size gate (it then fails
+        # payload validation with 400 because the body field exceeds its own
+        # cap, which proves the 413 gate was cleared), one byte more -> 413.
+        from kiro_crew.dashboard.handlers.notifications_push import _MAX_BODY_BYTES
+
+        prefix = b'{"channel": "ticket-update", "title": "t", "body": "'
+        suffix = b'"}'
+        filler = _MAX_BODY_BYTES - len(prefix) - len(suffix)
+
+        async def gen(extra: int):
+            yield prefix
+            yield b"x" * (filler + extra)
+            yield suffix
+
+        state = _FakeState()
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                at_cap = await client.post(
+                    "/api/notifications/push",
+                    data=gen(0),
+                    headers={"Content-Type": "application/json"},
+                )
+                over_cap = await client.post(
+                    "/api/notifications/push",
+                    data=gen(1),
+                    headers={"Content-Type": "application/json"},
+                )
+        assert at_cap.status != 413
+        assert over_cap.status == 413
+
+    def test_resolve_app_channels_is_read_only(self):
+        # Regression: _resolve_app_channels runs in a worker thread, so it
+        # must never call get_app (its version-sync write to installed.json
+        # would race loop-side writers).
+        from kiro_crew.dashboard.handlers.notifications_push import _resolve_app_channels
+
+        with patch("kiro_crew.apps.manager.get_app") as get_app_mock, patch(
+            "kiro_crew.dashboard.handlers.notifications_push.is_app_enabled",
+            return_value=False,
+        ):
+            assert _resolve_app_channels("some-app") is None
+        get_app_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_app_token_denial_emits_sel_audit(self):
+        # Regression: every denial path must emit a SEL audit event -- the
+        # no-app-token 403 previously skipped it.
+        state = _FakeState()
+        with patch(
+            "kiro_crew.dashboard.handlers.notifications_push.sel"
+        ) as sel_mock:
+            async with TestClient(TestServer(_make_app(state, {"app": ""}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 403
+        calls = sel_mock.return_value.log_api_access.call_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs["outcome"] == "denied"
+        assert calls[0].kwargs["error"] == "app token required"
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_does_not_consume_rate_token(self):
+        # Regression: the rate limiter caps DELIVERED notifications -- invalid
+        # payloads (400) must not drain the budget and block later retries.
+        state = _FakeState()
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                for _ in range(RATE_LIMIT_BURST + 3):
+                    resp = await client.post(
+                        "/api/notifications/push",
+                        json={"channel": "ticket-update", "title": "t", "body": "b",
+                              "url": "https://evil.example.com/"},
+                    )
+                    assert resp.status == 400
+                # Budget untouched: a valid push still succeeds.
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 200
+        assert len(state.delivered) == 1
+
+    @pytest.mark.asyncio
+    async def test_corrupt_manifest_priority_returns_400_not_500(self):
+        # Regression: a corrupt on-disk manifest defaultPriority previously
+        # raised out of register_channel unhandled (500).
+        state = _FakeState()
+        with _patch_channels(channels={"ticket-update": "not-a-priority"}):
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 400
+        assert state.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_register_once_does_not_stomp_runtime_priority_override(self):
+        # Regression: re-registering on every push would reset a runtime
+        # per-channel priority override (RFC Phase 3) back to the manifest
+        # default. Registration must be first-push-only -- assert the call
+        # count explicitly rather than relying on the priority side-effect.
+        state = _FakeState()
+        register_spy = MagicMock(wraps=state.notification_bus.register_channel)
+        state.notification_bus.register_channel = register_spy  # type: ignore[method-assign]
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                # Simulate a Phase 3 runtime override (direct bus call, not
+                # via the spy -- the spy wraps the same underlying method).
+                register_spy("oncall-radar.ticket-update", "critical")
+                await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t2", "body": "b"},
+                )
+        # Explicit call-args assertion: the handler registered exactly once
+        # (first push, manifest default); the only other call is the test's
+        # own override. A handler that re-registered on the second push would
+        # append a third ("default") call AND flip the delivered priority.
+        assert register_spy.call_args_list == [
+            (("oncall-radar.ticket-update", "default"), {}),
+            (("oncall-radar.ticket-update", "critical"), {}),
+        ]
+        assert state.delivered[1]["priority"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_corrupt_manifest_400_does_not_consume_rate_token(self):
+        # Regression: registration failure (corrupt manifest priority) is a
+        # 400 that delivers nothing -- it must not drain the rate budget.
+        state = _FakeState()
+        with _patch_channels(channels={"ticket-update": "not-a-priority"}):
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                for _ in range(RATE_LIMIT_BURST + 3):
+                    resp = await client.post(
+                        "/api/notifications/push",
+                        json={"channel": "ticket-update", "title": "t", "body": "b"},
+                    )
+                    assert resp.status == 400
+        # Budget untouched: with a sane channel map the same app still pushes.
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_sink_failure_returns_clean_500_with_sel_audit(self):
+        # Regression: a sink failure (e.g. disk full during persist) must be
+        # a clean SEL-logged 500, not an unhandled exception.
+        state = _FakeState()
+
+        def exploding_sink(note):
+            raise OSError("disk full")
+
+        state.notification_bus = NotificationBus(sink=exploding_sink)
+        with _patch_channels(), patch(
+            "kiro_crew.dashboard.handlers.notifications_push.sel"
+        ) as sel_mock:
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                body = await resp.json()
+        assert resp.status == 500
+        assert body["error"] == "notification delivery failed"
+        outcomes = [c.kwargs.get("outcome") for c in sel_mock.return_value.log_api_access.call_args_list]
+        assert "error" in outcomes
+
+
+class TestPushDurability:
+    @pytest.mark.asyncio
+    async def test_persist_failure_returns_500_with_sel_audit(self):
+        """A 200 is a durability guarantee: when the sink's persist job
+        reports failure, the endpoint returns 500 and SEL-audits it (token
+        stays spent -- the note WAS broadcast)."""
+        state = _FakeState()
+
+        def failing_sink(note):
+            state.delivered.append(note)
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(False)  # persist reported failure
+            state.last_notification_persist = fut
+
+        state.notification_bus = NotificationBus(sink=failing_sink)
+        with _patch_channels(), patch(
+            "kiro_crew.dashboard.handlers.notifications_push.sel"
+        ) as sel_mock:
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                body = await resp.json()
+        assert resp.status == 500
+        assert body["error"] == "notification persistence failed"
+        outcomes = [
+            c.kwargs.get("outcome")
+            for c in sel_mock.return_value.log_api_access.call_args_list
+        ]
+        assert "error" in outcomes
+
+    @pytest.mark.asyncio
+    async def test_success_returns_enriched_note(self):
+        """Per the system spec, a 200 carries the enriched note (resolved
+        source, full channel, effective priority, server ts)."""
+        state = _FakeState()
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body["ok"] is True
+        note = body["note"]
+        assert note["source"] == "app:oncall-radar"
+        assert note["channel"] == "oncall-radar.ticket-update"
+        assert note["priority"]
+        assert note["ts"]
+
+    @pytest.mark.asyncio
+    async def test_durable_persist_success_returns_200(self):
+        """When the persist future resolves True, the push succeeds."""
+        state = _FakeState()
+
+        def durable_sink(note):
+            state.delivered.append(note)
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(True)
+            state.last_notification_persist = fut
+
+        state.notification_bus = NotificationBus(sink=durable_sink)
+        with _patch_channels():
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "ticket-update", "title": "t", "body": "b"},
+                )
+        assert resp.status == 200
+
+
+class TestSigningPayloadCoversNotifications:
+    def test_channel_tamper_changes_signing_payload(self):
+        # Regression: notifications.channels must be signature-covered --
+        # tampering with declarations (e.g. escalating defaultPriority to
+        # critical) must invalidate the admission signature.
+        base = AppManifest(name="a", version="1.0.0")
+        signed = AppManifest(
+            name="a", version="1.0.0",
+            notifications=NotificationsConfig(
+                channels=[NotificationChannel(id="alerts", name="Alerts")]
+            ),
+        )
+        tampered = AppManifest(
+            name="a", version="1.0.0",
+            notifications=NotificationsConfig(
+                channels=[NotificationChannel(id="alerts", name="Alerts", defaultPriority="critical")]
+            ),
+        )
+        assert signed.signing_payload() != base.signing_payload()
+        assert tampered.signing_payload() != signed.signing_payload()
+
+    def test_no_channels_keeps_pre_phase2_payload_shape(self):
+        # Manifests signed before notifications existed must keep producing
+        # the identical payload (no key present when channels are empty).
+        m = AppManifest(name="a", version="1.0.0")
+        assert b"notifications" not in m.signing_payload()


### PR DESCRIPTION
## Summary
Phase 2 of the local notification bus RFC (`docs/request-for-change/rfc-local-notification-bus.md`): apps become first-class notification producers. Supersedes #184 (#183/#182/#158) — single-commit PR Hygiene + blocked force-push means each review round ships as a fresh branch.

- **POST /api/notifications/push** — app-token-only endpoint; `source` is server-resolved from the verified token identity, never body-supplied. **A 200 is a durability guarantee**: the handler awaits the persist job before acknowledging and returns the enriched note `{ok, note}`; a persistence failure returns a SEL-audited 500 (token stays spent — the note was broadcast).
- **app.json `notifications.channels`** — manifest-declared channels (8-channel cap, kebab-case ids, per-channel `defaultPriority`)
- **Signing coverage** — `signing_payload()` covers `notifications` (tamper-evident channel declarations; byte-identical payload for channel-less manifests)
- **Rate limiting** — state-owned `AppRateLimiter` (30 per 5 min, burst 10); tokens consumed only by delivered notifications
- **Least privilege** — deny-by-default app-token grant scoped to the single push-only path; read-only `is_app_enabled()` safe for `asyncio.to_thread`
- **Event-loop safety + write ordering** — ALL notification file mutations (delivery appends AND delete/ack/unack/clear/ack-all rewrites) serialize through one single-worker executor in submission order: no file I/O or locks on the event loop, no resurrection of deleted rows. Mutation endpoints await durability; legacy system producers stay explicitly best-effort fire-and-forget (`_persist_notification` reports success via return value, sink stashes the future on `state.last_notification_persist`).
- **System spec** — `docs/system-specs/features/app-notifications.md` (endpoint contract incl. exact response shape, pipeline order, manifest schema matching the parser, authz, rate limiting, serialized persistence + durability semantics)

## Review history
Ported from the internal tree (5-round adversarial review, 9 findings fixed). All Codex findings across 4 rounds fixed: #158 loop-blocking persist + missing spec; #182 rewrite/append ordering + loop-side lock + spec field mismatch; #183 ack-all outside the executor; #184 push acknowledging before durability + response shape not matching the documented contract. Claude Review passed on #158 with one LOW advisory (reserved `system` app-name shadowing) — recorded as a follow-up in the spec.

## Testing
- 42 handler + 20 persistence tests (new this round: persist-failure 500 + SEL, enriched-note response contract, durable-success 200)
- `test_action_interactions.py` (28) covering the awaited Slack ack path; bus (48) + manifest (48) suites unaffected
- isort + flake8 + mypy clean