### PR TITLE
fix(acp): send /compact via session/prompt — string-form commands/execute kills kiro-cli

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -73,8 +73,10 @@ check (`dashboard/handlers/cron.py`).
 ## Key Behaviors
 
 - **Context compaction**: at ≥ configured threshold (`session.autocompact_pct`, default 90%, valid 5–90), compacts **in place** on both
-  backends: kiro-cli via native `/compact` (command execute +
-  `_kiro.dev/compaction/status` wait), claude via SDK `/compact`. The
+  backends: kiro-cli via a `/compact` **prompt** (`session/prompt` +
+  `_kiro.dev/compaction/status` watch — never the string form of
+  `_kiro.dev/commands/execute`, which kiro-cli 2.14.0 exits rc=0 on),
+  claude via SDK `/compact`. The
   process and session ID survive, so queued/agentic work continues
   automatically. kiro-cli only: if the in-place compact fails, times out,
   or the provider lacks native support, falls back to the legacy

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -224,6 +224,11 @@ class AcpSessionHandle:
         self._inflight_tool: ToolCallState | None = None
         # Last monotonic ts a WORKING-verdict deferral was logged (rate limit).
         self._working_logged_ts = 0.0
+        # Terminal compaction status captured by compact() while draining its
+        # own prompt turn (kiro-cli may emit _kiro.dev/compaction/status
+        # BEFORE end_turn). wait_for_compaction() consumes it first so the
+        # drain never strands a caller into a spurious 120s timeout.
+        self._compact_result: dict[str, str] | None = None
         self._cancelled = False
         # Unresponsive-cancel tracking (mirrors AcpClient._cancel_ts /
         # _cancel_grace_secs). Set by cancel(); the dispatch loop uses them to
@@ -558,18 +563,47 @@ class AcpSessionHandle:
     # ── Compaction ──
 
     async def compact(self, context: str = "") -> None:
-        """Trigger context compaction via /compact command."""
+        """Trigger context compaction via a ``/compact`` prompt.
+
+        Sent through ``session/prompt`` (drained to turn end), NOT through
+        ``_kiro.dev/commands/execute``: kiro-cli 2.14.0 exits rc=0 without a
+        response on the STRING form of commands/execute (live-probe confirmed
+        for /compact and /help alike; the object form used by /effort is
+        fine). The prompt transport matches the dashboard's manual /compact
+        and Slack's !compact: kiro ACKs the prompt (end_turn) and then emits
+        ``_kiro.dev/compaction/status``, which ``wait_for_compaction()``
+        picks up from the session queue.
+        """
         cmd = "/compact"
         if context:
             cmd = f"/compact {context}"
-        await self.send_command(cmd)
+        # Capture a terminal status emitted MID-TURN (before end_turn) while
+        # draining — otherwise it would be consumed and lost, stranding a
+        # subsequent wait_for_compaction() until timeout even though the
+        # compact succeeded. wait_for_compaction() consumes this cache first.
+        self._compact_result = None
+        async for event in self.prompt(cmd):
+            if event.kind == EVENT_COMPACTION_STATUS and event.text in (
+                "completed",
+                "failed",
+            ):
+                self._compact_result = {
+                    "type": event.text,
+                    "summary": event.title or "",
+                }
 
     async def wait_for_compaction(self, timeout: float = 120.0) -> dict[str, str]:
         """Wait for compaction completed/failed event from the session queue.
 
         Returns {"type": "completed"|"failed"|"timeout", "summary": "..."}.
-        Drains the queue looking for COMPACTION_STATUS notifications.
+        Consumes the result compact() captured mid-turn if there is one,
+        otherwise drains the queue looking for COMPACTION_STATUS
+        notifications (the async-after-end_turn case).
         """
