### PR TITLE
feat: consolidate remote instance top bar into one header

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -83,7 +83,7 @@ const MAX_WAIT_MS = 30_000; // 30s max wait for backend
 const IS_MAC = process.platform === "darwin";
 // The dashboard view fills the whole content area on all platforms. On macOS
 // the window is frameless (titleBarStyle:"hidden") and the dashboard's own
-// 52px header doubles as the title bar: an injected drag region makes it
+// 42px header doubles as the title bar: an injected drag region makes it
 // draggable and the native traffic lights are inset into it (see
 // positionTrafficLights).
 
@@ -627,13 +627,13 @@ function setupWindowContents(win, backendUrl) {
       #electron-drag-bar {
         position: fixed;
         top: 0; left: 0; right: 0;
-        height: 52px;
+        height: 42px;
         -webkit-app-region: drag;
         z-index: 99999;
         pointer-events: none;
       }
       a, button, input, select, textarea,
-      [role="button"], [tabindex] {
+      [role="button"], [tabindex], iframe {
         -webkit-app-region: no-drag;
       }
     `);
@@ -676,26 +676,27 @@ function setupWindowContents(win, backendUrl) {
 
 // ── Traffic lights ──
 //
-// The SPA renders a 52px (CSS px) header that acts as the title bar. The
+// The SPA renders a 42px (CSS px) header that acts as the title bar. The
 // native traffic lights are AppKit controls with a fixed ~14px visual height —
 // they do not scale with webContents zoom. To keep them visually centered in
 // the header at any zoom level, recompute their inset from the current zoom
-// factor: the header's on-screen height is 52 * zoomFactor, so both the x
+// factor: the header's on-screen height is 42 * zoomFactor, so both the x
 // inset and the vertical centering scale with it.
-const HEADER_CSS_PX = 52;
-// The instance tab strip (InstanceTabBar, h-8 = 32px) becomes the topmost row
-// whenever >=1 remote is connected; the native lights then sit over IT, not the
-// 52px header, so they must be centered against the strip's height — otherwise
-// they land ~10px too low and look off-row from the tab pills. The renderer
-// reports this via the "instancebar-inset-changed" IPC (see App.tsx).
-const INSTANCEBAR_CSS_PX = 32;
-const TRAFFIC_LIGHT_NATIVE_H = 14;
+const HEADER_CSS_PX = 42;
+// Visible AppKit traffic-light control height (fixed; does not scale with zoom).
+const TRAFFIC_LIGHT_NATIVE_H = 12;
+// AppKit anchors the button GROUP a few px below the naive top inset, so the
+// naive (H - buttonH)/2 lands the group low. Measured from a user screenshot at
+// a 42px header (lights centered ~3px below the search bar / selector midline),
+// this constant nudges the group up to sit on the header centerline. It is a
+// fixed device-px correction, applied after the zoom-scaled centering term.
+const TRAFFIC_LIGHT_Y_NUDGE = -4;
 
-function trafficLightPositionForZoom(zoomFactor, stripCssPx = HEADER_CSS_PX) {
-  const stripPx = Math.round(stripCssPx * zoomFactor);
+function trafficLightPositionForZoom(zoomFactor) {
+  const stripPx = Math.round(HEADER_CSS_PX * zoomFactor);
   return {
     x: Math.round(16 * zoomFactor),
-    y: Math.max(6, Math.round((stripPx - TRAFFIC_LIGHT_NATIVE_H) / 2)),
+    y: Math.max(4, Math.round((stripPx - TRAFFIC_LIGHT_NATIVE_H) / 2) + TRAFFIC_LIGHT_Y_NUDGE),
   };
 }
 
@@ -703,8 +704,7 @@ function positionTrafficLights(win) {
   if (!IS_MAC || !win || win.isDestroyed()) return;
   try {
     const zoom = win._mcView ? win._mcView.webContents.getZoomFactor() : 1;
-    const stripCssPx = win._mcInstanceBarInset ? INSTANCEBAR_CSS_PX : HEADER_CSS_PX;
-    win.setWindowButtonPosition(trafficLightPositionForZoom(zoom, stripCssPx));
+    win.setWindowButtonPosition(trafficLightPositionForZoom(zoom));
   } catch { /* window mid-teardown */ }
 }
 
@@ -743,7 +743,7 @@ function createWindow() {
     titleBarStyle: "hidden",
     backgroundColor: "#0f1117",
   };
-  // Inset the native traffic lights into the dashboard's 52px header row.
+  // Inset the native traffic lights into the dashboard's 42px header row.
   // Kept in sync with zoom by positionTrafficLights().
   if (IS_MAC) opts.trafficLightPosition = trafficLightPositionForZoom(1);
   // Only include `fullscreen` when we actually want fullscreen: the flag
@@ -1581,20 +1581,6 @@ app.whenReady().then(async () => {
   ipcMain.handle("zoom:set", (event, factor) => applyZoom(event.sender, clampZoomFactor(factor)));
   ipcMain.handle("zoom:step", (event, dir) =>
     applyZoom(event.sender, stepZoomFactor(event.sender.getZoomFactor(), dir > 0 ? +1 : -1)));
-
-  // The renderer reports whether the 32px instance tab strip is the topmost row
-  // (App.tsx macInstanceBarInset). When it is, the native traffic lights sit
-  // over that strip, so re-center them for its height instead of the 52px
-  // header — keeps the buttons on the same row as the tab pills.
-  ipcMain.on("instancebar-inset-changed", (event, on) => {
-    // Target the window that actually sent this — connection windows load the
-    // same SPA and can each emit it, so hardcoding mainWindow would cross-wire
-    // their traffic-light positions.
-    const win = windowForWebContents(event.sender);
-    if (!win || win.isDestroyed()) return;
-    win._mcInstanceBarInset = !!on;
-    positionTrafficLights(win);
-  });
 
   // Enable the chat input's screen-snip tool inside the Electron shell.
   // Without a display-media request handler, Electron (>= 20) rejects the

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -30,10 +30,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("fullscreen-changed", handler);
     return () => ipcRenderer.removeListener("fullscreen-changed", handler);
   },
-  // Reports whether the 32px instance tab strip is the topmost row, so main
-  // can center the native traffic lights against the strip (32px) rather than
-  // the 52px header. See App.tsx macInstanceBarInset.
-  setInstanceBarInset: (on) => ipcRenderer.send("instancebar-inset-changed", !!on),
 });
 
 // Native zoom bridge for the Settings > Display "Zoom Level" stepper.

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -26,7 +26,7 @@ import { ZoomProvider } from './hooks/ZoomProvider'
 import { api, isAuthBannerShown } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
-import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, ArrowLeftToLine, Globe, LayoutGrid, Lightbulb, ExternalLink, SquareTerminal } from 'lucide-react'
+import { Rocket, Menu, Bell, Users, BookOpen, BookOpenText, MessageSquareDot, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, Inbox, Gamepad2, AudioWaveform, ClipboardCheck, Brain, FolderTree, FlaskConical, ScanSearch, ChevronUp, MoreHorizontal, Coins, Contact, PanelLeftClose, Globe, LayoutGrid, Lightbulb, ExternalLink, SquareTerminal } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import OnboardingFlow from './components/OnboardingFlow'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -58,8 +58,9 @@ import ArtifactDeployPage from './pages/ArtifactDeployPage'
 import SettingsPage from './pages/SettingsPage'
 import EmbedSettingsPage from './pages/EmbedSettingsPage'
 import KiroCrewNavBridge from './components/KiroCrewNavBridge'
-import InstanceTabBar, { visibleInstanceTabs } from './components/InstanceTabBar'
+import InstanceTabBar from './components/InstanceTabBar'
 import InstancesViewport from './components/InstancesViewport'
+import EmbeddedHostBridge from './components/EmbeddedHostBridge'
 import EmbedTabStrip from './components/EmbedTabStrip'
 import DeveloperPage from './pages/DeveloperPage'
 import SchedulePage from './pages/SchedulePage'
@@ -776,19 +777,6 @@ export default function App() {
   // (the native dashboard); a non-null id means a remote instance's embedded
   // dashboard is shown instead, so the Local pane is hidden (not unmounted).
   const activeInstanceId = useAppSelector(s => s.instances.activeId)
-  // macOS traffic-light clearance: when the instance tab bar is the topmost
-  // strip (>=1 remote connected) the native lights sit over IT, not the header,
-  // so the 84px header inset must move onto the bar (see .mac-instancebar-inset
-  // in index.css). Reuse the shared visibleInstanceTabs rule and the cache-
-  // shared ['instances'] query so this can't diverge from InstanceTabBar. Only
-  // relevant on macOS Electron, and never while fullscreen (lights are hidden).
-  const instanceWarm = useAppSelector(s => s.instances.warm)
-  const { data: instancesData } = useQuery({
-    queryKey: ['instances'],
-    queryFn: () => api.listInstances(),
-    enabled: isMacElectron,
-    retry: false,
-  })
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
   // Dynamic app nav items — all apps (builtin + installed) with UI pages
@@ -1106,23 +1094,11 @@ export default function App() {
     const api = (window as { electronAPI?: { onFullScreenChanged?: (cb: (fs: boolean) => void) => () => void } }).electronAPI
     return api?.onFullScreenChanged?.(setMacFullscreen)
   }, [])
-  // True when the standalone instance tab-bar STRIP is the topmost strip on
-  // macOS (only while a remote pane is active — on the local pane the tabs live
-  // inline in the consolidated header, which keeps its own 84px clearance). The
-  // native traffic lights then sit over the strip, so relocate the inset to it.
-  const macInstanceBarInset =
-    isMacElectron &&
-    !macFullscreen &&
-    activeInstanceId !== null &&
-    visibleInstanceTabs(instancesData?.instances ?? [], instanceWarm).length > 0
-  // Tell the Electron main process which strip is topmost so it can center the
-  // native traffic lights against the 32px instance bar (when shown) instead of
-  // the 52px header — otherwise the buttons sit ~10px below the tab row.
-  useEffect(() => {
-    if (!isMacElectron) return
-    const api = (window as { electronAPI?: { setInstanceBarInset?: (on: boolean) => void } }).electronAPI
-    api?.setInstanceBarInset?.(macInstanceBarInset)
-  }, [macInstanceBarInset])
+  // Native traffic lights always sit over the consolidated 42px header now
+  // (option B removed the standalone instance strip), so there is no separate
+  // strip inset to relay to Electron — positionTrafficLights centers on the
+  // header height directly. Remote panes get their own inset via `macInset`.
+  const macInset = isMacElectron && !macFullscreen
   const { data: sysMetrics, isError: sysMetricsError, dataUpdatedAt: sysMetricsUpdatedAt } = useQuery({ queryKey: ['system-metrics'], queryFn: () => api.system().then(d => ({ memUsed: d.mem_used_gb, memTotal: d.mem_total_gb, cpuPct: d.cpu_pct, diskTotal: d.disk_total_gb, diskFree: d.disk_free_gb })), refetchInterval: metricsOpen ? 30_000 : false, enabled: metricsOpen })
   // Tick every 10s while widget is open so `sysMetricsStale` re-evaluates even when the query stops refetching (backgrounded tab, network drop).
   const [, setStaleTick] = useState(0)
@@ -1332,12 +1308,10 @@ export default function App() {
         </div>
       </div>
     ) : (
-    <div className={`h-screen w-screen flex flex-col overflow-hidden bg-bg ${macInstanceBarInset ? 'mac-instancebar-inset' : ''}`}>
-      {/* Standalone instance tab bar — shown ONLY while a remote pane is active
-          (the local pane below is hidden then, so its inline in-header tabs are
-          not visible; this strip is what lets you switch back to Local). On the
-          local pane the tabs render inline inside the consolidated header. */}
-      {activeInstanceId !== null && <InstanceTabBar />}
+    <div className="h-screen w-screen flex flex-col overflow-hidden bg-bg">
+      {/* Embedded remote panes receive their switcher model from the parent via
+          this bridge (option B) — no-op in the top-level dashboard. */}
+      <EmbeddedHostBridge />
       <div className="flex-1 min-h-0 relative">
       {/* Local pane: the native dashboard. Hidden (not unmounted) while a remote
           instance tab is active, so local state/websocket survive the switch. */}
@@ -1661,9 +1635,9 @@ export default function App() {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1, transition: { duration: 0.18, ease: 'easeOut', delay: 0.12 } }}
                     exit={{ opacity: 0, transition: { duration: 0.12, ease: 'easeIn' } }}
-                    className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center text-muted pointer-events-none"
+                    className="absolute right-0 inset-y-0 my-auto h-4 flex items-center text-muted pointer-events-none"
                   >
-                    <ArrowLeftToLine size={16} />
+                    <PanelLeftClose size={16} />
                   </motion.span>
                 )}
               </AnimatePresence>
@@ -1893,7 +1867,7 @@ export default function App() {
       </div>{/* /Local pane */}
       {/* Remote instance panes — embedded dashboards kept warm (mounted, hidden)
           so switching is instant; the active instance fills the pane. */}
-      <InstancesViewport />
+      <InstancesViewport macInset={macInset} />
       </div>{/* /pane stack */}
     </div>
     )}

--- a/website/src/components/EmbeddedHostBridge.tsx
+++ b/website/src/components/EmbeddedHostBridge.tsx
@@ -1,0 +1,90 @@
+/**
+ * EmbeddedHostBridge — the embedded (remote-pane) half of the option-B
+ * consolidated-header relay.
+ *
+ * When this dashboard SPA runs inside an InstancesViewport <iframe> it has no
+ * knowledge of the parent's instance list, which pane is active, or whether the
+ * parent is a macOS Electron window whose native traffic lights overlap the top
+ * of the pane. The parent relays all of that down as a single `mc-host-model`
+ * postMessage; this bridge stores it in `instances.host` so the embedded header
+ * can render the instance switcher inline (EmbeddedInstanceTabBar) and the
+ * readout capsule can show the tunnel refresh countdown (item 1) — collapsing
+ * the remote pane's previously-stacked two bars into one.
+ *
+ * Security: we only trust messages whose `event.source` is our direct parent
+ * (`window.parent`). The parent independently validates the loopback ORIGIN of
+ * our switch requests (see InstancesViewport / tunnelOrigin), so trust is gated
+ * on both ends. Non-embedded (top-level) dashboards mount this as a no-op.
+ */
+import { useEffect } from 'react'
+import { useAppDispatch } from '../store'
+import { setHostModel, type HostModel } from '../store/instancesSlice'
+import { isEmbeddedPane } from '../lib/embedded'
+
+const MAC_INSET_CLASS = 'embedded-mac-inset'
+
+/** Narrow an untrusted payload to a HostModel, dropping anything malformed. */
+function parseHostModel(data: unknown): HostModel | null {
+  if (!data || typeof data !== 'object') return null
+  const d = data as Record<string, unknown>
+  if (d.type !== 'mc-host-model') return null
+  const rawTabs = Array.isArray(d.tabs) ? d.tabs : []
+  const tabs = rawTabs
+    .filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
+    .map(t => ({
+      id: String(t.id ?? ''),
+      name: String(t.name ?? ''),
+      sshHost: String(t.sshHost ?? ''),
+      state: typeof t.state === 'string' ? t.state : undefined,
+      unread: Number(t.unread) || 0,
+    }))
+    .filter(t => t.id)
+  const rawSelf = d.self && typeof d.self === 'object' ? (d.self as Record<string, unknown>) : null
+  const self = rawSelf
+    ? {
+        state: typeof rawSelf.state === 'string' ? rawSelf.state : undefined,
+        ttlRemaining: typeof rawSelf.ttlRemaining === 'number' ? rawSelf.ttlRemaining : undefined,
+        ttlTotal: typeof rawSelf.ttlTotal === 'number' ? rawSelf.ttlTotal : undefined,
+      }
+    : null
+  return {
+    tabs,
+    activeId: typeof d.activeId === 'string' ? d.activeId : null,
+    self,
+    macInset: !!d.macInset,
+  }
+}
+
+export default function EmbeddedHostBridge() {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    if (!isEmbeddedPane()) return
+
+    const onMessage = (e: MessageEvent) => {
+      // Only trust our direct parent — origin is validated on the parent side.
+      if (e.source !== window.parent) return
+      const model = parseHostModel(e.data)
+      if (!model) return
+      dispatch(setHostModel(model))
+      document.documentElement.classList.toggle(MAC_INSET_CLASS, model.macInset)
+    }
+    window.addEventListener('message', onMessage)
+    // Announce readiness so the parent (re)sends the current model even if its
+    // initial broadcast raced our mount / a reload.
+    try {
+      // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+      window.parent?.postMessage({ type: 'mc-embedded-ready', v: 1 }, '*')
+    } catch {
+      /* no parent / cross-origin restriction — the parent's periodic re-post covers it */
+    }
+
+    return () => {
+      window.removeEventListener('message', onMessage)
+      document.documentElement.classList.remove(MAC_INSET_CLASS)
+      dispatch(setHostModel(null))
+    }
+  }, [dispatch])
+
+  return null
+}

--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -61,6 +61,134 @@ function fmtDuration(secs: number): string {
   return h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`
 }
 
