### PR TITLE
feat(artifacts): remote-artifact detail view + inbound comment sync

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -62,6 +62,10 @@ art = store.update(art.slug, content="<table>… age column …</table>")
 versions = store.list_versions(art.slug)
 items = store.list(tag="ops")
 store.delete(art.slug)
+
+# Reconcile a provider's authoritative comments into the local mirror
+# (fetch-on-view). Returns the merged list; leaves origin=="local" untouched.
+store.merge_remote_comments(art.slug, "artifactory", remote_comments)
 ```
 
 The store is thread-safe. A module-level singleton is available via
@@ -154,6 +158,17 @@ The CLI proxies through the gateway HTTP API (matches `kirocrew learn`).
 | `GET` | `/api/remote-artifacts/{provider}/browse` | Provider-routed discovery: `?q=` → `search_remote`, else `list_remote(?scope=mine\|shared\|public)`; rows annotated with `local_slug`; unregistered provider → 503 (matches clone/fork) |
 | `POST` | `/api/remote-artifacts/{provider}/clone` | Bidirectional clone (`publish_sync.clone_from_remote`, sets `auto_sync=True` → arms future pushes); **gated by `_publish_governance_denied` on the routed provider**; empty registry → 503. Body: `{ "external_id": ... }` (provider-native ids can contain `/`, which a path segment can't carry) |
 | `POST` | `/api/remote-artifacts/{provider}/fork` | Independent copy with pull-only `fork_metadata` lineage (`publish_sync.fork_from_remote`); ungated ingress; empty registry → 503. Body: `{ "external_id": ... }` |
+| `GET` | `/api/remote-artifacts/{provider}/{external_id}` | Read-only detail fetch (metadata + content) for a provider-hosted artifact the user has no local copy of — content source for the remote-detail viewer; ungated ingress; passes `_redact_remote_response`; empty registry → 503 |
+| `GET` | `/api/remote-artifacts/{provider}/{external_id}/comments` | List comments on a provider-hosted artifact (`fetch_comments`, `COMMENTS_READ`); TTL-cached in memory; provider failure surfaces as `remote_sync_error`, not a 500; ungated ingress; anchor/body redacted per comment |
+| `POST` | `/api/remote-artifacts/{provider}/{external_id}/comments` | Post a top-level comment straight through to the provider (`post_comment`, `COMMENTS_WRITE`, scope=shared); **egress — gated by `_publish_governance_denied` on the routed provider** |
+| `POST` | `/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}/reply` | Reply to a provider thread (`reply_comment`); **egress — gated by `_publish_governance_denied`** |
+| `POST` | `/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}/review` | Advance a provider thread to REVIEW (`mark_review`); **egress — gated by `_publish_governance_denied`** |
+| `DELETE` | `/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}` | Delete a provider comment (`delete_comment`); **egress — gated by `_publish_governance_denied`** |
+
+`external_id` (and `comment_id`) travel as percent-encoded path segments on
+these routes; aiohttp's `path_safe` matching (3.9.2+) preserves `%2F`, so a
+provider-native id containing `/` round-trips correctly (browse-listing ids are
+slash-free in practice). Clone/fork keep the id in the JSON body instead.
 
 POST/PATCH/DELETE require an unrestricted session. The HTTP body envelope is
 capped at 2 MiB; the store enforces a per-content cap of 25 MiB
@@ -203,8 +218,13 @@ ungated, so the two egress-arming routes go through
 `_publish_governance_denied` (fail-closed `capabilities.publish ∩
 destinations:<provider>`) BEFORE dispatch — `overwrite-remote` on the resolved
 `publication.provider`, and `clone` on the routed provider (a clone sets
-`auto_sync=True`, arming every future snapshot push). Fork and the read-only
-routes (browse, upstream-status, pull-latest) stay ungated ingress. All remote
+`auto_sync=True`, arming every future snapshot push). The four remote comment
+WRITE routes (post / reply / review / delete) are outbound egress too, so each
+goes through the same `_publish_governance_denied` gate BEFORE the provider call
+— a denial is an audited 403 and no bytes leave the box (there is no local
+mirror to fall back to, unlike the local shared-comment path). Fork and the
+read-only routes (browse, upstream-status, pull-latest, remote-artifact detail,
+remote comment list) stay ungated ingress. All remote
 payloads pass `_redact_remote_response` (recursive credential/exfil-URL
 redaction, depth-capped, `localPath` stripped). Browse rows are annotated with
 `local_slug` BEFORE redaction (so a credential-shaped `external_id` isn't
@@ -326,6 +346,31 @@ provider push status (`local_only | pending_push | synced | push_failed`).
 Provider push/reconcile itself is companion-edition-only behavior behind the
 CPP publish seam — the open-source core carries the `sync_state` field and
 enforces the provider-origin guards, but ships no remote reconcile loop.
+
+**Inbound comment sync (fetch-on-view).** `GET /api/artifacts/{slug}/comments`
+opportunistically pulls the provider's comments (`fetch_comments`, when the
+publication provider advertises `COMMENTS_READ`) and reconciles them into the
+local mirror via `ArtifactStore.merge_remote_comments(slug, provider, comments)`
+before returning. Each merged mirror carries `target_provider`/`target_external_id`
+(the publication's provider + artifact id) so a later local edit/review/delete of
+that comment routes back to the source — the write handlers gate on
+`target_external_id` before calling the provider, so without it those mutations
+would silently stay local and be resurrected on the next fetch. The provider is
+authoritative for its own comments; the merge
+drops mirrors that came back tombstoned (cascade-dropping a whole thread when its
+ROOT is deleted upstream), syncs mutable fields (status/body/author) of changed
+provider comments, adds newly-seen ones, and leaves `origin == "local"` comments
+untouched — while keeping provider comments merely absent from one fetch (a
+transient/paginated empty is not a delete). The fetch is network IO and the merge
+is blocking filesystem IO, so both run off the event loop; any failure is
+best-effort and surfaces as `remote_sync_error` rather than failing the list.
+With no provider registered (the public default) `get_provider` raises and the
+endpoint degrades to local-only comments. Comment `body`, `author`, **and** the
+anchor `quote`/`prefix`/`suffix` are run through `_redact_text` (credential +
+exfil-URL redaction) at every read boundary — the local list endpoint and the
+remote-detail serializer (`_serialize_remote_comment`) — because
+provider-controlled comments are merged into the mirror raw, so redaction cannot
+live only on the local POST path.
 
 **Agent disposition contract** (owner decision 2026-07-13; rubric ships in
 the builtin `artifacts` skill):

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -1718,6 +1718,91 @@ class ArtifactStore:
                 return True
             return False
 
+    def merge_remote_comments(
+        self, slug: str, provider: str, remote_comments: _List["ArtifactComment"]
+    ) -> _List["ArtifactComment"]:
+        """Reconcile remote (provider) comments into the local mirror.
+
+        The provider is authoritative for its own comments. This:
+          * drops local mirrors that came back tombstoned (``deleted``) — so a
+            comment deleted on the remote disappears locally;
+          * syncs mutable fields (status/body/author) of changed provider
+            comments — so an inbound resolve/edit is reflected;
+          * adds newly-seen provider comments;
+          * leaves local comments (``origin == "local"``) untouched, and keeps
+            provider comments absent from this fetch (avoids wiping on a
+            transient/paginated empty — real deletes return as tombstones).
+        """
+        slug = _validate_slug(slug)
+        with self._lock:
+            existing = self._load_comments(slug)
+            incoming = {
+                rc.origin: rc for rc in remote_comments if rc.origin and rc.origin != "local"
+            }
+            deleted_origins = {
+                origin for origin, rc in incoming.items() if getattr(rc, "deleted", False)
+            }
+            # Threads whose ROOT was deleted upstream — cascade-drop the whole
+            # subtree, not just the tombstoned root. Two confirmed realities:
+            #   * some remotes do NOT cascade-delete replies when a parent is
+            #     deleted — the replies keep coming back deleted=False — so we drop
+            #     them by thread rather than waiting for per-reply tombstones.
+            #   * the remote retains the deleted ROOT as a tombstone in *every*
+            #     fetch, so seed the drop-set from the INCOMING tombstones (the
+            #     authoritative, always-present signal), not only the local mirror
+            #     — that mirror is gone after the first cascade, which is exactly
+            #     why the orphans used to come back on the next fetch.
+            # Replies share the root's thread_id (provider: thread_id =
+            # parentCommentId or commentId), so this drops the subtree on every
+            # fetch — self-healing, no persistent local tombstone needed. Local
+            # threads can't collide: a deleted root is always a provider comment.
+            dropped_threads: set[str] = set()
+            for irc in incoming.values():
+                irc_root = not irc.parent_id or irc.thread_id == irc.id
+                if getattr(irc, "deleted", False) and irc_root:
+                    dropped_threads.add(irc.thread_id)
+                    dropped_threads.add(irc.id)
+            for c in existing:
+                if c.origin in deleted_origins and (not c.parent_id or c.thread_id == c.id):
+                    dropped_threads.add(c.thread_id)
+                    dropped_threads.add(c.id)
+            result: _List["ArtifactComment"] = []
+            seen: set[str] = set()
+            changed = False
+            for c in existing:
+                if c.thread_id in dropped_threads:
+                    # Reply (local or provider) under a root deleted upstream —
+                    # cascade-drop it too, even if it's local-origin (orphaned).
+                    changed = True
+                    continue
+                if not c.origin or c.origin == "local":
+                    result.append(c)  # local comment — never touched by remote sync
+                    continue
+                if c.origin in deleted_origins:
+                    changed = True  # tombstoned on the provider — drop the mirror
+                    continue
+                rc = incoming.get(c.origin)
+                if rc is None:
+                    result.append(c)  # not in this fetch — keep (don't wipe)
+                    continue
+                seen.add(c.origin)
+                if c.status != rc.status or c.body != rc.body or c.author != rc.author:
+                    c.status, c.body, c.author = rc.status, rc.body, rc.author
+                    c.updated_at = rc.updated_at or c.updated_at
+                    changed = True
+                result.append(c)
+            for origin, rc in incoming.items():
+                if origin in seen or origin in deleted_origins:
+                    continue
+                if rc.thread_id in dropped_threads:
+                    continue  # belongs to a thread whose root was deleted upstream
+                result.append(rc)
+                changed = True
+            if changed:
+                self._write_comments(slug, result)
+                return result
+            return existing
+
     def _rescan_comment_anchors_locked(self, slug: str, content: str) -> None:
         """Re-validate every anchored comment against ``content`` and flip
         ``anchor_orphaned`` accordingly. MUST be called with ``self._lock``

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -31,7 +31,9 @@ import logging
 import os
 import re
 import threading
+import time
 import uuid
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -2836,13 +2838,66 @@ async def api_artifact_comments(request: web.Request) -> web.Response:
         # Existence check + sidecar read are blocking filesystem IO (store.get
         # reads current.html up to MAX_CONTENT_BYTES = 25 MiB); offload off the
         # event loop (no-blocking-call-on-event-loop).
-        await _run_off_loop(lambda: store.get(slug))
+        art = await _run_off_loop(lambda: store.get(slug))
     except ArtifactNotFoundError as exc:
         return _err(str(exc), status=404)
 
-    # Surfaced to the UI so a provider-side failure would be visible rather than
-    # silently dropped. Always None in the public fork (no remote comment sync).
+    # Surfaced to the UI so a provider-side failure (e.g. the remote comment op
+    # not being reachable) is visible rather than silently dropped.
     remote_sync_error: str | None = None
+
+    # Fetch-on-view: if this artifact is published to a provider that supports
+    # COMMENTS_READ, pull the remote comments and reconcile them into the local
+    # mirror before returning. The provider fetch is network IO and the merge is
+    # blocking filesystem IO, so both run off the event loop. Best-effort: any
+    # failure is surfaced as remote_sync_error but never fails the list. When no
+    # provider is registered (the public default), get_provider raises and this
+    # degrades to local-only comments — identical to the prior behavior.
+    if art.publication and art.publication.artifact_id:
+        try:
+            provider = get_provider(art.publication.provider)
+            if Capability.COMMENTS_READ in provider.capabilities():
+                remote = await provider.fetch_comments(external_id=art.publication.artifact_id)
+                if remote:
+                    mapped = [
+                        ArtifactComment(
+                            id=rc.remote_id,
+                            origin=f"{art.publication.provider}:{rc.remote_id}",
+                            provider=art.publication.provider,
+                            scope="shared",
+                            author=rc.author,
+                            is_agent=rc.is_agent,
+                            body=rc.body,
+                            anchor_quote=rc.anchor.quote if rc.anchor else None,
+                            anchor_prefix=rc.anchor.prefix if rc.anchor else None,
+                            anchor_suffix=rc.anchor.suffix if rc.anchor else None,
+                            anchor_start_offset=rc.anchor.start_offset if rc.anchor else None,
+                            anchor_end_offset=rc.anchor.end_offset if rc.anchor else None,
+                            anchor_version=rc.anchor.version_number if rc.anchor else None,
+                            thread_id=rc.thread_id,
+                            parent_id=rc.parent_id,
+                            status=rc.status,
+                            # Routing metadata so a later local edit/review/delete
+                            # of this merged mirror reaches the provider — the
+                            # write handlers gate on target_external_id before
+                            # calling the provider, so without it those mutations
+                            # would silently stay local and be resurrected/
+                            # overwritten by the next fetch-on-view.
+                            target_provider=art.publication.provider,
+                            target_external_id=art.publication.artifact_id,
+                            sync_state="synced",
+                            created_at=rc.created_at,
+                            updated_at=rc.updated_at,
+                            deleted=rc.deleted,
+                        )
+                        for rc in remote
+                    ]
+                    await _run_off_loop(
+                        lambda: store.merge_remote_comments(slug, art.publication.provider, mapped)
+                    )
+        except Exception as exc:  # noqa: BLE001 — fetch-on-view is best-effort
+            logger.warning("fetch-on-view comments failed for %s: %s", slug, exc)
+            remote_sync_error = _redact_text(str(exc))
 
     comments = await _run_off_loop(lambda: store.list_comments(slug))
     result = []
@@ -2852,7 +2907,11 @@ async def api_artifact_comments(request: web.Request) -> web.Response:
             "origin": c.origin,
             "provider": c.provider,
             "scope": c.scope,
-            "author": c.author,
+            # Provider-controlled: a remote comment merged into the mirror carries
+            # the provider's author string verbatim, so redact credentials/exfil
+            # URLs at this read boundary like the body/anchor (comments are stored
+            # raw; redaction happens on the way out — backend-security-controls).
+            "author": _redact_text(c.author),
             "is_agent": c.is_agent,
             "body": _redact_text(c.body),
             "thread_id": c.thread_id,
@@ -2864,10 +2923,15 @@ async def api_artifact_comments(request: web.Request) -> web.Response:
             "updated_at": c.updated_at,
         }
         if c.anchor_quote:
+            # Anchor text can carry provider/agent-influenced content and is
+            # echoed to the dashboard, so redact credentials/exfil-URLs like the
+            # body (backend-security-controls). Remote comments merged from a
+            # provider are stored raw, so redaction must happen at this read
+            # boundary too — not only on the local POST path.
             entry["anchor"] = {
-                "quote": c.anchor_quote,
-                "prefix": c.anchor_prefix,
-                "suffix": c.anchor_suffix,
+                "quote": _redact_text(c.anchor_quote),
+                "prefix": _redact_text(c.anchor_prefix) if c.anchor_prefix else c.anchor_prefix,
+                "suffix": _redact_text(c.anchor_suffix) if c.anchor_suffix else c.anchor_suffix,
                 "start_offset": c.anchor_start_offset,
                 "end_offset": c.anchor_end_offset,
                 "version_number": c.anchor_version,
@@ -3842,3 +3906,402 @@ async def api_remote_artifacts_fork(request: web.Request) -> web.Response:
         ),
         status=201,
     )
+
+
+async def api_remote_artifact_get(request: web.Request) -> web.Response:
+    """GET /api/remote-artifacts/{provider}/{external_id} — fetch one remote artifact.
+
+    Provider-neutral read of a provider-hosted artifact the user has no local
+    copy of — the content source for the remote-detail view. Routes through the
+    registered provider's ``fetch_content`` (``Capability.CONTENT_PULL``); the
+    returned ``{content, content_type, title, owner, visibility, ...}`` is
+    redacted before it leaves the process. When no provider is registered (the
+    public default) ``get_provider`` raises and this returns a clear error, not a
+    500. Read-only, so no publish-governance gate.
+    """
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    try:
+        provider = get_provider(provider_name)
+        if Capability.CONTENT_PULL not in provider.capabilities():
+            return _err(f"{provider_name} does not support fetching content", status=400)
+        result = await provider.fetch_content(external_id=external_id)
+    except Exception as exc:  # noqa: BLE001 — provider failure must not 500 the view
+        _audit(
+            tool="remote_artifact_fetch",
+            request=request,
+            outcome="error",
+            error=_redact_text(str(exc)),
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(_redact_text(str(exc)), status=502)
+
+    if result is None:
+        return _err("remote artifact not found or unreadable", status=404)
+
+    _audit(
+        tool="remote_artifact_fetch",
+        request=request,
+        outcome="success",
+        extra={"provider": provider_name, "external_id": external_id},
+    )
+    # Redact the provider payload (content + any metadata) before it leaves.
+    return _json_response(_redact_remote_response(dict(result)))
+
+
+# ── Remote-artifact comments (browse a provider-hosted artifact directly) ────
+# A user can open an artifact hosted by a publish provider that they do NOT have
+# a local copy of (via the remote-detail page). These endpoints read/write that
+# artifact's comments straight through to the provider — there is no local store
+# to mirror into — with a short in-memory TTL cache in front of the GET so
+# repeated views don't re-hit the provider. When no provider is registered (the
+# public default) get_provider raises and every endpoint degrades to a clear
+# error rather than a 500.
+
+_REMOTE_COMMENT_TTL_SECS = 300
+# Cap retained entries so the cache tracks ACTIVE artifacts, not lifetime browse
+# count: without a bound, every distinct provider:external_id ever opened would
+# live for the process lifetime (a slow leak on long-running gateways).
+_REMOTE_COMMENT_CACHE_MAX = 256
+# key "provider:external_id" -> (fetched_at_monotonic, serialized_comments)
+_remote_comment_cache: "OrderedDict[str, tuple[float, list[dict[str, Any]]]]" = OrderedDict()
+
+
+def _remote_cache_sweep(now: float) -> None:
+    """Evict entries older than the TTL so cache size tracks active artifacts."""
+    stale = [
+        k for k, (ts, _) in _remote_comment_cache.items() if now - ts >= _REMOTE_COMMENT_TTL_SECS
+    ]
+    for k in stale:
+        _remote_comment_cache.pop(k, None)
+
+
+def _remote_cache_put(key: str, value: "tuple[float, list[dict[str, Any]]]") -> None:
+    """Insert/refresh an entry LRU-style and evict the oldest past the cap."""
+    _remote_comment_cache.pop(key, None)  # move-to-end on refresh
+    _remote_comment_cache[key] = value
+    while len(_remote_comment_cache) > _REMOTE_COMMENT_CACHE_MAX:
+        _remote_comment_cache.popitem(last=False)  # evict oldest
+
+
+def _serialize_remote_comment(rc: Any, provider: str) -> dict[str, Any]:
+    """Serialize a provider RemoteComment to the same wire shape the local
+    comments endpoint uses, so the frontend renders both identically.
+
+    ``provider`` is the route's provider name — the origin/provider fields are
+    keyed off it (never a hardcoded provider) so this stays provider-neutral.
+    """
+    entry: dict[str, Any] = {
+        "id": rc.remote_id,
+        "origin": f"{provider}:{rc.remote_id}",
+        "provider": provider,
+        "scope": "shared",
+        # Provider-controlled author string — redact credentials/exfil URLs like
+        # the body/anchor before it reaches the dashboard (backend-security-controls).
+        "author": _redact_text(rc.author),
+        "is_agent": rc.is_agent,
+        "body": _redact_text(rc.body),
+        "thread_id": rc.thread_id,
+        "parent_id": rc.parent_id,
+        "status": rc.status,
+        "sync_state": "synced",
+        "created_at": rc.created_at,
+        "updated_at": rc.updated_at,
+    }
+    if rc.anchor and rc.anchor.quote:
+        # Provider-controlled anchor text is echoed to the dashboard, so redact
+        # credentials/exfil-URLs like the body (backend-security-controls).
+        entry["anchor"] = {
+            "quote": _redact_text(rc.anchor.quote),
+            "prefix": (_redact_text(rc.anchor.prefix) if rc.anchor.prefix else rc.anchor.prefix),
+            "suffix": (_redact_text(rc.anchor.suffix) if rc.anchor.suffix else rc.anchor.suffix),
+            "start_offset": rc.anchor.start_offset,
+            "end_offset": rc.anchor.end_offset,
+            "version_number": rc.anchor.version_number,
+        }
+    return entry
+
+
+def _invalidate_remote_comment_cache(provider: str, external_id: str) -> None:
+    _remote_comment_cache.pop(f"{provider}:{external_id}", None)
+
+
+async def api_remote_artifact_comments(request: web.Request) -> web.Response:
+    """GET /api/remote-artifacts/{provider}/{external_id}/comments.
+
+    Fetch comments for a provider-hosted artifact (no local store). TTL-cached
+    in memory. Provider failures surface as ``remote_sync_error`` rather than a
+    500, so the remote detail view still renders content.
+    """
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+    cache_key = f"{provider_name}:{external_id}"
+
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    now = time.monotonic()
+    _remote_cache_sweep(now)
+    cached = _remote_comment_cache.get(cache_key)
+    if cached and (now - cached[0]) < _REMOTE_COMMENT_TTL_SECS:
+        return _json_response({"comments": cached[1], "remote_sync_error": None, "cached": True})
+
+    comments: list[dict[str, Any]] = []
+    remote_sync_error: str | None = None
+    try:
+        provider = get_provider(provider_name)
+        if Capability.COMMENTS_READ not in provider.capabilities():
+            remote_sync_error = f"{provider_name} does not support comments"
+        else:
+            remote = await provider.fetch_comments(external_id=external_id)
+            comments = [
+                _serialize_remote_comment(rc, provider_name) for rc in remote if not rc.deleted
+            ]
+            _remote_cache_put(cache_key, (time.monotonic(), comments))
+    except Exception as exc:  # noqa: BLE001 — provider failure must not 500 the view
+        logger.warning("remote comments fetch failed for %s: %s", cache_key, exc)
+        remote_sync_error = _redact_text(str(exc))
+
+    return _json_response({"comments": comments, "remote_sync_error": remote_sync_error})
+
+
+async def api_remote_artifact_post_comment(request: web.Request) -> web.Response:
+    """POST /api/remote-artifacts/{provider}/{external_id}/comments — scope=shared."""
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+    try:
+        body = await _read_json_body(request)
+    except ArtifactValidationError as exc:
+        return _err(str(exc))
+
+    text = str(body.get("text") or "").strip()
+    if not text:
+        return _err("text is required")
+    if len(text) > 10000:
+        return _err("text exceeds 10000 chars")
+    text = _redact_text(text)
+
+    # Writing a comment to a provider-hosted artifact is outbound egress (bytes
+    # leave the box), so it goes through the same fail-closed capabilities.publish
+    # gate as artifact publish and the local shared-comment path — otherwise a
+    # policy denying publish for this provider would be bypassed. No local mirror
+    # to fall back to here, so a denial is an audited 403.
+    gov_denial = _publish_governance_denied(request, provider_name)
+    if gov_denial is not None:
+        _audit(
+            tool="remote_artifact_post_comment",
+            request=request,
+            outcome="denied",
+            error=gov_denial,
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(gov_denial, status=403)
+
+    try:
+        provider = get_provider(provider_name)
+        if Capability.COMMENTS_WRITE not in provider.capabilities():
+            return _err(f"{provider_name} does not support comments", status=400)
+
+        anchor_obj = None
+        anchor_data = body.get("anchor")
+        if isinstance(anchor_data, dict) and anchor_data.get("quote"):
+            anchor_obj = CommentAnchor(
+                quote=anchor_data.get("quote"),
+                prefix=anchor_data.get("prefix"),
+                suffix=anchor_data.get("suffix"),
+                start_offset=anchor_data.get("start_offset"),
+                end_offset=anchor_data.get("end_offset"),
+                version_number=anchor_data.get("version_number"),
+            )
+        rc = await provider.post_comment(external_id=external_id, body=text, anchor=anchor_obj)
+    except Exception as exc:  # noqa: BLE001
+        _audit(
+            tool="remote_artifact_post_comment",
+            request=request,
+            outcome="error",
+            error=_redact_text(str(exc)),
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(_redact_text(str(exc)), status=502)
+
+    _invalidate_remote_comment_cache(provider_name, external_id)
+    _audit(
+        tool="remote_artifact_post_comment",
+        request=request,
+        outcome="success",
+        extra={"provider": provider_name, "external_id": external_id},
+    )
+    return _json_response({"comment": _serialize_remote_comment(rc, provider_name)}, status=201)
+
+
+async def api_remote_artifact_reply_comment(request: web.Request) -> web.Response:
+    """POST /api/remote-artifacts/{provider}/{external_id}/comments/{id}/reply."""
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+    parent_id = request.match_info["comment_id"]
+    try:
+        body = await _read_json_body(request)
+    except ArtifactValidationError as exc:
+        return _err(str(exc))
+
+    text = str(body.get("text") or "").strip()
+    if not text:
+        return _err("text is required")
+    if len(text) > 10000:
+        return _err("text exceeds 10000 chars")
+    text = _redact_text(text)
+
+    # Replying is outbound egress to the provider — same fail-closed publish gate.
+    gov_denial = _publish_governance_denied(request, provider_name)
+    if gov_denial is not None:
+        _audit(
+            tool="remote_artifact_reply_comment",
+            request=request,
+            outcome="denied",
+            error=gov_denial,
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(gov_denial, status=403)
+
+    try:
+        provider = get_provider(provider_name)
+        if Capability.COMMENTS_WRITE not in provider.capabilities():
+            return _err(f"{provider_name} does not support comments", status=400)
+        rc = await provider.reply_comment(
+            external_id=external_id, parent_remote_id=parent_id, body=text
+        )
+    except Exception as exc:  # noqa: BLE001
+        _audit(
+            tool="remote_artifact_reply_comment",
+            request=request,
+            outcome="error",
+            error=_redact_text(str(exc)),
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(_redact_text(str(exc)), status=502)
+
+    _invalidate_remote_comment_cache(provider_name, external_id)
+    _audit(
+        tool="remote_artifact_reply_comment",
+        request=request,
+        outcome="success",
+        extra={"provider": provider_name, "external_id": external_id},
+    )
+    return _json_response({"comment": _serialize_remote_comment(rc, provider_name)}, status=201)
+
+
+async def api_remote_artifact_mark_review(request: web.Request) -> web.Response:
+    """POST /api/remote-artifacts/{provider}/{external_id}/comments/{id}/review.
+
+    Advance a shared-artifact comment thread to REVIEW on the provider. The
+    user does not own this artifact locally, so the status change writes
+    straight through to the source.
+    """
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+    comment_id = request.match_info["comment_id"]
+
+    # Advancing a thread's status mutates provider-side state — same publish gate.
+    gov_denial = _publish_governance_denied(request, provider_name)
+    if gov_denial is not None:
+        _audit(
+            tool="remote_artifact_mark_review",
+            request=request,
+            outcome="denied",
+            error=gov_denial,
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(gov_denial, status=403)
+
+    try:
+        provider = get_provider(provider_name)
+        if Capability.COMMENTS_WRITE not in provider.capabilities():
+            return _err(f"{provider_name} does not support comments", status=400)
+        await provider.mark_review(external_id=external_id, remote_id=comment_id)
+    except Exception as exc:  # noqa: BLE001
+        _audit(
+            tool="remote_artifact_mark_review",
+            request=request,
+            outcome="error",
+            error=_redact_text(str(exc)),
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(_redact_text(str(exc)), status=502)
+
+    _invalidate_remote_comment_cache(provider_name, external_id)
+    _audit(
+        tool="remote_artifact_mark_review",
+        request=request,
+        outcome="success",
+        extra={"provider": provider_name, "external_id": external_id},
+    )
+    return _json_response({"status": "review"})
+
+
+async def api_remote_artifact_delete_comment(request: web.Request) -> web.Response:
+    """DELETE /api/remote-artifacts/{provider}/{external_id}/comments/{id}.
+
+    Delete a shared-artifact comment on the provider (writes through to the
+    source — the user has no local copy to mirror it in).
+    """
+    state = request.app.get("state")
+    if state is None or _is_restricted_session(state, request):
+        return _err("restricted session", status=403)
+
+    provider_name = request.match_info["provider"]
+    external_id = request.match_info["external_id"]
+    comment_id = request.match_info["comment_id"]
+
+    # Deleting a provider comment mutates provider-side state — same publish gate.
+    gov_denial = _publish_governance_denied(request, provider_name)
+    if gov_denial is not None:
+        _audit(
+            tool="remote_artifact_delete_comment",
+            request=request,
+            outcome="denied",
+            error=gov_denial,
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(gov_denial, status=403)
+
+    try:
+        provider = get_provider(provider_name)
+        if Capability.COMMENTS_WRITE not in provider.capabilities():
+            return _err(f"{provider_name} does not support comments", status=400)
+        await provider.delete_comment(external_id=external_id, remote_id=comment_id)
+    except Exception as exc:  # noqa: BLE001
+        _audit(
+            tool="remote_artifact_delete_comment",
+            request=request,
+            outcome="error",
+            error=_redact_text(str(exc)),
+            extra={"provider": provider_name, "external_id": external_id},
+        )
+        return _err(_redact_text(str(exc)), status=502)
+
+    _invalidate_remote_comment_cache(provider_name, external_id)
+    _audit(
+        tool="remote_artifact_delete_comment",
+        request=request,
+        outcome="success",
+        extra={"provider": provider_name, "external_id": external_id},
+    )
+    return _json_response({"deleted": True})

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -86,6 +86,12 @@ from kiro_crew.dashboard.handlers.artifacts import (
     api_artifact_versions,
     api_artifacts_create,
     api_artifacts_list,
+    api_remote_artifact_comments,
+    api_remote_artifact_delete_comment,
+    api_remote_artifact_get,
+    api_remote_artifact_mark_review,
+    api_remote_artifact_post_comment,
+    api_remote_artifact_reply_comment,
     api_remote_artifacts_browse,
     api_remote_artifacts_clone,
     api_remote_artifacts_fork,
@@ -634,6 +640,37 @@ def _register_mcp_routes(app: web.Application) -> None:
     # slash before matching and 404s. Body transport is slash-safe.
     app.router.add_post("/api/remote-artifacts/{provider}/clone", api_remote_artifacts_clone)
     app.router.add_post("/api/remote-artifacts/{provider}/fork", api_remote_artifacts_fork)
+    # Single remote artifact fetch (content source for the remote-detail view).
+    # external_id is a path segment here — browser-only, and the ids that reach
+    # this route come from the browse listing (no embedded slash). The more
+    # specific {external_id}/comments* routes below still match first.
+    app.router.add_get("/api/remote-artifacts/{provider}/{external_id}", api_remote_artifact_get)
+    # Per-remote-artifact comments (remote-detail view of a provider-hosted
+    # artifact the user has no local copy of). external_id here IS a path segment
+    # — these are browser-only, comment ops target a single already-resolved
+    # artifact, and the provider ids that reach this route are the browse/detail
+    # listing's own ids (no embedded slash). Empty registry -> get_provider raises
+    # -> the handlers return a clear error, never a 500.
+    app.router.add_get(
+        "/api/remote-artifacts/{provider}/{external_id}/comments",
+        api_remote_artifact_comments,
+    )
+    app.router.add_post(
+        "/api/remote-artifacts/{provider}/{external_id}/comments",
+        api_remote_artifact_post_comment,
+    )
+    app.router.add_post(
+        "/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}/reply",
+        api_remote_artifact_reply_comment,
+    )
+    app.router.add_post(
+        "/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}/review",
+        api_remote_artifact_mark_review,
+    )
+    app.router.add_delete(
+        "/api/remote-artifacts/{provider}/{external_id}/comments/{comment_id}",
+        api_remote_artifact_delete_comment,
+    )
 
     # Artifact folders. ``/api/artifact-folders`` (hyphen) never
     # collides with the ``/api/artifacts/{slug}`` dynamic route.

--- a/test/test_artifact_comment_handlers.py
+++ b/test/test_artifact_comment_handlers.py
@@ -562,3 +562,79 @@ class TestCommentLifecycleEvents:
         resp = await h.api_artifact_comments(_req(match={"slug": "doc"}))
         cmt = _j(resp)["comments"][0]
         assert cmt["anchor_orphaned"] is True
+
+
+class TestFetchOnViewMerge:
+    """The GET-comments fetch-on-view path (artifact WITH a publication): a
+    provider that advertises COMMENTS_READ has its comments merged into the
+    local mirror before the list is returned. Two invariants this locks in:
+
+      * provider-controlled ``author`` is redacted at the read boundary (it is
+        stored raw in the mirror, so redaction lives on the way out — like body
+        / anchor), and
+      * each merged mirror carries ``target_provider`` / ``target_external_id``
+        so a later local edit/review/delete routes back to the source.
+    """
+
+    def _publish(self, store: ArtifactStore) -> None:
+        from kiro_crew.artifacts import ArtifactPublication
+
+        store.set_publication(
+            "doc",
+            ArtifactPublication(artifact_id="EXT1", view_url="https://x/EXT1", provider="fakeprov"),
+        )
+
+    def _patch_provider(self, monkeypatch, remote):
+        from kiro_crew.publish_provider import Capability
+
+        class _Prov:
+            def capabilities(self):
+                return {Capability.COMMENTS_READ}
+
+            async def fetch_comments(self, *, external_id):
+                assert external_id == "EXT1"
+                return remote
+
+        monkeypatch.setattr(h, "get_provider", lambda name: _Prov())
+
+    @pytest.mark.asyncio
+    async def test_provider_author_redacted_at_read_boundary(self, store, monkeypatch):
+        from kiro_crew.publish_provider import RemoteComment
+
+        self._publish(store)
+        self._patch_provider(
+            monkeypatch,
+            [
+                RemoteComment(
+                    remote_id="7",
+                    thread_id="7",
+                    author="AKIAIOSFODNN7EXAMPLE",
+                    body="looks good",
+                )
+            ],
+        )
+        resp = await h.api_artifact_comments(_req(match={"slug": "doc"}))
+        assert resp.status == 200
+        cmt = next(c for c in _j(resp)["comments"] if c["origin"] == "fakeprov:7")
+        # Credential in the provider-controlled author never reaches the wire.
+        assert "AKIAIOSFODNN7EXAMPLE" not in cmt["author"]
+        # ...but it IS stored raw in the mirror (redaction is read-boundary only).
+        stored = next(c for c in store.list_comments("doc") if c.origin == "fakeprov:7")
+        assert stored.author == "AKIAIOSFODNN7EXAMPLE"
+
+    @pytest.mark.asyncio
+    async def test_merged_mirror_carries_routing_metadata(self, store, monkeypatch):
+        from kiro_crew.publish_provider import RemoteComment
+
+        self._publish(store)
+        self._patch_provider(
+            monkeypatch,
+            [RemoteComment(remote_id="9", thread_id="9", author="alice", body="hi")],
+        )
+        resp = await h.api_artifact_comments(_req(match={"slug": "doc"}))
+        assert resp.status == 200
+        stored = next(c for c in store.list_comments("doc") if c.origin == "fakeprov:9")
+        # Without these a later edit/review/delete would stay local and be
+        # resurrected by the next fetch — the write handlers gate on them.
+        assert stored.target_provider == "fakeprov"
+        assert stored.target_external_id == "EXT1"

--- a/test/test_artifact_merge_remote_comments.py
+++ b/test/test_artifact_merge_remote_comments.py
@@ -1,0 +1,149 @@
+"""Tests for ArtifactStore.merge_remote_comments — inbound provider comment sync.
+
+The provider is authoritative for its own comments; the local store mirrors them
+on fetch-on-view. These cover the reconciliation contract: add new, update
+mutable fields, drop tombstones, cascade-drop a deleted thread root, never touch
+local comments, and never wipe provider comments merely absent from one fetch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.artifacts import ArtifactComment, ArtifactStore
+
+_PROVIDER = "artifactory"
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = ArtifactStore(root=tmp_path / "artifacts")
+    s.create(name="Test Artifact", content="<p>Hello</p>", slug="test-art")
+    return s
+
+
+def _remote(remote_id, *, body="b", status="open", parent=None, deleted=False, author="alice"):
+    """Build a provider-origin ArtifactComment as the fetch-on-view mapper would."""
+    origin = f"{_PROVIDER}:{remote_id}"
+    thread_id = parent if parent else remote_id
+    return ArtifactComment(
+        id=remote_id,
+        origin=origin,
+        provider=_PROVIDER,
+        scope="shared",
+        author=author,
+        body=body,
+        thread_id=thread_id,
+        parent_id=parent,
+        status=status,
+        sync_state="synced",
+        deleted=deleted,
+    )
+
+
+def _local(cid, *, body="local body"):
+    c = ArtifactComment(id=cid, origin="local", scope="private", author="me", body=body)
+    c.thread_id = cid
+    return c
+
+
+class TestMergeRemoteComments:
+    def test_adds_new_provider_comments(self, store):
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1", body="hi")])
+        got = store.list_comments("test-art")
+        assert len(got) == 1
+        assert got[0].origin == f"{_PROVIDER}:r1"
+        assert got[0].body == "hi"
+
+    def test_updates_mutable_fields(self, store):
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1", status="open")])
+        store.merge_remote_comments(
+            "test-art", _PROVIDER, [_remote("r1", status="resolved", body="edited")]
+        )
+        got = store.list_comments("test-art")
+        assert len(got) == 1
+        assert got[0].status == "resolved"
+        assert got[0].body == "edited"
+
+    def test_drops_tombstoned(self, store):
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1")])
+        assert len(store.list_comments("test-art")) == 1
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1", deleted=True)])
+        assert store.list_comments("test-art") == []
+
+    def test_cascade_drops_deleted_root_thread(self, store):
+        # A root + a reply, then the root comes back tombstoned — both go.
+        root = _remote("root")
+        reply = _remote("reply", parent="root")
+        store.merge_remote_comments("test-art", _PROVIDER, [root, reply])
+        assert len(store.list_comments("test-art")) == 2
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("root", deleted=True), reply])
+        assert store.list_comments("test-art") == []
+
+    def test_leaves_local_untouched(self, store):
+        store.add_comment("test-art", _local("loc1"))
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1")])
+        got = {c.id: c for c in store.list_comments("test-art")}
+        assert "loc1" in got and got["loc1"].origin == "local"
+        assert "r1" in got
+
+    def test_absent_provider_comment_not_wiped(self, store):
+        # A provider comment seen once, then absent from a later (empty) fetch —
+        # keep it (transient/paginated empty is NOT a delete; deletes tombstone).
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1")])
+        store.merge_remote_comments("test-art", _PROVIDER, [])
+        got = store.list_comments("test-art")
+        assert len(got) == 1 and got[0].id == "r1"
+
+    def test_returns_existing_when_no_change(self, store):
+        store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1")])
+        # Same fetch again → no change → returns the existing list unchanged.
+        result = store.merge_remote_comments("test-art", _PROVIDER, [_remote("r1")])
+        assert len(result) == 1 and result[0].id == "r1"
+
+
+_AKIA = "AKIAIOSFODNN7EXAMPLE"  # canonical AWS access-key-id shaped test token
+
+
+class TestRemoteCommentAnchorRedaction:
+    """Provider-controlled anchor text is echoed to the dashboard, so the
+    serializer must run it through the same credential/exfil redactor as the
+    body — merged remote comments are stored raw, so redaction can't only live
+    on the local POST path (backend-security-controls)."""
+
+    def test_serialize_remote_comment_redacts_anchor_fields(self):
+        from kiro_crew.dashboard.handlers.artifacts import _serialize_remote_comment
+        from kiro_crew.publish_provider import CommentAnchor, RemoteComment
+
+        rc = RemoteComment(
+            remote_id="c1",
+            thread_id="c1",
+            author="alice",
+            body=f"body {_AKIA}",
+            anchor=CommentAnchor(
+                quote=f"quote {_AKIA}",
+                prefix=f"prefix {_AKIA}",
+                suffix=f"suffix {_AKIA}",
+            ),
+        )
+        entry = _serialize_remote_comment(rc, _PROVIDER)
+        assert _AKIA not in entry["body"]
+        assert _AKIA not in entry["anchor"]["quote"]
+        assert _AKIA not in entry["anchor"]["prefix"]
+        assert _AKIA not in entry["anchor"]["suffix"]
+
+    def test_serialize_remote_comment_preserves_none_anchor_parts(self):
+        from kiro_crew.dashboard.handlers.artifacts import _serialize_remote_comment
+        from kiro_crew.publish_provider import CommentAnchor, RemoteComment
+
+        rc = RemoteComment(
+            remote_id="c2",
+            thread_id="c2",
+            author="bob",
+            body="clean body",
+            anchor=CommentAnchor(quote="just a quote", prefix=None, suffix=None),
+        )
+        entry = _serialize_remote_comment(rc, _PROVIDER)
+        assert entry["anchor"]["quote"] == "just a quote"
+        assert entry["anchor"]["prefix"] is None
+        assert entry["anchor"]["suffix"] is None

--- a/test/test_remote_artifacts.py
+++ b/test/test_remote_artifacts.py
@@ -28,11 +28,15 @@ from kiro_crew.dashboard.handlers.artifacts import (
     api_artifact_pull_latest,
     api_artifact_update,
     api_artifact_upstream_status,
+    api_remote_artifact_delete_comment,
+    api_remote_artifact_mark_review,
+    api_remote_artifact_post_comment,
+    api_remote_artifact_reply_comment,
     api_remote_artifacts_browse,
     api_remote_artifacts_clone,
     api_remote_artifacts_fork,
 )
-from kiro_crew.publish_provider import PublishProvider
+from kiro_crew.publish_provider import Capability, PublishProvider, RemoteComment
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -1054,3 +1058,107 @@ class TestRoutesAndAllowlist:
 
         assert "/api/remote-artifacts" in _MIXED_INTERNAL_API_PATHS
         assert "/api/artifacts" in _MIXED_INTERNAL_API_PATHS
+
+
+# ── Remote comment writes: publish governance gate ──────────────────────────
+
+
+class _CommentProvider(BrowseFakeProvider):
+    """Fake provider that supports comment writes, recording each provider
+    call so a test can assert the governance gate ran BEFORE any egress."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.writes: list[str] = []
+
+    def capabilities(self):
+        return {Capability.COMMENTS_READ, Capability.COMMENTS_WRITE}
+
+    async def post_comment(self, *, external_id, body, anchor=None):
+        self.writes.append("post")
+        return RemoteComment(remote_id="rc1", thread_id="rc1", author="me", body=body)
+
+    async def reply_comment(self, *, external_id, parent_remote_id, body):
+        self.writes.append("reply")
+        return RemoteComment(
+            remote_id="rc2",
+            thread_id=parent_remote_id,
+            author="me",
+            body=body,
+            parent_id=parent_remote_id,
+        )
+
+    async def mark_review(self, *, external_id, remote_id):
+        self.writes.append("review")
+
+    async def delete_comment(self, *, external_id, remote_id):
+        self.writes.append("delete")
+
+
+@pytest.fixture
+def comment_provider(monkeypatch):
+    prov = _CommentProvider()
+    saved = dict(publish_provider._FACTORIES)
+    publish_provider.reset_providers()
+    publish_provider.register_provider(prov.name, lambda: prov)
+    publish_provider._INSTANCES[prov.name] = prov
+    yield prov
+    publish_provider._FACTORIES.clear()
+    publish_provider._FACTORIES.update(saved)
+    publish_provider.reset_providers()
+
+
+_MATCH = {"provider": "fakeprov", "external_id": "ext-1", "comment_id": "c9"}
+
+
+class TestRemoteCommentGovernanceGate:
+    """Every remote comment WRITE is outbound egress, so it must pass the same
+    fail-closed capabilities.publish gate as artifact publish. A denied gate
+    returns 403 and the provider write is never reached (bytes never leave)."""
+
+    @pytest.mark.asyncio
+    async def test_post_comment_denied_403_before_egress(
+        self, patch_restricted, comment_provider, gate_denied
+    ):
+        req = _request(body={"text": "hi"}, match=_MATCH)
+        resp = await api_remote_artifact_post_comment(req)
+        assert resp.status == 403
+        assert comment_provider.writes == []
+        assert gate_denied == ["fakeprov"]
+
+    @pytest.mark.asyncio
+    async def test_reply_comment_denied_403_before_egress(
+        self, patch_restricted, comment_provider, gate_denied
+    ):
+        req = _request(body={"text": "re"}, match=_MATCH)
+        resp = await api_remote_artifact_reply_comment(req)
+        assert resp.status == 403
+        assert comment_provider.writes == []
+
+    @pytest.mark.asyncio
+    async def test_mark_review_denied_403_before_egress(
+        self, patch_restricted, comment_provider, gate_denied
+    ):
+        req = _request(match=_MATCH)
+        resp = await api_remote_artifact_mark_review(req)
+        assert resp.status == 403
+        assert comment_provider.writes == []
+
+    @pytest.mark.asyncio
+    async def test_delete_comment_denied_403_before_egress(
+        self, patch_restricted, comment_provider, gate_denied
+    ):
+        req = _request(match=_MATCH)
+        resp = await api_remote_artifact_delete_comment(req)
+        assert resp.status == 403
+        assert comment_provider.writes == []
+
+    @pytest.mark.asyncio
+    async def test_gate_open_permits_post_and_reaches_provider(
+        self, patch_restricted, comment_provider, gate_open
+    ):
+        req = _request(body={"text": "hi"}, match=_MATCH)
+        resp = await api_remote_artifact_post_comment(req)
+        assert resp.status == 201
+        assert comment_provider.writes == ["post"]
+        assert gate_open == ["fakeprov"]

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -53,6 +53,7 @@ import CapabilitiesPage from './pages/CapabilitiesPage'
 import KnowledgePage from './pages/KnowledgePage'
 import ArtifactsPage from './pages/ArtifactsPage'
 import ArtifactDetailPage from './pages/ArtifactDetailPage'
+import RemoteArtifactDetailPage from './pages/RemoteArtifactDetailPage'
 import ArtifactDeployPage from './pages/ArtifactDeployPage'
 import SettingsPage from './pages/SettingsPage'
 import EmbedSettingsPage from './pages/EmbedSettingsPage'
@@ -1870,6 +1871,7 @@ export default function App() {
             <Route path="/developer" element={<DeveloperPage />} />
             <Route path="/artifacts" element={<ArtifactsPage />} />
             <Route path="/artifacts/deploy" element={<Navigate to="/deploy" replace />} />
+            <Route path="/artifacts/remote/:provider/:externalId" element={<ErrorBoundary><RemoteArtifactDetailPage /></ErrorBoundary>} />
             <Route path="/artifacts/:slug" element={<ArtifactDetailPage />} />
             <Route path="/deploy" element={<ArtifactDeployPage />} />
             {/* Builtin app routes — auto-discovered from registry. React Router v6

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -962,6 +962,25 @@ export const api = {
         (opts?.q ? `&q=${encodeURIComponent(opts.q)}` : '') +
         (opts?.pageToken ? `&pageToken=${encodeURIComponent(opts.pageToken)}` : ''),
     ).then(j),
+  // Read-only detail fetch for a provider-hosted artifact (metadata + content),
+  // powering the remote-artifact detail page's viewer. external_id can contain
+  // "/", so it is percent-encoded into the path segment.
+  remoteArtifactDetail: (provider: string, externalId: string) =>
+    get(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}`).then(j),
+  // Remote artifact comments (view-without-fork): these write straight through
+  // to the provider (scope=shared) and are TTL-cached server-side. external_id
+  // + comment_id travel in the path, percent-encoded (provider-native ids may
+  // contain "/").
+  remoteArtifactComments: (provider: string, externalId: string) =>
+    get(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}/comments`).then(j),
+  postRemoteArtifactComment: (provider: string, externalId: string, body: { text: string; anchor?: object }) =>
+    post(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}/comments`, body).then(j),
+  replyRemoteArtifactComment: (provider: string, externalId: string, commentId: string, body: { text: string }) =>
+    post(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}/comments/${encodeURIComponent(commentId)}/reply`, body).then(j),
+  markReviewRemoteComment: (provider: string, externalId: string, commentId: string) =>
+    post(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}/comments/${encodeURIComponent(commentId)}/review`, {}).then(j),
+  deleteRemoteComment: (provider: string, externalId: string, commentId: string) =>
+    del(`/api/remote-artifacts/${encodeURIComponent(provider)}/${encodeURIComponent(externalId)}/comments/${encodeURIComponent(commentId)}`).then(j),
   updateArtifactSharing: (slug: string, body: { visibility: 'PRIVATE' | 'SHARED' | 'PUBLIC'; shared_with?: string[] }) =>
     patch(`/api/artifacts/${encodeURIComponent(slug)}/sharing`, body).then(j),
   unpublishArtifact: (slug: string) => del(`/api/artifacts/${encodeURIComponent(slug)}/publish`).then(j),

