### PR TITLE
feat(subagent): add Stop button to SubagentProgressBar

### DIFF
--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect, useMemo, memo } from 'react'
-import { Bot, ChevronDown } from 'lucide-react'
+import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react'
+import { Bot, ChevronDown, X } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { sseSubagentDone } from '../../store/chatSlice'
 import { api } from '../../api/client'
@@ -29,6 +29,19 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   const activeListRef = useRef(activeList)
   activeListRef.current = activeList
   const hasActive = running > 0
+  // Only running/tool agents are cancellable via spawnDelete; pending agents
+  // (awaiting approval) are resolved through the approval reject path instead.
+  const stoppableCount = useMemo(() => activeList.filter(a => a.status === 'running' || a.status === 'tool').length, [activeList])
+  // Cancel a running subagent. A failed spawnDelete is swallowed with only a
+  // debug breadcrumb -- the 30s reconcile loop below is the safety net that
+  // drops any agent the backend actually stopped, so a failed DELETE self-heals
+  // and a toast would just be noise. Mirrors ActivityViewer's onCancel.
+  const stopAgent = useCallback((id: string) => {
+    api.spawnDelete(id).catch(() => console.warn(`spawnDelete failed for subagent ${id}; reconcile loop will resync`))
+  }, [])
+  const stopAll = useCallback(() => {
+    activeListRef.current.forEach(a => { if (a.status === 'running' || a.status === 'tool') stopAgent(a.id) })
+  }, [stopAgent])
   const [expanded, setExpanded] = useState(false)
   const [, setTick] = useState(0)
   // 1Hz tick to update elapsed timers + 30s reconciliation to clear phantom agents