+// Shared tab pill styling. Selected state uses a tinted background ONLY — no
+// highlighted border (item 3) — with a transparent border kept on every tab so
+// the 24px height never shifts when selection changes.
+function tabCls(active: boolean): string {
+  return (
+    'flex items-center gap-1.5 h-6 px-2.5 rounded-md text-[12px] whitespace-nowrap transition-colors border shrink-0 ' +
+    (active
+      ? 'bg-accent-subtle text-accent border-transparent font-bold'
+      : 'bg-transparent text-muted border-transparent font-medium hover:text-text hover:bg-bg-hover')
+  )
+}
+
+/** Map a live tunnel state to its per-tab status-dot color. */
+function stateDotCls(state?: string): string {
+  return state === 'connected'
+    ? 'bg-[var(--ok)]'
+    : state === 'error'
+      ? 'bg-[var(--danger)]'
+      : state === 'connecting'
+        ? 'bg-[var(--warn)]'
+        : 'bg-[var(--muted)]'
+}
+
+/** The "Local" tab — native dashboard. Shared by the local and embedded bars. */
+function LocalTab({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      className={tabCls(active)}
+      onClick={onClick}
+      title="Local dashboard"
+    >
+      <Home size={13} /> Local
+    </button>
+  )
+}
+
+/** One remote-instance tab. Shared by the local and embedded bars. */
+function InstanceTab({
+  name,
+  title,
+  state,
+  connecting,
+  unread,
+  active,
+  onClick,
+}: {
+  name: string
+  title: string
+  state?: string
+  connecting?: boolean
+  unread?: number
+  active: boolean
+  onClick: () => void
+}) {
+  const badge = unread || 0
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      className={tabCls(active)}
+      onClick={onClick}
+      title={title}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${stateDotCls(state)}`} aria-hidden />
+      {connecting ? <Loader2 size={13} className="animate-spin" /> : <Server size={13} />}
+      <span className="max-w-[160px] truncate">{name}</span>
+      {badge > 0 && (
+        <span
+          aria-label={`${badge} unread`}
+          className="ml-0.5 min-w-[16px] h-4 px-1 rounded-full bg-accent text-accent-fg text-[10px] leading-4 text-center"
+        >
+          {badge}
+        </span>
+      )}
+    </button>
+  )
+}
+
+// Outer container classes per variant. Inline is h-full so its 24px pills sit
+// vertically centered in the 42px header (item 3).
+function barCls(variant: 'strip' | 'inline'): string {
+  return variant === 'inline'
+    ? 'instance-tab-bar-inline flex items-center h-full gap-1 min-w-0 overflow-x-auto no-scrollbar'
+    : 'topbar-glass instance-tab-bar flex items-center gap-2 h-8 px-2 border-b border-border shrink-0 z-[46]'
+}
+
+/**
+ * Embedded (remote pane) switcher: renders the SAME inline tab bar as the local
+ * tab, driven by the model the parent relays into `instances.host` (option B),
+ * and posts switch requests back up so the parent flips `activeId`. This is what
+ * collapses the remote pane's two stacked bars into one consolidated header.
+ */
+function EmbeddedInstanceTabBar({ variant }: { variant: 'strip' | 'inline' }) {
+  const host = useAppSelector(s => s.instances.host)
+  const onLocal = useCallback(() => {
+    // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+    window.parent?.postMessage({ type: 'mc-switch-instance', v: 1, id: null }, '*')
+  }, [])
+  const onSelect = useCallback((id: string) => {
+    // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+    window.parent?.postMessage({ type: 'mc-switch-instance', v: 1, id }, '*')
+  }, [])
+  if (!host || host.tabs.length === 0) return null
+  return (
+    <div className={barCls(variant)} role="tablist" aria-label="Instances">
+      <div className={`flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar ${variant === 'strip' ? 'flex-1' : ''}`}>
+        <LocalTab active={host.activeId === null} onClick={onLocal} />
+        {host.tabs.map(t => (
+          <InstanceTab
+            key={t.id}
+            name={t.name}
+            title={`${t.name} (${t.sshHost})`}
+            state={t.state}
+            connecting={t.state === 'connecting'}
+            unread={t.unread}
+            active={host.activeId === t.id}
+            onClick={() => onSelect(t.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip' | 'inline' } = {}) {
   const dispatch = useAppDispatch()
   const activeId = useAppSelector(s => s.instances.activeId)
@@ -68,7 +196,8 @@ export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip
   const unread = useAppSelector(s => s.instances.unread)
 
   // Embedded instance panes are single-level: never run the instances poll or
-  // render the switcher, so a remote pane can't recursively connect onward.
+  // render the local switcher. Instead they render the parent-relayed switcher
+  // (EmbeddedInstanceTabBar) so the remote pane shows one consolidated header.
   const embedded = isEmbeddedPane()
   // Shared with InstancesViewport / InstancesPanel via the React Query cache.
   const instancesQuery = useQuery({ queryKey: ['instances'], queryFn: () => api.listInstances(), enabled: !embedded })
@@ -115,15 +244,14 @@ export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip
   )
   const onLocal = useCallback(() => dispatch(setActiveId(null)), [dispatch])
 
-  // Single-instance experience is unchanged: no bar until a remote instance is
-  // connected or remembered. Embedded panes never render the switcher.
-  if (embedded || disabled || tabInstances.length === 0) return null
+  // Embedded panes render the parent-relayed switcher (option B). Hooks above
+  // still run unconditionally (rules-of-hooks); the instances poll is disabled
+  // when embedded, so this is cheap.
+  if (embedded) return <EmbeddedInstanceTabBar variant={variant} />
 
-  const tabCls = (active: boolean) =>
-    'flex items-center gap-1.5 h-6 px-2.5 rounded-md text-[12px] whitespace-nowrap transition-colors border shrink-0 ' +
-    (active
-      ? 'bg-accent-subtle text-accent border-accent/40 font-bold'
-      : 'bg-transparent text-muted border-transparent font-medium hover:text-text hover:bg-bg-hover')
+  // Single-instance experience is unchanged: no bar until a remote instance is
+  // connected or remembered.
+  if (disabled || tabInstances.length === 0) return null
 
   // Right-aligned tunnel-status cluster: the ACTIVE remote pane's connection
   // state + countdown to the next token auto-refresh. On the Local tab there is
@@ -158,74 +286,25 @@ export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip
   }
 
   return (
-    <div
-      className={
-        variant === 'inline'
-          ? 'instance-tab-bar-inline flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar'
-          : 'topbar-glass instance-tab-bar flex items-center gap-2 h-8 px-2 border-b border-border shrink-0 z-[46]'
-      }
-      role="tablist"
-      aria-label="Instances"
-    >
+    <div className={barCls(variant)} role="tablist" aria-label="Instances">
       <div className={`flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar ${variant === 'strip' ? 'flex-1' : ''}`}>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeId === null}
-          className={tabCls(activeId === null)}
-          onClick={onLocal}
-          title="Local dashboard"
-        >
-          <Home size={13} /> Local
-        </button>
+        <LocalTab active={activeId === null} onClick={onLocal} />
         {tabInstances.map(inst => {
-          const isActive = activeId === inst.id
           const st = inst.status?.state
           const isConnecting =
             (connectMutation.isPending && connectMutation.variables === inst.id) ||
             st === 'connecting'
-          const badge = unread[inst.id] || 0
-          // Per-tab state dot — green connected, amber connecting, red error,
-          // muted disconnected — so a restored-but-down tab reads as broken
-          // without having to open it.
-          const dotCls =
-            st === 'connected'
-              ? 'bg-[var(--ok)]'
-              : st === 'error'
-                ? 'bg-[var(--danger)]'
-                : st === 'connecting'
-                  ? 'bg-[var(--warn)]'
-                  : 'bg-[var(--muted)]'
-          const stateLabel =
-            st === 'connected'
-              ? 'connected'
-              : st === 'error'
-                ? 'error'
-                : st === 'connecting'
-                  ? 'connecting'
-                  : 'disconnected'
           return (
-            <button
+            <InstanceTab
               key={inst.id}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              className={tabCls(isActive)}
+              name={inst.name}
+              title={`${inst.name} (${inst.ssh_host}) — ${st || 'disconnected'}`}
+              state={st}
+              connecting={isConnecting}
+              unread={unread[inst.id] || 0}
+              active={activeId === inst.id}
               onClick={() => onSelectInstance(inst.id)}
-              title={`${inst.name} (${inst.ssh_host}) — ${stateLabel}`}
-            >
-              <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotCls}`} aria-hidden />
-              {isConnecting ? <Loader2 size={13} className="animate-spin" /> : <Server size={13} />}
-              <span className="max-w-[160px] truncate">{inst.name}</span>
-              {badge > 0 && (
-                <span
-                  aria-label={`${badge} unread`}
-                  className="ml-0.5 min-w-[16px] h-4 px-1 rounded-full bg-accent text-accent-fg text-[10px] leading-4 text-center"
-                >
-                  {badge}
-                </span>
-              )}
-            </button>
+            />
           )
         })}
       </div>

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -27,7 +27,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { api } from '../api/client'
 import { useAppDispatch, useAppSelector } from '../store'
