### PR TITLE
fix(browser): converge duplicate Playwright MCP + harden artifact scan

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -61,7 +61,7 @@ Playwright MCP handles all browser interaction. KiroCrew only handles enterprise
 | File | Purpose |
 |------|---------|
 | `browser/auth.py` | SSO cookies, federated SSO, KRB5CCNAME, health checks, URL validation |
-| `browser/setup.py` | AIM install, config generation, storage state refresh, MCP config patching |
+| `browser/setup.py` | Plugin-manager install, config generation, storage state refresh, MCP config patching |
 | `browser/cli.py` | `kirocrew browse` CLI: setup, auth health/refresh/inject/federate, extension on/off |
 | `mcp_playwright_proxy.py` | Stdio proxy: intercepts Playwright MCP responses, compresses accessibility trees |
 | `skills/browser-auth/SKILL.md` | Agent skill for auth + Playwright MCP workflow |
@@ -79,12 +79,62 @@ Playwright MCP's `browser_snapshot` returns full accessibility trees (50-100K to
 - Compresses to compact outline: only interactive elements (links, buttons, inputs, headings, images) with refs
 - ~95% token reduction on heavy pages
 
-**Registration:** The proxy is auto-registered in `mcp.json` via:
-- `kirocrew setup` — new installs get the proxy from the start
-- Gateway startup — `_migrate_playwright_to_proxy()` auto-migrates existing `npm-playwright-mcp` entries
-- Settings → Browser save — `patch_mcp_extension()`/`patch_mcp_headless()` always write the proxy command
+**Registration (one canonical server, no duplicates):** kiro-cli splits an agent
+`@server` reference on `/`, so a slash-containing key like `@playwright/mcp` is
+mis-parsed as `@server/tool` and exposes none of the server's tools. The proxy is
+therefore always registered under the **slash-free canonical alias**
+`playwright-mcp` (`mcp_server_alias("@playwright/mcp")`), and every writer drops
+the superseded keys it historically used so exactly one Playwright entry survives:
 
