### PR TITLE
fix(sel): harden audit-chain HMAC key handling and chain-tip recovery

### DIFF
--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -38,6 +38,12 @@ _DEFAULT_DIR = Path.home() / ".kirocrew"
 _SEL_FILE = "security_events.jsonl"
 _RETENTION_DAYS = 365
 _HMAC_KEY_FILE = "sel_hmac.key"
+# Minimum accepted HMAC key length. os.urandom(32) is always written, so a
+# shorter key on disk means truncation/corruption/tampering — signing the
+# audit chain with an empty or short key yields a predictable, forgeable MAC
+# and silently disables the chain's tamper-evidence. Mirrors the >= 32-byte
+# requirement enforced in dashboard/token_secret.py.
+_HMAC_KEY_MIN_BYTES = 32
 _MAX_ARG_LEN = 500
 # Background-writer tuning. The queue is unbounded so callers never block; a
 # crash/kill can lose at most the events still queued (audit log is
@@ -222,6 +228,20 @@ class SecurityEventLog:
                     0o600,
                 )
                 with os.fdopen(fd, "a", encoding="utf-8") as f:
+                    # If a crash mid-append left a truncated tail line WITHOUT a
+                    # trailing newline, writing directly (O_APPEND) would glue
+                    # this record onto the corrupt fragment, forming a single
+                    # unparseable line. _read_last_hash() recovers the correct
+                    # prev_hash from the last complete record, but that glued
+                    # line stays unreadable by verify_integrity — so the new
+                    # event, though correctly chained, is orphaned from every
+                    # parseable record. Insert a newline boundary first so the
+                    # new record starts on a fresh, parseable line. We do NOT
+                    # truncate the corrupt fragment: the SEL log is append-only
+                    # forensic evidence, and the fragment is preserved as its
+                    # own (skipped) line.
+                    if self._ends_without_newline():
+                        f.write("\n")
                     f.write("".join(lines))
                 # Ensure permissions are correct even if file pre-existed with
                 # wrong mode (e.g. created by an older version).
@@ -277,42 +297,202 @@ class SecurityEventLog:
         key_path = self._dir / _HMAC_KEY_FILE
         self._dir.mkdir(parents=True, exist_ok=True)
         if key_path.exists():
-            return key_path.read_bytes()
+            existing = key_path.read_bytes()
+            # Validate the key BEFORE it is ever used to sign the chain. A
+            # 0-byte or too-short key is accepted silently by hmac.new(),
+            # producing a predictable, forgeable MAC that disables the audit
+            # chain's tamper-evidence. Fail HARD (mirroring token_secret.py's
+            # >= 32-byte requirement) rather than silently falling back to a
+            # weak key. We RAISE instead of regenerating (unlike
+            # token_secret.py's fall-through) because a fresh key would orphan
+            # every already-chained record — an operator must consciously
+            # rotate/restore the key.
+            if len(existing) < _HMAC_KEY_MIN_BYTES:
+                raise RuntimeError(
+                    f"SEL HMAC key {key_path} is too short ({len(existing)} bytes; "
+                    f"require >= {_HMAC_KEY_MIN_BYTES}). Refusing to sign the audit "
+                    "chain with a weak/forgeable key. Restore the correct key from "
+                    "backup, or remove the file to start a fresh chain with a new key."
+                )
+            # Re-enforce owner-only perms at LOAD time, not just at creation:
+            # the mode may have been relaxed since (backup restore, manual edit,
+            # migration) and this key signs the entire audit chain — a
+            # group/world-readable key lets any local user forge valid MACs.
+            # Mirrors token_secret.py's load-time restrict_to_owner. Fail-SOFT
+            # at the call site (warn, don't crash): a read-only FS / chmod
+            # failure must not take down SecurityEventLog init.
+            try:
+                platform_compat.restrict_to_owner(key_path)
+            except OSError:
+                # Logs the key file PATH, never the key bytes.
+                logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                    "failed to enforce owner-only permissions on SEL HMAC key %s; "
+                    "file may be readable by other users",
+                    key_path,
+                    exc_info=True,
+                )
+            return existing
         key = os.urandom(32)
