### PR TITLE
fix(chat): fix so that Changes tab not disappearing mid session

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1142,8 +1142,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // Preserve the persisted strip until that source-of-truth load settles.
     if (slotLoading) return
     if (sourceLinks.length === 0) {
+      // Changes is a permanently pinned tab (SidePanel.syncPinned) — never
+      // auto-close it here. Just clear the source selection; the tab stays put
+      // and renders its empty state until sources are detected again.
       setSelectedSourceUrl('')
-      tabsCtl.closeTab('changes')
       return
     }
     if (!sourceLinks.some(source => source.url === selectedSourceUrl)) {

--- a/website/src/test/ChatPage.persist.integration.test.tsx
+++ b/website/src/test/ChatPage.persist.integration.test.tsx
@@ -175,4 +175,25 @@ describe('ChatPage unmount slot persistence (real component)', () => {
     expect(panel.result.current.tabs.map(tab => tab.id)).toEqual(['changes'])
     expect(panel.result.current.activeId).toBe('changes')
   })
+
+  it('keeps the Changes tab pinned when a settled slot has no source links (regression)', async () => {
+    // Before the fix, ChatPage's source-reconcile effect called
+    // tabsCtl.closeTab('changes') whenever sourceLinks was empty — fighting
+    // SidePanel's always-pinned model and making the Changes tab vanish
+    // mid-session (it only reappeared on reload, when syncPinned re-ran).
+    // Changes is a permanent pinned tab; an empty source set must NOT close it.
+    const panel = renderHook(() => usePanelTabs('chat-2'))
+    act(() => panel.result.current.openView('changes'))
+    expect(panel.result.current.tabs.map(tab => tab.id)).toEqual(['changes'])
+
+    // Settled hydration (slotLoading: false) + no messages ⇒ no source links,
+    // which is exactly the branch that used to auto-close the tab.
+    renderChatPage(undefined, 'chat-2', allSlots, {
+      messages: [],
+      slotLoading: false,
+    })
+    await act(async () => {})
+
+    expect(panel.result.current.tabs.map(tab => tab.id)).toEqual(['changes'])
+  })
 })


### PR DESCRIPTION
## Problem

The **Changes** side-panel tab intermittently disappears mid-session (reported on browser, not an Electron cache issue). It comes back on reload, then vanishes again while using the app.

## Root cause

Two controllers fight over the Changes tab:

- **SidePanel** (`syncPinned`) pins Changes/Files/Artifacts unconditionally — but only on mount.
- **ChatPage**'s source-reconcile effect still ran the *old content-gated* logic: when a slot had no PR/source links (`sourceLinks.length === 0`), it called `tabsCtl.closeTab('changes')`.

So on mount SidePanel pins Changes; then ChatPage sees no source links and closes it; `syncPinned` doesn't re-run (mount-only), so it stays gone until reload. This leftover was never removed when the always-pinned model landed because ChatPage was intentionally kept out of that PR's scope.

## Fix

Remove the `closeTab('changes')` call — clearing the source selection is sufficient. The pinned tab stays put and renders its empty state until sources are detected again.

## Tests

- Added a regression test in `ChatPage.persist.integration.test.tsx` ("keeps the Changes tab pinned when a settled slot has no source links"). Verified it **fails** with the old `closeTab('changes')` and **passes** with the fix.
- `tsc -b` clean; persist integration + panel-tab + responsive-panel suites green (31 tests).