### PR TITLE
fix(apps): serve app UI files with no-cache revalidation

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -1397,8 +1397,14 @@ async def handle_app_ui_file(request: web.Request) -> web.Response:
     # change and must always see the latest bytes. Use the in-memory cache
     # (maintained by the dev-mode watcher) so this hot path does NO disk IO on
     # the event loop for every asset served (no-blocking-call-on-event-loop).
+    # Everything else: no-cache (NOT no-store) — the browser may cache but MUST
+    # revalidate each load. FileResponse answers conditional requests
+    # (If-Modified-Since / If-None-Match from its Last-Modified/ETag) with a
+    # body-less 304, so unchanged files stay cheap while app updates are picked
+    # up on a plain refresh. The previous public,max-age=3600 served every
+    # app's UI stale for up to an hour after an update.
     from kiro_crew.apps.dev_mode import is_dev_mode_cached
-    cache = "no-store" if is_dev_mode_cached(name) else "public, max-age=3600"
+    cache = "no-store" if is_dev_mode_cached(name) else "no-cache"
     return web.FileResponse(full_path, headers={"Content-Type": content_type, "Cache-Control": cache})  # type: ignore[return-value]
 
 

--- a/test/test_app_routes.py
+++ b/test/test_app_routes.py
@@ -147,3 +147,45 @@ async def test_uninstall(tmp_path, monkeypatch):
 
         resp = await client.get("/api/apps/api-test-app")
         assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# UI file serving — cache policy
+# ---------------------------------------------------------------------------
+
+def _make_app_source_with_ui(tmp_path, name="ui-cache-app"):
+    src = _make_app_source(tmp_path, name)
+    ui = src / "ui"
+    ui.mkdir()
+    (ui / "index.mjs").write_text("export default function App() { return null }\n")
+    manifest = json.loads((src / APP_MANIFEST_FILENAME).read_text())
+    manifest["ui"] = {"entry": "index.mjs", "pages": [{"route": f"/{name}", "label": name}]}
+    (src / APP_MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
+    return src
+
+
+@pytest.mark.asyncio
+async def test_ui_file_no_cache_revalidation(tmp_path, monkeypatch):
+    """App UI files are served with Cache-Control: no-cache so browsers
+    revalidate every load (app updates / dev edits show on plain refresh),
+    and conditional requests get a body-less 304 so unchanged files stay cheap.
+
+    Regression: the previous ``public, max-age=3600`` served every app's UI
+    stale for up to an hour after an update.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source_with_ui(tmp_path)))
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get("/apps/ui-cache-app/ui/index.mjs")
+        assert resp.status == 200
+        assert resp.headers.get("Cache-Control") == "no-cache"
+        assert "max-age" not in resp.headers.get("Cache-Control", "")
+        last_modified = resp.headers.get("Last-Modified")
+        assert last_modified  # FileResponse provides the validator
+
+        # A revalidation request with the validator must yield 304 (no body).
+        resp304 = await client.get(
+            "/apps/ui-cache-app/ui/index.mjs",
+            headers={"If-Modified-Since": last_modified},
+        )
+        assert resp304.status == 304


### PR DESCRIPTION
## Summary
App UI bundles (`/apps/{name}/ui/*`) were served with `Cache-Control: public, max-age=3600`, so browsers kept a stale UI for up to an hour after an app update — and during app development a plain refresh never picked up edits.

This switches the header to `no-cache` (revalidate every load, NOT no-store). aiohttp's `FileResponse` already emits `Last-Modified`/`ETag` and answers conditional requests with a body-less `304`, so unchanged files remain cheap while updates appear on a plain refresh.

## Testing
- New regression test `test_ui_file_no_cache_revalidation`: asserts the `no-cache` header (and absence of `max-age`), and that a conditional request with `If-Modified-Since` yields `304`.
- Full local gate: flake8 clean, CI-parity mypy (442 files) clean, backend 15,802 passed (2 known host-environment failures unrelated: hardlink-permission + missing-binary exit-127), tsc clean, vitest 4,072 passed.

## Blocked / out of scope
- No frontend changes; the dashboard loader needs no cache-busting once revalidation works.