### PR TITLE
feat(devfleet): expandable provision log panel with failure persistence

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -143,11 +143,67 @@ after the unit was installed.
 ## Async Runs
 
 Long-running operations (sync, provision) are tracked via `_RUNS` dict with:
-- Streamed stdout (last 500 lines kept)
+- Streamed stdout (last 500 lines kept **server-side**)
 - Watchdog deadline (30 min default, configurable via `_RUN_DEADLINE_S`)
 - Status: `running` → `done` | `timeout`
 
-Clients poll `/apps/dev-fleet/api/run?id=<run_id>` for progress.
+Clients poll `/apps/dev-fleet/api/run?id=<run_id>` for progress. The endpoint
+returns only the **last 60 lines** of `run.output` (a sliding tail window), not
+the full server-side 500-line buffer — see the accumulation note below.
+
+### Provision progress UX (frontend)
+
+A worktree being provisioned renders an inline **stepper strip** spanning the
+row's right columns (mirroring the main-row Pull+Build stepper): spinner +
+`Provisioning` label + a coarse phase tag (`venv`/`dist`, derived from
+provision.py's `[provision] creating venv …` / `[provision] building dist …`
+markers) + the last output line + elapsed time + a `log ▾`/`log ▴` toggle. The
+toggle expands a `<pre>` panel under the row showing the accumulated log
+(auto-scrolled while streaming).
+
+**Log accumulation (what "full log" actually means).** The `/run` endpoint only
+returns the last 60 output lines per poll, so a long provision scrolls early
+lines out of that window. The client therefore **accumulates** windows rather
+than replacing state each poll: `mergeLogWindow(buffer, window)` finds the
+longest suffix of the running buffer that is also a prefix of the newly polled
+window and appends only the non-overlapping remainder. This reconstructs the
+full stream across the normal case where the window advances by fewer than 60
+lines between two ~2s polls. **Honest limitation:** output that scrolls more
+than a full 60-line window between two polls (extremely fast-scrolling bursts)
+has no overlap to anchor on and those intermediate lines are lost. When that
+happens (zero overlap against a non-empty buffer), the client inserts a visible
+`[… lines missed …]` marker line into the panel so the transcript never
+silently overstates its completeness — the panel is the best client-side
+reconstruction plus an explicit gap signal, not a guaranteed-complete
+transcript. The heuristic's retirement path (a `since=<index>` cursor or raised
+tail on `/run` for a guaranteed-complete log) is tracked in issue #321.
+
+**Reattach on button-click (single-flight).** The provision endpoint is
+single-flighted per checkout: if a provision is already running it replies
+`{ok:false, error:"provision already running", run_id:<in-flight rid>}`. The
+frontend treats **any** response carrying a `run_id` as a run to attach to and
+resumes polling it — it does **not** render a failure. Only a response with no
+`run_id` is a genuine "failed to start". This makes a second Provision click
+during an in-flight build reattach to the live run instead of showing a false
+red state.
+
+**Failure persistence:** on failure/timeout the run is **not** cleared — the
+strip shows a red `✕ Provision failed (exit N)` label with the log
+auto-expanded, and both persist until the user clicks the dismiss `×`
+(dismiss also refreshes the fleet). On success it flashes a green
+`✓ Provisioned` briefly, then clears (the fleet refetch flips the row to its
+built state).
+
+**Known limitation — no reattach after a page reload.** Provision run state
+(including the persisted failed run and its log) lives only in component memory.
+A browser reload during or after a provision loses it, because the `/fleet`
+payload exposes no provision run ids to reattach to on mount (unlike sync, which
+reattaches via `sync_run_id`). The single-flight reattach above only covers a
+Provision **button-click** while a run is in flight, not a fresh page load.
+Server-backed reattach (exposing active/failed provision run ids in `/fleet` so
+the page can reattach on mount, mirroring `sync_run_id`) is tracked as follow-up
+work ([issue #321](https://github.com/kirodotdev/KiroCrew/issues/321); see also
+[issue #231](https://github.com/kirodotdev/KiroCrew/issues/231), PR #320).
 
 ## Make Live
 

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -15,7 +15,7 @@ import { addNotification } from '../store/notificationsSlice'
 import { setPendingInput } from '../store/chatSlice'
 import {
   Server, RefreshCw, Play, Square, ExternalLink, ChevronRight, Trash2,
-  LoaderCircle, Check, Video,
+  LoaderCircle, Check, Video, X,
   Ellipsis, RotateCw, FileText, GitCommit, Rocket,
 } from 'lucide-react'
 import * as api from './devFleetApi'
@@ -66,6 +66,71 @@ function syncPhaseFromLines(lines: string[], prev: number): number {
 
 function filterStepMarkers(lines: string[]): string[] {
   return lines.filter((l) => !STEP_MARKER_RE.test(l))
+}
+
+/* ─── Provision progress model (issue #231) ─── */
+// The last non-blank output line — the "current activity" shown inline.
+function lastLine(lines: string[] | undefined): string {
+  if (!lines) return ''
+  for (let i = lines.length - 1; i >= 0; i--) { if (lines[i]?.trim()) return lines[i] }
+  return ''
+}
+
+// Coarse phase tag derived from provision.py's markers ("[provision] creating
+// venv …" then "[provision] building dist …"). Scans newest→oldest so the tag
+// reflects the current step; returns null when nothing recognizable is in view.
+function provPhase(lines: string[] | undefined): string | null {
+  if (!lines) return null
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const l = (lines[i] || '').toLowerCase()
+    if (l.includes('building dist') || l.includes('npm run build') || l.includes('vite') || l.includes('tsc ')) return 'dist'
+    if (l.includes('creating venv') || l.includes('pip install') || l.includes('venv')) return 'venv'
+  }
+  return null
+}
+
+// The /api/run endpoint returns only the last ~60 output lines (server-side
+// tail). Long provisions scroll early lines out of that window, so we
+// accumulate client-side: merge each polled window into the running buffer by
+// finding the longest suffix of the buffer that is also a prefix of the new
+// window, then appending only the non-overlapping remainder. Robust to the
+// window sliding forward between polls; the only unrecoverable case is output
+// that scrolls more than a full window between two polls -- detected via zero
+// overlap and surfaced with a visible LOG_GAP_MARKER line (documented in
+// dev-fleet.md as an honest limitation).
+export const LOG_GAP_MARKER = '[\u2026 lines missed \u2026]'
+
+export function mergeLogWindow(buffer: string[], window: string[]): string[] {
+  if (!window.length) return buffer
+  if (!buffer.length) return window.slice()
+  const max = Math.min(buffer.length, window.length)
+  let overlap = 0
+  for (let k = max; k > 0; k--) {
+    let match = true
+    for (let i = 0; i < k; i++) {
+      if (buffer[buffer.length - k + i] !== window[i]) { match = false; break }
+    }
+    if (match) { overlap = k; break }
+  }
+  if (overlap === 0) {
+    // Zero overlap with a non-empty buffer means the server's tail window slid
+    // completely past what we last saw -- lines were (or may have been) missed.
+    // Insert a visible gap marker so the panel never overstates completeness.
+    return buffer.concat([LOG_GAP_MARKER], window)
+  }
+  return buffer.concat(window.slice(overlap))
+}
+
+// Auto-scrolling <pre> for the FULL provision log (mirrors the sync log panel's
+// styling). Sticks to the bottom while output is still streaming.
+function ProvLogPre({ lines, streaming }: { lines: string[]; streaming: boolean }) {
+  const ref = useRef<HTMLPreElement | null>(null)
+  useEffect(() => {
+    if (streaming && ref.current) ref.current.scrollTop = ref.current.scrollHeight
+  }, [lines, streaming])
+  return (
+    <pre ref={ref} style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties}>{lines.join('\n') || '(no output yet)'}</pre>
+  )
 }
 
 function syncPercent(phase: number, phaseAtMs: number | undefined): number {
@@ -230,6 +295,10 @@ interface Worktree {
 }
 interface FleetData { worktrees: Worktree[]; error?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean }
 interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; phase: number; phaseAt?: number; lines: string[]; startedAt: number; exit?: number | null; last?: string }
+// Provision run state (issue #231): the FULL output is kept (not just the last
+// line) so the expandable log panel can show everything, and a failed run
+// persists (failed=true) until the user dismisses it rather than vanishing.
+interface ProvRun { status: 'starting' | 'running' | 'done' | 'failed'; lines: string[]; startedAt: number; exit?: number | null; failed?: boolean; done?: boolean }
 interface RebaseResult { kind: 'ok' | 'conflict' | 'error'; text: string }
 
 /* ─── Detail Panel (expanded row) ─── */
@@ -378,7 +447,9 @@ export default function DevFleetPage() {
   const [detail, setDetail] = useState<Record<string, any>>({})
   const [detailLoading, setDetailLoading] = useState<Record<string, boolean>>({})
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [prov, setProv] = useState<Record<string, any>>({})
+  const [prov, setProv] = useState<Record<string, ProvRun | null>>({})
+  const [provLogOpen, setProvLogOpen] = useState<Record<string, boolean>>({})
+  const provDoneTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   const [rebaseResult, setRebaseResult] = useState<Record<string, RebaseResult>>({})
   const [podLogs, setPodLogs] = useState<Record<string, string>>({})
   const [podLogsLoading, setPodLogsLoading] = useState<Record<string, boolean>>({})
@@ -399,6 +470,13 @@ export default function DevFleetPage() {
     if (rid) cancelledRunsRef.current.add(rid)
     setSyncRun(null); setSyncLogOpen(false)
   }
+  function dismissProv(name: string) {
+    clearTimeout(provDoneTimersRef.current[name])
+    setProv((p) => { const n = { ...p }; delete n[name]; return n })
+    setProvLogOpen((o) => { const n = { ...o }; delete n[name]; return n })
+    invalidateFleet()
+  }
+  function toggleProvLog(name: string) { setProvLogOpen((o) => ({ ...o, [name]: !o[name] })) }
   const [confirmReq, setConfirmReq] = useState<{ title: string; desc: ReactNode; confirmLabel?: string; danger?: boolean; width?: number; resolve: (v: boolean) => void } | null>(null)
   const [restarting, setRestarting] = useState(false)
   const [pruneDialog, setPruneDialog] = useState<{ candidates: { name: string; code?: string }[]; kept: { name: string; code?: string }[]; scanned: number } | null>(null)
@@ -434,11 +512,13 @@ export default function DevFleetPage() {
 
   /* ─── Tick for elapsed counter ─── */
   const [, setTick] = useState(0)
+  // Elapsed counter ticks while a sync OR any provision is actively running.
+  const provTicking = Object.values(prov).some((p) => !!p && (p.status === 'running' || p.status === 'starting'))
   useEffect(() => {
-    if (!syncRun || syncRun.status !== 'running') return
+    if ((!syncRun || syncRun.status !== 'running') && !provTicking) return
     const t = setInterval(() => setTick((n) => n + 1), 1000)
     return () => clearInterval(t)
-  }, [syncRun?.status]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [syncRun?.status, provTicking]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function pollSyncRun(rid: string, startedAt: number) {
     let phase = 0
@@ -529,27 +609,84 @@ export default function DevFleetPage() {
     navigate('/chat?autoSend=1&newSession=1')
   }
 
+  // Poll a single provision run to completion, accumulating the server's
+  // sliding 60-line output window into a full client-side buffer
+  // (mergeLogWindow) so the "full log" panel keeps early output. Shared by a
+  // fresh provision and by reattaching to an already-in-flight run.
+  async function pollProvisionRun(name: string, rid: string, startedAt: number) {
+    let acc: string[] = []
+    for (let i = 0; i < 900; i++) {
+      await sleep(2000)
+      if (!pollAliveRef.current) return
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let run: any = null; try { run = await api.get('/run?id=' + rid) } catch { continue }
+      if (!run) continue
+      acc = mergeLogWindow(acc, run.output || [])
+      const lines = acc
+      if (run.status === 'done') {
+        const ok = run.exit_code === 0
+        notify(ok ? 'Provisioned' : 'Provision failed (exit ' + run.exit_code + ')', { type: ok ? 'success' : 'error' })
+        if (ok) {
+          // Flash a brief green "Provisioned", then clear (as before). The
+          // fleet refetch flips the row to its built state in the meantime.
+          setProv((p) => ({ ...p, [name]: { status: 'done', done: true, lines, startedAt, exit: 0 } }))
+          invalidateFleet()
+          provDoneTimersRef.current[name] = setTimeout(() => {
+            setProv((p) => { const n = { ...p }; delete n[name]; return n })
+            setProvLogOpen((o) => { const n = { ...o }; delete n[name]; return n })
+          }, 2500)
+        } else {
+          // FAILURE PERSISTENCE: keep the run, auto-expand the log, hold until
+          // the user dismisses it — a multi-minute failed provision must not
+          // vanish into an empty row (issue #231).
+          setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines, startedAt, exit: run.exit_code } }))
+          setProvLogOpen((o) => ({ ...o, [name]: true }))
+          invalidateFleet()
+        }
+        return
+      }
+      if (run.status !== 'running') {
+        notify(run.status === 'timeout' ? 'Provision timed out' : 'Provision failed (' + run.status + ')', { type: 'error' })
+        setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: lines.length ? lines : ['Provision ' + run.status], startedAt, exit: run.exit_code ?? null } }))
+        setProvLogOpen((o) => ({ ...o, [name]: true }))
+        invalidateFleet()
+        return
+      }
+      setProv((p) => ({ ...p, [name]: { status: 'running', lines, startedAt } }))
+    }
+    // Poll budget exhausted (e.g. run id lost across a gateway restart): keep
+    // the failed marker + accumulated log so the user has something to act on.
+    notify('Provision polling timed out \u2014 check pod logs', { type: 'error' })
+    setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: acc.length ? acc : ['Provision polling timed out \u2014 check pod logs'], startedAt, exit: null } }))
+    setProvLogOpen((o) => ({ ...o, [name]: true }))
+    invalidateFleet()
+  }
+
   async function provision(name: string) {
-    setProv((p) => ({ ...p, [name]: { status: 'starting', last: 'starting\u2026' } }))
+    const startedAt = Date.now()
+    clearTimeout(provDoneTimersRef.current[name])
+    setProvLogOpen((o) => { const n = { ...o }; delete n[name]; return n })
+    setProv((p) => ({ ...p, [name]: { status: 'starting', lines: [], startedAt } }))
     try {
       const r = await api.post<{ ok?: boolean; run_id?: string }>('/pod/provision', { name })
-      if (!r?.ok || !r.run_id) { notify('Provision failed', { type: 'error' }); setProv((p) => ({ ...p, [name]: null })); return }
-      const rid = r.run_id
-      for (let i = 0; i < 900; i++) {
-        await sleep(2000)
-        if (!pollAliveRef.current) return
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let run: any = null; try { run = await api.get('/run?id=' + rid) } catch { continue }
-        if (!run) continue; setProv((p) => ({ ...p, [name]: { status: run.status, last: (run.output || []).slice(-1)[0] || '' } }))
-        if (run.status === 'done') { notify(run.exit_code === 0 ? 'Provisioned' : 'Provision failed (exit ' + run.exit_code + ')', { type: run.exit_code === 0 ? 'success' : 'error' }); setProv((p) => ({ ...p, [name]: null })); invalidateFleet(); return }
-        if (run.status !== 'running') { notify(run.status === 'timeout' ? 'Provision timed out' : 'Provision failed (' + run.status + ')', { type: 'error' }); setProv((p) => ({ ...p, [name]: null })); invalidateFleet(); return }
+      // The single-flight guard replies {ok:false, run_id:<in-flight rid>} when
+      // a provision for this checkout is already running — that is NOT a
+      // failure. Reattach to the existing run instead of rendering a false red
+      // "Provision failed" state. Only a response with no run id to attach to
+      // is a genuine failure (issue #231 / PR #320).
+      if (!r?.run_id) {
+        notify('Provision failed to start', { type: 'error' })
+        setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: ['Provision failed to start'], startedAt, exit: null } }))
+        setProvLogOpen((o) => ({ ...o, [name]: true }))
+        return
       }
