### PR TITLE
perf: transcript LRU cache and tail reads

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -15,9 +15,10 @@ import os
 import re
 import threading
 import time as _time
+from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
@@ -194,6 +195,105 @@ def _safe_key(key: str) -> str:
     return re.sub(r"[^\w\-.]", "_", key)
 
 
+#: Default upper bound on the number of distinct session keys held in the
+#: in-memory transcript / metadata caches.  The previous implementation used
+#: plain ``dict`` caches that grew one entry per session key touched and never
+#: evicted — on a gateway serving thousands of sessions the parsed message
+#: lists (each up to ~200 messages / 2 MB of source JSONL) accumulated in RAM
+#: for the lifetime of the process.  A bounded LRU keeps hot sessions resident
+#: while giving the working set a deterministic ceiling.
+_TRANSCRIPT_CACHE_MAX = 256
+
+
+_V = TypeVar("_V")
+
+
+class _LRUCache(Generic[_V]):
+    """A tiny bounded LRU cache with a dict-compatible surface.
+
+    Backed by an :class:`collections.OrderedDict`; the most recently
+    accessed key is kept at the end and eviction pops from the front
+    (least-recently-used), so eviction order is fully deterministic for a
+    given access sequence. Supports the subset of the mapping protocol the
+    caller relies on (``get`` / ``__getitem__`` / ``__setitem__`` / ``pop`` /
+    ``__contains__`` / ``__len__`` / ``clear``). Both reads (``get`` /
+    ``__getitem__``) and writes mark a key as recently used.
+
+    ``maxsize <= 0`` disables bounding (behaves like an ordinary dict) so a
+    caller can opt out without a code-path split.
+
+    Thread safety: the same :class:`ConversationLog` instance is touched from
+    the event loop *and* from worker threads (``chat_persistence`` flush /
+    restore, ``chat_regenerate`` / ``chat_rewind`` via ``asyncio.to_thread``,
+    ``handlers/cron`` and ``slack/gateway`` off-loop ``read_messages`` calls).
+    Every method therefore takes ``self._lock`` so each is atomic and the
+    compound read-modify-write sequences (``move_to_end`` + index in ``get`` /
+    ``__getitem__``; the eviction ``len()`` + ``popitem`` loop in
+    ``__setitem__``) cannot interleave with a concurrent ``pop`` / ``clear``.
+    Without it a concurrent ``pop`` landing in the bytecode gap between a
+    successful ``move_to_end`` and the following index raised ``KeyError``
+    (crashing the request/background task) instead of returning the default.
+    The operations are tiny in-memory dict ops, so lock contention is
+    negligible. A plain :class:`threading.Lock` suffices — no method calls
+    another locked method, so the lock is never re-entered.
+    """
+
+    def __init__(self, maxsize: int = _TRANSCRIPT_CACHE_MAX) -> None:
+        self._maxsize = maxsize
+        self._data: "OrderedDict[str, _V]" = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: str, default: _V | None = None) -> _V | None:
+        with self._lock:
+            try:
+                self._data.move_to_end(key)
+            except KeyError:
+                return default
+            return self._data[key]
+
+    def __getitem__(self, key: str) -> _V:
+        with self._lock:
+            self._data.move_to_end(key)
+            return self._data[key]
+
+    def __setitem__(self, key: str, value: _V) -> None:
+        with self._lock:
+            self._data[key] = value
+            self._data.move_to_end(key)
+            # Evict least-recently-used entries until within the bound.
+            if self._maxsize > 0:
+                while len(self._data) > self._maxsize:
+                    self._data.popitem(last=False)
+
+    def pop(self, key: str, default: _V | None = None) -> _V | None:
+        with self._lock:
+            return self._data.pop(key, default)
+
+    def pop_prefix(self, prefix: str) -> None:
+        """Remove every entry whose (string) key starts with *prefix*.
+
+        Used to invalidate all cached ``recent()`` windows for one session key
+        (composite keys are ``"<key>\\x00<max>\\x00<roles>"``) without touching
+        other sessions' entries. Atomic under the lock.
+        """
+        with self._lock:
+            doomed = [k for k in self._data if isinstance(k, str) and k.startswith(prefix)]
+            for k in doomed:
+                del self._data[k]
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return key in self._data
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
 class ConversationLog:
     """Append-only JSONL conversation store with provenance and rotation."""
 
@@ -203,12 +303,46 @@ class ConversationLog:
     _file_locks: dict[str, threading.RLock] = {}
     _file_locks_guard = threading.Lock()
 
-    def __init__(self, base_dir: Path | None = None):
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        *,
+        cache_max: int = _TRANSCRIPT_CACHE_MAX,
+    ):
         self._dir = base_dir or _sessions_dir()
