### PR TITLE
feat(autonudge): session-managed babysit loops for dashboard, Slack, and Discord

### DIFF
--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: babysit
+description: Same-session monitoring loop for PRs, CI runs, tickets, and deployments using the monitor_start / autonudge_stop MCP tools. The loop re-injects your check instructions into THIS session on an idle interval — same context, same tools — and works from dashboard chat, Slack threads, and Discord DMs. Use when the user says "babysit", "monitor", "keep checking", "keep an eye on", "loop on this PR", "let me know when", or wants polling that outlives a wait+poll window. NOT for fresh-session work (use cron_add) or external-system callbacks (use register_hook).
+tags: [skill, kirocrew, monitor, babysit, autonudge, loop]
+---
+
+# Babysit (same-session monitoring loop)
+
+## Overview
+
+`monitor_start(message, interval_secs?, max_cycles?)` binds a monitoring loop
+to **your current session**. After each of your turns completes and the
+session sits idle for `interval_secs`, the message is re-injected as your
+next turn. You keep the full conversation context, memory, and tools on every
+cycle. Loops persist to `~/.kirocrew/autonudge.json` and survive gateway
+restarts.
+
+Works from:
+
+| Surface | Binding | Cadence |
+|---|---|---|
+| Dashboard chat | bare slot key | idle timer (re-armed after every turn) |
+| Slack thread | `slack:<thread_ts>` | fixed interval after each unattended turn |
+| Discord DM | `discord:{agent}:direct:{user}` | fixed interval after each unattended turn |
+
+`autonudge_stop(reason?)` stops the loop bound to the current session from
+any of those surfaces.
+
+## Decision table
+
+- User is waiting and total time < 30 min → `wait` + poll, no loop.
+- "Babysit / monitor / keep checking" in THIS conversation → `monitor_start`.
+- Work belongs in a fresh isolated session each cycle → `cron_add`.
+- External system will call back → `register_hook`.
+- Non-session context (cron/webhook) needs monitoring → HEARTBEAT.md task.
+
+## Workflow
+
+1. **Write the message as instructions to your future self.** Include:
+   - what to check (PR URL, job id, ticket),
+   - what to do with findings (fix + push, summarize, escalate),
+   - the exit condition, ending with: "when met, tell the user and call
+     `autonudge_stop`".
+2. **Call `monitor_start`.** `interval_secs` default 300 suits CI/review
+   polling; use `max_cycles` as a safety cap when the task has a natural
+   bound (e.g. 20 cycles ≈ 100 min at 300s).
+3. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
+   you — do not wait+poll on top of it.
+4. **Each cycle:** do the check, act, and report only real signals. Don't
+   post "nothing new" every cycle.
+5. **On the exit condition** (or the user saying stop): report, then call
+   `autonudge_stop` with a reason.
+
+## Example
+
+User: "babysit PR #247 until it's review-ready"
+
+```
+monitor_start(
+  message="Check PR #247: CI checks and review-bot comments. Fix legitimate
+           High/Medium findings and push (single commit, force-with-lease).
+           Rebut false positives. When all checks are green and every thread
+           is resolved, tell the user the PR is review-ready and call
+           autonudge_stop.",
+  interval_secs=300,
+  max_cycles=20,
+)
+```
+
+## Rules & gotchas
+
+- **One loop per session** — a new `monitor_start` replaces the existing loop.
+- **Busy sessions skip a cycle** (never queue) — a long-running turn delays
+  the next check to the following interval; skipped cycles don't count
+  toward `max_cycles`.
+- **Unattended turns are bounded to 30 min** on Slack/Discord; keep each
+  cycle's work small and incremental.
+- **Slack/Discord loops auto-approve tools** on the unattended turn
+  (Slack always; Discord follows the gateway approval mode — under
+  interactive approval a Discord cycle cannot use tools, so prefer
+  dashboard/Slack for tool-heavy babysitting or run the gateway with
+  `--approval yolo`/`auto`).
+- **Kill switches:** `autonudge_stop` (preferred), the dashboard 🎯 popover
+  (dashboard loops), `max_cycles`, or the per-loop STOP sentinel file.
+- Loops fire `[auto-nudge cycle N]`-tagged messages — treat them as your own
+  scheduled wake-ups, not user input.

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -51,6 +51,19 @@ _REARM_BACKOFF_MAX_SHIFT = 16  # clamp the 2**shift exponent
 # Sentinel file per loop: creating it halts the loop on next cycle.
 STOP_SENTINEL = "STOP"
 
+# Namespaced session-key prefixes that identify messaging-channel sessions
+# (as opposed to bare dashboard chat-slot keys). Channel-bound loops have no
+# dashboard turn-lifecycle hooks (notify_turn_complete / notify_user_input),
+# so they run on a fixed interval instead of an idle timer: the timer re-arms
+# itself right after every delivered fire.
+_CHANNEL_KEY_PREFIXES = ("slack:", "discord:", "telegram:", "whatsapp:", "unified:")
+
+
+def is_channel_key(key: str) -> bool:
+    """True when *key* names a messaging-channel session (``slack:<ts>``,
+    ``discord:{agent}:direct:{user}`` ...) rather than a dashboard chat slot."""
+    return key.startswith(_CHANNEL_KEY_PREFIXES)
+
 
 def enabled() -> bool:
     """Feature flag — on by default. Set ``KIROCREW_AUTONUDGE=0`` to disable."""
@@ -69,7 +82,14 @@ def get_instance() -> "AutoNudgeService | None":
 
 @dataclass
 class NudgeLoop:
-    """A single auto-nudge loop bound to one slot."""
+    """A single auto-nudge loop bound to one session.
+
+    ``slot_key`` is the binding key: either a bare dashboard chat-slot key
+    (e.g. ``chat-1-1721...``, idle-timer driven via notify_turn_complete) or a
+    namespaced messaging-channel session key (e.g. ``slack:<thread_ts>``,
+    ``discord:{agent}:direct:{user_id}``), which runs on a fixed interval.
+    The field keeps its historical name for store/REST/WS compatibility.
+    """
 
     id: str
     slot_key: str
@@ -376,3 +396,11 @@ class AutoNudgeService:
         loop.last_fire_ts = time.time()
         self._save()
         self._emit("fired", loop)
+        # Channel-bound loops (Slack/Discord/...) have no dashboard
+        # turn-lifecycle hook to re-arm them (notify_turn_complete never fires
+        # for these keys), so they self-re-arm on a fixed interval. The fire
+        # callback runs the turn inline, so the next fire lands idle_secs
+        # after the previous turn finished; the busy-skip + backoff above
+        # handles any overlap.
+        if is_channel_key(loop.slot_key) and loop.active and loop.id in self._loops:
+            self._arm_timer(loop)

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -95,33 +95,24 @@ When the user asks you to submit code for review and address automated comments 
 5. If no comments or only false positives: report done to the user
 6. Stop the loop and report remaining issues to the user if EITHER: you've iterated 3+ times without the comment count decreasing, OR you've completed 5 total iterations.
 
