### PR TITLE
fix(subagents): restore native activity after reconnect

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -189,7 +189,9 @@ On timeout (inner or outer):
 
 `_inject_with_retry()` in `gateway.py` makes up to 3 attempts (1 initial + 2 retries) of `stream_and_collect` on AcpError. Between retries: cancels orphaned prompt, exponential backoff. On `PromptBusyExhaustedError`: kills provider, queues failure event. Note: the 1200s outer cap (`_ON_DONE_TIMEOUT`) bounds total wall-clock time, so not all retries may fire if earlier attempts consume the budget.
 
-**Reconnect recovery**: `subscribe_subagents` in `ws.py` sends `subagent_done` events for recently completed subagents on WS reconnect. This ensures the dashboard recovers completion status even if the WS connection dropped during the 30-90s window between task completion and event delivery.
+**Reconnect recovery**: `subscribe_subagents` in `ws.py` restores both managed and native subagent cards. Managed subagents are authoritative in `SubagentManager`: running records replay as `subagent_snapshot`, and recently completed records replay as `subagent_done`. Managed results remain disk-backed and are not copied into inline Redux card payloads.
+
+Native kiro-cli subagents run inside the parent ACP turn and are owned by the parent dashboard slot. `DashboardState.native_subagent_snapshots()` replays running native cards as `subagent_snapshot` and recent terminal cards as `subagent_done`. A native `subagent_done` payload may include optional `task`, `agent`, and `result` fields. `result` is a redacted output tail bounded to 8,000 characters, with an explicit truncation marker when earlier output was dropped. Running output retained for replay is bounded to 40,000 characters, with an 80,000-character hard accumulation ceiling. Terminal native records are retained globally up to 50 cards for at most one hour. The client treats `done` and `error` as monotonic terminal states, so a stale running snapshot interleaved after a live completion cannot demote the card.
 
 **Redaction**: All subagent event payloads (running snapshots and done events) have the `agent` field redacted before sending to the dashboard. Task text is redacted before truncation to prevent credential patterns spanning the boundary.
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -79,6 +79,12 @@ from kiro_crew.dashboard.handlers.usage import persist_token_record_async
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
+    NATIVE_SUBAGENT_DONE_RESULT_CAP,
+    NATIVE_SUBAGENT_DONE_TRUNC_MARKER,
+    NATIVE_SUBAGENT_OUTPUT_HARD,
+    NATIVE_SUBAGENT_OUTPUT_TAIL,
+    NATIVE_SUBAGENT_TERMINAL_KEEP,
+    NATIVE_SUBAGENT_TERMINAL_TTL_SECS,
     REFUSAL_RECOVERY_PREFIX,
     STALE_RECOVERY_PREFIX,
     SUBAGENT_COMPLETION_PREFIX,
@@ -785,19 +791,37 @@ def _mask_quoted_separators(text: str) -> tuple[str, dict[str, str]]:
 # ``subagent`` tool call's ``stages`` — the list_update gives authoritative
 # per-sub-agent identity/status that the stages payload lacked.
 
-
 _NATIVE_SUBAGENT_STALE_SECS = 120.0  # auto-close cards with no progress after 2 min
 
 
-def _native_card_feed(card_output, card_id: str) -> str:
-    """Join a native card's accumulated feed, truncate, and redact.
+def _native_done_result(chunks: "list[str] | None") -> str:
+    """Return the newest bounded native-card output with a truncation marker."""
+    joined = "".join(chunks or [])
+    if len(joined) <= NATIVE_SUBAGENT_DONE_RESULT_CAP:
+        return joined
+    return NATIVE_SUBAGENT_DONE_TRUNC_MARKER + joined[-NATIVE_SUBAGENT_DONE_RESULT_CAP:]
 
-    Defense in depth: card_output entries are redacted at append time, but
-    never trust LLM output at the broadcast boundary — re-apply both
-    redactions before the payload leaves the process. Single choke point for
-    every ``subagent_done`` result broadcast on the native card path.
-    """
-    feed = "".join((card_output or {}).get(card_id, []))[:8000]
+
+def _append_native_output(
+    buf: list[str],
+    text: str,
+    total: int,
+    cap: int = NATIVE_SUBAGENT_OUTPUT_TAIL,
+    hard: int = NATIVE_SUBAGENT_OUTPUT_HARD,
+) -> int:
+    """Append output and collapse it to the newest tail past the hard ceiling."""
+    buf.append(text)
+    total += len(text)
+    if total > hard:
+        tail = "".join(buf)[-cap:]
+        buf[:] = [tail]
+        total = len(tail)
+    return total
+
+
+def _native_card_feed(card_output, card_id: str) -> str:
+    """Build, bound, and redact native output at the broadcast boundary."""
+    feed = _native_done_result((card_output or {}).get(card_id))
     if feed:
         feed, _ = redact_exfiltration_urls(feed)
         feed, _ = redact_credentials(feed)
@@ -863,8 +887,13 @@ def _native_subagent_sync(state, slot, subagents, tracker, card_output=None) -> 
                 )
                 continue
             tracker[sid] = {
-                "started": now, "done": False, "agent": agent, "task": task,
+                "id": card_id,
+                "started": now,
+                "done": False,
+                "agent": agent,
+                "task": task,
                 "last_activity": now,
+                "last_tool": "",
             }
             # Register in state-level dict so DELETE /api/spawn can cancel native cards.
             _register_native_card(state, card_id, slot.key, sid)
@@ -894,23 +923,30 @@ def _native_subagent_sync(state, slot, subagents, tracker, card_output=None) -> 
                 err = err[:200]
             info["done"] = True
             _feed = _native_card_feed(card_output, card_id)
+            _elapsed = time.time() - info["started"]
+            _result = _feed or "(output in chat)"
+            info["elapsed"] = _elapsed
+            info["error"] = err
+            info["result"] = _result
+            info["done_at"] = time.time()
             _unregister_native_card(state, card_id)
             state.broadcast_ws(
                 "subagent_done",
                 {
                     "id": card_id,
                     "slot": slot.key,
-                    "elapsed": time.time() - info["started"],
+                    "elapsed": _elapsed,
                     "error": err,
                     "task": info["task"],
                     "agent": info["agent"],
-                    "result": _feed or "(output in chat)",
+                    "result": _result,
                 },
             )
         elif smsg and smsg.lower() != "running":
             # Surface a non-generic status message as the card's current tool.
             tool, _ = redact_exfiltration_urls(smsg)
             tool, _ = redact_credentials(tool)