-        # mtime-based message cache: key → (mtime, messages)
-        self._msg_cache: dict[str, tuple[float, list[dict]]] = {}
-        # mtime-based metadata cache: key → (mtime, metadata)
-        self._meta_cache: dict[str, tuple[float, dict]] = {}
+        # Bounded, mtime-keyed LRU caches (key → (mtime, payload)). Bounded so
+        # a long-lived gateway touching thousands of sessions cannot grow the
+        # parsed-transcript working set without limit. Eviction is
+        # least-recently-used and deterministic; writes invalidate per-key via
+        # _invalidate_cache so a stale entry can never outlive a file change.
+        self._msg_cache: _LRUCache[tuple[float, list[dict]]] = _LRUCache(cache_max)
+        self._meta_cache: _LRUCache[tuple[float, dict]] = _LRUCache(cache_max)
+        #: Bounded, mtime-keyed LRU of formatted ``recent()`` windows keyed by
+        #: (key, max_messages, roles). The tail-read fast path intentionally
+        #: never warms ``_msg_cache`` (it returns a partial view), so a session
+        #: accessed *only* via ``recent()`` — the hot per-turn context path —
+        #: would otherwise re-open and re-parse the file tail on every single
+        #: call. This memoizes the formatted window; the stored mtime guards
+        #: staleness (an append bumps the file mtime, so the entry is
+        #: recomputed on the next call). Own ``_LRUCache`` → own internal lock.
+        self._recent_cache: _LRUCache[tuple[float, list[dict]]] = _LRUCache(cache_max)
+        #: tab_id → [session keys] index for chained reads. Initialized eagerly
+        #: (no ``hasattr`` dance) and guarded by ``self._lock`` because
+        #: ``read_messages_chained`` is reachable from worker threads while the
+        #: event loop may clear it via ``invalidate_tab_id_cache`` — an
+        #: unsynchronized lazy-init/read/clear produced a transient empty index
+        #: or ``AttributeError``.
+        self._tab_id_index: dict[str, list[str]] = {}
+        #: Coarse instance lock protecting the lazily-built ``_tab_id_index``
+        #: rebuild/read/clear. The message/metadata/recent LRUs are each
+        #: internally locked; this guards the shared mutable state that lives
+        #: directly on the instance.
+        self._lock = threading.RLock()
+        #: When True, ``recent``/``recent_chained`` may satisfy a cache miss by
+        #: reading only the TAIL of the session file instead of parsing the
+        #: whole thing (recommendation #10). Correctness-neutral — see
+        #: :meth:`_read_tail_messages`.
+        self._tail_reads = True
 
     def _file_lock(self, key: str) -> threading.RLock:
         """Return the process-wide reentrant lock guarding *key*'s session file.
@@ -327,6 +461,16 @@ class ConversationLog:
         the just-flushed current-turn user message as history when the
         background flush wins the race against kiro-cli spawn.
         """
+        # Recommendation #10: recent-only access with no trailing exclusion can
+        # be served by reading just the TAIL of the file, skipping a full parse
+        # of a potentially 2 MB session log. Only taken on a cache miss (a fresh
+        # full-parse cache is already O(1) and is preferred). Returns None to
+        # signal "fall through to the full read" (missing file, or a full cache
+        # is fresh — in which case the full path is a cheap cache hit).
+        if exclude_last_n == 0 and self._tail_reads:
+            tail = self._recent_via_tail(key, max_messages, roles)
+            if tail is not None:
+                return tail
         messages = self._read_messages(key)
         if exclude_last_n > 0:
             messages = messages[:-exclude_last_n]
@@ -706,7 +850,12 @@ class ConversationLog:
         return [{"role": m["role"], "content": m["content"]} for m in candidates[-max_messages:]]
 
     def read_messages(self, key: str) -> list[dict]:
-        """Public access to session messages."""
+        """Public access to session messages.
+
+        The returned list may be the shared cached object (see
+        :meth:`_read_messages`); treat it as read-only and copy before
+        mutating.
+        """
         return self._read_messages(key)
 
     def read_messages_chained(self, key: str) -> list[dict]:
@@ -723,13 +872,18 @@ class ConversationLog:
         tid = meta.get("tab_id")
         if not tid:
             return self._read_messages(key)
-        if not hasattr(self, "_tab_id_index"):
-            self._tab_id_index: dict[str, list[str]] = {}
-        if tid not in self._tab_id_index:
-            self._rebuild_tab_id_index()
+        # Guard the lazy build/read of the shared _tab_id_index: this method is
+        # reachable from worker threads (chat_persistence restore/save) while the
+        # event loop may clear the index via invalidate_tab_id_cache(). Without
+        # the lock two threads could rebuild concurrently, or one could read a
+        # half-cleared index. Snapshot the key list under the lock, then do the
+        # (potentially slow) per-file reads outside it.
+        with self._lock:
             if tid not in self._tab_id_index:
