### PR TITLE
fix(security): resolve pre-existing CodeQL security findings

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -1,6 +1,7 @@
 """Shared constants used across cli and gateway modules."""
 
 import os
+import re
 
 # Retained for backward compatibility; intentionally empty in the public build
 # (no internal registry/package). Callers treat empty as "skip".
@@ -47,3 +48,37 @@ DATA_WARNING = (
 # ``acp/client.py``); this cap is the upper safety ceiling for genuinely runaway
 # work, not a "this turn took too long" guard.
 CHAT_TURN_TIMEOUT = 7200.0
+
+
+# ── Canonical "[OPTIONS: a | b | c]" trailer parsers ────────────────────────
+# The agent emits a trailing ``[OPTIONS: choice1 | choice2 | ...]`` marker that
+# every surface renders as tappable choices. Two variants exist because the
+# surfaces scan differently, but their GRAMMAR must stay identical — so both are
+# defined here ONCE and imported everywhere (was five hand-mirrored copies kept
+# in sync only by a "keep in lockstep" comment; a one-character slip flips the
+# flag semantics or reintroduces the ReDoS class below on a single surface).
+#
+# Body: a TEMPERED greedy repetition that allows every bracket EXCEPT a ``[``
+# that begins a fresh ``[OPTIONS:``. This matters for ReDoS (py/polynomial-redos):
+# a plain greedy ``.*`` body can itself consume a ``[`` that also starts the outer
+# ``[OPTIONS:`` literal, so over untrusted text with many ``[OPTIONS:`` prefixes
+# ``search()``/``findall()`` re-explore the body from each position — polynomial
+# backtracking. The tempered body is unambiguous (linear) while still capturing a
+# literal ``]`` and any other inner ``[`` inside an option ("Fix [x] logging",
+# "a[1]"). This parser runs over untrusted LLM/relayed text before Slack, the
+# dashboard, Discord, Telegram, and WeCom render it.
+#
+# LINE (``re.MULTILINE``, ``$`` anchor) — for Slack/dashboard, where the marker
+# ends a LINE (not necessarily the whole message). The negated class EXCLUDES
+# ``\n`` (``[^[\n]``): in Python ``re`` a negated class matches ``\n`` regardless
+# of DOTALL, so ``[^[]`` here would silently widen the single-line body to span
+# lines (deleting/splitting a multi-line span the old single-line ``.*`` never
+# matched). Trailing class is ``[ \t]`` (NOT ``\s``, which under MULTILINE would
+# also match ``\n``).
+OPTIONS_RE_LINE = re.compile(r"\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*)\][ \t]*$", re.MULTILINE)
+
+# TRAILER (``re.DOTALL``, ``\Z`` anchor) — for the Discord/Telegram/WeCom
+# renderers, which match the marker only at the very END of the message and
+# allow it to span newlines (the body keeps ``[^[]`` because the old ``.*``
+# already spanned newlines under DOTALL). Trailing ``\s*`` before ``\Z``.
+OPTIONS_RE_TRAILER = re.compile(r"\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*)\]\s*\Z", re.DOTALL)

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -115,13 +115,17 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
     if not spec_path:
         return web.json_response({"error": "spec path required"}, status=400)
 
-    # Validate non-inline paths against traversal
+    # Validate non-inline paths against traversal, then forward the *validated*
+    # resolved path (not the raw input) to the sink below so the guard and the
+    # use share one value — no gap where spec_path could differ from what was
+    # checked, and the containment guard is visible to static analysis.
     if not spec_path.startswith("__inline__:"):
         resolved = Path(spec_path).resolve()
         if ".." in Path(spec_path).parts or not resolved.is_file():
             return web.json_response({"error": "invalid spec path"}, status=400)
         if is_sensitive_path(str(resolved)):
             return web.json_response({"error": "access denied"}, status=403)
+        spec_path = str(resolved)
 
     # Handle inline spec content
     if spec_path.startswith("__inline__:"):

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -22,6 +22,7 @@ from aiohttp import web
 from kiro_crew.acp.types import STOP_REASON_CANCELLED
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import DASHBOARD_PORT, config_dir
+from kiro_crew.constants import OPTIONS_RE_LINE
 from kiro_crew.dashboard.side_state import SideState
 from kiro_crew.knowledge.store import KnowledgeStore
 from kiro_crew.notifications.bus import (
@@ -566,11 +567,14 @@ def build_tool_stall_recovery_prompt(
     return "\n".join(lines)
 
 
-# Anchor the closing ']' to end-of-line so the non-greedy body expands past a
-# literal ']' inside option text (e.g. "Fix [x] logging") instead of truncating
-# at the first inner bracket. Mirrors slack/format.py's _OPTIONS_RE so both the
-# dashboard pills and Slack buttons parse OPTIONS identically.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.+?)\]\s*$", re.MULTILINE)
+# [OPTIONS: a | b | c] — the marker ends a LINE here, so use the MULTILINE/
+# single-line canonical parser. Defined once in constants.py (shared with
+# slack/format.py and the renderer surfaces) so the ReDoS-hardened grammar can
+# never drift between copies; see OPTIONS_RE_LINE for the full rationale
+# (tempered body, ``\n`` exclusion under MULTILINE). Per-choice whitespace is
+# stripped by the caller; dashboard pills and Slack buttons parse OPTIONS
+# identically because they share this exact object.
+_OPTIONS_RE = OPTIONS_RE_LINE
 
 
 def _redact(text: str) -> str:

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -35,6 +35,7 @@ import secrets
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 
@@ -61,8 +62,13 @@ _STYLE_SECONDARY = 2
 _STYLE_SUCCESS = 3
 _STYLE_DANGER = 4
 
-# Trailing "[OPTIONS: a | b | c]" -- extracted for button-row rendering.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.*?)\]\s*\Z", re.DOTALL)
+# Trailing "[OPTIONS: a | b | c]" -- extracted for button-row rendering. Matched
+# only at the very END of the message, so use the DOTALL/trailer canonical
+# parser. Defined once in constants.py (shared with the Slack/dashboard/Telegram/
+# WeCom surfaces) so the ReDoS-hardened grammar can never drift; see
+# OPTIONS_RE_TRAILER for the full rationale. Per-choice whitespace is stripped by
+# the caller.
+_OPTIONS_RE = OPTIONS_RE_TRAILER
 
 # kiro-cli's inline "[STEERING steer-<id>: …]" steer-ack marker (see the
 # Telegram renderer for the full rationale — Discord likewise has no parser).

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import re
 
+from kiro_crew.constants import OPTIONS_RE_LINE
+
 SLACK_MAX_TEXT = 39_000
 
-# Pattern: [OPTIONS: choice1 | choice2 | choice3]
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.+?)\]\s*$", re.MULTILINE)
+# [OPTIONS: choice1 | choice2 | ...] — the marker ends a LINE here, so use the
+# MULTILINE/single-line canonical parser. Defined once in constants.py (shared
+# with dashboard/state.py and the renderer surfaces) so the ReDoS-hardened
+# grammar can never drift between copies; see OPTIONS_RE_LINE for the full
+# rationale. Per-choice whitespace is stripped by extract_options().
+_OPTIONS_RE = OPTIONS_RE_LINE
 
 # Action ID prefix for OPTIONS buttons
 OPTIONS_ACTION_PREFIX = "options_choice_"

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -30,6 +30,7 @@ import re
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 
@@ -59,7 +60,12 @@ _EDIT_THROTTLE_S = 1.0
 _APPROVAL_TIMEOUT_S = 300.0
 
 # Trailing "[OPTIONS: a | b | c]" -- extracted for inline-keyboard rendering.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.*?)\]\s*\Z", re.DOTALL)
+# Matched only at the very END of the message, so use the DOTALL/trailer
+# canonical parser. Defined once in constants.py (shared with the Slack/
+# dashboard/Discord/WeCom surfaces) so the ReDoS-hardened grammar can never
+# drift; see OPTIONS_RE_TRAILER for the full rationale. Per-choice whitespace is
+# stripped by the caller.
+_OPTIONS_RE = OPTIONS_RE_TRAILER
 
 
 def _extract_options(text: str) -> tuple[str, list[str]]:

--- a/src/kiro_crew/webex/renderer.py
+++ b/src/kiro_crew/webex/renderer.py
@@ -25,10 +25,10 @@ Dependency direction is ``webex -> messaging`` (allowed).
 from __future__ import annotations
 
 import logging
-import re
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.webex.client import chunk_utf8
@@ -51,8 +51,12 @@ _THINKING = "🤔 Thinking…"
 _ERROR_TEXT = "⚠️ Something went wrong — please try again."
 
 # Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention Webex
-# can't render as tappable chips). Matched only at the very end of the message.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.*?)\]\s*\Z", re.DOTALL)
+# can't render as tappable chips). Matched only at the very END of the message,
+# so use the DOTALL/trailer canonical parser. Defined once in constants.py
+# (shared with the Slack/dashboard/Discord/Telegram/WeCom surfaces) so the
+# ReDoS-hardened grammar can never drift; see OPTIONS_RE_TRAILER for the full
+# rationale. Per-choice whitespace is stripped by the caller.
+_OPTIONS_RE = OPTIONS_RE_TRAILER
 
 
 def _strip_options(text: str) -> str:

--- a/src/kiro_crew/wechat/renderer.py
+++ b/src/kiro_crew/wechat/renderer.py
@@ -24,10 +24,10 @@ Dependency direction is ``wechat -> messaging`` (allowed).
 from __future__ import annotations
 
 import logging
-import re
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.wechat.client import new_stream_id
@@ -45,8 +45,12 @@ _STREAM_THROTTLE_S = 0.7
 _THINKING = "🤔 …"
 
 # Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention WeCom
-# can't render as tappable chips). Matched only at the very end of the message.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:\s*(.*?)\]\s*\Z", re.DOTALL)
+# can't render as tappable chips). Matched only at the very END of the message,
+# so use the DOTALL/trailer canonical parser. Defined once in constants.py
+# (shared with the Slack/dashboard/Discord/Telegram surfaces) so the
+# ReDoS-hardened grammar can never drift; see OPTIONS_RE_TRAILER for the full
+# rationale. Per-choice whitespace is stripped by the caller.
+_OPTIONS_RE = OPTIONS_RE_TRAILER
 
 
 def _strip_options(text: str) -> str:

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -422,6 +422,27 @@ class TestExtractOptions:
         assert body == "Pick one"
         assert opts == []
 
+    def test_unterminated_options_tag_is_not_redos(self) -> None:
+        # Regression (py/polynomial-redos): a plain greedy ``.*`` body could
+        # consume a "[" that ALSO starts the outer "[OPTIONS:" literal, so over
+        # text with many "[OPTIONS:" prefixes search() re-explored the body from
+        # each position — polynomial. The tempered body
+        # (?:[^[]|\[(?!OPTIONS:))* forbids only a re-occurring "[OPTIONS:", so
+        # the body is unambiguous (linear). A whitespace-padded unterminated tag
+        # and many repeated "[OPTIONS:" prefixes (the real pump) must both return
+        # promptly.
+        import time
+
+        for evil in (
+            "[OPTIONS:" + ("\t" * 200_000) + "x",
+            "[OPTIONS:" * 100_000 + "x",
+        ):
+            start = time.perf_counter()
+            body, opts = _extract_options(evil)
+            elapsed = time.perf_counter() - start
+            assert elapsed < 1.0, f"_extract_options took {elapsed:.2f}s (possible ReDoS)"
+            assert opts == []
+
 
 class TestStripSteering:
     def test_removes_complete_marker(self) -> None:

--- a/test/test_options_buttons.py
+++ b/test/test_options_buttons.py
@@ -27,6 +27,45 @@ class TestExtractOptions:
         _, choices = extract_options("[OPTIONS:  X |  Y  | Z ]")
         assert choices == ["X", "Y", "Z"]
 
+    def test_bracket_inside_option_text_survives(self):
+        # The closing ']' is anchored to end-of-line, so a literal ']' inside
+        # an option (e.g. "Fix [x] logging") must not truncate the body.
+        _, choices = extract_options("[OPTIONS: Fix [x] logging | Skip]")
+        assert choices == ["Fix [x] logging", "Skip"]
+
+    def test_body_does_not_span_newlines(self):
+        # The MULTILINE body must stay single-line: an assistant message that
+        # mentions "[OPTIONS:" mid-text on one line and has a LATER line ending
+        # in "]" must NOT match across the newline (which would delete a
+        # multi-line span from the visible text and emit bogus pills). The
+        # tempered body excludes \n (``[^[\n]``) precisely so this cannot happen.
+        cleaned, choices = extract_options("See [OPTIONS: in my notes\nsummary ]")
+        assert choices == []
+        assert cleaned == "See [OPTIONS: in my notes\nsummary ]"
+
+    def test_unterminated_options_tag_is_not_redos(self):
+        # Regression (py/polynomial-redos): a plain greedy ``.*`` body could
+        # consume a ``[`` that ALSO starts the outer ``[OPTIONS:`` literal, so
+        # over text with many ``[OPTIONS:`` prefixes ``search()`` re-explored the
+        # body from each position — polynomial. The tempered body
+        # ``(?:[^[\n]|\[(?!OPTIONS:))*`` forbids only a re-occurring ``[OPTIONS:``,
+        # so the body is unambiguous (linear). Two adversarial inputs — a long
+        # whitespace-padded unterminated tag, and many repeated ``[OPTIONS:``
+        # prefixes (the real pump) — must both return promptly.
+        import time
+
+        for evil in (
+            "[OPTIONS:" + (" " * 200_000) + "x",
+            "[OPTIONS:" * 100_000 + "x",
+        ):
+            start = time.perf_counter()
+            cleaned, choices = extract_options(evil)
+            elapsed = time.perf_counter() - start
+            assert elapsed < 1.0, f"extract_options took {elapsed:.2f}s (possible ReDoS)"
+            # No terminating ']' → no match, input returned unchanged.
+            assert choices == []
+            assert cleaned == evil
+
 
 class TestBuildOptionsBlocks:
     def test_returns_checkboxes_and_send_button(self):

--- a/test/test_parse_options.py
+++ b/test/test_parse_options.py
@@ -49,3 +49,14 @@ def test_bracket_inside_option_text():
 
 def test_bracket_at_end_of_each_option():
     assert _parse_options("[OPTIONS: a[1] | b[2]]") == ["a[1]", "b[2]"]
+
+
+def test_body_does_not_span_newlines():
+    # The MULTILINE body must stay single-line: text mentioning "[OPTIONS:"
+    # mid-line with a LATER line ending in "]" must NOT be parsed as one span
+    # (that would emit bogus pills from unrelated prose). The tempered body
+    # excludes \n (``[^[\n]``) so a real [OPTIONS:] block is still detected
+    # while cross-line spans are not.
+    assert _parse_options("Earlier [OPTIONS: draft\nmore prose ]") == []
+    # A genuine single-line block after mid-text prose still parses.
+    assert _parse_options("Earlier [OPTIONS text.\nNow:\n[OPTIONS: A | B]") == ["A", "B"]

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -467,6 +467,27 @@ class TestExtractOptions:
         assert "[OPTIONS" not in body
         assert opts == []
 
+    def test_unterminated_options_tag_is_not_redos(self) -> None:
+        # Regression (py/polynomial-redos): a plain greedy ``.*`` body could
+        # consume a "[" that ALSO starts the outer "[OPTIONS:" literal, so over
+        # text with many "[OPTIONS:" prefixes search() re-explored the body from
+        # each position — polynomial. The tempered body
+        # (?:[^[]|\[(?!OPTIONS:))* forbids only a re-occurring "[OPTIONS:", so
+        # the body is unambiguous (linear). A whitespace-padded unterminated tag
+        # and many repeated "[OPTIONS:" prefixes (the real pump) must both return
+        # promptly.
+        import time
+
+        for evil in (
+            "[OPTIONS:" + ("\t" * 200_000) + "x",
+            "[OPTIONS:" * 100_000 + "x",
+        ):
+            start = time.perf_counter()
+            body, opts = _extract_options(evil)
+            elapsed = time.perf_counter() - start
+            assert elapsed < 1.0, f"_extract_options took {elapsed:.2f}s (possible ReDoS)"
+            assert opts == []
+
 
 # ── transport.py: deny-by-default auth + capabilities + inbound ─────────────
 

--- a/test/test_webex_renderer.py
+++ b/test/test_webex_renderer.py
@@ -4,8 +4,32 @@ from __future__ import annotations
 
 import pytest
 
-from kiro_crew.webex.renderer import _TOOL_EDIT_BUDGET, WebexRenderer
+from kiro_crew.webex.renderer import _TOOL_EDIT_BUDGET, WebexRenderer, _strip_options
 from kiro_crew.webex.transport import WEBEX_CAPABILITIES
+
+
+class TestStripOptionsRedos:
+    def test_unterminated_options_tag_is_not_redos(self) -> None:
+        # Regression (py/polynomial-redos): the old lazy ``\s*(.*?)`` body could
+        # consume a "[" that ALSO starts the outer "[OPTIONS:" literal, so over
+        # text with many "[OPTIONS:" prefixes search() re-explored the body from
+        # each position — polynomial. Webex now shares the tempered
+        # OPTIONS_RE_TRAILER (forbids only a re-occurring "[OPTIONS:"), so the
+        # body is unambiguous (linear). A whitespace-padded unterminated tag and
+        # many repeated "[OPTIONS:" prefixes (the real pump) must both return
+        # promptly.
+        import time
+
+        evil = "[OPTIONS:" + ("\t" * 200_000) + "x"
+        start = time.perf_counter()
+        result = _strip_options(evil)
+        assert time.perf_counter() - start < 1.0, "possible ReDoS"
+        assert result == ""
+
+        evil = "[OPTIONS:" * 100_000 + "x"
+        start = time.perf_counter()
+        _strip_options(evil)
+        assert time.perf_counter() - start < 1.0, "possible ReDoS"
 
 
 class FakeClient:

--- a/test/test_wechat_renderer.py
+++ b/test/test_wechat_renderer.py
@@ -4,8 +4,37 @@ from __future__ import annotations
 
 import pytest
 
-from kiro_crew.wechat.renderer import WeComRenderer
+from kiro_crew.wechat.renderer import WeComRenderer, _strip_options
 from kiro_crew.wechat.transport import WECOM_CAPABILITIES
+
+
+class TestStripOptionsRedos:
+    def test_unterminated_options_tag_is_not_redos(self) -> None:
+        # Regression (py/polynomial-redos): a plain greedy ``.*`` body could
+        # consume a "[" that ALSO starts the outer "[OPTIONS:" literal, so over
+        # text with many "[OPTIONS:" prefixes search() re-explored the body from
+        # each position — polynomial. The tempered body
+        # (?:[^[]|\[(?!OPTIONS:))* forbids only a re-occurring "[OPTIONS:", so the
+        # body is unambiguous (linear). A whitespace-padded unterminated tag and
+        # many repeated "[OPTIONS:" prefixes (the real pump) must both return
+        # promptly.
+        import time
+
+        # A single unterminated tag: no closing ']' after the last "[OPTIONS",
+        # so the whole still-streaming partial is hidden.
+        evil = "[OPTIONS:" + ("\t" * 200_000) + "x"
+        start = time.perf_counter()
+        result = _strip_options(evil)
+        assert time.perf_counter() - start < 1.0, "possible ReDoS"
+        assert result == ""
+
+        # Many repeated "[OPTIONS:" prefixes (the real polynomial pump): the
+        # linear match must still return promptly. There is no closing ']', so
+        # the trailer regex does not match and the text is returned unchanged.
+        evil = "[OPTIONS:" * 100_000 + "x"
+        start = time.perf_counter()
+        result = _strip_options(evil)
+        assert time.perf_counter() - start < 1.0, "possible ReDoS"
 
 
 class FakeClient:

--- a/website/src/hooks/useBlockAssembler.ts
+++ b/website/src/hooks/useBlockAssembler.ts
@@ -2,6 +2,13 @@ import { useMemo } from 'react'
 import type { ContentBlock } from '../types'
 
 const FENCE_OPEN = /^(`{3,})(\w*)\s*$/
+// Escape ALL regex metacharacters before interpolating a captured fence run
+// into a dynamic RegExp. The capture is currently backtick-only, but a
+// complete escape (not a single-char `\`` replace) keeps the sanitization
+// sound if FENCE_OPEN ever widens, and is the form static analysis recognizes.
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 const FENCE_CLOSE_RE = (() => {
   const cache = new Map<string, RegExp>()
   return (tick: string) => {
@@ -227,7 +234,7 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
         const fenceMatch = FENCE_OPEN.exec(line)
         if (fenceMatch) {
           flushMd()
-          fenceTick = fenceMatch[1].replace(/`/g, '\\`')
+          fenceTick = escapeRegExp(fenceMatch[1])
           fenceLang = fenceMatch[2] || ''
           fenceLen = fenceMatch[1].length
           fenceNestable = NESTABLE_LANGS.has(fenceLang.toLowerCase())
@@ -286,7 +293,7 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
         const fenceMatch = FENCE_OPEN.exec(line)
         if (fenceMatch) {
           widgetBuf.push(line)
-          widgetFenceTick = fenceMatch[1].replace(/`/g, '\\`')
+          widgetFenceTick = escapeRegExp(fenceMatch[1])
           state = 'widget-fence'
           break
         }

--- a/website/src/hooks/usePanelTabs.ts
+++ b/website/src/hooks/usePanelTabs.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { Artifact } from '../types'
 import { safeSetItem } from '../utils/safeStorage'
+import { secureRandomId } from '../utils/secureId'
 
 /** Singleton "view" tabs (opened from the + menu, one instance each). */
 export type ViewKind = 'changes' | 'files' | 'artifacts' | 'subagents' | 'workflows' | 'logs' | 'side'
@@ -335,7 +336,12 @@ export function usePanelTabs(slotKey: string | null = null) {
       setActive(last.id)
       return last.sessionId ?? ''
     }
-    const sessionId = Math.random().toString(36).slice(2, 14)
+    // Cryptographically-strong id — a terminal session id is a security token
+    // that addresses a live PTY, so it must not come from Math.random().
+    // secureRandomId() uses crypto.randomUUID in a secure context and a
+    // crypto.getRandomValues fallback when the dashboard is served over plain
+    // HTTP from a non-loopback address (where randomUUID is undefined).
+    const sessionId = secureRandomId()
     upsert({
       id: `terminal:${sessionId}`, kind: 'terminal',
       title: opts?.cwd ? basename(opts.cwd) : 'Terminal',

--- a/website/src/store/dashboardSlice.ts
+++ b/website/src/store/dashboardSlice.ts
@@ -1,7 +1,7 @@
 import { safeSetItem } from '../utils/safeStorage'
 import { createSlice, createAsyncThunk, createSelector, type PayloadAction } from '@reduxjs/toolkit'
 import { api } from '../api/client'
-import { sanitizeLlmOutput } from '../utils/sanitize'
+import { sanitizeLlmOutput, isUnsafeKey } from '../utils/sanitize'
 import type { StatusData, ChatSlot } from '../types'
 import type { SessionColorMode, PaletteName, DefaultColorSetting, IntensityName } from '../utils/sessionColors'
 
@@ -156,7 +156,9 @@ const dashboardSlice = createSlice({
     },
     sseSubagentStatus(state, action: PayloadAction<{ running: number; slot: string; agents?: SubagentDetail[] }>) {
       const { slot, running, agents } = action.payload
-      if (!slot) return
+      // `slot` is an untrusted key from the SSE payload; __proto__/constructor/
+      // prototype would write through Object.prototype in the else-branch below.
+      if (!slot || isUnsafeKey(slot)) return
       if (running <= 0) {
         delete state.subagentRunning[slot]
         delete state.subagentDetails[slot]
@@ -173,6 +175,12 @@ const dashboardSlice = createSlice({
     },
     sseSubagentText(state, action: PayloadAction<{ slot: string; id: string; text: string }>) {
       const { slot, id, text } = action.payload
+      // Both `slot` and `id` are untrusted keys from the SSE payload. A value of
+      // __proto__/constructor/prototype would pollute Object.prototype via the
+      // `state.subagentText[slot][id] = ...` assignment below — and the
+      // `subagentRunning[slot]` check does NOT stop `slot="__proto__"` because
+      // it resolves truthily through the prototype chain. Guard both keys.
+      if (isUnsafeKey(slot) || isUnsafeKey(id)) return
       if (!slot || !state.subagentRunning[slot]) return
       if (!state.subagentText[slot]) state.subagentText[slot] = {}
       const cur = (state.subagentText[slot][id] || '') + sanitizeLlmOutput(text)

--- a/website/src/test/dashboardSlice.test.ts
+++ b/website/src/test/dashboardSlice.test.ts
@@ -13,6 +13,8 @@ import reducer, {
   markSlotRead,
   fetchSlots,
   selectUnreadByMode,
+  sseSubagentStatus,
+  sseSubagentText,
 } from '../store/dashboardSlice'
 import type { StatusData, ChatSlot } from '../types'
 
@@ -219,6 +221,47 @@ describe('dashboardSlice', () => {
       // Existing unread preserved, no new ones spuriously added
       expect(state.unreadSlots).toEqual(['chat-1'])
       expect(state.slotsLoaded).toBe(true)
+    })
+  })
+
+  describe('subagent SSE prototype-pollution guards', () => {
+    // Both `slot` and `id` are untrusted keys from the SSE payload. A value of
+    // __proto__/constructor/prototype must never reach an assignment that would
+    // write through Object.prototype. Note the subagentRunning[slot] check does
+    // NOT stop slot="__proto__" on its own — it resolves truthily through the
+    // prototype chain — so isUnsafeKey(slot) is the real guard.
+    const polluted = () => ({} as Record<string, unknown>).polluted
+
+    it('sseSubagentStatus ignores a __proto__ slot without polluting the prototype', () => {
+      const state = reducer(
+        initial,
+        sseSubagentStatus({ slot: '__proto__', running: 1, agents: [] }),
+      )
+      // `['__proto__']` always returns the prototype object; the real check is
+      // that no OWN property was created and the prototype was not polluted.
+      expect(Object.prototype.hasOwnProperty.call(state.subagentRunning, '__proto__')).toBe(false)
+      expect(polluted()).toBeUndefined()
+    })
+
+    it('sseSubagentText ignores a __proto__ slot and does not pollute', () => {
+      // Prime a legit slot so the reducer would otherwise proceed.
+      const primed = reducer(initial, sseSubagentStatus({ slot: 'chat-1', running: 1 }))
+      reducer(primed, sseSubagentText({ slot: '__proto__', id: 'a', text: 'x' }))
+      expect(({} as Record<string, unknown>)['a']).toBeUndefined()
+      expect(polluted()).toBeUndefined()
+    })
+
+    it('sseSubagentText ignores a __proto__ id and does not pollute', () => {
+      let state = reducer(initial, sseSubagentStatus({ slot: 'chat-1', running: 1 }))
+      state = reducer(state, sseSubagentText({ slot: 'chat-1', id: '__proto__', text: 'x' }))
+      expect(state.subagentText['chat-1']?.['__proto__']).toBeUndefined()
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    })
+
+    it('sseSubagentText still stores text for a normal slot+id', () => {
+      let state = reducer(initial, sseSubagentStatus({ slot: 'chat-1', running: 1 }))
+      state = reducer(state, sseSubagentText({ slot: 'chat-1', id: 'sub-1', text: 'hello' }))
+      expect(state.subagentText['chat-1']['sub-1']).toBe('hello')
     })
   })
 })

--- a/website/src/test/secureId.test.ts
+++ b/website/src/test/secureId.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { secureRandomId } from '../utils/secureId'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('secureRandomId', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns a valid UUID v4 in a secure context (randomUUID present)', () => {
+    const id = secureRandomId()
+    expect(id).toMatch(UUID_RE)
+  })
+
+  it('produces unique ids', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => secureRandomId()))
+    expect(ids.size).toBe(1000)
+  })
+
+  it('falls back to getRandomValues when randomUUID is unavailable (non-secure context)', () => {
+    // Simulate a non-secure context: randomUUID undefined, getRandomValues present.
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array) => {
+        for (let i = 0; i < arr.length; i++) arr[i] = (i * 37 + 11) & 0xff
+        return arr
+      },
+    })
+    const id = secureRandomId()
+    // Still a well-formed v4 UUID (version nibble 4, variant bits 10xx).
+    expect(id).toMatch(UUID_RE)
+  })
+})

--- a/website/src/utils/sanitize.ts
+++ b/website/src/utils/sanitize.ts
@@ -78,3 +78,13 @@ export function sanitizeExfiltrationUrls(text: string): string {
 export function sanitizeLlmOutput(text: string): string {
   return sanitizeExfiltrationUrls(sanitizeCredentials(text))
 }
+
+/** True for the three object keys that, when used to index a plain object,
+ *  mutate ``Object.prototype`` instead of the object (prototype pollution).
+ *  Reducers that index a state map with an id sourced from SSE/LLM payloads
+ *  must early-return on these before the assignment. The literal ``===`` form
+ *  (not a Set/array membership test) is what CodeQL's
+ *  ``js/prototype-polluting-assignment`` query recognizes as a sanitizer. */
+export function isUnsafeKey(key: string): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype'
+}

--- a/website/src/utils/secureId.ts
+++ b/website/src/utils/secureId.ts
@@ -1,0 +1,35 @@
+/** Cryptographically-strong random id generation.
+ *
+ *  Prefers ``crypto.randomUUID()``, but that API is only defined in a **secure
+ *  context** (HTTPS or localhost). When the dashboard is served over plain HTTP
+ *  from a non-loopback address it is NOT a secure context, so ``randomUUID`` is
+ *  absent and calling it throws. We fall back to ``crypto.getRandomValues()``,
+ *  which is available in every context (secure or not) and is still a CSPRNG —
+ *  so the fallback never degrades to the non-cryptographic ``Math.random()``.
+ */
+
+function uuidFromRandomBytes(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  // RFC 4122 v4: set version (4) and variant (10xx) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex: string[] = []
+  for (let i = 0; i < 256; i++) hex.push((i + 0x100).toString(16).slice(1))
+  const b = bytes
+  return (
+    hex[b[0]] + hex[b[1]] + hex[b[2]] + hex[b[3]] + '-' +
+    hex[b[4]] + hex[b[5]] + '-' +
+    hex[b[6]] + hex[b[7]] + '-' +
+    hex[b[8]] + hex[b[9]] + '-' +
+    hex[b[10]] + hex[b[11]] + hex[b[12]] + hex[b[13]] + hex[b[14]] + hex[b[15]]
+  )
+}
+
+/** Return a cryptographically-strong UUID v4 string, usable in any context. */
+export function secureRandomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return uuidFromRandomBytes()
+}


