### PR TITLE
fix(artifacts): audit remote-artifact permission denials + off-loop redaction

### DIFF
--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -3908,6 +3908,27 @@ async def api_remote_artifacts_fork(request: web.Request) -> web.Response:
     )
 
 
+def _audit_remote_denied(tool: str, request: web.Request, reason: str) -> None:
+    """Emit a denied SEL event for a remote-artifact permission rejection.
+
+    Every permission decision on the remote-artifact endpoints must produce an
+    SEL record (backend-security-controls) — both the restricted-session guard
+    and the provider capability-gate rejection. Provider/external_id are pulled
+    from the route match so the event carries the same context as the
+    success/error audits, without assuming the local vars are bound yet.
+    """
+    _audit(
+        tool=tool,
+        request=request,
+        outcome="denied",
+        error=reason,
+        extra={
+            "provider": request.match_info.get("provider", ""),
+            "external_id": request.match_info.get("external_id", ""),
+        },
+    )
+
+
 async def api_remote_artifact_get(request: web.Request) -> web.Response:
     """GET /api/remote-artifacts/{provider}/{external_id} — fetch one remote artifact.
 
@@ -3924,11 +3945,17 @@ async def api_remote_artifact_get(request: web.Request) -> web.Response:
 
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_fetch",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     try:
         provider = get_provider(provider_name)
         if Capability.CONTENT_PULL not in provider.capabilities():
+            _audit_remote_denied("remote_artifact_fetch", request, "provider lacks CONTENT_PULL")
             return _err(f"{provider_name} does not support fetching content", status=400)
         result = await provider.fetch_content(external_id=external_id)
     except Exception as exc:  # noqa: BLE001 — provider failure must not 500 the view
@@ -3950,8 +3977,12 @@ async def api_remote_artifact_get(request: web.Request) -> web.Response:
         outcome="success",
         extra={"provider": provider_name, "external_id": external_id},
     )
-    # Redact the provider payload (content + any metadata) before it leaves.
-    return _json_response(_redact_remote_response(dict(result)))
+    # Redact the provider payload (content + any metadata) before it leaves. The
+    # content can be large (up to MAX_CONTENT_BYTES), so run the redaction regex
+    # off the event loop — same discipline as api_artifact_comments.
+    payload = dict(result)
+    redacted = await _run_off_loop(lambda: _redact_remote_response(payload))
+    return _json_response(redacted)
 
 
 # ── Remote-artifact comments (browse a provider-hosted artifact directly) ────
@@ -4044,6 +4075,11 @@ async def api_remote_artifact_comments(request: web.Request) -> web.Response:
 
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_comments",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     now = time.monotonic()
@@ -4057,6 +4093,9 @@ async def api_remote_artifact_comments(request: web.Request) -> web.Response:
     try:
         provider = get_provider(provider_name)
         if Capability.COMMENTS_READ not in provider.capabilities():
+            _audit_remote_denied(
+                "remote_artifact_comments", request, "provider lacks COMMENTS_READ"
+            )
             remote_sync_error = f"{provider_name} does not support comments"
         else:
             remote = await provider.fetch_comments(external_id=external_id)
@@ -4075,6 +4114,11 @@ async def api_remote_artifact_post_comment(request: web.Request) -> web.Response
     """POST /api/remote-artifacts/{provider}/{external_id}/comments — scope=shared."""
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_post_comment",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     provider_name = request.match_info["provider"]
@@ -4110,6 +4154,9 @@ async def api_remote_artifact_post_comment(request: web.Request) -> web.Response
     try:
         provider = get_provider(provider_name)
         if Capability.COMMENTS_WRITE not in provider.capabilities():
+            _audit_remote_denied(
+                "remote_artifact_post_comment", request, "provider lacks COMMENTS_WRITE"
+            )
             return _err(f"{provider_name} does not support comments", status=400)
 
         anchor_obj = None
@@ -4148,6 +4195,11 @@ async def api_remote_artifact_reply_comment(request: web.Request) -> web.Respons
     """POST /api/remote-artifacts/{provider}/{external_id}/comments/{id}/reply."""
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_reply_comment",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     provider_name = request.match_info["provider"]
@@ -4180,6 +4232,9 @@ async def api_remote_artifact_reply_comment(request: web.Request) -> web.Respons
     try:
         provider = get_provider(provider_name)
         if Capability.COMMENTS_WRITE not in provider.capabilities():
+            _audit_remote_denied(
+                "remote_artifact_reply_comment", request, "provider lacks COMMENTS_WRITE"
+            )
             return _err(f"{provider_name} does not support comments", status=400)
         rc = await provider.reply_comment(
             external_id=external_id, parent_remote_id=parent_id, body=text
@@ -4213,6 +4268,11 @@ async def api_remote_artifact_mark_review(request: web.Request) -> web.Response:
     """
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_mark_review",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     provider_name = request.match_info["provider"]
@@ -4234,6 +4294,9 @@ async def api_remote_artifact_mark_review(request: web.Request) -> web.Response:
     try:
         provider = get_provider(provider_name)
         if Capability.COMMENTS_WRITE not in provider.capabilities():