@@ -53,16 +66,27 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   return (
     <div className="px-5 mx-auto w-full" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
     <div className="mb-1 rounded-md bg-accent/10 border border-accent/20 animate-slide-up overflow-hidden">
-      <button
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] font-mono cursor-pointer hover:bg-accent/5 transition-colors"
-        onClick={() => setExpanded(e => !e)}
-        aria-expanded={expanded}
-        aria-label={`${running} subagent${running > 1 ? 's' : ''} running`}
-      >
-        <Bot size={14} className="text-accent shrink-0" />
-        <span className="text-text-strong font-medium">{running} agent{running > 1 ? 's' : ''} running</span>
-        <ChevronDown size={14} className={`text-muted ml-auto shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
-      </button>
+      <div className="w-full flex items-center gap-2 pr-2">
+        <button
+          className="flex-1 min-w-0 flex items-center gap-2 px-3 py-1.5 text-[13px] font-mono cursor-pointer hover:bg-accent/5 transition-colors text-left bg-transparent border-none"
+          onClick={() => setExpanded(e => !e)}
+          aria-expanded={expanded}
+          aria-label={`${running} subagent${running > 1 ? 's' : ''} running`}
+        >
+          <Bot size={14} className="text-accent shrink-0" />
+          <span className="text-text-strong font-medium">{running} agent{running > 1 ? 's' : ''} running</span>
+          <ChevronDown size={14} className={`text-muted ml-auto shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+        </button>
+        {stoppableCount > 0 && (
+          <button
+            className="shrink-0 flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded border border-danger/40 text-danger/70 hover:bg-danger-subtle hover:text-danger cursor-pointer transition-all bg-transparent"
+            onClick={stopAll}
+            aria-label={stoppableCount > 1 ? 'Stop all running subagents' : 'Stop running subagent'}
+          >
+            <X size={11} /> Stop{stoppableCount > 1 ? ' all' : ''}
+          </button>
+        )}
+      </div>
       {expanded && activeList.length > 0 && (
         <div className="px-3 pb-2 space-y-0.5">
           {activeList.map((a, i) => {
@@ -79,6 +103,16 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
                   </div>
                   {a.lastTool && <div className="text-accent/60 truncate">→ {sanitizeLlmOutput(a.lastTool)}</div>}
                 </div>
+                {(a.status === 'running' || a.status === 'tool') && (
+                  <button
+                    className="shrink-0 flex items-center text-[11px] px-1 py-0.5 rounded border border-danger/40 text-danger/70 hover:bg-danger-subtle hover:text-danger cursor-pointer transition-all bg-transparent"
+                    onClick={() => stopAgent(a.id)}
+                    aria-label={`Stop subagent ${sanitizeLlmOutput(a.agent || a.id)}`}
+                    title="Stop this subagent"
+                  >
+                    <X size={11} />
+                  </button>
+                )}
               </div>
             )
           })}

--- a/website/src/test/SubagentProgressBar.test.tsx
+++ b/website/src/test/SubagentProgressBar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer, { setActiveSlot, sseSubagentSpawn, sseSubagentPending } from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+
+vi.mock('../api/client', () => ({
+  api: {
+    spawnDelete: vi.fn().mockResolvedValue({}),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+  },
+}))
+
+import SubagentProgressBar from '../pages/chat/SubagentProgressBar'
+import { api } from '../api/client'
+
+const SLOT = 'test-slot'
+
+/** Build a store with `running` running agents + optionally one pending agent, all in SLOT. */
+function makeStore(running: string[], pending?: string) {
+  const store = configureStore({
+    reducer: { chat: chatReducer, dashboard: dashboardReducer, notifications: notificationsReducer },
+  })
+  store.dispatch(setActiveSlot(SLOT))
+  running.forEach(id => store.dispatch(sseSubagentSpawn({ slot: SLOT, id, task: `task ${id}`, agent: `agent-${id}` })))
+  if (pending) store.dispatch(sseSubagentPending({ slot: SLOT, id: pending, task: `task ${pending}`, approval_id: `appr-${pending}` }))
+  return store
+}
+
+function renderBar(store: ReturnType<typeof makeStore>) {
+  return render(
+    <Provider store={store}>
+      <SubagentProgressBar slot={SLOT} />
+    </Provider>,
+  )
+}
+
+describe('SubagentProgressBar — in-chat stop controls', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('stops a single running agent from its per-row button (excludes pending from stop-all)', () => {
+    // 1 running + 1 pending: only the running agent is stoppable.
+    renderBar(makeStore(['a1'], 'p1'))
+    // Header reflects the total active count (running + pending).
+    fireEvent.click(screen.getByLabelText('2 subagents running'))
+    // Exactly one per-row stop button (the running agent, not the pending one).
+    const rowStops = screen.getAllByLabelText(/^Stop subagent/)
+    expect(rowStops).toHaveLength(1)
+    fireEvent.click(rowStops[0])
+    expect(api.spawnDelete).toHaveBeenCalledTimes(1)
+    expect(api.spawnDelete).toHaveBeenCalledWith('a1')
+  })
+
+  it('"Stop all" cancels every running agent but never a pending one', () => {
+    renderBar(makeStore(['a1', 'a2'], 'p1'))
+    fireEvent.click(screen.getByLabelText('Stop all running subagents'))
+    expect(api.spawnDelete).toHaveBeenCalledTimes(2)
+    expect(api.spawnDelete).toHaveBeenCalledWith('a1')
+    expect(api.spawnDelete).toHaveBeenCalledWith('a2')
+    expect(api.spawnDelete).not.toHaveBeenCalledWith('p1')
+  })
+
+  it('labels the header stop control "Stop" (not "Stop all") when exactly one agent is stoppable', () => {
+    renderBar(makeStore(['a1']))
+    expect(screen.getByLabelText('Stop running subagent')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Stop all running subagents')).not.toBeInTheDocument()
+  })
+
+  it('renders no stop controls when every active agent is pending (stoppableCount === 0)', () => {
+    renderBar(makeStore([], 'p1'))
+    // The pending agent still shows in the header, but offers no stop affordance.
+    fireEvent.click(screen.getByLabelText('1 subagent running'))
+    expect(screen.queryByLabelText(/^Stop/)).toBeNull()
+    expect(api.spawnDelete).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Syncs the cancel-subagent UI from the upstream (MeshClaw) SubagentProgressBar into KiroCrew's inline chat progress bar component.

### What was missing

The backend (`DELETE /api/spawn/:id`), the API client (`api.spawnDelete`), and the sidebar cancel (ActivityViewer) all already existed. The only gap was the **inline progress bar above the composer** -- it showed running agents but offered no way to stop them without navigating to the sidebar or Agents page.

### Changes

| File | What |
|------|------|
| `website/src/pages/chat/SubagentProgressBar.tsx` | Added `stopAgent`/`stopAll` callbacks, header-level "Stop"/"Stop all" button, per-row × button. Added `useCallback` + `X` import. Restructured header to flex container for button placement. |
| `website/src/test/SubagentProgressBar.test.tsx` | **New** -- 4 tests covering: single-agent stop, stop-all excludes pending, singular/plural label, no stop controls when all pending. |

### Behaviour

- `pending` agents (awaiting tool approval) are **excluded** from stop controls -- they go through the approval reject path
- Failed `spawnDelete` calls are swallowed (warn-only); the 30s reconcile loop is the safety net
- Exactly mirrors the existing ActivityViewer cancel semantics

### Screenshots

The Stop button appears at the right edge of the progress bar header (same position as upstream):

```
[Bot icon] 1 agent running         [▼]  [× Stop]
```

When expanded, each running row gets its own × button.