### PR TITLE
feat(notifications): per-channel settings + priority wiring (RFC Phase 3 backend)

### DIFF
--- a/docs/system-specs/features/app-notifications.md
+++ b/docs/system-specs/features/app-notifications.md
@@ -70,6 +70,21 @@ Validation (`apps/manifest.py`): max 8 channels per app, kebab-case ids, unique 
 
 Channels register lazily on an app's first push to each declared channel. On app uninstall or disable, `NotificationBus.unregister_app_channels(app_name)` removes every `<app>.*` channel from the registry (wired in `apps/routes.py`); re-enabling re-registers lazily on the next push. System channels are never removable. The app name `system` is rejected at manifest validation (`RESERVED_APP_NAMES`) AND denied defense-in-depth at the push endpoint, so app channels can never shadow the reserved `system.*` namespace.
 
+## Per-channel settings (Phase 3)
+
+User preferences per channel, stored in `~/.kirocrew/notification_settings.json` (`notifications/settings.py`, state-owned `ChannelSettings`, atomic-rename writes, corrupt file falls back to defaults):
+
+- **Mute**: the note still lands in history (mute silences, it does not destroy) but is stamped `silenced: true` with priority forced to `passive`, so every attention surface skips it — the unread badge counts only non-passive rows, and sound/banner/feed styling key off the same fields.
+- **Priority override**: the user's value replaces the producer-requested priority and channel default.
+- **Protected channels** (`system.approval`): cannot be muted and cannot have priority lowered — enforced at the settings API (400) AND at apply time, so even a hand-edited settings file cannot silence approvals (RFC exit criteria: approval still interrupts while heartbeat can be silenced everywhere).
+
+Settings are applied at the delivery sink (`_deliver_note`), before append/broadcast, so SSE clients and disk both see the user's view; the bus stays pure.
+
+API (dashboard-user only; app tokens have no grant here):
+- `GET /api/notifications/channels` — every registered channel plus channels with stored settings (even if currently unregistered, e.g. app disabled), each with `source`, `default_priority`, `protected`, and `settings`.
+- `PUT /api/notifications/channels/settings` — body `{"channel", "muted"?, "priority"?}`; `priority: null` clears the override. Changes broadcast over WS as `notification_channel_settings`.
+
 ## Known follow-ups
 
