### PR TITLE
feat(telegram): expose forum per-thread config in settings panel

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -359,7 +359,9 @@ Slack settings API they are registered in the dashboard route block (NOT
 
 - `GET /api/telegram/config` — masked bot-token preview + presence boolean,
   `enabled` flag, `allowed_user_ids` (serialized as digit strings for the tag
-  editor), `soft_threshold_pct`, and live status: `connected` (true only
+  editor), `soft_threshold_pct`, forum per-topic config (`allow_forum` bool and
+  `allowed_forum_chat_ids` — negative supergroup chat_ids serialized as strings
+  for the tag editor), and live status: `connected` (true only
   after startup proved the token with an authenticated `getMe` and the
   long-polling transport started; when Telegram is unreachable at boot the
   channel still starts and reports not-connected until the first successful
@@ -386,6 +388,11 @@ Slack settings API they are registered in the dashboard route block (NOT
   empty, so leaving it behind would resurrect a removed credential on the
   next restart. `allowed_user_ids` accepts digit strings or ints and stores
   canonical deduplicated ints; `soft_threshold_pct` is an int in 1–100.
+  `allow_forum` must be a strict boolean; `allowed_forum_chat_ids` accepts
+  integer-like strings or ints and stores canonical deduplicated ints —
+  supergroup chat_ids are NEGATIVE (e.g. `-1001234567890`), so the validator
+  accepts a leading minus (NOT the digits-only check used for
+  `allowed_user_ids`) and rejects non-integer garbage.
   Every Telegram field is boot-read (consumed in the orchestrator's
   constructor), so `restart_required` is true for any actual change and only
   for actual change.

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2183,6 +2183,11 @@ async def api_telegram_config_get(request: web.Request) -> web.Response:
             # accepts digit strings and stores canonical ints.
             "allowed_user_ids": [str(u) for u in tg.allowed_user_ids],
             "soft_threshold_pct": int(tg.soft_threshold_pct),
+            # Forum per-topic config. chat_ids are serialized as strings for
+            # the tag editor UI; they are NEGATIVE (e.g. "-1001234567890"),
+            # so the save path accepts a leading minus (not a digits-only check).
+            "allow_forum": bool(tg.allow_forum),
+            "allowed_forum_chat_ids": [str(c) for c in tg.allowed_forum_chat_ids],
         }
     )
 
@@ -2316,6 +2321,36 @@ async def _telegram_config_save_locked(request: web.Request) -> web.Response:
         if pct != int(tg_cfg.get("soft_threshold_pct", 80)):
             staged["soft_threshold_pct"] = pct
             applied.append("soft_threshold_pct")
+
+    if "allow_forum" in body:
+        val = body.get("allow_forum")
+        if not isinstance(val, bool):
+            return _deny("allow_forum must be a boolean")
+        if val != bool(tg_cfg.get("allow_forum", False)):
+            staged["allow_forum"] = val
+            applied.append("allow_forum")
+
+    if "allowed_forum_chat_ids" in body:
+        raw_chat_ids = body.get("allowed_forum_chat_ids")
+        if not isinstance(raw_chat_ids, list):
+            return _deny("allowed_forum_chat_ids must be a list")
+        new_chat_ids: list[int] = []
+        for item in raw_chat_ids:
+            s = str(item).strip()
+            if not s:
+                continue
+            # Forum supergroup chat_ids are NEGATIVE (e.g. -1001234567890),
+            # so accept an optional leading minus — the digits-only check used
+            # for allowed_user_ids would wrongly reject every group id here.
+            digits = s[1:] if s.startswith("-") else s
+            if not digits.isdigit():
+                return _deny(f"invalid Telegram chat ID: {s} (integer IDs only)")
+            cid = int(s)
+            if cid not in new_chat_ids:
+                new_chat_ids.append(cid)
+        if new_chat_ids != list(tg_cfg.get("allowed_forum_chat_ids", [])):
+            staged["allowed_forum_chat_ids"] = new_chat_ids
+            applied.append("allowed_forum_chat_ids")
 
     # Whenever the .env token is set or cleared, also drop the legacy
     # config.json ``telegram.bot_token`` fallback. The gateway (and GET above)

--- a/test/test_telegram_config_handlers.py
+++ b/test/test_telegram_config_handlers.py
@@ -311,3 +311,88 @@ def test_get_masks_token_and_reports_state(tmp_path: Path, monkeypatch) -> None:
     assert body["connected"] is False
     assert body["enabled"] is True
     assert body["allowed_user_ids"] == ["42"]
+
+
+def test_get_returns_forum_fields_as_strings(tmp_path: Path, monkeypatch) -> None:
+    """GET serializes forum config; negative chat_ids come back as strings."""
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        '{"telegram": {"enabled": true, "allowed_user_ids": [42], '
+        '"allow_forum": true, "allowed_forum_chat_ids": [-1001234567890]}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    class _State:
+        telegram_connected = False
+        telegram_connect_error = ""
+
+    req = make_mocked_request("GET", "/api/telegram/config", app={"state": _State()})
+    resp = asyncio.run(mod.api_telegram_config_get(req))
+    assert resp.status == 200
+    body = json.loads(resp.text)
+    assert body["allow_forum"] is True
+    # Serialized as strings for the tag editor, preserving the leading minus.
+    assert body["allowed_forum_chat_ids"] == ["-1001234567890"]
+
+
+def test_save_persists_forum_fields_with_negative_ids(tmp_path: Path, monkeypatch) -> None:
+    """PUT accepts allow_forum + negative chat_ids and stores canonical ints."""
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    (status_body, _) = _client_put(
+        mod,
+        monkeypatch,
+        tmp_path,
+        {
+            "allow_forum": True,
+            # String and int forms, negative supergroup ids, plus a duplicate.
+            "allowed_forum_chat_ids": ["-1001234567890", -1009876543210, "-1001234567890"],
+        },
+    )
+    status, body = status_body
+    assert status == 200
+    assert body["restart_required"] is True
+    cfg = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert cfg["telegram"]["allow_forum"] is True
+    # Canonical, deduplicated ints (order preserved, minus retained).
+    assert cfg["telegram"]["allowed_forum_chat_ids"] == [-1001234567890, -1009876543210]
+
+
+def test_save_rejects_non_boolean_allow_forum(tmp_path: Path, monkeypatch) -> None:
+    """allow_forum must be a strict boolean; a string is rejected before write."""
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    (status_body, _) = _client_put(mod, monkeypatch, tmp_path, {"allow_forum": "true"})
+    status, body = status_body
+    assert status == 400
+    assert "allow_forum" in body["error"]
+    assert not (tmp_path / "config.json").exists()  # nothing staged/written
+
+
+def test_save_rejects_garbage_forum_chat_ids(tmp_path: Path, monkeypatch) -> None:
+    """Non-integer chat ids (and a bare minus) are rejected; nothing written."""
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    for bad in ("@supergroup", "-", "12.5", "-100abc"):
+        (status_body, _) = _client_put(
+            mod, monkeypatch, tmp_path, {"allowed_forum_chat_ids": [bad]}
+        )
+        status, body = status_body
+        assert status == 400, f"chat_id={bad!r} should be rejected"
+        assert "chat ID" in body["error"]
+
+    # A non-list value is rejected too.
+    (status_body, _) = _client_put(
+        mod, monkeypatch, tmp_path, {"allowed_forum_chat_ids": "-100"}
+    )
+    assert status_body[0] == 400
+    assert "must be a list" in status_body[1]["error"]

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -98,6 +98,9 @@ export interface TelegramConfigData {
   enabled: boolean
   allowed_user_ids: string[]
   soft_threshold_pct: number
+  // Forum per-topic config. chat_ids are negative supergroup ids as strings.
+  allow_forum?: boolean
+  allowed_forum_chat_ids?: string[]
 }
 
 /** Writable Discord config fields sent to PUT /api/discord/config. */
@@ -117,6 +120,8 @@ export interface TelegramConfigSave {
   enabled: boolean
   allowed_user_ids: string[]
   soft_threshold_pct: number
+  allow_forum?: boolean
+  allowed_forum_chat_ids?: string[]
 }
 
 /** Webex config as returned by GET /api/webex/config (secret masked). */

--- a/website/src/components/settings.tsx
+++ b/website/src/components/settings.tsx
@@ -20,7 +20,10 @@ import { Input, Toggle } from './ui'
 
 interface SettingsToggleProps {
   label: string
-  description?: string
+  // ReactNode (not just string) so callers can pass rich copy — e.g. the
+  // Telegram forum toggle describes setup with inline <span className="font-mono">
+  // fragments. The render path already wraps it in a <div>, so any node is safe.
+  description?: React.ReactNode
   checked: boolean
   onChange: (value: boolean) => void
   disabled?: boolean

--- a/website/src/pages/settings/BotChannelPanel.forum.test.tsx
+++ b/website/src/pages/settings/BotChannelPanel.forum.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for the optional Telegram forum block in the shared BotChannelPanel.
+ *
+ * The forum toggle + supergroup-chat-id allowlist render ONLY when the channel
+ * spec supplies a `forum` block, and the forum fields are added to the save
+ * payload ONLY in that case — so Discord/Webex (which omit `forum`) never send
+ * `allow_forum`/`allowed_forum_chat_ids`. These tests drive the panel with fake
+ * specs (mock getConfig/saveConfig) so they exercise panel logic, not the API.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '../../test/helpers'
+import {
+  BotChannelPanel,
+  type BotChannelSpec,
+  type BotChannelConfigData,
+} from './BotChannelPanel'
+
+const FORUM_TOGGLE = 'Serve forum Topics as per-Topic sessions'
+const FORUM_ALLOWLIST = 'Allowed supergroup chat IDs'
+const FORUM_EMPTY_HINT = 'Forum enabled but no allow-listed chats'
+
+function config(overrides: Partial<BotChannelConfigData> = {}): BotChannelConfigData {
+  return {
+    connected: false,
+    connect_error: '',
+    configured: true,
+    read_only: false,
+    bot_token_set: true,
+    bot_token_preview: '1102…saw',
+    enabled: true,
+    allowed_user_ids: ['42'],
+    soft_threshold_pct: 80,
+    allow_forum: false,
+    allowed_forum_chat_ids: [],
+    ...overrides,
+  }
+}
+
+/** A minimal spec; pass `withForum` to attach the forum block (Telegram-style). */
+function makeSpec(
+  cfg: BotChannelConfigData,
+  saveConfig: BotChannelSpec['saveConfig'],
+  withForum: boolean,
+): BotChannelSpec {
+  const spec: BotChannelSpec = {
+    name: 'Telegram',
+    queryKey: `test-${withForum ? 'forum' : 'plain'}-${Math.random()}`,
+    logo: <span />,
+    description: 'desc',
+    host: 'api.telegram.org',
+    setupGuide: 'https://example.invalid/guide',
+    guideBody: 'guide',
+    guideLink: { label: 'Open', href: 'https://example.invalid' },
+    tokenDescription: 'token desc',
+    tokenPlaceholder: 'token',
+    allowlistDescription: 'user ids',
+    allowlistPlaceholder: '123',
+    thresholdDescription: 'threshold',
+    emptyAllowlistHint: 'no users',
+    getConfig: () => Promise.resolve(cfg),
+    saveConfig,
+  }
+  if (withForum) {
+    spec.forum = {
+      toggleLabel: FORUM_TOGGLE,
+      toggleDescription: <>route each topic</>,
+      allowlistLabel: FORUM_ALLOWLIST,
+      allowlistDescription: 'negative supergroup chat ids',
+      allowlistPlaceholder: '-1001234567890',
+      emptyHint:
+        'Forum enabled but no allow-listed chats: all forum traffic is denied.',
+    }
+  }
+  return spec
+}
+
+describe('BotChannelPanel forum block', () => {
+  it('renders the forum toggle + chat-id allowlist when spec.forum is present', async () => {
+    const spec = makeSpec(config(), vi.fn(), true)
+    renderWithProviders(<BotChannelPanel spec={spec} />)
+    expect(await screen.findByText(FORUM_TOGGLE)).toBeInTheDocument()
+    expect(screen.getByText(FORUM_ALLOWLIST)).toBeInTheDocument()
+    expect(screen.getByText('Forum topics')).toBeInTheDocument()
+  })
+
+  it('omits the forum block entirely when spec.forum is absent (Discord/Webex)', async () => {
+    const spec = makeSpec(config(), vi.fn(), false)
+    renderWithProviders(<BotChannelPanel spec={spec} />)
+    // Wait for the panel to hydrate (the enable toggle is always present).
+    expect(await screen.findByText('Enable Telegram')).toBeInTheDocument()
+    expect(screen.queryByText(FORUM_TOGGLE)).not.toBeInTheDocument()
+    expect(screen.queryByText('Forum topics')).not.toBeInTheDocument()
+  })
+
+  it('shows the fail-closed hint when the toggle is on but no chat ids are listed', async () => {
+    const spec = makeSpec(config({ allow_forum: true, allowed_forum_chat_ids: [] }), vi.fn(), true)
+    renderWithProviders(<BotChannelPanel spec={spec} />)
+    expect(await screen.findByText(new RegExp(FORUM_EMPTY_HINT))).toBeInTheDocument()
+  })
+
+  it('includes allow_forum + allowed_forum_chat_ids in the save payload when spec.forum is present', async () => {
+    const saveConfig = vi
+      .fn()
+      .mockResolvedValue({ ok: true, restart_required: true, verify_warning: '' })
+    const spec = makeSpec(
+      config({ allow_forum: true, allowed_forum_chat_ids: ['-1001234567890'] }),
+      saveConfig,
+      true,
+    )
+    renderWithProviders(<BotChannelPanel spec={spec} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Save Telegram settings/i }))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+    const payload = saveConfig.mock.calls[0][0]
+    expect(payload).toMatchObject({
+      allow_forum: true,
+      allowed_forum_chat_ids: ['-1001234567890'],
+    })
+  })
+
+  it('never includes forum fields in the save payload when spec.forum is absent', async () => {
+    const saveConfig = vi
+      .fn()
+      .mockResolvedValue({ ok: true, restart_required: false, verify_warning: '' })
+    const spec = makeSpec(config(), saveConfig, false)
+    renderWithProviders(<BotChannelPanel spec={spec} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Save Telegram settings/i }))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+    const payload = saveConfig.mock.calls[0][0]
+    expect(payload).not.toHaveProperty('allow_forum')
+    expect(payload).not.toHaveProperty('allowed_forum_chat_ids')
+  })
+})

