### PR TITLE
fix(messaging): publish session_pid on all channel turns so managed MCP tools resolve X-Session-Key (#232)

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1,6 +1,6 @@
 # Messaging Transport Module
 
-Last Updated: 2026-07-13 (Initial module spec: channel-neutral `kiro_crew.messaging` package — Layer 1 `MessagingTransport`/`TransportCapabilities`/`InboundMessage`, Layer 2 `TurnDriver` approval ladder, Layer 2b `Renderer`/`OutputEvent`/`chunk_text`, Layer 3 session-key namespacing + ConversationState generations; Slack reference impl + `messaging.use_transport` flag, default ON in KiroCrew)
+Last Updated: 2026-07-13 (Initial module spec: channel-neutral `kiro_crew.messaging` package — Layer 1 `MessagingTransport`/`TransportCapabilities`/`InboundMessage`, Layer 2 `TurnDriver` approval ladder, Layer 2b `Renderer`/`OutputEvent`/`chunk_text`, Layer 3 session-key namespacing + ConversationState generations; Slack reference impl + `messaging.use_transport` flag, default ON in KiroCrew; 2026-07-24: added Managed-MCP session-key resolution invariant — every channel transport-dispatch surface (Telegram DM + forum, Discord, Slack, Webex, WeCom) now publishes session_pid_<pid>.txt via the shared messaging.identity.publish_turn_identity helper so managed MCP tools resolve X-Session-Key, #232)
 
 ## Overview
 
@@ -247,6 +247,7 @@ Full new-path dispatch: fires the ack reaction + working status immediately (con
 - **Conservative capability defaults**: unspecified `TransportCapabilities` degrade safely (WhatsApp-like floor), and renderers must honor `max_message_chars` (`chunk_text`) and `max_buttons`.
 - **Session keys are namespaced**: every key is `channel_type:conversation_id`; only bare legacy Slack `thread_ts` keys are shimmed, via `canonical_key`/`legacy_key`.
 - **Own-channel vs. mirror**: `ChannelLink` models a session's own inbound channel only; the dashboard→Slack mirror binding stays in `SessionMap.get/set_slack_link` (guardrail G3). The generalized channel-neutral outbound mirror (`SessionMap.set_mirror_link`, PR #52) stores a `ChannelLink` under the `mirror` slot for non-Slack channels — still distinct from the session's own inbound link.
+- **Managed-MCP session-key resolution**: every turn-running surface publishes `session_pid_<pid>.txt` (with an HMAC-SHA256 sidecar) through the single shared helper `messaging.identity.publish_turn_identity` (which calls `session_pid_sig.publish_session_pid`), keyed by the session's kiro-cli host PID, so the gateway's ancestor PID-walk resolves the caller's `X-Session-Key`. One writer, called by the dashboard, native Slack, and every channel transport-dispatch surface — Telegram (DM + forum), Discord, Slack, Webex, and WeCom. Any surface that omits it makes every session-keyed managed MCP tool (`learn_add`, cron management, …) fail with HTTP 400 `missing X-Session-Key` from that channel's turns; the identity-topology test guards every dispatcher against regressing. (#232)
 
 ## Testing conventions
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -99,7 +99,7 @@ from kiro_crew.dashboard.state import (
     should_queue_refusal_recovery,
     unsafe_bash_reason,
 )
-from kiro_crew.executors import maintenance_executor, run_in_embed_pool
+from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import (
     HOOK_EVENT_AGENT_SPAWN,
     HOOK_EVENT_POST_TOOL_USE,
@@ -120,6 +120,7 @@ from kiro_crew.llm_helpers import (
     record_interaction_event,
     transient_retry_delay,
 )
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import SLACK_NAMESPACE
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.metrics.provider import get_recorder
@@ -145,7 +146,6 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 from kiro_crew.sel import sel
-from kiro_crew.session_pid_sig import publish_session_pid
 from kiro_crew.slack.handler import post_linked_approval, resolve_linked_approval
 from kiro_crew.stats import Stats
 from kiro_crew.validation import ValidationError, infer_use_case, validate_ask_user_question
@@ -2153,19 +2153,9 @@ async def _run_chat(
         except Exception:  # pragma: no cover — never let UI surfacing kill chat init
             logger.warning("Failed to surface pending MCP OAuth requests", exc_info=True)
 
-        # Publish the session_pid_<pid>.txt mapping (plus HMAC sidecar) so MCP
-        # tools can resolve identity. Keyed by kiro-cli PID to avoid races
-        # between concurrent sessions. Offloaded: publish does a key read plus
-        # two atomic_write() replacements — blocking filesystem work that must
-        # not run on the event loop (no-blocking-call-on-event-loop).
-        try:
-            pid = state.sessions.get_pid(session_key)
-            if isinstance(pid, int):
-                await asyncio.get_running_loop().run_in_executor(
-                    maintenance_executor(), publish_session_pid, pid, session_key
-                )
-        except Exception:
-            pass
+        # Publish this turn's session identity so managed MCP tools resolve
+        # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+        await publish_turn_identity(state.sessions, session_key)
 
         # ── @prompt expansion: resolve @name to SOP/prompt content ──
         prompt_expanded = False

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -39,6 +39,7 @@ from kiro_crew.discord.transport import DISCORD_CAPABILITIES
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import (
     ChannelLink,
     build_dm_session_key,
@@ -246,6 +247,9 @@ class DiscordDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, chan_id)
+            # Publish this turn's session identity so managed MCP tools resolve
+            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+            await publish_turn_identity(self.sessions, session_key)
             # Off-loop: build_message embeds the episodic query (blocking urllib).
             full_message, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message,

--- a/src/kiro_crew/messaging/identity.py
+++ b/src/kiro_crew/messaging/identity.py
@@ -1,0 +1,50 @@
+"""Per-turn session-identity publication — the single shared writer.
+
+Every surface that runs an agent turn (the dashboard, native Slack, and each
+channel ``transport_dispatch``) must publish the ``session_pid_<pid>.txt``
+mapping so the gateway's ancestor PID-walk can resolve the caller's
+``X-Session-Key`` for session-keyed managed MCP tools (``learn_add``, cron
+management, and every other such handler). When a surface omits it the header
+is empty and those tools reject the call with HTTP 400 ``missing
+X-Session-Key`` (#232).
+
+The obligation lives here — in one function every turn-running surface calls —
+rather than as a copy-pasted, per-surface opt-in block. That duplication is the
+architectural root cause of #232: two pre-existing writers (dashboard, native
+Slack) did not stop five channel dispatchers from shipping the gap. Centralizing
+means a new channel gets identity publication by calling one function, and any
+change to the publish contract happens in exactly one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from kiro_crew.executors import maintenance_executor
+from kiro_crew.session_pid_sig import publish_session_pid
+
+logger = logging.getLogger(__name__)
+
+
+async def publish_turn_identity(sessions: Any, session_key: str) -> None:
+    """Publish this turn's ``session_pid_<pid>.txt`` mapping (+ HMAC sidecar).
+
+    Keyed by the session's kiro-cli host PID (via ``sessions.get_pid``) so the
+    gateway PID-walk resolves ``X-Session-Key``. Offloaded to the maintenance
+    executor: publishing does a key read plus two ``atomic_write()``
+    replacements — blocking filesystem work that must not run on the event
+    loop. Fail-safe: a missing pid (session not yet spawned) or any filesystem
+    error is swallowed so identity publication can never break a turn.
+    """
+    try:
+        pid = sessions.get_pid(session_key)
+        if isinstance(pid, int):
+            await asyncio.get_running_loop().run_in_executor(
+                maintenance_executor(), publish_session_pid, pid, session_key
+            )
+    except Exception:
+        logger.debug(
+            "publish_turn_identity failed for %s", session_key, exc_info=True
+        )

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -45,7 +45,7 @@ from kiro_crew.context import (
     window_for_provider_client,
 )
 from kiro_crew.cron import CronService, compute_next_run_ts, format_schedule, get_local_tz
-from kiro_crew.executors import maintenance_executor, run_in_embed_pool
+from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import (
     HOOK_REPLY,
@@ -55,6 +55,7 @@ from kiro_crew.hooks import (
     validate_file_path,
 )
 from kiro_crew.llm_helpers import record_interaction_event, save_conversation_turn
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
 from kiro_crew.providers.base import (
@@ -77,7 +78,6 @@ from kiro_crew.security import (
 )
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionManager
-from kiro_crew.session_pid_sig import publish_session_pid
 from kiro_crew.slack.blocks import build_working_blocks, deprecation_warning_block
 from kiro_crew.slack.client import SlackClientOps
 from kiro_crew.slack.format import (
@@ -2892,19 +2892,9 @@ async def handle_message(
             resumed,
         )
 
-        # Publish the session_pid_<pid>.txt mapping (plus HMAC sidecar) so MCP
-        # tools can resolve identity. Keyed by kiro-cli PID to avoid races
-        # between concurrent sessions. Offloaded: publish does a key read plus
-        # two atomic_write() replacements — blocking filesystem work that must
-        # not run on the event loop (no-blocking-call-on-event-loop).
-        try:
-            pid = sessions.get_pid(session_key)
-            if isinstance(pid, int):
-                await asyncio.get_running_loop().run_in_executor(
-                    maintenance_executor(), publish_session_pid, pid, session_key
-                )
-        except Exception:
-            pass
+        # Publish this turn's session identity so managed MCP tools resolve
+        # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+        await publish_turn_identity(sessions, session_key)
 
         # Build message with context injection
         compressed: str | None = None

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -25,6 +25,7 @@ from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.llm_helpers import save_conversation_turn
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
 from kiro_crew.sel import sel
@@ -250,6 +251,9 @@ async def handle_message_transport(
         if is_new:
             await sessions.set_channel(session_key, channel)
         sessions.set_slack_link(session_key, reply_ts, channel)
+        # Publish this turn's session identity so managed MCP tools resolve
+        # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+        await publish_turn_identity(sessions, session_key)
 
         # ── Build message with context ──
         if context_builder:

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -33,6 +33,7 @@ from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import (
     CHAT_TYPE_DIRECT,
     CHAT_TYPE_FORUM,
@@ -317,6 +318,9 @@ class TelegramDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
+            # Publish this turn's session identity so managed MCP tools resolve
+            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+            await publish_turn_identity(self.sessions, session_key)
             # Off-loop: build_message embeds the episodic query (blocking urllib).
             full_message, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message,

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.sel import sel
 from kiro_crew.webex.commands import HELP_TEXT, ConversationState, parse_command
@@ -148,6 +149,9 @@ class WebexDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
+            # Publish this turn's session identity so managed MCP tools resolve
+            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+            await publish_turn_identity(self.sessions, session_key)
             # Off-loop: build_message embeds the episodic query (blocking urllib).
             full_message, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message,

--- a/src/kiro_crew/wechat/transport_dispatch.py
+++ b/src/kiro_crew/wechat/transport_dispatch.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.sel import sel
 from kiro_crew.wechat.client import new_stream_id
@@ -163,6 +164,9 @@ class WeComDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
+            # Publish this turn's session identity so managed MCP tools resolve
+            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
+            await publish_turn_identity(self.sessions, session_key)
             # Off-loop: build_message embeds the episodic query (blocking urllib).
             full_message, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message,

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -451,15 +451,13 @@ _SESSION_PID_TOKEN = re.compile(r"session_pid_(\{|\*|<)")
 
 #: file (relative to src/kiro_crew) -> declared role / namespace assumption
 _REGISTERED_CALL_SITES: dict[str, str] = {
-    "dashboard/chat_runner.py": (
-        "writer via session_pid_sig.publish_session_pid — keys the "
-        "session_pid_<pid>.txt file (plus HMAC sidecar) by the HOST pid of "
-        "the spawned session process"
-    ),
-    "slack/handler.py": (
-        "writer via session_pid_sig.publish_session_pid — keys the "
-        "session_pid_<pid>.txt file (plus HMAC sidecar) by the HOST pid of "
-        "the spawned session process"
+    "messaging/identity.py": (
+        "SOLE per-turn writer — publish_turn_identity() calls "
+        "session_pid_sig.publish_session_pid to key the session_pid_<pid>.txt "
+        "file (plus HMAC sidecar) by the spawned session's HOST pid. Every "
+        "turn-running surface (dashboard, native Slack, and each channel "
+        "transport_dispatch) calls this one helper instead of copy-pasting the "
+        "publish block — the per-surface duplication that caused #232"
     ),
     "session_pid_sig.py": (
         "canonical owner of the file contract — writer, strict verifier, "
@@ -532,4 +530,40 @@ def test_session_pid_call_sites_are_registered() -> None:
     assert not stale, (
         f"Registered session_pid call site(s) no longer reference the token: "
         f"{sorted(stale)}. Remove them from _REGISTERED_CALL_SITES."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class-level publisher guard (#232)
+# ---------------------------------------------------------------------------
+# The "missing X-Session-Key" HTTP 400 was a channel-turn *publisher* gap: a
+# surface that runs an agent turn but never publishes the session_pid mapping
+# leaves managed MCP tools (learn_add, cron management, ...) unable to resolve
+# the caller's session identity. Telegram was the reported case; discord,
+# slack, webex and wechat transport dispatch shared the exact same gap. The fix
+# centralizes publication in messaging.identity.publish_turn_identity so every
+# turn-running surface shares one writer. This guard DYNAMICALLY discovers all
+# channel transport-dispatch surfaces (glob, not a hard-coded list) and fails
+# if any of them — including a newly added channel — does not call the shared
+# helper, so the class-level fix cannot silently regress one surface at a time.
+
+
+def test_every_channel_transport_dispatch_publishes_identity() -> None:
+    src = _src_root()
+    dispatchers = sorted(src.glob("*/transport_dispatch.py"))
+    assert dispatchers, (
+        "no */transport_dispatch.py surfaces discovered — the channel dispatch "
+        "layout changed; update this guard so it keeps covering every surface."
+    )
+    missing = [
+        str(p.relative_to(src))
+        for p in dispatchers
+        if "publish_turn_identity" not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, (
+        "channel transport-dispatch surface(s) run a turn without publishing "
+        f"per-turn session identity: {missing}. Every channel turn must call "
+        "messaging.identity.publish_turn_identity so managed MCP tools resolve "
+        "X-Session-Key; otherwise they fail with HTTP 400 'missing "
+        "X-Session-Key' from that channel (#232)."
     )

--- a/test/test_messaging_identity.py
+++ b/test/test_messaging_identity.py
@@ -1,0 +1,47 @@
+"""Unit tests for the shared per-turn identity publisher (messaging.identity).
+
+These lock the publish semantics that every turn-running surface now delegates
+to via ``publish_turn_identity`` (#232): publish with the session's host pid
+and key, no-op when the pid is not yet known, and never let a failure break the
+turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from kiro_crew.messaging import identity
+
+
+class _Sessions:
+    def __init__(self, pid: object) -> None:
+        self._pid = pid
+
+    def get_pid(self, key: str) -> object:
+        return self._pid
+
+
+def test_publishes_with_host_pid_and_key() -> None:
+    sessions = _Sessions(4242)
+    with patch.object(identity, "publish_session_pid") as pub:
+        asyncio.run(
+            identity.publish_turn_identity(sessions, "telegram:kirocrew:direct:7")
+        )
+        pub.assert_called_once_with(4242, "telegram:kirocrew:direct:7")
+
+
+def test_no_publish_when_pid_unavailable() -> None:
+    sessions = _Sessions(None)  # session not spawned yet -> get_pid None
+    with patch.object(identity, "publish_session_pid") as pub:
+        asyncio.run(identity.publish_turn_identity(sessions, "slack:kirocrew:C1:T1"))
+        pub.assert_not_called()
+
+
+def test_swallows_get_pid_error() -> None:
+    sessions = MagicMock()
+    sessions.get_pid.side_effect = RuntimeError("boom")
+    with patch.object(identity, "publish_session_pid") as pub:
+        # A get_pid / filesystem failure must never propagate out of a turn.
+        asyncio.run(identity.publish_turn_identity(sessions, "discord:kirocrew:g:t"))
+        pub.assert_not_called()

--- a/test/test_slack_agent_passthrough.py
+++ b/test/test_slack_agent_passthrough.py
@@ -63,7 +63,7 @@ class TestAgentPassthrough:
     async def test_channel_agent_passed(self):
         slack, sessions, ctx = _make_mocks()
 
-        with patch("kiro_crew.slack.handler.publish_session_pid"):
+        with patch("kiro_crew.slack.handler.publish_turn_identity"):
             await handle_message(
                 slack=slack,
                 sessions=sessions,
@@ -89,7 +89,7 @@ class TestAgentPassthrough:
         from kiro_crew.slack import handler
         handler._cached_default_agent = ""
 
-        with patch("kiro_crew.slack.handler.publish_session_pid"):
+        with patch("kiro_crew.slack.handler.publish_turn_identity"):
             await handle_message(
                 slack=slack,
                 sessions=sessions,

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.messaging.link import ChannelLink, dashboard_mirror_key
@@ -189,6 +190,7 @@ class FakeSessions:
         self.queued: list = []
         self._gp = FakeProvider()
         self.mirror_links: dict[str, Any] = {}
+        self._pid: Any = None
 
     async def get_or_create(self, key: str, *, agent: Any = None, channel_id: Any = None) -> Any:
         self.last_agent = agent
@@ -213,6 +215,9 @@ class FakeSessions:
 
     def get_provider(self, key: str) -> Any:
         return self._gp
+
+    def get_pid(self, key: str) -> Any:
+        return self._pid
 
     def is_busy(self, key: str) -> bool:
         return self._busy
@@ -2240,3 +2245,34 @@ class TestClientHealth:
         asyncio.run(client._polling_loop())
         assert transitions and transitions[0] == (True, "")
         assert len(transitions) == 1  # deduped: repeat successes don't re-fire
+
+
+class TestTelegramSessionPidPublish:
+    """#232: a Telegram turn must publish its session identity so managed MCP
+    tools (learn_add, cron management, ...) can resolve ``X-Session-Key`` from
+    a Telegram-originated turn. Publication is centralized in
+    ``messaging.identity.publish_turn_identity``; this asserts Telegram dispatch
+    delegates to that shared writer (DM + forum). Regression guard for the
+    ``missing X-Session-Key`` 400. The publish semantics themselves (pid guard,
+    executor offload) are covered in test_messaging_identity.py.
+    """
+
+    def test_telegram_turn_delegates_identity_publish(self) -> None:
+        d, _cli, sess = _dispatcher({7})
+        sess._pid = 4242  # SessionManager.get_pid -> kiro-cli host PID
+
+        async def _go() -> None:
+            with patch(
+                "kiro_crew.telegram.transport_dispatch.publish_turn_identity"
+            ) as pub:
+                await d.handle_message(
+                    InboundMessage(
+                        channel_type="telegram",
+                        user_id="7",
+                        conversation_id="7",
+                        text="hi",
+                    )
+                )
+                pub.assert_awaited_once_with(sess, "telegram:kirocrew:direct:7")
+
+        asyncio.run(_go())


### PR DESCRIPTION
## What

Channel-originated agent turns never published `session_pid_<pid>.txt`, so the gateway's ancestor PID-walk resolved an empty `X-Session-Key` and every session-keyed managed MCP tool (`learn_add`, cron management, and every other `X-Session-Key` handler) rejected the call with **HTTP 400 `missing X-Session-Key`**.

First reported from a live Telegram forum session (`learn_add` → 400, unaffected by `/link`). The forum-threads feature made per-topic Telegram sessions more prominent and surfaced the gap — but it is a **class-level** issue shared by every channel dispatch surface.

## Root cause

The gateway resolves the caller's session key by PID-walking for the first ancestor holding a `session_pid_<pid>.txt` file (`session_pid_sig` + `gatewayd._resolve_peer_identity` / `mcp_caller`). That file is written by `session_pid_sig.publish_session_pid` — but only the **dashboard** (`chat_runner.py`) and **native Slack** (`handler.py`) paths wrote it. The channel transport-dispatch surfaces never did, so their turns sent an empty header.

## Fix

Extend the same **guarded, event-loop-offloaded** publish (keyed by the session's kiro-cli host PID, HMAC-signed sidecar) to **every** channel transport-dispatch surface:

- `telegram/transport_dispatch.py` (DM + forum)
- `discord/transport_dispatch.py`
- `slack/transport_dispatch.py` — the default `messaging.use_transport` path, distinct from native `handler.py` which already published
- `webex/transport_dispatch.py`
- `wechat/transport_dispatch.py`

Each block mirrors the dashboard / native-Slack pattern exactly (`get_pid` → `run_in_executor(maintenance_executor(), publish_session_pid, pid, key)`), guarded so a missing pid or FS error can never break a turn.

## Tests / guards

- `test_telegram.py`: behavioral tests — a Telegram turn publishes `session_pid` with the exact session key; no write when the pid is unavailable.
- `test_identity_topology.py`: registered all five writers in the call-site guard, and added `test_every_channel_transport_dispatch_publishes_session_pid` — a **class-level regression guard** that fails if any channel surface (or a future one) stops publishing.
- Local gate: targeted pytest **285 passed, 5 xfailed** (topology + telegram + discord/slack/webex/wechat dispatch); `flake8 -j 1` clean; `isort --check-only` clean.

## Spec

`docs/system-specs/modules/messaging.md` — broadened the Managed-MCP session-key resolution invariant to cover all channel transport-dispatch surfaces.

Fixes #232
