### PR TITLE
fix(security): stop leaking secret prefix in credential-redaction warning

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3630,7 +3630,15 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
         matched = m.group()
         tag = _REDACTED_CREDENTIAL_TAG
         result = result.replace(matched, tag, 1)
-        warnings.append(f"Redacted credential pattern: {matched[:20]}...")
+        # Emit ONLY non-sensitive metadata (length). Do NOT slice any part of
+        # `matched` into the warning: `_CREDENTIAL_PATTERNS` matches the raw
+        # secret value itself (e.g. `ghp_…`, `sk-ant-…`), so even a short prefix
+        # is genuine plaintext key material — a fixed-length token prefix leaves
+        # ~12-16 secret chars in a 20-char slice. The warnings list is a
+        # redaction-subsystem output expected to be safe to log/surface, so it
+        # must carry no secret bytes. Mirrors the base64 / bare-secret branches
+        # below, which already log length only.
+        warnings.append(f"Redacted credential pattern ({len(matched)} chars)")
 
     # 2. Detect and redact base64-encoded credentials
     for m in _B64_CHUNK_RE.finditer(text):

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -230,6 +230,39 @@ class TestRedactCredentials:
         assert "[REDACTED: credential]" in result
         assert len(warnings) == 1
 
+    @pytest.mark.parametrize(
+        "secret",
+        [
+            "ghp_" "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12",  # GitHub classic PAT
+            "sk-ant-api03-" "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP",  # Anthropic
+            "sk-proj-" "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234",  # OpenAI
+            "sk_live_" "51HG7aBcDeFgHiJkLmNoPqRsTuVwXyZ",  # Stripe live
+            "xoxb-" "1234567890-abcdefghijklmnop",  # Slack bot token
+        ],
+    )
+    def test_warning_does_not_leak_secret_prefix(self, secret: str) -> None:
+        """The warnings list must carry NO secret bytes — only length metadata.
+
+        Regression for the pentest finding: the plaintext branch previously
+        emitted ``matched[:20]``, leaking a 12-16 char slice of the real secret
+        (a fingerprint of exactly which key matched) into a list that sinks
+        expect to be safe to log/surface. High-entropy API-key prefixes
+        (``ghp_``, ``sk-ant-``, ``sk-proj-``, ``sk_live_``, ``xoxb-``) are the
+        worst case; assert none of the raw secret survives in any warning.
+        """
+        text = f"KEY={secret}"
+        _, warnings = redact_credentials(text)
+        assert len(warnings) == 1
+        joined = " ".join(warnings)
+        # The full secret must not appear, and neither may any leading slice of
+        # it beyond the (non-secret) provider prefix — assert the whole value
+        # and its first 20 chars (the old leak window) are both absent.
+        assert secret not in joined
+        assert secret[:20] not in joined
+        # Positive: the warning still reports the redaction with a length.
+        assert "Redacted credential pattern" in joined
+        assert f"{len(secret)} chars" in joined
+
     def test_redacts_db_uri_with_embedded_password(self) -> None:
         text = "DATABASE_URL=postgres://admin:SuperSecret123@db.example.com:5432/prod"
         result, _ = redact_credentials(text)


### PR DESCRIPTION
## Problem
`redact_credentials()` correctly replaces raw credentials in the *returned text*, but the warning it appends alongside each plaintext redaction embedded the raw match verbatim:

```python
warnings.append(f"Redacted credential pattern: {matched[:20]}...")
```

`matched` is the entire matched credential substring, and `_CREDENTIAL_PATTERNS` matches the secret **values** themselves (not just labels). Because each provider token has a short fixed-length prefix, the 20-char cap exposed a meaningful slice of the real secret in plaintext:

| Token class | Prefix | Raw secret chars in `matched[:20]` |
|---|---|---|
| GitHub `ghp_` | 4 | ~16 |
| Slack `xoxb-` | 5 | ~15 |
| Anthropic `sk-ant-` | 7 | ~13 |
| OpenAI `sk-proj-` / Stripe `sk_live_` | 8 | ~12 |
| DB URI `postgresql://` | 13 | start of embedded `user:pass` |

## Why it matters
The returned `warnings` list is a redaction-subsystem output that callers treat as safe to log, emit to telemetry, or surface in the UI. Leaking a 12-16 char prefix of a high-entropy API key both fingerprints exactly which secret matched and, for shorter tokens, discloses a substantial fraction of the value — defeating the purpose of the redactor for any sink that records these warnings.

## Fix (symptoms → root cause → change)
- **Symptom:** a partial plaintext secret appears in `warnings` even though the same secret is redacted in the returned text.
- **Root cause:** the warning string was built from the raw match bytes (`matched[:20]`), unlike the sibling branches in the same function — the base64 branch logs `({len(chunk)} chars)` and the bare-secret branch logs `({len(run)} chars)`. Only the plaintext branch emitted secret material, confirming this was an oversight rather than intent.
- **Change:** emit non-sensitive metadata only, mirroring the sibling branches:
  ```python
  warnings.append(f"Redacted credential pattern ({len(matched)} chars)")
  ```
  Length is not secret-bearing and is already the established convention here. A pattern-identity hint was considered but not adopted: `_CREDENTIAL_PATTERNS` is a single large alternation with no named groups, so recovering "which alternative matched" would require invasively threading named groups through the whole regex for marginal benefit — length-only is the minimal, consistent fix.

## Tests
- Added `TestRedactCredentials::test_warning_does_not_leak_secret_prefix` — a parametrized regression test over the worst-case high-entropy prefixes (`ghp_`, `sk-ant-`, `sk-proj-`, `sk_live_`, `xoxb-`). It asserts neither the full secret **nor its first-20-char slice** (the old leak window) appears in any warning, while still confirming the redaction is reported with a length.
- Existing `TestRedactCredentials` suite continues to pass (67 passed locally), locking in that redaction of the returned text and warning counts are unchanged.

## Manual verification
N/A — unit coverage is sufficient; the change is a pure string-construction fix on an in-process function and the regression test exercises the exact leak vector across all affected token classes.
