### PR TITLE
feat(ci): fail Design Review check on BLOCK verdict

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -335,14 +335,18 @@ jobs:
             echo "Created new design-review comment"
           fi
 
-      # This step only surfaces the verdict in the Actions log (notice for
-      # PASS/CONCERNS, warning for BLOCK / errored review) and exits 0 — it does
-      # not itself fail the check. But the JOB still goes RED when the model step
-      # above failed (continue-on-error was intentionally dropped). That red is
-      # by design and NON-BLOCKING: keep "Design Review" OUT of required status
-      # checks so it can never gate merge. Design judgment is advisory — humans
-      # act on the PR comment.
-      - name: Design review status (advisory, non-blocking)
+      # This step converts the design verdict into the "Design Review" check
+      # status. A real BLOCK verdict now FAILS the check (emits ::error:: and
+      # exits 1) — the one case where the design itself is judged wrong. Every
+      # other outcome stays NON-BLOCKING and exits 0: PASS/CONCERNS, the
+      # Dependabot skip, and — critically — any run that DID NOT COMPLETE
+      # (Bedrock overload / throttle / 403 / action error → UNKNOWN or empty
+      # verdict). An errored or overloaded review must NEVER fail this gate; only
+      # a genuine BLOCK does. NOTE: failing here only turns the "Design Review"
+      # check red — it gates MERGE only if the check is added to the base
+      # branch's REQUIRED status checks (a repo branch-protection setting, out of
+      # scope of this workflow). Do NOT widen the failing branch beyond BLOCK.
+      - name: Design review status (gates on BLOCK)
         if: always()
         env:
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -350,15 +354,17 @@ jobs:
           VERDICT: ${{ steps.post.outputs.verdict }}
         run: |
           if [ "$ACTOR" = "dependabot[bot]" ]; then
-            echo "Dependabot PR: design review skipped (advisory)."
+            echo "Dependabot PR: design review skipped (non-blocking)."
             exit 0
           fi
           case "$VERDICT" in
             PASS|CONCERNS)
-              echo "Design review verdict for $HEAD: $VERDICT (advisory, non-blocking)." ;;
+              echo "Design review verdict for $HEAD: $VERDICT (non-blocking)."
+              exit 0 ;;
             BLOCK)
-              echo "::warning::Design review verdict for $HEAD: BLOCK (advisory) — a human should weigh the design concern in the PR comment before merging." ;;
+              echo "::error::Design review verdict for $HEAD: BLOCK — the design gate failed. Read the design concern in the PR comment and fix the design, or have a human override the concern before merging."
+              exit 1 ;;
             *)
-              echo "::warning::Design review did not produce a verdict for $HEAD (advisory — not blocking). See the Design review job logs / re-run." ;;
+              echo "::warning::Design review did not produce a verdict for $HEAD (errored / overloaded / incomplete — NOT blocking). See the Design review job logs / re-run."
+              exit 0 ;;
           esac
-          exit 0


### PR DESCRIPTION
## Problem
The Design Review workflow's final status step (`.github/workflows/design-review.yml`) always `exit 0`. A `BLOCK` verdict from the design reviewer only emitted a `::warning::` — the "Design Review" check stayed green, so the model's strongest judgment ("the design itself is wrong") produced no red signal and was easy to miss.

## Why it matters
BLOCK is reserved for real design failures (no real problem, doesn't solve the stated problem, a clearly better alternative ignored, or an unsafe one-way door with no migration/compat story). A design gate that can never turn red on its own verdict isn't a gate — it's a comment nobody has to read.

## Fix (symptom → root cause → change)
- **Symptom:** BLOCK verdicts never surface as a failed check.
- **Root cause:** the status step unconditionally `exit 0` for every verdict.
- **Change:** the `verdict==BLOCK` branch now emits `::error::` and `exit 1`, turning the check red. Everything else stays **non-blocking** (`exit 0`):
  - Dependabot skip (no Bedrock secrets/OIDC).
  - PASS / CONCERNS.
  - **Did-not-complete** runs (Bedrock overload / throttle / 403 / action error → `UNKNOWN` or empty verdict). An errored or overloaded review must **never** fail the gate — only a genuine BLOCK does.
- Renamed the step `Design review status (advisory, non-blocking)` → `Design review status (gates on BLOCK)`, and rewrote its header comment block to describe the new behavior.

## Tests
N/A — CI-workflow-only change (no application code). The logic is self-testing by design: the same-repo/Dependabot guards and the per-verdict branches are exercised by the workflow itself on each PR run.

## Manual verification
- `git diff` confirms **only** `.github/workflows/design-review.yml` changed (untracked `setup.cfg.bak` was not staged).
- Branch logic reviewed: BLOCK → `::error::` + `exit 1`; PASS/CONCERNS → `exit 0`; `*)` (UNKNOWN/empty/errored) → `::warning::` + `exit 0`; Dependabot → `exit 0`.

## Note
Failing here only turns the **"Design Review"** check red. To actually **gate merges**, the check must be added to the base branch's **required status checks** — a repo branch-protection setting, out of scope of this diff.