### PR TITLE
fix: atomic writes + locking for 4 crash/data-loss persistence bugs

### DIFF
--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -97,7 +97,7 @@ class TaskRunner:
     # task_executor.execute_task()/self_review(), task_reporter.build_status()
 
     async def run(self, spec_path: str | Path, task_id: str = "", name: str = "", source: str = "file") -> TaskRun
-    def start_background(self, spec_path: str | Path, agent: str = "", name: str = "", source: str = "file") -> str
+    async def start_background(self, spec_path: str | Path, agent: str = "", name: str = "", source: str = "file") -> str
     def cancel(self, task_id: str | None = None) -> None  # None = cancel all
     def status(self) -> dict
 
@@ -106,9 +106,17 @@ class TaskRunner:
     @property
     def current_run(self) -> TaskRun | None
 
-    # Internal but accessed by handlers for delete
+    # Mutation APIs await fsync-backed persistence off the event loop.
+    async def update_plan(task_id: str, tasks: list[dict]) -> TaskRun
+    async def update_task(task_id: str, index: int, updates: dict) -> dict
+    async def execute_plan(task_id: str, ...) -> str
+    async def retry_from_task(task_id: str, from_task: int, agent: str = "") -> str
+    async def delete_run(task_id: str) -> bool
+
+    # Internal but accessed by handlers for read-only projection
     _runs: dict[str, TaskRun]