-      // Poll budget exhausted (e.g. run id lost across a gateway restart):
-      // clear the chip so the retry control reappears, and refresh state.
-      notify('Provision polling timed out \u2014 check pod logs', { type: 'error' })
-      setProv((p) => ({ ...p, [name]: null }))
-      invalidateFleet()
-    } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setProv((p) => ({ ...p, [name]: null })) }
+      await pollProvisionRun(name, r.run_id, startedAt)
+    } catch (e: unknown) {
+      const msg = (e as Error)?.message || String(e)
+      notify(msg, { type: 'error' })
+      setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: [msg], startedAt, exit: null } }))
+      setProvLogOpen((o) => ({ ...o, [name]: true }))
+    }
   }
 
   async function removeWorktree(name: string, d: Worktree) {
@@ -772,10 +909,9 @@ export default function DevFleetPage() {
     }
     const out: ReactNode[] = []
     if (!w.has_dist) {
-      const pr = prov[w.name]
-      out.push(pr
-        ? <span key="p" style={{ fontSize: 11, color: 'var(--warn)', display: 'inline-flex', alignItems: 'center', gap: 4 } as CSSProperties}><LoaderCircle size={12} className="lucide-inline" />{pr.last || 'provisioning\u2026'}</span>
-        : <Btn key="prov" onClick={() => provision(w.name)}>Provision</Btn>)
+      // Active/failed provisioning is rendered as a row-spanning stepper (see
+      // renderProvStepper), so this branch only offers the entry-point button.
+      out.push(<Btn key="prov" onClick={() => provision(w.name)}>Provision</Btn>)
     } else if (w.running) {
       out.push(<Btn key="open" onClick={() => act(w.name, 'open')}>{iconLabel(<ExternalLink size={13} className="lucide-inline" />, 'Open')}</Btn>)
     }
@@ -836,6 +972,47 @@ export default function DevFleetPage() {
     )
   }
 