--- a/website/src/pages/settings/BotChannelPanel.tsx
+++ b/website/src/pages/settings/BotChannelPanel.tsx
@@ -18,6 +18,9 @@ export interface BotChannelConfigData {
   allowed_user_ids: string[]
   allowed_thread_ids?: string[]
   soft_threshold_pct: number
+  /** Telegram forum per-topic config (optional; only Telegram sends these). */
+  allow_forum?: boolean
+  allowed_forum_chat_ids?: string[]
 }
 
 /** Writable fields shared by every bot-token channel save endpoint. */
@@ -28,6 +31,8 @@ export interface BotChannelConfigSave {
   allowed_user_ids: string[]
   allowed_thread_ids?: string[]
   soft_threshold_pct: number
+  allow_forum?: boolean
+  allowed_forum_chat_ids?: string[]
 }
 
 /** Everything channel-specific: names, copy, endpoints, and guide content. */
@@ -66,6 +71,20 @@ export interface BotChannelSpec {
     help: ReactNode
     warning: ReactNode
   }
+  /**
+   * Optional forum/per-topic config (Telegram supergroups). When present, the
+   * panel renders an allow_forum toggle plus a chat-id tag editor; channels
+   * that omit it (Discord, Webex) are unaffected and never send forum fields.
+   */
+  forum?: {
+    toggleLabel: string
+    toggleDescription: ReactNode
+    allowlistLabel: string
+    allowlistDescription: string
+    allowlistPlaceholder: string
+    /** Fail-closed hint shown when the toggle is on but the list is empty. */
+    emptyHint: string
+  }
   /** API calls. */
   getConfig: () => Promise<BotChannelConfigData>
   saveConfig: (body: Partial<BotChannelConfigSave>) => Promise<{ ok: boolean; restart_required: boolean; verify_warning: string }>
