### PR TITLE
feat(desktop): stable ⇄ insider channel switcher in Settings > About

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -61,6 +61,32 @@ function channelForVersion(version) {
 }
 
 /**
+ * Resolve the EFFECTIVE update channel from the build stamp + the user's
+ * channel preference (the Settings > About switcher).
+ *
+ * Rules (stable ⇄ insider opt-in design):
+ * - nightly-stamped builds are PINNED to nightly: the nightly app is a
+ *   separate side-by-side install, and honoring a preference here would
+ *   migrate the dev app onto a production channel.
+ * - unstamped (dev, stamped === null) builds have no update lane; the
+ *   preference cannot conjure one.
+ * - production stamps (insider/stable) follow the preference when set,
+ *   else their own stamp. Switching BACK can be a downgrade mid-cycle
+ *   (insider 0.2.0-insider.1 -> stable 0.1.0); safeCheck's compare gate
+ *   deliberately engages on any version DIFFERENCE, so that works.
+ *
+ * @param {"nightly"|"insider"|"stable"|null} stamped - channelForVersion(version)
+ * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = follow stamp
+ * @returns {"nightly"|"insider"|"stable"|null}
+ */
+function resolveChannel(stamped, preference) {
+  if (stamped === "nightly") return "nightly";
+  if (stamped === null) return null;
+  if (preference === "insider" || preference === "stable") return preference;
+  return stamped;
+}
+
+/**
  * Build the static feed URL for a channel. Pure + testable.
  * @param {{base:string, channel:string}} o
  * @returns {string}
@@ -146,6 +172,7 @@ function initAutoUpdate(deps) {
     dialog,
     Notification,
     getFlavor,
+    getChannelPreference = () => "",
     stopGateway,
     platform = "darwin-arm64",
     feedBase = process.env.KIROCREW_UPDATE_FEED || DEFAULT_FEED_BASE,
@@ -158,9 +185,12 @@ function initAutoUpdate(deps) {
   // the native dialog stays as the fallback for headless / no-renderer cases.
   const uiDriven = typeof onUpdateState === "function";
   // Single channel resolver used for the feed AND everything reported to
-  // the UI: stamped version wins, flavor is the unstamped-dev fallback.
+  // the UI. Read the preference FRESH on every call: configureFeed() runs
+  // per check, so a Settings channel switch takes effect on the next check
+  // with no re-init. Flavor stays the unstamped-dev display fallback.
   function currentChannel() {
-    return channelForVersion(app.getVersion()) || channelForFlavor(getFlavor());
+    const stamped = channelForVersion(app.getVersion());
+    return resolveChannel(stamped, getChannelPreference()) || channelForFlavor(getFlavor());
   }
   function emit(state, extra = {}) {
     if (!uiDriven) return;
@@ -171,7 +201,18 @@ function initAutoUpdate(deps) {
     }
   }
   function getInfo() {
-    return { version: app.getVersion(), channel: currentChannel(), platform, packaged: !!app.isPackaged };
+    const stamped = channelForVersion(app.getVersion());
+    return {
+      version: app.getVersion(),
+      channel: currentChannel(),
+      // Switcher inputs: the build's own lane, whether this build may switch
+      // (nightly is pinned; dev has no lane), and the stored preference.
+      stampedChannel: stamped,
+      channelSwitchable: stamped === "insider" || stamped === "stable",
+      channelPreference: getChannelPreference() || "",
+      platform,
+      packaged: !!app.isPackaged,
+    };
   }
 
   // Squirrel is unavailable for unsigned / not-installed dev builds.
@@ -391,4 +432,4 @@ function initAutoUpdate(deps) {
   };
 }
 
-module.exports = { initAutoUpdate, channelForFlavor, channelForVersion, buildFeedUrl, fetchFeedHttps };
+module.exports = { initAutoUpdate, channelForFlavor, channelForVersion, resolveChannel, buildFeedUrl, fetchFeedHttps };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -35,6 +35,7 @@ const store = new Store({
     sshTimeoutMs: 20000,
     windowState: null,                     // persisted main-window geometry (see window-state.js)
     themeAccent: "",                       // user's resolved theme accent hex; injected into the boot splash
+    updateChannel: "",                     // "" = follow build stamp; "insider"|"stable" = user opt-in (Settings > About)
   },
 });
 
@@ -1646,6 +1647,7 @@ app.whenReady().then(async () => {
     dialog,
     Notification,
     getFlavor: () => "stable",
+    getChannelPreference: () => store.get("updateChannel", ""),
     stopGateway: () => stopGatewayGracefully(),
     onUpdateState: broadcastUpdateState,
   });
@@ -1654,6 +1656,20 @@ app.whenReady().then(async () => {
   ipcMain.handle("update:check", () => { updater.check(); return { ok: true }; });
   ipcMain.handle("update:download", () => { updater.download(); return { ok: true }; });
   ipcMain.handle("update:install", async () => { await updater.install(); return { ok: true }; });
+  // Channel switcher (stable ⇄ insider opt-in). Set persists the preference
+  // and immediately re-checks so the other channel's build surfaces as the
+  // normal consent card -- switching never downloads or installs by itself.
+  // Validation is strict: nightly is NOT offered (the nightly app is a
+  // separate pinned install), and unknown strings are rejected.
+  ipcMain.handle("update:set-channel", (_e, channel) => {
+    const c = typeof channel === "string" ? channel : "";
+    if (c !== "" && c !== "insider" && c !== "stable") {
+      return { ok: false, error: `invalid channel: ${c}` };
+    }
+    store.set("updateChannel", c);
+    updater.check();
+    return { ok: true, info: updater.getInfo() };
+  });
 
   app.on("activate", () => {
     if (!mainWindow?.isVisible()) mainWindow?.show();

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -49,4 +49,7 @@ contextBridge.exposeInMainWorld("updateAPI", {
   download: () => ipcRenderer.invoke("update:download"),
   install: () => ipcRenderer.invoke("update:install"),
   getInfo: () => ipcRenderer.invoke("update:get-info"),
+  // Channel switcher (Settings > About): "" follows the build stamp,
+  // "insider"|"stable" opts the production app onto that lane.
+  setChannel: (channel) => ipcRenderer.invoke("update:set-channel", channel),
 });

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -308,3 +308,93 @@ test("re-check while a download is in flight does NOT re-engage Squirrel (stagin
     handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721182718");
     assert.ok(calls.states.includes("downloaded"));
   }));
+
+// ---------------------------------------------------------------------------
+// Channel switcher (stable ⇄ insider opt-in): resolveChannel decision table
+// and the preference wiring through initAutoUpdate.
+// ---------------------------------------------------------------------------
+
+const { resolveChannel } = require("../auto-update");
+
+test("resolveChannel: nightly stamp is pinned -- preference ignored", () => {
+  assert.strictEqual(resolveChannel("nightly", "stable"), "nightly");
+  assert.strictEqual(resolveChannel("nightly", "insider"), "nightly");
+  assert.strictEqual(resolveChannel("nightly", ""), "nightly");
+});
+
+test("resolveChannel: dev (null stamp) has no lane -- preference cannot conjure one", () => {
+  assert.strictEqual(resolveChannel(null, "insider"), null);
+  assert.strictEqual(resolveChannel(null, ""), null);
+});
+
+test("resolveChannel: production stamps follow the preference when set", () => {
+  assert.strictEqual(resolveChannel("stable", "insider"), "insider");
+  assert.strictEqual(resolveChannel("insider", "stable"), "stable");
+});
+
+test("resolveChannel: no/invalid preference falls back to the stamp", () => {
+  assert.strictEqual(resolveChannel("stable", ""), "stable");
+  assert.strictEqual(resolveChannel("insider", undefined), "insider");
+  assert.strictEqual(resolveChannel("stable", "nightly"), "stable"); // nightly is not a valid opt-in
+  assert.strictEqual(resolveChannel("insider", "bogus"), "insider");
+});
+
+test("preference points the FEED at the opted-in channel", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "0.1.0-insider.3",
+      feed: { version: "0.1.0-insider.3", url: "https://cdn.example.dev/x.zip" },
+    });
+    deps.getChannelPreference = () => "stable";
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.setFeedURL.every((u2) => u2.includes("/stable/")),
+      `expected stable feed URLs, got: ${calls.setFeedURL}`);
+    assert.strictEqual(u.getInfo().channel, "stable");
+  }));
+
+test("switch-back downgrade surfaces the consent card (gate engages on difference)", () =>
+  withDarwin(async () => {
+    // Running insider 0.2.0-insider.1, preference=stable, stable feed has the
+    // OLDER 0.1.0: the check must surface "found" (never auto-download).
+    const { deps, calls } = makeDeps({
+      appVersion: "0.2.0-insider.1",
+      feed: { version: "0.1.0", url: "https://cdn.example.dev/desktop/stable/0.1.0/KiroCrew.zip" },
+    });
+    deps.getChannelPreference = () => "stable";
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
+    assert.strictEqual(calls.checkForUpdates, 0); // consent gate: discovery never downloads
+  }));
+
+test("getInfo exposes switcher inputs: stamped lane, switchability, preference", () =>
+  withDarwin(async () => {
+    const { deps } = makeDeps({
+      appVersion: "0.1.0-insider.3",
+      feed: { version: "0.1.0-insider.3", url: "https://cdn.example.dev/x.zip" },
+    });
+    deps.getChannelPreference = () => "stable";
+    const u = initAutoUpdate(deps);
+    const info = u.getInfo();
+    assert.strictEqual(info.stampedChannel, "insider");
+    assert.strictEqual(info.channelSwitchable, true);
+    assert.strictEqual(info.channelPreference, "stable");
+  }));
+
+test("nightly build reports not switchable and stays on nightly", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "0.1.0-nightly.20260722233638",
+      feed: { version: "0.1.0-nightly.20260722233638", url: "https://cdn.example.dev/x.zip" },
+    });
+    deps.getChannelPreference = () => "stable"; // must be ignored
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(u.getInfo().channelSwitchable, false);
+    assert.ok(calls.setFeedURL.every((u2) => u2.includes("/nightly/")),
+      `expected nightly feed URLs, got: ${calls.setFeedURL}`);
+  }));

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -6,6 +6,7 @@ import { useBranding } from '../../hooks/useBranding'
 import { useAppSelector } from '../../store'
 import { codeBrowserBranchUrl, codeBrowserCommitUrl } from '../../lib/codeBrowser'
 import MarkdownRenderer from '../../components/MarkdownRenderer'
+import SegmentedControl from '../../components/SegmentedControl'
 import { api, ApiError } from '../../api/client'
 import { sanitize } from '../../api/helpers'
 
@@ -21,6 +22,9 @@ type UpdateState = {
 type UpdateInfo = {
   version?: string
   channel?: string
+  stampedChannel?: string | null
+  channelSwitchable?: boolean
+  channelPreference?: string
   platform?: string
   packaged?: boolean
   disabled?: string
@@ -32,6 +36,7 @@ type UpdateAPI = {
   download: () => Promise<unknown>
   install: () => Promise<unknown>
   getInfo: () => Promise<UpdateInfo>
+  setChannel?: (channel: string) => Promise<{ ok: boolean; error?: string }>
 }
 
 function getUpdateApi(): UpdateAPI | undefined {
@@ -97,6 +102,14 @@ export function AboutPanel() {
   // and installing each happen only when the user clicks.
   const downloadMutation = useMutation({ mutationFn: () => desktopApi!.download() })
   const installMutation = useMutation({ mutationFn: () => desktopApi!.install() })
+  // Channel switcher (stable ⇄ insider opt-in). Switching persists the
+  // preference and triggers a check; the other channel's build then arrives
+  // as the normal consent card above -- never an automatic install. Nightly
+  // builds report channelSwitchable=false (separate pinned install).
+  const channelMutation = useMutation({
+    mutationFn: (next: string) => desktopApi!.setChannel!(next),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['update-info'] }),
+  })
 
   const version = info?.version || gatewayVersion || '—'
   const channel = info?.channel
@@ -283,7 +296,29 @@ export function AboutPanel() {
           </span>
         </div>
 
-        {isDesktop && channel && <Row label="Update channel">{channel}</Row>}
+        {isDesktop && channel && (
+          info?.channelSwitchable && desktopApi?.setChannel ? (
+            <div className="flex items-center justify-between py-1.5 text-sm gap-3" data-testid="channel-switcher">
+              <div className="flex flex-col min-w-0">
+                <span className="text-muted">Update channel</span>
+                <span className="text-[11.5px] text-muted opacity-80">
+                  Insider gets prerelease builds early. Switching offers the other channel&apos;s current build as a normal update.
+                </span>
+              </div>
+              <div className="shrink-0 flex items-center gap-2">
+                {channelMutation.isPending && <RefreshCw size={13} className="lucide-inline animate-spin text-muted" />}
+                <SegmentedControl
+                  segments={[{ key: 'stable', label: 'Stable' }, { key: 'insider', label: 'Insider' }]}
+                  value={channel === 'insider' ? 'insider' : 'stable'}
+                  onChange={next => { if (next !== channel && !channelMutation.isPending) channelMutation.mutate(next) }}
+                  layoutId="update-channel"
+                />
+              </div>
+            </div>
+          ) : (
+            <Row label="Update channel">{channel}</Row>
+          )
+        )}
         {isDesktop && info?.platform && <Row label="Platform">{info.platform}</Row>}
       </Card>
 

--- a/website/src/test/AboutPanel.channelSwitcher.test.tsx
+++ b/website/src/test/AboutPanel.channelSwitcher.test.tsx
@@ -1,0 +1,102 @@
+// Channel switcher (stable ⇄ insider opt-in) in Settings > About.
+//
+// Contract under test:
+// - switchable production builds render the Stable | Insider control
+// - picking the other lane calls updateAPI.setChannel with that lane
+// - non-switchable builds (nightly / no setChannel bridge) keep the plain
+//   read-only channel row
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { store } from '../store'
+import { AboutPanel } from '../pages/settings/AboutPanel'
+
+function mountWithUpdateApi(info: Record<string, unknown>, setChannel?: (c: string) => Promise<{ ok: boolean }>) {
+  ;(window as unknown as { updateAPI?: unknown }).updateAPI = {
+    onState: () => () => {},
+    check: vi.fn().mockResolvedValue({ ok: true }),
+    download: vi.fn().mockResolvedValue({ ok: true }),
+    install: vi.fn().mockResolvedValue({ ok: true }),
+    getInfo: vi.fn().mockResolvedValue(info),
+    ...(setChannel ? { setChannel } : {}),
+  }
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <Provider store={store}>
+      <QueryClientProvider client={qc}>
+        <AboutPanel />
+      </QueryClientProvider>
+    </Provider>,
+  )
+}
+
+describe('AboutPanel channel switcher', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => ({}),
+      text: async () => '',
+      headers: new Headers({ 'content-type': 'application/json' }),
+    }))
+  })
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    delete (window as unknown as { updateAPI?: unknown }).updateAPI
+  })
+
+  it('renders the switcher for a switchable production build and sets the other lane', async () => {
+    const setChannel = vi.fn().mockResolvedValue({ ok: true })
+    mountWithUpdateApi(
+      {
+        version: '0.1.0',
+        channel: 'stable',
+        stampedChannel: 'stable',
+        channelSwitchable: true,
+        channelPreference: '',
+        platform: 'darwin-arm64',
+        packaged: true,
+      },
+      setChannel,
+    )
+    const switcher = await screen.findByTestId('channel-switcher')
+    expect(switcher).toBeTruthy()
+    // jsdom reports zero width, so SegmentedControl renders its responsive
+    // dropdown mode: a toggle labeled with the current lane, options after
+    // opening. Open it, then pick Insider.
+    fireEvent.click(screen.getByRole('button', { name: /stable/i }))
+    const insider = await screen.findByRole('button', { name: /insider/i })
+    fireEvent.click(insider)
+    await waitFor(() => expect(setChannel).toHaveBeenCalledWith('insider'))
+  })
+
+  it('does not call setChannel when re-picking the current lane', async () => {
+    const setChannel = vi.fn().mockResolvedValue({ ok: true })
+    mountWithUpdateApi(
+      { version: '0.1.0', channel: 'stable', stampedChannel: 'stable', channelSwitchable: true, packaged: true },
+      setChannel,
+    )
+    await screen.findByTestId('channel-switcher')
+    // Open the dropdown (toggle carries the current lane's label), then
+    // re-pick the CURRENT lane -- onChange fires but the handler must not
+    // call setChannel for a no-op selection.
+    fireEvent.click(screen.getByRole('button', { name: /stable/i }))
+    const stableButtons = await screen.findAllByRole('button', { name: /stable/i })
+    fireEvent.click(stableButtons[stableButtons.length - 1]) // the option, not the toggle
+    await new Promise(r => setTimeout(r, 20))
+    expect(setChannel).not.toHaveBeenCalled()
+  })
+
+  it('nightly (channelSwitchable=false) keeps the read-only channel row', async () => {
+    mountWithUpdateApi({
+      version: '0.1.0-nightly.20260722233638',
+      channel: 'nightly',
+      stampedChannel: 'nightly',
+      channelSwitchable: false,
+      packaged: true,
+    })
+    await screen.findByText('nightly')
+    expect(screen.queryByTestId('channel-switcher')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

PR 2 of the channel architecture (follows #193/#215). Production installs — insider/stable are ONE app on two update lanes — can now **opt between channels in place** from Settings > About, the Slack-beta model. A persisted preference overrides the version-derived channel; the nightly app and unstamped dev builds are excluded by construction.

## How

- **`resolveChannel(stamped, preference)`** (pure, exported, tested): nightly stamps are **pinned** — the nightly app is a separate side-by-side install and a preference must not migrate it onto production lanes; dev (`null`) has no lane; production stamps follow the preference (`insider`/`stable`), invalid values fall back to the stamp.
- **Preference is read fresh on every check**: `currentChannel()` resolves through the injected `getChannelPreference` and `configureFeed()` already runs per check, so a switch takes effect on the next check with no re-init.
- **Switch-back downgrades work by existing design**: the compare gate engages on any version *difference* (`feed.version !== app.getVersion()`), so insider `0.2.0-insider.1` → stable `0.1.0` surfaces as a normal found card. **Switching never downloads or installs by itself** — the consent-card flow (macOS Software Update semantics) is untouched; `update:set-channel` persists and triggers a discovery check only.
- **IPC**: `update:set-channel` with strict validation (`""`|`insider`|`stable`; nightly and unknown strings rejected). `getInfo()` gains `stampedChannel` / `channelSwitchable` / `channelPreference` for the UI.
- **UI**: Stable | Insider `SegmentedControl` replaces the read-only channel row on switchable builds (nightly/dev keep the plain row), with a one-line explanation. No-op re-picks don't call the bridge.

## Testing

- **Electron 209/209** including 9 new: `resolveChannel` decision table, preference→feed-URL wiring, downgrade surfaces `found` without engaging Squirrel, `getInfo` switcher fields, nightly pinned end-to-end
- **Frontend**: 3 new AboutPanel tests (switcher renders + `setChannel('insider')` on pick, no-op re-pick guarded, nightly keeps the plain row); `tsc` clean
- Rebased onto #217 (boot splash) with a trivial store-defaults merge; full suites re-run green on the rebased tree