### PR TITLE
fix(acp): offer only 'auto' when /api/models is unavailable + reject canonical model keys

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
+from kiro_crew import model_registry
 from kiro_crew.config.loader import (
     KiroCrewConfig,
     _workspace_name_for_dir,
@@ -1421,6 +1422,36 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "agent": agent_name, "workspace": workspace})
 
 
+def _model_rejected_reason(model_name: str) -> str | None:
+    """Reason to reject ``model_name`` for the active provider, or None to allow.
+
+    The dashboard model dropdown falls back to canonical registry keys (e.g.
+    ``fable-5-1m``) when /api/models is unavailable (gateway restart / kiro-cli
+    cold-start timeout). Those keys are DISPLAY identifiers the ACP CLI rejects
+    as model ids (-32603 "model not available") — selecting one used to write it
+    into ``slot.model`` and break the next turn. This guard is defense-in-depth
+    behind the frontend fix (auto-only fallback): a stale client, a direct API
+    call, or the openai-compat path can never persist a canonical key. ``auto``
+    and ``""`` (provider default) always pass; for the ``claude_code`` provider
+    canonical keys ARE the wire format, so they pass there too.
+    """
+    if not model_name or model_name == "auto":
+        return None
+    try:
+        provider = KiroCrewConfig.load().agent.provider
+    except Exception:  # pragma: no cover - config load is resilient
+        provider = ""
+    if provider == "claude_code":
+        return None
+    if model_registry.is_canonical_key(model_name):
+        return (
+            f"{model_name!r} is a display-only model identifier the "
+            f"{provider or 'active'} provider does not accept; "
+            f"select a listed model or 'auto'."
+        )
+    return None
+
+
 async def api_chat_slot_model(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/model — set model for a chat slot."""
     state: DashboardState = request.app["state"]
@@ -1433,6 +1464,10 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     model_name = _normalize_model(body.get("model", ""))
+    reason = _model_rejected_reason(model_name)
+    if reason:
+        logger.warning("Slot %s model rejected: %s", name, reason)
+        return web.json_response({"error": reason}, status=400)
     if slot.model == model_name:
         return web.json_response({"ok": True, "model": model_name})
     slot.model = model_name
@@ -1461,6 +1496,9 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     model_name = _normalize_model(body.get("model", ""))
+    reason = _model_rejected_reason(model_name)
+    if reason:
+        return web.json_response({"error": reason}, status=400)
     skip_running = body.get("skip_running", True)
     if not isinstance(skip_running, bool):
         return web.json_response({"error": "skip_running must be a boolean"}, status=400)

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -238,6 +238,19 @@ def default(provider: str) -> str:
     return _DEFAULTS.get(provider, _FALLBACK_CANONICAL)
 
 
+def is_canonical_key(name: str) -> bool:
+    """True if ``name`` is a top-level canonical registry key (e.g. ``fable-5-1m``).
+
+    Distinguishes a canonical KEY from a provider alias or id: ``claude-fable-5``
+    is an alias (False), ``fable-5-1m`` is a key (True). The set-model guard uses
+    this to reject canonical keys on non-``claude_code`` providers, where they are
+    display-only identifiers the ACP CLI rejects as model ids (-32603 "model not
+    available"). ``auto`` is a registry key too, so callers that must permit the
+    Auto sentinel check for it separately.
+    """
+    return name in _REGISTRY
+
+
 def canonicalize_for_provider(stored_model: str, provider: str) -> str:
     """Map a stored model string to its canonical registry key — but ONLY for
     ``claude_code``, where the wire/dropdown values are canonical keys.

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10064,6 +10064,106 @@ class TestBulkModelSwitch:
 
         assert resp.status == 400
 
+    @pytest.mark.asyncio
+    async def test_canonical_key_rejected_no_slot_touched(self, tmp_path):
+        # A canonical registry key (the /api/models cold-start fallback trap)
+        # is rejected 400 for the acp provider; no slot is switched or reset.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.get_or_create_slot("a", model="claude-fable-5")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/model", json={"model": "fable-5-1m"}
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert "fable-5-1m" in data["error"]
+        assert state._slots["a"].model == "claude-fable-5"
+        state.sessions.reset.assert_not_awaited()
+
+
+class TestSlotModelGuard:
+    """POST /api/chat/slots/{slot}/model — reject canonical registry keys the
+    ACP CLI cannot accept (the /api/models cold-start fallback -32603 trap)."""
+
+    @staticmethod
+    def _app(state: DashboardState) -> web.Application:
+        from kiro_crew.dashboard.chat import api_chat_slot_model
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_canonical_key_rejected_slot_unchanged(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.get_or_create_slot("a", model="claude-fable-5")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "fable-5-1m"}
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert "fable-5-1m" in data["error"]
+        # The slot keeps its valid model and the session is NOT reset.
+        assert state._slots["a"].model == "claude-fable-5"
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_string_auto_default_is_allowed(self, tmp_path):
+        # The frontend maps 'auto' -> '' before calling; '' is the provider
+        # default and always passes.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.get_or_create_slot("a", model="claude-fable-5")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/a/model", json={"model": ""})
+
+        assert resp.status == 200
+        assert state._slots["a"].model == ""
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_literal_is_allowed(self, tmp_path):
+        # A literal 'auto' (registry key, but the safe sentinel) always passes.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.get_or_create_slot("a", model="claude-fable-5")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "auto"})
+
+        assert resp.status == 200
+        assert state._slots["a"].model == "auto"
+
+    @pytest.mark.asyncio
+    async def test_valid_kiro_alias_is_allowed(self, tmp_path):
+        # kiro/acp ids (registry aliases, not top-level keys) pass through.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.get_or_create_slot("a", model="claude-fable-5")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        assert state._slots["a"].model == "claude-opus-4.8"
+        state.sessions.reset.assert_awaited_once()
+
 
 def _make_tail_fork_slot(state):
     slot = state.get_or_create_slot("src")

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -12,6 +12,23 @@ class TestModelRegistry:
             == "global.anthropic.claude-opus-4-8[1m]"
         )
 
+    def test_is_canonical_key_true_for_top_level_keys(self):
+        # Top-level registry keys — the display-only ids the /api/models
+        # fallback wrongly offered and the set-model guard must reject.
+        assert mr.is_canonical_key("fable-5-1m") is True
+        assert mr.is_canonical_key("opus-4.8-1m") is True
+        assert mr.is_canonical_key("opus-4.8") is True
+        # 'auto' is a registry key too; the set-model guard allows it separately.
+        assert mr.is_canonical_key("auto") is True
+
+    def test_is_canonical_key_false_for_aliases_and_unknowns(self):
+        # kiro/acp ids are ALIASES (or unregistered), never top-level keys, so
+        # they pass the guard unchanged.
+        assert mr.is_canonical_key("claude-fable-5") is False
+        assert mr.is_canonical_key("claude-opus-4.8") is False
+        assert mr.is_canonical_key("claude-sonnet-5") is False
+        assert mr.is_canonical_key("") is False
+
     def test_to_provider_id_identity_passthrough_for_provider_id(self):
         # An already-resolved provider id passes through unchanged (back-compat).
         pid = "global.anthropic.claude-opus-4-8[1m]"

--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -1,6 +1,5 @@
 import { api } from '../../api/client'
 import modelTokensRaw from '../../model_tokens.json'
-import { displayModels } from '../modelRegistry'
 import type {
   ProviderAdapter,
   ProviderCapabilities,
@@ -190,14 +189,20 @@ export class AcpAdapter implements ProviderAdapter {
     }
   }
 
-  /** Static fallback from the canonical model registry — used when the backend
-   *  is unavailable (gateway restart, kiro-cli cold-start timeout, auth race). */
+  /** Fallback when the backend model list is unavailable (gateway restart /
+   *  kiro-cli cold-start timeout / auth race on /api/models). Exposes ONLY the
+   *  "auto" sentinel — never the canonical registry keys (opus-4.8-1m,
+   *  fable-5-1m, …). Those keys are DISPLAY identifiers the ACP CLI rejects as
+   *  model ids: selecting one during the cold-start window wrote it verbatim
+   *  into slot.model and kiro-cli failed the turn with -32603 "model not
+   *  available". "auto" always resolves server-side, so it is the only safe
+   *  offering until the real list loads. */
   private _defaultModels(): ModelInfo[] {
-    return displayModels().map(m => ({
-      name: m.name,
-      description: m.description,
-      contextWindow: m.contextWindow,
-    }))
+    return [{
+      name: 'auto',
+      description: 'Models chosen by task for optimal usage and consistent quality',
+      contextWindow: MODEL_TOKENS['auto'] ?? DEFAULT_CONTEXT,
+    }]
   }
 
   getContextWindow(model: string): number {

--- a/website/src/test/AcpAdapter.models.test.ts
+++ b/website/src/test/AcpAdapter.models.test.ts
@@ -26,31 +26,34 @@ describe('AcpAdapter.fetchAvailableModels', () => {
     expect(models[2].description).toBe('Everyday tasks')
   })
 
-  it('falls back to static registry when API returns non-array (e.g. error object)', async () => {
+  it('falls back to AUTO-ONLY when API returns non-array (e.g. error object)', async () => {
     ;(api.models as any).mockResolvedValue({ error: 'Token required' })
     const models = await new AcpAdapter().fetchAvailableModels()
-    expect(models.length).toBeGreaterThan(0)
-    expect(models.some(m => m.name.includes('opus') || m.name.includes('sonnet'))).toBe(true)
+    // Never surface canonical registry keys (opus-4.8-1m, fable-5-1m, …): the
+    // ACP CLI rejects them as model ids (-32603). Only 'auto' is safe.
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
+    expect(models.some(m => m.name.includes('-1m') || m.name === 'opus-4.8')).toBe(false)
   })
 
-  it('falls back to static registry when API returns empty array', async () => {
+  it('falls back to AUTO-ONLY when API returns empty array', async () => {
     ;(api.models as any).mockResolvedValue([])
     const models = await new AcpAdapter().fetchAvailableModels()
-    expect(models.length).toBeGreaterThan(0)
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
   })
 
-  it('falls back to static registry when API throws (timeout, network error)', async () => {
+  it('falls back to AUTO-ONLY when API throws (timeout, network error)', async () => {
     ;(api.models as any).mockRejectedValue(new Error('fetch timeout'))
     const models = await new AcpAdapter().fetchAvailableModels()
-    expect(models.length).toBeGreaterThan(0)
-    expect(models.some(m => m.name.includes('opus'))).toBe(true)
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
   })
 
-  it('static fallback includes context window from registry', async () => {
+  it('auto-only fallback carries a sensible context window', async () => {
     ;(api.models as any).mockRejectedValue(new Error('boom'))
     const models = await new AcpAdapter().fetchAvailableModels()
-    const opus1m = models.find(m => m.name === 'opus-4.8-1m')
-    expect(opus1m).toBeDefined()
-    expect(opus1m!.contextWindow).toBe(1_000_000)
+    expect(models[0].name).toBe('auto')
+    expect(models[0].contextWindow).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Problem

On gateway restart / kiro-cli cold start, the **first** `kiro-cli chat --list-models`
spawn is slow and `/api/models` times out → returns **503**
(`handlers/agents.py`). The dashboard model picker then falls back to
`AcpAdapter._defaultModels()`, which returned the **static canonical registry
keys** (`opus-4.8-1m`, `fable-5-1m`, `opus-4.8`, …).

Those canonical keys are **display identifiers** — the ACP CLI does not accept
them as model ids. If the user picks one during the ~1–2 min cold-start window,
the FE writes it into `slot.model` and the next turn fails with
`-32603 "model not available"`. Users perceive this as "the model resets to a
broken/default state after every restart".

## Fix

**Frontend** (`website/src/providers/adapters/acp.ts`)
- `_defaultModels()` now returns **only the `auto` sentinel** instead of the
  canonical registry list. `auto` always resolves server-side, so it is the one
  safe offering while the real list is unavailable. Removed the now-unused
  `displayModels` import.

**Backend** (`dashboard/chat_handlers.py`, `model_registry.py`)
- New `model_registry.is_canonical_key()` distinguishes a top-level canonical
  key (`fable-5-1m`) from a provider **alias/id** (`claude-fable-5`).
- New guard `_model_rejected_reason()` wired into both
  `POST /api/chat/slots/{slot}/model` and the bulk
  `POST /api/chat/slots/model`: on a non-`claude_code` provider, a canonical
  registry key is **rejected 400** — the slot keeps its existing valid model and
  the session is **not** reset. `auto` / `""` (provider default) always pass;
  for `claude_code` (where canonical keys are the wire format) they pass too.
  This is defense-in-depth behind the FE fix — a stale client, a direct API
  call, or the openai-compat path can never persist a broken id.

## Testing

- `flake8` (single-process): clean
- `tsc -b`: clean
- `vitest run`: **3936 passed / 3 skipped** — flipped the 3 `AcpAdapter`
  fallback assertions to expect auto-only; rewrote the context-window case.
- `pytest`: **15309 passed**; the 5 failures are pre-existing sandbox/env issues
  (`unshare CLONE_NEWUSER EPERM`, pidfd child-watcher, hardlink `EPERM`) in
  `test_app_backend` / `test_cli` / `test_deploy_round30_fixes` — none reference
  the changed modules. New coverage: `is_canonical_key` unit tests + single-slot
  & bulk guard route tests (canonical → 400 + slot untouched; `""` / `auto` /
  valid kiro alias → 200).

## Blast radius

Narrow. Only the `/api/models`-unavailable fallback path and the set-model
handlers change. The normal path (backend returns the live model list) is
untouched; valid kiro ids (registry aliases like `claude-opus-4.8`) and `auto`
are unaffected.
