### PR TITLE
feat(taskrunner): expose per-run workspace folder + plan YAML export in dashboard

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -755,7 +755,7 @@ export const api = {
   setLogLevel: (level: string) => post('/api/logs/level', { level }).then(j),
   // Task runner
   taskRunnerStatus: () => fetch('/api/taskrunner').then(j),
-  startTaskRunner: (spec: string, agent?: string) => post('/api/taskrunner', { spec, agent: agent || '' }).then(j),
+  startTaskRunner: (spec: string, agent?: string, workspaceDir?: string) => post('/api/taskrunner', { spec, agent: agent || '', workspace_dir: workspaceDir || '' }).then(j),
   cancelTaskRunner: (taskId?: string) => post('/api/taskrunner/cancel', taskId ? { task_id: taskId } : undefined).then(j),
   pauseTaskRun: (taskId: string) => post('/api/taskrunner/' + encodeURIComponent(taskId) + '/pause').then(j),
   deleteTaskRun: (taskId: string) => del('/api/taskrunner/' + encodeURIComponent(taskId)).then(j),
@@ -770,8 +770,8 @@ export const api = {
   refineTaskInput: (input: string) => post('/api/taskrunner/refine', { input }).then(j),
   refineStatus: () => fetch('/api/taskrunner/refine').then(j),
   refineCancel: () => post('/api/taskrunner/refine/cancel').then(j),
-  planTask: (input: string, source: string, spec?: string, agent?: string) =>
-    post('/api/taskrunner/plan', { input, source, spec: spec || '', agent: agent || '' }).then(j),
+  planTask: (input: string, source: string, spec?: string, agent?: string, workspaceDir?: string) =>
+    post('/api/taskrunner/plan', { input, source, spec: spec || '', agent: agent || '', workspace_dir: workspaceDir || '' }).then(j),
   cancelPlan: () => post('/api/taskrunner/plan/cancel').then(j),
   updatePlan: (taskId: string, steps: PlanStepInput[]) =>
     put('/api/taskrunner/' + encodeURIComponent(taskId) + '/plan', { steps }).then(j),
@@ -781,6 +781,28 @@ export const api = {
     post('/api/taskrunner/from-chat', { steps, task_id: taskId || '', original_input: originalInput || '' }).then(j),
   planContext: (taskId: string) =>
     fetch('/api/taskrunner/' + encodeURIComponent(taskId) + '/plan-context').then(j),
+  /** Download the run's plan as a YAML workflow (re-importable via the "From YAML" tab).
+   *  Fetches with the auth header, then triggers a browser download honoring the
+   *  server's sanitized Content-Disposition filename. */
+  exportPlanYaml: async (taskId: string) => {
+    const r = await get('/api/taskrunner/' + encodeURIComponent(taskId) + '/plan.yaml')
+    if (!r.ok) {
+      const t = await r.text()
+      throw new ApiError(r.status, t || `HTTP ${r.status}`)
+    }
+    const blob = await r.blob()
+    const cd = r.headers.get('Content-Disposition') || ''
+    const m = /filename="?([^";]+)"?/.exec(cd)
+    const filename = (m && m[1]) || `${taskId}.yaml`
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  },
   // Update
   checkUpdate: () => fetch('/api/update/check').then(j),
   changelog: () => fetch('/api/changelog').then(j),

--- a/website/src/pages/ProjectDetailPage.tsx
+++ b/website/src/pages/ProjectDetailPage.tsx
@@ -10,7 +10,7 @@ import PhasedView from './aidlc/PhasedView';
 import TaskDetailPanel from './aidlc/TaskDetailPanel';
 import PixelCanvasWidget from '../components/PixelCanvasWidget';
 import { api } from '../api/client';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Download } from 'lucide-react';
 
 type Tab = 'idea' | 'tasks';
 type ViewMode = 'dag' | 'phased';
@@ -91,6 +91,13 @@ export default function ProjectDetailPage({ run, onRetry, onRefresh }: Props) {
       api.updateTask(run.task_id, index, updates),
     onSuccess: () => { onRefresh?.(); queryClient.invalidateQueries({ queryKey: ['approvals', run.task_id] }); },
   });
