### PR TITLE
fix(ui): Correct notification timestamp parsing for numeric epochs

### DIFF
--- a/website/src/components/notifications/notifMeta.tsx
+++ b/website/src/components/notifications/notifMeta.tsx
@@ -40,11 +40,33 @@ export function loadActiveKinds(): Set<Kind> {
   return new Set(KIND_KEYS)
 }
 
-export function parseTs(ts: string): Date {
-  let d = new Date(ts)
-  if (isNaN(d.getTime())) {
-    const epoch = parseFloat(ts)
-    if (!isNaN(epoch)) d = new Date(epoch * 1000)
+export function parseTs(ts: string | number): Date {
+  // A numeric epoch (number, or an all-digits string) can arrive in any unit —
+  // seconds, milliseconds, microseconds, or nanoseconds — depending on the
+  // producer. Detect the unit by magnitude and normalize to milliseconds.
+  //
+  // The previous implementation did `new Date(ts)` then, only on failure,
+  // `new Date(parseFloat(ts) * 1000)`. That broke for a millisecond epoch
+  // passed as a string: `new Date("1784784205932")` is Invalid Date in V8, so
+  // it fell through and multiplied ms by 1000 (treating it as seconds), which
+  // rendered the year as ~58527. Detecting the unit up front fixes both the
+  // ms-as-string and microsecond-as-number cases.
+  const num =
+    typeof ts === 'number'
+      ? ts
+      : /^\s*\d+(\.\d+)?\s*$/.test(ts)
+        ? parseFloat(ts)
+        : NaN
+  let d: Date
+  if (!isNaN(num)) {
+    let ms: number
+    if (num >= 1e17) ms = num / 1e6 // nanoseconds → ms
+    else if (num >= 1e14) ms = num / 1e3 // microseconds → ms
+    else if (num >= 1e11) ms = num // milliseconds (already)
+    else ms = num * 1e3 // seconds → ms
+    d = new Date(ms)
+  } else {
+    d = new Date(ts) // ISO 8601 / RFC date string
   }
   if (isNaN(d.getTime()) || d.getTime() < Date.UTC(2020, 0, 1)) return new Date(NaN)
   return d
@@ -72,12 +94,12 @@ export const KIND_META: Record<string, { icon: ReactNode; color: string; label: 
 }
 export const DEFAULT_META = { icon: <Bell className="lucide-inline" />, color: 'bg-muted/15 text-muted', label: 'Notification', borderColor: 'border-l-muted' }
 
-export function fmtTime(ts: string): string {
+export function fmtTime(ts: string | number): string {
   const d = parseTs(ts)
   return isNaN(d.getTime()) ? 'Unknown date' : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
-export function fmtFull(ts: string): string {
+export function fmtFull(ts: string | number): string {
   const d = parseTs(ts)
   return isNaN(d.getTime()) ? 'Unknown date' : d.toLocaleString()
 }

--- a/website/src/test/notifMeta.parseTs.test.ts
+++ b/website/src/test/notifMeta.parseTs.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { parseTs, fmtFull } from '../components/notifications/notifMeta'
+
+// A fixed reference instant: 2026-07-23T05:34:56.123Z
+const REF_MS = Date.UTC(2026, 6, 23, 5, 34, 56, 123)
+
+describe('parseTs epoch-unit normalization', () => {
+  it('parses ISO 8601 strings', () => {
+    expect(parseTs('2026-07-23T05:34:56.123+00:00').getTime()).toBe(REF_MS)
+  })
+
+  it('parses epoch seconds (string and number)', () => {
+    const sec = Math.floor(REF_MS / 1000)
+    expect(parseTs(String(sec)).getFullYear()).toBe(2026)
+    expect(parseTs(sec).getFullYear()).toBe(2026)
+  })
+
+  it('parses fractional epoch seconds', () => {
+    expect(parseTs(String(REF_MS / 1000)).getTime()).toBe(REF_MS)
+  })
+
+  // Regression: a millisecond epoch passed as a STRING used to render as
+  // year ~58527 (new Date("<13-digit>") is Invalid in V8, then the old
+  // fallback multiplied ms by 1000 as if it were seconds).
+  it('parses epoch milliseconds as string without inflating the year', () => {
+    const d = parseTs(String(REF_MS))
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getTime()).toBe(REF_MS)
+  })
+
+  it('parses epoch milliseconds as number', () => {
+    expect(parseTs(REF_MS).getTime()).toBe(REF_MS)
+  })
+
+  // Regression: a microsecond epoch as a number used to render as ~58527.
+  it('parses epoch microseconds (string and number)', () => {
+    expect(parseTs(String(REF_MS * 1000)).getFullYear()).toBe(2026)
+    expect(parseTs(REF_MS * 1000).getFullYear()).toBe(2026)
+  })
+
+  it('parses epoch nanoseconds (string and number)', () => {
+    expect(parseTs(String(REF_MS * 1e6)).getFullYear()).toBe(2026)
+    expect(parseTs(REF_MS * 1e6).getFullYear()).toBe(2026)
+  })
+
+  it('rejects garbage and pre-2020 timestamps as invalid', () => {
+    expect(isNaN(parseTs('not-a-date').getTime())).toBe(true)
+    expect(isNaN(parseTs('2019-01-01T00:00:00Z').getTime())).toBe(true)
+  })
+
+  it('fmtFull returns "Unknown date" for unparseable input, never a bogus year', () => {
+    expect(fmtFull('not-a-date')).toBe('Unknown date')
+    expect(fmtFull(String(REF_MS))).not.toContain('58527')
+  })
+})


### PR DESCRIPTION
## Problem

<img width="1086" height="274" alt="image" src="https://github.com/user-attachments/assets/31b6d2ba-eea0-4bff-b4f2-24183382221e" />

Notification timestamps rendered as **year ~58527** in the bell/detail panel (see the \`500 Internal Server Error\` example). Root cause is in \`parseTs()\` (\`website/src/components/notifications/notifMeta.tsx\`):

\`\`\`ts
let d = new Date(ts)
if (isNaN(d.getTime())) {
  const epoch = parseFloat(ts)
  if (!isNaN(epoch)) d = new Date(epoch * 1000)  // assumes seconds
}
\`\`\`

A **millisecond epoch passed as a string** (e.g. \`"1784784205932"\`) is \`Invalid Date\` in V8, so it took the fallback and multiplied ms by 1000 as if it were seconds — a 1000× inflation that pushed the year to ~58527. A **microsecond epoch number** hit the same inflation via the direct \`new Date()\` path.

The system notification bus emits ISO strings (which parsed fine), so this only surfaced for producers that send a numeric epoch (e.g. an app/webhook push).

## Fix

Detect the epoch unit by magnitude (seconds / ms / microseconds / nanoseconds) and normalize to **milliseconds** before constructing the \`Date\`:

- ISO 8601 / RFC strings keep the existing \`new Date()\` path.
- The pre-2020 lower-bound guard still rejects garbage/stale values (\`Unknown date\`).
- \`parseTs\` / \`fmtTime\` / \`fmtFull\` param types widened to \`string | number\` (numeric \`ts\` does reach the frontend at runtime).

## Tests

New \`website/src/test/notifMeta.parseTs.test.ts\` — 9 cases covering ISO, seconds/ms/us/ns (string + number), fractional seconds, garbage, and pre-2020 rejection, with explicit regression assertions that the year is never inflated.

\`\`\`
✓ src/test/notifMeta.parseTs.test.ts (9 tests)
Test Files  1 passed (1)   Tests  9 passed (9)
\`\`\`

\`tsc --noEmit\` and \`eslint\` clean on both files; full \`vite build\` passes.

## Verification

Seeded a dev notification with a 13-digit ms-string \`ts\` and a microsecond-number \`ts\`; before the fix both showed 58527, after the fix both render the correct current date. ISO control unchanged.

<img width="1332" height="382" alt="Screenshot 2026-07-22 at 10 42 06 PM" src="https://github.com/user-attachments/assets/93067d2e-7d20-456d-b137-e5ea3bda7f0e" />
<img width="1330" height="377" alt="Screenshot 2026-07-22 at 10 42 12 PM" src="https://github.com/user-attachments/assets/eb9b363d-e9e0-4853-a817-2c807f4817b3" />
<img width="1332" height="379" alt="Screenshot 2026-07-22 at 10 42 21 PM" src="https://github.com/user-attachments/assets/e7a09e6b-b143-47cf-98da-a5acc9dea651" />
