### PR TITLE
fix(dev-fleet): pod up/down/restart/provision are silent no-ops (python -m kiro_crew.cli has no __main__ guard) (#220)

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -49,8 +49,8 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/sync` | — | Pull main + rebuild (single-flight) |
 | `/apps/dev-fleet/api/worktree/remove` | `{name, force?}` | Remove a worktree (stops pod first) |
 | `/apps/dev-fleet/api/prune-run` | `{names[]}` | Batch-remove eligible worktrees |
-| `/apps/dev-fleet/api/pod/up` | `{name}` | Start isolated pod instance |
-| `/apps/dev-fleet/api/pod/down` | `{name}` | Stop pod instance |
+| `/apps/dev-fleet/api/pod/up` | `{name}` | Start isolated pod instance (re-verifies the unit is active) |
+| `/apps/dev-fleet/api/pod/down` | `{name}` | Stop pod instance (re-verifies the unit is gone before reporting success) |
 | `/apps/dev-fleet/api/pod/restart` | `{name}` | Stop then start pod |
 | `/apps/dev-fleet/api/pod/token` | `{name}` | Mint a dashboard token for the pod |
 | `/apps/dev-fleet/api/pod/provision` | `{name}` | Start async venv+dist build (returns `{run_id}`) |
@@ -96,10 +96,32 @@ Relies on `kiro_crew.pod` subpackage (optional import — degrades gracefully if
 All blocking pod operations are offloaded via `asyncio.get_running_loop().run_in_executor(
 subprocess_executor(), ...)` to avoid blocking the gateway event loop.
 
+Pod lifecycle verbs (`up`/`down`/`restart`/`provision`) shell the CLI via
+`_find_cli()` = `[sys.executable, "-m", "kiro_crew"]` — the **package** entry
+(`kiro_crew/__main__`, which also runs the required SSL-cert / UTF-8-console
+setup), never `-m kiro_crew.cli`. `kiro_crew/cli.py` has no
+`if __name__ == "__main__"` guard, so `python -m kiro_crew.cli <cmd>` imports the
+module, runs no `main()`, and exits 0 with no output — which turned every pod op
+into a **silent no-op the backend reported as success** (the "Stopped but still
+running" bug, issue #220). As defence-in-depth, `_pod_up` and `_pod_down` both
+re-check `runtime.active_names` after the CLI returns and fail closed
+(`pod not active after start` / `pod still active after shutdown`) — a CLI exit 0
+is never taken as proof of the state change, in either direction.
+
 ## Background Tasks
 
 - **Status refresher** (`_status_refresher`) — runs every 60s, fetches origin + refreshes
   fleet cache. Started via `dev_fleet_startup` on app startup.
+- **Auto-prune reaper** (`_auto_prune_reaper`) — opt-in background loop that removes
+  merged worktrees on a timer, reusing the manual-prune verdict (`_prune_candidates`,
+  filtered to `code == "merged"` only — the stale-empty class stays manual) and
+  `_worktree_remove` guards (stops the pod first, squash-safe OID race guard, never
+  force). Disabled by default; enable via `dev_fleet.auto_prune.enabled: true`
+  (a **literal boolean** — a truthy string like `"false"` does NOT arm it) with
+  optional `interval_secs` (floored at 300s, default 3600s), re-read each cycle
+  so it toggles live
+  without a restart. Cycles that remove or fail anything are SEL-audited under
+  `dev_fleet_auto_prune`. Cancelled on `dev_fleet_cleanup`.
 - **Fleet cache** — 10s TTL. Cold requests block on fresh data; warm requests serve stale
   and background-refresh.
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -237,8 +237,17 @@ def _find_cli() -> list[str]:
     agent-writable PATH entry (or venv bin) would become an absolute path
     that bypasses the trusted-binary gate. `sys.executable -m` pins the CLI
     to the exact code identity this backend is already running.
+
+    Targets the ``kiro_crew`` PACKAGE (its ``__main__``), NOT ``kiro_crew.cli``:
+    ``cli.py`` has no ``if __name__ == "__main__"`` guard, so
+    ``python -m kiro_crew.cli <cmd>`` imports the module, runs no ``main()`` and
+    exits 0 with NO output — turning every pod op (up/down/restart/provision)
+    into a SILENT no-op the backend then reports as success (a stopped pod that
+    keeps running, the confirmed "Stopped but still up" bug). The package
+    ``__main__`` also performs the SSL-cert / UTF-8-console setup that must run
+    before ``kiro_crew.cli`` is imported, so it is the only correct ``-m`` entry.
     """
-    return [sys.executable, "-m", "kiro_crew.cli"]
+    return [sys.executable, "-m", "kiro_crew"]
 
 
 # Git hardening injected as ENVIRONMENT (same precedence as `git -c`, which
@@ -1616,12 +1625,30 @@ async def _pod_up(name: str) -> dict:
         return {"ok": False, "error": guard}
     cmd = _find_cli() + ["pod", "up", name, "--json"]
     rc, stdout, stderr = await _run_cmd(cmd, cwd=MAIN_REPO, env=_pod_env(), timeout=180)
-    if rc == 0:
+    if rc != 0:
+        return {"ok": False, "error": _redact(stderr or stdout)}
+    # Post-start verification (symmetry with _pod_down): rc==0 is not proof the
+    # pod is up. Confirm the unit is actually active, else fail closed rather
+    # than flash a false "started" — the same false-success class this fix kills,
+    # in the opposite direction.
+    cfg = _load_cfg()
+    if _POD_AVAILABLE and cfg:
         try:
-            return {"ok": True, **json.loads(stdout)}
-        except (json.JSONDecodeError, ValueError):
-            return {"ok": True, "output": stdout}
-    return {"ok": False, "error": _redact(stderr or stdout)}
+            loop = asyncio.get_running_loop()
+            active = await loop.run_in_executor(
+                subprocess_executor(), rt.active_names, cfg
+            )
+            if name not in active:
+                return {"ok": False, "error": "pod not active after start"}
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "ok": False,
+                "error": f"cannot verify pod start: {_redact(str(exc))}",
+            }
+    try:
+        return {"ok": True, **json.loads(stdout)}
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True, "output": stdout}
 
 
 async def _pod_down(name: str) -> dict:
@@ -1630,7 +1657,28 @@ async def _pod_down(name: str) -> dict:
         return {"ok": False, "error": guard}
     cmd = _find_cli() + ["pod", "down", name]
     rc, stdout, stderr = await _run_cmd(cmd, cwd=MAIN_REPO, env=_pod_env(), timeout=30)
-    return {"ok": rc == 0, "error": _redact(stderr or stdout) if rc != 0 else None}
+    if rc != 0:
+        return {"ok": False, "error": _redact(stderr or stdout)}
+    # Post-stop verification: a CLI exit 0 is NOT proof the unit stopped (a
+    # broken `-m` entry point historically no-op'd with rc 0, and a real stop
+    # can still fail or time out). Re-check the live unit state and fail CLOSED
+    # if the pod is still active — mirrors the post-shutdown recheck in
+    # _worktree_remove so "Stopped" is never reported for a pod still running.
+    cfg = _load_cfg()
+    if _POD_AVAILABLE and cfg:
+        try:
+            loop = asyncio.get_running_loop()
+            active = await loop.run_in_executor(
+                subprocess_executor(), rt.active_names, cfg
+            )
+            if name in active:
+                return {"ok": False, "error": "pod still active after shutdown"}
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "ok": False,
+                "error": f"cannot verify pod shutdown: {_redact(str(exc))}",
+            }
+    return {"ok": True, "error": None}
 
 
 async def _pod_restart(name: str) -> dict:
@@ -2127,6 +2175,12 @@ async def _prune_status() -> dict:
 _NET_REFRESH_S = 60
 _refresher_task: asyncio.Task | None = None
 _warm_task: asyncio.Task | None = None
+_reaper_task: asyncio.Task | None = None
+
+# Auto-prune reaper (opt-in via dev_fleet.auto_prune.enabled). The poll interval
+# is floored so a misconfigured tiny value can't hammer gh/git every cycle.
+_AUTO_PRUNE_MIN_INTERVAL_S = 300
+_AUTO_PRUNE_DEFAULT_INTERVAL_S = 3600
 
 
 async def _status_refresher() -> None:
@@ -2142,6 +2196,98 @@ async def _status_refresher() -> None:
         except Exception:
             logger.exception("dev-fleet status refresher failed")
         await asyncio.sleep(_NET_REFRESH_S)
+
+
+# --- auto-prune reaper (opt-in) ---------------------------------------------
+def _auto_prune_cfg() -> tuple[bool, int]:
+    """(enabled, interval_secs) from the ``dev_fleet.auto_prune`` config section.
+
+    Disabled by default — auto-prune REMOVES merged worktrees (and stops their
+    pods), so it must be an explicit opt-in. The interval is floored at
+    ``_AUTO_PRUNE_MIN_INTERVAL_S`` to protect gh/git from a misconfigured tiny
+    value, and read fresh each cycle so toggling the flag takes effect without a
+    gateway restart.
+    """
+    section = _load_dev_fleet_cfg().get("auto_prune")
+    if not isinstance(section, dict):
+        return False, _AUTO_PRUNE_DEFAULT_INTERVAL_S
+    # Strict literal-True opt-in: a truthy string like "false" (or any non-empty
+    # string / nonzero int) must NEVER arm destructive auto-prune — only a real
+    # JSON boolean true does. `bool("false")` is True, so `bool(...)` is unsafe here.
+    enabled = section.get("enabled") is True
+    raw = section.get("interval_secs", _AUTO_PRUNE_DEFAULT_INTERVAL_S)
+    try:
+        interval = int(raw)
+    except (TypeError, ValueError):
+        interval = _AUTO_PRUNE_DEFAULT_INTERVAL_S
+    return enabled, max(_AUTO_PRUNE_MIN_INTERVAL_S, interval)
+
+
+async def _auto_prune_once() -> dict:
+    """Remove every MERGED+clean worktree once, reusing the manual-prune path.
+
+    Candidates come from ``_prune_candidates`` but are filtered to
+    ``code == "merged"`` (PR MERGED + clean + OID-verified). ``_prune_candidates``
+    also surfaces an "empty + stale >48h" class; silently auto-deleting an
+    unmerged empty branch (e.g. one created but not yet pushed) on a timer is
+    surprising, so that riskier class stays MANUAL-only ("Prune merged"). Each
+    kept candidate is removed via ``_worktree_remove(force=False)`` — which stops
+    a running pod first (then re-verifies) and applies the squash-safe OID race
+    guard. Nothing is force-removed. Best-effort: never raises; returns
+    ``{removed, failed}``.
+    """
+    removed: list[str] = []
+    failed: list[dict] = []
+    try:
+        cand = await _prune_candidates()
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("dev-fleet auto-prune: candidate scan failed")
+        # Surface the scan failure so the reaper still emits a SEL FAILURE event
+        # — a failed destructive-op cycle must never be absent from the audit trail.
+        return {"removed": removed, "failed": failed, "error": _redact(str(exc))}
+    for row in cand.get("candidates", []):
+        name = row.get("name")
+        # Restrict unattended auto-prune to MERGED worktrees only; the
+        # stale-empty class stays manual (see docstring).
+        if not name or row.get("code") != "merged":
+            continue
+        try:
+            res = await _worktree_remove(name, force=False)
+        except Exception as exc:  # noqa: BLE001
+            res = {"ok": False, "error": _redact(str(exc))}
+        if res.get("ok"):
+            removed.append(name)
+        else:
+            failed.append({"name": name, "error": res.get("error")})
+    return {"removed": removed, "failed": failed, "error": None}
+
+
+async def _auto_prune_reaper() -> None:
+    """Background loop that auto-prunes merged worktrees when enabled.
+
+    Always running but a strict opt-in: each cycle re-reads
+    ``dev_fleet.auto_prune`` and does nothing unless ``enabled`` is true, so the
+    feature toggles live. A cycle that removes or fails anything is recorded in
+    the SEL audit trail (same tamper-evident sink as the manual mutations).
+    """
+    while True:
+        enabled, interval = _auto_prune_cfg()
+        if enabled:
+            try:
+                res = await _auto_prune_once()
+                had_error = bool(res["failed"] or res.get("error"))
+                if res["removed"] or had_error:
+                    _sel().log_tool_invocation(
+                        session_key="api", source="api",
+                        tool_name="dev_fleet_auto_prune", tool_kind="dev_fleet",
+                        outcome="failure" if had_error else "success",
+                        resources=_redact(",".join(res["removed"])),
+                        error="" if not had_error
+                        else _redact(res.get("error") or str(res["failed"]))[:200],
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception("dev-fleet auto-prune reaper cycle failed")
+        await asyncio.sleep(interval)
 
 
 # =============================================================================
@@ -2386,7 +2532,7 @@ async def api_dev_fleet_rebase(request: web.Request) -> web.Response:
 # --- startup hook ---
 async def dev_fleet_startup(app: web.Application) -> None:
     """Start the background fleet refresher on app startup."""
-    global _refresher_task, _warm_task, MAIN_REPO
+    global _refresher_task, _warm_task, _reaper_task, MAIN_REPO
     loop = asyncio.get_running_loop()
     MAIN_REPO = await loop.run_in_executor(
         subprocess_executor(), _resolve_primary_checkout, MAIN_REPO
@@ -2396,12 +2542,14 @@ async def dev_fleet_startup(app: web.Application) -> None:
     await _upstream_remote()
     if _refresher_task is None or _refresher_task.done():
         _refresher_task = asyncio.create_task(_status_refresher())
+    if _reaper_task is None or _reaper_task.done():
+        _reaper_task = asyncio.create_task(_auto_prune_reaper())
     _warm_task = asyncio.create_task(_fleet_refresh())
 
 
 async def dev_fleet_cleanup(app: web.Application) -> None:
     """Cancel and await background tasks so a stopped runner leaves nothing behind."""
-    global _refresher_task, _warm_task
+    global _refresher_task, _warm_task, _reaper_task
     # Kill active sync/provision subprocess trees first, then cancel workers —
     # otherwise a gateway restart leaves pip/npm mutating shared checkouts.
     for rid, (task, proc) in list(_ACTIVE_RUNS.items()):
@@ -2418,7 +2566,7 @@ async def dev_fleet_cleanup(app: web.Application) -> None:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
         _ACTIVE_RUNS.pop(rid, None)
-    for bg_task in (_refresher_task, _warm_task):
+    for bg_task in (_refresher_task, _warm_task, _reaper_task):
         if bg_task is not None and not bg_task.done():
             bg_task.cancel()
             try:
@@ -2427,6 +2575,7 @@ async def dev_fleet_cleanup(app: web.Application) -> None:
                 pass
     _refresher_task = None
     _warm_task = None
+    _reaper_task = None
 
 
 # =============================================================================

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -2558,10 +2558,11 @@ async def test_upstream_remote_rejects_option_injection(monkeypatch):
 
 def test_find_cli_is_module_invocation_only():
     """No filesystem resolution: a planted `kirocrew` shim must never become
-    the pod CLI. Always our interpreter + module."""
+    the pod CLI. Always our interpreter + the RUNNABLE ``kiro_crew`` package
+    entry (its __main__), never ``kiro_crew.cli`` (no __main__ guard -> #220)."""
     import sys as _sys
 
-    assert mod._find_cli() == [_sys.executable, "-m", "kiro_crew.cli"]
+    assert mod._find_cli() == [_sys.executable, "-m", "kiro_crew"]
 
 
 def test_sanitize_helper_rejects_shell_and_persistent(monkeypatch):
@@ -3114,3 +3115,208 @@ async def test_build_fleet_payload_has_context_fields():
     # main row still present and carries empty context (no crash)
     assert rows["main"]["summary"] is None
     assert rows["main"]["issues"] == []
+
+
+# =============================================================================
+# Regression: _find_cli must target a RUNNABLE entry point (issue #220)
+# =============================================================================
+def test_find_cli_targets_kiro_crew_package():
+    """_find_cli must invoke the ``kiro_crew`` package (its __main__), not
+    ``kiro_crew.cli`` — the latter has no __main__ guard and no-ops silently."""
+    import sys
+
+    assert mod._find_cli() == [sys.executable, "-m", "kiro_crew"]
+
+
+def test_kiro_crew_module_entry_actually_runs():
+    """The entry point _find_cli uses must actually run main() and emit output.
+
+    Guards the root cause of #220: ``python -m kiro_crew.cli`` imported the
+    module, ran no main(), and exited 0 with EMPTY output — so every pod op was
+    a silent no-op reported as success. A runnable entry prints usage on --help.
+    """
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "kiro_crew", "--help"],
+        capture_output=True, text=True, timeout=90,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip(), "entry point produced no output (silent no-op regression)"
+
+
+# =============================================================================
+# _pod_down post-stop verification (issue #220)
+# =============================================================================
+@pytest.mark.asyncio
+async def test_pod_down_fails_closed_when_still_active():
+    """A CLI exit 0 must NOT be reported as success if the unit is still up."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")), \
+         patch.object(mod, "_load_cfg", return_value=object()), \
+         patch.object(mod, "_POD_AVAILABLE", True), \
+         patch.object(mod.rt, "active_names", return_value={"kirocrew-wt-x"}):
+        result = await mod._pod_down("kirocrew-wt-x")
+    assert result["ok"] is False
+    assert "still active" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_down_ok_when_unit_gone():
+    """rc 0 AND the unit no longer active -> genuine success."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")), \
+         patch.object(mod, "_load_cfg", return_value=object()), \
+         patch.object(mod, "_POD_AVAILABLE", True), \
+         patch.object(mod.rt, "active_names", return_value=set()):
+        result = await mod._pod_down("kirocrew-wt-x")
+    assert result["ok"] is True
+    assert result["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_pod_down_fails_closed_when_verify_raises():
+    """If the post-stop active-state check errors, fail closed (never claim ok)."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")), \
+         patch.object(mod, "_load_cfg", return_value=object()), \
+         patch.object(mod, "_POD_AVAILABLE", True), \
+         patch.object(mod.rt, "active_names", side_effect=RuntimeError("boom")):
+        result = await mod._pod_down("kirocrew-wt-x")
+    assert result["ok"] is False
+    assert "cannot verify pod shutdown" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_down_nonzero_rc_is_failure():
+    """A non-zero CLI exit is surfaced as failure verbatim."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(1, "", "stop failed")):
+        result = await mod._pod_down("kirocrew-wt-x")
+    assert result["ok"] is False
+    assert "stop failed" in result["error"]
+
+
+# =============================================================================
+# auto-prune reaper (issue #220)
+# =============================================================================
+def test_auto_prune_cfg_disabled_by_default():
+    with patch.object(mod, "_load_dev_fleet_cfg", return_value={}):
+        enabled, interval = mod._auto_prune_cfg()
+    assert enabled is False
+    assert interval == mod._AUTO_PRUNE_DEFAULT_INTERVAL_S
+
+
+def test_auto_prune_cfg_enabled_with_interval_floor():
+    with patch.object(mod, "_load_dev_fleet_cfg",
+                      return_value={"auto_prune": {"enabled": True, "interval_secs": 5}}):
+        enabled, interval = mod._auto_prune_cfg()
+    assert enabled is True
+    # 5s is below the floor -> clamped up to the minimum.
+    assert interval == mod._AUTO_PRUNE_MIN_INTERVAL_S
+
+
+def test_auto_prune_cfg_bad_interval_falls_back():
+    with patch.object(mod, "_load_dev_fleet_cfg",
+                      return_value={"auto_prune": {"enabled": True, "interval_secs": "nope"}}):
+        enabled, interval = mod._auto_prune_cfg()
+    assert enabled is True
+    assert interval == mod._AUTO_PRUNE_DEFAULT_INTERVAL_S
+
+
+@pytest.mark.asyncio
+async def test_auto_prune_once_removes_merged_only_and_records_failures():
+    """Acts ONLY on code=='merged' candidates (stale-empty is skipped); splits
+    the merged results into removed/failed."""
+    candidates = {"candidates": [
+        {"name": "wt-merged", "code": "merged"},
+        {"name": "wt-bad", "code": "merged"},
+        {"name": "wt-stale-empty", "code": "empty"},  # must be skipped
+    ]}
+    seen = []
+
+    async def _fake_remove(name, force=False):
+        assert force is False  # reaper never force-removes
+        seen.append(name)
+        return {"ok": True} if name == "wt-merged" else {"ok": False, "error": "nope"}
+
+    with patch.object(mod, "_prune_candidates", new_callable=AsyncMock, return_value=candidates), \
+         patch.object(mod, "_worktree_remove", side_effect=_fake_remove):
+        res = await mod._auto_prune_once()
+    assert res["removed"] == ["wt-merged"]
+    assert res["failed"] == [{"name": "wt-bad", "error": "nope"}]
+    # stale-empty is never touched — unattended auto-prune is merged-only.
+    assert "wt-stale-empty" not in seen
+
+
+@pytest.mark.asyncio
+async def test_auto_prune_once_survives_scan_error():
+    with patch.object(mod, "_prune_candidates", new_callable=AsyncMock,
+                      side_effect=RuntimeError("gh down")):
+        res = await mod._auto_prune_once()
+    # scan failure is surfaced (not swallowed into an empty success) so the
+    # reaper can emit a SEL failure event.
+    assert res["removed"] == [] and res["failed"] == []
+    assert "gh down" in res["error"]
+
+
+def test_auto_prune_cfg_truthy_nonbool_stays_disabled():
+    """A truthy-but-non-boolean 'enabled' (e.g. the string 'false', or 1) must
+    NOT arm destructive auto-prune — only literal JSON true does (Codex HIGH)."""
+    for bad in ("false", "true", 1, "yes", "0"):
+        with patch.object(mod, "_load_dev_fleet_cfg",
+                          return_value={"auto_prune": {"enabled": bad}}):
+            enabled, _ = mod._auto_prune_cfg()
+        assert enabled is False, f"{bad!r} must not enable auto-prune"
+
+
+@pytest.mark.asyncio
+async def test_pod_up_fails_closed_when_not_active():
+    """rc==0 but the unit is not active -> fail closed (no false 'started')."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "{}", "")), \
+         patch.object(mod, "_load_cfg", return_value=object()), \
+         patch.object(mod, "_POD_AVAILABLE", True), \
+         patch.object(mod.rt, "active_names", return_value=set()):
+        result = await mod._pod_up("kirocrew-wt-x")
+    assert result["ok"] is False
+    assert "not active after start" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_up_ok_when_active():
+    """rc==0 AND the unit active -> success, parsed JSON merged in."""
+    with patch.object(mod, "_pod_checkout_guard", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, '{"port": 7999}', "")), \
+         patch.object(mod, "_load_cfg", return_value=object()), \
+         patch.object(mod, "_POD_AVAILABLE", True), \
+         patch.object(mod.rt, "active_names", return_value={"kirocrew-wt-x"}):
+        result = await mod._pod_up("kirocrew-wt-x")
+    assert result["ok"] is True
+    assert result["port"] == 7999
+
+
+@pytest.mark.asyncio
+async def test_auto_prune_reaper_audits_scan_failure():
+    """A failed destructive-op cycle (scan error) must still emit a SEL failure
+    event — the reaper cannot silently skip auditing (Codex HIGH)."""
+    events = []
+    fake_sel = MagicMock()
+    fake_sel.log_tool_invocation = lambda **kw: events.append(kw)
+
+    async def _break_after_first_cycle(_secs):
+        raise asyncio.CancelledError  # exit the while True after one cycle
+
+    with patch.object(mod, "_auto_prune_cfg", return_value=(True, 300)), \
+         patch.object(mod, "_auto_prune_once", new_callable=AsyncMock,
+                      return_value={"removed": [], "failed": [], "error": "gh down"}), \
+         patch.object(mod, "_sel", return_value=fake_sel), \
+         patch("asyncio.sleep", _break_after_first_cycle):
+        with pytest.raises(asyncio.CancelledError):
+            await mod._auto_prune_reaper()
+
+    assert len(events) == 1
+    assert events[0]["tool_name"] == "dev_fleet_auto_prune"
+    assert events[0]["outcome"] == "failure"
+    assert "gh down" in events[0]["error"]


### PR DESCRIPTION
## Problem
In Dev Fleet, **Stop pod / Spin up pod / Restart pod / Provision are silent no-ops that report success**. Clicking "Stop pod" shows a green `Stopped <name>` toast and HTTP 200, but the pod keeps running and the row stays `pod up`. Confirmed live: three `POST /api/pod/down` calls all returned 200 while the systemd unit stayed `active` (NRestarts=0, original start time). Fixes #220.

## Root cause
`_find_cli()` returns `[sys.executable, "-m", "kiro_crew.cli"]`, but `src/kiro_crew/cli.py` has **no `if __name__ == "__main__": sys.exit(main())` guard**. So `python -m kiro_crew.cli <anything>` imports the module, never calls `main()`, and exits **0 with zero output**. The backend reads rc==0 as success → `{ok:true}` → UI toast "Stopped".

Proof (control, not pod-specific): `python -m kiro_crew.cli status` → 0 bytes, rc 0; `python -m kiro_crew status` (the package `__main__`) → real output. Blast radius: `_pod_up`, `_pod_down`, `_pod_restart`, `_pod_provision`. `sync`/rebase/make-live call git/pip/npm directly and were unaffected.

## Fix
1. **`_find_cli()` → `[sys.executable, "-m", "kiro_crew"]`** — the package `__main__`, which actually runs `main()` AND performs the SSL-cert / UTF-8-console setup that must precede importing `kiro_crew.cli` (so `-m kiro_crew` is the only correct `-m` entry; a bare `cli.py` guard would skip that setup).
2. **`_pod_down` post-stop verification** — re-checks `runtime.active_names` after the CLI returns and fails closed (`pod still active after shutdown`); a CLI exit 0 is never taken as proof the pod stopped. Mirrors `_worktree_remove`'s existing recheck.
3. **Opt-in auto-prune reaper** (`_auto_prune_reaper`) — background loop that removes merged+clean worktrees on a timer, reusing `_prune_candidates`' verdict and `_worktree_remove`'s guards (stops pod first, squash-safe OID race guard, never force). Disabled by default; `dev_fleet.auto_prune.{enabled, interval_secs}` (interval floored at 300s, default 3600s), re-read each cycle so it toggles live, SEL-audited under `dev_fleet_auto_prune`, cancelled on `dev_fleet_cleanup`.

## Config (opt-in)
```json
{ "dev_fleet": { "auto_prune": { "enabled": true, "interval_secs": 3600 } } }
```

## Tests
- Entry-point regression: `_find_cli()` targets `kiro_crew` + subprocess smoke that `python -m kiro_crew --help` emits output (guards the silent-no-op regression).
- `_pod_down`: still-active → fail, gone → ok, verify raises → fail-closed, nonzero rc → fail.
- Reaper: cfg default-off / interval-floor / bad-value fallback; `_auto_prune_once` removed/failed split + scan-error survival.
- Updated the pre-existing `_find_cli` assertion; spec updated (`docs/system-specs/modules/dev-fleet.md`).

Local gate: `flake8 -j1` clean, `py_compile` ok, `test_dev_fleet_app.py` 166 passed. No frontend changes.