+        cached = self._compact_result
+        if cached is not None:
+            self._compact_result = None
+            return cached
         deadline = time.monotonic() + timeout
         buffered: list[JsonRpcMessage] = []
         try:

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -19,7 +19,12 @@ from kiro_crew.acp.client import (
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
 from kiro_crew.acp.session_provider import AcpSessionProvider
-from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, STOP_REASON_CANCELLED, STOP_REASON_END_TURN
+from kiro_crew.acp.types import (
+    ACP_BACKEND_CLAUDE,
+    EVENT_COMPACTION_STATUS,
+    STOP_REASON_CANCELLED,
+    STOP_REASON_END_TURN,
+)
 from kiro_crew.effort import (
     EFFORT_LEVELS,
     effort_settings_key,
@@ -243,6 +248,9 @@ class AcpProvider(LLMProvider):
         if agent:
             kwargs["agent"] = agent
         self._client = AcpClient(**kwargs)
+        # Terminal compaction status captured by compact() while draining its
+        # prompt turn; consumed by wait_for_compaction() (see compact()).
+        self._compact_result: dict | None = None
         # Per-model reasoning-effort. Resolution priority (see effort.py):
         # slot override > workspace defaults > None. The kiro backend applies
         # this via a workspace cli.json overlay read at spawn; the claude
@@ -885,14 +893,31 @@ class AcpProvider(LLMProvider):
             message = f"/compact Preserve this session context in the summary:\n{prompt}"
         else:
             message = "/compact"
-        # claude-agent-acp does not implement _kiro.dev/commands/execute —
-        # send /compact through session/prompt, which the claude backend
-        # handles natively as a slash command.
-        if self.is_claude_backend:
-            async for _ in self._client.stream_events(message):
-                pass
-            return
-        await self._client.send_command(message)
+        # BOTH backends send /compact through session/prompt.
+        # - claude-agent-acp does not implement _kiro.dev/commands/execute;
+        #   the claude backend handles the slash command natively in-prompt.
+        # - kiro-cli DOES advertise commands/execute, but its STRING form
+        #   (`"command": "/compact"`) makes kiro-cli 2.14.0 exit rc=0 without
+        #   a response — live-probe confirmed for /compact AND /help, while
+        #   the object form (`{"command": "help", "args": {}}`, used by
+        #   /effort) works. The prompt transport is the path the dashboard's
+        #   manual /compact and Slack's !compact have always used: kiro ACKs
+        #   the prompt (end_turn) and then emits _kiro.dev/compaction/status
+        #   started/completed, which wait_for_compaction() picks up.
+        # Capture a terminal status emitted MID-TURN (before end_turn) while
+        # draining — otherwise it would be consumed and lost, stranding a
+        # subsequent wait_for_compaction() (task_executor, wechat, cli_chat)
+        # until timeout even though the compact succeeded.
+        self._compact_result = None
+        async for event in self._client.stream_events(message):
+            if event.kind == EVENT_COMPACTION_STATUS and event.text in (
+                "completed",
+                "failed",
+            ):
+                self._compact_result = {
+                    "type": event.text,
+                    "summary": event.title or "",
+                }
 
     async def cancel(self, *, wait_ack_timeout: float = 0.0) -> CancelOutcome:
         """Cancel in-flight operation via ACP session/cancel."""
@@ -936,7 +961,16 @@ class AcpProvider(LLMProvider):
         return bool(getattr(self._client, "supports_steer", False))
 
     async def wait_for_compaction(self, timeout: float = 120.0) -> dict:
-        """Wait for compaction completed/failed after stream ends."""
+        """Wait for compaction completed/failed after stream ends.
+
+        Consumes the result compact() captured mid-turn if there is one
+        (kiro-cli may emit the terminal status before end_turn), otherwise
+        delegates to the client's queue wait (async-after-end_turn case).
+        """
+        cached = getattr(self, "_compact_result", None)
+        if cached is not None:
+            self._compact_result = None
+            return cached
         return await self._client.wait_for_compaction(timeout)
 
     async def new_conversation(self) -> None:

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -2439,13 +2439,35 @@ class SessionManager:
         try:
 
             async def _run() -> None:
-                await session.provider.compact()
-                result = await session.provider.wait_for_compaction(
-                    timeout=_COMPACT_RESULT_WAIT_SECS
-                )
-                rtype = result.get("type") if isinstance(result, dict) else None
-                if rtype != "completed":
-                    raise RuntimeError(f"compaction reported {rtype or 'no result'}")
+                # Lazy import: kiro_crew.acp.__init__ eagerly pulls client/
+                # runtime; a module-level import here would recreate the
+                # providers<->session cycle this file avoids everywhere else.
+                from kiro_crew.acp.types import EVENT_COMPACTION_STATUS
+
+                # Mirror the proven Slack !compact flow: send /compact as a
+                # PROMPT and watch the stream for the compaction status
+                # inline. kiro-cli may emit _kiro.dev/compaction/status
+                # either mid-turn (before end_turn) or asynchronously after
+                # it — watching the stream first means a mid-turn status is
+                # never eaten by a blind drain (which would strand
+                # wait_for_compaction until timeout and wrongly recycle a
+                # just-compacted healthy session).
+                status: str | None = None
+                async for event in session.provider.stream_command("/compact"):
+                    if event.kind == EVENT_COMPACTION_STATUS and event.text in (
+                        "completed",
+                        "failed",
+                    ):
+                        status = event.text
+                if status is None:
+                    # No terminal status mid-turn (a "started" may have
+                    # streamed) — the result arrives async after end_turn.
+                    result = await session.provider.wait_for_compaction(
+                        timeout=_COMPACT_RESULT_WAIT_SECS
+                    )
+                    status = result.get("type") if isinstance(result, dict) else None
+                if status != "completed":
+                    raise RuntimeError(f"compaction reported {status or 'no result'}")
 
             await asyncio.wait_for(_run(), timeout=_COMPACT_TIMEOUT_SECS)
         except (Exception, asyncio.TimeoutError):

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -125,27 +125,86 @@ class TestToLlmEventFieldPropagation:
 
 class TestCompactRouting:
     @pytest.mark.asyncio
-    async def test_kiro_backend_uses_send_command(self):
+    async def test_kiro_backend_uses_session_prompt(self):
+        """kiro-cli 2.14.0 exits rc=0 on the string form of
+        _kiro.dev/commands/execute (live-probe confirmed), so /compact must
+        flow through session/prompt on the kiro backend too."""
         provider = _build_provider(backend="")
         provider._client.send_command = AsyncMock(return_value="")
         provider._client.stream_events = MagicMock(return_value=_async_iter([]))
 
         await provider.compact()
 
-        provider._client.send_command.assert_awaited_once_with("/compact")
-        provider._client.stream_events.assert_not_called()
+        provider._client.stream_events.assert_called_once_with("/compact")
+        provider._client.send_command.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_kiro_backend_send_command_with_context(self):
+    async def test_kiro_backend_prompt_with_context(self):
         provider = _build_provider(backend="")
         provider._client.send_command = AsyncMock(return_value="")
+        provider._client.stream_events = MagicMock(return_value=_async_iter([]))
 
         await provider.compact("important context")
 
-        provider._client.send_command.assert_awaited_once()
-        sent = provider._client.send_command.await_args.args[0]
+        provider._client.stream_events.assert_called_once()
+        sent = provider._client.stream_events.call_args.args[0]
         assert sent.startswith("/compact ")
         assert "important context" in sent
+        provider._client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_midturn_terminal_status_cached_for_wait(self):
+        """kiro-cli may emit the terminal compaction status BEFORE end_turn.
+        compact()'s drain must capture it so a subsequent
+        wait_for_compaction() (task_executor, wechat, cli_chat) returns it
+        instead of stalling 120s and resetting a compacted session."""
+        provider = _build_provider(backend="")
+        status = AcpEvent(kind="compaction_status", text="completed", title="sum")
+        provider._client.stream_events = MagicMock(return_value=_async_iter([status]))
+        provider._client.wait_for_compaction = AsyncMock(
+            return_value={"type": "timeout"}  # would be WRONG if consulted
+        )
+
+        await provider.compact()
+        result = await provider.wait_for_compaction(timeout=1.0)
+
+        assert result == {"type": "completed", "summary": "sum"}
+        provider._client.wait_for_compaction.assert_not_awaited()
+        # Cache is one-shot: the next wait falls through to the client.
+        result2 = await provider.wait_for_compaction(timeout=1.0)
+        assert result2 == {"type": "timeout"}
+
+    @pytest.mark.asyncio
+    async def test_async_status_falls_through_to_client_wait(self):
+        """No terminal status mid-turn — wait_for_compaction delegates to the
+        client's queue wait (the async-after-end_turn case)."""
+        provider = _build_provider(backend="")
+        provider._client.stream_events = MagicMock(return_value=_async_iter([]))
+        provider._client.wait_for_compaction = AsyncMock(
+            return_value={"type": "completed", "summary": ""}
+        )
+
+        await provider.compact()
+        result = await provider.wait_for_compaction(timeout=1.0)
+
+        assert result["type"] == "completed"
+        provider._client.wait_for_compaction.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_new_compact_clears_stale_cached_result(self):
+        """A fresh compact() must not leave a PREVIOUS attempt's cached
+        result satisfying a later wait."""
+        provider = _build_provider(backend="")
+        status = AcpEvent(kind="compaction_status", text="completed", title="old")
+        provider._client.stream_events = MagicMock(return_value=_async_iter([status]))
+        await provider.compact()  # caches "old"
+
+        provider._client.stream_events = MagicMock(return_value=_async_iter([]))
+        provider._client.wait_for_compaction = AsyncMock(return_value={"type": "failed"})
+        await provider.compact()  # no mid-turn status this time
+        result = await provider.wait_for_compaction(timeout=1.0)
+
+        assert result == {"type": "failed"}
 
     @pytest.mark.asyncio
     async def test_claude_backend_uses_session_prompt(self):

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2510,15 +2510,25 @@ class TestKiroInPlaceCompaction:
     the fallback. Fix for 'session stops after auto-compaction'."""
 
     @staticmethod
-    def _inplace_provider_factory(result: dict):
-        """Provider whose native compaction reports *result*."""
+    def _inplace_provider_factory(result: dict, *, stream_events: list | None = None):
+        """Provider whose native compaction reports *result*.
+
+        ``stream_command("/compact")`` yields *stream_events* (default: none —
+        the terminal status arrives async via ``wait_for_compaction``,
+        mirroring kiro-cli's post-end_turn status emission).
+        """
 
         def factory(session_key=None, agent=None, channel_id=None, **kwargs):
             m = AsyncMock()
             m.start = AsyncMock()
             m.shutdown = AsyncMock()
             m.context_usage_pct = lambda: 0.0
-            m.compact = AsyncMock()
+
+            async def _stream(_cmd):
+                for ev in stream_events or []:
+                    yield ev
+
+            m.stream_command = MagicMock(side_effect=_stream)
             m.wait_for_compaction = AsyncMock(return_value=result)
             return m
 
@@ -2539,7 +2549,7 @@ class TestKiroInPlaceCompaction:
         # Session survives in place: same entry, same provider, no SIGKILL.
         assert "dashboard:chat-1" in mgr._sessions
         assert mgr._sessions["dashboard:chat-1"].provider is provider
-        provider.compact.assert_awaited_once()
+        provider.stream_command.assert_called_once_with("/compact")
         provider.shutdown.assert_not_awaited()
         cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
         # Semaphore released: the next turn can proceed immediately.
@@ -2600,6 +2610,55 @@ class TestKiroInPlaceCompaction:
         await mgr.close_all()
 
     @pytest.mark.asyncio
+    async def test_inplace_midstream_terminal_status_skips_async_wait(self, cfg):
+        """kiro-cli may emit the terminal compaction status MID-TURN (before
+        end_turn). The stream watcher must latch it so the blind drain never
+        eats it — otherwise wait_for_compaction would stall to timeout and
+        wrongly recycle a just-compacted healthy session."""
+        from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, AcpEvent
+
+        mid = AcpEvent(kind=EVENT_COMPACTION_STATUS, text="completed", title="sum")
+        mgr = SessionManager(
+            cfg,
+            provider_factory=self._inplace_provider_factory(
+                {"type": "timeout"},  # async wait would FAIL if consulted
+                stream_events=[mid],
+            ),
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # Mid-stream status decided the outcome; async wait never consulted.
+        assert "dashboard:chat-1" in mgr._sessions
+        provider.wait_for_compaction.assert_not_awaited()
+        provider.shutdown.assert_not_awaited()
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_inplace_never_uses_commands_execute(self, cfg):
+        """Regression for the 2026-07-23 production failure: /compact sent
+        via the string form of _kiro.dev/commands/execute makes kiro-cli
+        2.14.0 exit rc=0. The auto-compact path must use the prompt
+        transport (stream_command), never send_command."""
+        mgr = SessionManager(
+            cfg, provider_factory=self._inplace_provider_factory({"type": "completed"})
+        )
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        provider.send_command = AsyncMock()
+        mgr.release("dashboard:chat-1")
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        provider.stream_command.assert_called_once_with("/compact")
+        provider.send_command.assert_not_awaited()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
     async def test_inplace_holds_semaphore_so_queued_turns_wait(self, cfg):
         """While the in-place compact runs, the session semaphore is held —
         a queued turn waits behind it and then continues on the compacted
@@ -2611,7 +2670,12 @@ class TestKiroInPlaceCompaction:
             m.start = AsyncMock()
             m.shutdown = AsyncMock()
             m.context_usage_pct = lambda: 0.0
-            m.compact = AsyncMock()
+
+            async def _stream(_cmd):
+                if False:  # pragma: no cover - empty async generator
+                    yield
+
+            m.stream_command = MagicMock(side_effect=_stream)
 
             async def _wait(timeout=120.0):
                 await gate.wait()


### PR DESCRIPTION
Follow-up to #178. The in-place auto-compaction it introduced fails in production because of a kiro-cli defect its transport choice tripped.

## Production evidence

`~/Library/Logs/Kiro Crew Nightly/gateway-launch.log`, 2026-07-23 02:12 PDT (nightly 20260723163514 with #178):

```
02:12:51 WARNING kiro_crew.session: Session dashboard:chat-2-… compacting — context at 94%
02:12:52 WARNING kiro_crew.acp.runtime: AcpRuntime dead (PID 13790): process exited (rc=None)
02:12:52 WARNING kiro_crew.session: … in-place /compact failed — falling back to recycle
kiro_crew.acp.client.AcpProcessDied: Runtime process died while waiting for response
```

The in-place attempt itself killed kiro-cli; the recycle fallback then reaped the corpse — reproducing exactly the 'session stops after compaction' behavior #178 was meant to fix, plus a misleading 'Auto-compacted at 94%' success banner.

## Root cause (live-probe confirmed, kiro-cli 2.14.0)

Raw JSON-RPC probes against a fresh healthy `kiro-cli acp` session:

| transport | result |
|---|---|
| `commands/execute` string form (`"command": "/compact"`) | **process exits rc=0, no response** |
| `commands/execute` string form (`"command": "/help"`) | **process exits rc=0** — channel-wide, not /compact-specific |
| `commands/execute` object form (`{"command": "help", "args": {}}` — what /effort uses) | works |
| `/compact` as `session/prompt` | `end_turn`, then `compaction/status: started → completed` with summary; session alive; follow-up prompt works |

`AcpProvider.compact()` and `AcpSessionHandle.compact()` both used the lethal string form. #178's auto-compact path was their first real production caller (wechat/task_executor/cli_chat also call `provider.compact()` and were equally exposed). The proven paths — dashboard manual `/compact`, Slack `!compact` — have always used the prompt transport.

## Fix

- `AcpProvider.compact()`: prompt transport (`stream_events`) for both backends; claude special-case collapses away.
- `AcpSessionHandle.compact()`: drain `self.prompt('/compact')` instead of `send_command` — no future caller can hit the lethal form.
- `SessionManager._compact_in_place()`: mirror the proven Slack flow — watch `stream_command('/compact')` for a terminal `compaction/status` inline, fall back to `wait_for_compaction()` only when the status arrives async after `end_turn`. Prevents a mid-turn status being eaten by a blind drain (which would stall to timeout and wrongly recycle a just-compacted healthy session).
- Spec (`docs/system-specs/modules/session.md`): compaction transport corrected.

## Testing

- 336/336 across `test_session.py`, `test_acp_provider.py`, `test_acp_session_provider.py`. New regressions: mid-stream terminal status skips the async wait; auto-compact never touches `send_command`; kiro compact routing asserts prompt transport.
- Live probes above validate the exact wire sequence the fixed code emits.
- flake8 + mypy clean.

## Follow-up (not this PR)

The string-form-execute kill is a kiro-cli 2.14.0 bug worth reporting upstream; `/effort`'s object-form usage is unaffected.