-        key_path.write_bytes(key)
-        # chmod_safe (logs + swallows OSError; no-op on Windows) — fail-SOFT by
-        # design: a read-only FS must not crash SecurityEventLog init (see
-        # test_chmod_failure_is_swallowed). The reviewer's note was only that the
-        # old `try: chmod_safe except OSError: pass` wrapper was dead (chmod_safe
-        # never raises) — so drop the wrapper, keep the fail-soft behavior. (Unlike
-        # token_secret.py, which is fail-LOUD; the SEL key tolerates chmod failure.)
-        platform_compat.chmod_safe(key_path, 0o600)
+        # Create the key ATOMICALLY: write the full 32 bytes to a temp file in
+        # the same dir (0o600 from birth, so never briefly world-readable) and
+        # os.replace() it into place — the same pattern prune() uses. A plain
+        # os.open()+os.write() is NOT atomic: a crash or full-disk partial
+        # write between the two calls leaves a 0-byte/short key on disk, which
+        # the load-time length check above would then reject with a hard
+        # RuntimeError on the NEXT boot — bricking every SecurityEventLog()
+        # init until an operator manually removes the file. os.replace() makes
+        # the key file visible only once it is complete, so KiroCrew itself can
+        # never manufacture the hard-fail state; it fires solely on genuine
+        # external corruption/tampering (which is what the error message is
+        # written for).
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(key_path.parent), prefix=".sel_hmac_", suffix=".tmp"
+        )
+        try:
+            # os.write() may return a SHORT count (fewer bytes than len(key)),
+            # notably when storage is nearly full. Ignoring it would publish a
+            # truncated key while the running process keeps signing with the
+            # full in-memory key — the next boot then hard-fails on the short
+            # on-disk key and the existing records can't be verified. Loop
+            # until every byte is written; treat a 0-byte write as an error.
+            mv = memoryview(key)
+            while mv:
+                n = os.write(tmp_fd, mv)
+                if n == 0:
+                    raise OSError("short write persisting SEL HMAC key (wrote 0 bytes)")
+                mv = mv[n:]
+            os.close(tmp_fd)
+            tmp_fd = -1
+            os.replace(tmp_path, str(key_path))
+        except BaseException:
+            if tmp_fd != -1:
+                os.close(tmp_fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        # Re-enforce owner-only perms (POSIX 0o600 / Windows owner-only DACL).
+        # Fail-SOFT by design: a read-only FS must not crash SecurityEventLog
+        # init (see test_chmod_failure_is_swallowed). Unlike token_secret.py,
+        # which treats the same failure as merely a warning too, the SEL key
+        # tolerates chmod failure at startup.
+        try:
+            platform_compat.restrict_to_owner(key_path)
+        except OSError:
+            # Logs the key file PATH, never the key bytes.
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "failed to set owner-only permissions on SEL HMAC key %s; "
+                "file may be readable by other users",
+                key_path,
+                exc_info=True,
+            )
         return key
 
+    def _ends_without_newline(self) -> bool:
+        """True if the log's final byte is not a newline.
+
+        A trailing byte other than ``\\n`` means the previous append was
+        truncated (crash / partial write) and left an unterminated fragment.
+        The writer uses this to insert a newline boundary before the next
+        record so the new line stays independently parseable (see
+        _flush_batch). Fail-soft: on any read error assume no separator is
+        needed rather than crashing the writer.
+        """
+        try:
+            with open(self._path, "rb") as f:
+                f.seek(0, 2)
+                if f.tell() == 0:
+                    return False
+                f.seek(-1, 2)
+                return f.read(1) != b"\n"
+        except OSError:
+            return False
+
     def _read_last_hash(self) -> str:
