### PR TITLE
fix(models): cache last-good model list + self-healing picker refetch

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X, ShieldCheck, BookOpen, Handshake, Rocket, Check } from 'lucide-react'
 import { SplitGlyph } from './SplitGlyph'
 import { useQuery, useMutation } from '@tanstack/react-query'
+import { modelListRefetchInterval } from '../providers/modelListHealth'
 import ChatMessageList from '../app-sdk/ChatMessageList'
 import ToolCallLine from '../pages/chat/ToolCallLine'
 import type { ChatMessage } from '../types'
@@ -103,6 +104,7 @@ export default function ChatPane({
       const models = await provider.fetchAvailableModels()
       return [{ name: 'auto', description: 'Default' }, ...models.filter((m) => m.name !== 'auto')]
     },
+    refetchInterval: modelListRefetchInterval,
   })
   const modelDD = useFilteredDropdown(availableModels)
 

--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
+import { modelListRefetchInterval } from '../providers/modelListHealth'
 import { Check, Star, StarOff, Brain, Plug, X, Pin, Package, ArrowUp, Lock, Hourglass, Bot, ChevronDown } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { useAppSelector } from '../store'
@@ -153,6 +154,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
       const models = await provider.fetchAvailableModels()
       return [{ name: 'auto', description: 'Default' }, ...models.filter(x => x.name && x.name !== 'auto')]
     },
+    refetchInterval: modelListRefetchInterval,
   })
   const modelOptions = modelOptionsData ?? []
   const { open: modelDropOpen, setOpen: setModelDropOpen, filter: modelFilter, setFilter: setModelFilter, dropdownRef: modelDropRef, inputRef: modelInputRef, filtered: filteredModels } = useFilteredDropdown(modelOptions)

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } fr
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
+import { modelListRefetchInterval } from '../providers/modelListHealth'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useSwipeEdge } from '../hooks/useSwipeEdge'
 import { useAppSelector, useAppDispatch, store } from '../store'
@@ -605,6 +606,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       const models = await provider.fetchAvailableModels()
       return [{ name: 'auto', description: 'Default' }, ...models.filter(m => m.name !== 'auto')]
     },
+    refetchInterval: modelListRefetchInterval,
   })
   const { open: modelDropdown, setOpen: setModelDropdown, filter: modelFilter, setFilter: setModelFilter, dropdownRef: modelDropdownRef, inputRef: modelInputRef, filtered: filteredModels } = useFilteredDropdown(availableModels)
   // Roving-focus keyboard nav for the agent + model dropdowns (shared with StyledSelect/AgentSelector).

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -8,6 +8,7 @@ import { DndContext, closestCenter, pointerWithin, KeyboardSensor, PointerSensor
 import { SortableContext, verticalListSortingStrategy, useSortable, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { modelListRefetchInterval } from '../providers/modelListHealth'
 import { useAppDispatch, useAppSelector } from '../store'
 import { useConnected } from '../hooks/useConnected'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent } from '../components/ui/dropdown-menu'
@@ -881,6 +882,7 @@ function ChatSidebar({
     },
     enabled: bulkModelOpen,
     staleTime: 60_000,
+    refetchInterval: modelListRefetchInterval,
   })
   const bulkRunningCount = useMemo(() => slots.filter(s => s.running).length, [slots])
   // Count only slots that would actually change: model differs from the target

--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -1,5 +1,6 @@
 import { api } from '../../api/client'
 import modelTokensRaw from '../../model_tokens.json'