--- a/website/src/components/RemoteArtifactCard.tsx
+++ b/website/src/components/RemoteArtifactCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Copy, GitFork, Loader2, User } from 'lucide-react'
 import { Btn, Badge } from './ui'
 import { api } from '../api/client'
-import { safeHttpUrl } from '../lib/safeUrl'
 import { timeAgo } from '../utils/timeAgo'
 import type { RemoteArtifact } from '../types'
 
@@ -46,6 +46,7 @@ export default function RemoteArtifactCard({
   const [forking, setForking] = useState(false)
   const [cloning, setCloning] = useState(false)
   const [error, setError] = useState('')
+  const navigate = useNavigate()
   const remoteName = providerLabel || provider || 'the remote provider'
 
   const handleFork = async () => {
@@ -82,15 +83,12 @@ export default function RemoteArtifactCard({
     }
   }
 
-  // The fork ships no in-app remote read-only viewer route, so the row opens
-  // the provider's own view URL (when the listing carries one). view_url comes
-  // from a provider response, so validate the scheme (http/https only) before
-  // opening — a malicious/compromised provider could otherwise supply a
-  // javascript:/file:/data: URL that executes or launches on click.
-  const safeViewUrl = safeHttpUrl(artifact.view_url ?? '')
-  const openRemote = () => {
-    if (safeViewUrl) window.open(safeViewUrl, '_blank', 'noopener,noreferrer')
-  }
+  // Open the in-app read-only viewer (read & comment; the provider's own "open
+  // original" link lives on that detail page, so it isn't duplicated here). The
+  // route is provider-neutral — provider name + external_id both percent-encoded
+  // since a provider-native id can contain "/".
+  const openRemote = () =>
+    navigate(`/artifacts/remote/${encodeURIComponent(provider)}/${encodeURIComponent(artifact.external_id)}`)
 
   return (
     <div
@@ -109,7 +107,7 @@ export default function RemoteArtifactCard({
           openRemote()
         }
       }}
-      title={`Open on ${remoteName}`}
+      title={`Open read-only viewer (read & comment; open the original on ${remoteName} from there)`}
       className="flex items-start justify-between gap-3 py-2.5 px-3 rounded-lg hover:bg-bg-elevated/60 transition-colors cursor-pointer focus-ring outline-none"
     >
       <div className="min-w-0 flex-1">

--- a/website/src/pages/RemoteArtifactDetailPage.tsx
+++ b/website/src/pages/RemoteArtifactDetailPage.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
+import { ArrowLeft, AlertTriangle, ExternalLink, GitFork, Loader2, User, MessageSquare } from 'lucide-react'
+import { useTheme } from '../hooks/useTheme'
+import { safeHttpUrl } from '../lib/safeUrl'
+import { sanitizeCssValue } from '../lib/cssSanitize'
+import { THEME_VAR_NAMES, buildSrcdoc } from '../lib/widgetSrcdoc'
+import { api } from '../api/client'
+import { PageHeader, Card, Badge, Btn } from '../components/ui'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import { CommentsSidebar } from '../components/CommentsSidebar'
+import { CommentPopover } from '../components/CommentOverlay'
+import { InlineCommentOverlay } from '../components/InlineCommentOverlay'
+import { useCommentBridge, type IframeSelection } from '../hooks/useCommentBridge'
+import type { ArtifactComment } from '../types'
+
+function readThemeVars(): Record<string, string> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return {}
+  const computed = getComputedStyle(document.documentElement)
+  const out: Record<string, string> = {}
+  for (const name of THEME_VAR_NAMES) {
+    const v = sanitizeCssValue(computed.getPropertyValue(name))
+    if (v) out[name] = v
+  }
+  return out
+}
+
+/** Shape of the `GET /api/remote-artifacts/{provider}/{external_id}` response.
+ *  These are the provider `fetch_content` contract fields — flat **snake_case**
+ *  (`content_type`, `current_version`, `view_url`, `owner`), forwarded verbatim
+ *  through `_redact_remote_response` (which never renames keys). Read them as
+ *  snake_case, matching `RemoteArtifactListing`/`RemoteArtifactCard`; a camelCase
+ *  mismatch here leaves every field `undefined` (HTML/Markdown fall back to plain
+ *  text, version defaults to 1, owner + "Open original" disappear). */
+interface RemoteArtifactDetail {
+  external_id?: string
+  title?: string
+  summary?: string
+  owner?: string
+  visibility?: string
+  content_type?: string
+  current_version?: number
+  view_url?: string
+  content?: string
+  tags?: string[]
+  /** Some providers may nest the metadata under "artifact" instead of returning
+   *  it flat; flatten both shapes below so field reads resolve either way. */
+  artifact?: RemoteArtifactDetail
+}
+
+/** Read-only detail view for a provider-hosted artifact the user is viewing
+ *  but does NOT own locally (no fork). Renders the remote content and the same
+ *  comment sidebar — comments post straight to the provider (scope=shared) and
+ *  are TTL-cached server-side. Reached from the Shared/Public browse list. */
+export default function RemoteArtifactDetailPage() {
+  const { provider = '', externalId = '' } = useParams<{ provider: string; externalId: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { theme, colorTheme, themeVersion } = useTheme()
+  // Collapsed by default; auto-reveals once the artifact has comments (effect
+  // below). Session-only — deliberately not persisted, so an empty comment
+  // panel never stays open on a dashboard/infographic.
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const sidebarUserToggledRef = useRef(false)
+  const [forking, setForking] = useState(false)
+  const [forkError, setForkError] = useState('')
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const mdPreviewRef = useRef<HTMLDivElement>(null)
+  const [popover, setPopover] = useState<{ x: number; y: number; quote: string; prefix?: string; suffix?: string; startOffset?: number; endOffset?: number } | null>(null)
+  const [flashComment, setFlashComment] = useState<{ id: string; nonce: number } | null>(null)
+  const [iframeScrollTarget, setIframeScrollTarget] = useState<{ id: string; nonce: number } | null>(null)
+  const mdScrollerRef = useRef<HTMLDivElement>(null)
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null)
+  const [mdScrollNonce, setMdScrollNonce] = useState(0)
+
+  const detailQuery = useQuery<RemoteArtifactDetail>({
+    queryKey: ['remote-artifact', provider, externalId],
+    queryFn: () => api.remoteArtifactDetail(provider, externalId),
+    enabled: !!externalId,
+  })
+  const commentsQuery = useQuery<{ comments: ArtifactComment[]; remote_sync_error?: string | null }>({
+    queryKey: ['remote-artifact-comments', provider, externalId],
+    queryFn: () => api.remoteArtifactComments(provider, externalId),
+    enabled: !!externalId,
+    staleTime: 30_000,
+  })
+
+  const raw = detailQuery.data
+  // The detail response may nest metadata under `artifact`, with content +
+  // view_url at the top level. Flatten so content_type (and title/owner/version)
+  // resolve — otherwise isHtml is always false and the page renders raw source
+  // instead of the iframe.
+  const meta = raw?.artifact ?? raw
+  const art: RemoteArtifactDetail | undefined = raw
+    ? { ...meta, content: raw.content ?? meta?.content, view_url: raw.view_url ?? meta?.view_url }
+    : undefined
+  const comments = commentsQuery.data?.comments ?? []
+  const remoteSyncError = commentsQuery.data?.remote_sync_error ?? null
+
+  const invalidateComments = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['remote-artifact-comments', provider, externalId] })
+  }, [queryClient, provider, externalId])
+
+  const toggleSidebar = useCallback(() => {
+    sidebarUserToggledRef.current = true
+    setSidebarOpen(v => !v)
+  }, [])
+  // Auto-reveal the sidebar when the artifact has comments; collapse when none.
+  // Skipped once the user takes manual control via the toggle. Navigating to a
+  // different remote artifact (this component is reused across the route)
+  // clears that override so each artifact gets the comment-driven default.
+  const sidebarNavRef = useRef(externalId)
+  useEffect(() => {
+    if (sidebarNavRef.current !== externalId) {
+      sidebarNavRef.current = externalId
+      sidebarUserToggledRef.current = false
+    }
+    if (sidebarUserToggledRef.current) return
+    setSidebarOpen(comments.length > 0)
+  }, [externalId, comments.length])
+
+  // Writes go through useMutation (use-react-query guideline): errors aren't
+  // swallowed and cache invalidation is centralized. Status-change + delete on
+  // a shared artifact write straight through to the provider.
+  const postMut = useMutation({
+    mutationFn: (vars: { text: string; anchor?: object }) =>
+      api.postRemoteArtifactComment(provider, externalId, vars),
+    onSuccess: invalidateComments, onError: invalidateComments,
+  })
+  const replyMut = useMutation({
+    mutationFn: (vars: { parentId: string; text: string }) =>
+      api.replyRemoteArtifactComment(provider, externalId, vars.parentId, { text: vars.text }),
+    onSuccess: invalidateComments, onError: invalidateComments,
+  })
+  const markReviewMut = useMutation({
+    mutationFn: (id: string) => api.markReviewRemoteComment(provider, externalId, id),
+    onSuccess: invalidateComments, onError: invalidateComments,
+  })
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => api.deleteRemoteComment(provider, externalId, id),
+    onSuccess: invalidateComments, onError: invalidateComments,
+  })
+  const onAdd = useCallback((text: string) => { postMut.mutate({ text }) }, [postMut])
+  const onReply = useCallback((parentId: string, text: string) => { replyMut.mutate({ parentId, text }) }, [replyMut])
+  const onMarkReview = useCallback((id: string) => { markReviewMut.mutate(id) }, [markReviewMut])
+  const onDelete = useCallback((id: string) => { deleteMut.mutate(id) }, [deleteMut])
+  const noop = useCallback(() => {}, [])
+  // Anchored commenting inside the HTML render: selection -> popover (posts
+  // scope=shared with anchor), highlights + bidirectional scroll.
+  const { scrollToAnchor } = useCommentBridge({
+    iframeRef,
+    comments,
+    activeId: activeCommentId,
+    onSelect: (sel: IframeSelection) => setPopover({ x: sel.x, y: sel.y, quote: sel.quote, prefix: sel.prefix, suffix: sel.suffix, startOffset: sel.startOffset, endOffset: sel.endOffset }),
+    onHighlightClick: (id: string) => { setActiveCommentId(id); setFlashComment({ id, nonce: Date.now() }) },
+  })
+  useEffect(() => { if (iframeScrollTarget?.id) scrollToAnchor(iframeScrollTarget.id) }, [iframeScrollTarget, scrollToAnchor])
+  const onAddAnchored = useCallback((text: string) => {
+    if (!popover) return
+    postMut.mutate({
+      text,
+      // The provider's create_comment REQUIRES start/end offsets + versionNumber
+      // on the anchor; the remote post has no local store to fall back to, so an
+      // incomplete anchor is rejected and the comment silently disappears.
+      anchor: {
+        quote: popover.quote,
+        prefix: popover.prefix,
+        suffix: popover.suffix,
+        start_offset: popover.startOffset ?? 0,
+        end_offset: popover.endOffset ?? (popover.startOffset ?? 0) + popover.quote.length,
+        version_number: art?.current_version ?? 1,
+      },
+    })
+    // Hand control back to the comment-driven default after a popover add:
+    // reveal now, and clear the manual override so a later delete-all collapses.
+    sidebarUserToggledRef.current = false
+    setSidebarOpen(true)
+    setPopover(null)
+    window.getSelection()?.removeAllRanges()
+  }, [popover, postMut, art])
+
+  const handleFork = useCallback(async () => {
+    setForking(true)
+    setForkError('')
+    try {
+      const res = await api.forkRemoteArtifact(provider, externalId)
+      if (res.error) setForkError(res.error)
+      else navigate(`/artifacts/${encodeURIComponent(res.slug)}`)
+    } catch (e: unknown) {
+      setForkError(e instanceof Error ? e.message : 'Fork failed')
+    } finally {
+      setForking(false)
+    }
+  }, [provider, externalId, navigate])
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const themeVars = useMemo(() => readThemeVars(), [theme, colorTheme, themeVersion])
+  const ctype = (art?.content_type ?? '').toLowerCase()
+  const isHtml = ctype.includes('html')
+  const isMarkdown = ctype.includes('markdown') || ctype.includes('text/md')
+  const srcdoc = useMemo(
+    () => (isHtml && art?.content ? buildSrcdoc({ html: art.content, themeVars, mode: theme, enableComments: true }) : null),
+    [isHtml, art?.content, themeVars, theme],
+  )
+  const [blobUrl, setBlobUrl] = useState<string | null>(null)
+  useEffect(() => {
+    if (!srcdoc) { setBlobUrl(null); return }
+    const blob = new Blob([srcdoc], { type: 'text/html;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    setBlobUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [srcdoc])
+
+  // Anchored-comment highlights for the remote markdown body use the SAME
+  // DOM-rect overlay as the local artifact page (InlineCommentOverlay), so
+  // markdown highlighting is one reliable mechanism everywhere; the HTML path
+  // uses the iframe bridge above. Clicking a highlight/bubble flashes the
+  // matching sidebar row.
+  const onMarkdownActivate = useCallback((id: string) => {
+    setActiveCommentId(id)
+    setFlashComment({ id, nonce: Date.now() })
+  }, [])
+
+  // Anchored-comment create on the remote markdown body: a text selection opens
+  // the popover (posts scope=shared with the anchor). Mirrors the local page's
+  // markdown selection path; the quote+prefix/suffix re-anchor the highlight.
+  const handleMdMouseUp = useCallback(() => {
+    if (!isMarkdown) return
+    const sel = window.getSelection()
+    const raw = sel?.toString() ?? ''
+    if (!sel || sel.isCollapsed || !raw.trim()) return
+    const root = mdPreviewRef.current
+    if (!root || !sel.anchorNode || !root.contains(sel.anchorNode)) return
+    const range = sel.getRangeAt(0)
+    if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return
+    const quote = raw.trim()
+    // Derive the selection's real offset from the Range, NOT full.indexOf(quote):
+    // indexOf finds the FIRST occurrence, so selecting a later repeat would store
+    // prefix/suffix (and the start/end offsets sent to the provider) for the
+    // wrong spot and mis-anchor the highlight. Range.toString() for both the full
+    // text and the pre-selection slice keeps the offset space consistent and
+    // matches the textContent the highlighter searches.
+    const fullRange = document.createRange()
+    fullRange.selectNodeContents(root)
+    const full = fullRange.toString()
+    const preRange = document.createRange()
+    preRange.setStart(root, 0)
+    preRange.setEnd(range.startContainer, range.startOffset)
+    const idx = preRange.toString().length + (raw.length - raw.trimStart().length)
+    const prefix = full.slice(Math.max(0, idx - 32), idx)
+    const suffix = full.slice(idx + quote.length, idx + quote.length + 32)
+    const rect = range.getBoundingClientRect()
+    const startOffset = idx
+    const endOffset = idx + quote.length
+    setPopover({ x: rect.left, y: rect.bottom, quote, prefix, suffix, startOffset, endOffset })
+  }, [isMarkdown])
+
+  if (detailQuery.isLoading) return <div className="p-6 text-muted">Loading…</div>
+  if (detailQuery.error || !art) {
+    const msg = detailQuery.error instanceof Error ? detailQuery.error.message : 'Failed to load remote artifact'
+    return (
+      <>
+        <PageHeader title="Remote artifact" subtitle={externalId} />
+        <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
+          <Card>
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="lucide-inline text-danger" />
+              <div>
+                <div className="text-sm text-danger font-medium">Failed to load remote artifact</div>
+                <div className="text-[13px] text-muted mt-1">{msg}</div>
+              </div>
+            </div>
+            <div className="mt-3"><Btn onClick={() => navigate('/artifacts')}>← Back to library</Btn></div>
+          </Card>
+        </div>
+      </>
+    )
+  }
+
+  const title = art.title || externalId
+  // The external "open original" link comes from a provider response, so
+  // validate the scheme (http/https only) before rendering it — a
+  // malicious/compromised provider could otherwise supply a
+  // javascript:/file:/data: URL that executes or launches on click.
+  const safeArtifactUrl = safeHttpUrl(art.view_url ?? '')
+
+  return (
+    <>
+      <PageHeader title={title} subtitle={`Remote artifact · ${provider}`} />
+      <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <Btn onClick={() => navigate('/artifacts')} className="flex items-center gap-1">
+            <ArrowLeft size={13} /> Back
+          </Btn>
+          {art.visibility && <Badge variant="ok">{art.visibility}</Badge>}
+          {art.owner && (
+            <span className="inline-flex items-center gap-1 text-[12px] text-muted">
+              <User size={12} /> {art.owner}
+            </span>
+          )}
+          {art.current_version != null && <span className="text-[12px] text-muted">v{art.current_version}</span>}
+          {(art.tags ?? []).map(t => (
+            <span key={t} className="text-[11px] px-1.5 py-0.5 rounded bg-bg-elevated border border-border text-muted">{t}</span>
+          ))}
+          <span className="ml-auto flex items-center gap-2">
+            <Btn
+              type="button"
+              onClick={toggleSidebar}
+              className={sidebarOpen ? 'border-accent text-accent bg-accent-subtle' : ''}
+              title={sidebarOpen ? 'Hide comments' : 'Show comments'}
+              aria-pressed={sidebarOpen}
+            >
+              <MessageSquare size={13} /> Comments
+              {comments.length > 0 && <span className="ml-0.5 px-1 rounded bg-accent/20 text-[10px]">{comments.length}</span>}
+            </Btn>
+            {safeArtifactUrl && (
+              <Btn
+                type="button"
+                onClick={() => window.open(safeArtifactUrl, '_blank', 'noopener,noreferrer')}
+                title="Open the original on the remote provider"
+              >
+                <ExternalLink size={13} /> Open original
+              </Btn>
+            )}
+            <Btn
+              type="button"
+              primary
+              onClick={handleFork}
+              disabled={forking}
+              title="Fork into your local artifacts (editable copy)"
+            >
+              {forking ? <Loader2 size={13} className="animate-spin" /> : <GitFork size={13} />} Fork
+            </Btn>
+          </span>
+        </div>
+
+        {art.summary && <div className="mb-3 text-sm text-muted italic">{art.summary}</div>}
+        {forkError && (
+          <div className="mb-3 px-3 py-2 rounded-md border border-danger/40 bg-danger-subtle text-[13px] text-danger">{forkError}</div>
+        )}
+
+        <div className="flex gap-4 items-start">
+          <div className="flex-1 min-w-0">
+            {isHtml ? (
+              <div className="rounded-xl border border-border bg-card overflow-hidden" style={{ minHeight: 480 }}>
+                {blobUrl ? (
+                  <iframe
+                    ref={iframeRef}
+                    src={blobUrl}
+                    sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+                    className="w-full border-none bg-card"
+                    style={{ height: 'calc(100vh - 240px)', minHeight: 480 }}
+                    title={`Remote artifact: ${externalId}`}
+                  />
+                ) : <div className="p-6 text-muted">Rendering…</div>}
+              </div>
+            ) : (
+              <div ref={mdScrollerRef} className="relative rounded-xl border border-border bg-card overflow-auto p-5" style={{ minHeight: 480, height: 'calc(100vh - 240px)' }}>
+                {isMarkdown
+                  ? <div ref={mdPreviewRef} onMouseUp={handleMdMouseUp} className="msg-content text-sm leading-relaxed"><MarkdownRenderer content={art.content ?? ''} /></div>
+                  : <pre className="text-[13px] text-text whitespace-pre-wrap break-words font-mono">{art.content ?? ''}</pre>}
+                {isMarkdown && comments.length > 0 && (
+                  <InlineCommentOverlay
+                    scrollRef={mdScrollerRef}
+                    textRef={mdPreviewRef}
+                    comments={comments}
+                    activeId={activeCommentId}
+                    scrollNonce={mdScrollNonce}
+                    onActivate={onMarkdownActivate}
+                  />
+                )}
+              </div>
+            )}
+            {popover && (
+              <CommentPopover
+                x={popover.x}
+                y={popover.y}
+                onSubmit={onAddAnchored}
+                onCancel={() => { setPopover(null); window.getSelection()?.removeAllRanges() }}
+              />
+            )}
+          </div>
+
+          {sidebarOpen && (
+            <CommentsSidebar
+              comments={comments}
+              loading={commentsQuery.isFetching}
+              remoteSyncError={remoteSyncError}
+              onAdd={onAdd}
+              onReply={onReply}
+              onResolve={noop}
+              onMarkReview={onMarkReview}
+              onDelete={onDelete}
+              onRefresh={invalidateComments}
+              onClose={toggleSidebar}
+              onCommentClick={isHtml ? (id: string) => { setActiveCommentId(id); setIframeScrollTarget({ id, nonce: Date.now() }) } : (id: string) => { setActiveCommentId(id); setMdScrollNonce(n => n + 1) }}
+              activeCommentId={activeCommentId}
+              flashCommentId={flashComment}
+              hideResolve
+              hideDelete
+            />
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/website/src/test/RemoteArtifactCard.test.tsx
+++ b/website/src/test/RemoteArtifactCard.test.tsx
@@ -1,16 +1,32 @@
 /**
  * Regression tests for RemoteArtifactCard — the browse-surface row.
  *
- * Covers two fork fixes:
+ * Covers:
  *  1. Keyboard activation of the inner Fork/Clone buttons must NOT be
- *     hijacked by the row's Enter/Space handler (which opens the remote).
+ *     hijacked by the row's Enter/Space handler (which now navigates to the
+ *     in-app remote-detail viewer).
  *  2. A millisecond-epoch updated_at string must render a sane relative age,
  *     not "just now" forever (ms value misread as a far-future seconds epoch).
+ *
+ * The row's primary action now NAVIGATES to the in-app read-only remote-detail
+ * viewer (/artifacts/remote/:provider/:externalId) instead of opening the
+ * provider's own view_url in a new tab — the "open original" affordance lives
+ * on that detail page. useNavigate requires a Router, so renders are wrapped in
+ * MemoryRouter and navigation is asserted via a mocked useNavigate.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import RemoteArtifactCard from '../components/RemoteArtifactCard'
 import type { RemoteArtifact } from '../types'
+
+const navigateMock = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 vi.mock('../api/client', () => ({
   api: { forkRemoteArtifact: vi.fn(), cloneRemoteArtifact: vi.fn() },
@@ -27,15 +43,21 @@ const mkRemote = (o: Partial<RemoteArtifact> = {}): RemoteArtifact => ({
   ...o,
 })
 
+const renderCard = (props: Parameters<typeof RemoteArtifactCard>[0]) =>
+  render(
+    <MemoryRouter>
+      <RemoteArtifactCard {...props} />
+    </MemoryRouter>
+  )
+
 describe('RemoteArtifactCard keyboard activation', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('Enter on the Fork button forks — does not open the remote view URL', async () => {
+  it('Enter on the Fork button forks — does not navigate to the viewer', async () => {
     const { api } = await import('../api/client')
     ;(api.forkRemoteArtifact as ReturnType<typeof vi.fn>).mockResolvedValue({ slug: 'local-x' })
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
     const onForked = vi.fn()
-    render(<RemoteArtifactCard artifact={mkRemote()} provider="companion" onForked={onForked} />)
+    renderCard({ artifact: mkRemote(), provider: 'companion', onForked })
 
     const forkBtn = screen.getByTitle(/Fork into your local artifacts/i)
     // React attaches keydown at the root; a keydown on the button bubbles to
@@ -45,31 +67,21 @@ describe('RemoteArtifactCard keyboard activation', () => {
     fireEvent.click(forkBtn)
 
     await waitFor(() => expect(api.forkRemoteArtifact).toHaveBeenCalledWith('companion', 'ext-1'))
-    expect(openSpy).not.toHaveBeenCalled()
-    openSpy.mockRestore()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
-  it('Enter on the row itself opens the remote view URL', () => {
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
-    render(<RemoteArtifactCard artifact={mkRemote()} provider="companion" />)
-    const row = screen.getByTitle(/Open on/i)
+  it('Enter on the row itself navigates to the in-app remote-detail viewer', () => {
+    renderCard({ artifact: mkRemote(), provider: 'companion' })
+    const row = screen.getByTitle(/Open read-only viewer/i)
     fireEvent.keyDown(row, { key: 'Enter' })
-    expect(openSpy).toHaveBeenCalledWith('https://remote.example.com/a/ext-1', '_blank', 'noopener,noreferrer')
-    openSpy.mockRestore()
+    expect(navigateMock).toHaveBeenCalledWith('/artifacts/remote/companion/ext-1')
   })
 
-  it('does NOT open a non-http(s) view URL (malicious provider scheme)', () => {
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
-    render(
-      <RemoteArtifactCard
-        artifact={mkRemote({ view_url: 'javascript:alert(1)' })}
-        provider="companion"
-      />
-    )
-    const row = screen.getByTitle(/Open on/i)
-    fireEvent.keyDown(row, { key: 'Enter' })
-    expect(openSpy).not.toHaveBeenCalled()
-    openSpy.mockRestore()
+  it('percent-encodes provider + external_id in the viewer route', () => {
+    renderCard({ artifact: mkRemote({ external_id: 'a/b c' }), provider: 'a co' })
+    const row = screen.getByTitle(/Open read-only viewer/i)
+    fireEvent.click(row)
+    expect(navigateMock).toHaveBeenCalledWith('/artifacts/remote/a%20co/a%2Fb%20c')
   })
 })
 
@@ -78,13 +90,7 @@ describe('RemoteArtifactCard actionsDisabled', () => {
 
   it('disables Fork/Clone and does not fork when actionsDisabled (stale rows)', async () => {
     const { api } = await import('../api/client')
-    render(
-      <RemoteArtifactCard
-        artifact={mkRemote({ editable: true })}
-        provider="companion"
-        actionsDisabled
-      />
-    )
+    renderCard({ artifact: mkRemote({ editable: true }), provider: 'companion', actionsDisabled: true })
     const forkBtn = screen.getByTitle(/Fork into your local artifacts/i) as HTMLButtonElement
     const cloneBtn = screen.getByTitle(/Clone into your artifacts/i) as HTMLButtonElement
     expect(forkBtn).toBeDisabled()
@@ -98,7 +104,7 @@ describe('RemoteArtifactCard actionsDisabled', () => {
 describe('RemoteArtifactCard updated_at rendering', () => {
   it('renders a millisecond-epoch updated_at as a real age, not "just now"', () => {
     // 2020-01-01T00:00:00Z in MILLISECONDS — years in the past.
-    render(<RemoteArtifactCard artifact={mkRemote({ updated_at: '1577836800000' })} provider="companion" />)
+    renderCard({ artifact: mkRemote({ updated_at: '1577836800000' }), provider: 'companion' })
     // Should read as days/years ago, never "just now" (which is the bug: a ms
     // value misread as seconds lands in the far future → negative age).
     expect(screen.queryByText('just now')).not.toBeInTheDocument()
@@ -107,7 +113,7 @@ describe('RemoteArtifactCard updated_at rendering', () => {
 
   it('still renders a seconds-epoch updated_at correctly', () => {
     // 2020-01-01T00:00:00Z in SECONDS.
-    render(<RemoteArtifactCard artifact={mkRemote({ updated_at: '1577836800' })} provider="companion" />)
+    renderCard({ artifact: mkRemote({ updated_at: '1577836800' }), provider: 'companion' })
     expect(screen.queryByText('just now')).not.toBeInTheDocument()
     expect(screen.getByText(/\d+d ago/)).toBeInTheDocument()
   })


### PR DESCRIPTION
## Description

Adds the provider-neutral **remote-artifact detail view** and **inbound comment
sync** to the artifact publish story. Today the public core ships the full
publish layer (`publish_sync`, the `PublishProvider` ABC + registry, share/browse
/clone/fork handlers and UI) behind an empty provider registry, but two pieces
were missing: (1) comments made on a published artifact's *destination* were
never pulled back, and (2) there was no in-app way to open + comment on an
artifact hosted by a provider that you don't have a local copy of.

Everything here is **provider-neutral** and routed through the registered
`PublishProvider` — with an empty registry (the public default) every new
endpoint degrades to a clear error, so standalone behavior is unchanged
(local-only comments, no remote detail view).

**Backend**
- `ArtifactStore.merge_remote_comments(slug, provider, remote_comments)` —
  reconcile a provider's comments into the local mirror: add new, sync mutable
  fields (status/body/author), drop tombstones, cascade-drop a thread whose root
  was deleted upstream, never touch local-origin comments, and never wipe a
  provider comment merely absent from one (transient/paginated) fetch.
- `GET /api/artifacts/{slug}/comments` now does **fetch-on-view**: if the
  artifact is published to a `COMMENTS_READ` provider, pull + merge remote
  comments before returning. Best-effort — surfaced as `remote_sync_error`,
  never a 500. Replaces the previously hardcoded `remote_sync_error = None`.
- Provider-hosted artifact endpoints (browser-only, no local store):
  - `GET /api/remote-artifacts/{provider}/{external_id}` — fetch content via
    `provider.fetch_content` (`CONTENT_PULL`-gated, redacted before it leaves).
  - `GET/POST .../comments`, `POST .../comments/{id}/reply`,
    `POST .../comments/{id}/review`, `DELETE .../comments/{id}` — read (TTL-cached)
    + write-through to the provider. `_serialize_remote_comment` is provider-keyed.

**Frontend**
- `RemoteArtifactDetailPage` — in-app read-only viewer with comments for a
  provider-hosted artifact; the "open original" link lives here.
- Route `/artifacts/remote/:provider/:externalId`; `RemoteArtifactCard` now
  navigates to it instead of opening the provider's URL in a new tab.
- `api` client: `remoteArtifactDetail` + five remote-comment methods.

## Related Issues

Completes the publish-provider comment story (the inbound half of the
bidirectional-sync surface).

## Testing

- [x] Existing tests pass — backend `merge_remote_comments` suite (+7) green;
      `RemoteArtifactCard` test updated to the navigate contract (6 pass).
- [x] New tests added for new functionality (`test_artifact_merge_remote_comments.py`;
      `RemoteArtifactCard.test.tsx` navigate + percent-encoding cases).
- [x] Manual verification: `flake8` + `mypy` (1.14.1) clean on touched backend;
      `tsc -b` clean; `eslint src/` 0 errors (well under the warning baseline).
      With no provider registered, every new endpoint returns a clear error, not
      a 500 — standalone unchanged.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — n/a (no documented behavior change
      for the standalone build; endpoints are inert without a registered provider)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: awaiting OSPO CLA wording. -->
