### PR TITLE
fix(apps): honor manifest cron enabled flag — register disabled crons paused

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -59,6 +59,13 @@ The app manifest (`app.json`) declares your app's identity, resources, and requi
 | `cron_expr` | string | Cron expression (mutually exclusive with `every`) |
 | `message` | string | Prompt sent to the agent on each run |
 | `agent` | string | Agent to run (optional, uses default if omitted) |
+| `enabled` | boolean | Default `true`. Must be a JSON boolean — any other type is rejected at manifest validation. When `false` the cron is registered **paused** (visible in the Schedule view, resumable) instead of firing on install/enable — for jobs that need user configuration first |
+
+> **Caveat:** disabling an app deletes its registered cron jobs, and re-enabling
+> the app re-registers them from the manifest. A cron shipped with
+> `"enabled": false` that a user later resumed will therefore be reset back to
+> the paused state after an app disable → re-enable cycle and must be resumed
+> again.
 
 ## Frontend UI
 

--- a/docs/system-specs/index.md
+++ b/docs/system-specs/index.md
@@ -1,6 +1,6 @@
 # System Specifications
 
-Last Updated: 2026-07-23
+Last Updated: 2026-07-24
 
 ## How to Use
 

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -75,6 +75,38 @@ Jobs can define `skip_dates` — a list of dates (YYYY-MM-DD) on which the job s
 
 Jobs receive random jitter by default (0-5min hourly, 0-59min daily) to spread load. Set `strict_schedule: true` on a job to disable jitter entirely — the job fires at the exact cron/interval time.
 
+### App-Manifest Cron `enabled` Flag (register-paused contract)
+
+App manifests (`app.json`) may declare crons with `"enabled": false` — a cron
+the app ships disabled-by-design (e.g. a nightly job that needs user
+configuration before it is useful). The contract, end to end:
+
+- **Parse**: `CronEntry.enabled` (`apps/manifest.py`, default `true`). The value
+  must be a JSON boolean — a non-boolean (e.g. the string `"false"`, truthy
+  under coercion) is rejected by `AppManifest.validate()` with a clear error;
+  coercion remains only on the self-written `app-crons.json` read path.
+  Serialization is sparse — `to_dict()` emits the key only when `false`.
+- **Persist**: `_register_crons()` carries `enabled` through the app's
+  `app-crons.json`. A legacy `app-crons.json` without the key registers
+  **active** (default `true` — behavior unchanged for existing apps).
+- **Register**: `register_app_crons_with_service()` (`apps/bridges.py`)
+  threads `enabled` to `CronSDK.add_job(enabled=...)` (`apps/cron_sdk.py`),
+  which forwards it to `CronService.add_job(enabled=...)`. A disabled cron is
+  **created paused** — `enabled=False` + `user_paused=True`, mirroring
+  `CronService.enable_job(False)` — **atomically in the job's first persist**
+  (never an enabled-then-paused two-save window that a crash or a concurrent
+  reader of `crons.json` could capture as enabled). It is visible in the
+  Schedule view and resumable via `cron_resume`/dashboard, never silently
+  active and never invisible.
+- **Startup idempotency**: gateway-startup re-registration skips existing
+  jobs by name using `list_jobs(include_disabled=True)`, so a paused job IS
+  found and skipped — a user-resumed cron survives gateway restart
+  un-clobbered.
+- **Lifecycle caveat**: `on_app_disable` removes the app's jobs; re-enabling
+  the app re-registers from the manifest, so a cron the user had resumed
+  returns to **paused** (manifest is the sole source of truth on
+  re-register). Documented in `docs/app-kit/manifest-reference.md`.
+
 ### Hide in Chat (`hide_in_chat`)
 
 By default a persistent-session agent cron auto-creates a linked dashboard chat slot (`cron-{job_id}`) on first delivery (see Auto-inject), so its runs appear in the active session list. Set `hide_in_chat: true` to suppress that slot creation — the run's result still reaches Slack/dashboard notifications, and the run stays visible in the History tab via the **cron execution-history store** (`CronHistoryStore`, written unconditionally by the executor and surfaced at `GET /api/crons/{id}/history`), but no entry clutters the Chats sidebar. Useful for fire-and-forget jobs (daily digests, log cleanups, polling). Default `false` (preserves prior behavior; absent field reads as `false`). Orthogonal to `silent`: `silent` suppresses the push notification, `hide_in_chat` suppresses the chat slot. The flag is a no-op for `script`/`command` crons, which never create a slot. The executor gates all three `inject_cron_result_to_dashboard` call sites on `not job.hide_in_chat`; the dashboard notification's CTA falls into the pre-existing no-slot branch ("View last result", which lazily rebuilds a slot from history on click) instead of "Continue session". Note: the `cron:{job_id}` *dashboard conversation_log* is written ONLY by `inject_cron_result_to_dashboard`, so it is intentionally empty for a hidden cron — it exists solely to give a dashboard follow-up turn context, which a no-slot cron never has. Hidden-cron result persistence is the execution-history store, not `cron:{job_id}`.

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -339,6 +339,7 @@ def _register_crons(app_name: str, manifest: AppManifest) -> list[str]:
             "env": cron.env,
             "persistent_session": cron.persistent_session,
             "silent": cron.silent,
