### PR TITLE
fix(ux): soften empty-response card to an info notice (#199)

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3772,15 +3772,23 @@ async def _run_chat(
                 # response. An ephemeral status indicator is not used here — it
                 # is emitted at turn-teardown and the frontend drops it once the
                 # streaming turn ends (so it never surfaces). Only the second
-                # consecutive empty surfaces a persisted error card below.
+                # consecutive empty surfaces a persisted notice card below.
                 slot._empty_response_retries += 1
                 slot.queue_insert(0, message)
                 _retrying_empty = True
             else:
-                # Single emit (see AcpProcessDied note): slot.append persists +
-                # broadcasts one chat_message via _on_message; no explicit broadcast_ws.
-                _empty_msg = "⟳ Empty response — please retry."
-                slot.append("error", _empty_msg, "msg msg-err")
+                # Recoverable, usually-transient: the runner already silently
+                # self-retried once (first empty = silent re-queue). Surface a
+                # soft "notice" card (not a red "error" card) so a self-healing
+                # event doesn't read like a crash — and phrase it to reflect
+                # that the retry already happened. Single emit (see AcpProcessDied
+                # note): slot.append persists + broadcasts one chat_message via
+                # _on_message; no explicit broadcast_ws.
+                _empty_msg = (
+                    "ℹ️ The model returned nothing this turn (it was retried "
+                    "automatically). Just send your message again to continue."
+                )
+                slot.append("notice", _empty_msg, "msg msg-info")
         # On an empty-response re-queue the turn produced nothing and will
         # immediately re-run; skip persistence / consolidation / success-recording
         # so we don't save a spurious empty turn or skew reliability metrics.

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -9019,9 +9019,9 @@ class TestEmptyResponseRetry:
         assert slot._empty_response_retries == 1
         # The message must be re-queued at the front of the queue.
         assert (0, "test message") in calls
-        # No error shown on first attempt
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert not any("Empty response" in m.get("content", "") for m in error_msgs)
+        # No notice card shown on first attempt — the empty is silently re-queued
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert not any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
         # Re-queue path must NOT persist/consolidate the spurious empty turn or
         # record success (item 3 of the CR).
         mock_save.assert_not_called()
@@ -9036,7 +9036,7 @@ class TestEmptyResponseRetry:
     @pytest.mark.asyncio
     async def test_empty_response_at_depth_gt0_shows_error_immediately(self, tmp_path: Path) -> None:
         """At _prompt_depth>0 an empty response is NOT silently retried — it shows the
-        terminal '⟳ Empty response — please retry.' card on the FIRST empty. The silent
+        terminal empty-response notice card on the FIRST empty. The silent
         re-queue is intentionally depth-0 only (nested tool-use turns must not silently
         re-queue and risk a runaway loop)."""
         state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
@@ -9046,8 +9046,8 @@ class TestEmptyResponseRetry:
 
         # depth>0: the `if _prompt_depth == 0 ...` guard is false, so the else fires —
         # terminal card immediately, no silent retry, no increment of the counter.
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert any("Empty response" in m.get("content", "") for m in error_msgs)
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
         assert slot._empty_response_retries == 0
 
     @pytest.mark.asyncio
@@ -9059,8 +9059,8 @@ class TestEmptyResponseRetry:
 
         await _run_chat(state, slot, "test message")
 
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert any("Empty response" in m.get("content", "") for m in error_msgs)
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
         # After the terminal second-empty error, the counter resets so the NEXT
         # independent user turn gets a fresh one-retry budget (not sticky at 1).
         assert slot._empty_response_retries == 0
@@ -9086,7 +9086,7 @@ class TestEmptyResponseRetry:
 
     @pytest.mark.asyncio
     async def test_compaction_turn_no_empty_response_error(self, tmp_path: Path) -> None:
-        """Compaction turns set assistant_text='' but should NOT trigger empty response error."""
+        """Compaction turns set assistant_text='' but should NOT trigger the empty-response notice."""
         from kiro_crew.providers.base import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, LLMEvent
 
         state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
@@ -9100,12 +9100,12 @@ class TestEmptyResponseRetry:
 
         await _run_chat(state, slot, "/compact")
 
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert not any("Empty response" in m.get("content", "") for m in error_msgs)
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert not any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
 
     @pytest.mark.asyncio
     async def test_clear_turn_no_empty_response_error(self, tmp_path: Path) -> None:
-        """Clear turns set assistant_text='' but should NOT trigger empty response error."""
+        """Clear turns set assistant_text='' but should NOT trigger the empty-response notice."""
         from kiro_crew.providers.base import EVENT_CLEAR_STATUS, EVENT_COMPLETE, LLMEvent
 
         state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
@@ -9119,12 +9119,12 @@ class TestEmptyResponseRetry:
 
         await _run_chat(state, slot, "/clear")
 
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert not any("Empty response" in m.get("content", "") for m in error_msgs)
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert not any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
 
     @pytest.mark.asyncio
     async def test_agent_switch_turn_no_empty_response_error(self, tmp_path: Path) -> None:
-        """Agent switch turns set assistant_text='' but should NOT trigger empty response error."""
+        """Agent switch turns set assistant_text='' but should NOT trigger the empty-response notice."""
         from kiro_crew.providers.base import EVENT_AGENT_SWITCHED, EVENT_COMPLETE, LLMEvent
 
         state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
@@ -9138,8 +9138,8 @@ class TestEmptyResponseRetry:
 
         await _run_chat(state, slot, "test message")
 
-        error_msgs = [m for m in slot.messages if m.get("role") == "error"]
-        assert not any("Empty response" in m.get("content", "") for m in error_msgs)
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert not any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
 
 
 class TestExpandDollarSkills:

--- a/website/src/app-sdk/ChatMessageList.tsx
+++ b/website/src/app-sdk/ChatMessageList.tsx
@@ -276,6 +276,16 @@ const ChatMessageList = memo(function ChatMessageList({
       )
     }
 
+    if (m.role === 'notice') {
+      return (
+        <div key={key} className="px-5 mx-auto w-full py-1" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
+          <div className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">
+            {m.content}
+          </div>
+        </div>
+      )
+    }
+
     if (m.role === 'thinking' || m.role === 'system' || m.role === 'done' || m.role === 'queued') return null
     if (m.role === 'file') return null // TODO: file download links
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2737,6 +2737,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (m.role === 'queued') return null
     if (m.kind === 'stop_event' || m.meta?.kind === 'stop_event') return <StopEventCard key={m.meta?.id as string ?? key} message={m} />
     if (m.role === 'error') return <div key={key} className="bg-danger-subtle text-danger text-[13px] px-3 py-2 rounded-md border border-danger/15 self-center animate-scale-in">{m.content}</div>
+    if (m.role === 'notice') return <div key={key} className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">{m.content}</div>
     if (m.role === 'permission') return null
     if (m.role === 'mcp_oauth') {
       const banner = renderMcpOAuthMessage(m)


### PR DESCRIPTION
## What

When the model returns an empty completion, the dashboard previously rendered a **red error card** `⟳ Empty response — please retry.` This downgrades it to a soft **info notice** and rewords it. The event is recoverable and usually transient — the chat runner already silently self-retries once before any card is shown — so surfacing it with crash-level severity (and telling the user to "please retry" when the system already did) is misleading.

Fixes #199.

## Changes

- `src/kiro_crew/dashboard/chat_runner.py` — the terminal (second-empty) branch now emits `slot.append("notice", …, "msg msg-info")` instead of `("error", …, "msg msg-err")`, reworded to: *"ℹ️ The model returned nothing this turn (it was retried automatically). Just send your message again to continue."*
- `website/src/app-sdk/ChatMessageList.tsx` + `website/src/pages/ChatPage.tsx` — render a `role: "notice"` message as a soft card (muted bg/border), distinct from the red `error` card.
- `test/test_dashboard_chat.py` — `TestEmptyResponseRetry` assertions updated from `role=="error"`/"Empty response" to `role=="notice"`/"returned nothing this turn". Behavior is unchanged (silent first-empty re-queue; terminal card on the second consecutive empty and at depth>0); tests were not weakened.

## Testing

- `flake8 -j1` on changed files: clean.
- `tsc -b`: clean.
- `pytest test/test_dashboard_chat.py::TestEmptyResponseRetry`: 7 passed.
- `vitest` (ChatMessageList / ChatPage suites): 117 passed.
- Full pytest/vitest left to CI's parallel shards.

## Notes

- A live demo video is impractical here — an empty completion can't be triggered on demand — so this relies on the unit tests + diff.
- Companion to #200 (the Make Live drain gap that surfaced this card).