+  /* ─── Provision stepper (inline at a worktree row, issue #231) ─── */
+  function renderProvStepper(w: Worktree) {
+    const pr = prov[w.name]
+    if (!pr) return null
+    const mono: CSSProperties = { fontFamily: 'ui-monospace, monospace', fontVariantNumeric: 'tabular-nums', fontSize: 11, color: 'var(--muted)' }
+    const open = !!provLogOpen[w.name]
+    const logToggle = (
+      <Clickable aria-label="Toggle provision log" onClick={() => toggleProvLog(w.name)} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 11, padding: 2 } as CSSProperties}>{open ? 'log \u25B4' : 'log \u25BE'}</Clickable>
+    )
+    if (pr.failed) {
+      return (
+        <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 } as CSSProperties}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--danger)', flexShrink: 0, display: 'inline-flex', alignItems: 'center', gap: 4 }}><X size={12} className="lucide-inline" />{'Provision failed' + (pr.exit != null ? ' (exit ' + pr.exit + ')' : '')}</span>
+          <span style={{ ...mono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } as CSSProperties} title={lastLine(pr.lines)}>{lastLine(pr.lines)}</span>
+          {logToggle}
+          <Clickable aria-label="Dismiss provision status" onClick={() => dismissProv(w.name)} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 14, padding: 2 } as CSSProperties}>&times;</Clickable>
+        </div>
+      )
+    }
+    if (pr.done) {
+      return (
+        <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 } as CSSProperties}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--ok)', display: 'inline-flex', alignItems: 'center', gap: 4 }}><Check size={12} className="lucide-inline" /> Provisioned</span>
+        </div>
+      )
+    }
+    // starting / running
+    const phase = provPhase(pr.lines)
+    const last = lastLine(pr.lines)
+    return (
+      <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 } as CSSProperties}>
+        <LoaderCircle size={12} className="lucide-inline" style={{ color: 'var(--accent)', flexShrink: 0 } as CSSProperties} />
+        <span style={{ fontSize: 11, fontWeight: 600, flexShrink: 0 }}>Provisioning</span>
+        {phase ? <span style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--accent)', background: 'var(--accent-subtle, rgba(99,102,241,0.14))', borderRadius: 5, padding: '1px 6px', flexShrink: 0 } as CSSProperties}>{phase}</span> : null}
+        <span style={{ ...mono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } as CSSProperties} title={last}>{last || 'starting\u2026'}</span>
+        <span style={mono}>{fmtElapsed(Date.now() - pr.startedAt)}</span>
+        {logToggle}
+      </div>
+    )
+  }
+
   const columnHeader = (
     <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '2px 0 4px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)' } as CSSProperties}>
       <span /><span>Pod</span><span>Worktree</span><span>PR</span><span title="Commits behind main">Behind</span><span title="Last commit activity">Updated</span><span style={{ textAlign: 'right' }}>Actions</span>
