### PR TITLE
fix(chat): keep steer bubble React key stable across steer_push reconcile

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2737,7 +2737,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   )
 
   const renderMessage = useCallback((i: number, m: ChatMessage) => {
-    const key = m.ts ? `${m.role}-${m.ts}` : `${m.role}-${i}`
+    // Prefer the optimistic client ts (stashed by the steer-echo reconcile in
+    // chatSlice.appendSlotMessage) over the server ts for the React key. A
+    // steered bubble is appended optimistically with a client ts, then the
+    // steer_push echo overwrites ts with the server ts — keying on ts alone
+    // would change the key mid-stream, remounting the bubble and replaying its
+    // one-shot entrance animation. clientTs keeps the key (and DOM) stable.
+    const keyTs = (m.meta?.clientTs as string | undefined) || m.ts
+    const key = keyTs ? `${m.role}-${keyTs}` : `${m.role}-${i}`
     if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} /> : null
     if (m.role === 'tool') {
       // Skip ✅/🚫 completion messages — completion shown via CircleCheckBig icon

--- a/website/src/pages/chat/UserMessage.tsx
+++ b/website/src/pages/chat/UserMessage.tsx
@@ -48,7 +48,13 @@ const UserMessage = memo(function UserMessage({ content, meta, timestamp, render
   const isSteer = !!(meta && (meta as { steer?: boolean }).steer)
   const [playSteer] = useState(() => {
     if (!isSteer) return false
-    const key = messageTs || content
+    // Stable identity across the steer lifecycle: the optimistic bubble mounts
+    // with a client ts (messageTs), then the steer_push reconcile stashes that
+    // client ts as meta.clientTs and swaps messageTs to the server ts. Keying
+    // the guard on clientTs first keeps the identity constant, so a
+    // virtualization remount after the reconcile still hits the set and the
+    // entrance animation plays exactly once.
+    const key = ((meta as { clientTs?: string })?.clientTs) || messageTs || content
     if (animatedSteers.has(key)) return false
     animatedSteers.add(key)
     return true

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -732,6 +732,14 @@ const chatSlice = createSlice({
         const bubble = target ?? fallback
         if (bubble) {
           if (message.content) bubble.content = message.content
+          // Preserve the optimistic (client-generated) ts as meta.clientTs
+          // BEFORE overwriting with the server ts. The chat renderer keys
+          // rows by `meta.clientTs ?? ts`; without this stash the ts change
+          // would change the React key, remounting the bubble and replaying
+          // the one-shot steer entrance animation (visible flicker).
+          if (message.ts && bubble.ts && message.ts !== bubble.ts) {
+            bubble.meta = { ...(bubble.meta || {}), clientTs: bubble.ts }
+          }
           if (message.ts) bubble.ts = message.ts
           bubble.meta = { ...(bubble.meta || {}), ...(message.meta || {}) }
           delete (bubble.meta as Record<string, unknown>).optimistic

--- a/website/src/test/UserMessage.test.tsx
+++ b/website/src/test/UserMessage.test.tsx
@@ -191,4 +191,22 @@ describe('UserMessage', () => {
     const bubble = container.querySelector('.msg-content') as HTMLElement
     expect(bubble.className).toContain('border-accent/40')
   })
+
+  // One-shot entrance guard identity: the optimistic bubble mounts with a client
+  // ts; the steer_push reconcile stashes it as meta.clientTs and swaps messageTs
+  // to the server ts. A later remount (virtualization scroll-away) must key the
+  // animatedSteers guard on clientTs so the entrance does NOT replay under the
+  // new server ts. The ring-pulse overlay (border-2 border-accent) only renders
+  // when the entrance plays.
+  it('does not replay the steer entrance on remount after the reconcile swapped in the server ts', () => {
+    const ringSelector = '.border-2.border-accent'
+    // First mount: optimistic bubble, client ts — entrance plays (ring present).
+    const first = render(<UserMessage content="steer me" meta={{ steer: true }} messageTs="client-ts-guard" renderContent={renderContent} />)
+    expect(first.container.querySelector(ringSelector)).not.toBeNull()
+    first.unmount()
+    // Remount post-reconcile: server ts, clientTs stashed in meta — guard must
+    // recognize the same message and skip the entrance (no ring).
+    const second = render(<UserMessage content="steer me" meta={{ steer: true, clientTs: 'client-ts-guard' }} messageTs="server-ts-guard" renderContent={renderContent} />)
+    expect(second.container.querySelector(ringSelector)).toBeNull()
+  })
 })

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -560,6 +560,39 @@ describe('appendSlotMessage steer reconcile', () => {
     expect(users[0].meta?.optimistic).toBe(true)
     expect(users[0].meta?.steer).toBeUndefined()
   })
+
+  it('stashes the optimistic client ts as meta.clientTs when the echo swaps in the server ts', () => {
+    // Remount-replay regression: the renderer keys rows by clientTs ?? ts.
+    // Overwriting ts without stashing the client ts changed the React key,
+    // remounting the bubble and replaying the steer entrance animation.
+    let state = { ...initial, activeSlot: 'A', messages: [] as any[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 'client-ts', meta: { steer: true, optimistic: true } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 'server-ts', meta: { steer: true } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].ts).toBe('server-ts')
+    expect(users[0].meta?.clientTs).toBe('client-ts')
+    expect(users[0].meta?.optimistic).toBeUndefined()
+  })
+
+  it('does not stash clientTs when the echo carries the same ts (key already stable)', () => {
+    let state = { ...initial, activeSlot: 'A', messages: [] as any[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 'same-ts', meta: { steer: true, optimistic: true } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 'same-ts', meta: { steer: true } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].meta?.clientTs).toBeUndefined()
+  })
+
+  it('does not stash clientTs when the echo has no ts (optimistic ts kept as-is)', () => {
+    let state = { ...initial, activeSlot: 'A', messages: [] as any[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 'client-ts', meta: { steer: true, optimistic: true } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'steered text', cls: 'msg msg-u', meta: { steer: true } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].ts).toBe('client-ts')
+    expect(users[0].meta?.clientTs).toBeUndefined()
+  })
 })
 
 describe('sseChatMessage', () => {


### PR DESCRIPTION
# fix(chat): keep steer bubble React key stable across steer_push reconcile

## Problem
When a steering message is sent mid-turn, the user bubble visibly glitches: it slides in, then a moment later flickers, snaps back, and replays the slide-in + ring-pulse entrance animation a second time.

## Why it matters
Steer is the default Enter action while a turn is running, so every mid-turn message hits this. The double-play entrance makes the chat feel broken and makes users doubt whether the steer landed once or twice.

## Fix (symptom → root cause → change)
- **Symptom:** the steer bubble's one-shot entrance animation replays when the backend echo arrives.
- **Root cause:** `steer()` appends the bubble optimistically with a client-generated `ts`. The `steer_push` WS echo reconcile in `chatSlice.appendSlotMessage` overwrites `ts` with the server timestamp. `renderMessage` keys rows by `ts`, so the React key changes mid-stream → React unmounts/remounts the bubble → the fresh mount re-runs the framer-motion entrance (the `animatedSteers` guard misses because it registered the old client ts).
- **Change (3 layers):**
  1. `chatSlice.ts` — the reconcile stashes the optimistic ts as `meta.clientTs` before adopting the server ts (only when they differ; server ts still wins for display/deep-links).
  2. `ChatPage.tsx` — `renderMessage` keys rows on `meta.clientTs ?? ts`, so the key (and DOM node) stays stable across the reconcile — no remount, no replay.
  3. `UserMessage.tsx` — the `animatedSteers` one-shot guard also keys on `clientTs` first, so a later virtualization remount (scroll away and back) after the reconcile doesn't replay the entrance either.

## Tests
- `chatSlice.test.ts` (3 new): reconcile stashes `meta.clientTs` when the echo swaps in a differing server ts; no stash when the ts is identical (key already stable); no stash when the echo carries no ts (optimistic ts kept).
- `UserMessage.test.tsx` (1 new): remount with server ts + stashed `clientTs` does not re-render the ring-pulse overlay — locks the guard's stable identity.

Full gate: `tsc -b` clean, vitest 352 files / 3974 tests pass, eslint 0 errors on touched files.

## Manual verification
N/A — the reducer + key + guard behaviors are each unit-locked; the visible defect was a transient animation replay driven exactly by the key change the tests now prevent.

## Screenshots
N/A — no static visual change; the fix removes a transient (sub-second) animation replay that stills cannot capture. Rendered appearance of the steer bubble is unchanged.
