### PR TITLE
fix: strict session resolver honors HMAC-verified sandbox host-pid identity

### DIFF
--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -42,6 +42,23 @@ The `config_bounds_clamped` event (`outcome=clamped`, `source=background`, `oper
 - **Key + log are on the sensitive-path floor (`cdf82704`):** both `sel_hmac.key` and `security_events.jsonl` are in `security._SENSITIVE_HOME_DIRS`, so the audited agent's `fs_read`/file-edit tools (gated by `is_sensitive_path()`) cannot read the key to forge the chain or rewrite the log. The gateway's own writer/reader (`sel.py`, `dashboard/session_health.py`) opens the files directly and bypasses that gate. Residual: the key still lives in the agent's home namespace — a deeper out-of-process signer is future hardening.
 - Verification: `verify_integrity()` walks the chain and reports tampered entries
 - Append-only: no in-place edits; pruning rewrites with chain rebuild
+- **Second protocol anchored on this key — domain-separated:** `session_pid_sig.py`
+  authenticates the `session_pid_<pid>.txt` -> session-key mapping consumed by
+  strict MCP identity resolvers. It does **not** sign with the raw
+  `sel_hmac.key`; it derives a purpose-specific subkey
+  (`HMAC(sel_hmac.key, "kirocrew.session_pid.sig.v1")`) so the sidecar MAC and
+  the SEL audit chain never share a signing key — a MAC minted under one
+  protocol is valueless to the other (no cross-protocol confusion/replay). The
+  key file remains a single on-disk trust root; only `SecurityEventLog` ever
+  *creates* it. **Recorded acceptance — widened compromise impact:** anchoring
+  session identity here means compromise of `sel_hmac.key` no longer only
+  permits forging the audit chain — it also permits minting valid
+  session-identity sidecars and driving state-mutating MCP tools against
+  another session (cross-session state mutation). The likelihood of compromise
+  is unchanged (same sensitive-path floor); the *impact* grew, and any future
+  hardening of this key (the out-of-process signer above, issue #302) must
+  treat `session_pid_sig` as a dependent of equal weight. See
+  `docs/system-specs/modules/session.md` for the sidecar contract.
 
 ## Async Writer
 

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -495,6 +495,55 @@ parent PID explicitly avoids this.
 - **Periodic**: `_cleanup_loop()` calls it alongside idle session expiry (~60s)
 - **At shutdown**: `cleanup_orphaned_sessions()` on signal/exit
 
+### session_pid sidecar contract (`session_pid_sig.py`)
+
+The gateway maps its direct child pid to a session key by publishing
+`config_dir()/session_pid_<pid>.txt` on session claim (writers:
+`dashboard/chat_runner.py`, `slack/handler.py` — both route through
+`session_pid_sig.publish_session_pid`, the single legitimate publish path).
+Because the `.txt` lives in the same-uid agent-writable config dir it is NOT
+a trust root on its own; publication therefore also writes a
+`session_pid_<pid>.sig` sidecar:
+
+- **MAC**: HMAC-SHA256 over `"<pid>:<session_key>"` — the pid is bound into
+  the MAC so one pid's pair cannot be replayed under another pid.
+- **Key**: a purpose-specific subkey derived from the SEL trust root via a
+  domain-separation label (`HMAC(sel_hmac.key, "kirocrew.session_pid.sig.v1")`).
+  The raw root never signs a sidecar; the sidecar protocol and the SEL audit
+  chain never share a signing key (see `sel.md`). Only `SecurityEventLog`
+  ever *creates* the key file.
+- **Writes are atomic** (`atomic_write` → `os.replace`): a pre-planted
+  symlink at the predictable paths is replaced, never followed.
+- **Consumers**: STRICT identity resolvers for state-mutating MCP tools
+  (`monitor_start`, `autonudge_stop`, `set_project`) accept the direct
+  `KIROCREW_HOST_PID` → mapping lookup only via
+  `session_pid_sig.verify_session_pid`, which fails closed to `""` on a
+  missing/short key, missing files, or MAC mismatch. Lenient (read-only)
+  resolvers keep reading the `.txt` without a signature check, but through
+  the same hardened reader (`session_pid_sig.read_session_pid_txt`:
+  no-follow, regular-file, size-bounded) — `session_pid_sig` owns both the
+  read and write discipline for the file family. Every `.txt` reader routes
+  through it: `mcp_core._resolve_session_key` (host-pid + walk),
+  `mcp_shared._resolve_excluded_tools` (policy walk),
+  `mcp_caller.CallerContext.from_env` (host-pid + walk; also serves
+  `mcp_gateway/stub.py`), and `mcp_gateway/gatewayd._resolve_peer_identity`
+  (server-side peer walk). The sidecar is additive.
+- **Unsigned degrade**: if the SEL key is unavailable at publish time the
+  `.txt` is still written (lenient readers keep working) and any stale
+  sidecar is removed — strict resolvers fail closed for that pid.
+- **Key rotation**: rotating/regenerating `sel_hmac.key` (e.g. snapshot
+  restore, which deliberately excludes the key) invalidates every existing
+  sidecar; strict resolvers fail closed until the next turn's publish
+  re-signs the mapping. Benign and self-healing — no migration step.
+- **Stale cleanup**: the orphan sweep removes `session_pid_<pid>.sig`
+  alongside its `.txt` for dead pids (`session_pid.py`).
+- **Threat model** (full version in the `session_pid_sig.py` module
+  docstring): file forgery, cross-pid replay, tampering, and symlink
+  planting are blocked; deliberate same-uid impersonation via
+  attacker-chosen env in self-launched processes is out of scope (identical
+  capability exists against env-only resolution) and is tracked as the
+  SO_PEERCRED gateway-authentication follow-up (issue #302).
+
 ### Orphan Sweep Active Set
 
 The periodic sweep of `kiro_session_pids.txt` (which kills tracked kiro-cli

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -31,7 +31,6 @@ from kiro_crew.acp.types import (
 from kiro_crew.autonudge import get_instance
 from kiro_crew.config.loader import (
     KiroCrewConfig,
-    config_dir,
     resolve_agent_bindings,
 )
 from kiro_crew.constants import CHAT_TURN_TIMEOUT
@@ -100,7 +99,7 @@ from kiro_crew.dashboard.state import (
     should_queue_refusal_recovery,
     unsafe_bash_reason,
 )
-from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.executors import maintenance_executor, run_in_embed_pool
 from kiro_crew.hooks import (
     HOOK_EVENT_AGENT_SPAWN,
     HOOK_EVENT_POST_TOOL_USE,
@@ -146,6 +145,7 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 from kiro_crew.sel import sel
+from kiro_crew.session_pid_sig import publish_session_pid
 from kiro_crew.slack.handler import post_linked_approval, resolve_linked_approval
 from kiro_crew.stats import Stats
 from kiro_crew.validation import ValidationError, infer_use_case, validate_ask_user_question
@@ -2150,12 +2150,17 @@ async def _run_chat(
         except Exception:  # pragma: no cover — never let UI surfacing kill chat init
             logger.warning("Failed to surface pending MCP OAuth requests", exc_info=True)
 
-        # Write current session key so MCP tools can pass it to spawn API.
-        # Keyed by kiro-cli PID to avoid races between concurrent sessions.
+        # Publish the session_pid_<pid>.txt mapping (plus HMAC sidecar) so MCP
+        # tools can resolve identity. Keyed by kiro-cli PID to avoid races
+        # between concurrent sessions. Offloaded: publish does a key read plus
+        # two atomic_write() replacements — blocking filesystem work that must
+        # not run on the event loop (no-blocking-call-on-event-loop).
         try:
             pid = state.sessions.get_pid(session_key)
             if isinstance(pid, int):
-                (config_dir() / f"session_pid_{pid}.txt").write_text(session_key, encoding="utf-8")
+                await asyncio.get_running_loop().run_in_executor(
+                    maintenance_executor(), publish_session_pid, pid, session_key
+                )
         except Exception:
             pass
 

--- a/src/kiro_crew/mcp_caller.py
+++ b/src/kiro_crew/mcp_caller.py
@@ -211,6 +211,7 @@ class CallerContext:
                 # circular import: config.loader imports mcp_caller top-level
                 # for CallerContext typing; we can only reach config_dir here.
                 from kiro_crew.config.loader import config_dir
+                from kiro_crew.session_pid_sig import read_session_pid_txt
 
                 # Walk the FULL ancestor chain, not
                 # just os.getppid(). The tree can be gateway -> kiro-cli (has
@@ -224,20 +225,22 @@ class CallerContext:
                 # works even when this process's /proc view of pids diverges
                 # from the host's (PID-namespace sandboxing), where the
                 # ancestor walk below can never match.
+                # Reads go through session_pid_sig's hardened reader (symlink
+                # refusal, regular-file check, size bound) — same read
+                # discipline as the strict verifier, minus the signature
+                # requirement.
                 host_pid = os.environ.get("KIROCREW_HOST_PID", "")
                 if host_pid.isdigit():
-                    pid_file = cfg_dir / f"session_pid_{host_pid}.txt"
-                    if pid_file.exists():
-                        sk = pid_file.read_text(encoding="utf-8").strip()
+                    sk = read_session_pid_txt(host_pid, cfg_dir)
+                    if sk:
                         source = "pidfile"
                 if not sk:
                     pid = os.getppid()
                     seen: set[int] = set()
                     while pid > 1 and pid not in seen:
                         seen.add(pid)
-                        pid_file = cfg_dir / f"session_pid_{pid}.txt"
-                        if pid_file.exists():
-                            sk = pid_file.read_text(encoding="utf-8").strip()
+                        sk = read_session_pid_txt(pid, cfg_dir)
+                        if sk:
                             source = "pidfile"
                             break
                         pid = _parent_pid(pid)

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -1789,23 +1789,28 @@ def _resolve_session_key() -> str:
     if sk:
         return sk
     try:
+        from kiro_crew.session_pid_sig import read_session_pid_txt
+
         cfg_dir = config_dir()
         # Sandbox launcher exports its own HOST pid (the pid the gateway keys
         # session_pid files by) — direct lookup works even when this
         # process's pid view diverges from the host's (PID-namespace
         # sandboxing), where the ancestor walk below can never match.
+        # Reads go through session_pid_sig's hardened reader (symlink
+        # refusal, regular-file check, size bound) — same read discipline
+        # as the strict verifier, minus the signature requirement.
         host_pid = os.environ.get("KIROCREW_HOST_PID", "")
         if host_pid.isdigit():
-            pid_file = cfg_dir / f"session_pid_{host_pid}.txt"
-            if pid_file.exists():
-                return pid_file.read_text(encoding="utf-8").strip()
+            key = read_session_pid_txt(host_pid, cfg_dir)
+            if key:
+                return key
         pid = os.getppid()
         seen: set[int] = set()
         while pid > 1 and pid not in seen:
             seen.add(pid)
-            pid_file = cfg_dir / f"session_pid_{pid}.txt"
-            if pid_file.exists():
-                return pid_file.read_text(encoding="utf-8").strip()
+            key = read_session_pid_txt(pid, cfg_dir)
+            if key:
+                return key
             pid = _get_ppid(pid)
     except Exception:
         pass
@@ -1813,20 +1818,48 @@ def _resolve_session_key() -> str:
 
 
 def _resolve_session_key_strict() -> str:
-    """Resolve the session key, refusing PID-walked identities.
+    """Resolve the session key, refusing PID-walked and unsigned identities.
 
-    Like ``_resolve_session_key`` but drops the ``/proc`` ancestor walk:
-    only the gateway-injected ``KIROCREW_SESSION_KEY`` env var is accepted.
-    Returns ``""`` when only the PID-walk would have matched.
+    Like ``_resolve_session_key`` but drops the ``/proc`` ancestor walk.
+    Two identity sources are accepted:
 
-    Required by state-mutating MCP tools. A subagent spawned via
-    ``spawn_run`` lives under the parent slot's process tree, so a
-    PID-walk from its MCP-core child silently resolves to the parent —
-    which would let the subagent mutate state on the wrong slot.
-    Read-only callers (audit, telemetry) keep the lenient resolver
-    where misattribution is harmless.
+    1. The gateway-injected ``KIROCREW_SESSION_KEY`` env var.
+    2. The direct ``KIROCREW_HOST_PID`` -> ``session_pid_<pid>.txt``
+       lookup, but ONLY when the HMAC sidecar written by the gateway
+       verifies (:func:`kiro_crew.session_pid_sig.verify_session_pid`).
+       PID-namespace sandboxing strips ``KIROCREW_SESSION_KEY`` from the
+       sandboxed env, but the sandbox launcher exports its OWN host pid
+       (``sandbox.py``) — exactly the pid the gateway keys
+       ``session_pid_<pid>.txt`` by on session claim. The bare ``.txt``
+       file is agent-writable and therefore forgeable; the sidecar is
+       signed with the SEL trust root (``sel_hmac.key``), which agents
+       cannot read, and binds the pid into the MAC so another pid's
+       pair cannot be replayed. Without this branch,
+       ``monitor_start``/``autonudge_stop``/``set_project`` fail closed
+       in every sandboxed dashboard session even though the session is
+       fully identified.
+
+    Returns ``""`` when only the ``/proc`` ancestor WALK would have
+    matched, or when the sidecar is missing/invalid. The walk stays
+    excluded: a subagent spawned via ``spawn_run`` lives under the
+    parent slot's process tree, so walking ancestors from its MCP-core
+    child silently resolves to the parent — which would let the
+    subagent mutate state on the wrong slot. Read-only callers (audit,
+    telemetry) keep the lenient resolver where misattribution is
+    harmless.
     """
-    return os.environ.get("KIROCREW_SESSION_KEY", "")
+    sk = os.environ.get("KIROCREW_SESSION_KEY", "")
+    if sk:
+        return sk
+    try:
+        host_pid = os.environ.get("KIROCREW_HOST_PID", "")
+        if host_pid.isdigit():
+            from kiro_crew.session_pid_sig import verify_session_pid
+
+            return verify_session_pid(host_pid)
+    except Exception:
+        pass
+    return ""
 
 
 def _vet_messaging_governance(caller_session: str) -> str | None:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -69,6 +69,7 @@ from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.sandbox import prewarm_backend
 from kiro_crew.sel import SecurityEventLog
+from kiro_crew.session_pid_sig import read_session_pid_txt
 
 logger = logging.getLogger(__name__)
 
@@ -1121,10 +1122,12 @@ def _resolve_peer_identity(peer_pid: int) -> tuple[str, list[int]]:
         seen.add(pid)
         chain.append(pid)
         if not session_key:
-            pid_file = cfg_dir / f"session_pid_{pid}.txt"
+            # Hardened read (symlink refusal, regular-file check, size
+            # bound) — gatewayd is a trusted process reading a predictable,
+            # agent-writable path, the exact symlink-planting surface
+            # session_pid_sig's reader exists to close.
             try:
-                if pid_file.exists():
-                    session_key = pid_file.read_text(encoding="utf-8").strip()
+                session_key = read_session_pid_txt(pid, cfg_dir)
             except OSError:
                 pass
         try:

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -189,24 +189,26 @@ def _resolve_excluded_tools() -> set[str]:
                     pass
                 return 0
 
+            from kiro_crew.session_pid_sig import read_session_pid_txt
+
             cfg_dir = config_dir()
             # Sandbox launcher exports its own HOST pid (the pid the gateway
-            # keys session_pid files by) — direct lookup works even when this
-            # process's pid view diverges from the host's (PID-namespace
+            # keys session_pid_<pid>.txt by) — direct lookup works even when
+            # this process's pid view diverges from the host's (PID-namespace
             # sandboxing), where the ancestor walk below can never match.
+            # Reads go through session_pid_sig's hardened reader (symlink
+            # refusal, regular-file check, size bound) — same read discipline
+            # as the strict verifier, minus the signature requirement.
             host_pid = os.environ.get("KIROCREW_HOST_PID", "")
             if host_pid.isdigit():
-                pid_file = cfg_dir / f"session_pid_{host_pid}.txt"
-                if pid_file.exists():
-                    session_key = pid_file.read_text(encoding="utf-8").strip()
+                session_key = read_session_pid_txt(host_pid, cfg_dir)
             if not session_key:
                 pid = os.getppid()
                 seen: set[int] = set()
                 while pid > 1 and pid not in seen:
                     seen.add(pid)
-                    pid_file = cfg_dir / f"session_pid_{pid}.txt"
-                    if pid_file.exists():
-                        session_key = pid_file.read_text(encoding="utf-8").strip()
+                    session_key = read_session_pid_txt(pid, cfg_dir)
+                    if session_key:
                         break
                     pid = _get_ppid(pid)
 

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -867,3 +867,22 @@ def _infer_source(session_key: str) -> str:
 def sel() -> SecurityEventLog:
     """Module-level accessor for the singleton SEL instance."""
     return SecurityEventLog()
+
+
+def sel_hmac_key_path() -> Path:
+    """Canonical on-disk location of the SEL trust-root key (``sel_hmac.key``).
+
+    Single source of truth shared by :class:`SecurityEventLog` (the key's
+    creator/owner) and dependent protocols (``session_pid_sig``) so they can
+    never diverge on which file anchors trust. Tracks the LIVE singleton's
+    directory when one is initialized (tests and embedded deployments pass a
+    ``base_dir``); otherwise falls back to the same default the singleton
+    would use. Dependent protocols must resolve the key through this accessor
+    rather than re-deriving the path (e.g. via ``config_dir()``, which honors
+    ``KIROCREW_HOME`` while ``_DEFAULT_DIR`` does not — resolving differently
+    would split the trust root under isolated-home deployments).
+    """
+    inst = SecurityEventLog._instance
+    if inst is not None and getattr(inst, "_initialized", False):
+        return inst._dir / _HMAC_KEY_FILE
+    return _DEFAULT_DIR / _HMAC_KEY_FILE

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -630,6 +630,10 @@ def cleanup_orphaned_sessions() -> None:
         # os.kill(pid, 0) would terminate the process on Windows — probe instead.
         if not platform_compat.pid_exists(pid):
             pid_file.unlink(missing_ok=True)
+            # Remove the HMAC sidecar (session_pid_<pid>.sig) alongside its
+            # .txt — a dangling sidecar is harmless (verification requires
+            # both) but would accumulate forever.
+            pid_file.with_suffix(".sig").unlink(missing_ok=True)
             stale_pid_files += 1
     if stale_pid_files:
         logger.info("Cleaned up %d stale session PID files", stale_pid_files)

--- a/src/kiro_crew/session_pid_sig.py
+++ b/src/kiro_crew/session_pid_sig.py
@@ -1,0 +1,328 @@
+"""Signed publication and verification of the ``session_pid_<pid>.txt`` contract.
+
+The gateway maps its direct child pid to a session key by writing
+``config_dir()/session_pid_<pid>.txt`` on session claim. Sandboxed identity
+resolvers look the file up directly via the launcher-exported
+``KIROCREW_HOST_PID`` (PID-namespace sandboxing strips ``KIROCREW_SESSION_KEY``
+from the sandboxed env, and renumbers pids so a ``/proc`` walk cannot match).
+
+The bare ``.txt`` file is NOT a trust root: it lives in ``config_dir()`` which
+is same-uid agent-writable, so an agent (or subagent) could forge a mapping for
+its own host pid pointing at another slot's key and cross the session
+authorization boundary. This module makes the mapping authenticated:
+
+* :func:`publish_session_pid` — the ONLY legitimate write path (gateway-side).
+  Writes the ``.txt`` file plus a ``session_pid_<pid>.sig`` sidecar containing
+  an HMAC-SHA256 over ``"<pid>:<session_key>"``, keyed with a subkey **derived
+  from** the SEL trust root (``sel_hmac.key`` — the same key that makes the
+  security event log tamper-evident, and whose reads are deny-listed for agent
+  shells in ``security.py``) via a domain-separation label. The raw root key
+  never signs a sidecar directly, so this protocol and the SEL audit chain
+  never share a signing key.
+* :func:`verify_session_pid` — used by STRICT identity resolvers
+  (state-mutating MCP tools). Returns the session key only when the sidecar
+  verifies; missing/invalid signature fails closed to ``""``.
+
+Why forgery dies: an agent cannot read ``sel_hmac.key`` (deny-listed), so it
+cannot produce a valid sidecar for a forged ``.txt``. Replaying another pid's
+``.txt``/``.sig`` pair under its own pid fails because the pid is bound into
+the MAC. Residual risk (an agent evading the deny-list to read the key) is
+identical to the existing SEL tamper-evidence threat model.
+
+Lenient resolvers (read-only callers where misattribution is harmless) keep
+reading the ``.txt`` without a signature check, but through
+:func:`read_session_pid_txt` (same hardened no-follow read path) — the
+sidecar is additive, no format break.
+
+Threat model — what the sidecar does and does NOT defend against:
+
+* IN SCOPE (blocked): file forgery (agent writes a bare ``.txt`` mapping its
+  own pid to another slot's key — no valid sidecar can be produced without
+  the deny-listed root key), cross-pid replay (copying another pid's
+  ``.txt``/``.sig`` pair — the pid is bound into the MAC), tampering
+  (redirecting a signed ``.txt`` — the old MAC no longer matches), and
+  symlink planting at the predictable paths on BOTH sides: publication uses
+  ``atomic_write``/``os.replace`` (swaps a symlink out rather than following
+  it), and verification opens with ``O_NOFOLLOW`` + regular-file check so a
+  planted symlink can never make the trusted MCP process read a sensitive
+  target (see :func:`_read_regular_nofollow`).
+* OUT OF SCOPE (unchanged from the env-only baseline): a same-uid agent
+  deliberately launching its OWN process with attacker-chosen env
+  (``KIROCREW_HOST_PID=<victim pid>``) to reuse a legitimate sidecar. This
+  is not a capability the sidecar adds — the identical attack defeats
+  env-only resolution (``KIROCREW_SESSION_KEY=<victim key>`` with the key
+  read from the same world-readable ``.txt`` files), and a shell-capable
+  same-uid agent can bypass client-side resolution entirely by minting a
+  local API token. The same equivalence covers STALE-pair replay: an agent
+  retaining a valid ``.txt``/``.sig`` pair and restoring it after the pid
+  is rekeyed to another session needs same-uid write access to
+  ``~/.kirocrew`` — the exact capability that already lets it read the
+  victim key from the pre-existing ``.txt`` and present it via env, so a
+  generation/nonce scheme here would not remove any attacker capability
+  (the publisher overwrites the pair atomically on every rekey, so stale
+  pairs never persist absent that deliberate same-uid interference). No
+  client-side resolver can prove process ownership; within gateway-managed
+  process trees (the strict resolver's actual threat model)
+  ``KIROCREW_HOST_PID`` is launcher-declared, not attacker-chosen.
+  Authenticating the calling process itself (e.g. SO_PEERCRED over a
+  gateway-controlled unix socket) is the stronger, orthogonal follow-up
+  tracked separately.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import stat
+from pathlib import Path
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import config_dir
+from kiro_crew.sel import sel_hmac_key_path
+
+logger = logging.getLogger(__name__)
+
+# Mirrors sel.py: minimum trust-root key length. A shorter key on disk means
+# truncation/corruption/tampering — signing with it would yield a predictable,
+# forgeable MAC, so both publish and verify treat a short key as absent (fail
+# closed on the verify side). The key PATH is not re-derived here: it comes
+# from :func:`kiro_crew.sel.sel_hmac_key_path`, the single source of truth
+# owned by the key's creator, so the sidecar protocol and the SEL audit chain
+# can never resolve different trust-root files (config_dir() honors
+# KIROCREW_HOME while SEL's default dir does not — deriving the path
+# independently would split the trust root under isolated-home deployments).
+_HMAC_KEY_MIN_BYTES = 32
+
+# Domain-separation label. ``sel_hmac.key`` anchors two independent protocols:
+# the SEL audit-log chain (``sel.py``) and this pid -> session-key sidecar. To
+# keep them cryptographically isolated we NEVER sign the sidecar with the raw
+# root key. Instead we derive a purpose-specific subkey via one HMAC step
+# (HKDF-extract-style key separation) keyed by this label. Consequences:
+#   * the two protocols use *different* signing keys, so a MAC minted under one
+#     can never be presented as a valid MAC for the other (no cross-protocol
+#     confusion / replay), even though both roots-of-trust are the same file;
+#   * the label is versioned — bumping it (``.v2``) rotates every sidecar's
+#     effective key without touching the SEL root or on-disk key file.
+# The raw root key is used ONLY as the derivation input, never to sign a
+# sidecar directly.
+_SUBKEY_DOMAIN = b"kirocrew.session_pid.sig.v1"
+
+
+def _txt_path(pid: int | str, cfg: Path) -> Path:
+    return cfg / f"session_pid_{pid}.txt"
+
+
+def _sig_path(pid: int | str, cfg: Path) -> Path:
+    return cfg / f"session_pid_{pid}.sig"
+
+
+def _load_hmac_key() -> bytes | None:
+    """Load the SEL trust-root key; None when absent/short (never creates).
+
+    Only ``SecurityEventLog`` creates the key (gateway boot). Creating it here
+    would let a first-touch race mint a key the SEL then distrusts. The path
+    comes from :func:`kiro_crew.sel.sel_hmac_key_path` so both protocols
+    always anchor on the same file.
+    """
+    try:
+        raw = sel_hmac_key_path().read_bytes()
+    except OSError:
+        return None
+    if len(raw) < _HMAC_KEY_MIN_BYTES:
+        return None
+    return raw
+
+
+def _derive_subkey(root: bytes) -> bytes:
+    """Derive the sidecar-signing subkey from the SEL trust root.
+
+    Domain-separated key derivation: the sidecar MAC key is a one-way function
+    of the SEL root and :data:`_SUBKEY_DOMAIN`, so the sidecar protocol and the
+    SEL audit chain never share a signing key. Reversing the derivation to
+    recover the root is infeasible, and a MAC produced by either protocol is
+    valueless to the other.
+    """
+    return hmac.new(root, _SUBKEY_DOMAIN, hashlib.sha256).digest()
+
+
+def _compute_sig(key: bytes, pid: int | str, session_key: str) -> str:
+    subkey = _derive_subkey(key)
+    return hmac.new(
+        subkey, f"{pid}:{session_key}".encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def publish_session_pid(pid: int, session_key: str) -> None:
+    """Publish the pid -> session-key mapping with its HMAC sidecar.
+
+    Gateway-side only. Writes ``session_pid_<pid>.txt`` (the lenient-reader
+    contract, unchanged) and ``session_pid_<pid>.sig`` (the strict-resolver
+    trust anchor). When the SEL key is unavailable the mapping is published
+    unsigned and any stale sidecar is removed — strict resolvers then fail
+    closed for this pid (pre-sidecar behavior) instead of trusting a
+    signature that no longer matches.
+
+    Both files are written via :func:`kiro_crew.atomic_write.atomic_write`
+    (fresh temp file + ``os.replace``), NEVER an in-place ``write_text``:
+    the destination paths are predictable and live in the same-uid
+    agent-writable config dir, so an agent could pre-plant a symlink at
+    ``session_pid_<pid>.txt``/``.sig`` pointing at an arbitrary writable
+    file — an in-place open would follow it and truncate the target.
+    ``os.replace`` swaps the symlink itself out instead of following it.
+    """
+    cfg = config_dir()
+    atomic_write(_txt_path(pid, cfg), session_key)
+    key = _load_hmac_key()
+    if key is None:
+        logger.warning(
+            "sel_hmac.key unavailable — session_pid_%s published unsigned "
+            "(strict resolvers will refuse this identity)",
+            pid,
+        )
+        try:
+            _sig_path(pid, cfg).unlink(missing_ok=True)
+        except OSError:
+            pass
+        return
+    atomic_write(_sig_path(pid, cfg), _compute_sig(key, pid, session_key))
+
+
+# Upper bound for mapping-file reads. Session keys are short strings
+# (< a few hundred bytes) and the sidecar is a 64-char hex MAC; anything
+# larger is not a legitimate mapping file. Bounding the read means an
+# agent swapping in a huge file cannot make the trusted MCP process
+# buffer it into memory / stall on a synchronous read.
+_MAX_MAPPING_FILE_BYTES = 4096
+
+
+def _read_regular_nofollow(path: Path) -> str | None:
+    """Read *path* as UTF-8, refusing symlinks, non-regular and oversized files.
+
+    The mapping directory is same-uid agent-writable, so an agent could
+    replace ``session_pid_<pid>.txt``/``.sig`` with a symlink to a sensitive
+    file; a plain ``read_text()`` in the trusted MCP process would follow it
+    (bypassing the agent-facing sensitive-path gate). Defenses, in order:
+
+    * ``O_NOFOLLOW`` (POSIX): the open itself refuses a symlink final
+      component — race-free, unlike an ``is_symlink()`` pre-check.
+    * ``lstat`` pre-check + post-open identity check (platforms without
+      ``O_NOFOLLOW``, i.e. Windows): the pre-check refuses a symlink final
+      component before the open, and the opened handle's ``fstat``
+      ``(st_dev, st_ino)`` must match the pre-check's ``lstat``. A swap to
+      a symlink in the lstat->open window makes the open follow the link,
+      so the handle reflects the TARGET file — whose identity cannot match
+      the vetted regular file — and the read is refused. This closes the
+      TOCTOU race without platform-specific open flags (``st_ino`` is the
+      NTFS file index on Windows since Python 3.5).
+    * ``fstat``/``S_ISREG``: rejects FIFOs/devices.
+    * Size bound (:data:`_MAX_MAPPING_FILE_BYTES`, checked against both
+      ``fstat`` and the actual bytes read): rejects oversized files so
+      verification can never buffer unbounded agent-controlled data.
+
+    Returns ``None`` on any refusal or I/O error (callers fail closed).
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    pre: os.stat_result | None = None
+    try:
+        if not nofollow:
+            pre = os.lstat(path)
+            if stat.S_ISLNK(pre.st_mode):
+                return None
+        fd = os.open(path, os.O_RDONLY | nofollow)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if pre is not None and (st.st_dev, st.st_ino) != (pre.st_dev, pre.st_ino):
+            # Path swapped between lstat and open (no-O_NOFOLLOW platforms):
+            # the handle points at a different file than the one vetted as a
+            # non-symlink — a symlink planted in that window would open its
+            # TARGET, which can never share the vetted file's identity.
+            return None
+        if not stat.S_ISREG(st.st_mode) or st.st_size > _MAX_MAPPING_FILE_BYTES:
+            return None
+        chunks = []
+        remaining = _MAX_MAPPING_FILE_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > _MAX_MAPPING_FILE_BYTES:
+            # Grew between fstat and read — treat as hostile.
+            return None
+        return data.decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    finally:
+        os.close(fd)
+
+
+def read_session_pid_txt(pid: int | str, cfg: Path | None = None) -> str:
+    """Return the session key from ``session_pid_<pid>.txt`` WITHOUT signature
+    verification, but through the same hardened read path as the strict
+    verifier (:func:`_read_regular_nofollow`: symlink refusal, regular-file
+    check, size bound).
+
+    This is the LENIENT read: callers that tolerate misattribution (the
+    lenient resolver's warm-pool / ancestor-walk fallback, read-only
+    audit/telemetry attribution) use it so the trusted MCP process never
+    follows a planted symlink on these predictable, same-uid agent-writable
+    paths. State-mutating callers MUST use :func:`verify_session_pid`.
+
+    *cfg* overrides the mapping directory (callers that already resolved
+    ``config_dir()`` pass it through); defaults to :func:`config_dir`.
+    Returns ``""`` on any refusal or I/O error. Never raises.
+    """
+    txt = _read_regular_nofollow(_txt_path(pid, cfg if cfg is not None else config_dir()))
+    return txt.strip() if txt is not None else ""
+
+
+def verify_session_pid(pid: int | str) -> str:
+    """Return the session key for *pid* iff its HMAC sidecar verifies.
+
+    Fails closed to ``""`` on: missing ``.txt``, missing ``.sig``, a symlink
+    or non-regular file at either path (see :func:`_read_regular_nofollow`),
+    missing or short SEL key, or signature mismatch. Never raises.
+    """
+    cfg = config_dir()
+    txt = _read_regular_nofollow(_txt_path(pid, cfg))
+    sig_raw = _read_regular_nofollow(_sig_path(pid, cfg))
+    if txt is None or sig_raw is None:
+        return ""
+    session_key = txt.strip()
+    sig = sig_raw.strip()
+    if not session_key or not sig:
+        return ""
+    key = _load_hmac_key()
+    if key is None:
+        # Distinguishable from the MAC-mismatch warning below: this branch
+        # means the trust root itself is absent/short ON THE VERIFY SIDE —
+        # the signature of a publisher/verifier trust-root split (e.g. SEL
+        # initialized with a custom base_dir in one process only) or a
+        # missing key, NOT forgery. Without this log, a trust-root drift
+        # silently reproduces the original sandboxed-session bug
+        # (strict resolvers fail closed everywhere) while looking
+        # identical to a forgery refusal.
+        logger.warning(
+            "SEL trust-root key absent/short at %s — refusing session_pid_%s "
+            "identity (strict resolvers fail closed; if monitoring is broken "
+            "in sandboxed sessions, check for a publisher/verifier trust-root "
+            "split)",
+            sel_hmac_key_path(),
+            pid,
+        )
+        return ""
+    expected = _compute_sig(key, pid, session_key)
+    if not hmac.compare_digest(expected, sig):
+        logger.warning(
+            "session_pid_%s signature mismatch — refusing identity "
+            "(possible forgery or stale sidecar)",
+            pid,
+        )
+        return ""
+    return session_key

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 from kiro_crew.acp.client import AcpError, AcpProcessDied, AcpPromptBusy, AcpTimeoutError
 from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.config.loader import ACTIVATION_REVIEW, KiroCrewConfig, config_dir, config_path
+from kiro_crew.config.loader import ACTIVATION_REVIEW, KiroCrewConfig, config_path
 from kiro_crew.context import (
     ContextBuilder,
     build_cancelled_turn_preamble,
@@ -45,7 +45,7 @@ from kiro_crew.context import (
     window_for_provider_client,
 )
 from kiro_crew.cron import CronService, compute_next_run_ts, format_schedule, get_local_tz
-from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.executors import maintenance_executor, run_in_embed_pool
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import (
     HOOK_REPLY,
@@ -77,6 +77,7 @@ from kiro_crew.security import (
 )
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionManager
+from kiro_crew.session_pid_sig import publish_session_pid
 from kiro_crew.slack.blocks import build_working_blocks, deprecation_warning_block
 from kiro_crew.slack.client import SlackClientOps
 from kiro_crew.slack.format import (
@@ -2891,12 +2892,17 @@ async def handle_message(
             resumed,
         )
 
-        # Write current session key so MCP tools can pass it to spawn API.
-        # Keyed by kiro-cli PID to avoid races between concurrent sessions.
+        # Publish the session_pid_<pid>.txt mapping (plus HMAC sidecar) so MCP
+        # tools can resolve identity. Keyed by kiro-cli PID to avoid races
+        # between concurrent sessions. Offloaded: publish does a key read plus
+        # two atomic_write() replacements — blocking filesystem work that must
+        # not run on the event loop (no-blocking-call-on-event-loop).
         try:
             pid = sessions.get_pid(session_key)
             if isinstance(pid, int):
-                (config_dir() / f"session_pid_{pid}.txt").write_text(session_key, encoding="utf-8")
+                await asyncio.get_running_loop().run_in_executor(
+                    maintenance_executor(), publish_session_pid, pid, session_key
+                )
         except Exception:
             pass
 

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -359,6 +359,85 @@ def test_gatewayd_peer_identity_resolves_via_host_walk(topo, monkeypatch) -> Non
 
 
 # ---------------------------------------------------------------------------
+# Hardened-reader wiring: every registered .txt reader must refuse a planted
+# symlink at the predictable session_pid_<pid>.txt path (same-uid agent
+# symlink-planting — the surface session_pid_sig.read_session_pid_txt
+# closes). mcp_core's refusal is locked in test_resolve_session_key.py;
+# these lock the remaining three readers.
+# ---------------------------------------------------------------------------
+
+
+def _plant_symlink(topo, host_pid: int) -> None:
+    """Replace the mapping file for *host_pid* with a symlink to a secret."""
+    secret = topo.cfg_dir / "victim-secret"
+    secret.write_text("dashboard:chat-stolen", encoding="utf-8")
+    txt = topo.cfg_dir / f"session_pid_{host_pid}.txt"
+    txt.unlink(missing_ok=True)
+    txt.symlink_to(secret)
+
+
+def test_from_env_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
+    from kiro_crew import mcp_caller
+
+    _plant_symlink(topo, SESSION_HOST)
+    _wire_common(monkeypatch, topo, "host")
+    monkeypatch.setattr(mcp_caller, "_parent_pid", topo.parent_lookup("host"))
+    monkeypatch.setattr(
+        "kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir
+    )
+
+    ctx = mcp_caller.CallerContext.from_env()
+    assert ctx.session_key == ""
+
+
+def test_mcp_shared_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
+    from kiro_crew import mcp_shared
+
+    monkeypatch.setattr(mcp_shared, "_excluded_tools", None)
+    monkeypatch.setattr(mcp_shared, "_last_failure_time", 0.0)
+    monkeypatch.setattr(mcp_shared, "_last_startup_race_time", 0.0)
+    monkeypatch.setattr(mcp_shared, "_failure_count", 0)
+
+    cfg = MagicMock()
+    cfg.dashboard.url = "http://localhost:5476/"
+    monkeypatch.setattr(
+        mcp_shared.KiroCrewConfig, "load", classmethod(lambda cls: cfg)
+    )
+    monkeypatch.setattr(mcp_shared, "parse_dashboard_url", lambda url: ("localhost", 5476))
+    monkeypatch.setattr(mcp_shared, "config_dir", lambda: topo.cfg_dir)
+    (topo.cfg_dir / ".local_secret").write_text("s")
+
+    # Symlink at the DIRECT parent's path (where the resolvable-case test
+    # plants a real file) plus one at the fixture-written SESSION_HOST path,
+    # so no ancestor resolves via a symlink.
+    _plant_symlink(topo, SESSION_HOST)
+    _plant_symlink(topo, KIRO_CLI)
+    _wire_common(monkeypatch, topo, "host")
+
+    urlopen = MagicMock()
+    monkeypatch.setattr(mcp_shared.urllib.request, "urlopen", urlopen)
+
+    # No key resolvable -> startup-race fail-open WITHOUT a policy call and,
+    # crucially, WITHOUT the stolen key ever being read through the symlink.
+    assert mcp_shared._resolve_excluded_tools() == set()
+    assert not urlopen.called
+
+
+def test_gatewayd_peer_identity_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
+    from kiro_crew.mcp_gateway import gatewayd as gw
+
+    _plant_symlink(topo, SESSION_HOST)
+    monkeypatch.setattr(gw, "_config_dir", lambda: topo.cfg_dir)
+    monkeypatch.setattr(gw, "_ppid_fn", topo.parent_lookup("host"))
+
+    key, chain = gw._resolve_peer_identity(MCP_SERVER)
+    assert key == ""
+    # The chain must remain complete for claim indexing even when the key
+    # is refused — identity repair happens later via claim-push.
+    assert chain == [MCP_SERVER, KIRO_CLI, SESSION_HOST, GATEWAY]
+
+
+# ---------------------------------------------------------------------------
 # Call-site registry guard
 # ---------------------------------------------------------------------------
 # Every file referencing the session_pid_<pid>.txt contract must be listed
@@ -372,20 +451,48 @@ _SESSION_PID_TOKEN = re.compile(r"session_pid_(\{|\*|<)")
 
 #: file (relative to src/kiro_crew) -> declared role / namespace assumption
 _REGISTERED_CALL_SITES: dict[str, str] = {
-    "dashboard/chat_runner.py": "writer: keys the file by the HOST pid of the spawned session process",
-    "slack/handler.py": "writer: keys the file by the HOST pid of the spawned session process",
-    "mcp_caller.py": "reader: client-side /proc ancestry walk — assumes caller sees HOST pids",
-    "mcp_core.py": "reader: /proc ancestry walk + stale-file cleanup glob — assumes HOST pids",
+    "dashboard/chat_runner.py": (
+        "writer via session_pid_sig.publish_session_pid — keys the "
+        "session_pid_<pid>.txt file (plus HMAC sidecar) by the HOST pid of "
+        "the spawned session process"
+    ),
+    "slack/handler.py": (
+        "writer via session_pid_sig.publish_session_pid — keys the "
+        "session_pid_<pid>.txt file (plus HMAC sidecar) by the HOST pid of "
+        "the spawned session process"
+    ),
+    "session_pid_sig.py": (
+        "canonical owner of the file contract — writer, strict verifier, "
+        "and lenient hardened reader: publishes session_pid_<pid>.txt with "
+        "an HMAC-SHA256 sidecar (session_pid_<pid>.sig, keyed by the "
+        "SEL trust root sel_hmac.key), verifies it for strict resolvers "
+        "(pid bound into the MAC), and exposes read_session_pid_txt "
+        "(no-follow, regular-file, size-bounded; unsigned) for lenient "
+        "readers — HOST-pid keyed"
+    ),
+    "mcp_caller.py": (
+        "reader: client-side /proc ancestry walk — assumes HOST pids; .txt "
+        "reads via session_pid_sig.read_session_pid_txt (hardened, unsigned)"
+    ),
+    "mcp_core.py": (
+        "reader: lenient /proc ancestry walk + stale-file cleanup glob "
+        "(assumes HOST pids), .txt reads via "
+        "session_pid_sig.read_session_pid_txt (hardened, unsigned); STRICT "
+        "path delegates to session_pid_sig.verify_session_pid "
+        "(HMAC-verified, direct KIROCREW_HOST_PID lookup, no walk)"
+    ),
     "mcp_shared.py": (
         "reader: policy session-key /proc ancestry walk inline in "
-        "_resolve_excluded_tools — assumes HOST pids"
+        "_resolve_excluded_tools — assumes HOST pids; .txt reads via "
+        "session_pid_sig.read_session_pid_txt (hardened, unsigned)"
     ),
     "mcp_gateway/stub.py": "reader via CallerContext.from_env; register-time caller block — assumes HOST pids",
     "mcp_gateway/gatewayd.py": (
         "reader: SERVER-side /proc ancestry walk from the SO_PEERCRED peer pid "
         "(_resolve_peer_identity) — runs in gatewayd's own (host) pid namespace, "
         "so it is immune to client-side namespace divergence; also indexes the "
-        "host ancestor chain for claim-push matching"
+        "host ancestor chain for claim-push matching; .txt reads via "
+        "session_pid_sig.read_session_pid_txt (hardened, unsigned)"
     ),
     "sandbox.py": (
         "writer-adjacent: launcher exports KIROCREW_HOST_PID (its own HOST pid — "
@@ -393,7 +500,7 @@ _REGISTERED_CALL_SITES: dict[str, str] = {
         "so in-namespace readers can look the file up directly without a /proc walk"
     ),
     "mcp_gateway/claim.py": "docstring reference to the contract (no code reads)",
-    "session_pid.py": "stale-file cleanup: globs session_pid_*.txt for dead processes",
+    "session_pid.py": "stale-file cleanup: globs session_pid_*.txt (+ .sig sidecars) for dead processes",
 }
 
 

--- a/test/test_mcp_core_set_project.py
+++ b/test/test_mcp_core_set_project.py
@@ -20,8 +20,27 @@ from kiro_crew import mcp_core
 
 
 class TestResolveSessionKeyStrict:
-    """Strict resolver: only the ``KIROCREW_SESSION_KEY`` env var produces a
-    value. The PID-walk fallback that the lenient resolver uses is dropped."""
+    """Strict resolver: the ``KIROCREW_SESSION_KEY`` env var, or the direct
+    ``KIROCREW_HOST_PID`` -> ``session_pid_<pid>.txt`` lookup — the latter
+    ONLY when the gateway-written HMAC sidecar verifies. The /proc ancestor
+    WALK the lenient resolver uses is dropped, and an unsigned or forged
+    file is refused."""
+
+    def _signed_env(self, monkeypatch, tmp_path, pid: str, session_key: str):
+        """Simulate the sandbox: env key stripped, HOST_PID set, and a
+        gateway-published (signed) mapping on disk."""
+        from kiro_crew import session_pid_sig
+
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", pid)
+        (tmp_path / "sel_hmac.key").write_bytes(b"k" * 32)
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            session_pid_sig.publish_session_pid(int(pid), session_key)
 
     def test_env_var_used(self, monkeypatch):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:slot-B")
@@ -31,7 +50,132 @@ class TestResolveSessionKeyStrict:
         """Lenient resolver would walk /proc and find a session_pid_*.txt;
         strict returns "" so the caller can refuse."""
         monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
         assert mcp_core._resolve_session_key_strict() == ""
+
+    def test_env_var_wins_over_host_pid(self, monkeypatch, tmp_path):
+        """When both identities are present the env var is authoritative."""
+        from kiro_crew import session_pid_sig
+
+        self._signed_env(monkeypatch, tmp_path, "4242", "dashboard:file-slot")
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:env-slot")
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert mcp_core._resolve_session_key_strict() == "dashboard:env-slot"
+
+    def test_signed_host_pid_mapping_accepted(self, monkeypatch, tmp_path):
+        """Sandboxed session: env key stripped, launcher-declared HOST_PID
+        maps to a gateway-published signed mapping — accepted."""
+        from kiro_crew import session_pid_sig
+
+        self._signed_env(
+            monkeypatch, tmp_path, "4242", "dashboard:chat-32-1784855955"
+        )
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert (
+                mcp_core._resolve_session_key_strict()
+                == "dashboard:chat-32-1784855955"
+            )
+
+    def test_unsigned_host_pid_file_refused(self, monkeypatch, tmp_path):
+        """FORGERY: an agent writes a bare session_pid_<pid>.txt pointing at
+        another slot's key. Without the HMAC sidecar (which requires the
+        agent-unreadable SEL key) the strict resolver must refuse."""
+        from kiro_crew import session_pid_sig
+
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "4242")
+        (tmp_path / "sel_hmac.key").write_bytes(b"k" * 32)
+        (tmp_path / "session_pid_4242.txt").write_text(
+            "dashboard:victim-slot", encoding="utf-8"
+        )
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert mcp_core._resolve_session_key_strict() == ""
+
+    def test_replayed_sidecar_for_other_pid_refused(self, monkeypatch, tmp_path):
+        """REPLAY: a subagent copies the parent's .txt/.sig pair under its own
+        pid. The pid is bound into the MAC, so verification must fail."""
+        from kiro_crew import session_pid_sig
+
+        (tmp_path / "sel_hmac.key").write_bytes(b"k" * 32)
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            # Gateway legitimately publishes the PARENT's mapping (pid 1000).
+            session_pid_sig.publish_session_pid(1000, "dashboard:parent-slot")
+        # Subagent (host pid 2000) replays the parent's pair under its own pid.
+        for ext in ("txt", "sig"):
+            (tmp_path / f"session_pid_2000.{ext}").write_text(
+                (tmp_path / f"session_pid_1000.{ext}").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "2000")
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert mcp_core._resolve_session_key_strict() == ""
+
+    def test_host_pid_without_file_returns_empty(self, monkeypatch, tmp_path):
+        """A subagent sandbox exports its own HOST_PID, but the gateway never
+        writes a session_pid file for it — strict must refuse, not walk."""
+        from kiro_crew import session_pid_sig
+
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "5555")
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert mcp_core._resolve_session_key_strict() == ""
+
+    def test_non_numeric_host_pid_ignored(self, monkeypatch, tmp_path):
+        """Malformed HOST_PID (path traversal, garbage) never reaches the
+        filesystem lookup."""
+        from kiro_crew import session_pid_sig
+
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "../../etc/passwd")
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            assert mcp_core._resolve_session_key_strict() == ""
+
+    def test_verifier_failure_returns_empty(self, monkeypatch):
+        """Any error inside verification fails closed to ''."""
+        from kiro_crew import session_pid_sig
+
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "4242")
+        with patch.object(
+            session_pid_sig, "verify_session_pid", side_effect=OSError("boom")
+        ):
+            assert mcp_core._resolve_session_key_strict() == ""
 
 
 # ───────────────────────────── set_project tool ─────────────────────────────

--- a/test/test_resolve_session_key.py
+++ b/test/test_resolve_session_key.py
@@ -93,6 +93,21 @@ class TestResolveSessionKey:
         ):
             assert _resolve_session_key() == ""
 
+    def test_symlinked_pid_file_refused(self, tmp_path):
+        """SYMLINK ATTACK on the lenient path: session_pid_<pid>.txt replaced
+        by a symlink to a sensitive file must NOT be followed — the lenient
+        resolver reads through session_pid_sig's hardened no-follow reader
+        (same discipline as the strict verifier, minus the signature)."""
+        secret = tmp_path / "victim-secret"
+        secret.write_text("dashboard:chat-stolen", encoding="utf-8")
+        ppid = os.getppid()
+        (tmp_path / f"session_pid_{ppid}.txt").symlink_to(secret)
+        env = {k: v for k, v in os.environ.items() if k != "KIROCREW_SESSION_KEY"}
+        with patch.dict("os.environ", env, clear=True), patch(
+            "kiro_crew.mcp_core.config_dir", return_value=tmp_path
+        ), patch("kiro_crew.mcp_core._get_ppid", return_value=0):
+            assert _resolve_session_key() == ""
+
     def test_handles_cycle_detection(self, tmp_path):
         """Stops if PID chain forms a cycle (prevents infinite loop)."""
 

--- a/test/test_session_pid_sig.py
+++ b/test/test_session_pid_sig.py
@@ -1,0 +1,263 @@
+"""Tests for :mod:`kiro_crew.session_pid_sig` — signed session_pid publication.
+
+The ``session_pid_<pid>.txt`` file is same-uid agent-writable, so the strict
+identity path must not trust it bare. These tests lock in the sidecar
+contract: publish writes ``.txt`` + HMAC ``.sig`` (keyed by the SEL trust
+root); verify accepts only a matching pair and fails closed on every
+tamper/degradation path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import session_pid_sig
+
+SESSION_KEY = "dashboard:chat-7-123456"
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    """Isolated config dir with a valid SEL trust-root key. Patches both the
+    mapping-file dir (config_dir) and the canonical trust-root path accessor
+    (sel_hmac_key_path — single source of truth owned by sel.py)."""
+    (tmp_path / "sel_hmac.key").write_bytes(b"\x01" * 32)
+    with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+         patch.object(
+             session_pid_sig,
+             "sel_hmac_key_path",
+             return_value=tmp_path / "sel_hmac.key",
+         ):
+        yield tmp_path
+
+
+class TestPublish:
+    def test_writes_txt_and_sig(self, cfg):
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert (cfg / "session_pid_4242.txt").read_text(encoding="utf-8") == SESSION_KEY
+        sig = (cfg / "session_pid_4242.sig").read_text(encoding="utf-8")
+        assert len(sig) == 64 and all(c in "0123456789abcdef" for c in sig)
+
+    def test_publish_without_key_writes_unsigned_and_drops_stale_sig(self, cfg):
+        """SEL key missing: txt still published (lenient readers keep
+        working) but any stale sidecar is removed so a rekeyed mapping can
+        never verify against an old signature."""
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)  # signed
+        (cfg / "sel_hmac.key").unlink()
+        session_pid_sig.publish_session_pid(4242, "dashboard:rekeyed")
+        assert (
+            cfg / "session_pid_4242.txt"
+        ).read_text(encoding="utf-8") == "dashboard:rekeyed"
+        assert not (cfg / "session_pid_4242.sig").exists()
+
+    def test_rekey_overwrites_both_files(self, cfg):
+        session_pid_sig.publish_session_pid(4242, "dashboard:old")
+        old_sig = (cfg / "session_pid_4242.sig").read_text(encoding="utf-8")
+        session_pid_sig.publish_session_pid(4242, "dashboard:new")
+        assert session_pid_sig.verify_session_pid(4242) == "dashboard:new"
+        assert (cfg / "session_pid_4242.sig").read_text(encoding="utf-8") != old_sig
+
+    def test_preplanted_symlink_not_followed(self, cfg):
+        """SYMLINK ATTACK: an agent plants symlinks at the predictable
+        mapping paths pointing at another writable file. Publication must
+        replace the symlink (os.replace semantics), never follow it and
+        truncate the target."""
+        victim = cfg / "victim.dat"
+        victim.write_text("precious", encoding="utf-8")
+        for name in ("session_pid_4242.txt", "session_pid_4242.sig"):
+            (cfg / name).symlink_to(victim)
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        # Victim untouched; both paths are now regular files, not symlinks.
+        assert victim.read_text(encoding="utf-8") == "precious"
+        assert not (cfg / "session_pid_4242.txt").is_symlink()
+        assert not (cfg / "session_pid_4242.sig").is_symlink()
+        assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+
+
+class TestVerify:
+    def test_round_trip(self, cfg):
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+        # str pid (as read from KIROCREW_HOST_PID) verifies identically.
+        assert session_pid_sig.verify_session_pid("4242") == SESSION_KEY
+
+    def test_missing_files_refused(self, cfg):
+        assert session_pid_sig.verify_session_pid(9999) == ""
+
+    def test_unsigned_txt_refused(self, cfg):
+        """FORGERY: bare .txt written without the SEL key."""
+        (cfg / "session_pid_4242.txt").write_text(
+            "dashboard:victim", encoding="utf-8"
+        )
+        assert session_pid_sig.verify_session_pid(4242) == ""
+
+    def test_tampered_txt_refused(self, cfg):
+        """FORGERY: legitimate pair, then the .txt is redirected at another
+        slot — the old signature no longer matches."""
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "session_pid_4242.txt").write_text(
+            "dashboard:victim", encoding="utf-8"
+        )
+        assert session_pid_sig.verify_session_pid(4242) == ""
+
+    def test_replayed_pair_under_other_pid_refused(self, cfg):
+        """REPLAY: parent's .txt/.sig copied under a different pid — the pid
+        is bound into the MAC."""
+        session_pid_sig.publish_session_pid(1000, "dashboard:parent")
+        for ext in ("txt", "sig"):
+            (cfg / f"session_pid_2000.{ext}").write_text(
+                (cfg / f"session_pid_1000.{ext}").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+        assert session_pid_sig.verify_session_pid(2000) == ""
+
+    def test_short_key_refused(self, cfg):
+        """A truncated/corrupted trust-root key must not verify anything."""
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "sel_hmac.key").write_bytes(b"\x01" * 8)
+        assert session_pid_sig.verify_session_pid(4242) == ""
+
+    def test_missing_key_refused(self, cfg, caplog):
+        """Missing trust root refuses AND emits the trust-root diagnostic —
+        distinguishable from the forgery (MAC-mismatch) warning so a
+        publisher/verifier trust-root split doesn't silently reproduce the
+        original sandboxed-session bug while looking like forgery refusal."""
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "sel_hmac.key").unlink()
+        with caplog.at_level("WARNING", logger=session_pid_sig.logger.name):
+            assert session_pid_sig.verify_session_pid(4242) == ""
+        assert any(
+            "trust-root key absent/short" in r.getMessage() for r in caplog.records
+        )
+
+    def test_symlinked_mapping_files_refused_on_read(self, cfg):
+        """READ-SIDE SYMLINK ATTACK: after a legitimate publish, an agent
+        swaps a mapping file for a symlink to a sensitive target. The
+        trusted verifier must refuse (O_NOFOLLOW) — never follow the link
+        and read the target."""
+        secret = cfg / "secret.dat"
+        secret.write_text("sensitive-content", encoding="utf-8")
+        # Symlinked .txt refused.
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "session_pid_4242.txt").unlink()
+        (cfg / "session_pid_4242.txt").symlink_to(secret)
+        assert session_pid_sig.verify_session_pid(4242) == ""
+        # Symlinked .sig refused (fresh legitimate pair first).
+        session_pid_sig.publish_session_pid(5555, SESSION_KEY)
+        (cfg / "session_pid_5555.sig").unlink()
+        (cfg / "session_pid_5555.sig").symlink_to(secret)
+        assert session_pid_sig.verify_session_pid(5555) == ""
+
+    def test_oversized_mapping_file_refused(self, cfg):
+        """RESOURCE ATTACK: an agent swaps a mapping file for a huge one.
+        Verification must reject it from fstat size, never buffer it."""
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "session_pid_4242.txt").write_text(
+            "x" * (session_pid_sig._MAX_MAPPING_FILE_BYTES + 1), encoding="utf-8"
+        )
+        assert session_pid_sig.verify_session_pid(4242) == ""
+
+
+class TestLenientReader:
+    """``read_session_pid_txt`` is the lenient (unsigned) read for callers
+    that tolerate misattribution — but it MUST share the strict verifier's
+    hardened read discipline: a planted symlink or non-regular file at the
+    predictable agent-writable path is refused, never followed."""
+
+    def test_reads_plain_txt_without_sig(self, cfg):
+        (cfg / "session_pid_4242.txt").write_text(SESSION_KEY, encoding="utf-8")
+        assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+        # Explicit cfg passthrough (lenient resolver passes its own dir).
+        assert session_pid_sig.read_session_pid_txt("4242", cfg) == SESSION_KEY
+
+    def test_missing_file_returns_empty(self, cfg):
+        assert session_pid_sig.read_session_pid_txt(9999) == ""
+
+    def test_symlinked_txt_refused(self, cfg, tmp_path):
+        """SYMLINK ATTACK on the lenient path: without the hardened reader a
+        plain read_text() in the trusted MCP process would follow this link
+        (the read-side twin of the strict-path defense)."""
+        secret = tmp_path / "victim-secret"
+        secret.write_text("hunter2", encoding="utf-8")
+        (cfg / "session_pid_4242.txt").symlink_to(secret)
+        assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+    def test_oversized_txt_refused(self, cfg):
+        (cfg / "session_pid_4242.txt").write_text(
+            "x" * (session_pid_sig._MAX_MAPPING_FILE_BYTES + 1), encoding="utf-8"
+        )
+        assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+
+class TestNoNofollowPlatform:
+    """Platforms without ``O_NOFOLLOW`` (Windows) use an ``lstat`` pre-check
+    plus a post-open ``(st_dev, st_ino)`` identity check. The identity check
+    closes the lstat->open TOCTOU window: a path swapped to a symlink in
+    that window opens the symlink's TARGET, whose identity can never match
+    the vetted regular file. Simulated on POSIX by removing ``O_NOFOLLOW``."""
+
+    def test_regular_file_still_reads(self, cfg, monkeypatch):
+        monkeypatch.delattr("os.O_NOFOLLOW")
+        (cfg / "session_pid_4242.txt").write_text(SESSION_KEY, encoding="utf-8")
+        assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+
+    def test_lstat_open_swap_refused(self, cfg, monkeypatch, tmp_path):
+        """TOCTOU RACE: the file vetted by lstat is not the file the open
+        lands on (as when an agent swaps in a symlink between the two
+        calls). Simulated by pointing lstat at a decoy file so the opened
+        handle's identity mismatches the vetted one."""
+        import os as _os
+
+        monkeypatch.delattr("os.O_NOFOLLOW")
+        target = cfg / "session_pid_4242.txt"
+        target.write_text(SESSION_KEY, encoding="utf-8")
+        decoy = tmp_path / "vetted-then-swapped"
+        decoy.write_text("x", encoding="utf-8")
+        real_lstat = _os.lstat
+        monkeypatch.setattr(
+            "os.lstat", lambda p, *a, **k: real_lstat(decoy)
+        )
+        assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+    def test_symlink_present_at_lstat_refused(self, cfg, monkeypatch, tmp_path):
+        """The pre-check itself still refuses a symlink already in place."""
+        monkeypatch.delattr("os.O_NOFOLLOW")
+        secret = tmp_path / "victim-secret"
+        secret.write_text("hunter2", encoding="utf-8")
+        (cfg / "session_pid_4242.txt").symlink_to(secret)
+        assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+
+class TestDomainSeparation:
+    """The sidecar and the SEL audit chain share one on-disk trust-root key
+    (``sel_hmac.key``) but MUST NOT share a signing key: the sidecar signs
+    with a subkey *derived* from the root via a domain-separation label, so a
+    MAC from one protocol can never be presented as a valid MAC for the
+    other."""
+
+    def test_sig_is_not_signed_with_raw_root_key(self, cfg):
+        import hashlib
+        import hmac
+
+        root = b"\x01" * 32
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        stored = (cfg / "session_pid_4242.sig").read_text(encoding="utf-8")
+
+        # A MAC computed with the RAW root key (the SEL scheme) must differ
+        # from the stored sidecar MAC — proving the root key is not used
+        # directly to sign the sidecar.
+        raw_mac = hmac.new(
+            root, f"4242:{SESSION_KEY}".encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        assert stored != raw_mac
+
+        # The stored MAC matches the DERIVED-subkey scheme.
+        subkey = hmac.new(
+            root, session_pid_sig._SUBKEY_DOMAIN, hashlib.sha256
+        ).digest()
+        derived_mac = hmac.new(
+            subkey, f"4242:{SESSION_KEY}".encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        assert stored == derived_mac

--- a/test/test_slack_agent_passthrough.py
+++ b/test/test_slack_agent_passthrough.py
@@ -63,7 +63,7 @@ class TestAgentPassthrough:
     async def test_channel_agent_passed(self):
         slack, sessions, ctx = _make_mocks()
 
-        with patch("kiro_crew.slack.handler.config_dir", return_value=MagicMock()):
+        with patch("kiro_crew.slack.handler.publish_session_pid"):
             await handle_message(
                 slack=slack,
                 sessions=sessions,
@@ -89,7 +89,7 @@ class TestAgentPassthrough:
         from kiro_crew.slack import handler
         handler._cached_default_agent = ""
 
-        with patch("kiro_crew.slack.handler.config_dir", return_value=MagicMock()):
+        with patch("kiro_crew.slack.handler.publish_session_pid"):
             await handle_message(
                 slack=slack,
                 sessions=sessions,


### PR DESCRIPTION
## Problem

`monitor_start`, `autonudge_stop`, and `set_project` fail closed with `session_key=''` in **every sandboxed dashboard session**, forcing noisy external cron fallbacks for PR monitoring.

## Why it matters

Same-session monitoring (the preferred babysit pattern) is unusable from sandboxed sessions; every monitoring loop degrades to a fresh-session cron that posts out-of-context "Cron Job Result" reports.

## Fix (symptom → root cause → change)

**Symptom:** strict identity resolution returns `''` in sandboxed sessions.
**Root cause:** `_resolve_session_key_strict()` accepted only the `KIROCREW_SESSION_KEY` env var — but PID-namespace sandboxing strips that var. The sandbox launcher (`sandbox.py`) exports `KIROCREW_HOST_PID` (its **own** pid — exactly the pid the gateway keys `session_pid_<pid>.txt` by on session claim). Confirmed live: env key empty, `KIROCREW_HOST_PID=25979`, `session_pid_25979.txt` → a fully-identified `dashboard:chat-*` key. Warm pool ruled out (`session.pool_size=0`).
**Change:** the strict resolver accepts the direct host-pid lookup — but **only when an HMAC sidecar written by the gateway verifies**. The bare `.txt` is same-uid agent-writable and therefore forgeable (GPT 5.6 review HIGH — a valid finding, addressed as follows):

- New `session_pid_sig` module: `publish_session_pid()` writes `session_pid_<pid>.txt` plus `session_pid_<pid>.sig` = HMAC-SHA256 over `"<pid>:<session_key>"`, keyed by the SEL trust root (`sel_hmac.key`, the same key that makes the security event log tamper-evident; agent reads of it are deny-listed in `security.py`). `verify_session_pid()` returns the key only for a valid pair — failing closed on missing/short key, missing files, or mismatch.
- Both legitimate writers (`dashboard/chat_runner.py`, `slack/handler.py`) now route through the shared helper (also removes the duplicated publish snippet).
- The `/proc` ancestor walk stays excluded from the strict path.
- **Why forgery dies:** an agent cannot read `sel_hmac.key` to sign a forged mapping; replaying another pid's `.txt`/`.sig` pair fails because the pid is bound into the MAC. Residual risk (an agent evading the deny-list to read the key) is identical to the existing SEL tamper-evidence threat model.
- **Why env injection is not sufficient instead:** session keys change over a process's lifetime (rekey without respawn), so a spawn-time env var can never be authoritative — the PID file is the freshness carrier; the sidecar adds the missing authenticity.
- Stale-file sweep (`session_pid.py`) now removes orphaned `.sig` sidecars; identity-topology call-site registry updated.

- **Hardened read path for the whole file family:** `read_session_pid_txt()` (no-follow open, `lstat` pre-check, regular-file check, 4 KB size bound) is the single lenient reader; every `.txt` read site routes through it — `mcp_core._resolve_session_key`, `mcp_shared._resolve_excluded_tools`, `mcp_caller.CallerContext.from_env` (also serving `mcp_gateway/stub.py`), and `mcp_gateway/gatewayd._resolve_peer_identity`. No bare `read_text()` remains on these agent-writable paths.
- **No-`O_NOFOLLOW` (Windows) TOCTOU closed:** the pre-open `lstat` is now paired with a post-open `(st_dev, st_ino)` identity check — a path swapped to a symlink between `lstat` and `open` lands on the link's target, whose identity cannot match the vetted file, so the read is refused (portable stdlib; no platform-specific open flags).
- **Event-loop safety:** `publish_session_pid` (key read + two `atomic_write`s) is offloaded via `maintenance_executor()` at both async publish sites (`chat_runner`, `slack/handler`) per `no-blocking-call-on-event-loop`.
- **Threat model documented in-module:** IN SCOPE (forgery, cross-pid replay, tampering, symlink planting on read+write) vs OUT OF SCOPE (same-uid attacker-chosen env / stale-pair replay after rekey — equivalent capability already defeats env-only resolution; real caller authentication via SO_PEERCRED tracked as #302).

## Tests

- 20+ tests in `test/test_session_pid_sig.py` (publish/verify, lenient reader symlink/size refusal, no-`O_NOFOLLOW` swap-race refusal, domain separation): publish/verify round-trip (int + str pid), forged bare `.txt` refused, tampered `.txt` refused, cross-pid replay refused, short/missing trust-root key refused, unsigned-degrade drops stale sidecars, rekey rotates the signature.
- 9 strict-resolver tests in `test/test_mcp_core_set_project.py`: env precedence, signed mapping accepted, **unsigned file refused (forgery)**, **replayed pair refused**, subagent no-file refusal, malformed-pid rejection, fail-closed on verifier errors.
- Existing suites updated: `test_slack_agent_passthrough.py` patch target; `test_identity_topology.py` call-site registry + new hardened-reader wiring section (each migrated reader refuses a planted symlink; gatewayd keeps the host chain complete for claim indexing when the key is refused); `test_resolve_session_key.py` lenient-path symlink refusal.

All 5 local gates green: flake8, isort, CI-parity mypy (444 files), pytest **16,069 passed** (`-n 8`; 2 known host-environment failures, identical on main), tsc + vitest **4,115 passed**.

## Manual verification

Root cause was confirmed live from a sandboxed dashboard session before the fix (empty env key, host-pid file resolving to the real session). Post-merge, `monitor_start` from a sandboxed dashboard session is the end-to-end check.

## Screenshots

N/A — no user-visible UI change.

