### PR TITLE
fix(desktop): survive macOS .DS_Store/ENOTEMPTY race in universal build

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -289,7 +289,35 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
     EB_ARGS+=( --linux )
   fi
 
-  CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "${EB_ARGS[@]}"
+  # Start from a pristine output dir. A prior interrupted universal build can
+  # leave dist/mac-universal-<arch>-temp dirs behind (with a .DS_Store inside);
+  # those linger and re-trip the ENOTEMPTY cleanup below on every later run.
+  rm -rf dist
+
+  # macOS universal .DS_Store/ENOTEMPTY race:
+  # electron-builder's universal step stages each arch into
+  # dist/mac-universal-<arch>-temp, lipo-merges them, then removes the temp
+  # dirs with a recursive fs.rm. If macOS Desktop Services (Finder/Spotlight)
+  # drops a .DS_Store into a temp dir *during* that removal, Node's fs.rm --
+  # which performs no retries -- fails the final rmdir with ENOTEMPTY and the
+  # whole build aborts (electron-userland/electron-builder#6890). It is a
+  # transient race, so retry from a swept, clean dir a bounded number of times.
+  attempt=1; max_attempts=3
+  while : ; do
+    eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
+    if CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "${EB_ARGS[@]}" 2>&1 | tee "$eb_log"; then
+      rm -f "$eb_log"; break
+    fi
+    if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
+      echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
+      find dist -name .DS_Store -delete 2>/dev/null || true
+      rm -rf dist/*-temp 2>/dev/null || true
+      rm -f "$eb_log"; attempt=$((attempt + 1)); sleep 2; continue
+    fi
+    rm -f "$eb_log"
+    echo "❌ electron-builder failed (not the .DS_Store race, or retries exhausted)." >&2
+    exit 1
+  done
 )
 
 # Universal post-gate: the staged shell binary must carry BOTH arch slices.


### PR DESCRIPTION
## Problem
`make desktop` (the macOS universal build) aborts with:

```
⨯ ENOTEMPTY: directory not empty, rmdir '.../website/electron/dist/mac-universal-x64-temp'  failedTask=build
```

The universal `.app` is actually lipo-merged successfully — only the post-merge temp-dir cleanup fails — but the non-zero exit means no DMG/zip is produced and the build is reported as failed.

## Why it matters
The universal DMG is the default `make desktop` output on macOS, so this blocks producing a distributable desktop app on Apple-Silicon build hosts. Worse, it's sticky: a failed run leaves `dist/mac-universal-*-temp` dirs behind, and because the script never wiped `dist`, **every subsequent run re-trips on the leftover dir**, turning a one-off race into a permanent failure until `dist` is manually cleared.

## Fix (symptoms → root cause → change)
- **Symptom:** `rmdir` of `dist/mac-universal-x64-temp` fails with `ENOTEMPTY`; the dir contains a `.DS_Store`.
- **Root cause:** electron-builder's universal step stages each arch into `dist/mac-universal-<arch>-temp`, lipo-merges them into `dist/mac-universal`, then removes the temp dirs with Node's `fs.rm` (which performs **no retries**). macOS Desktop Services (Finder/Spotlight) can write a `.DS_Store` into a temp dir *during* that recursive removal, so the final `rmdir` syscall races and throws `ENOTEMPTY` (electron-userland/electron-builder#6890). Since `build-desktop.sh` never pre-cleaned `dist`, stale `*-temp` dirs from a failed run then re-tripped later runs.
- **Change** (`packaging/build-desktop.sh`, packaging step 4):
  1. `rm -rf dist` before invoking electron-builder, so stale temp dirs never accumulate across runs.
  2. Wrap the electron-builder invocation in a bounded retry (max 3 attempts). On failure it inspects the captured output and **only** retries when the output contains `ENOTEMPTY` — sweeping `.DS_Store` and leftover `*-temp` dirs between attempts. Any other failure aborts immediately, so genuine build errors are never masked or silently retried.

## Tests
N/A — this is a packaging shell script with no unit-test harness. Change verified by `bash -n packaging/build-desktop.sh` (syntax) and by manual reasoning about the retry control flow under `set -euo pipefail` (the `if … then` guards keep a failing electron-builder from tripping `set -e`; `pipefail` propagates electron-builder's status through the `| tee`).

## Manual verification
- Reproduced the original failure and confirmed the offending `dist/mac-universal-x64-temp` held a `.DS_Store`.
- Cleared the stale temp dirs to unblock the local build.
- `bash -n packaging/build-desktop.sh` passes.
- Full `make desktop` universal build run is the end-to-end check (long; needs Rosetta x86_64 backend) — recommended before merge.
