### PR TITLE
fix(ci): use bare Bedrock inference-profile id for Fable design review

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -71,8 +71,19 @@ jobs:
           # Inference via Amazon Bedrock (region from the AWS creds step above).
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Fable 5's Bedrock inference-profile id (from model_registry.json:
-          # canonical `fable-5-1m` → claude_code provider id). Read-only tools
+          # Fable 5's BARE, REGIONAL (`us.`) Bedrock inference-profile id.
+          # Two reasons it must be this exact form:
+          #  - No `[1m]` tag: that suffix is the Anthropic-API/claude_code
+          #    provider-id form in model_registry.json; the Bedrock path
+          #    (use_bedrock) rejects it as an unknown model.
+          #  - `us.` not `global.`: Fable requires data-retention mode
+          #    `provider_data_share`, set at the ACCOUNT level in us-west-2.
+          #    The regional `us.` profile honors that account setting; the
+          #    `global.` profile routes cross-region and falls back to
+          #    `default`, which the model rejects ("data retention mode
+          #    'default' is not available for this model"). Matches the
+          #    working claude-review.yml (`us.anthropic.claude-opus-4-8`).
+          # Read-only tools
           # only — the design reviewer inspects the diff, it does not edit or
           # post; the workflow parses the review from the run's execution_file
           # and posts it itself. NOTE: we deliberately do NOT use --json-schema —
@@ -82,8 +93,16 @@ jobs:
           # structured_output and errored. Plain-text capture + a parsed verdict
           # header is robust. Automation mode: `prompt` runs on the trigger
           # without an @claude mention.
+          #
+          # --fallback-model pins the overload fallback to Opus 4.8 (regional
+          # `us.` profile, as in claude-review.yml). Without it, Claude Code
+          # falls back to its own smaller/older default (e.g. 4.6) when Fable 5
+          # is overloaded; pinning keeps the reviewer on a top-tier model.
+          # us.anthropic.* is already IAM-granted and honors the account
+          # provider_data_share retention mode.
           claude_args: |
-            --model global.anthropic.claude-fable-5[1m]
+            --model us.anthropic.claude-fable-5
+            --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |


### PR DESCRIPTION
## Problem

The advisory **Design Review (Fable 5)** check produced no verdict: the run finished `is_error: true` at `$0` cost — the model call was rejected before any generation happened.

## Why it matters

The workflow runs with `continue-on-error` / `always()` and exits 0, so a rejected model call silently no-ops. PRs get **no** Fable design review while the check still shows as "passed," masking the failure.

## Fix (symptom → root cause → change)

Two independent defects made the `--model` slot invalid on the Bedrock `use_bedrock` path:

1. The value carried the `[1m]` context-window tag (`global.anthropic.claude-fable-5[1m]`). That suffix is the Anthropic-API / `claude_code` provider-id form from `model_registry.json`; the Bedrock path rejects it as an unknown model.
2. Even bare, the `global.` profile is wrong. Fable requires data-retention mode `provider_data_share` (set at the **account** level in us-west-2). The regional `us.` profile honors that account setting; the `global.` profile routes cross-region and falls back to `default`, which the model rejects (`data retention mode 'default' is not available for this model`).

**Change:** `--model us.anthropic.claude-fable-5` (bare, regional), matching the working `claude-review.yml` (`us.anthropic.claude-opus-4-8`). IAM already grants `us.anthropic.*`. `model_registry.json` / `model_tokens.json` (parity-tested) are left unchanged. Also pins `--fallback-model us.anthropic.claude-opus-4-8` so an overloaded Fable falls back only to Opus 4.8 (regional `us.` profile), never Claude Code's smaller default; fallback triggers only on overload (529).

## Tests

N/A — CI-workflow-only change. It is self-testing: this PR's own Design Review (Fable 5) run exercises the fixed configuration.

## Manual verification

- `get-account-data-retention` → `provider_data_share` in us-west-2.
- `bedrock converse`: `us.anthropic.claude-fable-5` replies; `global.anthropic.claude-fable-5` errors.
- `list-inference-profiles` shows `us.anthropic.claude-fable-5` ACTIVE.

## Note

The account-level `provider_data_share` data-retention change is an operator/account setting applied out-of-band on account `116101834266`; it is **not** part of this diff.