-- Phase 3 (per RFC): per-channel user settings and runtime priority overrides.
+- Phase 3 frontend: settings UI section (channel list grouped by source), priority tiers wired through sound/native banner/feed styling, provisional keep/mute prompt for the first notification from a new app channel.
+- Phase 4 (per RFC): inline actions and grouping.

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -228,6 +228,8 @@ from kiro_crew.dashboard.handlers.messaging import (  # noqa: E402, F401
     api_notification_delete,
     api_notification_unack,
     api_notifications,
+    api_notification_channel_settings,
+    api_notification_channels,
     api_notifications_ack_all,
     api_notifications_clear,
     api_send_message,

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -418,6 +418,84 @@ async def api_notifications_ack_all(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+async def api_notification_channels(request: web.Request) -> web.Response:
+    """GET /api/notifications/channels — registered channels + user settings.
+
+    Returns every channel the bus knows about, grouped by source (``system``
+    or the owning app name), each with its default priority, the user's
+    stored settings, and whether it is protected (approval cannot be muted).
+    Channels with stored settings but no live registration (e.g. app
+    currently disabled) are included so mutes remain visible and editable.
+    """
+    from kiro_crew.notifications.settings import PROTECTED_CHANNELS
+
+    state: DashboardState = request.app["state"]
+    registered = state.notification_bus.channels()
+    stored = state.notification_channel_settings.all_settings()
+    channels = []
+    for channel in sorted(set(registered) | set(stored)):
+        source = channel.split(".", 1)[0]
+        channels.append(
+            {
+                "channel": channel,
+                "source": source,
+                "registered": channel in registered,
+                "default_priority": registered.get(channel),
+                "protected": channel in PROTECTED_CHANNELS,
+                "settings": stored.get(channel, {}),
+            }
+        )
+    return web.json_response({"channels": channels})
+
+
+async def api_notification_channel_settings(request: web.Request) -> web.Response:
+    """PUT /api/notifications/channels/settings — update one channel's settings.
+
+    Body: ``{"channel": str, "muted"?: bool, "priority"?: str|null}`` —
+    ``priority: null`` clears the override. Protected channels reject mute
+    and priority-lowering with 400.
+    """
+    from kiro_crew.notifications.settings import ChannelSettingsError
+
+    state: DashboardState = request.app["state"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+    if not isinstance(body, dict):
+        # Valid-but-non-object JSON ([], null, "str") would AttributeError on
+        # body.get below -- an unintended 500 instead of a validation 400.
+        return web.json_response({"error": "body must be a JSON object"}, status=400)
+    channel = body.get("channel")
+    if not isinstance(channel, str) or not channel.strip():
+        return web.json_response({"error": "channel is required"}, status=400)
+    channel = channel.strip()
+    if len(channel) > 256:
+        return web.json_response({"error": "channel name too long"}, status=400)
+    muted = body.get("muted")
+    if muted is not None and not isinstance(muted, bool):
+        return web.json_response({"error": "muted must be a boolean"}, status=400)
+    has_priority = "priority" in body
+    priority = body.get("priority")
+    if has_priority and priority is not None and not isinstance(priority, str):
+        return web.json_response({"error": "priority must be a string or null"}, status=400)
+    try:
+        # update() persists via atomic_write (blocking file I/O) -- keep it
+        # off the event loop. ChannelSettings serializes internally with its
+        # own lock, so concurrent updates from worker threads are safe.
+        entry = await asyncio.to_thread(
+            state.notification_channel_settings.update,
+            channel,
+            muted=muted,
+            priority=priority if has_priority and priority is not None else None,
+            clear_priority=has_priority and priority is None,
+        )
+    except ChannelSettingsError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    state.broadcast_ws("notification_channel_settings", {"channel": channel, "settings": entry})
+    return web.json_response({"ok": True, "channel": channel, "settings": entry})
+
+
 _MAX_BLOCKS = 50  # Slack Block Kit limit
 _MAX_WALK_DEPTH = 10  # defense-in-depth against deeply nested LLM output
 

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1567,6 +1567,8 @@ async def start_dashboard(
     app.router.add_post("/api/notifications/ack", handlers.api_notification_ack)
     app.router.add_post("/api/notifications/unack", handlers.api_notification_unack)
     app.router.add_post("/api/notifications/ack-all", handlers.api_notifications_ack_all)
+    app.router.add_get("/api/notifications/channels", handlers.api_notification_channels)
+    app.router.add_put("/api/notifications/channels/settings", handlers.api_notification_channel_settings)
     app.router.add_get("/api/update/check", handlers.api_update_check)
     app.router.add_get("/api/changelog", handlers.api_changelog)
     app.router.add_post("/api/update", handlers.api_update_apply)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -31,6 +31,7 @@ from kiro_crew.notifications.bus import (
     payload_from_legacy,
 )
 from kiro_crew.notifications.rate_limit import AppRateLimiter
+from kiro_crew.notifications.settings import ChannelSettings
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -1369,6 +1370,9 @@ class DashboardState:
         # global) so its lifecycle matches the gateway instance and tests get
         # isolation for free.
         self.notification_rate_limiter = AppRateLimiter()
+        # Per-channel user settings (RFC Phase 3): mute + priority override,
+        # applied at the delivery sink so the bus stays pure.
+        self.notification_channel_settings = ChannelSettings()
         self._slots: dict[str, _ChatSlot] = {}
         self._slack_to_slot: dict[str, str] = {}  # Slack session_key → slot name
         self._slot_counter = 0
@@ -1827,8 +1831,16 @@ class DashboardState:
         for key, value in note.items():
             if key != "ts":
                 note[key] = _redact_note_value(value)
+        # Per-channel user settings (RFC Phase 3): mute stamps silenced=True
+        # + forces passive; priority override replaces the effective priority.
+        # Applied before append/broadcast so SSE clients and disk both see
+        # the user's view.
+        self.notification_channel_settings.apply(note)
         self._notification_log.append(note)
-        self._unread_count += 1
+        # Badge counts attention-worthy rows only (RFC Phase 3: passive rows
+        # -- including muted-channel notes -- are excluded).
+        if note.get("priority") != "passive":
+            self._unread_count += 1
         self._broadcast(note)
         # Persistence does blocking file I/O (append + possible trim). The
         # bus sink is now externally drivable (Phase 2 app producers), so on

--- a/src/kiro_crew/notifications/bus.py
+++ b/src/kiro_crew/notifications/bus.py
@@ -243,6 +243,10 @@ class NotificationBus:
     def is_registered(self, channel: str) -> bool:
         return channel in self._channels
 
+    def channels(self) -> dict[str, str]:
+        """Snapshot of registered channels: {channel: default_priority}."""
+        return dict(self._channels)
+
     def push(self, payload: NotificationPayload) -> dict[str, Any]:
         """Validate, enrich, and deliver a notification.
 

--- a/src/kiro_crew/notifications/settings.py
+++ b/src/kiro_crew/notifications/settings.py
@@ -1,0 +1,171 @@
+"""Per-channel notification settings (RFC local notification bus, Phase 3).
+
+User preferences for each notification channel: mute and priority override.
+Stored in ``~/.kirocrew/notification_settings.json`` as::
+
+    {"channel_settings": {"system.heartbeat": {"muted": true},
+                          "oncall-radar.ticket-update": {"priority": "critical"}}}
+
+Semantics (applied at the delivery sink, keeping the bus pure):
+
+- **muted**: the note is still delivered to history (history is a cache and
+  the user asked to silence, not to destroy) but is stamped ``silenced: true``
+  and its priority forced to ``passive``, so every attention surface (badge
+  count, sound, native banner, feed styling) skips it.
+- **priority**: user override wins over the producer-requested priority and
+  the channel default.
+- ``system.approval`` is protected: it cannot be muted and its priority
+  cannot be lowered (RFC exit criteria: approval still interrupts while
+  heartbeat can be silenced everywhere).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import config_dir
+from kiro_crew.notifications.bus import PRIORITIES
+
+logger = logging.getLogger(__name__)
+
+# Channels whose attention semantics the user may not weaken: approvals gate
+# agent actions, so silencing them would stall work invisibly.
+PROTECTED_CHANNELS = frozenset({"system.approval"})
+
+_SETTINGS_FILENAME = "notification_settings.json"
+_lock = threading.Lock()
+
+
+def _settings_path():
+    return config_dir() / _SETTINGS_FILENAME
+
+
+class ChannelSettingsError(ValueError):
+    """Invalid channel settings input (unknown priority, protected channel)."""
+
+
+class ChannelSettings:
+    """Load/store/apply per-channel user settings.
+
+    In-memory dict guarded by a lock; writes are atomic-rename. Owned by
+    ``DashboardState`` (one instance per gateway) like the bus and the rate
+    limiter.
+    """
+
+    def __init__(self) -> None:
+        self._settings: dict[str, dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        path = _settings_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                raw = data.get("channel_settings", {})
+                if isinstance(raw, dict):
+                    self._settings = {
+                        ch: dict(entry)
+                        for ch, entry in raw.items()
+                        if isinstance(entry, dict)
+                    }
+        except Exception:
+            # Corrupt settings must not take down the gateway; fall back to
+            # defaults (everything unmuted, producer priorities honored).
+            logger.warning("Failed to load %s; using defaults", path, exc_info=True)
+            self._settings = {}
+
+    def all_settings(self) -> dict[str, dict[str, Any]]:
+        """Snapshot of every channel's stored settings.
+
+        Lock-free: ``update()`` rebinds ``self._settings`` to a fresh dict
+        (never mutates in place), so readers see either the old or the new
+        complete mapping. Loop-side callers (``apply()`` on every delivery)
+        therefore never block on a worker-thread writer holding the lock
+        across the file write.
+        """
+        settings = self._settings
+        return {ch: dict(entry) for ch, entry in settings.items()}
+
+    def get(self, channel: str) -> dict[str, Any]:
+        """One channel's stored settings (lock-free; see all_settings)."""
+        return dict(self._settings.get(channel, {}))
+
+    def update(
+        self,
+        channel: str,
+        *,
+        muted: bool | None = None,
+        priority: str | None = None,
+        clear_priority: bool = False,
+    ) -> dict[str, Any]:
+        """Update one channel's settings and persist. Returns the new entry.
+
+        Raises :class:`ChannelSettingsError` for an unknown priority value,
+        or an attempt to mute / lower a protected channel.
+        """
+        if priority is not None and priority not in PRIORITIES:
+            raise ChannelSettingsError(
+                f"priority must be one of {PRIORITIES}, got {priority!r}"
+            )
+        if channel in PROTECTED_CHANNELS:
+            if muted:
+                raise ChannelSettingsError(f"{channel} cannot be muted")
+            if priority is not None and priority != "critical":
+                raise ChannelSettingsError(f"{channel} priority cannot be lowered")
+        # _lock serializes WRITERS only (read-modify-write below); readers
+        # are lock-free because this method rebinds self._settings wholesale.
+        with _lock:
+            entry = dict(self._settings.get(channel, {}))
+            if muted is not None:
+                if muted:
+                    entry["muted"] = True
+                else:
+                    entry.pop("muted", None)
+            if clear_priority:
+                entry.pop("priority", None)
+            elif priority is not None:
+                entry["priority"] = priority
+            # Persist the candidate FIRST, commit memory only on success:
+            # otherwise a full/read-only filesystem would leave the rejected
+            # setting active in memory (until restart) while disk kept the
+            # old value -- runtime disagreeing with both the HTTP response
+            # and persisted configuration.
+            candidate = dict(self._settings)
+            if entry:
+                candidate[channel] = entry
+            else:
+                candidate.pop(channel, None)
+            payload = json.dumps({"channel_settings": candidate}, indent=2)
+            atomic_write(_settings_path(), payload)
+            self._settings = candidate
+            return dict(entry)
+
+    def apply(self, note: dict[str, Any]) -> dict[str, Any]:
+        """Apply the note's channel settings in place and return it.
+
+        Mute stamps ``silenced: true`` and forces priority ``passive`` (all
+        attention surfaces key off these); a priority override replaces the
+        effective priority. Notes without a channel pass through untouched.
+        """
+        channel = note.get("channel")
+        if not channel:
+            return note
+        entry = self.get(channel)
+        if not entry:
+            return note
+        override = entry.get("priority")
+        if override in PRIORITIES and not (
+            channel in PROTECTED_CHANNELS and override != "critical"
+        ):
+            # Protected channels keep their attention floor even for rows
+            # that never went through update() (hand-edited settings file):
+            # a non-critical override on system.approval is ignored.
+            note["priority"] = override
+        if entry.get("muted") and channel not in PROTECTED_CHANNELS:
+            note["silenced"] = True
+            note["priority"] = "passive"
+        return note

--- a/test/test_notification_settings.py
+++ b/test/test_notification_settings.py
@@ -1,0 +1,333 @@
+"""Tests for per-channel notification settings (RFC Phase 3)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers.messaging import (
+    api_notification_channel_settings,
+    api_notification_channels,
+)
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.notifications.settings import (
+    PROTECTED_CHANNELS,
+    ChannelSettings,
+    ChannelSettingsError,
+)
+
+
+@pytest.fixture()
+def settings(monkeypatch, tmp_path) -> ChannelSettings:
+    monkeypatch.setattr("kiro_crew.notifications.settings.config_dir", lambda: tmp_path)
+    return ChannelSettings()
+
+
+def _make_state(monkeypatch, tmp_path) -> DashboardState:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("kiro_crew.notifications.settings.config_dir", lambda: tmp_path)
+    return DashboardState(
+        sessions=MagicMock(count=0),
+        crons=MagicMock(),
+        lessons=MagicMock(),
+        start_time=0.0,
+    )
+
+
+class TestChannelSettingsStore:
+    def test_mute_persists_and_reloads(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "kiro_crew.notifications.settings.config_dir", lambda: tmp_path
+        )
+        s = ChannelSettings()
+        s.update("system.heartbeat", muted=True)
+        # Fresh instance reads back from disk
+        s2 = ChannelSettings()
+        assert s2.get("system.heartbeat") == {"muted": True}
+
+    def test_unmute_removes_empty_entry(self, settings):
+        settings.update("a.b", muted=True)
+        settings.update("a.b", muted=False)
+        assert settings.get("a.b") == {}
+        assert settings.all_settings() == {}
+
+    def test_priority_override_and_clear(self, settings):
+        settings.update("a.b", priority="critical")
+        assert settings.get("a.b") == {"priority": "critical"}
+        settings.update("a.b", clear_priority=True)
+        assert settings.get("a.b") == {}
+
+    def test_invalid_priority_rejected(self, settings):
+        with pytest.raises(ChannelSettingsError, match="priority"):
+            settings.update("a.b", priority="urgent")
+
+    def test_protected_channel_cannot_be_muted_or_lowered(self, settings):
+        with pytest.raises(ChannelSettingsError, match="muted"):
+            settings.update("system.approval", muted=True)
+        with pytest.raises(ChannelSettingsError, match="lowered"):
+            settings.update("system.approval", priority="passive")
+        # Explicit critical is a no-op but allowed
+        settings.update("system.approval", priority="critical")
+
+    def test_corrupt_file_falls_back_to_defaults(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "kiro_crew.notifications.settings.config_dir", lambda: tmp_path
+        )
+        (tmp_path / "notification_settings.json").write_text("{not json", encoding="utf-8")
+        s = ChannelSettings()
+        assert s.all_settings() == {}
+
+    def test_apply_mute_forces_passive_and_silenced(self, settings):
+        settings.update("system.heartbeat", muted=True)
+        note = {"channel": "system.heartbeat", "priority": "default"}
+        settings.apply(note)
+        assert note["silenced"] is True
+        assert note["priority"] == "passive"
+
+    def test_apply_priority_override(self, settings):
+        settings.update("app.chan", priority="critical")
+        note = {"channel": "app.chan", "priority": "default"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+        assert "silenced" not in note
+
+    def test_apply_untouched_without_settings(self, settings):
+        note = {"channel": "app.chan", "priority": "default"}
+        settings.apply(note)
+        assert note == {"channel": "app.chan", "priority": "default"}
+
+
+class TestSinkIntegration:
+    def test_muted_channel_excluded_from_badge(self, monkeypatch, tmp_path):
+        """RFC exit criteria: muting system.heartbeat silences it everywhere
+        while badge count excludes passive rows."""
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_channel_settings.update("system.heartbeat", muted=True)
+        state._deliver_note(
+            {"ts": "t1", "kind": "heartbeat", "channel": "system.heartbeat",
+             "priority": "default", "title": "hb", "body": "b"}
+        )
+        state._deliver_note(
+            {"ts": "t2", "kind": "cron", "channel": "system.cron",
+             "priority": "default", "title": "job", "body": "b"}
+        )
+        assert state._unread_count == 1  # only the cron note counts
+        hb = state._notification_log[0]
+        assert hb["silenced"] is True and hb["priority"] == "passive"
+        # Still in history (mute silences, it does not destroy)
+        assert len(state._notification_log) == 2
+
+    def test_passive_priority_never_counts_toward_badge(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state._deliver_note(
+            {"ts": "t1", "kind": "subagent", "channel": "system.subagent",
+             "priority": "passive", "title": "s", "body": "b"}
+        )
+        assert state._unread_count == 0
+
+    def test_approval_still_interrupts(self, monkeypatch, tmp_path):
+        """system.approval cannot be silenced even with a rogue settings row
+        on disk (protected at apply time too)."""
+        state = _make_state(monkeypatch, tmp_path)
+        # Simulate a hand-edited settings file muting approval
+        state.notification_channel_settings._settings["system.approval"] = {"muted": True}
+        state._deliver_note(
+            {"ts": "t1", "kind": "approval", "channel": "system.approval",
+             "priority": "critical", "title": "a", "body": "b"}
+        )
+        note = state._notification_log[0]
+        assert "silenced" not in note
+        assert note["priority"] == "critical"
+        assert state._unread_count == 1
+
+
+def _make_app(state) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/api/notifications/channels", api_notification_channels)
+    app.router.add_put(
+        "/api/notifications/channels/settings", api_notification_channel_settings
+    )
+    return app
+
+
+class TestChannelSettingsApi:
+    @pytest.mark.asyncio
+    async def test_list_channels_includes_settings_and_protection(
+        self, monkeypatch, tmp_path
+    ):
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_bus.register_channel("my-app.alerts", "default")
+        state.notification_channel_settings.update("my-app.alerts", muted=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/notifications/channels")
+            body = await resp.json()
+        assert resp.status == 200
+        by_name = {c["channel"]: c for c in body["channels"]}
+        assert by_name["my-app.alerts"]["settings"] == {"muted": True}
+        assert by_name["my-app.alerts"]["source"] == "my-app"
+        assert by_name["system.approval"]["protected"] is True
+        assert by_name["system.cron"]["default_priority"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_stored_setting_for_unregistered_channel_still_listed(
+        self, monkeypatch, tmp_path
+    ):
+        state = _make_state(monkeypatch, tmp_path)
+        state.notification_channel_settings.update("gone-app.chan", muted=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/notifications/channels")
+            body = await resp.json()
+        by_name = {c["channel"]: c for c in body["channels"]}
+        assert by_name["gone-app.chan"]["registered"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_mute_roundtrip(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "system.heartbeat", "muted": True},
+            )
+            body = await resp.json()
+        assert resp.status == 200
+        assert body["settings"] == {"muted": True}
+        assert state.notification_channel_settings.get("system.heartbeat") == {
+            "muted": True
+        }
+        state.broadcast_ws.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_put_priority_null_clears_override(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.notification_channel_settings.update("a.b", priority="critical")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "priority": None},
+            )
+        assert resp.status == 200
+        assert state.notification_channel_settings.get("a.b") == {}
+
+    @pytest.mark.asyncio
+    async def test_put_protected_channel_mute_rejected(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "system.approval", "muted": True},
+            )
+            body = await resp.json()
+        assert resp.status == 400
+        assert "muted" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_validation_errors(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            r1 = await client.put(
+                "/api/notifications/channels/settings", json={"muted": True}
+            )
+            r2 = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "priority": "urgent"},
+            )
+            r3 = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "muted": "yes"},
+            )
+        assert r1.status == 400
+        assert r2.status == 400
+        assert r3.status == 400
+
+    @pytest.mark.asyncio
+    async def test_settings_file_written_atomically(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "a.b", "muted": True},
+            )
+        data = json.loads((tmp_path / "notification_settings.json").read_text())
+        assert data == {"channel_settings": {"a.b": {"muted": True}}}
+
+
+class TestProtectedConstant:
+    def test_approval_is_protected(self):
+        assert "system.approval" in PROTECTED_CHANNELS
+
+
+class TestReviewRegressions:
+    def test_apply_ignores_noncritical_override_on_protected_channel(self, settings):
+        """Hand-edited {'system.approval': {'priority': 'passive'}} must NOT
+        lower approval's priority -- the apply-time floor covers the
+        priority branch, not just mute."""
+        settings._settings["system.approval"] = {"priority": "passive"}
+        note = {"channel": "system.approval", "priority": "critical"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+        assert "silenced" not in note
+
+    def test_apply_allows_critical_override_on_protected_channel(self, settings):
+        settings._settings["system.approval"] = {"priority": "critical"}
+        note = {"channel": "system.approval", "priority": "critical"}
+        settings.apply(note)
+        assert note["priority"] == "critical"
+
+    def test_persist_failure_leaves_memory_unchanged(self, settings, monkeypatch):
+        """A failed write must not leave the rejected setting active in
+        memory: persist the candidate first, commit only on success."""
+        settings.update("a.b", muted=True)
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("kiro_crew.notifications.settings.atomic_write", boom)
+        with pytest.raises(OSError):
+            settings.update("a.b", muted=False)
+        # Memory still reflects the last successfully persisted state
+        assert settings.get("a.b") == {"muted": True}
+
+    @pytest.mark.asyncio
+    async def test_put_oversized_channel_name_rejected(self, monkeypatch, tmp_path):
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.put(
+                "/api/notifications/channels/settings",
+                json={"channel": "x" * 300, "muted": True},
+            )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_non_object_json_returns_400(self, monkeypatch, tmp_path):
+        """Valid-but-non-object JSON must be a validation 400, not a 500."""
+        state = _make_state(monkeypatch, tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            for payload in ("[]", "null", '"str"'):
+                resp = await client.put(
+                    "/api/notifications/channels/settings",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 400, payload
+
+    def test_readers_are_lock_free(self, settings):
+        """apply()/get() must not block on the writer lock: with the lock
+        held (simulating a worker-thread update mid-write), reads and
+        apply still complete."""
+        import kiro_crew.notifications.settings as mod
+
+        settings.update("a.b", muted=True)
+        with mod._lock:  # writer holds the lock across its file write
+            assert settings.get("a.b") == {"muted": True}
+            assert settings.all_settings() == {"a.b": {"muted": True}}
+            note = {"channel": "a.b", "priority": "default"}
+            settings.apply(note)
+            assert note["silenced"] is True


### PR DESCRIPTION
## Summary
Phase 3 backend of the local notification bus RFC: per-channel user settings and priority tiers wired through badge counting. **Stacked on #189** (base branch = `fix/notification-channel-risks`); after #189 merges, this retargets to `main` with a single commit.

- **Storage** — `notifications/settings.py`: state-owned `ChannelSettings`, persisted to `~/.kirocrew/notification_settings.json` via atomic rename; corrupt file falls back to defaults
- **Mute semantics** — muted-channel notes still land in history (mute silences, it does not destroy) but are stamped `silenced: true` with priority forced to `passive`; the unread badge now counts only non-passive rows (RFC: 'badge count excludes passive rows')
- **Priority override** — user value replaces the producer-requested priority and channel default
- **Protected channels** — `system.approval` cannot be muted or lowered, enforced at the settings API (400) AND at apply time, so even a hand-edited settings file cannot silence approvals (RFC exit criteria: approval still interrupts while heartbeat can be silenced everywhere)
- **Applied at the sink** — `_deliver_note` applies settings before append/broadcast so SSE clients and disk both see the user's view; the bus stays pure
- **API** (dashboard-user only; app tokens have no grant): `GET /api/notifications/channels` and `PUT /api/notifications/channels/settings` (`priority: null` clears); changes broadcast over WS as `notification_channel_settings`

Phase 3 frontend (settings UI, sound/banner/feed styling wiring, keep/mute prompt) is the recorded follow-up in the spec — next PR.

## Testing
- 20 new tests: store roundtrip + reload-from-disk, protected-channel rejection at both API and apply layers, corrupt-file fallback, mute-excluded badge, approval-still-interrupts (rogue on-disk row), API roundtrips + validation, atomic file shape
- 232 tests across notification/dashboard/api/appkit suites pass; isort + flake8 + mypy clean