-import { removeWarm, setUnread, setWarm } from '../store/instancesSlice'
+import { removeWarm, setActiveId, setUnread, setWarm } from '../store/instancesSlice'
+import { visibleInstanceTabs } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { isEmbeddedPane } from '../lib/embedded'
 
@@ -48,12 +49,13 @@ function ttlToSeconds(ttl: string): number {
   return m[2] === 'h' ? n * 3600 : n * 60
 }
 
-export default function InstancesViewport() {
+export default function InstancesViewport({ macInset = false }: { macInset?: boolean } = {}) {
   const dispatch = useAppDispatch()
   const queryClient = useQueryClient()
   const warm = useAppSelector(s => s.instances.warm)
   const activeId = useAppSelector(s => s.instances.activeId)
   const mru = useAppSelector(s => s.instances.mru)
+  const unread = useAppSelector(s => s.instances.unread)
 
   // Embedded instance panes never host nested panes (single-level by design),
   // so skip the poll and render nothing — see isEmbeddedPane / InstanceTabBar.
@@ -75,6 +77,13 @@ export default function InstancesViewport() {
   warmRef.current = warm
   const refreshingRef = useRef<Set<string>>(new Set())
   const lastRefreshRef = useRef<Map<string, number>>(new Map())
+  // Live iframe elements by id, so the parent can postMessage the switcher model
+  // into each embedded pane (option B relay). Set/cleared by the iframe ref cb.
+  const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map())
+  // Read-only mirrors for the long-lived message listener, kept current without
+  // re-subscribing (mirrors the warmRef / portToIdRef pattern already used here).
+  const postModelToRef = useRef<(id: string) => void>(() => {})
+  const instancesRef = useRef<Array<{ id: string }>>([])
 
   // Force a fresh token mint for one instance and reload its iframe by updating
   // warm[id].token (srcFor re-derives the ?token= URL, so changing the token
@@ -144,6 +153,24 @@ export default function InstancesViewport() {
         // the in-pane paste-token banner. No foreground guard here — the active
         // pane is exactly the one the user wants restored.
         void refreshToken(id)
+      } else if (data.type === 'mc-switch-instance') {
+        // The embedded pane's inline switcher (option B) asks the parent to flip
+        // the active tab. The SENDER is already trusted (its origin resolved to a
+        // warm tunnel above); validate the TARGET is Local (null) or a known
+        // instance before honoring it.
+        const target = (data as { id?: unknown }).id
+        if (target === null) {
+          dispatch(setActiveId(null))
+        } else if (
+          typeof target === 'string' &&
+          (instancesRef.current.some(i => i.id === target) || !!warmRef.current[target])
+        ) {
+          dispatch(setActiveId(target))
+        }
+      } else if (data.type === 'mc-embedded-ready') {
+        // The pane just (re)mounted and asked for the current model — send it now
+        // rather than waiting for the next input-driven broadcast.
+        postModelToRef.current(id)
       }
     }
     window.addEventListener('message', onMessage)
@@ -227,6 +254,58 @@ export default function InstancesViewport() {
     [warm],
   )
 
+  // Build the switcher model relayed to the embedded pane `id`: the full tab
+  // list (same rule as the local inline bar), which tab is active, this pane's
+  // OWN tunnel status (for its readout capsule, item 1), and the macOS inset.
+  const buildModelFor = useCallback(
+    (id: string) => {
+      const insts = instancesQuery.data?.instances ?? []
+      const tabs = visibleInstanceTabs(insts, warm).map(i => ({
+        id: i.id,
+        name: i.name,
+        sshHost: i.ssh_host,
+        state: i.status?.state,
+        unread: unread[i.id] || 0,
+      }))
+      const selfInst = insts.find(i => i.id === id)
+      const self = selfInst
+        ? {
+            state: selfInst.status?.state,
+            ttlRemaining: selfInst.status?.token_ttl_remaining,
+            ttlTotal: ttlToSeconds(selfInst.ttl),
+          }
+        : null
+      return { type: 'mc-host-model', v: 1, tabs, activeId, self, macInset }
+    },
+    [instancesQuery.data, warm, unread, activeId, macInset],
+  )
+
+  // Post the model into one embedded pane, addressed to its exact loopback
+  // origin (never '*') so it can't leak to an unexpected frame.
+  const postModelTo = useCallback(
+    (id: string) => {
+      const el = iframeRefs.current.get(id)
+      const w = warm[id]
+      if (!el?.contentWindow || !w) return
+      const origin = `${window.location.protocol}//${window.location.hostname}:${w.port}`
+      try {
+        el.contentWindow.postMessage(buildModelFor(id), origin)
+      } catch {
+        /* frame mid-navigation — the next broadcast / ready ping retries */
+      }
+    },
+    [warm, buildModelFor],
+  )
+  postModelToRef.current = postModelTo
+  instancesRef.current = instancesQuery.data?.instances ?? []
+
+  // Broadcast the model to every warm pane whenever any input changes (active
+  // tab, tunnel status, unread, inset). Cheap: each post is a structured clone
+  // to a loopback frame.
+  useEffect(() => {
+    for (const id of Object.keys(warm)) postModelTo(id)
+  }, [warm, activeId, unread, macInset, instancesQuery.data, postModelTo])
+
   // Keep warm iframes mounted across Local<->remote switches (hide-not-unmount).
   // Also render when the active tab is a remote instance with no warm iframe
   // ((re)connecting or down) so we can show the in-pane panel instead of a blank
@@ -260,8 +339,13 @@ export default function InstancesViewport() {
       {warmIds.map(id => (
         <iframe
           key={id}
+          ref={el => {
+            if (el) iframeRefs.current.set(id, el)
+            else iframeRefs.current.delete(id)
+          }}
           title={nameFor(id)}
           src={srcFor(id)}
+          onLoad={() => postModelTo(id)}
           className="absolute inset-0 w-full h-full border-0"
           style={{ display: id === activeId ? 'block' : 'none' }}
         />

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1279,15 +1279,15 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 /* Fullscreen: AppKit hides the traffic lights, so the clearance inset drops
    and the branding sits flush left again (back to the header's own pl-5). */
 .mac-electron.mac-fullscreen header.topbar-glass{padding-left:1.25rem}
-/* When the instance tab bar is the topmost strip (>=1 remote connected), the
-   native traffic lights sit over IT, not the header below. Relocate the 84px
-   clearance: the header returns to its own flush pl-5, and the bar reserves the
-   inset so its first tab clears the lights. Root flag set by App.tsx; it is
-   never set while fullscreen, so this never fights the mac-fullscreen rule.
+/* Embedded remote pane (option B): the pane is a separate document loaded in an
+   iframe, so its SPA can't see Electron — `isMacElectron` is false inside it and
+   the `.mac-electron` rule never applies. The parent relays whether it is a
+   non-fullscreen macOS Electron window; the embedded bridge toggles
+   `.embedded-mac-inset` on <html> so the pane's now-topmost header insets clear
+   of the parent window's native traffic lights.
    Keep 84px in sync with TRAFFIC_LIGHT_INSET_PX in src/lib/electron.ts. */
-.mac-instancebar-inset .mac-electron header.topbar-glass{padding-left:1.25rem}
-.mac-instancebar-inset .instance-tab-bar{padding-left:84px}
-/* The injected #electron-drag-bar (electron/main.js) marks the top 52px as a
+.embedded-mac-inset header.topbar-glass{padding-left:84px}
+/* The injected #electron-drag-bar (electron/main.js) marks the top 42px as a
    window drag region and only exempts native controls (button/a/input/
    [role="button"]/[tabindex]). The side panel's tab strip lives in that zone
    and its chips are divs — punch the whole strip out of the drag region so

--- a/website/src/lib/electron.ts
+++ b/website/src/lib/electron.ts
@@ -2,10 +2,10 @@
  * Electron shell detection + frameless-window layout constants.
  *
  * The desktop app (electron/main.js) is a frameless window on macOS
- * (titleBarStyle:"hidden"): the SPA's 52px header row doubles as the title
+ * (titleBarStyle:"hidden"): the SPA's 42px header row doubles as the title
  * bar, and the native traffic lights are inset into the top-left of the
  * window (see trafficLightPositionForZoom in electron/main.js — x=16,
- * vertically centered in the 52px header, rescaled on zoom). The header gets
+ * vertically centered in the 42px header, rescaled on zoom). The header gets
  * a left inset clearing them via the `.mac-electron` rule in index.css.
  */
 const mc = (window as { kirocrew?: { isElectron?: boolean; platform?: string } }).kirocrew

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2937,7 +2937,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && filteredSlots.length > 0 && (() => {
         const RADIUS = 12 // same as the panel's rounded-xl — constant through the morph
         const PANEL = { top: 8, left: 0, width: sidebarWidth, height: Math.max(0, containerH - 16), borderRadius: RADIUS, opacity: 1 }
-        const BTN = { top: 15, left: 8, width: 34, height: 34, borderRadius: RADIUS, opacity: 1 }
+        const BTN = { top: 20, left: 8, width: 34, height: 34, borderRadius: RADIUS, opacity: 1 }
         const MORPH = { duration: 0.32, ease: [0.32, 0.72, 0, 1] as const }
         return (
           <>
@@ -2957,7 +2957,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
             <button
               type="button"
               onClick={() => window.dispatchEvent(new CustomEvent('toggle-pin-chat-sidebar'))}
-              className="absolute top-[15px] left-2 z-[61] w-[34px] h-[34px] rounded-xl flex items-center justify-center cursor-pointer text-muted hover:text-text transition-colors bg-transparent border-none"
+              className="absolute top-[20px] left-2 z-[61] w-[34px] h-[34px] rounded-xl flex items-center justify-center cursor-pointer text-muted hover:text-text transition-colors bg-transparent border-none"
               title={sidebarOpen ? 'Hide sessions' : 'Show sessions'}
               aria-label={sidebarOpen ? 'Hide sessions sidebar' : 'Show sessions sidebar'}
             >

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2099,10 +2099,14 @@ function ChatSidebar({
         <div className="w-[2px] h-full bg-transparent group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-colors duration-200" />
       </div>
 
-      {/* Header */}
-      <div className="flex justify-between items-center px-2 h-12">
+      {/* Header — per Figma (node 3108:9725): all elements (collapse icon,
+          "Sessions" title, kebab, New button) centered on one line at ~28px
+          from the panel top (mt-2 ≈ panel 8px pad, then centered in a 40px row),
+          matching the left-menu header baseline. Equal top/right gap so the New
+          button sits equidistant from the panel's top and right edges. */}
+      <div className="flex justify-between items-center pl-2 pr-3.5 mt-2 h-10">
         <div className={`flex items-center gap-1.5 min-w-0 flex-1 ${collapsible && !isMobile ? 'pl-8' : ''}`}>
-          {!tinyHeader && <span className="sessions-panel-title text-[13px] font-medium text-muted uppercase tracking-[.04em] truncate">Sessions</span>}
+          {!tinyHeader && <span className="sessions-panel-title text-sm font-medium text-muted tracking-[.04em] truncate">Sessions</span>}
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <DropdownMenu>

--- a/website/src/store/instancesSlice.ts
+++ b/website/src/store/instancesSlice.ts
@@ -10,6 +10,13 @@
  * `activeId` is the instance currently filling the page body, or `null` for the
  * native dashboard (the "Local" tab). `mru` is recency order (front = most
  * recent) for K-cap eviction. `unread` is the validated postMessage relay count.
+ *
+ * `host` is the ONLY field written inside an embedded remote pane: the parent
+ * dashboard relays the switcher model (tabs + which one is active + this pane's
+ * own tunnel status + macOS traffic-light inset) down via postMessage so the
+ * embedded header can render the instance switcher inline — exactly like the
+ * local tab — instead of the parent stacking a second standalone strip on top
+ * of the pane (option B). It is null in the top-level (non-embedded) dashboard.
  */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
@@ -18,11 +25,41 @@ export interface WarmConn {
   token: string
 }
 
+/** One switcher tab as relayed to an embedded pane (parent → frame). */
+export interface HostTab {
+  id: string
+  name: string
+  sshHost: string
+  /** Live tunnel state driving the per-tab dot: connected|connecting|error|disconnected. */
+  state?: string
+  unread: number
+}
+
+/** The embedded pane's OWN tunnel status, used by its readout capsule (item 1). */
+export interface HostSelfTunnel {
+  state?: string
+  /** Seconds of token life remaining (parent-owned). */
+  ttlRemaining?: number
+  /** Total token TTL in seconds. */
+  ttlTotal?: number
+}
+
+/** Full model the parent relays to each embedded pane. */
+export interface HostModel {
+  tabs: HostTab[]
+  activeId: string | null
+  self: HostSelfTunnel | null
+  /** True when the parent is a macOS Electron window not in fullscreen, so the
+   *  embedded header must inset its content clear of the native traffic lights. */
+  macInset: boolean
+}
+
 interface InstancesState {
   warm: Record<string, WarmConn>
   activeId: string | null
   mru: string[]
   unread: Record<string, number>
+  host: HostModel | null
 }
 
 const initialState: InstancesState = {
@@ -30,6 +67,7 @@ const initialState: InstancesState = {
   activeId: null,
   mru: [],
   unread: {},
+  host: null,
 }
 
 const instancesSlice = createSlice({
@@ -59,11 +97,16 @@ const instancesSlice = createSlice({
     setUnread(state, action: PayloadAction<{ id: string; count: number }>) {
       state.unread[action.payload.id] = action.payload.count
     },
+    /** Embedded panes only: store the switcher model relayed by the parent. */
+    setHostModel(state, action: PayloadAction<HostModel | null>) {
+      state.host = action.payload
+    },
     clearInstances() {
       return initialState
     },
   },
 })
 
-export const { setWarm, setActiveId, removeWarm, setUnread, clearInstances } = instancesSlice.actions
+export const { setWarm, setActiveId, removeWarm, setUnread, setHostModel, clearInstances } =
+  instancesSlice.actions
 export default instancesSlice.reducer

--- a/website/src/test/EmbeddedSwitcher.test.tsx
+++ b/website/src/test/EmbeddedSwitcher.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders, createTestStore } from './helpers'
+import InstanceTabBar from '../components/InstanceTabBar'
+import EmbeddedHostBridge from '../components/EmbeddedHostBridge'
+import type { HostModel } from '../store/instancesSlice'
+
+// Embedded panes never hit the instances API; mock it to a no-op so the import
+// is inert and any accidental call is observable.
+vi.mock('../api/client', () => ({
+  ApiError: class extends Error {},
+  api: { listInstances: vi.fn(), connectInstance: vi.fn() },
+}))
+vi.mock('../lib/embedded', () => ({ isEmbeddedPane: vi.fn(() => true) }))
+import { isEmbeddedPane } from '../lib/embedded'
+
+const model = (over: Partial<HostModel> = {}): HostModel => ({
+  tabs: [{ id: 'cd-1', name: 'Cloud One', sshHost: 'cd-1-alias', state: 'connected', unread: 0 }],
+  activeId: 'cd-1',
+  self: null,
+  macInset: false,
+  ...over,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(isEmbeddedPane).mockReturnValue(true)
+})
+afterEach(() => {
+  document.documentElement.classList.remove('embedded-mac-inset')
+})
+
+describe('EmbeddedInstanceTabBar (option B)', () => {
+  it('renders the relayed switcher and posts a switch request to the parent', async () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: model() },
+    })
+    renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+
+    // Local + the relayed instance tab both render.
+    expect(screen.getByRole('tab', { name: /Local/ })).toBeTruthy()
+    const cloud = screen.getByRole('tab', { name: /Cloud One/ })
+    expect(cloud).toBeTruthy()
+
+    await userEvent.click(cloud)
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mc-switch-instance', id: 'cd-1' }),
+      '*',
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /Local/ }))
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mc-switch-instance', id: null }),
+      '*',
+    )
+  })
+
+  it('renders nothing when the parent has not relayed a model yet', () => {
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: null },
+    })
+    const { container } = renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+    expect(container.querySelector('[role="tablist"]')).toBeNull()
+  })
+})
+
+describe('EmbeddedHostBridge (option B relay)', () => {
+  it('pings the parent on mount and ingests a relayed model + toggles the mac inset', async () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore()
+    renderWithProviders(<EmbeddedHostBridge />, { store })
+
+    // Announces readiness so the parent (re)sends the model.
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'mc-embedded-ready' }), '*')
+
+    // A message from the parent updates the store + applies the traffic-light inset.
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: window.parent,
+          data: { type: 'mc-host-model', ...model({ macInset: true, self: { state: 'connected' } }) },
+        }),
+      )
+    })
+    await waitFor(() => expect(store.getState().instances.host?.tabs).toHaveLength(1))
+    expect(store.getState().instances.host?.macInset).toBe(true)
+    expect(document.documentElement.classList.contains('embedded-mac-inset')).toBe(true)
+  })
+
+  it('ignores messages that are not from the direct parent', async () => {
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore()
+    renderWithProviders(<EmbeddedHostBridge />, { store })
+    act(() => {
+      // source omitted (null) — not window.parent, so it must be rejected.
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'mc-host-model', ...model() } }),
+      )
+    })
+    expect(store.getState().instances.host).toBeNull()
+  })
+})

