### PR TITLE
fix(notifications): Phase 2 reviewer risks + Phase 3 per-channel settings backend

### DIFF
--- a/docs/system-specs/features/app-notifications.md
+++ b/docs/system-specs/features/app-notifications.md
@@ -66,7 +66,25 @@ Validation (`apps/manifest.py`): max 8 channels per app, kebab-case ids, unique 
 
 `test/test_notifications_push.py` (39 tests): auth bypass attempts, undeclared channels, oversized/chunked bodies, rate limit + refund semantics, falsy-but-valid fields, signing-payload coverage, register-once behavior, sink-failure 500. `test/test_dashboard.py` covers persistence, load-time redaction, and the executor-offloaded persist path.
 
+## Channel lifecycle
+
+Channels register lazily on an app's first push to each declared channel. On app uninstall or disable, `NotificationBus.unregister_app_channels(app_name)` removes every `<app>.*` channel from the registry (wired in `apps/routes.py`); re-enabling re-registers lazily on the next push. System channels are never removable. The app name `system` is rejected at manifest validation (`RESERVED_APP_NAMES`) AND denied defense-in-depth at the push endpoint, so app channels can never shadow the reserved `system.*` namespace.
+
+## Per-channel settings (Phase 3)
+
+User preferences per channel, stored in `~/.kirocrew/notification_settings.json` (`notifications/settings.py`, state-owned `ChannelSettings`, atomic-rename writes, corrupt file falls back to defaults):
+
+- **Mute**: the note still lands in history (mute silences, it does not destroy) but is stamped `silenced: true` with priority forced to `passive`, so every attention surface skips it — the unread badge counts only non-passive rows, and sound/banner/feed styling key off the same fields.
+- **Priority override**: the user's value replaces the producer-requested priority and channel default.
+- **Protected channels** (`system.approval`): cannot be muted and cannot have priority lowered — enforced at the settings API (400) AND at apply time, so even a hand-edited settings file cannot silence approvals (RFC exit criteria: approval still interrupts while heartbeat can be silenced everywhere).
+
+Settings are applied at the delivery sink (`_deliver_note`), before append/broadcast, so SSE clients and disk both see the user's view; the bus stays pure.
+
+API (dashboard-user only; app tokens have no grant here):
+- `GET /api/notifications/channels` — every registered channel plus channels with stored settings (even if currently unregistered, e.g. app disabled), each with `source`, `default_priority`, `protected`, and `settings`.
+- `PUT /api/notifications/channels/settings` — body `{"channel", "muted"?, "priority"?}`; `priority: null` clears the override. Changes broadcast over WS as `notification_channel_settings`.
+
 ## Known follow-ups
 
-- An app named `system` could produce `full_channel == "system.<id>"`, shadowing reserved system channels (cosmetic spoofing only — `source` stays `app:system` and is SEL-audited). Follow-up: reject reserved app names at install or namespace app channels distinctly.
-- Phase 3 (per RFC): per-channel user settings and runtime priority overrides.
+- Phase 3 frontend: settings UI section (channel list grouped by source), priority tiers wired through sound/native banner/feed styling, provisional keep/mute prompt for the first notification from a new app channel.
+- Phase 4 (per RFC): inline actions and grouping.

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -25,6 +25,12 @@ from typing import Any
 KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([+-]|$)")
 