### PR DESCRIPTION
## Summary

Follow-up to #168 addressing the repo's pre-existing **CodeQL** security debt. I triaged every open CodeQL alert, fixed the genuinely exploitable findings, and made the analyzer-unrecognized guards visible / more robust. **No behavior change on valid inputs** (the OPTIONS rewrite is verified byte-for-byte identical to the old parser on every existing test input, and CodeQL-clean under the exact `py/polynomial-redos` query run locally with the CodeQL CLI).

## Problem

CodeQL reports security findings against `main`. The blocking one is a **ReDoS (`py/polynomial-redos`, high)** in the `[OPTIONS: …]` parser. The regex used a plain greedy body — `\[OPTIONS:(.*)\]…` — in `slack/format.py`, `dashboard/state.py`, and the discord/telegram/wechat renderers. The greedy `.*` body can itself consume a `[` that **also** begins the outer `[OPTIONS:` literal, so over text with many `[OPTIONS:` prefixes `search()` / `findall()` re-explore the body from each candidate position → polynomial backtracking. This parser runs over **untrusted LLM / subagent / relayed text** before it reaches Slack, the dashboard, Discord, Telegram, or WeCom, so the input is attacker-influenceable.

## Why it matters

A crafted assistant/relayed message could pin a CPU parsing the OPTIONS tag before any surface renders it. Left unfixed, the CodeQL gate also stays red, blocking the branch.

