### PR TITLE
docs(dev-fleet): review-then-attach workflow for QA media on PRs

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/kirocrew-worktree-dev/SKILL.md
@@ -138,6 +138,13 @@ gh pr create --base main --title "feat: <description>" --body "<details>"
   first. CI is for confirmation, not discovery.
 - Address review comments in the worktree, amend or add commits, force-push the
   branch.
+- **QA media (screenshots / demo videos): review-then-attach.** Deliver the
+  media to the user for review first; once the user approves it, attach it to
+  the PR automatically without asking again — commit under
+  `temp-screenshots/<feature>/`, amend into the single commit, force-push, and
+  embed commit-SHA-pinned raw URLs in the PR body (images inline, mp4 as a
+  labelled link). Full recipe: the **pod-e2e** skill → "Attach approved QA
+  media to the PR".
 
 ## Why these rules exist (gotchas they prevent)
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -215,3 +215,29 @@ no dist → build-or-`--provision`.
 This skill only ever talks to pod ports (78xx). It must never restart or touch
 the live gateway. If the derived port ever resolves to the production port the
 orchestrator refuses and exits.
+
+## Attach approved QA media to the PR (MANDATORY workflow)
+
+QA screenshots and demo videos follow a **review-then-attach** contract:
+
+1. **Deliver to the user first.** Send the screenshots/video for review (after
+   the usual frame inspection for overlays -- first-run modals, toasts, theme
+   pickers). Never attach media the user has not seen.
+2. **Wait for explicit approval of the media.** A silent user is NOT approval.
+3. **On approval, attach to the PR automatically -- do NOT ask again.**
+   - Copy the approved files into `<worktree>/temp-screenshots/<feature>/`
+     (top-level ephemeral dir; NEVER under `docs/` or `src/kiro_crew/**` --
+     those trees ship in the wheel/sdist and desktop DMG).
+   - Stage `temp-screenshots/<feature>/`, **amend into the PR's single
+     commit**, and force-push with lease (standalone push command naming the
+     feature branch).
+   - Update the PR body with **commit-SHA-pinned** raw URLs:
+     - Images inline: `![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)`
+       -- put the 2-3 most telling shots inline, fold the rest into `<details>`.
+     - Videos: GitHub does not inline-play raw blob mp4s -- add a labelled link
+       line instead: `[Demo video (Ns, XMB)](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.mp4)`.
+   - After ANY later amend, re-pin every media URL to the new SHA.
+   - Verify the body update landed (`gh api repos/<o>/<r>/pulls/<n> --jq .body | grep temp-screenshots`).
+4. **Batch to minimize approval resets.** A force-push resets PR approvals --
+   attach media BEFORE asking the user to approve the PR itself, and fold the
+   media amend into any pending code amend rather than pushing twice.


### PR DESCRIPTION
## Problem
The bundled `pod-e2e` and `kirocrew-worktree-dev` skills describe recording QA screenshots/demo videos but never say what happens after the user reviews them. Agents deliver media to chat and stop — approved evidence never lands on the PR, so reviewers don't see it.

Fixes #324

## Why it matters
PR reviewers approve UI changes without ever seeing the visual evidence QA already produced; the media rots in chat scrollback and outbox dirs.

## Fix
Skill-doc-only change (2 files, bundled Dev Fleet skills):
- `pod-e2e/SKILL.md`: new **'Attach approved QA media to the PR'** section defining the review-then-attach contract — deliver media to the user first, wait for explicit approval (silence ≠ approval), then attach automatically: commit under `temp-screenshots/<feature>/` (never packaged paths), amend into the PR's single commit, force-push with lease, embed commit-SHA-pinned raw URLs in the PR body (images inline, mp4 as a labelled link since GitHub won't inline-play raw blobs), re-pin URLs after later amends, and batch media with code amends to minimize approval resets.
- `kirocrew-worktree-dev/SKILL.md`: Rule 7 gains a pointer entry to the full recipe.

## Tests
N/A — markdown-only skill documentation; no code paths changed.

## Manual verification
Rendered both files; section anchors and cross-reference verified.

## Screenshots
N/A — no UI change.