+# App names that would collide with reserved notification namespaces: an app
+# named "system" would produce channels "system.<id>", shadowing the bus's
+# reserved system channels (e.g. "system.approval"). Rejected at manifest
+# validation AND defense-in-depth at the push endpoint.
+RESERVED_APP_NAMES = frozenset({"system"})
+
 
 def _path_escapes_app_root(rel_path: str, app_root: Path | None) -> bool:
     """Return True if ``rel_path`` is an unsafe app-resource path.
@@ -751,6 +757,11 @@ class AppManifest:
         elif not KEBAB_RE.match(self.name):
             errors.append(
                 f"name must be kebab-case (lowercase alphanumeric + hyphens), got: {self.name!r}"
+            )
+        elif self.name in RESERVED_APP_NAMES:
+            errors.append(
+                f"app name {self.name!r} is reserved (would shadow the "
+                f"{self.name}.* notification channel namespace)"
             )
 
         if not self.version:

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -182,6 +182,23 @@ def _redact_warning(msg: str) -> str:
 _BUILTIN_SERVICE_APPS: dict[str, tuple[str, str]] = {}
 
 
+def _unregister_notification_channels(request: web.Request, name: str) -> None:
+    """Drop *name*'s notification channels from the bus registry.
+
+    Called on uninstall/disable so channels don't linger as ghosts. Best
+    effort and side-effect free beyond the in-memory registry: the push
+    path independently re-checks enablement, so this is hygiene, not a
+    security control. Re-enabling re-registers lazily on first push.
+    """
+    state = request.app.get("state")
+    bus = getattr(state, "notification_bus", None) if state is not None else None
+    if bus is None:
+        return
+    removed = bus.unregister_app_channels(name)
+    if removed:
+        logger.info("Unregistered %d notification channel(s) for app %s", removed, name)
+
+
 def _sync_builtin_config(name: str, *, enabled: bool) -> None:
     """Update config.json for a builtin app so gateway reads the right state on restart."""
     cfg_key, _ = _BUILTIN_SERVICE_APPS.get(name, (None, None))
@@ -760,6 +777,7 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         sel().log_api_access(caller="dashboard", operation="app_uninstall", outcome="failed", resources=name, error=result.error)
         return web.json_response(result.to_dict(), status=400)
     invalidate_app_secret_cache(name)
+    _unregister_notification_channels(request, name)
 
     # Step 5: Clean up workspace (each registry app has its own workspace)
     if is_registry_source(info.get("source", "")):
@@ -968,6 +986,7 @@ async def handle_disable_app(request: web.Request) -> web.Response:
         if not result.ok:
             sel().log_api_access(caller="dashboard", operation="app_disable", outcome="failed", resources=name, error=result.error)
             return web.json_response(result.to_dict(), status=400)
+        _unregister_notification_channels(request, name)
 
         # Run builtin on_disable hook if available
         if name in BUILTIN_NAMES:

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -225,6 +225,8 @@ from kiro_crew.dashboard.handlers.messaging import (  # noqa: E402, F401
     api_discord_config_get,
     api_discord_config_save,
     api_notification_ack,
+    api_notification_channel_settings,
+    api_notification_channels,
     api_notification_delete,
     api_notification_unack,
     api_notifications,

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -418,6 +418,84 @@ async def api_notifications_ack_all(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+async def api_notification_channels(request: web.Request) -> web.Response:
+    """GET /api/notifications/channels — registered channels + user settings.
+
+    Returns every channel the bus knows about, grouped by source (``system``
+    or the owning app name), each with its default priority, the user's
+    stored settings, and whether it is protected (approval cannot be muted).
+    Channels with stored settings but no live registration (e.g. app
+    currently disabled) are included so mutes remain visible and editable.
+    """
+    from kiro_crew.notifications.settings import PROTECTED_CHANNELS
+
+    state: DashboardState = request.app["state"]
+    registered = state.notification_bus.channels()
+    stored = state.notification_channel_settings.all_settings()
+    channels = []
+    for channel in sorted(set(registered) | set(stored)):
+        source = channel.split(".", 1)[0]
+        channels.append(
+            {
+                "channel": channel,
+                "source": source,
+                "registered": channel in registered,
+                "default_priority": registered.get(channel),
+                "protected": channel in PROTECTED_CHANNELS,
+                "settings": stored.get(channel, {}),
+            }
+        )
+    return web.json_response({"channels": channels})
+
+
+async def api_notification_channel_settings(request: web.Request) -> web.Response:
+    """PUT /api/notifications/channels/settings — update one channel's settings.
+
+    Body: ``{"channel": str, "muted"?: bool, "priority"?: str|null}`` —
+    ``priority: null`` clears the override. Protected channels reject mute
+    and priority-lowering with 400.
+    """
+    from kiro_crew.notifications.settings import ChannelSettingsError
+
+    state: DashboardState = request.app["state"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+    if not isinstance(body, dict):
+        # Valid-but-non-object JSON ([], null, "str") would AttributeError on
+        # body.get below -- an unintended 500 instead of a validation 400.
+        return web.json_response({"error": "body must be a JSON object"}, status=400)
+    channel = body.get("channel")
+    if not isinstance(channel, str) or not channel.strip():
+        return web.json_response({"error": "channel is required"}, status=400)
+    channel = channel.strip()
+    if len(channel) > 256:
+        return web.json_response({"error": "channel name too long"}, status=400)
+    muted = body.get("muted")
+    if muted is not None and not isinstance(muted, bool):
+        return web.json_response({"error": "muted must be a boolean"}, status=400)
+    has_priority = "priority" in body
+    priority = body.get("priority")
+    if has_priority and priority is not None and not isinstance(priority, str):
+        return web.json_response({"error": "priority must be a string or null"}, status=400)
+    try:
+        # update() persists via atomic_write (blocking file I/O) -- keep it
+        # off the event loop. ChannelSettings serializes internally with its
+        # own lock, so concurrent updates from worker threads are safe.
+        entry = await asyncio.to_thread(
+            state.notification_channel_settings.update,
+            channel,
+            muted=muted,
+            priority=priority if has_priority and priority is not None else None,
+            clear_priority=has_priority and priority is None,
+        )
+    except ChannelSettingsError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    state.broadcast_ws("notification_channel_settings", {"channel": channel, "settings": entry})
+    return web.json_response({"ok": True, "channel": channel, "settings": entry})
+
+
 _MAX_BLOCKS = 50  # Slack Block Kit limit
 _MAX_WALK_DEPTH = 10  # defense-in-depth against deeply nested LLM output
 

--- a/src/kiro_crew/dashboard/handlers/notifications_push.py
+++ b/src/kiro_crew/dashboard/handlers/notifications_push.py
@@ -22,7 +22,8 @@ from typing import Any
 
 from aiohttp import web
 
-from kiro_crew.apps.manager import get_app_manifest, is_app_enabled
+from kiro_crew.apps.manager import app_lifecycle_lock, get_app_manifest, is_app_enabled
+from kiro_crew.apps.manifest import RESERVED_APP_NAMES
 from kiro_crew.notifications.bus import (
     NotificationPayload,
     NotificationValidationError,
@@ -43,6 +44,12 @@ def _resolve_app_channels(app_name: str) -> dict[str, str] | None:
     effect that would race loop-side writers of ``installed.json``).
     """
     if not is_app_enabled(app_name):
