### PR TITLE
feat: surface sub-agent progress and detect stalls in the running-card

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -39,6 +39,7 @@
         "subagent_spawn_stagger_secs": 2.0,
         "subagent_max_turns": 100,
         "subagent_timeout_secs": 1800,
+        "subagent_stall_idle_secs": 120,
         "completion_keep": "head",
         "completion_keep_chars": 3000,
         "subagent_result_ttl_secs": 3600,
@@ -414,6 +415,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 1800
+    },
+    {
+      "path": "agent.subagent_stall_idle_secs",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "SubAgent Stall Idle (seconds)",
+      "help": "Seconds with no stream activity before a running subagent is surfaced as 'stalled' in the running-card. 0 uses hardcoded default (120s).",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 120
     },
     {
       "path": "agent.completion_keep",

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -18,6 +18,7 @@ Supports `on_tool_approval` callback for interactive tool approval (routed throu
 | `INJECTION_TIMEOUT` | 300 | Inner cap: max seconds for a single `stream_and_collect` call (5 minutes) |
 | `_RESET_TIMEOUT` | 30 | Max seconds for session reset in finally block |
 | `_TURN_LIMIT` | 100 | Default tool-call budget per subagent (configurable via `agent.subagent_max_turns`, per-spawn via `max_turns`) |
+| `_STALL_IDLE_SECS` | 120 | Seconds with no stream activity before a running subagent is surfaced as **stalled** in the running-card (configurable via `agent.subagent_stall_idle_secs`). Surface-only — a stalled subagent is never auto-terminated; the user closes it from the UX (per-row stop / Stop-all) and the 30-min `_TIMEOUT_SECS` ceiling still applies. |
 | `_SYSTEM_PREFIX` | (string) | Injected before task text to prevent spawn recursion |
 | `COMPLETION_KEEP_DEFAULT_CHARS` | 3000 | Default character cap for the completion event injected into the parent session (configurable via `agent.completion_keep_chars`). Lives in `context_management.py` alongside the helper. |
 
@@ -119,6 +120,10 @@ class SubagentInfo:
     result_truncated: bool  # completion copy dropped content → event carries summary+path
     error: str            # error message if failed
     elapsed: float        # seconds from start to completion (set in _run finally)
+    tool_count: int       # observed tool calls (incl. auto-approved); drives running-card progress
+    last_activity: float  # time.time() of last stream event; reset to _exec_started; drives idle-stall
+    stalled: bool         # reaper flagged this subagent as idle/stalled (UI signal)
+    _awaiting_approval: bool  # blocked on a human tool-approval prompt → exempt from idle-stall
 ```
 
 ## Session Lifecycle
@@ -144,6 +149,22 @@ class SubagentInfo:
 - `_sigkill_session`: best-effort SIGKILL when graceful reset hangs
 - After decrementing `_running_count`, `_force_reap` calls `_drain_queue()` so the freed slot immediately starts a queued spawn. Normal completion pumps the queue via its `finally` block, but that block is gated on `not info.reaped`; a reap sets `reaped=True` and decrements the count itself, so without this explicit drain a queued spawn would sit stranded until an unrelated agent finished or a new spawn arrived.
 - Wired up in `gateway.py` after `SubagentManager` init
+
+### Idle-Stall Detection
+
+The main-agent watchdog stack (liveness oracle, `tool_stall_suspect`) does **not** govern subagents; `_maybe_flag_stall(agent_id, info, now)` (called from the reaper sweep) is their equivalent. Each stream event calls `_touch_activity(info)`, which updates `info.last_activity` and clears a prior `stalled` flag (re-emitting `subagent_stalled {stalled: false}` when work resumes). `info.last_activity` is (re)initialised to `_exec_started` at the top of `_run_inner` so a queue / spawn-approval wait is never counted as idle.
+
+Per sweep, for an agent that has actually started (`turns > 0` or a live `_pid`) and is **not** blocked on a human approval prompt (`_awaiting_approval`):
+- `idle > _stall_idle_secs` and not already flagged → set `info.stalled = True`, emit `subagent_stalled {stalled: true, idle_secs}` (surface-only; the card shows a "no activity" warning), and append a record of the slow command to `~/.kirocrew/subagents/slow_commands.jsonl` for later analysis.
+- Detection is **surface-only**: `_maybe_flag_stall` never terminates the agent. A genuinely-hung subagent is closed by the user from the UX (per-row stop → `spawnDelete` → `SubagentManager.cancel(agent_id)`, or header Stop-all). This is a deliberate choice — because session-sharing subagents share the parent's runtime PID, no per-PID liveness oracle can distinguish a wedged tool from a slow-but-healthy one, so the system surfaces + records rather than guessing and killing.
+
+The slow-command record (`record_slow_command`, `subagent_persistence.py`) is append-only and deliberately NOT a tombstone: a tombstone marks an agent dead and is consumed by orphan-reconciliation / TTL cleanup, whereas a stalled subagent is still running. Fields: `id`, `flagged` (ts), `last_tool` (redacted), `tool_count`, `turns`, `idle_secs`, `elapsed_secs`, `parent_session`, `session_sharing`.
+
+`_awaiting_approval` is set around the human tool-approval await in the `EVENT_PERMISSION_REQUEST` branch (reset in `finally`, which also refreshes `last_activity`), so a slow approval never looks stalled.
+
+### Running-card progress events
+
+`subagent_tool` is fired on **`EVENT_TOOL_CALL`** (not only `EVENT_PERMISSION_REQUEST`) — kiro-auto-allowed tools surface only as informational `tool_call` updates, so this is the sole progress signal a simple/read-only task emits. Payload carries `{tool, tool_kind, turns, tool_count}`; `info.tool_count` increments per observed tool call. The `subagent_snapshot` reconnect payload (`dashboard/ws.py`) also carries `tool_count` and `stalled` so a reloading client recovers progress/stall state (a transition-only WS signal always needs a matching snapshot field).
 
 ## Completion Injection
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -642,6 +642,14 @@ class AgentConfig:
             "Wall-clock timeout per subagent execution. 0 uses hardcoded default (1800s).",
         ),
     )
+    subagent_stall_idle_secs: int = field(
+        default=120,
+        metadata=_meta(
+            "SubAgent Stall Idle (seconds)",
+            "Seconds with no stream activity before a running subagent is surfaced "
+            "as 'stalled' in the running-card. 0 uses hardcoded default (120s).",
+        ),
+    )
     completion_keep: str = field(
         default="head",
         metadata=_meta(
@@ -3019,6 +3027,7 @@ class KiroCrewConfig:
                 ),
                 subagent_max_turns=agent_data.get("subagent_max_turns", 100),
                 subagent_timeout_secs=agent_data.get("subagent_timeout_secs", 1800),
+                subagent_stall_idle_secs=_safe_int(agent_data.get("subagent_stall_idle_secs", 120), 120),
                 completion_keep=_validated_completion_keep(
                     agent_data.get("completion_keep", "head")
                 ),

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -182,6 +182,8 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                                                 "agent": _r(a.agent),
                                                 "streaming": _r(a.streaming_text),
                                                 "last_tool": _r(a.last_tool),
+                                                "tool_count": a.tool_count,
+                                                "stalled": a.stalled,
                                                 "started": a.started,
                                             },
                                         }

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3287,6 +3287,7 @@ class GatewayOrchestrator:
             max_concurrent=resolve_max_subagents(self._cfg),
             default_turn_limit=self._cfg.agent.subagent_max_turns,
             default_timeout=self._cfg.agent.subagent_timeout_secs,
+            stall_idle_secs=self._cfg.agent.subagent_stall_idle_secs,
             on_tool_approval=_approve_subagent,
             on_spawn_approval=_spawn_approve,
             is_yolo=_is_yolo,

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -71,6 +71,7 @@ from kiro_crew.subagent_persistence import (
     list_orphans,
     mark_delivered,
     prune_stale_tombstones,
+    record_slow_command,
     update_state,
     write_result_chunk,
     write_tombstone,
@@ -205,6 +206,7 @@ _RESET_TIMEOUT = 30.0  # max seconds for session reset in finally block
 _STARTUP_TIMEOUT_SECS = 120  # max seconds a subagent may sit pre-first-turn with no runtime before the startup watchdog reaps it
 _ON_DONE_TIMEOUT = 1200.0  # outer cap: max total seconds for semaphore wait + injection
 INJECTION_TIMEOUT = 300.0  # inner cap: max seconds for a single stream_and_collect call
+_STALL_IDLE_SECS = 120  # seconds with no stream activity before a running subagent is surfaced as "stalled"
 
 
 def _timeout_context(info: "SubagentInfo", *, include_elapsed: bool = True) -> str:
@@ -713,6 +715,10 @@ class SubagentInfo:
     silent: bool = False  # suppress completion notification (dashboard + Slack)
     turns: int = 0
     last_tool: str = ""
+    tool_count: int = 0  # count of observed tool calls (incl. auto-approved); drives running-card progress
+    last_activity: float = field(default_factory=time.time)  # time.time() of last stream event; drives idle-stall detection
+    stalled: bool = False  # True while the reaper has flagged this subagent as idle/stalled (UI signal)
+    _awaiting_approval: bool = False  # True while blocked on a human tool-approval prompt; exempt from idle-stall
     max_turns: int = 0
     reaped: bool = False
     streaming_text: str = ""
@@ -780,6 +786,7 @@ class SubagentManager:
         default_turn_limit: int = _TURN_LIMIT,
         default_timeout: int = _TIMEOUT_SECS,
         startup_timeout: int = _STARTUP_TIMEOUT_SECS,
+        stall_idle_secs: int = _STALL_IDLE_SECS,
         on_tool_approval: ToolApprovalCallback | None = None,
         on_tool_approval_factory: (
             Callable[["SubagentInfo"], Callable[[LLMEvent], Awaitable[bool]]] | None
@@ -797,6 +804,7 @@ class SubagentManager:
         self._default_turn_limit = default_turn_limit
         self._default_timeout = default_timeout if default_timeout > 0 else _TIMEOUT_SECS
         self._startup_deadline = startup_timeout if startup_timeout > 0 else _STARTUP_TIMEOUT_SECS
+        self._stall_idle_secs = stall_idle_secs if stall_idle_secs > 0 else _STALL_IDLE_SECS
         self._on_tool_approval = on_tool_approval  # fallback for non-auto sessions
         self._on_tool_approval_factory = on_tool_approval_factory
         self._on_spawn_approval = on_spawn_approval
@@ -1238,6 +1246,13 @@ class SubagentManager:
                     except Exception:
                         logger.exception("Reaper: failed to reap %s", agent_id)
                     continue
+                # Idle-stall detection (see _maybe_flag_stall). The main-agent
+                # watchdog stack does not govern subagents; this is their
+                # equivalent — surface a "stalled" UI signal well before the
+                # 30-min ceiling. Surface-only: it never terminates the agent
+                # (users close it from the UX), so we always fall through to
+                # the wall-clock check below.
+                await self._maybe_flag_stall(agent_id, info, now)
                 if elapsed <= self._default_timeout:
                     continue
                 logger.warning(
@@ -1280,6 +1295,73 @@ class SubagentManager:
         return (
             info.turns == 0 and info._pid is None and (now - exec_started) > self._startup_deadline
         )
+
+    async def _maybe_flag_stall(self, agent_id: str, info: SubagentInfo, now: float) -> None:
+        """Idle-stall detection for a running subagent (surface-only).
+
+        A subagent that has actually started (>=1 turn or a live runtime PID)
+        but has emitted no stream activity for ``_stall_idle_secs`` is likely
+        wedged in a single hung tool call — or simply running one slow, silent
+        command. Unlike the main agent, subagents get no liveness oracle /
+        tool-stall watchdog, and (because session-sharing subagents share the
+        parent's runtime PID) a per-PID oracle could not tell the two apart.
+
+        So this is deliberately *surface-only*: it emits a ``subagent_stalled``
+        UI signal (so the user understands why a "simple" task is taking so
+        long) and records the slow command for later analysis, but it NEVER
+        terminates the agent — the user closes a genuinely-hung subagent from
+        the UX (per-row stop / Stop-all). This means a slow-but-healthy command
+        can only ever produce a self-clearing badge, never a kill.
+        """
+        if not (info.turns > 0 or info._pid is not None):
+            return
+        # A subagent blocked on a human tool-approval prompt is healthy, not
+        # stalled — the permission request bumps `turns` before the approval
+        # wait, so without this a slow approval would be mislabelled idle.
+        if info._awaiting_approval:
+            return
+        idle = now - info.last_activity
+        if not info.stalled and idle > self._stall_idle_secs:
+            info.stalled = True
+            logger.warning(
+                "Reaper: subagent %s idle %.0fs (no stream activity) — marking stalled",
+                agent_id, idle,
+            )
+            # Persist the slow command for future analysis. Best-effort; must
+            # not disturb the still-running agent (NOT a tombstone — the agent
+            # is alive, not dead).
+            self._record_slow_command(info, idle)
+            try:
+                await self._fire_event(
+                    "subagent_stalled", info, {"stalled": True, "idle_secs": int(idle)}
+                )
+            except Exception:
+                logger.debug(
+                    "Reaper: failed to emit subagent_stalled for %s", agent_id, exc_info=True
+                )
+
+    @staticmethod
+    def _record_slow_command(info: SubagentInfo, idle: float) -> None:
+        """Best-effort append of a stalled subagent's slow command for analysis.
+
+        Writes to ``~/.kirocrew/subagents/slow_commands.jsonl`` (append-only,
+        survives per-agent folder cleanup). Deliberately separate from the
+        tombstone path, which marks an agent dead — a stalled agent is still
+        running.
+        """
+        try:
+            record_slow_command(
+                info.id,
+                last_tool=_redact(info.last_tool or ""),
+                tool_count=info.tool_count,
+                turns=info.turns,
+                idle_secs=int(idle),
+                elapsed_secs=int(time.time() - info.started),
+                parent_session=info.parent_session_key or "",
+                session_sharing=info._session_sharing,
+            )
+        except Exception:
+            logger.debug("Failed to record slow command for %s", info.id, exc_info=True)
 
     async def _force_reap(
         self, agent_id: str, info: SubagentInfo, elapsed: float, *, reason: str = ""
@@ -1594,6 +1676,8 @@ class SubagentManager:
                 "agent": _r(a.agent),
                 "turns": a.turns,
                 "last_tool": _r(a.last_tool),
+                "tool_count": a.tool_count,
+                "stalled": a.stalled,
                 "startedAt": a.started,
             }
             for a in self._agents.values()
@@ -2196,6 +2280,18 @@ class SubagentManager:
             except Exception:
                 logger.exception("Subagent announce failed for %s", info.id)
 
+    async def _touch_activity(self, info: SubagentInfo) -> None:
+        """Record stream activity for idle-stall detection.
+
+        Updates ``last_activity`` and, if the subagent was previously flagged
+        stalled by the reaper, clears the flag and notifies the UI so the
+        running-card drops the "stalled" warning the moment work resumes.
+        """
+        info.last_activity = time.time()
+        if info.stalled:
+            info.stalled = False
+            await self._fire_event("subagent_stalled", info, {"stalled": False})
+
     async def _fire_event(self, etype: str, info: SubagentInfo, extra: dict | None = None) -> None:
         if self._on_event:
             try:
@@ -2225,6 +2321,12 @@ class SubagentManager:
         # watchdog measures from here, not from registration (which may include
         # an arbitrary spawn-approval wait). Must be the first statement.
         info._exec_started = time.time()
+        # Reset the activity clock to execution start too: last_activity is set
+        # at registration (like ``started``), which can include a long spawn-
+        # approval / queue wait. Without this, _maybe_flag_stall would treat
+        # that pre-execution delay as idle time and prematurely surface a
+        # healthy, just-started subagent as "stalled".
+        info.last_activity = info._exec_started
         # Inherit approval policy from parent session; yolo/trust overrides
         parent_policy = self._sessions.get_approval_policy(info.parent_session_key)
         # Explicit approval_mode from spawn caller (e.g. Mochi bg agent)
@@ -2411,6 +2513,12 @@ class SubagentManager:
         # Mirrors kiro_crew.dashboard.chat_runner._pending_tools.
         _pending_tools: dict[str, str] = {}
         async for event in client.stream(full_message):
+            # Refresh the activity clock for EVERY event kind (thinking chunks,
+            # tool-call updates, etc.) before dispatch, so idle-stall detection
+            # only trips on a genuine no-event hang — not on an event kind this
+            # switch does not special-case. Approval waits stay exempt via
+            # _awaiting_approval.
+            await self._touch_activity(info)
             if event.kind == EVENT_TEXT_CHUNK:
                 result_text += event.text
                 write_result_chunk(info.id, event.text)
@@ -2435,7 +2543,12 @@ class SubagentManager:
                 await self._fire_event(
                     "subagent_tool",
                     info,
-                    {"tool": _redact(event.title or ""), "tool_kind": event.tool_kind},
+                    {
+                        "tool": _redact(event.title or ""),
+                        "tool_kind": event.tool_kind,
+                        "turns": info.turns,
+                        "tool_count": info.tool_count,
+                    },
                 )
                 if turns > turn_limit:
                     info.result = result_text or "_Partial output._"
@@ -2479,7 +2592,12 @@ class SubagentManager:
                     continue
                 if self._on_tool_approval_factory:
                     approve_cb = self._on_tool_approval_factory(info)
-                    approved = await approve_cb(event)
+                    info._awaiting_approval = True
+                    try:
+                        approved = await approve_cb(event)
+                    finally:
+                        info._awaiting_approval = False
+                        info.last_activity = time.time()
                     if not approved:
                         await self._reject_and_log(
                             client,
@@ -2497,7 +2615,12 @@ class SubagentManager:
                         metadata={"subagent_id": info.id},
                     )
                 elif self._on_tool_approval:
-                    approved = await self._on_tool_approval(event, info.parent_session_key)
+                    info._awaiting_approval = True
+                    try:
+                        approved = await self._on_tool_approval(event, info.parent_session_key)
+                    finally:
+                        info._awaiting_approval = False
+                        info.last_activity = time.time()
                     if not approved:
                         await self._reject_and_log(client, event.request_id, session_key, event)
                         continue
@@ -2519,6 +2642,23 @@ class SubagentManager:
                     )
                     continue
             elif event.kind == EVENT_TOOL_CALL:
+                # Auto-allowed (kiro-internal) tools surface here as informational
+                # tool_call updates and NEVER as EVENT_PERMISSION_REQUEST, so this
+                # is the only progress signal a simple/read-only subagent task emits.
+                # Count it, record it, and broadcast the same subagent_tool event
+                # the permission path uses so the running-card shows live activity.
+                info.tool_count += 1
+                info.last_tool = event.title or info.last_tool
+                await self._fire_event(
+                    "subagent_tool",
+                    info,
+                    {
+                        "tool": _redact(event.title or ""),
+                        "tool_kind": event.tool_kind,
+                        "turns": info.turns,
+                        "tool_count": info.tool_count,
+                    },
+                )
                 # Fire PreToolUse hooks for auto-approved tools (informational only)
                 sel().log_tool_invocation(
                     session_key=session_key,

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -165,6 +165,26 @@ def mark_delivered(agent_id: str) -> None:
     write_tombstone(agent_id, cause="delivered", recovery_action="delivered")
 
 
+# ── slow-command record (stalled but STILL RUNNING) ──────────────────
+
+
+def record_slow_command(agent_id: str, **fields: object) -> None:
+    """Append a stalled subagent's slow command to ``slow_commands.jsonl``.
+
+    Unlike :func:`write_tombstone`, this does NOT mark the agent dead — a
+    stalled subagent is still running; the record is purely for later analysis
+    of which commands run slow. Append-only, at the subagents-dir root so it
+    survives per-agent folder cleanup. Best-effort: never raises to the caller.
+    """
+    entry = {"id": agent_id, "flagged": time.time(), **fields}
+    try:
+        _SUBAGENTS_DIR.mkdir(parents=True, exist_ok=True)
+        with open(_SUBAGENTS_DIR / "slow_commands.jsonl", "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, default=str) + "\n")
+    except OSError:
+        logger.warning("record_slow_command failed for %s", agent_id, exc_info=True)
+
+
 # ── delete ───────────────────────────────────────────────────────────
 
 

--- a/test/test_subagent_persistence.py
+++ b/test/test_subagent_persistence.py
@@ -14,6 +14,7 @@ from kiro_crew.subagent_persistence import (
     mark_delivered,
     prune_stale_tombstones,
     read_state,
+    record_slow_command,
     update_state,
     write_result_chunk,
     write_tombstone,
@@ -1213,3 +1214,26 @@ class TestPathTraversal:
 
         with pytest.raises(ValueError, match="Invalid agent_id"):
             _agent_dir("../etc")
+
+
+# ── record_slow_command ──────────────────────────────────────────────
+
+
+class TestRecordSlowCommand:
+    def test_appends_jsonl_entry(self, agent_root):
+        record_slow_command("ag1", last_tool="fs_read", idle_secs=200, turns=2)
+        log = agent_root / "slow_commands.jsonl"
+        assert log.exists()  # NOT a tombstone — a separate analysis log
+        assert not (agent_root / "ag1" / "tombstone.json").exists()
+        entry = json.loads(log.read_text().strip())
+        assert entry["id"] == "ag1"
+        assert entry["last_tool"] == "fs_read"
+        assert entry["idle_secs"] == 200
+        assert "flagged" in entry
+
+    def test_appends_multiple_lines(self, agent_root):
+        record_slow_command("ag1", idle_secs=200)
+        record_slow_command("ag2", idle_secs=300)
+        lines = (agent_root / "slow_commands.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert {json.loads(lines[0])["id"], json.loads(lines[1])["id"]} == {"ag1", "ag2"}

--- a/test/test_subagent_stall.py
+++ b/test/test_subagent_stall.py
@@ -1,0 +1,161 @@
+"""Tests for subagent idle-stall detection and activity tracking (subagent.py).
+
+Covers ``SubagentManager._maybe_flag_stall`` (surface-only: after
+``_stall_idle_secs`` of no stream activity it marks the subagent stalled,
+emits a ``subagent_stalled`` UI signal, and records the slow command for
+later analysis — but NEVER terminates the agent) and ``_touch_activity``
+(records activity and clears a prior stalled flag).
+
+The main-agent watchdog stack does not govern spawned subagents, and because
+session-sharing subagents share the parent's runtime PID a per-PID liveness
+oracle cannot isolate one subagent. So this is deliberately surface-only:
+a genuinely-hung subagent is closed by the user from the UX, not auto-reaped.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+
+def _make_manager(stall_idle_secs: int = 120) -> SubagentManager:
+    mgr = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        stall_idle_secs=stall_idle_secs,
+    )
+    mgr._fire_event = AsyncMock()
+    return mgr
+
+
+def _info(**overrides) -> SubagentInfo:
+    info = SubagentInfo(id="a1b2c3d4", task="t", agent="")
+    for k, v in overrides.items():
+        setattr(info, k, v)
+    return info
+
+
+# ── _maybe_flag_stall ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_not_flagged_before_start():
+    """A subagent with no turn and no runtime pid is pre-start — never stalled."""
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(turns=0, _pid=None, last_activity=now - 5_000)
+    await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    assert info.stalled is False
+    mgr._fire_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flagged_when_idle_beyond_threshold():
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(turns=1, last_activity=now - 200)
+    with patch("kiro_crew.subagent.record_slow_command") as rec:
+        await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    assert info.stalled is True  # surfaced, but not terminated
+    mgr._fire_event.assert_awaited_once()
+    etype, _info_arg, extra = mgr._fire_event.await_args.args
+    assert etype == "subagent_stalled"
+    assert extra["stalled"] is True
+    assert extra["idle_secs"] >= 200
+    rec.assert_called_once()  # slow command recorded for analysis
+
+
+@pytest.mark.asyncio
+async def test_not_flagged_within_idle_window():
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(_pid=4242, last_activity=now - 30)
+    await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    assert info.stalled is False
+    mgr._fire_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_not_re_emitted_when_already_stalled():
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(turns=1, last_activity=now - 300, stalled=True)
+    with patch("kiro_crew.subagent.record_slow_command") as rec:
+        await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    mgr._fire_event.assert_not_called()  # already flagged; no duplicate event
+    rec.assert_not_called()  # and no duplicate record
+
+
+@pytest.mark.asyncio
+async def test_not_flagged_while_awaiting_approval():
+    """A subagent blocked on a human approval prompt is healthy, not stalled —
+    even well past the idle threshold it must not be flagged or recorded."""
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(turns=1, last_activity=now - 700, _awaiting_approval=True)
+    with patch("kiro_crew.subagent.record_slow_command") as rec:
+        await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    assert info.stalled is False
+    mgr._fire_event.assert_not_called()
+    rec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slow_command_record_fields():
+    """The recorded slow command carries the diagnostic fields for analysis."""
+    mgr = _make_manager(stall_idle_secs=120)
+    now = 1_000.0
+    info = _info(
+        turns=3, tool_count=5, last_tool="fs_read", last_activity=now - 200,
+        started=now - 260, parent_session_key="dashboard:main",
+    )
+    with patch("kiro_crew.subagent.record_slow_command") as rec:
+        await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    rec.assert_called_once()
+    kwargs = rec.call_args.kwargs
+    assert kwargs["last_tool"] == "fs_read"
+    assert kwargs["tool_count"] == 5
+    assert kwargs["turns"] == 3
+    assert kwargs["idle_secs"] >= 200
+    assert kwargs["parent_session"] == "dashboard:main"
+
+
+@pytest.mark.asyncio
+async def test_flag_never_reaps():
+    """Surface-only: flagging a stall must never force-reap the agent."""
+    mgr = _make_manager(stall_idle_secs=120)
+    mgr._force_reap = AsyncMock()
+    now = 1_000.0
+    info = _info(turns=1, started=now - 5_000, last_activity=now - 5_000)
+    with patch("kiro_crew.subagent.record_slow_command"):
+        await mgr._maybe_flag_stall("a1b2c3d4", info, now)
+    assert info.stalled is True
+    assert info.done is False
+    mgr._force_reap.assert_not_called()
+
+
+# ── _touch_activity ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_touch_activity_updates_timestamp():
+    mgr = _make_manager()
+    info = _info(last_activity=0.0)
+    await mgr._touch_activity(info)
+    assert info.last_activity > 0.0
+    mgr._fire_event.assert_not_called()  # was not stalled -> no event
+
+
+@pytest.mark.asyncio
+async def test_touch_activity_clears_stalled_and_notifies():
+    mgr = _make_manager()
+    info = _info(stalled=True, last_activity=0.0)
+    await mgr._touch_activity(info)
+    assert info.stalled is False
+    mgr._fire_event.assert_awaited_once()
+    etype, _info_arg, extra = mgr._fire_event.await_args.args
+    assert etype == "subagent_stalled"
+    assert extra["stalled"] is False

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -5,7 +5,7 @@ import { store } from '../store'
 import { sseStatus, sseConnected, sseDisconnected, sseSlots, setChannelTrusted, sseSlotTitle, triggerRefresh, fetchSlots, markSlotUnread, setUpdateProgress, sseSubagentStatus, sseSubagentText, touchSlotActivity, type SubagentDetail } from '../store/dashboardSlice'
 import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, fetchNotifications } from '../store/notificationsSlice'
 import { MC_NOTIFICATION_EVENT, type McNotificationDetail } from './notificationEvent'
-import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, sseSubagentPending, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentDone, sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard } from '../store/chatSlice'
+import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, sseSubagentPending, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone, sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard } from '../store/chatSlice'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import type { StatusData, ChatSlot, Notification } from '../types'
@@ -461,13 +461,16 @@ export function useWebSocket() {
             dispatch(sseSubagentChunk(data as { slot: string; id: string; text: string }))
             break
           case 'subagent_tool':
-            dispatch(sseSubagentTool(data as { slot: string; id: string; tool: string }))
+            dispatch(sseSubagentTool(data as { slot: string; id: string; tool: string; turns?: number; tool_count?: number }))
+            break
+          case 'subagent_stalled':
+            dispatch(sseSubagentStalled(data as { slot: string; id: string; stalled: boolean; idle_secs?: number }))
             break
           case 'subagent_done':
             dispatch(sseSubagentDone(data as { slot: string; id: string; elapsed: number; error?: string }))
             break
           case 'subagent_snapshot':
-            dispatch(sseSubagentSnapshot(data as { id: string; slot: string; task: string; agent: string; streaming: string; last_tool: string; started: number }))
+            dispatch(sseSubagentSnapshot(data as { id: string; slot: string; task: string; agent: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean }))
             break
           case 'workflow_run_event':
             // Dynamic-workflow run events folded into chat.workflowRuns and

--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react'
-import { Bot, ChevronDown, X } from 'lucide-react'
+import { Bot, ChevronDown, X, AlertTriangle } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { sseSubagentDone } from '../../store/chatSlice'
 import { api } from '../../api/client'
@@ -26,6 +26,8 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   const subagents = useAppSelector(s => slot === s.chat.activeSlot ? s.chat.subagents : s.chat.slotActivity[slot ?? '']?.subagents ?? EMPTY_SUBAGENTS)
   const activeList = useMemo(() => Object.values(subagents).filter(a => a.status === 'running' || a.status === 'tool' || a.status === 'pending'), [subagents])
   const running = activeList.length
+  const lead = activeList[activeList.length - 1]
+  const anyStalled = useMemo(() => activeList.some(a => a.stalled), [activeList])
   const activeListRef = useRef(activeList)
   activeListRef.current = activeList
   const hasActive = running > 0
@@ -74,8 +76,16 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
           aria-label={`${running} subagent${running > 1 ? 's' : ''} running`}
         >
           <Bot size={14} className="text-accent shrink-0" />
-          <span className="text-text-strong font-medium">{running} agent{running > 1 ? 's' : ''} running</span>
-          <ChevronDown size={14} className={`text-muted ml-auto shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+          <span className="text-text-strong font-medium shrink-0">{running} agent{running > 1 ? 's' : ''} running</span>
+          <span className="flex-1 min-w-0 truncate text-left">
+            {!expanded && lead?.lastTool ? <span className="text-accent/70">→ {sanitizeLlmOutput(lead.lastTool)}</span> : null}
+          </span>
+          {anyStalled && (
+            <span className="shrink-0 inline-flex items-center gap-1 text-warn" title="No activity — possibly stalled">
+              <AlertTriangle size={12} /> stalled
+            </span>
+          )}
+          <ChevronDown size={14} className={`text-muted shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
         </button>
         {stoppableCount > 0 && (
           <button
@@ -99,9 +109,14 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5">
                     <span className="truncate text-text">{taskPreview || sanitizeLlmOutput(a.agent || 'agent')}</span>
-                    <span className="shrink-0 tabular-nums text-muted/50">{elapsed}s</span>
+                    <span className="shrink-0 tabular-nums text-muted/50">{elapsed}s{typeof a.toolCount === 'number' && a.toolCount > 0 ? ` · ${a.toolCount} tool${a.toolCount > 1 ? 's' : ''}` : ''}</span>
                   </div>
-                  {a.lastTool && <div className="text-accent/60 truncate">→ {sanitizeLlmOutput(a.lastTool)}</div>}
+                  {a.stalled ? (
+                    <div className="text-warn flex items-center gap-1">
+                      <AlertTriangle size={11} className="shrink-0" />
+                      <span className="truncate">stalled{a.lastTool ? ` at ${sanitizeLlmOutput(a.lastTool)}` : ''} — no activity</span>
+                    </div>
+                  ) : (a.lastTool && <div className="text-accent/60 truncate">→ {sanitizeLlmOutput(a.lastTool)}</div>)}
                 </div>
                 {(a.status === 'running' || a.status === 'tool') && (
                   <button

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -900,6 +900,7 @@ const chatSlice = createSlice({
       subs[safeKey(action.payload.id)] = {
         id: action.payload.id, task: action.payload.task, agent: action.payload.agent || 'kirocrew',
         status: 'running', streaming: existing?.streaming || '', lastTool: '', startedAt: existing?.startedAt || Date.now(), elapsed: 0,
+        toolCount: 0, stalled: false,
       }
     },
     sseSubagentChunk(state, action: PayloadAction<{ slot: string; id: string; text: string }>) {
@@ -911,9 +912,23 @@ const chatSlice = createSlice({
         }
       }
     },
-    sseSubagentTool(state, action: PayloadAction<{ slot: string; id: string; tool: string }>) {
-      const a = getSlotSubs(state, action.payload.slot)?.[action.payload.id]
-      if (a) { a.lastTool = action.payload.tool; a.status = 'tool' }
+    sseSubagentTool(state, action: PayloadAction<{ slot: string; id: string; tool: string; turns?: number; tool_count?: number }>) {
+      const { slot, id } = action.payload
+      // Guard the user-controlled id against prototype-pollution keys before
+      // indexing (id === '__proto__' would resolve to Object.prototype).
+      if (id === '__proto__' || id === 'constructor' || id === 'prototype') return
+      const a = getSlotSubs(state, slot)?.[id]
+      if (a) {
+        a.lastTool = action.payload.tool; a.status = 'tool'
+        if (typeof action.payload.tool_count === 'number') a.toolCount = action.payload.tool_count
+        a.stalled = false
+      }
+    },
+    sseSubagentStalled(state, action: PayloadAction<{ slot: string; id: string; stalled: boolean; idle_secs?: number }>) {
+      const { slot, id } = action.payload
+      if (id === '__proto__' || id === 'constructor' || id === 'prototype') return
+      const a = getSlotSubs(state, slot)?.[id]
+      if (a) a.stalled = action.payload.stalled
     },
     sseSubagentDone(state, action: PayloadAction<{ slot: string; id: string; elapsed: number; error?: string; task?: string; agent?: string; result?: string }>) {
       if (isUnsafeKey(action.payload.slot) || isUnsafeKey(action.payload.id)) return
@@ -1016,7 +1031,7 @@ const chatSlice = createSlice({
       if (last?.role === 'user') side.messages.pop()
       side.pending = false
     },
-    sseSubagentSnapshot(state, action: PayloadAction<{ id: string; slot: string; task: string; agent: string; streaming: string; last_tool: string; started: number }>) {
+    sseSubagentSnapshot(state, action: PayloadAction<{ id: string; slot: string; task: string; agent: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean }>) {
       const d = action.payload
       if (isUnsafeKey(d.slot) || isUnsafeKey(d.id)) return
       const subs = d.slot && d.slot !== state.activeSlot
@@ -1027,6 +1042,7 @@ const chatSlice = createSlice({
         id: d.id, task: d.task, agent: d.agent || 'kirocrew',
         status: d.last_tool ? 'tool' : 'running', streaming: d.streaming, lastTool: d.last_tool,
         startedAt: d.started * 1000, elapsed: 0,
+        toolCount: d.tool_count ?? 0, stalled: d.stalled ?? false,
         approval_id: existing?.approval_id, approving: existing?.approving,
       }
     },
@@ -1712,7 +1728,7 @@ export const {
   setActiveSlot, clearSlotState, setPendingInput, setQuestionCard, clearQuestionCard, appendMessage, appendSlotMessage, updateStreamingMessage, finalizeAssistant,
   removeThinking, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage,
   sseContextUsage, setVoicePlaying, setVoiceAudio,
-  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentDone,
+  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone,
   sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent,
   sseWorkflowEvent, clearWorkflowRun,
   sseSideResult, sideClose, sideOptimisticAppend, sideOptimisticRollback,

--- a/website/src/test/SubagentProgress.reducers.test.tsx
+++ b/website/src/test/SubagentProgress.reducers.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Sub-agent progress reducers (Fix A/B): the running-card is driven by
+ * chat.subagents. These verify the new progress fields land:
+ *  - sseSubagentTool records toolCount (fired on EVENT_TOOL_CALL too, so a
+ *    simple/auto-approved task now shows live tool activity) and clears stalled.
+ *  - sseSubagentStalled toggles the idle/stalled flag surfaced by the reaper.
+ */
+import { describe, it, expect } from 'vitest'
+import { createTestStore } from './helpers'
+import { sseSubagentSpawn, sseSubagentTool, sseSubagentStalled } from '../store/chatSlice'
+
+const ID = 'a1b2c3d4'
+
+function spawn(store: ReturnType<typeof createTestStore>) {
+  const SLOT = store.getState().chat.activeSlot
+  store.dispatch(sseSubagentSpawn({ slot: SLOT, id: ID, task: 'do a thing', agent: 'kirocrew' }))
+  return SLOT
+}
+const sub = (store: ReturnType<typeof createTestStore>) => store.getState().chat.subagents[ID]
+
+describe('subagent progress reducers', () => {
+  it('sseSubagentTool records tool name + toolCount and sets status tool', () => {
+    const store = createTestStore()
+    const SLOT = spawn(store)
+    expect(sub(store).toolCount).toBe(0)
+    store.dispatch(sseSubagentTool({ slot: SLOT, id: ID, tool: 'fs_read', turns: 0, tool_count: 3 }))
+    const a = sub(store)
+    expect(a.status).toBe('tool')
+    expect(a.lastTool).toBe('fs_read')
+    expect(a.toolCount).toBe(3)
+  })
+
+  it('sseSubagentStalled toggles the stalled flag, and tool activity clears it', () => {
+    const store = createTestStore()
+    const SLOT = spawn(store)
+    store.dispatch(sseSubagentStalled({ slot: SLOT, id: ID, stalled: true, idle_secs: 200 }))
+    expect(sub(store).stalled).toBe(true)
+    // Fresh activity clears the stalled state.
+    store.dispatch(sseSubagentTool({ slot: SLOT, id: ID, tool: 'grep', tool_count: 4 }))
+    expect(sub(store).stalled).toBe(false)
+  })
+})

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -219,6 +219,8 @@ export interface SubagentActivity {
   status: 'pending' | 'running' | 'tool' | 'done' | 'error'
   streaming: string; lastTool: string
   startedAt: number; elapsed: number; error?: string
+  toolCount?: number      // observed tool calls (incl. auto-approved) — running-card progress
+  stalled?: boolean       // reaper flagged this subagent as idle/stalled
   approval_id?: string
   approving?: boolean
 }


### PR DESCRIPTION
## Problem

A running sub-agent's execution card showed only "running a task/command" with no progress, so even a simple/short task looked stuck for a long time. Separately, none of the main agent's stall handling governs sub-agents, so a genuinely-hung sub-agent gave no signal until the 30-minute wall-clock ceiling.

## Why it matters

Users couldn't tell a fast sub-agent from a wedged one — the card sat at "spawn" then jumped to "done" — which reads as the whole dashboard hanging. This erodes trust in the sub-agent feature and hides real hangs.

## Fix (symptom → root cause → change)

**Fix A — progress visibility.** Root cause: the only all-clients per-tool broadcast, `subagent_tool`, fired *exclusively* off `EVENT_PERMISSION_REQUEST`; but on the default kiro backend safe tools are auto-approved, so a simple task emits zero permission requests and the card never updated. Change: also fire `subagent_tool` on `EVENT_TOOL_CALL` (the event simple tasks *do* emit), carrying `tool_count`/`turns`; the collapsed card now shows the live tool + elapsed without expanding.

**Fix B — stall handling, surface-only (no auto-kill).** Root cause: sub-agents get no liveness detection at all. Design constraint: session-sharing sub-agents run inside the **parent's shared `AcpRuntime` process** and report the *same* runtime PID as parent + siblings, so the main agent's per-PID `/proc` Liveness Oracle cannot isolate one sub-agent; and a pure stream-cadence timer cannot distinguish a slow-but-healthy silent command from a wedged one. Change: after `subagent_stall_idle_secs` (default 120s) of no stream activity, emit a `subagent_stalled` UI signal ("no activity for Ns") — **surface-only, it never terminates the agent**. This means a slow-but-healthy command can only ever produce a self-clearing badge, never a kill.

- **Termination stays with the user.** A genuinely-hung sub-agent is closed from the UX — per-row stop / header Stop-all → `SubagentManager.cancel(agent_id)` (already shipped).
- **Slow commands are recorded for analysis.** On first flag we append the slow command (redacted `last_tool`, `tool_count`, `turns`, `idle`/`elapsed` secs, parent, `session_sharing`) to `~/.kirocrew/subagents/slow_commands.jsonl`. This is deliberately **not** a tombstone — a tombstone marks an agent *dead* and is consumed by orphan-reconciliation/TTL cleanup, whereas a stalled sub-agent is still *running*.

Config: adds `agent.subagent_stall_idle_secs` (default 120; `config-baseline.json` regenerated in sync). No auto-kill knob — detection is surface-only by design.

## Tests

- Backend (`test/test_subagent_stall.py`): surface-only flagging past threshold, `_awaiting_approval` exemption, no-duplicate-event when already stalled, **never-reaps**, slow-command record fields, and `_touch_activity` clearing the flag.
- Backend (`test/test_subagent_persistence.py`): `record_slow_command` appends JSONL and does **not** write a tombstone.
- Frontend (`website/src/test/SubagentProgress.reducers.test.tsx`): progress + stalled reducer/card rendering.

## Manual verification

N/A for the stall path — it's time-based and fully unit-covered. The progress card was eyeballed on an isolated pod in an earlier revision; no UI behavior changed in the surface-only pivot beyond removing the (never-default) auto-kill path.
