### PR TITLE
fix(heartbeat): title dashboard-delivered heartbeat sessions

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2262,6 +2262,28 @@ class GatewayOrchestrator:
             }
         return None
 
+    async def _persist_slot_title(self, slot: "_ChatSlot") -> None:
+        """Persist a dashboard slot's title so it survives a gateway restart.
+
+        Best-effort and off the event loop (``set_title`` does a synchronous
+        read + rewrite): a slow or failed write must never break heartbeat
+        delivery. Mirrors the auto-research worker-slot titling path.
+        """
+        conv_log = getattr(self.dashboard_state, "conversation_log", None)
+        if conv_log is None:
+            return
+        # Lazy import avoids a circular dependency (dashboard.chat_utils → gateway).
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        try:
+            await asyncio.to_thread(
+                conv_log.set_title, _history_key_for(slot.key), slot.title
+            )
+        except Exception:
+            logger.warning(
+                "Heartbeat: failed to persist slot title for %s", slot.key, exc_info=True
+            )
+
     async def _deliver_result(
         self,
         title: str,
@@ -2410,7 +2432,20 @@ class GatewayOrchestrator:
         if deliver == "dashboard":
             if self.dashboard_state:
                 slot = self.dashboard_state.get_or_create_slot()
+                # Heartbeat delivery appends only an assistant message, so the
+                # interactive LLM auto-titler never fires for this slot
+                # (_maybe_auto_title gates on user_count >= 1) and it would be
+                # stuck on the "New Session…" placeholder forever. Seed a
+                # meaningful title from the (already-redacted) task summary,
+                # mirroring the cron/auto-research slot pattern: set the title,
+                # lock _titled so display_title returns it, and persist it so it
+                # survives a gateway restart (best-effort, off the event loop).
+                seed = " ".join(task_summary.split())
+                slot.title = f"💓 {seed}"[:80] if seed else title
+                slot._titled = True
+                await self._persist_slot_title(slot)
                 slot.append("assistant", f"{title}\n\n{result_text}", "msg msg-a")
+                self.dashboard_state.push_slot_title(slot.key, slot.title)
                 self.dashboard_state.push_slots_update()
                 self.dashboard_state.notify("heartbeat", title, body, meta={"slot": slot.key})
             return

--- a/test/test_heartbeat_deliver_default.py
+++ b/test/test_heartbeat_deliver_default.py
@@ -68,3 +68,66 @@ class TestDefaultDeliverConfig:
         # explicit slack branch posts the DM and never creates a dashboard slot
         orch.slack.open_dm.assert_awaited_once()
         orch.dashboard_state.get_or_create_slot.assert_not_called()
+
+
+class TestDashboardNewSlotTitle:
+    """Regression: heartbeat ``dashboard`` (new-slot) delivery must title the slot.
+
+    A heartbeat slot receives only an assistant message and never a user
+    message, so the interactive LLM auto-titler (``_maybe_auto_title``, gated on
+    ``user_count >= 1``) never fires. Without an explicit title the slot is stuck
+    on the ``NEW_SESSION_TITLE`` placeholder ("New Session…") forever — the
+    reported bug. The delivery path must seed a title from the (already-redacted)
+    task summary, lock ``_titled`` so ``display_title`` returns it, push it to the
+    sidebar, and persist it so it survives a gateway restart.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_new_slot_gets_title_from_task_summary(self, monkeypatch):
+        orch, state = _make_orch("dashboard", monkeypatch)
+        slot = state.get_or_create_slot.return_value
+        await orch._deliver_result(
+            "💓 Heartbeat", "Checking PR #163 CI status now.", "body", "dashboard"
+        )
+        assert slot.title == "💓 Checking PR #163 CI status now."
+        assert slot._titled is True
+        # Title pushed to the sidebar via the dedicated SSE event.
+        state.push_slot_title.assert_called_once_with(slot.key, slot.title)
+
+    @pytest.mark.asyncio()
+    async def test_new_slot_title_is_persisted(self, monkeypatch):
+        orch, state = _make_orch("dashboard", monkeypatch)
+        slot = state.get_or_create_slot.return_value
+        await orch._deliver_result("💓 Heartbeat", "task summary", "body", "dashboard")
+        state.conversation_log.set_title.assert_called_once()
+        key_arg, title_arg = state.conversation_log.set_title.call_args.args
+        assert key_arg == "dashboard:chat-1"  # _history_key_for(slot.key)
+        assert title_arg == slot.title
+
+    @pytest.mark.asyncio()
+    async def test_new_slot_title_falls_back_when_summary_blank(self, monkeypatch):
+        orch, state = _make_orch("dashboard", monkeypatch)
+        slot = state.get_or_create_slot.return_value
+        # Whitespace-only summary collapses to empty → use the generic title arg.
+        await orch._deliver_result("💓 Heartbeat", "   ", "body", "dashboard")
+        assert slot.title == "💓 Heartbeat"
+        assert slot._titled is True
+
+    @pytest.mark.asyncio()
+    async def test_new_slot_title_capped_at_80_chars(self, monkeypatch):
+        orch, state = _make_orch("dashboard", monkeypatch)
+        slot = state.get_or_create_slot.return_value
+        await orch._deliver_result("💓 Heartbeat", "x" * 200, "body", "dashboard")
+        assert len(slot.title) <= 80
+
+    @pytest.mark.asyncio()
+    async def test_persist_failure_does_not_break_delivery(self, monkeypatch):
+        """Title persistence is best-effort: a set_title error must not stop the
+        assistant message from being appended or the slot update from firing."""
+        orch, state = _make_orch("dashboard", monkeypatch)
+        slot = state.get_or_create_slot.return_value
+        state.conversation_log.set_title.side_effect = OSError("disk full")
+        await orch._deliver_result("💓 Heartbeat", "task", "body", "dashboard")
+        slot.append.assert_called_once()
+        state.push_slots_update.assert_called_once()
+        state.notify.assert_called_once()


### PR DESCRIPTION
## Problem
Heartbeat completions delivered to the dashboard (`<!-- deliver:dashboard -->`, or the `heartbeat.default_deliver=dashboard` config) create a brand-new chat session that is stuck on the **"New Session…"** placeholder in the sidebar instead of getting a real title.

![New Session… placeholder on a heartbeat session](https://github.com/kirodotdev/KiroCrew/assets/placeholder)

## Why it matters
Every heartbeat delivery spawns its own dashboard session. With no title, the sidebar fills with indistinguishable "New Session…" entries — the user can't tell what each heartbeat was about (which PR, which check) without opening it. This degrades wayfinding for exactly the recurring, unattended tasks heartbeat exists to run.

## Fix (symptom → root cause → change)
- **Symptom:** heartbeat dashboard sessions show "New Session…" forever.
- **Root cause:** in `_deliver_result()` the `deliver == "dashboard"` branch creates a new slot and appends **only an assistant message**. The interactive LLM auto-titler (`_maybe_auto_title`) gates on `user_count >= 1`, and a heartbeat slot has zero user messages, so it never fires. `_ChatSlot.display_title` then falls through to the `NEW_SESSION_TITLE` placeholder.
- **Change:** seed the slot title from the (already-redacted) task summary, lock `_titled` so `display_title` returns it, push it to the sidebar via `push_slot_title`, and persist it best-effort off the event loop. This mirrors the existing cron/auto-research worker-slot titling pattern (slots that likewise never receive a user message). Title is capped at 80 chars and falls back to the generic "💓 Heartbeat" when the summary is blank.

Added a small `_persist_slot_title` helper (best-effort, `asyncio.to_thread`, lazy import of `_history_key_for` to avoid a circular import) so a slow/failed title write can never break heartbeat delivery.

Scope note: the `dashboard:<slot>` and `prompt:dashboard:<slot>` branches target an already-existing (already-titled) slot and are unchanged — this was specifically the new-slot path.

## Tests
Added `TestDashboardNewSlotTitle` to `test/test_heartbeat_deliver_default.py`:
- title is seeded from the task summary and `_titled` is locked
- title is persisted via `conversation_log.set_title` under the correct history key
- blank/whitespace summary falls back to the generic title
- title is capped at 80 chars
- a `set_title` failure does not break message append / slot update / notify (best-effort persistence)

## Manual verification
N/A — unit coverage exercises the delivery branch directly (title, persistence, fallback, cap, and failure-safety). Existing heartbeat/gateway suites (233 tests) pass unchanged; flake8 clean. Frontend untouched.
