### PR TITLE
feat(apps): dev mode with live reload for app UI development

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -101,7 +101,8 @@ All `on*` methods return an unsubscribe function.
 
 WebSocket event types: `chat_chunk`, `chat_done`, `chat_message`, `chat_error`,
 `tool_call`, `notification`, `slots`, `slot_title`, `dashboard`, `log`, `refresh`,
-`approval`, `subagent_done`, `task_update`, `task_complete`, `proactive_notification`, `error`.
+`approval`, `subagent_done`, `task_update`, `task_complete`, `proactive_notification`,
+`app_reload`, `error`.
 
 ### Subagents
 
@@ -418,6 +419,7 @@ endpoints. Apps can also call them directly via `fetch()`.
 | POST | `/api/apps/{name}/uninstall` | Uninstall app |
 | POST | `/api/apps/{name}/enable` | Enable app |
 | POST | `/api/apps/{name}/disable` | Disable app |
+| POST | `/api/apps/{name}/dev` | Toggle dev mode (live reload) — body `{"enabled": bool}` |
 | POST | `/api/apps/{name}/open` | Launch app via openCommand |
 | GET | `/apps/{name}/ui/{path}` | Serve app UI bundle files |
 | * | `/apps/{name}/api/{path}` | Reverse proxy to app backend (HMAC-signed) |
@@ -447,3 +449,43 @@ the value in the `X-KiroCrew-Proxy` header (constant-time), rejecting stale time
 > to bind `sha256(body)` while keeping the constant-time compare and ±60s freshness. A gateway
 > that signs body-bound HMACs will fail verification against any deployed old verifier, so the
 > client release must ship together with this change.
