### PR TITLE
fix(side-panel): preserve file diff state on re-open

### DIFF
--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -156,6 +156,10 @@ interface Props {
   onSubmitComments?: (message: string) => void
   onRefresh?: (filePath: string) => Promise<void>
   reserveWidth?: number
+  /** Restored file-tab preference. Undefined allows the initial modified-file
+   *  auto-diff; false explicitly keeps the normal preview/source view. */
+  initialDiffMode?: boolean
+  onDiffModeChange?: (diffMode: boolean) => void
   /** Render as a SidePanel tab body (fills parent, no resize handle/border). */
   embedded?: boolean
 }
@@ -612,7 +616,7 @@ const CommentOverlayBlock = memo(function CommentOverlayBlock({ popover, addComm
   )
 })
 
-export default memo(function MarkdownPanel({ filePath, content, onContentChange, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, embedded }: Props) {
+export default memo(function MarkdownPanel({ filePath, content, onContentChange, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded }: Props) {
   const qc = useQueryClient()
   // Code files (non-rich, non-markdown) have no meaningful preview — their
   // "preview" was just a read-only render of the same text. They open
@@ -621,7 +625,12 @@ export default memo(function MarkdownPanel({ filePath, content, onContentChange,
     if (MD_EXTS.has(extOf(filePath))) return false
     return !['image', 'svg', 'csv', 'json', 'jsonl', 'html', 'pdf'].includes(detectFileType(filePath))
   })
-  const [diffMode, setDiffMode] = useState(false)
+  const [diffMode, setDiffMode] = useState(initialDiffMode ?? false)
+  const toggleDiffMode = useCallback(() => {
+    const next = !diffMode
+    setDiffMode(next)
+    onDiffModeChange?.(next)
+  }, [diffMode, onDiffModeChange])
   // Unified vs side-by-side diff rendering — persisted, and shares its key
   // with SidePanel's diff tabs so the preference is app-wide.
   const [diffSplit, setDiffSplit] = usePersistedBool('mc-diff-split', true)
@@ -898,15 +907,22 @@ export default memo(function MarkdownPanel({ filePath, content, onContentChange,
     staleTime: 10_000,
   })
   const originalContent = diffData?.original ?? ''
-  // Auto-open diff mode on first load only for a genuine edit (an existing
-  // tracked file that was modified). For a brand-new / untracked file there's
-  // no prior HEAD content, so every line is an addition and the whole document
-  // renders green — that hurts readability while conveying little. Skip
-  // auto-diff there; the git-diff toggle in the header stays available.
-  if (diffData && diffInitFileRef.current !== filePath) {
+  // Auto-open diff mode once for a genuine edit unless this file tab already
+  // carries an explicit choice. File-tab metadata survives ChatPage unmounts,
+  // so returning to a session restores preview/source instead of re-enabling
+  // diff after the user turned it off.
+  useEffect(() => {
+    if (!diffData || diffInitFileRef.current === filePath) return
     diffInitFileRef.current = filePath
-    if (diffData.diff && diffData.status === 'modified') setDiffMode(true)
-  }
+    if (initialDiffMode !== undefined) {
+      setDiffMode(initialDiffMode)
+      return
+    }
+    if (diffData.diff && diffData.status === 'modified') {
+      setDiffMode(true)
+      onDiffModeChange?.(true)
+    }
+  }, [diffData, filePath, initialDiffMode, onDiffModeChange])
 
   const revealOrCopy = useCallback(async (path: string, action: 'open' | 'reveal') => {
     try {
@@ -1254,7 +1270,7 @@ export default memo(function MarkdownPanel({ filePath, content, onContentChange,
 
   const editorToolbarButtons = (<>
     {!isRichType && (
-      <button className={`p-1.5 rounded-md border cursor-pointer ${diffMode ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`} onClick={() => { setDiffMode(!diffMode) }} title="Toggle diff view" aria-label="Toggle diff view"><FileDiff size={14} /></button>
+      <button className={`p-1.5 rounded-md border cursor-pointer ${diffMode ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`} onClick={toggleDiffMode} title="Toggle diff view" aria-label="Toggle diff view"><FileDiff size={14} /></button>
     )}
     {!isRichType && editing && (
       <button className={`p-1.5 rounded-md border cursor-pointer transition-all ${wordWrap ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`} onClick={() => setWordWrap(!wordWrap)} title="Toggle word wrap" aria-label="Toggle word wrap"><WrapText size={14} /></button>
@@ -1341,7 +1357,7 @@ export default memo(function MarkdownPanel({ filePath, content, onContentChange,
               <button className={barIconBtn(!diffSplit)} onClick={() => setDiffSplit(!diffSplit)} title={diffSplit ? 'Switch to unified view' : 'Switch to split view'} aria-label={diffSplit ? 'Switch to unified view' : 'Switch to split view'} aria-pressed={!diffSplit}><Columns2 size={14} /></button>
             )}
             {!isRichType && (
-              <button className={barIconBtn(diffMode)} onClick={() => setDiffMode(!diffMode)} title="Toggle diff view" aria-label="Toggle diff view" aria-pressed={diffMode}><FileDiff size={14} /></button>
+              <button className={barIconBtn(diffMode)} onClick={toggleDiffMode} title="Toggle diff view" aria-label="Toggle diff view" aria-pressed={diffMode}><FileDiff size={14} /></button>
             )}
             <OverflowMenu filePath={filePath} content={content} revealOrCopy={revealOrCopy}
               onRefresh={handleRefresh} refreshDisabled={refreshing || dirty} refreshTitle={dirty ? 'Save or discard changes first' : 'Refresh file (re-read from disk)'}

--- a/website/src/hooks/usePanelTabs.ts
+++ b/website/src/hooks/usePanelTabs.ts
@@ -24,6 +24,9 @@ export interface PanelTab {
   content?: string
   original?: string
   modified?: string
+  /** Last selected working-tree diff view for file tabs. Persisted with the
+   *  tab so leaving and returning to a chat does not re-enable auto-diff. */
+  diffMode?: boolean
   artifactSlug?: string
   artifactKind?: Artifact['kind']
   // ── terminal fields ──

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -416,6 +416,7 @@ export default function SidePanel({
                 tab={t} active={isActive}
                 onClose={() => handleCloseTab(t.id)}
                 onContentChange={(c) => patchTab(t.id, { content: c })}
+                onDiffModeChange={(diffMode) => patchTab(t.id, { diffMode })}
                 onFileSave={onFileSave}
                 onFileOpen={onFileOpen}
                 onSubmitComments={onSubmitComments}
@@ -438,9 +439,10 @@ export default function SidePanel({
  *  type on every SidePanel render, forcing React to unmount/remount the whole
  *  subtree — which reset editor state and re-fired xterm's focus-on-visible
  *  effect, stealing focus from the chat input on every keystroke. */
-function TabBody({ tab, active, onClose, onContentChange, onFileSave, onFileOpen, onSubmitComments, onTerminalSendToChat, diffLineNumbers, setDiffLineNumbers, diffSideBySide, setDiffSideBySide }: {
+function TabBody({ tab, active, onClose, onContentChange, onDiffModeChange, onFileSave, onFileOpen, onSubmitComments, onTerminalSendToChat, diffLineNumbers, setDiffLineNumbers, diffSideBySide, setDiffSideBySide }: {
   tab: PanelTab; active: boolean; onClose: () => void
   onContentChange: (c: string) => void
+  onDiffModeChange: (diffMode: boolean) => void
   onFileSave: (fp: string, c: string) => Promise<void>
   onFileOpen?: (p: string) => void
   onSubmitComments?: (m: string) => void
@@ -456,6 +458,8 @@ function TabBody({ tab, active, onClose, onContentChange, onFileSave, onFileOpen
         filePath={tab.path || ''}
         content={tab.content || ''}
         onContentChange={onContentChange}
+        initialDiffMode={tab.diffMode}
+        onDiffModeChange={onDiffModeChange}
         onSave={onFileSave}
         onClose={onClose}
         liveWatch

--- a/website/src/test/usePanelTabs.test.ts
+++ b/website/src/test/usePanelTabs.test.ts
@@ -179,6 +179,22 @@ describe('usePanelTabs — per-slot isolation', () => {
     expect(result.current.activeId).toBe('diff:/b.ts')
   })
 
+  it('restores a file tab\'s selected diff view after leaving and returning to a chat', () => {
+    const { result, rerender } = renderHook(({ slot }: { slot: string | null }) => usePanelTabs(slot), {
+      initialProps: { slot: 'chat-a' as string | null },
+    })
+    act(() => result.current.openFile('/README.md', '# current'))
+    act(() => result.current.patchTab('file:/README.md', { diffMode: false }))
+
+    rerender({ slot: 'chat-b' })
+    expect(result.current.tabs).toEqual([])
+    rerender({ slot: 'chat-a' })
+
+    expect(result.current.activeTab).toMatchObject({
+      id: 'file:/README.md', diffMode: false,
+    })
+  })
+
   it('operations only touch the active slot\'s bucket (closeAll in B leaves A intact)', () => {
     const { result, rerender } = renderHook(({ slot }: { slot: string | null }) => usePanelTabs(slot), {
       initialProps: { slot: 'chat-a' as string | null },


### PR DESCRIPTION
## Problem
A modified file automatically opens in Git diff mode. If the user turns diff off, leaves the chat session, and later returns, the file sidebar remounts and forces diff mode on again.

## Why it matters
The sidebar discards an explicit view choice during normal navigation, repeatedly interrupting users who want to read or edit the regular file preview.

## Fix
The symptom came from `MarkdownPanel` storing diff mode only in component-local state while the surrounding per-session tab survives route and session changes. Persist each file tab's selected diff mode in the existing panel-tab metadata, restore it when the file panel remounts, and only run modified-file auto-diff when no prior choice exists. The auto-diff initialization now runs in an effect instead of updating state during render.

## Tests
- Added a `usePanelTabs` regression test that turns diff off, switches to another chat, and verifies the original chat restores `diffMode: false`.
- `npx tsc -b`
- `npx vitest run src/test/usePanelTabs.test.ts` — 18 passed
- `npx vitest run` — 3,937 passed, 3 skipped
- `flake8 -j 1 src/ test/` — clean
- Full backend pytest completed with only known host-environment failures: subagent tests hit the 4 GB memory floor and one hardlink test is blocked by the filesystem sandbox. No backend files changed.

## Manual verification
Automated state-transition coverage verifies the reported leave-and-return path; no live-gateway cutover was performed.