+        """Return the entry_hash of the last COMPLETE record, or "" if none.
+
+        A crash mid-append can leave a truncated/partial final line. The old
+        implementation wrapped the parse in a blanket ``except: return ""``, so
+        one corrupt tail line silently restarted the HMAC chain from genesis —
+        severing the tamper-evidence link and masking exactly the corruption
+        the chain exists to detect. Instead we scan backward and skip an
+        unparseable trailing line to chain from the last COMPLETE valid record;
+        we only return "" when the log is genuinely empty/absent or contains no
+        parseable record at all (nothing to chain from). Skipped corrupt tail
+        lines are logged so the integrity concern is surfaced, not hidden.
+        """
         if not self._path.exists():
             return ""
         try:
-            # Read last non-empty line
             with open(self._path, "rb") as f:
                 f.seek(0, 2)
                 pos = f.tell()
                 if pos == 0:
                     return ""
-                # Scan backward for last newline
+                # Scan backward in chunks. ``buf`` holds bytes not yet split
+                # into complete lines; while pos > 0 its first split element is
+                # a possibly-partial line whose start lies in an earlier chunk,
+                # so we hold it back until more is read (or we reach the file
+                # start). This lets us walk past a truncated tail line to find
+                # the last complete record.
                 buf = b""
+                skipped_corrupt = False
                 while pos > 0:
-                    pos = max(pos - 4096, 0)
-                    f.seek(pos)
-                    buf = f.read() + buf
-                    lines = buf.split(b"\n")
-                    for line in reversed(lines):
+                    read_start = max(pos - 4096, 0)
+                    f.seek(read_start)
+                    buf = f.read(pos - read_start) + buf
+                    pos = read_start
+                    parts = buf.split(b"\n")
+                    if pos > 0:
+                        # First element may be incomplete — defer it.
+                        buf = parts[0]
+                        complete = parts[1:]
+                    else:
+                        # Reached the file start: every element is complete.
+                        buf = b""
+                        complete = parts
+                    for line in reversed(complete):
                         line = line.strip()
-                        if line:
+                        if not line:
+                            continue
+                        try:
                             data = json.loads(line)
-                            return data.get("entry_hash", "")
+                        except (json.JSONDecodeError, ValueError):
+                            # Truncated/corrupt line — skip backward to the last
+                            # complete record rather than resetting the chain to
+                            # genesis. Flag it so the corruption is not hidden.
+                            skipped_corrupt = True
+                            logger.warning(
+                                "SEL: skipping unparseable audit-log line while "
+                                "resolving chain tip in %s; chaining from the last "
+                                "complete record instead of resetting to genesis",
+                                self._path,
+                            )
+                            continue
+                        if not isinstance(data, dict):
+                            # Parseable JSON but not a record object — treat as
+                            # corrupt and keep scanning backward.
+                            skipped_corrupt = True
+                            logger.warning(
+                                "SEL: skipping non-object audit-log line while "
+                                "resolving chain tip in %s",
+                                self._path,
+                            )
+                            continue
+                        if skipped_corrupt:
+                            logger.warning(
+                                "SEL: recovered chain tip from an earlier complete "
+                                "record after a corrupt/truncated tail in %s",
+                                self._path,
+                            )
+                        return data.get("entry_hash", "")
+            # No parseable record anywhere in the file — nothing to chain from.
             return ""
-        except Exception:
+        except OSError:
+            logger.warning(
+                "SEL: failed to read chain tip from %s", self._path, exc_info=True
+            )
             return ""
 
     def _compute_hash(self, event: SecurityEvent) -> str:

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -903,3 +903,315 @@ class TestCriticalWrite:
                 )
         finally:
             mp.undo()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Audit-chain hardening regression tests (Track B):