-**Long task or "keep an eye on it":** use Heartbeat.
+**Long task or "keep an eye on it" / "babysit" / "monitor":** use `monitor_start`.
 
-Heartbeat is a self-cleaning task queue that runs every few minutes, survives gateway restarts, and handles multiple tasks in parallel. Tasks are automatically removed once complete — no manual cleanup needed.
+`monitor_start(message, interval_secs?, max_cycles?)` starts a monitoring loop on YOUR CURRENT session — after your turn completes and the session idles for `interval_secs`, the message is re-injected as your next turn (same context, same tools, same conversation). Works from dashboard chat, Slack threads, and Discord DMs, and survives gateway restarts.
 
-**When to use heartbeat:**
-- User says "keep checking", "monitor", "let me know when"
-- Task may take longer than 30 minutes
+**When to use monitor_start:**
+- User says "keep checking", "monitor", "babysit", "let me know when"
+- Task may take longer than 30 minutes (beyond wait+poll territory)
 - You need to poll an external system until a condition is met (CR analysis, deployment, ticket resolution)
 
-**Writing a heartbeat task:**
-1. Write a checklist entry to `~/.kirocrew/workspace/HEARTBEAT.md`:
-   `- [ ] Check CR-XXXXX for new reviewer comments. If found, summarize them and respond with HEARTBEAT_KEEP. If none and nothing is owed, complete silently (no notification). <!-- deliver:dashboard -->`
+**Using monitor_start:**
+1. Put the full check instructions AND the exit condition in the message, e.g.: `Check PR #123 for new CI results and review comments. Fix legitimate findings and push. When the PR is review-ready (checks green, threads resolved), tell the user and call autonudge_stop.`
+2. Call `monitor_start` with a sensible interval (300s for CI/review polling), then tell the user monitoring is active and END YOUR TURN — the loop wakes you.
+3. Each cycle: do the check, act on findings, report only real signals (don't post "nothing new" every cycle).
+4. When the exit condition is met or the user says stop, call `autonudge_stop`. Set `max_cycles` as a safety cap when the task has a natural bound.
 
-   Notify only on a real signal (a failure, a blocked CR, an item needing action). For a routine "nothing to do" completion, keep the response minimal — do not post a "passed ✅" status. Append `<!-- deliver:dashboard -->` to route the completion to the dashboard bell only (no Slack DM); omit the tag to use the `heartbeat.default_deliver` config default (`slack`), or use `<!-- deliver:slack -->` to force a Slack DM for something genuinely urgent.
-2. Tell the user it's been added to heartbeat monitoring
-3. End the session — heartbeat re-processes retained tasks on the next cycle, creating a monitor-until-done loop
+One loop per session — starting a new one replaces the old. The user can also stop dashboard loops from the 🎯 popover.
 
-**Task retention (HEARTBEAT_KEEP):**
-When the heartbeat service executes your task, it checks your response to decide whether to keep or remove it:
-- Task complete → omit `HEARTBEAT_KEEP` → task is removed from the file
-- Task incomplete → include `HEARTBEAT_KEEP` in your response → task is retained for the next cycle
-- Task raises an exception → task is retained automatically
-
-Example response for an incomplete task:
-```
-Ticket TT-123 is still in "Assigned" status. Will check again next cycle. HEARTBEAT_KEEP
-```
+**Heartbeat (fallback):** the `~/.kirocrew/workspace/HEARTBEAT.md` task queue still exists for cases monitor_start can't cover: work that should run OUTSIDE this session (fresh context each cycle), or contexts where monitor_start is unavailable (cron/webhook sessions). Tasks are checklist entries processed every few minutes; include `HEARTBEAT_KEEP` in the response to retain a task for the next cycle, omit it when complete. Route completion with `<!-- deliver:dashboard -->` / `<!-- deliver:slack -->` tags. Notify only on real signals.
 
 ### Webhook-Triggered Sessions
 

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -10,6 +10,7 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew.autonudge import get_instance as _autonudge_get
+from kiro_crew.autonudge import is_channel_key
 from kiro_crew.config.loader import workspace_dir_for
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import is_sensitive_path
@@ -67,11 +68,58 @@ async def api_autonudge_start(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
-    slot_key = (body.get("slot_key") or "").strip()
+    slot_key = (body.get("session_key") or body.get("slot_key") or "").strip()
     message = (body.get("message") or "").strip()
     if not slot_key or not message:
-        return web.json_response({"error": "slot_key and message required"}, status=400)
-    if slot_key not in state._slots:
+        return web.json_response({"error": "session_key (or slot_key) and message required"}, status=400)
+    if is_channel_key(slot_key):
+        # Channel-bound loop (Slack / Discord ...). Validate the session is
+        # routable so a nudge fired later has somewhere to reply.
+        if slot_key.startswith("slack:"):
+            sessions = getattr(state, "sessions", None)
+            if sessions is None or not sessions.get_channel(slot_key):
+                return web.json_response(
+                    {"error": f"unknown slack session {slot_key}"}, status=404
+                )
+        elif slot_key.startswith("discord:"):
+            # Deny-by-default (mirrors the Discord inbound allowlist): only DM
+            # sessions of ALLOWLISTED users, and only the user's CURRENT
+            # session key exactly as the dispatcher derives it. Anything else
+            # would let an authenticated dashboard caller mint loops that DM
+            # arbitrary Discord users through the agent.
+            transports = getattr(state, "channel_transports", None) or {}
+            transport = transports.get("discord")
+            dispatcher = transport.dispatcher if transport is not None else None
+            if transport is None or dispatcher is None:
+                return web.json_response(
+                    {"error": "discord transport not running"}, status=404
+                )
+            parts = slot_key.split(":")
+            if len(parts) < 4 or parts[2] != "direct":
+                return web.json_response(
+                    {"error": f"unsupported discord session {slot_key} (DM sessions only)"},
+                    status=400,
+                )
+            user_id = parts[3]
+            if not dispatcher.is_authorized(user_id):
+                return web.json_response(
+                    {"error": "discord user is not in the allowed_user_ids allowlist"},
+                    status=403,
+                )
+            try:
+                current_key = dispatcher.current_session_key(user_id)
+            except Exception:
+                current_key = ""
+            if slot_key != current_key:
+                return web.json_response(
+                    {"error": "discord session key does not match the user's current session"},
+                    status=404,
+                )
+        else:
+            return web.json_response(
+                {"error": f"unsupported channel session {slot_key}"}, status=400
+            )
+    elif slot_key not in state._slots:
         return web.json_response({"error": f"unknown slot {slot_key}"}, status=404)
     if len(message) > 8000:
         return web.json_response({"error": "message too long (max 8000 chars)"}, status=400)
@@ -80,12 +128,16 @@ async def api_autonudge_start(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "stop_sentinel_path points to a sensitive location"}, status=400
         )
-    # Auto-default: per-slot sentinel so multiple loops don't clash
+    # Auto-default: per-session sentinel so multiple loops don't clash
     if not stop_sentinel_path:
-        slot = state._slots.get(slot_key)
-        if slot:
-            stop_sentinel_path = resolve_stop_sentinel(slot_key, getattr(slot, "workspace", "default"))
+        if is_channel_key(slot_key):
+            stop_sentinel_path = resolve_stop_sentinel(slot_key)
             Path(stop_sentinel_path).unlink(missing_ok=True)
+        else:
+            slot = state._slots.get(slot_key)
+            if slot:
+                stop_sentinel_path = resolve_stop_sentinel(slot_key, getattr(slot, "workspace", "default"))
+                Path(stop_sentinel_path).unlink(missing_ok=True)
     loop = await svc.add(
         slot_key=slot_key,
         message=message,

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -91,6 +91,21 @@ class DiscordTransport(MessagingTransport):
         """The underlying Gateway/REST client (held + exposed, not hidden)."""
         return self._client
 
+    @property
+    def dispatcher(self) -> Any:
+        """The ``DiscordDispatcher`` whose bound ``handle_message`` was wired
+        as ``dispatch``, or ``None`` when unwired (tests) or wired to a plain
+        function.
+
+        Public surface for out-of-band injectors (AutoNudge fire path, the
+        REST loop-create endpoint): they need the dispatcher's authorization
+        and session-key contract (``is_authorized`` / ``current_session_key``
+        / ``handle_message``), and this property is the one sanctioned way to
+        reach it — reaching into ``_dispatch`` from outside this class is a
+        rename-away from silently killing active loops.
+        """
+        return getattr(self._dispatch, "__self__", None)
+
     # -- Tier-1 core --------------------------------------------------------
     async def send_message(
         self, conversation_id: str, content: str, thread_id: str | None = None

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -566,6 +566,21 @@ class DiscordDispatcher:
             )
             await self.handle_message(synthetic)
 
+    # ── Public injection surface ────────────────────────────────────────────
+    # Contract for out-of-band callers (AutoNudge fire path, the REST create
+    # endpoint, future channel injectors): synthetic turns bypass
+    # transport.receive, so authorization and session-key derivation MUST go
+    # through these methods — renaming the private helpers behind them breaks
+    # loudly here instead of silently at fire time.
+
+    def is_authorized(self, user_id: str) -> bool:
+        """Deny-by-default allowlist check for out-of-band (synthetic) turns."""
+        return self._authorized(user_id)
+
+    def current_session_key(self, user_id: str) -> str:
+        """The user's CURRENT DM session key (dm_scope + ``!new`` generation)."""
+        return self._session_key(user_id)
+
     # ── Helpers ────────────────────────────────────────────────────────────
 
     def _authorized(self, user_id: str) -> bool:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -33,7 +33,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 from kiro_crew import platform_compat
 from kiro_crew.aim_agents import list_agents
@@ -94,6 +94,7 @@ from kiro_crew.validation import (
     MAX_MEDIUM_STRING,
     MAX_SHORT_STRING,
     MCP_CORE_SCHEMAS,
+    MONITOR_START_SCHEMA,
     REGISTER_HOOK_SCHEMA,
     SEARCH_CHAT_HISTORY_SCHEMA,
     SET_PROJECT_SCHEMA,
@@ -1199,6 +1200,48 @@ def _list_tools() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "monitor_start",
+            "description": (
+                "Start a monitoring loop on YOUR CURRENT session: after each of "
+                "your turns completes and the session sits idle for "
+                "interval_secs, the given message is re-injected into this same "
+                "session as your next turn — same context, same tools, same "
+                "conversation. Works from dashboard chat, Slack threads, and "
+                "Discord DMs. Use when the user asks to babysit / monitor / "
+                "keep checking something (a PR, CI run, ticket, deployment): "
+                "put the check instructions and the exit condition in the "
+                "message, then END YOUR TURN — the loop wakes you on the "
+                "interval. When the exit condition is met (or the user says "
+                "stop), call autonudge_stop. One loop per session; starting a "
+                "new one replaces the old. Survives gateway restarts."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": (
+                            "The recurring instruction to re-inject each cycle, "
+                            "including what to check and when to stop (max 8000 chars)"
+                        ),
+                    },
+                    "interval_secs": {
+                        "type": "integer",
+                        "description": (
+                            "Idle seconds between cycles (15-86400, default 300)"
+                        ),
+                    },
+                    "max_cycles": {
+                        "type": "integer",
+                        "description": (
+                            "Safety cap on delivered cycles; 0 = unlimited (default 0)"
+                        ),
+                    },
+                },
+                "required": ["message"],
+            },
+        },
+        {
             "name": "local_knowledge_search",
             "description": (
                 "Search the user's knowledge library. Call ONLY when the user's "
@@ -2167,6 +2210,42 @@ def _delete_user(path: str) -> dict:
         return _http_error_body(e)
     except Exception as e:
         return {"error": str(e)}
+
+
+def _post_user(path: str, body: dict) -> dict:
+    """POST JSON to a user-token-gated route (e.g. ``POST /api/autonudge``)."""
+    token = _local_user_token()
+    if not token:
+        return {"error": "could not obtain local user token"}
+    req = urllib.request.Request(
+        f"{_API}{_with_token(path, token)}",
+        method="POST",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- _API is the loopback dashboard base resolved from local config and path is code-constructed; no user-controlled URL reaches urlopen (same trust profile as _get_user/_delete_user)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return _http_error_body(e)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _autonudge_binding_key(sk: str) -> str | None:
+    """Map a session key to its AutoNudge binding key, or None if unsupported.
+
+    ``dashboard:chat-N-TS`` → bare slot key ``chat-N-TS`` (the autonudge REST
+    layer keys dashboard loops on the bare slot key); ``slack:``/``discord:``
+    session keys pass through unchanged (channel-bound loops). Anything else
+    (``cron:``, ``hook:``, ``subagent:`` ...) is not a nudge-able session.
+    """
+    if sk.startswith("dashboard:"):
+        return sk.split(":", 1)[1]
+    if sk.startswith(("slack:", "discord:")):
+        return sk
+    return None
 
 
 def _artifact_ref_link(slug: str, name: str) -> str:
@@ -3942,24 +4021,29 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # point (matches spawn_run pattern above).
         args = validate_tool_args(args, AUTONUDGE_STOP_SCHEMA)
 
-        # Resolve the current session's slot key and stop any loop bound to it.
-        sk = _resolve_session_key()
-        # Session key is formatted "dashboard:chat-N-TS" for chat slots
-        # or "cron:<id>", "hook:<id>", etc. AutoNudge only binds to chat slots.
-        if not sk.startswith("dashboard:"):
+        # Resolve the current session's binding key and stop any loop on it.
+        # STRICT resolution (env-var only, no PID walk): this tool mutates
+        # another process's persistent loop state, and a subagent lives under
+        # the parent slot's process tree — a PID-walk would let it silently
+        # stop the PARENT session's loop (matches set_project's rule).
+        sk = _resolve_session_key_strict()
+        # AutoNudge binds to dashboard chat slots and slack:/discord: channel
+        # sessions — never to "cron:<id>", "hook:<id>", "subagent:<id>", etc.
+        slot_key = _autonudge_binding_key(sk)
+        if slot_key is None:
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="autonudge_stop", outcome="noop"
             )
             return (
                 "No auto-nudge loop to stop: this tool only works from within "
-                f"a dashboard chat session (current session_key={sk!r})."
+                "a dashboard, Slack, or Discord session "
+                f"(current session_key={sk!r})."
             )
-        slot_key = sk.split(":", 1)[1]
         reason = args.get("reason", "").strip()
         # /api/autonudge* rejects X-Internal-Secret and requires a user-scoped
         # token, so use the token-aware helpers (bootstrapped via
         # /api/token/local) rather than the plain internal-secret _get/_delete.
-        lookup = _get_user(f"/api/autonudge/slot/{slot_key}")
+        lookup = _get_user(f"/api/autonudge/slot/{quote(slot_key, safe='')}")
         if lookup.get("error"):
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="autonudge_stop", outcome="error"
@@ -3989,6 +4073,65 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"Auto-nudge loop {loop_id} stopped on session {slot_key}"
             + (f" (reason: {reason})" if reason else "")
             + ". No further nudges will fire."
+        )
+
+    if name == "monitor_start":
+        args = validate_tool_args(args, MONITOR_START_SCHEMA)
+        # STRICT resolution (env-var only, no PID walk): monitor_start creates
+        # a persistent unattended loop that repeatedly runs tools in the bound
+        # session. A subagent under the parent's process tree must NOT be able
+        # to PID-walk into the parent's identity and mint a loop the parent
+        # user never asked for (crosses the session authorization boundary).
+        sk = _resolve_session_key_strict()
+        binding_key = _autonudge_binding_key(sk)
+        if binding_key is None:
+            sel().log_tool_invocation(
+                session_key=sk, source="mcp", tool_name="monitor_start", outcome="noop"
+            )
+            return (
+                "monitor_start only works from within a dashboard, Slack, or "
+                f"Discord session (current session_key={sk!r}). For other "
+                "contexts use cron_add or a HEARTBEAT.md task."
+            )
+        message = args["message"].strip()
+        if not message:
+            return "monitor_start: message must not be empty."
+        interval_secs = int(args.get("interval_secs") or 300)
+        max_cycles = int(args.get("max_cycles") or 0)
+        resp = _post_user(
+            "/api/autonudge",
+            {
+                "session_key": binding_key,
+                "message": message,
+                "idle_secs": interval_secs,
+                "max_cycles": max_cycles,
+            },
+        )
+        if resp.get("error"):
+            sel().log_tool_invocation(
+                session_key=sk, source="mcp", tool_name="monitor_start", outcome="error"
+            )
+            return f"Failed to start monitor loop: {resp['error']}"
+        loop = resp.get("loop") or {}
+        sel().log_tool_invocation(
+            session_key=sk,
+            source="mcp",
+            tool_name="monitor_start",
+            outcome="success",
+            metadata={
+                "binding_key": binding_key,
+                "loop_id": loop.get("id", ""),
+                "interval_secs": interval_secs,
+                "max_cycles": max_cycles,
+            },
+        )
+        return (
+            f"Monitor loop {loop.get('id', '?')} started on session {binding_key}: "
+            f"the message will be re-injected into this session after every "
+            f"~{interval_secs}s of idle"
+            + (f", stopping after {max_cycles} cycles" if max_cycles else "")
+            + ". End your turn now — the loop wakes you. Call autonudge_stop "
+            "when the exit condition is met."
         )
 
     if name == "search_chat_history":

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -49,6 +49,9 @@ from kiro_crew.autonudge import (
     NudgeLoop,
 )
 from kiro_crew.autonudge import enabled as autonudge_enabled
+from kiro_crew.autonudge import (
+    is_channel_key,
+)
 from kiro_crew.channel_history import ChannelHistory
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
@@ -122,6 +125,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     rewrite_agents,
 )
 from kiro_crew.memory import MemoryStore
