### PR TITLE
fix(instances): keep tab strip reachable while a remote pane loads or dies

### DIFF
--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -21,13 +21,21 @@
  * For an active instance with no warm iframe (down / reconnecting after a
  * restart) it renders an in-pane error/reconnect panel; otherwise it renders
  * nothing only when nothing is warm.
+ *
+ * - **Pane readiness** (strand fix): a warm iframe is only trusted once its
+ *   embedded SPA posts `mc-embedded-ready` for the current src. Until then the
+ *   active pane shows a loading overlay that carries the tab strip (the local
+ *   header is hidden while a remote tab is active, so without it a slow or
+ *   dead load stranded the user on a black pane with no tabs). If readiness
+ *   never arrives within PANE_LOAD_TIMEOUT_MS the error panel surfaces with
+ *   Retry, which force-reloads the iframe even for an identical re-minted src.
  */
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { api } from '../api/client'
 import { useAppDispatch, useAppSelector } from '../store'
-import { removeWarm, setActiveId, setUnread, setWarm } from '../store/instancesSlice'
+import { removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { TRAFFIC_LIGHT_INSET_PX } from '../lib/electron'
@@ -42,6 +50,13 @@ const REFRESH_AT_ELAPSED_FRAC = 0.8
 // reactive (auth-expired) path so a persistently-rejecting remote can't spin
 // a reconnect/reload storm.
 const REFRESH_MIN_INTERVAL_MS = 10_000
+// If the ACTIVE pane's embedded SPA hasn't announced `mc-embedded-ready`
+// within this long of its iframe (re)loading, treat the load as failed and
+// surface the error panel (with the tab strip) instead of a silent black pane.
+// Iframes report no load errors to the parent, and the backend can say
+// "connected" while the browser-side load is dead (tunnel half-up, token
+// rejected, remote gateway mid-restart) — this watchdog is the only signal.
+const PANE_LOAD_TIMEOUT_MS = 15_000
 
 /** Parse a ``<int>[hm]`` TTL (e.g. "20h", "30m") to seconds; 0 if unparseable. */
 function ttlToSeconds(ttl: string): number {
@@ -58,6 +73,9 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   const activeId = useAppSelector(s => s.instances.activeId)
   const mru = useAppSelector(s => s.instances.mru)
   const unread = useAppSelector(s => s.instances.unread)
+  // Panes whose embedded SPA has announced readiness for their CURRENT src.
+  // Tests preload partial slices, so tolerate a missing map.
+  const ready = useAppSelector(s => s.instances.ready) ?? {}
 
   // Embedded instance panes never host nested panes (single-level by design),
   // so skip the poll and render nothing — see isEmbeddedPane / InstanceTabBar.
@@ -171,7 +189,10 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         }
       } else if (data.type === 'mc-embedded-ready') {
         // The pane just (re)mounted and asked for the current model — send it now
-        // rather than waiting for the next input-driven broadcast.
+        // rather than waiting for the next input-driven broadcast. Also record
+        // readiness: this is the parent's only proof the pane actually loaded
+        // (drives the loading overlay + load watchdog below).
+        dispatch(setPaneReady(id))
         postModelToRef.current(id)
       }
     }
@@ -210,6 +231,44 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       void queryClient.invalidateQueries({ queryKey: ['instances'] })
     },
   })