-                self._tab_id_index[tid] = []  # sentinel: prevent repeated rebuilds
-        keys = self._tab_id_index.get(tid, [])
+                self._rebuild_tab_id_index()
+                if tid not in self._tab_id_index:
+                    self._tab_id_index[tid] = []  # sentinel: prevent repeated rebuilds
+            keys = list(self._tab_id_index.get(tid, []))
         if not keys:
             return self._read_messages(key)
         all_msgs: list[dict] = []
@@ -738,7 +892,11 @@ class ConversationLog:
         return all_msgs or self._read_messages(key)
 
     def _rebuild_tab_id_index(self) -> None:
-        """Scan all dashboard session files and build tab_id → [keys] mapping."""
+        """Scan all dashboard session files and build tab_id → [keys] mapping.
+
+        Caller MUST hold ``self._lock`` — this replaces the shared
+        ``_tab_id_index`` mapping.
+        """
         index: dict[str, list[str]] = {}
         for path in sorted(self._dir.glob("dashboard_chat-*.jsonl")):
             try:
@@ -754,7 +912,7 @@ class ConversationLog:
 
     def invalidate_tab_id_cache(self) -> None:
         """Clear the tab_id index so it's rebuilt on next chained read."""
-        if hasattr(self, "_tab_id_index"):
+        with self._lock:
             self._tab_id_index.clear()
 
     def delete_session(self, key: str) -> bool:
@@ -848,6 +1006,17 @@ class ConversationLog:
         """Read all non-metadata entries from a session JSONL file.
 
         Uses mtime-based caching to avoid re-parsing unchanged files.
+
+        .. warning::
+            On a cache hit this returns the **shared cached list object by
+            identity** (see ``test_cache_hit_returns_same_object``) — the
+            memoization that makes repeated reads O(1). Callers MUST treat the
+            result as **immutable**: mutating it in place (append/pop/sort or
+            editing a contained dict) silently corrupts the cache for every
+            future reader, and — combined with cross-thread access — for other
+            threads iterating the same list concurrently. Slice or ``list(...)``
+            it before mutating. All current callers copy/slice; this contract
+            keeps that invariant explicit.
         """
         path = self._path(key)
         if not path.exists():
@@ -875,10 +1044,131 @@ class ConversationLog:
         self._msg_cache[key] = (mtime, messages)
         return messages
 
+    #: Starting tail window (bytes) for :meth:`_read_tail_messages`. Sized to
+    #: comfortably cover a few dozen JSONL message lines in one read; grown
+    #: geometrically if it doesn't yield enough matching messages.
+    _TAIL_MIN_BYTES = 8_192
+    #: Rough average serialized-message size used to pick an initial window
+    #: from ``max_messages`` so a large request opens a proportionally larger
+    #: window on the first read.
+    _TAIL_AVG_MSG_BYTES = 512
+    #: Max window-doubling attempts before we accept whatever the window held
+    #: (it is always correct: the newest messages are always inside the tail).
+    _TAIL_MAX_GROWTHS = 6
+
+    def _recent_via_tail(
+        self, key: str, max_messages: int, roles: set[str] | None
+    ) -> list[dict] | None:
+        """Return the formatted recent window via a tail read, or None to defer.
+
+        Returns None (caller falls through to the full-read path) when the file
+        is missing OR a fresh full-parse cache already exists — in both cases
+        the full path is at least as cheap and keeps the shared cache warm.
+        Otherwise returns the last *max_messages* entries (role-filtered) as
+        ``[{role, content}]``.
+
+        The formatted window is memoized in ``_recent_cache`` keyed by
+        (key, max_messages, roles) with the file mtime, so a session accessed
+        only via ``recent()`` — which never warms ``_msg_cache`` — is served
+        O(1) from memory on subsequent turns instead of re-opening and
+        re-parsing the file tail on every call. The mtime guard makes the
+        memo self-invalidating: an :meth:`append` bumps the file mtime, so the
+        stale entry misses and is recomputed. A fresh list of fresh dicts is
+        returned each call so callers can freely mutate the result without
+        corrupting the shared entry.
+        """
+        path = self._path(key)
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return None  # missing/unreadable → let the full path return []
+        cached = self._msg_cache.get(key)
+        if cached and cached[0] == mtime:
+            return None  # fresh full cache → full path is a cheap O(1) hit
+        rc_key = self._recent_cache_key(key, max_messages, roles)
+        rc = self._recent_cache.get(rc_key)
+        if rc is not None and rc[0] == mtime:
+            return [dict(m) for m in rc[1]]  # memo hit — no disk I/O
+        tail = self._read_tail_messages(path, max_messages, roles)
+        formatted = [{"role": m["role"], "content": m["content"]} for m in tail]
+        self._recent_cache[rc_key] = (mtime, formatted)
+        return [dict(m) for m in formatted]
+
+    @staticmethod
+    def _recent_cache_key(key: str, max_messages: int, roles: set[str] | None) -> str:
+        """Build a stable ``_recent_cache`` key from the recent() parameters.
+
+        ``\\x00`` cannot appear in a session key, so it is an unambiguous field
+        separator; roles are sorted so ``{"user", "assistant"}`` and
+        ``{"assistant", "user"}`` collapse to the same entry.
+        """
+        roles_part = ",".join(sorted(roles)) if roles else ""
+        return f"{key}\x00{max_messages}\x00{roles_part}"
+
+    def _read_tail_messages(
+        self, path: Path, max_messages: int, roles: set[str] | None
+    ) -> list[dict]:
+        """Read the last *max_messages* messages by seeking to the file tail.
+
+        Reads a bounded window from the END of the file and parses backwards,
+        growing the window geometrically until it holds at least *max_messages*
+        matching (role-filtered) messages or the window covers the whole file.
+        The newest messages always sit at EOF, so the returned slice is always
+        the true most-recent window — correctness is identical to a full parse
+        followed by ``[-max_messages:]``; only older lines beyond the window are
+        skipped, and those can never be part of the answer.
+
+        Metadata lines and lines that don't parse as JSON are ignored, matching
+        :meth:`_read_messages`. Never populates ``_msg_cache`` (the result is a
+        partial view, not the authoritative full list).
+        """
+        if max_messages <= 0:
+            return []
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return []
+        window = max(self._TAIL_MIN_BYTES, max_messages * self._TAIL_AVG_MSG_BYTES * 2)
+        messages: list[dict] = []
+        for _ in range(self._TAIL_MAX_GROWTHS):
+            covered = size <= window
+            try:
+                with open(path, "rb") as f:
+                    if not covered:
+                        f.seek(size - window)
+                        f.readline()  # discard the (likely partial) first line
+                    raw = f.read().decode("utf-8", errors="replace")
+            except OSError:
+                return []
+            messages = []
+            for line in raw.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if data.get("_type") == "metadata":
+                    continue
+                if roles and data.get("role") not in roles:
+                    continue
+                messages.append(data)
+            if covered or len(messages) >= max_messages:
+                break
+            window *= 4
+        return messages[-max_messages:]
+
     def _invalidate_cache(self, key: str) -> None:
         """Invalidate caches for a key after a write operation."""
         self._msg_cache.pop(key, None)
         self._meta_cache.pop(key, None)