+            "enabled": cron.enabled,
         })
         registered.append(namespaced)
 
@@ -460,6 +461,7 @@ def register_app_crons_with_service(app_name: str, cron_service: Any) -> list[st
                 env=d.get("env") or None,
                 persistent_session=d.get("persistent_session", False),
                 silent=bool(d.get("silent", False)),
+                enabled=bool(d.get("enabled", True)),
             )
             newly_registered.append(name)
             sel().log_api_access(

--- a/src/kiro_crew/apps/cron_sdk.py
+++ b/src/kiro_crew/apps/cron_sdk.py
@@ -48,6 +48,7 @@ class CronSDK:
         env: dict[str, str] | None = None,
         persistent_session: bool = True,
         silent: bool = False,
+        enabled: bool = True,
     ) -> Any:
         """Create a cron job owned by this app.
 
@@ -124,6 +125,14 @@ class CronSDK:
         kwargs: dict[str, Any] = {
             "name": name,
             "message": message,
+            # An app can ship a cron disabled (manifest "enabled": false) when
+            # it needs user configuration before the job is useful. Passing
+            # enabled through add_job registers it paused (user_paused=True,
+            # mirroring the dashboard pause semantics so cron_resume / the UI
+            # can re-enable it) atomically in the job's FIRST persist — no
+            # enabled-then-paused window for a crash or concurrent store
+            # reader to capture.
+            "enabled": enabled,
         }
         if every_secs is not None:
             kwargs["every_secs"] = every_secs

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -70,6 +70,16 @@ class CronEntry:
     env: dict[str, str] = field(default_factory=dict)  # environment variables for the job
     persistent_session: bool = True  # whether to carry context between runs
     silent: bool = False  # suppress dashboard notifications
+    # When False the cron is registered in a paused state (visible in the
+    # dashboard Schedule view, resumable) instead of firing on install/enable.
+    # Apps that need user configuration before their crons are useful ship
+    # them disabled and enable/resume once configured.
+    enabled: bool = True
+    # Parse-time type violation: manifest "enabled" was present but not a JSON
+    # boolean (e.g. the string "false", which bool() would coerce truthy —
+    # silently re-creating the fires-unconfigured bug). Reported as a
+    # validation error; never serialized.
+    enabled_type_invalid: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"name": self.name}
@@ -93,6 +103,8 @@ class CronEntry:
             d["persistent_session"] = False
         if self.silent:
             d["silent"] = True
+        if not self.enabled:
+            d["enabled"] = False
         return d
 
     @classmethod
@@ -112,6 +124,15 @@ class CronEntry:
             env={str(k): str(v) for k, v in data.get("env", {}).items()},
             persistent_session=bool(data.get("persistent_session", True)),
             silent=bool(data.get("silent", False)),
+            # STRICT boolean: "enabled" gates whether a cron fires at all, so a
+            # type slip (the string "false" is truthy) must not silently
+            # re-enable a disabled-by-design cron. Non-boolean values are
+            # flagged and rejected by AppManifest.validate(); the value falls
+            # back to True only so the flagged manifest still round-trips.
+            enabled=(data["enabled"] if isinstance(data.get("enabled"), bool)
+                     else True),
+            enabled_type_invalid=("enabled" in data
+                                  and not isinstance(data["enabled"], bool)),
         )
 
 
@@ -830,6 +851,11 @@ class AppManifest:
             if cron.command and cron.script:
                 errors.append(
                     f"cron entry {cron.name!r}: 'command' and 'script' are mutually exclusive"
+                )
+            if cron.enabled_type_invalid:
+                errors.append(
+                    f"cron entry {cron.name!r}: 'enabled' must be a JSON boolean "
+                    "(true/false) — got a non-boolean value"
                 )
             if not (cron.agent or cron.agent_sequence or cron.message or cron.command or cron.script):
                 errors.append(

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -764,8 +764,15 @@ class CronService:
         delete_after_run: bool = False,
         created_by: str = "",
         approval_mode: str = "",
+        enabled: bool = True,
     ) -> CronJob:
-        """Add a new job. Provide one of ``every_secs``, ``at_ts``, or ``cron_expr``."""
+        """Add a new job. Provide one of ``every_secs``, ``at_ts``, or ``cron_expr``.
+
+        ``enabled=False`` creates the job already paused (``user_paused=True``,
+        mirroring :meth:`enable_job`) so the paused state is part of the FIRST
+        persist — never an enabled-then-paused two-save window that a crash or
+        a concurrent reader of the store could capture as enabled.
+        """
         valid_approval_modes = ("", "auto")
         if approval_mode not in valid_approval_modes:
             raise ValueError(f"Invalid approval_mode: {approval_mode!r}")
@@ -787,7 +794,8 @@ class CronService:
             schedule=schedule,
             channel=channel,
             thread_ts=thread_ts,
-            enabled=True,
+            enabled=enabled,
+            user_paused=not enabled,
             created_ts=time.time(),
             delete_after_run=delete_after_run,
             created_by=created_by,

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -209,6 +209,27 @@ class TestCronRegistration:
         assert defs[0]["name"] == "test-app/refresh"
         assert defs[0]["every"] == 3600
 
+    def test_register_crons_persists_enabled_flag(self, tmp_path, app_env):
+        """A manifest cron shipped disabled keeps enabled:false in app-crons.json."""
+        src = _make_app_source(
+            tmp_path,
+            crons=[{
+                "name": "nightly-run",
+                "cron_expr": "0 22 * * *",
+                "agent": "my-agent",
+                "enabled": False,
+            }],
+        )
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+
+        _register_crons("test-app", manifest)
+        defs = load_app_cron_defs("test-app")
+        assert len(defs) == 1
+        assert defs[0]["enabled"] is False
+
     def test_deregister_crons(self, tmp_path, app_env):
         src = _make_app_source(tmp_path)
         install_app(src)
@@ -837,7 +858,101 @@ class TestCronServiceBridge:
             env={"FOO": "bar"},
             persistent_session=False,
             silent=True,
+            enabled=True,
         )
+
+    def test_disabled_cron_registers_paused(self, tmp_path, app_env, monkeypatch):
+        """A manifest cron with enabled:false is passed through as enabled=False."""
+        from unittest.mock import MagicMock, patch
+
+        from kiro_crew.apps.bridges import register_app_crons_with_service
+
+        cron_defs = [{
+            "name": "test-app/nightly-run",
+            "every": 0,
+            "cron_expr": "0 22 * * *",
+            "agent": "discovery",
+            "message": "",
+            "app": "test-app",
+            "enabled": False,
+        }]
+        self._write_app_crons(tmp_path, "test-app", cron_defs)
+
+        mock_cron_service = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.list_jobs.return_value = []
+        mock_sdk.add_job.return_value = MagicMock(id="abc123")
+
+        with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
+            result = register_app_crons_with_service("test-app", mock_cron_service)
+
+        assert result == ["test-app/nightly-run"]
+        assert mock_sdk.add_job.call_args.kwargs["enabled"] is False
+
+    def test_legacy_defs_without_enabled_default_active(self, tmp_path, app_env, monkeypatch):
+        """Pre-existing app-crons.json without the enabled key registers active."""
+        from unittest.mock import MagicMock, patch
+
+        from kiro_crew.apps.bridges import register_app_crons_with_service
+
+        cron_defs = [{
+            "name": "test-app/legacy",
+            "every": 600,
+            "agent": "a",
+            "message": "m",
+            "app": "test-app",
+        }]
+        self._write_app_crons(tmp_path, "test-app", cron_defs)
+
+        mock_cron_service = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.list_jobs.return_value = []
+        mock_sdk.add_job.return_value = MagicMock(id="abc123")
+
+        with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
+            register_app_crons_with_service("test-app", mock_cron_service)
+
+        assert mock_sdk.add_job.call_args.kwargs["enabled"] is True
+
+    def test_startup_skips_existing_disabled_job(self, tmp_path, app_env, monkeypatch):
+        """Gateway-startup re-registration must not re-add (and thus re-pause)
+        a job that already exists in a disabled state.
+
+        CronSDK.list_jobs() includes disabled jobs, so a paused job counts as
+        existing — preserving a user's resume/pause state across restarts.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from kiro_crew.apps.bridges import register_app_crons_with_service
+
+        cron_defs = [{
+            "name": "test-app/nightly-run",
+            "every": 0,
+            "cron_expr": "0 22 * * *",
+            "agent": "discovery",
+            "message": "",
+            "app": "test-app",
+            "enabled": False,
+        }]
+        self._write_app_crons(tmp_path, "test-app", cron_defs)
+
+        existing = MagicMock()
+        existing.name = "test-app/nightly-run"
+        existing.enabled = False  # currently paused
+        existing.user_paused = True
+
+        mock_cron_service = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.list_jobs.return_value = [existing]
+
+        with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
+            result = register_app_crons_with_service("test-app", mock_cron_service)
+
+        assert result == []
+        mock_sdk.add_job.assert_not_called()
+        # The existing job's state is untouched — no duplicate, no re-pause.
+        assert existing.enabled is False
+        assert existing.user_paused is True
 
     def test_registers_command_type_cron(self, tmp_path, app_env, monkeypatch):
         """Apps declaring command-type crons get them registered as command jobs."""
