### PR TITLE
fix(pod): provision installs npm deps before dist build and dev extras in venv

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -108,6 +108,29 @@ re-check `runtime.active_names` after the CLI returns and fail closed
 (`pod not active after start` / `pod still active after shutdown`) — a CLI exit 0
 is never taken as proof of the state change, in either direction.
 
+### Provisioning Dependency Install
+
+`provision.ensure_venv` and `provision.build_dist` install the dependencies each
+step needs before using them, so provisioning a **fresh** worktree (no
+`.venv`, no gitignored `website/node_modules`) does not fail on missing tools:
+
+- **venv (`ensure_venv`)** — after `python -m venv`, upgrades pip, then runs
+  `pip install --editable <checkout> --group dev` so the PEP 735 `dev`
+  dependency-group (pytest, flake8, isort, mypy, …) is present and the build
+  gate can run inside the pod venv (issue #230). `pip --group` needs pip
+  ≥ 25.1; if the command exits nonzero (older pip) it falls back to a
+  runtime-only `pip install --editable <checkout>` and `_say`s a warning that
+  dev tools were skipped — provisioning never hard-fails just because the dev
+  extras could not be installed.
+- **dist (`build_dist`)** — before `npm run build`, calls
+  `ensure_node_modules(website)`: if `website/node_modules/.bin/tsc` is missing
+  it runs `npm ci` (falling back to a NON-MUTATING `npm install
+  --no-package-lock` on lockfile drift — the flag keeps the fallback from
+  rewriting the tracked `website/package-lock.json`, so provisioning never
+  dirties the worktree), otherwise
+  it skips (fast idempotent path). Without this, a fresh worktree's `npm run
+  build` dies with `tsc: command not found` (issue #229).
+
 ### Pod Unit ExecStart Self-Heal
 
 On `pod up`, if the installed systemd unit template's `ExecStart` binary no longer exists

--- a/src/kiro_crew/pod/provision.py
+++ b/src/kiro_crew/pod/provision.py
@@ -82,10 +82,58 @@ def ensure_venv(checkout: Path) -> bool:
     if _run([py, "-m", "venv", str(venv_dir)], checkout) != 0:
         return False
     pip = venv_dir / "bin" / "pip"
+    # Upgrade pip first — `pip install --group` (PEP 735) needs pip >= 25.1, and a
+    # fresh `python -m venv` ships an older pip on many hosts.
     _run([str(pip), "install", "--quiet", "--upgrade", "pip"], checkout)
-    if _run([str(pip), "install", "--editable", str(checkout)], checkout) != 0:
-        return False
+    # Install runtime deps AND the PEP 735 `dev` dependency-group (pytest, flake8,
+    # isort, mypy, …) so the documented build gate can run inside the pod venv
+    # (issue #230). If `--group` is unsupported (pip < 25.1) the command exits
+    # nonzero, so fall back to a runtime-only editable install and warn — never
+    # hard-fail provisioning just because the dev extras could not be installed.
+    if _run(
+        [str(pip), "install", "--editable", str(checkout), "--group", "dev"],
+        checkout,
+    ) != 0:
+        _say(
+            "[provision] `pip install --group dev` failed (pip < 25.1?) — falling "
+            "back to a runtime-only editable install; dev tools (pytest/flake8) "
+            "were skipped, so the build gate can't run in this venv"
+        )
+        if _run([str(pip), "install", "--editable", str(checkout)], checkout) != 0:
+            return False
     return has_venv(checkout)
+
+
+def _has_node_modules(website: Path) -> bool:
+    """True when ``website/`` already has installed npm deps (with ``tsc``), so the
+    install step can be skipped on the fast idempotent path. ``tsc`` is the build's
+    key binary; its presence stands in for "deps are installed"."""
+    return (website / "node_modules" / ".bin" / "tsc").exists()
+
+
+def ensure_node_modules(website: Path) -> bool:
+    """Install ``website/`` npm dependencies if missing (issue #229).
+
+    A fresh worktree has no ``website/node_modules`` (gitignored), so ``npm run
+    build`` dies with ``tsc: command not found``. Install deps first: prefer
+    ``npm ci`` (clean, lockfile-exact) and, if that fails (e.g. lockfile drift),
+    fall back to ``npm install --no-package-lock``. The ``--no-package-lock``
+    flag keeps the fallback NON-MUTATING: it installs into ``node_modules``
+    without rewriting the tracked ``website/package-lock.json`` — provisioning
+    must never dirty tracked files (accidental lockfile churn would block
+    prune/rebase). Skips entirely when ``node_modules`` is already present, so
+    re-provisioning stays fast. Returns True when deps are ready."""
+    if _has_node_modules(website):
+        return True
+    _say("[provision] installing website npm deps (node_modules missing)…")
+    if _run(["npm", "ci"], website) == 0:
+        return True
+    _say(
+        "[provision] `npm ci` failed (lockfile drift?) — falling back to "
+        "`npm install --no-package-lock` (non-mutating: won't rewrite the "
+        "tracked package-lock.json)"
+    )
+    return _run(["npm", "install", "--no-package-lock"], website) == 0
 
 
 def build_dist(checkout: Path) -> bool:
@@ -102,6 +150,11 @@ def build_dist(checkout: Path) -> bool:
         f"[provision] building dist for {checkout.name} "
         f"(slow — Vite SPA build, several minutes)…"
     )
+    # A fresh worktree has no website/node_modules (gitignored); install deps
+    # before building or `npm run build` dies with `tsc: command not found`.
+    if not ensure_node_modules(website):
+        _say("FATAL: failed to install website npm deps")
+        return False
     if _run(["npm", "run", "build"], website) != 0:
         _say("FATAL: npm run build failed")
         return False

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -379,6 +379,119 @@ class TestProvisionBuildPaths:
         assert prov._find_python() == "/opt/python3.12"
 
 
+class TestProvisionDependencyInstall:
+    """Dependency-gap fixes: npm deps before dist build (#229), dev extras in
+    the venv with graceful fallback for old pip (#230)."""
+
+    def _venv_seeding_run(self, co: Path, calls: list[list[str]], group_fails: bool = False):
+        """Return a fake _run that records calls and materializes the venv bin on
+        `python -m venv`, so has_venv() passes. Optionally fail `--group` cmds."""
+
+        def fake_run(cmd: list[str], cwd: Path) -> int:
+            calls.append(cmd)
+            if cmd[1:3] == ["-m", "venv"]:
+                b = co / ".venv" / "bin"
+                b.mkdir(parents=True, exist_ok=True)
+                (b / "kirocrew").write_text("#!/bin/sh\n")
+                (b / "kirocrew").chmod(0o755)
+            if group_fails and "--group" in cmd:
+                return 1
+            return 0
+
+        return fake_run
+
+    # ---- #229: website npm deps ----
+
+    def test_npm_ci_when_node_modules_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        website = tmp_path / "wt" / "website"
+        website.mkdir(parents=True)
+        calls: list[list[str]] = []
+        monkeypatch.setattr(prov, "_run", lambda cmd, cwd: calls.append(cmd) or 0)
+        assert prov.ensure_node_modules(website) is True
+        assert ["npm", "ci"] in calls
+        # ci succeeded → no fallback (non-mutating install never runs)
+        assert ["npm", "install", "--no-package-lock"] not in calls
+
+    def test_node_modules_skipped_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        website = tmp_path / "wt" / "website"
+        (website / "node_modules" / ".bin").mkdir(parents=True)
+        (website / "node_modules" / ".bin" / "tsc").write_text("#!/bin/sh\n")
+
+        def boom(cmd: list[str], cwd: Path) -> int:
+            raise AssertionError(f"must not run npm when node_modules present: {cmd}")
+
+        monkeypatch.setattr(prov, "_run", boom)
+        assert prov.ensure_node_modules(website) is True
+
+    def test_npm_install_fallback_when_ci_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        website = tmp_path / "wt" / "website"
+        website.mkdir(parents=True)
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], cwd: Path) -> int:
+            calls.append(cmd)
+            return 1 if cmd == ["npm", "ci"] else 0  # ci fails, install succeeds
+
+        monkeypatch.setattr(prov, "_run", fake_run)
+        assert prov.ensure_node_modules(website) is True
+        # Fallback must be NON-MUTATING: --no-package-lock so the tracked
+        # website/package-lock.json is never rewritten (would dirty the worktree).
+        assert ["npm", "ci"] in calls
+        assert ["npm", "install", "--no-package-lock"] in calls
+        assert ["npm", "install"] not in calls  # plain (mutating) install never runs
+
+    def test_build_dist_installs_node_modules_before_build(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        co = tmp_path / "wt"
+        website = co / "website"
+        website.mkdir(parents=True)
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], cwd: Path) -> int:
+            calls.append(cmd)
+            if cmd == ["npm", "run", "build"]:
+                (website / "dist").mkdir(parents=True, exist_ok=True)
+                (website / "dist" / "index.html").write_text("<html>")
+            return 0
+
+        monkeypatch.setattr(prov, "_run", fake_run)
+        assert prov.build_dist(co) is True
+        assert calls.index(["npm", "ci"]) < calls.index(["npm", "run", "build"])
+
+    # ---- #230: venv dev extras ----
+
+    def test_pip_group_dev_attempted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        co = tmp_path / "wt"
+        co.mkdir()
+        monkeypatch.setattr(prov, "_find_python", lambda version="3.12": "/usr/bin/python3.12")
+        calls: list[list[str]] = []
+        monkeypatch.setattr(prov, "_run", self._venv_seeding_run(co, calls))
+        assert prov.ensure_venv(co) is True
+        assert any(c[-2:] == ["--group", "dev"] for c in calls)
+
+    def test_pip_group_dev_fallback_on_old_pip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        co = tmp_path / "wt"
+        co.mkdir()
+        monkeypatch.setattr(prov, "_find_python", lambda version="3.12": "/usr/bin/python3.12")
+        calls: list[list[str]] = []
+        monkeypatch.setattr(prov, "_run", self._venv_seeding_run(co, calls, group_fails=True))
+        assert prov.ensure_venv(co) is True
+        assert any("--group" in c for c in calls)  # attempted --group dev
+        pip = str(co / ".venv" / "bin" / "pip")
+        assert [pip, "install", "--editable", str(co)] in calls  # then fell back
+
+
 class TestPodEnv:
     def test_scrubs_slack_and_nonaws_tokens_keeps_aws(
         self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
Two provisioning dependency gaps that break fresh worktrees, fixed together (same file, same domain).

Fixes #229
Fixes #230

## Root causes
- **#229**: the dist step ran `npm run build` with no preceding `npm ci`. Fresh worktrees have no `website/node_modules` (gitignored, not transferred by `git worktree add`), so `tsc: command not found` kills provisioning at the dist step — which then blocks Make Live (`missing_dist`).
- **#230**: the venv step ran `pip install --editable <checkout>` only — runtime deps, no pytest/flake8 — so the documented build gate cannot run from the worktree's own venv.

## Fix
- `ensure_node_modules()`: when `website/node_modules/.bin/tsc` is missing, run `npm ci` (falling back to `npm install` on lockfile mismatch) before `npm run build`; skip when already present (fast idempotent path).
- `ensure_venv()`: install the PEP 735 `dev` dependency group via `pip install --editable <checkout> --group dev` (pip upgraded first, since `--group` needs pip ≥ 25.1), falling back to the runtime-only install with a logged warning on old pip — provisioning never hard-fails just because dev tools couldn't install.

## Testing
- `pytest --override-ini=addopts= -q test/test_pod.py` → 94 passed (7 new tests: npm ci invoked when node_modules missing / skipped when present / npm install fallback; `--group dev` attempted / fallback path). `_run` mocked — no real npm/pip in tests.
- `flake8 -j 1` + `isort --check-only` clean on changed files.
- Spec updated: `docs/system-specs/modules/dev-fleet.md` provisioning section.