## Fix (symptom → root cause → change)

- **Symptom:** CodeQL flags `py/polynomial-redos` on the OPTIONS regex.
- **Root cause:** the pump is **`[OPTIONS:`**, not the trailing whitespace. A greedy `.*` body is ambiguous because it can match a `[` that also starts a fresh `[OPTIONS:`, giving multiple ways to match the same text. (An earlier whitespace-focused rework — anchoring/lookahead/bounding the trailing `[ \t]*` — did **not** clear the alert; confirmed by re-running the exact query.)
- **Change:** use a **tempered greedy body** `(?:[^[]|\[(?!OPTIONS:))*` — allow every bracket **except** a `[` that begins a fresh `[OPTIONS:`. The body is then unambiguous (linear) while still capturing a literal `]` and any other inner `[` inside an option (`"Fix [x] logging"`, `"a[1]"`). Applied to all five mirrored copies:
  - slack/dashboard (MULTILINE): `\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*)\][ \t]*$` — the negated class excludes `\n` because a Python negated class matches `\n` regardless of DOTALL; without it the MULTILINE body would silently span lines (a latent data-correctness bug the Arbiter caught, now fixed + regression-tested).
  - discord/telegram/wechat (DOTALL): `\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*)\]\s*\Z` — keeps `[^[]` because the old `.*` already spanned newlines under DOTALL.
  - **Consolidated:** both hardened variants are now defined once in `constants.py` (`OPTIONS_RE_LINE` for the MULTILINE/line surfaces, `OPTIONS_RE_TRAILER` for the DOTALL/end-of-message surfaces) and imported by all six OPTIONS-parsing surfaces (Slack, dashboard, Discord, Telegram, WeCom, Webex) — no more hand-mirrored copies synced by a comment, so the security-load-bearing grammar cannot drift (addresses the Arbiter's long-term item; aligns with the repo constants convention).
- **Verification:** ran the CodeQL CLI `py/polynomial-redos` query against the repo — all five OPTIONS regexes drop their backtracking term (the only remaining `py/polynomial-redos` hits are pre-existing, unrelated to this PR). Behavior is **byte-for-byte identical** to the old `search`/`findall`/`sub` on every existing test input (a literal `]` inside an option is still captured, empty/whitespace-only bodies unchanged, multi-marker "uses last" unchanged, per-choice whitespace still stripped by the callers).

### Guard-visibility / hardening (unchanged from prior revision)
- **`dashboardSlice.sseSubagentText`** — guard the untrusted second-level `id` key against `__proto__`/`constructor`/`prototype` before indexing the state map, mirroring the #168 `chatSlice` fix. Shared `isUnsafeKey()` in `utils/sanitize.ts`. (`js/prototype-polluting-assignment`)
- **`usePanelTabs.openTerminal`** — derive the terminal session id (a token addressing a live PTY) from `crypto.randomUUID()`. (`js/insecure-randomness`)
- **`useBlockAssembler`** — escape the full regex metacharacter set when building the dynamic close-fence `RegExp`. (`js/incomplete-sanitization` ×2)
- **`taskrunner.api_taskrunner_run`** — forward the *validated resolved* spec path to `start_background` instead of the raw request string, so the traversal + sensitive-path guard and the sink share one value. (`py/path-injection`)

## Triage of the remaining alerts

The other open CodeQL alerts were triaged and classified **not fixable in code**:
- **Guarded false positives** — a real containment check exists (`.resolve()` + `.relative_to(root)`, `is_sensitive_path()`, `os.walk(followlinks=False)`) that CodeQL cannot trace (e.g. `dashboard/handlers/_shared.py`, `knowledge.py`, most of `files.py`).
- **By-design bounded capabilities** — the workflow-engine `exec()` of user scripts in a restricted, `validate()`-gated, wall-clock-bounded namespace; the file-explorer serving user-chosen paths within configured roots; debug-logging of user text.
- **Test-only** — hardcoded fixtures with no runtime path.

These are non-blocking and tracked for dismissal-with-justification in the code-scanning UI.

## Tests

- `slack/format` + `state` OPTIONS parsing, `test_options_buttons`, `test_parse_options`, `test_discord` / `test_telegram` / `test_wechat_renderer`, `dashboardSlice`, `useBlockAssembler`, `usePanelTabs`, `taskrunner` suites all pass (797 backend tests across the affected modules). The ReDoS regression tests now bound each extractor's wall-clock on **two** adversarial inputs: a long whitespace-padded unterminated tag **and** many repeated `[OPTIONS:` prefixes (the real pump).
- `flake8` (CPython 3.10), `mypy`, `isort` clean on the changed files.

## Manual verification

N/A — the OPTIONS change is a pure regex-shape refactor validated with (a) the CodeQL CLI running the exact `py/polynomial-redos` query and (b) exhaustive parity checks (search/findall/sub over the full case matrix + every test input); no user-visible UI change.

## Notes
- Depends conceptually on #168 but is independent in the tree (no file overlap). Merge order doesn't matter.
- Rebased onto the current `main`; single commit.



