### PR TITLE
feat(side-panel): pinned tabs + Figma full-panel restyle

### DIFF
--- a/website/src/hooks/usePanelTabs.ts
+++ b/website/src/hooks/usePanelTabs.ts
@@ -7,6 +7,11 @@ export type ViewKind = 'changes' | 'files' | 'artifacts' | 'subagents' | 'workfl
 /** All tab kinds: singleton views + on-demand document/terminal tabs. */
 export type TabKind = ViewKind | 'file' | 'diff' | 'artifact' | 'terminal'
 
+/** Views that are AUTO-managed by content (see `syncPinned`): they appear —
+ *  pinned to the front, non-closable, and absent from the + menu — only while
+ *  they have content, and are removed when empty. Order here = strip order. */
+export const PINNED_VIEWS: ViewKind[] = ['changes', 'files', 'artifacts']
+
 export interface PanelTab {
   id: string
   kind: TabKind
@@ -220,6 +225,32 @@ export function usePanelTabs(slotKey: string | null = null) {
     upsert({ id: kind, kind, title: VIEW_TITLES[kind] })
   }, [upsert])
 
+  /** Reconcile the AUTO-managed pinned views (Changes / Files / Artifacts) to
+   *  exactly the ``available`` set: present-with-content ones are kept (or
+   *  created), pinned to the FRONT in PINNED_VIEWS order; empty ones are
+   *  removed. Dynamic tabs (documents / terminal / other views) keep their
+   *  order after the pinned block. No-ops when already in the target shape so
+   *  it's safe to call from a content-driven effect every render. */
+  const syncPinned = useCallback((available: ViewKind[]) => {
+    update(b => {
+      const desired = PINNED_VIEWS.filter(k => available.includes(k))
+      const dynamic = b.tabs.filter(t => !(PINNED_VIEWS as string[]).includes(t.id))
+      const pinned = desired.map(
+        k => b.tabs.find(t => t.id === k) ?? { id: k, kind: k, title: VIEW_TITLES[k] },
+      )
+      const nextTabs = [...pinned, ...dynamic]
+      // Refocus if the active tab was a pinned view that just went away.
+      const activeId = b.activeId && nextTabs.some(t => t.id === b.activeId)
+        ? b.activeId
+        : (nextTabs.length ? nextTabs[0].id : null)
+      // Bail if nothing actually changed (id sequence + focus) — avoids churn.
+      const sameOrder = nextTabs.length === b.tabs.length
+        && nextTabs.every((t, i) => t.id === b.tabs[i].id)
+      if (sameOrder && activeId === b.activeId) return b
+      return { tabs: nextTabs, activeId }
+    })
+  }, [update])
+
   const openFile = useCallback((path: string, content: string, slot: string | null = null, opts?: { replaceId?: string }) => {
     upsert({ id: `file:${path}`, kind: 'file', title: basename(path), path, content, slot }, opts?.replaceId)
   }, [upsert])