+import { markModelsDegraded } from '../modelListHealth'
 import type {
   ProviderAdapter,
   ProviderCapabilities,
@@ -16,6 +17,61 @@ const MODEL_TOKENS: Record<string, number> = Object.fromEntries(
   Object.entries(modelTokensRaw).filter(([k]) => !k.startsWith('_')) as [string, number][]
 )
 const DEFAULT_CONTEXT = 200_000
+
+// Persist the last SUCCESSFUL live /api/models list so a transient backend
+// failure (a creds/token hiccup, or a cold `--list-models` spawn exceeding the
+// gateway's timeout → 503) degrades to the real, last-known-good list instead
+// of collapsing to auto-only. The cached ids came from the backend, so they are
+// valid ACP model ids — unlike the canonical registry keys (fable-5-1m, …)
+// which the ACP CLI rejects (-32603). A TTL bounds staleness: entitlements /
+// available models can change while the backend is unreachable, so a very old
+// cache could still offer a model the CLI no longer accepts (a residual, now
+// time-boxed, -32603 window). Versioned key so a shape change invalidates.
+const MODELS_CACHE_KEY = 'kc.acp.models.v1'
+const MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h — bound stale-model exposure
+
+interface CachedModels {
+  ts: number
+  models: ModelInfo[]
+}
+
+/** Read the last-good live model list from localStorage, or null if absent,
+ *  expired (older than the TTL), or unusable. Fully guarded: SSR (no
+ *  localStorage), disabled storage, quota, and corrupt JSON all degrade to null
+ *  so the caller falls through to auto-only. */
+function readCachedModels(): ModelInfo[] | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    const raw = localStorage.getItem(MODELS_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedModels
+    if (!parsed || typeof parsed.ts !== 'number' || !Array.isArray(parsed.models)) return null
+    const age = Date.now() - parsed.ts
+    // Reject a stale cache AND a future timestamp: a cache written while the
+    // clock was ahead yields a negative age after the clock is corrected, which
+    // would otherwise slip past a `> TTL` check and be served indefinitely.
+    if (age < 0 || age > MODELS_CACHE_TTL_MS) return null
+    const clean = parsed.models.filter(
+      (m): m is ModelInfo =>
+        !!m && typeof m.name === 'string' && m.name.length > 0
+    )
+    return clean.length > 0 ? clean : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist a live model list with a timestamp. Best-effort — storage errors
+ *  (quota, disabled, SSR) are swallowed so caching never breaks the picker. */
+function writeCachedModels(models: ModelInfo[]): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    const payload: CachedModels = { ts: Date.now(), models }
+    localStorage.setItem(MODELS_CACHE_KEY, JSON.stringify(payload))
+  } catch {
+    /* quota exceeded / storage disabled — non-fatal */
+  }
+}
 
 /** Raw daily-usage entry from /api/usage/kiro. */
 interface RawDailyHistory {
@@ -177,15 +233,26 @@ export class AcpAdapter implements ProviderAdapter {
   async fetchAvailableModels(): Promise<ModelInfo[]> {
     try {
       const models = await api.models()
-      if (!Array.isArray(models)) return this._defaultModels()
+      if (!Array.isArray(models) || models.length === 0) {
+        // Empty/non-array success: NOT a live list — keep polling, serve the
+        // last-good live list if we have one, else auto-only.
+        markModelsDegraded(this.id, true)
+        return readCachedModels() ?? this._defaultModels()
+      }
       const result = models.map((m: RawModel) => ({
         name: m.model_name,
         description: m.description || '',
         contextWindow: MODEL_TOKENS[m.model_name] ?? DEFAULT_CONTEXT,
       }))
-      return result.length > 0 ? result : this._defaultModels()
+      writeCachedModels(result) // remember this good live list for next hiccup
+      markModelsDegraded(this.id, false) // live success → self-heal can stop polling
+      return result
     } catch {
-      return this._defaultModels()
+      // Transient backend failure (503 / network): NOT live — keep polling.
+      // Serve the last-good live list if we have one, else auto-only. Never
+      // surface canonical registry keys — the ACP CLI rejects them (-32603).
+      markModelsDegraded(this.id, true)
+      return readCachedModels() ?? this._defaultModels()
     }
   }
 

--- a/website/src/providers/modelListHealth.ts
+++ b/website/src/providers/modelListHealth.ts
@@ -1,0 +1,40 @@
+// Tracks whether the model list currently served for a given provider came from
+// a LIVE /api/models success or from a DEGRADED fallback (cached list or
+// auto-only). The model-picker query polls until a live fetch succeeds, so the
+// self-heal decision must key off this explicit signal — NOT the shape/length
+// of the list, which cannot distinguish a live single-model backend from a
+// degraded fallback, and (the bug this replaces) stops polling the moment a
+// possibly-stale cached multi-entry list is served.
+//
+// Keyed by provider id (read from the ['available-models', <providerId>] query
+// key) so it is provider-safe. Default is "not degraded" (undefined → false):
+// a provider whose adapter never marks itself only ever stops polling, so this
+// can never regress an unmarked provider into perpetual polling.
+
+const degradedByProvider = new Map<string, boolean>()
+
+/** Record whether the last fetch for a provider was degraded (fallback) or
+ *  live. The adapter calls this on every fetch outcome. */
+export function markModelsDegraded(providerId: string, degraded: boolean): void {
+  degradedByProvider.set(providerId, degraded)
+}
+
+/** True only when the provider's last served list is known to be a degraded
+ *  fallback. Unknown/never-fetched providers report false (not degraded). */
+export function modelsDegraded(providerId: string): boolean {
+  return degradedByProvider.get(providerId) === true
+}
+
+/**
+ * refetch cadence for the ['available-models', <providerId>] query: poll every
+ * 8s WHILE the served list is a degraded fallback, then stop the instant a LIVE
+ * fetch succeeds. Reads the provider id from the query key (index 1), so it is
+ * decoupled from the list shape and safe across providers. RQ v5 passes the
+ * Query instance.
+ */
+export function modelListRefetchInterval(
+  query: { queryKey: readonly unknown[] },
+): number | false {
+  const providerId = typeof query.queryKey[1] === 'string' ? query.queryKey[1] : ''
+  return modelsDegraded(providerId) ? 8_000 : false
+}

--- a/website/src/test/AcpAdapter.models.test.ts
+++ b/website/src/test/AcpAdapter.models.test.ts
@@ -9,9 +9,17 @@ vi.mock('../api/client', () => ({
 
 import { api } from '../api/client'
 import { AcpAdapter } from '../providers/adapters/acp'
+import {
+  markModelsDegraded,
+  modelsDegraded,
+  modelListRefetchInterval,
+} from '../providers/modelListHealth'
 
 describe('AcpAdapter.fetchAvailableModels', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
 
   it('returns backend-advertised models on success', async () => {
     ;(api.models as any).mockResolvedValue([
@@ -55,5 +63,131 @@ describe('AcpAdapter.fetchAvailableModels', () => {
     const models = await new AcpAdapter().fetchAvailableModels()
     expect(models[0].name).toBe('auto')
     expect(models[0].contextWindow).toBeGreaterThan(0)
+  })
+
+  it('persists a good live list to localStorage', async () => {
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+    ])
+    await new AcpAdapter().fetchAvailableModels()
+    const raw = localStorage.getItem('kc.acp.models.v1')
+    expect(raw).toBeTruthy()
+    const cached = JSON.parse(raw as string)
+    expect(cached.models.map((m: any) => m.name)).toEqual(['auto', 'claude-opus-4.8'])
+    expect(typeof cached.ts).toBe('number')
+  })
+
+  it('serves the last-good cached list (not auto-only) when the API throws', async () => {
+    // Prime the cache with a good live fetch.
+    ;(api.models as any).mockResolvedValueOnce([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+      { model_name: 'claude-fable-5', description: 'c' },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    // Next fetch fails transiently — should degrade to the cached 3, not auto-only.
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const models = await adapter.fetchAvailableModels()
+    expect(models).toHaveLength(3)
+    expect(models.map(m => m.name)).toContain('claude-fable-5')
+  })
+
+  it('falls back to auto-only when the API throws and there is no cache', async () => {
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const models = await new AcpAdapter().fetchAvailableModels()
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
+  })
+
+  it('does not overwrite the cache with an empty/failed result', async () => {
+    ;(api.models as any).mockResolvedValueOnce([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    ;(api.models as any).mockResolvedValue([]) // empty success must not clobber cache
+    await adapter.fetchAvailableModels()
+    const cached = JSON.parse(localStorage.getItem('kc.acp.models.v1') as string)
+    expect(cached.models).toHaveLength(2)
+  })
+
+  it('ignores a cache older than the TTL (bounds -32603 exposure)', async () => {
+    // Write a stale cache (25h old) directly.
+    localStorage.setItem(
+      'kc.acp.models.v1',
+      JSON.stringify({
+        ts: Date.now() - 25 * 60 * 60 * 1000,
+        models: [{ name: 'auto' }, { name: 'stale-model' }],
+      }),
+    )
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const models = await new AcpAdapter().fetchAvailableModels()
+    // Too stale to trust → auto-only, not the stale cached list.
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
+  })
+
+  it('ignores a cache with a future timestamp (clock skew)', async () => {
+    localStorage.setItem(
+      'kc.acp.models.v1',
+      JSON.stringify({
+        ts: Date.now() + 60 * 60 * 1000, // 1h in the future
+        models: [{ name: 'auto' }, { name: 'skewed-model' }],
+      }),
+    )
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const models = await new AcpAdapter().fetchAvailableModels()
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
+  })
+})
+
+describe('model-list liveness (self-heal signal)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    markModelsDegraded('acp', false)
+  })
+
+  it('marks degraded on failure and clears it on a live success', async () => {
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    expect(modelsDegraded('acp')).toBe(true)
+    // Poll continues while degraded, regardless of served list length.
+    expect(modelListRefetchInterval({ queryKey: ['available-models', 'acp'] })).toBe(8_000)
+
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+    ])
+    await adapter.fetchAvailableModels()
+    expect(modelsDegraded('acp')).toBe(false)
+    // Live success → stop polling.
+    expect(modelListRefetchInterval({ queryKey: ['available-models', 'acp'] })).toBe(false)
+  })
+
+  it('keeps polling on a degraded CACHED multi-model list (the -32603/stale bug)', async () => {
+    // Prime a good live list, then fail: the served list is multi-entry but
+    // degraded — polling MUST continue (the old length>1 heuristic stopped it).
+    ;(api.models as any).mockResolvedValueOnce([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+      { model_name: 'claude-fable-5', description: 'c' },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    const served = await adapter.fetchAvailableModels()
+    expect(served.length).toBeGreaterThan(1) // multi-entry cached list
+    expect(modelsDegraded('acp')).toBe(true)
+    expect(modelListRefetchInterval({ queryKey: ['available-models', 'acp'] })).toBe(8_000)
+  })
+
+  it('does not poll an unmarked/unknown provider', () => {
+    expect(modelListRefetchInterval({ queryKey: ['available-models', 'other'] })).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem
When `/api/models` briefly fails — a creds/token hiccup, or a cold `kiro-cli --list-models` spawn exceeding the gateway timeout → HTTP 503 — the model picker collapses to an **auto-only** list (a single entry). Because `fetchAvailableModels()` catches the failure and returns that fallback as a *successful* result, React Query caches it and only refetches on window-refocus/remount, so the picker can sit stuck on the short list for a long time. Users saw "far fewer models than normal" and slow self-heal.

## Why it matters
The model picker is a core chat control. Collapsing to auto-only (and staying there) hides every real model for an extended window, and registry-key fallbacks (`fable-5-1m`, …) are invalid ACP ids the CLI rejects (`-32603`) — so the user can't reliably switch models until the backend recovers.

## Fix (symptom → root cause → change)
- **Symptom:** picker shows only `auto` (or a stale short list) and takes a long time to recover.
- **Root cause:** (1) no memory of the last good list, so a transient 503 degrades to auto-only; (2) the caught fallback is cached as success with a 30s staleTime and **no polling**, so recovery waits for refocus/remount.
- **Change:**
  1. **localStorage last-good cache** (`kc.acp.models.v1`, TTL 24h) in `AcpAdapter`: each successful live `/api/models` result is persisted with a timestamp; on a transient 503/empty result the adapter serves the **last-known-good live list** (real backend ids) instead of auto-only, falling through to auto-only only when there is no fresh cache. The 24h TTL bounds staleness so an old cache can't offer a since-removed model indefinitely (see note below). Empty/failed results never clobber the cache.
  2. **Explicit liveness-driven self-heal** (`providers/modelListHealth.ts`): the adapter marks the served list live or degraded per provider; `modelListRefetchInterval` polls every 8s **while the list is degraded** and stops **only after a live fetch succeeds** — keyed off an explicit signal (read from the query key), NOT the list shape. Wired into the four `['available-models']` query sites (`ChatPane`, `ChatPage`, `AgentsPage`, `ChatSidebar`).

## Reviewer findings addressed
- **Codex MEDIUM / Design finding 1 & 3 (stop polling only after a live response):** the earlier `length > 1` heuristic couldn't tell a live success from a stale multi-entry cache, so polling stopped on any multi-entry list and stale options could later hit `-32603`. Replaced with the explicit `markModelsDegraded`/`modelsDegraded` liveness signal above, so recovery continues until a genuine live fetch lands. The invariant now lives in one place (`modelListHealth.ts`), decoupled from the list shape.
- **Design finding 2 (stale cache → `-32603`):** added the 24h TTL; the residual window is now time-boxed rather than unbounded. This is a deliberate mitigation, not a claim of zero risk.
- **Design finding 1 (non-throwing adapter contract):** kept deliberately — the four call sites have no per-query error UX, and returning the cached list keeps the picker populated during a hiccup. Failures are still surfaced through the degraded-state polling + the existing error paths rather than an unhandled throw.

## Tests
`website/src/test/AcpAdapter.models.test.ts` (existing behavior preserved; new cases):
- persists a good live list (with timestamp) to localStorage;
- serves the last-good cached list (not auto-only) when the API throws;
- falls back to auto-only when the API throws and there is no cache;
- an empty/failed result does not overwrite a good cache;
- **ignores a cache older than the TTL** (bounds `-32603` exposure);
- **marks degraded on failure, clears it on a live success**, and keeps polling on a degraded *multi-model cached* list (the exact bug the reviewers flagged);
- does not poll an unmarked/unknown provider.

## Manual verification
N/A — unit coverage exercises the fallback/persistence/TTL branches and the liveness/refetch predicate directly. No visual layout change.

## Screenshots
N/A — no visual/layout change. The fix is purely behavioral (which models populate the existing picker during a transient backend failure, and how quickly it recovers).
