### PR TITLE
fix(website): align left-nav item tint with logo edge and width

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -394,7 +394,13 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
       whileHover={collapsed ? undefined : { scale: 1.02 }}
       whileTap={{ scale: 0.97 }}
       transition={{ duration: 0.15 }}
-      className={`nav-item group/nav relative flex items-center rounded-md cursor-pointer text-sm font-medium whitespace-nowrap gap-2.5 py-2 pl-3 pr-3 transition-colors duration-200 ${collapsed ? '' : 'overflow-hidden'} ${active ? 'nav-active text-text-strong bg-accent-subtle' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
+      // mx-1 insets the whole box (incl. its selected tint) by an even 4px on
+      // each side so it lines up with the logo, which sits 4px further in than
+      // the px-2 nav container (logo row adds p-1). Expanded: tint left edge
+      // aligns with the logo's left edge; icon/label keep their prior x (pl-2 +
+      // mx-1 == old pl-3). Collapsed: box becomes 32px wide (== logo width),
+      // centered under the logo (justify-center), so the tint mirrors the logo.
+      className={`nav-item group/nav relative flex items-center rounded-md cursor-pointer text-sm font-medium whitespace-nowrap gap-2.5 py-2 mx-1 transition-colors duration-200 ${collapsed ? 'justify-center px-0' : 'pl-2 pr-2 overflow-hidden'} ${active ? 'nav-active text-text-strong bg-accent-subtle' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
       onClick={activate}
       onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate() } }}
       onMouseEnter={showTip}
@@ -410,8 +416,12 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
       {iconEl}
       {!collapsed && <span className="whitespace-nowrap overflow-hidden">{label}</span>}
       {collapsed && tip && createPortal(
+        // pl-2 pr-2 (not pl-3) so the flyout icon lands at the same x as the
+        // rest-state rail icon. The flyout is anchored to the row's border box
+        // (tip.left), which the row's mx-1 inset by 4px; matching pl-2 puts the
+        // icon back on the rail icon's centered spot instead of 4px to its right.
         <div
-          className={`fixed flex items-center gap-2.5 pl-3 pr-3 rounded-md bg-card border border-border shadow-lg text-text text-sm font-medium z-[9999] pointer-events-none whitespace-nowrap transition-opacity duration-150 ${tipOn ? 'opacity-100' : 'opacity-0'}`}
+          className={`fixed flex items-center gap-2.5 pl-2 pr-2 rounded-md bg-card border border-border shadow-lg text-text text-sm font-medium z-[9999] pointer-events-none whitespace-nowrap transition-opacity duration-150 ${tipOn ? 'opacity-100' : 'opacity-0'}`}
           style={{ top: tip.top, left: tip.left, height: tip.height }}
         >
           <span className={`app-icon-nav w-4 h-4 flex items-center justify-center shrink-0 ${active ? 'text-accent is-lit' : ''}`}>{icon}</span>


### PR DESCRIPTION
## What

Aligns the left-nav item selected/hover tint with the sidebar logo.

- **Expanded** — the tint's left edge now lines up with the logo's left edge (previously started 4px to its left).
- **Collapsed** — the tint is now 32px wide (matching the logo) and centered under it (previously spanned the full rail width).
- **Collapsed hover flyout** — its icon now lands on the same x as the rest-state rail icons (previously 4px to their right after the inset).

## How

The logo sits 4px further in than the nav item container: the container has `px-2` (8px) and the logo row adds `p-1` (4px), so the logo starts at 12px and is 32px wide. Item tints started at 8px and stretched the full rail width, so they looked misaligned.

- Inset each `NavItem` box by an even 4px via `mx-1`. Expanded keeps icon/label at their prior x (`pl-2` + `mx-1` == old `pl-3`); collapsed uses `justify-center` so the 32px box centers the icon under the logo.
- Match the collapsed hover flyout padding (`pl-2` instead of `pl-3`) — the flyout is anchored to the row's border box (`tip.left`), which `mx-1` moved in by 4px, so `pl-2` puts its icon back on the rail icon's spot.

## Testing

- `tsc --noEmit` — clean
- `eslint src/App.tsx` — clean
- Single-file change (`website/src/App.tsx`), scoped entirely to `NavItem`.

## Screenshots
<img width="348" height="273" alt="image" src="https://github.com/user-attachments/assets/b5b75340-029f-4285-80b2-950f589e7225" />
<img width="350" height="255" alt="image" src="https://github.com/user-attachments/assets/ffef5805-9a00-441c-a767-80c9e45fb481" />
<img width="505" height="274" alt="image" src="https://github.com/user-attachments/assets/c7d0f7d1-b527-4e63-b978-fe9641068e53" />