-    _persist_runs() -> None
+    async def _apersist_runs() -> None
+    _persist_runs() -> None  # synchronous compatibility/testing helper only
 ```
 
 ### Task Source & Visibility
@@ -180,7 +188,8 @@ class Project:
 
 - `_runs: dict[str, TaskRun]` — keyed by task_id
 - `_tasks: dict[str, asyncio.Task]` — background asyncio tasks
-- `start_background()` accepts optional `agent` param, returns task_id (`{spec_stem}_{timestamp}`)
+- `start_background()` accepts optional `agent` param, returns a collision-resistant task ID (`{spec_stem}_{time_ns}`)
+- `_start_lock` serializes concurrency admission, completed-run pruning, ID allocation, durable planning-placeholder persistence, and `_tasks` registration
 - All `get_or_create()` calls pass `agent=self._agent` so the task runs with the specified agent
 - Each step gets its own session: `taskrunner:{task_id}:task{N}` (fresh per step, reset after)
 - Each task gets its own work dir: `{work_dir}/{spec_stem}/`

--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -250,7 +250,7 @@ Heartbeat is a self-cleaning task queue that runs every few minutes, survives ga
 - You need to poll an external system until a condition is met (CR analysis, deployment, ticket resolution)
 
 **Writing a heartbeat task:**
-1. Write a checklist entry to `~/.kirocrew/workspace/HEARTBEAT.md`:
+1. Append the checklist entry by calling `kiro_crew.heartbeat.append_heartbeat_task(entry)` from Python; never edit or append `~/.kirocrew/workspace/HEARTBEAT.md` directly. The helper shares the service's cross-process lock, preventing a cycle-end rewrite from losing the entry:
    `- [ ] Check CR-XXXXX for new code-review comments. If found, fix them, push a new revision, and respond with HEARTBEAT_KEEP. If none, notify user "CR-XXXXX passed ✅"`
 2. Tell the user it's been added to heartbeat monitoring
 3. End the session — heartbeat re-processes retained tasks on the next cycle, creating a monitor-until-done loop

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -112,7 +112,7 @@ When the user asks you to submit code for review and address automated comments 
 
 One loop per session — starting a new one replaces the old. The user can also stop dashboard loops from the 🎯 popover.
 
-**Heartbeat (fallback):** the `~/.kirocrew/workspace/HEARTBEAT.md` task queue still exists for cases monitor_start can't cover: work that should run OUTSIDE this session (fresh context each cycle), or contexts where monitor_start is unavailable (cron/webhook sessions). Tasks are checklist entries processed every few minutes; include `HEARTBEAT_KEEP` in the response to retain a task for the next cycle, omit it when complete. Route completion with `<!-- deliver:dashboard -->` / `<!-- deliver:slack -->` tags. Notify only on real signals.
+**Heartbeat (fallback):** the `~/.kirocrew/workspace/HEARTBEAT.md` task queue still exists for cases monitor_start can't cover: work that should run OUTSIDE this session (fresh context each cycle), or contexts where monitor_start is unavailable (cron/webhook sessions). Append checklist entries by calling `kiro_crew.heartbeat.append_heartbeat_task(entry)` from Python; never edit the file directly, because the helper shares the service's cross-process lock. Tasks are processed every few minutes; include `HEARTBEAT_KEEP` in the response to retain a task for the next cycle, omit it when complete. Route completion with `<!-- deliver:dashboard -->` / `<!-- deliver:slack -->` tags. Notify only on real signals.
 
 ### Webhook-Triggered Sessions
 

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -372,33 +372,53 @@ async def api_stt_config(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         path = config_path()
-        try:
-            data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-        except Exception:
-            data = {}
-        stt = data.setdefault("stt", {})
-        if "enabled" in body:
-            stt["enabled"] = bool(body["enabled"])
-        if "provider" in body and body["provider"] in _stt_providers():
-            stt["provider"] = body["provider"]
-        if "model" in body and body["model"] in _STT_MODEL_SIZES:
-            stt["model"] = body["model"]
-        if (
-            "mlx_model" in body
-            and isinstance(body["mlx_model"], str)
-            and body["mlx_model"] in _STT_MLX_MODELS
-        ):
-            stt["mlx_model"] = body["mlx_model"]
-        if "transcribe_region" in body and isinstance(body["transcribe_region"], str):
-            stt["transcribe_region"] = body["transcribe_region"]
-        if "transcribe_profile" in body and isinstance(body["transcribe_profile"], str):
-            stt["transcribe_profile"] = body["transcribe_profile"]
-        if "language_code" in body and isinstance(body["language_code"], str):
-            stt["language_code"] = body["language_code"]
-        if "streaming" in body and isinstance(body["streaming"], bool):
-            stt["streaming"] = body["streaming"]
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        from kiro_crew.agent import _atomic_json_write  # noqa: F811
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock  # noqa: F811
+
+        # Serialize the full read-modify-write behind the shared config lock so
+        # concurrent PUTs (or another config writer) can't interleave and clobber
+        # each other's fields, and write atomically (temp + fsync + os.replace)
+        # so a crash mid-write can't leave a corrupt config JSON — matching the
+        # established pattern used by the other config handlers in this module.
+        async with _get_config_lock():
+            try:
+                raw = await asyncio.to_thread(path.read_text, encoding="utf-8")
+                data = json.loads(raw)
+            except FileNotFoundError:
+                data = {}
+            except Exception:
+                # Fail loud on a corrupt config rather than proceeding with {}:
+                # an atomic write from a {} base would durably clobber every
+                # other user setting with an stt-only file. Matches the sibling
+                # config handler in this module, which returns 500 on an
+                # unparseable config instead of silently resetting it.
+                logger.warning("STT config PUT: config.json is unparseable", exc_info=True)
+                return web.json_response(
+                    {"error": "failed to read config file"}, status=500
+                )
+            stt = data.setdefault("stt", {})
+            if "enabled" in body:
+                stt["enabled"] = bool(body["enabled"])
+            if "provider" in body and body["provider"] in _stt_providers():
+                stt["provider"] = body["provider"]
+            if "model" in body and body["model"] in _STT_MODEL_SIZES:
+                stt["model"] = body["model"]
+            if (
+                "mlx_model" in body
+                and isinstance(body["mlx_model"], str)
+                and body["mlx_model"] in _STT_MLX_MODELS
+            ):
+                stt["mlx_model"] = body["mlx_model"]
+            if "transcribe_region" in body and isinstance(body["transcribe_region"], str):
+                stt["transcribe_region"] = body["transcribe_region"]
+            if "transcribe_profile" in body and isinstance(body["transcribe_profile"], str):
+                stt["transcribe_profile"] = body["transcribe_profile"]
+            if "language_code" in body and isinstance(body["language_code"], str):
+                stt["language_code"] = body["language_code"]
+            if "streaming" in body and isinstance(body["streaming"], bool):
+                stt["streaming"] = body["streaming"]
+            await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+            await asyncio.to_thread(_atomic_json_write, path, data)
         cfg = KiroCrewConfig.load()
 
     provider = cfg.stt.provider

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -146,7 +146,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         auto_approve = _gate_auto_approve(
             request, body.get("auto_approve") is True, claimed_source, endpoint="start"
         )
-        task_id = state.task_runner.start_background(
+        task_id = await state.task_runner.start_background(
             spec_path, agent=agent, name=task_name, source=source, workspace_dir=workspace_dir,
             auto_approve=auto_approve,
         )
@@ -213,7 +213,7 @@ async def api_taskrunner_delete(request: web.Request) -> web.Response:
         return web.json_response({"error": "cancel first"}, status=409)
     state.task_runner._runs.pop(task_id, None)
     state.task_runner._stall_cancelled_ids.discard(task_id)
-    state.task_runner._persist_runs()
+    await state.task_runner._apersist_runs()
     return web.json_response({"ok": True})
 
 
@@ -234,7 +234,7 @@ async def api_taskrunner_rename(request: web.Request) -> web.Response:
     if not name:
         return web.json_response({"error": "name required"}, status=400)
     run.name = name
-    state.task_runner._persist_runs()
+    await state.task_runner._apersist_runs()
     return web.json_response({"ok": True, "name": name})
 
 
@@ -253,7 +253,7 @@ async def api_taskrunner_update_task(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     try:
-        result = state.task_runner.update_task(task_id, index, data)
+        result = await state.task_runner.update_task(task_id, index, data)
         # SEL audit for all task field changes
         _sel().log_tool_invocation(
             session_key="dashboard",
@@ -286,7 +286,7 @@ async def api_taskrunner_retry(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid JSON"}, status=400)
     from_step = body.get("from_step", 1)
     try:
-        state.task_runner.retry_from_task(task_id, from_step, agent=state.task_runner._agent or "")
+        await state.task_runner.retry_from_task(task_id, from_step, agent=state.task_runner._agent or "")
         return web.json_response({"ok": True, "task_id": task_id})
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
@@ -522,7 +522,7 @@ async def api_taskrunner_update_plan(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid JSON"}, status=400)
     steps = body.get("steps", [])
     try:
-        run = state.task_runner.update_plan(task_id, steps)
+        run = await state.task_runner.update_plan(task_id, steps)
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response(
@@ -567,7 +567,7 @@ async def api_taskrunner_execute_plan(request: web.Request) -> web.Response:
         request, body.get("auto_approve") is True, None, endpoint="execute"
     )
     try:
-        state.task_runner.execute_plan(task_id, agent=agent, fresh=fresh, workspace_dir=workspace_dir, auto_approve=auto_approve)
+        await state.task_runner.execute_plan(task_id, agent=agent, fresh=fresh, workspace_dir=workspace_dir, auto_approve=auto_approve)
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response({"ok": True, "task_id": task_id})
@@ -590,7 +590,7 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
         return web.json_response({"error": "steps array required"}, status=400)
     try:
         if task_id:
-            run = state.task_runner.update_plan(task_id, steps)
+            run = await state.task_runner.update_plan(task_id, steps)
         else:
             new_id = f"plan_{uuid.uuid4().hex[:8]}"
             task_dir = state.task_runner._work_dir / new_id
@@ -606,7 +606,7 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
             )
             state.task_runner._runs[new_id] = run
             try:
-                run = state.task_runner.update_plan(new_id, steps)
+                run = await state.task_runner.update_plan(new_id, steps)
             except ValueError:
                 state.task_runner._runs.pop(new_id, None)
                 raise

--- a/src/kiro_crew/dashboard/handlers_project.py
+++ b/src/kiro_crew/dashboard/handlers_project.py
@@ -67,14 +67,14 @@ async def api_project_update(request):
         raise web.HTTPNotFound(text=f"Project {pid} not found")
     if "name" in data:
         run.name = data["name"]
-        tr._persist_runs()
+        await tr._apersist_runs()
     return web.json_response(_run_to_project(run))
 
 
 async def api_project_delete(request):
     tr = _runner(request)
     pid = request.match_info["id"]
-    if not tr or not tr.delete_run(pid):
+    if not tr or not await tr.delete_run(pid):
         raise web.HTTPNotFound(text=f"Project {pid} not found")
     return web.json_response({"ok": True})
 

--- a/src/kiro_crew/heartbeat.py
+++ b/src/kiro_crew/heartbeat.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import os
 import re
+from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Coroutine
 
-from kiro_crew import shutdown_event
+from kiro_crew import platform_compat, shutdown_event
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import maintenance_executor
 from kiro_crew.memory import MemoryStore, workspace_dir
@@ -51,6 +54,62 @@ def heartbeat_path() -> Path:
     return workspace_dir() / HEARTBEAT_FILE
 
 
+def heartbeat_lock_path(path: Path | None = None) -> Path:
+    """Return the sibling lock file shared by all HEARTBEAT.md writers."""
+    target = path or heartbeat_path()
+    return target.with_name(f"{target.name}.lock")
+
+
+def append_heartbeat_task(entry: str, path: Path | None = None) -> None:
+    """Append one heartbeat entry under the cross-process writer lock.
+
+    Internal producers must use this helper rather than opening HEARTBEAT.md
+    directly, so the service's final read→replace transaction cannot overwrite
+    an append from another process.
+    """
+    target = path or heartbeat_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = heartbeat_lock_path(target)
+    with open(lock_path, "a+b") as lock_file:
+        with platform_compat.file_lock(lock_file.fileno(), exclusive=True):
+            if not target.exists():
+                atomic_write(target, _HEADER, fsync=True)
+            with open(target, "a", encoding="utf-8") as heartbeat_file:
+                heartbeat_file.write(entry.rstrip("\n") + "\n")
+                heartbeat_file.flush()
+                os.fsync(heartbeat_file.fileno())
+
+
+def _rewrite_heartbeat_locked(
+    path: Path,
+    original_tasks: list[tuple[str, str]],
+    keep: list[tuple[str, str]],
+) -> int:
+    """Re-read, merge, and atomically replace HEARTBEAT.md under an OS lock."""
+    lock_path = heartbeat_lock_path(path)
+    with open(lock_path, "a+b") as lock_file:
+        with platform_compat.file_lock(lock_file.fileno(), exclusive=True):
+            try:
+                current_tasks = _extract_tasks(path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                current_tasks = []
+
+            remaining = Counter(t for t, _ in original_tasks)
+            appended: list[tuple[str, str]] = []
+            for task_text, deliver in current_tasks:
+                if remaining.get(task_text, 0) > 0:
+                    remaining[task_text] -= 1
+                else:
+                    appended.append((task_text, deliver))
+
+            lines = _HEADER
+            for task_text, deliver in keep + appended:
+                suffix = f"  <!-- deliver:{deliver} -->" if deliver else ""
+                lines += f"- {task_text}{suffix}\n"
+            atomic_write(path, lines, fsync=True)
+            return len(appended)
+
+
 class HeartbeatService:
     """Periodic wake-up that runs background maintenance tasks."""
 
@@ -75,6 +134,9 @@ class HeartbeatService:
         self._tick = 0
         self._processing = False
         self._task: asyncio.Task | None = None  # type: ignore[type-arg]
+        # Serializes the HEARTBEAT.md read→process→rewrite window within this
+        # process so two cycles can't clobber each other's rewrite.
+        self._file_lock = asyncio.Lock()
 
     async def start(self) -> None:
         path = heartbeat_path()
@@ -141,49 +203,59 @@ class HeartbeatService:
 
     async def _process_heartbeat_file(self) -> None:
         path = heartbeat_path()
-        if not path.exists():
-            return
-        content = path.read_text(encoding="utf-8").strip()
-        tasks = _extract_tasks(content)
-        if not tasks or not self._on_task:
-            return
+        # Hold the file lock across the whole read→process→rewrite window so a
+        # concurrent cycle can't rewrite the file from a stale snapshot.
+        async with self._file_lock:
+            if not path.exists():
+                return
+            content = path.read_text(encoding="utf-8").strip()
+            tasks = _extract_tasks(content)
+            if not tasks or not self._on_task:
+                return
 
-        self._processing = True
-        try:
-            logger.info("Heartbeat: %d task(s) found", len(tasks))
-            keep: list[tuple[str, str]] = []
-            results = await asyncio.gather(
-                *[self._run_one_task(t, d) for t, d in tasks],
-                return_exceptions=True,
-            )
-            for (task_text, deliver), result in zip(tasks, results):
-                if isinstance(result, BaseException):
-                    logger.warning(
-                        "Heartbeat task failed: %s", task_text[:80], exc_info=result,
+            self._processing = True
+            try:
+                logger.info("Heartbeat: %d task(s) found", len(tasks))
+                keep: list[tuple[str, str]] = []
+                results = await asyncio.gather(
+                    *[self._run_one_task(t, d) for t, d in tasks],
+                    return_exceptions=True,
+                )
+                for (task_text, deliver), result in zip(tasks, results):
+                    if isinstance(result, BaseException):
+                        logger.warning(
+                            "Heartbeat task failed: %s", task_text[:80], exc_info=result,
+                        )
+                        keep.append((task_text, deliver))
+                    elif _should_keep(result):
+                        logger.info("Heartbeat task incomplete, keeping: %s", task_text[:80])
+                        keep.append((task_text, deliver))
+
+                # Re-read, merge mid-cycle appends, and replace atomically while
+                # holding the sibling OS lock. Every internal writer uses the
+                # same lock via append_heartbeat_task(), so no append can land
+                # between this final read and os.replace. The entire durable
+                # transaction runs off the gateway event-loop thread.
+                appended_count = await asyncio.to_thread(
+                    _rewrite_heartbeat_locked, path, tasks, keep,
+                )
+                if appended_count:
+                    logger.info(
+                        "Heartbeat: preserving %d task(s) appended mid-cycle",
+                        appended_count,
                     )
-                    keep.append((task_text, deliver))
-                elif _should_keep(result):
-                    logger.info("Heartbeat task incomplete, keeping: %s", task_text[:80])
-                    keep.append((task_text, deliver))
-
-            # Rewrite: keep incomplete/failed tasks so they retry next tick
-            lines = _HEADER
-            for text, deliver in keep:
-                suffix = f"  <!-- deliver:{deliver} -->" if deliver else ""
-                lines += f"- {text}{suffix}\n"
-            path.write_text(lines, encoding="utf-8")
-        finally:
-            self._processing = False
-            # Cycle-end teardown — runs once after ALL tasks in this cycle
-            # complete.  Owner can use this to conditionally recycle the
-            # shared heartbeat session (e.g. only when context > threshold)
-            # so multi-task cycles don't tear down the session another
-            # in-flight task is still using.
-            if self._on_cycle_end is not None:
-                try:
-                    await self._on_cycle_end()
-                except Exception:
-                    logger.warning("Heartbeat: on_cycle_end callback failed", exc_info=True)
+            finally:
+                self._processing = False
+                # Cycle-end teardown — runs once after ALL tasks in this cycle
+                # complete.  Owner can use this to conditionally recycle the
+                # shared heartbeat session (e.g. only when context > threshold)
+                # so multi-task cycles don't tear down the session another
+                # in-flight task is still using.
+                if self._on_cycle_end is not None:
+                    try:
+                        await self._on_cycle_end()
+                    except Exception:
+                        logger.warning("Heartbeat: on_cycle_end callback failed", exc_info=True)
 
 
 def _should_keep(result: str | None) -> bool:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -13,6 +13,7 @@ import logging
 import math
 import os
 import re
+import threading
 import time as _time
 from datetime import datetime
 from pathlib import Path
@@ -196,12 +197,32 @@ def _safe_key(key: str) -> str:
 class ConversationLog:
     """Append-only JSONL conversation store with provenance and rotation."""
 
+    # Per-file reentrant locks shared across every instance in this process so
+    # transcript mutations (append / rewrite / metadata edit) targeting the
+    # same session file are serialized and never lose each other's writes.
+    _file_locks: dict[str, threading.RLock] = {}
+    _file_locks_guard = threading.Lock()
+
     def __init__(self, base_dir: Path | None = None):
         self._dir = base_dir or _sessions_dir()
         # mtime-based message cache: key → (mtime, messages)
         self._msg_cache: dict[str, tuple[float, list[dict]]] = {}
         # mtime-based metadata cache: key → (mtime, metadata)
         self._meta_cache: dict[str, tuple[float, dict]] = {}
+
+    def _file_lock(self, key: str) -> threading.RLock:
+        """Return the process-wide reentrant lock guarding *key*'s session file.
+
+        Reentrant so a locked method (e.g. ``append``) can call another locked
+        helper (``_maybe_rotate``) without deadlocking.
+        """
+        lock_key = str(self._path(key))
+        with ConversationLog._file_locks_guard:
+            lock = ConversationLog._file_locks.get(lock_key)
+            if lock is None:
+                lock = threading.RLock()
+                ConversationLog._file_locks[lock_key] = lock
+            return lock
 
     def init(self) -> None:
         """Create sessions directory if missing."""
@@ -246,39 +267,45 @@ class ConversationLog:
         use :meth:`update_metadata` to change the agent after creation.)
         """
         path = self._path(key)
-        if not path.exists():
-            self._dir.mkdir(parents=True, exist_ok=True)
-            meta: dict = {
-                "_type": "metadata",
-                "created_at": datetime.now().isoformat(),
-                "last_consolidated": 0,
+        # Serialize the create-if-missing + append + rotate against concurrent
+        # rewrites (compaction / consolidation) so no write is lost and readers
+        # never observe a torn file.
+        with self._file_lock(key):
+            if not path.exists():
+                self._dir.mkdir(parents=True, exist_ok=True)
+                meta: dict = {
+                    "_type": "metadata",
+                    "created_at": datetime.now().isoformat(),
+                    "last_consolidated": 0,
+                }
+                if agent:
+                    meta["agent"] = agent
+                if tab_id:
+                    meta["tab_id"] = tab_id
+                path.write_text(json.dumps(meta) + "\n", encoding="utf-8")
+
+            msg: dict = {
+                "role": role,
+                "content": content,
+                "ts": datetime.now().isoformat(),
             }
-            if agent:
-                meta["agent"] = agent
-            if tab_id:
-                meta["tab_id"] = tab_id
-            path.write_text(json.dumps(meta) + "\n", encoding="utf-8")
+            if tools:
+                msg["tools"] = tools
+            if source_thread:
+                msg["source_thread"] = source_thread
+            if source_user:
+                msg["source_user"] = source_user
 
-        msg: dict = {
-            "role": role,
-            "content": content,
-            "ts": datetime.now().isoformat(),
-        }
-        if tools:
-            msg["tools"] = tools
-        if source_thread:
-            msg["source_thread"] = source_thread
-        if source_user:
-            msg["source_user"] = source_user
+            # Session transcripts are intentionally local plaintext JSONL (the
+            # documented storage format), not a credential/secret store.
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(msg) + "\n")  # lgtm[py/clear-text-storage-sensitive-data]
 
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(msg) + "\n")
+            # Invalidate cache since file changed
+            self._invalidate_cache(key)
 
-        # Invalidate cache since file changed
-        self._invalidate_cache(key)
-
-        # Rotate if file exceeds size limit
-        self._maybe_rotate(path)
+            # Rotate if file exceeds size limit
+            self._maybe_rotate(path)
 
     def recent(
         self,
@@ -362,21 +389,25 @@ class ConversationLog:
     def mark_consolidated(self, key: str, offset: int) -> None:
         """Rewrite metadata line with updated last_consolidated offset."""
         path = self._path(key)
-        if not path.exists():
-            return
-        prev_mtime = _safe_mtime(path)
-        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-        if not lines:
-            return
-        meta = json.loads(lines[0])
-        meta["last_consolidated"] = offset
-        meta["updated_at"] = datetime.now().isoformat()
-        lines[0] = json.dumps(meta) + "\n"
-        path.write_text("".join(lines), encoding="utf-8")
-        # Housekeeping bookkeeping — must not advance the session's mtime
-        # (see _restore_mtime). Otherwise consolidation floats stale sessions
-        # to the top of list_sessions on every gateway restart.
-        _restore_mtime(path, prev_mtime)
+        # Serialize behind the per-file lock and re-read under it so a
+        # concurrent append (guarded by the same lock) is never lost, and
+        # write atomically so a crash mid-write can't truncate the transcript.
+        with self._file_lock(key):
+            if not path.exists():
+                return
+            prev_mtime = _safe_mtime(path)
+            lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+            if not lines:
+                return
+            meta = json.loads(lines[0])
+            meta["last_consolidated"] = offset
+            meta["updated_at"] = datetime.now().isoformat()
+            lines[0] = json.dumps(meta) + "\n"
+            atomic_write(path, "".join(lines), fsync=True)
+            # Housekeeping bookkeeping — must not advance the session's mtime
+            # (see _restore_mtime). Otherwise consolidation floats stale sessions
+            # to the top of list_sessions on every gateway restart.
+            _restore_mtime(path, prev_mtime)
         self._invalidate_cache(key)
 
     def unconsolidated_count(self, key: str) -> int:
@@ -743,6 +774,16 @@ class ConversationLog:
     def update_metadata(self, key: str, fields: dict) -> None:
         """Merge *fields* into the session's metadata line and persist.
 
+        Serialized behind the per-file lock so a concurrent append or rewrite
+        of the same session file can't clobber this metadata edit (and vice
+        versa).
+        """
+        with self._file_lock(key):
+            self._update_metadata_locked(key, fields)
+
+    def _update_metadata_locked(self, key: str, fields: dict) -> None:
+        """Merge *fields* into the session's metadata line and persist.
+
         Upsert semantics: if the session file does not exist yet (e.g. ``!ta
         <agent> --clean`` is issued before the first message is logged), the
         file is created with a fresh metadata line carrying *fields*.  Without
@@ -960,6 +1001,13 @@ class ConversationLog:
 
     def rewrite_session(self, key: str, messages: list[dict]) -> None:
         """Rewrite session JSONL with only the given messages."""
+        # Serialize the full rewrite against concurrent appends so a live
+        # session's writes aren't lost, and (via atomic_write below) so a crash
+        # can't truncate the transcript.
+        with self._file_lock(key):
+            self._rewrite_session_locked(key, messages)
+
+    def _rewrite_session_locked(self, key: str, messages: list[dict]) -> None:
         path = self._path(key)
         self._dir.mkdir(parents=True, exist_ok=True)
         # Compaction is housekeeping, not new activity — preserve the pre-write
@@ -1486,8 +1534,14 @@ class HistoryConsolidator:
 
             # Only advance the consolidated offset for history consolidation.
             # Prefs-only consolidation uses a separate in-memory offset.
+            # mark_consolidated does a synchronous, fsync-backed rewrite of the
+            # whole transcript (up to a couple of MB) behind the per-file lock.
+            # _consolidate runs on the gateway event loop (fired via
+            # asyncio.create_task), so offload the blocking rewrite to a worker
+            # thread — otherwise a slow filesystem freezes the loop (heartbeats,
+            # Slack, dashboard). Same rationale as the offloads above.
             if include_history:
-                self._log.mark_consolidated(key, total)
+                await asyncio.to_thread(self._log.mark_consolidated, key, total)
 
         except Exception:
             logger.exception("Consolidation failed for %s", key)

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -2306,7 +2306,7 @@ async def maybe_handle_keyword_command(
 
     # ── Task runner: "run <spec-path>" ──
     if task_runner:
-        run_reply = _handle_run_command(text, task_runner, slack, channel, reply_ts)
+        run_reply = await _handle_run_command(text, task_runner, slack, channel, reply_ts)
         if run_reply:
             await slack.post_message(channel, run_reply, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
@@ -4454,7 +4454,7 @@ def _handle_cron_command(
     return None
 
 
-def _handle_run_command(
+async def _handle_run_command(
     text: str,
     runner: TaskRunner,
     slack: SlackClientOps,
@@ -4506,7 +4506,7 @@ def _handle_run_command(
         return f"❌ Spec file not found: `{spec_path}`"
 
     try:
-        runner.start_background(spec_path, source="chat")
+        await runner.start_background(spec_path, source="chat")
     except Exception as exc:
         return f"❌ Failed to start: {exc}"
     return f"🚀 Task started: `{spec_path.name}`\nUse `task run status` to check progress."

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 from kiro_crew import git_coord, shutdown_event
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.llm_helpers import stream_and_collect_json
@@ -153,6 +155,12 @@ def _resolve_workspace_dir(raw: str) -> str:
     return resolved
 
 
+def _read_spec_prefix(path: str, max_chars: int) -> str:
+    """Read and normalize a bounded spec prefix on a worker thread."""
+    with open(path, encoding="utf-8") as spec_file:
+        return spec_file.read(max_chars).strip()
+
+
 def _decompose_yaml_with_audit(yaml_content: str, task_id: str) -> list[Task]:
     """Decompose YAML with SEL audit logging."""
     try:
@@ -235,7 +243,16 @@ class TaskRunner:
         else:
             self._max_parallel_steps = auto_cap
         self._runs: dict[str, Project] = {}
+        # Serialize registry writes and enforce monotonic ordering. Snapshots
+        # are always built on the event-loop thread (see _serialize_runs), so
+        # an older snapshot whose offloaded write lands late must not clobber a
+        # newer one: _commit_snapshot skips any write whose sequence is behind
+        # what has already been persisted.
+        self._persist_lock = threading.Lock()
+        self._persist_seq = 0  # last sequence handed out (event-loop thread only)
+        self._persist_written = 0  # highest sequence persisted (lock-guarded)
         self._tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+        self._start_lock = asyncio.Lock()
         self._plan_task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._on_tool_approval: Callable[[LLMEvent], Awaitable[bool]] | None = None
         self._stall_cancelled_ids: set[str] = set()
@@ -335,24 +352,24 @@ class TaskRunner:
         if not run.tasks:
             raise ValueError("Could not generate a plan. Try rephrasing.")
         self._runs[task_id] = run
-        self._persist_runs()
+        await self._apersist_runs()
         return run
 
     def cancel_plan(self) -> None:
         if self._plan_task and not self._plan_task.done():
             self._plan_task.cancel()
 
-    def update_plan(self, task_id: str, tasks: list[dict]) -> Project:
+    async def update_plan(self, task_id: str, tasks: list[dict]) -> Project:
         run = self._runs.get(task_id)
         if not run:
             raise ValueError(f"Run {task_id} not found")
         if run.status in ("running", "cancelling"):
             raise ValueError(f"Cannot update plan while {run.status}")
         result = update_plan_tasks(run, tasks)
-        self._persist_runs()
+        await self._apersist_runs()
         return result
 
-    def update_task(self, task_id: str, index: int, updates: dict) -> dict:
+    async def update_task(self, task_id: str, index: int, updates: dict) -> dict:
         """Update a single PENDING task in-place without resetting the run."""
         run = self._resolve_task(task_id)
         if not run:
@@ -394,10 +411,10 @@ class TaskRunner:
         # Apply atomically
         for key, value in changes.items():
             setattr(task, key, value)
-        self._persist_runs()
+        await self._apersist_runs()
         return {"index": task.index, "title": task.title, "description": task.description, "depends_on": task.depends_on, "requires_approval": task.requires_approval, "force_approval": task.force_approval}
 
-    def execute_plan(self, task_id: str, agent: str = "", fresh: bool = False, workspace_dir: str = "", auto_approve: bool = False) -> str:
+    async def execute_plan(self, task_id: str, agent: str = "", fresh: bool = False, workspace_dir: str = "", auto_approve: bool = False) -> str:
         run = self._runs.get(task_id)
         if not run:
             raise ValueError(f"Run {task_id} not found")
@@ -432,10 +449,10 @@ class TaskRunner:
             run.error = ""
             run.replan_count = 0
             run.status = "planned"
-            self._persist_runs()
+            await self._apersist_runs()
 
         self._grant_run_trust(run, bool(auto_approve))
-        self._persist_runs()
+        await self._apersist_runs()
 
         self._agent = agent
         history_key = f"taskrunner:run:{task_id}"
@@ -445,7 +462,7 @@ class TaskRunner:
             try:
                 run.status = "running"
                 run.started_at = run.last_task_time = time.time()
-                self._persist_runs()  # persist immediately so crash recovery works
+                await self._apersist_runs()  # persist immediately so crash recovery works
                 try:
                     await git_coord.init_workspace(run)
                 except Exception:
@@ -485,7 +502,7 @@ class TaskRunner:
                     run.status = "paused" if run.status == "pausing" else "cancelled"
                 run.finished_at = time.time()
                 save_progress(run)
-                self._persist_runs()
+                await self._apersist_runs()
                 if run.branch_name:
                     try:
                         await git_coord.finalize(run)
@@ -537,7 +554,7 @@ class TaskRunner:
         run.work_dir = str(task_dir)
         self._grant_run_trust(run, bool(auto_approve))
         self._runs[task_id] = run
-        self._persist_runs()  # persist immediately so crash recovery works
+        await self._apersist_runs()  # persist immediately so crash recovery works
         watchdog_task: asyncio.Task | None = None  # type: ignore[type-arg]
         history_key = f"taskrunner:run:{spec_path.stem}"
         try:
@@ -557,7 +574,7 @@ class TaskRunner:
                 run.error = "Failed to decompose spec into tasks"
                 await self._notify("\u274c Task failed", run.error, run=run)
                 return run
-            self._persist_runs()  # persist tasks so resume works after crash
+            await self._apersist_runs()  # persist tasks so resume works after crash
             try:
                 await git_coord.init_workspace(run)
             except Exception as exc:
@@ -610,7 +627,7 @@ class TaskRunner:
                 run.status = "paused" if run.status == "pausing" else "cancelled"
             run.finished_at = time.time()
             save_progress(run)
-            self._persist_runs()
+            await self._apersist_runs()
             if run.branch_name:
                 try:
                     await git_coord.finalize(run)
@@ -670,7 +687,7 @@ class TaskRunner:
                     return
                 if task.result and len(task.result) > _RESULT_MEM_CAP:
                     task.result = task.result[:_RESULT_MEM_CAP]
-                self._persist_runs()  # persist after each task so crash recovery preserves progress
+                await self._apersist_runs()  # persist after each task so crash recovery preserves progress
             else:
                 titles = ", ".join(t.title for t in resolved)
                 await self._notify(
@@ -721,7 +738,7 @@ class TaskRunner:
                 for t in resolved:
                     if t.result and len(t.result) > _RESULT_MEM_CAP:
                         t.result = t.result[:_RESULT_MEM_CAP]
-                self._persist_runs()  # persist after parallel group so crash recovery preserves progress
+                await self._apersist_runs()  # persist after parallel group so crash recovery preserves progress
 
     async def _build_task_prompt(self, run: Project, task: Task, attempt: int = 1) -> str:
         """Delegate to standalone build_task_prompt for backward compat."""
@@ -839,73 +856,105 @@ class TaskRunner:
                 return await self._try_replan(run, task)
         return True
 
-    def start_background(
+    async def start_background(
         self, spec_path: str | Path, agent: str = "", name: str = "", source: str = "",
         workspace_dir: str = "", auto_approve: bool = False,
     ) -> str:
-        # Validate the per-run workspace override synchronously so the caller
-        # (HTTP handler) surfaces a bad/sensitive path immediately, not inside
-        # the background task where run() would re-resolve it.
+        # Validate the per-run workspace override before entering the admission
+        # lock so a bad/sensitive path fails without blocking other starts.
         _resolve_workspace_dir(workspace_dir)
-        active = sum(1 for t in self._tasks.values() if not t.done())
-        if active >= _MAX_CONCURRENT_TASKS:
-            raise ValueError(
-                f"Too many concurrent tasks ({active}/{_MAX_CONCURRENT_TASKS}). "
-                "Cancel or wait for a running task to finish."
-            )
-
-        completed = [
-            tid for tid, r in self._runs.items() if r.status in ("completed", "failed", "cancelled")
-        ]
-        # Always purge completed cron runs; keep last 10 others
-        cron_done = [tid for tid in completed if self._runs[tid].source == "cron"]
-        for tid in cron_done:
-            self._runs.pop(tid, None)
-            self._stall_cancelled_ids.discard(tid)
-        other_done = [tid for tid in completed if tid in self._runs]
-        for tid in other_done[:-10]:
-            self._runs.pop(tid, None)
-            self._stall_cancelled_ids.discard(tid)
-        task_id = f"{Path(spec_path).stem}_{int(time.time())}"
         self._agent = agent
         try:
             from kiro_crew.hooks import validate_file_path
 
             safe_sp = validate_file_path(str(spec_path))
             if safe_sp:
-                with open(safe_sp, encoding="utf-8") as f:
-                    early_content = f.read(4000).strip()
+                early_content = await asyncio.to_thread(
+                    _read_spec_prefix, safe_sp, 4000,
+                )
             else:
                 early_content = ""
         except Exception:
             early_content = ""
-        self._runs[task_id] = Project(
-            spec_path=str(spec_path),
-            spec_content=early_content,
-            task_id=task_id,
-            name=name or Path(spec_path).stem,
-            status="planning",
-            started_at=time.time(),
-            source=source,
-            auto_approve=bool(auto_approve),
-        )
-        self._persist_runs()  # persist planning state for crash recovery
 
-        async def _wrapped() -> None:
+        # Admission is one transaction: concurrency check, pruning, unique ID
+        # allocation, placeholder persistence, and task registration. In
+        # particular, do not release this lock while _apersist_runs() yields;
+        # otherwise two same-spec starts can both pass the limit and overwrite
+        # each other's timestamp-based ID before either appears in _tasks.
+        async with self._start_lock:
+            active = sum(1 for task in self._tasks.values() if not task.done())
+            if active >= _MAX_CONCURRENT_TASKS:
+                raise ValueError(
+                    f"Too many concurrent tasks ({active}/{_MAX_CONCURRENT_TASKS}). "
+                    "Cancel or wait for a running task to finish."
+                )
+
+            completed = [
+                task_id
+                for task_id, run in self._runs.items()
+                if run.status in ("completed", "failed", "cancelled")
+            ]
+            # Always purge completed cron runs; keep last 10 others.
+            cron_done = [
+                task_id for task_id in completed
+                if self._runs[task_id].source == "cron"
+            ]
+            for task_id in cron_done:
+                self._runs.pop(task_id, None)
+                self._stall_cancelled_ids.discard(task_id)
+            other_done = [task_id for task_id in completed if task_id in self._runs]
+            for task_id in other_done[:-10]:
+                self._runs.pop(task_id, None)
+                self._stall_cancelled_ids.discard(task_id)
+
+            # Nanosecond IDs avoid routine same-second collisions. The guarded
+            # increment is a deterministic fallback if a clock/platform returns
+            # the same value for two starts.
+            id_suffix = time.time_ns()
+            task_id = f"{Path(spec_path).stem}_{id_suffix}"
+            while task_id in self._runs or task_id in self._tasks:
+                id_suffix += 1
+                task_id = f"{Path(spec_path).stem}_{id_suffix}"
+
+            self._runs[task_id] = Project(
+                spec_path=str(spec_path),
+                spec_content=early_content,
+                task_id=task_id,
+                name=name or Path(spec_path).stem,
+                status="planning",
+                started_at=time.time(),
+                source=source,
+                auto_approve=bool(auto_approve),
+            )
             try:
-                await self.run(spec_path, task_id=task_id, name=name, source=source, workspace_dir=workspace_dir, auto_approve=auto_approve)
-            except Exception as exc:
-                logger.exception("start_background task %s failed", task_id)
-                placeholder = self._runs.get(task_id)
-                if placeholder and placeholder.status == "planning":
-                    placeholder.status = "failed"
-                    placeholder.error = str(exc)
-                    self._persist_runs()
-            finally:
-                self._tasks.pop(task_id, None)
+                await self._apersist_runs()  # durable before background execution
+            except BaseException:
+                self._runs.pop(task_id, None)
+                raise
 
-        self._tasks[task_id] = asyncio.create_task(_wrapped())
-        return task_id
+            async def _wrapped() -> None:
+                try:
+                    await self.run(
+                        spec_path,
+                        task_id=task_id,
+                        name=name,
+                        source=source,
+                        workspace_dir=workspace_dir,
+                        auto_approve=auto_approve,
+                    )
+                except Exception as exc:
+                    logger.exception("start_background task %s failed", task_id)
+                    placeholder = self._runs.get(task_id)
+                    if placeholder and placeholder.status == "planning":
+                        placeholder.status = "failed"
+                        placeholder.error = str(exc)
+                        await self._apersist_runs()
+                finally:
+                    self._tasks.pop(task_id, None)
+
+            self._tasks[task_id] = asyncio.create_task(_wrapped())
+            return task_id
 
     @staticmethod
     def _reset_incomplete_tasks(run: Project) -> None:
@@ -987,7 +1036,7 @@ class TaskRunner:
         except Exception:
             logger.debug("deactivate auto-approve scope failed for %s", run.task_id, exc_info=True)
 
-    def delete_run(self, task_id: str) -> bool:
+    async def delete_run(self, task_id: str) -> bool:
         run = self._runs.get(task_id)
         if not run:
             return False
@@ -998,7 +1047,7 @@ class TaskRunner:
             bg_task.cancel()
         self._runs.pop(task_id, None)
         self._stall_cancelled_ids.discard(task_id)
-        self._persist_runs()
+        await self._apersist_runs()
         try:
             from kiro_crew.sel import sel
 
@@ -1048,7 +1097,7 @@ class TaskRunner:
         if t and not t.done():
             t.cancel()
 
-    def retry_from_task(self, task_id: str, from_task: int, agent: str = "") -> str:
+    async def retry_from_task(self, task_id: str, from_task: int, agent: str = "") -> str:
         run = self._resolve_task(task_id)
         if not run:
             raise ValueError(f"Run {task_id} not found")
@@ -1066,7 +1115,7 @@ class TaskRunner:
         run.error = ""
         run.finished_at = 0.0
         run.started_at = run.last_task_time = time.time()
-        self._persist_runs()  # persist immediately so crash recovery works
+        await self._apersist_runs()  # persist immediately so crash recovery works
         self._agent = agent
         history_key = f"taskrunner:run:{Path(run.spec_path).stem}"
 
@@ -1104,7 +1153,7 @@ class TaskRunner:
                     run.status = "paused" if run.status == "pausing" else "cancelled"
                 run.finished_at = time.time()
                 save_progress(run)
-                self._persist_runs()
+                await self._apersist_runs()
                 if watchdog_task and not watchdog_task.done():
                     watchdog_task.cancel()
                 self._tasks.pop(task_id, None)
@@ -1301,6 +1350,21 @@ class TaskRunner:
         return self._work_dir / self._RUNS_FILE
 
     def _persist_runs(self) -> None:
+        # Synchronous compatibility helper for internal/off-loop callers and
+        # focused persistence tests. Production mutation APIs await
+        # _apersist_runs so the fsync-backed atomic write never blocks the
+        # gateway event loop.
+        self._commit_snapshot(self._next_persist_seq(), self._serialize_runs())
+
+    def _serialize_runs(self) -> str:
+        """Serialize the runs registry to a JSON string.
+
+        MUST be called on the thread that owns ``_runs`` (the event loop).
+        Iterating the live registry in a worker thread while the loop mutates
+        it can raise ``RuntimeError: dictionary changed size during iteration``
+        or capture a torn snapshot, so persistence always snapshots here first
+        and offloads only the byte-level write.
+        """
         data = []
         for run in self._runs.values():
             if run.source == "cron":
@@ -1339,17 +1403,95 @@ class TaskRunner:
                         ],
                     }
                 )
-        try:
-            self._runs_path().write_text(json.dumps(data), encoding="utf-8")
-        except Exception:
-            logger.debug("Failed to persist runs", exc_info=True)
+        return json.dumps(data)
+
+    def _next_persist_seq(self) -> int:
+        # Handed out on the event-loop thread only (both _persist_runs and the
+        # pre-offload part of _apersist_runs run there), so the bump needs no
+        # lock — it establishes the causal order of snapshots.
+        self._persist_seq += 1
+        return self._persist_seq
+
+    def _commit_snapshot(self, seq: int, payload: str) -> None:
+        # Serialize concurrent writers and enforce monotonic ordering under the
+        # lock: a stale snapshot (older seq) whose offloaded write is scheduled
+        # late must never overwrite a newer one that already landed.
+        with self._persist_lock:
+            if seq < self._persist_written:
+                return
+            try:
+                # Atomic write: serialize to a temp file in the same dir, fsync,
+                # then os.replace onto the final path so a crash/kill/full-disk
+                # mid-write can never leave a truncated registry that
+                # _load_runs would otherwise have to discard.
+                atomic_write(self._runs_path(), payload, fsync=True)
+            except OSError:
+                logger.debug("Failed to persist runs", exc_info=True)
+                return
+            self._persist_written = seq
+
+    async def _apersist_runs(self) -> None:
+        """Persist the runs registry without blocking the event loop.
+
+        The JSON snapshot is built synchronously on THIS (event-loop) thread —
+        which owns ``_runs`` — so we never iterate the live registry in a
+        worker while the loop mutates it (that could raise ``dictionary
+        changed size during iteration`` or capture a torn snapshot). Only the
+        blocking, fsync-backed atomic write is offloaded to a worker thread, so
+        a slow/full disk can't stall the loop, while a per-snapshot sequence
+        number preserves write ordering. Every production mutation API awaits
+        this method before returning, preserving durability without blocking
+        unrelated gateway work.
+        """
+        seq = self._next_persist_seq()
+        payload = self._serialize_runs()
+        await asyncio.to_thread(self._commit_snapshot, seq, payload)
 
     def _load_runs(self) -> None:
+        path = self._runs_path()
         try:
-            path = self._runs_path()
-            if not path.exists():
-                return
-            for item in json.loads(path.read_text(encoding="utf-8")):
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # No registry yet — seed a fresh one rather than treating a
+            # missing file as an error.
+            return
+        except OSError:
+            # File exists but is unreadable (permission error, transient
+            # sharing violation, etc.). _load_runs is called from
+            # TaskRunner.__init__, so raising here would prevent the runner —
+            # and potentially the gateway — from starting. Log loudly and
+            # start with an empty in-memory registry without touching the file
+            # on disk (so a later, successful read can still recover it).
+            logger.error(
+                "Failed to read runs registry %s; starting with an empty "
+                "registry (file left untouched)",
+                path,
+                exc_info=True,
+            )
+            return
+        try:
+            items = json.loads(raw)
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            # Never silently discard run state on a corrupt/truncated file:
+            # surface the corruption loudly and preserve the bad file as a
+            # sidecar for recovery instead of returning an empty registry.
+            bak = path.with_suffix(path.suffix + ".corrupt")
+            logger.error(
+                "Runs registry %s is corrupt (%s); preserved as %s, starting "
+                "with an empty registry",
+                path,
+                exc,
+                bak,
+            )
+            try:
+                path.replace(bak)
+            except OSError:
+                logger.warning(
+                    "Failed to preserve corrupt runs registry", exc_info=True
+                )
+            return
+        try:
+            for item in items:
                 tasks = [
                     Task(
                         index=t["index"],
@@ -1420,7 +1562,13 @@ class TaskRunner:
                             t.status = TaskStatus.CANCELLED
                     logger.info("Recovered crashed cancelling run %s — marked as cancelled", run.task_id)
         except Exception:
-            logger.debug("Failed to load runs", exc_info=True)
+            # A structural error while rebuilding an individual run (not a
+            # parse failure — that is handled above) is surfaced loudly and
+            # leaves the runs already loaded intact, rather than silently
+            # discarding the whole registry.
+            logger.error(
+                "Failed to deserialize a run from registry %s", path, exc_info=True
+            )
 
     def _save_progress(self, run: Project) -> None:
         save_progress(run)

--- a/test/test_approval_and_update_task.py
+++ b/test/test_approval_and_update_task.py
@@ -69,31 +69,35 @@ class TestUpdateTask:
         sessions = _mock_sessions()
         return TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
-    def test_update_title(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_title(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="Old", description="d")]
         runner._runs = {"t1": run}
-        result = runner.update_task("t1", 1, {"title": "New Title"})
+        result = await runner.update_task("t1", 1, {"title": "New Title"})
         assert result["title"] == "New Title"
 
-    def test_update_description(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_description(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="old")]
         runner._runs = {"t1": run}
-        result = runner.update_task("t1", 1, {"description": "new desc"})
+        result = await runner.update_task("t1", 1, {"description": "new desc"})
         assert result["description"] == "new desc"
 
-    def test_update_force_approval(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_force_approval(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
-        result = runner.update_task("t1", 1, {"force_approval": True})
+        result = await runner.update_task("t1", 1, {"force_approval": True})
         assert result["force_approval"] is True
 
-    def test_update_depends_on(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_depends_on(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [
@@ -101,42 +105,47 @@ class TestUpdateTask:
             Step(index=2, title="B", description="b"),
         ]
         runner._runs = {"t1": run}
-        result = runner.update_task("t1", 2, {"depends_on": [1]})
+        result = await runner.update_task("t1", 2, {"depends_on": [1]})
         assert result["depends_on"] == [1]
 
-    def test_update_requires_approval(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_requires_approval(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
-        result = runner.update_task("t1", 1, {"requires_approval": True})
+        result = await runner.update_task("t1", 1, {"requires_approval": True})
         assert result["requires_approval"] is True
 
-    def test_reject_empty_title(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_empty_title(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="non-empty string"):
-            runner.update_task("t1", 1, {"title": ""})
+            await runner.update_task("t1", 1, {"title": ""})
 
-    def test_reject_long_title(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_long_title(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="title too long"):
-            runner.update_task("t1", 1, {"title": "x" * 501})
+            await runner.update_task("t1", 1, {"title": "x" * 501})
 
-    def test_reject_long_description(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_long_description(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="description too long"):
-            runner.update_task("t1", 1, {"description": "x" * 5001})
+            await runner.update_task("t1", 1, {"description": "x" * 5001})
 
-    def test_reject_non_pending_task(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_non_pending_task(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         step = Step(index=1, title="T", description="d")
@@ -144,37 +153,41 @@ class TestUpdateTask:
         run.tasks = [step]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="Can only edit pending"):
-            runner.update_task("t1", 1, {"title": "New"})
+            await runner.update_task("t1", 1, {"title": "New"})
 
-    def test_reject_unknown_run(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_unknown_run(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         runner._runs = {}
         with pytest.raises(ValueError, match="not found"):
-            runner.update_task("missing", 1, {"title": "X"})
+            await runner.update_task("missing", 1, {"title": "X"})
 
-    def test_reject_unknown_task_index(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_unknown_task_index(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="Task 99 not found"):
-            runner.update_task("t1", 99, {"title": "X"})
+            await runner.update_task("t1", 99, {"title": "X"})
 
-    def test_reject_non_string_description(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_reject_non_string_description(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="description must be a string"):
-            runner.update_task("t1", 1, {"description": 123})
+            await runner.update_task("t1", 1, {"description": 123})
 
-    def test_invalid_depends_on_type(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_depends_on_type(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="running", task_id="t1")
         run.tasks = [Step(index=1, title="T", description="d")]
         runner._runs = {"t1": run}
         with pytest.raises(ValueError, match="depends_on must be a list"):
-            runner.update_task("t1", 1, {"depends_on": "invalid"})
+            await runner.update_task("t1", 1, {"depends_on": "invalid"})
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -114,24 +114,26 @@ class TestAutoApproveDefault:
 
 
 class TestSettersSetAutoApprove:
-    def test_execute_plan_sets_auto_approve(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_execute_plan_sets_auto_approve(self, tmp_path: Path) -> None:
         runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="planned", task_id="t1")
         run.tasks = [Step(index=1, title="A", description="d")]
         runner._runs = {"t1": run}
         # Prevent the background _execute task from actually running.
         with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
-            runner.execute_plan("t1", auto_approve=True)
+            await runner.execute_plan("t1", auto_approve=True)
         assert run.auto_approve is True
         assert safety_override().is_scope_active(_auto_approve_scope("t1")) is True
 
-    def test_execute_plan_defaults_false(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_execute_plan_defaults_false(self, tmp_path: Path) -> None:
         runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
         run = TaskRun(spec_path="s.md", spec_content="s", status="planned", task_id="t1")
         run.tasks = [Step(index=1, title="A", description="d")]
         runner._runs = {"t1": run}
         with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
-            runner.execute_plan("t1")
+            await runner.execute_plan("t1")
         assert run.auto_approve is False
         assert safety_override().is_scope_active(_auto_approve_scope("t1")) is False
 
@@ -155,7 +157,7 @@ class TestSettersSetAutoApprove:
         spec.write_text("# Bg\n## Steps\n1. Do thing", encoding="utf-8")
         runner = TaskRunner(sessions=_mock_sessions(), auto_test=False, work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock) as mock_run:
-            task_id = runner.start_background(spec, auto_approve=True)
+            task_id = await runner.start_background(spec, auto_approve=True)
             await asyncio.sleep(0)  # let the wrapper task run
         # Placeholder Project carries the flag immediately …
         assert runner._runs[task_id].auto_approve is True
@@ -472,7 +474,7 @@ class TestAutoApproveProvenanceGating:
 
     async def _execute_auto_approve_passed(self, request_app: str, auto_approve: bool = True):
         runner = MagicMock()
-        runner.execute_plan = MagicMock(return_value=None)
+        runner.execute_plan = AsyncMock(return_value=None)
         app = web.Application()
         app["state"] = SimpleNamespace(task_runner=runner)
         req = make_mocked_request(

--- a/test/test_heartbeat_atomic_merge.py
+++ b/test/test_heartbeat_atomic_merge.py
@@ -1,0 +1,115 @@
+"""Regression test for heartbeat mid-cycle append preservation (Track A, bug 3).
+
+The heartbeat cycle reads HEARTBEAT.md, runs tasks, then rewrites the file. A
+task appended by another session/agent *while the cycle is running* must not be
+clobbered by the stale in-memory snapshot — the rewrite re-reads the file under
+the lock and merges any new entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.heartbeat as hb_mod
+from kiro_crew.heartbeat import _HEADER, HeartbeatService
+
+
+@pytest.mark.asyncio
+async def test_midcycle_append_preserved(tmp_path: Path) -> None:
+    hb_path = tmp_path / "HEARTBEAT.md"
+    hb_path.write_text(_HEADER + "- original task\n", encoding="utf-8")
+
+    async def on_task(text: str, deliver: str) -> str:
+        # Simulate another session appending a new task mid-cycle (lock-free
+        # append directly to the file), then complete the original task.
+        with open(hb_path, "a", encoding="utf-8") as f:
+            f.write("- newly appended task\n")
+        return "All done!"  # no HEARTBEAT_KEEP → original should be removed
+
+    svc = HeartbeatService(memory=MagicMock(), on_task=on_task)
+
+    original = hb_mod.heartbeat_path
+    hb_mod.heartbeat_path = lambda: hb_path
+    try:
+        await svc._process_heartbeat_file()
+    finally:
+        hb_mod.heartbeat_path = original
+
+    content = hb_path.read_text(encoding="utf-8")
+    # Completed task is dropped, but the mid-cycle append is preserved.
+    assert "original task" not in content
+    assert "newly appended task" in content
+    # File remains well-formed (header intact, no temp artifacts left behind).
+    assert content.startswith("# Heartbeat Tasks")
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_midcycle_append_preserved_alongside_kept(tmp_path: Path) -> None:
+    hb_path = tmp_path / "HEARTBEAT.md"
+    hb_path.write_text(_HEADER + "- keep me\n", encoding="utf-8")
+
+    async def on_task(text: str, deliver: str) -> str:
+        with open(hb_path, "a", encoding="utf-8") as f:
+            f.write("- appended mid cycle\n")
+        return "still working. HEARTBEAT_KEEP"  # original retained
+
+    svc = HeartbeatService(memory=MagicMock(), on_task=on_task)
+
+    original = hb_mod.heartbeat_path
+    hb_mod.heartbeat_path = lambda: hb_path
+    try:
+        await svc._process_heartbeat_file()
+    finally:
+        hb_mod.heartbeat_path = original
+
+    content = hb_path.read_text(encoding="utf-8")
+    assert "keep me" in content  # incomplete original retained
+    assert "appended mid cycle" in content  # mid-cycle append preserved
+
+
+@pytest.mark.asyncio
+async def test_append_serialized_with_final_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A writer using the shared lock appends only after replace completes."""
+    hb_path = tmp_path / "HEARTBEAT.md"
+    hb_path.write_text(_HEADER + "- completed task\n", encoding="utf-8")
+
+    rewrite_started = threading.Event()
+    allow_replace = threading.Event()
+    real_atomic_write = hb_mod.atomic_write
+
+    def paused_atomic_write(path, content, *, fsync=False) -> None:
+        rewrite_started.set()
+        assert allow_replace.wait(timeout=5)
+        real_atomic_write(path, content, fsync=fsync)
+
+    monkeypatch.setattr(hb_mod, "atomic_write", paused_atomic_write)
+
+    async def on_task(text: str, deliver: str) -> str:
+        return "done"
+
+    svc = HeartbeatService(memory=MagicMock(), on_task=on_task)
+    monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: hb_path)
+
+    cycle = asyncio.create_task(svc._process_heartbeat_file())
+    assert await asyncio.to_thread(rewrite_started.wait, 5)
+
+    append = asyncio.create_task(
+        asyncio.to_thread(hb_mod.append_heartbeat_task, "- contended append", hb_path)
+    )
+    await asyncio.sleep(0.05)
+    assert not append.done()
+
+    allow_replace.set()
+    await asyncio.gather(cycle, append)
+
+    content = hb_path.read_text(encoding="utf-8")
+    assert "completed task" not in content
+    assert "contended append" in content

--- a/test/test_history_atomic_rewrite.py
+++ b/test/test_history_atomic_rewrite.py
@@ -1,0 +1,144 @@
+"""Regression tests for atomic + locked transcript rewrites (Track A, bug 4).
+
+ConversationLog.mark_consolidated (and the other full-rewrite paths) must:
+- write atomically (temp + fsync + os.replace) so a crash can't truncate the
+  transcript, and
+- serialize behind a per-file lock so a concurrent append is never lost and
+  readers never observe a torn file.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.history import ConversationLog
+
+
+class TestMarkConsolidatedAtomic:
+    def test_preserves_messages_and_updates_offset(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m1")
+        log.append("k", "assistant", "m2")
+        log.append("k", "user", "m3")
+
+        log.mark_consolidated("k", 2)
+
+        fresh = ConversationLog(base_dir=tmp_path)
+        msgs = fresh._read_messages("k")
+        assert [m["content"] for m in msgs] == ["m1", "m2", "m3"]
+        assert fresh.get_metadata("k")["last_consolidated"] == 2
+
+    def test_leaves_no_temp_files(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m1")
+        log.mark_consolidated("k", 1)
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        # No file for this key — must not raise.
+        log.mark_consolidated("nope", 0)
+
+
+class TestMarkConsolidatedOffloaded:
+    @pytest.mark.asyncio
+    async def test_mark_consolidated_runs_off_loop_thread(self) -> None:
+        """mark_consolidated does a synchronous fsync-backed transcript rewrite
+        (up to a couple MB) behind the per-file lock. _consolidate runs on the
+        gateway event loop, so it MUST offload the rewrite to a worker thread —
+        otherwise a slow filesystem freezes the loop (heartbeats, Slack,
+        dashboard). Regression guard for the Codex HIGH loop-stall finding."""
+        import threading
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from kiro_crew.history import HistoryConsolidator
+
+        loop_thread_id = threading.get_ident()
+        mark_thread_id: dict[str, int] = {}
+
+        log = MagicMock()
+        log.get_unconsolidated.return_value = ([{"role": "user", "content": "hi"}], 1)
+        log.get_metadata.return_value = {}
+        log.mark_consolidated.side_effect = lambda *a, **k: mark_thread_id.__setitem__(
+            "id", threading.get_ident()
+        )
+
+        memory = MagicMock()
+        memory.read_preferences.return_value = ""
+        memory.read_projects.return_value = ""
+        vector_store = MagicMock()
+        vector_store.get_all_semantic.return_value = []
+
+        c = HistoryConsolidator(
+            log=log, memory=memory, sessions=None,
+            vector_store=vector_store, migrated=True,
+        )
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm, \
+                patch.object(c, "_write_structured_memory"):
+            llm.return_value = {"episodic": [{"text": "x" * 20}]}
+            await c._consolidate("k", include_history=True)
+
+        assert mark_thread_id.get("id") is not None, "mark_consolidated was not called"
+        assert mark_thread_id["id"] != loop_thread_id, (
+            "mark_consolidated ran on the event loop thread — its fsync-backed "
+            "rewrite must be offloaded via asyncio.to_thread()."
+        )
+
+
+class TestConcurrentAppendVsRewrite:
+    def test_no_message_lost_and_never_torn(self, tmp_path: Path) -> None:
+        """Hammer append (live session) against mark_consolidated/rewrite
+        (compaction) from separate threads. The per-file lock must guarantee
+        every appended message survives and the file always stays parseable."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+
+        stop = threading.Event()
+        appended: list[str] = []
+        errors: list[Exception] = []
+
+        def appender() -> None:
+            i = 0
+            while not stop.is_set():
+                content = f"msg-{i}"
+                try:
+                    log.append("k", "user", content)
+                    appended.append(content)
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+                i += 1
+
+        def consolidator() -> None:
+            reader = ConversationLog(base_dir=tmp_path)
+            while not stop.is_set():
+                try:
+                    log.mark_consolidated("k", 1)
+                    # Concurrent read must never see a truncated/torn file.
+                    path = reader._path("k")
+                    for line in path.read_text(encoding="utf-8").splitlines():
+                        if line.strip():
+                            json.loads(line)
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=appender),
+            threading.Thread(target=consolidator),
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(0.4)
+        stop.set()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m["content"] for m in fresh._read_messages("k")]
+        for a in appended:
+            assert a in contents

--- a/test/test_plan_mode.py
+++ b/test/test_plan_mode.py
@@ -159,7 +159,8 @@ class TestAcceptanceCriteriaIgnored:
 
 
 class TestUpdatePlan:
-    def test_update_replaces_steps(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_replaces_steps(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         _planned_run(
             runner,
@@ -169,7 +170,7 @@ class TestUpdatePlan:
                 Step(index=3, title="Old3", description="O3"),
             ],
         )
-        run = runner.update_plan(
+        run = await runner.update_plan(
             "plan_test",
             [
                 {"title": "New1", "description": "N1"},
@@ -181,10 +182,11 @@ class TestUpdatePlan:
         assert run.tasks[0].title == "New1"
         assert run.tasks[1].index == 2
 
-    def test_update_validates_deps(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_validates_deps(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         _planned_run(runner)
-        run = runner.update_plan(
+        run = await runner.update_plan(
             "plan_test",
             [
                 {"title": "A", "depends_on": []},
@@ -193,49 +195,54 @@ class TestUpdatePlan:
         )
         assert run.tasks[1].depends_on == [1]
 
-    def test_update_rejects_non_planned(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_rejects_non_planned(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         run = _planned_run(runner)
         run.status = "running"
         with pytest.raises(ValueError, match="Cannot update plan while"):
-            runner.update_plan("plan_test", [{"title": "X"}])
+            await runner.update_plan("plan_test", [{"title": "X"}])
 
-    def test_update_rejects_not_found(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_rejects_not_found(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         with pytest.raises(ValueError, match="not found"):
-            runner.update_plan("nonexistent", [{"title": "X"}])
+            await runner.update_plan("nonexistent", [{"title": "X"}])
 
-    def test_update_cancelled_project_resets_to_planned(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_cancelled_project_resets_to_planned(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         run = _planned_run(runner)
         run.status = "cancelled"
         run.error = "old error"
         run.replan_count = 3
-        runner.update_plan("plan_test", [{"title": "New Step"}])
+        await runner.update_plan("plan_test", [{"title": "New Step"}])
         assert run.status == "planned"
         assert run.error == ""
         assert run.replan_count == 0
         assert len(run.tasks) == 1
         assert run.tasks[0].title == "New Step"
 
-    def test_update_failed_project_resets_to_planned(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_failed_project_resets_to_planned(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         run = _planned_run(runner)
         run.status = "failed"
         run.error = "old error"
         run.replan_count = 2
-        runner.update_plan("plan_test", [{"title": "Retry Step"}])
+        await runner.update_plan("plan_test", [{"title": "Retry Step"}])
         assert run.status == "planned"
         assert run.error == ""
         assert run.replan_count == 0
         assert len(run.tasks) == 1
         assert run.tasks[0].title == "Retry Step"
 
-    def test_update_rejects_empty_steps(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_rejects_empty_steps(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         _planned_run(runner)
         with pytest.raises(ValueError, match="No valid tasks"):
-            runner.update_plan("plan_test", [{"no_title": True}])
+            await runner.update_plan("plan_test", [{"no_title": True}])
 
 
 # ── TestExecutePlan ──
@@ -247,19 +254,20 @@ class TestExecutePlan:
         runner = _make_runner(tmp_path)
         _planned_run(runner)
         with patch("kiro_crew.taskrunner.git_coord"):
-            task_id = runner.execute_plan("plan_test")
+            task_id = await runner.execute_plan("plan_test")
         assert task_id == "plan_test"
         # Give the async task a tick to start
         await asyncio.sleep(0.05)
         run = runner._runs["plan_test"]
         assert run.status in ("running", "completed", "failed")
 
-    def test_execute_rejects_non_planned(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_execute_rejects_non_planned(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         run = _planned_run(runner)
         run.status = "completed"
         with pytest.raises(ValueError, match="not in a startable state"):
-            runner.execute_plan("plan_test")
+            await runner.execute_plan("plan_test")
 
     @pytest.mark.asyncio
     async def test_execute_cancelled_project_resets_pending(self, tmp_path: Path) -> None:
@@ -272,7 +280,7 @@ class TestExecutePlan:
         run.tasks[1].result = "old result"
         run.error = "Shutdown signal received"
         with patch("kiro_crew.taskrunner.git_coord"):
-            runner.execute_plan("plan_test")
+            await runner.execute_plan("plan_test")
         # Reset happens synchronously before async execution starts
         assert run.tasks[0].status == StepStatus.PASSED  # preserved
         assert run.tasks[1].status == StepStatus.PENDING
@@ -291,7 +299,7 @@ class TestExecutePlan:
         run.tasks[1].result = "partial output"
         run.error = "Task 2 failed"
         with patch("kiro_crew.taskrunner.git_coord"):
-            runner.execute_plan("plan_test")
+            await runner.execute_plan("plan_test")
         # Reset happens synchronously before async execution starts
         assert run.tasks[0].status == StepStatus.PASSED  # preserved
         assert run.tasks[1].status == StepStatus.PENDING
@@ -309,7 +317,7 @@ class TestExecutePlan:
         run.tasks[1].status = StepStatus.FAILED
         run.tasks[1].error = "old error"
         with patch("kiro_crew.taskrunner.git_coord"):
-            runner.execute_plan("plan_test", fresh=True)
+            await runner.execute_plan("plan_test", fresh=True)
         # fresh=True resets ALL tasks including PASSED
         assert run.tasks[0].status == StepStatus.PENDING
         assert run.tasks[0].result == ""
@@ -330,7 +338,7 @@ class TestExecutePlan:
             ],
         )
         with patch("kiro_crew.taskrunner.git_coord"):
-            runner.execute_plan("plan_test")
+            await runner.execute_plan("plan_test")
             # Wait for completion
             task = runner._tasks.get("plan_test")
             if task:
@@ -367,7 +375,7 @@ class TestExecutePlan:
             ],
         )
         with patch("kiro_crew.taskrunner.git_coord"):
-            runner.execute_plan("plan_test")
+            await runner.execute_plan("plan_test")
             task = runner._tasks.get("plan_test")
             if task:
                 await asyncio.wait_for(task, timeout=10)
@@ -376,7 +384,8 @@ class TestExecutePlan:
         assert run.tasks[0].status == StepStatus.PASSED
         assert run.status == "completed"
 
-    def test_concurrent_guard_preserves_state_on_rejection(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_concurrent_guard_preserves_state_on_rejection(self, tmp_path: Path) -> None:
         """If MAX_CONCURRENT_TASKS is hit, state must NOT be mutated."""
         from kiro_crew.taskrunner import _MAX_CONCURRENT_TASKS
 
@@ -395,7 +404,7 @@ class TestExecutePlan:
             runner._tasks[f"fake_{i}"] = mock_task  # type: ignore[assignment]
 
         with pytest.raises(ValueError, match="Too many concurrent tasks"):
-            runner.execute_plan("plan_test", fresh=True)
+            await runner.execute_plan("plan_test", fresh=True)
 
         # State must be unchanged — guard fired before mutation
         assert run.status == "failed"
@@ -446,14 +455,15 @@ class TestPlanToChat:
         assert isinstance(parsed, list)
         assert len(parsed) == 2  # 2 original steps
 
-    def test_round_trip_json(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_round_trip_json(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)
         _planned_run(runner)
         output = runner.plan_to_chat_context("plan_test")
         start = output.index("```json") + 7
         end = output.index("```", start)
         parsed = json.loads(output[start:end])
