### PR TITLE
fix(registry): kill and reap subprocesses on timeout in clone/detect/install paths

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -33,7 +33,6 @@ import os
 import platform as _platform
 import re
 import shutil
-import signal
 import sys
 import time
 from pathlib import Path
@@ -441,8 +440,10 @@ async def _fetch_app_manifest(
             stderr=asyncio.subprocess.PIPE,
             env=minimal_env(),
             preexec_fn=resource_limit_preexec(),
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=_CLONE_TIMEOUT)
+        _, stderr = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
         if proc.returncode != 0:
             logger.debug(
                 "manifest clone failed for %s: %s",
@@ -698,11 +699,30 @@ async def _communicate_with_timeout(
     proc: asyncio.subprocess.Process,
     timeout: float,
 ) -> tuple[bytes, bytes]:
-    """Communicate with a subprocess, killing it on timeout to prevent leaks."""
+    """Communicate with a subprocess, killing its whole process tree on timeout.
+
+    A timed-out ``git clone`` or ``/bin/sh -c <probe>`` can have descendants
+    (SSH, a version-probe binary, ...). Killing only the immediate child with
+    ``proc.kill()`` re-parents those grandchildren, so repeated timeouts leak
+    processes. We instead signal the child's entire process group via
+    ``platform_compat.kill_process_tree_async`` (killpg on POSIX, ``taskkill
+    /T`` on Windows) and then reap the direct child. Callers MUST spawn the
+    child with ``start_new_session`` (POSIX) / ``CREATE_NEW_PROCESS_GROUP``
+    (Windows) so the group signal targets the child's own group and not the
+    gateway's — every caller in this module does. If the group kill fails
+    (e.g. the child already exited, or it was never made a group leader) we
+    fall back to a pid-scoped ``proc.kill()`` so the child is never left
+    un-reaped.
+    """
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        proc.kill()
+        try:
+            await platform_compat.kill_process_tree_async(
+                proc.pid, platform_compat.SIGKILL
+            )
+        except OSError:
+            proc.kill()
         await proc.wait()
         raise
 
@@ -785,6 +805,8 @@ async def _fetch_external_registry_index(
             stderr=asyncio.subprocess.PIPE,
             env=minimal_env(),
             preexec_fn=resource_limit_preexec(),
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         )
         _, _ = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
         if proc.returncode != 0:
@@ -961,8 +983,10 @@ async def list_registry() -> list[dict[str, Any]]:
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
                 preexec_fn=resource_limit_preexec(),
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             )
-            await asyncio.wait_for(proc.communicate(), timeout=5)
+            await _communicate_with_timeout(proc, timeout=5)
             if proc.returncode == 0:
                 detected.add(name)
                 logger.info("Detected external install: %s", name)
