### PR TITLE
fix(ui): render build-pending badge em-dash instead of literal escape

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -748,7 +748,7 @@ export default function DevFleetPage() {
         }
       }
       if (fleet?.build_pending) {
-        out.push(<Badge key="bp" variant="warn">build pending \u2014 restart gateway to apply (kirocrew restart)</Badge>)
+        out.push(<Badge key="bp" variant="warn">{'build pending \u2014 restart gateway to apply (kirocrew restart)'}</Badge>)
       }
       return out
     }

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -182,7 +182,11 @@ describe('DevFleetPage', () => {
       return Promise.resolve(new Response('{}', { status: 200 }))
     })
     renderPage()
-    await waitFor(() => expect(screen.getByText(/build pending/i)).toBeInTheDocument())
+    const chip = await waitFor(() => screen.getByText(/build pending/i))
+    // The em-dash must render as the actual character, not a literal escape
+    // sequence (regression: \u2014 written in bare JSX text renders literally).
+    expect(chip.textContent).toContain('\u2014')
+    expect(chip.textContent).not.toContain('\\u2014')
   })
 
   it('single-column list layout for worktrees (no auto-fill truncation)', async () => {


### PR DESCRIPTION
Fixes #196

## Problem
The Dev Fleet main-row build-pending badge shows the raw text `build pending \u2014 ...apply...` — the unicode escape appears literally instead of an em-dash (user screenshot in #196).

## Why it matters
Ships a visibly broken string on the most prominent row of the fleet page, right after the build-pending state became common (post-merge Pull+Build flow).

## Fix (symptom → root cause → change)
Literal `\u2014` on screen → the escape was written in **bare JSX text content**, where JSX performs no escape interpretation (escapes only resolve inside JS string literals — every other occurrence in the file is correctly quoted, e.g. the BEHIND column arrows) → wrap the badge text in a string-literal expression `{'... \u2014 ...'}` so it resolves to the em-dash character. One line.

## Tests
Strengthened the existing 'shows build-pending chip' test: it previously matched `/build pending/i` which passed even with the bug; it now asserts the rendered textContent contains the real em-dash character and does NOT contain the literal escape sequence. Full vitest: 3936 passed / 0 failed; tsc clean; eslint clean on touched files.

## Manual verification
Repo-wide scan (regex for unicode escapes in JSX text outside string literals) confirms this was the only occurrence of the bug class. N/A beyond the unit assertion — pure text rendering, unit coverage sufficient.