-**Source:** `src/kiro_crew/mcp_playwright_proxy.py`
+- `kirocrew setup` — new installs get the canonical proxy entry from the start.
+- `patch_mcp_extension()` / `patch_mcp_headless()` — write the entry under the
+  canonical alias, after `_drop_superseded_playwright()` removes any legacy proxy
+  key (`@playwright/mcp`, `playwright-proxy-mcp`) **and** KiroCrew's legacy
+  *direct* `npm:@playwright/mcp` entry (that `npm:`-prefixed key is a KiroCrew
+  install artifact; a user's own direct server under the bare `@playwright/mcp`
+  key is left untouched — authorship is by launch target, not key name).
+- Gateway startup — `_migrate_playwright_to_proxy()` delegates to
+  `migrate_owned_playwright_registration()`, which converges KiroCrew's own
+  browse entry in `~/.kiro/settings/mcp.json` to the canonical key — including
+  upgrading a legacy *direct* `npm:@playwright/mcp` entry (from installs predating
+  the compression proxy) to the proxy — converges KiroCrew's own
+  `~/.kirocrew/mcp.json` at the SOURCE (so a stale proxy key there is healed once,
+  not re-injected into every rebuild), and sweeps the KiroCrew-generated agent
+  configs (the exact `kirocrew*` filenames it writes, not a bare `*.json` glob, so
+  a user's own agents are never rewritten) so a duplicate proxy entry collapses
+  onto the one canonical server. This self-heals an existing machine on a plain
+  restart.
+- Every agent-config rebuild — `converge_playwright_servers()` runs right after
+  key normalization in `build_agent_config` as a BACKSTOP (the owned source files
+  are healed at boot above; this catches anything re-merged mid-rebuild),
+  collapsing any Playwright-proxy entry by *resolved launch target* (an entry that
+  invokes `mcp-playwright-proxy`). This catches a slash-free legacy key (e.g.
+  `playwright-proxy-mcp`) that key normalization — which only rewrites
+  slash-containing keys — cannot fold. Convergence keeps the canonical key
+  (unless a user's own *direct*, non-proxy server already occupies it — then the
+  proxy is left under its own non-conflicting key rather than clobbering the user
+  entry), rewrites dropped `@refs` in `tools`/`allowedTools`, and never touches a
+  user-declared, non-proxy server. Together with discovery read-folding and pool
+  launch-target dedupe, all surfaces agree on the single `playwright-mcp` server,
+  so no second backend, dashboard row, or probe is derived.
+
+**Ownership signals (authorship of an MCP entry).** `~/.kiro/settings/mcp.json` is
+co-owned with kiro-cli, and kiro-cli validates it (and agent specs) with
+`deny_unknown_fields`, so an in-spec ownership sentinel is impossible. KiroCrew
+therefore records the MCP keys it writes in an out-of-band sidecar manifest
+`~/.kirocrew/owned-mcp-keys.json` (`_record_owned_mcp_key`, mode 0600), written by
+`patch_mcp_extension()` / `patch_mcp_headless()`. Drop/converge decisions consult
+this manifest **first** (`_load_owned_mcp_keys`); the `mcp-playwright-proxy`
+launch-target heuristic (`_spec_is_proxy`) and the `npm:@playwright/mcp` legacy-key
+rule remain the fallback for entries written by installs that predate the
+manifest. This stops the unmarked-entry population from growing so future
+migrations rely less on forensic heuristics on a destructive, every-restart path.
+*Follow-up:* extend the manifest to the agent-config writers and to all
+drop/converge sites (currently the sidecar sweep still keys on the owned-filename
+allowlist + launch target), and consider consolidating the per-surface
+convergence passes behind one canonicalizing `mcp_utils` accessor.
+
+**Source:** `src/kiro_crew/mcp_playwright_proxy.py`, `src/kiro_crew/browser/setup.py`
 
 ### Live Browse Mirror
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -38,6 +38,14 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import agent_state, platform_compat
+from kiro_crew.agent_files import (
+    AGENT_FILENAME,
+)
+from kiro_crew.agent_files import HEARTBEAT_AGENT_FILENAME as _HEARTBEAT_AGENT_FILENAME
+from kiro_crew.agent_files import KNOWLEDGE_AGENT_FILENAME as _KNOWLEDGE_AGENT_FILENAME
+from kiro_crew.agent_files import LITE_AGENT_FILENAME as _LITE_AGENT_FILENAME
+from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
+from kiro_crew.browser.setup import converge_playwright_servers
 from kiro_crew.config import config_path as _mc_config_path
 from kiro_crew.env import augmented_path
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -84,7 +92,7 @@ def _atomic_json_write(path: Path, data: dict) -> None:
 
 
 KIRO_AGENTS_DIR = Path.home() / ".kiro" / "agents"
-AGENT_FILENAME = "kirocrew.json"
+# AGENT_FILENAME imported from agent_files (single source of truth).
 _MAIN_AGENT_NAME = "kirocrew"
 # Cheap Claude Code model for KiroCrew's background agents (lite / heartbeat).
 # Stored in the agent_state sidecar, never in the kiro spec (deny_unknown_fields).
@@ -1837,6 +1845,16 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # their stale @refs are normalized too. See mcp_server_alias.
     _normalize_mcp_server_keys(config)
 
+    # Converge every Playwright-proxy entry onto the single canonical
+    # ``playwright-mcp`` server, keyed by resolved launch target. Runs on EVERY
+    # rebuild (not just gateway boot) so a slash-free legacy proxy key —
+    # e.g. ``playwright-proxy-mcp`` re-injected from ~/.kirocrew/mcp.json by the
+    # merges above — cannot survive to spawn a second backend. Slash-free legacy
+    # keys are invisible to _normalize_mcp_server_keys (which only rewrites
+    # slash-containing keys), so this launch-target-keyed pass closes the
+    # duplicate for them.
+    converge_playwright_servers(config)
+
     # Sync shared (user-installed) servers to tools/allowedTools.
     # These are explicitly installed by the user via `aim mcp install` or
     # manual mcp.json edits — unlike managed servers, they should always
@@ -1946,9 +1964,6 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     return path
 
 
-_LITE_AGENT_FILENAME = "kirocrew-lite.json"
-
-
 # Backward-compat alias — callers may still use the old name.
 install_agent = rebuild_agent_config
 
@@ -1994,8 +2009,6 @@ def _install_lite_agent_fallback() -> None:
     agent_state.set_cc_model("kirocrew-lite", _BACKGROUND_CC_MODEL)
 
 
-_KNOWLEDGE_AGENT_FILENAME = "kirocrew-knowledge.json"
-
 _KNOWLEDGE_SYSTEM_PROMPT = (
     "You are a knowledge extraction specialist for KiroCrew's Knowledge Library. "
     "Your job is to analyze documents and extract structured information.\n\n"
@@ -2032,8 +2045,6 @@ def _install_knowledge_agent() -> None:
     _atomic_json_write(path, config)
     logger.info("Installed knowledge agent config: %s", path)
 
-
-_RESEARCH_AGENT_FILENAME = "kirocrew-research.json"
 
 _RESEARCH_SYSTEM_PROMPT = """# KiroCrew Research Worker
 
@@ -2127,8 +2138,6 @@ def _install_research_agent() -> None:
     _atomic_json_write(path, config)
     logger.info("Installed research agent config: %s", path)
 
-
-_HEARTBEAT_AGENT_FILENAME = "kirocrew-heartbeat.json"
 
 _HEARTBEAT_SYSTEM_PROMPT = """# KiroCrew Heartbeat Worker
 

--- a/src/kiro_crew/agent_files.py
+++ b/src/kiro_crew/agent_files.py
@@ -1,0 +1,42 @@
+"""Canonical filenames of the agent configs KiroCrew generates.
+
+Single source of truth for the on-disk names KiroCrew writes into
+``~/.kiro/agents/`` (kiro specs) and ``~/.claude/agents/`` (the Claude Code MCP
+sidecar). This is a **leaf module** (no intra-package imports) so both
+``agent.py`` (which writes these files) and ``browser/setup.py`` (whose
+Playwright convergence sweep must touch only KiroCrew-owned files) can import it
+without an import cycle — ``agent.py`` imports ``converge_playwright_servers``
+from ``browser/setup.py``, so ``browser/setup.py`` cannot import ``agent.py``.
+
+Keeping the names here — rather than duplicating them as a literal in each
+consumer — means adding a new managed agent spec is a one-line change in ONE
+place: add its filename to ``OWNED_KIRO_AGENT_FILES`` and every consumer
+(including the boot-time self-heal sweep) picks it up.
+"""
+
+from __future__ import annotations
+
+# The primary KiroCrew agent spec.
+AGENT_FILENAME = "kirocrew.json"
+
+# Background/auxiliary managed agent specs KiroCrew writes under ~/.kiro/agents/.
+LITE_AGENT_FILENAME = "kirocrew-lite.json"
+KNOWLEDGE_AGENT_FILENAME = "kirocrew-knowledge.json"
+RESEARCH_AGENT_FILENAME = "kirocrew-research.json"
+HEARTBEAT_AGENT_FILENAME = "kirocrew-heartbeat.json"
+
+# The Claude Code MCP sidecar filename under ~/.claude/agents/.
+CC_MCP_SIDECAR_FILENAME = "kirocrew.mcp.json"
+
+# Collective allowlists — the EXACT filenames KiroCrew owns in each dir. Used by
+# the Playwright convergence sweep (browser/setup.py) so it rewrites only files
+# KiroCrew generates, never a user's own agent config that happens to share a
+# prefix (e.g. a hand-authored ``kirocrew-custom.json``).
+OWNED_KIRO_AGENT_FILES = (
+    AGENT_FILENAME,
+    LITE_AGENT_FILENAME,
+    KNOWLEDGE_AGENT_FILENAME,
+    RESEARCH_AGENT_FILENAME,
+    HEARTBEAT_AGENT_FILENAME,
+)
+OWNED_CC_AGENT_FILES = (CC_MCP_SIDECAR_FILENAME,)

--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -9,15 +9,68 @@ working, but SSO setup is a no-op and reports "not available in OSS".
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 import shutil
+import stat
 import time
 from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
+from kiro_crew.agent_files import OWNED_CC_AGENT_FILES, OWNED_KIRO_AGENT_FILES
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser.auth import SSO_COOKIE_PATH, parse_netscape_cookies
+from kiro_crew.mcp_utils import mcp_server_alias
+
+logger = logging.getLogger(__name__)
+
+# The public npm package name for the Playwright MCP server. Used only as the
+# input to ``mcp_server_alias`` to derive the canonical slash-free key
+# (``playwright-mcp``) KiroCrew registers the proxy under.
+_PLAYWRIGHT_MCP_PACKAGE = "@playwright/mcp"
+
+# Key names KiroCrew (or the predecessor install it descends from) historically
+# registered the Playwright PROXY under. When KiroCrew (re)writes its own
+# registration it converges these to the canonical ``mcp_server_alias`` form.
+#
+# IMPORTANT — a key name in this set is NOT proof of KiroCrew authorship. A user
+# may hand-declare a *direct* (non-proxy) Playwright server under the public
+# package name ``@playwright/mcp``. Authorship is decided ONLY by the resolved
+# launch target (:func:`_spec_is_proxy` — the entry invokes
+# ``mcp-playwright-proxy``); every drop/converge site gates on that, so a
+# superseded key whose spec is a direct server is left untouched. This tuple is
+# only the set of *candidate* names to inspect, never a standalone authorship
+# signal — do not add a name here expecting it to be dropped by name alone.
+# ``npm:@playwright/mcp`` is the legacy on-disk key earlier installs wrote; it is
+# data to clean up FROM, not a key this module ever emits (both it and
+# ``@playwright/mcp`` alias to the same canonical ``playwright-mcp``).
+_SUPERSEDED_PLAYWRIGHT_KEYS = (
+    "@playwright/mcp",
+    "npm:@playwright/mcp",
+    "playwright-proxy-mcp",
+)
+
+# The on-disk key earlier KiroCrew installs wrote for a DIRECT npm-launched
+# Playwright server (before the compression proxy existed). Unlike the bare
+# ``@playwright/mcp`` key — which a user may legitimately hand-author for their
+# own direct server — the ``npm:`` prefix is a KiroCrew-generated artifact, so a
+# *direct* spec under THIS specific key is KiroCrew's legacy entry and is safe to
+# upgrade to the proxy and remove. (A proxy spec under any superseded key is
+# handled by _drop_superseded_playwright.)
+_LEGACY_DIRECT_PLAYWRIGHT_KEY = "npm:@playwright/mcp"
+
+# EXACT filenames KiroCrew generates under ``~/.kiro/agents/`` (kiro specs) and
+# ``~/.claude/agents/`` (the CC MCP sidecar). The convergence sweep rewrites ONLY
+# these — an explicit allowlist, never a ``kirocrew*`` prefix glob, because a
+# user is free to hand-author e.g. ``~/.kiro/agents/kirocrew-custom.json`` and a
+# filename prefix does not prove KiroCrew authorship; rewriting it on a restart
+# would corrupt the user's own config. Single source of truth is the leaf module
+# ``agent_files`` (imported by both ``agent.py``, which WRITES these files, and
+# here) so adding a managed spec is a one-line change in one place — no drift.
+_OWNED_KIRO_AGENT_FILES = OWNED_KIRO_AGENT_FILES
+_OWNED_CC_AGENT_FILES = OWNED_CC_AGENT_FILES
 
 
 def is_playwright_installed() -> bool:
@@ -161,6 +214,397 @@ def _kirocrew_bin() -> str:
     return shutil.which("kirocrew") or "kirocrew"
 
 
+def _spec_is_proxy(spec: Any) -> bool:
+    """True iff a server spec's resolved launch target is KiroCrew's proxy.
+
+    The ONLY reliable authorship signal: the entry invokes
+    ``mcp-playwright-proxy`` (which only KiroCrew registers). A key *name*
+    matching a superseded key is NOT proof of authorship — a user may key a
+    *direct* (non-proxy) Playwright server under the public package name
+    ``@playwright/mcp``. That user entry must never be dropped or rewritten.
+    """
+    if not isinstance(spec, dict):
+        return False
+    args = spec.get("args") or []
+    if not isinstance(args, list):
+        return False
+    return "mcp-playwright-proxy" in args
+
+
+def _drop_superseded_playwright(servers: dict[str, Any], canonical: str) -> None:
+    """Drop KiroCrew's own superseded Playwright entries from a servers dict.
+
+    Operates in place; never drops the ``canonical`` key. Removes:
+
+    * any superseded key recorded in the ownership MANIFEST (the authoritative
+      "KiroCrew wrote this" signal), or whose spec is actually the KiroCrew proxy
+      (``_spec_is_proxy`` — the launch-target fallback for pre-manifest installs);
+      and
+    * KiroCrew's legacy DIRECT entry under ``_LEGACY_DIRECT_PLAYWRIGHT_KEY``
+      (``npm:@playwright/mcp``) even when it is a *direct* (non-proxy) spec —
+      that ``npm:``-prefixed key is a KiroCrew install artifact, so once we write
+      the canonical proxy the old direct entry is superseded and must be removed
+      (otherwise it lingers as a second Playwright backend).
+
+    A user-declared *direct* server under the BARE ``@playwright/mcp`` key (which
+    a user may legitimately hand-author) is left untouched — it is neither in the
+    manifest, nor a proxy spec, nor the ``npm:``-prefixed legacy key. Used when
+    KiroCrew rewrites its own registration so the canonical (slash-free alias)
+    entry is the only KiroCrew-authored one left behind.
+    """
+    owned = _load_owned_mcp_keys()
+    for key in _SUPERSEDED_PLAYWRIGHT_KEYS:
+        if key == canonical or key not in servers:
+            continue
+        if key in owned or _spec_is_proxy(servers[key]) or key == _LEGACY_DIRECT_PLAYWRIGHT_KEY:
+            del servers[key]
+
+
+def migrate_owned_playwright_registration() -> None:
+    """Converge KiroCrew's own Playwright registration to one canonical server.
+
+    Runs on gateway init. The Playwright proxy must be registered under the
+    slash-free ``mcp_server_alias`` form (so kiro-cli can ``@``-reference it and
+    the gateway does not derive a second pooled backend). Two KiroCrew-owned
+    surfaces are converged, keyed by *resolved launch target* (an entry that
+    invokes ``mcp-playwright-proxy``) plus KiroCrew's superseded keys:
+
+    1. kiro's ``~/.kiro/settings/mcp.json`` — the browse entry KiroCrew
+       co-manages — is rewritten to the canonical proxy entry. This also upgrades
+       KiroCrew's legacy DIRECT ``npm:@playwright/mcp`` entry (written by installs
+       that predate the compression proxy) to the proxy, preserving the original
+       boot migration's direct-to-proxy behavior.
+    2. KiroCrew's own ``~/.kirocrew/mcp.json`` — the agent-specific MCP override
+       merged into the agent config on every rebuild — is converged at the
+       SOURCE, so a stale ``playwright-proxy-mcp`` key there is healed once rather
+       than re-injected on every rebuild for the per-rebuild
+       :func:`converge_playwright_servers` backstop to undo indefinitely.
+    3. The KiroCrew-generated agent configs (the exact filenames in
+       ``_OWNED_KIRO_AGENT_FILES`` / ``_OWNED_CC_AGENT_FILES``) are swept so any
+       duplicate proxy entry (e.g. a legacy ``playwright-proxy-mcp``) collapses
+       into the single canonical ``playwright-mcp``. This self-heals an existing
+       machine on a plain gateway restart, without waiting for a full agent
+       rebuild. Only the exact files KiroCrew writes are touched — a user's own
+       custom agents in the same dirs are never rewritten.
+
+    Never adds Playwright where none exists, never rewrites a user-declared
+    server, and never mutates the user-owned discovery sources
+    (``~/.claude.json``) — those converge for *display* on read (discovery
+    canonicalization) and at launch (pool dedupe), not by mutating files.
+    """
+    _migrate_owned_kiro_registration()
+    _converge_kirocrew_mcp_json()
+    _converge_playwright_agent_files()
+
+
+def _migrate_owned_kiro_registration() -> None:
+    """Rewrite KiroCrew's browse entry in kiro's ``mcp.json`` to the canonical key."""
+    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
+    if not mcp_json.is_file():
+        return
+    try:
+        data = json.loads(mcp_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    if not isinstance(servers, dict):
+        return
+    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+    canon_entry = servers.get(canonical)
+    canon_is_proxy = _spec_is_proxy(canon_entry)
+    # There are two KiroCrew-owned things worth migrating to the canonical proxy:
+    #   (a) a superseded PROXY entry (a duplicate proxy under a legacy key), and
+    #   (b) KiroCrew's legacy DIRECT ``npm:@playwright/mcp`` entry — the key
+    #       earlier KiroCrew installs wrote for a direct npm-launched Playwright
+    #       (before the compression proxy existed). Upgrading it to the proxy is
+    #       the ORIGINAL purpose of this boot migration; dropping it would leave
+    #       existing users on the direct server with no compression.
+    # A user-declared *direct* server under the BARE ``@playwright/mcp`` key is
+    # NOT KiroCrew's (authorship is by launch target, not key name) and is left
+    # untouched — only the ``npm:``-prefixed key is a KiroCrew legacy artifact.
+    superseded_proxy_present = any(
+        key != canonical and _spec_is_proxy(servers.get(key))
+        for key in _SUPERSEDED_PLAYWRIGHT_KEYS
+    )
+    legacy_direct = servers.get(_LEGACY_DIRECT_PLAYWRIGHT_KEY)
+    legacy_direct_present = isinstance(legacy_direct, dict) and not _spec_is_proxy(legacy_direct)
+    # Leave the file untouched unless there is a KiroCrew-owned entry to migrate,
+    # AND the canonical slot is either empty or already our proxy (safe to
+    # (re)write). If the canonical key holds a user-declared *direct* (non-proxy)
+    # server, migrating would call patch_mcp_*, which does servers[canonical] =
+    # proxy_entry and would clobber that user config on every boot — so skip.
+    if not (superseded_proxy_present or legacy_direct_present):
+        return
+    if canon_entry is not None and not canon_is_proxy:
+        return
+    if has_playwright_extension():
+        token = get_extension_token() or ""
+        if token:
+            patch_mcp_extension(token)
+        else:
+            patch_mcp_headless()
+    else:
+        patch_mcp_headless()
+
+
+def _converge_kirocrew_mcp_json() -> None:
+    """Converge Playwright proxies in KiroCrew's own ``~/.kirocrew/mcp.json``.
+
+    ``rebuild_agent_config`` merges every server from this file into the agent
+    config, so a stale duplicate proxy key here (e.g. a legacy
+    ``playwright-proxy-mcp``) would be re-injected on EVERY rebuild — forcing the
+    per-rebuild :func:`converge_playwright_servers` backstop to undo it forever.
+    Healing it at the SOURCE here (this file is unambiguously KiroCrew-owned,
+    unlike the deliberately-excluded user discovery source ``~/.claude.json``)
+    makes the rebuild-time pass a true backstop rather than the primary cure.
+    Mode-preserving atomic write; silently skips an unreadable/non-dict/absent
+    file and a no-op convergence.
+    """
+    path = Path.home() / ".kirocrew" / "mcp.json"
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+    if not converge_playwright_servers(data):
+        return
+    try:
+        prev_mode: int | None = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        prev_mode = None
+    try:
+        atomic_write(path, json.dumps(data, indent=2), mode=prev_mode)
+    except OSError:
+        pass
+
+
+def _entry_is_playwright_proxy(name: str, spec: Any, canonical: str) -> bool:
+    """True iff a server entry is KiroCrew's Playwright proxy.
+
+    Authorship is proven ONLY by the *resolved launch target* — the entry
+    invokes ``mcp-playwright-proxy`` (:func:`_spec_is_proxy`). The key name is
+    NOT a proof of authorship: a user may hand-declare a *direct* Playwright
+    server under the public package name ``@playwright/mcp`` (a superseded key),
+    and that entry must never be collapsed or dropped. The single exception is
+    the canonical key when it already holds the proxy — but that is covered by
+    the launch-target check too, so name matching is unnecessary.
+    """
+    return _spec_is_proxy(spec)
+
+
+def _redact_spec_for_log(spec: Any) -> Any:
+    """Return a shallow copy of *spec* safe to log: ``env`` VALUES masked, keys
+    kept. Leaves ``command``/``args`` intact (an ``--extension``/``--config``
+    wiring is diagnostic, not secret) so a dropped entry can be reconstructed
+    from the log without exposing a token like ``PLAYWRIGHT_MCP_EXTENSION_TOKEN``.
+    """
+    if not isinstance(spec, dict):
+        return spec
+    safe = dict(spec)
+    env = safe.get("env")
+    if isinstance(env, dict):
+        safe["env"] = {k: "***" for k in env}
+    return safe
+
+
+def converge_playwright_servers(config: dict) -> bool:
+    """Collapse every KiroCrew Playwright-proxy entry in ``config`` to the single
+    canonical ``playwright-mcp`` server. Mutates ``config`` in place; returns
+    ``True`` iff anything changed.
+
+    Convergence is keyed by resolved launch target (:func:`_spec_is_proxy` — the
+    entry invokes ``mcp-playwright-proxy``), so two entries that launch the same
+    proxy under different names (e.g. ``playwright-mcp`` and the legacy
+    ``playwright-proxy-mcp``) become one. The survivor keeps the canonical key;
+    when no canonical entry exists the most completely-wired proxy entry is
+    renamed to it (never dropped). ``@<dropped>`` references in
+    ``tools``/``allowedTools`` are rewritten to ``@playwright-mcp`` and
+    de-duplicated. Never adds Playwright where none exists, and never touches a
+    server whose spec is not the proxy — including a user-declared *direct*
+    ``@playwright/mcp`` entry (identity is by launch target, not key name).
+    Every collapse/rename is logged so a disappearing entry is diagnosable.
+    """
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        return False
+    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+    proxy_names = [n for n, s in servers.items() if _entry_is_playwright_proxy(n, s, canonical)]
+    # Nothing to converge: no proxy entry, or exactly the single canonical one.
+    if not proxy_names or proxy_names == [canonical]:
+        return False
+
+    # The user's recorded browse mode is the authority for which wiring should
+    # win when two proxies are both configured: an ``--extension`` entry and a
+    # stale ``--config`` headless entry both score as "wired", but arg-count
+    # alone would let the headless one (more args) silently replace the active
+    # extension entry and disable extension-mode browsing. Rank an entry matching
+    # the current mode first, THEN by generic wired-ness, THEN by arg count.
+    want_extension = has_playwright_extension()
+
+    def _completeness(name: str) -> tuple[int, int, int]:
+        spec = servers.get(name)
+        args = (spec.get("args") or []) if isinstance(spec, dict) else []
+        has_ext = "--extension" in args
+        has_cfg = "--config" in args
+        mode_match = 1 if (has_ext if want_extension else has_cfg) else 0
+        wired = 1 if (has_ext or has_cfg) else 0
+        return (mode_match, wired, len(args))
+
+    # The SURVIVOR SPEC is the proxy that best matches the user's current mode
+    # (falling back to the most completely-wired one) regardless of which key
+    # currently owns it — so convergence never discards the active configuration
+    # in favor of a stale or bare duplicate.
+    survivor_spec = servers[max(proxy_names, key=_completeness)]
+
+    # Pick the SURVIVOR KEY. The canonical key is used only when it is free or
+    # already holds KiroCrew's proxy — never when it holds a user-declared
+    # *direct* (non-proxy) server, or that user config would be clobbered.
+    #   * canonical free / already-proxy  -> survivor lives at ``canonical``;
+    #   * canonical occupied by a non-proxy user server -> survivor stays under
+    #     the most-complete legacy proxy key so the user's canonical entry is
+    #     untouched and we only collapse *duplicate* proxies onto it.
+    canon_spec = servers.get(canonical)
+    if canonical not in servers or _spec_is_proxy(canon_spec):
+        target = canonical
+    else:
+        target = max(
+            (n for n in proxy_names if n != canonical),
+            key=_completeness,
+        )
+
+    dropped = [n for n in proxy_names if n != target]
+    if not dropped:
+        # Survivor already sits alone under ``target`` (a lone legacy proxy while
+        # a user's direct server holds canonical) — nothing to collapse. Leaving
+        # it in place is correct: never delete the last proxy, never move it onto
+        # the user's canonical entry.
+        return False
+    # Log each dropped spec IN FULL (env VALUES redacted, keys kept) BEFORE
+    # deleting it. Convergence is a destructive, unattended, every-restart path
+    # whose survivor ranking depends on a live ``has_playwright_extension()``
+    # probe; if that were ever transiently wrong it could drop a still-wanted
+    # entry's args/env. Logging the whole spec (not just the key name) leaves a
+    # forensic trail to reconstruct a wrongly-deleted entry — without ever
+    # writing a token value to the log.
+    dropped_specs = {n: _redact_spec_for_log(servers.get(n)) for n in dropped}
+    for n in dropped:
+        servers.pop(n, None)
+    servers[target] = survivor_spec
+    logger.info(
+        "Converged Playwright proxy entries %s onto %r; dropped specs (env "
+        "values redacted): %s",
+        proxy_names,
+        target,
+        dropped_specs,
+    )
+
+    new_ref = f"@{target}"
+    drop_refs = {f"@{n}" for n in dropped}
+    for key in ("tools", "allowedTools"):
+        lst = config.get(key)
+        if isinstance(lst, list):
+            config[key] = list(dict.fromkeys(new_ref if t in drop_refs else t for t in lst))
+    return True
+
+
+def _converge_playwright_agent_files() -> None:
+    """Sweep KiroCrew-generated agent configs, converging Playwright to one
+    canonical server. Runs on gateway init so an existing machine self-heals on
+    a plain restart. Only KiroCrew-OWNED agent-config files are touched — the
+    EXACT filenames in ``_OWNED_KIRO_AGENT_FILES`` under ``~/.kiro/agents/`` and
+    ``_OWNED_CC_AGENT_FILES`` under ``~/.claude/agents/``, an explicit allowlist
+    (not a ``kirocrew*`` prefix glob). A user's OWN agents — even one they name
+    ``kirocrew-custom.json`` — live in the same dirs and may carry intentionally
+    distinct Playwright entries; matching exact generated filenames is what keeps
+    a restart from rewriting configs KiroCrew did not author. Silently skips
+    unreadable/non-dict/absent files.
+    """
+    agent_files: list[Path] = []
+    kiro_dir = Path.home() / ".kiro" / "agents"
+    for name in _OWNED_KIRO_AGENT_FILES:
+        p = kiro_dir / name
+        if p.is_file():
+            agent_files.append(p)
+    cc_dir = Path.home() / ".claude" / "agents"
+    for name in _OWNED_CC_AGENT_FILES:
+        p = cc_dir / name
+        if p.is_file():
+            agent_files.append(p)
+    for path in agent_files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if converge_playwright_servers(data):
+            try:
+                # Preserve the file's existing permission bits: an agent config
+                # may hold MCP ``env`` credentials and be mode 0600 — atomic_write
+                # would otherwise recreate it with the umask default (commonly
+                # 0644), exposing secrets to other local users after startup.
+                try:
+                    prev_mode: int | None = stat.S_IMODE(path.stat().st_mode)
+                except OSError:
+                    prev_mode = None
+                # Atomic write: a live kiro-cli session reads kirocrew.json
+                # through the agent-config path, so a torn write (truncated
+                # mid-flush) could be parsed as a corrupt config. Rename-based
+                # replace makes the swap all-or-nothing.
+                atomic_write(path, json.dumps(data, indent=2), mode=prev_mode)
+            except OSError:
+                pass
+
+
+# Sidecar manifest recording the MCP server keys KiroCrew itself has written.
+# kiro-cli validates ~/.kiro/settings/mcp.json (and agent specs) with
+# ``deny_unknown_fields``, so an in-spec ownership sentinel is impossible; the
+# manifest lives OUT of band under ~/.kirocrew/ (a dir KiroCrew owns outright).
+# It is the FIRST authorship signal for drop/converge decisions — the
+# ``mcp-playwright-proxy`` launch-target heuristic remains the fallback for
+# entries written by installs that predate this manifest.
+_OWNED_MCP_KEYS_MANIFEST = "owned-mcp-keys.json"
+
+
+def _owned_mcp_keys_path() -> Path:
+    return Path.home() / ".kirocrew" / _OWNED_MCP_KEYS_MANIFEST
+
+
+def _load_owned_mcp_keys() -> set[str]:
+    """Return the set of MCP keys KiroCrew has recorded writing (empty on any
+    read/parse error — a missing/corrupt manifest just means fall back to the
+    launch-target heuristic, never a crash)."""
+    path = _owned_mcp_keys_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return set()
+    keys = data.get("keys") if isinstance(data, dict) else None
+    return {k for k in keys if isinstance(k, str)} if isinstance(keys, list) else set()
+
+
+def _record_owned_mcp_key(key: str) -> None:
+    """Record *key* as KiroCrew-written in the sidecar manifest (mode 0600).
+
+    Idempotent and best-effort: a failure to persist the marker must never break
+    the MCP write it accompanies (the launch-target heuristic still covers the
+    entry), so all errors are swallowed.
+    """
+    try:
+        current = _load_owned_mcp_keys()
+        if key in current:
+            return
+        current.add(key)
+        path = _owned_mcp_keys_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(path, json.dumps({"keys": sorted(current)}, indent=2), mode=0o600)
+    except OSError:
+        pass
+
+
 def patch_mcp_extension(token: str) -> None:
     """Update MCP config to use proxy with --extension and token env var."""
     mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
@@ -174,9 +618,12 @@ def patch_mcp_extension(token: str) -> None:
             "args": ["mcp-playwright-proxy", "--extension"],
             "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": token},
         }
-        servers["@playwright/mcp"] = entry
+        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+        _drop_superseded_playwright(servers, canonical)
+        servers[canonical] = entry
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
         platform_compat.chmod_safe(str(mcp_json), 0o600)
+        _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
         pass
 
@@ -194,8 +641,11 @@ def patch_mcp_headless() -> None:
             "command": _kirocrew_bin(),
             "args": ["mcp-playwright-proxy", "--config", config_path],
         }
