### PR TITLE
fix(memory): self-heal only on real corruption + serialize history appends

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1437,7 +1437,12 @@ class HistoryConsolidator:
                 return
 
             if entry := result.get("history_entry"):
-                memory.append_history(entry)
+                # Offloaded to a worker thread: append_history takes a blocking
+                # advisory file lock (cross-process) and does synchronous file
+                # IO, and _consolidate runs on the event loop thread (fired via
+                # asyncio.create_task). Running it inline would let cross-process
+                # lock contention stall the whole gateway loop.
+                await run_in_embed_pool(memory.append_history, entry)
                 logger.info("Consolidated %d messages for %s", len(unconsolidated), key)
 
             # Structured memory writes (Phase 2/3). Offloaded to a worker thread:

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from kiro_crew._sqlite_compat import FTS5_UNAVAILABLE_HINT, fts5_available, sqlite3
 from kiro_crew.config.loader import config_dir
+from kiro_crew.platform_compat import file_lock
 
 if TYPE_CHECKING:
     from kiro_crew.vector_memory import VectorMemoryStore
@@ -45,6 +46,39 @@ _DEFAULT_PROJECTS = "# Active Projects\n\n<!-- Current work context -->\n"
 # staying fresh; the cache key includes the day so the decay window shifting at
 # midnight invalidates naturally, and append/prune invalidate explicitly.
 _HISTORY_CACHE_TTL_SECS = 5.0
+
+# How long a sqlite connection waits out 'database is locked' contention before
+# giving up. Applied both as connect(timeout=) and PRAGMA busy_timeout so a
+# transient lock is retried/waited out rather than surfacing as an error the
+# self-heal path would misread as corruption.
+_DB_BUSY_TIMEOUT_SECS = 5.0
+
+# Substrings that mark a *genuinely* corrupt on-disk index (safe to delete +
+# rebuild). Note: 'database is locked'/'is busy' are transient contention, NOT
+# corruption, and must never trigger the delete-and-rebuild self-heal.
+_DB_CORRUPTION_MARKERS = (
+    "database disk image is malformed",
+    "file is not a database",
+    "malformed",
+    "not a database",
+)
+
+
+def _is_corruption_error(exc: BaseException) -> bool:
+    """True only for errors indicating genuine on-disk FTS index corruption.
+
+    Deleting and rebuilding the index is destructive (it drops all indexed
+    data), so it must fire only for real corruption. A 'database is locked' /
+    'database is busy' error is transient contention under concurrent access —
+    treating it as corruption would turn normal lock contention into permanent
+    data loss, so those are explicitly excluded.
+    """
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    msg = str(exc).lower()
+    if "locked" in msg or "busy" in msg:
+        return False
+    return any(marker in msg for marker in _DB_CORRUPTION_MARKERS)
 
 
 def workspace_dir() -> Path:
@@ -195,20 +229,31 @@ class MemoryStore:
         return self._history_dir / f"{date}.md"
 
     def append_history(self, entry: str) -> None:
-        """Append a timestamped entry to today's daily history file."""
+        """Append a timestamped entry to today's daily history file.
+
+        The whole read-modify-write is serialized behind an exclusive advisory
+        file lock so concurrent appends from other sessions/threads or processes
+        cannot interleave and clobber each other's entries. The lock uses
+        :func:`kiro_crew.platform_compat.file_lock` (real cross-platform locking
+        — ``flock`` on POSIX, ``msvcrt`` on Windows). The lock covers read +
+        rewrite; indexing and cache invalidation run after it is released.
+        """
         self._history_dir.mkdir(parents=True, exist_ok=True)
         path = self._today_history_file()
+        lock_path = self._history_dir / ".append.lock"
         timestamp = datetime.now().astimezone().strftime("%H:%M %Z")
 
-        content = ""
-        if path.exists():
-            content = path.read_text(encoding="utf-8")
-        if not content:
-            date = datetime.now().strftime("%Y-%m-%d")
-            content = f"# {date}\n"
+        with open(lock_path, "w") as fd:
+            with file_lock(fd.fileno(), exclusive=True):
+                content = ""
+                if path.exists():
+                    content = path.read_text(encoding="utf-8")
+                if not content:
+                    date = datetime.now().strftime("%Y-%m-%d")
+                    content = f"# {date}\n"
 
-        content += f"\n#### {timestamp}\n{entry.strip()}\n"
-        path.write_text(content, encoding="utf-8")
+                content += f"\n#### {timestamp}\n{entry.strip()}\n"
+                path.write_text(content, encoding="utf-8")
         self._index_file(path, content)
         self._invalidate_history_cache()  # today's window changed
 