@@ -78,6 +97,8 @@ type Draft = {
   allowed_user_ids: string[]
   allowed_thread_ids: string[]
   soft_threshold_pct: string
+  allow_forum: boolean
+  allowed_forum_chat_ids: string[]
 }
 
 function draftFrom(c: BotChannelConfigData): Draft {
@@ -86,6 +107,8 @@ function draftFrom(c: BotChannelConfigData): Draft {
     allowed_user_ids: [...c.allowed_user_ids],
     allowed_thread_ids: [...(c.allowed_thread_ids ?? [])],
     soft_threshold_pct: String(c.soft_threshold_pct),
+    allow_forum: !!c.allow_forum,
+    allowed_forum_chat_ids: [...(c.allowed_forum_chat_ids ?? [])],
   }
 }
 
@@ -203,6 +226,10 @@ export function BotChannelPanel({ spec }: { spec: BotChannelSpec }) {
       soft_threshold_pct: pct,
     }
     if (spec.threadAllowlist) payload.allowed_thread_ids = draft.allowed_thread_ids
+    if (spec.forum) {
+      payload.allow_forum = draft.allow_forum
+      payload.allowed_forum_chat_ids = draft.allowed_forum_chat_ids
+    }
     if (botClear) payload.bot_token_clear = true
     else if (botToken.trim()) payload.bot_token = botToken.trim()
     saveMut.mutate(payload)