--- a/website/src/test/instancesSlice.test.ts
+++ b/website/src/test/instancesSlice.test.ts
@@ -7,7 +7,7 @@ import reducer, {
   clearInstances,
 } from '../store/instancesSlice'
 
-const initial = { warm: {}, activeId: null, mru: [], unread: {} }
+const initial = { warm: {}, activeId: null, mru: [], unread: {}, host: null }
 
 describe('instancesSlice', () => {
   it('setWarm stores the conn and fronts it in mru', () => {


### PR DESCRIPTION
## Summary

Remote-instance tabs previously showed **two stacked top bars** — the parent app's standalone instance strip plus the embedded pane's own header. This moves the instance switcher **into the embedded pane's own header** via a parent→frame `postMessage` relay, so a remote tab now renders a single consolidated header that matches the local tab.

### What changed
- **Option B relay:** the parent broadcasts a `HostModel` to each embedded pane (`mc-host-model`); the pane renders the switcher inline (`EmbeddedInstanceTabBar`) and posts `mc-switch-instance` / `mc-embedded-ready` back. Standalone parent strip removed. New: `EmbeddedHostBridge.tsx`, `instances.host` slice state.
- **macOS traffic lights:** recentred on the 42px header via a box-model offset (`HEADER_CSS_PX=42`, `TRAFFIC_LIGHT_NATIVE_H=12`, `TRAFFIC_LIGHT_Y_NUDGE=-4`) that stays stable across webContents zoom / fractional Retina scale. Removed the obsolete `instancebar-inset` IPC path. Left-menu collapse icon centering switched from a `translateY(-50%)` transform to box-model (`inset-y-0 my-auto`) so it rounds identically to the sessions icon at any zoom.
- **Sessions panel header** aligned to the Figma spec (node 3104-2203): `PanelLeftClose` icon, title-case "Sessions" at nav-item size, single centered row with the New button equidistant from the panel edges.
- **Selected instance pill:** tinted background only (no border).
- Iframe carved out of the Electron drag region so the embedded pane's now-topmost header stays interactive.

## Testing
- `tsc --noEmit` clean
- `eslint` — 0 errors (pre-existing warnings only)
- `vite build` succeeds; `jscpd` 0 clones
- `vitest` — 3960 pass / 3 skip / 0 fail (adds `EmbeddedSwitcher.test.tsx`)
- electron tests — 201 pass

## Notes
- Single commit, rebased on latest `main`.
- Unrelated dirty `config-baseline.json` deliberately excluded.