### PR TITLE
chore: MeshClaw dual-repo beta sync 2026-07-23 (batch-56: 3 ported — 2 backend + 1 frontend)

### DIFF
--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -18,6 +18,7 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any
 
+from kiro_crew.security import canonicalize_ip
 from kiro_crew.skill_providers.base import SkillSearchResult
 
 logger = logging.getLogger(__name__)
@@ -279,6 +280,28 @@ def _sync_fetch_text(url: str) -> str | None:
         return None
 
 
+def _audit_ssrf_blocked(url: str, host: str, canonical_host: str) -> None:
+    """Emit a SEL audit event for a blocked SSRF-to-internal-IP attempt.
+
+    Best-effort: a security event log failure must never turn the SSRF *defense*
+    into a crash, so every error is swallowed. Imported lazily to avoid a
+    module-load cycle (sel -> ... -> skill_providers).
+    """
+    try:
+        from kiro_crew.sel import sel  # circular import: sel -> ... -> skill_providers
+
+        detail = host if host == canonical_host else f"{host} -> {canonical_host}"
+        sel().log_api_access(
+            caller="skillsh",
+            operation="ssrf_blocked",
+            outcome="blocked",
+            source="skill_provider",
+            resources=f"{detail} ({url[:120]})",
+        )
+    except Exception:  # noqa: BLE001 — auditing must never break the guard
+        logger.debug("SEL audit of blocked SSRF failed", exc_info=True)
+
+
 def _is_internal_url(url: str) -> bool:
     """Return True if the URL resolves to a private/internal/loopback address.
 
@@ -286,7 +309,8 @@ def _is_internal_url(url: str) -> bool:
     - IPv4 private ranges (10.x, 172.16.x, 192.168.x, 127.x, 169.254.x)
     - IPv6 loopback (::1), link-local (fe80::), ULA (fd00::)
     - IPv6-mapped IPv4 (::ffff:127.0.0.1)
-    - Hex/octal/decimal IP representations (0x7f000001, 0177.0.0.1, 2130706433)
+    - Hex/octal/decimal/short-form IP encodings (0x7f000001, 0177.0.0.1,
+      2130706433, 127.1) — normalized via ``canonicalize_ip`` before parsing
     - localhost hostname
 
     Called BEFORE AND AFTER redirect resolution to prevent both pre-connect
@@ -302,17 +326,39 @@ def _is_internal_url(url: str) -> bool:
         if host == "localhost":
             return True
 
-        # Try to parse as an IP address directly (handles hex, octal, decimal,
-        # IPv6, and IPv4-mapped IPv6 forms)
+        # Normalize alternate IPv4 encodings the OS resolver / libc inet_aton
+        # accept but ipaddress.ip_address() rejects — hex (0x7f000001), octal
+        # (0177.0.0.1), 32-bit decimal (2130706433), and short forms (127.1).
+        # Without this, ip_address() raises ValueError on those, we fall through
+        # to the hostname branch, and a redirect to e.g. http://2852039166/ (==
+        # 169.254.169.254, the cloud instance metadata endpoint) is treated as
+        # "not internal" — an SSRF-to-metadata credential-read bypass.
+        # canonicalize_ip (security.py) is the same hardened resolver used by the
+        # bash-command metadata gate; it returns the dotted-quad for any encoding,
+        # or the input unchanged for a real hostname.
+        canonical_host = canonicalize_ip(host)
+
+        # Try to parse as an IP address directly (now covers hex/octal/decimal/
+        # short forms via canonicalize_ip, plus IPv6 and IPv4-mapped IPv6).
         try:
-            ip = ipaddress.ip_address(host)
-            return (
+            ip = ipaddress.ip_address(canonical_host)
+            internal = (
                 ip.is_private
                 or ip.is_loopback
                 or ip.is_link_local
                 or ip.is_reserved
                 or ip.is_multicast
+                or ip.is_unspecified
             )
+            if internal:
+                # A URL naming an internal IP literal is a genuine SSRF attempt
+                # (a legitimate skills.sh/github fetch never targets one). Emit a
+                # SEL audit event so blocked attempts are visible to audit tooling
+                # — especially the metadata-via-encoded-IP redirect vector this
+                # guard closes. canonical_host may differ from host (e.g.
+                # 0xa9fea9fe -> 169.254.169.254), so log both.
+                _audit_ssrf_blocked(url, host, canonical_host)
+            return internal
         except ValueError:
             pass  # not a literal IP — it's a hostname
 

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -33,8 +33,22 @@ pytestmark = pytest.mark.xdist_group(name="subprocess_spawn")
 
 
 @pytest.fixture(autouse=True)
-def clean_backend():
-    """Reset cached backend between tests."""
+def clean_backend(monkeypatch):
+    """Reset cached backend between tests.
+
+    Also neutralize the host's real kiro internal-sandbox setting: on a macOS
+    dev box where ``~/.kiro/settings/amazon-internal.json`` has
+    ``{"sandbox": true}``, the darwin kiro-delegation branch in ``wrap_argv``
+    preempts the mocked ``detect_backend`` and these unit tests — which exercise
+    KiroCrew's OWN backend selection / fail-closed path — never reach the code
+    they assert on. Point the settings path at a non-existent file so delegation
+    is off by default; the dedicated delegation tests set
+    ``_KIRO_INTERNAL_SETTINGS_PATH`` explicitly and are unaffected.
+    """
+    monkeypatch.setattr(
+        "kiro_crew.sandbox._KIRO_INTERNAL_SETTINGS_PATH",
+        "/nonexistent/kirocrew-test/amazon-internal.json",
+    )
     reset_backend()
     yield
     reset_backend()

--- a/test/test_sandbox_backend_cache.py
+++ b/test/test_sandbox_backend_cache.py
@@ -34,7 +34,18 @@ _EPERM_REASON = "unshare(CLONE_NEWUSER|CLONE_NEWNS) failed with errno 1 (EPERM)"
 
 @pytest.fixture(autouse=True)
 def clean_backend(monkeypatch):
-    """Reset cached backend + probe detail + warm thread; no real sleeping in retry path."""
+    """Reset cached backend + probe detail + warm thread; no real sleeping in retry path.
+
+    Also neutralize the host's real kiro internal-sandbox setting: on a macOS
+    dev box where ``~/.kiro/settings/amazon-internal.json`` has
+    ``{"sandbox": true}``, the darwin kiro-delegation branch in ``wrap_argv``
+    preempts the mocked ``detect_backend`` so the fail-closed ``RuntimeError``
+    these tests assert on never raises. Point the settings path at a
+    non-existent file so delegation is off by default.
+    """
+    monkeypatch.setattr(
+        sb, "_KIRO_INTERNAL_SETTINGS_PATH", "/nonexistent/kirocrew-test/amazon-internal.json"
+    )
     sb.reset_backend()
     sb._warm_thread = None
     monkeypatch.setattr(sb.time, "sleep", lambda _s: None)

--- a/test/test_skill_providers.py
+++ b/test/test_skill_providers.py
@@ -372,3 +372,70 @@ class TestSkillsShDownloadUrl:
             assert await p.fetch_skill_bundle("") is None
 
         assert calls["n"] == 0  # malformed ids never reach the network
+
+
+class TestIsInternalUrlSSRF:
+    """The skills.sh SSRF guard (_is_internal_url), used as both a pre-connect
+    check and the redirect gate in _SafeRedirectHandler, must block the alternate
+    IPv4 encodings the OS resolver / libc inet_aton accept but
+    ipaddress.ip_address() rejects. Pre-fix those raised ValueError, were
+    swallowed, and the URL was classified "not internal" — so a 302 redirect from
+    the third-party skills.sh registry to e.g. http://2852039166/ (== the cloud
+    instance metadata endpoint 169.254.169.254) was followed, reading instance
+    credentials (SSRF-to-metadata). The docstring already claimed hex/octal/
+    decimal coverage.
+    """
+
+    # Every form below resolves to the metadata endpoint (169.254.169.254) or loopback.
+    ENCODED_INTERNAL = [
+        "http://2852039166/latest/meta-data/",  # decimal metadata endpoint
+        "http://0xa9fea9fe/",   # hex metadata endpoint
+        "http://2130706433/",   # decimal 127.0.0.1
+        "http://0x7f000001/",   # hex 127.0.0.1
+        "http://0177.0.0.1/",   # octal-leading 127.0.0.1
+        "http://127.1/",        # short-form 127.0.0.1
+        "http://[::ffff:169.254.169.254]/",  # IPv6-mapped IPv4 metadata endpoint
+    ]
+    PLAIN_INTERNAL = [
+        "http://169.254.169.254/latest/meta-data/",  # plain metadata endpoint (control)
+        "http://localhost/",
+        "http://127.0.0.1/",
+        "http://10.0.0.5/",
+        "http://192.168.1.1/",
+        "http://[::1]/",
+        "http://0.0.0.0/",  # unspecified address (is_unspecified)
+    ]
+    EXTERNAL_ALLOWED = [
+        "https://raw.githubusercontent.com/org/repo/main/SKILL.md",
+        "https://skills.sh/api/download/some-skill",
+        "https://example.com/x",
+    ]
+
+    def test_encoded_internal_ips_are_blocked(self):
+        for url in self.ENCODED_INTERNAL:
+            assert _is_internal_url(url) is True, f"SSRF bypass — not blocked: {url}"
+
+    def test_plain_internal_ips_are_blocked(self):
+        for url in self.PLAIN_INTERNAL:
+            assert _is_internal_url(url) is True, f"should be internal: {url}"
+
+    def test_external_hosts_are_allowed(self):
+        for url in self.EXTERNAL_ALLOWED:
+            assert _is_internal_url(url) is False, f"legit host wrongly blocked: {url}"
+
+    def test_missing_host_is_blocked(self):
+        # No host = suspicious = block (fail closed).
+        assert _is_internal_url("http:///no-host") is True
+
+    def test_blocked_internal_ip_emits_sel_audit(self):
+        # A blocked SSRF-to-internal-IP is a security-relevant event and must be
+        # visible to audit tooling.
+        with patch("kiro_crew.skill_providers.skillsh._audit_ssrf_blocked") as m:
+            assert _is_internal_url("http://0xa9fea9fe/") is True  # hex metadata endpoint
+            assert m.called, "blocked SSRF attempt did not emit a SEL audit event"
+
+    def test_external_host_does_not_emit_sel_audit(self):
+        # Allowed hosts must NOT spam the audit log.
+        with patch("kiro_crew.skill_providers.skillsh._audit_ssrf_blocked") as m:
+            assert _is_internal_url("https://raw.githubusercontent.com/o/r/main/S.md") is False
+            assert not m.called

--- a/website/src/hooks/useMessageSearch.ts
+++ b/website/src/hooks/useMessageSearch.ts
@@ -91,6 +91,14 @@ export function useMessageSearch(messages: ChatMessage[], activeSlot: string | n
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        // Yield Cmd/Ctrl+F to app surfaces that own their own in-file find
+        // (e.g. the file explorer). Without this, an in-file search hijacks
+        // the key and opens the chat message-search pane instead. This
+        // document-level handler runs before the file explorer's window-level
+        // handler (bubble order), so bailing here lets that handler run.
+        // Guard the closest() call: e.target may be Document (no closest()).
+        const target = e.target as Element | null
+        if (target && typeof target.closest === 'function' && target.closest('.mc-fe-root')) return
         e.preventDefault()
         setIsOpen(true)
         setFocusNonce(n => n + 1)

--- a/website/src/test/useMessageSearch.test.ts
+++ b/website/src/test/useMessageSearch.test.ts
@@ -292,4 +292,21 @@ describe('useMessageSearch keyboard shortcuts', () => {
     act(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })) })
     expect(result.current.isOpen).toBe(false)
   })
+
+  it('Ctrl/Cmd+F is ignored when the keystroke originates inside the file explorer (.mc-fe-root)', () => {
+    const { result } = renderHook(() => useMessageSearch(messages, 'slot-1'))
+    // Simulate an in-file search: target lives inside a .mc-fe-root subtree.
+    const root = document.createElement('div')
+    root.className = 'mc-fe-root'
+    const inner = document.createElement('input')
+    root.appendChild(inner)
+    document.body.appendChild(root)
+    try {
+      act(() => { inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', metaKey: true, bubbles: true })) })
+      // Chat search must NOT open — the file explorer owns Cmd+F here.
+      expect(result.current.isOpen).toBe(false)
+    } finally {
+      document.body.removeChild(root)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

MeshClaw → KiroCrew **beta sync (batch-56)** — 3 fixes ported (2 backend + 1 frontend). Triaged 4 candidates: 3 ported, 1 skipped (CHANGELOG-only). Independent of #223 (batch-54) and #277 (batch-55) — no file overlap.

## Problem

An SSRF bypass in the skills.sh provider, non-hermetic sandbox tests, and a Cmd/Ctrl+F key-hijack in chat search.

## Why it matters

- **SSRF (the important one)**: `_is_internal_url()` — the SSRF guard for the third-party skills.sh registry fetch + redirect gate — only recognized standard dotted-quad IPs. Alternate IPv4 encodings (hex `0x7f000001`, octal `0177.0.0.1`, 32-bit decimal `2130706433`, short `127.1`) raised `ValueError`, were swallowed, and classified "not internal". So a 302 redirect to e.g. `http://2852039166/` (== `169.254.169.254`, the cloud instance metadata endpoint) was **followed**, reading instance credentials — a real SSRF-to-metadata path.
- **Sandbox tests**: on a macOS dev box with kiro-cli's internal sandbox enabled, the backend-selection unit tests never reached the code they assert on (they failed environmentally — the same flake worked around in batches 54/55).
- **Cmd/Ctrl+F**: chat search hijacked the key even when focus was in the file explorer, which owns its own in-file find.

## Fix

| Commit | Change |
|---|---|
| `fix(security)` | Normalize the host through `security.canonicalize_ip()` (the hardened inet_aton resolver) before the `ipaddress` classification, so every encoding collapses to its dotted-quad and is flagged private/loopback/link-local/reserved/multicast/unspecified. Best-effort SEL audit on each block. New `TestIsInternalUrlSSRF` (encoded forms, plain internal, legit external, host-less fail-closed, audit emit/skip). |
| `test(sandbox)` | `clean_backend` fixtures monkeypatch `sandbox._KIRO_INTERNAL_SETTINGS_PATH` to a non-existent file, so the tests are hermetic regardless of the host's kiro sandbox setting. PARTIAL — dropped the commit's CHANGELOG/version-bump. |
| `fix(search)` | `useMessageSearch` bails when the keystroke originates inside a `.mc-fe-root` subtree (guarding `closest()` since `e.target` may be Document). + regression test. |

## Tests

Each fix carries its regression test. Local: flake8/isort/mypy clean; `test_skill_providers` (41) + `test_sandbox_argv`/`test_sandbox_backend_cache` (102, **with the host settings file present** — proving the hermeticity fix) pass; frontend `tsc -b` + `useMessageSearch` vitest (28) pass.

## Manual verification

De-Amazon audit: zero new `code.amazon`/`taskei`/`Mesh-`/`CR-`/`P<digits>` markers in added source (provenance in commit bodies only); "AWS IMDS / IAM" prose genericized to "cloud instance metadata endpoint / instance credentials" (the `169.254.169.254` link-local address is an RFC-3927 standard, kept). Proved the SSRF bypass: `_is_internal_url('http://2852039166/')` now returns `True` (was `False`). Does **not** merge — review + CI gate first.