+from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import safety_override
@@ -170,11 +174,16 @@ logger = logging.getLogger(__name__)
 # Max retries for injecting subagent results into parent sessions.
 _MAX_INJECT_ATTEMPTS = 2
 
+# Per-turn hard deadline for an unattended AutoNudge turn in a channel session
+# (Slack/Discord babysit loops). Mirrors HEARTBEAT_TASK_TIMEOUT_SECS / cron's
+# _JOB_TIMEOUT_SECS: no human is present, so the turn MUST be bounded.
+_NUDGE_TURN_TIMEOUT = 1800.0  # 30 min
+
 # Approval sources that run UNATTENDED (no human responder). These deny-fast on a
 # short window instead of burning the full 2h human-approval window. Subagent
 # approvals are NOT background: they route to the dashboard where the spawning
 # human is present (via the parent slot), so they keep the long interactive window.
-_BACKGROUND_APPROVAL_SOURCES = frozenset({"cron", "heartbeat", "taskrunner", ""})
+_BACKGROUND_APPROVAL_SOURCES = frozenset({"cron", "heartbeat", "taskrunner", "autonudge", ""})
 
 # Slack Block Kit section.text hard limit is 3000 chars.
 # We split cron output at this boundary so each chunk fits in a section block.
@@ -2166,6 +2175,200 @@ class GatewayOrchestrator:
         )
         await self.heartbeat_svc.start()
 
