### PR TITLE
fix(sidebar): hide CI status icons on merged PR chips

### DIFF
--- a/website/integration/ChatSidebar.integration.test.tsx
+++ b/website/integration/ChatSidebar.integration.test.tsx
@@ -116,6 +116,27 @@ describe('ChatSidebar Folder Grouping', () => {
     expect(githubChip).not.toHaveTextContent('Merged')
   })
 
+  it('hides CI status icons on merged pull request chips', async () => {
+    const slotsWithSources = [
+      {
+        ...baseSlots[0],
+        source_links: [
+          { provider: 'github' as const, number: 284, url: 'https://github.com/kirodotdev/KiroCrew/pull/284', state: 'merged' as const, ci: 'passed' as const },
+          { provider: 'github' as const, number: 285, url: 'https://github.com/kirodotdev/KiroCrew/pull/285', state: 'open' as const, ci: 'passed' as const },
+        ],
+      },
+    ]
+    renderWithProviders(<ChatSidebar {...defaultProps} slots={slotsWithSources} />)
+
+    const mergedChip = (await screen.findByText('#284')).closest('span')
+    const openChip = screen.getByText('#285').closest('span')
+    // Merged chip keeps the merge icon but drops the CI check — merged is terminal.
+    expect(mergedChip?.querySelector('[aria-label="Merged"]')).toBeInTheDocument()
+    expect(mergedChip?.querySelector('[aria-label="Checks passed"]')).not.toBeInTheDocument()
+    // Open chip still shows its CI status.
+    expect(openChip?.querySelector('[aria-label="Checks passed"]')).toBeInTheDocument()
+  })
+
   it('shows new folder action in the create menu', async () => {
     const user = userEvent.setup()
     renderWithProviders(<ChatSidebar {...defaultProps} />)

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1856,9 +1856,10 @@ function ChatSidebar({
                       </span>
                     )}
                     {link.state === 'closed' && <span className="capitalize text-danger">{link.state}</span>}
-                    {link.ci === 'running' && <Loader2 className="lucide-inline shrink-0 animate-spin" aria-label="Checks running" />}
-                    {link.ci === 'passed' && <Check className="lucide-inline shrink-0 text-ok" aria-label="Checks passed" />}
-                    {link.ci === 'failed' && <X className="lucide-inline shrink-0 text-danger" aria-label="Checks failed" />}
+                    {/* CI status is moot once the PR is merged — the merge icon is the terminal signal. */}
+                    {link.state !== 'merged' && link.ci === 'running' && <Loader2 className="lucide-inline shrink-0 animate-spin" aria-label="Checks running" />}
+                    {link.state !== 'merged' && link.ci === 'passed' && <Check className="lucide-inline shrink-0 text-ok" aria-label="Checks passed" />}
+                    {link.state !== 'merged' && link.ci === 'failed' && <X className="lucide-inline shrink-0 text-danger" aria-label="Checks failed" />}
                   </span>
                 ))}
                 {typeof s.source_links_total === 'number' && s.source_links_total > s.source_links.length && (


### PR DESCRIPTION
## Problem
The sidebar PR chip keeps showing the green "checks passed" icon after a PR is merged, so a merged chip renders both the purple merge icon and a green check (e.g. `#284 ⎇ ✓`).

## Why it matters
Once merged, CI state is moot — the merge icon is the terminal signal. The extra check is visual noise in an already-dense chip and implies there's still something to watch.

## Fix (symptom → root cause → change)
The chip renders `link.state` badges and `link.ci` icons as independent conditionals, so a merged PR that finished CI green shows both. Gate all three CI icons (`running` / `passed` / `failed`) on `link.state !== 'merged'` in `ChatSidebar.tsx` — merged chips now show only the merge icon; open/draft chips are unchanged.

## Tests
- New integration test in `ChatSidebar.integration.test.tsx`: a merged chip with `ci: 'passed'` keeps the merge icon but renders no "Checks passed" icon, while an open chip with the same CI state still shows it.

## Manual verification
N/A — unit coverage sufficient; the change is a pure render-condition guard on an existing chip.

## Screenshots
Before (from user report — merged icon plus redundant green check):

`#284 [merged icon] [green check]` → after: `#284 [merged icon]`

(No new UI surface; the change only removes an icon from an existing chip.)