+        return None
+    if app_name in RESERVED_APP_NAMES:
+        # Defense-in-depth: manifest validation rejects reserved names at
+        # install, but an app installed before that rule existed (or via a
+        # path that skipped validation) must still be unable to push into
+        # the "<reserved>.*" channel namespace (e.g. "system.approval").
         return None
     manifest = get_app_manifest(app_name)
     if manifest is None:
@@ -89,38 +96,54 @@ async def api_push_notification(request: web.Request) -> web.Response:
     if not isinstance(body, dict):
         return web.json_response({"error": "body must be a JSON object"}, status=400)
 
-    # get_app/get_app_manifest read installed.json + app.json from disk (and
-    # may even write a version sync) -- keep that off the event loop. The
-    # await window this opens between the enablement check and bus.push()
-    # means an app disabled mid-request can still land one final
-    # notification; that is accepted (harmless) rather than locked against.
-    channels = await asyncio.to_thread(_resolve_app_channels, app_name)
-    if channels is None:
-        sel().log_api_access(
-            caller=app_name,
-            operation="notification_push",
-            outcome="denied",
-            source="notifications_api",
-            error="app not installed or not enabled",
-        )
-        return web.json_response({"error": "app not installed or not enabled"}, status=403)
-
-    channel_id = str(body.get("channel", ""))
-    if channel_id not in channels:
-        sel().log_api_access(
-            caller=app_name,
-            operation="notification_push",
-            outcome="denied",
-            source="notifications_api",
-            error=f"undeclared channel: {channel_id!r}",
-        )
-        return web.json_response(
-            {"error": f"channel not declared in app manifest: {channel_id!r}"}, status=400
-        )
-
     state = request.app["state"]
     bus = state.notification_bus
+    channel_id = str(body.get("channel", ""))
     full_channel = f"{app_name}.{channel_id}"
+
+    # Serialize enablement-check + channel registration with disable/
+    # uninstall (which unregister this app's channels under the same lock):
+    # without this, a push that passed the enablement check could re-register
+    # a channel AFTER disable's unregister ran, leaving registry residue for
+    # a disabled app. The lock is per-app and uncontended on the hot path;
+    # delivery itself happens after release (a disable landing in that gap
+    # unregisters the channel and the push fails closed with a refunded 400).
+    async with app_lifecycle_lock(app_name):
+        # get_app_manifest reads installed.json + app.json from disk -- keep
+        # that off the event loop.
+        channels = await asyncio.to_thread(_resolve_app_channels, app_name)
+        if channels is None:
+            sel().log_api_access(
+                caller=app_name,
+                operation="notification_push",
+                outcome="denied",
+                source="notifications_api",
+                error="app not installed or not enabled",
+            )
+            return web.json_response({"error": "app not installed or not enabled"}, status=403)
+
+        if channel_id not in channels:
+            sel().log_api_access(
+                caller=app_name,
+                operation="notification_push",
+                outcome="denied",
+                source="notifications_api",
+                error=f"undeclared channel: {channel_id!r}",
+            )
+            return web.json_response(
+                {"error": f"channel not declared in app manifest: {channel_id!r}"}, status=400
+            )
+
+        try:
+            # Register once per channel while still holding the lock. Its only
+            # failure mode (corrupt on-disk manifest defaultPriority) is a 400
+            # that delivers nothing and consumes no token. Re-registering on
+            # every push would stomp any later runtime priority override (RFC
+            # Phase 3); manifest priority changes take effect on restart.
+            if not bus.is_registered(full_channel):
+                bus.register_channel(full_channel, channels[channel_id])
+        except NotificationValidationError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
 
     priority_raw = body.get("priority")
     # ``is not None`` (not truthiness): falsy-but-valid values like
@@ -151,16 +174,9 @@ async def api_push_notification(request: web.Request) -> web.Response:
         # Validate BEFORE consuming a rate-limit token: the limiter's purpose
         # is capping delivered notifications (RFC "Rate limiting"), and
         # invalid payloads deliver nothing -- they must not drain the budget
-        # and then 429-block legitimate retries.
+        # and then 429-block legitimate retries. (Channel registration
+        # already happened above, under the lifecycle lock.)
         payload.validate()