+    async def _fire_slack_nudge(self, loop: NudgeLoop) -> bool:
+        """Drive one unattended nudge turn in a Slack thread session.
+
+        Mirrors the subagent-completion Slack injection: acquire the session,
+        run the turn with auto-approval, post the reply into the originating
+        thread, persist for dashboard replay. Returns True when the turn ran;
+        False on skip (busy/unroutable/error) — the AutoNudge service re-arms
+        with backoff on False.
+        """
+        key = loop.slot_key
+        if self.sessions is None or self.slack is None:
+            return False
+        if self.sessions.is_busy(key):
+            logger.info("AutoNudge skip: slack session %s busy (loop %s)", key, loop.id)
+            return False
+        channel = self.sessions.get_channel(key)
+        thread_ts = self.sessions.get_thread(key)
+        if not thread_ts and key.startswith("slack:"):
+            # Canonical keys embed the thread root ts.
+            thread_ts = key.split(":", 1)[1]
+        if not channel:
+            logger.warning(
+                "AutoNudge: slack session %s unroutable — removing loop %s", key, loop.id
+            )
+            if self.autonudge_svc:
+                await self.autonudge_svc.remove(loop.id)
+            return False
+        msg_body = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg_body}"
+        # Fail closed: an unattended turn MUST run under the HookManager
+        # PreToolUse governance gate (mirrors cron's default approval path).
+        # Without ctx_builder there are no hooks to enforce the gate — skip.
+        if self.ctx_builder is None or self.ctx_builder.hooks is None:
+            logger.warning(
+                "AutoNudge: no hook manager available — refusing unattended "
+                "slack nudge turn for %s (loop %s)",
+                key,
+                loop.id,
+            )
+            return False
+        response: str | None = None
+        _acquired = False
+        try:
+            client, is_new, _resumed = await self.sessions.get_or_create(key)
+            _acquired = True
+            _provider = self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"
+            full_msg, _ = await run_in_embed_pool(
+                self.ctx_builder.build_message, tagged, is_new, key, provider_type=_provider
+            )
+            response = await asyncio.wait_for(
+                stream_and_collect(
+                    client,
+                    full_msg,
+                    retry_transient=False,
+                    # Same governance contract as unattended cron turns: the
+                    # HookManager PreToolUse gate decides tool approvals, and
+                    # anything it can't decide goes to the deny-fast
+                    # background-approval window (source "autonudge").
+                    approval_policy=ToolApprovalPolicy.HOOK_BASED,
+                    hooks=self.ctx_builder.hooks,
+                    on_tool_approval=self._interactive_approval("autonudge"),
+                ),
+                timeout=_NUDGE_TURN_TIMEOUT,
+            )
+        except Exception:
+            logger.exception("AutoNudge: slack nudge turn failed for %s (loop %s)", key, loop.id)
+            return False
+        finally:
+            if _acquired:
+                try:
+                    await self.sessions.cancel_current(key)
+                except Exception:
+                    logger.debug("AutoNudge: cancel_current failed for %s", key, exc_info=True)
+                try:
+                    self.sessions.release(key)
+                except Exception:
+                    logger.exception("AutoNudge: failed to release session %s", key)
+        # Post the response into the originating thread (best-effort — the
+        # turn itself already ran, so failures here don't fail the cycle).
+        try:
+            if response:
+                reply_text, _ = redact_exfiltration_urls(to_slack_mrkdwn(response))
+                reply_text, _ = redact_credentials(reply_text)
+                for part in split_message(reply_text):
+                    await self.slack.post_message(channel, part, thread_ts)
+        except Exception:
+            logger.exception("AutoNudge: slack posting failed for %s (turn ran)", key)
+        # Persist for dashboard replay (mirrors subagent Slack injection).
+        if self.conv_log and not (is_thread_temporary(key) or is_thread_incognito(key)):
+            try:
+                safe_nudge, _ = redact_exfiltration_urls(tagged)
+                safe_nudge, _ = redact_credentials(safe_nudge)
+                safe_response, _ = redact_exfiltration_urls(response or "")
+                safe_response, _ = redact_credentials(safe_response)
+                save_conversation_turn(
+                    self.conv_log,
+                    key,
+                    safe_nudge,
+                    safe_response,
+                    source_thread=key,
+                    source_user="autonudge",
+                    agent=_get_agent_for_session(key),
+                )
+            except Exception:
+                logger.warning(
+                    "AutoNudge: failed to persist nudge turn for %s", key, exc_info=True
+                )
+        return True
+
+    async def _fire_discord_nudge(self, loop: NudgeLoop) -> bool:
+        """Drive one unattended nudge turn in a Discord DM session.
+
+        Synthesizes an ``InboundMessage`` and routes it through the Discord
+        dispatcher — the exact path a real DM takes — so busy/steer/queue
+        handling, rendering, chunking, and persistence behave like a user
+        turn. ``interpret_commands=False`` keeps the nudge from being parsed
+        as a ``!command``.
+        """
+        key = loop.slot_key
+        transports = getattr(self.dashboard_state, "channel_transports", None) or {}
+        transport = transports.get("discord")
+        dispatcher = transport.dispatcher if transport is not None else None
+        if transport is None or dispatcher is None:
+            logger.info("AutoNudge skip: discord transport not running (loop %s)", loop.id)
+            return False
+        # Key shape: discord:{agent}:direct:{user_id}[:genN]
+        parts = key.split(":")
+        if len(parts) < 4 or parts[2] != "direct":
+            logger.warning(
+                "AutoNudge: unsupported discord key %s — removing loop %s", key, loop.id
+            )
+            if self.autonudge_svc:
+                await self.autonudge_svc.remove(loop.id)
+            return False
+        user_id = parts[3]
+        # Defense-in-depth: re-check the inbound allowlist at fire time (the
+        # create endpoint enforces it too, but the allowlist can shrink after
+        # a loop was created). Synthetic injection bypasses transport.receive,
+        # so authorization is this caller's responsibility — mirrors
+        # on_interaction's _authorized re-check. Uses the dispatcher's public
+        # injection surface; a missing method raises loudly instead of
+        # silently retiring the loop.
+        if not dispatcher.is_authorized(user_id):
+            logger.warning(
+                "AutoNudge: discord user %s not authorized — removing loop %s",
+                user_id,
+                loop.id,
+            )
+            if self.autonudge_svc:
+                await self.autonudge_svc.remove(loop.id)
+            return False
+        # Generation guard: the dispatcher derives the CURRENT key for this
+        # user (dm_scope + `!new` generation). If it no longer matches the
+        # loop's stored key, the monitored conversation is gone — a synthetic
+        # turn would run in a fresh session with none of the loop's context,
+        # and autonudge_stop from that new session could never find this
+        # loop. Retire it instead of firing into the wrong generation.
+        try:
+            current_key = dispatcher.current_session_key(user_id)
+        except Exception:
+            current_key = key
+        if current_key != key:
+            logger.info(
+                "AutoNudge: discord session rotated (%s -> %s) — removing loop %s",
+                key,
+                current_key,
+                loop.id,
+            )
+            if self.autonudge_svc:
+                await self.autonudge_svc.remove(loop.id)
+            return False
+        sessions = getattr(dispatcher, "sessions", None)
+        if sessions is not None and sessions.is_busy(key):
+            logger.info("AutoNudge skip: discord session %s busy (loop %s)", key, loop.id)
+            return False
+        msg_body = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg_body}"
+        try:
+            conversation_id = await transport.resolve_conversation(user_id)
+            synthetic = InboundMessage(
+                channel_type="discord",
+                user_id=user_id,
+                conversation_id=conversation_id,
+                text=tagged,
+            )
+            await asyncio.wait_for(
+                dispatcher.handle_message(synthetic, interpret_commands=False),
+                timeout=_NUDGE_TURN_TIMEOUT,
+            )
+            return True
+        except Exception:
+            logger.exception("AutoNudge: discord nudge failed for %s (loop %s)", key, loop.id)
+            return False
+
     async def _init_autonudge(self) -> None:
         """Initialize and start the auto-nudge service (feature-flagged)."""
         if not autonudge_enabled():
