### PR TITLE
fix(security): allowlist markdown attributes and scope reaper PassRole to lambda

### DIFF
--- a/src/kiro_crew/deploy/iam.py
+++ b/src/kiro_crew/deploy/iam.py
@@ -481,9 +481,25 @@ def policy_document(*, include_custom_domain: bool = False, tier: str = "static"
                     "iam:DeleteRole", "iam:GetRole",
                     "iam:PutRolePolicy", "iam:DeleteRolePolicy",
                     "iam:AttachRolePolicy", "iam:DetachRolePolicy",
-                    "iam:PassRole", "iam:TagRole",
+                    "iam:TagRole",
                 ],
                 "Resource": "arn:aws:iam::*:role/kirocrew-deploy-reaper*",
+            },
+            {
+                # PassRole scoped to lambda only — the reaper execution role is
+                # passed solely to the EventBridge-timed reaper Lambda. Mirrors
+                # IAMPassRoleLambdaOnly for app roles so the role can't be
+                # passed to any other service (resource prefix bounds WHICH
+                # role; PassedToService bounds TO WHICH service).
+                "Sid": "ReaperPassRoleLambdaOnly",
+                "Effect": "Allow",
+                "Action": ["iam:PassRole"],
+                "Resource": "arn:aws:iam::*:role/kirocrew-deploy-reaper*",
+                "Condition": {
+                    "StringEquals": {
+                        "iam:PassedToService": "lambda.amazonaws.com"
+                    }
+                },
             },
             {
                 "Sid": "ReaperEvents",

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -217,6 +217,23 @@ def test_policy_fullstack_passrole_scoped_to_lambda():
     assert cond.get("StringEquals", {}).get("iam:PassedToService") == "lambda.amazonaws.com"
 
 
+def test_policy_reaper_passrole_scoped_to_lambda():
+    """Reaper PassRole must be split out and constrained to lambda.amazonaws.com,
+    mirroring IAMPassRoleLambdaOnly — resource prefix alone bounds WHICH role but
+    not TO WHICH service."""
+    doc = iam_mod.policy_document(tier="fullstack")
+    pass_stmt = next(
+        (s for s in doc["Statement"] if s.get("Sid") == "ReaperPassRoleLambdaOnly"), None)
+    assert pass_stmt is not None, "ReaperPassRoleLambdaOnly statement missing"
+    assert pass_stmt["Action"] == ["iam:PassRole"]
+    assert "kirocrew-deploy-reaper" in pass_stmt["Resource"]
+    cond = pass_stmt.get("Condition", {})
+    assert cond.get("StringEquals", {}).get("iam:PassedToService") == "lambda.amazonaws.com"
+    # PassRole must no longer be bundled in the general ReaperIAMRole statement.
+    reaper_iam = next(s for s in doc["Statement"] if s["Sid"] == "ReaperIAMRole")
+    assert "iam:PassRole" not in reaper_iam["Action"]
+
+
 def test_policy_custom_domain_no_delete_certificate():
     """acm:DeleteCertificate must not be granted (no template uses it)."""
     doc = iam_mod.policy_document(include_custom_domain=True)

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -297,9 +297,65 @@ const ALLOWED_TAGS = new Set([
   // Math (rehypeKatex pipeline -- pass through rehypeRaw)
   'math', 'inlinemath',
 ])
-const DANGEROUS_ATTR_RE = /^on/i  // onclick, onerror, onload, etc.
 const DANGEROUS_PROTOCOLS = ['javascript:', 'data:', 'vbscript:']
 const cleanUrl = (url: string) => url.replace(/[\x00-\x1f\x7f]/g, '').trim().toLowerCase()
+
+/**
+ * Attribute ALLOWLIST (replaces the former on-handler / protocol denylist).
+ *
+ * frontend-security: for an allowlisted element we now KEEP only the attributes
+ * explicitly permitted for it and DROP everything else — so `style`,
+ * `formaction`, `srcset`-on-the-wrong-tag, unknown `on*` handlers, etc. are all
+ * removed by default rather than only the handful we remembered to block.
+ *
+ * Matching is case-insensitive because hast camelCases some property names
+ * (`viewBox`, `colSpan`, `ariaHidden`, `data-*` → `dataSourcepos`); we always
+ * compare on the lowercased key. `aria*`/`data*` prefixes are allowed wholesale
+ * (inert, a11y/metadata only).
+ */
+const GLOBAL_ATTRS = new Set([
+  'classname', 'class', 'id', 'title', 'dir', 'lang', 'role', 'align',
+])
+const TAG_ATTRS: Record<string, Set<string>> = {
+  a: new Set(['href', 'name', 'target', 'rel']),
+  img: new Set(['src', 'alt', 'width', 'height', 'loading']),
+  input: new Set(['type', 'checked', 'disabled']),
+  ol: new Set(['start', 'type', 'reversed']),
+  li: new Set(['value']),
+  td: new Set(['colspan', 'rowspan', 'headers']),
+  th: new Set(['colspan', 'rowspan', 'scope', 'headers']),
+  col: new Set(['span', 'width']),
+  colgroup: new Set(['span', 'width']),
+  source: new Set(['src', 'srcset', 'type', 'media', 'sizes']),
+  video: new Set(['src', 'controls', 'width', 'height', 'poster', 'loop', 'muted', 'preload']),
+  audio: new Set(['src', 'controls', 'loop', 'muted', 'preload']),
+  details: new Set(['open']),
+  time: new Set(['datetime']),
+}
+// SVG-family elements share a pool of inert presentation/geometry attributes.
+const SVG_TAGS = new Set([
+  'svg', 'path', 'circle', 'rect', 'line', 'polyline', 'polygon', 'text', 'g',
+  'defs', 'use', 'tspan', 'ellipse', 'lineargradient', 'radialgradient', 'stop',
+  'clippath', 'marker',
+])
+const SVG_ATTRS = new Set([
+  'viewbox', 'xmlns', 'fill', 'stroke', 'strokewidth', 'strokelinecap',
+  'strokelinejoin', 'strokedasharray', 'strokeopacity', 'fillopacity',
+  'fillrule', 'cliprule', 'clippath', 'opacity', 'transform', 'd', 'points',
+  'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx', 'ry', 'width',
+  'height', 'offset', 'stopcolor', 'stopopacity', 'gradientunits',
+  'gradienttransform', 'preserveaspectratio', 'markerwidth', 'markerheight',
+  'refx', 'refy', 'orient',
+])
+/** True when `key` is a permitted attribute for element `tag` (both lowercased). */
+function isAllowedAttr(tag: string, key: string): boolean {
+  const k = key.toLowerCase()
+  if (k.startsWith('aria') || k.startsWith('data')) return true
+  if (GLOBAL_ATTRS.has(k)) return true
+  if (TAG_ATTRS[tag]?.has(k)) return true
+  if (SVG_TAGS.has(tag) && SVG_ATTRS.has(k)) return true
+  return false
+}
 
 /** Elements that cannot have children per HTML spec (used by escapedNodeTree). */
 const VOID_ELEMENTS = new Set(['img', 'br', 'hr', 'input', 'source', 'wbr', 'col'])
@@ -388,12 +444,17 @@ function rehypeSanitize() {
           }
         }
 
