### PR TITLE
fix(apps): exec shell launcher backend entrypoints instead of feeding them to Python

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -149,7 +149,13 @@ and detail cards. The path form depends on how the app is distributed:
 | `backend.port` | string | `"auto"` | Port number or `"auto"` for auto-assignment |
 | `backend.healthCheck` | string | `"/health"` | Health check endpoint path |
 | `backend.routes` | string | | Base route path for the backend |
-| `backend.type` | string | `""` | Backend runtime: `"python"`, `"asgi"`, `"node"`, or `""` (auto-detect from `entryPoint`) |
+| `backend.type` | string | `""` | Backend runtime: `"python"`, `"asgi"`, `"node"`, `"exec"` (execute the entry point file as-is), or `""` (auto-detect from `entryPoint` — a `.sh` file or an extensionless executable with a non-Python shebang is treated as a shell launcher) |
+
+> **Note:** the shell-launcher auto-detect reads the entry point's shebang
+> line, so a compiled/binary launcher (e.g. an ELF executable) cannot be
+> auto-detected — declare `"type": "exec"` explicitly for those. Exec
+> backends are POSIX-only: on native Windows the backend is refused at spawn
+> with a logged error (use a Python or Node entry point instead).
 
 App backends are accessible through the Gateway's reverse proxy at
 `/apps/{name}/api/{path}`, which avoids CORS issues for dashboard UI pages.

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -183,6 +183,54 @@ def _is_asgi_entry(entry: Any) -> bool:
         return False
 
 
+def _is_shell_entry(entry: Path) -> bool:
+    """Heuristic: is this entry point a shell launcher script?
+
+    True for a ``.sh`` file, or an extensionless executable whose first line
+    is a non-Python shebang (e.g. ``bin/<name>`` with
+    ``#!/usr/bin/env bash``). Files with any other extension (``.py``,
+    ``.js``, ...) and python-shebang launchers are NOT shell entries — they
+    keep their existing interpreter branches.
+    """
+    name = entry.name
+    if name.endswith(".sh"):
+        return True
+    if "." in name:
+        return False  # some other extension — not a bare launcher
+    if not os.access(entry, os.X_OK):
+        return False
+    try:
+        with open(entry, "rb") as fh:
+            first_line = fh.readline(256)
+    except OSError:
+        return False
+    return first_line.startswith(b"#!") and b"python" not in first_line
+
+
+def _shebang_argv(entry: Path) -> list[str]:
+    """Interpreter argv from a script's shebang, or ``["/bin/sh"]`` fallback.
+
+    A non-executable script can't rely on kernel shebang exec, so re-create
+    it: parse ``#!<interp> [arg]`` and return ``[interp, arg]`` (the kernel
+    passes at most one argument; whitespace-splitting covers the
+    ``#!/usr/bin/env bash`` form). Running bash source under ``/bin/sh``
+    breaks on bash-isms like ``set -euo pipefail`` wherever sh is dash, so
+    /bin/sh is only the last resort for a script with no shebang at all.
+    """
+    try:
+        with open(entry, "rb") as fh:
+            first = fh.readline(256)
+    except OSError:
+        return ["/bin/sh"]
+    if not first.startswith(b"#!"):
+        return ["/bin/sh"]
+    try:
+        parts = first[2:].decode("utf-8", "strict").strip().split()
+    except UnicodeDecodeError:
+        return ["/bin/sh"]
+    return parts if parts else ["/bin/sh"]
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle
 # ---------------------------------------------------------------------------
@@ -579,6 +627,38 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         python_bin = sys.executable
         cmd = [python_bin, "-m", entry_point]
         cwd = str(Path(__file__).resolve().parent.parent.parent)
