### PR TITLE
fix(session): self-heal stale native session lock at session/load (F2 load-recovery)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -267,6 +267,33 @@ parent snapshot + accumulated side history.
 - `close_all()`: saves all active mappings before killing processes.
 - `start_pool()`: prunes stale entries (files deleted by kiro-cli GC).
 
+### Load Recovery (stale native session lock — F2)
+
+On restart / Make-Live cutover the previous gateway's kiro-cli is killed. If it
+died uncleanly (SIGKILL, crash, OOM, or a drain timeout), its per-session lock
+can stay held briefly, so the new gateway's `session/load` is rejected with an
+**"active in another process"** error. Recovery happens at the resume
+chokepoint (`AcpProvider._load_session_with_retry`, `providers/acp.py`) and
+self-heals regardless of *why* the resume failed — it never depends on the dead
+holder cooperating (unlike cooperative drain), so it covers every kill mode:
+
+1. **Phase 1 — bounded retry (lossless).** Re-issue `session/load` up to
+   `_RESUME_MAX_ATTEMPTS` (4) times with exponential backoff
+   (`_RESUME_BACKOFF_BASE_S` → 1s, 2s, 4s). If the stale lock releases, the
+   session resumes with full native history. A genuine (non-lock) load error is
+   **not** retried, and a dead runtime aborts the loop immediately (the caller's
+   respawn path takes over).
+2. **Phase 2 — fresh session + history replay (backstop).** If the lock never
+   clears, `_start_kiro_runtime_impl` falls through to a fresh `session/new` and
+   sets `AcpProvider._history_replay_needed`. `get_or_create` reads that flag and
+   sets `_Session.provider_switch_replay = True`, so `build_session_replay`
+   injects KiroCrew's `conversation_log` into the new native session on the first
+   prompt (the same replay path used for cross-provider switches). The slot
+   resumes seamlessly instead of returning empty completions.
+
+Observability: a successful Phase-1 recovery logs at INFO; exhausting all
+attempts logs a single grep-able WARNING before migrating to Phase 2.
+
 ### Cross-Provider Continuity
 
 kiro session IDs and the removed provider's session IDs are NOT interchangeable:

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -18,6 +18,7 @@ from kiro_crew.acp.client import (
     AcpError,
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
+from kiro_crew.acp.session_handle import AcpSessionHandle
 from kiro_crew.acp.session_provider import AcpSessionProvider
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
@@ -208,6 +209,16 @@ def _read_cli_overlay(work_dir: Path) -> dict[str, str]:
     return out
 
 
+# ── F2 load-recovery: session/load retry past a stale native session lock ──
+# A kiro-cli holder killed uncleanly (SIGKILL, crash, OOM, or a gateway-restart
+# drain timeout) can leave its per-session lock held briefly. Re-issuing
+# session/load a few times with exponential backoff lets the stale lock release
+# so the new gateway resumes LOSSLESSLY. If the lock never clears we fall back
+# to a fresh session + KiroCrew history replay (see _start_kiro_runtime_impl).
+_RESUME_MAX_ATTEMPTS = 4  # total session/load attempts before fresh fallback
+_RESUME_BACKOFF_BASE_S = 1.0  # backoff = base * 2**attempt → 1s, 2s, 4s between attempts
+
+
 class AcpProvider(LLMProvider):
     """LLMProvider backed by ACP JSON-RPC over stdio (kiro-cli or claude-agent-acp)."""
 
@@ -248,6 +259,12 @@ class AcpProvider(LLMProvider):
         if agent:
             kwargs["agent"] = agent
         self._client = AcpClient(**kwargs)
+        # F2 load-recovery: set True by _start_kiro_runtime_impl when a resume
+        # falls back to a FRESH native session (the prior session's lock never
+        # cleared). Signals SessionManager.get_or_create to replay KiroCrew's
+        # conversation_log into the fresh session on the first prompt so the slot
+        # is not context-free.
+        self._history_replay_needed: bool = False
         # Terminal compaction status captured by compact() while draining its
         # prompt turn; consumed by wait_for_compaction() (see compact()).
         self._compact_result: dict | None = None
@@ -356,6 +373,85 @@ class AcpProvider(LLMProvider):
         except Exception:  # never let telemetry break session startup
             logger.debug("kiro startup metric emit failed", exc_info=True)
 
+    async def _load_session_with_retry(
+        self,
+        runtime: AcpRuntime,
+        session_file: str,
+        resume_sid: str,
+        work_dir: str | Path | None,
+        agent: str | None,
+    ) -> AcpSessionHandle | None:
+        """Resume via session/load, retrying past a stale native session lock.
+
+        F2 load-recovery (Phase 1). A kiro-cli holder killed uncleanly can leave
+        its per-session lock held for a short window; re-issuing session/load a
+        few times with exponential backoff lets the stale lock release so we
+        resume LOSSLESSLY (full native history). Outcomes:
+
+        * load succeeds            → return the handle (fast path: no sleep).
+        * "active in another        → retry up to ``_RESUME_MAX_ATTEMPTS`` with
+          process" lock held         backoff; return the handle if it clears.
+        * lock never clears        → return ``None`` (caller falls back to a
+                                       fresh session + history replay — Phase 2).
+        * any OTHER load error     → return ``None`` immediately (retrying a
+                                       genuine failure only wastes time).
+        * runtime dies mid-retry   → return ``None`` (caller's respawn handles it).
+        """
+        for attempt in range(_RESUME_MAX_ATTEMPTS):
+            try:
+                handle = await runtime.load_session(
+                    session_file,
+                    resume_sid,
+                    cwd=work_dir,
+                    agent=agent or None,
+                )
+                if attempt:
+                    logger.info(
+                        "Resume of kiro session %s recovered on attempt %d/%d "
+                        "(stale lock released)",
+                        resume_sid,
+                        attempt + 1,
+                        _RESUME_MAX_ATTEMPTS,
+                    )
+                return handle
+            except Exception as exc:
+                if "active in another process" not in str(exc).lower():
+                    # Genuine load failure — will not clear with time.
+                    logger.warning(
+                        "Failed to resume session %s, starting fresh",
+                        resume_sid,
+                        exc_info=True,
+                    )
+                    return None
+                if not runtime.is_alive():
+                    logger.warning(
+                        "Runtime died while retrying resume of session %s; starting fresh",
+                        resume_sid,
+                    )
+                    return None
+                if attempt + 1 < _RESUME_MAX_ATTEMPTS:
+                    backoff = _RESUME_BACKOFF_BASE_S * (2**attempt)
+                    logger.info(
+                        "Resume of kiro session %s refused (lock active in "
+                        "another process); retry %d/%d in %.1fs",
+                        resume_sid,
+                        attempt + 1,
+                        _RESUME_MAX_ATTEMPTS,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+        # Exhausted every attempt on a persistent lock. Loud, grep-able marker;
+        # the caller migrates to a fresh session with KiroCrew history replay.
+        logger.warning(
+            "Resume of kiro session %s failed after %d attempts (lock still "
+            "active in another process — a stale lock from an uncleanly-killed "
+            "holder, or a rare same-gateway session-key alias miss); migrating "
+            "to a fresh session with KiroCrew history replay",
+            resume_sid,
+            _RESUME_MAX_ATTEMPTS,
+        )
+        return None
+
     async def _start_kiro_runtime_impl(self, phases: dict[str, float]) -> None:
         """Spawn an AcpRuntime and replace self._client with AcpSessionProvider.
 
@@ -429,38 +525,23 @@ class AcpProvider(LLMProvider):
             if resume_sid:
                 session_file = Path.home() / ".kiro" / "sessions" / "cli" / f"{resume_sid}.json"
                 if session_file.exists():
-                    try:
-                        handle = await runtime.load_session(
-                            str(session_file),
-                            resume_sid,
-                            cwd=work_dir,
-                            agent=agent or None,
-                        )
-                        resumed = True
-                    except Exception as exc:
-                        if "active in another process" in str(exc).lower():
-                            # A live provider for this kiro session exists in
-                            # THIS gateway, addressed under a different session
-                            # key (bare vs canonical ``slack:<ts>`` alias).
-                            # Starting fresh silently splits the thread into a
-                            # context-free duplicate. The alias fold in
-                            # SessionManager.get_or_create should make this
-                            # unreachable — loud, grep-able marker so any
-                            # recurrence is visible.
-                            logger.error(
-                                "Resume refused: kiro session %s is active in "
-                                "another process — likely a session-key alias "
-                                "miss (bare vs slack:<ts>); starting fresh "
-                                "orphans the live session's native history",
-                                resume_sid,
-                            )
-                        else:
-                            logger.warning(
-                                "Failed to resume session %s, starting fresh",
-                                resume_sid,
-                                exc_info=True,
-                            )
-                        handle = None
+                    # F2 load-recovery: retry past a stale "active in another
+                    # process" lock (Phase 1); on persistent failure fall through
+                    # to a fresh session/new below WITH KiroCrew history replay
+                    # (Phase 2, self._history_replay_needed). This self-heals
+                    # regardless of WHY the resume failed (SIGKILL'd holder,
+                    # crash, OOM, drain timeout) — it never depends on the dead
+                    # holder cooperating.
+                    handle = await self._load_session_with_retry(
+                        runtime,
+                        str(session_file),
+                        resume_sid,
+                        work_dir,
+                        agent,
+                    )
+                    resumed = handle is not None
+                    if handle is None:
+                        self._history_replay_needed = True
                 else:
                     logger.info("Session file missing for %s, skipping load", resume_sid)
 

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -2120,7 +2120,13 @@ class SessionManager:
                         approval_policy=approval_policy,
                         agent=agent or "",
                     )
-                    if _provider_switched:
+                    if _provider_switched or (
+                        getattr(provider, "_history_replay_needed", False) is True
+                    ):
+                        # provider_switch_replay OR F2 load-recovery fell back to
+                        # a fresh native session (stale lock never cleared):
+                        # replay KiroCrew's conversation_log into the new session
+                        # on the first prompt so the slot isn't context-free.
                         sess.provider_switch_replay = True
                     self._sessions[key] = sess
                     logger.info(

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -759,3 +759,84 @@ class TestFixBDeadRuntimeRespawn:
         # create_session called on the NEW runtime (not the dead one)
         new_runtime.create_session.assert_awaited_once()
         dead_runtime.create_session.assert_not_called()
+
+
+class TestLoadSessionWithRetry:
+    """F2 load-recovery Phase 1: ``_load_session_with_retry`` retries past a
+    stale 'active in another process' lock, and returns None (caller falls back
+    to a fresh session + history replay) on a persistent lock, a non-lock load
+    error, or a dead runtime."""
+
+    @staticmethod
+    def _runtime(load_session, *, alive: bool = True) -> MagicMock:
+        rt = MagicMock()
+        rt.is_alive.return_value = alive
+        rt.load_session = load_session
+        return rt
+
+    @pytest.mark.asyncio
+    async def test_fast_path_success_no_retry(self):
+        provider = _build_provider(backend="")
+        handle = object()
+        rt = self._runtime(AsyncMock(return_value=handle))
+        with patch("kiro_crew.providers.acp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            got = await provider._load_session_with_retry(rt, "/s.json", "sid", None, None)
+        assert got is handle
+        assert rt.load_session.await_count == 1
+        assert sleep_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_recovers_after_stale_lock_releases(self):
+        provider = _build_provider(backend="")
+        handle = object()
+        rt = self._runtime(
+            AsyncMock(
+                side_effect=[
+                    RuntimeError("kiro session sid is active in another process"),
+                    RuntimeError("kiro session sid is active in another process"),
+                    handle,
+                ]
+            )
+        )
+        with patch("kiro_crew.providers.acp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            got = await provider._load_session_with_retry(rt, "/s.json", "sid", None, None)
+        assert got is handle
+        assert rt.load_session.await_count == 3
+        assert sleep_mock.await_count == 2  # backoff before attempts 2 and 3
+
+    @pytest.mark.asyncio
+    async def test_persistent_lock_exhausts_and_falls_back(self):
+        from kiro_crew.providers.acp import _RESUME_MAX_ATTEMPTS
+
+        provider = _build_provider(backend="")
+        rt = self._runtime(
+            AsyncMock(side_effect=RuntimeError("session is active in another process"))
+        )
+        with patch("kiro_crew.providers.acp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            got = await provider._load_session_with_retry(rt, "/s.json", "sid", None, None)
+        assert got is None
+        assert rt.load_session.await_count == _RESUME_MAX_ATTEMPTS
+        assert sleep_mock.await_count == _RESUME_MAX_ATTEMPTS - 1
+
+    @pytest.mark.asyncio
+    async def test_non_lock_error_does_not_retry(self):
+        provider = _build_provider(backend="")
+        rt = self._runtime(AsyncMock(side_effect=RuntimeError("session/load parse error")))
+        with patch("kiro_crew.providers.acp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            got = await provider._load_session_with_retry(rt, "/s.json", "sid", None, None)
+        assert got is None
+        assert rt.load_session.await_count == 1  # a genuine failure is not retried
+        assert sleep_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_dead_runtime_stops_retry(self):
+        provider = _build_provider(backend="")
+        rt = self._runtime(
+            AsyncMock(side_effect=RuntimeError("active in another process")),
+            alive=False,
+        )
+        with patch("kiro_crew.providers.acp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            got = await provider._load_session_with_retry(rt, "/s.json", "sid", None, None)
+        assert got is None
+        assert rt.load_session.await_count == 1  # bail as soon as the runtime is dead
+        assert sleep_mock.await_count == 0

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -3512,3 +3512,39 @@ class TestOpenTaskSession:
         mgr.release(key)
         await mgr.release_subagent_runtime(parent)
         await mgr.close_all()
+
+
+class TestLoadRecoveryHistoryReplay:
+    """F2 load-recovery Phase 2: when a provider signals it fell back to a FRESH
+    native session (the prior session's lock never cleared), get_or_create flags
+    the new slot for KiroCrew conversation_log replay on the first prompt so the
+    slot is not context-free."""
+
+    @staticmethod
+    def _factory(history_replay_needed: bool):
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+            m._history_replay_needed = history_replay_needed
+            return m
+
+        return factory
+
+    @pytest.mark.asyncio
+    async def test_fresh_fallback_triggers_history_replay(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=self._factory(True))
+        _provider, is_new, _resumed = await mgr.get_or_create("thread1")
+        assert is_new is True
+        sess = next(iter(mgr._sessions.values()))
+        assert sess.provider_switch_replay is True
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_native_resume_does_not_trigger_replay(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=self._factory(False))
+        await mgr.get_or_create("thread1")
+        sess = next(iter(mgr._sessions.values()))
+        assert sess.provider_switch_replay is False
+        await mgr.close_all()


### PR DESCRIPTION
## Summary

Root fix for #200 (Make Live cutover → empty responses). Self-heals a stale
kiro-cli native session lock at `session/load` time, **independent of how the
previous gateway's process died** — so it covers SIGKILL / crash / OOM / drain
timeout, not just graceful restarts.

Closes #261.

## Problem

On restart / Make Live cutover the previous gateway's kiro-cli is killed. An
unclean death can leave its per-session lock held briefly, so the new gateway's
`session/load` is rejected with **"active in another process"**. Today that
rejection falls straight through to a fresh `session/new` with **no retry and no
history** → empty completions / context-free resume until the lock clears.

## Fix

`AcpProvider._load_session_with_retry` (`providers/acp.py`):

- **Phase 1 — bounded retry (lossless):** re-issue `session/load` up to
  `_RESUME_MAX_ATTEMPTS` (4) with exponential backoff (1s, 2s, 4s). If the stale
  lock releases, the session resumes with full native history. Non-lock load
  errors and a dead runtime are **not** retried.
- **Phase 2 — fresh session + history replay (backstop):** on persistent
  failure, fall back to a fresh `session/new` and set
  `AcpProvider._history_replay_needed`; `SessionManager.get_or_create` flags
  `_Session.provider_switch_replay` so `build_session_replay` injects KiroCrew's
  `conversation_log` into the new session on the first prompt (reuses the
  cross-provider replay path).

Covers **all** kill modes at one central point — unlike cooperative drain
(#207), which only mitigates graceful restarts and must be wired per
dispatch-surface. This also architecturally covers #207's residual
dispatch-race window: a turn opened after the drain snapshot and killed
mid-flight self-heals when the next gateway loads that session.

## Tests

- `TestLoadSessionWithRetry` — fast-path (no retry), recover-on-retry,
  exhaust→fallback, non-lock-error→no-retry, dead-runtime→bail.
- `TestLoadRecoveryHistoryReplay` — Phase-2 flag → `provider_switch_replay`;
  native resume does not trigger replay.

## Local gate

isort ✓ · flake8 -j1 ✓ · mypy (changed src) ✓ · targeted pytest 7 passed. Full
suites run in CI shards.

## Spec

`docs/system-specs/modules/session.md` — new **Load Recovery** section.

## Companion

- Root fix for #200.
- Companion to #207 (cooperative drain — best-effort on interactive paths).