+
+## App Dev Mode (live reload)
+
+Dev mode speeds up app-UI iteration: no manual copy-and-hard-refresh loop. When
+an installed app is in dev mode the gateway serves its UI files with
+`Cache-Control: no-store` and watches the app's `ui/` directory; on any file
+change it broadcasts an `app_reload` WebSocket event and the dashboard reloads
+the app so edits appear immediately. The recommended setup symlinks
+`~/.kirocrew/apps/<name>/ui/` to your source tree so the watcher sees edits at
+the real files.
+
+**Contract surface:**
+
+- **`installed.json` field — `dev: bool`** (default `false`): persisted per-app
+  flag. Tolerant on read (absent ⇒ `false`); reversible; no migration needed.
+  Builtin apps cannot enter dev mode.
+- **Endpoint — `POST /api/apps/{name}/dev`**, body `{"enabled": <bool>}`.
+  Returns `{"name": <name>, "dev": <bool>}`. `400` for a non-boolean body,
+  a builtin app, or an unsafe app name; `404` if the app is not installed.
+  Behind the standard gateway auth; emits an `app_dev_mode` SEL audit event.
+- **WebSocket event — `app_reload`**, payload `{"app": <name>, "ts": <float>}`.
+  Re-dispatched to the frontend as the `mc:app-reload` window CustomEvent; the
+  AppHost triggers a full page reload for the matching app.
+- **CLI — `kirocrew app dev <name> [--off]`**: toggles the flag out-of-process;
+  the gateway watcher picks up the change within one poll interval, so no
+  gateway restart is needed.
+
+**Cost model:** dev mode is off for essentially all gateways. The
+authoritative per-app state is the `installed.json` `dev` field above; to keep
+the steady-state cost negligible the gateway also maintains an **internal,
+unstable cache** (a small sentinel file under `~/.kirocrew/apps/`, plus an
+in-memory mirror) listing the app names currently in dev mode. The watcher
+`stat()`s only that one file each second and walks a `ui/` tree solely for apps
+in the set — so a gateway with no dev apps pays one `stat()` per second and
+never invokes the heavier `list_apps()` walk; the in-memory mirror lets the
+UI-serving hot path decide the cache header with no per-request disk IO. This
+sentinel is a derived cache and **not** part of the App Kit contract: its path,
+name, and format are internal implementation details, may change without
+notice, and must not be read or written by app or third-party tooling — treat
+`installed.json` `dev` as the only supported source of truth.

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -31,6 +31,8 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew doctor` | Verify kiro-cli is installed and config is valid |
 | `kirocrew cron add/list/remove` | Manage cron jobs |
 | `kirocrew spawn run/list` | Manage background subagents |
+| `kirocrew app install/list/enable/disable/uninstall` | Manage App Kit apps |
+| `kirocrew app dev <name> [--off]` | Toggle an installed app into/out of dev mode (no-store UI serving + live reload on file change). See [App Dev Mode](#app-dev-mode). |
 | `kirocrew learn add/list/remove` | Manage learned corrections |
 | `kirocrew run TASK.md` | Run an autonomous task from a spec file |
 | `kirocrew token` | Print a dashboard access URL with auth token |
@@ -369,3 +371,36 @@ are ignored).
 
 `kirocrew status` queries the running gateway's `/api/status` endpoint
 and prints uptime, sessions, messages, tool calls, subagents, crons, lessons.
+
+## App Dev Mode
+
+`kirocrew app dev <name> [--off]` toggles an installed App Kit app into (or,
+with `--off`, out of) **dev mode**, which speeds the app-UI edit loop by serving
+UI files uncached and live-reloading the dashboard on file change. The command
+writes the flag out-of-process; the running gateway's watcher picks it up within
+one poll interval, so no gateway restart is needed. Full App Kit developer docs
+live in `docs/app-kit/api-reference.md`; the durable contract surfaces this
+feature introduces are:
+
+- **Persisted schema — `installed.json` `dev: bool`** (default `false`): a
+  per-app flag in each app's `~/.kirocrew/apps/<name>/installed.json`. Tolerant
+  on read (absent ⇒ `false`), reversible, no migration. This field is the sole
+  authoritative source of truth for an app's dev-mode state. Builtin apps cannot
+  enter dev mode.
+- **Endpoint — `POST /api/apps/{name}/dev`**, body `{"enabled": <bool>}`,
+  returns `{"name": <name>, "dev": <bool>}`. Behind standard gateway auth; emits
+  an `app_dev_mode` SEL audit event. `400` for a non-boolean body, a builtin
+  app, or an unsafe app name; `404` when the app is not installed. Equivalent to
+  the CLI toggle for in-dashboard control.
+- **WebSocket event — `app_reload`**, payload `{"app": <name>, "ts": <float>}`,
+  broadcast when a dev-mode app's `ui/` tree changes; the dashboard reloads that
+  app so edits appear immediately.
+- **Serving behavior:** while an app is in dev mode the gateway serves its UI
+  with `Cache-Control: no-store`; otherwise the standard revalidation header
+  applies.
+
+An internal, unstable sentinel cache under `~/.kirocrew/apps/` mirrors the set of
+dev-mode apps so the zero-dev-apps steady state costs one `stat()` per second.
+It is a derived cache reconciled from `installed.json` at watcher init (under a
+cross-process lock, atomic with concurrent toggles), **not** part of the App Kit
+contract — its path and format are internal and may change without notice.

--- a/src/kiro_crew/apps/dev_mode.py
+++ b/src/kiro_crew/apps/dev_mode.py
@@ -1,0 +1,413 @@
+"""App dev mode — live-reload support for app UI development.
+
+When an installed app has ``dev: true`` in its ``installed.json``:
+
+* ``handle_app_ui_file`` serves its UI files with ``Cache-Control: no-store``
+  (never cached, not even with revalidation), and
+* a gateway-side watcher polls the app's ``ui/`` directory (symlinks followed —
+  the recommended dev setup symlinks ``ui/`` to the developer's source tree)
+  and broadcasts an ``app_reload`` WebSocket event whenever any file changes.
+  The dashboard's AppHost reloads so edits appear without a manual refresh.
+
+Toggling dev mode is a metadata-only change (``installed.json``), picked up by
+the watcher within one poll interval — no gateway restart needed.
+
+Cost model (dev mode is off for essentially all production gateways):
+  The watcher must NOT make every always-on gateway pay for a dev-only feature.
+  ``set_dev_mode`` maintains a tiny sentinel file (:data:`_DEV_SENTINEL`) listing
+  the app names currently in dev mode. Each tick the watcher ``stat()``s only
+  that one file and re-reads it solely when it changes — so the zero-dev-apps
+  steady state is a single ``stat()`` per second with no ``list_apps()`` call
+  (which reads every app's manifest and can even *write* ``installed.json``) and
+  no ``ui/`` walks. Only when at least one app is in dev mode does it walk that
+  app's ``ui/`` tree. The set is also mirrored into an in-memory cache
+  (:data:`_dev_apps_cache`) so ``handle_app_ui_file`` can decide the cache header
+  without any per-request disk IO on the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from kiro_crew import platform_compat
+from kiro_crew.apps.manager import (
+    _check_path_safety,
+    _read_installed,
+    _write_installed,
+    app_dir,
+    apps_dir,
+)
+from kiro_crew.atomic_write import atomic_write
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECS = 1.0
+#: Safety cap on files scanned per app per tick — a runaway ui/ dir (e.g.
+#: node_modules symlinked in) must not stall the loop.
+_MAX_SCAN_FILES = 2000
+
+#: Mask folding each file hash into a fixed-width non-negative int so the
+#: accumulated digest stays bounded regardless of file count.
+_DIGEST_MASK = (1 << 63) - 1
+
+#: Sentinel file (a JSON array of app names in dev mode) under ``apps_dir()``.
+#: ``list_apps()`` skips non-directory entries, so this file is invisible to it.
+_DEV_SENTINEL = ".dev-apps.json"
+
+_watch_task: asyncio.Task | None = None
+
+#: In-memory mirror of the dev-app set, refreshed by the watcher and by
+#: ``set_dev_mode`` (in-process). Lets the UI-serving hot path avoid a disk read
+#: on every request. Empty until first seeded — a newly-started gateway may
+#: serve a dev app cached for up to one poll interval, which is harmless.
+_dev_apps_cache: set[str] = set()
+
+
+def _sentinel_path() -> Path:
+    return apps_dir() / _DEV_SENTINEL
+
+
+@contextmanager
+def _sentinel_lock() -> Iterator[None]:
+    """Hold a cross-process exclusive lock guarding the sentinel read-modify-write.
+
+    The lock is taken on a DEDICATED ``.lock`` file, never on the sentinel
+    itself: :func:`_write_dev_sentinel` replaces the sentinel via
+    ``atomic_write`` (write-temp + rename), so a lock held on the sentinel's own
+    fd would guard a soon-to-be-orphaned inode and let a concurrent toggle race
+    in. Concurrent gateway/CLI toggles of different apps otherwise read the same
+    sentinel, mutate private copies, and last-writer-wins clobbers the others'
+    entries — silently dropping an app from the watched/no-store set. Serializing
+    the read → mutate → write → cache-update sequence closes that race.
+    """
+    lock_path = apps_dir() / (_DEV_SENTINEL + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+", encoding="utf-8") as fh:
+        with platform_compat.file_lock(fh.fileno(), exclusive=True):
+            yield
+
+
+def _read_dev_sentinel() -> set[str]:
+    """Read the raw dev-app-name set from the sentinel file (empty on any error)."""
+    try:
+        data = json.loads(_sentinel_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    if isinstance(data, list):
+        return {str(x) for x in data}
+    return set()
+
+
+def _load_dev_apps() -> set[str]:
+    """Read the sentinel and drop stale entries not backed by a dev-mode install.
+
+    Defense-in-depth against a stale sentinel: an app uninstalled (or its
+    ``installed.json`` ``dev`` flag cleared) out-of-band may leave its name in
+    the sentinel. Left unfiltered, a DIFFERENT app later reinstalled under that
+    same name would silently inherit dev-mode ``no-store`` serving and file
+    watching despite its own metadata saying ``dev: false``. Filtering each
+    candidate against the authoritative on-disk metadata prevents that
+    misattribution even if the uninstall-time cleanup was skipped (e.g. a crash
+    mid-uninstall). Off the hot path — called only by the watcher when the
+    sentinel changes and at seeding, never per UI request.
+    """
+    keep: set[str] = set()
+    for name in _read_dev_sentinel():
+        try:
+            meta = _read_installed(name)
+        except Exception:
+            continue
+        if meta is not None and meta.dev:
+            keep.add(name)
+    return keep
+
+
+def _write_dev_sentinel(names: set[str]) -> None:
+    """Atomically write the dev-app-name set to the sentinel file."""
+    path = _sentinel_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(path, json.dumps(sorted(names), indent=2) + "\n")
+
+
+def _scan_installed_dev_apps() -> set[str]:
+    """Return the dev-app set derived authoritatively from every ``installed.json``.
+
+    Unlike :func:`_load_dev_apps` (which only *filters* the sentinel against
+    on-disk metadata and can never *add* an entry the sentinel is missing), this
+    walks the apps directory and reads each app's ``installed.json`` ``dev``
+    flag directly. It is the source of truth for reconciling the sentinel at
+    startup, so a ``dev: true`` written to ``installed.json`` out-of-band
+    (snapshot restore, hand-edit, a crash between the metadata write and the
+    sentinel write) is actually honored — the documented contract field, not
+    the internal sentinel, decides. Blocking filesystem IO — offload to a
+    thread; called only once at watcher init, never on the hot path.
+    """
+    keep: set[str] = set()
+    root = apps_dir()
+    if not root.is_dir():
+        return keep
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        try:
+            meta = _read_installed(entry.name)
+        except Exception:
+            continue
+        if meta is not None and meta.dev:
+            keep.add(entry.name)
+    return keep
+
+
+def _reconcile_sentinel_from_installed() -> set[str]:
+    """Rebuild the sentinel from ``installed.json`` so the docs' field is authoritative.
+
+    Runs the authoritative scan and, only when it diverges from the current
+    sentinel, rewrites the sentinel to match. Returns the reconciled dev-app
+    set. Blocking IO — offload to a thread.
+
+    The scan MUST run *inside* the cross-process lock, atomic with the sentinel
+    read → compare → write → cache-update. If the scan ran before the lock, a
+    concurrent :func:`set_dev_mode` toggle (which itself holds the lock) could
+    land between the scan and the lock acquisition: the toggle writes
+    ``installed.json`` ``dev: true`` and adds the app to the sentinel, then
+    reconcile acquires the lock with its *stale* scan (missing that app), sees a
+    divergence, and rewrites the sentinel to exclude it — silently dropping the
+    just-toggled app from the watched/no-store set until the next restart
+    reconcile, even though the toggle reported success.
+    """
+    with _sentinel_lock():
+        installed = _scan_installed_dev_apps()
+        current = _read_dev_sentinel()
+        if current != installed:
+            logger.info(
+                "app dev-mode: reconciling sentinel from installed.json "
+                "(sentinel=%s -> installed=%s)",
+                sorted(current),
+                sorted(installed),
+            )
+            _write_dev_sentinel(installed)
+        _set_dev_cache(installed)
+    return installed
+
+
+def _stat_sentinel() -> tuple[float, int] | None:
+    """Return the sentinel's (mtime, size), or None if it doesn't exist."""
+    try:
+        st = _sentinel_path().stat()
+    except OSError:
+        return None
+    return (st.st_mtime, st.st_size)
+
+
+def _set_dev_cache(names: set[str]) -> None:
+    global _dev_apps_cache
+    _dev_apps_cache = set(names)
+
+
+def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
+    """Toggle dev mode for an installed app. Returns a result dict.
+
+    Blocking filesystem IO — callers on the event loop MUST offload this to a
+    thread (``await asyncio.to_thread(set_dev_mode, ...)``).
+    """
+    if not _check_path_safety(name):
+        return {"error": f"invalid app name {name!r}"}
+    # Cheap validation read outside the lock — builtin/not-installed status does
+    # not change under us. The authoritative read → mutate → write happens again
+    # INSIDE the lock below so the installed.json write is atomic with the
+    # sentinel update.
+    meta = _read_installed(name)
+    if meta is None:
+        return {"error": f"app {name!r} is not installed"}
+    if meta.origin == "builtin":
+        return {"error": "builtin apps cannot be put in dev mode"}
+    # The installed.json write AND the sentinel read-modify-write run under one
+    # cross-process lock so a concurrent gateway POST + CLI toggle of the same
+    # app cannot interleave (write-meta A, write-meta B, sentinel B, sentinel A)
+    # and leave installed.json saying dev:true while the sentinel excludes it —
+    # silently disabling watching + no-store serving until a restart reconcile.
+    # meta is re-read inside the lock so we never clobber a concurrent writer's
+    # other installed.json fields (e.g. an update_app version bump).
+    with _sentinel_lock():
+        meta = _read_installed(name)
+        if meta is None:
+            return {"error": f"app {name!r} is not installed"}
+        meta.dev = enabled
+        _write_installed(name, meta)
+        names = _read_dev_sentinel()
+        if enabled:
+            names.add(name)
+        else:
+            names.discard(name)
+        _write_dev_sentinel(names)
+        # Update the in-process cache immediately so a same-process POST toggle
+        # takes effect on the very next UI request (no wait for a watcher tick).
+        _set_dev_cache(names)
+    return {"name": name, "dev": enabled}
+
+
+def remove_dev_app(name: str) -> None:
+    """Drop *name* from the dev sentinel + in-memory cache (idempotent, best-effort).
+
+    Called from :func:`kiro_crew.apps.manager.uninstall_app` so an app removed
+    while in dev mode does not leave a stale sentinel entry that a later app
+    reinstalled under the same name would inherit. Runs under the same
+    cross-process lock as :func:`set_dev_mode`; never raises.
+    """
+    try:
+        with _sentinel_lock():
+            names = _read_dev_sentinel()
+            if name not in names:
+                return
+            names.discard(name)
+            _write_dev_sentinel(names)
+            _set_dev_cache(names)
+    except Exception:
+        logger.debug("dev-mode sentinel cleanup for %r failed", name, exc_info=True)
+
+
+def is_dev_mode(name: str) -> bool:
+    """Whether an app is in dev mode, read authoritatively from disk.
+
+    Blocking IO — do NOT call on the event loop per-request; use
+    :func:`is_dev_mode_cached` on hot paths.
+    """
+    if not _check_path_safety(name):
+        return False
+    meta = _read_installed(name)
+    return bool(meta and meta.dev)
+
+
+def is_dev_mode_cached(name: str) -> bool:
+    """Whether an app is in dev mode, from the in-memory cache (no disk IO).
+
+    Safe to call on the event loop per-request. The cache is seeded at watcher
+    init and refreshed each tick, so it lags disk by at most one poll interval.
+    """
+    return name in _dev_apps_cache
+
+
+def _scan_ui_mtimes(ui_dir: Path) -> tuple[int, int]:
+    """Return (file_count, digest) summarizing the app's ui/ tree.
+
+    Follows the ui/ symlink (Path.rglob resolves through it) so the
+    symlink-to-source dev setup is watched at the real source. Bounded by
+    _MAX_SCAN_FILES; errors count as "no change" rather than crashing the loop.
+
+    ``digest`` folds every file's (relative path, mtime, size) into a single
+    order-independent accumulator (XOR of per-file hashes). A bare
+    ``(count, max_mtime)`` signature missed real edits: rewriting a file whose
+    new mtime stayed below another file's mtime (``cp -p``/``rsync -a`` of an
+    older bundle, a clock skew, a future-dated pin) left both count and max
+    unchanged, so no reload fired. Incorporating each file's own mtime and size
+    means any edit that changes a file's metadata changes the digest, and XOR
+    keeps it insensitive to rglob's traversal order.
+    """
+    digest = 0
+    count = 0
+    try:
+        for p in ui_dir.rglob("*"):
+            if count >= _MAX_SCAN_FILES:
+                break
+            try:
+                if p.is_file():
+                    count += 1
+                    st = p.stat()
+                    rel = p.relative_to(ui_dir).as_posix()
+                    digest ^= hash((rel, st.st_mtime_ns, st.st_size)) & _DIGEST_MASK
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        return (0, 0)
+    return (count, digest)
+
+
+async def _watch_loop(broadcast_fn: Callable[[str, dict], None]) -> None:
+    """Poll dev-mode apps' ui/ dirs; broadcast ``app_reload`` on change.
+
+    Steady-state cost when NO app is in dev mode: one ``stat()`` of the sentinel
+    per tick — no ``list_apps()``, no ``ui/`` walks, no writes. The dev-app set
+    is re-read (off the event loop) only when the sentinel's stat changes.
+
+    Per-app state is (file_count, digest): a changed count catches
+    adds/deletes, a changed digest catches edits (each file's mtime + size is
+    folded in). The first observation of an app only seeds state (no reload
+    storm at startup or on dev-mode enable).
+    """
+    state: dict[str, tuple[int, int]] = {}
+    sentinel_sig: tuple[float, int] | None = None
+    dev_apps: set[str] = set()
+    while True:
+        try:
+            await asyncio.sleep(POLL_INTERVAL_SECS)
+            # Cheap change-detection: stat one small file off the event loop.
+            sig = await asyncio.to_thread(_stat_sentinel)
+            if sig != sentinel_sig:
+                sentinel_sig = sig
+                dev_apps = await asyncio.to_thread(_load_dev_apps)
+                _set_dev_cache(dev_apps)
+                # Drop state for apps that left dev mode so re-enabling re-seeds.
+                for gone in set(state) - dev_apps:
+                    state.pop(gone, None)
+            # Walk ui/ trees ONLY for dev apps (inherent to the feature; zero
+            # dev apps => zero walks). Off the event loop — the rglob/stat walk
+            # is synchronous filesystem IO (no-blocking-call-on-event-loop rule).
+            for name in dev_apps:
+                sig2 = await asyncio.to_thread(_scan_ui_mtimes, app_dir(name) / "ui")
+                prev = state.get(name)
+                state[name] = sig2
+                if prev is not None and sig2 != prev and sig2 != (0, 0):
+                    logger.info("app dev mode: %s ui changed — broadcasting reload", name)
+                    try:
+                        broadcast_fn("app_reload", {"app": name, "ts": time.time()})
+                    except Exception:
+                        logger.debug("app_reload broadcast failed", exc_info=True)
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            logger.exception("app dev-mode watcher error")
+            await asyncio.sleep(POLL_INTERVAL_SECS)
+
+
+async def init_dev_mode_watcher(broadcast_fn: Callable[[str, dict], None]) -> None:
+    """Start the singleton watcher task (idempotent). Called at gateway startup.
+
+    Async because the one-time startup seed touches the filesystem: it walks
+    every app's ``installed.json`` to reconcile the sentinel (so the documented
+    ``dev`` field is authoritative even after an out-of-band write) and seeds
+    the UI-serving cache. That read is offloaded via ``asyncio.to_thread`` so it
+    never blocks the gateway's event loop during startup
+    (``no-blocking-call-on-event-loop``).
+    """
+    global _watch_task
+    if _watch_task is not None and not _watch_task.done():
+        return
+    # Reconcile the sentinel from installed.json and seed the in-memory cache
+    # once, off the event loop, so the UI hot path is correct immediately at
+    # startup rather than after the first tick.
+    await asyncio.to_thread(_reconcile_sentinel_from_installed)
+    _watch_task = asyncio.get_running_loop().create_task(_watch_loop(broadcast_fn))
+    logger.info("app dev-mode watcher started (%.0fs cadence)", POLL_INTERVAL_SECS)
+
+
+async def stop_dev_mode_watcher() -> None:
+    """Cancel the watcher task and await its teardown (shutdown / tests).
+
+    Awaits the cancelled task so the coroutine has actually unwound before we
+    return — an in-process restart can then start a fresh watcher without the
+    old one lingering on the event loop with a stale ``broadcast_ws``.
+    """
+    global _watch_task
+    task = _watch_task
+    _watch_task = None
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import stat
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -103,6 +103,7 @@ class InstalledApp:
     migratedTo: str = (
         ""  # noqa: N815  — target standalone app: "registry:{name}" or "standalone:{name}"
     )
+    dev: bool = False  # dev mode: no-store UI serving + file-watch live reload
 
     def validate_fields(self) -> list[str]:
         """Validate classification field values. Returns error list (empty = valid)."""
@@ -133,6 +134,7 @@ class InstalledApp:
             lifecycle=str(data.get("lifecycle", "gateway")),
             schemaVersion=int(data.get("schemaVersion", 1)),
             migratedTo=str(data.get("migratedTo", "")),
+            dev=bool(data.get("dev", False)),
         )
         # Migrate old "managed" field to new classification fields
         if inst.schemaVersion < 2 and "origin" not in data:
@@ -671,13 +673,18 @@ def update_app(source: str | Path, *, expected_name: str | None = None) -> AppRe
             pass
         return AppResult(ok=False, name=name, error=f"failed to update app files: {exc}")
 
-    # Update metadata — preserve enabled state and install time
-    meta = InstalledApp(
-        name=name,
+    # Update metadata — carry every persisted field forward from ``existing``
+    # via dataclasses.replace, overriding only what the update actually changes
+    # (version/displayName/updatedAt/source). Constructing a fresh InstalledApp
+    # here silently dropped any field not re-listed (enabled, installedAt,
+    # origin, resources, lifecycle, schemaVersion, migratedTo, and — the bug
+    # that surfaced this — the ``dev`` flag, so updating an app being iterated
+    # on in dev mode wrote ``dev: false`` and later dropped it from live
+    # reload). ``replace`` makes new fields regression-proof by construction.
+    meta = replace(
+        existing,
         version=manifest.version,
         displayName=manifest.displayName,
-        enabled=existing.enabled,
-        installedAt=existing.installedAt,
         updatedAt=_now_iso(),
         source=str(source),
     )
@@ -744,6 +751,15 @@ def uninstall_app(name: str, *, keep_data: bool = False) -> AppResult:
         return AppResult(ok=False, name=name, error=f"failed to remove app: {exc}")
 
     logger.info("Uninstalled app %s (keep_data=%s)", name, keep_data)
+    # Drop any dev-mode sentinel entry so an app later reinstalled under this
+    # name does not inherit stale dev-mode serving/watching. Lazy import avoids
+    # a module-level cycle (dev_mode imports from manager).
+    try:
+        from kiro_crew.apps.dev_mode import remove_dev_app
+
+        remove_dev_app(name)
+    except Exception:
+        logger.debug("dev-mode cleanup on uninstall of %r failed", name, exc_info=True)
     return AppResult(ok=True, name=name, message=f"uninstalled {name}")
 
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -1393,7 +1393,42 @@ async def handle_app_ui_file(request: web.Request) -> web.Response:
     except ValueError:
         return web.json_response({"error": "invalid path"}, status=400)
     content_type = _CONTENT_TYPES.get(ext, "application/octet-stream")
-    return web.FileResponse(full_path, headers={"Content-Type": content_type, "Cache-Control": "public, max-age=3600"})  # type: ignore[return-value]
+    # Dev-mode apps: never cache — the file-watch live-reload reloads on every
+    # change and must always see the latest bytes. Use the in-memory cache
+    # (maintained by the dev-mode watcher) so this hot path does NO disk IO on
+    # the event loop for every asset served (no-blocking-call-on-event-loop).
+    from kiro_crew.apps.dev_mode import is_dev_mode_cached
+    cache = "no-store" if is_dev_mode_cached(name) else "public, max-age=3600"
+    return web.FileResponse(full_path, headers={"Content-Type": content_type, "Cache-Control": cache})  # type: ignore[return-value]
+
+
+async def handle_app_dev_mode(request: web.Request) -> web.Response:
+    """POST /api/apps/{name}/dev — toggle dev mode (body: {"enabled": bool}).
+
+    Metadata-only change (installed.json); the dev-mode watcher picks it up
+    within one poll interval, so no gateway restart is needed.
+    """
+    from kiro_crew.apps.dev_mode import set_dev_mode
+    name = request.match_info["name"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON"}, status=400)
+    enabled = body.get("enabled")
+    if not isinstance(enabled, bool):
+        return web.json_response({"error": "enabled must be a boolean"}, status=400)
+    # set_dev_mode does blocking filesystem IO (reads/writes installed.json and
+    # the dev sentinel) — offload it so the gateway event loop never stalls.
+    result = await asyncio.to_thread(set_dev_mode, name, enabled)
+    if "error" in result:
+        return web.json_response(result, status=404 if "not installed" in result["error"] else 400)
+    sel().log_api_access(
+        caller=request.get("user", "dashboard"),
+        operation="app_dev_mode",
+        outcome="ok",
+        resources=f"{name} enabled={enabled}",
+    )
+    return web.json_response(result)
 
 
 # ---------------------------------------------------------------------------
@@ -2047,6 +2082,7 @@ def register_app_routes(app: web.Application) -> None:
     app.router.add_post("/api/apps/{name}/enable", handle_enable_app)
     app.router.add_post("/api/apps/{name}/disable", handle_disable_app)
     app.router.add_post("/api/apps/{name}/open", handle_open_app)
+    app.router.add_post("/api/apps/{name}/dev", handle_app_dev_mode)
     app.router.add_delete("/api/apps/{name}/migrate-cleanup", handle_migrate_cleanup)
     app.router.add_get("/apps/{name}/ui/{path:.*}", handle_app_ui_file)
     # Reverse proxy: dashboard app UI → app backend (same-origin, avoids CORS)

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1581,6 +1581,11 @@ Examples:
     )
     app_info = app_sub.add_parser("info", help="Show app details")
     app_info.add_argument("name", help="App name")
+    app_dev = app_sub.add_parser(
+        "dev", help="Toggle dev mode (no-store UI serving + live reload on file change)"
+    )
+    app_dev.add_argument("name", help="App name")
+    app_dev.add_argument("--off", action="store_true", help="Turn dev mode off")
     app_init = app_sub.add_parser("init", help="Scaffold a new app")
     app_init.add_argument("name", help="App name (kebab-case)")
     app_init.add_argument("--dir", default=".", help="Output directory (default: current)")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -521,6 +521,23 @@ def _handle_app(args: argparse.Namespace) -> None:
             print(f"❌ {result.error}", file=sys.stderr)
             sys.exit(1)
 
+    elif action == "dev":
+        from kiro_crew.apps.dev_mode import set_dev_mode
+
+        enabled = not getattr(args, "off", False)
+        dev_result = set_dev_mode(args.name, enabled)
+        if "error" in dev_result:
+            print(f"❌ {dev_result['error']}", file=sys.stderr)
+            sys.exit(1)
+        if enabled:
+            print(f"✅ {args.name} is now in dev mode")
+            print("   UI files served with no-store; edits under ui/ trigger a live reload")
+            print("   in the dashboard within ~1s (picked up by the gateway watcher).")
+            print("   Tip: symlink the installed ui/ to your source tree for zero-copy edits.")
+            print(f"   Turn off with: kirocrew app dev {args.name} --off")
+        else:
+            print(f"✅ {args.name} dev mode off (normal caching restored)")
+
     elif action == "info":
         info = get_app(args.name)
         if not info:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1746,6 +1746,11 @@ async def start_dashboard(
             cron_service=state.crons,
             broadcast_fn=state.broadcast if hasattr(state, "broadcast") else None,
         )
+        # App dev-mode live reload: watch dev-flagged apps' ui/ dirs and
+        # broadcast app_reload WS events on change (see apps/dev_mode.py).
+        from kiro_crew.apps.dev_mode import init_dev_mode_watcher
+
+        await init_dev_mode_watcher(state.broadcast_ws)
 
     app.on_startup.append(_hooks_startup)
 
@@ -1770,6 +1775,12 @@ async def start_dashboard(
 
     async def _hooks_shutdown(app_: web.Application) -> None:
         await on_gateway_shutdown()
+        # Cancel the app dev-mode watcher started in _hooks_startup so an
+        # in-process gateway restart does not leak the module-global task (which
+        # holds a stale broadcast_ws targeting dead clients). Await cancellation.
+        from kiro_crew.apps.dev_mode import stop_dev_mode_watcher
+
+        await stop_dev_mode_watcher()
 
     app.on_cleanup.append(_hooks_shutdown)
 

--- a/test/test_app_dev_mode.py
+++ b/test/test_app_dev_mode.py
@@ -1,0 +1,727 @@
+"""Tests for kiro_crew.apps.dev_mode — app dev-mode live reload."""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.apps.dev_mode import (
+    _read_dev_sentinel,
+    _reconcile_sentinel_from_installed,
+    _scan_installed_dev_apps,
+    _scan_ui_mtimes,
+    is_dev_mode,
+    is_dev_mode_cached,
+    set_dev_mode,
+)
+from kiro_crew.apps.manager import (
+    APP_MANIFEST_FILENAME,
+    _read_installed,
+    install_app,
+    update_app,
+)
+from kiro_crew.apps.routes import register_app_routes
+
+
+@pytest.fixture(autouse=True)
+def _reset_dev_cache():
+    """Reset the module-global in-memory dev-app cache around every test.
+
+    ``_dev_apps_cache`` persists across tests (module global); without this
+    reset a dev app enabled in one test would leak into the next and flip an
+    unrelated Cache-Control assertion.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+    dev_mode._set_dev_cache(set())
+    yield
+    dev_mode._set_dev_cache(set())
+
+
+def _make_app_source(tmp_path, name="dev-mode-app"):
+    src = tmp_path / "source" / name
+    (src / "ui").mkdir(parents=True)
+    (src / "ui" / "index.mjs").write_text("export default () => null\n")
+    manifest = {
+        "name": name,
+        "version": "1.0.0",
+        "displayName": "Dev Mode App",
+        "description": "App for dev-mode testing",
+        "author": "tester",
+        "ui": {"entry": "index.mjs", "pages": [{"route": f"/{name}", "label": name}]},
+    }
+    (src / APP_MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
+    return src
+
+
+def _setup_env(tmp_path, monkeypatch):
+    home = tmp_path / "kirocrew-home"
+    home.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    kiro_agents = tmp_path / "kiro-agents"
+    kiro_agents.mkdir()
+    import kiro_crew.apps.bridges as bridges_mod
+    monkeypatch.setattr(bridges_mod, "KIRO_AGENTS_DIR", kiro_agents)
+    return home
+
+
+def _make_web_app():
+    app = web.Application()
+    register_app_routes(app)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# set_dev_mode / is_dev_mode
+# ---------------------------------------------------------------------------
+
+
+def test_set_dev_mode_toggles_installed_json(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    assert is_dev_mode("dev-mode-app") is False
+
+    result = set_dev_mode("dev-mode-app", True)
+    assert result == {"name": "dev-mode-app", "dev": True}
+    assert is_dev_mode("dev-mode-app") is True
+    assert _read_installed("dev-mode-app").dev is True
+
+    result = set_dev_mode("dev-mode-app", False)
+    assert result == {"name": "dev-mode-app", "dev": False}
+    assert is_dev_mode("dev-mode-app") is False
+
+
+def test_set_dev_mode_not_installed(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    result = set_dev_mode("nope", True)
+    assert "not installed" in result["error"]
+
+
+def test_set_dev_mode_rejects_traversal(tmp_path, monkeypatch):
+    """Path-traversal app names must be rejected before any filesystem op.
+
+    Regression guard for the HIGH finding: unchecked names like ``../../x``
+    would escape ~/.kirocrew/apps/ and read/overwrite an external installed.json.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    for bad in ("../../project", "..", "a/b", "a\\b", "../evil"):
+        result = set_dev_mode(bad, True)
+        assert "invalid app name" in result["error"], bad
+    # is_dev_mode / is_dev_mode_cached also refuse traversal names safely.
+    assert is_dev_mode("../../project") is False
+
+
+def test_set_dev_mode_maintains_sentinel_and_cache(tmp_path, monkeypatch):
+    """set_dev_mode keeps the dev sentinel file and in-memory cache in sync."""
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode_cached("dev-mode-app") is False
+
+    set_dev_mode("dev-mode-app", True)
+    assert _read_dev_sentinel() == {"dev-mode-app"}
+    assert is_dev_mode_cached("dev-mode-app") is True
+
+    set_dev_mode("dev-mode-app", False)
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode_cached("dev-mode-app") is False
+
+
+def test_set_dev_mode_rejects_builtin(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    meta = _read_installed("dev-mode-app")
+    meta.origin = "builtin"
+    from kiro_crew.apps.manager import _write_installed
+    _write_installed("dev-mode-app", meta)
+    result = set_dev_mode("dev-mode-app", True)
+    assert "builtin" in result["error"]
+
+
+def test_concurrent_toggles_do_not_clobber_sentinel(tmp_path, monkeypatch):
+    """Concurrent set_dev_mode calls must not drop each other's sentinel entries.
+
+    Regression guard for the HIGH finding: without a cross-process lock around
+    the sentinel read-modify-write, threads that read the same state, mutate
+    private copies, and write back last-writer-wins, silently dropping apps from
+    the watched/no-store set. The lock serializes RMW so every enabled app
+    survives.
+    """
+    import threading
+
+    _setup_env(tmp_path, monkeypatch)
+    names = [f"dev-app-{i}" for i in range(8)]
+    for n in names:
+        install_app(str(_make_app_source(tmp_path, name=n)))
+
+    barrier = threading.Barrier(len(names))
+
+    def _enable(app_name):
+        barrier.wait()  # maximize overlap on the RMW window
+        set_dev_mode(app_name, True)
+
+    threads = [threading.Thread(target=_enable, args=(n,)) for n in names]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert _read_dev_sentinel() == set(names)
+
+
+def test_set_dev_mode_writes_metadata_under_lock(tmp_path, monkeypatch):
+    """set_dev_mode re-reads + writes installed.json INSIDE the sentinel lock.
+
+    Regression guard for the GPT 5.6 MEDIUM / Long-Term Impact BLOCK item: the
+    installed.json write used to run before ``with _sentinel_lock():`` so two
+    concurrent toggles could interleave (write-meta A, write-meta B, sentinel B,
+    sentinel A), leaving installed.json ``dev: true`` while the sentinel excludes
+    the app. Moving the read → mutate → write inside the lock also means a
+    metadata change that races in while we wait for the lock is preserved,
+    because meta is re-read under the lock rather than reusing the stale copy
+    read during validation.
+
+    Simulate that race with a lock wrapper that mutates installed.json on lock
+    entry (i.e. after set_dev_mode's outer validation read). If the write were
+    outside the lock (or reused the stale meta), the concurrent field change
+    would be clobbered.
+    """
+    from contextlib import contextmanager
+
+    import kiro_crew.apps.dev_mode as dev_mode
+    from kiro_crew.apps.manager import _write_installed
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    real_lock = dev_mode._sentinel_lock
+
+    @contextmanager
+    def _racing_lock():
+        # A concurrent writer bumped an unrelated field while we waited for the
+        # lock — happens AFTER set_dev_mode's outer validation read.
+        m = _read_installed("dev-mode-app")
+        m.version = "9.9.9"
+        _write_installed("dev-mode-app", m)
+        with real_lock():
+            yield
+
+    monkeypatch.setattr(dev_mode, "_sentinel_lock", _racing_lock)
+    result = set_dev_mode("dev-mode-app", True)
+    assert result == {"name": "dev-mode-app", "dev": True}
+
+    final = _read_installed("dev-mode-app")
+    assert final.dev is True          # our toggle landed
+    assert final.version == "9.9.9"   # concurrent writer's field preserved
+    assert _read_dev_sentinel() == {"dev-mode-app"}
+
+
+def test_uninstall_clears_dev_sentinel(tmp_path, monkeypatch):
+    """Uninstalling a dev-mode app removes it from the sentinel (+ cache).
+
+    Regression guard for the MEDIUM finding: a stale sentinel entry would make a
+    different app reinstalled under the same name inherit dev-mode serving.
+    """
+    from kiro_crew.apps.manager import uninstall_app
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    assert _read_dev_sentinel() == {"dev-mode-app"}
+    assert is_dev_mode_cached("dev-mode-app") is True
+
+    result = uninstall_app("dev-mode-app")
+    assert result.ok is True
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode_cached("dev-mode-app") is False
+
+
+def test_load_dev_apps_filters_stale_entries(tmp_path, monkeypatch):
+    """_load_dev_apps drops sentinel names not backed by a dev-mode install.
+
+    Defense-in-depth for the MEDIUM finding: even if a stale name survives in
+    the sentinel (e.g. crash mid-uninstall), a reinstall under that name with
+    dev:false must not be treated as a dev app.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    # Inject a stale sentinel: a name with no matching install, plus one that is
+    # installed but NOT in dev mode.
+    dev_mode._write_dev_sentinel({"ghost-app", "dev-mode-app"})
+    assert _read_dev_sentinel() == {"ghost-app", "dev-mode-app"}
+    # dev-mode-app is installed but dev:false; ghost-app is not installed.
+    assert dev_mode._load_dev_apps() == set()
+
+    set_dev_mode("dev-mode-app", True)
+    dev_mode._write_dev_sentinel({"ghost-app", "dev-mode-app"})
+    assert dev_mode._load_dev_apps() == {"dev-mode-app"}
+
+
+# ---------------------------------------------------------------------------
+# UI serving: dev mode -> no-store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ui_file_no_store_in_dev_mode(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    async with TestClient(TestServer(_make_web_app())) as client:
+        resp = await client.get("/apps/dev-mode-app/ui/index.mjs")
+        assert resp.status == 200
+        assert resp.headers.get("Cache-Control") != "no-store"
+
+        set_dev_mode("dev-mode-app", True)
+        resp = await client.get("/apps/dev-mode-app/ui/index.mjs")
+        assert resp.status == 200
+        assert resp.headers.get("Cache-Control") == "no-store"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/apps/{name}/dev endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dev_endpoint_toggles_and_validates(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    async with TestClient(TestServer(_make_web_app())) as client:
+        resp = await client.post("/api/apps/dev-mode-app/dev", json={"enabled": True})
+        assert resp.status == 200
+        assert (await resp.json()) == {"name": "dev-mode-app", "dev": True}
+        assert is_dev_mode("dev-mode-app") is True
+
+        # non-boolean rejected
+        resp = await client.post("/api/apps/dev-mode-app/dev", json={"enabled": "yes"})
+        assert resp.status == 400
+
+        # unknown app -> 404
+        resp = await client.post("/api/apps/ghost/dev", json={"enabled": True})
+        assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Watch scan helper
+# ---------------------------------------------------------------------------
+
+
+def test_scan_ui_mtimes_detects_edit_add_delete(tmp_path):
+    ui = tmp_path / "ui"
+    sub = ui / "chunks"
+    sub.mkdir(parents=True)
+    f1 = ui / "index.mjs"
+    f1.write_text("a")
+    f2 = sub / "x.mjs"
+    f2.write_text("b")
+
+    count, digest = _scan_ui_mtimes(ui)
+    assert count == 2
+
+    # Edit bumps the digest (mtime + size fold in)
+    time.sleep(0.01)
+    f1.write_text("aa")
+    import os
+    os.utime(f1, (time.time() + 5, time.time() + 5))
+    count2, digest2 = _scan_ui_mtimes(ui)
+    assert (count2, digest2) != (count, digest)
+
+    # Delete changes count
+    f2.unlink()
+    count3, _ = _scan_ui_mtimes(ui)
+    assert count3 == 1
+
+    # Missing dir is a no-change sentinel, not an error
+    assert _scan_ui_mtimes(tmp_path / "ghost") == (0, 0)
+
+
+def test_scan_ui_mtimes_detects_edit_with_older_mtime(tmp_path):
+    """A file rewritten with an mtime BELOW the tree's max must still be seen.
+
+    Regression guard for the GPT 5.6 MEDIUM: a ``(count, max-mtime)`` signature
+    missed edits when the touched file's new mtime stayed under another file's
+    mtime (``cp -p``/``rsync -a`` of an older bundle, clock skew, a future-dated
+    pin). The per-file digest folds each file's own mtime + size, so the change
+    registers regardless of where it sits relative to the max.
+    """
+    import os
+
+    ui = tmp_path / "ui"
+    ui.mkdir()
+    pinned = ui / "pinned.mjs"
+    pinned.write_text("x")
+    target = ui / "index.mjs"
+    target.write_text("v1")
+    # Pin one file far in the future so it owns the max mtime.
+    os.utime(pinned, (time.time() + 10_000, time.time() + 10_000))
+    # Give the target an mtime well BELOW the pinned max.
+    os.utime(target, (time.time() - 100, time.time() - 100))
+
+    _, digest = _scan_ui_mtimes(ui)
+
+    # Edit the target but keep its mtime still below the pinned max.
+    target.write_text("v2-different-size")
+    os.utime(target, (time.time() - 50, time.time() - 50))
+    _, digest2 = _scan_ui_mtimes(ui)
+
+    assert digest2 != digest, "edit below the max mtime must change the digest"
+
+
+def test_scan_ui_mtimes_follows_symlink(tmp_path):
+    real = tmp_path / "real-ui"
+    real.mkdir()
+    (real / "index.mjs").write_text("x")
+    link = tmp_path / "ui"
+    link.symlink_to(real)
+    count, digest = _scan_ui_mtimes(link)
+    assert count == 1
+    assert digest != 0
+
+
+# ---------------------------------------------------------------------------
+# Watch loop: offloaded filesystem IO still detects edits and broadcasts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_broadcasts_reload_on_edit(tmp_path, monkeypatch):
+    """_watch_loop must detect a ui/ edit and broadcast app_reload.
+
+    Regression guard for the offloaded filesystem IO: the sentinel stat, the
+    sentinel read, and _scan_ui_mtimes() all run via asyncio.to_thread, and the
+    path must still seed state on first tick (no reload storm) and fire exactly
+    on change.
+    """
+    import asyncio
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    # Tight cadence so the test runs fast.
+    monkeypatch.setattr(dev_mode, "POLL_INTERVAL_SECS", 0.02)
+
+    events: list[tuple[str, dict]] = []
+
+    def _capture(event: str, payload: dict) -> None:
+        events.append((event, payload))
+
+    task = asyncio.get_running_loop().create_task(dev_mode._watch_loop(_capture))
+    try:
+        # Let the loop seed state for a couple ticks — no reload yet.
+        await asyncio.sleep(0.1)
+        assert events == [], "seeding must not broadcast a reload"
+
+        # Edit a ui/ file with a clearly-newer mtime, then wait for detection.
+        ui_file = dev_mode.app_dir("dev-mode-app") / "ui" / "index.mjs"
+        ui_file.write_text("export default () => 'edited'\n")
+        import os
+        os.utime(ui_file, (time.time() + 5, time.time() + 5))
+
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if events:
+                break
+    finally:
+        task.cancel()
+        # _watch_loop catches CancelledError and returns cleanly, so awaiting
+        # the cancelled task may return normally rather than re-raising.
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert events, "an edit under a dev app's ui/ must broadcast app_reload"
+    event, payload = events[0]
+    assert event == "app_reload"
+    assert payload["app"] == "dev-mode-app"
+
+
+@pytest.mark.asyncio
+async def test_stop_dev_mode_watcher_awaits_cancellation(tmp_path, monkeypatch):
+    """stop_dev_mode_watcher cancels the watcher task and awaits its teardown.
+
+    Regression guard for the GPT 5.6 MEDIUM / Long-Term Impact BLOCK item: the
+    watcher started at gateway startup was never stopped on shutdown, leaking
+    the module-global task (holding a stale broadcast_ws) across an in-process
+    restart. stop_dev_mode_watcher is now async — it must cancel the task, await
+    it fully unwound, and clear the module global so a fresh init can start
+    cleanly.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(dev_mode, "POLL_INTERVAL_SECS", 0.02)
+
+    def _noop_broadcast(event: str, payload: dict) -> None:
+        pass
+
+    await dev_mode.init_dev_mode_watcher(_noop_broadcast)
+    task = dev_mode._watch_task
+    assert task is not None and not task.done()
+
+    await dev_mode.stop_dev_mode_watcher()
+    assert dev_mode._watch_task is None
+    assert task.done(), "watcher task must be fully unwound after stop"
+
+    # Idempotent: a second stop with nothing running is a no-op.
+    await dev_mode.stop_dev_mode_watcher()
+    assert dev_mode._watch_task is None
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_no_ui_walk_when_no_dev_apps(tmp_path, monkeypatch):
+    """Cost model: with zero dev apps the watcher must never walk any ui/ tree.
+
+    Regression guard for the Long-Term Impact finding — the watcher must not
+    make every always-on production gateway pay for a dev-only feature. When
+    no app is in dev mode the steady state is a single sentinel stat() per
+    tick: _scan_ui_mtimes must not be invoked at all.
+    """
+    import asyncio
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))  # installed but NOT in dev mode
+    monkeypatch.setattr(dev_mode, "POLL_INTERVAL_SECS", 0.02)
+
+    scan_calls: list = []
+    real_scan = dev_mode._scan_ui_mtimes
+    monkeypatch.setattr(
+        dev_mode,
+        "_scan_ui_mtimes",
+        lambda p: (scan_calls.append(p), real_scan(p))[1],
+    )
+
+    task = asyncio.get_running_loop().create_task(dev_mode._watch_loop(lambda *a: None))
+    try:
+        await asyncio.sleep(0.2)  # ~10 ticks
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert scan_calls == [], "watcher walked a ui/ tree with zero dev apps"
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_picks_up_out_of_process_toggle(tmp_path, monkeypatch):
+    """Enabling dev mode mid-run (sentinel change) starts watching that app.
+
+    Simulates the out-of-process `kirocrew app dev` CLI: the sentinel changes,
+    the watcher re-reads it off the event loop, seeds state, then fires on edit.
+    """
+    import asyncio
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    monkeypatch.setattr(dev_mode, "POLL_INTERVAL_SECS", 0.02)
+
+    events: list[tuple[str, dict]] = []
+    task = asyncio.get_running_loop().create_task(
+        dev_mode._watch_loop(lambda e, p: events.append((e, p)))
+    )
+    try:
+        await asyncio.sleep(0.1)  # running with no dev apps
+        assert events == []
+
+        # Out-of-process toggle: write the sentinel + installed.json.
+        set_dev_mode("dev-mode-app", True)
+        await asyncio.sleep(0.1)  # watcher re-reads sentinel, seeds state
+        assert events == [], "seeding a newly-dev app must not broadcast"
+
+        ui_file = dev_mode.app_dir("dev-mode-app") / "ui" / "index.mjs"
+        ui_file.write_text("export default () => 'edited'\n")
+        import os
+        os.utime(ui_file, (time.time() + 5, time.time() + 5))
+
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if events:
+                break
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert events and events[0][0] == "app_reload"
+    assert events[0][1]["app"] == "dev-mode-app"
+
+
+# ---------------------------------------------------------------------------
+# update_app preserves the dev flag (and all other persisted fields)
+# ---------------------------------------------------------------------------
+
+
+def test_update_app_preserves_dev_flag(tmp_path, monkeypatch):
+    """Updating a dev-mode app must NOT silently reset ``dev`` — or ANY other
+    persisted field — to its default.
+
+    Regression guard for the GPT 5.6 MEDIUM / Long-Term Impact BLOCK item 1:
+    update_app() rebuilt InstalledApp field-by-field and omitted ``dev`` (and
+    other newer fields), so an app developer updating the very app they were
+    iterating on in dev mode had ``installed.json`` flip to ``dev: false`` —
+    and at the next sentinel reconcile/restart the app dropped out of live
+    reload. dataclasses.replace now carries every persisted field forward, so
+    this asserts the full field set survives, not just ``dev``.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    src = _make_app_source(tmp_path)
+    install_app(str(src))
+    set_dev_mode("dev-mode-app", True)
+    assert _read_installed("dev-mode-app").dev is True
+
+    # Stamp distinctive non-default values on EVERY carried-forward persisted
+    # field. update_app() overrides only version/displayName/updatedAt/source;
+    # this asserts the dataclasses.replace guard matches the real scope of the
+    # fix (all persisted metadata), not merely the ``dev`` flag that surfaced
+    # it — so a future field added to InstalledApp can't silently regress.
+    from kiro_crew.apps.manager import _write_installed
+    meta0 = _read_installed("dev-mode-app")
+    meta0.enabled = False
+    meta0.installedAt = "2020-01-01T00:00:00Z"
+    meta0.origin = "local"
+    meta0.resources = "app"
+    meta0.lifecycle = "app"
+    meta0.schemaVersion = 99
+    meta0.migratedTo = "standalone:dev-mode-app"
+    _write_installed("dev-mode-app", meta0)
+
+    # Bump the source version and update in place.
+    manifest_path = src / APP_MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text())
+    manifest["version"] = "1.1.0"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    result = update_app(str(src))
+    assert result.ok is True
+
+    meta = _read_installed("dev-mode-app")
+    # Overridden by the update:
+    assert meta.version == "1.1.0"
+    # Every other persisted field must carry forward untouched:
+    assert meta.dev is True, "update_app must preserve the dev flag"
+    assert meta.enabled is False
+    assert meta.installedAt == "2020-01-01T00:00:00Z"
+    assert meta.origin == "local"
+    assert meta.resources == "app"
+    assert meta.lifecycle == "app"
+    assert meta.schemaVersion == 99
+    assert meta.migratedTo == "standalone:dev-mode-app"
+
+
+# ---------------------------------------------------------------------------
+# Sentinel reconciliation makes installed.json authoritative at startup
+# ---------------------------------------------------------------------------
+
+
+def test_scan_installed_dev_apps_reads_from_installed_json(tmp_path, monkeypatch):
+    """_scan_installed_dev_apps derives the dev set straight from installed.json."""
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path, name="app-a")))
+    install_app(str(_make_app_source(tmp_path, name="app-b")))
+    assert _scan_installed_dev_apps() == set()
+
+    set_dev_mode("app-a", True)
+    assert _scan_installed_dev_apps() == {"app-a"}
+
+
+def test_reconcile_sentinel_adds_missing_entry(tmp_path, monkeypatch):
+    """A ``dev: true`` written to installed.json out-of-band is honored on reconcile.
+
+    Regression guard for the Long-Term Impact BLOCK item 2: _load_dev_apps only
+    ever FILTERS the sentinel and can never ADD an entry, so a dev flag set via
+    snapshot restore / hand-edit / a crash between the metadata and sentinel
+    writes left the documented contract field saying ``dev: true`` while the
+    watcher never engaged. Reconciling from installed.json at startup makes the
+    documented field authoritative.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    # Simulate an out-of-band dev flag: set installed.json dev=true WITHOUT
+    # touching the sentinel (as a snapshot restore or hand-edit would).
+    meta = _read_installed("dev-mode-app")
+    meta.dev = True
+    from kiro_crew.apps.manager import _write_installed
+    _write_installed("dev-mode-app", meta)
+    assert _read_dev_sentinel() == set(), "sentinel is stale/missing the entry"
+
+    reconciled = _reconcile_sentinel_from_installed()
+    assert reconciled == {"dev-mode-app"}
+    assert _read_dev_sentinel() == {"dev-mode-app"}, "sentinel rebuilt from installed.json"
+    assert is_dev_mode_cached("dev-mode-app") is True
+
+
+def test_reconcile_sentinel_drops_stale_entry(tmp_path, monkeypatch):
+    """Reconcile also removes a sentinel entry not backed by a dev-mode install."""
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    # Sentinel claims dev, but installed.json says dev:false.
+    dev_mode._write_dev_sentinel({"dev-mode-app", "ghost"})
+
+    reconciled = _reconcile_sentinel_from_installed()
+    assert reconciled == set()
+    assert _read_dev_sentinel() == set()
+
+
+def test_reconcile_scans_inside_lock_preserves_racing_toggle(tmp_path, monkeypatch):
+    """Reconcile runs its installed.json scan INSIDE the sentinel lock.
+
+    Regression guard for the GPT 5.6 HIGH: the authoritative scan used to run
+    BEFORE ``with _sentinel_lock():``. A concurrent ``set_dev_mode`` toggle
+    (which holds the lock) could land between the scan and the lock acquisition
+    — the toggle writes installed.json ``dev: true`` and adds the app to the
+    sentinel, then reconcile takes the lock with its STALE scan (missing that
+    app), sees a divergence, and rewrites the sentinel to exclude it, silently
+    dropping the just-toggled app from the watched/no-store set until the next
+    restart. Moving the scan inside the lock makes scan → compare → write → cache
+    atomic against toggles.
+
+    Simulate the race with a lock wrapper that enables dev mode for the app on
+    lock entry (i.e. after any pre-lock scan would have already run). With the
+    scan inside the lock the wrapper's dev flag is visible to the scan, so the
+    app is kept; if the scan ran before the lock it would see dev:false and drop
+    the app.
+    """
+    from contextlib import contextmanager
+
+    import kiro_crew.apps.dev_mode as dev_mode
+    from kiro_crew.apps.manager import _write_installed
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    real_lock = dev_mode._sentinel_lock
+
+    @contextmanager
+    def _racing_lock():
+        # A concurrent toggle enabled dev mode while we waited for the lock:
+        # both installed.json AND the sentinel now say the app is a dev app.
+        m = _read_installed("dev-mode-app")
+        m.dev = True
+        _write_installed("dev-mode-app", m)
+        dev_mode._write_dev_sentinel({"dev-mode-app"})
+        with real_lock():
+            yield
+
+    monkeypatch.setattr(dev_mode, "_sentinel_lock", _racing_lock)
+    reconciled = _reconcile_sentinel_from_installed()
+
+    # The racing toggle must survive: scanned inside the lock, dev:true is seen.
+    assert reconciled == {"dev-mode-app"}
+    assert _read_dev_sentinel() == {"dev-mode-app"}
+    assert is_dev_mode_cached("dev-mode-app") is True

--- a/website/src/components/AppHost.tsx
+++ b/website/src/components/AppHost.tsx
@@ -11,7 +11,7 @@
  * The app is a normal React component in the same tree — no iframes,
  * no Web Components, no Shadow DOM.
  */
-import { Suspense, lazy, useMemo, useState, useCallback } from 'react'
+import { Suspense, lazy, useMemo, useState, useCallback, useEffect } from 'react'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, RefreshCw, PowerOff, AlertTriangle, Package, Bot } from 'lucide-react'
@@ -198,6 +198,23 @@ function AppNoUI({ app }: { app: AppHostProps['app'] }) {
 function AppHostInner({ app }: AppHostProps) {
   const navigate = useNavigate()
   const [resetKey, setResetKey] = useState(0)
+
+  // App dev-mode live reload: the gateway broadcasts app_reload when a
+  // dev-flagged app's ui/ files change (useWebSocket re-dispatches it as a
+  // window CustomEvent). We do a FULL PAGE RELOAD rather than only bumping the
+  // entry-module import URL: cache-busting just the entry leaves its statically
+  // imported dependency chunks pinned to their original URLs, and the browser's
+  // ESM module map is keyed by URL — so edits confined to a chunk would stay
+  // stale. A page reload re-fetches every module (the app's assets are served
+  // no-store in dev mode), guaranteeing the latest bytes across the whole graph.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { app?: string } | undefined
+      if (detail?.app === app.name) window.location.reload()
+    }
+    window.addEventListener('mc:app-reload', handler)
+    return () => window.removeEventListener('mc:app-reload', handler)
+  }, [app.name])
 
   const entry = app.manifest?.ui?.entry
   const permissions = app.manifest?.permissions || {}

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -469,6 +469,11 @@ export function useWebSocket() {
           case 'subagent_done':
             dispatch(sseSubagentDone(data as { slot: string; id: string; elapsed: number; error?: string }))
             break
+          case 'app_reload':
+            // App dev-mode live reload: the gateway watched a dev-flagged app's
+            // ui/ dir change. AppHost listens for this and re-imports the bundle.
+            window.dispatchEvent(new CustomEvent('mc:app-reload', { detail: data as { app: string } }))
+            break
           case 'subagent_snapshot':
             dispatch(sseSubagentSnapshot(data as { id: string; slot: string; task: string; agent: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean }))
             break


### PR DESCRIPTION
## Summary
Building a KiroCrew app UI today means editing files, copying them into `~/.kirocrew/apps/<name>/ui/`, and hard-refreshing past a 1-hour browser cache. This adds a first-class dev mode:

```
kirocrew app dev my-app        # on
kirocrew app dev my-app --off  # off
```

When enabled (also via `POST /api/apps/{name}/dev`):
- **UI files are served with `Cache-Control: no-store`** — never cached.
- **A gateway watcher** (single 1s-cadence loop for all dev apps, mtime scan, symlink-following, 2000-file safety cap) broadcasts an `app_reload` WS event when any `ui/` file changes.
- **AppHost re-imports the bundle with a cache-busted URL** (`?dev=N`) — required because the browser's ESM module cache is keyed by URL, so even uncached HTTP wouldn't refresh the module. Edits appear in the dashboard within ~1s, no manual refresh.

Design notes: dev mode is a metadata-only flag in `installed.json` (no restart to toggle), builtin apps are rejected, the watcher seeds state before firing (no reload storm at startup or on enable), and watcher errors never kill the loop.

## Incidental fix — `update_app()` metadata preservation (user-visible, all apps)
While wiring the `dev` flag through, `update_app()` was found to **rebuild `InstalledApp` field-by-field**, silently resetting `origin`, `resources`, `lifecycle`, `schemaVersion`, `migratedTo` (and dropping the new `dev` flag) on **every app update, for every user — not just dev-mode apps**. This is a real persisted-`installed.json` data-correctness fix, not dev-only tooling: `update_app()` now uses `dataclasses.replace(existing, …)`, overriding only `version`/`displayName`/`updatedAt`/`source` and carrying every other persisted field forward, so future fields are regression-proof by construction. Reviewers: please review this at persisted-metadata depth, not dev-feature depth.

## Testing
- New/extended backend tests (`test/test_app_dev_mode.py`, 20 total): toggle persistence, builtin rejection, not-installed error, dev→`no-store` header flip, endpoint boolean validation + 404, scan helper edit/add/delete detection, symlinked-ui scan, sentinel reconcile (add/drop, installed.json authoritative), watcher offloads blocking IO. `test_update_app_preserves_dev_flag` now stamps distinctive non-default values on **every** carried-forward field (`enabled`, `installedAt`, `origin`, `resources`, `lifecycle`, `schemaVersion`, `migratedTo`, `dev`) and asserts all survive `update_app()` — the guard matches the real scope of the `replace()` fix, not just the `dev` flag that surfaced it.
- Full local gates: flake8 clean, CI-parity mypy (443 files) clean, backend suite passing (2 known host-env failures deselected: hardlink-permission, missing-binary exit-127), tsc clean, vitest 4,072 passed.

## Notes
- Touches the same `Cache-Control` line as #281 (no-cache default for app UI files); whichever lands second rebases trivially — the two changes compose (`no-store` when dev, #281's `no-cache` otherwise).