+
+  // Load watchdog + forced reload. `timedOut[id]` flips true when the active
+  // pane's iframe has been loading for PANE_LOAD_TIMEOUT_MS without the
+  // embedded SPA announcing readiness; the render below then swaps the black
+  // pane for the error panel (which carries the tab strip, so the user is
+  // never stranded). `reloadSeq[id]` is bumped by Retry to force an iframe
+  // remount even when the backend returns the SAME cached port+token (identical
+  // src would otherwise not reload a dead frame).
+  const [timedOut, setTimedOut] = useState<Record<string, boolean>>({})
+  const [reloadSeq, setReloadSeq] = useState<Record<string, number>>({})
+  const activeWarmConn = activeId ? warm[activeId] : undefined
+  // Primitive deps for the watchdog effect (a fresh conn object identity on
+  // every setWarm would defeat the dep comparison; the src only depends on these).
+  const activeWarmPort = activeWarmConn?.port
+  const activeWarmToken = activeWarmConn?.token
+  const activeReady = activeId ? !!ready[activeId] : true
+  const activeSeq = activeId ? reloadSeq[activeId] || 0 : 0
+  useEffect(() => {
+    if (!activeId || activeWarmPort === undefined || activeReady) return
+    const id = activeId
+    const t = window.setTimeout(() => {
+      setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
+    }, PANE_LOAD_TIMEOUT_MS)
+    return () => window.clearTimeout(t)
+    // Restart the countdown whenever the pane's src (port/token) or forced
+    // reload sequence changes — each of those reloads the iframe.
+  }, [activeId, activeWarmPort, activeWarmToken, activeSeq, activeReady])
+
+  const retry = useCallback(
+    (id: string) => {
+      // Clear the stale verdict and force a reload even if the re-mint returns
+      // an identical token (setWarm would be a no-op for the iframe src).
+      setTimedOut(prev => ({ ...prev, [id]: false }))
+      setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
+      connectMutation.mutate(id)
+    },
+    [connectMutation],
+  )
 
   // K-cap eviction drops only the least-recently-used non-active *warm iframe*
   // to free memory — it does NOT disconnect the tunnel or clear was_connected,
@@ -321,7 +380,16 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // in the results) is treated as "no evidence of disconnection" so we never
   // flash the panel over a perfectly healthy warm iframe.
   const activeLive = !activeInst || activeInst.status?.state === 'connected'
-  const showPanel = activeId !== null && (!warm[activeId] || !activeLive)
+  // Watchdog verdict for the active pane: only meaningful while it has still
+  // not announced readiness (a late `mc-embedded-ready` clears the alarm).
+  const activeTimedOut = activeId !== null && !!timedOut[activeId] && !activeReady
+  const showPanel = activeId !== null && (!warm[activeId] || !activeLive || activeTimedOut)
+  // Loading overlay: the active pane is warm and the backend says connected,
+  // but the embedded SPA hasn't announced readiness yet. Without this the
+  // window between Retry succeeding (setWarm) and the remote SPA rendering its
+  // embedded switcher is a black pane with NO tabs — the local header is
+  // display:none while a remote tab is active, so the user was stranded.
+  const showLoading = !showPanel && activeId !== null && !!warm[activeId] && !activeReady
   if (embedded || (warmIds.length === 0 && !showPanel)) return null
 
   const nameFor = (id: string) =>