-        // Strip event handler attributes, dangerous protocol URLs, and srcdoc
+        // Attribute ALLOWLIST: keep only attributes permitted for this element;
+        // drop everything else (was: a denylist that stripped on*/protocol/srcdoc
+        // and kept the rest). Retained URL-bearing attrs still get the
+        // dangerous-protocol check below.
         if (node.properties) {
           for (const [key, val] of Object.entries(node.properties)) {
-            if (DANGEROUS_ATTR_RE.test(key)) {
+            if (!isAllowedAttr(tagLower, key)) {
               delete node.properties[key]
-            } else if (typeof val === 'string') {
+              continue
+            }
+            if (typeof val === 'string') {
               const cleaned = cleanUrl(val)
               if (DANGEROUS_PROTOCOLS.some(p => cleaned.startsWith(p))) {
                 // Allow data:image/* on img src (inline base64 images)
@@ -404,7 +465,6 @@ function rehypeSanitize() {
               }
             }
           }
-          delete node.properties.srcdoc
         }
       }
       if (node.children) {

--- a/website/src/test/MarkdownRenderer.sanitize.test.tsx
+++ b/website/src/test/MarkdownRenderer.sanitize.test.tsx
@@ -127,6 +127,45 @@ describe('rehypeSanitize allowlist (React #290 fix)', () => {
     expect(container.querySelector('tspan')).not.toBeNull()
     expect(container.textContent).not.toContain('<tspan')
   })
+
+  it('drops non-allowlisted attributes (style) from allowed tags', () => {
+    // Attribute ALLOWLIST: `style` is not permitted, so CSS-injection payloads
+    // never reach the DOM even though the tag itself is allowed.
+    const { container } = render(
+      <MarkdownRenderer content={'<div style="background:url(javascript:alert(1))">x</div>'} />
+    )
+    const div = container.querySelector('div')
+    expect(div).not.toBeNull()
+    expect(div!.getAttribute('style')).toBeNull()
+    expect(container.innerHTML).not.toContain('javascript:')
+  })
+
+  it('drops formaction and unknown handler-ish attributes', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'<div formaction="x" onpointerdown="alert(1)">body</div>'} />
+    )
+    const html = container.innerHTML
+    expect(html).not.toContain('formaction')
+    expect(html).not.toContain('onpointerdown')
+    // Tag itself still renders.
+    expect(container.querySelector('div')).not.toBeNull()
+    expect(container.textContent).toContain('body')
+  })
+
+  it('keeps attributes the renderer depends on (href, svg geometry)', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'<a href="/x" title="t">link</a>'} />
+    )
+    expect(container.querySelector('a')!.getAttribute('href')).toBe('/x')
+
+    const svg = render(
+      <MarkdownRenderer content={'<svg><path d="M0 0" stroke="red"/></svg>'} />
+    )
+    const path = svg.container.querySelector('path')!
+    expect(path).not.toBeNull()
+    expect(path.getAttribute('d')).toBe('M0 0')
+    expect(path.getAttribute('stroke')).toBe('red')
+  })
 })
 
 describe('MessageErrorBoundary (per-message containment)', () => {


### PR DESCRIPTION
## Problem

Two issues raised in a security review of the KiroCrew code:

1. **Markdown HTML sanitizer denylists attributes.** `website/src/components/MarkdownRenderer.tsx` renders raw HTML embedded in markdown (via `rehypeRaw`) into the app's own origin. Its sanitizer *allowlists tags* but only *denylists attributes* — it strips `on*` handlers, dangerous-protocol values, and `srcdoc`, and keeps **everything else**. So an allowlisted element retains `style`, `formaction`, `srcset`, and any attribute nobody remembered to block.
2. **`iam:PassRole` without `PassedToService`.** In `src/kiro_crew/deploy/iam.py`, the reaper role statement bundled `iam:PassRole` with no `iam:PassedToService` condition (resource-scoped to `kirocrew-deploy-reaper*` only), unlike the app-role grant which is already lambda-scoped.

## Why it matters

- The markdown path renders into the dashboard's own origin, which holds the session that talks to the local gateway (tool/shell/agent execution). A denylist-based attribute filter is the fragile pattern where the miss is always the attribute nobody listed — an attacker-influenced attribute that slips through becomes a same-origin injection with a real command-execution ceiling (applies in both the browser and the hardened Electron app). Interactive widgets/artifacts are **not** affected (they render in a separate null-origin sandboxed iframe).
- Unconstrained-by-service `PassRole` is a standard IAM least-privilege gap; the sibling app statement already sets `PassedToService`, so the reaper statement should match.

## Fix (symptom → root cause → change)

**1. Attribute denylist → allowlist (`MarkdownRenderer.tsx`).**
Root cause: the sanitizer’s attribute loop deleted known-bad keys and kept the rest. Change: invert to a per-tag **attribute allowlist** — `GLOBAL_ATTRS` + per-tag `TAG_ATTRS` + `SVG_TAGS`/`SVG_ATTRS`, matched case-insensitively (hast camelCases `viewBox`/`colSpan`/`dataSourcepos`), with `aria*`/`data*` allowed as inert prefixes. Any attribute not permitted for the element is dropped; retained URL-bearing attrs still pass the dangerous-protocol check (with the existing `data:image/*`-on-`img` exception). The **tag** allowlist and the unknown-tag escaped-text behavior are unchanged, so GFM/task-lists/footnotes/inline-SVG/collapsibles still render and KaTeX/mermaid (which run outside the sanitizer) are untouched. Removed the now-unused `on*` denylist regex.

**2. Scope reaper `PassRole` to lambda (`deploy/iam.py`).**
Root cause: `iam:PassRole` was bundled into `ReaperIAMRole` with no service constraint. Change: split it into a dedicated `ReaperPassRoleLambdaOnly` statement with `Condition: StringEquals iam:PassedToService = lambda.amazonaws.com`, mirroring `IAMPassRoleLambdaOnly`. Resource prefix still bounds *which* role can be passed; `PassedToService` now bounds *to which service*. The reaper is a Lambda execution role only ever passed to `lambda.amazonaws.com`, so this is behavior-preserving.

## Tests

- `website/src/test/MarkdownRenderer.sanitize.test.tsx`: added cases asserting `style` is dropped, `formaction`/`on*` are dropped, and required attrs (`href`, SVG `d`/`stroke`) are kept. Full MarkdownRenderer suites: **71 passed**; `tsc -b` clean.
- `test/test_deploy_web_iam.py`: added `test_policy_reaper_passrole_scoped_to_lambda` (asserts the new statement exists, is lambda-scoped, and `iam:PassRole` no longer sits in `ReaperIAMRole`). Deploy-web IAM suite: **27 passed**; flake8/isort clean.

## Manual verification

N/A — unit coverage is sufficient. The markdown change is behavior-preserving for legitimate content (verified by the existing rendering suites), and the IAM change is a policy-generation diff verified by the policy tests.

## Screenshots

N/A — no user-visible UI change (the sanitizer change only removes non-allowlisted attributes that were never rendered by our components; the IAM change is backend policy generation).