+#   1. HMAC key length validation (reject empty/short keys — hard fail)
+#   2. HMAC key permission re-enforcement on load
+#   3. _read_last_hash no longer resets the chain to genesis on a corrupt
+#      trailing line when prior complete records exist
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestHmacKeyValidation:
+    def test_rejects_empty_key_file(self, tmp_path: Path) -> None:
+        """A 0-byte key file must hard-fail init, not sign with an empty key."""
+        (tmp_path / "sel_hmac.key").write_bytes(b"")
+        with pytest.raises(RuntimeError, match="too short"):
+            SecurityEventLog(base_dir=tmp_path, sync=True)
+
+    def test_rejects_short_key_file(self, tmp_path: Path) -> None:
+        """A present-but-too-short key (< 32 bytes) must hard-fail init."""
+        (tmp_path / "sel_hmac.key").write_bytes(b"x" * 16)
+        with pytest.raises(RuntimeError, match="require >= 32"):
+            SecurityEventLog(base_dir=tmp_path, sync=True)
+
+    def test_accepts_exactly_min_length_key(self, tmp_path: Path) -> None:
+        """A key of exactly the minimum length is accepted."""
+        key = b"k" * 32
+        (tmp_path / "sel_hmac.key").write_bytes(key)
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log._hmac_key == key
+
+    def test_generated_key_meets_minimum_length(self, tmp_path: Path) -> None:
+        """The auto-generated key must satisfy the validation on next load."""
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert len((tmp_path / "sel_hmac.key").read_bytes()) >= 32
+        # Re-init from the on-disk key must not raise.
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert len(log2._hmac_key) == 32
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
+class TestHmacKeyPermissionEnforcement:
+    def test_created_key_is_owner_only(self, tmp_path: Path) -> None:
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        mode = (tmp_path / "sel_hmac.key").stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_reenforces_perms_on_load(self, tmp_path: Path) -> None:
+        """A key file left group/world-readable must be tightened to 0600 on load."""
+        key_path = tmp_path / "sel_hmac.key"
+        key_path.write_bytes(b"k" * 32)
+        os.chmod(key_path, 0o644)  # simulate relaxed perms (backup restore, etc.)
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        mode = key_path.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_chmod_failure_on_load_is_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A chmod failure while re-enforcing perms on load must warn, not crash."""
+        key = b"k" * 32
+        (tmp_path / "sel_hmac.key").write_bytes(key)
+
+        def _boom(*a, **kw):
+            raise OSError("chmod denied")
+
+        monkeypatch.setattr("kiro_crew.platform_compat.os.chmod", _boom)
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log._hmac_key == key
+
+
+class TestReadLastHashCorruptTail:
+    def test_corrupt_tail_chains_from_last_valid_record(self, tmp_path: Path) -> None:
+        """A truncated final line must NOT reset the chain to genesis when
+        prior complete records exist — the next record chains off the last
+        COMPLETE record's entry_hash."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="e0"))
+        log.log(_make_event(event_id="e1"))
+        good_tip = log._last_hash
+        path = tmp_path / "security_events.jsonl"
+        # Simulate a crash mid-append: a partial/truncated trailing line.
+        with open(path, "a", encoding="utf-8") as f:
+            f.write('{"event_id": "e2", "prev_hash": "abc", "entry_ha')
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        # Chain tip recovered from the last COMPLETE record, not reset to "".
+        assert log2._last_hash == good_tip
+        assert log2._last_hash != ""
+
+    def test_new_record_after_corrupt_tail_keeps_chain_linked(self, tmp_path: Path) -> None:
+        """After recovering past a corrupt tail, appending a new record links
+        it to the surviving complete record (verify_integrity stays clean for
+        the intact prefix)."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="a0"))
+        log.log(_make_event(event_id="a1"))
+        prev_tip = log._last_hash
+        path = tmp_path / "security_events.jsonl"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write('{"truncated": tru')  # invalid JSON tail
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log2._last_hash == prev_tip
+
+    def test_only_corrupt_lines_returns_empty(self, tmp_path: Path) -> None:
+        """When NO complete record exists, "" is still the correct tip (nothing
+        to chain from) — preserves the genuine genesis case."""
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "security_events.jsonl").write_text("not-json-at-all\n")
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log._last_hash == ""
+
+    def test_non_object_json_tail_is_skipped(self, tmp_path: Path) -> None:
+        """A valid-JSON-but-non-object trailing line (e.g. a bare number) must
+        be skipped, not crash init on the .get() call."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="n0"))
+        good_tip = log._last_hash
+        path = tmp_path / "security_events.jsonl"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("12345\n")
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log2._last_hash == good_tip
+
+    def test_corrupt_tail_across_4kb_boundary(self, tmp_path: Path) -> None:
+        """The recovery scan works even when the last complete record is more
+        than one 4 KB chunk before the truncated tail."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        big = "x" * 200
+        for i in range(60):  # ~15 KB — spans multiple 4 KB chunks
+            log.log(_make_event(event_id=f"c{i:02d}", resources=big))
+        good_tip = log._last_hash
+        path = tmp_path / "security_events.jsonl"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write('{"event_id": "trunc", "entry_ha')  # truncated tail
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log2._last_hash == good_tip
+
+
+class TestCorruptTailNewlineBoundary:
+    """A record appended after recovering past an UNTERMINATED corrupt tail
+    must start on a fresh line — never glued onto the truncated fragment.
+
+    Regression for the silent-void bug: _read_last_hash() recovers the right
+    prev_hash, but if the writer O_APPENDs directly onto a tail line with no
+    trailing newline, the new record fuses into that fragment as one
+    unparseable line — so the event, though correctly chained, is orphaned
+    from every readable record (recent()/verify_integrity can't see it).
+    """
+
+    def _crash_with_truncated_tail(self, tmp_path: Path) -> tuple[str, str]:
+        """Log two clean events, then simulate a crash mid-append (a trailing
+        line with NO newline). Returns (recovered_tip, fragment)."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="e0"))
+        log.log(_make_event(event_id="e1"))
+        tip = log._last_hash
+        fragment = '{"event_id": "e2", "prev_hash": "abc", "entry_ha'
+        with open(tmp_path / "security_events.jsonl", "a", encoding="utf-8") as f:
+            f.write(fragment)
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        return tip, fragment
+
+    def test_new_record_is_parseable_after_corrupt_tail(self, tmp_path: Path) -> None:
+        tip, fragment = self._crash_with_truncated_tail(tmp_path)
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log2._last_hash == tip  # recovered, not reset to genesis
+        log2.log(_make_event(event_id="e_after"))
+
+        lines = (tmp_path / "security_events.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        # Last physical line must be the NEW record, cleanly parseable — not
+        # the corrupt fragment glued to it.
+        last = json.loads(lines[-1])
+        assert last["event_id"] == "e_after"
+        # And it chains off the recovered tip.
+        assert last["prev_hash"] == tip
+        # The corrupt fragment is PRESERVED as its own line (append-only
+        # forensic evidence), not truncated away.
+        assert any(fragment in ln for ln in lines)
+
+    def test_new_record_surfaces_in_recent_after_corrupt_tail(
+        self, tmp_path: Path
+    ) -> None:
+        self._crash_with_truncated_tail(tmp_path)
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log2.log(_make_event(event_id="visible"))
+        # recent() skips the corrupt fragment but MUST surface the new event —
+        # proof it isn't orphaned by gluing.
+        assert any(e["event_id"] == "visible" for e in log2.recent(limit=10))
+
+    def test_intact_prefix_still_verifies_after_recovery(self, tmp_path: Path) -> None:
+        tip, _ = self._crash_with_truncated_tail(tmp_path)
+        log2 = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log2.log(_make_event(event_id="post"))
+        total, valid = log2.verify_integrity()
+        # The two original records + the post-recovery record all chain and
+        # verify; only the single corrupt fragment line is non-valid.
+        assert valid == 3
+        assert total - valid == 1  # exactly the preserved corrupt fragment
+
+    def test_no_separator_inserted_when_tail_is_clean(self, tmp_path: Path) -> None:
+        """Normal appends (file ends with a newline) must NOT gain a blank
+        separator line — the boundary fix triggers only on a truncated tail."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="s0"))
+        log.log(_make_event(event_id="s1"))
+        raw = (tmp_path / "security_events.jsonl").read_text(encoding="utf-8")
+        assert "\n\n" not in raw  # no spurious blank line between records
+
+    def test_ends_without_newline_helper(self, tmp_path: Path) -> None:
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        path = tmp_path / "security_events.jsonl"
+        # A freshly-created log ends with a newline → no separator needed.
+        assert log._ends_without_newline() is False
+        # Empty file → no separator needed.
+        path.write_text("", encoding="utf-8")
+        assert log._ends_without_newline() is False
+        # Properly terminated line → no separator needed.
+        path.write_text("{}\n", encoding="utf-8")
+        assert log._ends_without_newline() is False
+        # Truncated tail (no trailing newline) → separator needed.
+        path.write_text('{"x": 1', encoding="utf-8")
+        assert log._ends_without_newline() is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
+class TestHmacKeyAtomicCreation:
+    """Key creation is atomic: the key file is only ever visible as the full
+    32 bytes, so a crash/partial-write can't leave a short key that the
+    load-time length check would then hard-fail on the next boot.
+    """
+
+    def test_created_key_is_full_length_and_owner_only(self, tmp_path: Path) -> None:
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        key_path = tmp_path / "sel_hmac.key"
+        assert len(key_path.read_bytes()) == 32
+        assert (key_path.stat().st_mode & 0o777) == 0o600
+
+    def test_no_temp_key_files_left_behind(self, tmp_path: Path) -> None:
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        leftovers = list(tmp_path.glob(".sel_hmac_*"))
+        assert leftovers == []
+
+    def test_crash_during_create_leaves_no_short_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the write crashes mid-creation, NO key file is published (so the
+        next boot regenerates cleanly instead of hard-failing on a short key),
+        and the temp file is cleaned up."""
+        real_write = os.write
+
+        def _boom(fd, data):  # fail only the key write
+            raise OSError("disk full during key write")
+
+        monkeypatch.setattr(os, "write", _boom)
+        with pytest.raises(OSError):
+            SecurityEventLog(base_dir=tmp_path, sync=True)
+        monkeypatch.setattr(os, "write", real_write)
+        # No published key, and no orphaned temp file.
+        assert not (tmp_path / "sel_hmac.key").exists()
+        assert list(tmp_path.glob(".sel_hmac_*")) == []
+
+    def test_short_write_still_persists_full_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """os.write() returning a SHORT count (e.g. near-full disk) must not
+        publish a truncated key — the writer loops until all 32 bytes land."""
+        real_write = os.write
+
+        def _short_write(fd, data):
+            # Write at most 8 bytes per call, forcing the write-all loop.
+            return real_write(fd, bytes(data)[:8])
+
+        monkeypatch.setattr(os, "write", _short_write)
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        monkeypatch.setattr(os, "write", real_write)
+        assert len((tmp_path / "sel_hmac.key").read_bytes()) == 32
+
+    def test_zero_byte_write_is_treated_as_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistent 0-byte write must raise (not spin forever) and leave no
+        published key or temp file."""
+        real_write = os.write
+
+        def _zero(fd, data):
+            return 0
+
+        monkeypatch.setattr(os, "write", _zero)
+        with pytest.raises(OSError):
+            SecurityEventLog(base_dir=tmp_path, sync=True)
+        monkeypatch.setattr(os, "write", real_write)
+        assert not (tmp_path / "sel_hmac.key").exists()
+        assert list(tmp_path.glob(".sel_hmac_*")) == []


### PR DESCRIPTION
## Problem
The SEL (Security Event Log) tamper-evident audit chain in `src/kiro_crew/sel.py` had silent-void failure modes that could quietly weaken or reset the chain without any signal:

1. A short/empty HMAC key was accepted and used to sign records, producing a weak, forgeable MAC.
2. Owner-only permissions on the key file were enforced only at creation, so a group/world-readable key (e.g. after a backup restore or manual edit) stayed readable.
3. `_read_last_hash` used a blanket `except: return ""`, so a truncated/corrupt tail line (e.g. a crash mid-append) silently reset the chain to genesis, breaking tamper-evidence for every prior record.

Two further edge cases were surfaced in review and fixed in this PR:

4. Key creation was non-atomic (`os.open` + `os.write`): a crash/partial write between the two calls could leave a 0-byte/short key on disk — which fix (1) would then hard-fail on the next boot, bricking every `SecurityEventLog()` init.
5. After recovering past a corrupt *unterminated* tail, the next `O_APPEND` write glued the new record onto the corrupt fragment, forming one unparseable line — orphaning the new (correctly-chained) event from every readable record.

## Why it matters
The SEL chain is the tamper-evidence mechanism for security-relevant events. Each of these bugs silently degrades that guarantee: a forgeable key defeats the MAC, a readable key exposes the signing secret, a genesis reset orphans the chain, a bricked init takes down every consumer (`security.py`, MCP gateway, dashboard), and a glued record silently drops an audit event. A tamper-evident log that fails silently is worse than no log, because it implies integrity it no longer has.

## Fix (symptom → root cause → change)
1. **Weak-key acceptance → no length validation on load → RuntimeError for `<32` bytes.** The key is validated on load and rejected with a hard `RuntimeError` if shorter than 32 bytes, mirroring `token_secret.py`. It raises rather than regenerating, because a fresh key would orphan the already-chained records.
2. **Loosened perms persisting → perms only set at create → re-enforce on load.** Owner-only `0600` / owner-DACL permissions are re-applied on load (not just create) via `platform_compat.restrict_to_owner`. Fail-soft (warn, don't crash) so read-only-FS init still works.
3. **Silent genesis reset → blanket bare `except` → backward scan to last valid record.** `_read_last_hash` now scans backward past corrupt/truncated tail lines to chain from the last complete valid record, returning `""` only when nothing is parseable. Recovery is logged, and the swallowed exception is narrowed to `OSError`.
4. **Brickable init → non-atomic key create → atomic `mkstemp` + `os.replace`.** The key is written to a temp file (0600 from birth) and atomically renamed into place (the pattern `prune()` already uses), so the key file is only ever visible as the full 32 bytes. KiroCrew can no longer manufacture the hard-fail state; it fires solely on genuine external corruption/tampering.
5. **Orphaned record after recovery → append glues onto unterminated fragment → newline boundary on append.** The writer inserts a `\n` before the next record when the log's last byte is not a newline, so the new record starts on a fresh, parseable line. The corrupt fragment is preserved as its own (skipped) line — the SEL log is append-only forensic evidence, so it is never truncated.

## Tests
`test/test_sel.py` — regression tests covering all five fixes:
- HMAC key length validation (accepts `>=32B`, raises for empty/short keys).
- Owner-only permission re-enforcement on both create and load, chmod-failure swallowed.
- Corrupt/truncated-tail recovery: chain continues from the last valid record; `""` only when nothing parseable; non-object JSON tail skipped; multi-chunk (>4 KB) boundary.
- Atomic key creation: full-length owner-only key, no temp leftovers, and a crash during create leaves no short key (next boot regenerates cleanly).
- Newline boundary: a record logged after recovering past a corrupt unterminated tail is independently parseable, surfaces in `recent()`, and the intact prefix + new record still `verify_integrity`; no spurious separator on a clean tail.

Local results: `test/test_sel.py` 90 passed; governance+sel-scoped suite 594 passed / 2 skipped; `flake8` clean.

## Manual verification
N/A — unit coverage is sufficient; these are non-UI, integrity-path changes fully exercised by the added regression tests.

## Screenshots
N/A — no user-visible UI change.