-        run = runner.update_plan("plan_test", parsed)
+        run = await runner.update_plan("plan_test", parsed)
         assert len(run.tasks) == 2  # 2 from JSON
         assert run.tasks[0].title == "Step A"
 
@@ -648,7 +658,8 @@ class TestPlanRecoveryAfterTabSwitch:
         assert "plan_test" in runner2._runs
         assert runner2._runs["plan_test"].status == "paused"
 
-    def test_update_plan_preserves_steps_for_applied(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_plan_preserves_steps_for_applied(self, tmp_path: Path) -> None:
         """update_plan changes steps; status() returns updated steps (Use as Plan flow)."""
         runner = _make_runner(tmp_path)
         _planned_run(
@@ -658,7 +669,7 @@ class TestPlanRecoveryAfterTabSwitch:
                 Step(index=2, title="Old B", description="OB"),
             ],
         )
-        runner.update_plan(
+        await runner.update_plan(
             "plan_test",
             [
                 {"title": "New X", "description": "NX"},
@@ -672,12 +683,13 @@ class TestPlanRecoveryAfterTabSwitch:
         assert run_data["task_details"][0]["title"] == "New X"
         assert run_data["task_details"][2]["title"] == "New Z"
 
-    def test_status_finds_correct_run_by_task_id(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_status_finds_correct_run_by_task_id(self, tmp_path: Path) -> None:
         """With multiple planned runs, status() returns all so frontend can filter by task_id."""
         runner = _make_runner(tmp_path)
         _planned_run(runner, task_id="plan_old")
         _planned_run(runner, task_id="plan_new")
-        runner.update_plan("plan_new", [{"title": "Updated", "description": "U"}])
+        await runner.update_plan("plan_new", [{"title": "Updated", "description": "U"}])
         s = runner.status()
         ids = {r["task_id"] for r in s["runs"] if r["status"] == "planned"}
         assert ids == {"plan_old", "plan_new"}
@@ -750,11 +762,12 @@ class TestCrossGroupDependencyNormalization:
         )
         assert steps[4].depends_on == [3, 4]
 
-    def test_update_plan_preserves_user_deps(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_update_plan_preserves_user_deps(self, tmp_path: Path) -> None:
         """update_plan respects user's explicit dependency edits (no normalization)."""
         runner = _make_runner(tmp_path)
         _planned_run(runner)
-        runner.update_plan(
+        await runner.update_plan(
             "plan_test",
             [
                 {"title": "X", "depends_on": []},

--- a/test/test_project_alias.py
+++ b/test/test_project_alias.py
@@ -193,6 +193,7 @@ class TestProjectHandlers:
     async def test_update_renames(self):
         run = _make_run("r1")
         runner = MagicMock()
+        runner._apersist_runs = AsyncMock()
         runner._runs = {"r1": run}
         req = _make_request(
             _make_app(runner=runner),
@@ -203,7 +204,7 @@ class TestProjectHandlers:
         resp = await api_project_update(req)
         assert resp.status == 200
         assert run.name == "New"
-        runner._persist_runs.assert_called_once()
+        runner._apersist_runs.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_update_not_found(self):
@@ -218,7 +219,7 @@ class TestProjectHandlers:
     @pytest.mark.asyncio
     async def test_delete_success(self):
         runner = MagicMock()
-        runner.delete_run.return_value = True
+        runner.delete_run = AsyncMock(return_value=True)
         req = _make_request(_make_app(runner=runner), match_info={"id": "r1"})
         resp = await api_project_delete(req)
         assert json.loads(resp.body) == {"ok": True}
@@ -226,7 +227,7 @@ class TestProjectHandlers:
     @pytest.mark.asyncio
     async def test_delete_not_found(self):
         runner = MagicMock()
-        runner.delete_run.return_value = False
+        runner.delete_run = AsyncMock(return_value=False)
         req = _make_request(_make_app(runner=runner), match_info={"id": "x"})
         with pytest.raises(web.HTTPNotFound):
             await api_project_delete(req)
@@ -244,18 +245,21 @@ class TestProjectHandlers:
 
 
 class TestDeleteRun:
-    def test_delete_nonexistent(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(self, tmp_path):
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
-        assert runner.delete_run("nope") is False
+        assert await runner.delete_run("nope") is False
 
-    def test_delete_completed_run(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_delete_completed_run(self, tmp_path):
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         runner._runs["r1"] = _make_run("r1", status="completed")
         with patch.object(runner, "_persist_runs"):
-            assert runner.delete_run("r1") is True
+            assert await runner.delete_run("r1") is True
         assert "r1" not in runner._runs
 
-    def test_delete_running_sets_cancelling(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_delete_running_sets_cancelling(self, tmp_path):
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         run = _make_run("r1", status="running")
         runner._runs["r1"] = run
@@ -263,18 +267,19 @@ class TestDeleteRun:
         mock_task.done.return_value = False
         runner._tasks["r1"] = mock_task
         with patch.object(runner, "_persist_runs"):
-            assert runner.delete_run("r1") is True
+            assert await runner.delete_run("r1") is True
         assert "r1" not in runner._runs
         mock_task.cancel.assert_called_once()
 
-    def test_delete_planning_cancels_bg_task(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_delete_planning_cancels_bg_task(self, tmp_path):
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         runner._runs["r1"] = _make_run("r1", status="planning")
         mock_task = MagicMock()
         mock_task.done.return_value = False
         runner._tasks["r1"] = mock_task
         with patch.object(runner, "_persist_runs"):
-            assert runner.delete_run("r1") is True
+            assert await runner.delete_run("r1") is True
         assert "r1" not in runner._runs
         mock_task.cancel.assert_called_once()
 
@@ -289,7 +294,7 @@ class TestStartBackgroundPlanning:
         spec.write_text("# Test\n## Steps\n1. Do thing\n   - run: echo hi")
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock):
-            task_id = runner.start_background(spec, name="test-bg")
+            task_id = await runner.start_background(spec, name="test-bg")
             assert task_id in runner._runs
             assert runner._runs[task_id].status == "planning"
             assert runner._runs[task_id].name == "test-bg"
@@ -302,7 +307,7 @@ class TestStartBackgroundPlanning:
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock, side_effect=ValueError("boom")):
             with patch.object(runner, "_persist_runs"):
-                task_id = runner.start_background(spec)
+                task_id = await runner.start_background(spec)
                 await asyncio.sleep(0.1)  # let _wrapped() run
                 run = runner._runs.get(task_id)
                 assert run is not None
@@ -315,7 +320,7 @@ class TestStartBackgroundPlanning:
         spec.write_text("# Test\n## Steps\n1. Do thing\n   - run: echo hi")
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock):
-            task_id = runner.start_background(spec, source="mcp")
+            task_id = await runner.start_background(spec, source="mcp")
             assert runner._runs[task_id].source == "mcp"
 
     @pytest.mark.asyncio
@@ -324,7 +329,7 @@ class TestStartBackgroundPlanning:
         spec.write_text("x" * 10000)
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock):
-            task_id = runner.start_background(spec)
+            task_id = await runner.start_background(spec)
             assert len(runner._runs[task_id].spec_content) <= 4000
 
 
@@ -332,14 +337,16 @@ class TestStartBackgroundPlanning:
 
 
 class TestProjectRunAlias:
-    def test_project_run_normalizes(self):
+    @pytest.mark.asyncio
+    async def test_project_run_normalizes(self):
         runner = MagicMock()
         runner.status.return_value = {"running": False, "runs": []}
-        _handle_run_command("project run status", runner, MagicMock(), "C123", "ts123")
+        await _handle_run_command("project run status", runner, MagicMock(), "C123", "ts123")
         runner.status.assert_called_once()
 
-    def test_non_matching_returns_none(self):
-        result = _handle_run_command("hello world", MagicMock(), MagicMock(), "C123", "ts")
+    @pytest.mark.asyncio
+    async def test_non_matching_returns_none(self):
+        result = await _handle_run_command("hello world", MagicMock(), MagicMock(), "C123", "ts")
         assert result is None
 
 

--- a/test/test_stt_config_atomic.py
+++ b/test/test_stt_config_atomic.py
@@ -1,0 +1,91 @@
+"""Regression tests for the STT config PUT handler (Track A, bug 2).
+
+The handler must perform its read-modify-write under the shared config lock
+(mutual exclusion vs other config writers) and write atomically, matching the
+established pattern used by the other config handlers in the module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+import kiro_crew.dashboard.handlers.core as core
+from kiro_crew.config.loader import config_path
+from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+
+def _put(body: dict):
+    req = MagicMock(spec=web.Request)
+    req.method = "PUT"
+    req.json = AsyncMock(return_value=body)
+    return req
+
+
+@pytest.fixture(autouse=True)
+def _stub_probes(monkeypatch):
+    # The GET-building tail probes the system (subprocess) — stub it out so the
+    # test is fast and deterministic and doesn't depend on the host.
+    monkeypatch.setattr(core, "_stt_prereq_commands", lambda provider: {})
+    monkeypatch.setattr(core, "is_available", lambda stt: False)
+
+
+@pytest.mark.asyncio
+async def test_put_persists_atomically(tmp_path) -> None:
+    resp = await core.api_stt_config(_put({"language_code": "fr-FR", "transcribe_region": "us-west-2"}))
+    assert resp.status == 200
+
+    data = json.loads(config_path().read_text(encoding="utf-8"))
+    assert data["stt"]["language_code"] == "fr-FR"
+    assert data["stt"]["transcribe_region"] == "us-west-2"
+    # Atomic write leaves no temp files behind.
+    assert list(config_path().parent.glob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_put_blocks_on_config_lock() -> None:
+    """The handler must acquire the shared config lock: while another writer
+    holds it, the STT PUT cannot proceed."""
+    lock = _get_config_lock()
+    await lock.acquire()
+    try:
+        task = asyncio.create_task(
+            core.api_stt_config(_put({"language_code": "de-DE"}))
+        )
+        await asyncio.sleep(0.05)
+        # Still blocked because the critical section is guarded by the lock.
+        assert not task.done()
+    finally:
+        lock.release()
+
+    resp = await task
+    assert resp.status == 200
+    data = json.loads(config_path().read_text(encoding="utf-8"))
+    assert data["stt"]["language_code"] == "de-DE"
+
+
+@pytest.mark.asyncio
+async def test_put_offloads_atomic_write(monkeypatch) -> None:
+    """A slow fsync-backed write must not run on the gateway event loop."""
+    import kiro_crew.agent as agent_mod
+
+    event_loop_thread = threading.get_ident()
+    write_threads: list[int] = []
+    original_write = agent_mod._atomic_json_write
+
+    def recording_write(path, data) -> None:
+        write_threads.append(threading.get_ident())
+        original_write(path, data)
+
+    monkeypatch.setattr(agent_mod, "_atomic_json_write", recording_write)
+
+    resp = await core.api_stt_config(_put({"language_code": "it-IT"}))
+
+    assert resp.status == 200
+    assert write_threads
+    assert all(thread_id != event_loop_thread for thread_id in write_threads)

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -2956,7 +2956,7 @@ class TestTaskNaming:
         spec.write_text("# Bg Task\n## Steps\n1. Do thing\n   - run: echo hi")
         runner = TaskRunner(sessions=_make_mock_sessions(), work_dir=tmp_path)
         with patch.object(runner, "run", new_callable=AsyncMock) as mock_run:
-            task_id = runner.start_background(spec, name="bg-task")
+            task_id = await runner.start_background(spec, name="bg-task")
             assert task_id
             await asyncio.sleep(0)  # yield to let the background task run
             mock_run.assert_called_once()
@@ -3010,13 +3010,14 @@ class TestWorkspaceDirValidation:
         with pytest.raises(ValueError, match="sensitive"):
             _resolve_workspace_dir("~/.aws")
 
-    def test_start_background_rejects_sensitive_workspace(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_start_background_rejects_sensitive_workspace(self, tmp_path):
         # The per-run override is validated synchronously at the top of
         # start_background so the HTTP handler surfaces a 400 immediately —
         # a bad path must raise before any background task is spawned.
         runner = TaskRunner(sessions=_make_mock_sessions(), auto_test=False, work_dir=tmp_path)
         with pytest.raises(ValueError, match="sensitive"):
-            runner.start_background("anything.md", workspace_dir="~/.ssh")
+            await runner.start_background("anything.md", workspace_dir="~/.ssh")
 
     @pytest.mark.asyncio
     async def test_plan_per_run_workspace_override(self, tmp_path):

--- a/test/test_taskrunner_atomic_persistence.py
+++ b/test/test_taskrunner_atomic_persistence.py
@@ -1,0 +1,255 @@
+"""Regression tests for atomic runs-registry persistence (Track A, bug 1).
+
+Covers taskrunner._persist_runs / _load_runs:
+- writes are atomic (temp + fsync + os.replace) so a crash can't truncate,
+- a corrupt/truncated registry is NOT silently discarded — it is surfaced
+  loudly (logged at error) and preserved as a ``.corrupt`` sidecar,
+- a missing registry seeds a fresh (empty) run set without error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from kiro_crew.taskrunner import Step, StepStatus, TaskRun, TaskRunner
+
+
+def _make_runner(work_dir: Path) -> TaskRunner:
+    return TaskRunner(sessions=MagicMock(), auto_test=False, work_dir=work_dir)
+
+
+def _make_run(task_id: str = "t1") -> TaskRun:
+    return TaskRun(
+        spec_path="/tmp/TASK.md",
+        spec_content="# demo",
+        task_id=task_id,
+        name="demo run",
+        status="paused",
+        source="text",
+        work_dir="/tmp",
+        tasks=[
+            Step(index=0, title="step one", description="do it", status=StepStatus.PENDING),
+        ],
+    )
+
+
+class TestPersistRoundTrip:
+    def test_persist_writes_valid_json(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        runner._runs[_make_run().task_id] = _make_run()
+        runner._persist_runs()
+
+        runs_file = tmp_path / "runs.json"
+        assert runs_file.exists()
+        data = json.loads(runs_file.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert data[0]["task_id"] == "t1"
+
+    def test_persist_leaves_no_temp_files(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        runner._runs["t1"] = _make_run()
+        runner._persist_runs()
+        # Atomic write must clean up its temp file after os.replace.
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_round_trip_reloads_run(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        runner._runs["t1"] = _make_run()
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        assert "t1" in reloaded._runs
+        assert reloaded._runs["t1"].status == "paused"
+        assert reloaded._runs["t1"].tasks[0].title == "step one"
+
+
+class TestLoadRunsResilience:
+    def test_missing_file_seeds_fresh(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        # No runs.json on disk.
+        runner._load_runs()
+        assert runner._runs == {}
+
+    def test_corrupt_file_not_silently_discarded(self, tmp_path: Path, caplog) -> None:
+        # A truncated/partial write left behind by a crash mid-persist.
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text('[{"task_id": "t1", "spec_pa', encoding="utf-8")
+
+        runner = _make_runner(tmp_path)
+        with caplog.at_level("ERROR"):
+            runner._load_runs()
+
+        # State is NOT silently dropped: the corruption is surfaced loudly and
+        # the bad file is preserved for recovery rather than overwritten/empty.
+        assert runner._runs == {}
+        assert any("corrupt" in r.message.lower() for r in caplog.records)
+        assert (tmp_path / "runs.json.corrupt").exists()
+        # Original path was moved aside (so the next persist starts clean).
+        assert not runs_file.exists()
+
+    def test_unreadable_file_does_not_prevent_startup(
+        self, tmp_path: Path, monkeypatch, caplog
+    ) -> None:
+        # An existing but unreadable registry (permission error / transient
+        # Windows sharing violation) must NOT raise out of _load_runs — that
+        # is called from TaskRunner.__init__ and would otherwise block startup.
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text("[]", encoding="utf-8")
+
+        orig_read_text = Path.read_text
+
+        def boom(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if self.name == "runs.json":
+                raise PermissionError("locked")
+            return orig_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        with caplog.at_level("ERROR"):
+            runner = _make_runner(tmp_path)  # __init__ -> _load_runs; must not raise
+
+        assert runner._runs == {}
+        assert any("failed to read" in r.message.lower() for r in caplog.records)
+        # File is left untouched (NOT moved to .corrupt) so a later successful
+        # read can still recover it.
+        assert runs_file.exists()
+        assert not (tmp_path / "runs.json.corrupt").exists()
+
+
+class TestConcurrentPersist:
+    def test_persist_lock_serializes_writes(self, tmp_path: Path) -> None:
+        """Overlapping persistence workers (dispatched via _apersist_runs ->
+        asyncio.to_thread) must never interleave their snapshot+write. The
+        registry file must always stay valid JSON with the full run set — an
+        older, slow os.replace can't clobber a newer one under the lock."""
+        runner = _make_runner(tmp_path)
+        for i in range(20):
+            runner._runs[f"t{i}"] = _make_run(f"t{i}")
+
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                for _ in range(30):
+                    runner._persist_runs()
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        data = json.loads((tmp_path / "runs.json").read_text(encoding="utf-8"))
+        assert len(data) == 20
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_stale_snapshot_does_not_overwrite_newer(self, tmp_path: Path) -> None:
+        """A snapshot with an older sequence whose (offloaded) write is
+        scheduled late must never clobber a newer snapshot that already
+        landed — _commit_snapshot enforces monotonic ordering."""
+        runner = _make_runner(tmp_path)
+        newer = json.dumps([{"task_id": "newer"}])
+        older = json.dumps([{"task_id": "older"}])
+
+        runner._commit_snapshot(5, newer)
+        assert json.loads((tmp_path / "runs.json").read_text())[0]["task_id"] == "newer"
+
+        # Older sequence arriving late is ignored.
+        runner._commit_snapshot(3, older)
+        assert json.loads((tmp_path / "runs.json").read_text())[0]["task_id"] == "newer"
+
+    def test_apersist_snapshots_on_caller_thread(self, tmp_path: Path) -> None:
+        """_apersist_runs must build the snapshot before offloading, so the
+        live _runs registry is never iterated in the worker thread."""
+        import asyncio
+
+        runner = _make_runner(tmp_path)
+        runner._runs["t1"] = _make_run("t1")
+        asyncio.run(runner._apersist_runs())
+
+        data = json.loads((tmp_path / "runs.json").read_text(encoding="utf-8"))
+        assert [d["task_id"] for d in data] == ["t1"]
+
+
+class TestAsyncMutationPersistence:
+    def test_update_plan_offloads_atomic_write(self, tmp_path: Path, monkeypatch) -> None:
+        """Public mutation APIs must await durability without running fsync on
+        the gateway event-loop thread."""
+        import asyncio
+
+        runner = _make_runner(tmp_path)
+        run = _make_run("t1")
+        run.status = "planned"
+        runner._runs[run.task_id] = run
+        loop_thread = threading.get_ident()
+        write_threads: list[int] = []
+
+        def record_write(path, content, *, fsync=False):  # type: ignore[no-untyped-def]
+            write_threads.append(threading.get_ident())
+            path.write_text(content, encoding="utf-8")
+
+        monkeypatch.setattr("kiro_crew.taskrunner.atomic_write", record_write)
+        asyncio.run(runner.update_plan("t1", [{"title": "updated"}]))
+
+        assert write_threads
+        assert all(thread_id != loop_thread for thread_id in write_threads)
+        assert runner._runs["t1"].tasks[0].title == "updated"
+
+
+class TestBackgroundStartAdmission:
+    def test_concurrent_starts_are_serialized_and_get_unique_ids(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Persistence yields must not let starts overwrite task/run tracking."""
+        spec = tmp_path / "same-spec.md"
+        spec.write_text("# Task\n", encoding="utf-8")
+        runner = _make_runner(tmp_path)
+        first_persist_entered = asyncio.Event()
+        allow_first_persist = asyncio.Event()
+        release_runs = asyncio.Event()
+        persist_calls = 0
+
+        async def delayed_persist() -> None:
+            nonlocal persist_calls
+            persist_calls += 1
+            if persist_calls == 1:
+                first_persist_entered.set()
+                await allow_first_persist.wait()
+
+        async def held_run(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            await release_runs.wait()
+
+        runner._apersist_runs = delayed_persist  # type: ignore[method-assign]
+        runner.run = held_run  # type: ignore[method-assign]
+        monkeypatch.setattr(time, "time_ns", lambda: 123456789)
+
+        async def exercise() -> None:
+            first = asyncio.create_task(runner.start_background(spec))
+            await asyncio.wait_for(first_persist_entered.wait(), timeout=2)
+            second = asyncio.create_task(runner.start_background(spec))
+            await asyncio.sleep(0)
+
+            # The second start cannot pass admission while the first durable
+            # placeholder write is in flight.
+            assert not second.done()
+            assert len(runner._runs) == 1
+
+            allow_first_persist.set()
+            first_id, second_id = await asyncio.gather(first, second)
+            assert first_id != second_id
+            assert {first_id, second_id} == set(runner._runs)
+            assert {first_id, second_id} == set(runner._tasks)
+
+            background_tasks = list(runner._tasks.values())
+            release_runs.set()
+            await asyncio.gather(*background_tasks)
+
+        asyncio.run(exercise())


### PR DESCRIPTION
## Problem
Four persistence paths could crash-corrupt or silently lose data under
concurrent access or a mid-write crash/kill/full-disk:

1. **Task runner** — `_persist_runs` wrote `runs.json` non-atomically, so a
   crash mid-write left a truncated file; `_load_runs` then swallowed the
   `JSONDecodeError` in a blanket `except` and silently discarded *all* run
   state.
2. **STT config** — the STT config `PUT` handler did an unlocked, non-atomic
   read-modify-write of `config.json`, so it could race concurrent config
   writers and a mid-write crash could corrupt config.
3. **Heartbeat** — `_process_heartbeat_file` read `HEARTBEAT.md`, processed,
   then rewrote from a stale in-memory snapshot with no lock, clobbering any
   task another session appended mid-cycle.
4. **History** — transcript mutations (`append` / `mark_consolidated` /
   `rewrite_session` / `update_metadata`) were unserialized and one path used a
   non-atomic `write_text`, so a concurrent append could be lost and readers
   could observe a torn file.

## Why it matters
These are crash / data-loss bugs on shared state. Losing the task-runs registry
wipes autonomous-task progress; a corrupt `config.json` breaks startup; dropped
heartbeat tasks silently abandon monitoring loops; torn transcript writes lose
conversation history. All are hard to reproduce and easy to hit under real
concurrency (multiple sessions) or an unclean shutdown.

## Fix (symptom → root cause → change)
- **taskrunner.py** — truncated/lost runs registry → non-atomic write + blanket
  `except` on load → `_persist_runs` routes through `atomic_write`
  (temp + fsync + `os.replace`); `_load_runs` distinguishes *missing* (seed
  fresh) from *corrupt* (log at error, preserve as a `.corrupt` sidecar) instead
  of silently discarding. Hot async task-execution paths persist via a new
  `_apersist_runs` wrapper (`asyncio.to_thread`) so the fsync can't stall the
  event loop. Every production mutation API (`update_plan`, `update_task`,
  `execute_plan`, `retry_from_task`, `start_background`, `delete_run`, rename)
  is now async and awaits durable persistence before returning; dashboard,
  project, and Slack callers were updated to await the new contract.
  Background starts additionally serialize admission, collision-resistant ID
  allocation, durable placeholder persistence, and task registration.
- **dashboard/handlers/core.py** — raced/corrupt config → unlocked non-atomic
  RMW → STT `PUT` now holds the shared `_get_config_lock()` across the full
  RMW while offloading config read, directory creation, and fsync-backed
  `_atomic_json_write` via `asyncio.to_thread`. On an
  unparseable config it now fails loud (`500`) instead of resetting to `{}` and
  durably wiping every other setting — matching the sibling config handler.
- **heartbeat.py** — clobbered mid-cycle appends → stale-snapshot rewrite with
  cross-process transaction → the final re-read→merge→atomic replace now runs
  under a sibling OS lock, off the event loop via `asyncio.to_thread`. A new
  durable `append_heartbeat_task` API takes the same lock, and agent prompts
  require all internal producers to use it. The merge still diffs by
  **occurrence count** (multiset), preserving duplicate-text appends.
- **history.py** — lost/torn transcript writes → unserialized mutations +
  non-atomic write → transcript mutations serialize behind a per-file reentrant
  lock; `mark_consolidated` re-reads under the lock and writes via `atomic_write`.

## Tests
17 regression tests across four files, all locking in the crash/concurrency behavior:
- `test/test_taskrunner_atomic_persistence.py` — atomic write on persist;
  corrupt journal preserved as `.corrupt` sidecar and not silently discarded;
  missing file seeds fresh; public mutation persistence performs the atomic
  fsync write on a worker thread; concurrent same-spec starts cannot race
  across a persistence yield or reuse the same task ID.
- `test/test_stt_config_atomic.py` — STT `PUT` takes the config lock, writes
  atomically, and performs the fsync-backed write off the event-loop thread.
- `test/test_heartbeat_atomic_merge.py` — mid-cycle appends survive, and a
  lock-participating writer cannot interleave with the final atomic replace.
- `test/test_history_atomic_rewrite.py` — concurrent append not lost; readers
  never see a torn file; `mark_consolidated` writes atomically.

## Review round (bot findings addressed)
- **Codex HIGH — heartbeat merge dropped a duplicate-text append:** fixed by
  switching the merge from set membership to occurrence-count (multiset) diff.
- **Codex HIGH — fsync on the event loop:** fixed comprehensively. All
  task-runner mutation APIs are async and await `_apersist_runs`; snapshotting
  stays on the event-loop owner thread, while only the sequence-guarded
  `atomic_write(..., fsync=True)` runs via `asyncio.to_thread`.
- **Codex HIGH — heartbeat append race after final re-read:** fixed with a
  cross-process OS lock shared by the final transaction and all internal writers.
- **Codex HIGH — synchronous STT atomic write:** fixed by offloading filesystem
  reads/mutations while retaining the shared config lock across the full RMW.
- **Codex HIGH — concurrent background-start tracking corruption:** fixed with
  serialized admission and guarded collision-resistant ID allocation.
- **Codex MEDIUM — async mutation API compatibility:** rebutted as an intentional,
  documented contract migration required for awaitable durability; every
  repository caller and the taskrunner system spec now use the async API.
- **Design (advisory) — STT wipe on corrupt config:** fixed (fail-loud 500).
- **CodeQL alert #362:** dismissed as a verified false positive. The sink is the
  documented pre-existing user-owned local transcript JSONL; the taint source is
  a test fixture containing the literal `secret`, not credential persistence.

## Manual verification
N/A — unit coverage exercises the crash/concurrency paths directly.

## Test execution note
- 394 affected backend tests pass locally after rebasing onto current `main`.
- `flake8 -j1 src/ test/` passes.
- CI-parity mypy 1.14.1 passes across 441 source files.
- The worktree has no frontend changes; local `website/node_modules` was absent,
  so CI is the frontend/full-parallel-suite confirmation after this push.

## Screenshots
N/A — no user-visible UI change (backend persistence + config handler only).