-        servers["@playwright/mcp"] = entry
+        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+        _drop_superseded_playwright(servers, canonical)
+        servers[canonical] = entry
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
         pass
 

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -640,15 +640,27 @@ def _set_pinned_and_reload(slug: str, pinned: bool) -> Any:
     return store.get(slug)
 
 
-def _scan_session_docs(
-    conversation_log: Any, saved_map: dict[str, str], session_key: str | None = None
+def _collect_session_docs(
+    conversation_log: Any,
+    saved_map: dict[str, str],
+    session_key: str | None = None,
 ) -> list[dict[str, Any]]:
     """Scan ALL sessions for non-code document file-changes (blocking).
 
     Returns one entry per distinct document path (latest session wins), each
-    ``{path, name, updated_at, session_key, message_ts, saved}``. ``saved`` is
-    True when the path already backs a real (materialized) artifact. Sorted
+    ``{path, name, updated_at, session_key, session_title, message_ts, saved,
+    slug}`` — with the **TRUE on-disk path** (never redacted). ``saved`` is True
+    when the path already backs a real (materialized) artifact. Sorted
     newest-first. Runs OFF the event loop — reads every session's jsonl.
+
+    INTERNAL ONLY — the raw ``path``/``name``/``session_title`` may contain a
+    credential-shaped substring. Callers that reach an external surface MUST go
+    through :func:`_scan_session_docs`, which redacts the display fields. The
+    authorization scan (:func:`_recorded_doc_identities`) uses this raw result
+    directly because it must ``stat`` the true path — redaction there would
+    corrupt a path that merely contains a credential-shaped substring (e.g. a
+    temp dir ``/var/folders/.../<hash>/``), silently emptying the materialize
+    allowlist so a legitimate document could not be saved.
     """
     best: dict[str, dict[str, Any]] = {}
     try:
@@ -708,28 +720,43 @@ def _scan_session_docs(
                     }
 
     out: list[dict[str, Any]] = []
+    for e in sorted(best.values(), key=lambda d: d["_mtime"], reverse=True):
+        mt = e.pop("_mtime")
+        raw_path = e["path"]
+        e["updated_at"] = datetime.fromtimestamp(mt).isoformat() if mt else ""
+        # saved/slug are keyed by the real source_path.
+        e["saved"] = raw_path in saved_map
+        e["slug"] = saved_map.get(raw_path, "")
+        out.append(e)
+    return out
+
+
+def _scan_session_docs(
+    conversation_log: Any,
+    saved_map: dict[str, str],
+    session_key: str | None = None,
+) -> list[dict[str, Any]]:
+    """Display-safe session-doc scan for the ``/session-docs`` API.
+
+    Wraps :func:`_collect_session_docs` and redacts every display field
+    (``path``, ``name``, ``session_title``) through the credential/exfiltration
+    redactors before the result leaves the process. Redaction is identity for
+    normal content, so ordinary paths still round-trip through ``/materialize``;
+    a path that actually contains a secret becomes intentionally unmatchable
+    (safe to refuse). Redaction lives HERE — at the one boundary that reaches an
+    external surface — so no shared flag can accidentally expose a raw path.
+    """
 
     def _redact(text: str) -> str:
         cleaned, _ = redact_credentials(text or "")
         cleaned, _ = redact_exfiltration_urls(cleaned)
         return cleaned
 
-    for e in sorted(best.values(), key=lambda d: d["_mtime"], reverse=True):
-        mt = e.pop("_mtime")
-        raw_path = e["path"]
-        e["updated_at"] = datetime.fromtimestamp(mt).isoformat() if mt else ""
-        # Compute saved/slug against the RAW path (saved_map is keyed by the
-        # real source_path) BEFORE redacting the display fields below.
-        e["saved"] = raw_path in saved_map
-        e["slug"] = saved_map.get(raw_path, "")
-        # Redact every display field per the credential/exfiltration blocking
-        # rule. Redaction is identity for normal content, so ordinary paths
-        # still round-trip through /materialize; a path that actually contains
-        # a secret becomes intentionally unmatchable (safe to refuse).
-        e["path"] = _redact(raw_path)
+    out = _collect_session_docs(conversation_log, saved_map, session_key)
+    for e in out:
+        e["path"] = _redact(e["path"])
         e["name"] = _redact(e["name"])
         e["session_title"] = _redact(e["session_title"])
-        out.append(e)
     return out
 
 
@@ -753,7 +780,12 @@ def _recorded_doc_identities(conversation_log: Any) -> set[tuple[int, int]]:
     entries are skipped.
     """
     out: set[tuple[int, int]] = set()
-    for e in _scan_session_docs(conversation_log, {}):
+    # Use the RAW collector (not _scan_session_docs): this is an in-process
+    # authorization scan whose result never reaches an external surface, and it
+    # must ``stat`` the TRUE path — a credential-shaped substring in the path
+    # (e.g. a temp-dir hash) would otherwise be redacted to a non-existent path
+    # and silently empty the allowlist, refusing a legitimate materialize.
+    for e in _collect_session_docs(conversation_log, {}):
         expanded = os.path.expanduser(e["path"])
         if not os.path.isabs(expanded):
             continue

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -6,7 +6,6 @@ import asyncio
 import errno
 import faulthandler
 import importlib
-import json
 import logging
 import os
 import time
@@ -25,12 +24,7 @@ from kiro_crew.apps.hooks_integration import (
     on_gateway_startup,
 )
 from kiro_crew.apps.manager import cleanup_migrated_builtin, register_builtin_apps
-from kiro_crew.browser.setup import (
-    get_extension_token,
-    has_playwright_extension,
-    patch_mcp_extension,
-    patch_mcp_headless,
-)
+from kiro_crew.browser.setup import migrate_owned_playwright_registration
 from kiro_crew.config import config_dir
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.constants import env_flag_enabled
@@ -464,30 +458,16 @@ def _register_dist_static_routes(app: web.Application, dist_dir: Path) -> None:
 
 
 def _migrate_playwright_to_proxy() -> None:
-    """Migrate existing mcp.json from direct npm-playwright-mcp to proxy."""
-    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
-    if not mcp_json.exists():
-        return
-    try:
-        data = json.loads(mcp_json.read_text(encoding="utf-8"))
-        servers = data.get("mcpServers", {})
-        entry = servers.get("npm:@playwright/mcp")
-        if not isinstance(entry, dict):
-            return
-        cmd = entry.get("command", "")
-        if "mcp-playwright-proxy" in cmd or "kirocrew" in cmd:
-            return
-        if has_playwright_extension():
-            token = get_extension_token() or ""
-            if token:
-                patch_mcp_extension(token)
-            else:
-                patch_mcp_headless()
-        else:
-            patch_mcp_headless()
-        logger.info("Migrated Playwright MCP to proxy in mcp.json")
-    except (json.JSONDecodeError, OSError):
-        pass
+    """Converge KiroCrew's own Playwright MCP registration to one canonical server.
+
+    Delegates to :func:`migrate_owned_playwright_registration`, which rewrites a
+    legacy or slash-keyed browse entry in ``~/.kiro/settings/mcp.json`` to the
+    canonical slash-free alias (``playwright-mcp``) proxy entry and sweeps the
+    KiroCrew-generated agent configs so a duplicate proxy entry collapses onto
+    the one canonical server. This self-heals an existing machine on a plain
+    gateway restart rather than waiting for a full agent rebuild.
+    """
+    migrate_owned_playwright_registration()
 
 
 def _precompute_telemetry(state: "DashboardState") -> None:

--- a/test/test_artifact_materialize.py
+++ b/test/test_artifact_materialize.py
@@ -153,6 +153,22 @@ def test_recorded_doc_identities_skips_missing_and_relative(tmp_path):
     assert len(ids) == 1
 
 
+def test_redaction_lives_at_the_api_boundary_only():
+    """Design-hardening regression: redaction is enforced structurally, not by a
+    shared flag. The external ``_scan_session_docs`` MUST redact a
+    credential-shaped path; the internal ``_collect_session_docs`` (used by the
+    authorization scan) MUST preserve the TRUE path so it can be ``stat``'d."""
+    cred_path = "/tmp/AKIAIOSFODNN7EXAMPLE/report.md"
+    log = _FakeLog([cred_path])
+    # API boundary: the path is redacted (never leaks a credential substring).
+    api = h._scan_session_docs(log, {})
+    assert api[0]["path"] != cred_path
+    assert "AKIAIOSFODNN7EXAMPLE" not in api[0]["path"]
+    # Internal collector: the true path is preserved (authorization can stat it).
+    raw = h._collect_session_docs(log, {})
+    assert raw[0]["path"] == cred_path
+
+
 class _BadTimestampLog:
     """Session log whose ``modified`` values are non-numeric / non-finite."""
 
@@ -171,9 +187,14 @@ class _BadTimestampLog:
         return [{"meta": {"file_changes": [{"path": self._doc}]}}]
 
 
-def test_scan_session_docs_survives_bad_timestamps(tmp_path):
+def test_collect_session_docs_survives_bad_timestamps(tmp_path):
     doc = _write_doc(tmp_path, "ts.md")
-    out = h._scan_session_docs(_BadTimestampLog(doc), {})
+    # Use the RAW collector so the assertion compares the true path, not the
+    # redacted display field: a tmp_path whose parent dir contains a
+    # credential-shaped segment (e.g. macOS ``/var/folders/<hash>/``) would
+    # otherwise be redacted and fail an equality check that is really about
+    # *discovery*, not display.
+    out = h._collect_session_docs(_BadTimestampLog(doc), {})
     # The document is still discovered despite malformed timestamps.
     assert [e["path"] for e in out] == [doc]
 

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -11,20 +11,34 @@ parsing, Playwright config generation and storage-state refresh still work.
 from __future__ import annotations
 
 import json
+import os
+import stat
 from pathlib import Path
 
 import pytest
 
 import kiro_crew.browser.setup as setup_mod
 from kiro_crew.browser.setup import (
+    _converge_playwright_agent_files,
+    _drop_superseded_playwright,
+    _entry_is_playwright_proxy,
+    converge_playwright_servers,
     ensure_playwright_installed,
     generate_playwright_config,
     get_playwright_mcp_args,
     inject_cookies_via_playwright,
     is_headed,
     is_playwright_installed,
+    migrate_owned_playwright_registration,
+    patch_mcp_extension,
+    patch_mcp_headless,
     refresh_storage_state,
 )
+from kiro_crew.mcp_utils import mcp_server_alias
+from kiro_crew.platform_compat import IS_POSIX
+
+# Canonical slash-free key KiroCrew registers the Playwright proxy under.
+_CANONICAL = mcp_server_alias("@playwright/mcp")  # "playwright-mcp"
 
 # ── Sample cookie data ────────────────────────────────────────────────────────
 
@@ -118,7 +132,9 @@ class TestInjectCookiesViaPlaywright:
         assert "user_name" in names
         assert "tpm_metrics" in names
 
-    def test_default_path_used_when_no_cookie_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_default_path_used_when_no_cookie_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         p = tmp_path / "cookie"
         p.write_text(SAMPLE_COOKIES)
         monkeypatch.setattr(setup_mod, "SSO_COOKIE_PATH", p)
@@ -156,7 +172,9 @@ class TestGeneratePlaywrightConfig:
         config_path = generate_playwright_config()
         assert config_path.exists()
 
-    def test_does_not_write_remote_debugging_port(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_does_not_write_remote_debugging_port(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         # B-minus dropped the CDP debug port — the live mirror now rides the
         # proxy's existing screenshot path, so no remote-debugging port is opened.
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -207,7 +225,9 @@ class TestGeneratePlaywrightConfig:
 
 
 class TestRefreshStorageState:
-    def test_returns_error_when_cookie_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_returns_error_when_cookie_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         missing = tmp_path / "no_cookie"
         monkeypatch.setattr(setup_mod, "SSO_COOKIE_PATH", missing)
         result = refresh_storage_state()
@@ -215,7 +235,9 @@ class TestRefreshStorageState:
         # OSS build has no bundled browser-auth cookie source.
         assert "not available in OSS" in result["error"]
 
-    def test_returns_error_when_no_cookies_parsed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_returns_error_when_no_cookies_parsed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         p = tmp_path / "cookie"
         p.write_text("# Netscape HTTP Cookie File\n# just comments\n")
         monkeypatch.setattr(setup_mod, "SSO_COOKIE_PATH", p)
@@ -223,7 +245,9 @@ class TestRefreshStorageState:
         assert result["ok"] is False
         assert "no cookies" in result["error"]
 
-    def test_success_creates_storage_state_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_success_creates_storage_state_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         p = tmp_path / "cookie"
         p.write_text(SAMPLE_COOKIES)
         sso_dir = tmp_path / ".sso"
@@ -236,7 +260,9 @@ class TestRefreshStorageState:
         storage_path = Path(result["path"])
         assert storage_path.exists()
 
-    def test_success_storage_state_valid_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_success_storage_state_valid_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         p = tmp_path / "cookie"
         p.write_text(SAMPLE_COOKIES)
         sso_dir = tmp_path / ".sso"
@@ -266,7 +292,9 @@ class TestRefreshStorageState:
 
 
 class TestGetPlaywrightMcpArgsWithConfig:
-    def test_includes_config_flag_when_file_exists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_includes_config_flag_when_file_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr(setup_mod, "is_headed", lambda: False)
         # Create the config file
@@ -283,3 +311,723 @@ class TestGetPlaywrightMcpArgsWithConfig:
         args = get_playwright_mcp_args()
         assert "--config" not in args
         assert "@playwright/mcp" in args
+
+
+# ── TestPatchWritesCanonicalKey ──────────────────────────────────────────────
+
+
+def _write_mcp_json(tmp_path: Path, servers: dict) -> Path:
+    """Seed ~/.kiro/settings/mcp.json under a monkeypatched home."""
+    mcp_json = tmp_path / ".kiro" / "settings" / "mcp.json"
+    mcp_json.parent.mkdir(parents=True, exist_ok=True)
+    mcp_json.write_text(json.dumps({"mcpServers": servers}, indent=2))
+    return mcp_json
+
+
+def _read_servers(mcp_json: Path) -> dict:
+    return json.loads(mcp_json.read_text())["mcpServers"]
+
+
+class TestPatchWritesCanonicalKey:
+    """patch_mcp_* register under the canonical alias and drop superseded keys."""
+
+    def test_headless_writes_canonical_and_drops_superseded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {
+                "@playwright/mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                "npm:@playwright/mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                "other-mcp": {"command": "foo"},
+            },
+        )
+        patch_mcp_headless()
+        servers = _read_servers(mcp_json)
+        # Exactly the canonical key + the untouched user server survive.
+        assert set(servers) == {_CANONICAL, "other-mcp"}
+        assert "mcp-playwright-proxy" in servers[_CANONICAL]["args"]
+
+    def test_extension_writes_canonical_and_drops_superseded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod.platform_compat, "chmod_safe", lambda *a, **k: None)
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {"npm:@playwright/mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]}},
+        )
+        patch_mcp_extension("tok-123")
+        servers = _read_servers(mcp_json)
+        assert set(servers) == {_CANONICAL}
+        assert servers[_CANONICAL]["env"]["PLAYWRIGHT_MCP_EXTENSION_TOKEN"] == "tok-123"
+
+    def test_drop_superseded_never_drops_canonical(self, tmp_path, monkeypatch):
+        # A superseded key is dropped ONLY when its spec is actually the proxy.
+        # (home -> tmp_path so no real ownership manifest colors the decision.)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        servers = {
+            _CANONICAL: {"command": "kirocrew"},
+            "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+        }
+        _drop_superseded_playwright(servers, _CANONICAL)
+        assert _CANONICAL in servers
+        assert "playwright-proxy-mcp" not in servers
+
+    def test_drop_superseded_preserves_user_direct_server(self, tmp_path, monkeypatch):
+        # A user-declared DIRECT (non-proxy) server keyed under a superseded name
+        # (@playwright/mcp pointing at the real npm package) is NOT KiroCrew's and
+        # must survive — authorship is by launch target, not key name. No manifest
+        # marks it, so it is preserved.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        servers = {
+            "@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp@latest"]},
+            "npm:@playwright/mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+        }
+        _drop_superseded_playwright(servers, _CANONICAL)
+        # The proxy-spec superseded key is dropped; the user's direct one stays.
+        assert "npm:@playwright/mcp" not in servers
+        assert servers["@playwright/mcp"] == {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"],
+        }
+
+    def test_patch_records_owned_key_in_manifest(self, tmp_path, monkeypatch):
+        # Arbiter regression (manifest-on-write): patch_mcp_* records the canonical
+        # key it wrote in the ~/.kirocrew ownership manifest, so future migrations
+        # have an explicit authorship signal (not just the argv heuristic).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        _write_mcp_json(tmp_path, {"other-mcp": {"command": "foo"}})
+        patch_mcp_headless()
+        assert _CANONICAL in setup_mod._load_owned_mcp_keys()
+        # Manifest file is owner-only.
+        if IS_POSIX:
+            mode = stat.S_IMODE(setup_mod._owned_mcp_keys_path().stat().st_mode)
+            assert mode == 0o600
+
+    def test_drop_superseded_uses_manifest_over_mutated_spec(self, tmp_path, monkeypatch):
+        # A superseded key recorded in the manifest is KiroCrew's even if its spec
+        # was later mutated to no longer look like the proxy — the explicit
+        # ownership marker wins over the argv heuristic.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".kirocrew").mkdir(parents=True)
+        setup_mod._record_owned_mcp_key("playwright-proxy-mcp")
+        servers = {
+            _CANONICAL: {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+            # Spec no longer looks like the proxy, but the manifest says it's ours.
+            "playwright-proxy-mcp": {"command": "wrapper", "args": ["--opaque"]},
+        }
+        _drop_superseded_playwright(servers, _CANONICAL)
+        assert "playwright-proxy-mcp" not in servers
+
+    def test_manifest_never_drops_unrecorded_user_direct_key(self, tmp_path, monkeypatch):
+        # Defense: a manifest recording OTHER keys must not cause a user's direct
+        # @playwright/mcp (not in the manifest, not a proxy) to be dropped.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".kirocrew").mkdir(parents=True)
+        setup_mod._record_owned_mcp_key("playwright-proxy-mcp")
+        servers = {
+            "@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp@latest"]},
+        }
+        _drop_superseded_playwright(servers, _CANONICAL)
+        assert servers["@playwright/mcp"] == {"command": "npx", "args": ["@playwright/mcp@latest"]}
+
+
+# ── TestMigrateOwnedPlaywrightRegistration ───────────────────────────────────
+
+
+class TestMigrateOwnedPlaywrightRegistration:
+    def test_migrates_legacy_key_to_canonical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {
+                "@playwright/mcp": {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                }
+            },
+        )
+        migrate_owned_playwright_registration()
+        servers = _read_servers(mcp_json)
+        assert set(servers) == {_CANONICAL}
+
+    def test_migrates_legacy_direct_npm_entry_to_proxy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # GPT 5.6 MEDIUM regression: KiroCrew's ORIGINAL boot migration upgraded a
+        # legacy DIRECT npm-launched Playwright (key `npm:@playwright/mcp`, command
+        # not the proxy) to the compression proxy. That direct->proxy upgrade must
+        # still happen — the `npm:` key is a KiroCrew install artifact, so a direct
+        # spec under it is ours to migrate (and remove), not left behind.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {"npm:@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp@latest"]}},
+        )
+        migrate_owned_playwright_registration()
+        servers = _read_servers(mcp_json)
+        # Upgraded: canonical proxy present, the legacy direct entry removed.
+        assert set(servers) == {_CANONICAL}
+        assert "mcp-playwright-proxy" in servers[_CANONICAL]["args"]
+
+    def test_drop_superseded_removes_legacy_direct_npm_key(self):
+        # The `npm:@playwright/mcp` key is a KiroCrew artifact: its DIRECT spec is
+        # dropped when KiroCrew rewrites its registration (so no second backend
+        # lingers). The bare `@playwright/mcp` direct key is NOT (user may own it).
+        servers = {
+            "npm:@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp@latest"]},
+            "@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp@latest"]},
+        }
+        _drop_superseded_playwright(servers, _CANONICAL)
+        assert "npm:@playwright/mcp" not in servers
+        assert servers["@playwright/mcp"] == {"command": "npx", "args": ["@playwright/mcp@latest"]}
+
+    def test_noop_when_already_canonical_no_churn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                }
+            },
+        )
+        before = mcp_json.read_text()
+        migrate_owned_playwright_registration()
+        # Byte-identical: an already-canonical proxy is left untouched (no churn).
+        assert mcp_json.read_text() == before
+
+    def test_does_not_add_when_no_playwright(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(tmp_path, {"some-user-mcp": {"command": "foo"}})
+        migrate_owned_playwright_registration()
+        servers = _read_servers(mcp_json)
+        assert set(servers) == {"some-user-mcp"}
+        assert _CANONICAL not in servers
+
+    def test_noop_when_mcp_json_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # No mcp.json, no agent dirs — must not raise.
+        migrate_owned_playwright_registration()
+
+    def test_leaves_user_direct_playwright_server_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # BLOCK-finding regression: a user's DIRECT @playwright/mcp entry in
+        # kiro's mcp.json (a superseded KEY, but a non-proxy spec) must not be
+        # rewritten or dropped by the boot-time convergence — its key name is
+        # not proof of KiroCrew authorship.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        mcp_json = _write_mcp_json(tmp_path, {"@playwright/mcp": dict(direct)})
+        before = mcp_json.read_text()
+        migrate_owned_playwright_registration()
+        # Byte-identical: the user's direct server was left exactly as-is.
+        assert mcp_json.read_text() == before
+        assert _read_servers(mcp_json)["@playwright/mcp"] == direct
+
+    def test_leaves_user_direct_server_under_canonical_key_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # GPT-review regression: a user's DIRECT (non-proxy) server keyed under
+        # the CANONICAL `playwright-mcp` key must not be clobbered on boot. With
+        # no superseded proxy to migrate, and canonical held by a user entry,
+        # the guard must return before calling patch_mcp_* (which would do
+        # servers[canonical] = proxy_entry and destroy the config every restart).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest", "--headless"]}
+        mcp_json = _write_mcp_json(tmp_path, {_CANONICAL: dict(direct)})
+        before = mcp_json.read_text()
+        migrate_owned_playwright_registration()
+        assert mcp_json.read_text() == before
+        assert _read_servers(mcp_json)[_CANONICAL] == direct
+
+    def test_leaves_user_canonical_even_when_superseded_proxy_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Defense in depth: a user owns the canonical key with a direct server
+        # AND a legacy proxy also exists. Migrating would overwrite the user's
+        # canonical entry, so the guard leaves mcp.json untouched (the legacy
+        # proxy is still folded for display/launch by the read/pool layers).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {
+                _CANONICAL: dict(direct),
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+            },
+        )
+        before = mcp_json.read_text()
+        migrate_owned_playwright_registration()
+        assert mcp_json.read_text() == before
+
+
+# ── TestConvergePlaywrightServers ────────────────────────────────────────────
+
+
+class TestConvergePlaywrightServers:
+    def test_collapses_canonical_and_legacy_by_target(self):
+        cfg = {
+            "mcpServers": {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                },
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                "user-helper": {"command": "node", "args": ["h.js"]},
+            },
+            "tools": ["@playwright-proxy-mcp", "@other"],
+            "allowedTools": [f"@{_CANONICAL}", "@playwright-proxy-mcp"],
+        }
+        assert converge_playwright_servers(cfg) is True
+        assert set(cfg["mcpServers"]) == {_CANONICAL, "user-helper"}
+        # Dropped @ref rewritten to canonical; allowedTools de-duped.
+        assert cfg["tools"] == [f"@{_CANONICAL}", "@other"]
+        assert cfg["allowedTools"] == [f"@{_CANONICAL}"]
+
+    def test_renames_sole_legacy_to_canonical(self):
+        cfg = {
+            "mcpServers": {
+                "playwright-proxy-mcp": {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                },
+            }
+        }
+        assert converge_playwright_servers(cfg) is True
+        assert set(cfg["mcpServers"]) == {_CANONICAL}
+        assert "--config" in cfg["mcpServers"][_CANONICAL]["args"]
+
+    def test_noop_when_only_canonical(self):
+        cfg = {
+            "mcpServers": {_CANONICAL: {"command": "kirocrew", "args": ["mcp-playwright-proxy"]}}
+        }
+        assert converge_playwright_servers(cfg) is False
+
+    def test_noop_when_no_playwright(self):
+        cfg = {"mcpServers": {"foo": {"command": "x"}}}
+        assert converge_playwright_servers(cfg) is False
+
+    def test_ignores_non_proxy_server_named_playwright(self):
+        # A user server whose name contains "playwright" but does NOT launch the
+        # proxy must not be matched or rewritten.
+        spec = {"command": "node", "args": ["my-playwright-helper.js"]}
+        assert _entry_is_playwright_proxy("my-playwright-helper", spec, _CANONICAL) is False
+        cfg = {"mcpServers": {"my-playwright-helper": spec}}
+        assert converge_playwright_servers(cfg) is False
+
+    def test_preserves_user_direct_playwright_under_superseded_key(self):
+        # BLOCK-finding regression: a user hand-declares a DIRECT (non-proxy)
+        # @playwright/mcp server (the real npm package, a superseded KEY name).
+        # Authorship is by launch target, so this is NOT collapsed/dropped even
+        # though its key is in _SUPERSEDED_PLAYWRIGHT_KEYS.
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest", "--headless"]}
+        assert _entry_is_playwright_proxy("@playwright/mcp", direct, _CANONICAL) is False
+        cfg = {"mcpServers": {"@playwright/mcp": direct}}
+        assert converge_playwright_servers(cfg) is False
+        assert cfg["mcpServers"]["@playwright/mcp"] == direct
+
+    def test_collapses_proxy_but_keeps_user_direct_alongside(self):
+        # A real proxy (legacy key) AND a user's direct @playwright/mcp coexist:
+        # the proxy converges onto the canonical key; the user's direct server is
+        # untouched.
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        cfg = {
+            "mcpServers": {
+                "@playwright/mcp": direct,
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+            }
+        }
+        assert converge_playwright_servers(cfg) is True
+        assert cfg["mcpServers"]["@playwright/mcp"] == direct
+        assert _CANONICAL in cfg["mcpServers"]
+        assert "playwright-proxy-mcp" not in cfg["mcpServers"]
+
+    def test_user_direct_under_canonical_key_never_clobbered_by_legacy_proxy(self):
+        # GPT 5.6 HIGH regression: a user's DIRECT (non-proxy) server occupies the
+        # canonical `playwright-mcp` key while a legacy KiroCrew proxy sits under
+        # another key. The survivor selection must NOT pick the non-proxy canonical
+        # entry and delete the real proxy — that would silently destroy KiroCrew's
+        # proxy. Since there is only one proxy and it can't move onto the user's
+        # canonical slot, nothing collapses and the config is left untouched.
+        user_direct = {"command": "npx", "args": ["@playwright/mcp@latest", "--headless"]}
+        proxy = {"command": "kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}
+        cfg = {
+            "mcpServers": {
+                _CANONICAL: user_direct,
+                "playwright-proxy-mcp": proxy,
+            }
+        }
+        assert converge_playwright_servers(cfg) is False
+        # Both entries survive byte-identical: the user's canonical direct server
+        # AND KiroCrew's proxy under its own legacy key.
+        assert cfg["mcpServers"][_CANONICAL] == user_direct
+        assert cfg["mcpServers"]["playwright-proxy-mcp"] == proxy
+
+    def test_extension_survivor_wins_over_headless_when_extension_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # GPT 5.6 MEDIUM regression: an active --extension entry and a stale
+        # --config headless entry coexist. The headless entry has MORE args, so
+        # arg-count alone would let it win and silently disable extension mode.
+        # With extension mode enabled, the --extension entry must survive.
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        ext = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        headless = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/x/pw.json"],
+        }
+        cfg = {"mcpServers": {_CANONICAL: headless, "playwright-proxy-mcp": ext}}
+        assert converge_playwright_servers(cfg) is True
+        assert set(cfg["mcpServers"]) == {_CANONICAL}
+        # The extension entry won despite having fewer args.
+        assert "--extension" in cfg["mcpServers"][_CANONICAL]["args"]
+
+    def test_headless_survivor_wins_over_extension_when_config_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Mirror: with extension mode OFF, the --config headless entry is the one
+        # that matches the current mode and must survive.
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        ext = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension", "--foo", "--bar"],
+        }
+        headless = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/x/pw.json"],
+        }
+        cfg = {"mcpServers": {_CANONICAL: ext, "playwright-proxy-mcp": headless}}
+        assert converge_playwright_servers(cfg) is True
+        assert set(cfg["mcpServers"]) == {_CANONICAL}
+        assert "--config" in cfg["mcpServers"][_CANONICAL]["args"]
+        assert "--extension" not in cfg["mcpServers"][_CANONICAL]["args"]
+
+    def test_survivor_is_most_complete_even_when_canonical_is_bare(self):
+        # GPT 5.6 HIGH regression: a BARE canonical proxy coexists with a
+        # fully-wired legacy proxy (--config/token). The survivor must be the
+        # WIRED spec (never discard a working configuration for a bare
+        # duplicate), stored under the canonical key.
+        bare_canon = {"command": "kirocrew", "args": ["mcp-playwright-proxy"]}
+        wired_legacy = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/x/pw.json"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        cfg = {
+            "mcpServers": {
+                _CANONICAL: bare_canon,
+                "playwright-proxy-mcp": wired_legacy,
+            }
+        }
+        assert converge_playwright_servers(cfg) is True
+        assert set(cfg["mcpServers"]) == {_CANONICAL}
+        # The wired spec survived under the canonical key; the bare one is gone.
+        assert cfg["mcpServers"][_CANONICAL] == wired_legacy
+
+    def test_dedupes_multiple_legacy_proxies_without_touching_user_canonical(self):
+        # Two legacy proxies coexist with a user's direct server under canonical.
+        # The two proxies must collapse to one (still under a legacy key, never
+        # onto the user's canonical slot); the user's canonical entry is untouched.
+        user_direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        proxy_full = {"command": "kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}
+        proxy_bare = {"command": "kirocrew", "args": ["mcp-playwright-proxy"]}
+        cfg = {
+            "mcpServers": {
+                _CANONICAL: user_direct,
+                "playwright-proxy-mcp": proxy_full,
+                "npm:@playwright/mcp": proxy_bare,
+            }
+        }
+        assert converge_playwright_servers(cfg) is True
+        assert cfg["mcpServers"][_CANONICAL] == user_direct
+        # Exactly one proxy survives (the more completely-wired one); the user's
+        # canonical direct server is preserved alongside it.
+        surviving_proxies = [
+            n for n, s in cfg["mcpServers"].items() if "mcp-playwright-proxy" in s.get("args", [])
+        ]
+        assert len(surviving_proxies) == 1
+        assert cfg["mcpServers"][surviving_proxies[0]] == proxy_full
+
+
+# ── TestConvergePlaywrightAgentFiles ─────────────────────────────────────────
+
+
+class TestConvergePlaywrightAgentFiles:
+    def test_sweeps_kiro_and_cc_agent_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kiro_dir = tmp_path / ".kiro" / "agents"
+        cc_dir = tmp_path / ".claude" / "agents"
+        kiro_dir.mkdir(parents=True)
+        cc_dir.mkdir(parents=True)
+        dup = {
+            "mcpServers": {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                },
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+            }
+        }
+        kiro_file = kiro_dir / "kirocrew.json"
+        cc_file = cc_dir / "kirocrew.mcp.json"
+        kiro_file.write_text(json.dumps(dup))
+        cc_file.write_text(json.dumps(dup))
+        # A .bak file must be skipped (only the exact owned filenames are swept).
+        (kiro_dir / "kirocrew.json.bak.123").write_text(json.dumps(dup))
+
+        _converge_playwright_agent_files()
+
+        assert set(json.loads(kiro_file.read_text())["mcpServers"]) == {_CANONICAL}
+        assert set(json.loads(cc_file.read_text())["mcpServers"]) == {_CANONICAL}
+        # The .bak file was NOT swept (still holds the duplicate).
+        assert (
+            "playwright-proxy-mcp"
+            in json.loads((kiro_dir / "kirocrew.json.bak.123").read_text())["mcpServers"]
+        )
+
+    def test_no_error_when_dirs_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _converge_playwright_agent_files()  # must not raise
+
+    def test_leaves_user_owned_agent_files_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # GPT 5.6 HIGH regression: the sweep rewrites ONLY the EXACT filenames
+        # KiroCrew generates (an explicit allowlist, not a ``kirocrew*`` prefix
+        # glob). A user's own agent — including one they named
+        # ``kirocrew-custom.json`` — may carry intentionally distinct proxy
+        # entries; a restart must not collapse them and overwrite the user's file.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kiro_dir = tmp_path / ".kiro" / "agents"
+        cc_dir = tmp_path / ".claude" / "agents"
+        kiro_dir.mkdir(parents=True)
+        cc_dir.mkdir(parents=True)
+        dup = {
+            "mcpServers": {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                },
+                "playwright-proxy-mcp": {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+            }
+        }
+        # KiroCrew-owned (exact generated names): swept.
+        owned = kiro_dir / "kirocrew.json"
+        owned_variant = kiro_dir / "kirocrew-research.json"
+        # User-owned: left alone — incl. a ``kirocrew``-PREFIXED custom name that
+        # a prefix glob would wrongly have matched, and unrelated names.
+        user_prefixed = kiro_dir / "kirocrew-custom.json"
+        user_kiro = kiro_dir / "my-custom-agent.json"
+        user_cc = cc_dir / "my-agent.mcp.json"
+        for f in (owned, owned_variant, user_prefixed, user_kiro, user_cc):
+            f.write_text(json.dumps(dup))
+
+        _converge_playwright_agent_files()
+
+        # KiroCrew-owned files converged to one server.
+        assert set(json.loads(owned.read_text())["mcpServers"]) == {_CANONICAL}
+        assert set(json.loads(owned_variant.read_text())["mcpServers"]) == {_CANONICAL}
+        # User-owned files byte-identical (both proxies preserved).
+        assert "playwright-proxy-mcp" in json.loads(user_prefixed.read_text())["mcpServers"]
+        assert "playwright-proxy-mcp" in json.loads(user_kiro.read_text())["mcpServers"]
+        assert "playwright-proxy-mcp" in json.loads(user_cc.read_text())["mcpServers"]
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_preserves_0600_file_mode_on_sweep(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # GPT 5.6 HIGH regression: an agent config holding MCP env credentials may
+        # be mode 0600. The convergence sweep's atomic write must NOT recreate it
+        # with the umask default (0644) and expose secrets to other local users.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kiro_dir = tmp_path / ".kiro" / "agents"
+        kiro_dir.mkdir(parents=True)
+        dup = {
+            "mcpServers": {
+                _CANONICAL: {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                "playwright-proxy-mcp": {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--config", "x"],
+                    "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "secret"},
+                },
+            }
+        }
+        secret_file = kiro_dir / "kirocrew.json"
+        secret_file.write_text(json.dumps(dup))
+        os.chmod(secret_file, 0o600)
+
+        _converge_playwright_agent_files()
+
+        # Converged (one server left) AND still owner-only readable.
+        assert set(json.loads(secret_file.read_text())["mcpServers"]) == {_CANONICAL}
+        assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
+
+
+# ── TestConvergeKirocrewMcpJson ──────────────────────────────────────────────
+
+
+class TestConvergeKirocrewMcpJson:
+    """Arbiter regression: KiroCrew's own ~/.kirocrew/mcp.json is healed at the
+    source, so a stale proxy key there isn't re-injected into the agent config on
+    every rebuild for the per-rebuild backstop to undo forever."""
+
+    def test_converges_stale_proxy_key_at_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        d = tmp_path / ".kirocrew"
+        d.mkdir(parents=True)
+        f = d / "mcp.json"
+        f.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        _CANONICAL: {
+                            "command": "kirocrew",
+                            "args": ["mcp-playwright-proxy", "--config", "x"],
+                        },
+                        "playwright-proxy-mcp": {
+                            "command": "kirocrew",
+                            "args": ["mcp-playwright-proxy"],
+                        },
+                    }
+                }
+            )
+        )
+        setup_mod._converge_kirocrew_mcp_json()
+        # The stale duplicate proxy is gone at the source.
+        assert set(json.loads(f.read_text())["mcpServers"]) == {_CANONICAL}
+
+    def test_noop_when_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        setup_mod._converge_kirocrew_mcp_json()  # must not raise
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_preserves_file_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        d = tmp_path / ".kirocrew"
+        d.mkdir(parents=True)
+        f = d / "mcp.json"
+        f.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        _CANONICAL: {"command": "kirocrew", "args": ["mcp-playwright-proxy"]},
+                        "playwright-proxy-mcp": {
+                            "command": "kirocrew",
+                            "args": ["mcp-playwright-proxy", "--config", "x"],
+                        },
+                    }
+                }
+            )
+        )
+        os.chmod(f, 0o600)
+        setup_mod._converge_kirocrew_mcp_json()
+        assert set(json.loads(f.read_text())["mcpServers"]) == {_CANONICAL}
+        assert stat.S_IMODE(f.stat().st_mode) == 0o600
+
+    def test_leaves_user_direct_server_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A user's direct (non-proxy) server in ~/.kirocrew/mcp.json is not a
+        # proxy, so convergence is a no-op and the file is left byte-identical.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        d = tmp_path / ".kirocrew"
+        d.mkdir(parents=True)
+        f = d / "mcp.json"
+        original = json.dumps(
+            {"mcpServers": {"@playwright/mcp": {"command": "npx", "args": ["@playwright/mcp"]}}}
+        )
+        f.write_text(original)
+        setup_mod._converge_kirocrew_mcp_json()
+        assert f.read_text() == original
+
+
+# ── TestConvergeDropLogging / owned-filename source of truth ──────────────────
+
+
+class TestConvergeForensics:
+    def test_dropped_spec_logged_with_env_values_redacted(self, caplog):
+        # Arbiter regression: a dropped proxy's spec is logged in full (so a
+        # wrongly-deleted entry can be reconstructed) but its env VALUES are
+        # masked — a token like PLAYWRIGHT_MCP_EXTENSION_TOKEN never hits the log.
+        import logging as _logging
+
+        cfg = {
+            "mcpServers": {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--extension"],
+                },
+                "playwright-proxy-mcp": {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy"],
+                    "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "super-secret-token"},
+                },
+            }
+        }
+        with caplog.at_level(_logging.INFO, logger="kiro_crew.browser.setup"):
+            assert converge_playwright_servers(cfg) is True
+        log_text = caplog.text
+        # The dropped key + its arg wiring are diagnosable; the token is not.
+        assert "playwright-proxy-mcp" in log_text
+        assert "super-secret-token" not in log_text
+        assert "PLAYWRIGHT_MCP_EXTENSION_TOKEN" in log_text  # key kept, value masked
+
+    def test_redact_spec_for_log_masks_env_values_only(self):
+        spec = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"TOK": "secret", "OTHER": "also-secret"},
+        }
+        safe = setup_mod._redact_spec_for_log(spec)
+        assert safe["command"] == "kirocrew"
+        assert safe["args"] == ["mcp-playwright-proxy", "--extension"]
+        assert safe["env"] == {"TOK": "***", "OTHER": "***"}
+        # Original spec is not mutated.
+        assert spec["env"]["TOK"] == "secret"
+
+    def test_owned_allowlist_is_the_leaf_module_source_of_truth(self):
+        # Item 2 regression: the sweep's allowlist IS the agent_files leaf module
+        # (not a hand-copied literal), so adding a managed spec in one place is
+        # picked up here with no drift.
+        from kiro_crew import agent_files
+
+        assert setup_mod._OWNED_KIRO_AGENT_FILES is agent_files.OWNED_KIRO_AGENT_FILES
+        assert setup_mod._OWNED_CC_AGENT_FILES is agent_files.OWNED_CC_AGENT_FILES
+        # And agent.py's own filename constants come from the same leaf module.
+        from kiro_crew import agent as agent_mod
+
+        assert agent_mod.AGENT_FILENAME == agent_files.AGENT_FILENAME
+        assert agent_mod.AGENT_FILENAME in agent_files.OWNED_KIRO_AGENT_FILES

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2855,6 +2855,13 @@ class TestKnowledgePoolIdleTtl:
         assert cfg.knowledge.pool_idle_ttl_secs == 300
 
     def test_string_falls_back_to_default(self) -> None:
