### PR TITLE
feat(website): Cmd+1-6 shortcuts to switch instance panes

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -79,6 +79,7 @@ import MigrationCheck from './components/MigrationCheck'
 import BuiltinAppRoute from './apps/BuiltinAppRoute'
 import { FEATURE_REQUEST_PROMPT } from './prompts/featureRequest'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { useInstanceShortcuts } from './hooks/useInstanceShortcuts'
 import { useCommandPalette } from './hooks/useCommandPalette'
 import { useProvider } from './providers/context'
 import { useAgents } from './hooks/useAgents'
@@ -1043,6 +1044,11 @@ export default function App() {
       api.chatSlotModel(activeSlot, models[prevIdx].name)
     },
   })
+  // Cmd+1..9 (⌘ mac / Ctrl win-linux) switches instance panes: 1=Local,
+  // 2=first remote, … — matching the InstanceTabBar left-to-right tab order.
+  // Registered here (once) rather than in InstanceTabBar, which can mount more
+  // than once (strip + inline header copies).
+  useInstanceShortcuts()
 
   // Kiro CLI monthly credit usage. /api/sessions/usage TRIGGERS the background
   // `kiro-cli /usage` fetch AND returns the cached result, so the pill is

--- a/website/src/components/EmbeddedHostBridge.tsx
+++ b/website/src/components/EmbeddedHostBridge.tsx
@@ -52,6 +52,7 @@ function parseHostModel(data: unknown): HostModel | null {
     activeId: typeof d.activeId === 'string' ? d.activeId : null,
     self,
     macInset: !!d.macInset,
+    electron: !!d.electron,
   }
 }
 

--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -16,12 +16,13 @@
  * (host SSH expiry lives in the title bar, not duplicated here).
  */
 import { useCallback, useMemo, type CSSProperties } from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Home, Server, Loader2 } from 'lucide-react'
 import { api, ApiError, type InstanceView } from '../api/client'
-import { useAppDispatch, useAppSelector } from '../store'
-import { setWarm, setActiveId, type WarmConn } from '../store/instancesSlice'
+import { useAppSelector } from '../store'
+import { type WarmConn } from '../store/instancesSlice'
 import { isEmbeddedPane } from '../lib/embedded'
+import { useSelectInstance } from '../hooks/useSelectInstance'
 
 /**
  * Instances that get a tab: sticky connect intent (`was_connected`, cleared
@@ -193,7 +194,6 @@ export default function InstanceTabBar({
   variant = 'strip',
   style,
 }: { variant?: 'strip' | 'inline'; style?: CSSProperties } = {}) {
-  const dispatch = useAppDispatch()
   const activeId = useAppSelector(s => s.instances.activeId)
   const warm = useAppSelector(s => s.instances.warm)
   const unread = useAppSelector(s => s.instances.unread)
@@ -216,36 +216,16 @@ export default function InstanceTabBar({
   // instead of vanishing and forcing the user back to Settings → Instances.
   const tabInstances = visibleInstanceTabs(instances, warm)
 
-  const connectMutation = useMutation({
-    mutationFn: (id: string) => api.connectInstance(id),
-    onSuccess: (st, id) => {
-      if (st.state === 'connected' && st.local_port && st.token) {
-        dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
-      }
-      // The tab was already activated on click; on failure the active pane shows
-      // the in-pane error/reconnect panel (see InstancesViewport).
-    },
-  })
+  // Select-and-maybe-reconnect semantics live in the shared useSelectInstance
+  // hook — the SAME unit the ⌘/Ctrl+digit chord uses (useInstanceShortcuts) —
+  // so the click path and the keyboard path cannot drift apart.
+  const { selectInstance, connectMutation } = useSelectInstance(instances)
 
   const onSelectInstance = useCallback(
-    (id: string) => {
-      // Always activate the clicked tab so its pane shows immediately — the warm
-      // iframe if connected, otherwise the in-pane connecting/error panel. If it
-      // isn't warm yet, kick off a (re)connect: success warms it, failure leaves
-      // the error pane up. A failed connect never removes the tab.
-      dispatch(setActiveId(id))
-      // Reconnect when the tab has no warm iframe yet OR when its live tunnel is
-      // no longer connected. The status check matters: a mid-session tunnel drop
-      // flips status to error/disconnected but does NOT clear the stale `warm`
-      // entry, so gating only on `!warm[id]` would skip the reconnect AND hide
-      // the error panel — clicking the (red) tab would do nothing visible.
-      const inst = instances.find(i => i.id === id)
-      const live = !inst || inst.status?.state === 'connected'
-      if (!warm[id] || !live) connectMutation.mutate(id)
-    },
-    [warm, instances, dispatch, connectMutation],
+    (id: string) => selectInstance(id),
+    [selectInstance],
   )
-  const onLocal = useCallback(() => dispatch(setActiveId(null)), [dispatch])
+  const onLocal = useCallback(() => selectInstance(null), [selectInstance])
 
   // Embedded panes render the parent-relayed switcher (option B). Hooks above
   // still run unconditionally (rules-of-hooks); the instances poll is disabled

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -32,6 +32,7 @@ import InstanceTabBar, { visibleInstanceTabs } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { TRAFFIC_LIGHT_INSET_PX } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
+import { isElectron } from '../lib/electron'
 
 // Refresh the embedded token once elapsed reaches this fraction of its TTL
 // (mirrors the gateway's default 80% threshold). Proactive refresh reloads the
@@ -276,7 +277,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
             ttlTotal: ttlToSeconds(selfInst.ttl),
           }
         : null
-      return { type: 'mc-host-model', v: 1, tabs, activeId, self, macInset }
+      return { type: 'mc-host-model', v: 1, tabs, activeId, self, macInset, electron: isElectron }
     },
     [instancesQuery.data, warm, unread, activeId, macInset],
   )

--- a/website/src/components/ShortcutsModal.tsx
+++ b/website/src/components/ShortcutsModal.tsx
@@ -2,10 +2,11 @@ import { safeSetItem } from '../utils/safeStorage'
 import { useEffect, useState } from 'react'
 import { X, Keyboard } from 'lucide-react'
 import { DEFAULT_SHORTCUTS, formatShortcut, SHORTCUTS_ENABLED_KEY, SHORTCUTS_ENABLED_EVENT, IS_MAC, MAC_CTRL_DIGITS_KEY } from '../hooks/useKeyboardShortcuts'
+import { isElectron } from '../lib/electron'
 import { Toggle } from './ui'
 
 /** Shortcut group headings, in display order. Shared with Settings → Shortcuts. */