+  const exportMutation = useMutation({
+    mutationFn: () => api.exportPlanYaml(run.task_id),
+    onError: (e) => {
+      // eslint-disable-next-line no-console -- surface plan-export failures for debugging
+      console.error('Failed to export plan YAML:', e);
+    },
+  });
   const handleToggleApproval = useCallback(async (index: number, field: 'requires_approval' | 'force_approval', value: boolean): Promise<boolean> => {
     try {
       const updates: Record<string, boolean> = { [field]: value };
@@ -167,6 +174,16 @@ export default function ProjectDetailPage({ run, onRetry, onRefresh }: Props) {
             </>
           )}
           <div className="flex-1" />
+          {!isPlanning && (run.task_details || []).length > 0 && (
+            <button
+              onClick={() => exportMutation.mutate()}
+              disabled={exportMutation.isPending}
+              title="Export this plan as a YAML workflow — re-importable via the 'From YAML' tab"
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-[13px] rounded border border-border text-muted cursor-pointer transition-all hover:text-accent hover:border-accent ${exportMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
+            >
+              <Download size={13} /> {exportMutation.isPending ? 'Exporting…' : 'Export YAML'}
+            </button>
+          )}
           {!isPlanning && <PixelCanvasWidget run={run} />}
         </div>
 

--- a/website/src/pages/ProjectsPage.tsx
+++ b/website/src/pages/ProjectsPage.tsx
@@ -5,7 +5,7 @@ import { useAppSelector, useAppDispatch } from '../store'
 import { setPendingInput, switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
 import type { TaskRunnerStatus, ProjectRun } from '../types'
-import { Card, PageHeader, SendBtn, Btn, Checkbox } from '../components/ui'
+import { Card, PageHeader, SendBtn, Btn, Checkbox, Input } from '../components/ui'
 import AgentSelector from '../components/AgentSelector'
 import type { KiroCrewAgent } from '../components/AgentSelector'
 import ProjectDetailPage from './ProjectDetailPage'
@@ -46,6 +46,13 @@ export default function ProjectsPage() {
   const [agent, setAgent] = useState('')
   const [agents, setAgents] = useState<KiroCrewAgent[]>([])
   const [defaultAgentName, setDefaultAgentName] = useState('')
+  // The user's explicit per-run workspace override. Starts empty and is only
+  // populated when the user actually types — an untouched field means "no
+  // override" so the backend keeps its per-run isolated scratch dir (and
+  // Execute/Resume can never silently re-target an existing plan). The backend
+  // default is shown as a placeholder only (defaultWorkspaceDir), never as a value.
+  const [workspaceDir, setWorkspaceDir] = useState('')
+  const [defaultWorkspaceDir, setDefaultWorkspaceDir] = useState('')
   const [isPlanning, setIsPlanning] = useState(() => sessionStorage.getItem('tr-planning') === '1')
   const [planError, setPlanError] = useState('')
   const [editingName, setEditingName] = useState(false)
@@ -68,6 +75,10 @@ export default function ProjectsPage() {
     try {
       const d = await api.taskRunnerStatus()
       setData(d)
+      // Surface the backend's default workspace folder as a PLACEHOLDER only —
+      // never as the field's value — so an untouched field stays empty ("no
+      // override") and doesn't collapse per-run workspace isolation.
+      if (d.default_workspace_dir) setDefaultWorkspaceDir(d.default_workspace_dir)
       // If ?applied set a pending selection, pick it up here
       const pending = appliedRef.current
       if (pending) {
@@ -134,7 +145,8 @@ export default function ProjectsPage() {
     // THIS run — always pass false. (Per-run trust requires an explicit dashboard
     // toggle + manual Execute.) Passing the component-wide `autoApprove` here would
     // also race the sync effect below and could leak a stale `true` from a
-    // previously-selected run onto this one.
+    // previously-selected run onto this one. Workspace is fixed at plan time
+    // (planTask baked it into work_dir), so execute never re-sends it.
     api.executePlan(selectedRun.task_id, agent, false).then(r => { if (r.ok) load() })
   }, [selectedRun, agent, load])
   // Sync the per-run auto-approve toggle from the selected run (default false).
@@ -149,7 +161,7 @@ export default function ProjectsPage() {
   const doPlan = async (input: string, source: string, spec: string | undefined, autoRun: boolean) => {
     setIsPlanning(true); setPlanError(''); sessionStorage.setItem('tr-planning', '1'); activePlanRef.current = true
     try {
-      const r = await api.planTask(input, source, spec, agent)
+      const r = await api.planTask(input, source, spec, agent, workspaceDir)
       if (r.ok) {
         if (autoRun && r.task_id) autoRunRef.current = r.task_id
         const d = await api.taskRunnerStatus()
@@ -258,6 +270,17 @@ export default function ProjectsPage() {
       <div className="flex gap-2 items-center mb-3">
         <span className="text-[13px] text-muted font-medium">Agent:</span>
         <AgentSelector agents={agents} defaultAgent={defaultAgentName} value={agent} onChange={(name) => setAgent(name)} />
+        <span className="text-[13px] text-muted font-medium ml-2">Workspace:</span>
+        <Input
+          type="text"
+          aria-label="Workspace folder"
+          value={workspaceDir}
+          onChange={e => setWorkspaceDir(e.target.value)}
+          placeholder={defaultWorkspaceDir || 'Default workspace folder'}
+          title="Root folder for a NEW plan. Leave blank to use the default per-run workspace; type a path to target a specific folder. Fixed at plan time — resuming an existing run keeps its original folder."
+          disabled={anyPlanning}
+          className={`min-w-[200px] px-2.5 py-1.5 text-[13px] font-mono ${anyPlanning ? 'opacity-50 cursor-not-allowed' : ''}`}
+        />
       </div>
       {mode === 'compose' ? (
         <div className="space-y-3">

--- a/website/src/test/ProjectDetailPage.test.tsx
+++ b/website/src/test/ProjectDetailPage.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 import ProjectDetailPage from '../pages/ProjectDetailPage'
+import { api } from '../api/client'
 import type { ProjectRun } from '../types'
 
 vi.mock('../pages/aidlc/DagView', () => ({ default: ({ nodes }: { nodes: unknown[] }) => <div data-testid="dag-view">{nodes.length} nodes</div> }))
@@ -68,5 +69,20 @@ describe('ProjectDetailPage', () => {
     renderWithProviders(<ProjectDetailPage run={mockRun({ spec_content: '', original_input: 'my idea' })} />)
     fireEvent.click(screen.getByText('Idea'))
     expect(screen.getByText('my idea')).toBeInTheDocument()
+  })
+
+  it('renders Export YAML button and calls exportPlanYaml on click', async () => {
+    const spy = vi.spyOn(api, 'exportPlanYaml').mockResolvedValue(undefined)
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    const btn = screen.getByText('Export YAML')
+    expect(btn).toBeInTheDocument()
+    fireEvent.click(btn)
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('run-1'))
+    spy.mockRestore()
+  })
+
+  it('hides Export YAML button when the run has no tasks', () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun({ task_details: [] })} />)
+    expect(screen.queryByText('Export YAML')).not.toBeInTheDocument()
   })
 })

--- a/website/src/test/ProjectsPage.test.tsx
+++ b/website/src/test/ProjectsPage.test.tsx
@@ -73,6 +73,37 @@ describe('ProjectsPage', () => {
     expect(screen.getByPlaceholderText('Describe your task...')).toBeInTheDocument()
   })
 
+  it('shows the backend default workspace folder as a placeholder, never a prefilled value', async () => {
+    const { api: mockApi } = await import('../api/client')
+    vi.mocked(mockApi.taskRunnerStatus).mockResolvedValue({ running: false, available: true, runs: [], default_workspace_dir: '/home/u/ws' })
+    renderWithProviders(<ProjectsPage />)
+    const ws = await screen.findByPlaceholderText('/home/u/ws') as HTMLInputElement
+    expect(ws).toBeInTheDocument()
+    // Untouched field stays empty → "no override" (preserves per-run isolation).
+    expect(ws.value).toBe('')
+  })
+
+  it('threads the typed workspace dir into planTask on Run', async () => {
+    const { api: mockApi } = await import('../api/client')
+    vi.mocked(mockApi.taskRunnerStatus).mockResolvedValue({ running: false, available: true, runs: [], default_workspace_dir: '/ws/root' })
+    renderWithProviders(<ProjectsPage />)
+    const ws = await screen.findByPlaceholderText('/ws/root')
+    fireEvent.change(ws, { target: { value: '/custom/dir' } })
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'do the thing' } })
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+    expect(mockApi.planTask).toHaveBeenCalledWith('do the thing', 'text', '', '', '/custom/dir')
+  })
+
+  it('sends an empty workspace (no override) when the field is untouched', async () => {
+    const { api: mockApi } = await import('../api/client')
+    vi.mocked(mockApi.taskRunnerStatus).mockResolvedValue({ running: false, available: true, runs: [], default_workspace_dir: '/ws/root' })
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByPlaceholderText('/ws/root')
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'do it' } })
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+    expect(mockApi.planTask).toHaveBeenCalledWith('do it', 'text', '', '', '')
+  })
+
   it('switches to From Spec mode with file upload', () => {
     renderWithProviders(<ProjectsPage />)
     fireEvent.click(screen.getByText(/From Spec/))

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -307,6 +307,9 @@ export interface ProjectRun {
 }
 export interface TaskRunnerStatus {
   running: boolean; available: boolean; runs: ProjectRun[]
+  /** Pre-fill value for the per-run workspace-folder selector: configured
+   *  taskrunner.workspace_dir if set, else the default per-run base directory. */
+  default_workspace_dir?: string
 }
 
 


### PR DESCRIPTION
## Problem
The Task Runner **backend** already supports a per-run workspace folder (`taskrunner.workspace_dir`) and a plan→YAML export endpoint (`GET /api/taskrunner/{task_id}/plan.yaml`), but the **dashboard never surfaced either**. Runs always executed in the default per-run scratch directory with no way to target a real folder, and a generated plan couldn't be downloaded/re-imported.

## Why it matters
- Pointing a run at the repo/folder the user actually wants to operate on is the primary real use of the task runner; without UI wiring the shipped backend capability is dead weight.
- Plans weren't exportable, so the backend's `From YAML` round-trip couldn't be used to reuse/share a generated plan.

## Fix (symptom → root cause → change)
**Symptom:** no workspace control + no plan export in the UI. **Root cause:** the frontend was never wired to the already-shipped backend `workspace_dir` threading and export endpoint. **Change:**
- `api/client.ts` — thread `workspace_dir` through `planTask` / `startTaskRunner` (**plan-time only**); add `exportPlanYaml` (fetches with the auth header, triggers a browser download honoring the server's sanitized `Content-Disposition` filename).
- `types/index.ts` — add `default_workspace_dir?` to `TaskRunnerStatus`.
- `ProjectsPage.tsx` — add a Workspace-folder field (shared `ui` `Input`) beside the Agent selector. It is **placeholder-only**: the backend default is shown as the placeholder, the value starts empty, and an **untouched field sends `""` (no override)** so the backend keeps its per-run isolated scratch dir. Workspace is a plan-time concept, so it is threaded into `planTask` only — `Execute`/`Resume` never re-target an already-planned run.
- `ProjectDetailPage.tsx` — add an **Export YAML** button (React Query `useMutation`) to the plan toolbar, **alongside** the existing workspace-animation widget.

**Ported from** MeshClaw CR-289490193, **adapted to KiroCrew's diverged frontend**: `executePlan` keeps its existing `autoApprove` argument untouched; export uses `useMutation` (this page already uses React Query); and — unlike the MeshClaw CR — the PixelCanvas widget is **retained** (its removal is an independent product decision, out of scope here).

### Review findings addressed
- **Codex HIGH #1 / Design #1+#2** — the default is no longer echoed back as an explicit override; the field is placeholder-only and plan-time-only, so per-run isolation is preserved and Execute/Resume can't retarget an existing plan.
- **Codex HIGH #2** — raw `<input>` replaced with the shared `Input` from `../components/ui`.
- **Codex MEDIUM #3 / Design #3** — `PixelCanvasWidget` retained; no unrelated feature removal, no orphaned sprite assets.

## Tests
- `ProjectsPage.test.tsx` — default shown as **placeholder** (value stays empty); typed workspace threaded into `planTask`; untouched field sends `""`; `executePlan` auto-approve arg unchanged.
- `ProjectDetailPage.test.tsx` — Export YAML button renders and calls `exportPlanYaml` on click; hidden when the run has no tasks.

## Manual verification
`tsc --noEmit` clean, `eslint` 0 errors (4 pre-existing a11y `<label>` warnings on the auto-approve toggles, unrelated to this change), 37/37 tests in the two affected suites pass. Interactive check recommended in a running dashboard: leaving the field blank runs in the isolated per-run dir; typing a path targets it; Export YAML downloads a re-importable file.
