### PR TITLE
feat(discord): support allowlisted server threads

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -2743,6 +2743,7 @@
         "enabled": false,
         "bot_token": "",
         "allowed_user_ids": [],
+        "allowed_thread_ids": [],
         "soft_threshold_pct": 80
       }
     },
@@ -2757,7 +2758,7 @@
         "discord"
       ],
       "label": "Enabled",
-      "help": "Enable the Discord channel (Gateway WebSocket, DM-only). Requires DISCORD_BOT_TOKEN (env/.env) or discord.bot_token.",
+      "help": "Enable the Discord channel (Gateway WebSocket, DMs plus optional allow-listed server threads). Requires DISCORD_BOT_TOKEN (env/.env) or discord.bot_token.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false
@@ -2789,13 +2790,43 @@
         "discord"
       ],
       "label": "Allowed User IDs",
-      "help": "Discord user IDs (snowflakes) permitted to DM the bot. Empty = deny all (fail closed): anyone sharing a server with the bot can DM it.",
+      "help": "Discord user IDs (snowflakes) permitted to message the bot. Empty = deny all (fail closed).",
       "hasChildren": true,
       "enumValues": null,
       "defaultValue": []
     },
     {
       "path": "discord.allowed_user_ids.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
+    },
+    {
+      "path": "discord.allowed_thread_ids",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "discord"
+      ],
+      "label": "Allowed Thread IDs",
+      "help": "Discord server thread IDs where approved users may run the agent. Empty = DMs only. Normal server channels are always denied.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": []
+    },
+    {
+      "path": "discord.allowed_thread_ids.*",
       "kind": "core",
       "type": "string",
       "required": false,

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -285,8 +285,10 @@ runtime enforces owner-only access.
 ## Discord channel
 
 **Transport (`kiro_crew/discord/`).** A concrete `MessagingTransport` over a
-pure-aiohttp Discord Gateway WebSocket client (`client.py`): identify with the
-`DIRECT_MESSAGES` intent only, heartbeat at the server interval with jitter,
+pure-aiohttp Discord Gateway WebSocket client (`client.py`): identify with
+`DIRECT_MESSAGES` for DM-only installs; when `allowed_thread_ids` is non-empty,
+also request `GUILD_MESSAGES` and privileged `MESSAGE_CONTENT`. Heartbeat uses
+the server interval with jitter,
 resume via `resume_gateway_url`/sequence tracking, exponential-backoff
 reconnect, and hard stop on non-recoverable close codes (4004/4010-4014).
 Outbound is REST v10 (send/edit/typing/reactions/interaction acks) with a
@@ -299,12 +301,19 @@ truthful via the `on_state_change` observer (a non-recoverable close flips it
 back off with the reason).
 
 **Security model.** `authorize` is deny-by-default against
-`discord.allowed_user_ids` (snowflakes kept as strings — they exceed 2^53);
-every denial is SEL-audited. DM-only fail-closed: any message carrying a
-`guild_id` is rejected even from allow-listed users so tool output can never
-land in a shared channel. Bot-authored messages (including our own) are
-dropped in the client as a loop guard. `DISCORD_BOT_TOKEN` is on the sandbox
-agent env denylist.
+`discord.allowed_user_ids` (snowflakes kept as strings — they exceed 2^53).
+DM denials and authorization failures in configured threads are SEL-audited.
+Because Discord's global guild/message-content intents deliver every visible
+channel message, unrelated guild chatter is discarded silently; an approved
+user attempting an unapproved thread remains audit-worthy. Guild turns require
+both an approved sender and an exact `discord.allowed_thread_ids` match, then a
+REST channel lookup must confirm Discord type 10/11/12 before dispatch. Normal
+guild channels are always rejected. An approved thread is a shared disclosure
+boundary: every member who can view it can read agent/tool output. Enabling any
+thread also means Discord delivers message content from every server channel
+the bot can see, although Kiro Crew immediately discards traffic outside
+approved threads. Bot-authored messages (including our own) are dropped as a
+loop guard. `DISCORD_BOT_TOKEN` is on the sandbox agent env denylist.
 
 **Dispatch + rendering.** Turns ride the shared `TurnDriver`
 (`transport_dispatch.py` mirrors the Telegram dispatcher: mid-turn
@@ -337,8 +346,9 @@ timeout and retires the nonce with it.
   and are verified against Discord `GET /users/@me` before storage; rejection
   returns 400 and writes nothing, network failure saves with
   `verify_warning`. `bot_token_clear` must be a strict boolean.
-  `allowed_user_ids` accepts numeric snowflake strings only. Secrets land in
-  `config_dir/.env` (atomic 0600) with `os.environ` synced; non-secrets go to
+  `allowed_user_ids` and `allowed_thread_ids` accept numeric snowflake strings
+  only. Secrets land in `config_dir/.env` (atomic 0600) with `os.environ`
+  synced; non-secrets go to
   `config.json` under `discord`. All fields are boot-read, so
   `restart_required` is true on any actual change.
 ## Telegram settings API

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2575,8 +2575,9 @@ class DiscordConfig:
         default=False,
         metadata=_meta(
             "Enabled",
-            "Enable the Discord channel (Gateway WebSocket, DM-only). Requires "
-            "DISCORD_BOT_TOKEN (env/.env) or discord.bot_token.",
+            "Enable the Discord channel (Gateway WebSocket, DMs plus optional "
+            "allow-listed server threads). Requires DISCORD_BOT_TOKEN (env/.env) "
+            "or discord.bot_token.",
             tags=["discord"],
         ),
     )
@@ -2594,8 +2595,17 @@ class DiscordConfig:
         default_factory=list,
         metadata=_meta(
             "Allowed User IDs",
-            "Discord user IDs (snowflakes) permitted to DM the bot. Empty = deny "
-            "all (fail closed): anyone sharing a server with the bot can DM it.",
+            "Discord user IDs (snowflakes) permitted to message the bot. Empty = "
+            "deny all (fail closed).",
+            tags=["discord"],
+        ),
+    )
+    allowed_thread_ids: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Allowed Thread IDs",
+            "Discord server thread IDs where approved users may run the agent. "
+            "Empty = DMs only. Normal server channels are always denied.",
             tags=["discord"],
         ),
     )
@@ -3267,6 +3277,7 @@ class KiroCrewConfig:
                 # keep them as strings (JSON round-trip safe, matches the
                 # transport's string comparison).
                 allowed_user_ids=_coerce_str_ids(discord_data.get("allowed_user_ids")),
+                allowed_thread_ids=_coerce_str_ids(discord_data.get("allowed_thread_ids")),
                 soft_threshold_pct=max(
                     1, min(100, _coerce_int(discord_data.get("soft_threshold_pct"), 80))
                 ),

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -1812,7 +1812,8 @@ async def _slack_config_save_locked(request: web.Request) -> web.Response:
 # ── Discord configuration API ──
 # The bot token lives in config_dir/.env as DISCORD_BOT_TOKEN (0600), with
 # config.json's discord.bot_token as a legacy fallback. Non-secret config
-# (enabled, allowed_user_ids, soft_threshold_pct) lives in config.json under
+# (enabled, allowed_user_ids, allowed_thread_ids, soft_threshold_pct) lives
+# in config.json under
 # the "discord" key. GET returns a masked preview + presence boolean; raw
 # token values are write-only (reset at the Developer Portal if ever needed).
 
@@ -1878,6 +1879,7 @@ async def api_discord_config_get(request: web.Request) -> web.Response:
             "bot_token_preview": _mask_secret(token),
             "enabled": bool(dc.enabled),
             "allowed_user_ids": [str(u) for u in dc.allowed_user_ids],
+            "allowed_thread_ids": [str(t) for t in dc.allowed_thread_ids],
             "soft_threshold_pct": int(dc.soft_threshold_pct),
         }
     )
@@ -2001,6 +2003,23 @@ async def _discord_config_save_locked(request: web.Request) -> web.Response:
         if new_ids != [str(u) for u in dc_cfg.get("allowed_user_ids", [])]:
             staged["allowed_user_ids"] = new_ids
             applied.append("allowed_user_ids")