-        # Register once per channel, also before the limiter: registration is
-        # cheap and idempotent, and its only failure mode (corrupt on-disk
-        # manifest defaultPriority) is a 400 that likewise delivers nothing.
-        # Re-registering on every push would stomp any later runtime priority
-        # override (RFC Phase 3 per-channel settings); manifest priority
-        # changes take effect on gateway restart.
-        if not bus.is_registered(full_channel):
-            bus.register_channel(full_channel, channels[channel_id])
     except NotificationValidationError as exc:
         return web.json_response({"error": str(exc)}, status=400)
 

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1608,6 +1608,8 @@ async def start_dashboard(
     app.router.add_post("/api/notifications/ack", handlers.api_notification_ack)
     app.router.add_post("/api/notifications/unack", handlers.api_notification_unack)
     app.router.add_post("/api/notifications/ack-all", handlers.api_notifications_ack_all)
+    app.router.add_get("/api/notifications/channels", handlers.api_notification_channels)
+    app.router.add_put("/api/notifications/channels/settings", handlers.api_notification_channel_settings)
     app.router.add_get("/api/update/check", handlers.api_update_check)
     app.router.add_get("/api/changelog", handlers.api_changelog)
     app.router.add_post("/api/update", handlers.api_update_apply)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -31,6 +31,7 @@ from kiro_crew.notifications.bus import (
     payload_from_legacy,
 )
 from kiro_crew.notifications.rate_limit import AppRateLimiter
+from kiro_crew.notifications.settings import ChannelSettings
 from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -1400,6 +1401,9 @@ class DashboardState:
         # global) so its lifecycle matches the gateway instance and tests get
         # isolation for free.
         self.notification_rate_limiter = AppRateLimiter()
+        # Per-channel user settings (RFC Phase 3): mute + priority override,
+        # applied at the delivery sink so the bus stays pure.
+        self.notification_channel_settings = ChannelSettings()
         self._slots: dict[str, _ChatSlot] = {}
         self._slack_to_slot: dict[str, str] = {}  # Slack session_key → slot name
         self._slot_counter = 0
@@ -1858,8 +1862,16 @@ class DashboardState:
         for key, value in note.items():
             if key != "ts":
                 note[key] = _redact_note_value(value)
+        # Per-channel user settings (RFC Phase 3): mute stamps silenced=True
+        # + forces passive; priority override replaces the effective priority.
+        # Applied before append/broadcast so SSE clients and disk both see
+        # the user's view.
+        self.notification_channel_settings.apply(note)
         self._notification_log.append(note)
-        self._unread_count += 1
+        # Badge counts attention-worthy rows only (RFC Phase 3: passive rows
+        # -- including muted-channel notes -- are excluded).
+        if note.get("priority") != "passive":
+            self._unread_count += 1
         self._broadcast(note)
         # Persistence does blocking file I/O (append + possible trim). The
         # bus sink is now externally drivable (Phase 2 app producers), so on

--- a/src/kiro_crew/notifications/bus.py
+++ b/src/kiro_crew/notifications/bus.py
@@ -224,8 +224,28 @@ class NotificationBus:
             return
         self._channels.pop(channel, None)
 
+    def unregister_app_channels(self, app_name: str) -> int:
+        """Remove every channel registered under *app_name* (``<app>.<id>``).
+
+        Called on app uninstall/disable so channels don't linger as ghosts in
+        the registry. System channels are never removed (the ``<app>.``
+        prefix cannot collide with them: ``system`` is a reserved app name).
+        Returns the number of channels removed.
+        """
+        prefix = f"{app_name}."
+        doomed = [
+            c for c in self._channels if c.startswith(prefix) and c not in SYSTEM_CHANNELS
+        ]
+        for channel in doomed:
+            self._channels.pop(channel, None)
+        return len(doomed)
+
     def is_registered(self, channel: str) -> bool:
         return channel in self._channels
+
+    def channels(self) -> dict[str, str]:
+        """Snapshot of registered channels: {channel: default_priority}."""
+        return dict(self._channels)
 
     def push(self, payload: NotificationPayload) -> dict[str, Any]:
         """Validate, enrich, and deliver a notification.

--- a/src/kiro_crew/notifications/settings.py
+++ b/src/kiro_crew/notifications/settings.py
@@ -1,0 +1,171 @@
+"""Per-channel notification settings (RFC local notification bus, Phase 3).
+
+User preferences for each notification channel: mute and priority override.
+Stored in ``~/.kirocrew/notification_settings.json`` as::
+
+    {"channel_settings": {"system.heartbeat": {"muted": true},
+                          "oncall-radar.ticket-update": {"priority": "critical"}}}
+
+Semantics (applied at the delivery sink, keeping the bus pure):
+
+- **muted**: the note is still delivered to history (history is a cache and
+  the user asked to silence, not to destroy) but is stamped ``silenced: true``
+  and its priority forced to ``passive``, so every attention surface (badge
+  count, sound, native banner, feed styling) skips it.
+- **priority**: user override wins over the producer-requested priority and
+  the channel default.
+- ``system.approval`` is protected: it cannot be muted and its priority
+  cannot be lowered (RFC exit criteria: approval still interrupts while
+  heartbeat can be silenced everywhere).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import config_dir
+from kiro_crew.notifications.bus import PRIORITIES
+
+logger = logging.getLogger(__name__)
+
+# Channels whose attention semantics the user may not weaken: approvals gate
+# agent actions, so silencing them would stall work invisibly.
+PROTECTED_CHANNELS = frozenset({"system.approval"})
+
+_SETTINGS_FILENAME = "notification_settings.json"
+_lock = threading.Lock()
+
+
+def _settings_path():
+    return config_dir() / _SETTINGS_FILENAME
+
+
+class ChannelSettingsError(ValueError):
+    """Invalid channel settings input (unknown priority, protected channel)."""
+
+
+class ChannelSettings:
+    """Load/store/apply per-channel user settings.
+
+    In-memory dict guarded by a lock; writes are atomic-rename. Owned by
+    ``DashboardState`` (one instance per gateway) like the bus and the rate
+    limiter.
+    """
+
+    def __init__(self) -> None:
+        self._settings: dict[str, dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        path = _settings_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                raw = data.get("channel_settings", {})
+                if isinstance(raw, dict):
+                    self._settings = {
+                        ch: dict(entry)
+                        for ch, entry in raw.items()
+                        if isinstance(entry, dict)
+                    }
+        except Exception:
+            # Corrupt settings must not take down the gateway; fall back to
+            # defaults (everything unmuted, producer priorities honored).
+            logger.warning("Failed to load %s; using defaults", path, exc_info=True)
+            self._settings = {}
+
+    def all_settings(self) -> dict[str, dict[str, Any]]:
+        """Snapshot of every channel's stored settings.
+
+        Lock-free: ``update()`` rebinds ``self._settings`` to a fresh dict
+        (never mutates in place), so readers see either the old or the new
+        complete mapping. Loop-side callers (``apply()`` on every delivery)
+        therefore never block on a worker-thread writer holding the lock
+        across the file write.
+        """
+        settings = self._settings
+        return {ch: dict(entry) for ch, entry in settings.items()}
+
+    def get(self, channel: str) -> dict[str, Any]:
+        """One channel's stored settings (lock-free; see all_settings)."""
+        return dict(self._settings.get(channel, {}))
+
+    def update(
+        self,
+        channel: str,
+        *,
+        muted: bool | None = None,
+        priority: str | None = None,
+        clear_priority: bool = False,
+    ) -> dict[str, Any]:
+        """Update one channel's settings and persist. Returns the new entry.
+
+        Raises :class:`ChannelSettingsError` for an unknown priority value,
+        or an attempt to mute / lower a protected channel.
+        """
+        if priority is not None and priority not in PRIORITIES:
+            raise ChannelSettingsError(
+                f"priority must be one of {PRIORITIES}, got {priority!r}"
+            )
+        if channel in PROTECTED_CHANNELS:
+            if muted:
+                raise ChannelSettingsError(f"{channel} cannot be muted")
+            if priority is not None and priority != "critical":
+                raise ChannelSettingsError(f"{channel} priority cannot be lowered")
+        # _lock serializes WRITERS only (read-modify-write below); readers
+        # are lock-free because this method rebinds self._settings wholesale.
+        with _lock:
+            entry = dict(self._settings.get(channel, {}))
+            if muted is not None:
+                if muted:
+                    entry["muted"] = True
+                else:
+                    entry.pop("muted", None)
+            if clear_priority:
+                entry.pop("priority", None)
+            elif priority is not None:
+                entry["priority"] = priority
+            # Persist the candidate FIRST, commit memory only on success:
+            # otherwise a full/read-only filesystem would leave the rejected
+            # setting active in memory (until restart) while disk kept the
+            # old value -- runtime disagreeing with both the HTTP response
+            # and persisted configuration.
+            candidate = dict(self._settings)
+            if entry:
+                candidate[channel] = entry
+            else:
+                candidate.pop(channel, None)
+            payload = json.dumps({"channel_settings": candidate}, indent=2)
+            atomic_write(_settings_path(), payload)
+            self._settings = candidate
+            return dict(entry)
+
+    def apply(self, note: dict[str, Any]) -> dict[str, Any]:
+        """Apply the note's channel settings in place and return it.
+
+        Mute stamps ``silenced: true`` and forces priority ``passive`` (all
+        attention surfaces key off these); a priority override replaces the
+        effective priority. Notes without a channel pass through untouched.
+        """
+        channel = note.get("channel")
+        if not channel:
+            return note
+        entry = self.get(channel)
+        if not entry:
+            return note
+        override = entry.get("priority")
+        if override in PRIORITIES and not (
+            channel in PROTECTED_CHANNELS and override != "critical"
+        ):
+            # Protected channels keep their attention floor even for rows
+            # that never went through update() (hand-edited settings file):
+            # a non-critical override on system.approval is ignored.
+            note["priority"] = override
+        if entry.get("muted") and channel not in PROTECTED_CHANNELS:
+            note["silenced"] = True
+            note["priority"] = "passive"
+        return note

--- a/test/test_notification_settings.py
+++ b/test/test_notification_settings.py
@@ -1,0 +1,333 @@
+"""Tests for per-channel notification settings (RFC Phase 3)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers.messaging import (
+    api_notification_channel_settings,
+    api_notification_channels,
+)
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.notifications.settings import (
+    PROTECTED_CHANNELS,
+    ChannelSettings,
+    ChannelSettingsError,
+)
+
+
+@pytest.fixture()
+def settings(monkeypatch, tmp_path) -> ChannelSettings:
+    monkeypatch.setattr("kiro_crew.notifications.settings.config_dir", lambda: tmp_path)
+    return ChannelSettings()
+
+
+def _make_state(monkeypatch, tmp_path) -> DashboardState:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("kiro_crew.notifications.settings.config_dir", lambda: tmp_path)
+    return DashboardState(
+        sessions=MagicMock(count=0),
+        crons=MagicMock(),
+        lessons=MagicMock(),
+        start_time=0.0,
+    )
+
+
+class TestChannelSettingsStore:
+    def test_mute_persists_and_reloads(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "kiro_crew.notifications.settings.config_dir", lambda: tmp_path
+        )
+        s = ChannelSettings()
+        s.update("system.heartbeat", muted=True)
+        # Fresh instance reads back from disk
+        s2 = ChannelSettings()
+        assert s2.get("system.heartbeat") == {"muted": True}
+
+    def test_unmute_removes_empty_entry(self, settings):
+        settings.update("a.b", muted=True)
+        settings.update("a.b", muted=False)
+        assert settings.get("a.b") == {}
+        assert settings.all_settings() == {}
+
+    def test_priority_override_and_clear(self, settings):
+        settings.update("a.b", priority="critical")
+        assert settings.get("a.b") == {"priority": "critical"}
+        settings.update("a.b", clear_priority=True)
+        assert settings.get("a.b") == {}
+
+    def test_invalid_priority_rejected(self, settings):
+        with pytest.raises(ChannelSettingsError, match="priority"):
+            settings.update("a.b", priority="urgent")
+
+    def test_protected_channel_cannot_be_muted_or_lowered(self, settings):
+        with pytest.raises(ChannelSettingsError, match="muted"):
+            settings.update("system.approval", muted=True)
+        with pytest.raises(ChannelSettingsError, match="lowered"):
+            settings.update("system.approval", priority="passive")
+        # Explicit critical is a no-op but allowed
+        settings.update("system.approval", priority="critical")
+
+    def test_corrupt_file_falls_back_to_defaults(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "kiro_crew.notifications.settings.config_dir", lambda: tmp_path
+        )
+        (tmp_path / "notification_settings.json").write_text("{not json", encoding="utf-8")
+        s = ChannelSettings()
+        assert s.all_settings() == {}
+
+    def test_apply_mute_forces_passive_and_silenced(self, settings):
+        settings.update("system.heartbeat", muted=True)
+        note = {"channel": "system.heartbeat", "priority": "default"}
+        settings.apply(note)
+        assert note["silenced"] is True
+        assert note["priority"] == "passive"
+
+    def test_apply_priority_override(self, settings):
+        settings.update("app.chan", priority="critical")
+        note = {"channel": "app.chan", "priority": "default"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+        assert "silenced" not in note
+
+    def test_apply_untouched_without_settings(self, settings):
+        note = {"channel": "app.chan", "priority": "default"}
+        settings.apply(note)
+        assert note == {"channel": "app.chan", "priority": "default"}
+
+
+class TestSinkIntegration:
+    def test_muted_channel_excluded_from_badge(self, monkeypatch, tmp_path):
+        """RFC exit criteria: muting system.heartbeat silences it everywhere
+        while badge count excludes passive rows."""
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_channel_settings.update("system.heartbeat", muted=True)
+        state._deliver_note(
+            {"ts": "t1", "kind": "heartbeat", "channel": "system.heartbeat",
+             "priority": "default", "title": "hb", "body": "b"}
+        )
+        state._deliver_note(
+            {"ts": "t2", "kind": "cron", "channel": "system.cron",
+             "priority": "default", "title": "job", "body": "b"}
+        )
+        assert state._unread_count == 1  # only the cron note counts
+        hb = state._notification_log[0]
+        assert hb["silenced"] is True and hb["priority"] == "passive"
+        # Still in history (mute silences, it does not destroy)
+        assert len(state._notification_log) == 2
+
+    def test_passive_priority_never_counts_toward_badge(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state._deliver_note(
+            {"ts": "t1", "kind": "subagent", "channel": "system.subagent",
+             "priority": "passive", "title": "s", "body": "b"}
+        )
+        assert state._unread_count == 0
+
+    def test_approval_still_interrupts(self, monkeypatch, tmp_path):
+        """system.approval cannot be silenced even with a rogue settings row
+        on disk (protected at apply time too)."""
+        state = _make_state(monkeypatch, tmp_path)
+        # Simulate a hand-edited settings file muting approval
+        state.notification_channel_settings._settings["system.approval"] = {"muted": True}
+        state._deliver_note(
+            {"ts": "t1", "kind": "approval", "channel": "system.approval",
+             "priority": "critical", "title": "a", "body": "b"}
+        )
+        note = state._notification_log[0]
+        assert "silenced" not in note
+        assert note["priority"] == "critical"
+        assert state._unread_count == 1
+
+
+def _make_app(state) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/api/notifications/channels", api_notification_channels)
+    app.router.add_put(
+        "/api/notifications/channels/settings", api_notification_channel_settings
+    )
+    return app
+
+
+class TestChannelSettingsApi:
+    @pytest.mark.asyncio
+    async def test_list_channels_includes_settings_and_protection(
+        self, monkeypatch, tmp_path
+    ):
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_bus.register_channel("my-app.alerts", "default")
+        state.notification_channel_settings.update("my-app.alerts", muted=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/notifications/channels")
+            body = await resp.json()
+        assert resp.status == 200
+        by_name = {c["channel"]: c for c in body["channels"]}
+        assert by_name["my-app.alerts"]["settings"] == {"muted": True}
+        assert by_name["my-app.alerts"]["source"] == "my-app"
+        assert by_name["system.approval"]["protected"] is True
+        assert by_name["system.cron"]["default_priority"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_stored_setting_for_unregistered_channel_still_listed(
+        self, monkeypatch, tmp_path
+    ):
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_channel_settings.update("gone-app.chan", muted=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/notifications/channels")
+            body = await resp.json()
+        by_name = {c["channel"]: c for c in body["channels"]}
+        assert by_name["gone-app.chan"]["registered"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_mute_roundtrip(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "system.heartbeat", "muted": True},
+            )
+            body = await resp.json()
+        assert resp.status == 200
+        assert body["settings"] == {"muted": True}
+        assert state.notification_channel_settings.get("system.heartbeat") == {
+            "muted": True
+        }
+        state.broadcast_ws.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_put_priority_null_clears_override(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.notification_channel_settings.update("a.b", priority="critical")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "priority": None},
+            )
+        assert resp.status == 200
+        assert state.notification_channel_settings.get("a.b") == {}
+
+    @pytest.mark.asyncio
+    async def test_put_protected_channel_mute_rejected(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "system.approval", "muted": True},
+            )
+            body = await resp.json()
+        assert resp.status == 400
+        assert "muted" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_validation_errors(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            r1 = await client.put(
+                "/api/notifications/channels/settings", json={"muted": True}
+            )
+            r2 = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "priority": "urgent"},
+            )
+            r3 = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "muted": "yes"},
+            )
+        assert r1.status == 400
+        assert r2.status == 400
+        assert r3.status == 400
+
+    @pytest.mark.asyncio
+    async def test_settings_file_written_atomically(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "muted": True},
+            )
+        data = json.loads((tmp_path / "notification_settings.json").read_text())
+        assert data == {"channel_settings": {"a.b": {"muted": True}}}
+
+
+class TestProtectedConstant:
+    def test_approval_is_protected(self):
+        assert "system.approval" in PROTECTED_CHANNELS
+
+
+class TestReviewRegressions:
+    def test_apply_ignores_noncritical_override_on_protected_channel(self, settings):
+        """Hand-edited {'system.approval': {'priority': 'passive'}} must NOT
+        lower approval's priority -- the apply-time floor covers the
+        priority branch, not just mute."""
+        settings._settings["system.approval"] = {"priority": "passive"}
+        note = {"channel": "system.approval", "priority": "critical"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+        assert "silenced" not in note
+
+    def test_apply_allows_critical_override_on_protected_channel(self, settings):
+        settings._settings["system.approval"] = {"priority": "critical"}
+        note = {"channel": "system.approval", "priority": "critical"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+
+    def test_persist_failure_leaves_memory_unchanged(self, settings, monkeypatch):
+        """A failed write must not leave the rejected setting active in
+        memory: persist the candidate first, commit only on success."""
+        settings.update("a.b", muted=True)
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("kiro_crew.notifications.settings.atomic_write", boom)
+        with pytest.raises(OSError):
+            settings.update("a.b", muted=False)
+        # Memory still reflects the last successfully persisted state
+        assert settings.get("a.b") == {"muted": True}
+
+    @pytest.mark.asyncio
+    async def test_put_oversized_channel_name_rejected(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "x" * 300, "muted": True},
+            )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_non_object_json_returns_400(self, monkeypatch, tmp_path):
+        """Valid-but-non-object JSON must be a validation 400, not a 500."""
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            for payload in ("[]", "null", '"str"'):
+                resp = await client.put(
+                    "/api/notifications/channels/settings",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 400, payload
+
+    def test_readers_are_lock_free(self, settings):
+        """apply()/get() must not block on the writer lock: with the lock
+        held (simulating a worker-thread update mid-write), reads and
+        apply still complete."""
+        import kiro_crew.notifications.settings as mod
+
+        settings.update("a.b", muted=True)
+        with mod._lock:  # writer holds the lock across its file write
+            assert settings.get("a.b") == {"muted": True}
+            assert settings.all_settings() == {"a.b": {"muted": True}}
+            note = {"channel": "a.b", "priority": "default"}
+            settings.apply(note)
+            assert note["silenced"] is True

--- a/test/test_notifications_push.py
+++ b/test/test_notifications_push.py
@@ -680,3 +680,110 @@ class TestSigningPayloadCoversNotifications:
         # the identical payload (no key present when channels are empty).
         m = AppManifest(name="a", version="1.0.0")
         assert b"notifications" not in m.signing_payload()
+
+
+class TestReservedAppName:
+    def test_manifest_rejects_reserved_system_name(self):
+        m = AppManifest(name="system", version="1.0.0")
+        errors = m.validate()
+        assert any("reserved" in e for e in errors)
+
+    def test_manifest_accepts_normal_name(self):
+        m = AppManifest(name="oncall-radar", version="1.0.0")
+        assert not any("reserved" in e for e in m.validate())
+
+    @pytest.mark.asyncio
+    async def test_push_from_reserved_app_name_denied(self):
+        """Defense-in-depth: even if an app named 'system' is installed
+        (pre-rule install or a validation bypass), it cannot push into the
+        system.* channel namespace -- 403, not a shadowed system.approval."""
+        state = _FakeState()
+        with patch(
+            "kiro_crew.dashboard.handlers.notifications_push.is_app_enabled",
+            return_value=True,
+        ), patch(
+            "kiro_crew.dashboard.handlers.notifications_push.get_app_manifest"
+        ) as gm:
+            async with TestClient(TestServer(_make_app(state, {"app": "system"}))) as client:
+                resp = await client.post(
+                    "/api/notifications/push",
+                    json={"channel": "approval", "title": "t", "body": "b"},
+                )
+        assert resp.status == 403
+        gm.assert_not_called()
+        assert state.delivered == []
+
+
+class TestUnregisterAppChannels:
+    @staticmethod
+    def _bus() -> NotificationBus:
+        return NotificationBus(sink=lambda note: None)
+
+    def test_removes_only_that_apps_channels(self):
+        bus = self._bus()
+        bus.register_channel("my-app.alpha", "default")
+        bus.register_channel("my-app.beta", "passive")
+        bus.register_channel("other-app.gamma", "default")
+        removed = bus.unregister_app_channels("my-app")
+        assert removed == 2
+        assert not bus.is_registered("my-app.alpha")
+        assert not bus.is_registered("my-app.beta")
+        assert bus.is_registered("other-app.gamma")
+
+    def test_never_removes_system_channels(self):
+        bus = self._bus()
+        assert bus.unregister_app_channels("system") == 0
+        assert bus.is_registered("system.approval")
+
+    def test_prefix_is_boundary_safe(self):
+        # "my-app" must not remove "my-app2.*" channels ("." terminates it).
+        bus = self._bus()
+        bus.register_channel("my-app2.other", "default")
+        assert bus.unregister_app_channels("my-app") == 0
+        assert bus.is_registered("my-app2.other")
+
+
+class TestDisablePushRace:
+    @pytest.mark.asyncio
+    async def test_push_registration_serialized_with_disable(self):
+        """A disable running concurrently with an in-flight push cannot be
+        interleaved between the push's enablement check and its channel
+        registration: both sides hold app_lifecycle_lock, so disable's
+        unregister runs either before the push's enablement check (push 403s)
+        or after the push completes (channels removed). Simulated by taking
+        the lock as 'disable', starting a push, flipping enablement off and
+        unregistering, then releasing: the push must fail closed with no
+        channel left registered."""
+        import asyncio as _asyncio
+
+        from kiro_crew.apps.manager import app_lifecycle_lock
+
+        state = _FakeState()
+        enabled = {"value": True}
+
+        def resolve(name):
+            # Enablement-aware resolver: mirrors the real one's None-on-disabled
+            return dict(_CHANNELS) if enabled["value"] else None
+
+        with patch(
+            "kiro_crew.dashboard.handlers.notifications_push._resolve_app_channels",
+            side_effect=resolve,
+        ):
+            async with TestClient(TestServer(_make_app(state, {"app": "oncall-radar"}))) as client:
+                lock = app_lifecycle_lock("oncall-radar")
+                await lock.acquire()  # act as the disable handler
+                push_task = _asyncio.create_task(
+                    client.post(
+                        "/api/notifications/push",
+                        json={"channel": "ticket-update", "title": "t", "body": "b"},
+                    )
+                )
+                await _asyncio.sleep(0.05)  # push is now blocked on the lock
+                # Disable completes: flip enablement, unregister channels
+                enabled["value"] = False
+                state.notification_bus.unregister_app_channels("oncall-radar")
+                lock.release()
+                resp = await push_task
+        assert resp.status == 403  # fails closed on the re-checked enablement
+        assert not state.notification_bus.is_registered("oncall-radar.ticket-update")
+        assert state.delivered == []


### PR DESCRIPTION
## Summary

This PR now delivers **both notification-bus follow-ups in one commit** (GitHub merged the stacked #191 into this branch -- its base was this branch, not main -- so the stack collapsed here; rebased onto current main and squashed for PR Hygiene).

### 1. Phase 2 reviewer risk fixes
- Reserved `system` app name rejected at manifest validation + defense-in-depth 403 at the push endpoint (an app named `system` could shadow `system.*` channels)
- Ghost channels: `unregister_app_channels` wired into uninstall/disable, boundary-safe prefix matching, system channels immune
- Disable/push race closed: the push's resolve->register holds the per-app lifecycle lock, same as disable/uninstall

### 2. Phase 3 backend: per-channel settings + priority wiring (RFC)
- `ChannelSettings` persisted to `~/.kirocrew/notification_settings.json`: **mute** (silenced + forced passive, kept in history) and **priority override**
- `system.approval` protected at the API AND at apply time -- a hand-edited settings file cannot silence approvals
- Badge counts non-passive rows only (RFC exit criteria)
- `GET/PUT /api/notifications/channels[/settings]` (dashboard-user only); `update()` off-loop via `asyncio.to_thread`; non-object JSON -> 400; lock-free readers (`update()` rebinds wholesale)

### Review history
Both halves reached **zero Codex findings at any severity** and no blocking Claude findings on their pre-squash commits (`a07112dc`, `b5c93848`). This head (`82efffb6`) is their rebase-squash onto current main plus one isort fix in `handlers/__init__.py` from the textual merge.

### Testing
- mypy clean (425 files), isort/flake8 clean
- 171 notification tests pass (push, settings, bus, manifest suites)
