### PR TITLE
feat(app-store): Add wide detail-page hero banners

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/app.json
+++ b/src/kiro_crew/apps/builtins/auto_research/app.json
@@ -16,5 +16,7 @@
   },
   "iconUrl": "/app-assets/auto-research/icon.svg",
   "heroImage": "/app-assets/auto-research/hero-light.svg",
-  "heroImageDark": "/app-assets/auto-research/hero-dark.svg"
+  "heroImageDark": "/app-assets/auto-research/hero-dark.svg",
+  "heroImageDetail": "/app-assets/auto-research/hero-detail-light.svg",
+  "heroImageDetailDark": "/app-assets/auto-research/hero-detail-dark.svg"
 }

--- a/src/kiro_crew/apps/builtins/code_review_sage/app.json
+++ b/src/kiro_crew/apps/builtins/code_review_sage/app.json
@@ -37,5 +37,7 @@
   },
   "iconUrl": "/app-assets/code-review-sage/icon.svg",
   "heroImage": "/app-assets/code-review-sage/hero-light.svg",
-  "heroImageDark": "/app-assets/code-review-sage/hero-dark.svg"
+  "heroImageDark": "/app-assets/code-review-sage/hero-dark.svg",
+  "heroImageDetail": "/app-assets/code-review-sage/hero-detail-light.svg",
+  "heroImageDetailDark": "/app-assets/code-review-sage/hero-detail-dark.svg"
 }

--- a/src/kiro_crew/apps/builtins/dev_fleet/app.json
+++ b/src/kiro_crew/apps/builtins/dev_fleet/app.json
@@ -24,5 +24,9 @@
     "entryPoint": "kiro_crew.apps.builtins.dev_fleet.server",
     "port": "auto",
     "healthCheck": "/health"
-  }
+  },
+  "heroImage": "/app-assets/dev-fleet/hero-light.svg",
+  "heroImageDark": "/app-assets/dev-fleet/hero-dark.svg",
+  "heroImageDetail": "/app-assets/dev-fleet/hero-detail-light.svg",
+  "heroImageDetailDark": "/app-assets/dev-fleet/hero-detail-dark.svg"
 }

--- a/src/kiro_crew/apps/builtins/file_explorer/app.json
+++ b/src/kiro_crew/apps/builtins/file_explorer/app.json
@@ -33,5 +33,7 @@
   },
   "iconUrl": "/app-assets/file-explorer/icon.svg",
   "heroImage": "/app-assets/file-explorer/hero-light.svg",
-  "heroImageDark": "/app-assets/file-explorer/hero-dark.svg"
+  "heroImageDark": "/app-assets/file-explorer/hero-dark.svg",
+  "heroImageDetail": "/app-assets/file-explorer/hero-detail-light.svg",
+  "heroImageDetailDark": "/app-assets/file-explorer/hero-detail-dark.svg"
 }

--- a/src/kiro_crew/apps/builtins/workflows/app.json
+++ b/src/kiro_crew/apps/builtins/workflows/app.json
@@ -35,5 +35,7 @@
     "healthCheck": "/health"
   },
   "heroImage": "/app-assets/workflows/hero-light.svg",
-  "heroImageDark": "/app-assets/workflows/hero-dark.svg"
+  "heroImageDark": "/app-assets/workflows/hero-dark.svg",
+  "heroImageDetail": "/app-assets/workflows/hero-detail-light.svg",
+  "heroImageDetailDark": "/app-assets/workflows/hero-detail-dark.svg"
 }

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1165,6 +1165,8 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "iconUrl": "/app-assets/worlds/icon.svg",
         "heroImage": "/app-assets/worlds/hero-light.svg",
         "heroImageDark": "/app-assets/worlds/hero-dark.svg",
+        "heroImageDetail": "/app-assets/worlds/hero-detail-light.svg",
+        "heroImageDetailDark": "/app-assets/worlds/hero-detail-dark.svg",
         "ui": {
             "pages": [{"route": "/worlds", "label": "Worlds", "icon": "Gamepad2"}],
         },
@@ -1199,6 +1201,8 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "iconUrl": "/app-assets/projects/icon.svg",
         "heroImage": "/app-assets/projects/hero-light.svg",
         "heroImageDark": "/app-assets/projects/hero-dark.svg",