+
+    # --- Exec (shell-launcher) backend ---
+    # Explicit `backend.type: "exec"` (exec the entry point file as-is — also
+    # the escape hatch for compiled/binary launchers the auto-detect can't
+    # identify), a `.sh` entry point, or an extensionless executable with a
+    # non-Python shebang (e.g. `bin/<name>` with `#!/usr/bin/env bash` — the
+    # common launcher-script pattern) is executed directly rather than
+    # falling through to the Python branch (which would run bash source under
+    # the Python interpreter and die on `set -euo pipefail`). Same
+    # wrap_argv() sandbox + cgroup scope as every other branch.
+    elif backend_type == "exec" or (not backend_type and _is_shell_entry(entry)):
+        if not platform_compat.IS_POSIX:
+            # Exec backends rely on POSIX shebang exec and /bin/sh — neither
+            # exists on native Windows. Fail fast with a clear message instead
+            # of an undefined Popen crash.
+            logger.error(
+                "App %s declares an exec (shell launcher) backend (%s) which "
+                "is not supported on native Windows. Use a Python or Node "
+                "entry point instead.",
+                app_name,
+                entry_str,
+            )
+            return None
+        if os.access(entry, os.X_OK):
+            cmd = [entry_str]
+        else:
+            # Not executable (e.g. lost the exec bit in transit) — the kernel
+            # won't honor the shebang, so invoke its interpreter explicitly.
+            # /bin/sh only for a script with no shebang at all (bash source
+            # under dash-as-sh dies on `set -euo pipefail`).
+            cmd = [*_shebang_argv(entry), entry_str]
+        cwd = str(root)
 
     # --- ASGI (Python) backend ---
     elif backend_type == "asgi" or (

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -265,7 +265,7 @@ class BackendConfig:
     port: str = "auto"  # "auto" or a specific port number
     healthCheck: str = "/health"  # health check endpoint path  # noqa: N815
     routes: str = ""  # base route path, e.g. /api/apps/oncall-watchtower
-    type: str = ""  # "python", "asgi", "node", or "" (auto-detect)
+    type: str = ""  # "python", "asgi", "node", "exec", or "" (auto-detect)
     hooks: HooksConfig = field(default_factory=HooksConfig)
 
     def to_dict(self) -> dict[str, Any]:

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -12,6 +12,7 @@ import pytest
 from kiro_crew.apps.backend import (
     AppProcess,
     _find_free_port,
+    _is_shell_entry,
     get_app_process,
     list_app_processes,
     start_app_backend,
@@ -195,6 +196,53 @@ class TestBackendLifecycle:
 
     def test_stop_not_running(self, app_env):
         assert stop_app_backend("nonexistent") is False
+
+    @_needs_sandbox_spawn
+    @pytest.mark.skipif(sys.platform == "win32", reason="shell launchers are POSIX-only")
+    def test_start_and_stop_shell_launcher(self, tmp_path, app_env):
+        """An extensionless bash launcher entrypoint is exec'd directly, not fed
+        to the Python interpreter (the common `bin/<name>` launcher pattern)."""
+        name = "shell-app"
+        src = tmp_path / "source" / name
+        src.mkdir(parents=True)
+        (src / APP_MANIFEST_FILENAME).write_text(json.dumps({
+            "name": name, "version": "1.0.0",
+            "displayName": "Shell App", "description": "bash launcher backend",
+            "author": "tester",
+            "backend": {
+                "entryPoint": "bin/shell-app",
+                "port": "auto",
+                "healthCheck": "/health",
+            },
+        }))
+        (src / "bin").mkdir()
+        launcher = src / "bin" / "shell-app"
+        # Bash launcher that would die instantly under a Python interpreter
+        # (`set -euo pipefail` is a SyntaxError), then execs a tiny server.
+        launcher.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f'exec "{sys.executable}" -c \''
+            "import http.server, os\n"
+            "port = int(os.environ.get(\"PORT\", 9100))\n"
+            "class H(http.server.BaseHTTPRequestHandler):\n"
+            "    def do_GET(self):\n"
+            "        self.send_response(200)\n"
+            "        self.end_headers()\n"
+            "        self.wfile.write(b\"ok\")\n"
+            "    def log_message(self, *a):\n"
+            "        pass\n"
+            "http.server.HTTPServer((\"127.0.0.1\", port), H).serve_forever()\n"
+            "'\n"
+        )
+        launcher.chmod(0o755)
+        install_app(src)
+        ap = start_app_backend(name)
+        assert ap is not None
+        assert ap.port > 0
+        assert ap.pid > 0
+        stopped = stop_app_backend(name)
+        assert stopped is True
 
     @_needs_sandbox_spawn
     def test_get_process(self, tmp_path, app_env):
@@ -496,6 +544,161 @@ class TestBackendLifecycle:
         assert result is None
         # The stale placeholder is gone, so a fresh start_app_backend can spawn again.
         assert "wedged-app" not in bmod._processes
+
+
+class TestShellEntryDetection:
+    """Unit coverage for _is_shell_entry (shell launcher heuristic)."""
+
+    def _write(self, tmp_path, name, content, executable=True):
+        f = tmp_path / name
+        f.write_text(content)
+        if executable:
+            f.chmod(0o755)
+        return f
+
+    def test_sh_suffix_is_shell(self, tmp_path):
+        f = self._write(tmp_path, "run.sh", "#!/bin/sh\necho hi\n", executable=False)
+        assert _is_shell_entry(f) is True
+
+    def test_extensionless_bash_shebang_is_shell(self, tmp_path):
+        f = self._write(tmp_path, "my-launcher", "#!/usr/bin/env bash\nset -euo pipefail\n")
+        assert _is_shell_entry(f) is True
+
+    def test_python_shebang_launcher_is_not_shell(self, tmp_path):
+        f = self._write(tmp_path, "launcher", "#!/usr/bin/env python3\nprint('hi')\n")
+        assert _is_shell_entry(f) is False
+
+    def test_py_extension_is_not_shell(self, tmp_path):
+        f = self._write(tmp_path, "server.py", "#!/usr/bin/env bash\n")
+        assert _is_shell_entry(f) is False
+
+    def test_extensionless_non_executable_is_not_shell(self, tmp_path):
+        f = self._write(tmp_path, "launcher", "#!/bin/bash\n", executable=False)
+        assert _is_shell_entry(f) is False
+
+    def test_extensionless_no_shebang_is_not_shell(self, tmp_path):
+        f = self._write(tmp_path, "launcher", "echo hi\n")
+        assert _is_shell_entry(f) is False
+
+
+class TestShellDispatch:
+    """Dispatch-level coverage: the shell branch selects the right argv without
+    a real spawn. Complements the e2e launcher test (which only covers the
+    auto-detect path) with the explicit ``backend.type: "exec"`` route and the
+    /bin/sh fallback for a non-executable ``.sh`` entry."""
+
+    def _dispatch_cmd(self, tmp_path, monkeypatch, name, entry_rel, content, *,
+                      executable, backend_type=""):
+        """Install an app, then capture the argv the dispatch builds."""
+        import kiro_crew.apps.backend as bmod
+        from kiro_crew.apps.manager import get_app_manifest
+
+        src = tmp_path / "source" / name
+        src.mkdir(parents=True)
+        backend: dict = {"entryPoint": entry_rel, "port": "auto"}
+        if backend_type:
+            backend["type"] = backend_type
+        (src / APP_MANIFEST_FILENAME).write_text(json.dumps({
+            "name": name, "version": "1.0.0",
+            "displayName": name, "description": "shell dispatch test",
+            "author": "tester",
+            "backend": backend,
+        }))
+        entry = src / entry_rel
+        entry.parent.mkdir(parents=True, exist_ok=True)
+        entry.write_text(content)
+        if executable:
+            entry.chmod(0o755)
+        install_app(src)
+
+        captured: dict = {}
+
+        def _capture_wrap(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return cmd, None
+
+        class _ReachedSpawn(Exception):
+            pass
+
+        def _sentinel(*a, **k):
+            raise _ReachedSpawn()
+
+        # Neutralize the sandbox wrap so the test isolates DISPATCH (its
+        # purpose) from sandbox availability, and stop before any real spawn.
+        monkeypatch.setattr(bmod, "wrap_argv", _capture_wrap)
+        monkeypatch.setattr(bmod.subprocess, "Popen", _sentinel)
+        manifest = get_app_manifest(name)
+        assert manifest is not None
+        with pytest.raises(_ReachedSpawn):
+            bmod._start_app_backend_body(name, manifest)
+        return captured["cmd"]
+
+    def test_explicit_backend_type_exec_routes_to_shell_branch(
+            self, tmp_path, app_env, monkeypatch):
+        # A launcher the auto-detect can NOT identify (extensionless, no
+        # shebang — the stand-in for a compiled/ELF binary) must still hit the
+        # shell branch when the manifest declares `"type": "exec"` explicitly.
+        cmd = self._dispatch_cmd(
+            tmp_path, monkeypatch, "explicit-shell", "bin/launcher",
+            "echo hi\n", executable=True, backend_type="exec",
+        )
+        assert len(cmd) == 1
+        assert cmd[0].endswith("bin/launcher")
+
+    def test_non_executable_sh_entry_falls_back_to_bin_sh(self, tmp_path, app_env,
+                                                          monkeypatch):
+        # A shebang-less `.sh` entry that lost its exec bit is run via /bin/sh
+        # as the last resort.
+        cmd = self._dispatch_cmd(
+            tmp_path, monkeypatch, "sh-fallback", "run.sh",
+            "echo hi\n", executable=False,
+        )
+        assert cmd[0] == "/bin/sh"
+        assert len(cmd) == 2
+        assert cmd[1].endswith("run.sh")
+
+    def test_non_executable_bash_entry_honors_shebang(self, tmp_path, app_env,
+                                                      monkeypatch):
+        # A non-executable launcher with a bash shebang must run under ITS
+        # declared interpreter, not /bin/sh — bash-isms like
+        # `set -euo pipefail` die under dash-as-sh (Debian/Ubuntu).
+        cmd = self._dispatch_cmd(
+            tmp_path, monkeypatch, "bash-shebang", "run.sh",
+            "#!/usr/bin/env bash\nset -euo pipefail\necho hi\n",
+            executable=False,
+        )
+        assert cmd[:2] == ["/usr/bin/env", "bash"]
+        assert cmd[2].endswith("run.sh")
+
+    def test_shell_backend_refused_on_non_posix(self, tmp_path, app_env,
+                                                monkeypatch):
+        # On native Windows (IS_POSIX False) the shell branch must fail fast
+        # with a logged error and return None — never reach Popen with a
+        # shebang-dependent argv or the nonexistent /bin/sh.
+        import kiro_crew.apps.backend as bmod
+        from kiro_crew.apps.manager import get_app_manifest
+
+        name = "win-shell-refused"
+        src = tmp_path / "source" / name
+        src.mkdir(parents=True)
+        (src / APP_MANIFEST_FILENAME).write_text(json.dumps({
+            "name": name, "version": "1.0.0",
+            "displayName": name, "description": "non-posix guard test",
+            "author": "tester",
+            "backend": {"entryPoint": "run.sh", "port": "auto",
+                        "type": "exec"},
+        }))
+        (src / "run.sh").write_text("#!/bin/sh\necho hi\n")
+        install_app(src)
+
+        def _boom(*a, **k):  # pragma: no cover - must not be reached
+            raise AssertionError("Popen must not be called on non-POSIX")
+
+        monkeypatch.setattr(bmod.subprocess, "Popen", _boom)
+        monkeypatch.setattr(bmod.platform_compat, "IS_POSIX", False)
+        manifest = get_app_manifest(name)
+        assert manifest is not None
+        assert bmod._start_app_backend_body(name, manifest) is None
 
 
 class TestBootAdmissionRevet:


### PR DESCRIPTION
## Summary

App backends whose entry point is a shell launcher script (`bin/<name>` with `#!/usr/bin/env bash`, or a `.sh` file) were fed to the **Python interpreter**, dying instantly on `set -euo pipefail` — `/health` never came up and the app UI was dead. This PR adds the missing runtime branch to the spawn dispatch.

Fixes #306

## Bug

The spawn dispatch in `src/kiro_crew/apps/backend.py` had branches for Node (`.js/.mjs/.cjs`), module-style Python, ASGI, and a plain-Python default. A shell launcher fell through to the Python branch: `cmd = [python_bin, entry]` → instant `SyntaxError`.

## Fix

- New exec branch: explicit `backend.type: "exec"` (execute the entry point file as-is — also the escape hatch for compiled/binary launchers the shebang auto-detect can't identify), a `.sh` entry, or an extensionless executable whose first line is a non-Python shebang is exec'd directly.
- A non-executable script runs under its **own declared shebang interpreter** (`#!/usr/bin/env bash` → bash); `/bin/sh` only when no shebang exists, so bash-isms never run under dash-as-sh.
- POSIX-only: on native Windows the spawn is refused with a logged error (same pattern as the missing-node-binary refusal) instead of an undefined `Popen` crash.
- Identical `wrap_argv()` sandbox + cgroup scope as every other branch; entryPoint path-containment and third-party provenance gates run before dispatch, unchanged.
- Branch precedence: node → module-style → exec → asgi → plain-python, explicit `backend.type` honored over extension sniffs.

## Testing

- e2e: a real `#!/usr/bin/env bash` launcher containing `set -euo pipefail` (dies under the old code path) comes up and serves `/health`.
- `_is_shell_entry` heuristic matrix (6 cases) + dispatch-level tests: explicit `"exec"` routing (compiled-binary stand-in), shebang-honoring non-executable fallback, `/bin/sh` last resort, non-POSIX refusal (Popen sentinel asserts unreachable).
- Local gates: pytest 16,046 passed (only the 3 known host-environment failures, reproduced identically on clean `main`), flake8 clean, `tsc -b` clean, vitest 4,162 passed.

## Review-finding history

- GPT 5.6 HIGH (shebang ignored in `/bin/sh` fallback): fixed — fallback now honors the declared interpreter.
- Long-Term Impact item 1 (enum naming one-way door): renamed `"shell"` → `"exec"` before first ship; docs describe the exec-as-is semantic directly.
- Long-Term Impact item 2 (internal references in commit/PR body): scrubbed; this adapts work originally drafted against an internal downstream, with provenance tracked on the internal side.
