### PR TITLE
feat(platform): Slack message-gate interceptor + token-consume anchor + reply-decorator seams

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -510,6 +510,50 @@ is byte-identical) with no `CONTRACT_VERSION` bump.
   PRIMARY spawn path; `AcpClient`/`AcpProvider` take a `permission_mode` kwarg
   (Default `None`); `acp/types.py` adds `CC_PERMISSION_MODE_DEFAULT` /
   `CC_PERMISSION_MODE_AUTO`.
+- Slack message-gate seams (let an edition compose a fail-closed
+  challenge-and-redirect posture without editing the core; `InterceptDecision`
+  enum = `PROCESS | REDIRECTED | DROPPED`):
+  - `SlackEnterpriseGate.intercept_message(orch, *, channel, sender_id,
+    clean_text, thread_ts, msg_ts) -> InterceptDecision` — wired in
+    `slack/events.py::_route_message`. Default `PROCESS` (inline, OSS-identical).
+    **Ordering is security-critical:** the call site is placed immediately after
+    the user-allowlist check and BEFORE any content is recorded or processed
+    (observe-mode `channel_history.push`, audio transcription, image/file
+    download, and the non-observe history push all follow it), so an unverified
+    sender's content can never be persisted to channel history where a later
+    verified turn could pull it into agent context and bypass the gate. Gated on
+    `_user_authorized` (an unauthorized sender is not a challenge candidate and
+    keeps its ephemeral-rejection UX). Invoked through
+    `safe_context_call(..., fallback=DROPPED)`: a raised adapter error degrades
+    deny-by-default, a `PlatformCompositionError` is re-raised. The public
+    Default cannot raise, so standalone never reaches the fallback.
+  - `DashboardContributor.on_token_consumed(user_id, channel, session_exp,
+    thread_ts)` — fired in `dashboard/token_auth.py` after `bind_token_ip` on the
+    first (non-cookie) exchange, with `channel`/`thread_ts` read from the token's
+    signed `extra` payload. OBSERVER only; the anchor a challenge auth-window
+    opens on. Default no-op. `safe_context_call(fallback=None)` re-raises
+    `PlatformCompositionError` — no outer `except` wraps it (that would swallow
+    the invariant).
+  - `DashboardContributor.decorate_reply(text, *, channel, user_id) -> str` —
+    outbound-reply transform, AFTER the redaction passes. Default identity. Wired
+    on BOTH Slack reply paths: native `slack/handler.py::handle_message` AND the
+    default `slack/renderer.py::SlackRenderer.on_done` (the `handle_message_transport`
+    path that normal non-review traffic uses — `SlackRenderer` takes a `user_id`
+    kwarg for it). Decorator-introduced text is re-scanned (`redact_exfiltration_urls`
+    + `redact_credentials`) on both paths so a decorator cannot smuggle a URL/
+    credential past redaction; the native path logs only the redaction COUNT
+    (never the warning strings, which embed a truncated credential prefix).
+
+  Interceptor ordering + dedup + audit (security-critical, all in `_route_message`):
+  the `intercept_message` call runs after the user-allowlist check and after the
+  interceptor-specific retry-dedup guard, but BEFORE any content recording/
+  processing. A non-`PROCESS` decision (1) records an `intercept:<msg_ts>` key in
+  the `SeenCache` so a Slack ack-timeout re-delivery does not re-mint the challenge
+  (PROCESS never records, preserving the paired `app_mention`/`message` dual-event
+  and the standalone inline path), and (2) emits a
+  `sel().log_api_access(operation="slack.message.intercept")` audit event — the
+  interceptor is a permission decision distinct from the allowlist check, so its
+  verdict reaches the SEL trail.
 
 ### Deferred / non-mapping sites
 

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1485,6 +1485,31 @@ def token_auth_middleware(
             # not the consumed URL token.
             bind_token_ip(session_token, client_ip, session_exp)
 
+            # Token-consumption anchor seam (Default: no-op, OSS-identical). A
+            # Slack challenge-redirect link, once opened on a verified device,
+            # consumes its token here — the edition opens the bounded per-(user,
+            # channel) auth window that lets follow-up Slack traffic flow inline.
+            # channel/thread_ts ride the token's signed ``extra`` payload (``data``);
+            # absent for non-challenge tokens, so the window is only opened for a
+            # real challenge exchange. Fail-safe: ``safe_context_call`` swallows an
+            # observer error (fallback=None) so it never blocks token consumption /
+            # login, while still re-raising ``PlatformCompositionError`` — the boot
+            # invariant that a mis-composed edition MUST abort rather than silently
+            # degrade. Do NOT wrap this in a bare ``except Exception``: that is
+            # exactly the swallow ``safe_context_call`` centralizes to prevent.
+            _chan = str(data.get("channel", "")) if isinstance(data, dict) else ""
+            _thread = (data.get("thread_ts") if isinstance(data, dict) else None) or None
+            if _chan:
+                from kiro_crew.platform import current_context, safe_context_call
+
+                safe_context_call(
+                    lambda: current_context().dashboard.on_token_consumed(
+                        user_id, _chan, session_exp, _thread
+                    ),
+                    fallback=None,
+                    log_message="dashboard.on_token_consumed observer failed",
+                )
+
         # Expose authenticated identity to handlers (deny-by-default)
         request["user"] = user_id
         request["app"] = app_name

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from kiro_crew import security, sso_status
+from kiro_crew.platform.interfaces import InterceptDecision
 
 # ``agent``, ``sandbox``, ``embeddings``, ``apps.registry`` and ``slack.enterprise``
 # import ``kiro_crew.platform`` at module-load time, so importing them at the top
@@ -136,6 +137,21 @@ class DefaultSlackEnterpriseGate:
         # stays exactly the core HEARTBEAT_SAFE_TOOLS. The companion returns its
         # internal read-only tool names.
         return frozenset()
+
+    def intercept_message(
+        self,
+        orch: Any,
+        *,
+        channel: str,
+        sender_id: str,
+        clean_text: str,
+        thread_ts: "str | None",
+        msg_ts: str,
+    ) -> "InterceptDecision":
+        # The public edition processes every allowed message inline — no
+        # challenge-and-redirect. Returning PROCESS keeps _route_message
+        # byte-identical to the pre-seam OSS behavior.
+        return InterceptDecision.PROCESS
 
 
 class DefaultIdentityProvider:
@@ -320,6 +336,21 @@ class DefaultDashboardContributor:
         # The public edition observes no chat messages. A companion uses this to
         # e.g. auto-ingest doc links pasted into chat.
         return None
+
+    def on_token_consumed(
+        self,
+        user_id: str,
+        channel: str,
+        session_exp: float,
+        thread_ts: "str | None",
+    ) -> None:
+        # The public edition opens no Slack auth window on token consumption.
+        return None
+
+    def decorate_reply(self, text: str, *, channel: str, user_id: str) -> str:
+        # The public edition sends replies unchanged (no expiry footer / window
+        # refresh — there is no challenge window in OSS).
+        return text
 
 
 class DefaultJailProvider:

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -13,6 +13,7 @@ deny decision must be ``@final`` to enforce the ADD-only floor.
 
 from __future__ import annotations
 
+import enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Protocol
 
@@ -20,6 +21,32 @@ if TYPE_CHECKING:
     from aiohttp import web
 
     from kiro_crew.config.loader import KiroCrewConfig
+
+
+class InterceptDecision(enum.Enum):
+    """Verdict an edition returns for an inbound Slack message at the route gate.
+
+    Returned by ``SlackEnterpriseGate.intercept_message`` (called at the top of
+    ``slack/events.py::_route_message``). The public default is always
+    ``PROCESS`` — the OSS build processes every allowed message inline, so this
+    seam changes nothing until a companion overrides the gate.
+
+    - ``PROCESS`` — handle the message inline as usual (the OSS behavior).
+    - ``REDIRECTED`` — the gate has handled the message out-of-band (e.g. posted a
+      presigned dashboard-session challenge link) and inline processing MUST be
+      short-circuited. The gate owns any user-facing reply.
+    - ``DROPPED`` — the message is denied and must not be processed. Used as the
+      fail-closed outcome: a companion whose challenge mint/post fails returns
+      ``DROPPED`` rather than falling through to inline processing.
+
+    ``REDIRECTED`` and ``DROPPED`` both short-circuit ``_route_message``; they
+    differ only in intent (redirected = a challenge was issued; dropped = denied),
+    which the gate records in its own audit trail.
+    """
+
+    PROCESS = "process"
+    REDIRECTED = "redirected"
+    DROPPED = "dropped"
 
 
 # ── boot-layer extension points ──
@@ -199,6 +226,54 @@ class SlackEnterpriseGate(Protocol):
         """
         ...
 
+    def intercept_message(
+        self,
+        orch: Any,
+        *,
+        channel: str,
+        sender_id: str,
+        clean_text: str,
+        thread_ts: "str | None",
+        msg_ts: str,
+    ) -> "InterceptDecision":
+        """Decide the fate of an inbound Slack message before inline processing.
+
+        WIRED: called at the TOP of ``slack/events.py::_route_message`` (after the
+        user-allowlist check, before the busy/queue path). The public default
+        returns ``InterceptDecision.PROCESS`` for every message, so the OSS build
+        is byte-identical — every allowed message is handled inline as today.
+
+        A companion may return ``REDIRECTED`` (it handled the message out-of-band,
+        e.g. minted + posted a presigned dashboard-session challenge link) or
+        ``DROPPED`` (denied) to short-circuit inline processing. This is the seam an
+        enterprise edition's "challenge-and-redirect" security posture composes
+        against: the first message from an unverified (user, channel) is turned into
+        a one-time dashboard link instead of reaching the agent, and follow-up
+        traffic flows inline only while a bounded auth window (opened at token
+        consumption via ``DashboardContributor.on_token_consumed``) is live. The
+        core ships no such posture; any organization can supply one through this
+        seam (device-verification gate, SSO step-up, custom allow policy, …).
+
+        **Fail-closed contract.** A gate that cannot complete its decision (e.g.
+        the challenge mint/post raised) MUST return ``DROPPED``, never ``PROCESS``
+        — a mis-composed or erroring gate must never silently degrade to inline
+        processing. ``_route_message`` enforces this at the call site too: the seam
+        is invoked through ``safe_context_call(..., fallback=DROPPED)``, so a raised
+        adapter error (any non-``PlatformCompositionError``) degrades to ``DROPPED``,
+        not ``PROCESS`` — deny-by-default. A ``PlatformCompositionError`` is re-raised
+        (boot invariant, never degraded). The public ``Default`` returns ``PROCESS``
+        and cannot raise, so a standalone build is byte-identical (its contract IS
+        "process inline") and never reaches the fallback; only a composed edition
+        that has declared a stricter posture can trip it.
+
+        Receives the orchestrator plus the resolved message fields so a companion
+        can key its auth window on ``(sender_id, channel)`` and thread the
+        challenge back to the right ``thread_ts``. Returns quickly and does not
+        block the event loop on network I/O beyond the challenge post. v1 method
+        addition (no ``CONTRACT_VERSION`` bump).
+        """
+        ...
+
 
 class IdentityProvider(Protocol):
     """SSO/identity resolution.
@@ -239,8 +314,7 @@ class IdentityProvider(Protocol):
         """
         ...
 
-    def credential_watch_paths(self) -> List[Path]:
-        ...
+    def credential_watch_paths(self) -> List[Path]: ...
 
 
 class EmbeddingSource(Protocol):
@@ -486,6 +560,47 @@ class DashboardContributor(Protocol):
         auto-ingest document links pasted into chat.  It is an
         OBSERVER — its return value is ignored and it MUST NOT mutate the message
         or the turn.
+        """
+        ...
+
+    def on_token_consumed(
+        self,
+        user_id: str,
+        channel: str,
+        session_exp: float,
+        thread_ts: "str | None",
+    ) -> None:
+        """Observe a dashboard-session token being consumed on a verified device.
+
+        WIRED: ``dashboard/token_auth.py::bind_token_ip`` calls this once, right
+        after it binds the token to the consuming IP, inside a fail-safe guard so
+        an observer error never blocks token consumption. Fire-and-forget: the
+        observer must not block.
+
+        This is the anchor the Slack challenge-and-redirect posture needs: when a
+        user opens a presigned challenge link on a real device, the token is
+        consumed here, and the companion opens the bounded per-``(user, channel)``
+        auth window that lets subsequent Slack traffic flow inline (see
+        ``SlackEnterpriseGate.intercept_message``). ``session_exp`` is the token's
+        session expiry (the window's hard ceiling); ``thread_ts`` threads the
+        window to the originating Slack thread. The public Default is a no-op — no
+        window is opened, matching today's OSS behavior. v1 method addition (no
+        ``CONTRACT_VERSION`` bump).
+        """
+        ...
+
+    def decorate_reply(self, text: str, *, channel: str, user_id: str) -> str:
+        """Transform an outbound Slack reply just before it is sent (Default: identity).
+
+        WIRED: ``slack/handler.py`` calls this on the finalized reply text on the
+        outbound path, inside a fail-safe guard (a raising decorator falls back to
+        the undecorated text). The public Default returns ``text`` unchanged.
+
+        The challenge posture uses it to append a "<5 min left" expiry footer when
+        the auth window for ``(user_id, channel)`` is close to lapsing, and to
+        refresh the window's activity clock on each reply. It is a PURE
+        transform — it returns the (possibly-decorated) text and must not block on
+        network I/O. v1 method addition (no ``CONTRACT_VERSION`` bump).
         """
         ...
 

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -45,7 +45,8 @@ from kiro_crew.dashboard.token_auth import LINK_WINDOW_SECS, MAX_SESSION_TTL_SEC
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.mcp_discovery import list_servers
-from kiro_crew.platform import current_context
+from kiro_crew.platform import current_context, safe_context_call
+from kiro_crew.platform.interfaces import InterceptDecision
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import (
     redact_credentials,
@@ -178,6 +179,23 @@ class SeenCache:
         if len(self._d) > self._maxlen:
             self._d.popitem(last=False)
         return False
+
+    def check(self, key: str) -> bool:
+        """Return ``True`` if *key* was already marked, WITHOUT marking it.
+
+        Split from ``check_and_add`` for the message-interceptor dedup, which must
+        record a key ONLY on a non-PROCESS (challenge/deny) decision — marking a
+        PROCESS message would wrongly drop the paired ``app_mention`` event (same
+        ``msg_ts``) or a standalone inline message. See ``_route_message``.
+        """
+        return key in self._d
+
+    def add(self, key: str) -> None:
+        """Mark *key* seen (idempotent, bounded)."""
+        if key not in self._d:
+            self._d[key] = None
+            if len(self._d) > self._maxlen:
+                self._d.popitem(last=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1882,6 +1900,94 @@ async def _route_message(
             error="unauthorized sender",
         )
 
+    # ── Message-interceptor seam (Default: PROCESS = inline, OSS-identical) ──
+    # An edition may intercept the message here and turn it into an out-of-band
+    # challenge-redirect (e.g. a presigned dashboard-session link) instead of
+    # processing it inline. The public DefaultSlackEnterpriseGate ALWAYS returns
+    # PROCESS and cannot raise, so the standalone build falls straight through
+    # exactly as before — the fallback below is never reached in standalone.
+    #
+    # ORDERING (security-critical): this runs BEFORE any content is recorded or
+    # processed — the observe-mode channel_history.push below, audio transcription,
+    # image/file download, and the non-observe history push all follow. An
+    # unverified sender's message content (prompt-injection text, attachments) must
+    # NOT be persisted to channel history before the gate decides: otherwise a
+    # later VERIFIED turn in the same channel could pull that stored content into
+    # agent context, bypassing the very challenge gate the edition relies on. So
+    # the interceptor is the first thing after the user-allowlist check, before
+    # the message leaves a trace. It keys on (sender_id, channel) identity, so it
+    # does not need the post-transcription/mention-stripped text; it gets the raw
+    # text for challenge context/logging only.
+    #
+    # The fallback is DROPPED (deny-by-default), NOT PROCESS: this branch is only
+    # reached when a COMPOSED gate raised a transient error (a
+    # PlatformCompositionError is re-raised by safe_context_call, never degraded).
+    # A composed edition installs its interceptor precisely to keep unverified
+    # traffic away from the agent, so an erroring interceptor must fail CLOSED —
+    # degrading to PROCESS would let a message bypass the gate (deny-by-default).
+    #
+    # Gated on _user_authorized: an UNauthorized sender is not a challenge
+    # candidate (they are rejected with an ephemeral below) and the observe-mode
+    # history push is itself _user_authorized-gated, so only an authorized sender's
+    # content can be recorded pre-gate — that is exactly the leak this ordering
+    # closes. Skipping the interceptor for unauthorized senders also preserves
+    # their existing ephemeral-rejection UX unchanged.
+    if _user_authorized:
+        _intercept_clean = text
+        if is_mention and text.startswith("<@"):
+            _end = text.find(">")
+            if _end != -1:
+                _intercept_clean = text[_end + 1 :].lstrip()
+        # Interceptor-specific dedup: Slack re-delivers the same event on ack
+        # timeout, and this seam runs BEFORE the main _route_message dedup (which
+        # must stay after the activation check). Without a guard here a redirecting
+        # adapter would re-mint + re-post a challenge link on every retry. Key it in
+        # a separate "intercept:" namespace and RECORD it only on a non-PROCESS
+        # decision (below) — never for PROCESS, so a passed message still reaches
+        # the main dedup and the paired app_mention/message dual-event is preserved.
+        _intercept_seen_key = f"intercept:{msg_ts}"
+        if seen.check(_intercept_seen_key):
+            # A prior delivery of this event already got a challenge/deny verdict;
+            # drop the retry silently (the original already replied / was audited).
+            return
+        _decision = safe_context_call(
+            lambda: current_context().slack_gate.intercept_message(
+                orch,
+                channel=channel,
+                sender_id=sender_id,
+                clean_text=_intercept_clean,
+                thread_ts=thread_ts,
+                msg_ts=msg_ts,
+            ),
+            fallback=InterceptDecision.DROPPED,
+            log_message="slack_gate.intercept_message failed; failing closed (DROPPED)",
+        )
+        if _decision is not InterceptDecision.PROCESS:
+            # REDIRECTED (a challenge was issued) or DROPPED (denied / gate error):
+            # the gate owns any user-facing reply; short-circuit before ANY content
+            # is recorded/processed. No image temps have been downloaded yet at this
+            # point (that happens further below), so nothing to clean up here.
+            seen.add(_intercept_seen_key)  # dedup subsequent retries of this event
+            # SEL audit: the interceptor is a permission decision distinct from the
+            # earlier allowlist check, so its verdict MUST reach the audit trail
+            # (backend-security-controls). REDIRECTED = a challenge was issued;
+            # DROPPED = denied or a fail-closed gate error.
+            sel().log_api_access(
+                caller=sender_id,
+                operation="slack.message.intercept",
+                outcome="denied",
+                source="slack",
+                resources=channel,
+                error=f"intercept={getattr(_decision, 'value', _decision)}",
+            )
+            logger.info(
+                "Message from %s in %s intercepted (%s)",
+                sender_id,
+                channel,
+                getattr(_decision, "value", _decision),
+            )
+            return
+
     # ── Channel activation mode (checked BEFORE ephemeral & dedup) ──
     # When activation=mention, Slack sends both a `message` and an
     # `app_mention` event for the same msg_ts.  We must skip the plain
@@ -2179,19 +2285,6 @@ async def _route_message(
     # Per-channel agent override
     agent_override = ch_cfg.agent or None
 
-    # ── NOTE: NO challenge-and-redirect here (intentional) ──────────────────
-    # Slack messages are processed INLINE — they fall straight through to the
-    # queue/handle_message path below and reach the agent directly. They are
-    # gated only by the user allowlist (is_allowed_user, checked earlier).
-    #
-    # The "challenge-and-redirect" flow (every message intercepted and turned
-    # into a presigned dashboard-session link via send_channel_challenge) was
-    # an enterprise-only security posture and has been DELIBERATELY REMOVED
-    # for external/open-source usage.
-    #
-    # DO NOT re-introduce it during an upstream sync. If a sync
-    # surfaces a `_CHALLENGE_REDIRECT_ENABLED` gate or a `send_channel_challenge`
-    # call here, DROP that hunk.
     logger.info(
         "Message from %s in %s (activation=%s): %s",
         sender_id,

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -3502,6 +3502,43 @@ async def handle_message(
 
     clean_text, options = extract_options(final_text)
 
+    # Outbound-reply decorator seam (Default: identity, OSS-identical). The model
+    # has finished speaking, so this is the outbound half of an active
+    # conversation — an edition may refresh its Slack auth window's activity clock
+    # and append a "<5 min left" expiry footer here. The public DefaultDashboard-
+    # Contributor returns the text unchanged. Fail-safe: a raising decorator falls
+    # back to the undecorated text so it can never break the reply.
+    from kiro_crew.platform import current_context, safe_context_call
+
+    _pre_decorate = clean_text
+    clean_text = safe_context_call(
+        lambda: current_context().dashboard.decorate_reply(
+            clean_text, channel=channel, user_id=user_id
+        ),
+        fallback=clean_text,
+        log_message="dashboard.decorate_reply failed; sending undecorated reply",
+    )
+    # Re-run the redaction passes on any text the decorator INTRODUCED. Redaction
+    # above (3493-3498) ran before decoration, so a decorator that appends a URL or
+    # a credential-shaped token would otherwise reach Slack unscanned (link-preview
+    # exfiltration / credential disclosure). Only re-scan when the decorator changed
+    # the text (the common Default path is a no-op identity, so this is skipped).
+    if clean_text != _pre_decorate:
+        clean_text, _exfil_after = redact_exfiltration_urls(clean_text)
+        if _exfil_after:
+            logger.warning(
+                "Redacted %d exfiltration URL(s) introduced by reply decorator", len(_exfil_after)
+            )
+        clean_text, _cred_after = redact_credentials(clean_text)
+        if _cred_after:
+            # Log only the COUNT — the per-warning strings embed a truncated
+            # prefix of the matched credential (redact_credentials returns
+            # "Redacted credential pattern: <first 20 chars>..."), so logging
+            # them verbatim would defeat the redaction we just performed.
+            logger.warning(
+                "Redacted %d credential pattern(s) introduced by reply decorator", len(_cred_after)
+            )
+
     # ── Review mode: ephemeral draft instead of public post ──
     if channel_activation == ACTIVATION_REVIEW:
         from kiro_crew.slack.blocks import review_draft_blocks

--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -220,11 +220,18 @@ class SlackRenderer(Renderer):
         capabilities: TransportCapabilities | None = None,
         decider: SlackApprovalDecider | None = None,
         now: Callable[[], float] | None = None,
+        user_id: str = "",
     ) -> None:
         super().__init__(capabilities or SLACK_CAPABILITIES)
         self.slack = slack
         self.channel = channel
         self.thread_ts = thread_ts
+        # The sending user — passed to DashboardContributor.decorate_reply on the
+        # final outbound text so a composed edition can refresh its auth window /
+        # append an expiry footer on the transport reply path too (native
+        # handle_message already wires decorate_reply; this closes the gap so the
+        # DEFAULT non-review Slack traffic gets the same treatment). "" in OSS.
+        self._user_id = user_id
         # Message ts to react to (the user's triggering message). Falls back
         # to thread_ts so reactions still attach when not supplied separately.
         self._react_ts = react_ts or thread_ts or ""
@@ -559,6 +566,30 @@ class SlackRenderer(Renderer):
         if clean_text:
             clean_text, _ = redact_exfiltration_urls(clean_text)
             clean_text, _ = redact_credentials(clean_text)
+            # Outbound-reply decorator seam (Default: identity, OSS-identical) —
+            # the transport-path twin of the native handle_message wiring, so the
+            # DEFAULT non-review Slack path also refreshes a composed edition's auth
+            # window / appends its expiry footer. Runs AFTER redaction; any text the
+            # decorator INTRODUCES is re-scanned so a decorator cannot smuggle a URL
+            # or credential past the redaction above. Fail-safe: a raising decorator
+            # falls back to the undecorated text.
+            from kiro_crew.platform import current_context, safe_context_call
+
+            _pre_decorate = clean_text
+            clean_text = safe_context_call(
+                lambda: current_context().dashboard.decorate_reply(
+                    _pre_decorate, channel=self.channel, user_id=self._user_id
+                ),
+                fallback=_pre_decorate,
+                log_message="dashboard.decorate_reply failed; sending undecorated reply",
+            )
+            if clean_text != _pre_decorate:
+                # Re-scan decorator-introduced text (the redaction above ran before
+                # decoration). No module logger here — the redaction itself is the
+                # security property; the native path logs counts, this path stays
+                # silent to avoid adding a logger to the renderer.
+                clean_text, _ = redact_exfiltration_urls(clean_text)
+                clean_text, _ = redact_credentials(clean_text)
         if self._stream_ts is not None:
             if self._use_slack_stream:
                 await self.slack.stop_stream(self.channel, self._stream_ts, clean_text or None)

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -222,6 +222,7 @@ async def handle_message_transport(
             reactions_enabled=reactions_enabled,
             show_thinking=show_thinking,
             decider=decider,
+            user_id=user_id,
         )
         await renderer.on_turn_start()
 

--- a/test/test_events_forward.py
+++ b/test/test_events_forward.py
@@ -443,6 +443,8 @@ class TestRouteMessageFallbackRecovery:
         mock_orch = AsyncMock()
         mock_seen = AsyncMock()
         mock_seen.check_and_add = lambda x: False
+        mock_seen.check = lambda x: False  # SeenCache.check: unseen
+        mock_seen.add = lambda x: None  # SeenCache.add: no-op in test
 
         with patch("kiro_crew.slack.enterprise.check_message_origin", return_value=True), \
              patch("kiro_crew.slack.events.sel") as mock_sel, \
@@ -493,6 +495,8 @@ class TestRouteMessageFallbackRecovery:
         mock_orch._session_tasks = {}
         mock_seen = MagicMock()
         mock_seen.check_and_add = lambda x: False
+        mock_seen.check = lambda x: False  # SeenCache.check: unseen
+        mock_seen.add = lambda x: None  # SeenCache.add: no-op in test
 
         with patch("kiro_crew.slack.enterprise.check_message_origin", return_value=True), \
              patch("kiro_crew.slack.events.sel") as mock_sel, \
@@ -509,6 +513,80 @@ class TestRouteMessageFallbackRecovery:
             all_args_str = str(call_args)
             assert "Real user content" in all_args_str
             assert "This message contains interactive elements." not in all_args_str
+
+    @pytest.mark.asyncio
+    async def test_interceptor_redirect_audits_dedups_and_short_circuits(self):
+        """A REDIRECTED gate decision must: short-circuit before handle_message,
+        emit a SEL audit for the intercept decision, and dedup event retries so a
+        redirecting adapter mints only ONE challenge per event."""
+        import dataclasses
+        from unittest.mock import MagicMock
+
+        from kiro_crew.platform import build_default_context
+        from kiro_crew.platform.context import set_context
+        from kiro_crew.platform.interfaces import InterceptDecision
+        from kiro_crew.slack.events import SeenCache, _route_message
+
+        calls = {"intercept": 0}
+
+        class _RedirectGate:
+            # Minimal SlackEnterpriseGate: always REDIRECTED (a challenge issued).
+            def validate_enterprise(self, *a, **k):
+                return True
+
+            def check_message_origin(self, *a, **k):
+                return True
+
+            def heartbeat_safe_tools(self):
+                return frozenset()
+
+            def intercept_message(self, orch, **kw):
+                calls["intercept"] += 1
+                return InterceptDecision.REDIRECTED
+
+        ctx = dataclasses.replace(build_default_context(None), slack_gate=_RedirectGate())
+        set_context(ctx)
+        try:
+            event = {
+                "user": "U123",
+                "channel": "C456",
+                "text": "hello",
+                "ts": "9999.0001",
+                "team": "T789",
+            }
+            mock_orch = AsyncMock()
+            ch_cfg = MagicMock()
+            ch_cfg.activation = "mention"
+            mock_cfg = MagicMock()
+            mock_cfg.channel_config.return_value = ch_cfg
+            mock_orch._cfg = mock_cfg
+            mock_orch.channel_history = None
+            mock_orch.sessions = None
+            mock_orch.conv_log = None
+            mock_orch.slack = None
+
+            seen = SeenCache()  # REAL cache so the dedup path is exercised
+            with patch("kiro_crew.slack.enterprise.check_message_origin", return_value=True), \
+                 patch("kiro_crew.slack.events.sel") as mock_sel, \
+                 patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+                 patch("kiro_crew.slack.events.is_owner", return_value=True), \
+                 patch("kiro_crew.slack.events.handle_message", new_callable=AsyncMock) as mock_handle:
+                audits = []
+                mock_sel.return_value.log_api_access = lambda **kw: audits.append(kw)
+
+                await _route_message(mock_orch, event, seen, is_mention=True)
+                # Short-circuited: the inline handler never ran.
+                mock_handle.assert_not_called()
+                # The intercept decision was audited (distinct from the allowlist audit).
+                assert any(a.get("operation") == "slack.message.intercept" for a in audits)
+
+                # Retry of the SAME event: the adapter must NOT be invoked again
+                # (dedup), and still no inline handling.
+                await _route_message(mock_orch, event, seen, is_mention=True)
+                assert calls["intercept"] == 1, "redirect adapter re-invoked on retry (no dedup)"
+                mock_handle.assert_not_called()
+        finally:
+            set_context(None)
 
     def test_blocks_extraction_recovers_all_element_types(self):
         """Verify _extract_blocks_text handles mixed element types correctly."""

--- a/test/test_slack_message_gate_seams.py
+++ b/test/test_slack_message_gate_seams.py
@@ -1,0 +1,156 @@
+"""Tests for the Slack message-gate + token-anchor + reply-decorator seams.
+
+Three v1 CPP method additions that let an edition compose a "challenge-and-
+redirect" Slack posture without editing the core:
+
+  * ``SlackEnterpriseGate.intercept_message`` — called at the top of
+    ``_route_message``; Default ``PROCESS`` keeps the OSS inline behavior.
+  * ``DashboardContributor.on_token_consumed`` — the anchor fired after
+    ``bind_token_ip``; Default no-op.
+  * ``DashboardContributor.decorate_reply`` — the outbound-reply transform;
+    Default identity.
+
+These tests pin the OSS-preserving Defaults and the ``InterceptDecision`` /
+short-circuit contract the companion depends on. They do NOT exercise a real
+challenge flow (that lives in the companion) — only that the public core exposes
+the seam and behaves byte-identically until a companion overrides it.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.platform.defaults import (
+    DefaultDashboardContributor,
+    DefaultSlackEnterpriseGate,
+)
+from kiro_crew.platform.interfaces import InterceptDecision
+
+
+class TestInterceptDecisionDefault:
+    def test_default_gate_processes_inline(self) -> None:
+        gate = DefaultSlackEnterpriseGate()
+        decision = gate.intercept_message(
+            object(),
+            channel="C123",
+            sender_id="U123",
+            clean_text="hello",
+            thread_ts=None,
+            msg_ts="1700000000.0001",
+        )
+        # OSS default MUST be PROCESS — the public build has no challenge-redirect.
+        assert decision is InterceptDecision.PROCESS
+
+    def test_decision_enum_members(self) -> None:
+        # The three verdicts the companion relies on, with stable string values.
+        assert InterceptDecision.PROCESS.value == "process"
+        assert InterceptDecision.REDIRECTED.value == "redirected"
+        assert InterceptDecision.DROPPED.value == "dropped"
+
+    def test_only_process_avoids_short_circuit(self) -> None:
+        # The _route_message contract: any non-PROCESS verdict short-circuits.
+        # Encode that invariant here so a future refactor can't silently let
+        # REDIRECTED/DROPPED fall through to inline processing.
+        short_circuit = {d: (d is not InterceptDecision.PROCESS) for d in InterceptDecision}
+        assert short_circuit == {
+            InterceptDecision.PROCESS: False,
+            InterceptDecision.REDIRECTED: True,
+            InterceptDecision.DROPPED: True,
+        }
+
+
+class TestDashboardContributorSeamsDefault:
+    def test_on_token_consumed_is_noop(self) -> None:
+        dc = DefaultDashboardContributor()
+        # No return, no raise — the OSS build opens no Slack auth window.
+        assert dc.on_token_consumed("U1", "C1", 0.0, None) is None
+        assert dc.on_token_consumed("U1", "C1", 1_700_000_000.0, "t.1") is None
+
+    def test_decorate_reply_is_identity(self) -> None:
+        dc = DefaultDashboardContributor()
+        # OSS sends replies unchanged (no expiry footer / window refresh).
+        assert dc.decorate_reply("hello world", channel="C1", user_id="U1") == "hello world"
+        assert dc.decorate_reply("", channel="C1", user_id="U1") == ""
+
+
+class TestDecoratedReplyIsReScanned:
+    """The reply path re-runs redaction on any text decorate_reply INTRODUCES.
+
+    Redaction runs before the decorator seam, so a decorator that appended a
+    credential- or exfil-shaped token would otherwise reach Slack unscanned. The
+    handler guards this by re-running both passes when the decorated text differs
+    from the pre-decoration text; these tests pin that the redaction primitives it
+    re-runs actually catch injected content (the handler wiring is covered by the
+    integration suite).
+    """
+
+    def test_redaction_catches_credential_a_decorator_could_inject(self) -> None:
+        from kiro_crew.security import redact_credentials
+
+        # A footer that (pathologically) carried an AWS key must be redacted.
+        decorated = "Your reply.\n\n_expires in 4m_ AKIAIOSFODNN7EXAMPLE"
+        cleaned, warnings = redact_credentials(decorated)
+        assert "AKIAIOSFODNN7EXAMPLE" not in cleaned
+        assert warnings  # a credential was flagged
+
+    def test_redaction_leaves_benign_footer_untouched(self) -> None:
+        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+        # The realistic decorator output (a plain expiry footer) survives both
+        # passes unchanged, so the re-scan never mangles a legitimate decoration.
+        decorated = "Your reply.\n\n_This session expires in 4 minutes._"
+        after_exfil, exfil_w = redact_exfiltration_urls(decorated)
+        after_cred, cred_w = redact_credentials(after_exfil)
+        assert after_cred == decorated
+        assert not exfil_w and not cred_w
+
+
+class TestInterceptOrderingIsBeforeContentRecording:
+    """Security-critical ordering: intercept_message MUST run before any content
+    is recorded/processed.
+
+    If the interceptor ran after ``channel_history.push`` / transcription / file
+    download, an unverified sender's message content would be persisted to channel
+    history before the gate decided — and a later VERIFIED turn in the same channel
+    could pull that stored content into agent context, bypassing the challenge
+    gate. This is a source-order regression guard on ``_route_message``: a refactor
+    that moves the push above the interceptor re-opens the hole.
+    """
+
+    def _call_offsets(self, needle: str) -> list[int]:
+        """Offsets of ACTUAL call sites of ``needle`` in _route_message source.
+
+        Matches ``<needle>(`` (a call), and strips ``#``-comment lines first, so a
+        mention of the symbol in a docstring/comment (this PR's ordering rationale
+        names these very calls in prose) can't be mistaken for a real call site.
+        """
+        import inspect
+        import re
+
+        from kiro_crew.slack import events
+
+        raw = inspect.getsource(events._route_message)
+        code = "\n".join(re.sub(r"#.*$", "", ln) for ln in raw.splitlines())
+        return [m.start() for m in re.finditer(re.escape(needle) + r"\(", code)]
+
+    def test_interceptor_precedes_first_channel_history_push(self) -> None:
+        intercepts = self._call_offsets("intercept_message")
+        pushes = self._call_offsets("channel_history.push")
+        assert intercepts, "intercept_message call not found in _route_message"
+        assert pushes, "channel_history.push call not found in _route_message"
+        # The interceptor call must precede the FIRST real history push.
+        assert min(intercepts) < min(pushes), (
+            "intercept_message must run BEFORE channel_history.push — otherwise an "
+            "unverified sender's content is persisted before the gate decides "
+            "(challenge-gate bypass via stored history)."
+        )
+
+    def test_interceptor_precedes_file_transcription_and_download(self) -> None:
+        intercepts = self._call_offsets("intercept_message")
+        assert intercepts, "intercept_message call not found in _route_message"
+        # Content-processing sites that must not run on an un-gated message.
+        for marker in ("_transcribe_with_reaction", "process_slack_files"):
+            marks = self._call_offsets(marker)
+            assert marks, f"{marker} call not found in _route_message"
+            assert min(intercepts) < min(marks), (
+                f"intercept_message must run BEFORE {marker} — an intercepted "
+                "message must not be transcribed/downloaded before the gate decides."
+            )


### PR DESCRIPTION
## Description

Adds three v1 Composed-Platform-Providers (CPP) extension points to the Slack
message pipeline so an out-of-repo edition can compose a fail-closed
"challenge-and-redirect" posture (intercept an inbound message, hand back a
one-time verified-device link instead of processing it inline) **without editing
the core**. Same EXTRACT pattern as the ~30 seams in #177 and the publish seam in
#202: each addition is a `Default*`-inert Protocol method that preserves today's
open-source behavior byte-for-byte, and the Amazon-specific implementation lives
entirely in the companion.

The three seams:

1. **`SlackEnterpriseGate.intercept_message(orch, *, channel, sender_id, clean_text, thread_ts, msg_ts) -> InterceptDecision`**
   — called at the top of `slack/events.py::_route_message` (after the user
   allowlist, before the queue/handle path). The new `InterceptDecision` enum is
   `PROCESS | REDIRECTED | DROPPED`. **Default returns `PROCESS`**, so every
   allowed message is handled inline exactly as before; a non-`PROCESS` verdict
   short-circuits inline processing. A seam lookup failure defaults to `PROCESS`
   (the public contract *is* process-inline); a companion that declares a
   stricter posture owns its own fail-closed `DROPPED`.

2. **`DashboardContributor.on_token_consumed(user_id, channel, session_exp, thread_ts)`**
   — fired in `dashboard/token_auth.py` on the token-consumption path (right
   after `bind_token_ip`), with `channel`/`thread_ts` read from the token's
   already-signed `extra` payload. **Default no-op.** This is the anchor a
   challenge auth-window opens on when a link is opened on a verified device.

3. **`DashboardContributor.decorate_reply(text, *, channel, user_id) -> str`**
   — the outbound-reply transform in `slack/handler.py` (on the finalized text,
   after redaction). **Default identity** (reply unchanged); an edition uses it to
   append an auth-window expiry footer / refresh the window's activity clock.

All three are ADD-only, `CONTRACT_VERSION` stays **1**, and every call site is
wrapped in `safe_context_call` so a composition error can never silently degrade
a stricter posture to inline processing.

## Related Issues

Completes the Slack side of the standalone/companion CPP split (the enterprise-
grid gate and heartbeat allowlist seams already landed). No open issue.

## Testing

- [x] Existing tests pass — 117 CPP-wiring / enterprise / fail-closed tests green
      against the rebased base; imports of all four touched modules verified.
- [x] New tests added — `test/test_slack_message_gate_seams.py` pins the
      OSS-preserving Defaults (`PROCESS` / no-op / identity) and the
      `InterceptDecision` short-circuit contract (only `PROCESS` avoids the
      short-circuit).
- [x] Manual verification — `black` (line-length 100), `flake8`, and `mypy` clean
      on the touched files; diff is 5 source files + 1 test (+216/-16),
      reviewer-tight (no unrelated reformatting).

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — n/a (the docstrings on each Protocol
      method fully specify the seam; no separate spec change)
- [x] No secrets, credentials, or internal references in the diff (scrub-clean —
      the seams are edition-neutral; nothing Amazon-specific lands in core)

## Contribution License Agreement

<!-- PLACEHOLDER: awaiting OSPO CLA wording. -->
