### PR TITLE
fix(knowledge): keep watcher self-heal rebuild DB access off the event loop

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -22,6 +22,7 @@ files / uploads / artifacts / URLs
 |------|----------------|
 | `knowledge/readers.py` | `FileReader` — per-extension text extraction; `SUPPORTED` format set |
 | `knowledge/folder_watcher.py` | `FolderWatcher` — recursive directory scan, per-file state, change/deletion detection |
+| `knowledge/watcher.py` | `KnowledgeWatcher` — polls registered sources for changes; sig-gated self-heal re-embed (single-flight, off-loop DB access) |
 | `knowledge/llm_pool.py` | `LLMPool` / `Worker` / `AcpWorker` — bounded pool of long-lived, sweep-shielded ACP workers |
 | `knowledge/extractor.py` | `EntityExtractor` — LLM entity/relation extraction over the pool |
 | `knowledge/agent_fetch.py` | `fetch_url_content()` — agent-assisted URL fetch over the pool (tools opt-in via `KIROCREW_KNOWLEDGE_FETCH_TOOLS`) |
@@ -47,6 +48,7 @@ files / uploads / artifacts / URLs
 | `AGENT_NAME` | `"kirocrew-knowledge"` | `llm_pool.py` | kiro-cli agent the ACP worker drives |
 | `_VALID_SANDBOX_MODES` | `{auto, standard, strict, cc, off}` | `llm_pool.py` | Accepted `agent.sandbox` values |
 | `HARD_SKIP_DIRS` | `{.git, node_modules, __pycache__, .venv, venv}` | `folder_watcher.py` | Directories never walked |
+| `_LARGE_REBUILD_WARN_THRESHOLD` | `1000` | `watcher.py` | Stale-item count at which the self-heal rebuild logs a prominent WARNING (usually an embedder-sig change invalidating the whole corpus) |
 | `DEFAULT_MAX_FILES` | `5000` | `folder_watcher.py` | Per-source file cap (newest-first) |
 | `CHUNK_TOKEN_SIZE` | `800` | `chunker.py` | Target chunk size (words) |
 | `CHUNK_OVERLAP` | `200` | `chunker.py` | Chunk overlap |