@@ -340,7 +408,9 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     >
       {warmIds.map(id => (
         <iframe
-          key={id}
+          // reloadSeq in the key forces a remount (= reload) on Retry even when
+          // the re-minted src is byte-identical to the dead frame's.
+          key={`${id}:${reloadSeq[id] || 0}`}
           ref={el => {
             if (el) iframeRefs.current.set(id, el)
             else iframeRefs.current.delete(id)
@@ -352,6 +422,24 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           style={{ display: id === activeId ? 'block' : 'none' }}
         />
       ))}
+      {showLoading && activeId && (
+        <div className="absolute inset-0 flex flex-col bg-bg">
+          {/* Same escape hatch as the error panel: while this overlay is up the
+              only other switcher lives inside the still-loading iframe, so the
+              strip is the user's sole way to reach Local or another instance. */}
+          <InstanceTabBar
+            variant="strip"
+            style={macInset ? { paddingLeft: TRAFFIC_LIGHT_INSET_PX } : undefined}
+          />
+          <div className="flex-1 flex items-center justify-center p-6">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <Loader2 size={28} className="animate-spin text-muted" />
+              <div className="text-sm font-medium text-text">{nameFor(activeId)}</div>
+              <div className="text-xs text-muted">Loading pane…</div>
+            </div>
+          </div>
+        </div>
+      )}
       {showPanel && activeId && (
         <div className="absolute inset-0 flex flex-col bg-bg">
           {/* Escape hatch (bug: stranded on the disconnect view). While a remote
@@ -376,10 +464,18 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
               <div className="text-xs text-muted">
                 {panelConnecting
                   ? 'Connecting…'
-                  : panelState === 'error'
-                    ? 'Connection error'
-                    : 'Disconnected'}
+                  : activeTimedOut
+                    ? 'Pane failed to load'
+                    : panelState === 'error'
+                      ? 'Connection error'
+                      : 'Disconnected'}
               </div>
+              {!panelConnecting && activeTimedOut && !panelError && (
+                <div className="text-xs text-muted">
+                  The tunnel looks connected but the remote dashboard never loaded. It may be
+                  restarting — retry, or switch tabs above.
+                </div>
+              )}
               {!panelConnecting && panelError && (
                 <div className="w-full max-h-32 overflow-auto rounded-md border border-border bg-bg-hover px-3 py-2 text-left text-xs text-muted whitespace-pre-wrap break-words">
                   {panelError}
@@ -388,7 +484,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
               <button
                 type="button"
                 disabled={panelConnecting}
-                onClick={() => connectMutation.mutate(activeId)}
+                onClick={() => retry(activeId)}
                 className="mt-1 inline-flex items-center gap-1.5 text-xs py-1.5 px-3.5 rounded-md bg-accent text-accent-fg disabled:opacity-60"
               >
                 <RefreshCw size={13} className={panelConnecting ? 'animate-spin' : ''} /> Retry

--- a/website/src/store/instancesSlice.ts
+++ b/website/src/store/instancesSlice.ts
@@ -63,6 +63,10 @@ interface InstancesState {
   activeId: string | null
   mru: string[]
   unread: Record<string, number>
+  /** Panes whose embedded SPA announced `mc-embedded-ready` for the CURRENT
+   *  src (port+token). Cleared whenever the src changes (a reload is coming),
+   *  so the viewport can tell a live pane from one still loading / dead. */
+  ready: Record<string, boolean>
   host: HostModel | null
 }
 
@@ -71,6 +75,7 @@ const initialState: InstancesState = {
   activeId: null,
   mru: [],
   unread: {},
+  ready: {},
   host: null,
 }
 
@@ -79,8 +84,17 @@ const instancesSlice = createSlice({
   initialState,
   reducers: {
     setWarm(state, action: PayloadAction<{ id: string; conn: WarmConn }>) {
-      state.warm[action.payload.id] = action.payload.conn
-      state.mru = [action.payload.id, ...state.mru.filter(x => x !== action.payload.id)]
+      const { id, conn } = action.payload
+      const prev = state.warm[id]
+      // A new port/token changes the iframe src (srcFor), which reloads the
+      // pane — its previous readiness no longer describes what's on screen.
+      // Tests preload partial slices, so tolerate a missing `ready` map.
+      if (!state.ready) state.ready = {}
+      if (!prev || prev.port !== conn.port || prev.token !== conn.token) {
+        delete state.ready[id]
+      }
+      state.warm[id] = conn
+      state.mru = [id, ...state.mru.filter(x => x !== id)]
     },
     setActiveId(state, action: PayloadAction<string | null>) {
       state.activeId = action.payload
@@ -95,8 +109,14 @@ const instancesSlice = createSlice({
       const id = action.payload
       delete state.warm[id]
       delete state.unread[id]
+      if (state.ready) delete state.ready[id]
       state.mru = state.mru.filter(x => x !== id)
       if (state.activeId === id) state.activeId = null
+    },
+    /** The pane's embedded SPA mounted and announced `mc-embedded-ready`. */
+    setPaneReady(state, action: PayloadAction<string>) {
+      if (!state.ready) state.ready = {}
+      state.ready[action.payload] = true
     },
     setUnread(state, action: PayloadAction<{ id: string; count: number }>) {
       state.unread[action.payload.id] = action.payload.count
@@ -111,6 +131,13 @@ const instancesSlice = createSlice({
   },
 })
 
-export const { setWarm, setActiveId, removeWarm, setUnread, setHostModel, clearInstances } =
-  instancesSlice.actions
+export const {
+  setWarm,
+  setActiveId,
+  removeWarm,
+  setPaneReady,
+  setUnread,
+  setHostModel,
+  clearInstances,
+} = instancesSlice.actions
 export default instancesSlice.reducer

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders, createTestStore } from './helpers'
 import InstancesViewport from '../components/InstancesViewport'
@@ -313,5 +313,172 @@ describe('InstancesViewport', () => {
     await waitFor(() => expect(store.getState().instances.warm['cd-1']).toBeUndefined())
     expect(store.getState().instances.warm['cd-2']).toBeDefined()
     expect(api.disconnectInstance).not.toHaveBeenCalled()
+  })
+
+  // Explicit connected-instance mock for the readiness/watchdog tests below —
+  // earlier tests override listInstances and clearAllMocks() does NOT restore
+  // implementations, so relying on the module-level default is order-dependent.
+  const mockConnectedCd1 = () =>
+    vi.mocked(api.listInstances).mockResolvedValue({
+      instances: [
+        {
+          id: 'cd-1',
+          name: 'Cloud One',
+          ssh_host: 'cd-1-alias',
+          remote_port: 7777,
+          local_port: 7778,
+          ttl: '20h',
+          remote_bin: '',
+          status: { instance_id: 'cd-1', state: 'connected', local_port: 7778, remote_port: 7777 },
+        },
+      ],
+      warm_set_cap: 5,
+    })
+
+  it('shows a loading overlay WITH the tab strip for an active warm pane that has not announced readiness', async () => {
+    // Regression (strand bug): after Retry succeeds, setWarm mounts the iframe
+    // and the error panel (with its escape-hatch tab strip) unmounted
+    // immediately — leaving a black loading pane with NO tabs. The overlay must
+    // keep the switcher reachable until the embedded SPA is actually up.
+    mockConnectedCd1()
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+
+    expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+    // The full switcher renders atop the overlay: the user can always escape.
+    const bar = await screen.findByRole('tablist', { name: /Instances/i })
+    expect(bar).toBeInTheDocument()
+    // Not the error panel — no Retry while the load is still in flight.
+    expect(screen.queryByText(/Connection error/i)).toBeNull()
+  })
+
+  it('dismisses the loading overlay when the pane posts mc-embedded-ready from its tunnel origin', async () => {
+    mockConnectedCd1()
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+    expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+
+    // The embedded SPA announces readiness from its validated loopback origin.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'mc-embedded-ready', v: 1 },
+        origin: 'http://127.0.0.1:7778',
+      }),
+    )
+    await waitFor(() => expect(store.getState().instances.ready['cd-1']).toBe(true))
+    await waitFor(() => expect(screen.queryByText(/Loading pane/i)).toBeNull())
+  })
+
+  it('ignores mc-embedded-ready from an unknown origin (no readiness, overlay stays)', async () => {
+    mockConnectedCd1()
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+    expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+
+    // Wrong port (no warm tunnel) and a non-loopback origin must both be dropped.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'mc-embedded-ready', v: 1 },
+        origin: 'http://127.0.0.1:9999',
+      }),
+    )
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'mc-embedded-ready', v: 1 },
+        origin: 'https://evil.example.com',
+      }),
+    )
+    expect(store.getState().instances.ready['cd-1']).toBeUndefined()
+    expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+  })
+
+  it('surfaces the error panel with Retry when the pane never becomes ready (load watchdog)', async () => {
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+
+      // 15s without mc-embedded-ready -> the silent black pane becomes an
+      // actionable error panel (backend still says connected, so without the
+      // watchdog nothing would ever surface it).
+      await act(async () => {
+        vi.advanceTimersByTime(15_000)
+      })
+      expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+    // The escape-hatch strip is on the panel (query resolves under real timers).
+    expect(await screen.findByRole('tablist', { name: /Instances/i })).toBeInTheDocument()
+  })
+
+  it('Retry after a load timeout force-reloads the iframe even for an identical token', async () => {
+    mockConnectedCd1()
+    // connectInstance returns the SAME port+token as the preloaded warm entry —
+    // the src is byte-identical, so only a keyed remount can reload a dead frame.
+    vi.mocked(api.connectInstance).mockResolvedValue({ state: 'connected', local_port: 7778, token: 'tok' })
+    vi.useFakeTimers()
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+    await act(async () => {
+      vi.advanceTimersByTime(15_000)
+    })
+    expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+    const before = document.querySelector('iframe') as HTMLIFrameElement
+    // Click under real timers — userEvent/waitFor deadlock with fake ones.
+    vi.useRealTimers()
+
+    const u = userEvent.setup()
+    await u.click(screen.getByRole('button', { name: /Retry/i }))
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1'))
+    // Back to the loading overlay (verdict cleared), not the error panel.
+    await waitFor(() => expect(screen.queryByText(/Pane failed to load/i)).toBeNull())
+    expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+    // The iframe was remounted (new element) to force the reload.
+    const after = document.querySelector('iframe') as HTMLIFrameElement
+    expect(after).not.toBe(before)
+  })
+
+  it('a late mc-embedded-ready clears a timed-out verdict without Retry', async () => {
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      await act(async () => {
+        vi.advanceTimersByTime(15_000)
+      })
+      expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+
+      // The pane was just slow — a late readiness announcement restores it.
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { type: 'mc-embedded-ready', v: 1 },
+            origin: 'http://127.0.0.1:7778',
+          }),
+        )
+      })
+      expect(store.getState().instances.ready['cd-1']).toBe(true)
+      expect(screen.queryByText(/Pane failed to load/i)).toBeNull()
+      expect(screen.queryByText(/Loading pane/i)).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/website/src/test/instancesSlice.test.ts
+++ b/website/src/test/instancesSlice.test.ts
@@ -3,11 +3,12 @@ import reducer, {
   setWarm,
   setActiveId,
   removeWarm,
+  setPaneReady,
   setUnread,
   clearInstances,
 } from '../store/instancesSlice'
 