+
+    if "allowed_thread_ids" in body:
+        raw_ids = body.get("allowed_thread_ids")
+        if not isinstance(raw_ids, list):
+            return _deny("allowed_thread_ids must be a list")
+        new_ids = []
+        for item in raw_ids:
+            s = str(item).strip()
+            if not s:
+                continue
+            if not s.isdigit():
+                return _deny(f"invalid Discord thread ID: {s} (numeric IDs only)")
+            if s not in new_ids:
+                new_ids.append(s)
+        if new_ids != [str(t) for t in dc_cfg.get("allowed_thread_ids", [])]:
+            staged["allowed_thread_ids"] = new_ids
+            applied.append("allowed_thread_ids")
 
     if "soft_threshold_pct" in body:
         pct = body.get("soft_threshold_pct")

--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -40,10 +40,16 @@ DISCORD_CHUNK_LIMIT = 1900
 _API_BASE = "https://discord.com/api/v10"
 _GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
 
-# Gateway intents: DIRECT_MESSAGES (1<<12) is all a DM-only bot needs.
-# Message content is always delivered for DMs — the privileged MESSAGE_CONTENT
-# intent (1<<15) only gates *guild* message content, which we deny anyway.
+# Gateway intents. DM-only installations request DIRECT_MESSAGES alone. When
+# an explicit server-thread allow-list is configured, GUILD_MESSAGES delivers
+# thread messages and the privileged MESSAGE_CONTENT intent exposes their text.
 _INTENT_DIRECT_MESSAGES = 1 << 12
+_INTENT_GUILD_MESSAGES = 1 << 9
+_INTENT_MESSAGE_CONTENT = 1 << 15
+_THREAD_INTENTS = _INTENT_GUILD_MESSAGES | _INTENT_MESSAGE_CONTENT
+
+# Discord channel types: announcement thread, public thread, private thread.
+_THREAD_CHANNEL_TYPES = frozenset({10, 11, 12})
 
 # Gateway opcodes.
 _OP_DISPATCH = 0
@@ -102,11 +108,15 @@ class DiscordClient:
         token: str,
         on_message: Callable[[DiscordInbound], Awaitable[None]] | None = None,
         on_interaction: Callable[[DiscordInteraction], Awaitable[None]] | None = None,
+        enable_guild_threads: bool = False,
         proxy: str | None = None,
     ) -> None:
         self._token = token
         self._on_message = on_message
         self._on_interaction = on_interaction
+        self._intents = _INTENT_DIRECT_MESSAGES | (
+            _THREAD_INTENTS if enable_guild_threads else 0
+        )
         self._proxy = proxy or _resolve_proxy()
         self._session: aiohttp.ClientSession | None = None
         self._session_lock: asyncio.Lock = asyncio.Lock()
@@ -123,6 +133,9 @@ class DiscordClient:
         self._handler_tasks: set[asyncio.Task[None]] = set()
         # Bot's own user id (from READY) so we can drop our own messages.
         self.bot_user_id: str = ""
+        # channel_id -> Discord channel type. This proves a configured ID is
+        # actually a thread before any shared-channel turn can run.
+        self._channel_types: dict[str, int] = {}
         # Set when the Gateway handshake reaches READY (cleared while
         # disconnected/reconnecting). ``wait_ready`` gates "connected" status.
         self.ready: asyncio.Event = asyncio.Event()
@@ -260,6 +273,24 @@ class DiscordClient:
         result = await self._api("POST", "/users/@me/channels", {"recipient_id": user_id})
         return str(result.get("id")) if result else ""
 
+    async def is_thread_channel(self, channel_id: str) -> bool:
+        """Confirm ``channel_id`` is a Discord thread, failing closed.
+
+        IDs are user-configured, but an ID alone does not prove channel type.
+        Resolve the channel once through Discord and cache its immutable type,
+        so accidentally allow-listing a normal guild channel cannot expose
+        agent or tool output there.
+        """
+        cached = self._channel_types.get(channel_id)
+        if cached is not None:
+            return cached in _THREAD_CHANNEL_TYPES
+        result = await self._api("GET", f"/channels/{channel_id}", None)
+        if not isinstance(result, dict) or not isinstance(result.get("type"), int):
+            return False
+        channel_type = int(result["type"])
+        self._channel_types[channel_id] = channel_type
+        return channel_type in _THREAD_CHANNEL_TYPES
+
     async def edit_message_components(
         self, channel_id: str, message_id: str, components: list[dict]
     ) -> bool:
