### PR TITLE
fix: escape hatch on the instance disconnect view

### DIFF
--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -15,7 +15,7 @@
  * ACTIVE remote pane's tunnel connection state + token auto-refresh countdown
  * (host SSH expiry lives in the title bar, not duplicated here).
  */
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, type CSSProperties } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { Home, Server, Loader2 } from 'lucide-react'
 import { api, ApiError, type InstanceView } from '../api/client'
@@ -189,7 +189,10 @@ function EmbeddedInstanceTabBar({ variant }: { variant: 'strip' | 'inline' }) {
   )
 }
 
-export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip' | 'inline' } = {}) {
+export default function InstanceTabBar({
+  variant = 'strip',
+  style,
+}: { variant?: 'strip' | 'inline'; style?: CSSProperties } = {}) {
   const dispatch = useAppDispatch()
   const activeId = useAppSelector(s => s.instances.activeId)
   const warm = useAppSelector(s => s.instances.warm)
@@ -286,7 +289,7 @@ export default function InstanceTabBar({ variant = 'strip' }: { variant?: 'strip
   }
 
   return (
-    <div className={barCls(variant)} role="tablist" aria-label="Instances">
+    <div className={barCls(variant)} style={style} role="tablist" aria-label="Instances">
       <div className={`flex items-center gap-1 min-w-0 overflow-x-auto no-scrollbar ${variant === 'strip' ? 'flex-1' : ''}`}>
         <LocalTab active={activeId === null} onClick={onLocal} />
         {tabInstances.map(inst => {

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -28,8 +28,9 @@ import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { api } from '../api/client'
 import { useAppDispatch, useAppSelector } from '../store'
 import { removeWarm, setActiveId, setUnread, setWarm } from '../store/instancesSlice'
-import { visibleInstanceTabs } from './InstanceTabBar'
+import InstanceTabBar, { visibleInstanceTabs } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
+import { TRAFFIC_LIGHT_INSET_PX } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
 
 // Refresh the embedded token once elapsed reaches this fraction of its TTL
@@ -351,36 +352,49 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         />
       ))}
       {showPanel && activeId && (
-        <div className="absolute inset-0 flex items-center justify-center bg-bg p-6">
-          <div className="max-w-md w-full flex flex-col items-center gap-3 text-center">
-            {panelConnecting ? (
-              <Loader2 size={28} className="animate-spin text-muted" />
-            ) : (
-              <AlertTriangle size={28} className="text-[var(--danger)]" />
-            )}
-            <div className="text-sm font-medium text-text">{nameFor(activeId)}</div>
-            <div className="text-xs text-muted">
-              {panelConnecting
-                ? 'Connecting…'
-                : panelState === 'error'
-                  ? 'Connection error'
-                  : 'Disconnected'}
-            </div>
-            {!panelConnecting && panelError && (
-              <div className="w-full max-h-32 overflow-auto rounded-md border border-border bg-bg-hover px-3 py-2 text-left text-xs text-muted whitespace-pre-wrap break-words">
-                {panelError}
+        <div className="absolute inset-0 flex flex-col bg-bg">
+          {/* Escape hatch (bug: stranded on the disconnect view). While a remote
+              tab is active the local header — and with it the only top-level
+              InstanceTabBar — is display:none, and the embedded switcher lives
+              INSIDE the (now dead/absent) iframe. Without this strip the panel
+              is a dead end: no way to reach Local or any other instance. The
+              non-embedded InstanceTabBar renders the full switcher; inset it
+              clear of the macOS traffic lights when this strip is topmost. */}
+          <InstanceTabBar
+            variant="strip"
+            style={macInset ? { paddingLeft: TRAFFIC_LIGHT_INSET_PX } : undefined}
+          />
+          <div className="flex-1 flex items-center justify-center p-6">
+            <div className="max-w-md w-full flex flex-col items-center gap-3 text-center">
+              {panelConnecting ? (
+                <Loader2 size={28} className="animate-spin text-muted" />
+              ) : (
+                <AlertTriangle size={28} className="text-[var(--danger)]" />
+              )}
+              <div className="text-sm font-medium text-text">{nameFor(activeId)}</div>
+              <div className="text-xs text-muted">
+                {panelConnecting
+                  ? 'Connecting…'
+                  : panelState === 'error'
+                    ? 'Connection error'
+                    : 'Disconnected'}
               </div>
-            )}
-            <button
-              type="button"
-              disabled={panelConnecting}
-              onClick={() => connectMutation.mutate(activeId)}
-              className="mt-1 inline-flex items-center gap-1.5 text-xs py-1.5 px-3.5 rounded-md bg-accent text-accent-fg disabled:opacity-60"
-            >
-              <RefreshCw size={13} className={panelConnecting ? 'animate-spin' : ''} /> Retry
-            </button>
-            <div className="text-[11px] text-muted">
-              This tab stays until you disconnect the instance in Settings → Instances.
+              {!panelConnecting && panelError && (
+                <div className="w-full max-h-32 overflow-auto rounded-md border border-border bg-bg-hover px-3 py-2 text-left text-xs text-muted whitespace-pre-wrap break-words">
+                  {panelError}
+                </div>
+              )}
+              <button
+                type="button"
+                disabled={panelConnecting}
+                onClick={() => connectMutation.mutate(activeId)}
+                className="mt-1 inline-flex items-center gap-1.5 text-xs py-1.5 px-3.5 rounded-md bg-accent text-accent-fg disabled:opacity-60"
+              >
+                <RefreshCw size={13} className={panelConnecting ? 'animate-spin' : ''} /> Retry
+              </button>
+              <div className="text-[11px] text-muted">
+                This tab stays until you disconnect the instance in Settings → Instances.
+              </div>
             </div>
           </div>
         </div>

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -231,6 +231,71 @@ describe('InstancesViewport', () => {
     expect(screen.queryByRole('button', { name: /Retry/i })).toBeNull()
   })
 
+  it('renders the instance tab bar on the disconnect panel so the user can escape', async () => {
+    // Regression: while a remote tab is active the local header (and its
+    // InstanceTabBar) is hidden, and the embedded switcher lives inside the
+    // dead iframe — without a strip on the panel the disconnect view was a
+    // dead end with no way to reach Local or any other instance.
+    vi.mocked(api.listInstances).mockResolvedValue({
+      instances: [
+        {
+          id: 'cd-1',
+          name: 'Cloud One',
+          ssh_host: 'cd-1-alias',
+          remote_port: 7777,
+          local_port: 0,
+          ttl: '20h',
+          remote_bin: '',
+          was_connected: true,
+          status: { instance_id: 'cd-1', state: 'error', error: 'ssh unreachable', remote_port: 7777 },
+        },
+      ],
+      warm_set_cap: 5,
+    })
+    const store = createTestStore({
+      instances: { warm: {}, activeId: 'cd-1', mru: ['cd-1'], unread: {} },
+    })
+    const u = userEvent.setup()
+    renderWithProviders(<InstancesViewport />, { store })
+
+    expect(await screen.findByText(/Connection error/i)).toBeInTheDocument()
+    // The full switcher renders atop the panel: Local + the instance tab.
+    const bar = await screen.findByRole('tablist', { name: /Instances/i })
+    expect(bar).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Local/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Cloud One/i })).toBeInTheDocument()
+
+    // Clicking Local escapes the disconnect view.
+    await u.click(screen.getByRole('tab', { name: /Local/i }))
+    expect(store.getState().instances.activeId).toBeNull()
+  })
+
+  it('insets the panel tab bar clear of the macOS traffic lights when macInset is set', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue({
+      instances: [
+        {
+          id: 'cd-1',
+          name: 'Cloud One',
+          ssh_host: 'cd-1-alias',
+          remote_port: 7777,
+          local_port: 0,
+          ttl: '20h',
+          remote_bin: '',
+          was_connected: true,
+          status: { instance_id: 'cd-1', state: 'error', error: 'ssh unreachable', remote_port: 7777 },
+        },
+      ],
+      warm_set_cap: 5,
+    })
+    const store = createTestStore({
+      instances: { warm: {}, activeId: 'cd-1', mru: ['cd-1'], unread: {} },
+    })
+    renderWithProviders(<InstancesViewport macInset />, { store })
+
+    const bar = await screen.findByRole('tablist', { name: /Instances/i })
+    expect(bar.style.paddingLeft).toBe('84px')
+  })
+
   it('K-cap eviction drops only the warm iframe, never disconnecting the tunnel', async () => {
     vi.mocked(api.listInstances).mockResolvedValue({ instances: [], warm_set_cap: 1 })
     const store = createTestStore({


### PR DESCRIPTION
## Summary
When a remote instance tab is active, the local header — and with it the only top-level `InstanceTabBar` — is `display:none` (hide-not-unmount). The switcher on a remote pane instead renders *inside* the embedded iframe. When the tunnel drops, `InstancesViewport` shows the full-screen error/Retry panel and the iframe is dead or absent — so **no tab bar renders anywhere** and the user is stranded on the disconnect view with no way back to Local or any other instance (only the undiscoverable ⌘1 shortcut escapes).

## Fix
Render the full (non-embedded) `InstanceTabBar` as a strip atop the in-pane error/connecting panel:
- `InstanceTabBar` gains an optional `style` passthrough.
- `InstancesViewport` renders `<InstanceTabBar variant="strip" />` above the panel content, inset clear of the macOS traffic lights via the existing `macInset` prop (`TRAFFIC_LIGHT_INSET_PX`).
- Covers both panel paths: active non-warm instance, and stale-warm with dropped tunnel. Also fixes the same trap on the 'Connecting…' panel.

## Testing
- 2 new regression tests in `InstancesViewport.test.tsx`: tab bar renders on the disconnect panel and clicking Local escapes (`activeId` → null); traffic-light inset applied when `macInset` is set.
- Full gates: tsc clean, vitest 352 files / 3972 passed, eslint no new findings, flake8 clean, pytest 15,368 passed (2 failures are sandbox-environmental: EPERM hardlink / blocked unshare — backend untouched by this diff).