+        # Also drop any memoized recent() windows for this key. Necessary
+        # because housekeeping rewrites (mark_consolidated/update_metadata/
+        # rewrite_session/rotation) restore the pre-write mtime via
+        # _restore_mtime, so the recent cache's mtime guard alone would let a
+        # stale window survive a content change.
+        self._recent_cache.pop_prefix(f"{key}\x00")
 
     #: Bytes read from the end of a session file for the last-message preview.
     #: One tail block comfortably covers several trailing JSONL lines without

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -2456,3 +2456,605 @@ class TestConsolidateSession:
         with patch.object(consolidator, "_consolidate", new_callable=AsyncMock) as mock_consolidate:
             await consolidator.consolidate_now("dashboard:chat-nonexist")
             mock_consolidate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PR unit C — recommendation #3: bounded LRU transcript/metadata caches
+# ---------------------------------------------------------------------------
+
+
+class TestLRUCache:
+    """Unit tests for the bounded _LRUCache primitive backing the caches."""
+
+    def test_hit_returns_value(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=4)
+        c["a"] = 1
+        assert c.get("a") == 1
+        assert c["a"] == 1
+
+    def test_miss_returns_default(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=4)
+        assert c.get("missing") is None
+        assert c.get("missing", 42) == 42
+
+    def test_eviction_is_deterministic_lru(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=3)
+        c["a"] = 1
+        c["b"] = 2
+        c["c"] = 3
+        # Insert a 4th → 'a' (least recently used) is evicted.
+        c["d"] = 4
+        assert "a" not in c
+        assert set(c._data.keys()) == {"b", "c", "d"}
+
+    def test_get_marks_recently_used(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=3)
+        c["a"] = 1
+        c["b"] = 2
+        c["c"] = 3
+        # Touch 'a' so it is no longer the LRU victim.
+        assert c.get("a") == 1
+        c["d"] = 4
+        # 'b' (now the LRU) is evicted instead of the touched 'a'.
+        assert "b" not in c
+        assert "a" in c
+
+    def test_setitem_update_marks_recently_used(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=3)
+        c["a"] = 1
+        c["b"] = 2
+        c["c"] = 3
+        c["a"] = 10  # re-write existing key → most recently used
+        c["d"] = 4
+        assert "b" not in c
+        assert c.get("a") == 10
+
+    def test_pop_and_contains_and_len(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=4)
+        c["a"] = 1
+        c["b"] = 2
+        assert len(c) == 2
+        assert "a" in c
+        assert c.pop("a") == 1
+        assert "a" not in c
+        assert c.pop("a", 99) == 99
+        assert len(c) == 1
+
+    def test_clear(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=4)
+        c["a"] = 1
+        c["b"] = 2
+        c.clear()
+        assert len(c) == 0
+
+    def test_maxsize_zero_disables_bound(self):
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=0)
+        for i in range(1000):
+            c[str(i)] = i
+        assert len(c) == 1000
+
+
+class TestConversationLogCacheBounded:
+    """The message/metadata caches on ConversationLog are LRU-bounded."""
+
+    def test_msg_cache_evicts_beyond_bound(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path, cache_max=4)
+        for i in range(10):
+            key = f"sess{i}"
+            log.append(key, "user", f"hi {i}")
+            log._read_messages(key)  # populate cache
+        # Never exceeds the configured bound despite 10 distinct sessions.
+        assert len(log._msg_cache) <= 4
+
+    def test_meta_cache_evicts_beyond_bound(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path, cache_max=3)
+        for i in range(10):
+            key = f"sess{i}"
+            log.append(key, "user", f"hi {i}")
+            log.get_metadata(key)  # populate meta cache
+        assert len(log._meta_cache) <= 3
+
+    def test_cache_hit_returns_same_object(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        log.append("t1", "user", "a")
+        first = log._read_messages("t1")
+        second = log._read_messages("t1")
+        # A cache hit returns the identical cached list object (no re-parse).
+        assert first is second
+
+    def test_write_invalidates_cache(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        log.append("t1", "user", "a")
+        first = log._read_messages("t1")
+        assert len(first) == 1
+        log.append("t1", "assistant", "b")  # write must invalidate
+        second = log._read_messages("t1")
+        assert len(second) == 2
+        assert first is not second
+
+    def test_evicted_then_reread_is_correct(self, tmp_path):
+        """A key evicted from the LRU is re-read correctly from disk."""
+        log = ConversationLog(base_dir=tmp_path, cache_max=2)
+        for i in range(5):
+            log.append(f"s{i}", "user", f"content {i}")
+            log._read_messages(f"s{i}")
+        # s0 was evicted long ago; re-reading returns correct content.
+        msgs = log._read_messages("s0")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "content 0"
+
+
+# ---------------------------------------------------------------------------
+# PR unit C — recommendation #10: tail/seek reads for recent-only access
+# ---------------------------------------------------------------------------
+
+
+class TestTailReads:
+    """recent() may serve a cache miss by reading only the file tail."""
+
+    def test_recent_matches_full_read(self, tmp_path):
+        """Tail-read recent() is byte-for-byte equivalent to the full-parse path."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(200):
+            log.append("t1", "user" if i % 2 == 0 else "assistant", f"message {i}")
+        # Force a cold cache so recent() takes the tail path.
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=10)
+        # Compare against the authoritative full read.
+        log._msg_cache.clear()
+        full = log._read_messages("t1")
+        expected = [{"role": m["role"], "content": m["content"]} for m in full[-10:]]
+        assert got == expected
+        assert got[0]["content"] == "message 190"
+        assert got[-1]["content"] == "message 199"
+
+    def test_recent_role_filter_matches_full_read(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(200):
+            log.append("t1", "user" if i % 2 == 0 else "assistant", f"m{i}")
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=5, roles={"assistant"})
+        log._msg_cache.clear()
+        full = log._read_messages("t1")
+        filtered = [m for m in full if m["role"] == "assistant"]
+        expected = [{"role": m["role"], "content": m["content"]} for m in filtered[-5:]]
+        assert got == expected
+        assert all(m["role"] == "assistant" for m in got)
+
+    def test_tail_does_not_populate_full_cache(self, tmp_path):
+        """A tail read must not leave a PARTIAL list in _msg_cache."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(100):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        log.recent("t1", max_messages=3)
+        # Tail path returned a partial view — the full cache must stay empty
+        # so load_transcript()/search still parse the whole file.
+        assert "t1" not in log._msg_cache
+
+    def test_tail_window_grows_when_insufficient(self, tmp_path):
+        """When the initial window holds too few messages, it grows to satisfy the request."""
+        log = ConversationLog(base_dir=tmp_path)
+        # 300 large messages so the 8 KiB starting window can't hold 50 of them.
+        for i in range(300):
+            log.append("t1", "user", f"msg{i} " + "x" * 300)
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=50)
+        assert len(got) == 50
+        assert got[-1]["content"].startswith("msg299 ")
+        assert got[0]["content"].startswith("msg250 ")
+
+    def test_tail_read_small_file(self, tmp_path):
+        """A file smaller than one window is fully covered and correct."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("t1", "user", "only one")
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=10)
+        assert got == [{"role": "user", "content": "only one"}]
+
+    def test_recent_nonexistent_session(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        assert log.recent("does-not-exist", max_messages=5) == []
+
+    def test_fresh_full_cache_preferred_over_tail(self, tmp_path):
+        """When a fresh full cache exists, recent() uses it (no tail read)."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(20):
+            log.append("t1", "user", f"m{i}")
+        log._read_messages("t1")  # warm the full cache
+        # _read_tail_messages must NOT be consulted on this fresh-cache path.
+        called = {"n": 0}
+        real = log._read_tail_messages
+
+        def spy(*a, **k):
+            called["n"] += 1
+            return real(*a, **k)
+
+        log._read_tail_messages = spy  # type: ignore[assignment]
+        got = log.recent("t1", max_messages=5)
+        assert called["n"] == 0
+        assert got[-1]["content"] == "m19"
+
+    def test_exclude_last_n_uses_full_path(self, tmp_path):
+        """exclude_last_n is only handled by the full-read path (tail bypassed)."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(10):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=3, exclude_last_n=2)
+        # Drops m8,m9 then takes last 3 of m0..m7 → m5,m6,m7
+        assert [m["content"] for m in got] == ["m5", "m6", "m7"]
+
+    def test_tail_reads_toggle_off(self, tmp_path):
+        """Disabling _tail_reads forces the full-read path (behaviour identical)."""
+        log = ConversationLog(base_dir=tmp_path)
+        log._tail_reads = False
+        for i in range(30):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=4)
+        # Full path populates the cache; result still correct.
+        assert "t1" in log._msg_cache
+        assert [m["content"] for m in got] == ["m26", "m27", "m28", "m29"]
+
+    def test_tail_skips_metadata_line(self, tmp_path):
+        """The metadata line is never surfaced as a message via the tail path."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("t1", "user", "first")  # creates metadata + message
+        log._msg_cache.clear()
+        got = log.recent("t1", max_messages=10)
+        assert all(m.get("role") != "metadata" for m in got)
+        assert got == [{"role": "user", "content": "first"}]
+
+
+# ---------------------------------------------------------------------------
+# Finding 0 / 4 — _LRUCache thread safety under concurrent access.
+# ---------------------------------------------------------------------------
+
+
+class TestLRUCacheConcurrency:
+    """The bounded cache is touched from the event loop AND worker threads.
+
+    These stress tests hammer the compound read-modify-write ops (move_to_end
+    + index in get/__getitem__; the eviction len()+popitem loop in
+    __setitem__) concurrently with pop/clear. Before the lock fix, a pop
+    landing between a successful move_to_end and the following index raised
+    KeyError out of get(); these tests would surface it as an escaped
+    exception. After the fix, no exception escapes.
+    """
+
+    def test_get_pop_interleave_no_exception(self):
+        import threading
+
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=64)
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def writer() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    c[str(i % 128)] = i
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def reader() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    # get() must NEVER raise KeyError even if the key is
+                    # concurrently popped in the move_to_end/index gap.
+                    c.get(str(i % 128))
+                    _ = str(i % 128) in c
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def popper() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    c.pop(str(i % 128), None)
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def clearer() -> None:
+            while not stop.is_set():
+                try:
+                    len(c)
+                    c.clear()
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        threads = [
+            threading.Thread(target=fn)
+            for fn in (writer, writer, reader, reader, reader, popper, clearer)
+        ]
+        for t in threads:
+            t.start()
+        import time as _t
+
+        _t.sleep(0.75)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors, f"cache raised under concurrency: {errors[:3]}"
+        # Bound is still respected after the storm.
+        assert len(c) <= 64
+
+    def test_getitem_pop_interleave_no_exception(self):
+        import threading
+
+        from kiro_crew.history import _LRUCache
+
+        c: _LRUCache[int] = _LRUCache(maxsize=32)
+        for i in range(32):
+            c[str(i)] = i
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def indexer() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    try:
+                        _ = c[str(i % 64)]
+                    except KeyError:
+                        pass  # a legitimate miss is fine; a race crash is not
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def churner() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    c[str(i % 64)] = i
+                    c.pop(str((i + 1) % 64), None)
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        threads = [threading.Thread(target=fn) for fn in (indexer, indexer, churner, churner)]
+        for t in threads:
+            t.start()
+        import time as _t
+
+        _t.sleep(0.5)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors, f"__getitem__ raised under concurrency: {errors[:3]}"
+
+
+class TestConversationLogConcurrency:
+    """append()/_invalidate_cache interleaved with recent()/read_messages().
+
+    Exercises the ConversationLog-level shared state (message/meta/recent LRUs
+    and the tab_id index) from multiple threads at once. No exception must
+    escape and results must stay well-formed.
+    """
+
+    def test_append_read_recent_interleave(self, tmp_path):
+        import threading
+
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        # Seed a few sessions.
+        for s in range(4):
+            for i in range(10):
+                log.append(f"s{s}", "user" if i % 2 == 0 else "assistant", f"m{i}")
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def appender(sid: int) -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    log.append(f"s{sid}", "user", f"more {i}")
+                    i += 1
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def recenter(sid: int) -> None:
+            while not stop.is_set():
+                try:
+                    r = log.recent(f"s{sid}", max_messages=5)
+                    assert isinstance(r, list)
+                    r2 = log.recent(f"s{sid}", max_messages=5, roles={"assistant"})
+                    assert isinstance(r2, list)
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def reader(sid: int) -> None:
+            while not stop.is_set():
+                try:
+                    msgs = log.read_messages(f"s{sid}")
+                    assert isinstance(msgs, list)
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        threads = []
+        for sid in range(4):
+            threads.append(threading.Thread(target=appender, args=(sid,)))
+            threads.append(threading.Thread(target=recenter, args=(sid,)))
+            threads.append(threading.Thread(target=reader, args=(sid,)))
+        for t in threads:
+            t.start()
+        import time as _t
+
+        _t.sleep(0.75)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors, f"ConversationLog raised under concurrency: {errors[:3]}"
+
+    def test_chained_read_invalidate_interleave(self, tmp_path):
+        """read_messages_chained() vs invalidate_tab_id_cache() across threads."""
+        import threading
+
+        log = ConversationLog(base_dir=tmp_path)
+        # Create dashboard sessions sharing a tab_id so the chained path builds
+        # the tab_id index.
+        for n in range(3):
+            log.append(f"dashboard:chat-{n}", "user", f"hi {n}", tab_id="tabX")
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def chained() -> None:
+            while not stop.is_set():
+                try:
+                    msgs = log.read_messages_chained("dashboard:chat-0")
+                    assert isinstance(msgs, list)
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def invalidator() -> None:
+            while not stop.is_set():
+                try:
+                    log.invalidate_tab_id_cache()
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+        threads = [
+            threading.Thread(target=chained),
+            threading.Thread(target=chained),
+            threading.Thread(target=invalidator),
+        ]
+        for t in threads:
+            t.start()
+        import time as _t
+
+        _t.sleep(0.5)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors, f"chained read raced with invalidate: {errors[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — recent() memoizes the tail window so a cold session accessed
+# only via recent() does not re-read the file on every call.
+# ---------------------------------------------------------------------------
+
+
+class TestRecentWindowMemoization:
+    def test_repeated_recent_reads_file_once(self, tmp_path):
+        """Repeated recent() on a cold session hits the memo, not the disk."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(50):
+            log.append("t1", "user", f"m{i}")
+        # Cold full cache — force the tail path.
+        log._msg_cache.clear()
+
+        calls = {"n": 0}
+        real = log._read_tail_messages
+
+        def spy(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        log._read_tail_messages = spy  # type: ignore[assignment]
+
+        first = log.recent("t1", max_messages=10)
+        # Same params, same mtime → served from the memo, no second tail read.
+        for _ in range(5):
+            again = log.recent("t1", max_messages=10)
+            assert again == first
+        assert calls["n"] == 1, "recent() re-read the file tail despite an unchanged session"
+
+    def test_recent_memo_returns_independent_lists(self, tmp_path):
+        """The memo must hand back fresh objects callers can safely mutate."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(10):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        a = log.recent("t1", max_messages=5)
+        b = log.recent("t1", max_messages=5)
+        assert a == b
+        assert a is not b
+        # Mutating one result must not corrupt the other or the cache.
+        a.append({"role": "user", "content": "INJECTED"})
+        a[0]["content"] = "TAMPERED"
+        c = log.recent("t1", max_messages=5)
+        assert all(m["content"] != "INJECTED" for m in c)
+        assert c[0]["content"] != "TAMPERED"
+
+    def test_recent_memo_invalidated_on_append(self, tmp_path):
+        """A new append must be reflected (mtime bump + explicit invalidation)."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(5):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        before = log.recent("t1", max_messages=3)
+        assert [m["content"] for m in before] == ["m2", "m3", "m4"]
+        log.append("t1", "user", "m5")
+        after = log.recent("t1", max_messages=3)
+        assert [m["content"] for m in after] == ["m3", "m4", "m5"]
+
+    def test_recent_memo_invalidated_on_rewrite_with_restored_mtime(self, tmp_path):
+        """rewrite_session restores the mtime; the memo must still refresh.
+
+        This is the case the mtime guard alone can't catch — rewrite_session
+        (compaction) changes message content but calls _restore_mtime, so the
+        cached window's stored mtime would still match. The explicit
+        _invalidate_cache -> pop_prefix in _invalidate_cache closes that gap.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(6):
+            log.append("t1", "user", f"m{i}")
+        log._msg_cache.clear()
+        _ = log.recent("t1", max_messages=3)  # populate the recent memo
+        # Compact down to the last two messages (rewrite restores mtime).
+        keep = log.read_messages("t1")[-2:]
+        log.rewrite_session("t1", [dict(m) for m in keep])
+        log._msg_cache.clear()  # force the tail path again
+        after = log.recent("t1", max_messages=3)
+        assert [m["content"] for m in after] == ["m4", "m5"]
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — _read_messages returns the shared cached list; document + guard
+# that a caller who copies is safe and the identity contract holds.
+# ---------------------------------------------------------------------------
+
+
+class TestReadMessagesImmutabilityContract:
+    def test_cache_hit_identity_is_intentional(self, tmp_path):
+        """A cache hit returns the same object (memoization invariant)."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("t1", "user", "a")
+        assert log._read_messages("t1") is log._read_messages("t1")
+
+    def test_copy_before_mutation_does_not_corrupt_cache(self, tmp_path):
+        """The documented safe pattern (copy, then mutate) leaves the cache intact."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("t1", "user", "a")
+        log.append("t1", "assistant", "b")
+        snapshot = list(log._read_messages("t1"))  # documented: copy before mutate
+        snapshot.append({"role": "user", "content": "local-only"})
+        snapshot[0] = {"role": "user", "content": "local-edit"}
+        # Cache is untouched: next read still yields the original 2 messages.
+        fresh = log._read_messages("t1")
+        assert len(fresh) == 2
+        assert fresh[0]["content"] == "a"
+        assert fresh[1]["content"] == "b"