@@ -847,6 +1024,8 @@ export default function DevFleetPage() {
     const mut: CSSProperties = { fontSize: 12.5, color: 'var(--muted)', fontVariantNumeric: 'tabular-nums', fontFamily: 'ui-monospace, SF Mono, Menlo, monospace' }
     const prUrl = w.pr?.url || ''
     const isMainWithStepper = w.is_main && syncRun
+    const pr = prov[w.name]
+    const provActive = !w.is_main && !!pr
     return (
       <div key={w.name}>
         <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '5px 0', borderTop: '1px solid var(--border)', minHeight: 30 } as CSSProperties}>
@@ -861,7 +1040,7 @@ export default function DevFleetPage() {
             {w.is_live ? <Badge variant="aim" className="text-[10px] px-1.5 py-0" title="The live gateway on this port runs from this checkout">live</Badge> : null}
             {w.summary ? <span title={w.summary} style={{ fontSize: 11.5, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: '0 1 auto' } as CSSProperties}>{w.summary}</span> : null}
           </div>
-          {isMainWithStepper ? renderSyncStepper() : (
+          {isMainWithStepper ? renderSyncStepper() : provActive ? renderProvStepper(w) : (
             <>
               {rs && prUrl ? <a href={prUrl} target="_blank" rel="noopener noreferrer" title={w.pr?.title || rs.word} style={{ textDecoration: 'none' }}><Badge variant={rs.variant}>{rs.word}</Badge></a> : <span style={{ ...mut, opacity: 0.5 }}>&mdash;</span>}
               <span style={{ ...mut, opacity: (w.behind ?? 0) > 0 ? 1 : 0.5 }} title={(w.behind ?? 0) > 0 ? w.behind + ' commits behind main' : 'up to date with main'}>{(w.behind ?? 0) > 0 ? '\u2193' + w.behind : '\u2014'}</span>
@@ -872,6 +1051,9 @@ export default function DevFleetPage() {
         </div>
         {w.is_main && syncRun && syncLogOpen ? (
           <pre style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties}>{filterStepMarkers(syncRun.lines || []).join('\n') || '(no output yet)'}</pre>
+        ) : null}
+        {provActive && provLogOpen[w.name] && pr ? (
+          <ProvLogPre lines={pr.lines || []} streaming={pr.status === 'running' || pr.status === 'starting'} />
         ) : null}
         {open && detailLoading[w.name] ? <ContentSkeleton rows={3} /> : null}
         {open && detail[w.name] ? (

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 
-import DevFleetPage from '../pages/DevFleetPage'
+import DevFleetPage, { mergeLogWindow, LOG_GAP_MARKER } from '../pages/DevFleetPage'
 
 function renderPage() {
   return renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
@@ -561,5 +561,163 @@ describe('DevFleetPage', () => {
     // Upward placement anchors via `bottom`, not `top`.
     expect(menu.style.bottom).not.toBe('')
     expect(menu.style.top).toBe('')
+  })
+
+  /* ─── Provision progress: expandable log panel + failure persistence (issue #231) ─── */
+  // 'unprov' is the only non-main has_dist:false row, so it renders the single
+  // "Provision" button. Provision polling uses real 2s sleeps, hence the
+  // generous per-test timeouts and waitFor windows below.
+  it('provision stepper shows the FULL output in an expandable log panel and the toggle opens/closes it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-p' }), { status: 200 }))
+      // Stays 'running' so the streaming stepper + toggle are observable.
+      if (u.includes('/run?id=run-p')) return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: ['[provision] creating venv for unprov', 'Collecting deps', '[provision] building dist for unprov'] }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Provision'))
+    // The row-spanning stepper replaces the tiny inline pill immediately.
+    await waitFor(() => expect(screen.getByText('Provisioning')).toBeInTheDocument())
+    // Open the log panel; it renders the WHOLE output, not just the last line.
+    fireEvent.click(screen.getByLabelText('Toggle provision log'))
+    // 'Collecting deps' is a NON-last line -> it exists only in the full panel
+    // (the inline strip shows just the last line), proving full-output capture.
+    await waitFor(() => expect(screen.getByText(/Collecting deps/)).toBeInTheDocument(), { timeout: 4000 })
+    // Toggling closed removes the panel again.
+    fireEvent.click(screen.getByLabelText('Toggle provision log'))
+    await waitFor(() => expect(screen.queryByText(/Collecting deps/)).toBeNull())
+  }, 15000)
+
+  it('failed provision PERSISTS with an auto-expanded log and a working dismiss', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-f' }), { status: 200 }))
+      if (u.includes('/run?id=run-f')) return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 1, output: ['npm ERR! boom', 'FATAL: npm run build failed'] }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Provision'))
+    // The persistent strip is proven by its dismiss button (the toast has no
+    // this uniquely targets the persisted stepper) survives instead of vanishing.
+    await waitFor(() => expect(screen.getByLabelText('Dismiss provision status')).toBeInTheDocument(), { timeout: 4000 })
+    // The log auto-expands on failure: a non-last output line shows in the panel.
+    expect(screen.getByText(/npm ERR! boom/)).toBeInTheDocument()
+    // Dismiss clears the persisted stepper and restores the Provision entry point.
+    fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+    await waitFor(() => expect(screen.queryByLabelText('Dismiss provision status')).toBeNull())
+    expect(screen.getByText('Provision')).toBeInTheDocument()
+  }, 15000)
+
+  it('successful provision flashes a green Provisioned status then clears back to the Provision button', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-s' }), { status: 200 }))
+      if (u.includes('/run?id=run-s')) return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 0, output: ['[provision] done'] }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Provision'))
+    // Brief green success flash (stepper span and/or toast).
+    await waitFor(() => expect(screen.getAllByText('Provisioned').length).toBeGreaterThan(0), { timeout: 4000 })
+    // The stepper auto-clears (~2.5s), so the row returns to its Provision entry
+    // point — a toast-independent proof the transient success state cleared.
+    await waitFor(() => expect(screen.getByText('Provision')).toBeInTheDocument(), { timeout: 6000 })
+  }, 15000)
+
+  // FINDING 1: the single-flight guard returns {ok:false, run_id:<in-flight>}
+  // when a provision is already running. That must RESUME polling that run, not
+  // render a false red "Provision failed" state.
+  it('single-flight response (ok:false + run_id) resumes polling instead of failing', async () => {
+    let polledInflight = false
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      // Guard reply: already running -> ok:false but carries the in-flight rid.
+      if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: false, error: 'provision already running', run_id: 'run-inflight' }), { status: 200 }))
+      if (u.includes('/run?id=run-inflight')) {
+        polledInflight = true
+        return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: ['[provision] creating venv for unprov', 'Collecting deps'] }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Provision'))
+    // Reattaches to the in-flight run: it actually polls the in-flight run id
+    // (proving it resumed rather than bailing on the ok:false response)...
+    await waitFor(() => expect(polledInflight).toBe(true), { timeout: 4000 })
+    // ...the streaming stepper is shown, and the false-failure copy never appears.
+    expect(screen.getByText('Provisioning')).toBeInTheDocument()
+    expect(screen.queryByText('Provision failed to start')).toBeNull()
+    expect(screen.queryByText(/Provision failed/)).toBeNull()
+  }, 15000)
+
+  // FINDING 3: /api/run tail-truncates to the last ~60 lines, so early output
+  // scrolls out of later windows. The client accumulates windows, so an early
+  // line remains visible even after it has left the server's window.
+  it('accumulates log output across polls so early lines survive the server window', async () => {
+    let call = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-acc' }), { status: 200 }))
+      if (u.includes('/run?id=run-acc')) {
+        call++
+        // The window slides forward each poll; 'line-early-1' is only present
+        // in the first window and is gone by the final one.
+        if (call === 1) return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: ['line-early-1', 'line-2', 'line-3'] }), { status: 200 }))
+        if (call === 2) return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: ['line-2', 'line-3', 'line-4'] }), { status: 200 }))
+        return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 1, output: ['line-3', 'line-4', 'line-5'] }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Provision'))
+    // Ends in failure so the accumulated log auto-expands and persists.
+    await waitFor(() => expect(screen.getByLabelText('Dismiss provision status')).toBeInTheDocument(), { timeout: 10000 })
+    // Both the earliest line (window 1, only ever in the first poll) and the
+    // latest (final window) are present, proving windows were merged not
+    // replaced. 'line-early-1' is unique to the panel; 'line-5' also shows in
+    // the inline last-line strip, hence getAllByText.
+    expect(screen.getByText(/line-early-1/)).toBeInTheDocument()
+    expect(screen.getAllByText(/line-5/).length).toBeGreaterThan(0)
+  }, 20000)
+})
+
+// FINDING 3 (unit): the overlap-merge algorithm behind client-side log
+// accumulation — dedupes the overlapping suffix/prefix and appends the rest.
+describe('mergeLogWindow', () => {
+  it('returns the window when the buffer is empty', () => {
+    expect(mergeLogWindow([], ['a', 'b'])).toEqual(['a', 'b'])
+  })
+  it('returns the buffer unchanged when the window is empty', () => {
+    expect(mergeLogWindow(['a', 'b'], [])).toEqual(['a', 'b'])
+  })
+  it('appends only the non-overlapping remainder of an advancing window', () => {
+    // buffer suffix ['b','c'] == window prefix ['b','c'] -> append only ['d'].
+    expect(mergeLogWindow(['a', 'b', 'c'], ['b', 'c', 'd'])).toEqual(['a', 'b', 'c', 'd'])
+  })
+  it('concatenates fully when there is no overlap (window jumped past a full window)', () => {
+    expect(mergeLogWindow(['a', 'b'], ['x', 'y'])).toEqual(['a', 'b', LOG_GAP_MARKER, 'x', 'y'])
+  })
+  it('adds nothing when the window is a subset already at the buffer tail', () => {
+    expect(mergeLogWindow(['a', 'b', 'c'], ['b', 'c'])).toEqual(['a', 'b', 'c'])
+  })
+  it('handles repeated lines by matching the longest suffix/prefix overlap', () => {
+    // Longest suffix of buffer that prefixes the window is ['x','x'] (len 2).
+    expect(mergeLogWindow(['x', 'x', 'x'], ['x', 'x', 'y'])).toEqual(['x', 'x', 'x', 'y'])
   })
 })