-export const SHORTCUT_GROUPS = ['Chat Navigation', 'Panel Navigation', 'Actions'] as const
+export const SHORTCUT_GROUPS = ['Chat Navigation', 'Panel Navigation', 'Actions', 'Instances'] as const
 
 export function Kbd({ children }: { children: string }) {
   return <kbd className="inline-flex items-center justify-center min-w-[24px] h-6 px-1.5 rounded-md bg-bg border border-border text-[12px] font-mono font-medium text-text-strong shadow-sm">{children}</kbd>
@@ -38,6 +39,11 @@ export function useShortcutPrefs() {
 
 /** Shortcuts in `group`, with the Mac Ctrl/Option digit display adjustment applied. */
 export function groupShortcuts(group: string, macCtrl: boolean) {
+  // The Instances chord (⌘/Ctrl+digit) only works in the Electron shell — in a
+  // plain browser those chords are reserved for browser tab switching and the
+  // handler never binds (see useInstanceShortcuts). Don't advertise a binding
+  // the host environment will steal.
+  if (group === 'Instances' && !isElectron) return []
   return DEFAULT_SHORTCUTS.filter(s => s.group === group).map(s => {
     // When Mac user toggles back to Alt+digit, adjust the display
     if (IS_MAC && !macCtrl && s.id.startsWith('chat-') && s.ctrl) {
@@ -102,16 +108,20 @@ export default function ShortcutsModal({ onClose }: { onClose: () => void }) {
           <div className="flex items-center gap-2 text-sm font-bold text-text-strong"><Keyboard size={16} /> Keyboard Shortcuts</div>
           <button className="text-muted cursor-pointer hover:text-text bg-transparent border-none" onClick={onClose} aria-label="Close"><X size={16} /></button>
         </div>
-        {SHORTCUT_GROUPS.map(group => (
-          <div key={group} className="mb-5 last:mb-0">
-            <div className="text-[12px] font-medium text-muted uppercase tracking-wider mb-2">{group}</div>
-            <div className="grid gap-1">
-              {groupShortcuts(group, macCtrl).map(s => (
-                <ShortcutRow key={s.id} label={s.label} keys={formatShortcut(s).split(' + ')} />
-              ))}
+        {SHORTCUT_GROUPS.map(group => {
+          const entries = groupShortcuts(group, macCtrl)
+          if (entries.length === 0) return null
+          return (
+            <div key={group} className="mb-5 last:mb-0">
+              <div className="text-[12px] font-medium text-muted uppercase tracking-wider mb-2">{group}</div>
+              <div className="grid gap-1">
+                {entries.map(s => (
+                  <ShortcutRow key={s.id} label={s.label} keys={formatShortcut(s).split(' + ')} />
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
         <div className="mb-5 last:mb-0">
           <div className="text-[12px] font-medium text-muted uppercase tracking-wider mb-2">Search</div>
           <div className="grid gap-1">

--- a/website/src/hooks/useInstanceShortcuts.ts
+++ b/website/src/hooks/useInstanceShortcuts.ts
@@ -1,0 +1,132 @@
+/**
+ * useInstanceShortcuts — ⌘+digit (macOS) / Ctrl+digit (Windows/Linux) jumps
+ * between the panes shown in the InstanceTabBar: digit 1 = Local, digit 2 = the
+ * first remote instance, and so on — mirroring the tab strip left-to-right,
+ * exactly like a native tab switcher.
+ *
+ * ELECTRON-ONLY by design: in a plain browser ⌘/Ctrl+digit is reserved for
+ * browser tab switching (Chromium may not even dispatch the keydown), so the
+ * page can never reliably claim it. Binding — and advertising in the shortcuts
+ * modal (see groupShortcuts) — is therefore gated on the Electron shell, where
+ * no menu accelerator holds these chords and the page genuinely wins them.
+ *
+ * DUAL CONTEXT — the same hook serves both halves of the pane architecture:
+ *  - Top-level dashboard: reads the shared ['instances'] React Query cache and
+ *    performs the switch directly, reusing InstanceTabBar.onSelectInstance's
+ *    exact semantics (activate immediately; (re)connect only when the pane
+ *    isn't warm or its tunnel is down; a failed connect never drops the tab).
+ *  - Embedded remote pane (an <iframe> running this same SPA): keyboard focus
+ *    lives INSIDE the iframe while the user works there, so the parent's
+ *    listener can never hear the chord. The embedded copy binds too, maps the
+ *    digit against the parent-relayed `instances.host` model, and posts the
+ *    switch up via the SAME `mc-switch-instance` relay the embedded tab bar's
+ *    click path uses (validated parent-side in InstancesViewport). Gated on
+ *    `host.electron` — the pane itself can't see the shell, so the parent
+ *    relays that fact down in the host model.
+ *
+ * DIGIT RANGE — derived from the INSTANCE_SHORTCUTS registry entries (the
+ * single source of truth also rendered by the shortcuts modal), so the chords
+ * the modal advertises and the chords this handler claims cannot drift apart.
+ *
+ * Registered ONCE from App.tsx. It must NOT live inside InstanceTabBar, which
+ * can mount more than once (strip + inline header copies) — that would
+ * double-fire every press.
+ */
+import { useCallback, useEffect, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { api, ApiError } from '../api/client'
+import { useAppSelector } from '../store'
+import { isEmbeddedPane } from '../lib/embedded'
+import { isElectron } from '../lib/electron'
+import { visibleInstanceTabs } from '../components/InstanceTabBar'
+import { useSelectInstance } from './useSelectInstance'
+import { IS_MAC, SHORTCUTS_ENABLED_KEY, INSTANCE_SHORTCUTS } from './useKeyboardShortcuts'
+
+/** Highest digit the chord claims — exactly the advertised registry entries. */
+const MAX_DIGIT = INSTANCE_SHORTCUTS.length
+
+/** ⌘ (mac) / Ctrl (win-linux) + un-shifted digit → 0-based pane index, or -1.
+ *  Exactly ONE primary modifier so we never shadow Ctrl+digit chat-nav (mac)
+ *  or Alt+digit chat-nav (win/linux). */
+function chordIndex(e: KeyboardEvent): number {
+  const primary = IS_MAC ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+  if (!primary || e.altKey || e.shiftKey) return -1
+  const code = e.code
+  if (code < 'Digit1' || code > `Digit${MAX_DIGIT}`) return -1
+  return parseInt(code.charAt(5)) - 1 // Digit1 -> 0 (Local), Digit2 -> 1, ...
+}
+
+const shortcutsEnabled = () => localStorage.getItem(SHORTCUTS_ENABLED_KEY) !== '0'
+
+export function useInstanceShortcuts() {
+  const warm = useAppSelector(s => s.instances.warm)
+  const host = useAppSelector(s => s.instances.host)
+
+  const embedded = isEmbeddedPane()
+  // Top-level only: share the ['instances'] React Query cache with
+  // InstanceTabBar / viewport — same cache entry, not a second network poll.
+  const instancesQuery = useQuery({ queryKey: ['instances'], queryFn: () => api.listInstances(), enabled: !embedded && isElectron })
+  const forbidden = instancesQuery.error instanceof ApiError && instancesQuery.error.status === 403
+  const instances = useMemo(() => instancesQuery.data?.instances ?? [], [instancesQuery.data?.instances])
+  // Same visibility rule as the bar, so the digit order matches the tabs 1:1.
+  const tabInstances = useMemo(() => visibleInstanceTabs(instances, warm), [instances, warm])
+
+  // Top-level select: the SAME shared unit the tab bar's click path uses
+  // (useSelectInstance), so keyboard and click semantics cannot drift apart.
+  const { selectInstance } = useSelectInstance(instances)
+
+  const selectByIndex = useCallback(
+    (idx: number) => {
+      if (idx === 0) {
+        selectInstance(null)
+        return
+      }
+      const inst = tabInstances[idx - 1]
+      if (inst) selectInstance(inst.id)
+    },
+    [tabInstances, selectInstance],
+  )
+
+  // Embedded select: relay up through the SAME channel as the embedded tab
+  // bar's click path (EmbeddedInstanceTabBar). The parent validates the target.
+  const relayByIndex = useCallback(
+    (idx: number) => {
+      if (!host) return false
+      const id = idx === 0 ? null : host.tabs[idx - 1]?.id
+      if (idx !== 0 && !id) return false
+      // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+      window.parent?.postMessage({ type: 'mc-switch-instance', v: 1, id }, '*')
+      return true
+    },
+    [host],
+  )
+
+  const handler = useCallback(
+    (e: KeyboardEvent) => {
+      // Respect the global shortcuts toggle (read live so a Settings change
+      // takes effect without re-registering the listener).
+      if (!shortcutsEnabled()) return
+      const idx = chordIndex(e)
+      if (idx < 0) return
+      if (embedded) {
+        // Gate on the parent-relayed electron flag; only claim the keystroke
+        // when the relay actually has a target for it.
+        if (!host?.electron) return
+        if (idx > host.tabs.length) return
+        if (relayByIndex(idx)) e.preventDefault()
+        return
+      }
+      if (!isElectron || forbidden) return
+      // Only claim the keystroke when a matching pane exists.
+      if (idx > tabInstances.length) return
+      e.preventDefault()
+      selectByIndex(idx)
+    },
+    [embedded, host, relayByIndex, forbidden, tabInstances.length, selectByIndex],
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [handler])
+}

--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -24,7 +24,7 @@ export interface ShortcutDef {
   meta?: boolean  // Cmd on Mac, Ctrl on Windows/Linux
   shift?: boolean
   label: string
-  group: 'Chat Navigation' | 'Panel Navigation' | 'Actions'
+  group: 'Chat Navigation' | 'Panel Navigation' | 'Actions' | 'Instances'
 }
 
 export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
@@ -62,7 +62,25 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: 'cycle-model', key: 's', alt: true, shift: true, label: 'Cycle model', group: 'Actions' },
   { id: 'cycle-prev-model', key: 'x', alt: true, shift: true, label: 'Previous model', group: 'Actions' },
   { id: 'optimize-prompt', key: 'Enter', meta: true, shift: true, label: 'Optimize prompt', group: 'Actions' },
+  // Instance switcher — Cmd on Mac / Ctrl on Win-Linux. 1 = Local, 2..6 = the
+  // 1st..5th remote instance, matching the InstanceTabBar left-to-right order.
+  // Handled by useInstanceShortcuts (not the Alt-based handler below); listed
+  // here so they appear in the shortcuts modal + Settings → Shortcuts.
+  { id: 'instance-1', key: '1', meta: true, label: 'Switch to Local', group: 'Instances' },
+  { id: 'instance-2', key: '2', meta: true, label: 'Switch to instance 1', group: 'Instances' },
+  { id: 'instance-3', key: '3', meta: true, label: 'Switch to instance 2', group: 'Instances' },
+  { id: 'instance-4', key: '4', meta: true, label: 'Switch to instance 3', group: 'Instances' },
+  { id: 'instance-5', key: '5', meta: true, label: 'Switch to instance 4', group: 'Instances' },
+  { id: 'instance-6', key: '6', meta: true, label: 'Switch to instance 5', group: 'Instances' },
 ]
+
+/**
+ * The instance-switch entries, exported as the single source of truth for
+ * useInstanceShortcuts: the handler accepts exactly Digit1..Digit<N> where N =
+ * INSTANCE_SHORTCUTS.length, so the chords the modal advertises and the chords
+ * the handler claims can never drift apart.
+ */
+export const INSTANCE_SHORTCUTS = DEFAULT_SHORTCUTS.filter(s => s.group === 'Instances')
 
 const isMac = () => typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
 

--- a/website/src/hooks/useSelectInstance.ts
+++ b/website/src/hooks/useSelectInstance.ts
@@ -1,0 +1,55 @@
+/**
+ * useSelectInstance — THE single owner of "switch to a pane" semantics, shared
+ * by every top-level switching surface (InstanceTabBar clicks and the
+ * useInstanceShortcuts keyboard chord), so the two paths can never drift:
+ * a future fix to how selection/reconnect works lands in both automatically.
+ *
+ * Semantics (hard-won — see the inline comments):
+ *  - Always activate the target so its pane shows immediately — the warm
+ *    iframe if connected, otherwise the in-pane connecting/error panel.
+ *  - (Re)connect when the pane has no warm iframe yet OR its live tunnel is no
+ *    longer connected. The status check matters: a mid-session tunnel drop
+ *    flips status to error/disconnected but does NOT clear the stale `warm`
+ *    entry, so gating only on `!warm[id]` would skip the reconnect AND hide
+ *    the error panel — selecting the (red) tab would do nothing visible.
+ *  - A failed connect never removes the tab; the in-pane error panel shows
+ *    (see InstancesViewport).
+ *
+ * Takes the caller's `instances` list (both consumers already subscribe to the
+ * shared ['instances'] React Query cache) rather than running its own query.
+ */
+import { useCallback } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { api, type InstanceView } from '../api/client'
+import { useAppDispatch, useAppSelector } from '../store'
+import { setWarm, setActiveId } from '../store/instancesSlice'
+
+export function useSelectInstance(instances: InstanceView[]) {
+  const dispatch = useAppDispatch()
+  const warm = useAppSelector(s => s.instances.warm)
+
+  const connectMutation = useMutation({
+    mutationFn: (id: string) => api.connectInstance(id),
+    onSuccess: (st, id) => {
+      if (st.state === 'connected' && st.local_port && st.token) {
+        dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
+      }
+      // The pane was already activated on select; on failure the active pane
+      // shows the in-pane error/reconnect panel (see InstancesViewport).
+    },
+  })
+
+  /** Switch to instance `id`, or to the Local dashboard when `id` is null. */
+  const selectInstance = useCallback(
+    (id: string | null) => {
+      dispatch(setActiveId(id))
+      if (id === null) return
+      const inst = instances.find(i => i.id === id)
+      const live = !inst || inst.status?.state === 'connected'
+      if (!warm[id] || !live) connectMutation.mutate(id)
+    },
+    [warm, instances, dispatch, connectMutation],
+  )
+
+  return { selectInstance, connectMutation }
+}

--- a/website/src/pages/settings/ShortcutsPanel.tsx
+++ b/website/src/pages/settings/ShortcutsPanel.tsx
@@ -32,16 +32,20 @@ export function ShortcutsPanel() {
           />
         )}
       </SettingsCard>
-      {SHORTCUT_GROUPS.map(group => (
-        <div key={group}>
-          <SettingsSection title={group} />
-          <SettingsCard>
-            {groupShortcuts(group, macCtrl).map(s => (
-              <ShortcutRow key={s.id} label={s.label} keys={formatShortcut(s).split(' + ')} />
-            ))}
-          </SettingsCard>
-        </div>
-      ))}
+      {SHORTCUT_GROUPS.map(group => {
+        const entries = groupShortcuts(group, macCtrl)
+        if (entries.length === 0) return null
+        return (
+          <div key={group}>
+            <SettingsSection title={group} />
+            <SettingsCard>
+              {entries.map(s => (
+                <ShortcutRow key={s.id} label={s.label} keys={formatShortcut(s).split(' + ')} />
+              ))}
+            </SettingsCard>
+          </div>
+        )
+      })}
       <SettingsSection title="Search" />
       <SettingsCard>
         <SearchEverywhereRow />

--- a/website/src/store/instancesSlice.ts
+++ b/website/src/store/instancesSlice.ts
@@ -52,6 +52,10 @@ export interface HostModel {
   /** True when the parent is a macOS Electron window not in fullscreen, so the
    *  embedded header must inset its content clear of the native traffic lights. */
   macInset: boolean
+  /** True when the parent shell is Electron. Gates the embedded ⌘/Ctrl+digit
+   *  instance-switch chord: in a plain browser those chords are reserved for
+   *  browser tab switching, so the pane must not bind (or advertise) them. */
+  electron: boolean
 }
 
 interface InstancesState {

--- a/website/src/test/EmbeddedSwitcher.test.tsx
+++ b/website/src/test/EmbeddedSwitcher.test.tsx
@@ -20,6 +20,7 @@ const model = (over: Partial<HostModel> = {}): HostModel => ({
   activeId: 'cd-1',
   self: null,
   macInset: false,
+  electron: true,
   ...over,
 })
 

--- a/website/src/test/useInstanceShortcuts.test.tsx
+++ b/website/src/test/useInstanceShortcuts.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { renderHookWithProviders, createTestStore } from './helpers'
+import { useInstanceShortcuts } from '../hooks/useInstanceShortcuts'
+import { IS_MAC, SHORTCUTS_ENABLED_KEY, INSTANCE_SHORTCUTS } from '../hooks/useKeyboardShortcuts'
+import type { InstanceView, SsoStatus } from '../api/client'
+import type { HostModel } from '../store/instancesSlice'
+
+vi.mock('../api/client', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  }
+  return {
+    ApiError,
+    api: { listInstances: vi.fn(), connectInstance: vi.fn() },
+  }
+})
+import { api } from '../api/client'
+vi.mock('../lib/embedded', () => ({ isEmbeddedPane: vi.fn(() => false) }))
+import { isEmbeddedPane } from '../lib/embedded'
+// The chord is Electron-only (browsers reserve ⌘/Ctrl+digit for tab switching).
+// Top-level tests run with the shell mocked as Electron; the non-Electron
+// embedded path is covered via host.electron=false (relayed flag).
+vi.mock('../lib/electron', () => ({ isElectron: true, isMacElectron: false }))
+
+const conn = (over: Partial<InstanceView> = {}): InstanceView => ({
+  id: 'cd-1',
+  name: 'Cloud One',
+  ssh_host: 'cd-1-alias',
+  remote_port: 7777,
+  local_port: 7778,
+  ttl: '20h',
+  remote_bin: '',
+  was_connected: false,
+  status: { instance_id: 'cd-1', state: 'connected', local_port: 7778, remote_port: 7777 },
+  ...over,
+})
+
+const okSso: SsoStatus = { state: 'ok', seconds_remaining: 72000, expires_at: null, reason: 'valid' }
+const listResp = (instances: InstanceView[]) => ({ active: true, instances, warm_set_cap: 5, sso: okSso })
+
+const hostModel = (over: Partial<HostModel> = {}): HostModel => ({
+  tabs: [{ id: 'cd-1', name: 'Cloud One', sshHost: 'cd-1-alias', state: 'connected', unread: 0 }],
+  activeId: 'cd-1',
+  self: null,
+  macInset: false,
+  electron: true,
+  ...over,
+})
+
+/** Dispatch the platform-correct instance-switch chord (⌘ mac / Ctrl else). */
+function pressDigit(n: number, over: KeyboardEventInit = {}) {
+  const init: KeyboardEventInit = {
+    code: `Digit${n}`,
+    key: String(n),
+    metaKey: IS_MAC,
+    ctrlKey: !IS_MAC,
+    bubbles: true,
+    cancelable: true,
+    ...over,
+  }
+  const ev = new KeyboardEvent('keydown', init)
+  act(() => { document.dispatchEvent(ev) })
+  return ev
+}
+
+/** Wait for the ['instances'] query to resolve AND re-render the hook so its
+ *  keydown closure captures the loaded tab list before we dispatch a chord. */
+async function loaded() {
+  await waitFor(() => expect(api.listInstances).toHaveBeenCalled())
+  await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(isEmbeddedPane).mockReturnValue(false)
+  localStorage.clear()
+})
+
+describe('useInstanceShortcuts — top-level (Electron)', () => {
+  it('digit 1 switches to Local (null pane)', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn()]))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 't' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    pressDigit(1)
+    expect(store.getState().instances.activeId).toBeNull()
+  })
+
+  it('digit 2 switches to the first remote instance (no reconnect when warm+live)', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn()]))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 't' } }, activeId: null, mru: ['cd-1'], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    pressDigit(2)
+    expect(store.getState().instances.activeId).toBe('cd-1')
+    await new Promise(r => setTimeout(r, 0))
+    expect(api.connectInstance).not.toHaveBeenCalled()
+  })
+
+  it('digit 2 reconnects a not-yet-warm instance', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn({ was_connected: true, status: { instance_id: 'cd-1', state: 'error', remote_port: 7777 } })]))
+    vi.mocked(api.connectInstance).mockResolvedValue({ instance_id: 'cd-1', state: 'connected', local_port: 7778, token: 'fresh' })
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    pressDigit(2)
+    expect(store.getState().instances.activeId).toBe('cd-1')
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1'))
+    await waitFor(() => expect(store.getState().instances.warm['cd-1']).toEqual({ port: 7778, token: 'fresh' }))
+  })
+
+  it('ignores a digit with no matching pane (default NOT prevented)', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn()]))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 't' } }, activeId: null, mru: ['cd-1'], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    // Only Local + 1 remote exist (indices 1 and 2). Digit 5 has no pane.
+    const ev = pressDigit(5)
+    expect(store.getState().instances.activeId).toBeNull()
+    expect(ev.defaultPrevented).toBe(false)
+  })
+
+  it('never claims a digit beyond the advertised registry range (no drift)', async () => {
+    // 8 remotes would make digit 9 a valid pane index — but the shortcuts
+    // modal only advertises INSTANCE_SHORTCUTS.length chords, and the handler
+    // derives its range from the same registry, so digit 9 must be ignored.
+    const many = Array.from({ length: 8 }, (_, i) => conn({ id: `cd-${i + 1}`, name: `Cloud ${i + 1}`, status: { instance_id: `cd-${i + 1}`, state: 'connected', remote_port: 7777 }, was_connected: true }))
+    vi.mocked(api.listInstances).mockResolvedValue(listResp(many))
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    expect(INSTANCE_SHORTCUTS.length).toBe(6)
+    const ev = pressDigit(9)
+    expect(store.getState().instances.activeId).toBeNull()
+    expect(ev.defaultPrevented).toBe(false)
+    // ...while the last advertised digit still works.
+    pressDigit(6)
+    expect(store.getState().instances.activeId).toBe('cd-5')
+  })
+
+  it('does nothing when shortcuts are globally disabled', async () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn()]))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 't' } }, activeId: null, mru: ['cd-1'], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    pressDigit(2)
+    expect(store.getState().instances.activeId).toBeNull()
+  })
+
+  it('ignores the chord when the wrong modifier is held', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(listResp([conn()]))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 't' } }, activeId: null, mru: ['cd-1'], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    await loaded()
+
+    // Alt+2 (chat-nav territory) must not switch instances.
+    pressDigit(2, { metaKey: false, ctrlKey: false, altKey: true })
+    expect(store.getState().instances.activeId).toBeNull()
+  })
+})
+
+describe('useInstanceShortcuts — embedded pane (relay)', () => {
+  beforeEach(() => {
+    vi.mocked(isEmbeddedPane).mockReturnValue(true)
+  })
+
+  it('relays the chord to the parent via mc-switch-instance (same channel as the click path)', () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: hostModel() },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+    // Embedded panes never run the instances poll.
+    expect(api.listInstances).not.toHaveBeenCalled()
+
+    const ev1 = pressDigit(1)
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'mc-switch-instance', id: null }), '*')
+    expect(ev1.defaultPrevented).toBe(true)
+
+    const ev2 = pressDigit(2)
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'mc-switch-instance', id: 'cd-1' }), '*')
+    expect(ev2.defaultPrevented).toBe(true)
+    post.mockRestore()
+  })
+
+  it('ignores a digit with no matching relayed tab', () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: hostModel() },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+
+    const ev = pressDigit(4) // host has only 1 tab (indices 1-2 valid)
+    expect(post).not.toHaveBeenCalled()
+    expect(ev.defaultPrevented).toBe(false)
+    post.mockRestore()
+  })
+
+  it('does not bind when the parent shell is not Electron (host.electron=false)', () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: hostModel({ electron: false }) },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+
+    const ev = pressDigit(1)
+    expect(post).not.toHaveBeenCalled()
+    expect(ev.defaultPrevented).toBe(false)
+    post.mockRestore()
+  })
+
+  it('does nothing before the parent relays a host model', () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: null },
+    })
+    renderHookWithProviders(() => useInstanceShortcuts(), { store })
+
+    const ev = pressDigit(1)
+    expect(post).not.toHaveBeenCalled()
+    expect(ev.defaultPrevented).toBe(false)
+    post.mockRestore()
+  })
+})