+        # `kirocrew config set` coerces numeric strings to real JSON numbers via
+        # cli_config._parse_value BEFORE writing, so a numeric field never
+        # legitimately arrives as a string. A string here is malformed input and
+        # falls back to the default (strict-parse contract). Loader-side coercion
+        # is deliberately NOT added: it would only run when the optional
+        # jsonschema dep is installed (undeclared), making the behavior differ
+        # between installs.
         cfg = _load_from_dict({"knowledge": {"pool_idle_ttl_secs": "60"}})
         assert cfg.knowledge.pool_idle_ttl_secs == 300
 


### PR DESCRIPTION
## Description

Rebased onto latest `main`. This PR now contains **two fixes** (the `aim`→`plugin` rename was superseded by #286 and dropped; the config-loader numeric-coercion change was reverted — see below):

### 1. Converge duplicate Playwright MCP registration

The proxy could be registered under multiple key names (`@playwright/mcp`, `npm:@playwright/mcp`, `playwright-proxy-mcp`, `playwright-mcp`) → duplicate dashboard rows / background probes / launched backends. The fork had the read-fold, pool launch-target dedupe, slash-alias, and normalized-spec dedupe layers — but **not** the registration/write convergence, so `patch_mcp_*` wrote the raw slash key while the agent config normalized to `playwright-mcp` → two logical servers.

- `browser/setup.py`: `patch_mcp_*` write under the canonical alias after `_drop_superseded_playwright` drops legacy proxy keys **and** KiroCrew's legacy *direct* `npm:@playwright/mcp` entry. `migrate_owned_playwright_registration` heals every KiroCrew-**owned** surface at the source on boot — `~/.kiro/settings/mcp.json` (incl. upgrading a legacy direct entry to the proxy), `~/.kirocrew/mcp.json` (so a stale key isn't re-injected on every rebuild), and the **exact** `kirocrew*` agent-config filenames (an explicit allowlist, never a bare `*.json` glob, so a user's own agents are never rewritten). **Authorship is by resolved launch target (`mcp-playwright-proxy` in argv), never key name** — a user-declared *direct* `@playwright/mcp` server is never touched. The survivor spec is the proxy matching the user's current browse mode (extension vs headless), falling back to the most completely-wired. Mode-preserving atomic writes keep `0600` credential-bearing configs owner-only. Every collapse is logged.
- `agent.py`: `converge_playwright_servers` runs after key normalization in `rebuild_agent_config` as a **backstop** (owned sources are healed at boot; this catches anything re-merged mid-rebuild).
- `dashboard/server.py`: boot migration delegates to `migrate_owned_playwright_registration` (self-heals on restart).

### 2. Harden pre-existing artifact `/materialize` authorization

`_recorded_doc_identities` `stat()`'d the credential-**redacted** display path from `_scan_session_docs`, so a document path containing a credential-shaped substring (e.g. a macOS temp-dir hash `/var/folders/<hash>/`) produced an empty inode allowlist and refused a legitimate materialize. Split the scan into `_collect_session_docs` (raw paths, internal, used by the authorization scan) and `_scan_session_docs` (redacts display fields at the one external `/session-docs` boundary) — the safe/unsafe distinction is now structural, not a shared boolean flag.

### Reverted (was fix #3 in earlier revisions): config-loader numeric-string coercion

An earlier revision added numeric-string coercion in `config/validation.py`. It was **reverted** because (a) its stated motivation was false — `kirocrew config set` already coerces `"5"`→`int` via `cli_config._parse_value` before writing, and a repo-wide audit found no first-party writer that persists a numeric field as a string — and (b) it lived in the jsonschema-gated `validate_config_data`, but `jsonschema` is an **undeclared** optional dependency, so the coercion never ran in the default install or CI (only where jsonschema happened to be installed). `config/validation.py` is now byte-identical to `main` and the original strict-parse test is restored with a comment recording the rationale.

## Testing

- [x] Existing tests pass; touched-file suite green in **both** jsonschema-present and jsonschema-absent (CI-parity) modes
- [x] New regression tests: dup-MCP convergence (survivor-by-mode, user-direct preservation under canonical + superseded keys, legacy-direct upgrade, owned-allowlist vs user agents, `~/.kirocrew/mcp.json` source-heal, 0600 mode preservation); artifact redaction-at-boundary
- [x] `scrub-lint --no-history`, `flake8`, `isort`, `mypy` all clean; Semgrep diff-scan exit 0

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (`docs/system-specs/modules/browser.md`)
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.ai/code)