@@ -1453,8 +1477,10 @@ async def install_from_registry(
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
                 preexec_fn=resource_limit_preexec(),
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             )
-            await asyncio.wait_for(proc.communicate(), timeout=5)
+            await _communicate_with_timeout(proc, timeout=5)
             if proc.returncode == 0:
                 return {
                     "ok": False,
@@ -1549,11 +1575,9 @@ async def install_from_registry(
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_SCRIPT_TIMEOUT)
             except asyncio.TimeoutError:
-                # Kill the entire process group (shell + children)
-                try:
-                    os.killpg(proc.pid, signal.SIGTERM)
-                except OSError:
-                    proc.kill()
+                # Kill the entire process group (shell + children), reap the
+                # child, and escalate SIGTERM -> SIGKILL if it ignores the term.
+                await _kill_process_group(proc)
                 return {
                     "ok": False,
                     "name": name,

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1,0 +1,341 @@
+"""Regression tests for subprocess-timeout remediation in apps/registry.py.
+
+These cover the audit findings that timed-out child subprocesses were left
+un-reaped (zombie/leak) or, for the install-script path, only sent a single
+SIGTERM with no reap and no SIGKILL escalation:
+
+  * git-clone manifest fetch  -> _communicate_with_timeout (tree-kill + reap)
+  * external registry index    -> _communicate_with_timeout (tree-kill + reap)
+  * list_registry detect probe -> _communicate_with_timeout (tree-kill + reap)
+  * install detect probe       -> _communicate_with_timeout (tree-kill + reap)
+  * install-script timeout      -> _kill_process_group (reap + SIGKILL)
+
+``_communicate_with_timeout`` now signals the child's whole process group
+(``platform_compat.kill_process_tree_async``) instead of ``proc.kill()``-ing
+only the immediate child, so a hung ``git clone``/``/bin/sh -c <probe>`` cannot
+leave re-parented grandchildren running. Each spawn feeding it is started with
+``start_new_session`` so the group signal targets the child's own group.
+
+This file lives in ``test/`` (not ``tests/``) so the ``setup.cfg``
+``testpaths = test transfer`` gate — and therefore CI — actually collects it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.apps import registry
+
+# A portable long-lived child: sleeps well past any test timeout without
+# relying on POSIX-only binaries (``sleep``/``bash`` are absent on native
+# Windows, where they would fail collection with FileNotFoundError).
+_SLEEP_SCRIPT = "import time; time.sleep(60)"
+# A portable child that ignores SIGTERM so the group kill must escalate to
+# SIGKILL to stop it. SIGTERM-ignore + SIGKILL escalation is POSIX signal
+# semantics, so tests using this are guarded with skipif(not IS_POSIX).
+_SIGTERM_IGNORE_SCRIPT = (
+    "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "\nwhile True: time.sleep(0.2)"
+)
+
+
+class _TimeoutProc:
+    """Fake subprocess whose ``communicate()`` times out.
+
+    Lets us exercise the timeout branch instantly (no real long-running
+    process) while recording whether the branch killed and reaped the child.
+    """
+
+    def __init__(self) -> None:
+        self.pid = 987654
+        self.returncode: int | None = None
+        self.kill_calls = 0
+        self.wait_calls = 0
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        raise asyncio.TimeoutError
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        if self.returncode is None:
+            self.returncode = -9
+        return self.returncode
+
+
+def _record_tree_kill(monkeypatch) -> list[int]:
+    """Patch the process-tree killer to record the pids it was asked to kill.
+
+    Returns the list that each ``_communicate_with_timeout`` timeout appends
+    its ``proc.pid`` to — proving the whole group was signalled rather than a
+    single ``proc.kill()``.
+    """
+    killed: list[int] = []
+
+    async def _fake_tree_kill(pid, sig):
+        killed.append(pid)
+        return True
+
+    monkeypatch.setattr(
+        registry.platform_compat, "kill_process_tree_async", _fake_tree_kill
+    )
+    return killed
+
+
+# --------------------------------------------------------------------------
+# Shared helper: _communicate_with_timeout (mechanism behind bugs 1, 2a, 2b)
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_communicate_with_timeout_kills_and_reaps_real_subprocess():
+    """A hung child (its own session leader) must be group-killed AND reaped."""
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _SLEEP_SCRIPT,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+    )
+    pid = proc.pid
+    with pytest.raises(asyncio.TimeoutError):
+        await registry._communicate_with_timeout(proc, timeout=0.2)
+
+    # Reaped: returncode is populated, so the child is not a zombie.
+    assert proc.returncode is not None
+    # And the process is genuinely gone (portable liveness check — never the
+    # prohibited raw ``os.kill(pid, 0)``, which kills on Windows PID reuse).
+    assert not platform_compat.pid_exists(pid)
+
+
+@pytest.mark.asyncio
+async def test_communicate_with_timeout_kills_whole_process_tree(monkeypatch):
+    """The timeout path signals the child's whole group, not just proc.kill()."""
+    proc = _TimeoutProc()
+    killed: list[tuple[int, int]] = []
+
+    async def _fake_tree_kill(pid, sig):
+        killed.append((pid, sig))
+        return True
+
+    monkeypatch.setattr(
+        registry.platform_compat, "kill_process_tree_async", _fake_tree_kill
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await registry._communicate_with_timeout(proc, timeout=0.01)
+
+    # Whole-tree kill was invoked with the child's pid + SIGKILL ...
+    assert killed == [(proc.pid, registry.platform_compat.SIGKILL)]
+    # ... the child was reaped ...
+    assert proc.wait_calls == 1
+    # ... and the single-process fallback was NOT needed.
+    assert proc.kill_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_communicate_with_timeout_falls_back_when_group_kill_fails(monkeypatch):
+    """If the group kill raises OSError, fall back to a pid-scoped kill + reap."""
+    proc = _TimeoutProc()
+
+    async def _boom(pid, sig):
+        raise ProcessLookupError  # subclass of OSError
+
+    monkeypatch.setattr(
+        registry.platform_compat, "kill_process_tree_async", _boom
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await registry._communicate_with_timeout(proc, timeout=0.01)
+
+    assert proc.kill_calls == 1
+    assert proc.wait_calls == 1
+
+
+# --------------------------------------------------------------------------
+# Bug 1 — git-clone manifest fetch reaps the clone tree on timeout
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_fetch_app_manifest_reaps_clone_tree_on_timeout(monkeypatch):
+    proc = _TimeoutProc()
+    killed = _record_tree_kill(monkeypatch)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    result = await registry._fetch_app_manifest(
+        repo="https://example.com/demo.git",
+        branch="main",
+        git_url="https://example.com/demo.git",
+    )
+
+    # Timeout is swallowed (listing must never crash) ...
+    assert result is None
+    # ... but the clone's whole process group was killed and the child reaped.
+    assert killed == [proc.pid]
+    assert proc.wait_calls == 1
+
+
+# --------------------------------------------------------------------------
+# Bug 2a — list_registry detectInstalled probe reaps the tree on timeout
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_list_registry_reaps_detect_probe_tree_on_timeout(monkeypatch):
+    entry = {"name": "probeapp", "repo": "x", "detectInstalled": "true"}
+    monkeypatch.setattr(registry, "_load_registry_file", lambda: [entry])
+
+    async def _no_external():
+        return []
+
+    monkeypatch.setattr(registry, "_load_external_registries", _no_external)
+    monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+    async def _resolve(e):
+        return e
+
+    monkeypatch.setattr(registry, "_resolve_manifest", _resolve)
+    monkeypatch.setattr(
+        registry, "_enrich_with_install_status", lambda e, m, d: {"detected": sorted(d)}
+    )
+
+    proc = _TimeoutProc()
+    killed = _record_tree_kill(monkeypatch)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    await registry.list_registry()
+
+    assert killed == [proc.pid]
+    assert proc.wait_calls == 1
+
+
+# --------------------------------------------------------------------------
+# Bug 2b — install_from_registry detect probe reaps the tree on timeout
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_install_from_registry_reaps_detect_probe_tree_on_timeout(monkeypatch):
+    entry = {
+        "name": "demoapp",
+        "repo": "https://example.com/demo.git",
+        "detectInstalled": "true",
+    }
+    monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+    monkeypatch.setattr(registry, "_entry_git_url", lambda e: "https://example.com/demo.git")
+
+    async def _fake_manifest(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(registry, "_fetch_app_manifest", _fake_manifest)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    proc = _TimeoutProc()
+    killed = _record_tree_kill(monkeypatch)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    # Stop right after the detect probe by failing the build fast.
+    async def _fake_build(*args, **kwargs):
+        return {"ok": False, "error": "stop-after-detect"}
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_build)
+
+    await registry.install_from_registry("demoapp")
+
+    assert killed == [proc.pid]
+    assert proc.wait_calls == 1
+
+
+# --------------------------------------------------------------------------
+# Bug 3 — install-script timeout: reap + SIGKILL escalation
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not platform_compat.IS_POSIX,
+    reason="SIGTERM-ignore + SIGKILL escalation is POSIX signal semantics",
+)
+async def test_kill_process_group_reaps_and_escalates_to_sigkill(monkeypatch):
+    """A process group that ignores SIGTERM must be escalated to SIGKILL and reaped."""
+    monkeypatch.setattr(registry, "_KILL_GRACE_PERIOD", 0.3)
+
+    # Child ignores SIGTERM and keeps running -> only SIGKILL can stop it.
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _SIGTERM_IGNORE_SCRIPT,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+    )
+    pid = proc.pid
+
+    await registry._kill_process_group(proc)
+
+    # Reaped after escalation.
+    assert proc.returncode is not None
+    # Portable liveness check — never the prohibited raw ``os.kill(pid, 0)``.
+    assert not platform_compat.pid_exists(pid)
+
+
+@pytest.mark.asyncio
+async def test_install_script_timeout_routes_through_kill_process_group(monkeypatch, tmp_path):
+    """On install-script timeout the code must call _kill_process_group (reap +
+    SIGKILL escalation), not the old fire-and-forget single SIGTERM."""
+    entry = {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"}
+    monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+    monkeypatch.setattr(registry, "_entry_git_url", lambda e: "https://example.com/demo.git")
+
+    async def _fake_manifest(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(registry, "_fetch_app_manifest", _fake_manifest)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    # Cloned app source carries an install script.
+    (tmp_path / "app.json").write_text(
+        json.dumps({"setup": {"onInstall": "sleep 999"}}), encoding="utf-8"
+    )
+
+    async def _fake_build(git_url, name, log_lines, branch="main"):
+        return {"ok": True, "pkg_dir": tmp_path}
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_build)
+
+    kpg_calls: list[object] = []
+
+    async def _fake_kpg(proc):
+        kpg_calls.append(proc)
+        proc.returncode = -9  # emulate reap
+
+    monkeypatch.setattr(registry, "_kill_process_group", _fake_kpg)
+
+    proc = _TimeoutProc()
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "timed out" in result["error"]
+    # The timeout path routed through the reaping/escalating helper.
+    assert kpg_calls == [proc]


### PR DESCRIPTION
## Problem

Timed-out child subprocesses in the app-registry paths were killed incompletely or not at all:

- `_communicate_with_timeout` (manifest clone, external-registry index clone, and the two `detectInstalled` probes) `proc.kill()`'d only the **immediate** child, re-parenting any grandchildren (SSH, a version-probe binary) so repeated timeouts leak processes.
- The install-script timeout path sent a raw `os.killpg(..., SIGTERM)` with **no reap and no SIGKILL escalation**, so a SIGTERM-ignoring install script kept running forever after the user was told the install "timed out" (and `os.killpg`/`signal.*` would `AttributeError` on Windows).

## Why it matters

Every App Store listing or install attempt that hits a hung `git clone` / detect probe / install script accumulates leaked or zombie processes on the user's machine, and a stubborn install script keeps consuming CPU/resources indefinitely.

## Fix (symptom → root cause → change)

Root cause: the timeout branches never reaped the whole process tree.

- `_communicate_with_timeout` now signals the child's **entire process group** via `platform_compat.kill_process_tree_async` (killpg on POSIX, `taskkill /T` on Windows) and reaps the child, falling back to a pid-scoped `proc.kill()` if the group signal fails. Every spawn feeding it — manifest clone, external index clone, and both detect probes — is now started with `start_new_session` (POSIX) / `CREATE_NEW_PROCESS_GROUP` (Windows) so the group signal targets the child's own group and not the gateway's. This closes the reviewer finding that the detect probes reaped the shell but not its grandchildren.
- The install-script timeout path routes through the existing `_kill_process_group` (SIGTERM → SIGKILL escalation + reap) instead of the raw `os.killpg` SIGTERM, and the now-unused `import signal` is dropped.

## Tests

`test/test_apps_registry.py` — placed under `test/` so it is collected by `setup.cfg`'s `testpaths = test transfer` and therefore actually runs in CI (the original location `tests/apps/` is not on any gate). Coverage:

- `_communicate_with_timeout` group-kills + reaps a real hung child, kills the whole process tree (asserts `kill_process_tree_async` is called with the child pid + SIGKILL, not `proc.kill()`), and falls back to a pid-scoped kill when the group kill raises.
- The manifest-clone, `list_registry` detect probe, and `install_from_registry` detect probe each route their timeout through the whole-tree kill + reap.
- The install-script timeout routes through `_kill_process_group` (SIGKILL escalation + reap).

## Manual verification

N/A — unit coverage exercises every changed timeout branch with the audited failure scenario.