### PR DESCRIPTION
## Problem

With multiple remote instances connected, switching between the Local dashboard and remote panes requires clicking the instance tab strip with the mouse. There is no keyboard way to jump between panes, unlike chat slots which already have digit shortcuts.

## Why it matters

Instance switching is a high-frequency action for anyone running dev boxes/cloud desktops through KiroCrew. Mouse-only switching breaks keyboard-driven workflows and is slower than the muscle-memory `⌘1/⌘2` pattern every browser and terminal user already has.

## Scope: Electron desktop app only (explicit product decision)

`⌘/Ctrl+digit` is a **reserved browser chord** (tab switching) — Chromium may not even dispatch the keydown to the page, so a web page can never reliably claim it. The feature is therefore hard-gated on the Electron shell (`isElectron`): the chord binds only there, and the shortcuts modal / Settings → Shortcuts hide the "Instances" group in plain browsers so we never advertise a binding the host environment will steal. Browser users keep their native tab switching untouched and see no dead UI. (A browser-safe alternative chord, e.g. `Alt+Shift+digit`, was considered and deferred — it can be added later without conflicting with this binding.)

## Fix (symptoms → root cause → change)

Root cause is simply a missing binding — the tab strip (`InstanceTabBar`) holds the switch logic but nothing maps keys to it.

