### PR TITLE
feat(telegram): per-thread sessions via forum topics (single-user)

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -251,6 +251,15 @@ class DashboardConfig:
     tips_model: str = "claude-haiku-4.5"  # model for tips generation (pinned to Haiku for cost)
     tips_explore_ratio: float = 0.2    # probability of random catalog pick vs personalized (clamped to [0, 1])
 
+@dataclass
+class TelegramConfig:
+    enabled: bool = False              # start the Telegram Bot API channel (long-polling) at gateway startup
+    bot_token: str = ""                # @BotFather token; prefer the TELEGRAM_BOT_TOKEN credential
+    allowed_user_ids: list[int] = []   # numeric user IDs allowed to drive the bot; empty = deny all (fail closed)
+    soft_threshold_pct: int = 80       # prompt to /compact or /new when context passes this %
+    allow_forum: bool = False          # serve supergroup forum Topics as per-Topic sessions (Slack-thread style). Fail-closed: also requires the supergroup's chat_id in allowed_forum_chat_ids, and only real Topics (message_thread_id present) are served — ordinary groups and the supergroup General chat are denied
+    allowed_forum_chat_ids: list[int] = []  # numeric supergroup chat_ids permitted to run forum-topic sessions; empty = deny all groups (fail closed)
+
 # Additional top-level DTOs (not fully expanded here — see loader.py):
 # OrchestratorConfig, CronHistoryConfig, TunnelConfig, InstancesConfig, HeartbeatConfig,
 # WorkspaceConfig, MemoryStoreConfig, ExternalRegistryConfig,

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -143,6 +143,40 @@ Session keys are namespaced as `f"{channel_type}:{conversation_id}"` (`session_k
 
 `MessagingConfig.use_transport` (`config/loader.py`, default `True` in KiroCrew; exposed in `config.json` under `messaging`) is the single switch. `slack/events.py::_route_message` checks `orch._cfg.messaging.use_transport`; when `True` it creates a task on `handle_message_transport` and skips the native `handle_message` monolith. (There is no challenge-redirect in this fork — Slack messages are processed inline.) Approval mode is resolved by `_resolve_approval_mode(orch)` (respects configured mode + operator YOLO/SafetyOverride TTL), and the per-channel `slack.channels.<id>.agent` override is passed through.
 
+## Telegram forum topics (per-Topic sessions)
+
+A Telegram **supergroup with Topics enabled** maps onto the same `thread_id`
+abstraction Slack uses, so one bot serves many parallel, topic-scoped sessions
+(Slack channel+threads) instead of a single session per user.
+
+- **Routing / session key.** The transport captures each update's
+  `message_thread_id` (the Topic id) and carries it as the neutral
+  `InboundMessage.thread_id`. The dispatcher folds `(chat_type, chat_id,
+  thread_id)` into a route and reuses the `chat_type` slot of
+  `build_dm_session_key`: a Topic keys to
+  `telegram:{agent}:forum:{chat_id}:{thread_id}`, while a private DM stays
+  byte-for-byte `telegram:{agent}:direct:{user_id}`. `messaging.dm_scope="unified"`
+  collapses **only** direct DMs into the `unified:{agent}` bucket — forum routes
+  always keep the full per-Topic key, so no group Topic can share a session with
+  a DM or another group.
+- **Per-Topic generation.** `ConversationState` is keyed on the same route, so
+  `/new`, idle/daily rotation and `/compact` are scoped to one Topic.
+- **Gate — fail-closed AND Topic-scoped.** `forum_gate_outcome(chat_type,
+  chat_id, message_thread_id, *, allow_forum, allowed_forum_chat_ids)` is the
+  single predicate guarding **both** `TelegramTransport.receive` (frozen
+  allow-list) and `TelegramDispatcher.on_callback` (live cfg). It authorizes a
+  turn/callback only for a real forum Topic — `chat_type == "supergroup"` AND a
+  `message_thread_id` — in an allow-listed chat (`telegram.allow_forum` **and**
+  `chat_id ∈ telegram.allowed_forum_chat_ids`). Ordinary groups and the
+  supergroup **General** chat (no thread) are denied and SEL-audited
+  (`denied_forum_not_allowed` / `denied_non_private_chat`); the owner
+  `allowed_user_ids` check still gates *who* may drive a turn.
+- **Outbound.** Streamed answers, command/notice replies, queue receipts, the
+  queue drain, callback re-dispatch, and the `/link` dashboard-mirror
+  `ChannelLink` all carry `message_thread_id`, so every reply lands in its Topic
+  and a queued message drains under the forum key (`editMessageText` is not
+  threaded — the message id already identifies the message within its Topic).
+
 ## Mid-turn routing & per-message overrides (Telegram)
 
 A message arriving while a turn is in flight is routed by

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2535,6 +2535,25 @@ class TelegramConfig:
             tags=["telegram"],
         ),
     )
+    allow_forum: bool = field(
+        default=False,
+        metadata=_meta(
+            "Allow Forum Topics",
+            "Serve Telegram supergroup forum Topics as per-topic sessions "
+            "(Slack-thread style). Fail-closed: also requires the supergroup's "
+            "chat_id in allowed_forum_chat_ids.",
+            tags=["telegram"],
+        ),
+    )
+    allowed_forum_chat_ids: list[int] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Allowed Forum Chat IDs",
+            "Numeric supergroup chat_ids permitted to run forum-topic sessions. "
+            "Empty = deny all groups (fail closed).",
+            tags=["telegram"],
+        ),
+    )
 
 
 @dataclass
@@ -3160,6 +3179,10 @@ class KiroCrewConfig:
                 allowed_user_ids=_coerce_int_ids(telegram_data.get("allowed_user_ids")),
                 soft_threshold_pct=max(
                     1, min(100, _coerce_int(telegram_data.get("soft_threshold_pct"), 80))
+                ),
+                allow_forum=bool(telegram_data.get("allow_forum", False)),
+                allowed_forum_chat_ids=_coerce_int_ids(
+                    telegram_data.get("allowed_forum_chat_ids")
                 ),
             ),
             discord=DiscordConfig(

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -89,9 +89,10 @@ DM_SCOPE_UNIFIED = "unified"
 #: stays separate; ``unified`` opts into one shared bucket per agent.
 DEFAULT_DM_SCOPE = DM_SCOPE_PER_CHANNEL_PEER
 
-#: Only ``direct`` (1:1 DM) is wired today; ``group`` is reserved for future
-#: group-chat support and is produced by no current channel.
+#: ``direct`` (1:1 DM) is the baseline; ``forum`` keys a Telegram supergroup
+#: forum Topic ``(chat_id, thread_id)`` to its own session (Slack-thread style).
 CHAT_TYPE_DIRECT = "direct"
+CHAT_TYPE_FORUM = "forum"
 
 
 def build_dm_session_key(
@@ -115,8 +116,12 @@ def build_dm_session_key(
     ``dm_scope``:
       * ``per-channel-peer`` (default) -- one bucket per ``(channel, user)``, so
         the same person on Telegram vs WeCom stays isolated.
-      * ``unified`` -- all DMs collapse into a single ``unified:{agent}`` bucket
-        for cross-surface continuity (channel and user drop out of the key).
+      * ``unified`` -- direct (1:1) DMs collapse into a single ``unified:{agent}``
+        bucket for cross-surface continuity (channel and user drop out of the
+        key). Applies ONLY to direct DMs: a forum route (``chat_type ==
+        CHAT_TYPE_FORUM``) ALWAYS keeps its full
+        ``{channel}:{agent}:{chat_type}:{user}`` bucket regardless of dm_scope,
+        so private DM content can never collapse into a shared group Topic.
 
     An unrecognized ``dm_scope`` falls back to per-channel-peer (safe isolation)
     rather than raising, so a hand-edited config can never crash dispatch.
@@ -128,7 +133,7 @@ def build_dm_session_key(
     carry no prior persisted history to migrate; the legacy bare-thread Slack
     keys keep their existing compatibility shim (see ``canonical_key``) untouched.
     """
-    if dm_scope == DM_SCOPE_UNIFIED:
+    if dm_scope == DM_SCOPE_UNIFIED and chat_type == CHAT_TYPE_DIRECT:
         bucket = f"{DM_SCOPE_UNIFIED}:{agent}"
     else:
         bucket = f"{channel}:{agent}:{chat_type}:{user}"
@@ -162,6 +167,7 @@ def seed_generation(
     agent: str,
     user_id: str,
     dm_scope: str,
+    chat_type: str = CHAT_TYPE_DIRECT,
 ) -> int:
     """Seed a DM ``ConversationState`` generation from the persisted session map.
 
@@ -171,8 +177,14 @@ def seed_generation(
     a stale on-disk generation instead of colliding with and resurrecting it.
     Shared by every DM dispatcher so the restart-safe seeding lives in one place
     rather than being copy-pasted per channel.
+
+    ``chat_type`` selects the bucket namespace (``direct`` for a 1:1 DM,
+    ``forum`` for a per-topic session); it defaults to ``direct`` so existing
+    callers keep their exact bucket shape.
     """
-    bucket = build_dm_session_key(channel, agent, user_id, gen=0, dm_scope=dm_scope)
+    bucket = build_dm_session_key(
+        channel, agent, user_id, gen=0, dm_scope=dm_scope, chat_type=chat_type
+    )
     return sessions.max_generation(bucket)
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -529,6 +529,12 @@ class GatewayOrchestrator:
         )
         self._telegram_enabled = bool(cfg.telegram.enabled and self._telegram_bot_token)
         self._telegram_allowed_user_ids: list[int] = list(cfg.telegram.allowed_user_ids)
+        # Forum-topic gate (fail closed): serve supergroup forum Topics only when
+        # allow_forum is set AND the supergroup's chat_id is allow-listed.
+        self._telegram_allow_forum: bool = bool(cfg.telegram.allow_forum)
+        self._telegram_allowed_forum_chat_ids: list[int] = list(
+            cfg.telegram.allowed_forum_chat_ids
+        )
         self._telegram_client: "TelegramClient | None" = None
         # Discord — the DISCORD_BOT_TOKEN credential (env/.env) overrides
         # cfg.discord.bot_token; all other settings come from the typed

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -44,6 +44,9 @@ class TelegramInbound:
     text: str = ""
     message_id: int = 0
     chat_type: str = ""  # "private" | "group" | "supergroup" | "channel"
+    # Forum-topic id in a supergroup (Bot API ``message_thread_id``); None in a
+    # 1:1 DM or the supergroup's General topic.
+    message_thread_id: int | None = None
 
 
 @dataclass
@@ -58,6 +61,8 @@ class TelegramCallback:
     label: str = ""  # button text, recovered from the message's reply_markup
     username: str = ""
     chat_type: str = ""  # "private" | "group" | "supergroup" | "channel"
+    # Forum-topic id of the message the button lives on (None outside a topic).
+    message_thread_id: int | None = None
 
 
 class TelegramClient:
@@ -132,6 +137,7 @@ class TelegramClient:
         reply_markup: dict | None = None,
         retry_plain: bool = True,
         reply_to_message_id: int | None = None,
+        message_thread_id: int | None = None,
     ) -> int | None:
         """Send a new message. Returns the message_id on success.
 
@@ -139,11 +145,16 @@ class TelegramClient:
         sending with parse_mode=HTML would make any bare ``<``/``>``/``&`` trip a
         Telegram 400 and force a second round-trip. Callers that generate real
         markup (e.g. a static help card) may pass parse_mode explicitly.
+
+        ``message_thread_id`` targets a supergroup forum Topic; it is included
+        only when set, so DM sends are byte-for-byte unchanged.
         """
         params: dict[str, Any] = {
             "chat_id": chat_id,
             "text": text[:TELEGRAM_MAX_TEXT],
         }
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
         if parse_mode:
             params["parse_mode"] = parse_mode
         if reply_markup:
@@ -166,7 +177,8 @@ class TelegramClient:
         return result.get("message_id") if result else None
 
     async def send_message_draft(
-        self, chat_id: int, draft_id: int, text: str, *, parse_mode: str | None = None
+        self, chat_id: int, draft_id: int, text: str, *, parse_mode: str | None = None,
+        message_thread_id: int | None = None,
     ) -> bool:
         """Stream an ephemeral partial-message draft (Bot API 9.3+ sendMessageDraft).
 
@@ -176,12 +188,17 @@ class TelegramClient:
         Requires the bot to have Forum Topic Mode enabled in BotFather; returns
         False (so the caller can fall back) if the API rejects it. Sent as
         plaintext (no parse_mode by default) so partial markdown never 400s.
+
+        ``message_thread_id`` targets a supergroup forum Topic; included only
+        when set.
         """
         params: dict[str, Any] = {
             "chat_id": chat_id,
             "draft_id": draft_id,
             "text": text[:TELEGRAM_MAX_TEXT],
         }
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
         if parse_mode:
             params["parse_mode"] = parse_mode
         result = await self._api("sendMessageDraft", params)
@@ -234,9 +251,13 @@ class TelegramClient:
         result = await self._api("editMessageReplyMarkup", params)
         return result is not None
 
-    async def send_typing(self, chat_id: int) -> None:
-        """Send 'typing...' chat action."""
-        await self._api("sendChatAction", {"chat_id": chat_id, "action": "typing"})
+    async def send_typing(self, chat_id: int, *, message_thread_id: int | None = None) -> None:
+        """Send 'typing...' chat action. ``message_thread_id`` targets a forum
+        Topic (included only when set)."""
+        params: dict[str, Any] = {"chat_id": chat_id, "action": "typing"}
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
+        await self._api("sendChatAction", params)
 
     async def answer_callback(self, callback_query_id: str, text: str = "") -> None:
         """Acknowledge a callback_query to stop the spinner on the button."""
@@ -341,6 +362,7 @@ class TelegramClient:
                 text=text,
                 message_id=msg.get("message_id", 0),
                 chat_type=chat.get("type", ""),
+                message_thread_id=msg.get("message_thread_id"),
             )
             task = asyncio.create_task(self._invoke_message(inbound))
             self._handler_tasks.add(task)
@@ -371,6 +393,7 @@ class TelegramClient:
                 label=label,
                 username=user.get("username", ""),
                 chat_type=chat.get("type", ""),
+                message_thread_id=(msg or {}).get("message_thread_id"),
             )
             task = asyncio.create_task(self._invoke_callback(callback))
             self._handler_tasks.add(task)

--- a/src/kiro_crew/telegram/gateway.py
+++ b/src/kiro_crew/telegram/gateway.py
@@ -77,7 +77,13 @@ async def maybe_start_telegram(orch: "GatewayOrchestrator") -> "TelegramClient |
         )
         client = TelegramClient(token=bot_token, on_callback=dispatcher.on_callback)
         transport = TelegramTransport(
-            client, allowed_user_ids=allowed_ids, dispatch=dispatcher.handle_message
+            client,
+            allowed_user_ids=allowed_ids,
+            allow_forum=bool(getattr(orch, "_telegram_allow_forum", False)),
+            allowed_forum_chat_ids=list(
+                getattr(orch, "_telegram_allowed_forum_chat_ids", []) or []
+            ),
+            dispatch=dispatcher.handle_message,
         )
         # Inbound: client long-poll -> transport.receive (authorize + normalize)
         # -> dispatcher.handle_message (drive the turn on the shared TurnDriver).

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -322,10 +322,15 @@ class TelegramRenderer(Renderer):
         capabilities: TransportCapabilities,
         *,
         session_key: str = "",
+        message_thread_id: int | None = None,
     ) -> None:
         super().__init__(capabilities)
         self._client = client
         self._chat_id = chat_id
+        # Forum-topic id: when set, every outbound send/typing is threaded into
+        # that Topic. None for a 1:1 DM or the supergroup General topic. Edits
+        # never carry it (message_id already locates the message in its topic).
+        self._thread_id = message_thread_id
         self._session_key = session_key
         self._buf: list[str] = []
         self._last_tool = ""
@@ -372,7 +377,9 @@ class TelegramRenderer(Renderer):
         try:
             while not self._closed:
                 try:
-                    await self._client.send_typing(self._chat_id)
+                    await self._client.send_typing(
+                        self._chat_id, message_thread_id=self._thread_id
+                    )
                 except Exception:
                     logger.debug("Telegram: typing refresh failed", exc_info=True)
                 await asyncio.sleep(_TYPING_REFRESH_S)
@@ -521,7 +528,9 @@ class TelegramRenderer(Renderer):
         self._last_edit = now
         self._shown = text
         if self._stream_mid is None:
-            mid = await self._client.send_message(self._chat_id, text)
+            mid = await self._client.send_message(
+                self._chat_id, text, message_thread_id=self._thread_id
+            )
             if mid is not None:
                 self._stream_mid = mid
         else:
@@ -555,10 +564,12 @@ class TelegramRenderer(Renderer):
         mid = await self._client.send_message(
             self._chat_id, html_text, parse_mode="HTML",
             reply_markup=keyboard, retry_plain=False,
+            message_thread_id=self._thread_id,
         )
         if mid is None:
             await self._client.send_message(
                 self._chat_id, _strip_md(text), reply_markup=keyboard,
+                message_thread_id=self._thread_id,
             )
 
     async def on_thinking(self, text: str) -> None:
@@ -597,12 +608,16 @@ class TelegramRenderer(Renderer):
         }
         tool = self._last_tool or "this tool"
         await self._client.send_message(
-            self._chat_id, f"🔐 Approve `{tool}`?", reply_markup=keyboard
+            self._chat_id, f"🔐 Approve `{tool}`?", reply_markup=keyboard,
+            message_thread_id=self._thread_id,
         )
 
     async def on_compaction(self, context_usage_pct: float) -> None:
         try:
-            await self._client.send_message(self._chat_id, "🗜️ Compacting context…")
+            await self._client.send_message(
+                self._chat_id, "🗜️ Compacting context…",
+                message_thread_id=self._thread_id,
+            )
         except Exception:
             logger.debug("Telegram: compaction notice send failed", exc_info=True)
 
@@ -658,7 +673,8 @@ class TelegramRenderer(Renderer):
                 )
             else:
                 await self._client.send_message(
-                    self._chat_id, placeholder, reply_markup=keyboard
+                    self._chat_id, placeholder, reply_markup=keyboard,
+                    message_thread_id=self._thread_id,
                 )
             return
         await self._seal_current(keyboard=keyboard)

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -42,6 +42,11 @@ class TelegramInboundMessage(InboundMessage):
     """
 
     message_id: int = 0
+    # Originating chat type ("private" | "group" | "supergroup"). The forum
+    # Topic id, when present, rides the base ``thread_id`` field. Consumers read
+    # it via ``getattr(msg, "chat_type", "private")`` so the neutral message
+    # stays channel-agnostic.
+    chat_type: str = "private"
 
 
 # A dispatch callback consumes a normalized, already-authorized message and
@@ -65,6 +70,44 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
 )
 
 
+def forum_gate_outcome(
+    chat_type: str,
+    chat_id: int,
+    message_thread_id: int | None,
+    *,
+    allow_forum: bool,
+    allowed_forum_chat_ids: Iterable[int],
+) -> str | None:
+    """Fail-closed forum authZ predicate shared by the inbound and callback paths.
+
+    Returns ``None`` when the chat is authorized to drive a turn/callback, else
+    the SEL audit ``outcome`` string the caller logs before dropping. Only a
+    message inside a **real forum Topic** (``supergroup`` AND a truthy
+    ``message_thread_id``) of an allow-listed chat is authorized:
+      * ``private``            -> ``None`` (1:1 DM, always allowed past auth).
+      * ``supergroup`` + Topic  -> ``None`` ONLY when forum topics are enabled
+        AND the chat_id is allow-listed; otherwise ``"denied_forum_not_allowed"``.
+      * everything else -> ``"denied_non_private_chat"``. This DENIES ordinary
+        groups (which cannot have Topics) AND the supergroup **General** chat
+        (no ``message_thread_id``) -- serving those would post to the whole
+        group's readable main chat (non-private exposure) and exceeds the
+        "forum topics" scope.
+
+    One predicate, two call sites (``TelegramTransport.receive`` +
+    ``TelegramDispatcher.on_callback``) so the security decision can never drift
+    between the inbound and callback paths. Each site passes its OWN allow-list
+    source -- the transport freezes it at construction, the dispatcher reads live
+    cfg -- and that difference is deliberate (see the call sites).
+    """
+    if chat_type == "private":
+        return None
+    if chat_type == "supergroup" and message_thread_id:
+        if allow_forum and int(chat_id) in set(allowed_forum_chat_ids):
+            return None
+        return "denied_forum_not_allowed"
+    return "denied_non_private_chat"
+
+
 class TelegramTransport(MessagingTransport):
     """Concrete Telegram transport over the low-level ``TelegramClient``."""
 
@@ -75,12 +118,21 @@ class TelegramTransport(MessagingTransport):
         client: TelegramClient,
         *,
         allowed_user_ids: Iterable[int] = (),
+        allow_forum: bool = False,
+        allowed_forum_chat_ids: Iterable[int] = (),
         dispatch: DispatchFn | None = None,
     ) -> None:
         self._client = client
         # Deny-by-default: freeze the allow-list as strings (to match
         # InboundMessage.user_id) so it can't mutate under an in-flight decision.
         self._allowed: frozenset[str] = frozenset(str(u) for u in allowed_user_ids)
+        # Forum-topic gate (fail closed): serve supergroup forum Topics only when
+        # explicitly enabled AND the supergroup's chat_id is allow-listed. The
+        # chat_ids are numeric ints (matched against the raw ``TelegramInbound``).
+        self._allow_forum = bool(allow_forum)
+        self._allowed_forum_chat_ids: frozenset[int] = frozenset(
+            int(c) for c in allowed_forum_chat_ids
+        )
         self._dispatch = dispatch
         self.capabilities = TELEGRAM_CAPABILITIES
 
@@ -93,7 +145,11 @@ class TelegramTransport(MessagingTransport):
     async def send_message(
         self, conversation_id: str, content: str, thread_id: str | None = None
     ) -> str:
-        mid = await self._client.send_message(int(conversation_id), content)
+        mid = await self._client.send_message(
+            int(conversation_id),
+            content,
+            message_thread_id=int(thread_id) if thread_id else None,
+        )
         return str(mid or "")
 
     async def resolve_conversation(self, user_id: str) -> str:
@@ -143,17 +199,29 @@ class TelegramTransport(MessagingTransport):
         inbound = raw_envelope
         if not inbound.text:
             return
-        # Private-chat-only, fail closed. A bot added to a group receives
-        # messages; even from an allow-listed user, running a turn would reply
-        # in the group (conversation_id == group chat_id at renderer time),
-        # exposing tool output to non-authorized members. resolve_conversation
-        # also assumes chat_id == user_id, which only holds in private chats.
-        # Deny anything not explicitly a private chat and audit it.
-        if inbound.chat_type != "private":
+        # Chat-type gate (fail closed). A bot added to a group receives every
+        # message and its replies land in that chat, so we serve ONLY a real
+        # forum Topic (supergroup + message_thread_id) whose chat_id is
+        # allow-listed; ordinary groups, the supergroup General chat (no
+        # thread), channels and other types are always denied. The decision
+        # lives in the shared ``forum_gate_outcome`` predicate so it can't drift
+        # from the callback path (on_callback). The allow-list source here is
+        # the construction-time FROZEN copy (self._allow_forum /
+        # self._allowed_forum_chat_ids) -- DELIBERATE, so the gate can't mutate
+        # under an in-flight decision (mirrors the frozen user-allowlist); the
+        # dispatcher's on_callback reads live cfg instead.
+        outcome = forum_gate_outcome(
+            inbound.chat_type,
+            inbound.chat_id,
+            inbound.message_thread_id,
+            allow_forum=self._allow_forum,
+            allowed_forum_chat_ids=self._allowed_forum_chat_ids,
+        )
+        if outcome is not None:
             sel().log_api_access(
                 caller=str(inbound.user_id) or "unknown",
                 operation="telegram_transport.receive",
-                outcome="denied_non_private_chat",
+                outcome=outcome,
                 source="telegram",
             )
             return
@@ -162,8 +230,11 @@ class TelegramTransport(MessagingTransport):
             user_id=str(inbound.user_id),
             conversation_id=str(inbound.chat_id),
             text=inbound.text,
-            thread_id=None,
+            thread_id=(
+                str(inbound.message_thread_id) if inbound.message_thread_id else None
+            ),
             message_id=inbound.message_id,
+            chat_type=inbound.chat_type,
         )
         if not self.authorize(msg):
             return

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -34,6 +34,8 @@ from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.link import (
+    CHAT_TYPE_DIRECT,
+    CHAT_TYPE_FORUM,
     ChannelLink,
     build_dm_session_key,
     dashboard_mirror_key,
@@ -47,7 +49,11 @@ from kiro_crew.telegram.commands import (
     parse_mid_turn_override,
 )
 from kiro_crew.telegram.renderer import TelegramApprovalDecider, TelegramRenderer
-from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+from kiro_crew.telegram.transport import (
+    TELEGRAM_CAPABILITIES,
+    TelegramInboundMessage,
+    forum_gate_outcome,
+)
 
 if TYPE_CHECKING:
     from kiro_crew.config.loader import KiroCrewConfig
@@ -189,6 +195,28 @@ class TelegramDispatcher:
         user_id = int(msg.user_id)
         chat_id = int(msg.conversation_id)
         text = msg.text
+        # Route to the conversation identity. DM (private) -> (direct, user_id),
+        # reproducing the pre-forum key EXACTLY; an authorized supergroup forum
+        # message always carries a Topic thread -> (forum, "chat:thread"). A
+        # threadless General message never reaches here (the forum gate in
+        # transport.receive / on_callback denies it); the threadless (forum,
+        # "chat") branch below is defensive dead code, not a served path.
+        # ``thread`` is the raw Topic id passed to the renderer so its outbound
+        # messages thread into the Topic. Everything downstream (session key,
+        # generation counter, awaiting flag) keys on ``route`` so /new, idle
+        # rotation and /compact are per-topic, not per-user.
+        route = self._route_key(
+            chat_type=getattr(msg, "chat_type", "private"),
+            user_id=user_id,
+            chat_id=chat_id,
+            thread=getattr(msg, "thread_id", None),
+        )
+        thread = getattr(msg, "thread_id", None)
+        # The Topic id (int) used to thread EVERY dispatcher-originated reply for
+        # this turn back into the user's Topic (command confirmations, receipts,
+        # the soft-threshold notice); None only for a DM (an authorized forum
+        # turn always carries a Topic — General is denied at the gate).
+        reply_thread = self._route_thread(route)
 
         # Per-message mid-turn override: "/queue …" / "/steer …" let the user
         # choose how THIS message is handled if it lands while a turn is running
@@ -211,24 +239,26 @@ class TelegramDispatcher:
             else None
         )
         if cmd == "new":
-            self._conv.bump_gen(user_id)
-            await self.client.send_message(chat_id, "✅ New conversation started.")
+            self._conv.bump_gen(route)
+            await self._reply(
+                chat_id, "✅ New conversation started.", thread=reply_thread
+            )
             return
         if cmd == "compact":
-            self._conv.clear_awaiting(user_id)
-            await self._handle_compact(user_id, chat_id)
+            self._conv.clear_awaiting(route)
+            await self._handle_compact(route, chat_id)
             return
         if cmd == "link":
-            await self._handle_link(user_id, chat_id)
+            await self._handle_link(route, chat_id)
             return
         if cmd == "unlink":
-            await self._handle_unlink(user_id, chat_id)
+            await self._handle_unlink(route, chat_id)
             return
         if cmd == "help":
-            await self.client.send_message(chat_id, _HELP_TEXT)
+            await self._reply(chat_id, _HELP_TEXT, thread=reply_thread)
             return
         if cmd == "stop":
-            await self._handle_stop(user_id, chat_id)
+            await self._handle_stop(route, chat_id)
             return
 
         # ── Mid-turn concurrency: check the CURRENT-generation key for an
@@ -236,18 +266,20 @@ class TelegramDispatcher:
         # mint a new key and miss the running turn, letting a second concurrent
         # turn bypass steer/queue. Surface the message (steer or queue) instead
         # of a silent block.
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(route)
         if self.sessions.is_busy(session_key):
-            await self._handle_busy(session_key, msg, text, override_mode)
+            await self._handle_busy(
+                session_key, msg, text, override_mode, thread=reply_thread
+            )
             return
 
         self._conv.maybe_rotate(
-            user_id,
+            route,
             time.time(),
             idle_minutes=self.cfg.messaging.idle_reset_minutes,
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(route)
         channel_id = f"telegram:{user_id}"
         # Resolve the kiro-cli agent: an explicit override wins, else the
         # configured default, else the canonical "kirocrew" agent — so the
@@ -261,7 +293,8 @@ class TelegramDispatcher:
             else None
         )
         renderer = TelegramRenderer(
-            self.client, chat_id, TELEGRAM_CAPABILITIES, session_key=session_key
+            self.client, chat_id, TELEGRAM_CAPABILITIES, session_key=session_key,
+            message_thread_id=int(thread) if thread else None,
         )
         # Expose this turn's renderer so a concurrent mid-turn steer (a separate
         # _handle_busy task) can hand it the user's typed steer text for the
@@ -341,7 +374,7 @@ class TelegramDispatcher:
                     "Telegram: persist_turn failed session=%s", session_key, exc_info=True
                 )
             try:
-                await self._maybe_notice(chat_id, user_id, session_key, provider)
+                await self._maybe_notice(chat_id, route, session_key, provider)
             except Exception:
                 logger.warning(
                     "Telegram: maybe_notice failed session=%s", session_key, exc_info=True
@@ -373,7 +406,13 @@ class TelegramDispatcher:
         # (queue_mode == "queue"). ``drain`` is False for drained turns so the
         # loop stays iterative at one level (no recursion); ``limit`` bounds it.
         if drain:
-            await self._drain_queue(session_key, user_id, chat_id)
+            await self._drain_queue(
+                session_key,
+                user_id,
+                chat_id,
+                chat_type=getattr(msg, "chat_type", "private"),
+                thread=thread,
+            )
 
     async def _handle_busy(
         self,
@@ -381,6 +420,8 @@ class TelegramDispatcher:
         msg: InboundMessage,
         text: str,
         override_mode: str | None,
+        *,
+        thread: int | None = None,
     ) -> None:
         """A message arrived mid-turn: steer the running turn or queue for after
         it. ``text`` is the message with any ``/queue``|``/steer`` directive
@@ -440,10 +481,20 @@ class TelegramDispatcher:
         # bubble. If the turn finished in the window the message is not queued, so
         # we run it now (re-entering handle_message, which re-strips the directive
         # and runs it as a fresh turn) instead of stranding it.
-        if not await self._enqueue_with_receipt(session_key, chat_id, text):
+        if not await self._enqueue_with_receipt(
+            session_key, chat_id, text, thread=thread
+        ):
             await self.handle_message(msg)
 
-    async def _drain_queue(self, session_key: str, user_id: int, chat_id: int) -> None:
+    async def _drain_queue(
+        self,
+        session_key: str,
+        user_id: int,
+        chat_id: int,
+        *,
+        chat_type: str = "private",
+        thread: str | None = None,
+    ) -> None:
         """Collapse every message queued during the just-finished turn into ONE
         combined turn (order preserved, blank-line joined) and answer them
         together, rather than replaying each as a separate turn.
@@ -489,11 +540,16 @@ class TelegramDispatcher:
             )
         combined = "\n\n".join(texts)
         await self.handle_message(
-            InboundMessage(
+            TelegramInboundMessage(
                 channel_type="telegram",
                 user_id=str(user_id),
                 conversation_id=str(chat_id),
                 text=combined,
+                # Carry the turn's ORIGINAL route so the drained turn resolves to
+                # the SAME forum session key -- a plain DM-shaped InboundMessage
+                # would drain a queued forum message under the DM key instead.
+                thread_id=thread,
+                chat_type=chat_type,
             ),
             drain=False,
             # Drained payloads are pure turn content: a queued "/new" must reach
@@ -504,7 +560,7 @@ class TelegramDispatcher:
     # ── Mid-turn queue receipt (single, in-place, persistent record) ───────
 
     async def _enqueue_with_receipt(
-        self, session_key: str, chat_id: int, text: str
+        self, session_key: str, chat_id: int, text: str, *, thread: int | None = None
     ) -> bool:
         """Atomically enqueue a mid-turn message and create/grow its collapsing
         "⏳ Queued (N): …" receipt, under ``_receipt_lock``.
@@ -525,7 +581,9 @@ class TelegramDispatcher:
                 return False
             receipt = self._queue_receipts.get(session_key)
             if receipt is None:
-                msg_id = await self.client.send_message(chat_id, _receipt_text([text]))
+                msg_id = await self._reply(
+                    chat_id, _receipt_text([text]), thread=thread
+                )
                 if msg_id is not None:
                     self._queue_receipts[session_key] = _QueueReceipt(
                         msg_id=msg_id, texts=[text]
@@ -580,7 +638,7 @@ class TelegramDispatcher:
         except Exception:
             logger.debug("telegram: queue receipt cancel-finalize failed", exc_info=True)
 
-    async def _handle_stop(self, user_id: int, chat_id: int) -> None:
+    async def _handle_stop(self, route: tuple[str, str], chat_id: int) -> None:
         """Hard cancel: abort the in-flight turn and clear everything.
 
         Aborts the running turn via the provider's cooperative ACP cancel,
@@ -590,7 +648,8 @@ class TelegramDispatcher:
         the acknowledgement is snappy.
         """
         assert self.client is not None
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(route)
+        thread = self._route_thread(route)
         cancelled_turn = False
         if self.sessions.is_busy(session_key):
             provider = self.sessions.get_provider(session_key)
@@ -606,9 +665,10 @@ class TelegramDispatcher:
         async with self._receipt_lock:
             self.sessions.clear_queue(session_key)
             await self._receipt_finish_cancelled_locked(session_key, chat_id)
-        await self.client.send_message(
+        await self._reply(
             chat_id,
             "🛑 Stopped." if cancelled_turn else "🛑 Nothing was running — queue cleared.",
+            thread=thread,
         )
 
     # ── Inline-button handler (client's on_callback) ───────────────────────
@@ -620,13 +680,47 @@ class TelegramDispatcher:
         # unauthorized user's press — avoids a wasted Bot API round-trip.
         if not self._authorized(cb.user_id):
             return
-        # Private-chat-only (mirrors receive()): buttons live on messages the
-        # bot sent, and turns are blocked in non-private chats, so a non-private
-        # callback shouldn't occur — deny defensively before acting on it.
-        if cb.chat_type != "private":
+        # Chat-type gate — an authZ boundary that MUST mirror
+        # ``transport.receive`` EXACTLY: buttons live on messages the bot sent,
+        # so a press can originate from a private DM or an allow-listed
+        # supergroup forum Topic. Uses the SHARED ``forum_gate_outcome`` predicate
+        # so this fail-closed decision can never drift from the inbound path.
+        # NEVER honor a callback from an ordinary group, a non-allow-listed
+        # supergroup, or the supergroup General chat (no thread). This gate is
+        # ADDITIONAL to the owner/user authorization above, not a replacement.
+        # The allow-list source here is LIVE cfg (self.cfg.telegram.*), whereas
+        # the transport uses its construction-time frozen copy; that source
+        # difference is DELIBERATE (see forum_gate_outcome).
+        outcome = forum_gate_outcome(
+            cb.chat_type,
+            cb.chat_id,
+            getattr(cb, "message_thread_id", None),
+            allow_forum=self.cfg.telegram.allow_forum,
+            allowed_forum_chat_ids=self.cfg.telegram.allowed_forum_chat_ids,
+        )
+        if outcome is not None:
+            sel().log_api_access(
+                caller=str(cb.user_id) or "unknown",
+                operation="telegram_transport.on_callback",
+                outcome=outcome,
+                source="telegram",
+            )
             return
         # Answer to dismiss the button spinner for the authorized user.
         await self.client.answer_callback(cb.callback_query_id)
+
+        # Route the callback to the same conversation identity its turn used so
+        # an approval/[OPTIONS:] press resolves against the correct session key:
+        # a private press -> (direct, user_id); an allow-listed forum press ->
+        # the per-Topic forum key (chat_type + message_thread_id carried through).
+        route = self._route_key(
+            chat_type=cb.chat_type,
+            user_id=cb.user_id,
+            chat_id=cb.chat_id,
+            thread=getattr(cb, "message_thread_id", None),
+        )
+        # Topic id to thread the [OPTIONS:] echo sends back into (None for a DM).
+        cb_thread = self._route_thread(route)
 
         data = cb.data or ""
 
@@ -635,7 +729,7 @@ class TelegramDispatcher:
             body = data[2:]
             rid, _, flag = body.rpartition(":")
             approved = flag == "1"
-            key = TelegramApprovalDecider.key(self._session_key(cb.user_id), rid)
+            key = TelegramApprovalDecider.key(self._session_key(route), rid)
             resolved = TelegramApprovalDecider.resolve_global(key, approved)
             if resolved:
                 verdict = "✅ Approved" if approved else "🚫 Denied"
@@ -660,29 +754,40 @@ class TelegramDispatcher:
                 cb.chat_id, cb.message_id, {"inline_keyboard": []}
             )
             if not choice_text:
-                await self.client.send_message(
+                await self._reply(
                     cb.chat_id,
                     "⚠️ Couldn't read that choice — please type it instead.",
+                    thread=cb_thread,
                 )
                 return
             # Echo the picked option as its own block (a quoted bubble) so the
             # user can see what they chose -- a button tap can't render as a
             # real user message, so this stands in for it. Then re-dispatch the
             # choice as a fresh turn whose answer streams in as a NEW message.
-            echoed = await self.client.send_message(
+            echoed = await self._reply(
                 cb.chat_id,
                 f"<blockquote>{html.escape(choice_text)}</blockquote>",
+                thread=cb_thread,
                 parse_mode="HTML",
                 retry_plain=False,
             )
             if echoed is None:  # malformed HTML -> plain fallback
-                await self.client.send_message(cb.chat_id, f"» {choice_text}")
-            # Re-inject the choice as a fresh turn via the normal path.
-            synthetic = InboundMessage(
+                await self._reply(cb.chat_id, f"» {choice_text}", thread=cb_thread)
+            # Re-inject the choice as a fresh turn via the normal path, carrying
+            # the callback's ORIGINAL route (chat_type + Topic thread) so a forum
+            # [OPTIONS:] press re-dispatches under the SAME forum session key
+            # instead of a DM-shaped key.
+            synthetic = TelegramInboundMessage(
                 channel_type="telegram",
                 user_id=str(cb.user_id),
                 conversation_id=str(cb.chat_id),
                 text=choice_text,
+                thread_id=(
+                    str(cb.message_thread_id)
+                    if getattr(cb, "message_thread_id", None)
+                    else None
+                ),
+                chat_type=cb.chat_type,
             )
             await self.handle_message(synthetic)
 
@@ -695,26 +800,91 @@ class TelegramDispatcher:
     def _resolve_agent(self) -> str:
         return self.agent or self.cfg.agent.default_agent or _DEFAULT_KIROCREW_AGENT
 
-    def _session_key(self, user_id: int) -> str:
-        gen = self._conv.current_gen(user_id)
+    def _route_key(
+        self,
+        *,
+        chat_type: str,
+        user_id: int,
+        chat_id: int,
+        thread: str | int | None,
+    ) -> tuple[str, str]:
+        """Map an inbound message/callback to its conversation-identity key.
+
+        Returns ``(slot, comp)`` where ``slot`` selects the session namespace:
+          * private DM -> ``(CHAT_TYPE_DIRECT, str(user_id))`` -- byte-for-byte
+            the pre-forum identity, so DM keys are unchanged.
+          * supergroup forum Topic -> ``(CHAT_TYPE_FORUM, "{chat_id}:{thread}")``.
+
+        A threadless supergroup (General) message is denied at the forum gate
+        and never reaches here; the ``str(chat_id)`` fallback below is defensive
+        dead code (kept for safety), NOT a served route.
+
+        The tuple is used as the ``ConversationState`` key (per-topic generation)
+        and, via ``_session_key``, as the session-key ``comp`` + ``chat_type``.
+        """
+        if chat_type in ("group", "supergroup"):
+            comp = f"{chat_id}:{thread}" if thread else str(chat_id)
+            return CHAT_TYPE_FORUM, comp
+        return CHAT_TYPE_DIRECT, str(user_id)
+
+    @staticmethod
+    def _route_thread(route: tuple[str, str]) -> int | None:
+        """The forum Topic id for a ``route``, or None for a DM.
+
+        Mirrors ``_route_key``'s ``comp`` encoding: a forum Topic route carries
+        ``"{chat_id}:{thread}"`` -> the Topic id; a DM (direct) route -> None.
+        An authorized forum turn always carries a Topic (General is denied at
+        the gate), so the threadless-``comp`` -> None case is only the defensive
+        fallback. Used to thread every dispatcher-originated send back into the
+        SAME Topic the turn came from.
+        """
+        slot, comp = route
+        if slot == CHAT_TYPE_FORUM and ":" in comp:
+            return int(comp.split(":", 1)[1])
+        return None
+
+    async def _reply(
+        self, chat_id: int, text: str, *, thread: int | None = None, **kw: Any
+    ) -> int | None:
+        """Send a user-facing chat message, threaded into the originating forum
+        Topic (``thread``) or the DM chat (``thread`` is None).
+
+        Single choke point for every dispatcher-originated send (command
+        confirmations, queue receipts, the soft-threshold notice, ``[OPTIONS:]``
+        echoes) so a forum turn's side messages land in the user's Topic. A
+        threadless supergroup General message is denied at the gate, so no served
+        send ever lands in the supergroup's General chat. ``answer_callback`` is
+        intentionally NOT routed here -- it is a callback ack, not a chat send.
+        """
+        assert self.client is not None
+        return await self.client.send_message(
+            chat_id, text, message_thread_id=thread, **kw
+        )
+
+    def _session_key(self, route: tuple[str, str]) -> str:
+        slot, comp = route
+        gen = self._conv.current_gen(route)
         return build_dm_session_key(
             "telegram",
             self._resolve_agent(),
-            str(user_id),
+            comp,
             gen=gen,
             dm_scope=self.cfg.messaging.dm_scope,
+            chat_type=slot,
         )
 
-    def _seed_gen(self, user_id: int) -> int:
+    def _seed_gen(self, route: tuple[str, str]) -> int:
+        slot, comp = route
         return seed_generation(
             self.sessions,
             channel="telegram",
             agent=self._resolve_agent(),
-            user_id=str(user_id),
+            user_id=comp,
             dm_scope=self.cfg.messaging.dm_scope,
+            chat_type=slot,
         )
 
-    async def _handle_link(self, user_id: int, chat_id: int) -> None:
+    async def _handle_link(self, route: tuple[str, str], chat_id: int) -> None:
         """Mirror this conversation's dashboard tab back to Telegram.
 
         Binds the current session's dashboard mirror slot to this chat so the
@@ -722,23 +892,36 @@ class TelegramDispatcher:
         here. ``/new`` starts a fresh, unlinked conversation.
         """
         assert self.client is not None
-        key = dashboard_mirror_key(self._session_key(user_id))
+        key = dashboard_mirror_key(self._session_key(route))
+        # Carry the forum Topic so dashboard-mirrored replies for a forum-linked
+        # session thread back into the SAME Topic (via
+        # ``_deliver_cross_surface_reply``'s ``thread_id=link.thread_id``), not
+        # the supergroup General. None only for a DM (an authorized forum turn
+        # always carries a Topic — General is denied at the gate).
+        topic = self._route_thread(route)
         self.sessions.set_mirror_link(
-            key, ChannelLink("telegram", channel_id=str(chat_id))
+            key,
+            ChannelLink(
+                "telegram",
+                channel_id=str(chat_id),
+                thread_id=(str(topic) if topic is not None else None),
+            ),
         )
-        await self.client.send_message(
+        await self._reply(
             chat_id,
             "✅ Linked. Replies from the dashboard for this conversation will "
             "also show up here. Send /unlink to stop.",
+            thread=self._route_thread(route),
         )
 
-    async def _handle_unlink(self, user_id: int, chat_id: int) -> None:
+    async def _handle_unlink(self, route: tuple[str, str], chat_id: int) -> None:
         assert self.client is not None
-        key = dashboard_mirror_key(self._session_key(user_id))
+        key = dashboard_mirror_key(self._session_key(route))
         was_linked = self.sessions.clear_mirror_link(key)
-        await self.client.send_message(
+        await self._reply(
             chat_id,
             "✅ Unlinked." if was_linked else "This conversation wasn't linked.",
+            thread=self._route_thread(route),
         )
 
     def _persist_turn(
@@ -755,7 +938,7 @@ class TelegramDispatcher:
             self.conv_log.set_title(session_key, title)
 
     async def _maybe_notice(
-        self, chat_id: int, user_id: int, session_key: str, provider: Any
+        self, chat_id: int, route: tuple[str, str], session_key: str, provider: Any
     ) -> None:
         """Soft-threshold context warning as a SEPARATE message (not persisted).
 
@@ -764,16 +947,17 @@ class TelegramDispatcher:
         """
         pct = self.sessions.check_context_usage(session_key, provider)
         soft_pct = self.cfg.telegram.soft_threshold_pct
-        if pct >= soft_pct and not self._conv.is_awaiting(user_id):
-            self._conv.set_awaiting(user_id)
+        if pct >= soft_pct and not self._conv.is_awaiting(route):
+            self._conv.set_awaiting(route)
             assert self.client is not None
-            await self.client.send_message(
+            await self._reply(
                 chat_id,
                 "⚠️ Context is getting long. Use /compact to compress or "
                 "/new to start fresh.",
+                thread=self._route_thread(route),
             )
 
-    async def _handle_compact(self, user_id: int, chat_id: int) -> None:
+    async def _handle_compact(self, route: tuple[str, str], chat_id: int) -> None:
         """In-place ACP ``/compact`` on the user's session (mirrors Slack).
 
         Holds the per-session semaphore for the WHOLE compaction. Each Telegram
@@ -785,25 +969,33 @@ class TelegramDispatcher:
         turn is already in flight); the ``finally`` always releases it.
         """
         assert self.client is not None
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(route)
+        thread = self._route_thread(route)
         # Atomically take the turn semaphore, or refuse. Distinguish "busy" (a
         # turn is streaming) from "no session yet" for the user-facing note.
         if not await self.sessions.try_acquire(session_key):
             if self.sessions.has_session(session_key):
-                await self.client.send_message(
+                await self._reply(
                     chat_id,
                     "⏳ Still working on your last message — try /compact once it finishes.",
+                    thread=thread,
                 )
             else:
-                await self.client.send_message(chat_id, "No active session to compact.")
+                await self._reply(
+                    chat_id, "No active session to compact.", thread=thread
+                )
             return
         try:
             provider = self.sessions.get_provider(session_key)
             if provider is None:
-                await self.client.send_message(chat_id, "No active session to compact.")
+                await self._reply(
+                    chat_id, "No active session to compact.", thread=thread
+                )
                 return
 
-            status_id = await self.client.send_message(chat_id, "🔄 Compacting context…")
+            status_id = await self._reply(
+                chat_id, "🔄 Compacting context…", thread=thread
+            )
             result_text: str | None = None
             try:
 
@@ -852,7 +1044,7 @@ class TelegramDispatcher:
             if status_id:
                 await self.client.edit_message(chat_id, status_id, final)
             else:
-                await self.client.send_message(chat_id, final)
+                await self._reply(chat_id, final, thread=thread)
         finally:
             # Always release the semaphore we took. No-op if the except path
             # already destroyed the session (release() looks up by key).

--- a/test/test_messaging_link.py
+++ b/test/test_messaging_link.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import time
 
 from kiro_crew.messaging.link import (
+    CHAT_TYPE_DIRECT,
+    CHAT_TYPE_FORUM,
     DEFAULT_DM_SCOPE,
     DM_SCOPE_PER_CHANNEL_PEER,
     DM_SCOPE_UNIFIED,
@@ -67,6 +69,35 @@ class TestBuildDmSessionKey:
         assert (
             build_dm_session_key("telegram", "a", "1", chat_type="group")
             == "telegram:a:group:1"
+        )
+
+    def test_unified_scopes_only_direct_dms_not_forum(self) -> None:
+        # SECURITY (issue #211, PR #219 Codex HIGH): dm_scope=unified must NOT
+        # collapse a forum Topic into the shared DM bucket — that would leak
+        # private DM content into a group Topic (and vice versa). A forum route
+        # keeps its FULL bucket regardless of dm_scope.
+        key = build_dm_session_key(
+            "telegram",
+            "kirocrew",
+            "-1001234567890:5",
+            dm_scope=DM_SCOPE_UNIFIED,
+            chat_type=CHAT_TYPE_FORUM,
+        )
+        assert key == "telegram:kirocrew:forum:-1001234567890:5"
+        assert not key.startswith(f"{DM_SCOPE_UNIFIED}:")
+
+    def test_unified_still_collapses_direct_dm(self) -> None:
+        # Regression: a direct (1:1) DM under unified still collapses to the
+        # single shared bucket (cross-surface continuity preserved).
+        assert (
+            build_dm_session_key(
+                "telegram",
+                "kirocrew",
+                "123",
+                dm_scope=DM_SCOPE_UNIFIED,
+                chat_type=CHAT_TYPE_DIRECT,
+            )
+            == "unified:kirocrew"
         )
 
 

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -23,7 +23,7 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
 )
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.telegram.client import TELEGRAM_CHUNK_LIMIT, TelegramInbound
+from kiro_crew.telegram.client import TELEGRAM_CHUNK_LIMIT, TelegramClient, TelegramInbound
 from kiro_crew.telegram.commands import (
     ConversationState,
     parse_command,
@@ -43,6 +43,7 @@ from kiro_crew.telegram.transport import (
     TELEGRAM_CAPABILITIES,
     TelegramInboundMessage,
     TelegramTransport,
+    forum_gate_outcome,
 )
 from kiro_crew.telegram.transport_dispatch import _STEER_ACK_EMOJI, TelegramDispatcher
 
@@ -60,13 +61,18 @@ class FakeClient:
         self.answered: list[str] = []
         self.reply_targets: list[Any] = []
         self.reactions: list[tuple[int, str]] = []
+        # Forum-topic ids captured per outbound send/typing (parallel to sent).
+        self.send_threads: list[Any] = []
+        self.typing_threads: list[Any] = []
         self._mid = 100
 
-    async def send_typing(self, chat_id: int) -> None:
+    async def send_typing(self, chat_id: int, *, message_thread_id: Any = None) -> None:
+        self.typing_threads.append(message_thread_id)
         return None
 
     async def send_message_draft(
-        self, chat_id: int, draft_id: int, text: str, *, parse_mode: Any = None
+        self, chat_id: int, draft_id: int, text: str, *, parse_mode: Any = None,
+        message_thread_id: Any = None,
     ) -> bool:
         self.drafts.append((draft_id, text))
         return True
@@ -74,12 +80,13 @@ class FakeClient:
     async def send_message(
         self, chat_id: int, text: str, *, parse_mode: Any = None,
         reply_markup: Any = None, retry_plain: bool = True,
-        reply_to_message_id: Any = None,
+        reply_to_message_id: Any = None, message_thread_id: Any = None,
     ) -> int:
         await asyncio.sleep(0)  # yield like a real network await (exposes races)
         self._mid += 1
         self.sent.append((text, reply_markup))
         self.reply_targets.append(reply_to_message_id)
+        self.send_threads.append(message_thread_id)
         return self._mid
 
     async def edit_message(
@@ -259,9 +266,19 @@ class FakeCtx:
         return text, None
 
 
-def _cfg(soft: int = 80, default_agent: str = "") -> Any:
+def _cfg(
+    soft: int = 80,
+    default_agent: str = "",
+    *,
+    allow_forum: bool = False,
+    allowed_forum_chat_ids: list | None = None,
+) -> Any:
     return SimpleNamespace(
-        telegram=SimpleNamespace(soft_threshold_pct=soft),
+        telegram=SimpleNamespace(
+            soft_threshold_pct=soft,
+            allow_forum=allow_forum,
+            allowed_forum_chat_ids=allowed_forum_chat_ids or [],
+        ),
         agent=SimpleNamespace(default_agent=default_agent),
         messaging=SimpleNamespace(
             dm_scope="per-channel-peer",
@@ -273,13 +290,18 @@ def _cfg(soft: int = 80, default_agent: str = "") -> Any:
 
 
 def _dispatcher(
-    allowed: set[int], *, raise_on_get: bool = False, default_agent: str = ""
+    allowed: set[int], *, raise_on_get: bool = False, default_agent: str = "",
+    allow_forum: bool = False, allowed_forum_chat_ids: list | None = None,
 ) -> tuple[TelegramDispatcher, FakeClient, FakeSessions]:
     sess = FakeSessions(raise_on_get=raise_on_get)
     d = TelegramDispatcher(
         sessions=sess,  # type: ignore[arg-type]
         ctx_builder=FakeCtx(),  # type: ignore[arg-type]
-        cfg=_cfg(default_agent=default_agent),
+        cfg=_cfg(
+            default_agent=default_agent,
+            allow_forum=allow_forum,
+            allowed_forum_chat_ids=allowed_forum_chat_ids,
+        ),
         allowed_user_ids=allowed,
         agent=None,
         conv_log=None,
@@ -1027,7 +1049,7 @@ class TestDispatcher:
             )
 
         asyncio.run(_go())
-        assert d._conv.current_gen(7) == 1
+        assert d._conv.current_gen(("direct", "7")) == 1
         assert "New conversation" in cli.sent[-1][0]
         assert sess.successes == []  # no turn ran
 
@@ -1099,7 +1121,7 @@ class TestDispatcher:
         d, cli, _ = _dispatcher({7})
 
         async def _go() -> bool:
-            key = TelegramApprovalDecider.key(d._session_key(7), "rq9")
+            key = TelegramApprovalDecider.key(d._session_key(("direct", "7")), "rq9")
             fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
             TelegramApprovalDecider._REGISTRY[key] = fut
             cb = SimpleNamespace(
@@ -1533,25 +1555,39 @@ class TestLinkCommand:
 
     def test_link_sets_mirror_on_dashboard_key(self) -> None:
         d, cli, sess = _dispatcher({7})
-        asyncio.run(d._handle_link(7, 7))
-        expected_key = dashboard_mirror_key(d._session_key(7))
+        asyncio.run(d._handle_link(("direct", "7"), 7))
+        expected_key = dashboard_mirror_key(d._session_key(("direct", "7")))
         assert expected_key in sess.mirror_links
         link = sess.mirror_links[expected_key]
         assert isinstance(link, ChannelLink)
         assert link.channel_type == "telegram"
         assert link.channel_id == "7"
+        assert link.thread_id is None  # DM /link carries no Topic thread
         assert any("Linked" in t for t, _ in cli.sent)
+
+    def test_forum_link_carries_topic_thread(self) -> None:
+        # Fix 2 (issue #211): /link inside a forum Topic must store the Topic id
+        # on the mirror link so dashboard-mirrored replies thread back into the
+        # Topic (not the supergroup General).
+        d, cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+        route = ("forum", "-1001234567890:5")
+        asyncio.run(d._handle_link(route, -1001234567890))
+        link = sess.mirror_links[dashboard_mirror_key(d._session_key(route))]
+        assert link.channel_id == "-1001234567890"
+        assert link.thread_id == "5"  # Topic id, as a str
 
     def test_unlink_clears_existing(self) -> None:
         d, cli, sess = _dispatcher({7})
-        asyncio.run(d._handle_link(7, 7))
-        asyncio.run(d._handle_unlink(7, 7))
+        asyncio.run(d._handle_link(("direct", "7"), 7))
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
         assert sess.mirror_links == {}
         assert any("Unlinked" in t for t, _ in cli.sent)
 
     def test_unlink_when_not_linked(self) -> None:
         d, cli, sess = _dispatcher({7})
-        asyncio.run(d._handle_unlink(7, 7))
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
         assert any("wasn't linked" in t for t, _ in cli.sent)
 
 
@@ -1566,3 +1602,503 @@ def test_receipt_text_caps_displayed_items() -> None:
     assert f"({len(texts)})" in out  # count prefix shows the true total
     assert f"…and {surplus} more" in out  # surplus collapsed, not listed verbatim
     assert texts[-1] not in out  # a beyond-cap item is not rendered verbatim
+
+
+# ── Forum topics (issue #211): per-topic sessions, single-user ──────────────
+
+
+class TestForumGateOutcome:
+    """Direct unit test of the shared fail-closed forum authZ predicate used by
+    BOTH transport.receive and dispatcher.on_callback (PR #219 Design #2). One
+    predicate → the two call sites can never drift. Only a real forum Topic
+    (supergroup + message_thread_id) of an allow-listed chat is authorized;
+    ordinary groups and the supergroup General chat (no thread) are DENIED."""
+
+    _LISTED = -1001234567890
+
+    def test_private_is_authorized(self) -> None:
+        assert (
+            forum_gate_outcome(
+                "private", 7, None, allow_forum=False, allowed_forum_chat_ids=[]
+            )
+            is None
+        )
+
+    def test_allowlisted_supergroup_topic_is_authorized(self) -> None:
+        # supergroup + a real Topic thread + allow-listed chat_id -> authorized.
+        assert (
+            forum_gate_outcome(
+                "supergroup",
+                self._LISTED,
+                5,
+                allow_forum=True,
+                allowed_forum_chat_ids=[self._LISTED],
+            )
+            is None
+        )
+
+    def test_supergroup_topic_not_allowlisted_denied_forum(self) -> None:
+        # Real Topic, but the supergroup's chat_id is NOT allow-listed.
+        assert (
+            forum_gate_outcome(
+                "supergroup",
+                self._LISTED,
+                5,
+                allow_forum=True,
+                allowed_forum_chat_ids=[-1009999999999],
+            )
+            == "denied_forum_not_allowed"
+        )
+
+    def test_supergroup_general_no_thread_denied(self) -> None:
+        # General chat (no message_thread_id) is NOT a Topic -> denied even when
+        # allow_forum is on and the chat_id IS allow-listed. Fail closed.
+        assert (
+            forum_gate_outcome(
+                "supergroup",
+                self._LISTED,
+                None,
+                allow_forum=True,
+                allowed_forum_chat_ids=[self._LISTED],
+            )
+            == "denied_non_private_chat"
+        )
+
+    def test_ordinary_group_denied_even_with_thread(self) -> None:
+        # An ordinary group can't have Topics; chat_type "group" is denied even
+        # if a (spurious) thread id and allow-listed chat_id are supplied.
+        assert (
+            forum_gate_outcome(
+                "group",
+                self._LISTED,
+                5,
+                allow_forum=True,
+                allowed_forum_chat_ids=[self._LISTED],
+            )
+            == "denied_non_private_chat"
+        )
+
+    def test_channel_denied_non_private(self) -> None:
+        # chat_type dominates: a channel is denied even with a thread + "listed" id.
+        assert (
+            forum_gate_outcome(
+                "channel",
+                -100777,
+                5,
+                allow_forum=True,
+                allowed_forum_chat_ids=[-100777],
+            )
+            == "denied_non_private_chat"
+        )
+
+
+class TestForumClientCapture:
+    """The raw ``message_thread_id`` on a supergroup update is normalized onto
+    ``TelegramInbound`` so downstream routing can key on the Topic."""
+
+    def _dispatch_and_capture(self, update: dict) -> list[TelegramInbound]:
+        captured: list[TelegramInbound] = []
+
+        async def _on(inb: TelegramInbound) -> None:
+            captured.append(inb)
+
+        async def _go() -> None:
+            cli = TelegramClient(token="x", on_message=_on)
+            cli._dispatch(update)
+            await asyncio.sleep(0.02)  # let the created handler task run
+
+        asyncio.run(_go())
+        return captured
+
+    def test_message_thread_id_captured_into_inbound(self) -> None:
+        captured = self._dispatch_and_capture(
+            {
+                "message": {
+                    "message_id": 9,
+                    "text": "hi",
+                    "message_thread_id": 5,
+                    "chat": {"id": -1001234567890, "type": "supergroup"},
+                    "from": {"id": 7},
+                }
+            }
+        )
+        assert len(captured) == 1
+        assert captured[0].message_thread_id == 5
+        assert captured[0].chat_type == "supergroup"
+
+    def test_dm_update_has_no_thread_id(self) -> None:
+        captured = self._dispatch_and_capture(
+            {
+                "message": {
+                    "message_id": 1,
+                    "text": "hi",
+                    "chat": {"id": 7, "type": "private"},
+                    "from": {"id": 7},
+                }
+            }
+        )
+        assert len(captured) == 1
+        assert captured[0].message_thread_id is None
+
+
+class TestForumTransportGate:
+    """Forum gating lives in transport.receive(): allow_forum + chat_id list.
+    Fail closed — a group/supergroup message is dropped unless BOTH hold."""
+
+    def _run_receive(
+        self,
+        inbound: TelegramInbound,
+        *,
+        allow_forum: bool,
+        allowed_forum_chat_ids: list[int],
+    ) -> list[InboundMessage]:
+        dispatched: list[InboundMessage] = []
+
+        async def _dispatch(m: InboundMessage) -> None:
+            dispatched.append(m)
+
+        t = TelegramTransport(
+            FakeClient(),  # type: ignore[arg-type]
+            allowed_user_ids=[7],
+            allow_forum=allow_forum,
+            allowed_forum_chat_ids=allowed_forum_chat_ids,
+            dispatch=_dispatch,
+        )
+        asyncio.run(t.receive(inbound))
+        return dispatched
+
+    def test_forum_allowed_dispatches_with_thread(self) -> None:
+        inbound = TelegramInbound(
+            chat_id=-1001234567890, user_id=7, text="hi",
+            chat_type="supergroup", message_thread_id=5,
+        )
+        out = self._run_receive(
+            inbound, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+        assert len(out) == 1
+        assert getattr(out[0], "chat_type", None) == "supergroup"
+        assert out[0].thread_id == "5"  # Topic id rides the base thread_id
+        assert out[0].conversation_id == "-1001234567890"
+        assert out[0].user_id == "7"
+
+    def test_forum_general_denied_no_thread(self) -> None:
+        # General chat (no message_thread_id) is NOT a real Topic -> DENIED at
+        # the gate even when allow_forum is on and the chat_id is allow-listed.
+        inbound = TelegramInbound(
+            chat_id=-1001234567890, user_id=7, text="hi",
+            chat_type="supergroup", message_thread_id=None,
+        )
+        assert (
+            self._run_receive(
+                inbound, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+            )
+            == []
+        )
+
+    def test_forum_denied_when_allow_forum_false(self) -> None:
+        inbound = TelegramInbound(
+            chat_id=-1001234567890, user_id=7, text="hi",
+            chat_type="supergroup", message_thread_id=5,
+        )
+        assert (
+            self._run_receive(
+                inbound, allow_forum=False, allowed_forum_chat_ids=[-1001234567890]
+            )
+            == []
+        )
+
+    def test_forum_denied_when_chat_id_not_allowlisted(self) -> None:
+        inbound = TelegramInbound(
+            chat_id=-1001234567890, user_id=7, text="hi",
+            chat_type="supergroup", message_thread_id=5,
+        )
+        assert (
+            self._run_receive(
+                inbound, allow_forum=True, allowed_forum_chat_ids=[-1009999999999]
+            )
+            == []
+        )
+
+
+class TestForumDispatchRouting:
+    """Per-topic session-key shape + generation isolation (dispatcher level)."""
+
+    def _forum_msg(
+        self, thread: str | None, *, chat_id: str = "-1001234567890", text: str = "hello"
+    ) -> TelegramInboundMessage:
+        return TelegramInboundMessage(
+            channel_type="telegram", user_id="7", conversation_id=chat_id,
+            text=text, chat_type="supergroup", thread_id=thread, message_id=1,
+        )
+
+    def test_forum_topic_session_key(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        asyncio.run(d.handle_message(self._forum_msg("5")))
+        assert sess.successes == ["telegram:kirocrew:forum:-1001234567890:5"]
+
+    # NB: there is deliberately NO "General session key" routing test — a
+    # threadless supergroup (General) message is denied at the forum gate
+    # (see TestForumGateOutcome.test_supergroup_general_no_thread_denied and
+    # TestForumTransportGate.test_forum_general_denied_no_thread) and never
+    # reaches handle_message, so no General route is ever served.
+
+    def test_private_dm_key_unchanged_regression(self) -> None:
+        # HARD INVARIANT: the private-DM key is byte-for-byte unchanged.
+        d, cli, sess = _dispatcher({7})
+        asyncio.run(
+            d.handle_message(
+                InboundMessage(
+                    channel_type="telegram", user_id="7", conversation_id="7", text="hi"
+                )
+            )
+        )
+        assert sess.successes == ["telegram:kirocrew:direct:7"]
+
+    def test_new_in_topic_isolates_generation(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        asyncio.run(d.handle_message(self._forum_msg("5", text="/new")))
+        # Only THIS topic's generation advanced …
+        assert d._conv.current_gen(("forum", "-1001234567890:5")) == 1
+        # … a sibling topic and the DM are untouched.
+        assert d._conv.current_gen(("forum", "-1001234567890:6")) == 0
+        assert d._conv.current_gen(("direct", "7")) == 0
+
+    def test_forum_outbound_send_threads_edit_does_not(self) -> None:
+        # A forum renderer threads EVERY send into the Topic; edits carry NO
+        # thread (FakeClient.edit_message has no message_thread_id param, so the
+        # run completing at all proves edits are unthreaded).
+        cli = FakeClient()
+        r = TelegramRenderer(
+            cli, -1001234567890, TELEGRAM_CAPABILITIES,  # type: ignore[arg-type]
+            session_key="telegram:kirocrew:forum:-1001234567890:5",
+            message_thread_id=5,
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="hello topic"))
+            await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
+
+        asyncio.run(_go())
+        assert cli.send_threads  # at least one send happened
+        assert all(tid == 5 for tid in cli.send_threads)  # every send threaded
+        assert cli.edits  # the seal edited in place (unthreaded)
+
+
+class TestForumConfig:
+    @staticmethod
+    def _load(data: dict) -> Any:
+        """Load a KiroCrewConfig from an in-memory dict via a temp config file
+        (mirrors the canonical loader entrypoint used across the config tests)."""
+        import json
+        import tempfile
+        import unittest.mock
+        from pathlib import Path
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch(
+                "kiro_crew.config.loader.config_path", return_value=tmp
+            ):
+                return KiroCrewConfig.load()
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_forum_fields_default_closed(self) -> None:
+        cfg = self._load({})
+        assert cfg.telegram.allow_forum is False
+        assert cfg.telegram.allowed_forum_chat_ids == []
+
+    def test_forum_fields_parse_and_serialize(self) -> None:
+        cfg = self._load(
+            {
+                "telegram": {
+                    "allow_forum": True,
+                    "allowed_forum_chat_ids": [-1001, "-1002", "bad", 1.5],
+                }
+            }
+        )
+        assert cfg.telegram.allow_forum is True
+        # _coerce_int_ids keeps clean base-10 ints, drops the rest (fail closed).
+        assert cfg.telegram.allowed_forum_chat_ids == [-1001, -1002]
+        out = cfg.to_dict()  # asdict round-trips the new fields
+        assert out["telegram"]["allow_forum"] is True
+        assert out["telegram"]["allowed_forum_chat_ids"] == [-1001, -1002]
+
+
+class TestForumReplyThreading:
+    """Fix A: every dispatcher-originated send in a forum turn threads back into
+    the user's Topic (message_thread_id=<topic>), never the supergroup General."""
+
+    @staticmethod
+    def _forum_msg(text: str, thread: str | None = "5") -> TelegramInboundMessage:
+        return TelegramInboundMessage(
+            channel_type="telegram", user_id="7",
+            conversation_id="-1001234567890", text=text,
+            chat_type="supergroup", thread_id=thread, message_id=1,
+        )
+
+    def test_new_confirmation_threads_into_topic(self) -> None:
+        d, cli, _ = _dispatcher({7})
+        asyncio.run(d.handle_message(self._forum_msg("/new")))
+        assert any("New conversation" in t for t, _ in cli.sent)
+        # The confirmation landed IN Topic 5, not the supergroup's General.
+        assert cli.send_threads == [5]
+
+    def test_compact_status_threads_into_topic(self) -> None:
+        d, cli, _ = _dispatcher({7})
+        asyncio.run(d.handle_message(self._forum_msg("/compact")))
+        # The "Compacting…" status message threads into the Topic.
+        assert cli.send_threads == [5]
+        assert any("Compact" in t for t, _ in cli.sent)
+
+    def test_dm_confirmation_unthreaded_regression(self) -> None:
+        # HARD INVARIANT: a private-DM /new reply carries NO message_thread_id.
+        d, cli, _ = _dispatcher({7})
+        asyncio.run(
+            d.handle_message(
+                InboundMessage(
+                    channel_type="telegram", user_id="7",
+                    conversation_id="7", text="/new",
+                )
+            )
+        )
+        assert cli.send_threads == [None]
+
+
+class TestForumQueueDrain:
+    """Fix B: a message queued mid-turn in a forum Topic drains under the FORUM
+    session key, not the DM key."""
+
+    def test_queued_forum_message_drains_under_forum_key(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        forum_key = "telegram:kirocrew:forum:-1001234567890:5"
+        # Simulate one message queued mid-turn for this Topic.
+        sess.queued.append(("t0", "queued in the topic", {}))
+        asyncio.run(
+            d._drain_queue(
+                forum_key, 7, -1001234567890,
+                chat_type="supergroup", thread="5",
+            )
+        )
+        # The drained turn resolved to the FORUM key (carried via chat_type +
+        # thread on the synthetic message), NOT the DM key.
+        assert sess.successes == [forum_key]
+        assert "telegram:kirocrew:direct:7" not in sess.successes
+
+    def test_dm_queue_drains_under_dm_key_regression(self) -> None:
+        # HARD INVARIANT: a DM drain still resolves to the DM key (param defaults).
+        d, cli, sess = _dispatcher({7})
+        sess.queued.append(("t0", "queued dm", {}))
+        asyncio.run(d._drain_queue("telegram:kirocrew:direct:7", 7, 7))
+        assert sess.successes == ["telegram:kirocrew:direct:7"]
+
+
+class TestForumCallbackGate:
+    """Fix C: forum callbacks are honored ONLY when the same gate
+    transport.receive enforces passes (allow_forum AND chat_id allow-listed).
+    Fail-closed authZ boundary — never open a callback from a non-allow-listed
+    group. DM callbacks are unchanged (covered by TestDispatcher)."""
+
+    @staticmethod
+    def _opt_cb() -> Any:
+        return SimpleNamespace(
+            callback_query_id="qf", user_id=7, chat_id=-1001234567890,
+            message_id=50, data="opt:0", label="Say Hi",
+            chat_type="supergroup", message_thread_id=5,
+        )
+
+    def test_forum_callback_processed_when_allowlisted(self) -> None:
+        d, cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+        asyncio.run(d.on_callback(self._opt_cb()))  # type: ignore[arg-type]
+        # Acked, and the [OPTIONS:] choice re-dispatched under the FORUM key.
+        assert cli.answered == ["qf"]
+        assert sess.successes == ["telegram:kirocrew:forum:-1001234567890:5"]
+        # Every callback-originated send threaded back into the Topic.
+        assert cli.send_threads and all(t == 5 for t in cli.send_threads)
+
+    def test_forum_callback_denied_when_chat_id_not_allowlisted(self) -> None:
+        # allow_forum on, but the supergroup's chat_id is NOT allow-listed.
+        d, cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1009999999999]
+        )
+        asyncio.run(d.on_callback(self._opt_cb()))  # type: ignore[arg-type]
+        # Fail closed: not even acked, no keyboard retire, no re-dispatch.
+        assert cli.answered == []
+        assert cli.markup_edits == []
+        assert sess.successes == []
+
+    def test_forum_callback_general_no_thread_denied(self) -> None:
+        # A press from the supergroup General chat (no message_thread_id) is NOT
+        # a real Topic -> DENIED even when allow_forum is on and the chat_id IS
+        # allow-listed. Mirrors the receive() gate exactly (fail closed).
+        d, cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+        cb = SimpleNamespace(
+            callback_query_id="qg", user_id=7, chat_id=-1001234567890,
+            message_id=51, data="opt:0", label="Say Hi",
+            chat_type="supergroup", message_thread_id=None,
+        )
+        asyncio.run(d.on_callback(cb))  # type: ignore[arg-type]
+        assert cli.answered == []
+        assert cli.markup_edits == []
+        assert sess.successes == []
+
+    def test_forum_callback_approval_resolves_only_when_allowlisted(self) -> None:
+        # Allow-listed: the approval decision resolves under the forum key.
+        d, cli, _ = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+
+        async def _go() -> bool:
+            key = TelegramApprovalDecider.key(
+                d._session_key(("forum", "-1001234567890:5")), "rqF"
+            )
+            fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+            TelegramApprovalDecider._REGISTRY[key] = fut
+            try:
+                cb = SimpleNamespace(
+                    callback_query_id="qF", user_id=7, chat_id=-1001234567890,
+                    message_id=60, data="a:rqF:1", label="",
+                    chat_type="supergroup", message_thread_id=5,
+                )
+                await d.on_callback(cb)  # type: ignore[arg-type]
+                return fut.done() and fut.result() is True
+            finally:
+                TelegramApprovalDecider._REGISTRY.pop(key, None)
+
+        assert asyncio.run(_go()) is True
+
+    def test_forum_callback_not_resolved_when_allow_forum_false(self) -> None:
+        # allow_forum OFF -> the identical approval press must NOT resolve the
+        # decider (fail closed) and must not even ack.
+        d, cli, _ = _dispatcher(
+            {7}, allow_forum=False, allowed_forum_chat_ids=[-1001234567890]
+        )
+
+        async def _go() -> bool:
+            key = TelegramApprovalDecider.key(
+                d._session_key(("forum", "-1001234567890:5")), "rqF"
+            )
+            fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+            TelegramApprovalDecider._REGISTRY[key] = fut
+            try:
+                cb = SimpleNamespace(
+                    callback_query_id="qF", user_id=7, chat_id=-1001234567890,
+                    message_id=61, data="a:rqF:1", label="",
+                    chat_type="supergroup", message_thread_id=5,
+                )
+                await d.on_callback(cb)  # type: ignore[arg-type]
+                return fut.done()
+            finally:
+                TelegramApprovalDecider._REGISTRY.pop(key, None)
+
+        assert asyncio.run(_go()) is False
+        assert cli.answered == []


### PR DESCRIPTION
Closes #211.

## What
Map **Telegram supergroup forum Topics** onto KiroCrew's existing `thread_id` abstraction so one bot runs many parallel, topic-scoped conversations — the Slack channel+threads model — instead of one-session-per-user (which previously forced a bot-per-topic workaround). Backend + config only.

| Slack | Telegram |
|---|---|
| channel | supergroup (Topics enabled) |
| thread | Topic |
| `thread_ts` | `message_thread_id` |

## Design
- **Session key** reuses the existing `chat_type` slot in `build_dm_session_key`:
  - private DM (unchanged, byte-for-byte): `telegram:{agent}:direct:{user_id}`
  - forum Topic: `telegram:{agent}:forum:{chat_id}:{thread_id}`
  - `messaging.dm_scope="unified"` applies **only** to direct DMs — forum routes always keep the full per-topic key (no cross-context collapse).
- **Per-topic generation** — `/new`, idle/daily rotation and `/compact` are scoped to one Topic, not the whole chat (shared `ConversationState` keyed on the `(chat_type, comp)` route; class internals untouched).
- **Gate — fail-closed AND Topic-scoped:** a turn (or callback) is authorized **only** for a real forum Topic — `chat_type == "supergroup"` **and** a `message_thread_id` — in an allow-listed chat (`telegram.allow_forum` on **and** `chat_id` in `telegram.allowed_forum_chat_ids`). **Ordinary groups and the supergroup General chat (no thread) are denied** and audited; the existing owner `allowed_user_ids` check still applies. One shared predicate (`forum_gate_outcome`) guards both `transport.receive` and `on_callback`, so the inbound and callback boundaries can't drift.
- **Outbound threading** — streamed answers (renderer), command/notice replies, queue receipts, queue **drain**, callback re-dispatch, and the `/link` dashboard mirror all carry `message_thread_id`, so replies land in the right Topic and *queued* messages drain under the forum key. `editMessageText` is intentionally not threaded (message_id already identifies the message within its Topic).

## Scope
- **In:** backend session-per-Topic routing + config schema. Works via `config.json` today.
- **Out (follow-ups):** dashboard settings UI for the forum fields — depends on the Telegram settings panel (#121), intentionally **not** touched here; and multi-user sharing / "treat all senders as one identity" (separate design with real tool-output-exposure implications).

## Operational note
Bot **privacy mode must be disabled** in @BotFather (`/setprivacy` → Disable) for the bot to see all messages inside a Topic; otherwise it only sees @mentions and replies.

## Testing
Build gate green locally: `pytest` telegram suite + messaging/config/discord blast radius (incl. rewritten forum gate unit tests: General/ordinary-group/channel all denied); `flake8` clean on changed files; `tsc -b` clean; `vitest` 3948 passed. Note: Telegram cannot be exercised in the pod harness (`telegram.enabled` is forced off in pods), so verification is unit-level + reviewed wiring; live forum behavior is validated manually in a real supergroup.
