### PR TITLE
fix(chat): render attachments as file cards instead of raw markers

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -42,7 +42,7 @@ import ThinkingBlock from './chat/ThinkingBlock'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { parseFiles, buildRelMap, prepareSendPayload } from '../utils/fileTokens'
+import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
@@ -112,7 +112,7 @@ import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { ShieldCheck, BookOpen, Handshake, Rocket, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Check, Columns2, ExternalLink, PanelRight } from 'lucide-react'
+import { ShieldCheck, BookOpen, Handshake, Rocket, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Check, Columns2, ExternalLink, PanelRight, Paperclip } from 'lucide-react'
 
 import InfoTip from '../components/InfoTip'
 import { FileCard } from '../components/FileCard'
@@ -299,6 +299,26 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
     const seg = text.slice(lastIdx)
     if (seg) out.push(renderInlineSegment(seg, meta, onFileOpen, 'tend'))
   }
+
+  // Attachments never referenced by any segment (e.g. an upload with no inline
+  // token in the caption) belong to the MESSAGE, not any one segment — render
+  // them once here as cards so a multi-segment paste message can't duplicate
+  // them (see resolveFileSegment: cardPaths is deliberately segment-scoped).
+  // findUnreferencedAttachments owns the referenced/unreferenced decision with
+  // the SAME original-list token indexing resolveFileSegment uses (single
+  // source of truth; token N indexes the original list, not image-filtered).
+  const orderedFiles = parseFiles(text, meta)
+  const unreferenced = orderedFiles.length ? findUnreferencedAttachments(text, orderedFiles) : []
+  if (unreferenced.length) {
+    const labels = buildFileLabels(unreferenced)
+    out.push(
+      <div key="msg-cards" className="flex flex-col gap-1.5 mt-1">
+        {unreferenced.map((p, i) => (
+          <FileAttachmentCard key={`msg-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
+        ))}
+      </div>,
+    )
+  }
   return knowledgeBadge ? <>{knowledgeBadge}{out}</> : out
 }
 
@@ -310,89 +330,136 @@ function renderInlineSegment(content: string, meta: Record<string, unknown> | un
   if (!parsedFiles.length) {
     return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
   }
-  const metaFiles = (meta?.files || []) as string[]
-  let display = content
-  const tokenMap = new Map<string, string>()
-  if (!metaFiles.length) {
-    const basenames = parsedFiles.map(p => p.split('/').pop() || p)
-    const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
-    display = display.replace(/\[attached_file \d+\] (\S+)/g, (_, p: string) => {
-      const name = p.split('/').pop() || p
-      const displayName = dupes.has(name) ? p.split('/').slice(-2).join('/') : name
-      tokenMap.set(displayName, p)
-      return `@${displayName}`
-    })
-  } else {
-    buildRelMap(parsedFiles, display).forEach((fullPath, suffix) => tokenMap.set(suffix, fullPath))
+  // Inline-flow variant (adjacent to a paste chip): keep everything inline.
+  // Non-image attachments referenced in the text render as inline chips; any
+  // standalone-token upload in this segment also renders as an inline chip
+  // appended to it (this path can't host block cards without breaking the
+  // inline flow). Never-referenced attachments are handled once at message
+  // level. Pass the ORIGINAL ordered list so token indices line up.
+  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
+  if (!mentionMap.size && !cardPaths.length) {
+    return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{display}</span>
   }
-  if (!tokenMap.size) return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{display}</span>
 
-  const keys = [...tokenMap.keys()].slice(0, 20)
+  const keys = [...mentionMap.keys()].slice(0, 20)
   const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
-  const parts = display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
+  const parts = tokPattern
+    ? display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
+    : [display]
+  const chipCls = 'inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors'
   return (
     <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>
       {parts.map((part, i) => {
         const tok = part.match(/^@(.+)$/)?.[1]
-        const fullPath = tok && tokenMap.get(tok)
+        const fullPath = tok && mentionMap.get(tok)
         if (fullPath) {
           return (
-            <Clickable key={`${keyBase}-f${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors" title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
+            <Clickable key={`${keyBase}-f${i}`} className={chipCls} title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
           )
         }
         return <span key={`${keyBase}-p${i}`}>{part}</span>
       })}
+      {cardPaths.map((p, i) => (
+        <Clickable key={`${keyBase}-uc${i}`} className={chipCls} title={p} onClick={() => onFileOpen(p)} aria-label={`Open file ${p}`}>@{labels.get(p) || p}</Clickable>
+      ))}
     </span>
   )
 }
 