@@ -383,15 +428,25 @@ class MemoryStore:
             # retrying loops on the same failure — fail loudly with a fix hint.
             if not fts5_available():
                 raise RuntimeError(FTS5_UNAVAILABLE_HINT) from e
+            # Only self-heal on GENUINE corruption. A transient 'database is
+            # locked'/'busy' error is contention (waited out by busy_timeout in
+            # _try_create_db), not corruption — deleting the index there would
+            # turn normal lock contention into permanent data loss, so re-raise
+            # anything that isn't unambiguously corrupt untouched.
+            if not _is_corruption_error(e):
+                raise
             # Self-healing: delete corrupted DB and retry
-            logger.warning("FTS index init failed (%s), deleting and retrying", e)
+            logger.warning("FTS index corrupted (%s), deleting and rebuilding", e)
             for suffix in ("", "-wal", "-shm"):
                 p = Path(str(self._index_db) + suffix)
                 p.unlink(missing_ok=True)
             return self._try_create_db()
 
     def _try_create_db(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self._index_db))
+        conn = sqlite3.connect(str(self._index_db), timeout=_DB_BUSY_TIMEOUT_SECS)
+        # Wait out transient 'database is locked' contention instead of letting
+        # it surface (where the self-heal used to misread it as corruption).
+        conn.execute(f"PRAGMA busy_timeout={int(_DB_BUSY_TIMEOUT_SECS * 1000)}")
         conn.execute(
             "CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5("
             "path, content, tokenize='porter unicode61')"

--- a/test/test_memory_selfheal.py
+++ b/test/test_memory_selfheal.py
@@ -1,0 +1,126 @@
+"""Regression tests for memory.py concurrency/self-heal fixes.
+
+Track C bugs:
+  1. FTS self-heal deleted the index on ANY sqlite error — including the
+     transient 'database is locked' — turning lock contention into permanent
+     data loss. It must only delete/rebuild on genuine corruption, and the
+     connection must carry a busy_timeout so locks are waited out.
+  2. append_history did an unlocked read-modify-write, so concurrent appends
+     interleaved and lost entries. It must serialize the whole append behind an
+     exclusive file lock.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from kiro_crew._sqlite_compat import sqlite3
+from kiro_crew.memory import MemoryStore, _is_corruption_error
+
+
+class TestCorruptionDetection:
+    """_is_corruption_error must distinguish contention from corruption."""
+
+    def test_locked_is_not_corruption(self):
+        assert _is_corruption_error(sqlite3.OperationalError("database is locked")) is False
+
+    def test_busy_is_not_corruption(self):
+        assert _is_corruption_error(sqlite3.OperationalError("database is busy")) is False
+
+    def test_malformed_is_corruption(self):
+        assert (
+            _is_corruption_error(sqlite3.DatabaseError("database disk image is malformed"))
+            is True
+        )
+
+    def test_not_a_database_is_corruption(self):
+        assert _is_corruption_error(sqlite3.DatabaseError("file is not a database")) is True
+
+    def test_non_sqlite_error_is_not_corruption(self):
+        assert _is_corruption_error(ValueError("boom")) is False
+
+
+class TestFtsSelfHealGating:
+    def test_lock_error_does_not_delete_db(self, tmp_path, monkeypatch):
+        """BUG 1 regression: a transient lock error must NOT delete the index."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        store.write_preferences("# Prefs\n\n- likes Python\n")
+        store.rebuild_index()
+
+        db_path = tmp_path / "memory_index.db"
+        assert db_path.exists()
+        before = db_path.read_bytes()
+
+        # Force _try_create_db to fail as if the DB is locked (contention).
+        def _locked(*_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(store, "_try_create_db", _locked)
+
+        # The lock error must propagate, NOT trigger a delete-and-rebuild.
+        raised = False
+        try:
+            store._get_db()
+        except sqlite3.OperationalError:
+            raised = True
+        assert raised, "lock error should propagate, not be swallowed by self-heal"
+
+        # The healthy index must survive untouched.
+        assert db_path.exists(), "self-heal wrongly deleted the DB on a lock error"
+        assert db_path.read_bytes() == before
+
+    def test_genuine_corruption_still_self_heals(self, tmp_path):
+        """Genuine on-disk corruption should still auto-rebuild."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        store.write_preferences("# Prefs\n\n- likes Python\n")
+        store.rebuild_index()
+
+        db_path = tmp_path / "memory_index.db"
+        assert db_path.exists()
+        db_path.write_bytes(b"this is not a valid sqlite database")
+
+        # rebuild_index -> _get_db detects "file is not a database" and rebuilds.
+        count = store.rebuild_index()
+        assert count >= 1
+        results = store.search("Python")
+        assert len(results) >= 1
+
+    def test_connection_has_busy_timeout(self, tmp_path):
+        """The connection must carry a non-zero busy_timeout to wait out locks."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        conn = store._get_db()
+        try:
+            timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            assert timeout >= 5000
+        finally:
+            conn.close()
+
+
+class TestConcurrentAppend:
+    def test_concurrent_appends_do_not_lose_entries(self, tmp_path):
+        """BUG 2 regression: parallel appends must all survive (no clobbering)."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+
+        n = 40
+        barrier = threading.Barrier(n)
+
+        def _worker(idx: int) -> None:
+            barrier.wait()  # maximize contention
+            store.append_history(f"entry-{idx}")
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        history_file = store._today_history_file()
+        content = history_file.read_text(encoding="utf-8")
+        # Every distinct entry must be present exactly once.
+        for i in range(n):
+            assert f"entry-{i}" in content, f"lost entry-{i} under concurrent append"
+        assert content.count("####") == n, "entry count mismatch — appends clobbered"


### PR DESCRIPTION
## Problem
Two data-loss bugs in the memory subsystem (`src/kiro_crew/memory.py`):

1. **FTS self-heal nuked the index on ordinary lock contention.** `_get_db()`
   caught *any* sqlite error during index init and responded by deleting
   `memory_index.db` (plus `-wal`/`-shm`) and rebuilding from scratch. Under
   concurrent access a transient `database is locked` / `database is busy`
   error would hit that path, so normal contention silently wiped the entire
   FTS index — all indexed memory gone.
2. **`append_history` did an unlocked read-modify-write.** It read today's
   history file, appended one entry in memory, and wrote the whole file back.
   Two concurrent appends (multiple sessions/threads/processes) would read the
   same base content and the later write would clobber the earlier entry — lost
   history.

## Why it matters
Both turn routine concurrency into permanent, silent data loss of the user's
persistent memory. Bug 1 can erase the whole searchable memory index on a
momentary lock; bug 2 drops history entries whenever two writers overlap. There
is no error surfaced to the user — the data is just gone.

## Fix (symptoms → root cause → change)
**Bug 1 — symptom:** memory index occasionally emptied under load. **Root
cause:** the self-heal treated transient lock errors as corruption. **Change:**
- Added `_is_corruption_error()` which returns `True` only for genuine on-disk
  corruption markers (`database disk image is malformed`, `file is not a
  database`, `malformed`, `not a database`) and explicitly returns `False` for
  anything containing `locked`/`busy`, and for non-`sqlite3.DatabaseError`.
- Gated the delete-and-rebuild in `_get_db()` behind `_is_corruption_error(e)`;
  every other error now re-raises untouched instead of destroying the index.
- Gave the connection a `connect(timeout=5.0)` + `PRAGMA busy_timeout=5000` in
  `_try_create_db()` so transient locks are waited out rather than surfacing as
  errors at all.

**Bug 2 — symptom:** history entries lost when writes overlap. **Root cause:**
the read-modify-write was not serialized. **Change:** wrapped the whole
read+rewrite of `append_history` in an exclusive advisory lock via
`kiro_crew.platform_compat.file_lock` (real cross-platform locking — `flock` on
POSIX, `msvcrt` on Windows, so the serialization holds on every supported
platform). The lock is released before indexing and cache invalidation. The
sole on-event-loop caller (`HistoryConsolidator._consolidate`) now invokes
`append_history` via `run_in_embed_pool` — matching the adjacent structured-
memory writes — so the blocking lock/IO never runs on the gateway event-loop
thread.

## Tests
`test/test_memory_selfheal.py` — 9 new tests:
- `TestCorruptionDetection` (5): `_is_corruption_error` returns `False` for
  `locked`/`busy` and non-sqlite errors, `True` for `malformed`/`not a
  database`.
- `TestFtsSelfHealGating` (3): a forced `database is locked` error propagates
  and leaves the index file byte-for-byte intact (bug 1 regression); genuine
  on-disk corruption still auto-rebuilds and stays searchable; the connection
  carries `busy_timeout >= 5000`.
- `TestConcurrentAppend` (1): 40 threads appending simultaneously behind a
  barrier — every distinct entry survives exactly once, `#### ` header count
  equals the entry count (bug 2 regression).

## Manual verification
N/A — the regression paths (lock-vs-corruption gating, byte-identical index
survival, and concurrent-append integrity) are directly reproduced and asserted
by the unit tests above; no integration/UI surface is involved.
