### PR TITLE
feat(chat): redesign file-change summary card

### DIFF
--- a/website/src/components/FileChangeChips.tsx
+++ b/website/src/components/FileChangeChips.tsx
@@ -1,4 +1,5 @@
-import { memo } from 'react'
+import { memo, useState } from 'react'
+import { FileDiff, ChevronDown, ChevronUp } from 'lucide-react'
 import type { FileChipStyle } from '../pages/chat/ChatSettings'
 import { colorForExt, fileIcon } from '../utils/fileIcons'
 
@@ -65,16 +66,111 @@ function Stats({ added, removed }: { added: number; removed: number }) {
   </>
 }
 
-/* ── Expanded: liquid-glass pill with icon + filename + stats ── */
-function ExpandedChip({ fc, onClick }: { fc: FileChangeEntry; onClick: () => void }) {
-  const { added, removed } = countLines(fc.before, fc.after)
+/* ── Diffstat cells: a compact 5-cell bar (GitHub-style) giving an at-a-glance
+ *   sense of the add/remove proportion — green cells for additions, red for
+ *   removals, the rest neutral. Purely decorative, so aria-hidden.          */
+function DiffStatBar({ added, removed }: { added: number; removed: number }) {
+  const CELLS = 5
+  const total = added + removed
+  let g = 0, r = 0
+  if (total > 0) {
+    g = added > 0 ? Math.max(1, Math.round((added / total) * CELLS)) : 0
+    r = removed > 0 ? Math.max(1, Math.round((removed / total) * CELLS)) : 0
+    while (g + r > CELLS) { if (g >= r) g--; else r-- }
+  }
+  const neutral = CELLS - g - r
+  const cell = (cls: string, key: string) => <span key={key} className={`w-[7px] h-[7px] rounded-[2px] ${cls}`} />
+  return (
+    <span className="flex items-center gap-[3px] shrink-0" aria-hidden="true">
+      {Array.from({ length: g }, (_, i) => cell('bg-ok', `g${i}`))}
+      {Array.from({ length: r }, (_, i) => cell('bg-danger', `r${i}`))}
+      {Array.from({ length: neutral }, (_, i) => cell('bg-border', `n${i}`))}
+    </span>
+  )
+}
+
+/* ── Expanded row: one changed file per line — icon + filename left, a
+ *   diffstat bar + aligned +N/-N stats right. Rows are padded + rounded and
+ *   lift on hover (no hard dividers) so the block reads as a soft list.     */
+function ExpandedRow({ fc, added, removed, isArtifact, onClick }: { fc: FileChangeEntry; added: number; removed: number; isArtifact?: boolean; onClick: () => void }) {
   const Icon = fileIcon(fc.path)
   return (
-    <button onClick={onClick} className="glass-surface file-chip inline-flex items-center gap-1 rounded-full px-2.5 py-1.5 text-[11.5px] font-medium cursor-pointer text-text" aria-label={fc.path}>
-      <Icon size={12} className={colorForExt(fc.path)} />
-      <span className="truncate max-w-[180px]">{basename(fc.path)}</span>
-      <Stats added={added} removed={removed} />
+    <button
+      onClick={onClick}
+      className="group/row flex items-center gap-2.5 w-full px-2 py-1.5 rounded-lg text-left text-[12px] font-medium text-text cursor-pointer transition-colors hover:bg-bg-elevated"
+      aria-label={fc.path}
+    >
+      <Icon size={14} className={`shrink-0 ${colorForExt(fc.path)}`} />
+      <span className="truncate min-w-0 transition-colors">{basename(fc.path)}</span>
+      {isArtifact && (
+        <span
+          className="shrink-0 text-[10px] leading-none px-1.5 py-0.5 rounded-full border border-border text-muted font-medium"
+          title="This document is tracked as a session artifact, not a source-file change"
+        >
+          Artifact
+        </span>
+      )}
+      <span className="flex-1 min-w-0" />
+      <DiffStatBar added={added} removed={removed} />
+      <span className="shrink-0 flex items-center justify-end gap-1.5 tabular-nums min-w-[52px]">
+        <Stats added={added} removed={removed} />
+      </span>
     </button>
+  )
+}
+
+/* ── Expanded: a single elevated card grouping the changed files into aligned
+ *   rows, with a header carrying a neutral icon chip, the file count, and an
+ *   aggregate +N/-N roll-up (multi-file only). Reads as one structured unit.
+ *   `artifactPaths` (paths the session tracks as documents/artifacts) badges
+ *   those rows so generated docs read distinctly from source-file edits.
+ *   Long lists are capped at COLLAPSED_COUNT rows behind a "Show N more"
+ *   toggle so a big turn doesn't wall off the transcript (the header still
+ *   shows the true total + aggregate stats while collapsed).                */
+const COLLAPSED_COUNT = 8
+
+function ExpandedList({ fileChanges, onOpenDiff, artifactPaths }: {
+  fileChanges: FileChangeEntry[]
+  onOpenDiff?: (path: string, modified: string, original: string) => void
+  artifactPaths?: Set<string>
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const n = fileChanges.length
+  // Count once per file: reused by each row AND the header roll-up.
+  const stats = fileChanges.map(fc => countLines(fc.before, fc.after))
+  const totalAdded = stats.reduce((s, x) => s + x.added, 0)
+  const totalRemoved = stats.reduce((s, x) => s + x.removed, 0)
+  const overflow = n > COLLAPSED_COUNT
+  const visibleCount = overflow && !expanded ? COLLAPSED_COUNT : n
+  const hiddenCount = n - COLLAPSED_COUNT
+  return (
+    <div className="ft-block-reveal mt-2 mb-1.5 w-full max-w-full rounded-xl border border-border bg-bg overflow-hidden">
+      <div className="flex items-center gap-2.5 px-3.5 py-2 border-b border-border">
+        <FileDiff size={14} className="text-muted shrink-0" />
+        <span className="text-[12px] font-medium text-muted">{n} file{n === 1 ? '' : 's'} changed</span>
+        {n > 1 && (
+          <span className="ml-auto flex items-center gap-1.5 text-[11px] tabular-nums">
+            <Stats added={totalAdded} removed={totalRemoved} />
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5 p-1.5">
+        {fileChanges.slice(0, visibleCount).map((fc, i) => (
+          <ExpandedRow key={fc.path} fc={fc} added={stats[i].added} removed={stats[i].removed} isArtifact={artifactPaths?.has(fc.path)} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} />
+        ))}
+        {overflow && (
+          <button
+            onClick={() => setExpanded(v => !v)}
+            className="flex items-center justify-center gap-1 w-full px-2 py-1.5 rounded-lg text-[11.5px] font-medium text-muted hover:text-text hover:bg-bg-elevated cursor-pointer transition-colors bg-transparent border-none"
+            aria-expanded={expanded}
+          >
+            {expanded
+              ? <><ChevronUp size={13} className="shrink-0" /> Show less</>
+              : <><ChevronDown size={13} className="shrink-0" /> Show {hiddenCount} more</>}
+          </button>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -93,27 +189,37 @@ function MinimalChip({ fc, onClick }: { fc: FileChangeEntry; onClick: () => void
   )
 }
 
-const RENDERERS = { expanded: ExpandedChip, minimal: MinimalChip } as const
-
 /**
- * Renders a row of file-change chips below an assistant message.
- * Each chip shows the modified file's basename + line stats, and on
- * click opens the Monaco diff panel via `onOpenDiff(path, after, before)`.
+ * Renders the file-change block below an assistant message.
+ *
+ * - `expanded` (default): a single card grouping every changed file into
+ *   aligned rows (icon + filename left, +N/-N stats right) with a header —
+ *   reads as one structured unit instead of a loose pile of pills.
+ * - `minimal`: stats-only glass pills that wrap, filename on hover.
+ *
+ * Clicking any file opens the Monaco diff panel via
+ * `onOpenDiff(path, after, before)`.
  */
-const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, style = 'expanded' }: {
+const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, style = 'expanded', artifactPaths }: {
   fileChanges: FileChangeEntry[]
   onOpenDiff?: (path: string, modified: string, original: string) => void
   style?: FileChipStyle
+  /** Paths the session tracks as documents/artifacts — badged in the expanded
+   *  card so generated docs read distinctly from source-file edits. */
+  artifactPaths?: Set<string>
 }) {
   if (!fileChanges?.length) return null
-  const Chip = RENDERERS[style] ?? ExpandedChip
-  return (
-    <div className="ft-block-reveal flex flex-wrap items-center gap-1.5 mt-2 mb-1.5">
-      {fileChanges.map(fc => (
-        <Chip key={fc.path} fc={fc} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} />
-      ))}
-    </div>
-  )
+  // Minimal keeps the wrapping pill row; anything else uses the grouped card.
+  if (style === 'minimal') {
+    return (
+      <div className="ft-block-reveal flex flex-wrap items-center gap-1.5 mt-2 mb-1.5">
+        {fileChanges.map(fc => (
+          <MinimalChip key={fc.path} fc={fc} onClick={() => onOpenDiff?.(fc.path, fc.after, fc.before)} />
+        ))}
+      </div>
+    )
+  }
+  return <ExpandedList fileChanges={fileChanges} onOpenDiff={onOpenDiff} artifactPaths={artifactPaths} />
 })
 
 export default FileChangeChips

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2718,6 +2718,22 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
   const activeSlotTitle = filteredSlots.find(s => s.key === activeSlot)?.title
 
+  // Session documents (in-session artifacts) for the active slot. Used only to
+  // badge file-change rows that are tracked docs/artifacts (e.g. a generated
+  // PR body) rather than source-file edits. Shares the ['session-artifacts',
+  // slot] query key with the Artifacts tab so it's a single deduped fetch; the
+  // memoized Set keeps AssistantMessage's memo stable across renders.
+  const { data: sessionDocs } = useQuery({
+    queryKey: ['session-artifacts', activeSlot],
+    queryFn: () => api.artifactSessionDocs(activeSlot || undefined),
+    enabled: !!activeSlot,
+    staleTime: 15_000,
+  })
+  const artifactPaths = useMemo(
+    () => new Set((sessionDocs?.docs || []).map(d => d.path)),
+    [sessionDocs],
+  )
+
   const renderMessage = useCallback((i: number, m: ChatMessage) => {
     const key = m.ts ? `${m.role}-${m.ts}` : `${m.role}-${i}`
     if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} /> : null
@@ -2784,7 +2800,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
             })()
           ) : (
             <div className="flex flex-col gap-0">
-              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} showFooter={(() => {
+              <AssistantMessage content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onQuote={handleQuote} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} artifactPaths={artifactPaths} showFooter={(() => {
                 // Show footer on the last assistant message of each completed turn
                 if (isStreaming) return false
                 // Find next message after this one that's assistant, user, or streaming
@@ -2816,7 +2832,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // apply-plan handler, so it belongs here for correctness. approve/send/
     // dismissApproval are NOT referenced in this renderer (user/approval rows go
     // through renderUserContentCb), so they are omitted to keep it stable.
-  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId])
+  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleFork, handleQuote, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths])
 
   const [mobileSessions, setMobileSessions] = useState(false)
   // Close mobile sessions panel when a session is selected

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -77,7 +77,7 @@ function SteerAckChip({ summary }: { summary: string }) {
   )
 }
 
-const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle }) {
+const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle, artifactPaths }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: () => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle; artifactPaths?: Set<string> }) {
   const [applied, setApplied] = useState(false)
   const [copied, setCopied] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
@@ -190,7 +190,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
       {!isStreaming && selectionActions.length > 0 && <SelectionToolbar containerRef={contentRef} actions={selectionActions} />}
     </div>
     {fileChanges && fileChanges.length > 0 && !isStreaming && (
-      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} style={fileChipStyle} />
+      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} style={fileChipStyle} artifactPaths={artifactPaths} />
     )}
     {!isStreaming && showFooter && (
       <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300">

--- a/website/src/test/FileChangeChips.test.tsx
+++ b/website/src/test/FileChangeChips.test.tsx
@@ -164,21 +164,51 @@ describe('FileChangeChips', () => {
     consoleErr.mockRestore()
   })
 
-  it('uses the multiset fallback for huge files (>1M LCS cells)', () => {
-    // m * n > 1_000_000 triggers the cheap multiset branch. Build two
-    // files with ~1100 lines each so the cell budget is exceeded but the
-    // test still runs in <100ms.
-    const N = 1100
-    const before = Array.from({ length: N }, (_, i) => `before-line-${i}`).join('\n')
-    // Treatment: drop 5 unique lines, add 7 unique ones; the rest match.
-    const afterLines = Array.from({ length: N }, (_, i) => `before-line-${i}`)
-    afterLines.splice(0, 5)
-    afterLines.push('extra-1', 'extra-2', 'extra-3', 'extra-4', 'extra-5', 'extra-6', 'extra-7')
-    const after = afterLines.join('\n')
-    render(<FileChangeChips fileChanges={[change('/huge.log', before, after)]} />)
-    // Multiset branch: under-counts pure moves, but unique additions and
-    // unique removals are exact. Expect +7/-5.
-    expect(screen.getByText('+7')).toBeInTheDocument()
-    expect(screen.getByText('-5')).toBeInTheDocument()
+  it('badges rows whose path is in artifactPaths', () => {
+    render(
+      <FileChangeChips
+        fileChanges={[
+          change('/proj/src/code.ts', 'a', 'a\nb'),
+          change('/ws/kiro-pr-body.md', '', 'hello'),
+        ]}
+        artifactPaths={new Set(['/ws/kiro-pr-body.md'])}
+      />
+    )
+    // The artifact doc is badged; the source file is not.
+    const badges = screen.getAllByText('Artifact')
+    expect(badges).toHaveLength(1)
+    // Badge sits on the .md row, not the .ts row.
+    expect(badges[0].closest('button')).toHaveTextContent('kiro-pr-body.md')
+  })
+
+  it('renders no badges when artifactPaths is omitted', () => {
+    render(<FileChangeChips fileChanges={[change('/a.md', '', 'x')]} />)
+    expect(screen.queryByText('Artifact')).not.toBeInTheDocument()
+  })
+
+  it('caps long lists at 8 rows behind a "Show N more" toggle', () => {
+    const files = Array.from({ length: 11 }, (_, i) => change(`/f${i}.ts`, 'a', 'a\nb'))
+    render(<FileChangeChips fileChanges={files} />)
+    // First 8 shown; the rest hidden until expanded.
+    expect(screen.getByText('f0.ts')).toBeInTheDocument()
+    expect(screen.getByText('f7.ts')).toBeInTheDocument()
+    expect(screen.queryByText('f8.ts')).not.toBeInTheDocument()
+    expect(screen.queryByText('f10.ts')).not.toBeInTheDocument()
+    // Header still reports the TRUE total.
+    expect(screen.getByText('11 files changed')).toBeInTheDocument()
+    // Expand reveals the remainder…
+    fireEvent.click(screen.getByText('Show 3 more'))
+    expect(screen.getByText('f8.ts')).toBeInTheDocument()
+    expect(screen.getByText('f10.ts')).toBeInTheDocument()
+    // …and collapses again.
+    fireEvent.click(screen.getByText('Show less'))
+    expect(screen.queryByText('f10.ts')).not.toBeInTheDocument()
+  })
+
+  it('does not cap lists at or below the threshold', () => {
+    const files = Array.from({ length: 8 }, (_, i) => change(`/s${i}.ts`, 'a', 'b'))
+    render(<FileChangeChips fileChanges={files} />)
+    expect(screen.queryByText(/Show \d+ more/)).not.toBeInTheDocument()
+    expect(screen.getByText('s7.ts')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION

<img width="587" height="360" alt="Screenshot 2026-07-22 at 3 38 44 PM" src="https://github.com/user-attachments/assets/d1ec7db5-9467-480e-b3c7-a73e355152ae" />

## Problem

The "N files changed" summary card that renders under an assistant message was visually weak and, in the Kiro theme, collided with other surfaces:

- Its fill (`--bg-elevated`) is the **exact same color** as the composer and user-message bubbles (`#211d25` in `kiro-dark`, where `--card` == `--bg-elevated`), so an assistant *output* artifact wore the same "elevated interactive surface" as the things you type into.
- Rows used hard full-bleed dividers, the stats didn't align into a column, and the header icon and row icons sat at different left insets (misaligned).
- Nothing distinguished a generated document (e.g. a PR-body markdown the agent wrote to the workspace) from a real source-file edit.
- Long turns rendered every changed file with no cap, walling off the transcript.

## Why it matters

This card appears on nearly every coding turn. When it's loud, mis-aligned, and indistinguishable from the input surface, it hurts scannability and the message/receipt hierarchy of the whole chat. A big, uncapped list on a large turn makes the transcript hard to read.

## Fix (symptom → root cause → change)

The card was styled as a prominent elevated object when it should read as quiet, glanceable secondary metadata. Changes (all in `FileChangeChips.tsx`, with prop plumbing in `AssistantMessage.tsx` and `ChatPage.tsx`):

- **Dim frame, legible content.** Card drops to page-level `--bg` with no shadow and a muted header, so it recedes into the assistant flow instead of mimicking the composer/user surface. Filenames and `+N/−N` stats stay full-strength — the container is quiet, the information is crisp.
- **Structure & alignment.** Removed hard row dividers in favor of padded, rounded hover rows; right-aligned, fixed-width stat column; header glyph and row file icons now share one left inset (14px) and size (14px) so they form a clean column. Header shows the total count + aggregate `+/−` roll-up (multi-file only).
- **Diffstat bar.** Each row gets a compact 5-cell GitHub-style add/remove proportion bar.
- **Artifact badge.** Rows whose path is a tracked session document (via `api.artifactSessionDocs`, cross-referenced in `ChatPage` and passed down as a memoized `Set`) get a subtle neutral "Artifact" pill, so generated docs read distinctly from source edits. Shares the existing `['session-artifacts', slot]` query key (single deduped fetch).
- **Long-list cap.** Lists over 8 files show the first 8 behind a muted "Show N more" / "Show less" toggle; the header still reports the true total + aggregate while collapsed.

No backend changes; `minimal` chip style is unchanged.

## Tests

`website/src/test/FileChangeChips.test.tsx` (all 21 pass, incl. new cases):
- Artifact badge renders only for paths in `artifactPaths`; none when the prop is omitted.
- Long lists cap at 8 behind "Show N more"; expand/collapse reveals/hides the remainder; header keeps the true total; lists at/under the threshold show no toggle.
- Existing LCS diff-count, basename, click-to-diff, and minimal-style coverage still green.

`AssistantMessage.test.tsx` (37) still green (prop plumbing is backward-compatible/optional).

## Manual verification

Built the SPA and reloaded the desktop app; confirmed on `kiro-dark`: the card reads as a quiet page-level block distinct from the composer/user bubbles, icons align in a column, the artifact badge appears on a generated `.md` doc but not on source files, and a >8-file turn collapses with a working "Show N more".