### PR DESCRIPTION
## Summary

PR unit **C** — implements two performance recommendations for the `ConversationLog` transcript/history layer (`src/kiro_crew/history.py`):

- **#3 — Bounded LRU transcript cache.** The `_msg_cache` / `_meta_cache` were plain `dict`s keyed by session key + mtime that grew one entry per session touched and **never evicted**. On a gateway serving thousands of sessions, parsed message lists (each up to ~200 messages / 2 MB of source JSONL) accumulated in RAM for the process lifetime. Replaced with a small `_LRUCache` (default `_TRANSCRIPT_CACHE_MAX = 256`, overridable via the `cache_max` constructor arg). Eviction is **deterministic least-recently-used**; existing per-key invalidation on writes (`_invalidate_cache`) is preserved unchanged.
- **#10 — Tail/seek reads for recent-only access.** `recent()` previously called `_read_messages()`, which reads and parses the **entire** file, then sliced `[-max_messages:]`. Added `_read_tail_messages()` which `seek()`s to a bounded window at the file tail and grows it geometrically until it holds enough (optionally role-filtered) messages, or covers the whole file. Used only on a cache miss with `exclude_last_n == 0`; a fresh full cache is still preferred, and the tail path never stores its partial view in the full cache.

## Before / after evidence

Microbenchmark on a ~407 KiB / 200-message session:

| Metric | Before | After |
|---|---|---|
| `recent(10)` cold cache | 1.366 ms/call (full parse) | 0.211 ms/call (tail read) — **6.5x faster** |
| `_msg_cache` entries after touching 200 distinct sessions | 200 (unbounded) | 64 (bounded example) / 256 default cap |
| tracemalloc peak (200 sessions) | 2982 KiB | 1941 KiB |

Correctness is identical to a full parse + `[-max_messages:]`: the newest messages always sit at EOF, so tail reads only ever skip *older* lines that can't be part of the answer. A dedicated test asserts tail-read output equals the full-read output (including role filtering).

## Migration / invalidation safety

- **No on-disk format change** and **no schema change** — the change is purely in-memory cache behavior + a read path. Session JSONL files are read/written exactly as before.
- **Invalidation preserved:** every write path (`append`, `mark_consolidated`, `update_metadata`, `rewrite_session`, `_maybe_rotate`, `delete_session`) still calls `_invalidate_cache`, which pops both caches. A stale entry cannot outlive a file change (mtime check remains as a second guard).
- **Eviction is safe:** an evicted key is transparently re-read from disk on next access (test `test_evicted_then_reread_is_correct`).
- **Bounding is opt-out-able:** `cache_max=0` disables the bound (dict-equivalent) for callers that want the old behavior.
- **Backward-compatible surface:** `_LRUCache` implements the `get` / `[]` / `pop` / `in` / `len` / `clear` subset the existing callers (incl. `dashboard/chat_handlers.py`, `list_sessions`, `search_sessions`) already use.

## Tests added

`test/test_history.py`:
- `TestLRUCache` — hit/miss/default, deterministic LRU eviction, get-marks-recently-used, update-marks-recently-used, pop/contains/len, clear, `maxsize=0` disables bound.
- `TestConversationLogCacheBounded` — msg/meta caches evict beyond bound, cache-hit returns same object, write invalidates, evicted-then-reread correctness.
- `TestTailReads` — tail read matches full read (plain + role filter), tail doesn't populate full cache, window grows when insufficient, small file, nonexistent session, fresh-cache preferred over tail, `exclude_last_n` bypasses tail, toggle off, metadata line never surfaced.

## Local gates

- `pytest test/test_history.py` → **169 passed**
- Current-main integration (`test_history.py`, `test_history_atomic_rewrite.py`, and the adjacent deploy regression suite) → **178 passed / 1 host-filesystem skip**
- `flake8 -j1` + CI-parity `isort --check-only` on the changed files → clean
- CI-parity `mypy src/kiro_crew/` → Success: no issues found in 444 source files
- Frontend gates (`tsc -b`, `vitest`) → N/A (no `website/` files changed)