+            _audit_remote_denied(
+                "remote_artifact_mark_review", request, "provider lacks COMMENTS_WRITE"
+            )
             return _err(f"{provider_name} does not support comments", status=400)
         await provider.mark_review(external_id=external_id, remote_id=comment_id)
     except Exception as exc:  # noqa: BLE001
@@ -4264,6 +4327,11 @@ async def api_remote_artifact_delete_comment(request: web.Request) -> web.Respon
     """
     state = request.app.get("state")
     if state is None or _is_restricted_session(state, request):
+        _audit_remote_denied(
+            "remote_artifact_delete_comment",
+            request,
+            "restricted session" if state is not None else "missing dashboard state",
+        )
         return _err("restricted session", status=403)
 
     provider_name = request.match_info["provider"]
@@ -4285,6 +4353,9 @@ async def api_remote_artifact_delete_comment(request: web.Request) -> web.Respon
     try:
         provider = get_provider(provider_name)
         if Capability.COMMENTS_WRITE not in provider.capabilities():
+            _audit_remote_denied(
+                "remote_artifact_delete_comment", request, "provider lacks COMMENTS_WRITE"
+            )
             return _err(f"{provider_name} does not support comments", status=400)
         await provider.delete_comment(external_id=external_id, remote_id=comment_id)
     except Exception as exc:  # noqa: BLE001

--- a/test/test_remote_artifacts.py
+++ b/test/test_remote_artifacts.py
@@ -28,7 +28,9 @@ from kiro_crew.dashboard.handlers.artifacts import (
     api_artifact_pull_latest,
     api_artifact_update,
     api_artifact_upstream_status,
+    api_remote_artifact_comments,
     api_remote_artifact_delete_comment,
+    api_remote_artifact_get,
     api_remote_artifact_mark_review,
     api_remote_artifact_post_comment,
     api_remote_artifact_reply_comment,
@@ -1162,3 +1164,91 @@ class TestRemoteCommentGovernanceGate:
         assert resp.status == 201
         assert comment_provider.writes == ["post"]
         assert gate_open == ["fakeprov"]
+
+
+class TestRemoteDenialAudit:
+    """Every permission decision on the remote-artifact endpoints emits an SEL
+    event (backend-security-controls): both the restricted-session guard and the
+    provider capability-gate rejection must audit a ``denied`` outcome."""
+
+    @pytest.fixture
+    def capture_audit(self, monkeypatch):
+        events: list[dict] = []
+        monkeypatch.setattr(
+            art_handlers,
+            "_audit",
+            lambda **kw: events.append(kw),
+        )
+        return events
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "handler,match,body",
+        [
+            (api_remote_artifact_get, {"provider": "p", "external_id": "e"}, None),
+            (api_remote_artifact_comments, {"provider": "p", "external_id": "e"}, None),
+            (api_remote_artifact_post_comment, _MATCH, {"text": "x"}),
+            (api_remote_artifact_reply_comment, _MATCH, {"text": "x"}),
+            (api_remote_artifact_mark_review, _MATCH, None),
+            (api_remote_artifact_delete_comment, _MATCH, None),
+        ],
+    )
+    async def test_restricted_session_emits_denied_audit(
+        self, patch_restricted, capture_audit, handler, match, body
+    ):
+        req = _request(match=match, body=body, restricted=True)
+        resp = await handler(req)
+        assert resp.status == 403
+        # A denied SEL event was recorded for the permission decision.
+        assert any(e.get("outcome") == "denied" for e in capture_audit)
+
+    @pytest.mark.asyncio
+    async def test_capability_rejection_emits_denied_audit(
+        self, patch_restricted, capture_audit, gate_open, monkeypatch
+    ):
+        # A provider that lacks COMMENTS_WRITE → post rejects with 400 + audit.
+        class _NoWrite(_CommentProvider):
+            def capabilities(self):
+                return {Capability.COMMENTS_READ}
+
+        prov = _NoWrite()
+        saved = dict(publish_provider._FACTORIES)
+        publish_provider.reset_providers()
+        publish_provider.register_provider(prov.name, lambda: prov)
+        publish_provider._INSTANCES[prov.name] = prov
+        try:
+            req = _request(body={"text": "x"}, match=_MATCH)
+            resp = await api_remote_artifact_post_comment(req)
+            assert resp.status == 400
+            assert any(e.get("outcome") == "denied" for e in capture_audit)
+        finally:
+            publish_provider._FACTORIES.clear()
+            publish_provider._FACTORIES.update(saved)
+            publish_provider.reset_providers()
+
+    @pytest.mark.asyncio
+    async def test_comments_read_rejection_emits_denied_audit(
+        self, patch_restricted, capture_audit, monkeypatch
+    ):
+        # The comments GET soft-degrades (200 + remote_sync_error) when the
+        # provider lacks COMMENTS_READ, but that capability-gate decision must
+        # still emit a denied SEL event like every other permission decision.
+        class _NoRead(_CommentProvider):
+            def capabilities(self):
+                return set()
+
+        prov = _NoRead()
+        saved = dict(publish_provider._FACTORIES)
+        publish_provider.reset_providers()
+        publish_provider.register_provider(prov.name, lambda: prov)
+        publish_provider._INSTANCES[prov.name] = prov
+        art_handlers._remote_comment_cache.clear()
+        try:
+            req = _request(match=_MATCH)
+            resp = await api_remote_artifact_comments(req)
+            assert resp.status == 200
+            assert any(e.get("outcome") == "denied" for e in capture_audit)
+        finally:
+            publish_provider._FACTORIES.clear()
+            publish_provider._FACTORIES.update(saved)
+            publish_provider.reset_providers()


### PR DESCRIPTION
## Description

Follow-up to #202 (which merged just before these two fixes landed on its branch).
Both harden the remote-artifact handlers added in #202; neither changes behavior
for the standalone public build (all remote endpoints are inert without a
registered publish provider).

**1. SEL audit on every permission denial (`backend-security-controls`).**
The six `api_remote_artifact_*` handlers returned `403` (restricted session) and
`400` (provider capability rejection) *before* calling `_audit()`, so those
permission decisions emitted no SEL event — the rule requires every permission
decision to be audited. This adds a small `_audit_remote_denied()` helper and
wires it into all **11 denial sites**: the 6 restricted-session guards + the 5
capability rejections (`CONTENT_PULL` on the content-fetch GET, `COMMENTS_WRITE`
on the four write handlers). Each now records a `denied` outcome with
provider/external_id context, matching the success/error audits already present.

**2. Off-loop redaction in `api_remote_artifact_get`.**
The provider content can be large (up to `MAX_CONTENT_BYTES`), and
`_redact_remote_response` runs a regex over it. It was running on the event loop;
this dispatches it via `_run_off_loop`, matching the discipline already used in
`api_artifact_comments` (`no-blocking-call-on-event-loop`).

## Related Issues

Follow-up to #202 — carries the final Codex-review HIGH finding (denial-path SEL
audit) that was outstanding on #202's branch at merge time, plus a deferred
non-blocking advisory (off-loop redaction).

## Testing

- [x] Existing tests pass — full remote + comment handler suites (102 tests) green.
- [x] New tests added — `TestRemoteDenialAudit` (+7): every restricted-session
      return and the provider-capability rejection record a `denied` SEL event.
- [x] Manual verification — `flake8` + `mypy` clean on the touched handler;
      diff is 2 files (+133/-2), scrub-clean, no internal references.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — n/a (no documented-behavior change;
      the audit is an internal security-controls invariant)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: awaiting OSPO CLA wording. -->