@@ -328,6 +355,40 @@ export function BotChannelPanel({ spec }: { spec: BotChannelSpec }) {
           )}
         </SettingsCard>
       </SettingsSection>
+
+      {/* ── Forum topics (optional; Telegram supergroups) ── */}
+      {spec.forum && (
+        <SettingsSection title="Forum topics">
+          <SettingsCard>
+            <SettingsToggle
+              label={spec.forum.toggleLabel}
+              description={spec.forum.toggleDescription}
+              checked={draft.allow_forum}
+              onChange={v => upd({ allow_forum: v })}
+              disabled={ro}
+            />
+            <div className="border-t border-border mt-4 pt-4">
+              <TagListEditor
+                label={spec.forum.allowlistLabel}
+                description={spec.forum.allowlistDescription}
+                values={draft.allowed_forum_chat_ids}
+                placeholder={spec.forum.allowlistPlaceholder}
+                onChange={v => upd({ allowed_forum_chat_ids: v })}
+                // Supergroup chat_ids are negative — allow an optional leading
+                // minus (a digits-only check would reject every valid id).
+                validate={v => /^-?\d+$/.test(v)}
+                readOnly={ro}
+              />
+              {draft.allow_forum && draft.allowed_forum_chat_ids.length === 0 && (
+                <p className="text-[12px] text-warn mt-2 mb-0 flex items-start gap-1.5">
+                  <AlertTriangle size={13} className="flex-none mt-0.5" />
+                  <span>{spec.forum.emptyHint}</span>
+                </p>
+              )}
+            </div>
+          </SettingsCard>
+        </SettingsSection>
+      )}
 
       {/* ── Behavior ── */}
       <SettingsSection title="Behavior">