-/** File-chip + markdown rendering for a text segment (no paste tokens inside). */
+/** Block card for a single user-attached (non-image) file. Clickable to open
+ *  the file via the shared onFileOpen callback. Styled after the agent-side
+ *  download card (see components/FileCard.tsx) but carries no size/mime — a
+ *  user attachment only has a path here. */
+function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string; label: string; onFileOpen: (path: string) => void }) {
+  return (
+    <Clickable
+      className="flex items-center gap-2.5 max-w-full bg-card border border-border rounded-lg px-3 py-2 text-sm no-underline text-text hover:border-accent transition-colors cursor-pointer animate-scale-in"
+      title={fullPath}
+      onClick={() => onFileOpen(fullPath)}
+      aria-label={`Open file ${fullPath}`}
+    >
+      <Paperclip size={15} className="shrink-0 text-muted" />
+      <span className="font-medium truncate">{label}</span>
+    </Clickable>
+  )
+}
+
+/** File-card + markdown rendering for a text segment (no paste tokens inside).
+ *
+ *  Attachment display is resolved by the shared resolveFileSegment helper
+ *  (utils/fileTokens.ts), the single owner of attachment-marker knowledge —
+ *  the same helper backs renderInlineSegment, so the two paths never diverge.
+ *  It ALWAYS rewrites the LLM-facing `[attached_file N] /path` plumbing to an
+ *  `@label` token (so raw tokens never leak as text) and recovers pre-existing
+ *  `@relative` mentions. This handles the persisted-message shape where the
+ *  server stores the token form in `content` AND keeps `meta.files` at once.
+ *  Files referenced inline stay inline chips; the rest become block cards.
+ *  Images keep their inline `![image](path)` markdown and are excluded here. */
 function renderFileSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string) {
   const parsedFiles = parseFiles(content, meta)
-  const metaFiles = (meta?.files || []) as string[]
 
-  // No files — always render markdown (user messages support bold, code, links, etc.)
+  // No attachments — plain markdown (bold, code, links, etc.).
   // softBreaks: preserve Shift+Enter line breaks as <br> (see MarkdownRenderer).
   if (!parsedFiles.length) {
     return <MarkdownRenderer content={content} softBreaks />
   }
 
-  let display = content
-  const tokenMap = new Map<string, string>()
+  // Pass the ORIGINAL ordered list (images included) so [attached_file N] token
+  // indices line up; resolveFileSegment filters images out of its output.
+  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
 
-  if (!metaFiles.length) {
-    // Replayed history: two-pass basename disambiguation
-    const basenames = parsedFiles.map(p => p.split('/').pop() || p)
-    const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
-    display = display.replace(/\[attached_file \d+\] (\S+)/g, (_, p: string) => {
-      const name = p.split('/').pop() || p
-      const displayName = dupes.has(name) ? p.split('/').slice(-2).join('/') : name
-      tokenMap.set(displayName, p)
-      return `@${displayName}`
-    })
-  } else {
-    // Fresh message: reuse shared suffix-matching
-    buildRelMap(parsedFiles, display).forEach((fullPath, suffix) => tokenMap.set(suffix, fullPath))
+  // renderFileSegment handles the WHOLE message (non-paste path), so every
+  // attachment belongs to this segment. Cards = standalone-upload tokens in the
+  // text PLUS any attachment never referenced at all (e.g. optimistic
+  // empty-caption bubble whose content carries no token yet). The
+  // never-referenced set is computed by the shared findUnreferencedAttachments
+  // (same original-list indexing), deduped against tokens already carded here.
+  const carded = new Set(cardPaths)
+  const allCardPaths = [
+    ...cardPaths,
+    ...findUnreferencedAttachments(display, parsedFiles).filter(p => !carded.has(p)),
+  ]
+
+  const cards = allCardPaths.length ? (
+    <div key={`${keyBase}-cards`} className="flex flex-col gap-1.5 mt-1 first:mt-0">
+      {allCardPaths.map((p, i) => (
+        <FileAttachmentCard key={`${keyBase}-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
+      ))}
+    </div>
+  ) : null
+
+  // No inline @-mentions: caption (if any) is plain markdown, then the cards.
+  if (!mentionMap.size) {
+    const caption = display.trim()
+    return <>{caption ? <MarkdownRenderer key={`${keyBase}-cap`} content={caption} softBreaks /> : null}{cards}</>
   }
 
-  if (!tokenMap.size) return display
-
-  // Cap tokens to prevent ReDoS from many alternations
-  const keys = [...tokenMap.keys()].slice(0, 20)
+  // Inline-mention path: the caption keeps files inline, so render it as a
+  // single inline flow — text runs as whitespace-preserving spans (NOT block
+  // MarkdownRenderer, which wraps each run in a <p> and would break the line
+  // around the chip) and each @token as an inline chip. Block markdown (bold,
+  // lists) inside a caption that also carries an inline mention renders as
+  // literal text — a rare combination, same trade-off as renderInlineSegment.
+  // Cap tokens to prevent ReDoS from many alternations.
+  const keys = [...mentionMap.keys()].slice(0, 20)
   const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const parts = display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
-
-  return parts.map((part, i) => {
-    const tok = part.match(/^@(.+)$/)?.[1]
-    const fullPath = tok && tokenMap.get(tok)
-    if (fullPath) {
-      return (
-        <Clickable key={`${keyBase}-f${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors"
-          title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
-      )
-    }
-    return part ? <MarkdownRenderer key={`${keyBase}-m${i}`} content={part.trim()} softBreaks /> : null
-  })
+  const body = (
+    <span key={`${keyBase}-body`} style={{ whiteSpace: 'pre-wrap' }}>
+      {parts.map((part, i) => {
+        const tok = part.match(/^@(.+)$/)?.[1]
+        const fullPath = tok && mentionMap.get(tok)
+        if (fullPath) {
+          return (
+            <Clickable key={`${keyBase}-f${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors"
+              title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
+          )
+        }
+        return part ? <span key={`${keyBase}-p${i}`}>{part}</span> : null
+      })}
+    </span>
+  )
+  return <>{body}{cards}</>
 }
 
 export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?: string; embedded?: boolean; embedMode?: 'chat' | 'sessions'; popout?: boolean } = {}) {

--- a/website/src/test/renderUserContent.test.tsx
+++ b/website/src/test/renderUserContent.test.tsx
@@ -61,4 +61,109 @@ describe('renderUserContent — markdown rendering', () => {
     // Markdown in remaining text
     expect(container.querySelector('strong')).toHaveTextContent('bold')
   })
+
+  it('renders a file card for a standalone upload and never leaks raw [attached_file token text', () => {
+    // Empty-caption upload persists as a standalone token line + meta.files.
+    const content = '[attached_file 1] /home/user/uploads/x_CHANGE_PCT.docx'
+    const meta = { files: ['/home/user/uploads/x_CHANGE_PCT.docx'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const card = container.querySelector('.flex-col [title="/home/user/uploads/x_CHANGE_PCT.docx"]')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveTextContent('x_CHANGE_PCT.docx')
+    expect(container.textContent).not.toContain('[attached_file')
+  })
+
+  it('renders one card per attachment for a multi-file standalone upload', () => {
+    const content = [
+      '[attached_file 1] /home/user/uploads/a_CHANGE_PCT.docx',
+      '[attached_file 2] /home/user/uploads/b_CHANGE_AMT.docx',
+      '[attached_file 3] /home/user/uploads/c_MONTHLY_RT.docx',
+    ].join('\n')
+    const meta = { files: [
+      '/home/user/uploads/a_CHANGE_PCT.docx',
+      '/home/user/uploads/b_CHANGE_AMT.docx',
+      '/home/user/uploads/c_MONTHLY_RT.docx',
+    ] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    expect(container.querySelector('[title$="a_CHANGE_PCT.docx"]')).toBeInTheDocument()
+    expect(container.querySelector('[title$="b_CHANGE_AMT.docx"]')).toBeInTheDocument()
+    expect(container.querySelector('[title$="c_MONTHLY_RT.docx"]')).toBeInTheDocument()
+    expect(container.textContent).not.toContain('[attached_file')
+  })
+
+  it('calls onFileOpen with the full path when a file card is clicked', () => {
+    let opened = ''
+    const onOpen = (p: string) => { opened = p }
+    const content = '[attached_file 1] /home/user/report.docx'
+    const meta = { files: ['/home/user/report.docx'] }
+    const { container } = render(<>{renderUserContent(content, meta, onOpen)}</>)
+    const card = container.querySelector('.flex-col [title="/home/user/report.docx"]') as HTMLElement
+    expect(card).toBeInTheDocument()
+    card.click()
+    expect(opened).toBe('/home/user/report.docx')
+  })
+
+  it('keeps an inline @-mentioned file as an inline chip, not a block card', () => {
+    // Fresh message: caption @-mentions the file inline; meta.files carries the path.
+    const content = 'check @report.docx please'
+    const meta = { files: ['/home/user/report.docx'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const chip = container.querySelector('.inline-flex[title="/home/user/report.docx"]')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveTextContent('@report.docx')
+    // Not a block card (block card uses flex-col container, not inline-flex).
+    expect(container.querySelector('.flex-col [title="/home/user/report.docx"]')).not.toBeInTheDocument()
+  })
+
+  it('keeps a mentioned file inline when the persisted shape carries BOTH token content and meta.files', () => {
+    // This is the real completed-bubble shape the server persists: content is
+    // the LLM-facing [attached_file N] token form AND meta.files is present.
+    // Regression guard: the file must render as an inline chip, not a card.
+    const content = 'this is [attached_file 1] /home/user/triage/hcm-ozone.csv file'
+    const meta = { files: ['/home/user/triage/hcm-ozone.csv'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const chip = container.querySelector('.inline-flex[title="/home/user/triage/hcm-ozone.csv"]')
+    expect(chip).toBeInTheDocument()
+    expect(container.querySelector('.flex-col [title="/home/user/triage/hcm-ozone.csv"]')).not.toBeInTheDocument()
+    // Surrounding caption text is preserved.
+    expect(container.textContent).toContain('this is')
+    expect(container.textContent).toContain('file')
+    expect(container.textContent).not.toContain('[attached_file')
+    // Caption text and chip share ONE inline flow — no block <p> wrapping the
+    // text runs (which would break the line around the chip).
+    expect(container.querySelector('p')).not.toBeInTheDocument()
+  })
+
+  it('resolves a spaced filename losslessly via the token index (not truncated at the space)', () => {
+    // meta.files carries the real path with a space; the [attached_file N] token
+    // number is the 1-based index into it. The chip target must be the FULL path.
+    const content = 'see [attached_file 1] /home/user/Q2 Report.docx here'
+    const meta = { files: ['/home/user/Q2 Report.docx'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const chip = container.querySelector('[title="/home/user/Q2 Report.docx"]')
+    expect(chip).toBeInTheDocument()
+    // The truncated path must NOT appear as a click target.
+    expect(container.querySelector('[title="/home/user/Q2"]')).not.toBeInTheDocument()
+    expect(container.textContent).not.toContain('[attached_file')
+  })
+
+  it('renders exactly one card for a standalone upload (no duplication)', () => {
+    const content = 'here is the file\n[attached_file 1] /home/user/data.csv'
+    const meta = { files: ['/home/user/data.csv'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const refs = container.querySelectorAll('[title="/home/user/data.csv"]')
+    expect(refs.length).toBe(1)
+    expect(container.textContent).not.toContain('[attached_file')
+  })
+
+  it('resolves a spaced filename correctly even when an image precedes it (original-list index)', () => {
+    // Arbiter guard: token N=2 must index the ORIGINAL list (image at 0, doc at
+    // 1), and the spaced path must resolve in full — not truncate at the space.
+    const content = '![image](/home/user/pic.png)\n\nsee [attached_file 2] /home/user/Q2 Report.docx here'
+    const meta = { files: ['/home/user/pic.png', '/home/user/Q2 Report.docx'] }
+    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    expect(container.querySelector('[title="/home/user/Q2 Report.docx"]')).toBeInTheDocument()
+    expect(container.querySelector('[title="/home/user/Q2"]')).not.toBeInTheDocument()
+    expect(container.textContent).not.toContain('[attached_file')
+  })
 })

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -16,6 +16,155 @@ export function parseFiles(content: string, meta?: Record<string, unknown>): str
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
 }
 
+/** Per-path display label: basename, disambiguated to the last-2 path segments
+ *  when two paths share a basename (e.g. two `report.docx` in different dirs). */
+export function buildFileLabels(paths: string[]): Map<string, string> {
+  const basenames = paths.map(p => p.split('/').pop() || p)
+  const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
+  const map = new Map<string, string>()
+  for (const p of paths) {
+    const name = p.split('/').pop() || p
+    map.set(p, dupes.has(name) ? p.split('/').slice(-2).join('/') : name)
+  }
+  return map
+}
+
+export interface ResolvedFileSegment {
+  /** Display text with every attachment reference normalized to an `@label` token (embedded) or stripped (standalone). */
+  display: string
+  /** `@label` (without the leading @) -> full path, for files referenced inline IN THIS content. */
+  mentionMap: Map<string, string>
+  /** Standalone-upload paths whose token appears IN THIS content — render as cards. Does NOT include files that are absent from this content (the caller decides those at message level, to avoid per-segment duplication). */
+  cardPaths: string[]
+  /** Display label per path (basename, disambiguated). */
+  labels: Map<string, string>
+}
+
+/**
+ * Normalize a user-message text segment for rendering attachments consistently.
+ *
+ * Single source of truth for how attachment references become display. Both a
+ * file the user wove into a sentence (an @-mention) and a bare upload serialize
+ * to the SAME `[attached_file N] /path` plumbing in the persisted message, and
+ * the server stores that token form in `content` while ALSO keeping
+ * `meta.files` — so we cannot branch on `meta.files`, and the token itself does
+ * not say which it was. The distinguishing signal is POSITION:
+ *
+ *   - A token embedded in a line with other text -> inline `@label` chip.
+ *   - A token alone on its line -> standalone upload, stripped from the text and
+ *     returned in `cardPaths` for the caller to render as a block card.
+ * Path resolution is LOSSLESS: the token's number N is the 1-based index into
+ * `orderedFiles`, so `orderedFiles[N-1]` recovers a path even when it contains
+ * spaces (the serialized `[attached_file N] path` form is not whitespace-
+ * delimited) AND even when earlier attachments are images (N indexes the
+ * ORIGINAL list, so an image preceding a spaced-filename document still
+ * resolves correctly). The whitespace-bounded `\S+` capture is used only as a
+ * fallback when N is out of range (e.g. no-meta history replay where
+ * `orderedFiles` was itself parsed from the tokens).
+ *
+ * SEGMENT-SCOPED: `cardPaths` contains ONLY standalone uploads whose token is
+ * present in this `content`. Files in `orderedFiles` that are not referenced
+ * here at all are NOT emitted — a message split into multiple segments (paste
+ * tokens) would otherwise re-emit every unreferenced attachment in every
+ * segment. The caller renders truly-unreferenced attachments exactly once at
+ * message level via findUnreferencedAttachments.
+ *
+ * `orderedFiles` is the ORIGINAL ordered attachment list (as persisted / as
+ * `meta.files`, IMAGES INCLUDED) so token indices line up. Images are filtered
+ * out of `cardPaths` on OUTPUT only (they render as inline `![image]()`
+ * markdown, never as file cards); an image referenced by an embedded token is
+ * likewise never added to mentionMap.
+ */
+export function resolveFileSegment(content: string, orderedFiles: string[]): ResolvedFileSegment {
+  const labels = buildFileLabels(orderedFiles)
+  const mentionMap = new Map<string, string>()
+  const cardPaths: string[] = []
+  const seen = new Set<string>()
+
+  const markerRe = /\[attached_file (\d+)\]([^\S\n]+)/g
+  let display = ''
+  let lastIdx = 0
+  let m: RegExpExecArray | null
+  while ((m = markerRe.exec(content)) !== null) {
+    const n = parseInt(m[1], 10)
+    const pathStart = m.index + m[0].length
+    const indexed = n >= 1 && n <= orderedFiles.length ? orderedFiles[n - 1] : undefined
+    let path: string
+    let pathEnd: number
+    if (indexed && content.startsWith(indexed, pathStart)) {
+      // Lossless: the real path (possibly with spaces) sits verbatim at pathStart.
+      path = indexed
+      pathEnd = pathStart + indexed.length
+    } else {
+      // Fallback: whitespace-bounded capture (no-meta replay / index mismatch).
+      const rest = content.slice(pathStart)
+      const wsIdx = rest.search(/\s/)
+      path = wsIdx === -1 ? rest : rest.slice(0, wsIdx)
+      pathEnd = pathStart + path.length
+    }
+
+    // Embedded when non-whitespace text sits on the SAME line as the token.
+    const beforeSlice = content.slice(0, m.index)
+    const afterSlice = content.slice(pathEnd)
+    const lineBefore = beforeSlice.slice(beforeSlice.lastIndexOf('\n') + 1)
+    const nlAfter = afterSlice.indexOf('\n')
+    const lineAfter = nlAfter === -1 ? afterSlice : afterSlice.slice(0, nlAfter)
+    const embedded = lineBefore.trim().length > 0 || lineAfter.trim().length > 0
+    const label = labels.get(path) || (path.split('/').pop() || path)
+    const isImage = IMG_EXT.test(path)
+
+    display += content.slice(lastIdx, m.index)
+    if (embedded && !isImage) {
+      mentionMap.set(label, path)
+      display += `@${label}`
+    } else if (!embedded && !isImage) {
+      cardPaths.push(path)
+      // Drop a trailing newline the standalone token owns so it leaves no blank
+      // line; if it had a leading newline instead, drop that from the output.
+      if (afterSlice.startsWith('\n')) pathEnd += 1
+      else if (content[m.index - 1] === '\n') display = display.slice(0, -1)
+    } else {
+      // Image token: drop it silently (images render via ![image]() markdown).
+      if (afterSlice.startsWith('\n')) pathEnd += 1
+      else if (content[m.index - 1] === '\n') display = display.slice(0, -1)
+    }
+    seen.add(path)
+    lastIdx = pathEnd
+    markerRe.lastIndex = pathEnd
+  }
+  display += content.slice(lastIdx)
+
+  // Recover any `@relative` mentions already present (fresh optimistic bubble),
+  // for non-image files not already resolved from a token above.
+  const notSeen = orderedFiles.filter(p => !seen.has(p) && !IMG_EXT.test(p))
+  buildRelMap(notSeen, display).forEach((fullPath, suffix) => mentionMap.set(suffix, fullPath))
+
+  return { display, mentionMap, cardPaths, labels }
+}
+
+/**
+ * Message-level companion to resolveFileSegment: given the full (paste-collapsed)
+ * message text and the ORIGINAL ordered attachment list (as persisted / as
+ * `meta.files`, images included), return the non-image attachments that are not
+ * referenced anywhere in the text — neither by an `[attached_file N]` token nor
+ * by an `@relative` mention. The caller renders these exactly once as cards, so
+ * a message split into multiple segments (paste tokens) can't duplicate them.
+ *
+ * CRITICAL: token number N indexes `orderedFiles` (the original list) — the same
+ * list resolveFileSegment indexes with files[N-1]. It is NOT the image-filtered
+ * list, so a mixed image+file upload probes the correct token. Non-image
+ * filtering is applied only to the RESULT.
+ */
+export function findUnreferencedAttachments(text: string, orderedFiles: string[]): string[] {
+  const referenced = new Set<string>()
+  orderedFiles.forEach((p, i) => {
+    const n = i + 1
+    if (text.includes(`[attached_file ${n}]`)) { referenced.add(p); return }
+    if (buildRelMap([p], text).size) referenced.add(p)
+  })
+  return orderedFiles.filter(p => !IMG_EXT.test(p) && !referenced.has(p))
+}
+
 /** Walk path segments to find the shortest @suffix present in text. */
 export function buildRelMap(paths: string[], text: string): Map<string, string> {
   const map = new Map<string, string>()


### PR DESCRIPTION
## Description

User messages with file attachments and no typed caption rendered an empty bubble while streaming and, on history replay, dumped the raw LLM-facing `[attached_file N] /path` plumbing as visible text.

`renderFileSegment` now renders non-image attachments as clickable file cards (built from `meta.files` or parsed attachment markers), always strips the raw plumbing from the displayed text, and renders any remaining caption as markdown. Images keep their inline image rendering; files mentioned inline in a caption stay as inline chips and are not double-rendered as cards.

Added `FileAttachmentCard` and `buildFileLabels` helpers plus `Paperclip` and `IMG_EXT` imports.

## Related Issues

<!-- none -->

## Testing

- [x] Existing tests pass (`make test`): full website suite 314 files / 3662 tests green, `tsc --noEmit` clean
- [x] New tests added for new functionality: empty-caption card render with no raw marker leak, multi-file card render, click-to-open calls onFileOpen
- [x] Manual verification performed: synced the fresh build into the running gateway's served bundle and confirmed attachments render as cards

### Before
<img width="1560" height="272" alt="image" src="https://github.com/user-attachments/assets/4bdbd1c8-f165-4cee-8405-150b24c706df" />
<img width="1160" height="532" alt="image" src="https://github.com/user-attachments/assets/c066e3f1-8355-4a5e-ab7a-fd52fc9ee334" />

### After
<img width="516" height="182" alt="image" src="https://github.com/user-attachments/assets/ba5cde11-0a3d-4eac-86f5-26a72b742190" />


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