@@ -882,6 +997,7 @@ class TestCronServiceBridge:
             env=None,
             persistent_session=False,
             silent=True,
+            enabled=True,
         )
 
     def test_rejects_malicious_command(self, tmp_path, app_env, monkeypatch):

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -151,6 +151,35 @@ class TestValidation:
         errors = m.validate()
         assert any("every" in e or "cron_expr" in e for e in errors)
 
+    def test_cron_enabled_non_boolean_rejected(self):
+        # The string "false" is truthy under bool() — a type slip here would
+        # silently re-enable a disabled-by-design cron. Manifest validation
+        # must reject non-boolean values with a clear error.
+        m = AppManifest.from_dict(_valid_manifest(
+            crons=[{"name": "j1", "every": 300, "message": "go",
+                    "enabled": "false"}]
+        ))
+        errors = m.validate()
+        assert any("'enabled' must be a JSON boolean" in e for e in errors)
+        # The flagged manifest must not accidentally register the cron
+        # disabled either — the parse falls back to the default.
+        assert m.crons[0].enabled is True
+
+    def test_cron_enabled_boolean_values_accepted(self):
+        for value, expected in ((False, False), (True, True)):
+            m = AppManifest.from_dict(_valid_manifest(
+                crons=[{"name": "j1", "every": 300, "message": "go",
+                        "enabled": value}]
+            ))
+            assert m.validate() == []
+            assert m.crons[0].enabled is expected
+        # Absent key: default enabled, no error.
+        m = AppManifest.from_dict(_valid_manifest(
+            crons=[{"name": "j1", "every": 300, "message": "go"}]
+        ))
+        assert m.validate() == []
+        assert m.crons[0].enabled is True
+
     def test_ui_page_missing_route(self):
         m = AppManifest.from_dict(_valid_manifest(
             ui={"pages": [{"label": "X"}]}

--- a/test/test_cron.py
+++ b/test/test_cron.py
@@ -98,6 +98,50 @@ class TestCronService:
         assert job.schedule.kind == "cron"
         assert job.schedule.cron_expr == "0 9 * * *"
 
+    def test_add_job_enabled_false_registers_paused(self, tmp_path: Path) -> None:
+        """enabled=False creates the job paused (user_paused=True) at creation."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(
+            name="shipped-disabled", message="", cron_expr="0 22 * * *",
+            enabled=False,
+        )
+        assert job.enabled is False
+        assert job.user_paused is True
+        # A fresh service reloading the store must also see it paused.
+        svc2 = CronService(base_dir=tmp_path)
+        svc2._load()
+        loaded = [j for j in svc2.list_jobs(include_disabled=True) if j.id == job.id]
+        assert loaded and loaded[0].enabled is False
+
+    def test_add_job_enabled_false_never_persisted_enabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The paused state is part of the FIRST persist — no save may ever
+        capture the disabled-by-manifest job in an enabled state (a crash or a
+        concurrent store reader between an enabled-then-paused save pair would
+        make the wrong state permanent via the startup skip-by-name)."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        snapshots: list[tuple[bool, bool]] = []
+        real_save = svc._save
+
+        def spy_save(*a, **k):
+            for j in svc._jobs:
+                if j.name == "shipped-disabled":
+                    snapshots.append((j.enabled, j.user_paused))
+            return real_save(*a, **k)
+
+        monkeypatch.setattr(svc, "_save", spy_save)
+        svc.add_job(
+            name="shipped-disabled", message="", cron_expr="0 22 * * *",
+            enabled=False,
+        )
+        assert snapshots, "add_job must persist the new job"
+        assert all(s == (False, True) for s in snapshots), (
+            f"a save captured the job enabled: {snapshots}"
+        )
+
     def test_add_job_invalid_cron_expr(self, tmp_path: Path) -> None:
         svc = CronService(base_dir=tmp_path)
         svc._load()

--- a/test/test_cron_sdk.py
+++ b/test/test_cron_sdk.py
@@ -33,6 +33,7 @@ class MockCronJob:
     persistent_session: bool = True
     silent: bool = False
     enabled: bool = True
+    user_paused: bool = False
     every_secs: int | None = None
     cron_expr: str | None = None
 
@@ -43,7 +44,13 @@ class MockCronService:
         self._next_id = 1
 
     def add_job(self, **kwargs: Any) -> MockCronJob:
-        job = MockCronJob(id=f"job-{self._next_id}", **kwargs)
+        # Mirror CronService.add_job register-paused semantics: enabled=False
+        # creates the job already paused (user_paused=True) at creation.
+        job = MockCronJob(
+            id=f"job-{self._next_id}",
+            user_paused=not kwargs.get("enabled", True),
+            **kwargs,
+        )
         self._next_id += 1
         self._jobs.append(job)
         return job
@@ -140,6 +147,52 @@ class TestCronJobCreation:
         assert job.env == env
         assert job.persistent_session == persistent
         assert job.silent == silent
+
+    def test_disabled_job_registers_paused(self) -> None:
+        """enabled=False creates the job in a paused, user-resumable state."""
+        svc = MockCronService()
+        sdk = CronSDK("my-app", svc)
+
+        job = sdk.add_job(
+            name="my-app/nightly-run",
+            message="",
+            cron_expr="0 22 * * *",
+            enabled=False,
+        )
+
+        assert job.enabled is False
+        assert job.user_paused is True
+
+    def test_enabled_default_registers_active(self) -> None:
+        """Default add_job (no enabled kwarg) creates an active job."""
+        svc = MockCronService()
+        sdk = CronSDK("my-app", svc)
+
+        job = sdk.add_job(name="my-app/refresh", message="go", cron_expr="* * * * *")
+
+        assert job.enabled is True
+        assert getattr(job, "user_paused", False) is False
+
+    def test_paused_at_registration_job_can_be_resumed(self) -> None:
+        """A job registered disabled can be re-enabled (resumed) via update_job."""
+        svc = MockCronService()
+        sdk = CronSDK("my-app", svc)
+
+        job = sdk.add_job(
+            name="my-app/nightly-run",
+            message="",
+            cron_expr="0 22 * * *",
+            enabled=False,
+        )
+        assert job.enabled is False
+
+        updated = sdk.update_job(job.id, enabled=True, user_paused=False)
+
+        assert updated is not None
+        assert updated.enabled is True
+        assert updated.user_paused is False
+        # Resumed job shows up in the active (non-disabled) list again.
+        assert job in svc.list_jobs()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

App-manifest crons declaring `"enabled": false` were silently registered **active** — every app cron fired on install/enable regardless of the flag. This PR makes the flag real end-to-end: parse → persist → register paused.

Fixes #310

## Bug

`CronEntry` (`src/kiro_crew/apps/manifest.py`) had no `enabled` field, `_register_crons()` didn't persist it through `app-crons.json`, and `register_app_crons_with_service()` (`bridges.py`) promoted every cron def unconditionally. An app shipping a deliberately-disabled cron (e.g. a nightly job that needs user configuration first) fires immediately on install against nothing.

## Fix

- `enabled` parses on `CronEntry` (sparse serialization — emitted only when `false`), persists through `app-crons.json`, and threads to `CronSDK.add_job(enabled=...)`.
- A disabled cron registers **paused** (`enabled=False`, `user_paused=True`): visible in the Schedule view and resumable via `cron_resume`/dashboard — never silently active, never invisible.
- Legacy `app-crons.json` without the key registers active (behavior unchanged).
- Docs: manifest reference documents the flag and the disable→re-enable caveat (re-enabling an app re-registers from the manifest, so a user-resumed disabled cron returns to paused).

## Testing

- New tests: manifest `enabled` round-trip, `app-crons.json` persistence, disabled pass-through, legacy default-active, SDK paused-state semantics.
- Hardening: gateway-startup re-registration skips an existing *disabled* job (a user-resumed cron survives restart un-clobbered — the `include_disabled` skip path), and `enable_job`/resume works on a paused-at-registration job.
- Local gates: pytest 16,045 passed (only the 3 known host-environment failures, which reproduce identically on clean `main`), flake8 clean, `tsc -b` clean; frontend untouched.

## Related

Sibling fix found in the same investigation (independent, disjoint hunks): #307