### PR DESCRIPTION
## What

Fixes #231 — the Dev Fleet provisioning log was crammed into a tiny inline pill and disappeared entirely on completion.

Reuses the existing main-row **Pull+Build stepper** pattern for worktree provisioning.

## Before

- The `provision()` poll loop kept **only the last output line** (`{ status, last: output.slice(-1)[0] }`), rendered as a tiny `var(--warn)` pill in the actions cell.
- On done/failure/timeout it set `prov[name] = null`, so the output **vanished** — a failed multi-minute provision left the user with an empty row and nothing to act on.

## After

- **Full output kept in state** — the whole `run.output` array, not just the last line.
- **Inline stepper strip** (spans the row's right columns while provisioning): spinner + **Provisioning** + a coarse phase tag (`venv`/`dist`, derived from `provision.py`'s `[provision] creating venv …` / `[provision] building dist …` markers) + last line (truncated) + elapsed time (tabular-nums) + a `log ▾`/`log ▴` toggle.
- **Expandable `<pre>` log panel** under the row (same styling as the sync log): renders the **full** output joined by newlines, auto-scrolled to the bottom while streaming.
- **Failure persistence (the key fix):** on failure/timeout the run is **not** cleared — a red `✕ Provision failed (exit N)` label shows, the log **auto-expands**, and both persist until the user clicks the dismiss `×` (which also refreshes the fleet). On success it flashes a green `✓ Provisioned` briefly, then clears (the fleet refetch flips the row to its built state).

## Scope

- Frontend only — `website/src/pages/DevFleetPage.tsx` (+ a small `ProvLogPre` auto-scroll component in the same file). No backend changes: `run.output` already carries the full log.
- Docs: `docs/system-specs/modules/dev-fleet.md` documents the new provision progress UX.

## Tests

Adds 3 vitest cases to `DevFleetPage.test.tsx`:
- full output rendered in the expandable panel + toggle opens/closes it
- failed provision persists with an auto-expanded log and a working dismiss
- successful provision flashes then clears back to the Provision button

Unicode in JSX uses `{'\u2026'}`-style expressions / string literals (never bare-JSX `\u` escapes — regression #196).

## Gate

- `npx tsc -b` ✅ clean
- `npx vitest run` ✅ **369 files, 4213 passed / 3 skipped, 0 failures** (DevFleetPage: 30/30)
- `npm run build` ✅ dist rebuilt
