### PR TITLE
fix(desktop): resolve symlinks in bundled kirocrew launcher

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -223,7 +223,18 @@ build_backend() {
   cat > "$out/bin/kirocrew" <<'LAUNCH'
 #!/bin/bash
 set -euo pipefail
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks before deriving DIR. When this launcher is reached through a
+# symlink (e.g. the ~/.local/bin/kirocrew shim planted on the user's PATH),
+# ${BASH_SOURCE[0]} is the symlink path, so a naive dirname points at the
+# symlink's directory and execs the wrong (or missing) python3.12. macOS ships
+# no `readlink -f`, so walk the symlink chain to the real wrapper location.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [ "${SOURCE:0:1}" != "/" ] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 exec "$DIR/python3.12" -s -m kiro_crew "$@"
 LAUNCH
   chmod +x "$out/bin/kirocrew"


### PR DESCRIPTION
## Problem
The bundled backend launcher `bin/kirocrew` (generated in `packaging/build-desktop.sh`) derives its directory from `${BASH_SOURCE[0]}` **without resolving symlinks**:
```bash
DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
exec "$DIR/python3.12" -s -m kiro_crew "$@"
```
The app plants a shim on the user's PATH at `~/.local/bin/kirocrew` as a **symlink** to this launcher. When `kirocrew` is invoked via that symlink, `${BASH_SOURCE[0]}` is the *symlink* path, so `DIR` resolves to `~/.local/bin` and the launcher execs `~/.local/bin/python3.12` — the wrong (often a uv-managed) interpreter that has no `kiro_crew`:
```
/Users/<you>/.local/bin/python3.12: No module named kiro_crew
```
This breaks the terminal `kirocrew` command on every app launch (the shim is recreated as a symlink each time).

## Fix
Resolve the symlink chain before deriving `DIR` so it always points at the *real* wrapper location inside the app bundle (next to the bundled `python3.12`). macOS ships no `readlink -f`, so we walk the chain portably.

## Testing
- Manually verified: symlinking `~/.local/bin/kirocrew` → the bundled launcher and invoking `kirocrew --version` / `kirocrew status` now resolves the bundled interpreter correctly instead of failing with `No module named kiro_crew`.
- Direct (non-symlink) invocation is unchanged.

## Notes
Only `packaging/build-desktop.sh` changed; the launcher heredoc is the single source for both `kirocrew-backend-arm64` and `kirocrew-backend-x64` wrappers.