+            info["last_tool"] = tool[:80]
             state.broadcast_ws(
                 "subagent_tool",
                 {"id": card_id, "slot": slot.key, "tool": tool[:80]},
@@ -931,17 +967,24 @@ def _native_subagent_sync(state, slot, subagents, tracker, card_output=None) -> 
             info["done"] = True
             _cid = f"native:{_redact_tool_field(sid)}"
             _feed = _native_card_feed(card_output, _cid)
+            _elapsed = now - info["started"]
+            _error = "timed out (no activity)"
+            _result = _feed or "(no output received)"
+            info["elapsed"] = _elapsed
+            info["error"] = _error
+            info["result"] = _result
+            info["done_at"] = now
             _unregister_native_card(state, _cid)
             state.broadcast_ws(
                 "subagent_done",
                 {
                     "id": _cid,
                     "slot": slot.key,
-                    "elapsed": now - info["started"],
-                    "error": "timed out (no activity)",
+                    "elapsed": _elapsed,
+                    "error": _error,
                     "task": info.get("task", ""),
                     "agent": info.get("agent", ""),
-                    "result": _feed or "(no output received)",
+                    "result": _result,
                 },
             )
             logger.info(
@@ -975,19 +1018,46 @@ def _native_subagent_close_all(state, slot, tracker, card_output=None) -> None:
         info["done"] = True
         _cid = f"native:{_redact_tool_field(sid)}"
         _feed = _native_card_feed(card_output, _cid)
+        _elapsed = time.time() - info.get("started", time.time())
+        _result = _feed or "(output in chat)"
+        info["elapsed"] = _elapsed
+        info["error"] = None
+        info["result"] = _result
+        info["done_at"] = time.time()
         _unregister_native_card(state, _cid)
         state.broadcast_ws(
             "subagent_done",
             {
                 "id": _cid,
                 "slot": slot.key,
-                "elapsed": time.time() - info.get("started", time.time()),
+                "elapsed": _elapsed,
                 "error": None,
                 "task": info.get("task", ""),
                 "agent": info.get("agent", ""),
-                "result": _feed or "(output in chat)",
+                "result": _result,
             },
         )
+
+
+def _retain_terminal_native(
+    tracker: "dict[str, dict]",
+    keep: int = NATIVE_SUBAGENT_TERMINAL_KEEP,
+    ttl_secs: float = NATIVE_SUBAGENT_TERMINAL_TTL_SECS,
+    now: "float | None" = None,
+) -> "dict[str, dict]":
+    """Retain recent terminal records for bounded post-turn reconnect replay."""
+    current = time.time() if now is None else now
+    terminal = [
+        (sid, info)
+        for sid, info in tracker.items()
+        if info.get("done")
+        and info.get("id")
+        and (current - float(info.get("done_at") or 0.0)) <= ttl_secs
+    ]
+    if keep >= 0 and len(terminal) > keep:
+        terminal.sort(key=lambda item: float(item[1].get("done_at") or 0.0), reverse=True)
+        terminal = terminal[:keep]
+    return {sid: info for sid, info in terminal}
 
 
 def _matches_trusted_pattern(tool_title: str, patterns: set[str]) -> str | None:
@@ -1801,7 +1871,9 @@ async def _run_chat(
     _pending_tools: dict[str, str] = {}  # tool_call_id -> tool_name
     # session_id -> {started, done, agent, task} for native kiro-cli subagents,
     # reconciled from `_kiro.dev/subagent/list_update` (one card per sub-agent).
+    # The slot holds the same live dict so reconnect snapshots can restore cards.
     _native_tracker: dict[str, dict] = {}
+    slot._native_subagent_tracker = _native_tracker
     # inner tool_call_id -> native card id, from `_kiro.dev/session/update`, so a
     # sub-agent's tool calls stream onto its own card.
     _native_tc_card: dict[str, str] = {}
@@ -1813,6 +1885,8 @@ async def _run_chat(
     # published frontend replaces a card's live `streaming` text with `result`
     # on done, so we persist the feed here and send it as the done `result`.
     _native_card_output: dict[str, list[str]] = {}
+    slot._native_subagent_output = _native_card_output
+    _native_card_output_len: dict[str, int] = {}
     needs_session_reset = False
     saw_compaction = False
     _produced_visible_output = False
@@ -2572,7 +2646,11 @@ async def _run_chat(
                     _ntool, _ = redact_exfiltration_urls(_raw or event.title or "")
                     _ntool, _ = redact_credentials(_ntool)
                     _ntool = _ntool[:80]
-                    _native_card_output.setdefault(_nat_card, []).append(f"\u2192 {_ntool}\n")
+                    _native_card_output_len[_nat_card] = _append_native_output(
+                        _native_card_output.setdefault(_nat_card, []),
+                        f"\u2192 {_ntool}\n",
+                        _native_card_output_len.get(_nat_card, 0),
+                    )
                     state.broadcast_ws(
                         "subagent_chunk",
                         {"id": _nat_card, "slot": slot.key, "text": f"\u2192 {_ntool}\n"},
@@ -2736,7 +2814,11 @@ async def _run_chat(
                     _native_result_seen.add(event.tool_call_id)
                     _nout, _ = redact_exfiltration_urls(event.tool_output)
                     _nout, _ = redact_credentials(_nout)
-                    _native_card_output.setdefault(_nat_card_r, []).append(f"{_nout[:4000]}\n")
+                    _native_card_output_len[_nat_card_r] = _append_native_output(
+                        _native_card_output.setdefault(_nat_card_r, []),
+                        f"{_nout[:4000]}\n",
+                        _native_card_output_len.get(_nat_card_r, 0),
+                    )
                     state.broadcast_ws(
                         "subagent_chunk",
                         {"id": _nat_card_r, "slot": slot.key, "text": f"{_nout[:4000]}\n"},
@@ -3570,6 +3652,11 @@ async def _run_chat(
                     _card_id = f"native:{_redact_tool_field(_sid)}"
                     _txt, _ = redact_exfiltration_urls(event.text)
                     _txt, _ = redact_credentials(_txt)
+                    _native_card_output_len[_card_id] = _append_native_output(
+                        _native_card_output.setdefault(_card_id, []),
+                        _txt,
+                        _native_card_output_len.get(_card_id, 0),
+                    )
                     state.broadcast_ws(
                         "subagent_chunk",
                         {"id": _card_id, "slot": slot.key, "text": _txt},
@@ -4309,6 +4396,14 @@ async def _run_chat(
         slot.append("error", _err_text, "msg msg-err")
         await state.sessions.record_failure(session_key)
     finally:
+        # Completion can be bypassed by cancellation, provider errors, or timeouts.
+        # Close cards idempotently and retain only bounded terminal records for
+        # reconnect replay until the next turn installs a fresh tracker.
+        try:
+            _native_subagent_close_all(state, slot, _native_tracker, _native_card_output)
+        finally:
+            slot._native_subagent_tracker = _retain_terminal_native(_native_tracker)
+            slot._native_subagent_output = {}
         slot._batch_rejected = False
         # Steer handle: turn is over, drop the live client ref so a late steer
         # can't target a dead session (the route also re-checks running state).

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -53,6 +53,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Native kiro-cli subagent reconnect policy. The slot state, writer, and replay
+# path all import these bounds so retention cannot drift between modules.
+NATIVE_SUBAGENT_OUTPUT_TAIL = 40_000
+NATIVE_SUBAGENT_OUTPUT_HARD = 80_000
+NATIVE_SUBAGENT_DONE_RESULT_CAP = 8_000
+NATIVE_SUBAGENT_DONE_TRUNC_MARKER = "…(earlier output truncated)\n"
+NATIVE_SUBAGENT_TERMINAL_KEEP = 50
+NATIVE_SUBAGENT_TERMINAL_TTL_SECS = 3600.0
+
+
+def native_subagent_output_tail(
+    chunks: list[str], limit: int = NATIVE_SUBAGENT_OUTPUT_TAIL
+) -> str:
+    """Join only the trailing ``limit`` characters of native-card output."""
+    if limit <= 0:
+        return ""
+    collected: list[str] = []
+    total = 0
+    for chunk in reversed(chunks):
+        collected.append(chunk)
+        total += len(chunk)
+        if total >= limit:
+            break
+    collected.reverse()
+    return "".join(collected)[-limit:]
+
+
 # Running build's git (branch, short_commit). Resolved ONCE by the CLI gateway
 # entrypoint via set_build_info() — AFTER KIROCREW_PROJECT_DIR is detected and
 # BEFORE asyncio.run() starts the loop. Deliberately NOT resolved at import time:
@@ -703,6 +730,8 @@ class _ChatSlot:
         "_browse_mode",
         "_side",
         "_acp_client",
+        "_native_subagent_tracker",
+        "_native_subagent_output",
         "_pending_steers",
     )
 
@@ -872,6 +901,10 @@ class _ChatSlot:
         # dashboard steer handler) reach the running session's client to inject
         # a mid-turn steer. None when idle.
         self._acp_client = None
+        # Native kiro-cli subagents run inside the parent ACP turn. Keep their
+        # live and terminal state on the slot so reconnects can hydrate cards.
+        self._native_subagent_tracker: dict[str, dict[str, Any]] = {}
+        self._native_subagent_output: dict[str, list[str]] = {}
         # Mid-turn steers handed to the backend but not yet confirmed consumed
         # (no steering_consumed / EVENT_STEER_CONSUMED echo yet). Appended by
         # the dashboard steer handler BEFORE the steer RPC's await (so a turn
@@ -1968,6 +2001,64 @@ class DashboardState:
     def get_slot(self, name: str) -> _ChatSlot | None:
         """Look up a slot by name without creating it. Returns None if absent."""
         return self._slots.get(name)
+
+    def native_subagent_snapshots(
+        self,
+        terminal_limit: int = NATIVE_SUBAGENT_TERMINAL_KEEP,
+        ttl_secs: float = NATIVE_SUBAGENT_TERMINAL_TTL_SECS,
+    ) -> list[dict[str, object]]:
+        """Return bounded native running and terminal cards for WS replay.
+
+        DashboardState owns the slot record shape. The WebSocket layer consumes
+        these transport-ready snapshots without reaching into private slot data.
+        """
+        now = time.time()
+        running: list[dict[str, object]] = []
+        done: list[dict[str, object]] = []
+        for slot in list(self._slots.values()):
+            output = slot._native_subagent_output
+            for info in list(slot._native_subagent_tracker.values()):
+                card_id = str(info.get("id") or "")
+                if not card_id:
+                    continue
+                base: dict[str, object] = {
+                    "id": card_id,
+                    "slot": slot.key,
+                    "task": str(info.get("task") or ""),
+                    "agent": str(info.get("agent") or ""),
+                }
+                if info.get("done"):
+                    done_at = float(info.get("done_at") or 0.0)
+                    if done_at and (now - done_at) > ttl_secs:
+                        continue
+                    done.append(
+                        {
+                            **base,
+                            "done": True,
+                            "elapsed": float(info.get("elapsed") or 0.0),
+                            "error": info.get("error"),
+                            "result": str(info.get("result") or ""),
+                            "done_at": done_at,
+                        }
+                    )
+                else:
+                    running.append(
+                        {
+                            **base,
+                            "done": False,
+                            "streaming": native_subagent_output_tail(output.get(card_id, [])),
+                            "last_tool": str(info.get("last_tool") or ""),
+                            "started": float(info.get("started") or now),
+                        }
+                    )
+        if terminal_limit >= 0 and len(done) > terminal_limit:
+            def snapshot_done_at(snapshot: dict[str, object]) -> float:
+                value = snapshot.get("done_at")
+                return float(value) if isinstance(value, (int, float)) else 0.0
+
+            done.sort(key=snapshot_done_at, reverse=True)
+            done = done[:terminal_limit]
+        return running + done
 
     def has_slot(self, name: str) -> bool:
         """Check if a slot exists by name."""

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -202,14 +202,56 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                         state.unsubscribe_logs(ws)
                     elif msg_type == "subscribe_subagents":
                         state.subscribe_subagents(ws)
-                        # Send snapshot of active subagents + done events for completed ones
+
+                        def _r(t: str) -> str:
+                            t, _ = redact_exfiltration_urls(t)
+                            t, _ = redact_credentials(t)
+                            return t
+
+                        # Native kiro-cli subagents run inside dashboard chat
+                        # slots, not the global SubagentManager. Replay their
+                        # slot-owned in-flight state before manager snapshots.
+                        # Running cards replay as snapshots; cards that finished
+                        # while the socket was down replay as done events so the
+                        # terminal card + output survive the reconnect clear.
+                        for native in state.native_subagent_snapshots():
+                            try:
+                                if native.get("done"):
+                                    _err = native.get("error")
+                                    await ws.send_json(
+                                        {
+                                            "type": "subagent_done",
+                                            "data": {
+                                                "id": native["id"],
+                                                "slot": native["slot"],
+                                                "elapsed": native["elapsed"],
+                                                "error": _r(str(_err)) if _err else None,
+                                                "task": _r(str(native["task"])),
+                                                "agent": _r(str(native["agent"])),
+                                                "result": _r(str(native["result"])),
+                                            },
+                                        }
+                                    )
+                                else:
+                                    await ws.send_json(
+                                        {
+                                            "type": "subagent_snapshot",
+                                            "data": {
+                                                "id": native["id"],
+                                                "slot": native["slot"],
+                                                "task": _r(str(native["task"])),
+                                                "agent": _r(str(native["agent"])),
+                                                "streaming": _r(str(native["streaming"])),
+                                                "last_tool": _r(str(native["last_tool"])),
+                                                "started": native["started"],
+                                            },
+                                        }
+                                    )
+                            except Exception:
+                                pass
+
+                        # Send snapshot of managed subagents + done events for completed ones
                         if state.subagents:
-
-                            def _r(t: str) -> str:
-                                t, _ = redact_exfiltration_urls(t)
-                                t, _ = redact_credentials(t)
-                                return t
-
                             for a in state.subagents.running:
                                 try:
                                     slot = a.parent_session_key.removeprefix("dashboard:")

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -119,6 +119,8 @@ class TestChatSlotStopState:
         slot = _ChatSlot("s1")
         assert slot._stop_state == "idle"
         assert slot._stopping is False
+        assert slot._native_subagent_tracker == {}
+        assert slot._native_subagent_output == {}
 
     def test_stopping_property_reflects_stop_state(self) -> None:
         from kiro_crew.dashboard.state import _ChatSlot
@@ -220,9 +222,7 @@ class TestCompactCallbackWiring:
         assert "92%" in added["content"]
 
     @pytest.mark.asyncio
-    async def test_callback_broadcasts_context_usage_reset(
-        self, state: DashboardState
-    ) -> None:
+    async def test_callback_broadcasts_context_usage_reset(self, state: DashboardState) -> None:
         ws = MagicMock(closed=False)
         ws.send_str = AsyncMock()
         state.register_ws(ws)
@@ -247,9 +247,7 @@ class TestCompactCallbackWiring:
         state.register_ws(ws)
         state.get_or_create_slot("chat-1")
         # _ChatSlot uses __slots__, so monkeypatch at the class level.
-        monkeypatch.setattr(
-            _ChatSlot, "append", MagicMock(side_effect=RuntimeError("append boom"))
-        )
+        monkeypatch.setattr(_ChatSlot, "append", MagicMock(side_effect=RuntimeError("append boom")))
         cb = self._captured_callback(state)
 
         await cb("dashboard:chat-1", 92.0, success=True)
@@ -266,8 +264,10 @@ class TestCompactCallbackWiring:
         cb = self._captured_callback(state)
         # Force broadcast to raise — append should still land, callback should return cleanly
         with pytest.MonkeyPatch.context() as mp:
+
             def boom(*a, **kw):
                 raise RuntimeError("ws boom")
+
             mp.setattr(state, "broadcast_ws", boom)
 
             await cb("dashboard:chat-1", 92.0, success=True)

--- a/test/test_native_subagent_spawn.py
+++ b/test/test_native_subagent_spawn.py
@@ -7,13 +7,24 @@ reconciles one Activity card per sub-agent (spawn / done) from that list.
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
 
 from kiro_crew.dashboard.chat_runner import (
+    _append_native_output,
+    _native_done_result,
     _native_subagent_close_all,
     _native_subagent_sync,
+    _retain_terminal_native,
+)
+from kiro_crew.dashboard.state import (
+    NATIVE_SUBAGENT_DONE_TRUNC_MARKER,
+    NATIVE_SUBAGENT_OUTPUT_HARD,
+    NATIVE_SUBAGENT_TERMINAL_KEEP,
+    DashboardState,
+    native_subagent_output_tail,
 )
 
 
@@ -26,6 +37,8 @@ def _make_state():
 def _make_slot():
     slot = MagicMock()
     slot.key = "slot-1"
+    slot._native_subagent_tracker = {}
+    slot._native_subagent_output = {}
     return slot
 
 
@@ -73,6 +86,52 @@ class TestNativeSubagentSync:
         assert by_id["native:s1"]["task"] == "summarize README"
         assert by_id["native:s1"]["agent"] == "gpu-multiagent-worker"
         assert len(tracker) == 3
+
+    def test_active_card_is_available_to_reconnect_snapshot(self):
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        _native_subagent_sync(
+            state,
+            slot,
+            [_sub("s1", "readme", "worker", "summarize README", "working", "reading")],
+            tracker,
+            slot._native_subagent_output,
+        )
+        slot._native_subagent_output["native:s1"] = ["→ read README.md\n"]
+
+        assert DashboardState.native_subagent_snapshots(state) == [
+            {
+                "id": "native:s1",
+                "slot": "slot-1",
+                "task": "summarize README",
+                "agent": "worker",
+                "done": False,
+                "streaming": "→ read README.md\n",
+                "last_tool": "reading",
+                "started": tracker["s1"]["started"],
+            }
+        ]
+
+        # After termination the card must still hydrate on reconnect — now as a
+        # terminal (done) record, not dropped — because a socket that dropped
+        # around completion would otherwise never see it again this turn.
+        _native_subagent_sync(
+            state,
+            slot,
+            [_sub("s1", "readme", "worker", "summarize README", "terminated")],
+            tracker,
+            slot._native_subagent_output,
+        )
+        snaps = DashboardState.native_subagent_snapshots(state)
+        assert len(snaps) == 1
+        done = snaps[0]
+        assert done["id"] == "native:s1"
+        assert done["done"] is True
+        assert done["error"] is None
+        assert "read README.md" in str(done["result"])
+        assert done["elapsed"] == tracker["s1"]["elapsed"]
 
     def test_spawn_is_idempotent_across_updates(self):
         state = _make_state()
@@ -123,18 +182,24 @@ class TestNativeSubagentSync:
         assert "git log -1" in result
         assert "commit abc123" in result
 
-    def test_done_result_truncated_to_8000(self):
+    def test_done_result_keeps_newest_tail_with_marker(self):
+        # Over the cap, keep the NEWEST 8000 chars and prefix an explicit
+        # truncation marker so the dropped head is signalled (finding 3).
         state = _make_state()
         slot = _make_slot()
         tracker: dict = {}
-        card_output = {"native:s1": ["x" * 10000]}
+        card_output = {"native:s1": ["A" * 2000 + "B" * 8000]}
         _native_subagent_sync(
             state, slot, [_sub("s1", "n", "w", "q", "working")], tracker, card_output
         )
         _native_subagent_sync(
             state, slot, [_sub("s1", "n", "w", "q", "terminated")], tracker, card_output
         )
-        assert len(_ws_calls(state)["subagent_done"][0]["result"]) <= 8000
+        result = _ws_calls(state)["subagent_done"][0]["result"]
+        assert result.startswith(NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+        body = result[len(NATIVE_SUBAGENT_DONE_TRUNC_MARKER) :]
+        assert len(body) == 8000
+        assert set(body) == {"B"}  # newest content only; older 'A' head dropped
 
     def test_done_fires_once(self):
         state = _make_state()
@@ -150,9 +215,7 @@ class TestNativeSubagentSync:
         slot = _make_slot()
         tracker: dict = {}
         _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "working")], tracker)
-        _native_subagent_sync(
-            state, slot, [_sub("s1", "n", "w", "q", "failed", "boom")], tracker
-        )
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "failed", "boom")], tracker)
         done = _ws_calls(state)["subagent_done"][0]
         assert done["error"] == "boom"
 
@@ -177,7 +240,8 @@ class TestNativeSubagentSync:
         state = _make_state()
         slot = _make_slot()
         _native_subagent_sync(
-            state, slot,
+            state,
+            slot,
             [_sub("s1", "n", "role", "key AKIAIOSFODNN7EXAMPLE here", "working")],
             {},
         )
@@ -236,7 +300,9 @@ class TestEmptyTaskSkip:
         state = _make_state()
         state._native_cards = {}
         tracker: dict = {}
-        _native_subagent_sync(state, _make_slot(), [_sub("s1", "", "worker", "", "working")], tracker)
+        _native_subagent_sync(
+            state, _make_slot(), [_sub("s1", "", "worker", "", "working")], tracker
+        )
         assert "subagent_spawn" not in _ws_calls(state)
         # Marked done so subsequent updates never re-process it
         assert tracker["s1"]["done"] is True
@@ -267,14 +333,19 @@ class TestStalenessTimeout:
         past = _time.time() - now_offset
         return {
             "gone": {
-                "started": past, "done": False, "agent": "w", "task": "t",
+                "started": past,
+                "done": False,
+                "agent": "w",
+                "task": "t",
                 "last_activity": past,
             }
         }
 
     def test_disappeared_stale_card_auto_closed(self):
         state = _make_state()
-        state._native_cards = {"native:gone": {"slot": "slot-1", "session_id": "gone", "started": 0}}
+        state._native_cards = {
+            "native:gone": {"slot": "slot-1", "session_id": "gone", "started": 0}
+        }
         tracker = self._stale_tracker()
         # Empty subagents list — 'gone' not reported anymore
         _native_subagent_sync(state, _make_slot(), [], tracker)
@@ -316,7 +387,13 @@ class TestStalenessTimeout:
         state._native_cards = {}
         recent = _time.time() - 5.0
         tracker = {
-            "s1": {"started": recent, "done": False, "agent": "w", "task": "t", "last_activity": recent}
+            "s1": {
+                "started": recent,
+                "done": False,
+                "agent": "w",
+                "task": "t",
+                "last_activity": recent,
+            }
         }
         _native_subagent_sync(state, _make_slot(), [], tracker)
         assert "subagent_done" not in _ws_calls(state)
@@ -394,8 +471,9 @@ class TestNativeCardFeedRedaction:
         from kiro_crew.dashboard.chat_runner import _native_card_feed
 
         out = _native_card_feed({"c1": ["a" * 5000, "b" * 5000]}, "c1")
-        assert len(out) <= 8000
-        assert out.startswith("a")
+        assert len(out) <= 8000 + len(NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+        assert out.startswith(NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+        assert out.endswith("b" * 5000)
 
     def test_feed_empty_when_no_output(self):
         from kiro_crew.dashboard.chat_runner import _native_card_feed
@@ -408,13 +486,16 @@ class TestNativeCardFeedRedaction:
 
         from kiro_crew.dashboard.chat_runner import _native_card_feed
 
-        with patch(
-            "kiro_crew.dashboard.chat_runner.redact_exfiltration_urls",
-            return_value=("URLS_REDACTED", 0),
-        ) as m_urls, patch(
-            "kiro_crew.dashboard.chat_runner.redact_credentials",
-            return_value=("FULLY_REDACTED", 0),
-        ) as m_creds:
+        with (
+            patch(
+                "kiro_crew.dashboard.chat_runner.redact_exfiltration_urls",
+                return_value=("URLS_REDACTED", 0),
+            ) as m_urls,
+            patch(
+                "kiro_crew.dashboard.chat_runner.redact_credentials",
+                return_value=("FULLY_REDACTED", 0),
+            ) as m_creds,
+        ):
             out = _native_card_feed({"c1": ["secret output"]}, "c1")
         m_urls.assert_called_once_with("secret output")
         m_creds.assert_called_once_with("URLS_REDACTED")
@@ -479,3 +560,374 @@ class TestNativeCancelHandler:
             resp = await api_spawn_delete(self._request(state, "native:s1"))
         # SEL failure must never break the cancel response
         assert json.loads(resp.text)["ok"] is True
+
+
+class TestTailJoin:
+    def test_returns_full_output_under_limit(self):
+        assert native_subagent_output_tail(["ab", "cd", "ef"], limit=100) == "abcdef"
+
+    def test_returns_only_trailing_chars_over_limit(self):
+        # Matches the old `"".join(chunks)[-limit:]` semantics exactly, without
+        # materializing the full accumulated output.
+        chunks = ["a" * 30_000, "b" * 30_000, "c" * 30_000]
+        joined_tail = "".join(chunks)[-40_000:]
+        assert native_subagent_output_tail(chunks, limit=40_000) == joined_tail
+        assert len(native_subagent_output_tail(chunks, limit=40_000)) == 40_000
+
+    def test_stops_walking_once_limit_covered(self):
+        # Once the accumulated tail covers the limit, earlier chunks are never
+        # walked. The final chunk alone fills the 100-char window, so neither the
+        # "EARLIEST" marker nor the middle chunk appear in the result.
+        chunks = ["EARLIEST", "b" * 100, "c" * 100]
+        result = native_subagent_output_tail(chunks, limit=100)
+        assert result == "c" * 100
+        assert "EARLIEST" not in result
+        assert "b" not in result
+
+    def test_empty_and_nonpositive_limit(self):
+        assert native_subagent_output_tail([]) == ""
+        assert native_subagent_output_tail(["abc"], limit=0) == ""
+
+    def test_snapshot_streaming_is_bounded_to_tail(self):
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        _native_subagent_sync(
+            state,
+            slot,
+            [_sub("s1", "readme", "worker", "q", "working", "reading")],
+            tracker,
+            slot._native_subagent_output,
+        )
+        slot._native_subagent_output["native:s1"] = ["x" * 50_000, "TAIL"]
+        streaming = DashboardState.native_subagent_snapshots(state)[0]["streaming"]
+        assert len(streaming) == 40_000
+        assert streaming.endswith("TAIL")
+
+
+class TestNativeTerminalHydration:
+    """Reconnect must restore native cards that finished while the socket was
+    down (parent turn still running), instead of silently dropping them."""
+
+    def test_disconnected_completion_is_replayed_as_done(self):
+        # A native subagent that spawned and then completed mid-turn must appear
+        # in the reconnect snapshot as a terminal record carrying its frozen
+        # elapsed/error/result, so the client can rebuild the done card.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        co = slot._native_subagent_output
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "working")], tracker, co)
+        co["native:s1"] = ["\u2192 git log\n", "commit abc123\n"]
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "terminated")], tracker, co)
+        snaps = DashboardState.native_subagent_snapshots(state)
+        assert len(snaps) == 1
+        rec = snaps[0]
+        assert rec["done"] is True
+        assert rec["id"] == "native:s1"
+        assert rec["error"] is None
+        assert "commit abc123" in str(rec["result"])
+        assert float(rec["elapsed"]) >= 0.0
+
+    def test_failed_completion_replays_error(self):
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "working")], tracker)
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "failed", "boom")], tracker)
+        rec = DashboardState.native_subagent_snapshots(state)[0]
+        assert rec["done"] is True
+        assert rec["error"] == "boom"
+
+    def test_running_and_done_coexist_for_reconnect(self):
+        # Mixed state: one card still running, one already done. Both hydrate.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        _native_subagent_sync(
+            state,
+            slot,
+            [_sub("s1", "n", "w", "q", "working"), _sub("s2", "n", "w", "q", "working")],
+            tracker,
+        )
+        _native_subagent_sync(
+            state,
+            slot,
+            [_sub("s1", "n", "w", "q", "working"), _sub("s2", "n", "w", "q", "terminated")],
+            tracker,
+        )
+        snaps = {s["id"]: s for s in DashboardState.native_subagent_snapshots(state)}
+        assert snaps["native:s1"]["done"] is False
+        assert snaps["native:s2"]["done"] is True
+
+    def test_slot_isolation(self):
+        # A done card in one slot and a running card in another must each
+        # replay under their own slot key with no cross-contamination.
+        state = _make_state()
+        slot_a = _make_slot()
+        slot_a.key = "slot-a"
+        slot_b = _make_slot()
+        slot_b.key = "slot-b"
+        state._slots = {"slot-a": slot_a, "slot-b": slot_b}
+        _native_subagent_sync(
+            state, slot_a, [_sub("a1", "n", "w", "q", "working")], slot_a._native_subagent_tracker
+        )
+        _native_subagent_sync(
+            state,
+            slot_a,
+            [_sub("a1", "n", "w", "q", "terminated")],
+            slot_a._native_subagent_tracker,
+        )
+        _native_subagent_sync(
+            state, slot_b, [_sub("b1", "n", "w", "q", "working")], slot_b._native_subagent_tracker
+        )
+        by_id = {s["id"]: s for s in DashboardState.native_subagent_snapshots(state)}
+        assert by_id["native:a1"]["slot"] == "slot-a"
+        assert by_id["native:a1"]["done"] is True
+        assert by_id["native:b1"]["slot"] == "slot-b"
+        assert by_id["native:b1"]["done"] is False
+
+    def test_terminal_cards_survive_turn_exit_then_clear_next_turn(self):
+        # Turn teardown retains terminal (done) cards (chat_runner finally uses
+        # _retain_terminal_native) so a reconnect after the parent turn exits
+        # still sees them; the next turn's fresh tracker clears them.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "working")], tracker)
+        _native_subagent_sync(state, slot, [_sub("s1", "n", "w", "q", "terminated")], tracker)
+        assert len(DashboardState.native_subagent_snapshots(state)) == 1
+        # Socket down through parent completion: the finally block retains
+        # terminal (done) cards (dropping running cards + output buffers) so a
+        # reconnect in the idle gap after the parent turn exits still replays
+        # them. A fresh tracker at the next turn start clears them — no
+        # cross-turn leak (finding 2).
+        slot._native_subagent_tracker = _retain_terminal_native(tracker)
+        slot._native_subagent_output = {}
+        after = DashboardState.native_subagent_snapshots(state)
+        assert len(after) == 1
+        assert after[0]["done"] is True
+        # Next turn reassigns a fresh tracker → terminal cards gone (no leak).
+        slot._native_subagent_tracker = {}
+        assert DashboardState.native_subagent_snapshots(state) == []
+
+    def test_stale_done_card_pruned_on_read(self):
+        # A done card older than the read-side TTL is not replayed, so a very
+        # late reconnect on an abandoned slot sees no stale completions.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        slot._native_subagent_tracker = {
+            "s1": {
+                "id": "native:s1",
+                "started": 0.0,
+                "done": True,
+                "agent": "w",
+                "task": "t",
+                "elapsed": 1.0,
+                "error": None,
+                "result": "r",
+                "done_at": time.time() - 10_000,
+            }
+        }
+        assert DashboardState.native_subagent_snapshots(state) == []
+
+    def test_terminal_retention_is_bounded(self):
+        # A native crew that completes many sub-agents in one turn must not
+        # replay every terminal card; retention caps to the most recent N.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        n = NATIVE_SUBAGENT_TERMINAL_KEEP + 10
+        _base = time.time()
+        for i in range(n):
+            tracker[f"s{i}"] = {
+                "id": f"native:s{i}",
+                "started": 0.0,
+                "done": True,
+                "agent": "w",
+                "task": "t",
+                "elapsed": 1.0,
+                "error": None,
+                "result": "r",
+                "done_at": _base + i,  # recent, ascending completion time
+            }
+        snaps = DashboardState.native_subagent_snapshots(state)
+        assert len(snaps) == NATIVE_SUBAGENT_TERMINAL_KEEP
+        # The most recently completed (largest done_at) are the ones retained.
+        kept = {s["id"] for s in snaps}
+        assert f"native:s{n - 1}" in kept
+        assert "native:s0" not in kept
+
+    def test_running_cards_not_capped_by_terminal_limit(self):
+        # Running cards always replay; only terminal cards are capped.
+        state = _make_state()
+        slot = _make_slot()
+        state._slots = {slot.key: slot}
+        tracker = slot._native_subagent_tracker
+        for i in range(NATIVE_SUBAGENT_TERMINAL_KEEP + 5):
+            tracker[f"r{i}"] = {
+                "id": f"native:r{i}",
+                "started": 0.0,
+                "done": False,
+                "agent": "w",
+                "task": "t",
+                "last_tool": "",
+            }
+        snaps = DashboardState.native_subagent_snapshots(state)
+        assert len(snaps) == NATIVE_SUBAGENT_TERMINAL_KEEP + 5
+        assert all(s["done"] is False for s in snaps)
+
+
+class TestAppendNativeOutput:
+    """`_append_native_output` keeps a bounded rolling buffer so a noisy native
+    sub-agent can't grow the feed or the completion join without limit."""
+
+    def test_below_cap_accumulates_verbatim(self):
+        buf: list[str] = []
+        total = 0
+        for chunk in ["ab", "cd", "ef"]:
+            total = _append_native_output(buf, chunk, total)
+        assert buf == ["ab", "cd", "ef"]
+        assert total == 6
+        assert "".join(buf) == "abcdef"
+
+    def test_collapses_once_past_hard_ceiling(self):
+        buf: list[str] = []
+        total = 0
+        # Push well past the hard ceiling in many small chunks.
+        for _ in range(200):
+            total = _append_native_output(buf, "x" * 1000, total)
+        # Buffer stays bounded by the hard ceiling (collapses to the CAP tail
+        # once it grows past HARD); length never runs away.
+        assert total <= NATIVE_SUBAGENT_OUTPUT_HARD
+        assert sum(len(c) for c in buf) <= NATIVE_SUBAGENT_OUTPUT_HARD
+        assert total == len("".join(buf))
+
+    def test_preserves_trailing_tail_exactly(self):
+        # After bounding, the retained content is always the trailing tail, so
+        # snapshot semantics (native_subagent_output_tail last 40 KB) are unaffected.
+        buf: list[str] = []
+        total = 0
+        # Distinct trailing marker after a large volume of filler.
+        for _ in range(90):
+            total = _append_native_output(buf, "f" * 1000, total)
+        total = _append_native_output(buf, "TAILMARKER", total)
+        joined = "".join(buf)
+        assert joined.endswith("TAILMARKER")
+        # Bounded by the hard ceiling between collapses.
+        assert len(joined) <= NATIVE_SUBAGENT_OUTPUT_HARD
+        # The last 40 KB tail is intact regardless of collapse state.
+        assert native_subagent_output_tail(buf, 40_000).endswith("TAILMARKER")
+        assert len(native_subagent_output_tail(buf, 40_000)) == 40_000
+
+    def test_bounded_buffer_keeps_done_result_within_cap(self):
+        # The done result is the trailing 8 KB of the (now bounded) buffer,
+        # prefixed with a truncation marker when the head is dropped.
+        buf: list[str] = []
+        total = 0
+        for _ in range(200):
+            total = _append_native_output(buf, "y" * 1000, total)
+        done_result = _native_done_result(buf)
+        assert len(done_result) <= 8000 + len(NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+        assert done_result.endswith("y" * 100)
+
+    def test_hard_ceiling_bounds_peak_memory(self):
+        # Between collapses the buffer never exceeds the hard ceiling by more
+        # than a single incoming chunk.
+        buf: list[str] = []
+        total = 0
+        peak = 0
+        for _ in range(500):
+            total = _append_native_output(buf, "z" * 100, total)
+            peak = max(peak, sum(len(c) for c in buf))
+        assert peak <= NATIVE_SUBAGENT_OUTPUT_HARD + 100
+
+
+class TestNativeDoneResult:
+    """`_native_done_result` sends the NEWEST 8 KB of a card's feed, with an
+    explicit marker when older output is dropped (finding 3)."""
+
+    def test_under_cap_verbatim(self):
+        assert _native_done_result(["hello ", "world"]) == "hello world"
+
+    def test_none_is_empty(self):
+        assert _native_done_result(None) == ""
+        assert _native_done_result([]) == ""
+
+    def test_over_cap_keeps_newest_tail_with_marker(self):
+        chunks = ["OLD" + "x" * 100, "y" * 9000]
+        result = _native_done_result(chunks)
+        assert result.startswith(NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+        body = result[len(NATIVE_SUBAGENT_DONE_TRUNC_MARKER) :]
+        assert len(body) == 8000
+        assert body == ("OLD" + "x" * 100 + "y" * 9000)[-8000:]
+        assert "OLD" not in body  # oldest head dropped
+
+    def test_exactly_at_cap_is_verbatim(self):
+        chunks = ["c" * 8000]
+        assert _native_done_result(chunks) == "c" * 8000  # no marker at the cap
+
+
+class TestRetainTerminalNative:
+    """Turn-exit retention keeps only terminal (done) cards, bounded + stale-
+    pruned, so a reconnect after the parent turn exits still replays them
+    without leaking across turns (finding 2)."""
+
+    def _done(self, sid, done_at):
+        return {
+            "id": f"native:{sid}",
+            "started": 0.0,
+            "done": True,
+            "agent": "w",
+            "task": "t",
+            "elapsed": 1.0,
+            "error": None,
+            "result": "r",
+            "done_at": done_at,
+        }
+
+    def test_keeps_only_done_records(self):
+        now = time.time()
+        tracker = {
+            "s1": self._done("s1", now),
+            "s2": {
+                "id": "native:s2",
+                "started": now,
+                "done": False,
+                "agent": "w",
+                "task": "t",
+                "last_tool": "",
+            },
+        }
+        retained = _retain_terminal_native(tracker, now=now)
+        assert set(retained) == {"s1"}
+
+    def test_prunes_stale_by_ttl(self):
+        now = time.time()
+        tracker = {
+            "fresh": self._done("fresh", now - 10),
+            "stale": self._done("stale", now - 10_000),  # older than the TTL
+        }
+        retained = _retain_terminal_native(tracker, now=now)
+        assert set(retained) == {"fresh"}
+
+    def test_bounded_to_keep_most_recent(self):
+        now = time.time()
+        tracker = {
+            f"s{i}": self._done(f"s{i}", now - (100 - i)) for i in range(NATIVE_SUBAGENT_TERMINAL_KEEP + 5)
+        }
+        retained = _retain_terminal_native(tracker, now=now)
+        assert len(retained) == NATIVE_SUBAGENT_TERMINAL_KEEP
+        assert f"s{NATIVE_SUBAGENT_TERMINAL_KEEP + 4}" in retained  # newest kept
+        assert "s0" not in retained  # oldest dropped
+
+    def test_empty_when_no_done(self):
+        tracker = {"r": {"id": "native:r", "done": False, "started": 0.0}}
+        assert _retain_terminal_native(tracker) == {}

--- a/website/integration/SubagentProgressBar.integration.test.tsx
+++ b/website/integration/SubagentProgressBar.integration.test.tsx
@@ -87,25 +87,31 @@ describe('SubagentProgressBar', () => {
     expect(screen.getByText('3 agents running')).toBeInTheDocument()
   })
 
-  it('expands to show task previews on click', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  it('shows task previews without an extra expansion step', () => {
     const store = storeWithActiveSlot()
     renderWithProviders(<SubagentProgressBar slot={SLOT} />, { store })
 
     act(() => { store.dispatch(sseSubagentSpawn(makeAgent('a1', 'Search the entire codebase for uses of SessionManager'))) })
 
-    const btn = screen.getByRole('button', { name: /1 subagent running/i })
-    expect(btn).toHaveAttribute('aria-expanded', 'false')
-
-    await user.click(btn)
-
-    expect(btn).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText(/Search the entire codebase/)).toBeInTheDocument()
-    expect(screen.getByText('└─')).toBeInTheDocument()
+    expect(screen.getAllByTestId('subagent-row')).toHaveLength(1)
   })
 
-  it('shows tree connectors for multiple agents', async () => {
+  it('opens the subagents sidebar when an agent row is clicked', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const store = storeWithActiveSlot()
+    renderWithProviders(<SubagentProgressBar slot={SLOT} />, { store })
+
+    act(() => { store.dispatch(sseSubagentSpawn(makeAgent('a1', 'Search codebase'))) })
+
+    expect(screen.queryByText('View agents')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /open search codebase in subagents sidebar/i }))
+
+    expect(store.getState().chat.activityOpen).toBe(true)
+    expect(store.getState().chat.activityTab).toBe('subagents')
+  })
+
+  it('shows one summary row for each active agent', () => {
     const store = storeWithActiveSlot()
     renderWithProviders(<SubagentProgressBar slot={SLOT} />, { store })
 
@@ -114,14 +120,12 @@ describe('SubagentProgressBar', () => {
       store.dispatch(sseSubagentSpawn(makeAgent('a2', 'Task two')))
     })
 
-    await user.click(screen.getByRole('button', { name: /2 subagents running/i }))
-
-    expect(screen.getByText('├─')).toBeInTheDocument()
-    expect(screen.getByText('└─')).toBeInTheDocument()
+    expect(screen.getAllByTestId('subagent-row')).toHaveLength(2)
+    expect(screen.getByText('Task one')).toBeInTheDocument()
+    expect(screen.getByText('Task two')).toBeInTheDocument()
   })
 
-  it('shows current tool when agent is using a tool', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  it('shows current tool when agent is using a tool', () => {
     const store = storeWithActiveSlot()
     renderWithProviders(<SubagentProgressBar slot={SLOT} />, { store })
 
@@ -129,8 +133,6 @@ describe('SubagentProgressBar', () => {
       store.dispatch(sseSubagentSpawn(makeAgent('a1', 'Search codebase')))
       store.dispatch(sseSubagentTool({ slot: SLOT, id: 'a1', tool: 'readFile' }))
     })
-
-    await user.click(screen.getByRole('button', { name: /1 subagent running/i }))
 
     expect(screen.getByText('→ readFile')).toBeInTheDocument()
   })
@@ -202,15 +204,12 @@ describe('SubagentProgressBar', () => {
     expect(store.getState().chat.subagents['real1']?.status).toBe('running')
   })
 
-  it('truncates task preview to 80 characters', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  it('truncates task preview to 80 characters', () => {
     const store = storeWithActiveSlot()
     renderWithProviders(<SubagentProgressBar slot={SLOT} />, { store })
 
     const longTask = 'A'.repeat(100)
     act(() => { store.dispatch(sseSubagentSpawn(makeAgent('a1', longTask))) })
-
-    await user.click(screen.getByRole('button', { name: /1 subagent running/i }))
 
     // Should show 80 chars + ellipsis
     const preview = screen.getByText(/^A+…$/)

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -5,7 +5,7 @@ import { store } from '../store'
 import { sseStatus, sseConnected, sseDisconnected, sseSlots, setChannelTrusted, sseSlotTitle, triggerRefresh, fetchSlots, markSlotUnread, setUpdateProgress, sseSubagentStatus, sseSubagentText, touchSlotActivity, type SubagentDetail } from '../store/dashboardSlice'
 import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, fetchNotifications } from '../store/notificationsSlice'
 import { MC_NOTIFICATION_EVENT, type McNotificationDetail } from './notificationEvent'
-import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, sseSubagentPending, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone, sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard } from '../store/chatSlice'
+import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone, sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard } from '../store/chatSlice'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import type { StatusData, ChatSlot, Notification } from '../types'
@@ -215,6 +215,7 @@ export function useWebSocket() {
         if (active) dispatch(refreshSlot(active))
         // Eagerly subscribe to subagent events so chunks arrive even when
         // Activity Panel isn't open — final result still comes via done event.
+        dispatch(clearSubagentsForSnapshot())
         ws.send(JSON.stringify({ type: 'subscribe_subagents' }))
         subagentSubRef.current = true
         if (logCbRef.current) ws.send(JSON.stringify({ type: 'subscribe_logs' }))
@@ -225,6 +226,7 @@ export function useWebSocket() {
       dispatch(fetchSlots())
       dispatch(fetchNotifications()).then(() => syncPendingApprovals())
       // Eagerly subscribe to subagent events on first connect too.
+      dispatch(clearSubagentsForSnapshot())
       ws.send(JSON.stringify({ type: 'subscribe_subagents' }))
       subagentSubRef.current = true
     }
@@ -467,7 +469,7 @@ export function useWebSocket() {
             dispatch(sseSubagentStalled(data as { slot: string; id: string; stalled: boolean; idle_secs?: number }))
             break
           case 'subagent_done':
-            dispatch(sseSubagentDone(data as { slot: string; id: string; elapsed: number; error?: string }))
+            dispatch(sseSubagentDone(data as { slot: string; id: string; elapsed: number; error?: string; task?: string; agent?: string; result?: string }))
             break
           case 'app_reload':
             // App dev-mode live reload: the gateway watched a dev-flagged app's

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -74,6 +74,9 @@ function SubagentPane({ a, onClick }: { a: SubagentActivity; onClick: () => void
   const autoScroll = useRef(true)
   const isPending = a.status === 'pending'
   const isDone = a.status === 'done' || a.status === 'error'
+  // Native cards have no SubagentManager record to lazy-load from disk; their
+  // output arrives inline on the done event (a.result).
+  const isNative = a.id.startsWith('native:')
   const [collapsed, setCollapsed] = useState(isDone)
   // Auto-collapse when transitioning to done (not on mount)
   const wasDone = useRef(isDone)
@@ -168,7 +171,7 @@ function SubagentPane({ a, onClick }: { a: SubagentActivity; onClick: () => void
       <div className="px-3 pb-2">
         <div className="text-[10px] text-muted/40 uppercase tracking-wider mb-1">Output</div>
         <pre ref={bodyRef} onScroll={onScroll} className="px-2.5 py-2 bg-bg rounded-md text-[12px] font-mono whitespace-pre-wrap break-all max-h-[240px] overflow-y-auto text-muted/80 leading-relaxed">
-          {a.streaming || (isDone ? <DiskLoader id={a.id} /> : <span className="text-muted/30 italic">Waiting for output…</span>)}
+          {a.streaming || a.result || (isDone ? (isNative ? <span className="text-muted/30 italic">(output shown in chat)</span> : <DiskLoader id={a.id} />) : <span className="text-muted/30 italic">Waiting for output…</span>)}
           {a.lastTool && <div className="text-accent mt-1"><Wrench className="lucide-inline" /> {a.lastTool}</div>}
         </pre>
       </div>

--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react'
-import { Bot, ChevronDown, X, AlertTriangle } from 'lucide-react'
+import { Bot, X, AlertTriangle } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
-import { sseSubagentDone } from '../../store/chatSlice'
+import { openActivityToTab, sseSubagentDone } from '../../store/chatSlice'
 import { api } from '../../api/client'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { SubagentActivity } from '../../types'
@@ -18,7 +18,7 @@ interface SpawnListResponse {
   agents?: SpawnListAgent[]
 }
 
-/** Compact subagent activity indicator above the chat input. */
+/** Active subagent summary above the chat input. */
 const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: string | null }) {
   // Use chatSlice.subagents — populated by subagent_spawn/tool/done WS events
   // (dashboardSlice.subagentRunning only updates on subagent_status which fires at completion)
@@ -26,7 +26,6 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   const subagents = useAppSelector(s => slot === s.chat.activeSlot ? s.chat.subagents : s.chat.slotActivity[slot ?? '']?.subagents ?? EMPTY_SUBAGENTS)
   const activeList = useMemo(() => Object.values(subagents).filter(a => a.status === 'running' || a.status === 'tool' || a.status === 'pending'), [subagents])
   const running = activeList.length
-  const lead = activeList[activeList.length - 1]
   const anyStalled = useMemo(() => activeList.some(a => a.stalled), [activeList])
   const activeListRef = useRef(activeList)
   activeListRef.current = activeList
@@ -35,16 +34,14 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   // (awaiting approval) are resolved through the approval reject path instead.
   const stoppableCount = useMemo(() => activeList.filter(a => a.status === 'running' || a.status === 'tool').length, [activeList])
   // Cancel a running subagent. A failed spawnDelete is swallowed with only a
-  // debug breadcrumb -- the 30s reconcile loop below is the safety net that
-  // drops any agent the backend actually stopped, so a failed DELETE self-heals
-  // and a toast would just be noise. Mirrors ActivityViewer's onCancel.
+  // debug breadcrumb. The 30s reconcile loop below is the safety net that
+  // drops any agent the backend actually stopped.
   const stopAgent = useCallback((id: string) => {
     api.spawnDelete(id).catch(() => console.warn(`spawnDelete failed for subagent ${id}; reconcile loop will resync`))
   }, [])
   const stopAll = useCallback(() => {
     activeListRef.current.forEach(a => { if (a.status === 'running' || a.status === 'tool') stopAgent(a.id) })
   }, [stopAgent])
-  const [expanded, setExpanded] = useState(false)
   const [, setTick] = useState(0)
   // 1Hz tick to update elapsed timers + 30s reconciliation to clear phantom agents
   useEffect(() => {
@@ -62,63 +59,58 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
     }, 30_000)
     return () => { cancelled = true; clearInterval(t); clearInterval(reconcile) }
   }, [hasActive, slot, dispatch])
-  // Auto-collapse when agents finish
-  useEffect(() => { if (!hasActive) setExpanded(false) }, [hasActive])
   if (!hasActive) return null
   return (
     <div className="px-5 mx-auto w-full" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
-    <div className="mb-1 rounded-md bg-accent/10 border border-accent/20 animate-slide-up overflow-hidden">
-      <div className="w-full flex items-center gap-2 pr-2">
-        <button
-          className="flex-1 min-w-0 flex items-center gap-2 px-3 py-1.5 text-[13px] font-mono cursor-pointer hover:bg-accent/5 transition-colors text-left bg-transparent border-none"
-          onClick={() => setExpanded(e => !e)}
-          aria-expanded={expanded}
-          aria-label={`${running} subagent${running > 1 ? 's' : ''} running`}
-        >
+      <div className="mb-1 rounded-md bg-accent/10 border border-accent/20 animate-slide-up overflow-hidden">
+        <div className="flex items-center gap-2 px-3 py-1.5 text-[13px] font-mono">
           <Bot size={14} className="text-accent shrink-0" />
-          <span className="text-text-strong font-medium shrink-0">{running} agent{running > 1 ? 's' : ''} running</span>
-          <span className="flex-1 min-w-0 truncate text-left">
-            {!expanded && lead?.lastTool ? <span className="text-accent/70">→ {sanitizeLlmOutput(lead.lastTool)}</span> : null}
-          </span>
+          <span className="text-text-strong font-medium">{running} agent{running > 1 ? 's' : ''} running</span>
           {anyStalled && (
-            <span className="shrink-0 inline-flex items-center gap-1 text-warn" title="No activity — possibly stalled">
+            <span className="ml-auto shrink-0 inline-flex items-center gap-1 text-warn" title="No activity — possibly stalled">
               <AlertTriangle size={12} /> stalled
             </span>
           )}
-          <ChevronDown size={14} className={`text-muted shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
-        </button>
-        {stoppableCount > 0 && (
-          <button
-            className="shrink-0 flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded border border-danger/40 text-danger/70 hover:bg-danger-subtle hover:text-danger cursor-pointer transition-all bg-transparent"
-            onClick={stopAll}
-            aria-label={stoppableCount > 1 ? 'Stop all running subagents' : 'Stop running subagent'}
-          >
-            <X size={11} /> Stop{stoppableCount > 1 ? ' all' : ''}
-          </button>
-        )}
-      </div>
-      {expanded && activeList.length > 0 && (
+          {stoppableCount > 0 && (
+            <button
+              className={`${anyStalled ? '' : 'ml-auto '}shrink-0 flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded border border-danger/40 text-danger/70 hover:bg-danger-subtle hover:text-danger cursor-pointer transition-all bg-transparent`}
+              onClick={stopAll}
+              aria-label={stoppableCount > 1 ? 'Stop all running subagents' : 'Stop running subagent'}
+            >
+              <X size={11} /> Stop{stoppableCount > 1 ? ' all' : ''}
+            </button>
+          )}
+        </div>
         <div className="px-3 pb-2 space-y-0.5">
           {activeList.map((a, i) => {
             const isLast = i === activeList.length - 1
             const taskPreview = sanitizeLlmOutput((a.task || '').slice(0, 80)) + ((a.task || '').length > 80 ? '…' : '')
+            const agentLabel = taskPreview || sanitizeLlmOutput(a.agent || 'agent')
             const elapsed = Math.round((Date.now() - a.startedAt) / 1000)
+            const stoppable = a.status === 'running' || a.status === 'tool'
             return (
-              <div key={a.id} className="flex items-start gap-1.5 text-[12px] text-muted font-mono">
-                <span className="shrink-0 text-border select-none">{isLast ? '└─' : '├─'}</span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <span className="truncate text-text">{taskPreview || sanitizeLlmOutput(a.agent || 'agent')}</span>
-                    <span className="shrink-0 tabular-nums text-muted/50">{elapsed}s{typeof a.toolCount === 'number' && a.toolCount > 0 ? ` · ${a.toolCount} tool${a.toolCount > 1 ? 's' : ''}` : ''}</span>
-                  </div>
-                  {a.stalled ? (
-                    <div className="text-warn flex items-center gap-1">
-                      <AlertTriangle size={11} className="shrink-0" />
-                      <span className="truncate">stalled{a.lastTool ? ` at ${sanitizeLlmOutput(a.lastTool)}` : ''} — no activity</span>
-                    </div>
-                  ) : (a.lastTool && <div className="text-accent/60 truncate">→ {sanitizeLlmOutput(a.lastTool)}</div>)}
-                </div>
-                {(a.status === 'running' || a.status === 'tool') && (
+              <div key={a.id} data-testid="subagent-row" className="flex items-start gap-1">
+                <button
+                  type="button"
+                  className="min-w-0 flex-1 flex items-start gap-1.5 rounded-sm text-left text-[12px] text-muted font-mono hover:bg-accent/5 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                  onClick={() => dispatch(openActivityToTab('subagents'))}
+                  aria-label={`Open ${agentLabel} in subagents sidebar`}
+                >
+                  <span aria-hidden="true" className="shrink-0 text-border select-none">{isLast ? '└─' : '├─'}</span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="min-w-0 flex-1 truncate text-text">{agentLabel}</span>
+                      <span className="shrink-0 tabular-nums text-muted/50">{elapsed}s{typeof a.toolCount === 'number' && a.toolCount > 0 ? ` · ${a.toolCount} tool${a.toolCount > 1 ? 's' : ''}` : ''}</span>
+                    </span>
+                    {a.stalled ? (
+                      <span className="text-warn flex items-center gap-1">
+                        <AlertTriangle size={11} className="shrink-0" />
+                        <span className="truncate">stalled{a.lastTool ? ` at ${sanitizeLlmOutput(a.lastTool)}` : ''} — no activity</span>
+                      </span>
+                    ) : (a.lastTool && <span className="block text-accent/60 truncate">→ {sanitizeLlmOutput(a.lastTool)}</span>)}
+                  </span>
+                </button>
+                {stoppable && (
                   <button
                     className="shrink-0 flex items-center text-[11px] px-1 py-0.5 rounded border border-danger/40 text-danger/70 hover:bg-danger-subtle hover:text-danger cursor-pointer transition-all bg-transparent"
                     onClick={() => stopAgent(a.id)}
@@ -132,8 +124,7 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
             )
           })}
         </div>
-      )}
-    </div>
+      </div>
     </div>
   )
 })

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -867,6 +867,22 @@ const chatSlice = createSlice({
     /** Clear after the matching pill has consumed the focus signal, so the same trigger
      *  doesn't re-fire on subsequent re-renders. */
     clearFocusToolCallId(state) { state.focusToolCallId = null },
+    /** Drop the previous connection's ephemeral subagent view before the gateway
+     *  replays its authoritative running/done snapshot. Without this reset, an
+     *  empty replay leaves agents from a restarted gateway visible indefinitely.
+     *  Pending spawn-approval cards are preserved: the subscribe_subagents replay
+     *  only re-emits native + managed running/done agents, so a card still
+     *  awaiting approval has no backend SubagentInfo to hydrate it and would be
+     *  lost (its approve/reject UI along with it) on a mid-approval reconnect. */
+    clearSubagentsForSnapshot(state) {
+      const keepPending = (subs: Record<string, SubagentActivity> | undefined): Record<string, SubagentActivity> => {
+        const kept: Record<string, SubagentActivity> = {}
+        if (subs) for (const [id, a] of Object.entries(subs)) if (a.status === 'pending') kept[id] = a
+        return kept
+      }
+      state.subagents = keepPending(state.subagents)
+      for (const activity of Object.values(state.slotActivity)) activity.subagents = keepPending(activity.subagents)
+    },
     sseSubagentPending(state, action: PayloadAction<{ slot: string; id: string; task: string; approval_id: string }>) {
       if (isUnsafeKey(action.payload.slot) || isUnsafeKey(action.payload.id)) return
       const entry: SubagentActivity = {
@@ -945,10 +961,7 @@ const chatSlice = createSlice({
         : state.subagents
       let a = subs[action.payload.id]
       if (!a) {
-        // Cross-slot fallback: the card may live under a different slot key
-        // than the done event's slot (e.g. the parent session was reset, or
-        // the pending card was created under the activeSlot fallback). Find
-        // it by id anywhere so the card doesn't stay stuck "running" forever.
+        // Cross-slot fallback: the card may live under a different slot key.
         if (state.subagents[action.payload.id]) a = state.subagents[action.payload.id]
         else {
           for (const sa of Object.values(state.slotActivity)) {
@@ -956,14 +969,30 @@ const chatSlice = createSlice({
           }
         }
       }
+      const isNative = action.payload.id.startsWith('native:')
       if (a) {
         a.status = action.payload.error ? 'error' : 'done'
         a.elapsed = action.payload.elapsed
         a.error = action.payload.error
         a.streaming = ''
         if (action.payload.task && !a.task) a.task = action.payload.task
+        if (action.payload.agent && !a.agent) a.agent = action.payload.agent
+        if (isNative && action.payload.result !== undefined) a.result = action.payload.result
       }
-      else { subs[safeKey(action.payload.id)] = { id: action.payload.id, task: action.payload.task || '', agent: action.payload.agent || 'kirocrew', status: action.payload.error ? 'error' : 'done', streaming: '', lastTool: '', startedAt: Date.now() - action.payload.elapsed * 1000, elapsed: action.payload.elapsed, error: action.payload.error } }
+      else {
+        subs[action.payload.id] = {
+          id: action.payload.id,
+          task: action.payload.task || '',
+          agent: action.payload.agent || 'kirocrew',
+          status: action.payload.error ? 'error' : 'done',
+          streaming: '',
+          lastTool: '',
+          startedAt: Date.now() - action.payload.elapsed * 1000,
+          elapsed: action.payload.elapsed,
+          error: action.payload.error,
+          result: isNative ? action.payload.result : undefined,
+        }
+      }
     },
     sseSideResult(state, action: PayloadAction<{ slot: string; run_id: string; role: 'user' | 'assistant'; content: string; ts?: number; is_error?: boolean; final?: boolean }>) {
       const { slot, run_id, role, content, ts, is_error, final } = action.payload
@@ -1046,6 +1075,9 @@ const chatSlice = createSlice({
         ? (state.slotActivity[safeKey(d.slot)] ??= { toolLog: [], subagents: {} }).subagents
         : state.subagents
       const existing = subs[d.id]
+      // Live events can interleave with replay because subscription starts before
+      // snapshots are sent. Never let a stale running snapshot demote a terminal card.
+      if (existing?.status === 'done' || existing?.status === 'error') return
       subs[safeKey(d.id)] = {
         id: d.id, task: d.task, agent: d.agent || 'kirocrew',
         status: d.last_tool ? 'tool' : 'running', streaming: d.streaming, lastTool: d.last_tool,
@@ -1736,7 +1768,7 @@ export const {
   setActiveSlot, clearSlotState, setPendingInput, setQuestionCard, clearQuestionCard, appendMessage, appendSlotMessage, updateStreamingMessage, finalizeAssistant,
   removeThinking, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage,
   sseContextUsage, setVoicePlaying, setVoiceAudio,
-  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone,
+  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentDone,
   sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent,
   sseWorkflowEvent, clearWorkflowRun,
   sseSideResult, sideClose, sideOptimisticAppend, sideOptimisticRollback,

--- a/website/src/test/SubagentProgressBar.test.tsx
+++ b/website/src/test/SubagentProgressBar.test.tsx
@@ -44,7 +44,6 @@ describe('SubagentProgressBar — in-chat stop controls', () => {
     // 1 running + 1 pending: only the running agent is stoppable.
     renderBar(makeStore(['a1'], 'p1'))
     // Header reflects the total active count (running + pending).
-    fireEvent.click(screen.getByLabelText('2 subagents running'))
     // Exactly one per-row stop button (the running agent, not the pending one).
     const rowStops = screen.getAllByLabelText(/^Stop subagent/)
     expect(rowStops).toHaveLength(1)
@@ -71,7 +70,6 @@ describe('SubagentProgressBar — in-chat stop controls', () => {
   it('renders no stop controls when every active agent is pending (stoppableCount === 0)', () => {
     renderBar(makeStore([], 'p1'))
     // The pending agent still shows in the header, but offers no stop affordance.
-    fireEvent.click(screen.getByLabelText('1 subagent running'))
     expect(screen.queryByLabelText(/^Stop/)).toBeNull()
     expect(api.spawnDelete).not.toHaveBeenCalled()
   })

--- a/website/src/test/useWebSocketReconnect.test.ts
+++ b/website/src/test/useWebSocketReconnect.test.ts
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createTestStore } from './helpers'
 import { useWebSocket } from '../hooks/useWebSocket'
 import { api } from '../api/client'
-import chatReducer from '../store/chatSlice'
+import chatReducer, { sseSubagentSpawn, sseSubagentPending, sseSubagentDone } from '../store/chatSlice'
 import type { RootState } from '../store'
 
 // Track markSlotUnread dispatches
@@ -84,6 +84,138 @@ describe('useWebSocket reconnect unread suppression', () => {
       createElement(QueryClientProvider, { client: qc }, children)
     )
   }
+
+  it('clears stale subagents before authoritative snapshot replay', () => {
+    vi.useFakeTimers()
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    testStore.dispatch(sseSubagentSpawn({ slot: 'chat-active', id: 'stale-active', task: 'Old active task', agent: 'kirocrew' }))
+    testStore.dispatch(sseSubagentSpawn({ slot: 'chat-other', id: 'stale-background', task: 'Old background task', agent: 'kirocrew' }))
+
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    const ws1 = WS_INSTANCES[0]
+    act(() => { ws1.simulateOpen() })
+
+    expect(testStore.getState().chat.subagents).toEqual({})
+    expect(testStore.getState().chat.slotActivity['chat-other']?.subagents).toEqual({})
+
+    act(() => {
+      ws1.simulateMessage({
+        type: 'subagent_snapshot',
+        data: { id: 'live-1', slot: 'chat-active', task: 'Live task', agent: 'kirocrew', streaming: '', last_tool: '', started: Date.now() / 1000 },
+      })
+    })
+    expect(testStore.getState().chat.subagents['live-1']?.status).toBe('running')
+
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) })
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+
+    expect(testStore.getState().chat.subagents).toEqual({})
+
+    act(() => {
+      ws2.simulateMessage({
+        type: 'subagent_snapshot',
+        data: { id: 'live-2', slot: 'chat-active', task: 'Current live task', agent: 'kirocrew', streaming: '', last_tool: '', started: Date.now() / 1000 },
+      })
+    })
+    expect(testStore.getState().chat.subagents['live-2']?.status).toBe('running')
+    expect(testStore.getState().chat.subagents['live-1']).toBeUndefined()
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('preserves pending spawn-approval cards through the reconnect clear', () => {
+    vi.useFakeTimers()
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    // A running card (has a backend record, will be re-hydrated by replay) and a
+    // pending spawn-approval card (no backend SubagentInfo yet, so nothing replays it).
+    testStore.dispatch(sseSubagentSpawn({ slot: 'chat-active', id: 'stale-running', task: 'Old task', agent: 'kirocrew' }))
+    testStore.dispatch(sseSubagentPending({ slot: 'chat-active', id: 'spawn:pending-1', task: 'Awaiting approval', approval_id: 'appr-1' }))
+
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    const ws1 = WS_INSTANCES[0]
+    act(() => { ws1.simulateOpen() })
+
+    // Running card is cleared; the pending approval card survives with its approval_id intact.
+    expect(testStore.getState().chat.subagents['stale-running']).toBeUndefined()
+    const pending = testStore.getState().chat.subagents['spawn:pending-1']
+    expect(pending?.status).toBe('pending')
+    expect(pending?.approval_id).toBe('appr-1')
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('hydrates a native card that completed while disconnected as a terminal done card', () => {
+    vi.useFakeTimers()
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    // A native card is live before the drop.
+    testStore.dispatch(sseSubagentSpawn({ slot: 'chat-active', id: 'native:s1', task: 'Summarize', agent: 'worker' }))
+
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    const ws1 = WS_INSTANCES[0]
+    act(() => { ws1.simulateOpen() })
+    // Reconnect clears the (now stale) running card.
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) })
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+    expect(testStore.getState().chat.subagents['native:s1']).toBeUndefined()
+
+    // The gateway replays the completion (it finished while the socket was down)
+    // as a subagent_done — the terminal card must be rebuilt, not lost.
+    act(() => {
+      ws2.simulateMessage({
+        type: 'subagent_done',
+        data: { slot: 'chat-active', id: 'native:s1', elapsed: 3, task: 'Summarize', agent: 'worker', result: 'done feed' },
+      })
+    })
+    const done = testStore.getState().chat.subagents['native:s1']
+    expect(done?.status).toBe('done')
+    expect(done?.elapsed).toBe(3)
+    expect(done?.task).toBe('Summarize')
+    // Native cards cannot lazy-load from disk, so the replayed result must be
+    // preserved inline on the rebuilt terminal card (finding 1).
+    expect(done?.result).toBe('done feed')
+
+    // Subscription starts before replay, so a live completion can arrive before
+    // a stale running snapshot captured for the same card. Terminal state is
+    // monotonic and must retain its result and elapsed time.
+    act(() => {
+      ws2.simulateMessage({
+        type: 'subagent_snapshot',
+        data: { id: 'native:s1', slot: 'chat-active', task: 'Summarize', agent: 'worker', streaming: 'stale', last_tool: 'read', started: Date.now() / 1000 },
+      })
+    })
+    const afterStaleSnapshot = testStore.getState().chat.subagents['native:s1']
+    expect(afterStaleSnapshot?.status).toBe('done')
+    expect(afterStaleSnapshot?.elapsed).toBe(3)
+    expect(afterStaleSnapshot?.result).toBe('done feed')
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('stores done result inline for native cards but not managed cards', () => {
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    // Native card: result stored inline (no SubagentManager record to disk-load).
+    testStore.dispatch(sseSubagentDone({ slot: 'chat-active', id: 'native:s9', elapsed: 2, task: 'T', agent: 'w', result: 'native feed' }))
+    expect(testStore.getState().chat.subagents['native:s9']?.result).toBe('native feed')
+    // Managed card: result left unset so the memory-friendly DiskLoader path is
+    // preserved even though the event carries a (potentially large) result.
+    testStore.dispatch(sseSubagentDone({ slot: 'chat-active', id: 'mgr-1', elapsed: 2, task: 'T', agent: 'w', result: 'x'.repeat(50000) }))
+    expect(testStore.getState().chat.subagents['mgr-1']?.result).toBeUndefined()
+  })
 
   it('suppresses markSlotUnread during reconnect catch-up window', async () => {
     vi.useFakeTimers()

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -223,6 +223,11 @@ export interface SubagentActivity {
   stalled?: boolean       // reaper flagged this subagent as idle/stalled
   approval_id?: string
   approving?: boolean
+  /** Inline terminal output for native (`native:*`) cards only. Native cards
+   *  cannot lazy-load from disk (no SubagentManager record), so the bounded
+   *  done-event result is stored here. Managed cards leave this unset and use
+   *  the on-demand DiskLoader to keep Redux memory bounded. */
+  result?: string
 }
 
 export interface ToolActivity {


### PR DESCRIPTION
## Problem

Native subagent activity cards disappear when the dashboard refreshes or its WebSocket reconnects. Completed native cards also lose their terminal state and result history, and stale client cards can remain when they are absent from the gateway's authoritative replay.

Ported from [KiroClaw PR #73](https://github.com/kirodotdev-labs/kiroclaw/pull/73) onto current Kiro Crew behavior.

## Why it matters

A refresh should not make active delegated work look lost or leave users guessing whether a subagent is still running. Reconnect state must also preserve approvals and controls without resurrecting stale work.

## Fix

This change:

- retains bounded native output and terminal history on each chat slot;
- replays running native cards as `subagent_snapshot` and retained terminal cards as `subagent_done`;
- clears reconnect state against authoritative replay while preserving pending approvals;
- restores native inline result tails while keeping managed result loading disk-backed;
- prevents stale running snapshots from demoting cards that already reached `done` or `error`;
- opens native rows on Activity's Subagents tab;
- keeps the per-agent progress list expanded so status and Stop controls remain visible; and
- preserves progress and stall indicators, Stop and Stop-all controls, empty-task filtering, native cancellation, and the 120-second stale timeout.

## Architecture

- `DashboardState.native_subagent_snapshots()` owns native slot record traversal and returns transport-ready replay records. `ws.py` no longer reaches into `_slots`, `_native_subagent_tracker`, or `_native_subagent_output`.
- Native output, result, terminal-count, and terminal-lifetime bounds are centralized in `state.py` and shared by writers and replay readers.
- Running output replay is capped at 40,000 characters. Accumulation has an 80,000-character hard ceiling. Completion result tails are capped at 8,000 characters with a truncation marker. Terminal replay is capped at the newest 50 records for one hour.
- Terminal client state is monotonic to handle live-event and replay interleaving without delaying subscription and risking dropped events.
- The subagent system specification documents managed and native replay, optional native `task`, `agent`, and `result` fields, bounds, redaction, and monotonic terminal behavior.
- Backend files were reconstructed from current `main` formatting and only behavioral reconnect hunks were reapplied, removing unrelated formatting churn.

## Tests

Added and updated backend, reducer, hook, component, and integration coverage for running and terminal hydration, stale-snapshot interleaving, authoritative stale-card removal, pending-approval preservation, output and result bounds, terminal TTL and count limits, slot isolation, cancellation, row navigation, stop controls, tool counts, stall state, and reconnect subscription behavior.

Validation on rebased remote commit `91711b91` with parent `57b433ea`:

- Focused backend: 92 passed.
- Full frontend Vitest: 363 files passed. 4,120 tests passed and 3 skipped.
- TypeScript: passed.
- Backend mypy 1.14.1: passed across 443 source files.
- Production frontend build: passed with 6,380 modules transformed. The existing large-chunk warning remains.
- Python Flake8: passed.
- Changed Python isort check: passed.
- `git diff --check origin/main...HEAD`: passed.
- Full backend pytest: 15,989 passed, 96 skipped, 5 xfailed, and 9 failed. The remaining failures are unchanged environment-sensitive tests for filesystem timestamp reload, process inspection, and unavailable AWS Polly CLI execution. None touch the dashboard or subagent paths changed here.

## Manual verification

Kyle approved the always-expanded progress layout in an isolated preview on localhost port `6873`. Native rows remained visible, opened Activity on the Subagents tab, retained progress, stall, and tool details, and kept sibling Stop and Stop-all controls through reconnect states. The isolated preview process was stopped after approval.

## Screenshots

No screenshot was committed. The approved preview was isolated locally and stopped after Kyle's visual review.