--- a/website/src/pages/settings/TelegramPanel.tsx
+++ b/website/src/pages/settings/TelegramPanel.tsx
@@ -31,6 +31,26 @@ const TELEGRAM_SPEC: BotChannelSpec = {
   thresholdDescription: 'Prompt to /compact or /new when the session context passes this percentage.',
   emptyAllowlistHint:
     'No allowed user IDs: the bot rejects every message (fail closed). Add your numeric Telegram user ID below.',
+  forum: {
+    toggleLabel: 'Serve forum Topics as per-Topic sessions',
+    toggleDescription: (
+      <>
+        Route each Topic of an allow-listed supergroup to its own agent session
+        (Slack-thread style). Create a supergroup, turn on <span className="font-mono">Topics</span>,
+        add the bot, then list the supergroup&apos;s <span className="font-mono">chat_id</span> below.
+        The General topic and ordinary (non-forum) groups are always denied.
+      </>
+    ),
+    allowlistLabel: 'Allowed supergroup chat IDs',
+    allowlistDescription:
+      'Numeric supergroup chat_ids permitted to run forum-topic sessions. These are negative ' +
+      '(e.g. -1001234567890) — find one by adding a bot like @getidsbot to the group. ' +
+      'Empty = deny all groups (fail closed).',
+    allowlistPlaceholder: '-1001234567890',
+    emptyHint:
+      'Forum enabled but no allow-listed chats: all forum traffic is denied. Add your supergroup ' +
+      'chat_id (a negative number like -100…).',
+  },
   getConfig: api.getTelegramConfig,
   saveConfig: api.saveTelegramConfig,
   // The backend updates connected/connect_error live (polling health), so


### PR DESCRIPTION
Closes #322

## What

Exposes the Telegram forum per-thread config (from #219) in the Telegram settings panel and its config API. Previously `telegram.allow_forum` and `telegram.allowed_forum_chat_ids` could only be set by hand-editing `config.json`.

## Changes

**Backend** (`src/kiro_crew/dashboard/handlers/messaging.py`):
- `GET /api/telegram/config` now returns `allow_forum` (bool) and `allowed_forum_chat_ids` (serialized as strings for the tag-editor UI, matching the `allowed_user_ids` convention)
- `PUT /api/telegram/config` accepts and validates both fields: `allow_forum` must be boolean; chat ids must be integer-like and accept a leading minus sign (forum supergroup ids are negative, e.g. `-1001234567890`). All validation is fail-before-write — a rejected payload writes nothing.

**Frontend**:
- `BotChannelPanel.tsx`: generic optional `spec.forum` block (toggle + chat-id tag editor with `/^-?\d+$/` validation + fail-closed hint when the toggle is on but the list is empty). Forum fields are only included in the save payload when `spec.forum` is present — Discord/Webex panels are unaffected.
- `TelegramPanel.tsx`: forum spec block with setup copy (create a supergroup, enable Topics, add the bot, allow-list the chat_id; each Topic gets its own session; General topic and ordinary groups are denied).
- `settings.tsx`: widened `SettingsToggle.description` from `string` to `React.ReactNode` (backward compatible — render path already wraps it in a `<div>`).

**Spec**: `docs/system-specs/modules/messaging.md` updated with the new API fields (config.md already documented the config fields).

## Tests

- Backend: 4 new tests in `test/test_telegram_config_handlers.py` — GET round-trip, PUT negative-id persist+dedup, non-bool rejection, garbage rejection (18/18 pass including pre-existing)
- Frontend: new `BotChannelPanel.forum.test.tsx` (5 tests) — forum block renders when spec present, absent otherwise, fail-closed hint, save payload inclusion/omission (12/12 pass including SettingsPage suite)

## Build gate

- `isort --check-only` ✓
- `flake8 -j 1` ✓
- `pytest test/test_telegram_config_handlers.py` → 18 passed
- `npx tsc -b` → clean
- `npx vitest run` (changed files) → 12 passed