@@ -2173,13 +2376,29 @@ class GatewayOrchestrator:
             return
 
         async def _fire(loop: NudgeLoop) -> bool:
-            """Inject nudge message into the bound chat slot.
+            """Inject nudge message into the bound session.
+
+            Routes by binding-key namespace: ``slack:``/``discord:`` keys run
+            an unattended turn in the channel session; bare keys are dashboard
+            chat slots (original path).
 
             Returns True if the nudge was actually dispatched, False if skipped
             (slot missing, dashboard not ready, or turn still active). The
             service uses this to avoid counting skipped cycles toward
             max_cycles.
             """
+            if is_channel_key(loop.slot_key):
+                if loop.slot_key.startswith("slack:"):
+                    return await self._fire_slack_nudge(loop)
+                if loop.slot_key.startswith("discord:"):
+                    return await self._fire_discord_nudge(loop)
+                logger.warning(
+                    "AutoNudge: unsupported channel key %s — removing loop %s",
+                    loop.slot_key,
+                    loop.id,
+                )
+                await self.autonudge_svc.remove(loop.id)  # type: ignore[union-attr]
+                return False
             # Guard (not assert): stripped under -O; also _init_autonudge() can
             # run before _init_dashboard(), and _init_dashboard is skipped
             # entirely in --no-dashboard mode. Mirrors _observer's guard below.

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -466,6 +466,19 @@ AUTONUDGE_STOP_SCHEMA = ToolSchema(
     ],
 )
 
+# monitor_start creates an AutoNudge loop bound to the calling session (the
+# agent-facing "babysit this PR" primitive). message caps match the REST
+# endpoint's 8000-char limit; interval bounds mirror autonudge's
+# _MIN_IDLE_SECS/_MAX_IDLE_SECS clamp.
+MONITOR_START_SCHEMA = ToolSchema(
+    tool_name="monitor_start",
+    fields=[
+        FieldSpec("message", str, required=True, max_len=8000),
+        FieldSpec("interval_secs", int, min_val=15, max_val=86400),
+        FieldSpec("max_cycles", int, min_val=0, max_val=1000),
+    ],
+)
+
 # delete_message reads args["channel"] and args["ts"] by subscript. Without a
 # schema, a call omitting either key raised KeyError, which is NOT caught by
 # call_tool_with_logging (only ValidationError is) and propagated out of the
@@ -1192,6 +1205,7 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "register_hook": REGISTER_HOOK_SCHEMA,
     "file_send": FILE_SEND_SCHEMA,
     "autonudge_stop": AUTONUDGE_STOP_SCHEMA,
+    "monitor_start": MONITOR_START_SCHEMA,
     "delete_message": DELETE_MESSAGE_SCHEMA,
     "local_knowledge_search": LOCAL_KNOWLEDGE_SEARCH_SCHEMA,
     "knowledge_dedup": KNOWLEDGE_DEDUP_SCHEMA,

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -460,3 +460,85 @@ def test_render_nudge_message():
     # None sentinel produces empty string
     result2 = render_nudge_message("create {{STOP_FILE}}", None)
     assert result2 == "create "
+
+
+# ── Channel-key (Slack / Discord babysit) loops ──
+
+
+def test_is_channel_key():
+    from kiro_crew.autonudge import is_channel_key
+
+    assert is_channel_key("slack:1700000000.123456")
+    assert is_channel_key("discord:kirocrew:direct:42")
+    assert is_channel_key("unified:kirocrew")
+    # Bare dashboard slot keys are NOT channel keys.
+    assert not is_channel_key("chat-1-123")
+    # Fully-qualified dashboard keys never appear as binding keys, but must
+    # not be misclassified either.
+    assert not is_channel_key("dashboard:chat-1-123")
+
+
+@pytest.mark.asyncio
+async def test_channel_loop_self_rearms_after_delivered_fire(svc, monkeypatch):
+    """Slack/Discord loops run on a fixed interval: the timer re-arms itself
+    after a delivered fire (notify_turn_complete never fires for these keys)."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    svc._on_fire = on_fire
+    import kiro_crew.autonudge as _an
+
+    _real_sleep = _an.asyncio.sleep
+
+    async def _nosleep(_secs):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    await svc.start()
+    # max_cycles=1 bounds the loop: the re-armed second timer run hits the
+    # cycle cap and deactivates, keeping the test deterministic.
+    loop = await svc.add(
+        slot_key="slack:1700000000.123456", message="check PR", idle_secs=15, max_cycles=1
+    )
+    await svc._timers[loop.id]
+    assert len(fired) == 1
+    # The re-armed second run hits the cycle cap and deactivates the loop —
+    # proof the channel loop re-armed itself. A dashboard loop would idle
+    # forever here waiting for notify_turn_complete.
+    for _ in range(100):
+        if not svc._loops[loop.id].active:
+            break
+        await _real_sleep(0)
+    assert not svc._loops[loop.id].active
+    assert len(fired) == 1  # cap check runs before firing — no second delivery
+    svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_loop_does_not_self_rearm(svc, monkeypatch):
+    """Dashboard loops stay idle-driven: after a delivered fire they wait for
+    notify_turn_complete instead of self-re-arming."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    svc._on_fire = on_fire
+    import kiro_crew.autonudge as _an
+
+    async def _nosleep(_secs):
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15)
+    timer1 = svc._timers[loop.id]
+    await timer1
+    assert len(fired) == 1
+    # No new timer was armed — the finished task is still the registered one.
+    assert svc._timers.get(loop.id) is timer1
+    svc.stop()

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -40,6 +40,8 @@ class _MockAutonudgeHandler(BaseHTTPRequestHandler):
     issued_token = "user-token-abc"
     # Set per-test: the loop returned by GET /api/autonudge/slot/{slot_key}.
     loop_for_slot: dict | None = {"id": "loop-1", "slot_key": "chat-3-1700000000"}
+    # Bodies received by POST /api/autonudge (monitor_start tests).
+    created_bodies: list[dict] = []
 
     def _json(self, status: int, body: dict) -> None:
         self.send_response(status)
@@ -90,6 +92,34 @@ class _MockAutonudgeHandler(BaseHTTPRequestHandler):
                 self._json(403, {"error": "Token required"})
                 return
             self._json(200, {"ok": True})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802
+        base = self.path.split("?", 1)[0]
+        if base == "/api/autonudge":
+            if self._reject_internal_secret():
+                return
+            if not self._has_valid_token():
+                self._json(403, {"error": "Token required"})
+                return
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            body = json.loads(self.rfile.read(length) or b"{}")
+            type(self).created_bodies.append(body)
+            key = body.get("session_key") or body.get("slot_key") or ""
+            self._json(
+                200,
+                {
+                    "ok": True,
+                    "loop": {
+                        "id": "loop-new",
+                        "slot_key": key,
+                        "message": body.get("message", ""),
+                        "idle_secs": body.get("idle_secs", 60),
+                        "max_cycles": body.get("max_cycles", 0),
+                    },
+                },
+            )
             return
         self._json(404, {"error": "not found"})
 
@@ -150,3 +180,100 @@ def test_internal_secret_handshake_would_403(mock_dashboard):
     resp = mcp_core._get("/api/autonudge/slot/chat-3-1700000000")
     assert "error" in resp
     assert "Token required" in resp["error"] or "403" in resp["error"]
+
+
+# ── monitor_start (babysit loops) ──
+
+
+def test_monitor_start_dashboard_session(mock_dashboard):
+    """monitor_start from a dashboard session posts the bare slot key."""
+    _MockAutonudgeHandler.created_bodies = []
+    result = _call_tool_inner(
+        "monitor_start",
+        {"message": "check PR #1 until green", "interval_secs": 300, "max_cycles": 5},
+    )
+    assert "started" in result.lower()
+    assert "loop-new" in result
+    assert len(_MockAutonudgeHandler.created_bodies) == 1
+    body = _MockAutonudgeHandler.created_bodies[0]
+    assert body["session_key"] == "chat-3-1700000000"
+    assert body["message"] == "check PR #1 until green"
+    assert body["idle_secs"] == 300
+    assert body["max_cycles"] == 5
+
+
+def test_monitor_start_slack_session(mock_dashboard, monkeypatch):
+    """monitor_start from a Slack thread session passes the namespaced key through."""
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "slack:1700000000.123456")
+    _MockAutonudgeHandler.created_bodies = []
+    result = _call_tool_inner("monitor_start", {"message": "watch CI"})
+    assert "started" in result.lower()
+    body = _MockAutonudgeHandler.created_bodies[0]
+    assert body["session_key"] == "slack:1700000000.123456"
+    assert body["idle_secs"] == 300  # default interval
+
+
+def test_monitor_start_discord_session(mock_dashboard, monkeypatch):
+    """monitor_start from a Discord DM session passes the namespaced key through."""
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "discord:kirocrew:direct:42")
+    _MockAutonudgeHandler.created_bodies = []
+    result = _call_tool_inner("monitor_start", {"message": "watch the deploy"})
+    assert "started" in result.lower()
+    assert _MockAutonudgeHandler.created_bodies[0]["session_key"] == "discord:kirocrew:direct:42"
+
+
+def test_monitor_start_rejects_cron_context(mock_dashboard, monkeypatch):
+    """Non-nudge-able contexts (cron/hook/subagent) get a clean noop message."""
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "cron:job-9")
+    _MockAutonudgeHandler.created_bodies = []
+    result = _call_tool_inner("monitor_start", {"message": "watch"})
+    assert "only works" in result.lower()
+    assert not _MockAutonudgeHandler.created_bodies
+
+
+def test_monitor_start_refuses_pid_walked_identity(mock_dashboard, monkeypatch):
+    """STRICT session resolution: no env var -> refuse, even if a PID walk
+    would resolve to a parent session.
+
+    A subagent spawned under a dashboard/Slack/Discord slot lives in the
+    parent's process tree; the lenient resolver would let it inherit the
+    parent identity and mint a persistent unattended loop the parent user
+    never asked for. monitor_start must use the env-var-only resolver.
+    """
+    monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+    # Simulate a PID walk that WOULD succeed if (wrongly) consulted.
+    monkeypatch.setattr(
+        mcp_core, "_resolve_session_key", lambda: "dashboard:chat-3-1700000000"
+    )
+    _MockAutonudgeHandler.created_bodies = []
+    result = _call_tool_inner("monitor_start", {"message": "watch"})
+    assert "only works" in result.lower()
+    assert not _MockAutonudgeHandler.created_bodies
+
+
+def test_autonudge_stop_refuses_pid_walked_identity(mock_dashboard, monkeypatch):
+    """autonudge_stop also mutates another session's loop state -> same
+    strict env-var-only resolution as monitor_start."""
+    monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+    monkeypatch.setattr(
+        mcp_core, "_resolve_session_key", lambda: "dashboard:chat-3-1700000000"
+    )
+    _MockAutonudgeHandler.loop_for_slot = {
+        "id": "loop-9",
+        "slot_key": "chat-3-1700000000",
+    }
+    result = _call_tool_inner("autonudge_stop", {})
+    assert "only works" in result.lower()
+    assert "loop-9" not in result
+
+
+def test_autonudge_stop_slack_session(mock_dashboard, monkeypatch):
+    """autonudge_stop works from a Slack session (channel-bound loop)."""
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "slack:1700000000.123456")
+    _MockAutonudgeHandler.loop_for_slot = {
+        "id": "loop-2",
+        "slot_key": "slack:1700000000.123456",
+    }
+    result = _call_tool_inner("autonudge_stop", {"reason": "PR is green"})
+    assert "stopped" in result.lower()
+    assert "loop-2" in result

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -469,6 +469,43 @@ class TestTransportAuth:
         assert DISCORD_CAPABILITIES.threads is False
 
 
+class TestPublicInjectionSurface:
+    """Locks the out-of-band injection contract used by AutoNudge + REST.
+
+    The AutoNudge fire path and POST /api/autonudge reach the dispatcher only
+    through ``transport.dispatcher`` and call only ``is_authorized`` /
+    ``current_session_key`` / ``handle_message``. If any of these are renamed,
+    these tests fail loudly — before a refactor can silently retire live
+    monitoring loops at fire time.
+    """
+
+    def test_transport_dispatcher_exposes_bound_dispatcher(self) -> None:
+        d, _cli, _sess = _dispatcher({"42"})
+        t = DiscordTransport(FakeClient(), dispatch=d.handle_message)  # type: ignore[arg-type]
+        assert t.dispatcher is d
+
+    def test_transport_dispatcher_none_when_unwired(self) -> None:
+        t = DiscordTransport(FakeClient())  # type: ignore[arg-type]
+        assert t.dispatcher is None
+
+    def test_is_authorized_deny_by_default(self) -> None:
+        d, _cli, _sess = _dispatcher(set())
+        assert d.is_authorized("42") is False
+        assert d.is_authorized("") is False
+
+    def test_is_authorized_allowlisted_user(self) -> None:
+        d, _cli, _sess = _dispatcher({"42"})
+        assert d.is_authorized("42") is True
+        assert d.is_authorized("99") is False
+
+    def test_current_session_key_matches_inbound_derivation(self) -> None:
+        d, _cli, _sess = _dispatcher({"42"}, default_agent="kirocrew")
+        # Must agree with the private derivation the inbound path uses — the
+        # generation guard compares a stored loop key against this value.
+        assert d.current_session_key("42") == d._session_key("42")
+        assert d.current_session_key("42").startswith("discord:")
+
+
 class TestTransportReceive:
     def _transport(self, allowed: list[str]) -> tuple[DiscordTransport, list[InboundMessage]]:
         dispatched: list[InboundMessage] = []


### PR DESCRIPTION
## Problem

"Babysit this PR" / "keep monitoring" requests route through the HEARTBEAT.md task queue — a detached, fresh-session-per-cycle mechanism that loses the originating conversation's context and is confusing to reason about. The session-native alternative (AutoNudge) was dashboard-slot-only and had no agent-facing start tool, so agents literally could not start a loop even in the dashboard.

## Why it matters

Monitoring loops are the most common long-running agent task. Fresh-session cycles re-derive context every time, can't build on the conversation, and the HEARTBEAT_KEEP contract is easy to get wrong. Users expect: "the session itself manages it, on an interval."

## Fix (symptoms → root cause → change)

Root cause was four missing wires, not architecture: (1) AutoNudge's fire callback only resolved dashboard slots; (2) its idle timer was only re-armed by dashboard turn hooks; (3) no MCP tool could create a loop; (4) no shared "run a turn in session X" path for channels.

- `autonudge.py` — NudgeLoop's binding key now also accepts namespaced channel session keys (`slack:<ts>`, `discord:{agent}:direct:{user}`). Channel loops self-re-arm on a fixed interval after each delivered fire (they have no dashboard turn-lifecycle hooks); dashboard loops keep idle-timer semantics. Store format unchanged — no migration.
- `slack/gateway.py` — `_fire` routes by key namespace. New `_fire_slack_nudge` runs an unattended turn (mirrors the proven subagent-completion Slack injector: acquire session, `stream_and_collect`, reply into the originating thread, persist for dashboard replay, always `cancel_current` + `release`). New `_fire_discord_nudge` synthesizes an `InboundMessage` through the Discord dispatcher (`interpret_commands=False`) so busy/steer/queue, rendering, and persistence behave exactly like a real DM. Both bounded by a 30-min unattended-turn cap.
- `mcp_core.py` — new `monitor_start(message, interval_secs?, max_cycles?)` tool creates a loop on the calling session via a new `_post_user` helper (the `/api/autonudge*` routes require user-token auth); `autonudge_stop` generalized to Slack/Discord sessions. Both share a `_autonudge_binding_key` mapper that rejects cron/hook/subagent contexts.
- REST `POST /api/autonudge` accepts `session_key` with per-namespace validation (Slack keys must be routable; Discord DM-only). Responses/WS payloads unchanged — zero frontend changes.
- `config/prompt.md` — monitor/babysit requests route to `monitor_start`; heartbeat demoted to fallback for out-of-session work. New `skills/babysit/SKILL.md` playbook.
- `discord/transport.py` + `discord/transport_dispatch.py` — public injection surface for out-of-band callers: `DiscordTransport.dispatcher` property plus `DiscordDispatcher.is_authorized()` / `current_session_key()`. The AutoNudge fire path and the REST create handler now use these instead of reaching into `_dispatch`/`_authorized`/`_session_key` via defensive `getattr` — a future dispatcher rename breaks loudly (test failure / raised error) instead of silently retiring live loops (design review finding 1).

## Tests

- `test_autonudge.py`: `is_channel_key` classification; channel loops self-re-arm after a delivered fire (cycle-cap deactivation proves the re-arm); dashboard loops do NOT self-re-arm (idle semantics preserved).
- `test_autonudge_stop_auth.py`: mock dashboard gained POST support; `monitor_start` from dashboard/Slack/Discord session keys posts the right binding key through the user-token auth chain; cron context is a clean noop; `autonudge_stop` works from a Slack session.
- `test_discord.py`: `TestPublicInjectionSurface` locks the out-of-band contract — `transport.dispatcher` resolves the wired dispatcher (None when unwired), `is_authorized` is deny-by-default, `current_session_key` agrees with the inbound derivation the generation guard depends on.
- Full gates: pytest 15,401 passed (2 failures pre-existing on main, environment-specific), flake8 clean, mypy (CI-parity venv) clean, tsc clean, vitest 3,972 passed.

## Manual verification

Not yet run live — pod infrastructure is unavailable in this dev environment (no `systemd --user` D-Bus session), and a live Slack/Discord loop additionally needs real channel credentials that a pod would not have. Live smoke of one Slack and one Discord loop remains a pre/post-merge follow-up on a credentialed gateway. Unit coverage exercises the service timer semantics and the tool→HTTP→auth chain; the gateway fire paths mirror the existing subagent-injection code path verbatim.

## Screenshots

N/A — no user-visible UI change (frontend untouched; existing 🎯 popover behavior unchanged).

## Known limitations (by design, documented in the skill)

- Discord unattended turns follow the gateway approval mode — under interactive approval a cycle can't use tools (deny-by-default after 300s). Slack cycles auto-approve via `stream_and_collect` defaults, matching subagent injection.
- `unified:`/`telegram:` keys are recognized as channel keys but not yet routable — the fire router removes such loops with a warning; wiring Telegram is a follow-up.
- The Slack/Discord fire paths are intentionally two mechanisms in this PR; extracting the shared unattended-turn primitive (uniform approval semantics, Telegram as a data change) is tracked in #267 (design review finding 2).