- New `useInstanceShortcuts` hook: `⌘digit` (mac) / `Ctrl+digit` (win/linux) in the Electron shell jumps to the pane at that tab position — `1` = Local, `2..6` = the 1st..5th remote instance (matching `warm_set_cap = 5`), mirroring the tab strip's left-to-right order.
- **Shared select semantics — one unit, two surfaces.** The activate-then-conditionally-reconnect logic (including the hard-won stale-`warm`/tunnel-drop status check) is extracted from `InstanceTabBar` into a new `useSelectInstance` hook consumed by BOTH the tab bar's click path and the keyboard chord, so the two can never drift apart. (Previously the tab bar owned it inline; the chord now has no copy of its own.)
- **Works from inside an embedded remote pane.** A remote pane is this same SPA in an `<iframe>`; while the user works there, keyboard focus lives inside the iframe and the parent's listener can never hear the chord. The embedded copy of the hook binds too, maps the digit against the parent-relayed `instances.host` model, and posts the switch up via the **existing** `mc-switch-instance` postMessage channel — the same validated relay the embedded tab bar's click path uses. To gate this on the shell (the pane can't see Electron itself), the parent's `mc-host-model` relay gains an additive `electron: boolean` field, parsed fail-closed (`!!d.electron`) so an old parent + new pane simply doesn't bind.
- **Digit range derived from the registry.** The handler accepts exactly `Digit1..DigitN` where N = the `INSTANCE_SHORTCUTS` entries the shortcuts modal renders — a single source of truth, so the advertised chords and the claimed chords cannot drift (no undocumented ⌘7–9).
- Registered **once** in `App.tsx` — deliberately not inside `InstanceTabBar`, which can mount more than once (strip + inline header copies) and would double-fire every press.
- Modifier choice avoids collisions: chat-nav digits use `Ctrl` (mac) / `Alt` (win/linux), instance digits use `⌘` (mac) / `Ctrl` (win/linux), so the two never shadow each other on either platform.
- `preventDefault()` fires only when a matching pane exists, so Electron's default behavior survives when there is nothing to jump to.
- Respects the global "Enable shortcuts" toggle (read live from localStorage).

## Tests

`website/src/test/useInstanceShortcuts.test.tsx` (11 cases):
- Top-level: digit 1 → Local; digit 2 → first remote without re-minting a warm+live connection; digit 2 reconnects a not-yet-warm instance; digit with no matching pane ignored and NOT `preventDefault`ed; globally-disabled no-op; wrong-modifier rejection; registry-drift lock (with 8 remotes connected, digit 9 is still ignored while digit 6 — the last advertised chord — works).
- Embedded: chord relays `mc-switch-instance` to the parent (same channel as the click path) and claims the keystroke; digit with no relayed tab ignored; `host.electron=false` (browser parent) never binds; no relayed model yet → no-op.

`InstanceTabBar` / `EmbeddedSwitcher` / `InstancesViewport` suites pass **unchanged** through the extracted `useSelectInstance` unit — behavioral proof the refactor preserved click-path semantics.

Full frontend gate: `tsc -b` clean, `vitest run` — 353 files / 3981 tests pass.

## Manual verification

N/A beyond unit coverage — the switching, reconnect, relay, and gating logic is exercised by the suites above; the Electron-shell claim (no menu accelerator holds ⌘1–9) is verified by the absence of `CmdOrCtrl+digit` accelerators in `website/electron/main.js`.

## Screenshots

The only visual change is a new "Instances" list group in the existing shortcuts modal (Electron only), rendered by the same `ShortcutRow` component as the current groups — no new visual surface or layout change.
