### PR TITLE
fix(app-store): resolve built-in icon and hero on the detail page

### DIFF
--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -31,6 +31,8 @@ type AppInfo = {
   highlights?: string[]
   screenshots?: string[]
   screenshotsDark?: string[]
+  heroImage?: string
+  heroImageDark?: string
   repo?: string
   branch?: string
   // Installed state
@@ -85,6 +87,13 @@ interface AppManifest {
   highlights?: string[]
   screenshots?: string[]
   screenshotsDark?: string[]
+  // Store-listing metadata. For built-in apps these live on the manifest
+  // (preserved through AppManifest.extra) rather than on a registry entry —
+  // built-ins are not part of the /api/apps/registry feed.
+  iconUrl?: string
+  heroImage?: string
+  heroImageDark?: string
+  ui?: { pages?: { route?: string; label?: string; icon?: string; iconUrl?: string }[] }
   agents?: string[]
   skills?: string[]
   crons?: { name: string }[]
@@ -215,12 +224,18 @@ export default function AppDetailPage() {
           description: m.description || '',
           version: registryEntry?.version || m.version || installed.version || '0.0.0',
           author: m.author || registryEntry?.author || '',
-          icon: registryEntry?.icon || '',
-          iconUrl: registryEntry?.iconUrl || '',
+          // Built-in apps aren't in the registry feed, so registryEntry is
+          // undefined for them — their icon/hero metadata lives on the
+          // manifest. Fall back to it so built-in detail pages render the real
+          // icon and hero instead of the generic Package box.
+          icon: registryEntry?.icon || m.ui?.pages?.[0]?.icon || '',
+          iconUrl: registryEntry?.iconUrl || m.iconUrl || m.ui?.pages?.[0]?.iconUrl || '',
           tags: m.tags || registryEntry?.tags || [],
           highlights: m.highlights || registryEntry?.highlights || [],
           screenshots: registryEntry?.screenshots || m.screenshots || [],
           screenshotsDark: registryEntry?.screenshotsDark || m.screenshotsDark || [],
+          heroImage: registryEntry?.heroImage || m.heroImage || '',
+          heroImageDark: registryEntry?.heroImageDark || m.heroImageDark || '',
           repo: registryEntry?.repo || '',
           installed: true,
           installedVersion: installed.version,
@@ -398,6 +413,10 @@ export default function AppDetailPage() {
   const agentCount = app.manifest?.agents?.length || 0
   const skillCount = app.manifest?.skills?.length || 0
   const cronCount = app.manifest?.crons?.length || 0
+  // Theme-aware hero banner source (mirrors the Browse card resolution).
+  const heroSrc = resolvedMode === 'dark'
+    ? (app.heroImageDark || app.heroImage || '')
+    : (app.heroImage || app.heroImageDark || '')
 
   return (
     <>
@@ -453,6 +472,20 @@ export default function AppDetailPage() {
                 </Btn>
               </div>
             </div>
+          </div>
+        )}
+
+        {/* Hero banner (only when the app ships one) */}
+        {heroSrc && (
+          <div className="w-full aspect-video max-h-72 rounded-2xl border border-border overflow-hidden mb-6 bg-[var(--card)]">
+            {/* onError is an image-load lifecycle handler (hide broken images). */}
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <img
+              src={heroSrc}
+              alt=""
+              className="w-full h-full object-cover"
+              onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+            />
           </div>
         )}
 

--- a/website/src/test/AppDetailPage.test.tsx
+++ b/website/src/test/AppDetailPage.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// --- Mocks -----------------------------------------------------------------
+const getApp = vi.fn()
+const listRegistry = vi.fn()
+const system = vi.fn()
+
+vi.mock('../api/client', () => ({
+  api: {
+    getApp: (...a: unknown[]) => getApp(...a),
+    listRegistry: (...a: unknown[]) => listRegistry(...a),
+    system: (...a: unknown[]) => system(...a),
+  },
+}))
+
+vi.mock('../hooks/useTheme', () => ({ useTheme: () => ({ theme: 'light' }) }))
+
+// Capture the props AppIcon receives so we can assert icon resolution without
+// depending on AppIcon's internal SVG-fetch/inline behavior.
+vi.mock('../components/AppIcon', () => ({
+  default: ({ icon, iconUrl }: { icon?: string; iconUrl?: string }) => (
+    <div data-testid="app-icon" data-icon={icon || ''} data-icon-url={iconUrl || ''} />
+  ),
+}))
+
+import AppDetailPage from '../pages/AppDetailPage'
+
+function renderDetail(name = 'agent-worlds') {
+  return render(
+    <MemoryRouter initialEntries={[`/apps/detail/${name}`]}>
+      <Routes>
+        <Route path="/apps/detail/:name" element={<AppDetailPage />} />
+        <Route path="/apps" element={<div>apps list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// A built-in app as returned by /api/apps/{name}: NOT present in the registry
+// feed, with icon/hero metadata living on the manifest (preserved via
+// AppManifest.extra on the backend).
+const BUILTIN = {
+  name: 'agent-worlds',
+  version: '1.0.0',
+  displayName: 'Agent Worlds',
+  enabled: false,
+  origin: 'builtin',
+  resources: 'gateway',
+  lifecycle: 'locked',
+  installed: true,
+  manifest: {
+    displayName: 'Agent Worlds',
+    description: 'Visualize your agents in interactive pixel-art scenes',
+    iconUrl: '/app-assets/worlds/icon.svg',
+    heroImage: '/app-assets/worlds/hero-light.svg',
+    heroImageDark: '/app-assets/worlds/hero-dark.svg',
+    ui: { pages: [{ route: '/worlds', label: 'Worlds', icon: 'Gamepad2' }] },
+  },
+}
+
+describe('AppDetailPage — built-in icon/hero resolution', () => {
+  beforeEach(() => {
+    getApp.mockReset()
+    listRegistry.mockReset()
+    system.mockReset()
+    system.mockResolvedValue({ hostname: '' })
+    // Registry feed never contains built-ins — this is the condition that
+    // previously left the detail page with a generic Package icon and no hero.
+    listRegistry.mockResolvedValue({ apps: [], serverPlatform: { os: 'linux', arch: 'x86_64' } })
+  })
+
+  it('resolves the icon from the manifest for a built-in absent from the registry', async () => {
+    getApp.mockResolvedValue(BUILTIN)
+    renderDetail()
+
+    const icon = await screen.findByTestId('app-icon')
+    expect(icon.getAttribute('data-icon-url')).toBe('/app-assets/worlds/icon.svg')
+  })
+
+  it('renders the hero banner from the manifest heroImage (light theme)', async () => {
+    getApp.mockResolvedValue(BUILTIN)
+    renderDetail()
+
+    await screen.findByTestId('app-icon')
+    const hero = document.querySelector('img[src="/app-assets/worlds/hero-light.svg"]')
+    expect(hero).not.toBeNull()
+  })
+
+  it('shows no hero banner when the built-in ships no hero image', async () => {
+    getApp.mockResolvedValue({
+      ...BUILTIN,
+      manifest: {
+        displayName: 'Agent Worlds',
+        description: 'no hero here',
+        iconUrl: '/app-assets/worlds/icon.svg',
+        ui: { pages: [{ route: '/worlds', label: 'Worlds', icon: 'Gamepad2' }] },
+      },
+    })
+    renderDetail()
+
+    await screen.findByTestId('app-icon')
+    // Icon still resolves, but no hero <img> is present.
+    expect(document.querySelector('img[src^="/app-assets/worlds/hero"]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem
Every built-in app's **App Store detail page** (`/apps/detail/:name`) renders a generic package box instead of the app's real icon, and shows no hero banner — even though the Browse grid displays both correctly. Agent Worlds is the visible example, but it affects all built-ins (Task Runner, Dev Fleet, Channels, etc.).

## Why it matters
Clicking any built-in from a rich Browse card lands on a stripped, broken-looking detail page. It reads as a bug across the whole store, undermining trust in the App Store surface. Functionality (install/enable/hide/uninstall) is unaffected — this is a metadata-rendering regression.

## Fix (symptom → root cause → change)
- **Symptom:** generic `Package` icon + missing hero on built-in detail pages.
- **Root cause:** `AppDetailPage.load()` resolved `icon`/`iconUrl`/hero **only** from `registryEntry` (the `/api/apps/registry` entry). Built-in apps are registered separately via `_BUILTIN_APPS` and are **never** in that feed, so `registryEntry` is `undefined` and the fields collapse to `''` → `AppIcon` falls back to `Package`. The Browse grid looked fine only because it reads the same data from the app **manifest**.
- **Change:** in the installed-app branch, fall back to the manifest for icon/hero (`registryEntry?.iconUrl || m.iconUrl || m.ui?.pages?.[0]?.iconUrl`, `registryEntry?.icon || m.ui?.pages?.[0]?.icon`) and carry `heroImage`/`heroImageDark`. Added a theme-aware hero banner to the detail page (only rendered when a hero image exists), mirroring the Browse card. Extended the local `AppInfo`/`AppManifest` types accordingly. Registry-sourced apps are unchanged (they still resolve from `registryEntry`, which now flows through the shared fields).

## Tests
New `website/src/test/AppDetailPage.test.tsx`:
- icon resolves from the manifest for a built-in absent from the registry feed;
- hero banner renders from `manifest.heroImage` (light theme);
- no hero banner when the built-in ships no hero image.

## Manual verification
N/A — unit coverage exercises the exact resolution path that was broken; full frontend gate green (tsc clean, 3936 vitest pass / 3 skipped). Backend untouched.