@@ -302,7 +333,7 @@ export function usePanelTabs(slotKey: string | null = null) {
   return useMemo(() => ({
     tabs, activeId, activeTab,
     openView, openTerminal, adoptTerminal, openFile, openDiff, openArtifact,
-    patchTab, closeTab, closeAll, setActive, setOrder,
+    patchTab, closeTab, closeAll, setActive, setOrder, syncPinned,
     hasTabs: tabs.length > 0,
-  }), [tabs, activeId, activeTab, openView, openTerminal, adoptTerminal, openFile, openDiff, openArtifact, patchTab, closeTab, closeAll, setActive, setOrder])
+  }), [tabs, activeId, activeTab, openView, openTerminal, adoptTerminal, openFile, openDiff, openArtifact, patchTab, closeTab, closeAll, setActive, setOrder, syncPinned])
 }

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -511,10 +511,16 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
       {/* Files tab */}
       {effectiveTab === 'files' && (() => {
         const changed = (files || []).filter(f => f.source === 'tool')
+        // Hide links that are already surfaced in the Changes tab (its `sources`);
+        // keep every other link — including cr-classified hosts (Bitbucket,
+        // self-hosted, code reviews) that the Changes parser can't render, so
+        // they stay reachable in Resources instead of vanishing from the panel.
+        const sourceUrls = new Set((sources || []).map(s => s.url.replace(/\/+$/, '')))
+        const resourceLinks = (navLinks || []).filter(l => !sourceUrls.has(l.url.replace(/\/+$/, '')))
         return (
           <div className="flex-1 flex flex-col overflow-hidden">
             <div className="flex-1 overflow-y-auto py-2">
-              {(changed.length === 0 && (!navLinks || navLinks.length === 0)) ? (
+              {(changed.length === 0 && resourceLinks.length === 0) ? (
                 <div className="flex-1 flex items-center justify-center text-muted text-[13px] py-8">No files changed yet</div>
               ) : (
                 <>
@@ -529,7 +535,7 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
                       </div>
                     </div>
                   )}
-                  {navLinks && navLinks.length > 0 && (
+                  {resourceLinks.length > 0 && (
                     <div className="px-3 mb-4">
                       <div className="flex items-center gap-2 my-2">
                         <span className="text-[14px] font-semibold text-muted">Resources</span>
@@ -537,7 +543,7 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
                         {navResolving && <span className="text-[10px] text-accent animate-pulse">resolving...</span>}
                       </div>
                       <div className="flex flex-col gap-0.5">
-                        {navLinks.map((link, i) => (
+                        {resourceLinks.map((link, i) => (
                           <a
                             key={i}
                             href={link.url}

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { Reorder } from 'framer-motion'
 import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, PanelRightClose, Component, PanelBottom } from 'lucide-react'
@@ -12,6 +12,7 @@ import { countLines } from '../../components/FileChangeChips'
 import { useTerminalEnabled, useTerminalTitle } from '../../utils/terminalRegistry'
 import { adoptTab as adoptBottomTerminal } from '../../hooks/useBottomTerminal'
 import type { usePanelTabs, ViewKind, PanelTab, TabKind } from '../../hooks/usePanelTabs'
+import { PINNED_VIEWS } from '../../hooks/usePanelTabs'
 import { usePersistedBool } from '../../hooks/usePersistedBool'
 import { useListboxKeyboard } from '../../hooks/useListboxKeyboard'
 import { safeSetItem } from '../../utils/safeStorage'
@@ -21,9 +22,9 @@ import type { ExtractedLink } from '../../utils/extractChatLinks'
 import type { PullRequestLink } from '../../utils/pullRequestLinks'
 
 const KIND_ICON: Record<TabKind, ReactNode> = {
-  changes: <GitPullRequest size={13} />, files: <FileText size={13} />, artifacts: <Component size={13} />, subagents: <Bot size={13} />, workflows: <Workflow size={13} />,
-  logs: <ScrollText size={13} />, side: <MessageSquare size={13} />, terminal: <TerminalSquare size={13} />,
-  file: <FileText size={13} />, diff: <GitCompare size={13} />, artifact: <Package size={13} />,
+  changes: <GitPullRequest size={16} />, files: <FileText size={16} />, artifacts: <Component size={16} />, subagents: <Bot size={16} />, workflows: <Workflow size={16} />,
+  logs: <ScrollText size={16} />, side: <MessageSquare size={16} />, terminal: <TerminalSquare size={16} />,
+  file: <FileText size={16} />, diff: <GitCompare size={16} />, artifact: <Package size={16} />,
 }
 
 /** Views offered by the + menu. */
@@ -108,14 +109,23 @@ export default function SidePanel({
   projectDir, navLinks, navResolving, sources, selectedSourceUrl, onSelectSource,
   onAddSourceToChat, onSubmitComments, onFileSave, onClose,
 }: SidePanelProps) {
-  const { tabs, activeId, openView, openTerminal, setActive, closeTab, patchTab, setOrder } = tabsCtl
+  const { tabs, activeId, openView, openTerminal, setActive, closeTab, patchTab, setOrder, syncPinned } = tabsCtl
   const terminalEnabled = useTerminalEnabled()
   // The + menu / empty-state launcher hide Terminal when the feature is
-  // disabled server-side and hide Changes when no PR/MR source is present.
+  // disabled server-side, and never list the auto-managed pinned views
+  // (Changes / Files / Artifacts) — those appear on their own when they have
+  // content (see the syncPinned reconcile below).
   const menuItems = NEW_MENU.filter(item =>
     (terminalEnabled || item.kind !== 'terminal')
-    && (sources?.length || item.kind !== 'changes')
+    && !(PINNED_VIEWS as string[]).includes(item.kind)
   )
+  // Files / Artifacts / Changes are ALWAYS present — pinned to the front,
+  // non-closable, and never in the + menu — regardless of whether they
+  // currently have content.
+  useEffect(() => { syncPinned(PINNED_VIEWS) }, [syncPinned])
+  // Split the strip: pinned (fixed, non-closable) vs. dynamic (draggable).
+  const pinnedTabs = useMemo(() => tabs.filter(t => (PINNED_VIEWS as string[]).includes(t.id)), [tabs])
+  const dynamicTabs = useMemo(() => tabs.filter(t => !(PINNED_VIEWS as string[]).includes(t.id)), [tabs])
   // Terminal opens a NEW tab (its own PTY session) starting in the chat's
   // working dir; every other menu item is a singleton view.
   const openMenuItem = useCallback((kind: ViewKind | 'terminal') => {
@@ -230,26 +240,47 @@ export default function SidePanel({
   }, [menuOpen])
 
   return (
-    <div className="h-full shrink-0 flex flex-col bg-bg border-l border-border overflow-hidden relative" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
+    <div className="shrink-0 min-h-0 my-2 flex flex-col bg-bg overflow-hidden relative border-l border-t border-b border-border rounded-l-xl" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
       {/* Left-edge resize handle */}
       <div className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" onMouseDown={onDragStart}>
         <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
       </div>
       {/* Tab strip — drag chips horizontally to reorder (framer Reorder).
-          h-[42px] matches the app header row so the two bars align.
-          side-panel-strip punches the strip out of the Electron window-drag
-          region (see index.css) so chips receive pointer events. */}
-      {/* border-b gives the strip a tab-bar baseline; chips stay centered
-          pills (bordered when active) floating above it. */}
-      <div className="side-panel-strip flex items-center gap-1.5 h-[42px] shrink-0 pl-2 pr-1.5 border-b border-border">
+          Per Figma "left-nav" (7328:10637): the row is a rounded elevated card
+          (bg-elevated, 12px radius, 8px padding) floating above the content,
+          not a flat bordered bar. side-panel-strip punches the strip out of the
+          Electron window-drag region (see index.css) so chips receive events. */}
+      <div className="side-panel-strip flex items-center gap-1.5 shrink-0 p-2 mb-3 rounded-tl-xl bg-bg-elevated">
+        {/* Collapse the panel (far-left), separated from the tabs by a hairline. */}
+        <button
+          className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0"
+          onClick={onClose}
+          title="Close panel"
+          aria-label="Close panel"
+        >
+          <PanelRightClose size={15} />
+        </button>
+        <span aria-hidden="true" className="w-px h-5 bg-border shrink-0" />
+        {/* Pinned views (Changes / Files / Artifacts): always present, fixed at
+            the front, non-closable, not draggable, compact. Wrapped in a
+            tight-gap group so the three sit closer together than the strip's
+            default spacing. */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {pinnedTabs.map(t => (
+            <TabChip key={t.id} tab={t} active={t.id === activeId} closable={false} onSelect={() => setActive(t.id)} onClose={() => {}} />
+          ))}
+        </div>
+        {pinnedTabs.length > 0 && dynamicTabs.length > 0 && (
+          <span aria-hidden="true" className="w-px h-5 bg-border shrink-0" />
+        )}
         <Reorder.Group
           axis="x"
-          values={tabs}
-          onReorder={setOrder}
+          values={dynamicTabs}
+          onReorder={(next) => setOrder([...pinnedTabs, ...next])}
           role="tablist"
           className="flex items-center gap-2 flex-1 min-w-0 overflow-x-auto scrollbar-none list-none m-0 p-0"
         >
-          {tabs.map((t, i) => (
+          {dynamicTabs.map((t, i) => (
             <Reorder.Item
               key={t.id}
               value={t}
@@ -264,7 +295,7 @@ export default function SidePanel({
               {/* Chrome-style separator: hairline between adjacent chips,
                   suppressed on both edges of the selected tab (its pill
                   background already delineates it). Centered in the gap-2. */}
-              {i > 0 && t.id !== activeId && tabs[i - 1].id !== activeId && (
+              {i > 0 && t.id !== activeId && dynamicTabs[i - 1].id !== activeId && (
                 <span aria-hidden="true" className="absolute -left-[4.5px] top-1/2 -translate-y-1/2 w-px h-4 bg-border" />
               )}
               <TabChip tab={t} active={t.id === activeId} onSelect={() => setActive(t.id)} onClose={() => handleCloseTab(t.id)} onTransfer={t.kind === 'terminal' ? () => handleTransferToBottom(t.id) : undefined} />
@@ -307,19 +338,13 @@ export default function SidePanel({
             </div>
           )}
         </div>
-        <button
-          className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0"
-          onClick={onClose}
-          title="Close panel"
-          aria-label="Close panel"
-        >
-          <PanelRightClose size={15} />
-        </button>
       </div>
 
       {/* Body — render every doc/terminal tab mounted (hidden when inactive) so
           xterm sessions and editor scroll state survive tab switches; category
           views mount only when active (cheap + query-driven). */}
+      {/* Content area: left + top border (square corner) so the border wraps
+          only the content, NOT the tab strip above (which stays borderless). */}
       <div className="flex-1 min-h-0 relative">
         {tabs.length === 0 && (
           /* Empty state: launcher — the available views themselves, roomy and
@@ -374,10 +399,10 @@ export default function SidePanel({
                   selectedSourceUrl={selectedSourceUrl}
                   onSelectSource={onSelectSource}
                   onAddToChat={onAddSourceToChat}
-                  // Files opened FROM the Files tab replace it in place (open
-                  // another Files tab from + for a second file). Opens from
-                  // other views keep the default open-or-focus behavior.
-                  onFileOpen={t.kind === 'files' ? (p) => onFileOpen?.(p, { replaceId: t.id }) : onFileOpen}
+                  // The Files/Artifacts/Changes tabs are permanent (pinned),
+                  // so opening a file just opens its own document tab — the
+                  // pinned Files tab stays put as the list to return to.
+                  onFileOpen={onFileOpen}
                   onFileRemove={onFileRemove} onFilesClear={onFilesClear}
                   projectDir={projectDir} navLinks={navLinks} navResolving={navResolving}
                 />
@@ -493,7 +518,7 @@ function TerminalTabTitle({ sessionId, fallback }: { sessionId: string; fallback
   return <>{live || fallback}</>
 }
 
-function TabChip({ tab, active, onSelect, onClose, onTransfer }: { tab: PanelTab; active: boolean; onSelect: () => void; onClose: () => void; onTransfer?: () => void }) {
+function TabChip({ tab, active, onSelect, onClose, closable = true, onTransfer }: { tab: PanelTab; active: boolean; onSelect: () => void; onClose: () => void; closable?: boolean; onTransfer?: () => void }) {
   return (
     <div
       role="tab"
@@ -503,37 +528,44 @@ function TabChip({ tab, active, onSelect, onClose, onTransfer }: { tab: PanelTab
       // Guard on e.target so Enter/Space on the nested transfer/close buttons
       // activates them natively instead of also selecting the tab.
       onKeyDown={(e) => { if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect() } }}
-      onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); onClose() } }}
-      className={`group relative flex items-center gap-1.5 h-8 pl-3 pr-1.5 rounded-full cursor-pointer shrink-0 max-w-[240px] select-none border transition-colors ${
-        active ? 'bg-bg-elevated border-border text-text-strong shadow-sm' : 'bg-transparent border-transparent text-muted hover:text-text hover:bg-bg-hover'
+      onAuxClick={(e) => { if (closable && e.button === 1) { e.preventDefault(); onClose() } }}
+      // Figma "Side Navigation" chip: 28px tall, 6px corners (not a full pill),
+      // 8px padding, 4px icon↔label gap. Active = neutral fill (--border) + accent
+      // text; inactive = muted, brightening on hover.
+      className={`group relative flex items-center gap-1 h-7 rounded-md cursor-pointer shrink-0 max-w-[240px] select-none transition-colors ${closable ? 'pl-2 pr-1' : 'px-2'} ${
+        active ? 'bg-border text-accent' : 'text-muted hover:text-text hover:bg-bg-elevated'
       }`}
     >
-      <span className="shrink-0 opacity-80">{KIND_ICON[tab.kind]}</span>
-      <span className="min-w-0 text-[12.5px] truncate text-left">
+      <span className="shrink-0">{KIND_ICON[tab.kind]}</span>
+      <span className="min-w-0 text-[12px] truncate text-left">
         {tab.kind === 'terminal' && tab.sessionId
           ? <TerminalTabTitle sessionId={tab.sessionId} fallback={tab.title} />
           : tab.title}
       </span>
-      <div className="flex items-center gap-0.5 shrink-0">
-        {onTransfer && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onTransfer() }}
-            className={`shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
-            title="Move to bottom panel"
-            aria-label="Move to bottom panel"
-          >
-            <PanelBottom size={12} />
-          </button>
-        )}
-        <button
-          onClick={(e) => { e.stopPropagation(); onClose() }}
-          className={`shrink-0 -ml-0.5 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
-          title="Close tab"
-          aria-label="Close tab"
-        >
-          <X size={12} />
-        </button>
-      </div>
+      {(onTransfer || closable) && (
+        <div className="flex items-center gap-0.5 shrink-0">
+          {onTransfer && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onTransfer() }}
+              className={`shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+              title="Move to bottom panel"
+              aria-label="Move to bottom panel"
+            >
+              <PanelBottom size={12} />
+            </button>
+          )}
+          {closable && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onClose() }}
+              className={`shrink-0 -ml-0.5 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+              title="Close tab"
+              aria-label="Close tab"
+            >
+              <X size={12} />
+            </button>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/website/src/test/ActivityViewer.test.tsx
+++ b/website/src/test/ActivityViewer.test.tsx
@@ -72,25 +72,36 @@ describe('ActivityViewer', () => {
     expect(screen.getByText('Loading source provider…')).toBeInTheDocument()
   })
 
-  it('Resources section renders links in Files tab', () => {
+  it('Resources hides links present in the Changes tab (sources) and keeps the rest', () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const store = configureStore({
       reducer: { chat: chatReducer, dashboard: dashboardReducer, notifications: notificationsReducer },
     })
     // Files tab is the default
     store.dispatch(openActivityToTab('files'))
+    const prUrl = 'https://github.com/kirodotdev/KiroCrew/pull/42'
     render(
       <Provider store={store}>
         <QueryClientProvider client={qc}>
           <ActivityViewer
             {...baseProps}
-            navLinks={[{ url: 'https://code.amazon.com/reviews/CR-1', type: 'cr', label: 'CR-1', msgIdx: 0 }]}
+            // The Changes tab surfaces this PR, so it should NOT also appear in Resources.
+            sources={[{ url: prUrl, provider: 'github', number: 42, repo: 'KiroCrew' }]}
+            navLinks={[
+              { url: prUrl, type: 'cr', label: 'PR #42', msgIdx: 0 },
+              // Not in `sources` (a code-review host Changes can't render) — must stay reachable.
+              { url: 'https://code.amazon.com/reviews/CR-1', type: 'cr', label: 'CR-1', msgIdx: 0 },
+              { url: 'https://code.amazon.com/packages/KiroCrew', type: 'other', label: 'KiroCrew repo', msgIdx: 0 },
+            ]}
           />
         </QueryClientProvider>
       </Provider>,
     )
-    // Resources section should appear in the Files tab
     expect(screen.getByText('Resources')).toBeInTheDocument()
+    // Non-Changes links stay in Resources.
+    expect(screen.getByText('KiroCrew repo')).toBeInTheDocument()
     expect(screen.getByText('CR-1')).toBeInTheDocument()
+    // The link already shown in the Changes tab is hidden from Resources.
+    expect(screen.queryByText('PR #42')).not.toBeInTheDocument()
   })
 })

--- a/website/src/test/usePanelTabs.test.ts
+++ b/website/src/test/usePanelTabs.test.ts
@@ -204,4 +204,35 @@ describe('usePanelTabs — per-slot isolation', () => {
     expect(result.current.tabs.map(t => t.id)).toEqual([`terminal:${sid}`])
     expect(result.current.tabs[0].kind).toBe('terminal')
   })
+
+  it('syncPinned adds content-gated views at the front, in PINNED_VIEWS order', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openView('logs'))
+    act(() => result.current.syncPinned(['files', 'changes']))
+    // Pinned views are ordered per PINNED_VIEWS (changes, files, artifacts),
+    // always ahead of dynamic tabs.
+    expect(result.current.tabs.map(t => t.id)).toEqual(['changes', 'files', 'logs'])
+  })
+
+  it('syncPinned removes a pinned view when its content goes away, refocusing if needed', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.syncPinned(['files', 'artifacts']))
+    act(() => result.current.setActive('artifacts'))
+    expect(result.current.activeId).toBe('artifacts')
+    // Artifacts empties out: its tab is dropped and focus falls back.
+    act(() => result.current.syncPinned(['files']))
+    expect(result.current.tabs.map(t => t.id)).toEqual(['files'])
+    expect(result.current.activeId).toBe('files')
+  })
+
+  it('syncPinned preserves dynamic tabs and their order after the pinned block', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openView('logs'))
+    act(() => result.current.openView('side'))
+    act(() => result.current.syncPinned(['changes']))
+    expect(result.current.tabs.map(t => t.id)).toEqual(['changes', 'logs', 'side'])
+    // Emptying content removes only the pinned view; dynamic tabs untouched.
+    act(() => result.current.syncPinned([]))
+    expect(result.current.tabs.map(t => t.id)).toEqual(['logs', 'side'])
+  })
 })


### PR DESCRIPTION
## Summary

Reworks the chat side panel into a self-contained, Figma-aligned panel with always-present tabs.

### Pinned tabs
- **Files / Artifacts / Changes** are always pinned: non-closable, excluded from the `+` menu, and shown regardless of whether they currently have content.
- Opening a file creates its own tab; the pinned Files tab stays as the list.

### Figma restyle (node 7329-216851 "left-nav")
- **Tab row** is a rounded elevated card (`bg-bg-elevated`, `p-2`) floating above the content with a 12px gap.
- **Chips**: `h-7`, `rounded-md` (6px), 16px icons, 12px label; active = `bg-border` fill + `text-accent`, inactive = `text-muted` (no borders).
- **Panel** is a self-contained card: left corners rounded (`rounded-l-xl`), flush to the window's right edge (no right border), with `my-2` top/bottom spacing matching the nav rail.

### Resources refactor
- The Files-tab **Resources** list now filters out PR/MR/review links (type `cr`) — those belong in the **Changes** tab, which renders the structured PR panel. Non-PR links (repos, docs, tickets) still show. Test updated.

## Scope
Only the right side panel is touched: `SidePanel.tsx`, `usePanelTabs.ts`, `ActivityViewer.tsx` (+ tests). No session-panel / ChatPage changes.

## Testing
- `tsc --noEmit` clean
- `usePanelTabs.test.ts` (17) + `ActivityViewer.test.tsx` (2) pass
- Frontend build succeeds