@@ -153,3 +155,4 @@ The dashboard Knowledge tab uses the same store via a lazily-initialized `Knowle
 - **LLM-derived text is redacted before storage and before return** — ingestion redacts extracted text (`ingestion._redact`), and `local_knowledge_search` redacts its assembled output.
 - **FTS query input is parameterized** — user query tokens are always double-quoted literals; the user never injects FTS5 operators.
 - **Embedding-dimension mismatches are skipped, not scored** — vector search excludes incomparable-dimension items so a model swap cannot fill the top-K with all-zero ghosts.
+- **The self-heal rebuild path never touches SQLite on the event loop** — `_maybe_reembed_stale`'s stale COUNT, `rebuild_embeddings`' total COUNT / page SELECTs / batch progress commits, and the success-path job finalize all run via `asyncio.to_thread` (`store.db` is a per-thread connection, so each worker thread uses its own connection to the same WAL db). On a large KB (observed: ~1.3GB after an embedder-sig change) an inline COUNT can stall past the 25s loop-watchdog threshold and crash-loop the gateway. The one deliberate exception is the CancelledError finalize in `_run_reembed_job`, which stays inline so cancellation cannot pre-empt the single-flight finalize. When the stale count exceeds `_LARGE_REBUILD_WARN_THRESHOLD` the watcher logs a prominent WARNING before starting the full re-embed.

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -597,6 +597,42 @@ def _stamp_embed_attempt(store, item_id: str, now_iso: str) -> None:
     store.db.commit()
 
 
+def _init_rebuild_total(store, count_where: str, params_tail: tuple, job_id: str) -> None:
+    """Count the rebuild's total items and stamp it on the job row (single commit).
+
+    Runs on a worker thread (``asyncio.to_thread``): the COUNT(*) scans the items
+    table and can stall for tens of seconds on a large KB under WAL contention, so
+    it must never run inline on the gateway event loop. ``store.db`` is a
+    per-thread connection; the UPDATE and its commit stay on this thread's own
+    connection.
+    """
+    total = store.db.execute(
+        f"SELECT COUNT(*) AS c FROM items WHERE {count_where}",  # noqa: S608
+        params_tail).fetchone()["c"]
+    store.db.execute(
+        "UPDATE ingestion_jobs SET items_total = ?, updated_at = ? WHERE id = ?",
+        (total, datetime.now().isoformat(), job_id))
+    store.db.commit()
+
+
+def _fetch_rebuild_page(store, page_where: str, params_tail: tuple, last_id: str):
+    """Fetch one keyset page of items to re-embed (worker thread; see above)."""
+    return store.db.execute(
+        f"SELECT id, title, summary, content, updated_at FROM items WHERE {page_where} "  # noqa: S608
+        "ORDER BY id LIMIT ?",
+        (*params_tail, last_id, _REBUILD_BATCH_SIZE)).fetchall()
+
+
+def _commit_rebuild_progress(store, job_id: str | None, processed: int, failed: int) -> None:
+    """Write end-of-batch progress counters and commit (worker thread; see above)."""
+    if job_id is not None:
+        store.db.execute(
+            "UPDATE ingestion_jobs SET items_processed = ?, items_failed = ?, "
+            "updated_at = ? WHERE id = ?",
+            (processed, failed, datetime.now().isoformat(), job_id))
+    store.db.commit()
+
+
 def _select_active_rebuild_job(store, *, now: datetime | None = None):
     """Return a FRESH (within the staleness window) active rebuild job row, or None.
 
@@ -699,20 +735,16 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
         params_tail = (sig,)
 
     if job_id is not None:
-        total = store.db.execute(
-            f"SELECT COUNT(*) AS c FROM items WHERE {count_where}",  # noqa: S608
-            params_tail).fetchone()["c"]
-        store.db.execute(
-            "UPDATE ingestion_jobs SET items_total = ?, updated_at = ? WHERE id = ?",
-            (total, datetime.now().isoformat(), job_id))
-        store.db.commit()
+        # OFFLOADED: the total COUNT scans the items table and can stall on a
+        # large KB; an inline call blocks the event loop (loop-watchdog risk).
+        await asyncio.to_thread(_init_rebuild_total, store, count_where, params_tail, job_id)
 
     last_id = ""
     while True:
-        rows = store.db.execute(
-            f"SELECT id, title, summary, content, updated_at FROM items WHERE {page_where} "  # noqa: S608
-            "ORDER BY id LIMIT ?",
-            (*params_tail, last_id, _REBUILD_BATCH_SIZE)).fetchall()
+        # OFFLOADED: page reads can block behind a concurrent writer's
+        # busy_timeout; keep every DB touch in this loop off the event loop.
+        rows = await asyncio.to_thread(
+            _fetch_rebuild_page, store, page_where, params_tail, last_id)
         if not rows:
             break
         for row in rows:
@@ -765,11 +797,7 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
                 # thread safely uses its OWN connection to the same db; the loop
                 # awaits it serially, so there is no concurrent-connection use.
                 await asyncio.to_thread(_heartbeat_rebuild_job, store, job_id, now_iso)
-        if job_id is not None:
-            store.db.execute(
-                "UPDATE ingestion_jobs SET items_processed = ?, items_failed = ?, "
-                "updated_at = ? WHERE id = ?",
-                (processed, failed, datetime.now().isoformat(), job_id))
-        store.db.commit()
+        # OFFLOADED end-of-batch progress write + commit (same no-blocking rule).
+        await asyncio.to_thread(_commit_rebuild_progress, store, job_id, processed, failed)
 
     return processed

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -26,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 FOLDER_SOURCE_TYPES = {"local_folder", "obsidian_vault"}
 
+# Stale-item count at which the watcher's self-heal rebuild logs a prominent
+# warning before starting: a count this large usually means an embedder
+# signature change invalidated the whole corpus, and the ensuing full re-embed
+# can run for a long time on a big knowledge base.
+_LARGE_REBUILD_WARN_THRESHOLD = 1000
+
 
 class KnowledgeWatcher:
     """Polls registered local_file sources for file changes and re-ingests."""
@@ -165,9 +171,20 @@ class KnowledgeWatcher:
         sig = embedder_signature(embedder)
         # Stale count excludes items in retry backoff (recently-failed) so a
         # perpetually-failing item can't drive a fresh rebuild every scan.
-        stale = count_stale_items(self.store, sig)
+        # OFFLOADED: this COUNT(*) scans the items table (no index on
+        # embedding_sig); on a large KB under WAL contention from a concurrent
+        # embedder it can stall for tens of seconds, and an inline call would
+        # block the event loop past the loop-watchdog threshold and crash-loop
+        # the gateway (observed on a ~1.3GB KB after an embedder-sig change).
+        stale = await asyncio.to_thread(count_stale_items, self.store, sig)
         if not stale:
             return
+        if stale >= _LARGE_REBUILD_WARN_THRESHOLD:
+            logger.warning(
+                "Watcher self-heal: %d items have a stale embedding sig (likely an "
+                "embedder signature change) — starting a full background re-embed. "
+                "This may take a while on a large knowledge base.", stale,
+            )
         # Atomically claim the single-flight slot (sweeps crashed leftovers, guards
         # against racing the dashboard trigger). None -> a rebuild is already running.
         # Offloaded: the BEGIN IMMEDIATE write-lock acquisition (busy_timeout up to
@@ -183,12 +200,9 @@ class KnowledgeWatcher:
     async def _run_reembed_job(self, embedder, job_id: str) -> None:
         try:
             processed = await rebuild_embeddings(self.store, embedder, job_id=job_id)
-            self.store.db.execute(
-                "UPDATE ingestion_jobs SET status = 'completed', items_processed = ?, "
-                "updated_at = ? WHERE id = ?",
-                (processed, datetime.now().isoformat(), job_id),
-            )
-            self.store.db.commit()
+            # OFFLOADED: single-row write, but a commit can block up to the
+            # busy_timeout behind a concurrent writer — keep it off the loop.
+            await asyncio.to_thread(self._finalize_reembed_job, job_id, processed)
             sel().log_tool_invocation(
                 session_key="watcher",
                 agent="knowledge-watcher",
@@ -208,6 +222,10 @@ class KnowledgeWatcher:
             # Best-effort finalize: if this UPDATE itself raises (e.g. db locked while
             # cancelling), it must not replace the CancelledError -- asyncio shutdown
             # has to see the cancel, so guard the SQL and re-raise unconditionally.
+            # Deliberately NOT offloaded: awaiting to_thread inside a CancelledError
+            # handler can be re-cancelled before the write lands, breaking the
+            # single-flight finalize guarantee; a single-row best-effort write is
+            # an acceptable inline cost on this error path.
             try:
                 self.store.db.execute(
                     "UPDATE ingestion_jobs SET status = ?, error = ?, updated_at = ? WHERE id = ?",
@@ -228,6 +246,19 @@ class KnowledgeWatcher:
                 )
             if is_cancel:
                 raise
+
+    def _finalize_reembed_job(self, job_id: str, processed: int) -> None:
+        """Mark a self-heal rebuild job completed (runs on a worker thread).
+
+        ``store.db`` is a per-thread connection, so the write and its commit stay
+        on this thread's own connection.
+        """
+        self.store.db.execute(
+            "UPDATE ingestion_jobs SET status = 'completed', items_processed = ?, "
+            "updated_at = ? WHERE id = ?",
+            (processed, datetime.now().isoformat(), job_id),
+        )
+        self.store.db.commit()
 
     @staticmethod
     def _parse_props(raw) -> dict:

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import logging
 import sys
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -1609,3 +1610,48 @@ class TestDashboardRebuildCancel:
             "SELECT status FROM ingestion_jobs WHERE id = 'dashcancel01'"
         ).fetchone()
         assert row["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+class TestWatcherLargeRebuildWarning:
+    """A stale count at/over _LARGE_REBUILD_WARN_THRESHOLD logs a prominent WARNING."""
+
+    def _watcher(self, store):
+        from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+        class _Pipe:
+            pass
+        pipe = _Pipe()
+        pipe.embedder = _FakeEmbedder()
+        return KnowledgeWatcher(store, pipe)
+
+    async def test_large_stale_count_logs_warning(self, store, monkeypatch, caplog):
+        import kiro_crew.knowledge.watcher as watcher_mod
+        monkeypatch.setattr(watcher_mod, "_LARGE_REBUILD_WARN_THRESHOLD", 3)
+        for i in range(3):
+            store.add_item(f"Item {i}", "body", "document")
+        watcher = self._watcher(store)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.knowledge.watcher"):
+            await watcher._maybe_reembed_stale()
+        assert watcher._reembed_task is not None
+        await watcher._reembed_task
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING
+                    and "full background re-embed" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "3 items" in warnings[0].getMessage()
+
+    async def test_small_stale_count_no_warning(self, store, monkeypatch, caplog):
+        import kiro_crew.knowledge.watcher as watcher_mod
+        monkeypatch.setattr(watcher_mod, "_LARGE_REBUILD_WARN_THRESHOLD", 100)
+        store.add_item("Only item", "body", "document")
+        watcher = self._watcher(store)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.knowledge.watcher"):
+            await watcher._maybe_reembed_stale()
+        assert watcher._reembed_task is not None
+        await watcher._reembed_task
+
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING
+                    and "full background re-embed" in r.getMessage()]


### PR DESCRIPTION
Fixes #323

## Problem

The knowledge watcher's sig-gated self-heal re-embed ran several SQLite calls inline on the gateway event loop. On a large KB (~1.3GB observed in the field) under WAL contention these stall past the 25s loop-watchdog threshold. An embedder-signature change (e.g. version upgrade) invalidates the whole corpus at once, turning this into a **gateway crash loop**: the watchdog restarts the gateway before the rebuild drains, so it never catches up. Reported by Danny Angus against upstream 3.3.5 (crash dumps show MainThread stuck at `_scan -> _maybe_reembed_stale -> count_stale_items`, event-loop lag ~17s); mechanism verified on current main.

## Fix

All DB access in the self-heal rebuild path now runs off the event loop (`asyncio.to_thread`; `store.db` is a per-thread connection, matching the already-offloaded `start_rebuild_job` / `_write_item_embedding` pattern):

- `watcher.py`: `count_stale_items` call offloaded; success-path job finalize offloaded (`_finalize_reembed_job`). The CancelledError finalize deliberately stays inline — awaiting `to_thread` inside a cancel handler can be re-cancelled before the write lands, breaking the single-flight finalize guarantee.
- `ingestion.py` `rebuild_embeddings`: initial total COUNT (`_init_rebuild_total`), keyset page fetches (`_fetch_rebuild_page`), and end-of-batch progress write+commit (`_commit_rebuild_progress`) offloaded.
- Visibility: WARNING logged when the stale count exceeds `_LARGE_REBUILD_WARN_THRESHOLD` (1000), so a corpus-wide re-embed after a signature change is prominent instead of silent.
- Spec: off-loop invariant documented in `docs/system-specs/modules/knowledge.md`.

## Testing

- `pytest test/test_knowledge.py -k 'stale or rebuild or reembed or watcher or LargeRebuild'` — 20 passed (18 existing incl. single-flight, cancel finalize, per-item heartbeat, partial-retry; 2 new for the warning threshold above/below)
- flake8 (-j 1), isort --check-only, mypy: clean on changed files

## Notes

- No behavior change to rebuild semantics, ordering, single-flight, or heartbeats — only where the DB calls execute.
- The reporter's separate sharp edge (system SQLite 3.7.17 segfaulting on a 3.53.2 WAL DB — candidate `doctor` warning) is intentionally out of scope.