@@ -385,7 +416,7 @@ class DiscordClient:
                 "op": _OP_IDENTIFY,
                 "d": {
                     "token": self._token,
-                    "intents": _INTENT_DIRECT_MESSAGES,
+                    "intents": self._intents,
                     "properties": {
                         "os": "linux",
                         "browser": "kirocrew",

--- a/src/kiro_crew/discord/gateway.py
+++ b/src/kiro_crew/discord/gateway.py
@@ -46,7 +46,7 @@ async def maybe_start_discord(orch: "GatewayOrchestrator") -> "DiscordClient | N
 
     Returns the running client (so the gateway can ``close()`` it on shutdown)
     or None. The transport + dispatcher stay alive via the client's handler
-    references. Token / enabled / allowed_user_ids are read once in the
+    references. Token / enabled / allow-lists are read once in the
     orchestrator's constructor and consumed off ``orch`` here.
     """
     if not getattr(orch, "_discord_enabled", False):
@@ -59,6 +59,9 @@ async def maybe_start_discord(orch: "GatewayOrchestrator") -> "DiscordClient | N
         assert orch.sessions is not None and orch.ctx_builder is not None
 
         allowed_ids: set[str] = set(getattr(orch, "_discord_allowed_user_ids", []) or [])
+        allowed_threads: set[str] = set(
+            getattr(orch, "_discord_allowed_thread_ids", []) or []
+        )
         if not allowed_ids:
             logger.warning(
                 "Discord: allowed_user_ids is empty — the bot is reachable by "
@@ -72,13 +75,21 @@ async def maybe_start_discord(orch: "GatewayOrchestrator") -> "DiscordClient | N
             ctx_builder=orch.ctx_builder,
             cfg=orch._cfg,
             allowed_user_ids=allowed_ids,
+            allowed_thread_ids=allowed_threads,
             agent=None,
             conv_log=getattr(orch, "conv_log", None),
             approval_mode=_resolve_approval_mode(orch),
         )
-        client = DiscordClient(token=bot_token, on_interaction=dispatcher.on_interaction)
+        client = DiscordClient(
+            token=bot_token,
+            on_interaction=dispatcher.on_interaction,
+            enable_guild_threads=bool(allowed_threads),
+        )
         transport = DiscordTransport(
-            client, allowed_user_ids=allowed_ids, dispatch=dispatcher.handle_message
+            client,
+            allowed_user_ids=allowed_ids,
+            allowed_thread_ids=allowed_threads,
+            dispatch=dispatcher.handle_message,
         )
         # Inbound: Gateway WS -> transport.receive (authorize + normalize)
         # -> dispatcher.handle_message (drive the turn on the shared TurnDriver).

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -8,11 +8,11 @@ instead of a hand-rolled turn loop.
 Dependency direction is ``discord -> messaging`` (allowed); the neutral
 ``messaging`` package never imports ``discord``.
 
-Security: :meth:`authorize` is **deny-by-default** and owner-only. A Discord
-bot can be DM'd by anyone who shares a server with it, so an empty
-``allowed_user_ids`` MUST authorize nobody (fail closed), never everybody.
-DM-only: guild messages are denied outright (mirrors Telegram's
-private-chat-only rule) so tool output can never leak into a shared channel.
+Security: :meth:`authorize` is **deny-by-default**. A Discord bot can be DM'd
+by anyone who shares a server with it, so an empty ``allowed_user_ids`` MUST
+authorize nobody. Guild traffic additionally requires an exact thread-ID
+allow-list match and a Discord-confirmed thread channel type; normal guild
+channels are always denied.
 """
 
 from __future__ import annotations
@@ -52,15 +52,16 @@ DispatchFn = Callable[[InboundMessage], Awaitable[None]]
 
 # Discord's capabilities: edit-based streaming, a 2000-char cap (we chunk at
 # 1900 for headroom), up to 5 buttons per action row, emoji reactions (used
-# for steer-ack receipts), native markdown rendering, and no threads in a DM.
-# Single source of truth for the renderer's degradation decisions.
+# for steer-ack receipts), native markdown rendering, and allow-listed server
+# threads (represented by Discord as channels). Single source of truth for the
+# renderer's degradation decisions.
 DISCORD_CAPABILITIES = TransportCapabilities(
     streaming=True,
     edit=True,
     reactions=True,  # add_reaction — used for the steer-ack receipt
     files=False,
     rich_blocks=False,
-    threads=False,
+    threads=True,
     max_message_chars=DISCORD_CHUNK_LIMIT,
     max_buttons=5,  # per action row (max 5 rows -> 25 total)
     supports_proactive_send=True,
@@ -77,12 +78,16 @@ class DiscordTransport(MessagingTransport):
         client: DiscordClient,
         *,
         allowed_user_ids: Iterable[str] = (),
+        allowed_thread_ids: Iterable[str] = (),
         dispatch: DispatchFn | None = None,
     ) -> None:
         self._client = client
-        # Deny-by-default: freeze the allow-list as strings (Discord snowflake
-        # ids) so it can't mutate under an in-flight decision.
+        # Deny-by-default: freeze both allow-lists as snowflake strings so they
+        # cannot mutate under an in-flight authorization decision.
         self._allowed: frozenset[str] = frozenset(str(u) for u in allowed_user_ids)
+        self._allowed_threads: frozenset[str] = frozenset(
+            str(t) for t in allowed_thread_ids
+        )
         self._dispatch = dispatch
         self.capabilities = DISCORD_CAPABILITIES
 
@@ -160,28 +165,40 @@ class DiscordTransport(MessagingTransport):
         inbound = raw_envelope
         if not inbound.text:
             return
-        # DM-only, fail closed. A bot in a server receives guild messages;
-        # even from an allow-listed user, running a turn would reply in the
-        # guild channel, exposing tool output to non-authorized members. Deny
-        # anything carrying a guild_id and audit it (mirrors Telegram's
-        # private-chat-only rule).
+        thread_id: str | None = None
         if inbound.guild_id:
-            sel().log_api_access(
-                caller=inbound.user_id or "unknown",
-                operation="discord_transport.receive",
-                outcome="denied_guild_message",
-                source="discord",
-            )
-            return
+            # Discord's guild intents deliver every visible channel message.
+            # Unrelated chatter is expected background traffic, not a security
+            # event: discard it silently unless an approved user tried to use
+            # an unapproved thread. Messages in configured threads still pass
+            # through the normal user authorization audit below.
+            if inbound.channel_id not in self._allowed_threads:
+                if inbound.user_id in self._allowed:
+                    sel().log_api_access(
+                        caller=inbound.user_id,
+                        operation="discord_transport.receive",
+                        outcome="denied_unapproved_thread",
+                        source="discord",
+                    )
+                return
+            thread_id = inbound.channel_id
         msg = DiscordInboundMessage(
             channel_type="discord",
             user_id=inbound.user_id,
             conversation_id=inbound.channel_id,
             text=inbound.text,
-            thread_id=None,
+            thread_id=thread_id,
             message_id=inbound.message_id,
         )
         if not self.authorize(msg):
+            return
+        if thread_id and not await self._client.is_thread_channel(thread_id):
+            sel().log_api_access(
+                caller=inbound.user_id,
+                operation="discord_transport.receive",
+                outcome="denied_non_thread_channel",
+                source="discord",
+            )
             return
         if self._dispatch is not None:
             await self._dispatch(msg)

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -139,6 +139,7 @@ class DiscordDispatcher:
         ctx_builder: "ContextBuilder",
         cfg: "KiroCrewConfig",
         allowed_user_ids: set[str],
+        allowed_thread_ids: set[str] | None = None,
         agent: str | None = None,
         conv_log: "ConversationLog | None" = None,
         approval_mode: str = APPROVAL_INTERACTIVE,
@@ -147,6 +148,7 @@ class DiscordDispatcher:
         self.ctx_builder = ctx_builder
         self.cfg = cfg
         self._allowed = set(allowed_user_ids or ())
+        self._allowed_threads = set(allowed_thread_ids or ())
         self.agent = agent
         self.conv_log = conv_log
         self.approval_mode = approval_mode
@@ -172,6 +174,8 @@ class DiscordDispatcher:
         assert self.client is not None, "DiscordDispatcher.client must be set"
         user_id = msg.user_id
         channel_id = msg.conversation_id
+        thread_id = msg.thread_id or ""
+        scope_id = self._scope_id(user_id, thread_id)
         text = msg.text
 
         # Per-message mid-turn override (!queue/!steer) — see the Telegram
@@ -183,41 +187,41 @@ class DiscordDispatcher:
         # ── Command intercept (no LLM session needed) ──
         cmd = parse_command(text) if interpret_commands and override_mode is None else None
         if cmd == "new":
-            self._conv.bump_gen(user_id)
+            self._conv.bump_gen(scope_id)
             await self.client.send_message(channel_id, "✅ New conversation started.")
             return
         if cmd == "compact":
-            self._conv.clear_awaiting(user_id)
-            await self._handle_compact(user_id, channel_id)
+            self._conv.clear_awaiting(scope_id)
+            await self._handle_compact(user_id, channel_id, thread_id)
             return
         if cmd == "link":
-            await self._handle_link(user_id, channel_id)
+            await self._handle_link(user_id, channel_id, thread_id)
             return
         if cmd == "unlink":
-            await self._handle_unlink(user_id, channel_id)
+            await self._handle_unlink(user_id, channel_id, thread_id)
             return
         if cmd == "help":
             await self.client.send_message(channel_id, _HELP_TEXT)
             return
         if cmd == "stop":
-            await self._handle_stop(user_id, channel_id)
+            await self._handle_stop(user_id, channel_id, thread_id)
             return
 
         # ── Mid-turn concurrency: check the CURRENT-generation key BEFORE any
         # idle/daily rotation (see the Telegram dispatcher's rationale). ──
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(user_id, thread_id)
         if self.sessions.is_busy(session_key):
             await self._handle_busy(session_key, msg, text, override_mode)
             return
 
         self._conv.maybe_rotate(
-            user_id,
+            scope_id,
             time.time(),
             idle_minutes=self.cfg.messaging.idle_reset_minutes,
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
-        session_key = self._session_key(user_id)
-        chan_id = f"discord:{user_id}"
+        session_key = self._session_key(user_id, thread_id)
+        chan_id = f"discord:{channel_id}" if thread_id else f"discord:{user_id}"
         agent = self._resolve_agent()
 
         decider = (
@@ -296,7 +300,7 @@ class DiscordDispatcher:
                     exc_info=True,
                 )
             try:
-                await self._maybe_notice(channel_id, user_id, session_key, provider)
+                await self._maybe_notice(channel_id, scope_id, session_key, provider)
             except Exception:
                 logger.warning(
                     "Discord: maybe_notice failed session=%s",
@@ -337,7 +341,7 @@ class DiscordDispatcher:
 
         # Drain anything queued during the turn (queue_mode == "queue").
         if drain:
-            await self._drain_queue(session_key, user_id, channel_id)
+            await self._drain_queue(session_key, user_id, channel_id, thread_id)
 
     async def _handle_busy(
         self,
@@ -381,7 +385,9 @@ class DiscordDispatcher:
         if not await self._enqueue_with_receipt(session_key, channel_id, text):
             await self.handle_message(msg)
 
-    async def _drain_queue(self, session_key: str, user_id: str, channel_id: str) -> None:
+    async def _drain_queue(
+        self, session_key: str, user_id: str, channel_id: str, thread_id: str = ""
+    ) -> None:
         """Collapse every message queued during the just-finished turn into ONE
         combined turn (order preserved). See the Telegram dispatcher for the
         lock/ordering rationale."""
@@ -417,6 +423,7 @@ class DiscordDispatcher:
                 user_id=user_id,
                 conversation_id=channel_id,
                 text=combined,
+                thread_id=thread_id or None,
             ),
             drain=False,
             interpret_commands=False,
@@ -482,10 +489,12 @@ class DiscordDispatcher:
         except Exception:
             logger.debug("discord: queue receipt cancel-finalize failed", exc_info=True)
 
-    async def _handle_stop(self, user_id: str, channel_id: str) -> None:
+    async def _handle_stop(
+        self, user_id: str, channel_id: str, thread_id: str = ""
+    ) -> None:
         """Hard cancel: abort the in-flight turn and clear everything."""
         assert self.client is not None
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(user_id, thread_id)
         cancelled_turn = False
         if self.sessions.is_busy(session_key):
             provider = self.sessions.get_provider(session_key)
@@ -516,8 +525,13 @@ class DiscordDispatcher:
         # Auth first (deny-by-default short-circuit).
         if not self._authorized(itx.user_id):
             return
-        # DM-only (mirrors receive()): deny guild interactions defensively.
-        if itx.guild_id:
+        # Guild buttons are accepted only in an allow-listed channel that
+        # Discord confirms is a thread. This mirrors transport.receive().
+        thread_id = itx.channel_id if itx.guild_id else ""
+        if itx.guild_id and (
+            thread_id not in self._allowed_threads
+            or not await self.client.is_thread_channel(thread_id)
+        ):
             return
         # Ack to dismiss Discord's "interaction failed" state.
         await self.client.ack_component_interaction(itx.interaction_id, itx.interaction_token)
@@ -532,7 +546,9 @@ class DiscordDispatcher:
             head, _, flag = body.rpartition(":")
             rid, _, nonce = head.rpartition(":")
             approved = flag == "1"
-            key = DiscordApprovalDecider.key(self._session_key(itx.user_id), rid)
+            key = DiscordApprovalDecider.key(
+                self._session_key(itx.user_id, thread_id), rid
+            )
             resolved = DiscordApprovalDecider.resolve_global(key, approved, nonce=nonce)
             if resolved:
                 verdict = "✅ Approved" if approved else "🚫 Denied"
@@ -563,6 +579,7 @@ class DiscordDispatcher:
                 user_id=itx.user_id,
                 conversation_id=itx.channel_id,
                 text=choice_text,
+                thread_id=thread_id or None,
             )
             await self.handle_message(synthetic)
 
@@ -590,17 +607,34 @@ class DiscordDispatcher:
     def _resolve_agent(self) -> str:
         return self.agent or self.cfg.agent.default_agent or _DEFAULT_KIROCREW_AGENT
 
-    def _session_key(self, user_id: str) -> str:
-        gen = self._conv.current_gen(user_id)
+    @staticmethod
+    def _scope_id(user_id: str, thread_id: str = "") -> str:
+        return f"thread:{thread_id}" if thread_id else f"user:{user_id}"
+
+    def _session_key(self, user_id: str, thread_id: str = "") -> str:
+        scope_id = self._scope_id(user_id, thread_id)
+        gen = self._conv.current_gen(scope_id)
         return build_dm_session_key(
             "discord",
             self._resolve_agent(),
-            user_id,
+            thread_id or user_id,
             gen=gen,
-            dm_scope=self.cfg.messaging.dm_scope,
+            dm_scope=("per-channel-peer" if thread_id else self.cfg.messaging.dm_scope),
+            chat_type=("group" if thread_id else "direct"),
         )
 
-    def _seed_gen(self, user_id: str) -> int:
+    def _seed_gen(self, scope_id: str) -> int:
+        if scope_id.startswith("thread:"):
+            thread_id = scope_id.removeprefix("thread:")
+            bucket = build_dm_session_key(
+                "discord",
+                self._resolve_agent(),
+                thread_id,
+                dm_scope="per-channel-peer",
+                chat_type="group",
+            )
+            return self.sessions.max_generation(bucket)
+        user_id = scope_id.removeprefix("user:")
         return seed_generation(
             self.sessions,
             channel="discord",
@@ -609,10 +643,12 @@ class DiscordDispatcher:
             dm_scope=self.cfg.messaging.dm_scope,
         )
 
-    async def _handle_link(self, user_id: str, channel_id: str) -> None:
+    async def _handle_link(
+        self, user_id: str, channel_id: str, thread_id: str = ""
+    ) -> None:
         """Mirror this conversation's dashboard tab back to Discord."""
         assert self.client is not None
-        key = dashboard_mirror_key(self._session_key(user_id))
+        key = dashboard_mirror_key(self._session_key(user_id, thread_id))
         self.sessions.set_mirror_link(key, ChannelLink("discord", channel_id=channel_id))
         await self.client.send_message(
             channel_id,
@@ -620,9 +656,11 @@ class DiscordDispatcher:
             "also show up here. Send `!unlink` to stop.",
         )
 
-    async def _handle_unlink(self, user_id: str, channel_id: str) -> None:
+    async def _handle_unlink(
+        self, user_id: str, channel_id: str, thread_id: str = ""
+    ) -> None:
         assert self.client is not None
-        key = dashboard_mirror_key(self._session_key(user_id))
+        key = dashboard_mirror_key(self._session_key(user_id, thread_id))
         was_linked = self.sessions.clear_mirror_link(key)
         await self.client.send_message(
             channel_id,
@@ -643,13 +681,13 @@ class DiscordDispatcher:
             self.conv_log.set_title(session_key, title)
 
     async def _maybe_notice(
-        self, channel_id: str, user_id: str, session_key: str, provider: Any
+        self, channel_id: str, scope_id: str, session_key: str, provider: Any
     ) -> None:
         """Soft-threshold context warning as a SEPARATE message (not persisted)."""
         pct = self.sessions.check_context_usage(session_key, provider)
         soft_pct = self.cfg.discord.soft_threshold_pct
-        if pct >= soft_pct and not self._conv.is_awaiting(user_id):
-            self._conv.set_awaiting(user_id)
+        if pct >= soft_pct and not self._conv.is_awaiting(scope_id):
+            self._conv.set_awaiting(scope_id)
             assert self.client is not None
             await self.client.send_message(
                 channel_id,
@@ -657,12 +695,12 @@ class DiscordDispatcher:
                 "`!new` to start fresh.",
             )
 
-    async def _handle_compact(self, user_id: str, channel_id: str) -> None:
-        """In-place ACP ``/compact`` on the user's session (mirrors Telegram —
-        including the atomic ``try_acquire`` that prevents a normal turn from
-        interleaving JSON-RPC with the compaction on one stdio channel)."""
+    async def _handle_compact(
+        self, user_id: str, channel_id: str, thread_id: str = ""
+    ) -> None:
+        """In-place ACP ``/compact`` on the conversation's session."""
         assert self.client is not None
-        session_key = self._session_key(user_id)
+        session_key = self._session_key(user_id, thread_id)
         if not await self.sessions.try_acquire(session_key):
             if self.sessions.has_session(session_key):
                 await self.client.send_message(

--- a/src/kiro_crew/docs/discord-integration.md
+++ b/src/kiro_crew/docs/discord-integration.md
@@ -1,71 +1,167 @@
 # Discord Integration
 
-Talk to your agent from Discord DMs. The channel connects outbound over
-Discord's Gateway WebSocket, so it works behind NAT and firewalls with no
-webhook or public address.
+Talk to your agent from Discord DMs and explicitly approved server threads.
+The channel connects outbound over Discord's Gateway WebSocket, so it works
+behind NAT and firewalls with no webhook, public address, or inbound port.
+
+## How the bot behaves
+
+| Context | Behavior |
+|---------|----------|
+| **DMs** | Responds to messages from an allow-listed user. No `@mention` needed. |
+| **Approved server threads** | Responds when both the sender's user ID and the exact thread ID are allow-listed. Everyone who can view the thread can read replies and tool output. |
+| **Normal server channels** | Always ignored, even if someone accidentally enters the channel ID in the thread allow-list. Kiro Crew verifies the Discord channel type before running a turn. |
+| **Unknown users or threads** | Denied. Security-relevant attempts are audited; unrelated guild chatter is discarded silently. Empty user allow-list denies everything; empty thread allow-list means DMs only. |
+
+Discord represents threads as specialized guild channels with their own channel
+IDs. Forum posts are threads too. Group DMs are different and are not supported
+by Discord's bot API.
 
 ## Setup
 
-1. **Create the app.** Open the [Discord Developer Portal](https://discord.com/developers/applications),
-   click **New Application**, and name it.
-2. **Get the bot token.** On the app's **Bot** page, click **Reset Token** and
-   copy it. No privileged intents are needed: the bot is DM-only and DM
-   content is always delivered.
-3. **Install the bot.** On **Installation**, copy the install link (or use
-   OAuth2 → URL Generator with the `bot` scope) and open it to add the bot to
-   any server you share. You can then DM it directly.
-4. **Find your user ID.** In Discord, enable **Settings → Advanced →
-   Developer Mode**, then right-click your name and choose **Copy User ID**.
-5. **Configure KiroCrew.** In the dashboard, open **Settings → Discord**:
-   enable the channel, paste the bot token, and add your user ID to the
-   allowed list. Or edit config directly:
+### 1. Create the app
 
-   ```bash
-   # ~/.kirocrew/.env
-   DISCORD_BOT_TOKEN=<your bot token>
-   ```
+Open the [Discord Developer Portal](https://discord.com/developers/applications),
+click **New Application**, and name it.
 
-   ```json
-   // ~/.kirocrew/config.json
-   {
-     "discord": {
-       "enabled": true,
-       "allowed_user_ids": ["123456789012345678"]
-     }
-   }
-   ```
+### 2. Get the bot token and choose intents
 
-6. **Restart the gateway** (`kirocrew restart`). The Settings page shows a
-   Connected badge once the channel is up.
+On the app's **Bot** page, click **Reset Token** and copy it. Discord shows the
+token only once; treat it like a password.
+
+- **DMs only:** leave Presence Intent, Server Members Intent, and Message Content
+  Intent **OFF**. DM content is always delivered.
+- **Server threads:** enable **Message Content Intent**. Discord requires this
+  privileged intent to deliver guild/thread message text. Presence and Server
+  Members intents remain unnecessary.
+
+Kiro Crew requests the guild/message-content Gateway intents only when at least
+one `allowed_thread_ids` entry is configured, so DM-only installs keep the
+narrower intent set.
+
+### 3. Install the bot
+
+On **Installation**, enable **Guild Install** and select the **`bot`** OAuth
+scope. `applications.commands` is not needed because Kiro Crew uses text
+commands such as `!help`, not Discord slash commands.
+
+For DMs only, no guild permissions are required. For server threads, grant:
+
+- **View Channel**
+- **Read Message History**
+- **Send Messages in Threads**
+- **Add Reactions** (used for mid-turn steer receipts)
+
+A manual thread-capable install URL is:
+
+```text
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot&permissions=274877973568
+```
+
+This permission set does not grant **Send Messages** in normal server channels.
+For a private thread, explicitly add the bot to that thread if Discord does not
+already show it as a member.
+
+### 4. Find the user and thread IDs
+
+Enable **Discord Settings → Advanced → Developer Mode**.
+
+- Right-click your own name → **Copy User ID**.
+- Right-click the thread → **Copy Channel ID**. Use the thread's own ID, not its
+  parent channel ID.
+
+Both values are long numeric snowflakes, for example `284102345871466496`.
+
+### 5. Configure Kiro Crew
+
+In **Settings → Discord**, enable the channel, paste the bot token, add every
+user who may run the agent, and optionally add approved server thread IDs.
+
+Or edit the local configuration directly:
+
+```bash
+# ~/.kirocrew/.env
+DISCORD_BOT_TOKEN=<your bot token>
+```
+
+```json
+// ~/.kirocrew/config.json
+{
+  "discord": {
+    "enabled": true,
+    "allowed_user_ids": ["123456789012345678"],
+    "allowed_thread_ids": ["234567890123456789"]
+  }
+}
+```
+
+Omit `allowed_thread_ids` or leave it empty for DMs only.
+
+### 6. Restart the gateway
+
+```bash
+kirocrew restart
+```
+
+Discord settings and Gateway intents are read at startup. The Settings page
+shows **Connected** once Discord accepts the IDENTIFY handshake and sends READY.
+If Discord closes with code 4014, enable Message Content Intent in the Developer
+Portal or clear the thread allow-list and restart in DM-only mode.
+
+### 7. Test both paths
+
+- **DM:** click the bot's name → **Message**, then send `!help`.
+- **Thread:** open an approved thread and send `!help`. No `@mention` is needed.
+- **Negative check:** send `!help` in the parent channel; the bot must remain
+  silent.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Enabled, but no Discord activity | Token missing or gateway not restarted | Set `DISCORD_BOT_TOKEN`, then `kirocrew restart` |
+| Gateway closes with 4004 | Bad or reset token | Reset the token, update `.env`, restart |
+| Gateway closes with 4014 after adding a thread | Message Content Intent is disabled | Enable it on the Bot page, then restart |
+| DMs are ignored | User ID is missing/wrong | Add the numeric user ID; inspect `kirocrew security events` |
+| Thread is ignored but DMs work | Thread ID missing/wrong, bot cannot view it, or Message Content Intent is off | Copy the thread's Channel ID, check permissions/membership, enable the intent, restart |
+| Parent channel is ignored | Expected behavior | Use an approved thread; normal channels are always disabled |
+| Bot can read but cannot reply in a thread | Missing guild permission or private-thread membership | Grant View Channel, Read Message History, Send Messages in Threads; add the bot to private threads |
+| Logs are silent on successful connection | `agent.log_level` is `WARNING` | Trust the Connected badge or lower the log level |
 
 ## Security model
 
-- **Deny-by-default allow-list.** Anyone sharing a server with the bot can DM
-  it, so an empty `allowed_user_ids` rejects every message (fail closed).
-  Every denial is recorded in the security event log.
-- **DM-only.** Messages in server channels are ignored even from allowed
-  users, so tool output can never land in a shared channel.
+- **Two allow-lists for threads.** A server-thread turn runs only when both the
+  sender and exact thread are approved. An empty user list denies all traffic;
+  an empty thread list preserves DM-only behavior.
+- **Channel-type verification.** Kiro Crew resolves an approved guild channel
+  through Discord and accepts only announcement, public, or private thread
+  types. Accidentally entering a normal channel ID does not enable it.
+- **Global intent scope.** Enabling any server thread turns on Discord's global
+  Message Content intent. Discord then delivers content from every server
+  channel the bot can see; Kiro Crew immediately discards traffic outside
+  approved threads and does not audit routine background chatter.
+- **Shared output warning.** Every member who can view an approved thread can
+  read agent replies, tool output, and interactive approvals. Approve only
+  threads whose membership and history are appropriate for that disclosure.
+- **Conversation scope.** Approved participants in one thread share that
+  thread's agent session and context. DMs remain isolated per user.
 - **Token handling.** The token lives in `~/.kirocrew/.env` (mode 0600), is
-  masked in the settings UI, is excluded from agent subprocess environments,
-  and config writes are accepted only from the machine running the gateway.
+  masked in Settings, excluded from agent subprocess environments, and can be
+  changed only from the machine running the gateway.
 
 ## Usage
 
-Send a DM to chat. Replies stream in and long answers split across messages.
+Send a DM or message an approved thread. Replies stream in place and long
+answers split across messages.
 
 | Command | Effect |
 |---------|--------|
-| `!new` | Start a fresh conversation |
-| `!compact` | Compress context when it gets long |
+| `!new` | Start a fresh conversation (shared for the current thread) |
+| `!compact` | Compress the current conversation context |
 | `!link` / `!unlink` | Mirror this conversation's dashboard tab here |
-| `!stop` | Stop the current reply and clear the queue |
+| `!stop` | Stop the current reply and clear its queue |
 | `!help` | Show commands |
 
 While a reply is running, prefix a message with `!steer` to fold it into the
-running turn, or `!queue` to answer it after. A plain mid-turn message follows
-the global `messaging.queue_mode` setting. Telegram-style `/` prefixes are
-also accepted, though Discord's own client may intercept bare `/` as a
-slash-command.
-
-`[OPTIONS:]` choices render as buttons. Tool approvals appear as
-Approve/Deny buttons when the approval mode is interactive.
+running turn or `!queue` to answer it afterward. `[OPTIONS:]` choices render as
+buttons, and interactive tool approvals render as Approve/Deny buttons.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -559,6 +559,9 @@ class GatewayOrchestrator:
         self._discord_bot_token = creds.get(CRED_DISCORD_BOT_TOKEN, "") or cfg.discord.bot_token
         self._discord_enabled = bool(cfg.discord.enabled and self._discord_bot_token)
         self._discord_allowed_user_ids: list[str] = [str(u) for u in cfg.discord.allowed_user_ids]
+        self._discord_allowed_thread_ids: list[str] = [
+            str(t) for t in cfg.discord.allowed_thread_ids
+        ]
         self._discord_client: "DiscordClient | None" = None
         # Webex — the WEBEX_BOT_TOKEN credential (env/.env) overrides
         # cfg.webex.bot_token; all other settings come from the typed

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -21,7 +21,11 @@ from kiro_crew.acp.types import (
     EVENT_TEXT_CHUNK,
 )
 from kiro_crew.discord.client import (
+    _INTENT_DIRECT_MESSAGES,
+    _INTENT_GUILD_MESSAGES,
+    _INTENT_MESSAGE_CONTENT,
     DISCORD_CHUNK_LIMIT,
+    DiscordClient,
     DiscordInbound,
     DiscordInteraction,
     _find_button_label,
@@ -64,7 +68,11 @@ class FakeClient:
         self.component_edits: list[tuple[str, Any]] = []
         self.acked: list[str] = []
         self.reactions: list[tuple[str, str]] = []
+        self.thread_channels: set[str] = set()
         self._mid = 100
+
+    async def is_thread_channel(self, channel_id: str) -> bool:
+        return channel_id in self.thread_channels
 
     async def send_typing(self, channel_id: str) -> None:
         return None
@@ -274,7 +282,11 @@ def _cfg(soft: int = 80, default_agent: str = "") -> Any:
 
 
 def _dispatcher(
-    allowed: set[str], *, raise_on_get: bool = False, default_agent: str = ""
+    allowed: set[str],
+    *,
+    allowed_threads: set[str] | None = None,
+    raise_on_get: bool = False,
+    default_agent: str = "",
 ) -> tuple[DiscordDispatcher, FakeClient, FakeSessions]:
     sess = FakeSessions(raise_on_get=raise_on_get)
     d = DiscordDispatcher(
@@ -282,6 +294,7 @@ def _dispatcher(
         ctx_builder=FakeCtx(),  # type: ignore[arg-type]
         cfg=_cfg(default_agent=default_agent),
         allowed_user_ids=allowed,
+        allowed_thread_ids=allowed_threads,
         agent=None,
         conv_log=None,
     )
@@ -437,6 +450,36 @@ class TestFindButtonLabel:
         assert _find_button_label(components, "opt:9") == ""
 
 
+# ── client.py Gateway intents ────────────────────────────────────────────
+
+
+class _FakeWs:
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, Any]] = []
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.payloads.append(payload)
+
+
+class TestGatewayIntents:
+    @pytest.mark.asyncio
+    async def test_dm_only_requests_no_privileged_intent(self) -> None:
+        client = DiscordClient(token="test", enable_guild_threads=False)
+        ws = _FakeWs()
+        await client._identify(ws)
+        assert ws.payloads[0]["d"]["intents"] == _INTENT_DIRECT_MESSAGES
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_requests_guild_messages_and_content(self) -> None:
+        client = DiscordClient(token="test", enable_guild_threads=True)
+        ws = _FakeWs()
+        await client._identify(ws)
+        intents = ws.payloads[0]["d"]["intents"]
+        assert intents & _INTENT_DIRECT_MESSAGES
+        assert intents & _INTENT_GUILD_MESSAGES
+        assert intents & _INTENT_MESSAGE_CONTENT
+
+
 # ── transport.py ─────────────────────────────────────────────────────────
 
 
@@ -466,7 +509,7 @@ class TestTransportAuth:
         assert DISCORD_CAPABILITIES.streaming is True
         assert DISCORD_CAPABILITIES.edit is True
         assert DISCORD_CAPABILITIES.reactions is True
-        assert DISCORD_CAPABILITIES.threads is False
+        assert DISCORD_CAPABILITIES.threads is True
 
 
 class TestPublicInjectionSurface:
@@ -507,22 +550,27 @@ class TestPublicInjectionSurface:
 
 
 class TestTransportReceive:
-    def _transport(self, allowed: list[str]) -> tuple[DiscordTransport, list[InboundMessage]]:
+    def _transport(
+        self, allowed: list[str], allowed_threads: list[str] | None = None
+    ) -> tuple[DiscordTransport, list[InboundMessage], FakeClient]:
         dispatched: list[InboundMessage] = []
 
         async def _dispatch(m: InboundMessage) -> None:
             dispatched.append(m)
 
+        client = FakeClient()
+        client.thread_channels.update(allowed_threads or [])
         t = DiscordTransport(
-            FakeClient(),  # type: ignore[arg-type]
+            client,  # type: ignore[arg-type]
             allowed_user_ids=allowed,
+            allowed_thread_ids=allowed_threads or [],
             dispatch=_dispatch,
         )
-        return t, dispatched
+        return t, dispatched, client
 
     @pytest.mark.asyncio
     async def test_authorized_dm_dispatches(self) -> None:
-        t, dispatched = self._transport(["u1"])
+        t, dispatched, _ = self._transport(["u1"])
         await t.receive(
             DiscordInbound(channel_id="c1", user_id="u1", text="hello", message_id="m1")
         )
@@ -533,32 +581,80 @@ class TestTransportReceive:
         assert msg.message_id == "m1"
 
     @pytest.mark.asyncio
-    async def test_guild_message_denied_even_for_allowed_user(self) -> None:
-        t, dispatched = self._transport(["u1"])
+    async def test_allowed_user_in_unapproved_thread_is_audited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            "kiro_crew.discord.transport.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kwargs: events.append(kwargs)),
+        )
+        t, dispatched, _ = self._transport(["u1"], ["t1"])
         await t.receive(DiscordInbound(channel_id="c1", user_id="u1", text="hello", guild_id="g1"))
+        assert dispatched == []
+        assert [event["outcome"] for event in events] == ["denied_unapproved_thread"]
+
+    @pytest.mark.asyncio
+    async def test_unrelated_guild_chatter_is_dropped_without_audit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            "kiro_crew.discord.transport.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kwargs: events.append(kwargs)),
+        )
+        t, dispatched, _ = self._transport(["u1"], ["t1"])
+        await t.receive(DiscordInbound(channel_id="c1", user_id="u2", text="hello", guild_id="g1"))
+        assert dispatched == []
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_thread_dispatches_for_allowed_user(self) -> None:
+        t, dispatched, _ = self._transport(["u1"], ["t1"])
+        await t.receive(
+            DiscordInbound(channel_id="t1", user_id="u1", text="hello", guild_id="g1")
+        )
+        assert len(dispatched) == 1
+        assert dispatched[0].thread_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_normal_channel_denied_even_if_id_is_allowlisted(self) -> None:
+        t, dispatched, client = self._transport(["u1"], ["c1"])
+        client.thread_channels.clear()
+        await t.receive(
+            DiscordInbound(channel_id="c1", user_id="u1", text="hello", guild_id="g1")
+        )
+        assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_thread_denies_unapproved_user(self) -> None:
+        t, dispatched, _ = self._transport(["u1"], ["t1"])
+        await t.receive(
+            DiscordInbound(channel_id="t1", user_id="u2", text="hello", guild_id="g1")
+        )
         assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_unauthorized_user_dropped(self) -> None:
-        t, dispatched = self._transport(["u1"])
+        t, dispatched, _ = self._transport(["u1"])
         await t.receive(DiscordInbound(channel_id="c1", user_id="u2", text="hello"))
         assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_empty_text_dropped(self) -> None:
-        t, dispatched = self._transport(["u1"])
+        t, dispatched, _ = self._transport(["u1"])
         await t.receive(DiscordInbound(channel_id="c1", user_id="u1", text=""))
         assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_non_inbound_envelope_ignored(self) -> None:
-        t, dispatched = self._transport(["u1"])
+        t, dispatched, _ = self._transport(["u1"])
         await t.receive({"random": "dict"})
         assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_resolve_conversation_creates_dm_channel(self) -> None:
-        t, _ = self._transport(["u1"])
+        t, _, _ = self._transport(["u1"])
         assert await t.resolve_conversation("u1") == "dm-u1"
 
 
@@ -828,6 +924,11 @@ class TestDispatcher:
         await d.handle_message(self._msg("hi"))
         assert sess.last_agent == "custom"
 
+    def test_thread_session_is_shared_but_dms_remain_per_user(self) -> None:
+        d, _, _ = _dispatcher({"u1", "u2"}, allowed_threads={"t1"})
+        assert d._session_key("u1", "t1") == d._session_key("u2", "t1")
+        assert d._session_key("u1") != d._session_key("u2")
+
 
 class TestInteractions:
     def _itx(self, custom_id: str, label: str = "", guild: str = "") -> DiscordInteraction:
@@ -853,6 +954,14 @@ class TestInteractions:
         d, cli, _ = _dispatcher({"u1"})
         await d.on_interaction(self._itx("a:r1:aabbccdd:1", guild="g1"))
         assert cli.acked == []
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_thread_interaction_is_acked(self) -> None:
+        d, cli, _ = _dispatcher({"u1"}, allowed_threads={"c1"})
+        cli.thread_channels.add("c1")
+        await d.on_interaction(self._itx("a:r9:aabbccdd:1", guild="g1"))
+        assert cli.acked == ["i1"]
+        assert any("expired" in text for _, text, _ in cli.edits)
 
     @pytest.mark.asyncio
     async def test_approval_resolves_pending_future(self) -> None:

--- a/test/test_discord_config_handlers.py
+++ b/test/test_discord_config_handlers.py
@@ -93,6 +93,7 @@ def test_save_persists_token_and_config(tmp_path: Path, monkeypatch) -> None:
             "bot_token": VALID_TOKEN,
             "enabled": True,
             "allowed_user_ids": ["123456789012345678", "987654321098765432"],
+            "allowed_thread_ids": ["234567890123456789"],
             "soft_threshold_pct": 75,
         },
     )
@@ -107,6 +108,10 @@ def test_save_persists_token_and_config(tmp_path: Path, monkeypatch) -> None:
     assert cfg["discord"]["allowed_user_ids"] == [
         "123456789012345678",
         "987654321098765432",
+    ]
+    assert cfg["discord"]["allowed_thread_ids"] == ["234567890123456789"]
+    assert loader.KiroCrewConfig.load().discord.allowed_thread_ids == [
+        "234567890123456789"
     ]
     assert cfg["discord"]["soft_threshold_pct"] == 75
 
@@ -176,6 +181,19 @@ def test_save_rejects_non_numeric_user_ids(tmp_path: Path, monkeypatch) -> None:
     assert "numeric" in body["error"]
 
 
+def test_save_rejects_non_numeric_thread_ids(tmp_path: Path, monkeypatch) -> None:
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    (status_body, _) = _client_put(
+        mod, monkeypatch, tmp_path, {"allowed_thread_ids": ["general"]}
+    )
+    status, body = status_body
+    assert status == 400
+    assert "thread ID" in body["error"]
+    assert "numeric" in body["error"]
+
+
 def test_clear_flag_must_be_strict_boolean(tmp_path: Path, monkeypatch) -> None:
     """Truthy non-bool clear flags (e.g. "false", 1) must not delete the token."""
     import kiro_crew.dashboard.handlers.messaging as mod
@@ -234,7 +252,8 @@ def test_get_masks_token_and_reports_state(tmp_path: Path, monkeypatch) -> None:
     env.write_text(f"DISCORD_BOT_TOKEN={VALID_TOKEN}\n", encoding="utf-8")
     cfg = tmp_path / "config.json"
     cfg.write_text(
-        '{"discord": {"enabled": true, "allowed_user_ids": ["42"]}}',
+        '{"discord": {"enabled": true, "allowed_user_ids": ["42"], '
+        '"allowed_thread_ids": ["99"]}}',
         encoding="utf-8",
     )
     monkeypatch.setattr(loader, "env_path", lambda: env)
@@ -257,3 +276,4 @@ def test_get_masks_token_and_reports_state(tmp_path: Path, monkeypatch) -> None:
     assert body["connected"] is False
     assert body["enabled"] is True
     assert body["allowed_user_ids"] == ["42"]
+    assert body["allowed_thread_ids"] == ["99"]

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -83,6 +83,7 @@ export interface DiscordConfigData {
   bot_token_preview: string
   enabled: boolean
   allowed_user_ids: string[]
+  allowed_thread_ids: string[]
   soft_threshold_pct: number
 }
 
@@ -105,6 +106,7 @@ export interface DiscordConfigSave {
   bot_token_clear: boolean
   enabled: boolean
   allowed_user_ids: string[]
+  allowed_thread_ids: string[]
   soft_threshold_pct: number
 }
 

--- a/website/src/pages/settings/BotChannelPanel.tsx
+++ b/website/src/pages/settings/BotChannelPanel.tsx
@@ -16,6 +16,7 @@ export interface BotChannelConfigData {
   bot_token_preview: string
   enabled: boolean
   allowed_user_ids: string[]
+  allowed_thread_ids?: string[]
   soft_threshold_pct: number
 }
 
@@ -25,6 +26,7 @@ export interface BotChannelConfigSave {
   bot_token_clear: boolean
   enabled: boolean
   allowed_user_ids: string[]
+  allowed_thread_ids?: string[]
   soft_threshold_pct: number
 }
 
@@ -56,6 +58,14 @@ export interface BotChannelSpec {
   thresholdDescription: string
   /** Fail-closed hint shown when enabled + token set but allowlist empty. */
   emptyAllowlistHint: string
+  /** Optional shared-thread allow-list rendered below user access controls. */
+  threadAllowlist?: {
+    label: string
+    description: string
+    placeholder: string
+    help: ReactNode
+    warning: ReactNode
+  }
   /** API calls. */
   getConfig: () => Promise<BotChannelConfigData>
   saveConfig: (body: Partial<BotChannelConfigSave>) => Promise<{ ok: boolean; restart_required: boolean; verify_warning: string }>
@@ -66,6 +76,7 @@ export interface BotChannelSpec {
 type Draft = {
   enabled: boolean
   allowed_user_ids: string[]
+  allowed_thread_ids: string[]
   soft_threshold_pct: string
 }
 
@@ -73,6 +84,7 @@ function draftFrom(c: BotChannelConfigData): Draft {
   return {
     enabled: c.enabled,
     allowed_user_ids: [...c.allowed_user_ids],
+    allowed_thread_ids: [...(c.allowed_thread_ids ?? [])],
     soft_threshold_pct: String(c.soft_threshold_pct),
   }
 }
@@ -190,6 +202,7 @@ export function BotChannelPanel({ spec }: { spec: BotChannelSpec }) {
       allowed_user_ids: draft.allowed_user_ids,
       soft_threshold_pct: pct,
     }
+    if (spec.threadAllowlist) payload.allowed_thread_ids = draft.allowed_thread_ids
     if (botClear) payload.bot_token_clear = true
     else if (botToken.trim()) payload.bot_token = botToken.trim()
     saveMut.mutate(payload)
@@ -293,6 +306,26 @@ export function BotChannelPanel({ spec }: { spec: BotChannelSpec }) {
             validate={v => /^\d+$/.test(v)}
             readOnly={ro}
           />
+          {spec.threadAllowlist && (
+            <div className="border-t border-border mt-4 pt-4">
+              <TagListEditor
+                label={spec.threadAllowlist.label}
+                description={spec.threadAllowlist.description}
+                values={draft.allowed_thread_ids}
+                placeholder={spec.threadAllowlist.placeholder}
+                onChange={v => upd({ allowed_thread_ids: v })}
+                validate={v => /^\d+$/.test(v)}
+                readOnly={ro}
+              />
+              <p className="text-[12px] text-muted mt-2 mb-0">
+                {spec.threadAllowlist.help}
+              </p>
+              <p className="text-[12px] text-warn mt-2 mb-0 flex items-start gap-1.5">
+                <AlertTriangle size={13} className="flex-none mt-0.5" />
+                <span>{spec.threadAllowlist.warning}</span>
+              </p>
+            </div>
+          )}
         </SettingsCard>
       </SettingsSection>
 

--- a/website/src/pages/settings/DiscordPanel.tsx
+++ b/website/src/pages/settings/DiscordPanel.tsx
@@ -9,31 +9,51 @@ const DISCORD_SPEC: BotChannelSpec = {
   queryKey: 'discord-config',
   logo: <DiscordIcon size={20} />,
   description:
-    'Talk to your agent from Discord DMs over the Gateway WebSocket (no webhook or ' +
-    'public address needed). Add allowed user IDs so the bot can respond.',
+    'Talk to your agent from Discord DMs or explicitly approved server threads over the ' +
+    'Gateway WebSocket. Normal server channels are always ignored.',
   host: 'discord.com',
   setupGuide: SETUP_GUIDE,
   guideBody: (
     <>
-      Create an app in the Discord Developer Portal, open the{' '}
-      <span className="font-mono">Bot</span> page, and click{' '}
-      <span className="font-mono">Reset Token</span> — paste the token below.
-      No privileged intents are needed (the bot is DM-only). Invite the bot to a
-      server you share, or use its install link. To find your user ID, enable
-      Developer Mode in Discord settings, then right-click your name and choose{' '}
-      <span className="font-mono">Copy User ID</span>.
+      Create an app in the Discord Developer Portal, then copy the token from the{' '}
+      <span className="font-mono">Bot</span> page. For DMs only, leave privileged intents
+      off. For server threads, enable <span className="font-mono">Message Content Intent</span>{' '}
+      and install with the <span className="font-mono">bot</span> scope plus View Channel,
+      Read Message History, and Send Messages in Threads. Enable Discord Developer Mode,
+      then right-click your name to copy your numeric user ID.
     </>
   ),
   guideLink: { label: 'Open Developer Portal', href: 'https://discord.com/developers/applications' },
   tokenDescription: "From the Developer Portal's Bot page (Reset Token to view it once).",
   tokenPlaceholder: 'Paste Discord bot token',
   allowlistDescription:
-    'Discord user IDs permitted to DM the bot. Empty = deny all (fail closed): ' +
-    'anyone sharing a server with the bot can DM it.',
+    'Discord user IDs permitted to run the agent in DMs or approved threads. ' +
+    'Empty = deny all (fail closed).',
   allowlistPlaceholder: '123456789012345678',
   thresholdDescription: 'Prompt to !compact or !new when the session context passes this percentage.',
   emptyAllowlistHint:
     'No allowed user IDs: the bot rejects every message (fail closed). Add your Discord user ID below.',
+  threadAllowlist: {
+    label: 'Allowed server thread IDs',
+    description:
+      'Optional. Approved users may run the agent only in these exact Discord threads. ' +
+      'Empty = DMs only.',
+    placeholder: '123456789012345678',
+    help: (
+      <>
+        With Developer Mode on, right-click the thread →{' '}
+        <span className="font-mono">Copy Channel ID</span>. Use the thread's ID, not its
+        parent channel ID.
+      </>
+    ),
+    warning: (
+      <>
+        Thread mode enables Discord's global Message Content intent. Discord delivers content
+        from every server channel the bot can see; Kiro Crew discards traffic outside approved
+        threads. Everyone who can view an approved thread can read agent replies and tool output.
+      </>
+    ),
+  },
   getConfig: api.getDiscordConfig,
   saveConfig: api.saveDiscordConfig,
 }

--- a/website/src/test/DiscordPanel.test.tsx
+++ b/website/src/test/DiscordPanel.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { DiscordPanel } from '../pages/settings/DiscordPanel'
+
+const mocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    getDiscordConfig: mocks.getConfig,
+    saveDiscordConfig: mocks.saveConfig,
+  },
+}))
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <DiscordPanel />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('DiscordPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getConfig.mockResolvedValue({
+      connected: false,
+      connect_error: '',
+      configured: true,
+      read_only: false,
+      bot_token_set: true,
+      bot_token_preview: 'abc…xyz',
+      enabled: true,
+      allowed_user_ids: ['111111111111111111'],
+      allowed_thread_ids: [],
+      soft_threshold_pct: 80,
+    })
+    mocks.saveConfig.mockResolvedValue({
+      ok: true,
+      restart_required: true,
+      verify_warning: '',
+    })
+  })
+
+  it('renders and saves the optional thread allow-list with its disclosure', async () => {
+    renderPanel()
+
+    expect(await screen.findByText('Allowed server thread IDs')).toBeInTheDocument()
+    expect(screen.getByText(/Discord delivers content from every server channel/)).toBeInTheDocument()
+
+    const idInputs = screen.getAllByPlaceholderText('123456789012345678')
+    fireEvent.change(idInputs[1], { target: { value: '222222222222222222' } })
+    fireEvent.click(screen.getAllByRole('button', { name: /add/i })[1])
+    fireEvent.click(screen.getByRole('button', { name: 'Save Discord settings' }))
+
+    await waitFor(() => {
+      expect(mocks.saveConfig).toHaveBeenCalledWith(expect.objectContaining({
+        allowed_user_ids: ['111111111111111111'],
+        allowed_thread_ids: ['222222222222222222'],
+      }))
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Kiro Crew's Discord transport is DM-only, so teams cannot use an agent in a shared Discord thread. The setup UI and guide also lacked a safe way to distinguish approved threads from ordinary guild channels.

## Why it matters

Discord threads are a useful shared conversation surface, but enabling guild messages without a second authorization boundary could expose agent replies, tool output, and approvals in arbitrary server channels. Thread support must remain opt-in and fail closed while preserving the existing DM path.

## Fix

- Add `discord.allowed_thread_ids`, defaulting to an empty list so existing installs remain DM-only.
- Request `GUILD_MESSAGES` and privileged `MESSAGE_CONTENT` intents only when at least one thread is configured; DM-only installs keep the narrower intent mask. Explicitly disclose that Discord then delivers content from every visible server channel before Kiro Crew discards unrelated traffic.
- Require both an approved user ID and exact thread ID, then verify through Discord's channel API that the configured ID is a real announcement/public/private thread. Normal guild channels remain denied even if their ID is entered accidentally.
- Scope one shared agent session per approved thread while keeping DMs isolated per user; apply the same checks to interactive buttons and approvals.
- Extend the shared `BotChannelPanel` with an optional thread allow-list, then add Discord-specific Developer Mode / Copy Channel ID guidance and shared-output/global-intent warnings without regressing Telegram.
- Drop unrelated guild background chatter silently to avoid flooding SEL; retain audit events for approved users attempting unapproved threads and authorization failures inside configured threads.
- Update the user guide and messaging architecture spec with OAuth scope, minimal permissions, Message Content intent, setup, testing, troubleshooting, and security guidance.
- Regenerate the tracked config metadata baseline for the new field.

## Tests

- Added focused coverage for conditional Gateway intents, approved/unapproved threads, normal-channel rejection, sender authorization, shared thread session scope, interaction authorization, and settings API validation/persistence.
- `90 passed` in `test/test_discord.py` and `test/test_discord_config_handlers.py`, including selective SEL-audit coverage.
- Added a focused Discord Settings test that verifies the shared panel renders and saves thread IDs with the global-intent disclosure; 8 focused frontend tests pass.
- Full backend run: `15168 passed, 66 skipped, 5 xfailed`; 29 known host-only failures remain in approval/subagent/hardlink tests because this Amazon Linux 2 host blocks user namespaces/semaphores. No Discord or config tests failed.
- `flake8 -j 1 src/ test/` passed.
- `npx tsc -b` passed.
- Full Vitest: 346 files passed; 3,911 tests passed and 3 skipped.

## Manual verification

Not run against a live Discord bot from the feature worktree. The guide includes the end-to-end check: DM `!help`, send `!help` in an approved thread, then confirm the parent channel remains silent. Unit coverage verifies the fail-closed authorization and channel-type checks.