+        "heroImageDetail": "/app-assets/projects/hero-detail-light.svg",
+        "heroImageDetailDark": "/app-assets/projects/hero-detail-dark.svg",
         "ui": {
             "pages": [{"route": "/projects", "label": "Task Runner", "icon": "ClipboardCheck"}],
         },

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -568,6 +568,15 @@ def _merge_manifest(entry: dict[str, Any], manifest: dict[str, Any]) -> dict[str
     hero_dark = manifest.get("heroImageDark", "")
     if hero_dark and repo:
         result["heroImageDark"] = f"/api/apps/blob?repo={repo}&path={hero_dark}"
+    # Detail-page hero images (wide banner ratio) — convert repo-relative paths
+    # to blob proxy URLs. The detail page prefers these over the (near-square)
+    # Browse-card hero so the wide banner isn't cropped.
+    hero_detail = manifest.get("heroImageDetail", "")
+    if hero_detail and repo:
+        result["heroImageDetail"] = f"/api/apps/blob?repo={repo}&path={hero_detail}"
+    hero_detail_dark = manifest.get("heroImageDetailDark", "")
+    if hero_detail_dark and repo:
+        result["heroImageDetailDark"] = f"/api/apps/blob?repo={repo}&path={hero_detail_dark}"
 
     return result
 

--- a/test/test_registry_hero_fields.py
+++ b/test/test_registry_hero_fields.py
@@ -16,6 +16,20 @@ def test_merge_manifest_converts_hero_image_dark_to_blob_proxy():
     assert result["heroImageDark"] == "/api/apps/blob?repo=TestApp&path=assets/hero-dark.svg"
 
 
+def test_merge_manifest_converts_hero_image_detail_to_blob_proxy():
+    entry = {"name": "test-app", "repo": "TestApp"}
+    manifest = {"heroImageDetail": "assets/hero-detail-light.svg"}
+    result = _merge_manifest(entry, manifest)
+    assert result["heroImageDetail"] == "/api/apps/blob?repo=TestApp&path=assets/hero-detail-light.svg"
+
+
+def test_merge_manifest_converts_hero_image_detail_dark_to_blob_proxy():
+    entry = {"name": "test-app", "repo": "TestApp"}
+    manifest = {"heroImageDetailDark": "assets/hero-detail-dark.svg"}
+    result = _merge_manifest(entry, manifest)
+    assert result["heroImageDetailDark"] == "/api/apps/blob?repo=TestApp&path=assets/hero-detail-dark.svg"
+
+
 def test_merge_manifest_converts_screenshots_dark_to_blob_proxy():
     entry = {"name": "test-app", "repo": "TestApp"}
     manifest = {"screenshotsDark": ["assets/s1-dark.png", "assets/s2-dark.png"]}

--- a/website/public/app-assets/auto-research/hero-detail-dark.svg
+++ b/website/public/app-assets/auto-research/hero-detail-dark.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288" fill="none">
+  <!-- Full-bleed background -->
+  <rect width="1200" height="288" fill="#1a1b26"/>
+
+  <!-- Subtle grid spread across the full width -->
+  <line x1="0" y1="144" x2="1200" y2="144" stroke="#2a2b3d" stroke-width="0.5"/>
+  <line x1="200" y1="0" x2="200" y2="288" stroke="#2a2b3d" stroke-width="0.5"/>
+  <line x1="400" y1="0" x2="400" y2="288" stroke="#2a2b3d" stroke-width="0.5"/>
+  <line x1="600" y1="0" x2="600" y2="288" stroke="#2a2b3d" stroke-width="0.5"/>
+  <line x1="800" y1="0" x2="800" y2="288" stroke="#2a2b3d" stroke-width="0.5"/>
+  <line x1="1000" y1="0" x2="1000" y2="288" stroke="#2a2b3d" stroke-width="0.5"/>
+
+  <!-- Glow backdrop behind subject -->
+  <circle cx="600" cy="148" r="120" fill="#7c3aed" opacity="0.08"/>
+  <circle cx="600" cy="148" r="75" fill="#a855f7" opacity="0.1"/>
+
+  <!-- Central subject: research flask (translated to canvas centre) -->
+  <g transform="translate(360,4)">
+    <!-- flask body -->
+    <path d="M220 80 L220 140 L195 200 Q190 215 205 215 L275 215 Q290 215 285 200 L260 140 L260 80" stroke="#a855f7" stroke-width="2.5" fill="#7c3aed" fill-opacity="0.15"/>
+    <!-- flask neck -->
+    <rect x="218" y="65" width="44" height="18" rx="3" stroke="#a855f7" stroke-width="2" fill="none"/>
+    <!-- liquid -->
+    <path d="M200 185 Q215 175 240 180 Q265 185 280 178 L275 215 Q290 215 285 200 L195 200 Q190 215 205 215 L200 185Z" fill="#7c3aed" opacity="0.5"/>
+    <!-- bubbles -->
+    <circle cx="225" cy="190" r="4" fill="#c084fc" opacity="0.8"/>
+    <circle cx="250" cy="175" r="3" fill="#e9d5ff" opacity="0.7"/>
+    <circle cx="235" cy="165" r="2.5" fill="#a855f7" opacity="0.9"/>
+    <circle cx="260" cy="155" r="3.5" fill="#c084fc" opacity="0.6"/>
+    <circle cx="228" cy="145" r="2" fill="#e9d5ff" opacity="0.8"/>
+    <circle cx="255" cy="135" r="2.5" fill="#a855f7" opacity="0.7"/>
+    <!-- rising particles -->
+    <circle cx="232" cy="110" r="1.5" fill="#e9d5ff" opacity="0.5"/>
+    <circle cx="248" cy="100" r="1" fill="#c084fc" opacity="0.4"/>
+    <circle cx="240" cy="55" r="1.5" fill="#a855f7" opacity="0.3"/>
+  </g>
+
+  <!-- Accent dots scattered across the full width -->
+  <circle cx="120" cy="86" r="2.5" fill="#7c3aed" opacity="0.4"/>
+  <circle cx="180" cy="212" r="1.5" fill="#c084fc" opacity="0.3"/>
+  <circle cx="300" cy="70" r="2" fill="#a855f7" opacity="0.3"/>
+  <circle cx="360" cy="220" r="2" fill="#7c3aed" opacity="0.35"/>
+  <circle cx="470" cy="120" r="1.5" fill="#c084fc" opacity="0.3"/>
+  <circle cx="470" cy="176" r="1.5" fill="#a855f7" opacity="0.25"/>
+  <circle cx="730" cy="118" r="1.5" fill="#a855f7" opacity="0.3"/>
+  <circle cx="730" cy="172" r="1.5" fill="#c084fc" opacity="0.25"/>
+  <circle cx="840" cy="72" r="2" fill="#7c3aed" opacity="0.35"/>
+  <circle cx="900" cy="216" r="2" fill="#a855f7" opacity="0.3"/>
+  <circle cx="1020" cy="90" r="2.5" fill="#c084fc" opacity="0.3"/>
+  <circle cx="1090" cy="208" r="1.5" fill="#7c3aed" opacity="0.35"/>
+</svg>

--- a/website/public/app-assets/auto-research/hero-detail-light.svg
+++ b/website/public/app-assets/auto-research/hero-detail-light.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288">
+  <defs>
+    <linearGradient id="bg-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a1a8a"/>
+      <stop offset="100%" stop-color="#3b0764"/>
+    </linearGradient>
+    <linearGradient id="fl-detail" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e9d5ff" stop-opacity=".3"/>
+      <stop offset="100%" stop-color="#c4b5fd" stop-opacity=".15"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Full-bleed background -->
+  <rect width="1200" height="288" fill="url(#bg-detail)"/>
+
+  <!-- Soft glows behind subject -->
+  <ellipse cx="600" cy="150" rx="150" ry="95" fill="#a78bfa" opacity=".12"/>
+  <ellipse cx="600" cy="248" rx="120" ry="12" fill="#a78bfa" opacity=".15"/>
+
+  <!-- Floating research cards spread across the full width -->
+  <!-- yellow, upper-left -->
+  <g>
+    <rect x="112" y="70" width="55" height="36" rx="6" fill="#fefce8" opacity=".1" stroke="#fbbf24" stroke-width=".8"/>
+    <rect x="118" y="78" width="28" height="3" rx="1" fill="#fbbf24" opacity=".5"/>
+    <rect x="118" y="85" width="40" height="2" rx="1" fill="#fde68a" opacity=".3"/>
+    <rect x="118" y="90" width="34" height="2" rx="1" fill="#fde68a" opacity=".25"/>
+  </g>
+  <!-- blue, lower-left -->
+  <g>
+    <rect x="176" y="184" width="50" height="32" rx="6" fill="#eff6ff" opacity=".1" stroke="#60a5fa" stroke-width=".8"/>
+    <rect x="182" y="192" width="24" height="3" rx="1" fill="#60a5fa" opacity=".5"/>
+    <rect x="182" y="199" width="36" height="2" rx="1" fill="#bfdbfe" opacity=".3"/>
+  </g>
+  <!-- cyan, mid-left -->
+  <g>
+    <rect x="322" y="128" width="46" height="30" rx="6" fill="#ecfeff" opacity=".1" stroke="#22d3ee" stroke-width=".8"/>
+    <rect x="328" y="135" width="22" height="3" rx="1" fill="#22d3ee" opacity=".5"/>
+    <rect x="328" y="142" width="32" height="2" rx="1" fill="#a5f3fc" opacity=".3"/>
+  </g>
+  <!-- pink, mid-right -->
+  <g>
+    <rect x="838" y="122" width="46" height="30" rx="6" fill="#fdf4ff" opacity=".1" stroke="#e879f9" stroke-width=".8"/>
+    <rect x="844" y="129" width="22" height="3" rx="1" fill="#e879f9" opacity=".5"/>
+    <rect x="844" y="136" width="32" height="2" rx="1" fill="#f5d0fe" opacity=".3"/>
+  </g>
+  <!-- green, upper-right -->
+  <g>
+    <rect x="982" y="72" width="55" height="36" rx="6" fill="#ecfdf5" opacity=".1" stroke="#34d399" stroke-width=".8"/>
+    <rect x="988" y="80" width="28" height="3" rx="1" fill="#34d399" opacity=".5"/>
+    <rect x="988" y="87" width="40" height="2" rx="1" fill="#6ee7b7" opacity=".3"/>
+    <rect x="988" y="92" width="34" height="2" rx="1" fill="#6ee7b7" opacity=".25"/>
+  </g>
+  <!-- magenta, lower-right -->
+  <g>
+    <rect x="1006" y="184" width="50" height="32" rx="6" fill="#fdf4ff" opacity=".1" stroke="#e879f9" stroke-width=".8"/>
+    <rect x="1012" y="192" width="24" height="3" rx="1" fill="#e879f9" opacity=".5"/>
+    <rect x="1012" y="199" width="36" height="2" rx="1" fill="#f5d0fe" opacity=".3"/>
+  </g>
+
+  <!-- Central subject: research flask (translated to canvas centre) -->
+  <g transform="translate(360,4)">
+    <!-- steam -->
+    <path d="M230 62Q225 48 230 36Q235 24 230 12" fill="none" stroke="#e9d5ff" stroke-width="1.5" opacity=".35" stroke-linecap="round"/>
+    <path d="M248 60Q253 44 248 30Q243 18 248 6" fill="none" stroke="#e9d5ff" stroke-width="1.2" opacity=".25" stroke-linecap="round"/>
+    <!-- flask body -->
+    <path d="M212 90v70q0 10-15 25l-15 15q-10 12 0 25v5q0 15 15 15h86q15 0 15-15v-5q10-13 0-25l-15-15q-15-15-15-25V90" fill="url(#fl-detail)" stroke="#c4b5fd" stroke-width="1.5"/>
+    <!-- neck + cap -->
+    <rect x="216" y="72" width="48" height="20" rx="4" fill="url(#fl-detail)" stroke="#c4b5fd" stroke-width="1.5"/>
+    <rect x="210" y="66" width="60" height="8" rx="4" fill="#ddd6fe" opacity=".4"/>
+    <!-- inner glow -->
+    <ellipse cx="240" cy="196" rx="45" ry="35" fill="#a78bfa" opacity=".12"/>
+    <!-- reaction bubbles -->
+    <circle cx="235" cy="206" r="8" fill="#f97316" opacity=".8"/>
+    <circle cx="255" cy="191" r="6" fill="#22d3ee" opacity=".8"/>
+    <circle cx="225" cy="179" r="5" fill="#4ade80" opacity=".7"/>
+    <circle cx="260" cy="216" r="7" fill="#f472b6" opacity=".75"/>
+    <circle cx="245" cy="164" r="4" fill="#22d3ee" opacity=".6"/>
+    <circle cx="232" cy="222" r="5" fill="#4ade80" opacity=".65"/>
+  </g>
+
+  <!-- Accent dots scattered across the full width -->
+  <circle cx="70" cy="58" r="3" fill="#fbbf24" opacity=".4"/>
+  <circle cx="256" cy="70" r="2" fill="#34d399" opacity=".35"/>
+  <circle cx="240" cy="238" r="2.5" fill="#f472b6" opacity=".3"/>
+  <circle cx="430" cy="96" r="2.5" fill="#22d3ee" opacity=".35"/>
+  <circle cx="452" cy="214" r="2" fill="#fbbf24" opacity=".3"/>
+  <circle cx="700" cy="212" r="3" fill="#4ade80" opacity=".3"/>
+  <circle cx="748" cy="72" r="2" fill="#f472b6" opacity=".35"/>
+  <circle cx="928" cy="216" r="2.5" fill="#22d3ee" opacity=".3"/>
+  <circle cx="1108" cy="118" r="3" fill="#fbbf24" opacity=".35"/>
+  <circle cx="1140" cy="204" r="2" fill="#34d399" opacity=".3"/>
+  <circle cx="60" cy="176" r="2" fill="#f472b6" opacity=".3"/>
+  <circle cx="1080" cy="60" r="2.5" fill="#fbbf24" opacity=".3"/>
+</svg>

--- a/website/public/app-assets/code-review-sage/hero-detail-dark.svg
+++ b/website/public/app-assets/code-review-sage/hero-detail-dark.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288" fill="none">
+  <!-- Full-bleed background -->
+  <rect width="1200" height="288" fill="#1a1b26"/>
+  <!-- Glows -->
+  <circle cx="460" cy="144" r="110" fill="#3b82f6" opacity="0.07"/>
+  <circle cx="460" cy="144" r="70" fill="#60a5fa" opacity="0.09"/>
+  <circle cx="960" cy="150" r="80" fill="#3b82f6" opacity="0.05"/>
+  <!-- Magnifying glass (primary subject) -->
+  <circle cx="460" cy="144" r="62" stroke="#60a5fa" stroke-width="3" fill="#3b82f6" fill-opacity="0.08"/>
+  <line x1="505" y1="189" x2="548" y2="232" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
+  <!-- Code lines inside lens -->
+  <rect x="428" y="122" width="44" height="4" rx="2" fill="#93c5fd" opacity="0.7"/>
+  <rect x="435" y="136" width="32" height="4" rx="2" fill="#60a5fa" opacity="0.6"/>
+  <rect x="430" y="150" width="50" height="4" rx="2" fill="#93c5fd" opacity="0.7"/>
+  <rect x="437" y="164" width="26" height="4" rx="2" fill="#60a5fa" opacity="0.5"/>
+  <!-- Code brackets flanking the lens -->
+  <path d="M360 104 L340 144 L360 184" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M560 104 L580 144 L560 184" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+  <!-- Diff panel right side -->
+  <rect x="640" y="64" width="220" height="160" rx="8" stroke="#334155" stroke-width="2" fill="#1e293b"/>
+  <!-- Diff lines -->
+  <rect x="656" y="84" width="90" height="4" rx="2" fill="#475569" opacity="0.6"/>
+  <rect x="656" y="104" width="120" height="4" rx="2" fill="#4ade80" opacity="0.7"/>
+  <rect x="656" y="124" width="75" height="4" rx="2" fill="#4ade80" opacity="0.6"/>
+  <rect x="656" y="144" width="100" height="4" rx="2" fill="#f87171" opacity="0.6"/>
+  <rect x="656" y="164" width="130" height="4" rx="2" fill="#475569" opacity="0.6"/>
+  <rect x="656" y="184" width="85" height="4" rx="2" fill="#4ade80" opacity="0.7"/>
+  <rect x="656" y="204" width="110" height="4" rx="2" fill="#475569" opacity="0.5"/>
+  <!-- Approval checkmark badge -->
+  <circle cx="960" cy="150" r="30" stroke="#4ade80" stroke-width="2.5" fill="#4ade80" fill-opacity="0.12"/>
+  <path d="M946 150 L956 160 L976 138" stroke="#4ade80" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Accent dots spread full width -->
+  <circle cx="90" cy="80" r="2" fill="#93c5fd" opacity="0.3"/>
+  <circle cx="120" cy="210" r="2.5" fill="#3b82f6" opacity="0.4"/>
+  <circle cx="200" cy="60" r="2" fill="#3b82f6" opacity="0.3"/>
+  <circle cx="1000" cy="240" r="2" fill="#93c5fd" opacity="0.3"/>
+  <circle cx="1080" cy="70" r="2" fill="#60a5fa" opacity="0.35"/>
+  <circle cx="1120" cy="200" r="2.5" fill="#60a5fa" opacity="0.3"/>
+</svg>

--- a/website/public/app-assets/code-review-sage/hero-detail-light.svg
+++ b/website/public/app-assets/code-review-sage/hero-detail-light.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288">
+  <defs>
+    <linearGradient id="bg-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e8f4fd"/>
+      <stop offset="100%" stop-color="#c5e3f6"/>
+    </linearGradient>
+    <linearGradient id="glass-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a9ede"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+    <linearGradient id="lens-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f0f7ff"/>
+      <stop offset="100%" stop-color="#dbeafe"/>
+    </linearGradient>
+  </defs>
+  <!-- Full-bleed background -->
+  <rect width="1200" height="288" fill="url(#bg-detail)"/>
+  <!-- Decorative circles spread across full width -->
+  <circle cx="90" cy="60" r="28" fill="#bfdbfe" opacity="0.5"/>
+  <circle cx="60" cy="150" r="8" fill="#93c5fd" opacity="0.4"/>
+  <circle cx="160" cy="232" r="22" fill="#93c5fd" opacity="0.35"/>
+  <circle cx="1000" cy="150" r="10" fill="#bfdbfe" opacity="0.4"/>
+  <circle cx="1060" cy="64" r="18" fill="#bfdbfe" opacity="0.45"/>
+  <circle cx="1130" cy="228" r="36" fill="#93c5fd" opacity="0.4"/>
+  <!-- Magnifying glass (primary subject) -->
+  <circle cx="460" cy="144" r="72" fill="url(#glass-detail)" opacity="0.9"/>
+  <circle cx="460" cy="144" r="60" fill="url(#lens-detail)"/>
+  <!-- Handle -->
+  <rect x="508" y="190" width="16" height="58" rx="8" fill="#2563eb" transform="rotate(40 512 216)"/>
+  <!-- Code brackets inside lens -->
+  <path d="M431 126 L419 144 L431 162" stroke="#1e40af" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M489 126 L501 144 L489 162" stroke="#1e40af" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="443" y1="162" x2="477" y2="126" stroke="#3b82f6" stroke-width="4" stroke-linecap="round"/>
+  <!-- Diff review lines -->
+  <rect x="640" y="72" width="180" height="24" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1.5"/>
+  <rect x="648" y="80" width="8" height="8" rx="2" fill="#22c55e"/>
+  <rect x="664" y="80" width="70" height="8" rx="3" fill="#4ade80"/>
+  <rect x="640" y="108" width="180" height="24" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1.5"/>
+  <rect x="648" y="116" width="8" height="8" rx="2" fill="#22c55e"/>
+  <rect x="664" y="116" width="96" height="8" rx="3" fill="#4ade80"/>
+  <rect x="640" y="144" width="180" height="24" rx="5" fill="#fee2e2" stroke="#fca5a5" stroke-width="1.5"/>
+  <rect x="648" y="152" width="8" height="8" rx="2" fill="#ef4444"/>
+  <rect x="664" y="152" width="60" height="8" rx="3" fill="#f87171"/>
+  <rect x="640" y="180" width="180" height="24" rx="5" fill="#fee2e2" stroke="#fca5a5" stroke-width="1.5"/>
+  <rect x="648" y="188" width="8" height="8" rx="2" fill="#ef4444"/>
+  <rect x="664" y="188" width="84" height="8" rx="3" fill="#f87171"/>
+  <!-- Approval checkmark badge -->
+  <circle cx="900" cy="150" r="34" fill="#22c55e"/>
+  <circle cx="900" cy="150" r="27" fill="#16a34a"/>
+  <path d="M884 150 L895 161 L918 138" stroke="white" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/website/public/app-assets/dev-fleet/hero-detail-dark.svg
+++ b/website/public/app-assets/dev-fleet/hero-detail-dark.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="288" viewBox="0 0 1200 288">
+  <defs>
+    <linearGradient id="gd-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="288" fill="url(#gd-detail)"/>
+  <g opacity="0.5" fill="none" stroke="#475569" stroke-width="2">
+    <path d="M-20 144 H1220"/>
+  </g>
+  <g fill="#64748b" opacity="0.6">
+    <circle cx="60" cy="144" r="5"/>
+    <circle cx="180" cy="144" r="8"/>
+    <circle cx="320" cy="144" r="5"/>
+    <circle cx="440" cy="144" r="7"/>
+    <circle cx="760" cy="144" r="7"/>
+    <circle cx="880" cy="144" r="5"/>
+    <circle cx="1020" cy="144" r="8"/>
+    <circle cx="1140" cy="144" r="5"/>
+  </g>
+  <rect x="470" y="112" width="260" height="64" rx="10" fill="url(#gd-detail)"/>
+  <text x="600" y="156" text-anchor="middle" fill="#94a3b8" font-family="system-ui" font-size="44" font-weight="600">Dev Fleet</text>
+</svg>

--- a/website/public/app-assets/dev-fleet/hero-detail-light.svg
+++ b/website/public/app-assets/dev-fleet/hero-detail-light.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="288" viewBox="0 0 1200 288">
+  <defs>
+    <linearGradient id="gl-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="288" fill="url(#gl-detail)"/>
+  <g opacity="0.4" fill="none" stroke="#cbd5e1" stroke-width="2">
+    <path d="M-20 144 H1220"/>
+  </g>
+  <g fill="#94a3b8" opacity="0.5">
+    <circle cx="60" cy="144" r="5"/>
+    <circle cx="180" cy="144" r="8"/>
+    <circle cx="320" cy="144" r="5"/>
+    <circle cx="440" cy="144" r="7"/>
+    <circle cx="760" cy="144" r="7"/>
+    <circle cx="880" cy="144" r="5"/>
+    <circle cx="1020" cy="144" r="8"/>
+    <circle cx="1140" cy="144" r="5"/>
+  </g>
+  <rect x="470" y="112" width="260" height="64" rx="10" fill="url(#gl-detail)"/>
+  <text x="600" y="156" text-anchor="middle" fill="#475569" font-family="system-ui" font-size="44" font-weight="600">Dev Fleet</text>
+</svg>

--- a/website/public/app-assets/file-explorer/hero-detail-dark.svg
+++ b/website/public/app-assets/file-explorer/hero-detail-dark.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" fill="none">
+  <rect width="1200" height="288" fill="#1a1b26"/>
+  <!-- full-width scattered accents so side-crop only trims decoration -->
+  <circle cx="60" cy="46" r="2.5" fill="#f59e0b" opacity="0.3"/>
+  <circle cx="150" cy="250" r="2" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="1050" cy="44" r="2" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="1150" cy="248" r="2.5" fill="#f59e0b" opacity="0.3"/>
+  <!-- left floating folder + dots -->
+  <rect x="60" y="122" width="16" height="12" rx="2" fill="#f59e0b" opacity="0.7"/>
+  <rect x="60" y="119" width="8" height="3" rx="1" fill="#f59e0b" opacity="0.5"/>
+  <circle cx="92" cy="100" r="2.5" fill="#d97706" opacity="0.5"/>
+  <circle cx="80" cy="170" r="2.5" fill="#d97706" opacity="0.5"/>
+  <!-- right floating folder + dots -->
+  <rect x="1116" y="120" width="16" height="12" rx="2" fill="#f59e0b" opacity="0.7"/>
+  <rect x="1116" y="117" width="8" height="3" rx="1" fill="#f59e0b" opacity="0.5"/>
+  <circle cx="1108" cy="98" r="2.5" fill="#d97706" opacity="0.5"/>
+  <circle cx="1132" cy="168" r="2.5" fill="#d97706" opacity="0.5"/>
+
+  <!-- LEFT PANEL: file tree -->
+  <rect x="180" y="44" width="300" height="200" rx="8" stroke="#334155" stroke-width="1.5" fill="#1e293b"/>
+  <rect x="204" y="72" width="16" height="12" rx="2" fill="#f59e0b" opacity="0.8"/>
+  <rect x="204" y="69" width="8" height="3" rx="1" fill="#f59e0b" opacity="0.6"/>
+  <rect x="228" y="75" width="60" height="4" rx="2" fill="#fbbf24" opacity="0.6"/>
+  <rect x="204" y="98" width="16" height="12" rx="2" fill="#f59e0b" opacity="0.7"/>
+  <rect x="204" y="95" width="8" height="3" rx="1" fill="#f59e0b" opacity="0.5"/>
+  <rect x="228" y="101" width="44" height="4" rx="2" fill="#fbbf24" opacity="0.5"/>
+  <circle cx="216" cy="128" r="2.5" fill="#d97706" opacity="0.6"/><rect x="228" y="125" width="66" height="4" rx="2" fill="#92400e" opacity="0.6"/>
+  <circle cx="216" cy="150" r="2.5" fill="#d97706" opacity="0.6"/><rect x="228" y="147" width="82" height="4" rx="2" fill="#fbbf24" opacity="0.7"/>
+  <circle cx="216" cy="172" r="2.5" fill="#d97706" opacity="0.5"/><rect x="228" y="169" width="52" height="4" rx="2" fill="#92400e" opacity="0.5"/>
+  <circle cx="216" cy="194" r="2.5" fill="#d97706" opacity="0.6"/><rect x="228" y="191" width="72" height="4" rx="2" fill="#fbbf24" opacity="0.6"/>
+  <circle cx="216" cy="216" r="2.5" fill="#d97706" opacity="0.5"/><rect x="228" y="213" width="44" height="4" rx="2" fill="#92400e" opacity="0.4"/>
+
+  <!-- dashed connector between panels -->
+  <line x1="480" y1="144" x2="520" y2="144" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4 3" opacity="0.4"/>
+
+  <!-- RIGHT PANEL: code -->
+  <rect x="520" y="44" width="500" height="200" rx="8" stroke="#334155" stroke-width="1.5" fill="#1e293b"/>
+  <g opacity="0.7"><rect x="548" y="94" width="40" height="4" rx="2" fill="#f59e0b"/><rect x="620" y="200" width="30" height="4" rx="2" fill="#f59e0b"/><rect x="572" y="150" width="34" height="4" rx="2" fill="#f59e0b"/></g>
+  <g opacity="0.5"><rect x="596" y="94" width="26" height="4" rx="2" fill="#fbbf24"/><rect x="632" y="128" width="22" height="4" rx="2" fill="#fbbf24"/><rect x="700" y="182" width="26" height="4" rx="2" fill="#fbbf24"/><rect x="852" y="94" width="60" height="4" rx="2" fill="#fbbf24"/></g>
+  <g opacity="0.6"><rect x="560" y="116" width="58" height="4" rx="2" fill="#4ade80"/><rect x="636" y="172" width="44" height="4" rx="2" fill="#4ade80"/><rect x="560" y="216" width="54" height="4" rx="2" fill="#4ade80"/><rect x="716" y="128" width="50" height="4" rx="2" fill="#4ade80"/><rect x="628" y="150" width="50" height="4" rx="2" fill="#4ade80"/><rect x="860" y="216" width="70" height="4" rx="2" fill="#4ade80"/></g>
+  <g opacity="0.6"><rect x="632" y="116" width="30" height="4" rx="2" fill="#60a5fa"/><rect x="560" y="128" width="40" height="4" rx="2" fill="#60a5fa"/><rect x="614" y="182" width="58" height="4" rx="2" fill="#60a5fa"/><rect x="660" y="216" width="64" height="4" rx="2" fill="#60a5fa"/><rect x="788" y="150" width="90" height="4" rx="2" fill="#60a5fa"/><rect x="700" y="94" width="120" height="4" rx="2" fill="#60a5fa"/></g>
+  <g opacity="0.5"><rect x="636" y="128" width="64" height="4" rx="2" fill="#c084fc"/><rect x="560" y="172" width="70" height="4" rx="2" fill="#c084fc"/><rect x="740" y="200" width="60" height="4" rx="2" fill="#c084fc"/><rect x="836" y="128" width="80" height="4" rx="2" fill="#c084fc"/></g>
+</svg>

--- a/website/public/app-assets/file-explorer/hero-detail-light.svg
+++ b/website/public/app-assets/file-explorer/hero-detail-light.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288">
+<defs>
+<linearGradient id="b-detail" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#FFF8E1"/><stop offset="100%" stop-color="#FFE082"/></linearGradient>
+<linearGradient id="f-detail"><stop offset="0%" stop-color="#FFB300"/><stop offset="100%" stop-color="#FF8F00"/></linearGradient>
+</defs>
+<rect width="1200" height="288" fill="url(#b-detail)"/>
+<!-- full-width scattered accent glyphs so side-crop only trims decoration -->
+<g opacity=".5"><circle cx="60" cy="46" r="3" fill="#FF8F00"/><circle cx="150" cy="252" r="3" fill="#FFB300"/><circle cx="1050" cy="42" r="3" fill="#FFB300"/><circle cx="1150" cy="250" r="3" fill="#FF8F00"/></g>
+<!-- left floating folder + dots -->
+<rect x="60" y="120" width="20" height="15" rx="3" fill="url(#f-detail)"/><rect x="60" y="120" width="11" height="4" rx="2" fill="#FF6F00"/>
+<circle cx="92" cy="98" r="3" fill="#90A4AE"/><circle cx="80" cy="172" r="3" fill="#90A4AE"/>
+<!-- right floating folder + dots -->
+<rect x="1112" y="118" width="20" height="15" rx="3" fill="url(#f-detail)"/><rect x="1112" y="118" width="11" height="4" rx="2" fill="#FF6F00"/>
+<circle cx="1104" cy="96" r="3" fill="#90A4AE"/><circle cx="1128" cy="170" r="3" fill="#90A4AE"/>
+
+<!-- LEFT PANEL: file tree -->
+<rect x="180" y="44" width="300" height="200" rx="12" fill="#fff" opacity=".95"/>
+<rect x="204" y="70" width="18" height="14" rx="3" fill="url(#f-detail)"/><rect x="204" y="70" width="10" height="4" rx="2" fill="#FF6F00"/>
+<rect x="230" y="74" width="60" height="6" rx="3" fill="#B0BEC5"/>
+<rect x="204" y="100" width="18" height="14" rx="3" fill="url(#f-detail)"/><rect x="204" y="100" width="10" height="4" rx="2" fill="#FF6F00"/>
+<rect x="230" y="104" width="44" height="6" rx="3" fill="#B0BEC5"/>
+<circle cx="222" cy="135" r="3" fill="#90A4AE"/><rect x="234" y="132" width="66" height="6" rx="3" fill="#CFD8DC"/>
+<circle cx="222" cy="159" r="3" fill="#90A4AE"/><rect x="234" y="156" width="80" height="6" rx="3" fill="#CFD8DC"/>
+<circle cx="222" cy="183" r="3" fill="#90A4AE"/><rect x="234" y="180" width="52" height="6" rx="3" fill="#CFD8DC"/>
+<circle cx="222" cy="207" r="3" fill="#90A4AE"/><rect x="234" y="204" width="70" height="6" rx="3" fill="#CFD8DC"/>
+<path d="M210 84V100M216 116V207M216 135h6M216 159h6M216 183h6M216 207h6" stroke="#CFD8DC" fill="none"/>
+
+<!-- dashed connector between panels -->
+<line x1="480" y1="144" x2="520" y2="144" stroke="#FF8F00" stroke-width="1.5" stroke-dasharray="4 3" opacity=".5"/>
+
+<!-- RIGHT PANEL: editor -->
+<rect x="520" y="44" width="500" height="200" rx="12" fill="#fff" opacity=".95"/>
+<rect x="520" y="44" width="500" height="32" rx="12" fill="#F5F5F5"/><rect x="520" y="60" width="500" height="16" fill="#F5F5F5"/>
+<rect x="536" y="52" width="64" height="18" rx="4" fill="#fff"/>
+<g fill="#BDBDBD"><circle cx="532" cy="96" r="2"/><circle cx="532" cy="114" r="2"/><circle cx="532" cy="132" r="2"/><circle cx="532" cy="150" r="2"/><circle cx="532" cy="168" r="2"/><circle cx="532" cy="186" r="2"/><circle cx="532" cy="204" r="2"/><circle cx="532" cy="222" r="2"/></g>
+<g fill="#7C4DFF"><rect x="548" y="96" width="70" height="6" rx="3"/><rect x="668" y="114" width="40" height="6" rx="3"/><rect x="758" y="132" width="80" height="6" rx="3"/><rect x="572" y="150" width="46" height="6" rx="3"/><rect x="644" y="168" width="56" height="6" rx="3"/><rect x="846" y="168" width="70" height="6" rx="3"/><rect x="712" y="186" width="44" height="6" rx="3"/><rect x="750" y="204" width="60" height="6" rx="3"/><rect x="548" y="222" width="32" height="6" rx="3"/></g>
+<g fill="#66BB6A"><rect x="628" y="96" width="50" height="6" rx="3"/><rect x="848" y="96" width="80" height="6" rx="3"/><rect x="720" y="114" width="60" height="6" rx="3"/><rect x="560" y="132" width="54" height="6" rx="3"/><rect x="628" y="150" width="52" height="6" rx="3"/><rect x="858" y="150" width="90" height="6" rx="3"/><rect x="712" y="168" width="40" height="6" rx="3"/><rect x="768" y="186" width="96" height="6" rx="3"/><rect x="560" y="204" width="48" height="6" rx="3"/><rect x="910" y="204" width="60" height="6" rx="3"/><rect x="590" y="222" width="60" height="6" rx="3"/></g>
+<g fill="#FF9800"><rect x="690" y="96" width="34" height="6" rx="3"/><rect x="792" y="114" width="44" height="6" rx="3"/><rect x="624" y="132" width="64" height="6" rx="3"/><rect x="850" y="132" width="60" height="6" rx="3"/><rect x="690" y="150" width="34" height="6" rx="3"/><rect x="764" y="168" width="70" height="6" rx="3"/><rect x="572" y="186" width="52" height="6" rx="3"/><rect x="618" y="204" width="32" height="6" rx="3"/><rect x="660" y="222" width="46" height="6" rx="3"/><rect x="848" y="222" width="100" height="6" rx="3"/></g>
+<g fill="#42A5F5"><rect x="736" y="96" width="90" height="6" rx="3"/><rect x="560" y="114" width="96" height="6" rx="3"/><rect x="848" y="114" width="100" height="6" rx="3"/><rect x="700" y="132" width="46" height="6" rx="3"/><rect x="736" y="150" width="110" height="6" rx="3"/><rect x="560" y="168" width="74" height="6" rx="3"/><rect x="632" y="186" width="68" height="6" rx="3"/><rect x="876" y="186" width="80" height="6" rx="3"/><rect x="660" y="204" width="78" height="6" rx="3"/><rect x="718" y="222" width="120" height="6" rx="3"/></g>
+</svg>

--- a/website/public/app-assets/projects/hero-detail-dark.svg
+++ b/website/public/app-assets/projects/hero-detail-dark.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288">
+  <defs>
+    <radialGradient id="glow-detail" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f97316" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#f97316" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="288" fill="#1a1b26"/>
+  <!-- Glow behind rocket -->
+  <ellipse cx="600" cy="144" rx="220" ry="150" fill="url(#glow-detail)"/>
+  <!-- Speed lines (left trail) -->
+  <rect x="120" y="96" width="120" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.25"/>
+  <rect x="70" y="128" width="160" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.2"/>
+  <rect x="150" y="160" width="95" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.18"/>
+  <rect x="95" y="192" width="140" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.15"/>
+  <!-- Speed lines (right, balancing full width) -->
+  <rect x="1010" y="70" width="130" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.22"/>
+  <rect x="1040" y="212" width="95" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.18"/>
+  <rect x="990" y="242" width="140" height="3" rx="1.5" fill="#fb923c" fill-opacity="0.14"/>
+  <!-- Rocket body (centered) -->
+  <path d="M600 45 Q570 85 570 140 L582 158 L618 158 L630 140 Q630 85 600 45" fill="#f97316" fill-opacity="0.15" stroke="#fb923c" stroke-width="2.5"/>
+  <!-- Window -->
+  <circle cx="600" cy="105" r="16" fill="#f97316" fill-opacity="0.3" stroke="#fb923c" stroke-width="2"/>
+  <!-- Side fins -->
+  <path d="M570 140 L550 170 L575 155" fill="#fb923c" fill-opacity="0.3" stroke="#fb923c" stroke-width="1"/>
+  <path d="M630 140 L650 170 L625 155" fill="#fb923c" fill-opacity="0.3" stroke="#fb923c" stroke-width="1"/>
+  <!-- Flame -->
+  <path d="M582 158 L578 185 L588 175 L600 195 L612 175 L622 185 L618 158" fill="#fbbf24" fill-opacity="0.8"/>
+  <!-- Exhaust -->
+  <circle cx="600" cy="210" r="5" fill="#fb923c" fill-opacity="0.5"/>
+  <circle cx="590" cy="225" r="3.5" fill="#f97316" fill-opacity="0.3"/>
+  <circle cx="610" cy="225" r="3.5" fill="#f97316" fill-opacity="0.3"/>
+  <circle cx="600" cy="240" r="2.5" fill="#f97316" fill-opacity="0.2"/>
+  <!-- Progress terminal (right) -->
+  <rect x="910" y="109" width="100" height="70" rx="8" fill="#f97316" fill-opacity="0.08" stroke="#fb923c" stroke-width="1" stroke-opacity="0.3"/>
+  <rect x="922" y="124" width="45" height="5" rx="2.5" fill="#4ade80" fill-opacity="0.7"/>
+  <rect x="922" y="136" width="65" height="5" rx="2.5" fill="#fb923c" fill-opacity="0.4"/>
+  <rect x="922" y="148" width="35" height="5" rx="2.5" fill="#fb923c" fill-opacity="0.3"/>
+  <rect x="922" y="160" width="55" height="5" rx="2.5" fill="#4ade80" fill-opacity="0.5"/>
+</svg>

--- a/website/public/app-assets/projects/hero-detail-light.svg
+++ b/website/public/app-assets/projects/hero-detail-light.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288">
+  <defs>
+    <linearGradient id="bg-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="100%" stop-color="#fbbf24"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="288" fill="url(#bg-detail)"/>
+  <!-- Speed lines (left trail) -->
+  <rect x="120" y="96" width="120" height="3" rx="1.5" fill="#fff" fill-opacity="0.3"/>
+  <rect x="70" y="128" width="160" height="3" rx="1.5" fill="#fff" fill-opacity="0.25"/>
+  <rect x="150" y="160" width="95" height="3" rx="1.5" fill="#fff" fill-opacity="0.22"/>
+  <rect x="95" y="192" width="140" height="3" rx="1.5" fill="#fff" fill-opacity="0.2"/>
+  <!-- Speed lines (right, balancing full width) -->
+  <rect x="1010" y="70" width="130" height="3" rx="1.5" fill="#fff" fill-opacity="0.28"/>
+  <rect x="1040" y="212" width="95" height="3" rx="1.5" fill="#fff" fill-opacity="0.22"/>
+  <rect x="990" y="242" width="140" height="3" rx="1.5" fill="#fff" fill-opacity="0.18"/>
+  <!-- Rocket body (centered) -->
+  <path d="M600 45 Q570 85 570 140 L582 158 L618 158 L630 140 Q630 85 600 45" fill="#fff" fill-opacity="0.9" stroke="#fff" stroke-width="2"/>
+  <!-- Window -->
+  <circle cx="600" cy="105" r="16" fill="#f97316" fill-opacity="0.5" stroke="#fff" stroke-width="2"/>
+  <!-- Side fins -->
+  <path d="M570 140 L550 170 L575 155" fill="#fff" fill-opacity="0.6"/>
+  <path d="M630 140 L650 170 L625 155" fill="#fff" fill-opacity="0.6"/>
+  <!-- Flame -->
+  <path d="M582 158 L578 185 L588 175 L600 195 L612 175 L622 185 L618 158" fill="#fbbf24" fill-opacity="0.9"/>
+  <!-- Exhaust particles -->
+  <circle cx="600" cy="210" r="5" fill="#fff" fill-opacity="0.5"/>
+  <circle cx="590" cy="225" r="3.5" fill="#fff" fill-opacity="0.35"/>
+  <circle cx="610" cy="225" r="3.5" fill="#fff" fill-opacity="0.35"/>
+  <circle cx="600" cy="240" r="2.5" fill="#fff" fill-opacity="0.2"/>
+  <!-- Progress terminal (right) -->
+  <rect x="910" y="109" width="100" height="70" rx="8" fill="#fff" fill-opacity="0.15"/>
+  <rect x="922" y="124" width="45" height="5" rx="2.5" fill="#10b981" fill-opacity="0.8"/>
+  <rect x="922" y="136" width="65" height="5" rx="2.5" fill="#fff" fill-opacity="0.5"/>
+  <rect x="922" y="148" width="35" height="5" rx="2.5" fill="#fff" fill-opacity="0.35"/>
+  <rect x="922" y="160" width="55" height="5" rx="2.5" fill="#10b981" fill-opacity="0.6"/>
+</svg>

--- a/website/public/app-assets/workflows/hero-detail-dark.svg
+++ b/website/public/app-assets/workflows/hero-detail-dark.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288" fill="none">
+  <rect width="1200" height="288" fill="#1a1b26"/>
+
+  <!-- Connection lines (full-width DAG) -->
+  <line x1="127" y1="144" x2="302" y2="144" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+  <line x1="354" y1="132" x2="551" y2="102" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+  <line x1="354" y1="156" x2="551" y2="186" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+  <line x1="599" y1="102" x2="794" y2="140" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+  <line x1="599" y1="186" x2="794" y2="148" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+  <line x1="843" y1="144" x2="1053" y2="144" stroke="#6366f1" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- Glow effects -->
+  <circle cx="110" cy="144" r="30" fill="#6366f1" opacity="0.08"/>
+  <circle cx="328" cy="144" r="28" fill="#818cf8" opacity="0.08"/>
+  <circle cx="575" cy="96" r="24" fill="#818cf8" opacity="0.08"/>
+  <circle cx="575" cy="192" r="24" fill="#818cf8" opacity="0.08"/>
+  <circle cx="818" cy="144" r="26" fill="#a78bfa" opacity="0.08"/>
+  <circle cx="1080" cy="144" r="24" fill="#c084fc" opacity="0.08"/>
+
+  <!-- Nodes -->
+  <circle cx="110" cy="144" r="17" stroke="#6366f1" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="110" cy="144" r="6" fill="#818cf8" opacity="0.8"/>
+
+  <circle cx="328" cy="144" r="16" stroke="#818cf8" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="328" cy="144" r="5" fill="#a5b4fc" opacity="0.8"/>
+
+  <circle cx="575" cy="96" r="14" stroke="#818cf8" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="575" cy="96" r="4" fill="#a5b4fc" opacity="0.8"/>
+
+  <circle cx="575" cy="192" r="14" stroke="#818cf8" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="575" cy="192" r="4" fill="#a5b4fc" opacity="0.8"/>
+
+  <circle cx="818" cy="144" r="15" stroke="#a78bfa" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="818" cy="144" r="5" fill="#c4b5fd" opacity="0.8"/>
+
+  <!-- End node (diamond) -->
+  <polygon points="1080,127 1097,144 1080,161 1063,144" stroke="#c084fc" stroke-width="2" fill="#1e1b4b"/>
+  <circle cx="1080" cy="144" r="4" fill="#e9d5ff" opacity="0.8"/>
+
+  <!-- Pulse rings -->
+  <circle cx="110" cy="144" r="23" stroke="#6366f1" stroke-width="0.5" fill="none" opacity="0.3"/>
+  <circle cx="818" cy="144" r="21" stroke="#a78bfa" stroke-width="0.5" fill="none" opacity="0.3"/>
+
+  <!-- Accent dots spread across full width -->
+  <circle cx="60" cy="52" r="1.5" fill="#6366f1" opacity="0.4"/>
+  <circle cx="230" cy="238" r="1" fill="#818cf8" opacity="0.3"/>
+  <circle cx="430" cy="44" r="1.5" fill="#a78bfa" opacity="0.3"/>
+  <circle cx="690" cy="246" r="1" fill="#818cf8" opacity="0.3"/>
+  <circle cx="900" cy="48" r="1.5" fill="#a78bfa" opacity="0.3"/>
+  <circle cx="1000" cy="240" r="1.5" fill="#c084fc" opacity="0.3"/>
+  <circle cx="1150" cy="60" r="1.5" fill="#6366f1" opacity="0.35"/>
+  <circle cx="1140" cy="228" r="1" fill="#c084fc" opacity="0.3"/>
+</svg>

--- a/website/public/app-assets/workflows/hero-detail-light.svg
+++ b/website/public/app-assets/workflows/hero-detail-light.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288">
+  <defs>
+    <linearGradient id="bg-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f0f4ff"/><stop offset="100%" stop-color="#e8eeff"/>
+    </linearGradient>
+    <linearGradient id="g1-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f46e5"/><stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="g2-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818cf8"/><stop offset="100%" stop-color="#a5b4fc"/>
+    </linearGradient>
+    <linearGradient id="g3-detail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="g4-detail" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1"/><stop offset="100%" stop-color="#4338ca"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="288" fill="url(#bg-detail)"/>
+
+  <!-- Connection lines (full-width DAG) -->
+  <path d="M136 144L296 144M356 132L551 100M356 156L551 188M599 100L786 140M599 188L786 148M846 144L1050 144"
+        stroke="#c7d2fe" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Arrowheads -->
+  <polygon points="292,140 300,144 292,148" fill="#c7d2fe"/>
+  <polygon points="545,96 553,100 546,105" fill="#c7d2fe"/>
+  <polygon points="546,184 553,189 545,193" fill="#c7d2fe"/>
+  <polygon points="782,136 790,140 781,143" fill="#c7d2fe"/>
+  <polygon points="781,146 790,149 782,153" fill="#c7d2fe"/>
+  <polygon points="1046,140 1054,144 1046,148" fill="#c7d2fe"/>
+
+  <!-- Start node -->
+  <circle cx="110" cy="144" r="26" fill="url(#g1-detail)" opacity="0.9"/>
+  <circle cx="110" cy="144" r="14" fill="none" stroke="#fff" stroke-width="2" opacity="0.6"/>
+
+  <!-- Process node (rounded square) -->
+  <rect x="300" y="116" width="56" height="56" rx="12" fill="url(#g4-detail)"/>
+  <rect x="312" y="128" width="32" height="32" rx="5" fill="none" stroke="#fff" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- Branch node top -->
+  <circle cx="575" cy="96" r="24" fill="url(#g3-detail)"/>
+  <circle cx="575" cy="96" r="12" fill="none" stroke="#fff" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- Branch node bottom -->
+  <circle cx="575" cy="192" r="24" fill="url(#g2-detail)"/>
+  <rect x="565" y="182" width="20" height="20" rx="4" fill="none" stroke="#fff" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- Merge node (pill) -->
+  <rect x="790" y="116" width="56" height="56" rx="28" fill="url(#g1-detail)"/>
+  <circle cx="818" cy="144" r="12" fill="none" stroke="#fff" stroke-width="2" opacity="0.7"/>
+
+  <!-- End node -->
+  <circle cx="1080" cy="144" r="26" fill="url(#g4-detail)" opacity="0.9"/>
+  <rect x="1068" y="132" width="24" height="24" rx="5" fill="none" stroke="#fff" stroke-width="2" opacity="0.6"/>
+
+  <!-- Accent dots spread across full width -->
+  <circle cx="60" cy="52" r="4" fill="#a5b4fc" opacity="0.4"/>
+  <circle cx="230" cy="238" r="3" fill="#6366f1" opacity="0.3"/>
+  <circle cx="430" cy="44" r="3" fill="#818cf8" opacity="0.3"/>
+  <circle cx="690" cy="246" r="4" fill="#818cf8" opacity="0.3"/>
+  <circle cx="900" cy="48" r="3" fill="#6366f1" opacity="0.25"/>
+  <circle cx="1000" cy="240" r="5" fill="#a5b4fc" opacity="0.35"/>
+  <circle cx="1150" cy="60" r="4" fill="#818cf8" opacity="0.3"/>
+  <circle cx="1140" cy="228" r="3" fill="#6366f1" opacity="0.3"/>
+</svg>

--- a/website/public/app-assets/worlds/hero-detail-dark.svg
+++ b/website/public/app-assets/worlds/hero-detail-dark.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288" fill="none">
+  <rect width="1200" height="288" fill="#0f172a"/>
+  <!-- Stars spread across full width -->
+  <circle cx="40" cy="34" r="1" fill="#e2e8f0" opacity="0.7"/>
+  <circle cx="130" cy="60" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="220" cy="28" r="1.2" fill="#e2e8f0" opacity="0.6"/>
+  <circle cx="310" cy="70" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="400" cy="40" r="1" fill="#e2e8f0" opacity="0.7"/>
+  <circle cx="480" cy="90" r="0.8" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="560" cy="30" r="0.7" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="640" cy="66" r="1" fill="#e2e8f0" opacity="0.6"/>
+  <circle cx="720" cy="24" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="800" cy="80" r="0.7" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="880" cy="38" r="1.2" fill="#e2e8f0" opacity="0.6"/>
+  <circle cx="950" cy="92" r="0.8" fill="#e2e8f0" opacity="0.5"/>
+  <circle cx="1120" cy="30" r="1" fill="#e2e8f0" opacity="0.7"/>
+  <circle cx="1170" cy="70" r="0.8" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="90" cy="100" r="0.6" fill="#e2e8f0" opacity="0.4"/>
+  <circle cx="1060" cy="110" r="0.7" fill="#e2e8f0" opacity="0.3"/>
+  <!-- Moon (spread to the side) -->
+  <circle cx="1050" cy="70" r="30" fill="#fde68a" opacity="0.05"/>
+  <circle cx="1050" cy="70" r="22" fill="#fde68a" opacity="0.9"/>
+  <circle cx="1042" cy="65" r="18" fill="#0f172a"/>
+  <!-- Ground across full width -->
+  <rect x="0" y="205" width="1200" height="83" fill="#064e3b" opacity="0.6"/>
+  <rect x="0" y="200" width="1200" height="8" rx="4" fill="#059669" opacity="0.3"/>
+  <!-- Pixel trees distributed along the horizon -->
+  <g transform="translate(-43,10)">
+    <rect x="80" y="180" width="6" height="15" fill="#065f46" opacity="0.7"/>
+    <polygon points="83,155 70,180 96,180" fill="#059669" opacity="0.6"/>
+  </g>
+  <g transform="translate(-102,10)">
+    <rect x="400" y="178" width="5" height="17" fill="#065f46" opacity="0.7"/>
+    <polygon points="402,153 391,178 414,178" fill="#059669" opacity="0.6"/>
+  </g>
+  <g transform="translate(477,10)">
+    <rect x="80" y="180" width="6" height="15" fill="#065f46" opacity="0.7"/>
+    <polygon points="83,155 70,180 96,180" fill="#059669" opacity="0.6"/>
+  </g>
+  <g transform="translate(478,10)">
+    <rect x="400" y="178" width="5" height="17" fill="#065f46" opacity="0.7"/>
+    <polygon points="402,153 391,178 414,178" fill="#059669" opacity="0.6"/>
+  </g>
+  <g transform="translate(1067,10)">
+    <rect x="80" y="180" width="6" height="15" fill="#065f46" opacity="0.7"/>
+    <polygon points="83,155 70,180 96,180" fill="#059669" opacity="0.6"/>
+  </g>
+  <!-- Green agent (center ~150) -->
+  <g transform="translate(0,5)">
+    <rect x="140" y="170" width="20" height="20" rx="2" fill="#4ade80" opacity="0.8"/>
+    <rect x="144" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="152" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="146" y="182" width="8" height="2" rx="1" fill="#0f172a"/>
+    <rect x="138" y="168" width="24" height="24" rx="3" stroke="#4ade80" stroke-width="1" fill="none" opacity="0.3"/>
+  </g>
+  <!-- Blue agent (center ~430) -->
+  <g transform="translate(179,5)">
+    <rect x="240" y="165" width="22" height="22" rx="2" fill="#60a5fa" opacity="0.8"/>
+    <rect x="245" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="253" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="247" y="178" width="8" height="2" rx="1" fill="#0f172a"/>
+    <rect x="238" y="163" width="26" height="26" rx="3" stroke="#60a5fa" stroke-width="1" fill="none" opacity="0.3"/>
+  </g>
+  <!-- Pink agent (center ~700) -->
+  <g transform="translate(361,5)">
+    <rect x="330" y="172" width="18" height="18" rx="2" fill="#f472b6" opacity="0.8"/>
+    <rect x="334" y="176" width="3" height="3" rx="1" fill="#0f172a"/>
+    <rect x="341" y="176" width="3" height="3" rx="1" fill="#0f172a"/>
+    <rect x="335" y="183" width="7" height="2" rx="1" fill="#0f172a"/>
+    <rect x="328" y="170" width="22" height="22" rx="3" stroke="#f472b6" stroke-width="1" fill="none" opacity="0.3"/>
+  </g>
+  <!-- Green agent (center ~950) -->
+  <g transform="translate(800,5)">
+    <rect x="140" y="170" width="20" height="20" rx="2" fill="#4ade80" opacity="0.8"/>
+    <rect x="144" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="152" y="174" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="146" y="182" width="8" height="2" rx="1" fill="#0f172a"/>
+    <rect x="138" y="168" width="24" height="24" rx="3" stroke="#4ade80" stroke-width="1" fill="none" opacity="0.3"/>
+  </g>
+  <!-- Blue agent (center ~1080) -->
+  <g transform="translate(829,5)">
+    <rect x="240" y="165" width="22" height="22" rx="2" fill="#60a5fa" opacity="0.8"/>
+    <rect x="245" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="253" y="170" width="4" height="4" rx="1" fill="#0f172a"/>
+    <rect x="247" y="178" width="8" height="2" rx="1" fill="#0f172a"/>
+    <rect x="238" y="163" width="26" height="26" rx="3" stroke="#60a5fa" stroke-width="1" fill="none" opacity="0.3"/>
+  </g>
+</svg>

--- a/website/public/app-assets/worlds/hero-detail-light.svg
+++ b/website/public/app-assets/worlds/hero-detail-light.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 288" width="1200" height="288">
+<defs><linearGradient id="sky-detail" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a8e6cf"/><stop offset="100%" stop-color="#dcedc1"/></linearGradient></defs>
+<rect width="1200" height="288" fill="url(#sky-detail)"/>
+<!-- Sun (sky decoration, spread to the side) -->
+<circle cx="1040" cy="66" r="30" fill="#ffd93d"/><circle cx="1040" cy="66" r="22" fill="#ffec8b"/>
+<circle cx="230" cy="52" r="20" fill="#ffd93d" opacity="0.35"/>
+<!-- Ground band across full width -->
+<rect x="0" y="205" width="1200" height="83" fill="#6bba75"/>
+<rect x="0" y="205" width="1200" height="8" fill="#4a9e5c"/>
+<!-- Trees distributed along the horizon -->
+<g transform="translate(-24,-5)">
+  <rect x="60" y="180" width="8" height="30" fill="#8b5e3c"/>
+  <polygon points="44,180 84,180 64,148" fill="#2d8a4e"/>
+  <polygon points="48,165 80,165 64,138" fill="#34a853"/>
+</g>
+<g transform="translate(-143,-5)">
+  <rect x="440" y="188" width="5" height="22" fill="#8b5e3c"/>
+  <polygon points="430,188 455,188 443,165" fill="#2d8a4e"/>
+</g>
+<g transform="translate(496,-5)">
+  <rect x="60" y="180" width="8" height="30" fill="#8b5e3c"/>
+  <polygon points="44,180 84,180 64,148" fill="#2d8a4e"/>
+  <polygon points="48,165 80,165 64,138" fill="#34a853"/>
+</g>
+<g transform="translate(437,-5)">
+  <rect x="440" y="188" width="5" height="22" fill="#8b5e3c"/>
+  <polygon points="430,188 455,188 443,165" fill="#2d8a4e"/>
+</g>
+<g transform="translate(1086,-5)">
+  <rect x="60" y="180" width="8" height="30" fill="#8b5e3c"/>
+  <polygon points="44,180 84,180 64,148" fill="#2d8a4e"/>
+  <polygon points="48,165 80,165 64,138" fill="#34a853"/>
+</g>
+<!-- Blue robot agent (center ~150) -->
+<g transform="translate(-8,-5)">
+  <rect x="140" y="168" width="36" height="42" rx="4" fill="#4a90d9"/>
+  <rect x="144" y="174" width="12" height="8" rx="2" fill="#fff"/>
+  <rect x="160" y="174" width="12" height="8" rx="2" fill="#fff"/>
+  <circle cx="148" cy="177" r="3" fill="#1a1a2e"/>
+  <circle cx="164" cy="177" r="3" fill="#1a1a2e"/>
+  <rect x="152" y="188" width="12" height="4" rx="2" fill="#2c5f8a"/>
+  <rect x="146" y="196" width="24" height="8" rx="2" fill="#3a7bc8"/>
+  <rect x="144" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+  <rect x="162" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+  <rect x="150" y="156" width="16" height="12" rx="6" fill="#6ba8e8"/>
+</g>
+<!-- Orange agent (center ~430) -->
+<g transform="translate(186,-5)">
+  <rect x="230" y="178" width="28" height="32" rx="3" fill="#f4845f"/>
+  <rect x="234" y="182" width="8" height="6" rx="1" fill="#fff"/>
+  <rect x="246" y="182" width="8" height="6" rx="1" fill="#fff"/>
+  <circle cx="237" cy="184" r="2" fill="#1a1a2e"/>
+  <circle cx="249" cy="184" r="2" fill="#1a1a2e"/>
+  <rect x="238" y="194" width="12" height="3" rx="1" fill="#d4644a"/>
+  <rect x="234" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+  <rect x="246" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+  <polygon points="244,168 248,178 240,178" fill="#f7a072"/>
+</g>
+<!-- Purple agent (center ~700) -->
+<g transform="translate(379,-5)">
+  <rect x="310" y="186" width="22" height="24" rx="3" fill="#9b59b6"/>
+  <rect x="313" y="190" width="6" height="5" rx="1" fill="#fff"/>
+  <rect x="323" y="190" width="6" height="5" rx="1" fill="#fff"/>
+  <circle cx="316" cy="192" r="2" fill="#1a1a2e"/>
+  <circle cx="326" cy="192" r="2" fill="#1a1a2e"/>
+  <rect x="316" y="200" width="10" height="2" rx="1" fill="#7d3c98"/>
+  <rect x="313" y="210" width="6" height="8" rx="1" fill="#9b59b6"/>
+  <rect x="323" y="210" width="6" height="8" rx="1" fill="#9b59b6"/>
+  <circle cx="321" cy="180" r="5" fill="#bb8fd0"/>
+</g>
+<!-- Blue robot agent (center ~950) -->
+<g transform="translate(792,-5)">
+  <rect x="140" y="168" width="36" height="42" rx="4" fill="#4a90d9"/>
+  <rect x="144" y="174" width="12" height="8" rx="2" fill="#fff"/>
+  <rect x="160" y="174" width="12" height="8" rx="2" fill="#fff"/>
+  <circle cx="148" cy="177" r="3" fill="#1a1a2e"/>
+  <circle cx="164" cy="177" r="3" fill="#1a1a2e"/>
+  <rect x="152" y="188" width="12" height="4" rx="2" fill="#2c5f8a"/>
+  <rect x="146" y="196" width="24" height="8" rx="2" fill="#3a7bc8"/>
+  <rect x="144" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+  <rect x="162" y="210" width="10" height="12" rx="2" fill="#4a90d9"/>
+  <rect x="150" y="156" width="16" height="12" rx="6" fill="#6ba8e8"/>
+</g>
+<!-- Orange agent (center ~1080) -->
+<g transform="translate(836,-5)">
+  <rect x="230" y="178" width="28" height="32" rx="3" fill="#f4845f"/>
+  <rect x="234" y="182" width="8" height="6" rx="1" fill="#fff"/>
+  <rect x="246" y="182" width="8" height="6" rx="1" fill="#fff"/>
+  <circle cx="237" cy="184" r="2" fill="#1a1a2e"/>
+  <circle cx="249" cy="184" r="2" fill="#1a1a2e"/>
+  <rect x="238" y="194" width="12" height="3" rx="1" fill="#d4644a"/>
+  <rect x="234" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+  <rect x="246" y="210" width="8" height="10" rx="2" fill="#f4845f"/>
+  <polygon points="244,168 248,178 240,178" fill="#f7a072"/>
+</g>
+<!-- Grass tufts scattered along the ground -->
+<rect x="90" y="232" width="12" height="4" rx="2" fill="#5aad68"/>
+<rect x="300" y="244" width="8" height="3" rx="1" fill="#5aad68"/>
+<rect x="520" y="236" width="10" height="4" rx="2" fill="#5aad68"/>
+<rect x="640" y="250" width="8" height="3" rx="1" fill="#5aad68"/>
+<rect x="800" y="238" width="12" height="4" rx="2" fill="#5aad68"/>
+<rect x="1000" y="248" width="8" height="3" rx="1" fill="#5aad68"/>
+<rect x="1140" y="236" width="10" height="4" rx="2" fill="#5aad68"/>
+</svg>

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -33,6 +33,8 @@ type AppInfo = {
   screenshotsDark?: string[]
   heroImage?: string
   heroImageDark?: string
+  heroImageDetail?: string
+  heroImageDetailDark?: string
   repo?: string
   branch?: string
   // Installed state
@@ -93,6 +95,8 @@ interface AppManifest {
   iconUrl?: string
   heroImage?: string
   heroImageDark?: string
+  heroImageDetail?: string
+  heroImageDetailDark?: string
   ui?: { pages?: { route?: string; label?: string; icon?: string; iconUrl?: string }[] }
   agents?: string[]
   skills?: string[]
@@ -236,6 +240,8 @@ export default function AppDetailPage() {
           screenshotsDark: registryEntry?.screenshotsDark || m.screenshotsDark || [],
           heroImage: registryEntry?.heroImage || m.heroImage || '',
           heroImageDark: registryEntry?.heroImageDark || m.heroImageDark || '',
+          heroImageDetail: registryEntry?.heroImageDetail || m.heroImageDetail || '',
+          heroImageDetailDark: registryEntry?.heroImageDetailDark || m.heroImageDetailDark || '',
           repo: registryEntry?.repo || '',
           installed: true,
           installedVersion: installed.version,
@@ -414,9 +420,19 @@ export default function AppDetailPage() {
   const skillCount = app.manifest?.skills?.length || 0
   const cronCount = app.manifest?.crons?.length || 0
   // Theme-aware hero banner source (mirrors the Browse card resolution).
-  const heroSrc = resolvedMode === 'dark'
+  // Prefer the wide detail-ratio banner (heroImageDetail*); fall back to the
+  // Browse hero, then the opposite theme.
+  const heroDetailSrc = resolvedMode === 'dark'
+    ? (app.heroImageDetailDark || app.heroImageDetail || '')
+    : (app.heroImageDetail || app.heroImageDetailDark || '')
+  const heroBrowseSrc = resolvedMode === 'dark'
     ? (app.heroImageDark || app.heroImage || '')
     : (app.heroImage || app.heroImageDark || '')
+  const heroSrc = heroDetailSrc || heroBrowseSrc
+  // When a dedicated detail banner is shown, size the container to its
+  // 1200x288 (25:6) ratio so object-cover doesn't horizontally crop the art
+  // on viewports narrower than 1200px. Fall back to 16:9 for the Browse hero.
+  const heroIsDetail = Boolean(heroDetailSrc)
 
   return (
     <>
@@ -477,7 +493,7 @@ export default function AppDetailPage() {
 
         {/* Hero banner (only when the app ships one) */}
         {heroSrc && (
-          <div className="w-full aspect-video max-h-72 rounded-2xl border border-border overflow-hidden mb-6 bg-[var(--card)]">
+          <div className={`w-full ${heroIsDetail ? 'aspect-[25/6]' : 'aspect-video'} max-h-72 rounded-2xl border border-border overflow-hidden mb-6 bg-[var(--card)]`}>
             {/* onError is an image-load lifecycle handler (hide broken images). */}
             {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
             <img


### PR DESCRIPTION
<img width="2560" height="1312" alt="Screenshot 2026-07-22 at 10 07 56 PM" src="https://github.com/user-attachments/assets/d5f471f1-8636-4876-a544-d3f078f71913" />

## Description

Fix the App Store **detail-page** hero banner. The Browse card renders the hero in a 16:9 box (`aspect-video`), but the detail page renders a full-width banner whose height is clamped by `max-h-72` (288px). At typical viewport widths that makes the detail banner roughly **4:1–5:1**, so reusing the near-square 16:9 Browse hero with `object-cover` blew the subject up and cropped it badly.

Adds dedicated detail-ratio art plus a field to point at it:

- New `heroImageDetail` / `heroImageDetailDark` fields, wired through the builtin `app.json` manifests, the `worlds`/`projects` builtins in `manager.py`, and the client-app blob proxy in `registry._merge_manifest`.
- `AppDetailPage` prefers the detail variant and falls back to the Browse hero (then the opposite theme), so apps without detail art still render.
- New `hero-detail-light/dark.svg` for all 7 apps, authored at `viewBox="0 0 1200 288"` (~4.17:1) to match the detail banner shape.
- Also wires `dev-fleet`'s hero, which was shipped but previously unlinked.

> **Note:** this fixes the banner **height**, not a fixed aspect ratio. The detail banner width stays fluid while the height is clamped, so `object-cover` still crops **horizontally** at wide viewports. The new art keeps the subject centered with decoration bled to both edges, so the residual crop only trims decoration — never the subject.

## Related Issues

<!-- none -->

## Testing

- [x] Existing tests pass — `AppDetailPage.test.tsx` (3/3) and the registry hero tests
- [x] New tests added for new functionality — registry blob-proxy conversion for `heroImageDetail` / `heroImageDetailDark`
- [x] Manual verification performed — `tsc --noEmit` clean; rebuilt the SPA and restaged into `static/dist`; confirmed the new detail assets are served. Visual QA of each app's detail banner recommended before merge.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — n/a
- [x] No secrets, credentials, or internal references in the diff (scrub-lint passed locally)

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->