-const initial = { warm: {}, activeId: null, mru: [], unread: {}, host: null }
+const initial = { warm: {}, activeId: null, mru: [], unread: {}, ready: {}, host: null }
 
 describe('instancesSlice', () => {
   it('setWarm stores the conn and fronts it in mru', () => {
@@ -52,5 +53,28 @@ describe('instancesSlice', () => {
     expect(s.unread.a).toBe(4)
     s = reducer(s, clearInstances())
     expect(s).toEqual(initial)
+  })
+
+  it('setPaneReady marks the pane; setWarm with a NEW src clears it (a reload is coming)', () => {
+    let s = reducer(initial, setWarm({ id: 'a', conn: { port: 7778, token: 't1' } }))
+    s = reducer(s, setPaneReady('a'))
+    expect(s.ready.a).toBe(true)
+    // Token refresh -> new src -> the old readiness no longer applies.
+    s = reducer(s, setWarm({ id: 'a', conn: { port: 7778, token: 't2' } }))
+    expect(s.ready.a).toBeUndefined()
+  })
+
+  it('setWarm with an IDENTICAL conn preserves readiness (no reload happens)', () => {
+    let s = reducer(initial, setWarm({ id: 'a', conn: { port: 7778, token: 't1' } }))
+    s = reducer(s, setPaneReady('a'))
+    s = reducer(s, setWarm({ id: 'a', conn: { port: 7778, token: 't1' } }))
+    expect(s.ready.a).toBe(true)
+  })
+
+  it('removeWarm clears readiness alongside warm/unread', () => {
+    let s = reducer(initial, setWarm({ id: 'a', conn: { port: 7778, token: 't1' } }))
+    s = reducer(s, setPaneReady('a'))
+    s = reducer(s, removeWarm('a'))
+    expect(s.ready).toEqual({})
   })
 })


### PR DESCRIPTION
## Problem

Clicking a remote instance tab and then **Retry** leaves the app on a completely black pane with **no tabs, no spinner, no error** — the dashboard looks dead and the only recourse is to wait. If the pane's browser-side load fails silently (tunnel half-up, token rejected, remote gateway mid-restart), the black state persists indefinitely.

## Why it matters

While a remote tab is active the entire local dashboard — including the top `InstanceTabBar` — is `display:none` (App.tsx pane stack), so this state has **zero navigation affordances**: the user cannot reach Local or any other instance and effectively loses the whole app until the remote pane happens to come up. Every user of the Instances feature hits this on any slow or failed reconnect.

## Fix (symptoms → root cause → change)

**Symptom chain:** Retry → black pane, no tabs.

**Root cause:** `InstancesViewport` showed the error panel (which carries the escape-hatch tab strip) only while `!warm[activeId] || !activeLive`. The moment Retry's `connectInstance` succeeded, `setWarm` fired → the panel and its tab strip **unmounted instantly**, while the freshly-mounted iframe had only started loading. The only remaining switcher lives *inside* that iframe, so until the remote SPA renders, there is nothing on screen. Worse, iframes report no load errors to the parent, and the backend can report `connected` while the browser-side load is dead — so the existing status-based panel check could never surface these failures, and the instances poll is 60 s.

**Change (deterministic, reuses an existing signal):**
- **Per-pane readiness** (`instancesSlice.ready`): the embedded pane already posts `mc-embedded-ready` on mount (`EmbeddedHostBridge`); the parent's existing origin-validated listener now records it. Readiness is cleared whenever the pane's src (port/token) changes, since that reloads the iframe.
- **Loading overlay with tabs:** while the active pane is warm but not ready, an overlay renders the full `InstanceTabBar` strip + a "Loading pane…" spinner above the loading iframe. The switcher is always reachable; the user is never stranded.
- **15 s load watchdog:** if readiness never arrives, the error panel surfaces ("Pane failed to load") with Retry and the tab strip — covering silent browser-side failures the backend can't see. A late `mc-embedded-ready` clears the verdict without user action.
- **Retry force-reloads:** Retry bumps a per-pane key on the iframe so it remounts even when the re-minted token is byte-identical to the dead frame's src (previously a no-op reload).

Security posture unchanged: readiness rides the existing `mc-embedded-ready` message and is gated by the same `resolveTunnelOrigin` loopback-origin + warm-port validation as the unread relay; messages from unknown origins are dropped (test-covered).

## Tests

9 new tests (all 4,030 frontend tests pass):

`InstancesViewport.test.tsx`
- loading overlay renders WITH the tab strip for an active warm pane that hasn't announced readiness (the strand regression)
- `mc-embedded-ready` from the validated tunnel origin dismisses the overlay
- `mc-embedded-ready` from an unknown port / non-loopback origin is ignored
- watchdog: 15 s without readiness surfaces the error panel with Retry + tab strip
- Retry after a timeout force-remounts the iframe even for an identical token, returning to the loading overlay
- a late `mc-embedded-ready` clears a timed-out verdict without Retry

`instancesSlice.test.ts`
- `setPaneReady` marks; `setWarm` with a NEW src clears readiness
- `setWarm` with an IDENTICAL conn preserves readiness (no reload happens)
- `removeWarm` clears readiness alongside warm/unread

## Manual verification

Needed (jsdom can't exercise real iframe loading): build the frontend, restart the local gateway, click a down instance tab → Retry. Expected: tab strip visible throughout, spinner while the pane loads, pane appears when ready; kill the remote gateway and retry → "Pane failed to load" panel after 15 s with working tab switching.
