### PR TITLE
fix(history): cross-process locking, tab_id cache invalidation, rotation and consolidation races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,4 +331,10 @@ jobs:
         # every turn is deterministic and offline: no Kiro/model calls, no cost.
         env:
           KIROCREW_E2E_REQUIRE: "1"
+          # CI-enforced on-loop persistence invariant: the e2e gateway boots with
+          # strict mode so any un-offloaded session-JSONL mutator that enters
+          # ``_locked`` on the event loop raises ``OnLoopPersistError`` and fails
+          # this gate at PR time (setup.py test_e2e also sets this; declared here
+          # for discoverability). See docs/system-specs/modules/history.md.
+          KIROCREW_STRICT_ON_LOOP_PERSIST: "1"
         run: python setup.py test_e2e

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -1,6 +1,6 @@
 # Conversation History Module
 
-Last Updated: 2026-07-13 (agent_usage roster ordering, folder_id in session metadata, _SEARCH_SCAN_WINDOW relevance search; session archive, configurable autocompact)
+Last Updated: 2026-07-24 (on-loop offload discipline enforcement via OnLoopPersistError + CI-enforced strict mode in the e2e gateway job + deferred single-writer-queue alternative; foreign-append timestamp-first bounded dedup with archive of ambiguous drops + creation-time uuid successor identity; agent_usage roster ordering, folder_id in session metadata, _SEARCH_SCAN_WINDOW relevance search; session archive, configurable autocompact)
 
 ## Overview
 
@@ -61,6 +61,57 @@ no longer destroy older turns.
   consistent snapshot: it reads `_disk_older_count`, snapshots
   `list(slot.messages)`, and re-checks `_disk_older_count` (bounded retry) so a
   concurrent trim cannot interleave with the read-serialize-write.
+- **Cross-process lock (`_locked`)**: `_save_slot_to_history` holds the session's
+  cross-process `_locked` (the SAME lock `append` / `append_off_loop` / rotate /
+  rewrite / metadata edits take) across its metadata read, frozen-prefix read,
+  archive diff, and `atomic_write`. Without it a concurrent `append_off_loop`
+  (e.g. a workflow/cron result appended to the originating dashboard session)
+  could land between the save's file snapshot and its file-replacing
+  `atomic_write`, silently deleting the acknowledged append. On the event loop
+  `_locked` makes ONE non-blocking acquire and raises `HistoryLockTimeout` under
+  contention rather than blocking the loop — so **on-loop callers MUST offload**:
+  `save_slot_off_loop(state, slot, …)` dispatches the save to a worker thread so
+  it takes the patient off-loop acquire path. It is `best_effort=True` by default
+  (a lock timeout / I/O error is logged, not raised — the in-memory slot is the
+  source of truth and the periodic flush retries); archival paths that must
+  confirm the durable write before removing the session (session close/cleanup)
+  pass `best_effort=False` so the exception propagates and the caller rolls back.
+  Off-loop callers (`_flush_dirty_slots`, `save_all_slots_to_history` at
+  shutdown) call `_save_slot_to_history` inline — off the loop `_locked` polls
+  patiently to a bounded deadline. The same discipline applies to every other
+  session-JSONL writer: `clear_closed` (resume un-flags `closed` under `_locked`,
+  offloaded via `asyncio.to_thread`) and all `history.py` mutators hold `_locked`.
+- **On-loop offload discipline is enforced, not convention-only**: the offload
+  invariant above was previously guaranteed only by convention — a future
+  contributor calling a raw mutator (`append` / `update_metadata` / `set_title`
+  / `delete_session` / `_save_slot_to_history`) from an async handler would get
+  a write that works in every uncontended test yet silently drops under real
+  contention (the on-loop `HistoryLockTimeout` swallowed by a best-effort
+  `try/except`), invisible in CI. `_locked` now calls
+  `_check_on_loop_persist_discipline(key)` on entry: if a running event loop is
+  detected it either **raises `OnLoopPersistError`** (strict mode — on under
+  `KIROCREW_STRICT_ON_LOOP_PERSIST=1` or `KIROCREW_DEV_MODE`) so an un-offloaded
+  call-site fails tests rather than losing data, or emits a **loud throttled
+  warning** and proceeds via the single non-blocking safety-net acquire
+  (default / production gateway, strict off — never a new hard failure in the
+  field). Strict is deliberately NOT auto-on under bare pytest (the suite's own
+  async harness calls several mutators directly on the loop as a convenience, so
+  auto-strict would flag harness code, not drift); the enforcement tests flip
+  the env flag explicitly. Off the loop the check is a no-op (the sanctioned
+  path). Tests that deliberately drive the low-level on-loop primitive wrap the
+  call in `history.allow_on_loop_persist()` (a `ContextVar`-scoped bypass);
+  production code must NEVER use it. **Considered-and-deferred alternative — a single-writer
+  queue:** funnel every session-file mutation through one dedicated writer thread
+  (or per-key `asyncio.Queue` drained off-loop) so the loop never touches
+  `_locked` at all and no caller can bypass the discipline structurally. It was
+  deferred because it reshapes every mutator into an async enqueue (touching the
+  same ~15 call-sites plus the synchronous CLI/subagent/cron writers that must
+  stay inline), serializes unrelated keys unless sharded, and complicates the
+  close/cleanup paths that need a confirmed durable write (`best_effort=False`).
+  The refcounted `_flock_state` + the strict on-loop guard give most of the
+  safety at a fraction of the churn; the single-writer queue is the intended
+  escape hatch if the guard's warn-and-proceed production fallback ever proves
+  insufficient (e.g. a hot on-loop path that must not be lost).
 - **Rewrite path** (`rewrite=True`, an explicit `messages` snapshot, or a slot
   left in `_pending_rewrite` — rewind/regenerate/fork): writes
   `metadata + frozen_prefix + serialize(snapshot)`. These INTENTIONALLY drop the
@@ -70,6 +121,75 @@ no longer destroy older turns.
   set by rewind/regenerate after they truncate the window and cleared only on a
   successful rewrite save, so a failed inline rewrite still gets retried as an
   archive-safe rewrite by the next flush (never silently overwritten).
+- **Foreign-append merge & timestamp-first dedup** (`_frozen_prefix_and_foreign_appends`):
+  a default save captures its `window` snapshot BEFORE taking `_locked`, so a
+  cross-process writer (subagent / cron / CLI) can fully append + release the
+  lock in that gap. A bare `meta + frozen + window` replace would then delete
+  that acknowledged append, so the save first scans the on-disk WINDOW region
+  (the bytes after the frozen prefix) for lines the in-memory window does not
+  represent and carries them into the payload as `foreign_lines`. A disk line is
+  classified as **ours** (dropped — the window re-serializes it) when EITHER:
+  (a) its `ts` matches a window entry — covers in-place edits that keep `ts` but
+  change content; OR (b) as a **count-bounded** tiebreak, its `(role, content)`
+  matches an **as-yet-unconsumed** window entry — covers a same-process
+  `append_if_absent` durable copy persisted with a fresh `ts` (the workflow/
+  cron-result injectors reflect the message in the slot AND write it via
+  `append_if_absent_off_loop`, so the same message legitimately exists twice with
+  different timestamps and must NOT be double-persisted). Only a line matching
+  NEITHER is foreign and preserved.
+  - **Timestamp-first identity (the fix for GPT 5.6's HIGH data-loss finding).**
+    `ts` is the primary identity; `(role, content)` is only a bounded tiebreak in
+    which **each window entry absorbs at most ONE disk copy**. So if the on-disk
+    window region holds two lines with identical `(role, content)` but distinct
+    timestamps — the window's own persisted copy (ts-matched, dropped) PLUS a
+    *genuinely distinct* event from another process (e.g. a cron that reports the
+    same status text twice) — the first is folded and the **second is preserved
+    as a foreign append**. An earlier plain-`(role, content)`-set match collapsed
+    both real events into one; the bounded, timestamp-first identity fixes it
+    while still folding the common `append_if_absent` fresh-`ts` copy.
+  - **Archive of ambiguous drops (no permanent loss).** A fresh-`ts` copy folded
+    by tiebreak (b) is the genuinely ambiguous case (indistinguishable from a
+    distinct same-content message without a stable id), so those drops are
+    returned as `dedup_dropped` and routed through `_archive_lines`
+    (`reason="foreign-dedup"`) by `_save_slot_to_history` before the atomic
+    replace — the trade-off loses no data permanently. (A ts-less / ts-matched
+    plain re-serialization is a normal window copy and is dropped silently to
+    avoid archive spam.)
+  - **Intended successor identity.** Timestamp is the closest thing to a stable
+    per-message id available today. The intended successor is a **creation-time
+    per-message uuid** (stamped when the message is created, carried through the
+    slot and onto disk) so identity is *exact* rather than inferred; the bounded
+    heuristic above is the bridge until that lands. This is a tracked, committed
+    follow-up — see
+    [issue #381](https://github.com/kirodotdev/KiroCrew/issues/381) — not an
+    open-ended aspiration: when the uuid lands it **demotes this heuristic to a
+    legacy fallback** used only for un-stamped (pre-uuid) lines, and both this
+    paragraph and the `test_foreign_append_content_identity_dedup_semantics`
+    contract test must be updated in the same commit.
+  - **Residual window (rewrite saves).** The scan runs only for default saves
+    (`collect_foreign = not rewrite`). Rewrite saves (rewind / regenerate / fork)
+    intentionally truncate the window and are same-session/same-process, so they
+    **skip** the foreign scan and can still clobber a concurrent cross-process
+    append that lands between the pre-lock window snapshot and the lock — a known,
+    narrow residual window (the dropped tail is handled by the rewrite's
+    archive-diff, not the foreign scan).
+- **Consolidation offset & rotation generation**: `last_consolidated` is an
+  absolute message index the consolidator snapshots (as `total`) BEFORE its slow
+  LLM call and writes back via `mark_consolidated`. A rotation firing during that
+  await truncates the file and shifts every surviving index, so the stale offset
+  can no longer be applied. Detection uses a monotonically-increasing
+  `rotation_generation` counter in the metadata line (bumped by `_maybe_rotate`
+  on every rotation, carried forward by compaction, absent field == 0 for legacy
+  files): the consolidator snapshots it alongside the offset
+  (`rotation_generation()`) and `mark_consolidated(key, total, generation=…)`
+  resets `last_consolidated` to 0 whenever the generation changed — **regardless
+  of how many messages the rotation retained**. This closes the gap a pure
+  `offset > msg_count` heuristic misses (a rotation retaining ≥ the offset leaves
+  `offset ≤ msg_count` true yet still shifted every index, silently marking
+  never-consolidated retained messages as done); the `offset > msg_count` check
+  remains as a defense-in-depth fallback for legacy callers that pass no
+  generation. Reconsolidating a few already-processed messages is harmless and
+  idempotent; dropping unprocessed ones is a persisted data-integrity failure.
 
 ## Session Archive (`history.py`)
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,20 @@ class E2eTestCommand(Command):
         base = os.path.dirname(os.path.abspath(__file__))
         env = dict(os.environ)
         env["KIROCREW_E2E"] = "1"
+        # Turn the on-loop persistence discipline into a CI-ENFORCED invariant
+        # (not just a dev-only convention). The e2e harness spawns a REAL gateway
+        # subprocess and drives real chat turns through it; ``spawn_feature_gateway``
+        # inherits this ``env``. With strict mode on, ANY session-JSONL mutator that
+        # enters ``ConversationLog._locked`` on the gateway event loop (i.e. a raw
+        # on-loop call that skipped the ``*_off_loop`` helpers) raises
+        # ``OnLoopPersistError`` immediately, failing the e2e gate at PR time —
+        # instead of silently losing transcript data under real production
+        # contention. Bare unit pytest deliberately stays non-strict (its async
+        # harness legitimately drives mutators on the loop as a convenience); the
+        # allowlist guard in test/test_history_locking_remediation.py adds a
+        # deterministic static check that no NEW un-offloaded production call-site
+        # appears regardless of e2e coverage.
+        env["KIROCREW_STRICT_ON_LOOP_PERSIST"] = "1"
         cmd = [
             sys.executable, "-m", "pytest",
             os.path.join("test", "test_e2e_smoke.py"),

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -10,7 +10,7 @@ import uuid
 
 from aiohttp import web
 
-from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
@@ -364,7 +364,7 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
     for slot in state._slots.values():
         if slot.folder_id == fid:
             slot.folder_id = ""
-            _save_slot_to_history(state, slot, force=True)
+            await save_slot_off_loop(state, slot, force=True)
     state.save_folders()
     state.push_slots_update()
     sel().log_api_access(
@@ -393,7 +393,7 @@ async def api_chat_slot_folder(request: web.Request) -> web.Response:
         slot._folder_changed = True  # re-inject [FOLDER] breadcrumb on next turn
     slot.folder_id = folder_id
     _unhide_folder(state, folder_id)
-    _save_slot_to_history(state, slot, force=True)
+    await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard", operation="chat.slot_folder",
@@ -415,7 +415,7 @@ async def api_chat_slot_pin(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     slot.pinned = bool(body.get("pinned", False))
-    _save_slot_to_history(state, slot, force=True)
+    await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard", operation="chat.slot_pin",
@@ -455,7 +455,7 @@ async def api_chat_slot_mode(request: web.Request) -> web.Response:
     # prevent stale "Go All" state from triggering on re-entry.
     if mode != "orchestrator" and getattr(slot, "_auto_run", False):
         slot._auto_run = False
-    _save_slot_to_history(state, slot, force=True)
+    await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard", operation="chat.slot_mode",

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
-from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import _history_key_for, _sync_dashboard_slots
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -139,7 +139,29 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             if new_msgs:
                 all_messages.extend(new_msgs)
         if slot._dirty:
-            _save_slot_to_history(state, slot)
+            # Persist with best_effort=False so a lock timeout / I/O failure
+            # PROPAGATES instead of being swallowed. The fork treats disk as the
+            # source of truth (it re-reads the full history above) and clears
+            # ``_dirty`` below — which also disables the periodic retry that
+            # would otherwise re-flush the slot. Clearing ``_dirty`` after a
+            # silently-dropped save would strand the unwritten source messages
+            # and lose them permanently on the next gateway restart. Only mark
+            # the slot clean once the durable write is CONFIRMED; on failure,
+            # abort the fork (leaving ``_dirty`` set) rather than fork from a
+            # partially-persisted source.
+            try:
+                await save_slot_off_loop(state, slot, best_effort=False)
+            except Exception:
+                logger.warning(
+                    "chat_fork: durable save of source slot=%s failed; "
+                    "aborting fork to avoid losing unwritten messages",
+                    slot.key, exc_info=True,
+                )
+                return web.json_response(
+                    {"error": "could not persist source session before fork; "
+                              "please retry"},
+                    status=503,
+                )
             slot._resumed_count = len(slot.messages)
             slot._dirty = False
         if not all_messages:
@@ -203,7 +225,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             cls = "msg msg-u" if role == "user" else "msg msg-a"
             new_slot.append(role, content, cls, ts=m.get("ts", ""), meta=m.get("meta"), broadcast=False)
         new_slot.drain()
-        _save_slot_to_history(state, new_slot)
+        await save_slot_off_loop(state, new_slot)
         new_slot._resumed_count = len(new_slot.messages)
     except Exception:
         state._slots.pop(new_slot.key, None)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -31,8 +31,8 @@ from kiro_crew.dashboard.chat_persistence import (
     _attach_variants,
     _redact_meta,
     _redact_meta_for_role,
-    _save_slot_to_history,
     get_reasoning_effort_values,
+    save_slot_off_loop,
 )
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.chat_title import _maybe_auto_title
@@ -1227,7 +1227,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
         except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
             pass
     try:
-        _save_slot_to_history(state, slot, closed=True)
+        await save_slot_off_loop(state, slot, closed=True, best_effort=False)
     except Exception:
         # Save failed — restore slot so data isn't lost
         logger.error("Failed to save slot %s to history, restoring", name, exc_info=True)
@@ -1333,7 +1333,7 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
         if not removed:
             continue
         try:
-            _save_slot_to_history(state, removed, closed=True)
+            await save_slot_off_loop(state, removed, closed=True, best_effort=False)
         except Exception:
             logger.error("Cleanup: failed to archive slot %s", name, exc_info=True)
             state._slots[name] = removed
@@ -1415,7 +1415,15 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     # advertise an agent we couldn't actually switch to.
     if state.conversation_log:
         try:
-            state.conversation_log.update_metadata(_history_key_for(name), {"agent": agent_name})
+            # update_metadata enters _locked (flock + os.close); those are
+            # blocking-on-loop-prohibited, so offload to a worker thread rather
+            # than run them on the event loop (a wedged peer must never freeze
+            # chat/WS/heartbeat).
+            await asyncio.to_thread(
+                state.conversation_log.update_metadata,
+                _history_key_for(name),
+                {"agent": agent_name},
+            )
         except Exception:
             logger.warning("Failed to persist agent for slot %s", name, exc_info=True)
     state.push_slots_update()
@@ -1908,22 +1916,13 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         slot.forked_from = meta["forked_from"]
     # Clear closed flag so session restores on next gateway restart
     if meta.get("closed"):
+        # Offload to a worker thread: clear_closed takes the per-session
+        # cross-process lock (so it can't race an append / rewrite and lose
+        # data), and on the event loop that lock fails fast under contention —
+        # the patient off-loop acquire path avoids both a loop-blocking disk
+        # write and a dropped edit. Best-effort: resume proceeds regardless.
         try:
-            path = state.conversation_log._path(history_key)
-            if path.exists():
-                lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-                if lines:
-                    first_line_data = json.loads(lines[0])
-                    first_line_data.pop("closed", None)
-                    lines[0] = json.dumps(first_line_data) + "\n"
-                    atomic_tmp = path.with_name(path.name + ".tmp")
-                    try:
-                        atomic_tmp.write_text("".join(lines), encoding="utf-8")
-                        atomic_tmp.replace(path)
-                        state.conversation_log._meta_cache.pop(history_key, None)
-                    except Exception:
-                        atomic_tmp.unlink(missing_ok=True)
-                        raise
+            await asyncio.to_thread(state.conversation_log.clear_closed, history_key)
         except Exception:
             logger.warning("Failed to clear closed flag for %s", history_key, exc_info=True)
     all_messages = state.conversation_log.read_messages_chained(history_key)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -19,7 +20,7 @@ from kiro_crew.dashboard.chat_utils import (
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
-from kiro_crew.history import _archive_lines
+from kiro_crew.history import _archive_lines, update_metadata_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import ARTIFACT_SLUG_RE
 
@@ -398,7 +399,13 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     tab_id = meta.get("tab_id")
     if not tab_id:
         tab_id = uuid.uuid4().hex[:12]
-        state.conversation_log.update_metadata(history_key, {"tab_id": tab_id})
+        # _rehydrate_slot_from_history runs on the event-loop thread (cold-slot
+        # resolution in api_send_message). update_metadata enters _locked
+        # (flock + os.close), a blocking-on-loop-prohibited op, so backfill the
+        # tab_id off the loop rather than on it.
+        update_metadata_off_loop(
+            state.conversation_log, history_key, {"tab_id": tab_id}
+        )
     slot._tab_id = tab_id
     # Use read_messages_chained (not read_messages) so the loaded window walks
     # the tab_id ancestry across forks, matching restore_recent_sessions.
@@ -551,7 +558,12 @@ def restore_recent_sessions(
         tab_id = meta.get("tab_id")
         if not tab_id:
             tab_id = uuid.uuid4().hex[:12]
-            state.conversation_log.update_metadata(key, {"tab_id": tab_id})
+            # restore_recent_sessions runs during on_startup (event loop live)
+            # — keep the _locked flock/os.close off the loop via the off-loop
+            # backfill helper.
+            update_metadata_off_loop(
+                state.conversation_log, key, {"tab_id": tab_id}
+            )
         slot._tab_id = tab_id
         messages = state.conversation_log.read_messages_chained(key)
         slot._disk_older_count = max(0, len(messages) - 500)
@@ -677,40 +689,181 @@ def _build_message_entry(m: dict) -> dict | None:
     return entry
 
 
-def _read_frozen_prefix(slot: _ChatSlot, path, disk_older: int) -> str:
-    """Return the frozen-prefix bytes: the first *disk_older* on-disk message lines.
+# Transient/streaming roles that are never persisted (mirrors
+# ``_build_message_entry``). A window-region disk line carrying one of these is
+# not a real message and is never treated as a cross-process append to preserve.
+_TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
 
-    These are the lines OLDER than the in-memory window — never rewritten, so
-    older history survives a restart that only loaded a recent window. The bytes
-    are cached on the slot keyed by ``(mtime, disk_older)`` so a steady 5s flush
-    is O(window) rather than O(file size) (#5): the cache hits whenever the file
-    has not changed on disk since the last save (the only writer of this file is
-    this slot, so its own atomic_write bumps the mtime and the next call re-reads
-    — but the prefix region is identical, so re-reads are rare in practice and
-    always correct).
 
-    Returns "" when there is no frozen prefix (a fresh slot, ``disk_older == 0``)
-    or the file is missing/unreadable/has no metadata line.
+def _frozen_prefix_and_foreign_appends(
+    slot: _ChatSlot,
+    path,
+    disk_older: int,
+    window_entries: list[dict],
+    *,
+    collect_foreign: bool = True,
+) -> tuple[str, list[str], list[str]]:
+    """Return ``(frozen_prefix, foreign_lines, dedup_dropped)`` for a save.
+
+    ``frozen_prefix`` is the verbatim bytes of the first *disk_older* on-disk
+    message lines — the turns OLDER than the in-memory window. They are never
+    rewritten, so older history survives a restart that only loaded a recent
+    window. The bytes are cached on the slot keyed by ``(mtime, size,
+    disk_older)`` so a steady 5s flush is O(window) rather than O(file size)
+    (#5).
+
+    ``foreign_lines`` are on-disk message lines in the WINDOW region (the bytes
+    after the frozen prefix) that this slot's in-memory *window_entries* do NOT
+    represent — i.e. acknowledged appends made by ANOTHER process (subagent /
+    cron / CLI) that this slot never saw. ``_save_slot_to_history`` captures its
+    ``window`` snapshot BEFORE taking ``_locked``, so a cross-process writer can
+    fully append + release between the snapshot and this save acquiring the lock;
+    a bare ``meta + frozen + window`` replace would then silently delete that
+    acknowledged message. Carrying these lines into the payload makes the save
+    non-destructive against cross-process appends (the data-loss finding). A
+    disk line is treated as ours (dropped; the window re-serializes it) when its
+    ``ts`` matches a window entry (covers in-place edits, which keep ``ts`` but
+    change content) OR — as a COUNT-BOUNDED tiebreak — its ``(role, content)``
+    matches an as-yet-unconsumed window entry (covers a same-process
+    ``append_if_absent`` copy persisted with a FRESH ``ts`` distinct from the
+    window entry's in-memory ``ts``). The tiebreak is bounded so each window
+    entry absorbs AT MOST ONE disk copy: if the on-disk window region holds two
+    lines with identical ``(role, content)`` but distinct timestamps — the
+    window's own persisted copy PLUS a genuinely distinct event from another
+    process (e.g. a repeated identical cron / workflow result) — only the first
+    is folded into the window and the second is preserved as a foreign append.
+    A plain ``(role, content)`` set collapsed those two real events into one
+    (the GPT 5.6 HIGH data-loss finding); the bounded, timestamp-first identity
+    fixes it. Timestamp is the closest thing to a stable per-message id today;
+    the intended successor is a creation-time per-message uuid that demotes this
+    heuristic to a legacy fallback for un-stamped lines — tracked as a committed
+    follow-up in https://github.com/kirodotdev/KiroCrew/issues/381 (see also
+    ``docs/system-specs/modules/history.md``). ``dedup_dropped`` returns any
+    fresh-``ts`` content-tiebreak drops so the caller can route them through the
+    archive — even the residual ambiguous case (a distinct message
+    indistinguishable from an ``append_if_absent`` copy without a stable id)
+    then loses no data permanently.
+
+    Fast path (#5): when BOTH the on-disk mtime AND size match the frozen-prefix
+    cache, THIS slot was the last writer and nothing has landed since, so the
+    prefix is served from cache and the foreign lines preserved by the previous
+    save are re-emitted verbatim from cache — the O(file) read/scan runs ONLY
+    when the file changed on disk since our last write. Size is part of the key
+    because an append always grows the file even inside a single coarse mtime
+    tick, so mtime alone is not a safe change signal for a data-loss guard.
+    Re-emitting the cached foreign lines (rather than assuming there are none)
+    is what makes the fast path non-destructive: a previous save may have
+    preserved a cross-process append INTO the on-disk window region, and since
+    ``disk_older`` is unchanged those preserved lines would otherwise be dropped
+    by a bare frozen-prefix + in-memory-window rebuild on the very next save.
+
+    Returns ``("", [])`` when the file is missing/unreadable/has no metadata line.
     """
-    if disk_older <= 0:
-        return ""
     try:
-        mtime = path.stat().st_mtime
+        st = path.stat()
+        mtime, size = st.st_mtime, st.st_size
     except OSError:
-        return ""
+        return ("", [], [])
     cache = slot._frozen_prefix_cache
-    if cache is not None and cache[0] == mtime and cache[1] == disk_older:
-        return cache[2]
+    if (
+        cache is not None
+        and cache[0] == mtime
+        and cache[1] == size
+        and cache[2] == disk_older
+    ):
+        # File is byte-identical to our last write → prefix AND the foreign
+        # lines that write preserved are both served from cache. Returning the
+        # cached foreign lines (a copy, so the caller cannot mutate the cache)
+        # keeps the fast path non-destructive: the previously-preserved
+        # cross-process append is re-emitted instead of silently dropped. No
+        # scan runs, so there are no fresh dedup drops to archive.
+        return (cache[3], list(cache[4]), [])
     try:
         existing = path.read_text(encoding="utf-8").splitlines(keepends=True)
     except OSError:
-        return ""
+        return ("", [], [])
     if not existing or '"_type"' not in existing[0]:
-        return ""
+        return ("", [], [])
     body = existing[1:]  # message lines only (metadata excluded)
-    prefix = "".join(body[:disk_older])
-    slot._frozen_prefix_cache = (mtime, disk_older, prefix)
-    return prefix
+    prefix = "".join(body[:disk_older]) if disk_older > 0 else ""
+    if not collect_foreign:
+        # Rewrite (rewind / regenerate / fork) INTENTIONALLY truncates the
+        # window, so a disk window-region line absent from the (truncated) window
+        # is ambiguous between a rewound tail (must drop) and a cross-process
+        # append (must keep). Those edits are same-session/same-process (not the
+        # cross-process loss this scan guards), so skip the scan and let the
+        # rewrite's archive-diff handle the dropped tail. Cache with no foreign
+        # lines so a subsequent fast path re-emits nothing extra.
+        slot._frozen_prefix_cache = (mtime, size, disk_older, prefix, [])
+        return (prefix, [], [])
+    # Scan the on-disk window region for lines the in-memory window does not
+    # carry — those are cross-process appends we must preserve. Identity is
+    # timestamp-first (the closest thing to a stable per-message id today), with
+    # (role, content) used only as a COUNT-BOUNDED tiebreak so each window entry
+    # absorbs at most ONE disk copy (see the module docstring / history.md).
+    #
+    # ``window_ts`` maps each window entry's ``ts`` to its ``(role, content)`` so
+    # a ts-match can also decrement that entry's content budget — otherwise a
+    # ts-matched entry could ALSO absorb a later same-content disk line and
+    # over-collapse. ``remaining_rc`` is the per-``(role, content)`` budget of
+    # window entries still available to absorb a disk copy.
+    window_ts = {
+        e["ts"]: (e.get("role"), e.get("content", ""))
+        for e in window_entries
+        if e.get("ts")
+    }
+    remaining_rc: dict[tuple[object, object], int] = {}
+    for e in window_entries:
+        _k = (e.get("role"), e.get("content", ""))
+        remaining_rc[_k] = remaining_rc.get(_k, 0) + 1
+    consumed_ts: set[str] = set()
+    foreign: list[str] = []
+    dedup_dropped: list[str] = []
+    for ln in body[disk_older:]:
+        if not ln.strip():
+            continue
+        try:
+            entry = json.loads(ln)
+        except (json.JSONDecodeError, ValueError):
+            continue  # corrupt window-region line — not a preservable message
+        if not isinstance(entry, dict) or entry.get("_type") == "metadata":
+            continue
+        role = entry.get("role")
+        if role is None or role in _TRANSIENT_ROLES:
+            continue
+        ts = entry.get("ts")
+        rc = (role, entry.get("content", ""))
+        norm = ln if ln.endswith("\n") else ln + "\n"
+        # 1) ts-match: an in-place edit keeps the ``ts`` but changes content, so
+        #    the window's version wins. Consume the matched entry from the
+        #    content budget too so a later same-content line can't re-claim it.
+        if ts and ts in window_ts and ts not in consumed_ts:
+            consumed_ts.add(ts)
+            wkey = window_ts[ts]
+            if remaining_rc.get(wkey, 0) > 0:
+                remaining_rc[wkey] -= 1
+            continue  # same message (possibly edited in place) — window wins
+        # 2) content tiebreak (bounded): a window entry with this exact
+        #    (role, content) that no ts-match already consumed absorbs this disk
+        #    copy — the ``append_if_absent`` fresh-``ts`` case. A drop carrying a
+        #    DISTINCT non-empty ``ts`` is the genuinely ambiguous case (it could
+        #    be a distinct message we cannot tell apart without a stable id), so
+        #    route it through the archive; a ts-less / matching re-serialization
+        #    is a plain window copy and is dropped silently to avoid archive spam.
+        if remaining_rc.get(rc, 0) > 0:
+            remaining_rc[rc] -= 1
+            if ts:
+                dedup_dropped.append(norm)
+            continue  # window already carries this content
+        # 3) genuinely foreign → preserve verbatim.
+        foreign.append(norm)
+    # Cache the frozen prefix AND the foreign lines together, keyed on the
+    # as-read (mtime, size). If this save's atomic_write later fails, the file
+    # on disk is unchanged, so a subsequent save that re-reads the same
+    # (mtime, size) must re-emit these same preserved foreign lines rather than
+    # drop them — hence they are cached here, not just at the post-write site.
+    slot._frozen_prefix_cache = (mtime, size, disk_older, prefix, foreign)
+    return (prefix, foreign, dedup_dropped)
 
 
 def _save_slot_to_history(
@@ -805,108 +958,257 @@ def _save_slot_to_history(
         return
     history_key = _history_key_for(slot.key)
     try:
-        existing_meta = state.conversation_log.get_metadata(history_key)
+        # Hold the SAME per-session cross-process lock that ``append`` /
+        # ``append_off_loop`` / rotate / rewrite / metadata mutations take, across
+        # the whole read-modify-atomic_write below (metadata read, frozen-prefix
+        # read, archive-diff read, and the file-replacing ``atomic_write``).
+        # Without it, a concurrent ``append_off_loop`` (e.g. a workflow/cron
+        # result appended to the originating dashboard session) can land between
+        # this save's snapshot of the file and its ``atomic_write`` — the save
+        # then replaces the file with meta+frozen+window and silently deletes the
+        # acknowledged append. ``_locked`` serializes the two so neither is lost.
+        # On the event loop ``_locked`` makes ONE non-blocking acquire and raises
+        # ``HistoryLockTimeout`` under contention (never blocking the loop); the
+        # ``save_slot_off_loop`` helper routes on-loop callers to a worker thread
+        # so they take the patient acquire path instead of dropping the save.
+        with state.conversation_log._locked(history_key):
+            existing_meta = state.conversation_log.get_metadata(history_key)
 
-        path = state.conversation_log._path(history_key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        meta_line: dict = {
-            "_type": "metadata",
-            "created_at": existing_meta.get("created_at") or slot.created_at,
-            "last_consolidated": existing_meta.get("last_consolidated", 0),
-        }
-        if closed:
-            meta_line["closed"] = True
-        meta_line["memory_mode"] = slot.memory_mode
-        if slot.title and slot.title != slot.key:
-            meta_line["title"] = slot.title
-        if slot.agent:
-            meta_line["agent"] = slot.agent
-        meta_line["model"] = slot.model
-        if slot.reasoning_effort:
-            meta_line["reasoning_effort"] = slot.reasoning_effort
-        if slot.mode:
-            meta_line["mode"] = slot.mode
-        if slot.workspace and slot.workspace != "default":
-            meta_line["workspace"] = slot.workspace
-        if slot.project:
-            meta_line["project"] = slot.project
-        if slot.folder_id:
-            meta_line["folder_id"] = slot.folder_id
-        if slot._app:
-            meta_line["app"] = slot._app
-        # Artifact companion binding — persisted so a bound
-        # session restored after a gateway restart (or resumed from the
-        # History page) comes back as the artifact's active bound session.
-        if slot._artifact:
-            meta_line["artifact"] = slot._artifact
-        if slot.pinned:
-            meta_line["pinned"] = True
-        if slot.color_index is not None:
-            meta_line["color_index"] = slot.color_index
-        if slot.color_theme:
-            meta_line["color_theme"] = slot.color_theme
-        if slot.tags:
-            meta_line["tags"] = list(slot.tags)
-        if slot.forked_from is not None:
-            meta_line["forked_from"] = slot.forked_from
-        tab_id = getattr(slot, "_tab_id", None) or existing_meta.get("tab_id")
-        if tab_id:
-            meta_line["tab_id"] = tab_id
-        meta_str = json.dumps(meta_line) + "\n"
+            path = state.conversation_log._path(history_key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            meta_line: dict = {
+                "_type": "metadata",
+                "created_at": existing_meta.get("created_at") or slot.created_at,
+                "last_consolidated": existing_meta.get("last_consolidated", 0),
+            }
+            # Preserve history-layer-owned metadata this dashboard save does NOT
+            # manage. ``rotation_generation`` (bumped by ``_maybe_rotate``, with
+            # its ``rotated_at`` stamp) lets a concurrent consolidation detect a
+            # rotation and skip applying a stale offset. Reconstructing the
+            # metadata subset here would drop it, resetting the generation to 0
+            # and re-opening the exact consolidation race the rotation-generation
+            # fix closed. Carry these forward verbatim (absent field == no-op).
+            for _meta_key in ("rotation_generation", "rotated_at", "compacted_at"):
+                if _meta_key in existing_meta:
+                    meta_line[_meta_key] = existing_meta[_meta_key]
+            if closed:
+                meta_line["closed"] = True
+            meta_line["memory_mode"] = slot.memory_mode
+            if slot.title and slot.title != slot.key:
+                meta_line["title"] = slot.title
+            if slot.agent:
+                meta_line["agent"] = slot.agent
+            meta_line["model"] = slot.model
+            if slot.reasoning_effort:
+                meta_line["reasoning_effort"] = slot.reasoning_effort
+            if slot.mode:
+                meta_line["mode"] = slot.mode
+            if slot.workspace and slot.workspace != "default":
+                meta_line["workspace"] = slot.workspace
+            if slot.project:
+                meta_line["project"] = slot.project
+            if slot.folder_id:
+                meta_line["folder_id"] = slot.folder_id
+            if slot._app:
+                meta_line["app"] = slot._app
+            # Artifact companion binding — persisted so a bound
+            # session restored after a gateway restart (or resumed from the
+            # History page) comes back as the artifact's active bound session.
+            if slot._artifact:
+                meta_line["artifact"] = slot._artifact
+            if slot.pinned:
+                meta_line["pinned"] = True
+            if slot.color_index is not None:
+                meta_line["color_index"] = slot.color_index
+            if slot.color_theme:
+                meta_line["color_theme"] = slot.color_theme
+            if slot.tags:
+                meta_line["tags"] = list(slot.tags)
+            if slot.forked_from is not None:
+                meta_line["forked_from"] = slot.forked_from
+            tab_id = getattr(slot, "_tab_id", None) or existing_meta.get("tab_id")
+            if tab_id:
+                meta_line["tab_id"] = tab_id
+            meta_str = json.dumps(meta_line) + "\n"
 
-        # ── Frozen prefix (never rewritten) + freshly serialized window ──────
-        # Read the verbatim bytes of the on-disk lines OLDER than the in-memory
-        # window (cached, O(window) on a steady flush — #5). Then re-serialize
-        # the ENTIRE window snapshot so in-place edits and reordering persist.
-        frozen_prefix = _read_frozen_prefix(slot, path, disk_older)
-        window_lines = [
-            json.dumps(e) + "\n"
-            for m in window
-            if (e := _build_message_entry(m)) is not None
-        ]
-        payload = meta_str + frozen_prefix + "".join(window_lines)
-
-        # Rewrite paths (rewind/regenerate/fork) intentionally TRUNCATE the
-        # window, so the dropped tail must be archived first to stay
-        # recoverable. The default save is a superset of what's on disk (frozen
-        # prefix unchanged + same-or-grown window), so it drops nothing — and we
-        # skip the O(file) archive-diff read there to keep a steady flush
-        # O(window) (#5). Both sides are passed as proper per-line lists so the
-        # normalized-JSON diff matches the frozen-prefix lines (never archived).
-        if rewrite and path.exists():
-            try:
-                old_lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-                new_lines = payload.splitlines(keepends=True)
-                _archive_dropped_lines(state, history_key, old_lines, new_lines)
-            except Exception:
-                logger.warning(
-                    "Failed to archive dropped lines for %s", history_key, exc_info=True
+            # ── Frozen prefix (never rewritten) + freshly serialized window ──
+            # Read the verbatim bytes of the on-disk lines OLDER than the
+            # in-memory window (cached, O(window) on a steady flush — #5), AND
+            # detect any cross-process appends that landed in the on-disk window
+            # region since our last write. Then re-serialize the ENTIRE window
+            # snapshot so in-place edits and reordering persist, and append the
+            # foreign lines so a concurrent cross-process append (landed between
+            # this save's pre-lock ``window`` snapshot and the lock) is preserved
+            # rather than clobbered by the meta+frozen+window replace.
+            window_entries = [
+                e for m in window if (e := _build_message_entry(m)) is not None
+            ]
+            window_lines = [json.dumps(e) + "\n" for e in window_entries]
+            frozen_prefix, foreign_lines, dedup_dropped = (
+                _frozen_prefix_and_foreign_appends(
+                    slot, path, disk_older, window_entries, collect_foreign=not rewrite
                 )
+            )
+            # A fresh-``ts`` disk copy folded into the window by the bounded
+            # (role, content) tiebreak is redundant with a window entry, so the
+            # payload does not carry it. It is nonetheless the genuinely ambiguous
+            # case (indistinguishable from a distinct same-content message without
+            # a stable per-message id), so archive it before the atomic replace so
+            # the trade-off loses no data permanently (arbiter long-term item 2b).
+            if dedup_dropped:
+                try:
+                    base = (
+                        state.conversation_log._dir
+                        if state.conversation_log
+                        else None
+                    )
+                    _archive_lines(
+                        history_key, dedup_dropped, reason="foreign-dedup", base=base
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to archive foreign-dedup drops for %s",
+                        history_key,
+                        exc_info=True,
+                    )
+            payload = (
+                meta_str + frozen_prefix + "".join(window_lines) + "".join(foreign_lines)
+            )
 
-        atomic_write(path, payload, fsync=True)
-        # A rewrite (archive-safe) save succeeded → clear the pending-rewrite
-        # flag so later saves return to the cheap default path (#3).
-        if rewrite:
-            slot._pending_rewrite = False
-        # Record how many window messages are now on disk so memory trimming
-        # can safely fold leading window messages into the frozen prefix (#8).
-        slot._disk_window_len = len(window)
-        # We just wrote the file, so we KNOW its frozen prefix is exactly
-        # ``frozen_prefix`` at the new mtime — refresh the cache rather than
-        # invalidating it, so the next steady flush is a cache hit (O(window),
-        # #5) instead of an O(file) re-read.
-        if disk_older > 0:
+            # Rewrite paths (rewind/regenerate/fork) intentionally TRUNCATE the
+            # window, so the dropped tail must be archived first to stay
+            # recoverable. The default save is a superset of what's on disk
+            # (frozen prefix unchanged + same-or-grown window), so it drops
+            # nothing — and we skip the O(file) archive-diff read there to keep a
+            # steady flush O(window) (#5). Both sides are passed as proper
+            # per-line lists so the normalized-JSON diff matches the
+            # frozen-prefix lines (never archived).
+            if rewrite and path.exists():
+                try:
+                    old_lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+                    new_lines = payload.splitlines(keepends=True)
+                    _archive_dropped_lines(state, history_key, old_lines, new_lines)
+                except Exception:
+                    logger.warning(
+                        "Failed to archive dropped lines for %s", history_key, exc_info=True
+                    )
+
+            atomic_write(path, payload, fsync=True)
+            # A rewrite (archive-safe) save succeeded → clear the pending-rewrite
+            # flag so later saves return to the cheap default path (#3).
+            if rewrite:
+                slot._pending_rewrite = False
+            # Record how many window messages are now on disk so memory trimming
+            # can safely fold leading window messages into the frozen prefix (#8).
+            slot._disk_window_len = len(window)
+            # Record the post-write mtime in the frozen-prefix cache (even when
+            # there is no frozen prefix, ``disk_older == 0``). The cache doubles
+            # as the "did another process touch this file since we last wrote
+            # it?" signal: a matching mtime on the next save proves THIS slot was
+            # the last writer, so the frozen prefix is reusable and no NEW
+            # cross-process append can have landed — letting the foreign-append
+            # scan take the O(window) fast path (#5) instead of re-reading the
+            # whole file. The foreign lines this save just preserved are cached
+            # alongside so the fast path re-emits them verbatim: they now live in
+            # the on-disk window region (after the frozen prefix), and because
+            # ``disk_older`` is unchanged a bare frozen+window rebuild on the next
+            # save would otherwise silently delete them (data-loss finding).
             try:
-                slot._frozen_prefix_cache = (path.stat().st_mtime, disk_older, frozen_prefix)
+                _st = path.stat()
+                slot._frozen_prefix_cache = (
+                    _st.st_mtime,
+                    _st.st_size,
+                    disk_older,
+                    frozen_prefix,
+                    foreign_lines,
+                )
             except OSError:
                 slot._frozen_prefix_cache = None
-        else:
-            slot._frozen_prefix_cache = None
-        state.conversation_log._invalidate_cache(history_key)
-        state.conversation_log.invalidate_tab_id_cache()
+            state.conversation_log._invalidate_cache(history_key)
+            state.conversation_log.invalidate_tab_id_cache()
     except Exception:
         logger.error("Failed to save slot %s to history", slot.key, exc_info=True)
         raise
+
+
+async def save_slot_off_loop(
+    state: DashboardState,
+    slot: _ChatSlot,
+    messages: list[dict] | None = None,
+    *,
+    closed: bool = False,
+    force: bool = False,
+    rewrite: bool = False,
+    best_effort: bool = True,
+) -> None:
+    """Persist a slot from the event loop without blocking or dropping the save.
+
+    :func:`_save_slot_to_history` now holds the per-session cross-process
+    ``_locked`` across its read-modify-``atomic_write`` (see the finding it
+    fixes). That lock, invoked on the gateway event loop, makes a single
+    non-blocking acquire and raises :class:`~kiro_crew.history.HistoryLockTimeout`
+    under any concurrent holder (e.g. a workflow/cron result appending via
+    :func:`~kiro_crew.history.append_off_loop`) — so calling the save inline on
+    the loop would both risk a disk write on the loop and drop the save under
+    benign contention, or surface the timeout into the aiohttp handler.
+
+    This helper mirrors :func:`~kiro_crew.history.append_off_loop`: on a running
+    loop it dispatches the save to a worker thread so it takes the *patient*
+    off-loop acquire path; off the loop it saves inline.
+
+    ``best_effort`` (default ``True``): a lock timeout / I/O error is logged and
+    the slot is marked ``_dirty`` so the periodic flush retries the write — the
+    in-memory slot is the source of truth. This retry re-arm matters for the
+    metadata mutation endpoints (pin / folder / tag / mode), which call this with
+    ``force=True`` but do not otherwise mark the slot dirty: without it a
+    swallowed failure would drop an acknowledged edit with no retry, losing it
+    after a restart. Pass ``best_effort=False`` for archival paths (session
+    close/cleanup) that must CONFIRM the durable write succeeded before removing
+    the session: the save still runs off-loop (patient acquire), but any
+    exception propagates so the caller can roll back and keep the slot.
+    """
+
+    def _do() -> None:
+        _save_slot_to_history(
+            state, slot, messages, closed=closed, force=force, rewrite=rewrite
+        )
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        if best_effort:
+            try:
+                _do()
+            except Exception:  # noqa: BLE001 - best-effort durable copy
+                # A swallowed failure must NOT be silently final: mark the slot
+                # dirty so the periodic flush retries the write. Metadata-only
+                # mutations (pin / folder / tag / mode) call this with
+                # ``force=True`` but do not otherwise set ``_dirty``; without this
+                # a lock timeout / I/O error would drop the change and the flush
+                # would never retry it, losing an acknowledged edit after restart.
+                slot._dirty = True
+                logger.warning(
+                    "save_slot_off_loop: inline save failed slot=%s", slot.key, exc_info=True
+                )
+            return
+        _do()
+        return
+    if best_effort:
+        try:
+            await loop.run_in_executor(None, _do)
+        except Exception:  # noqa: BLE001 - best-effort durable copy
+            # See the inline branch above: re-arm the periodic flush so a
+            # swallowed metadata/message save is retried rather than lost.
+            slot._dirty = True
+            logger.warning(
+                "save_slot_off_loop: offloaded save failed slot=%s", slot.key, exc_info=True
+            )
+        return
+    # Non-best-effort: propagate so the caller can roll back (do NOT remove the
+    # session until the durable write is confirmed).
+    await loop.run_in_executor(None, _do)
 
 
 def _build_history_prefix(slot: _ChatSlot) -> str:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -41,7 +41,7 @@ from kiro_crew.context_management import (
     strip_plan_markers,
     validate_plan_format,
 )
-from kiro_crew.dashboard.chat_persistence import _build_history_prefix, _save_slot_to_history
+from kiro_crew.dashboard.chat_persistence import _build_history_prefix, save_slot_off_loop
 from kiro_crew.dashboard.chat_title import (
     _extract_and_redact_plan_metadata,
     _maybe_auto_title,
@@ -4017,7 +4017,7 @@ async def _run_chat(
             # Attach accumulated file changes to last assistant message before persist
             _flush_file_changes(slot)
             # Save to history and trigger memory consolidation
-            _save_slot_to_history(state, slot)
+            await save_slot_off_loop(state, slot)
             # Reset ALL retry budgets once the cycle completes (success OR the
             # terminal second-empty error) so each new user turn gets fresh budgets.
             # Guarded by _retrying_empty so the empty re-queue iteration preserves

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -8,7 +8,7 @@ from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard import state as dashboard_state
-from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import _history_key_for
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_and_truncate
@@ -271,7 +271,7 @@ async def api_chat_slot_handoff(request: web.Request) -> web.Response:
         return web.json_response({"error": "no conversation log"}, status=500)
 
     try:
-        _save_slot_to_history(state, slot)
+        await save_slot_off_loop(state, slot)
     except Exception:
         pass
 

--- a/src/kiro_crew/dashboard/chat_tags.py
+++ b/src/kiro_crew/dashboard/chat_tags.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from aiohttp import web
 
-from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.sel import sel
 
@@ -117,7 +117,7 @@ async def api_chat_tag_delete(request: web.Request) -> web.Response:
     for slot in state._slots.values():
         if tid in slot.tags:
             slot.tags = [t for t in slot.tags if t != tid]
-            _save_slot_to_history(state, slot, force=True)
+            await save_slot_off_loop(state, slot, force=True)
     # Strip from sidebar columns (flat list of column dicts).
     changed_boards = False
     for col in state._tag_boards:
@@ -159,7 +159,7 @@ async def api_chat_slot_tags(request: web.Request) -> web.Response:
         if isinstance(tid, str) and tid in valid_ids and tid not in new_tags:
             new_tags.append(tid)
     slot.tags = new_tags
-    _save_slot_to_history(state, slot, force=True)
+    await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard", operation="chat.slot_tags",
@@ -339,7 +339,7 @@ async def api_chat_slot_drop(request: web.Request) -> web.Response:
     target_id = status_tags[0]["id"]
     kept = [t for t in slot.tags if t in tag_index and not tag_index[t].get("status")]
     slot.tags = kept + [target_id]
-    _save_slot_to_history(state, slot, force=True)
+    await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard", operation="chat.slot_drop",

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -345,13 +345,21 @@ async def _generate_title_via_kiro(
     return title[:80]
 
 
-def _persist_title(state: DashboardState, slot: _ChatSlot) -> None:
-    """Save the slot title to the conversation history file."""
+async def _persist_title(state: DashboardState, slot: _ChatSlot) -> None:
+    """Save the slot title to the conversation history file.
+
+    ``set_title`` -> ``update_metadata`` enters ``_locked`` (cross-process flock
+    acquire + ``os.close``). Those are blocking-on-loop-prohibited, so the write
+    is dispatched to a worker thread rather than run on the event-loop thread
+    where a wedged peer could freeze chat/WS/heartbeat.
+    """
 
     if state.conversation_log:
         history_key = _history_key_for(slot.key)
         try:
-            state.conversation_log.set_title(history_key, slot.title)
+            await asyncio.to_thread(
+                state.conversation_log.set_title, history_key, slot.title
+            )
             logger.debug("Persisted title %r for slot %s", slot.title, slot.key)
         except Exception:
             logger.debug("Failed to persist title for slot %s", slot.key)
@@ -417,7 +425,7 @@ async def _maybe_auto_title(state: DashboardState, slot: _ChatSlot) -> None:
             # first message with an ellipsis.
             slot.title = _fallback_title_from_messages(slot.messages)
             slot._titled = True
-            _persist_title(state, slot)
+            await _persist_title(state, slot)
             state.push_slot_title(slot.key, slot.title)
         return
     slot._title_in_flight = True
@@ -435,7 +443,7 @@ async def _maybe_auto_title(state: DashboardState, slot: _ChatSlot) -> None:
             await _reveal_title(state, slot, title)
             slot.title = title
             slot._titled = True
-            _persist_title(state, slot)
+            await _persist_title(state, slot)
             state.push_slot_title(slot.key, title)
         else:
             # LLM returned SKIP/empty. Show the truncated fallback name right
@@ -448,7 +456,7 @@ async def _maybe_auto_title(state: DashboardState, slot: _ChatSlot) -> None:
             # LLM title.
             slot.title = _fallback_title_from_messages(slot.messages)
             slot._titled = attempt_has_assistant
-            _persist_title(state, slot)
+            await _persist_title(state, slot)
             state.push_slot_title(slot.key, slot.title)
             logger.info(
                 "Auto-title: fell back to truncated message for slot %s (locked=%s)",
@@ -488,7 +496,7 @@ async def api_chat_slot_generate_title(request: web.Request) -> web.Response:
     if title and not fallback_is_placeholder:
         slot.title = title
         slot._titled = True
-        _persist_title(state, slot)
+        await _persist_title(state, slot)
         state.push_slot_title(slot.key, title)
 
     return web.json_response({"ok": True, "title": "" if fallback_is_placeholder else title})
@@ -512,7 +520,7 @@ async def api_chat_slot_rename(request: web.Request) -> web.Response:
         return web.json_response({"error": "title required"}, status=400)
     slot.title = title
     slot._titled = True
-    _persist_title(state, slot)
+    await _persist_title(state, slot)
     state.push_slot_title(slot.key, title)
     sel().log_api_access(
         caller="dashboard",

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 if TYPE_CHECKING:
@@ -51,11 +52,24 @@ def inject_cron_result_to_dashboard(
             # execution key).
             log_key = f"cron:{job.id}"
             if state.conversation_log is not None:
-                existing = state.conversation_log.read_messages(log_key)
-                if not any(m.get("content") == context for m in existing):
-                    state.conversation_log.append(
-                        log_key, "assistant", context, agent=job.agent_id or None
-                    )
+                # append_if_absent performs the duplicate check under the SAME
+                # per-session cross-process lock as the write itself, so the
+                # existence test and the append are one atomic critical section.
+                # The previous unlocked read_messages() + append_off_loop left a
+                # TOCTOU window in which a concurrent slot save (or a cron
+                # re-fire) could land the identical result between the check and
+                # the fire-and-forget append — duplicating it on disk and
+                # replaying it twice to the follow-up agent turn after a restart.
+                # append_off_loop dispatches to a worker thread (patient acquire)
+                # and swallows lock/I/O errors — the slot above already carries
+                # the message.
+                append_if_absent_off_loop(
+                    state.conversation_log,
+                    log_key,
+                    "assistant",
+                    context,
+                    agent=job.agent_id or None,
+                )
     state.push_slots_update()
 
 

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -417,7 +417,9 @@ async def api_session_delete(request: web.Request) -> web.Response:
     key = request.match_info["key"]
     if not state.conversation_log:
         return web.json_response({"error": "no conversation log"}, status=400)
-    ok = state.conversation_log.delete_session(key)
+    # delete_session enters _locked (flock acquire + os.close); offload off the
+    # loop so a wedged cross-process peer can't freeze chat/WS/heartbeat.
+    ok = await asyncio.to_thread(state.conversation_log.delete_session, key)
     if ok:
         try:
             await _remove_slot_for_history_key(state, key)
@@ -508,7 +510,9 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
             skipped += 1
             continue
         try:
-            if state.conversation_log.delete_session(key):
+            # delete_session enters _locked (flock + os.close) — offload off the
+            # event loop so a wedged peer can't stall the bulk clear on it.
+            if await asyncio.to_thread(state.conversation_log.delete_session, key):
                 cleanup_tasks.append(_remove_slot_for_history_key(state, key))
                 count += 1
             else:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -334,9 +334,20 @@ async def _restart_gateway(state: DashboardState) -> None:
     # kiro_crew.dashboard.handlers (which re-exports this module), so this
     # must stay inline to avoid an import cycle at module load.
     from kiro_crew.dashboard.chat import save_all_slots_to_history
+    from kiro_crew.executors import subprocess_executor
 
     try:
-        save_all_slots_to_history(state)
+        # Offload the synchronous per-slot save (per-session lock + disk I/O)
+        # to the bounded subprocess_executor with a deadline: on the event loop
+        # a contended session raises HistoryLockTimeout and a wedged disk would
+        # block the restart, so a slot's final save must run off-loop and be
+        # time-bounded rather than stall (or silently drop) here.
+        await asyncio.wait_for(
+            asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), save_all_slots_to_history, state
+            ),
+            timeout=5.0,
+        )
     except Exception:
         logger.debug("History save before restart failed", exc_info=True)
     try:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -886,9 +886,12 @@ class _ChatSlot:
         # message lines, OLDER than the in-memory window) + a fresh re-serialize
         # of the whole window. The prefix is never rewritten, so a restart that
         # loaded only a recent window can no longer destroy older history. This
-        # caches the prefix bytes keyed by (path-mtime, _disk_older_count) so a
-        # 5s flush is O(window), not O(file). See chat_persistence._save_*.
-        self._frozen_prefix_cache: tuple[float, int, str] | None = None
+        # caches the prefix bytes keyed by (path-mtime, path-size,
+        # _disk_older_count) so a 5s flush is O(window), not O(file). The
+        # (mtime, size) pair also doubles as the "did another process write this
+        # file since we last saved?" signal that gates the cross-process
+        # foreign-append merge. See chat_persistence._save_*.
+        self._frozen_prefix_cache: tuple[float, int, int, str, list[str]] | None = None
         # Set by rewind/regenerate after they TRUNCATE the window. While set,
         # _save_slot_to_history takes the archive-safe rewrite path so the
         # dropped tail is archived — even if the inline rewrite save failed

--- a/src/kiro_crew/dashboard/workflow_inject.py
+++ b/src/kiro_crew/dashboard/workflow_inject.py
@@ -18,6 +18,7 @@ import re
 from typing import Any, Callable, Optional
 
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # Matches absolute POSIX paths to a file with an extension (artifacts a workflow
@@ -158,7 +159,24 @@ def inject_workflow_result(
             # Persist so a follow-up chat turn has the result as context.
             try:
                 if state.conversation_log is not None:
-                    state.conversation_log.append(session_key, "assistant", msg)
+                    # inject_workflow_result runs on the event loop (invoked from
+                    # the workflow runner's on_done inside an asyncio task), so
+                    # offload the lock-backed disk append to a worker thread —
+                    # otherwise the on-loop _locked path drops it under any
+                    # concurrent holder. The slot.append above already surfaces
+                    # the result to the live UI; this is the durable replay copy.
+                    #
+                    # Use append_if_absent (not a plain append): slot.append has
+                    # already put this message into the DIRTY in-memory slot, so
+                    # a periodic slot save may serialize it to disk before this
+                    # durable copy runs. A plain append would then write it a
+                    # SECOND time and the workflow result would be replayed twice
+                    # after a restart. append_if_absent does the existence check
+                    # under the SAME per-session lock the slot save takes, so the
+                    # write collapses to a no-op when the save already landed it.
+                    append_if_absent_off_loop(
+                        state.conversation_log, session_key, "assistant", msg
+                    )
             except Exception:  # noqa: BLE001
                 pass
             # Auto-run the launching agent on the fresh result, but ONLY in the

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -296,7 +296,9 @@ class DiscordDispatcher:
             # ── Post-turn bookkeeping (each guarded — see Telegram). ──
             self.sessions.record_success(session_key)
             try:
-                self._persist_turn(session_key, text, accumulated, is_new)
+                await asyncio.to_thread(
+                    self._persist_turn, session_key, text, accumulated, is_new
+                )
             except Exception:
                 logger.warning(
                     "Discord: persist_turn failed session=%s",

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -8,6 +8,8 @@ Files auto-rotate at 512KB, keeping last 200 lines.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import contextvars
 import json
 import logging
 import math
@@ -16,10 +18,12 @@ import re
 import threading
 import time as _time
 from collections import OrderedDict
+from collections.abc import Callable, Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.executors import run_in_embed_pool
@@ -52,6 +56,343 @@ _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages
 
 _SESSION_MAX_BYTES = 2 * 1024 * 1024  # 2MB
 _SESSION_KEEP_LINES = 200
+# Bounded cross-process lock acquisition. The per-session sidecar ``flock`` is
+# acquired on the hot ``append`` path, which some transports (Telegram/WeChat/
+# Webex dispatch, workflow/cron injection) may still call synchronously from the
+# gateway event loop. An UNBOUNDED blocking acquire there would let one wedged
+# writer in another process freeze the whole gateway indefinitely, and simply
+# *proceeding* after a timeout would write WITHOUT the cross-process lock — a
+# stale rewrite in the holder can then clobber that write (silent transcript
+# loss). So we do neither: we poll ``try_acquire_lock`` up to a bounded deadline
+# and, on timeout, RAISE ``HistoryLockTimeout`` (fail the mutation) instead of
+# writing unlocked. The critical sections under the lock are all short (append a
+# line / rewrite one metadata line / rotate) so a real contention window clears
+# in milliseconds; a timeout means a genuinely wedged holder.
+#
+# The acquire strategy is chosen by execution context. Off the event loop
+# (worker threads, subagents, crons, CLI) a caller can afford to poll patiently
+# up to ``_FLOCK_ACQUIRE_TIMEOUT_S``. ON a running asyncio loop we must NEVER
+# block or sleep — even a sub-second poll stalls every chat/heartbeat/websocket
+# on the gateway's sole event loop — so the loop path makes exactly ONE
+# non-blocking acquire attempt and fails fast on contention. Callers on the loop
+# should offload persistence via ``asyncio.to_thread`` (see the transport
+# dispatchers' ``_persist_turn``) or via :func:`append_off_loop` (see the
+# dashboard ``inject_cron_result_to_dashboard`` / ``inject_workflow_result``
+# injectors); the single non-blocking attempt is the safety net for any that
+# don't.
+_FLOCK_ACQUIRE_TIMEOUT_S = 10.0
+_FLOCK_POLL_INTERVAL_S = 0.05
+
+
+class HistoryLockTimeout(TimeoutError):
+    """Raised when the cross-process session lock cannot be acquired in time.
+
+    The mutation is abandoned (never applied without the lock) so a concurrent
+    rewrite in another process cannot silently clobber an unlocked write. A
+    timeout indicates a wedged lock holder, not ordinary contention (critical
+    sections are sub-millisecond).
+
+    On-loop callers must NOT let this raise into an async handler (it would turn
+    a transient, retryable lock contention into a user-visible 500). The two
+    supported disciplines are: (1) offload the mutation off the loop so it takes
+    the patient acquire path — the transport dispatchers' ``_persist_turn`` use
+    ``asyncio.to_thread`` and the dashboard injectors use
+    :func:`append_off_loop`; or (2) wrap the mutation in ``try/except`` and skip
+    persistence on this error. Call-sites that do neither will surface it as the
+    mutation's failure — by design, fail rather than write unlocked.
+    """
+
+
+class OnLoopPersistError(AssertionError):
+    """A session-file mutation entered :meth:`ConversationLog._locked` directly
+    on the event loop, violating the off-loop persistence discipline.
+
+    The offload invariant (see the ``_locked`` contract and
+    ``docs/system-specs/modules/history.md``) is that NO session-JSONL mutator
+    runs on the gateway event loop: on-loop callers route through
+    ``append_off_loop`` / ``append_if_absent_off_loop`` / ``update_metadata_off_loop``
+    / ``save_slot_off_loop`` (or ``asyncio.to_thread``), all of which dispatch
+    the mutation to a worker thread so ``_locked`` runs OFF the loop and takes
+    the patient acquire path. A raw on-loop mutator call works in every low-
+    traffic test and use (the flock is uncontended) and only loses data under
+    real concurrency — where the on-loop path makes a single non-blocking
+    acquire, raises :class:`HistoryLockTimeout`, and the caller's best-effort
+    ``try/except`` swallows it as silent transcript loss.
+
+    Because that failure is invisible in CI, ``_locked`` fails LOUD instead:
+    when strict enforcement is active (:func:`_on_loop_persist_strict` — on under
+    ``KIROCREW_STRICT_ON_LOOP_PERSIST`` or ``KIROCREW_DEV_MODE``) any on-loop
+    entry raises this error so an un-offloaded call-site fails tests rather than
+    losing data in production. In production (strict off) the same on-loop entry
+    is instead logged loudly (throttled) and proceeds via the single non-blocking
+    safety-net acquire. Tests that deliberately exercise the low-level on-loop
+    primitive wrap the call in :func:`allow_on_loop_persist`.
+    """
+
+
+# When True (default in production), on-loop entry into ``_locked`` is a logged
+# warning + single non-blocking acquire. When strict enforcement is active it
+# raises :class:`OnLoopPersistError` instead. A ``ContextVar`` (async-safe, no
+# cross-task bleed) lets the low-level primitive tests opt a single call out.
+_allow_on_loop_persist: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "kirocrew_allow_on_loop_persist", default=False
+)
+
+# Throttle the production on-loop warning so a mis-wired hot path cannot flood
+# the log; the diagnostic still fires once per window per process.
+_ON_LOOP_WARN_INTERVAL_S = 60.0
+_on_loop_warn_last: float = 0.0
+
+
+@contextlib.contextmanager
+def allow_on_loop_persist() -> Iterator[None]:
+    """Suppress the strict on-loop persistence assertion for the current context.
+
+    Reserved for tests (and any genuinely-vetted call-site) that intentionally
+    drive a session mutator directly on the event loop to exercise the
+    low-level ``_locked`` primitive — e.g. the HistoryLockTimeout fail-fast
+    path. Production code must NEVER use this: it must offload instead.
+    """
+    token = _allow_on_loop_persist.set(True)
+    try:
+        yield
+    finally:
+        _allow_on_loop_persist.reset(token)
+
+
+def _on_loop_persist_strict() -> bool:
+    """Whether an on-loop ``_locked`` entry should RAISE (vs. warn-and-proceed).
+
+    Strict enforcement turns the convention-only offload discipline into a hard,
+    test-catchable failure. It is on when EITHER:
+
+    - ``KIROCREW_STRICT_ON_LOOP_PERSIST`` is truthy (explicit opt-in — the knob
+      the discipline-enforcement tests flip, and a CI/dev harness can export to
+      make an un-offloaded call-site fail instead of ship), or
+    - ``KIROCREW_DEV_MODE`` is truthy (developer gateway runs — where all
+      persistence is already offloaded, so a raise means a real newly-added
+      un-offloaded path, surfaced immediately rather than lost under contention).
+
+    A truthy ``KIROCREW_STRICT_ON_LOOP_PERSIST`` wins; an explicit falsy value
+    force-disables even under dev-mode (so the production-fallback path stays
+    testable). It is deliberately NOT auto-on under bare pytest: the suite's own
+    async harness calls several mutators directly on the loop as a convenience
+    (not a production path), so auto-strict would flag harness code, not drift.
+    The default (no flag) is the production behavior — a loud throttled warning
+    plus the non-blocking safety-net acquire — so shipping never introduces a new
+    hard failure in the field.
+    """
+    explicit = os.environ.get("KIROCREW_STRICT_ON_LOOP_PERSIST", "").strip().lower()
+    if explicit in _ON_LOOP_TRUTHY:
+        return True
+    if explicit in _ON_LOOP_FALSY:
+        return False
+    return os.environ.get("KIROCREW_DEV_MODE", "").strip().lower() in _ON_LOOP_TRUTHY
+
+
+_ON_LOOP_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_ON_LOOP_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _check_on_loop_persist_discipline(key: str) -> None:
+    """Enforce (strict) or diagnose (production) an on-loop ``_locked`` entry.
+
+    Called at the top of :meth:`ConversationLog._locked`. If there is no running
+    event loop the caller is already off-loop (worker thread / CLI / subagent /
+    cron) and this is a no-op — the common, correct case. On the loop it either
+    raises :class:`OnLoopPersistError` (strict) or logs a throttled warning
+    (production) so the un-offloaded call-site is never silent.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return  # off-loop: the sanctioned path — nothing to flag
+    if _allow_on_loop_persist.get():
+        return  # explicitly-vetted low-level primitive exercise (tests)
+    if _on_loop_persist_strict():
+        raise OnLoopPersistError(
+            f"session mutation for {key!r} entered _locked on the event loop; "
+            f"on-loop callers MUST offload (append_off_loop / "
+            f"append_if_absent_off_loop / update_metadata_off_loop / "
+            f"save_slot_off_loop / asyncio.to_thread) so the write takes the "
+            f"patient off-loop acquire path — a raw on-loop mutation loses data "
+            f"under real contention (HistoryLockTimeout swallowed as silent "
+            f"transcript loss). Wrap in history.allow_on_loop_persist() only to "
+            f"test the low-level primitive itself."
+        )
+    global _on_loop_warn_last
+    now = _time.monotonic()
+    if now - _on_loop_warn_last >= _ON_LOOP_WARN_INTERVAL_S:
+        _on_loop_warn_last = now
+        logger.warning(
+            "history: session mutation for %s ran _locked ON the event loop "
+            "without offloading; this drops the write under real contention "
+            "(HistoryLockTimeout swallowed by best-effort callers). Route it "
+            "through append_off_loop/save_slot_off_loop/asyncio.to_thread.",
+            key, stack_info=True,
+        )
+
+
+def append_off_loop(
+    conversation_log: "ConversationLog",
+    key: str,
+    role: str,
+    content: str,
+    *,
+    agent: str | None = None,
+) -> None:
+    """Persist a message without blocking (or fail-fast-dropping on) the loop.
+
+    The lock-backed :meth:`ConversationLog.append` acquires a cross-process
+    flock and writes to disk. On the gateway event loop that primitive makes a
+    single non-blocking acquire attempt and raises :class:`HistoryLockTimeout`
+    on *any* concurrent holder (see the ``_locked`` contract), so calling it
+    directly from an async context both risks a disk write on the loop and drops
+    the write under benign contention.
+
+    This helper routes around both problems: on a running asyncio loop the
+    append is dispatched to a worker thread (``run_in_executor``) so it takes the
+    patient off-loop acquire path and never stalls the loop; off the loop it
+    appends inline. Persistence is best-effort — the caller has already reflected
+    the message in the in-memory slot, so a lock timeout or I/O error only skips
+    the durable replay copy and is logged rather than raised.
+    """
+
+    def _do() -> None:
+        conversation_log.append(key, role, content, agent=agent)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        try:
+            _do()
+        except Exception:  # noqa: BLE001 - best-effort durable copy
+            logger.warning(
+                "append_off_loop: inline append failed key=%s", key, exc_info=True
+            )
+        return
+
+    def _report(fut: "asyncio.Future[None]") -> None:
+        exc = fut.exception()
+        if exc is not None:
+            logger.warning(
+                "append_off_loop: offloaded append failed key=%s: %r", key, exc
+            )
+
+    loop.run_in_executor(None, _do).add_done_callback(_report)
+
+
+def append_if_absent_off_loop(
+    conversation_log: "ConversationLog",
+    key: str,
+    role: str,
+    content: str,
+    *,
+    agent: str | None = None,
+) -> None:
+    """Idempotent, loop-safe variant of :func:`append_off_loop`.
+
+    Routes :meth:`ConversationLog.append_if_absent` — which atomically skips a
+    message already persisted under the same session lock — off the event loop
+    exactly like :func:`append_off_loop`. Used by the workflow-result and
+    cron-result injectors, which ALSO reflect the message in the in-memory slot
+    (``slot.append``); the periodic slot save can therefore serialize the same
+    message before this durable copy runs. The plain ``append`` would then
+    double-write it; ``append_if_absent`` performs the disk check under the
+    lock so the second write is a no-op. Best-effort — a lock timeout / I/O
+    error only skips the durable replay copy (the slot already carries it) and
+    is logged rather than raised.
+    """
+
+    def _do() -> None:
+        conversation_log.append_if_absent(key, role, content, agent=agent)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        try:
+            _do()
+        except Exception:  # noqa: BLE001 - best-effort durable copy
+            logger.warning(
+                "append_if_absent_off_loop: inline append failed key=%s",
+                key, exc_info=True,
+            )
+        return
+
+    def _report(fut: "asyncio.Future[None]") -> None:
+        exc = fut.exception()
+        if exc is not None:
+            logger.warning(
+                "append_if_absent_off_loop: offloaded append failed key=%s: %r",
+                key, exc,
+            )
+
+    loop.run_in_executor(None, _do).add_done_callback(_report)
+
+
+def update_metadata_off_loop(
+    conversation_log: "ConversationLog",
+    key: str,
+    fields: dict,
+) -> None:
+    """Merge session metadata without running the flock/fd ops on the loop.
+
+    Mirrors :func:`append_off_loop`, but for the lock-backed
+    :meth:`ConversationLog.update_metadata`. That method enters ``_locked``,
+    which ``os.open``\\ s the sidecar, takes a cross-process ``flock`` and
+    ``os.close``\\ s the fd. Those primitives are ``blocking: true`` under the
+    ``no-blocking-call-on-event-loop`` rule: a wedged cross-process peer can
+    stall the acquire (or, mid-release, the close) and freeze chat, WebSockets,
+    and heartbeat until the watchdog restarts the gateway. This helper keeps
+    them off the loop.
+
+    Use it from *synchronous* helpers that may run on the event-loop thread
+    (e.g. slot rehydration / startup restore) where ``await`` is not available.
+    Async handlers that can ``await`` should prefer
+    ``await asyncio.to_thread(conversation_log.update_metadata, ...)`` so the
+    write is ordered against the response.
+
+    On a running loop the update is dispatched to a worker thread (which takes
+    ``_locked``'s patient off-loop acquire path); off the loop it runs inline.
+    Persistence is best-effort — the mutation is metadata backfill the caller
+    has already reflected in memory, so a lock timeout or I/O error is logged
+    rather than raised.
+    """
+
+    def _do() -> None:
+        conversation_log.update_metadata(key, fields)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        try:
+            _do()
+        except Exception:  # noqa: BLE001 - best-effort metadata backfill
+            logger.warning(
+                "update_metadata_off_loop: inline update failed key=%s",
+                key,
+                exc_info=True,
+            )
+        return
+
+    def _report(fut: "asyncio.Future[None]") -> None:
+        exc = fut.exception()
+        if exc is not None:
+            logger.warning(
+                "update_metadata_off_loop: offloaded update failed key=%s: %r",
+                key,
+                exc,
+            )
+
+    loop.run_in_executor(None, _do).add_done_callback(_report)
+
+
 SEARCH_MIN_CHARS = 2  # shortest query string that triggers backend search
 _TITLE_BOOST = 10  # field-boost multiplier for title matches in search_sessions
 _SEARCH_SCAN_WINDOW = 500  # cap files scanned per search to bound I/O
@@ -303,6 +644,28 @@ class ConversationLog:
     _file_locks: dict[str, threading.RLock] = {}
     _file_locks_guard = threading.Lock()
 
+    # Cross-process advisory-lock state. The per-file ``threading.RLock`` above
+    # only serializes writers *inside this process*; a subagent, cron, or CLI
+    # invocation runs in a SEPARATE process and would otherwise interleave its
+    # create/append/rotate/rewrite against ours and silently lose updates (or
+    # let a reader observe a torn file mid-rewrite). ``_locked`` layers a POSIX
+    # ``flock`` (advisory, cross-process) on a per-session ``.lock`` sidecar on
+    # top of the in-process RLock. ``_flock_state`` maps lock_key →
+    # ``[fd, depth, held]`` (``held`` = 1 while the ``flock`` is currently taken
+    # on ``fd``) so re-entrant same-key acquisition (RLock is reentrant) reuses
+    # the single held fd instead of ``flock``-ing a second fd of the same file —
+    # which, on POSIX, blocks forever against ourselves. Crucially, the entry is
+    # *kept alive with ``held``=1* across the brief window between a depth→0 exit
+    # and the off-loop release actually running: a sequential same-key
+    # re-acquire in that window REUSES the still-held flock (never re-``flock``s
+    # a fresh fd, which would spuriously EWOULDBLOCK against our own not-yet-
+    # released fd and fail the single non-blocking on-loop attempt). Guarded by
+    # ``_flock_guard`` for the (fast, non-blocking) dict bookkeeping only; the
+    # blocking ``flock`` call happens outside the guard so distinct keys never
+    # serialize on it.
+    _flock_state: dict[str, list[int]] = {}
+    _flock_guard = threading.Lock()
+
     def __init__(
         self,
         base_dir: Path | None = None,
@@ -326,13 +689,15 @@ class ConversationLog:
         #: staleness (an append bumps the file mtime, so the entry is
         #: recomputed on the next call). Own ``_LRUCache`` → own internal lock.
         self._recent_cache: _LRUCache[tuple[float, list[dict]]] = _LRUCache(cache_max)
-        #: tab_id → [session keys] index for chained reads. Initialized eagerly
-        #: (no ``hasattr`` dance) and guarded by ``self._lock`` because
+        #: tab_id → [session keys] chain index. ``None`` means "stale, rebuild
+        #: on next chained read"; a dict is an authoritative snapshot. Rebuilt
+        #: lazily by _rebuild_tab_id_index, invalidated by
+        #: invalidate_tab_id_cache on every append / metadata edit / delete
+        #: that can change the chain. Guarded by ``self._lock`` because
         #: ``read_messages_chained`` is reachable from worker threads while the
-        #: event loop may clear it via ``invalidate_tab_id_cache`` — an
-        #: unsynchronized lazy-init/read/clear produced a transient empty index
-        #: or ``AttributeError``.
-        self._tab_id_index: dict[str, list[str]] = {}
+        #: event loop may mark it stale — an unsynchronized rebuild/read/clear
+        #: produced a transient empty index or ``AttributeError``.
+        self._tab_id_index: dict[str, list[str]] | None = None
         #: Coarse instance lock protecting the lazily-built ``_tab_id_index``
         #: rebuild/read/clear. The message/metadata/recent LRUs are each
         #: internally locked; this guards the shared mutable state that lives
@@ -357,6 +722,217 @@ class ConversationLog:
                 lock = threading.RLock()
                 ConversationLog._file_locks[lock_key] = lock
             return lock
+
+    def _lock_path(self, key: str) -> Path:
+        """Sidecar lock-file path for *key* (``<session>.jsonl.lock``).
+
+        A dedicated sidecar is used rather than locking the session file's own
+        fd because writes go through ``atomic_write`` (temp file + ``os.replace``),
+        which swaps the inode — a lock held on the pre-replace fd would guard a
+        now-unlinked inode and protect nothing. The sidecar's inode is stable.
+        The ``.lock`` suffix keeps it out of every ``*.jsonl`` glob (list/search/
+        tab-id-index) so it is never mistaken for a session file.
+        """
+        p = self._path(key)
+        return p.parent / (p.name + ".lock")
+
+    @staticmethod
+    def _run_fd_cleanup_off_loop(cleanup: Callable[[], None]) -> None:
+        """Run a blocking lock-fd cleanup without ever stalling the event loop.
+
+        ``platform_compat.release_lock`` (``flock(LOCK_UN)``) and ``os.close``
+        are ``blocking: true`` under the ``no-blocking-call-on-event-loop``
+        rule: on a wedged descriptor they can freeze chat, WebSockets, and the
+        heartbeat until the watchdog restarts the gateway. ``_locked`` may run
+        synchronously ON the loop thread — an on-loop caller that did not
+        offload relies on the single non-blocking acquire as a safety net (see
+        the module docstring and ``append_off_loop``) — so its descriptor
+        release/close must never execute inline on the loop.
+
+        Off the loop we run the cleanup inline. On the loop we dispatch it to
+        the default executor (fire-and-forget: the caller awaits nothing). The
+        release cleanup re-validates the ``_flock_state`` entry under the
+        per-key RLock before touching the fd, so scheduling it while the entry
+        is still live (kept alive with ``held``=1 across the depth→0 → release
+        window) is safe — a same-key re-acquire simply cancels it. A failed
+        unlock/close of an already-doomed fd is not actionable, so the future's
+        exception is consumed to avoid a spurious "exception was never
+        retrieved" warning.
+
+        NOTE: this is only the *release* side. The first-entry acquire still
+        ``os.open``s the local sidecar synchronously because the fd must exist
+        before it can be ``flock``ed; that open is a fast local-FS syscall and,
+        unlike the release, is on the critical path. On-loop callers that want
+        to keep even the acquire off the loop must offload the whole mutation
+        (``append_off_loop`` / ``update_metadata_off_loop`` / ``save_slot_off_loop``).
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is None:
+            cleanup()
+            return
+        fut = loop.run_in_executor(None, cleanup)
+        fut.add_done_callback(lambda f: f.exception())
+
+    @contextlib.contextmanager
+    def _locked(self, key: str) -> Iterator[None]:
+        """Hold BOTH the in-process RLock and a cross-process advisory flock.
+
+        Serializes create/append/rotate/rewrite/metadata mutations of a single
+        session file against every other writer — threads in this process (via
+        the RLock) *and* other processes such as subagents, crons, and the CLI
+        (via the ``flock`` on the sidecar lock file). Reentrant: a nested
+        ``_locked`` for the same key on the same thread reuses the held fd.
+        """
+        # Fail loud (strict) or diagnose (production) if a mutation reached the
+        # lock ON the event loop — the un-offloaded-call-site guard (see
+        # OnLoopPersistError). No-op off the loop, which is the sanctioned path.
+        _check_on_loop_persist_discipline(key)
+        with self._file_lock(key):
+            lock_key = str(self._path(key))
+            with ConversationLog._flock_guard:
+                state = ConversationLog._flock_state.get(lock_key)
+                if state is None:
+                    lock_path = self._lock_path(key)
+                    lock_path.parent.mkdir(parents=True, exist_ok=True)
+                    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+                    state = [fd, 0, 0]  # fd, depth, held
+                    ConversationLog._flock_state[lock_key] = state
+                state[1] += 1
+                # ``held`` == 1 means the ``flock`` is already taken on
+                # ``state[0]`` — either by an outer reentrant frame OR because a
+                # depth→0 exit's off-loop release has not run yet. In BOTH cases
+                # we reuse the held flock rather than ``flock``-ing a fresh fd
+                # (which would EWOULDBLOCK against our own fd and, on the loop,
+                # fail the single non-blocking attempt). The re-bumped depth
+                # also cancels any pending release (it re-checks depth == 0).
+                need_acquire = state[2] == 0
+            # Bounded cross-process acquire done OUTSIDE _flock_guard (only when
+            # the flock is not already held) so unrelated keys never serialize
+            # on the bookkeeping mutex. The RLock we hold guarantees no other
+            # thread races this same key. On timeout/contention we RAISE
+            # HistoryLockTimeout — we never proceed with the mutation unlocked,
+            # because a concurrent rewrite could then clobber the unlocked write
+            # (silent data loss). ON a running asyncio loop we make exactly ONE
+            # non-blocking attempt and fail fast (never sleep/poll — that would
+            # block the sole event loop). Off-loop we poll patiently to a
+            # bounded deadline.
+            if need_acquire:
+                try:
+                    on_loop = True
+                    try:
+                        asyncio.get_running_loop()
+                    except RuntimeError:
+                        on_loop = False
+                    if on_loop:
+                        if not platform_compat.try_acquire_lock(
+                            state[0], exclusive=True
+                        ):
+                            logger.warning(
+                                "history: cross-process lock for %s busy on the "
+                                "event loop; abandoning mutation rather than "
+                                "blocking the loop or writing unlocked (a "
+                                "concurrent rewrite could clobber it)",
+                                key,
+                            )
+                            raise HistoryLockTimeout(
+                                f"could not acquire cross-process lock for "
+                                f"{key!r} without blocking the event loop"
+                            )
+                    else:
+                        deadline = _time.monotonic() + _FLOCK_ACQUIRE_TIMEOUT_S
+                        while not platform_compat.try_acquire_lock(
+                            state[0], exclusive=True
+                        ):
+                            if _time.monotonic() >= deadline:
+                                logger.warning(
+                                    "history: cross-process lock for %s not "
+                                    "acquired within %.1fs; abandoning mutation "
+                                    "to avoid an unlocked write that a "
+                                    "concurrent rewrite could clobber",
+                                    key, _FLOCK_ACQUIRE_TIMEOUT_S,
+                                )
+                                raise HistoryLockTimeout(
+                                    f"could not acquire cross-process lock for "
+                                    f"{key!r} within "
+                                    f"{_FLOCK_ACQUIRE_TIMEOUT_S:.1f}s"
+                                )
+                            _time.sleep(_FLOCK_POLL_INTERVAL_S)
+                    with ConversationLog._flock_guard:
+                        state[2] = 1  # flock now held on state[0]
+                except BaseException:
+                    with ConversationLog._flock_guard:
+                        state[1] -= 1
+                        # Only tear the fd down if we are the last frame AND the
+                        # flock was never taken; a concurrent reuse (depth > 0)
+                        # or a held flock must keep the fd alive.
+                        drop = state[1] == 0 and state[2] == 0
+                        if drop:
+                            ConversationLog._flock_state.pop(lock_key, None)
+                    if drop:
+                        # Acquire failed → the flock was never taken, so only
+                        # the fd needs releasing. ``os.close`` is ``blocking:
+                        # true`` under the no-blocking-call-on-event-loop rule;
+                        # defer it off the loop (see ``_run_fd_cleanup_off_loop``).
+                        _fd = state[0]
+                        self._run_fd_cleanup_off_loop(lambda: os.close(_fd))
+                    raise
+            try:
+                yield
+            finally:
+                with ConversationLog._flock_guard:
+                    state[1] -= 1
+                    done = state[1] == 0
+                if done:
+                    # Depth hit 0. ``platform_compat.release_lock`` (flock
+                    # LOCK_UN) and ``os.close`` are both ``blocking: true``
+                    # syscalls, so run them off the event loop — a wedged
+                    # descriptor must never freeze chat/WS/heartbeat (the
+                    # finding this addresses). We DO NOT pop the state here:
+                    # the entry stays alive with ``held``=1 so a sequential
+                    # same-key re-acquire before the release runs reuses the
+                    # still-held flock instead of ``flock``-ing a fresh fd (the
+                    # regression that spuriously raised HistoryLockTimeout under
+                    # executor load). The deferred release re-checks depth and
+                    # its own fd under the guard, so a reuse cancels it.
+                    self._schedule_flock_release(key, lock_key, state[0])
+
+    def _schedule_flock_release(
+        self, key: str, lock_key: str, fd: int
+    ) -> None:
+        """Release+close *fd* off the loop iff the entry is still idle.
+
+        Scheduled on a depth→0 exit of :meth:`_locked`. Runs the blocking
+        ``flock(LOCK_UN)`` + ``os.close`` off the event loop (they can stall on
+        a wedged descriptor). Re-validates under the per-key RLock and
+        ``_flock_guard`` that the ``_flock_state`` entry still refers to *fd*
+        and its depth is still 0 — if a same-key re-acquire bumped the depth in
+        the meantime (reusing the still-held flock) or the fd was already
+        replaced, the release is a no-op and ownership passes to that frame's
+        own eventual depth→0 exit. This closes the window in which the entry was
+        popped while the flock was still held, which made the next on-loop
+        acquire EWOULDBLOCK against our own not-yet-released fd.
+        """
+
+        def _release_and_close() -> None:
+            # Reentrant RLock: off-loop this runs on a worker thread and blocks
+            # until no same-key frame holds it; inline (no loop) it re-enters on
+            # the current thread. Either way, serializing with _locked bodies
+            # guarantees the depth check below cannot race an acquire.
+            with self._file_lock(key):
+                with ConversationLog._flock_guard:
+                    st = ConversationLog._flock_state.get(lock_key)
+                    if st is None or st[0] != fd or st[1] != 0:
+                        return  # reused or replaced — leave the flock in place
+                    ConversationLog._flock_state.pop(lock_key, None)
+                try:
+                    platform_compat.release_lock(fd)
+                finally:
+                    os.close(fd)
+
+        self._run_fd_cleanup_off_loop(_release_and_close)
 
     def init(self) -> None:
         """Create sessions directory if missing."""
@@ -403,8 +979,11 @@ class ConversationLog:
         path = self._path(key)
         # Serialize the create-if-missing + append + rotate against concurrent
         # rewrites (compaction / consolidation) so no write is lost and readers
-        # never observe a torn file.
-        with self._file_lock(key):
+        # never observe a torn file. ``_locked`` also takes a cross-process
+        # advisory flock so a subagent / cron / CLI writing the SAME session
+        # file in another process can't interleave and lose this append.
+        with self._locked(key):
+            created_with_tab_id = False
             if not path.exists():
                 self._dir.mkdir(parents=True, exist_ok=True)
                 meta: dict = {
@@ -416,6 +995,7 @@ class ConversationLog:
                     meta["agent"] = agent
                 if tab_id:
                     meta["tab_id"] = tab_id
+                    created_with_tab_id = True
                 path.write_text(json.dumps(meta) + "\n", encoding="utf-8")
 
             msg: dict = {
@@ -438,8 +1018,53 @@ class ConversationLog:
             # Invalidate cache since file changed
             self._invalidate_cache(key)
 
+            # A newly-created file carrying a tab_id adds a fresh key to that
+            # tab_id's chain — drop the cached tab_id→[keys] index so the next
+            # chained read rebuilds it and actually sees this session (a stale
+            # index would silently omit it from the chain).
+            if created_with_tab_id:
+                self.invalidate_tab_id_cache()
+
             # Rotate if file exceeds size limit
             self._maybe_rotate(path)
+
+    def append_if_absent(
+        self,
+        key: str,
+        role: str,
+        content: str,
+        *,
+        agent: str | None = None,
+        tab_id: str | None = None,
+    ) -> bool:
+        """Append a message only if an identical one is not already persisted.
+
+        Returns ``True`` if the message was written, ``False`` if a message
+        with the same ``(role, content)`` already exists on disk.
+
+        The disk check and the append run together under ``_locked`` so they
+        are ATOMIC against a concurrent writer of the same session file — in
+        particular the periodic dashboard slot save
+        (``_save_slot_to_history``), which serializes the in-memory slot window
+        (already carrying this message via ``slot.append``) and takes the SAME
+        per-session cross-process lock. Without this, a fire-and-forget
+        :func:`append_off_loop` scheduled after the slot save has already
+        written the identical message would append it a SECOND time; the
+        duplicate then survives a restart and is replayed twice to subsequent
+        agent turns. This is the workflow-result / cron-result double-append
+        race: the read-modify-write must be one locked critical section, not a
+        separate unlocked existence check followed by a later append.
+        """
+        with self._locked(key):
+            if self._path(key).exists():
+                for m in self._read_messages(key):
+                    if m.get("role") == role and m.get("content") == content:
+                        return False
+            # Reentrant: ``append`` re-enters ``_locked`` for the same key on
+            # this thread (RLock + refcounted flock), so the write stays inside
+            # the critical section we already hold.
+            self.append(key, role, content, agent=agent, tab_id=tab_id)
+            return True
 
     def recent(
         self,
@@ -530,13 +1155,86 @@ class ConversationLog:
         offset = self._read_metadata(key).get("last_consolidated", 0)
         return messages[offset:], len(messages)
 
-    def mark_consolidated(self, key: str, offset: int) -> None:
-        """Rewrite metadata line with updated last_consolidated offset."""
+    def rotation_generation(self, key: str) -> int:
+        """Return the session's rotation generation counter.
+
+        Incremented by :meth:`_maybe_rotate` on every rotation. A consolidator
+        snapshots this alongside the message offset before its (slow) LLM call
+        and passes it back to :meth:`mark_consolidated`, which resets the offset
+        whenever the generation changed — closing the rotation-during-await race
+        for ANY retained count, not just files that shrank below the offset.
+        Absent field (legacy metadata / never rotated) reads as ``0``.
+        """
+        return int(self._read_metadata(key).get("rotation_generation", 0) or 0)
+
+    def snapshot_for_consolidation(
+        self, key: str
+    ) -> tuple[list[dict], int, int]:
+        """Atomically snapshot ``(unconsolidated_messages, total, generation)``.
+
+        The consolidator needs the unconsolidated tail, the total message count
+        (the absolute offset it later passes to :meth:`mark_consolidated`), and
+        the rotation generation counter to reflect the SAME point in time. Read
+        as three separate calls (``get_unconsolidated`` + ``rotation_generation``)
+        an append can trigger a rotation *between* them, pairing pre-rotation
+        messages/offset with the post-rotation generation. ``mark_consolidated``
+        then sees matching generations and applies the stale (shifted) offset —
+        and when the retained count is >= that offset the count fallback misses
+        it too — silently marking never-processed messages as consolidated and
+        dropping them from memory/history extraction.
+
+        Holding :meth:`_locked` across all three reads makes the snapshot
+        atomic: no append/rotation can interleave, so the returned offset and
+        generation are guaranteed consistent. Returns
+        ``(messages[offset:], len(messages), generation)``. The returned list is
+        a fresh slice (never the shared ``_read_messages`` cache object), so the
+        caller may treat it as owned.
+        """
+        with self._locked(key):
+            messages = self._read_messages(key)
+            meta = self._read_metadata(key)
+            offset = meta.get("last_consolidated", 0)
+            generation = int(meta.get("rotation_generation", 0) or 0)
+            return list(messages[offset:]), len(messages), generation
+
+    def mark_consolidated(
+        self, key: str, offset: int, generation: int | None = None
+    ) -> None:
+        """Rewrite metadata line with updated ``last_consolidated`` offset.
+
+        *offset* is an absolute message index captured by the caller BEFORE a
+        (potentially slow) LLM consolidation call. *generation* is the rotation
+        generation counter (:meth:`rotation_generation`) captured at the same
+        moment. If a rotation fired while the consolidator awaited the LLM, the
+        file was truncated to its newest messages, ``last_consolidated`` reset
+        to 0, and the generation bumped — so the caller's *offset* is in the
+        stale PRE-rotation numbering: every surviving index shifted by the
+        number of dropped lines, so applying it would silently mark
+        never-consolidated retained messages as already processed.
+
+        Detection uses two independent signals:
+
+        1. **Generation change** (primary, when *generation* is supplied):
+           any rotation between snapshot and write bumps the counter, so a
+           mismatch resets ``last_consolidated`` to 0 regardless of how many
+           messages the rotation retained. This closes the case a pure
+           offset-vs-count heuristic misses — a rotation that keeps >= *offset*
+           messages leaves ``offset <= msg_count`` true yet has still shifted
+           every index.
+        2. **Offset exceeds current count** (fallback, always): the file shrank
+           below the captured offset (rotation truncated it). Retained if
+           *generation* is unavailable (legacy callers) or as defense-in-depth.
+
+        In either case ``last_consolidated`` is reset to 0 and the retained tail
+        is reconsolidated rather than clamping the offset to EOF (which would
+        silently mark post-rotation messages as already consolidated and drop
+        them from memory/history extraction). When neither trips, the offset is
+        applied as-is.
+        """
         path = self._path(key)
-        # Serialize behind the per-file lock and re-read under it so a
-        # concurrent append (guarded by the same lock) is never lost, and
-        # write atomically so a crash mid-write can't truncate the transcript.
-        with self._file_lock(key):
+        # Serialize behind the cross-process lock and re-read under it so a
+        # concurrent append (in this or another process) is never lost.
+        with self._locked(key):
             if not path.exists():
                 return
             prev_mtime = _safe_mtime(path)
@@ -544,10 +1242,60 @@ class ConversationLog:
             if not lines:
                 return
             meta = json.loads(lines[0])
-            meta["last_consolidated"] = offset
+            # Reconcile the caller's absolute *offset* against the messages
+            # actually present now. Line 0 is the metadata line; every other
+            # non-blank line is a message.
+            msg_count = sum(1 for ln in lines[1:] if ln.strip())
+            current_generation = int(meta.get("rotation_generation", 0) or 0)
+            if generation is not None and current_generation != generation:
+                # PRIMARY signal: a rotation fired between the caller's snapshot
+                # and now (the generation counter advanced). The offset is in
+                # the stale PRE-rotation numbering — every surviving index has
+                # shifted by the number of dropped lines — so it cannot be
+                # applied regardless of how many messages the rotation retained.
+                # A rotation that kept >= *offset* messages leaves
+                # ``offset <= msg_count`` true and would sail past the count
+                # heuristic below, silently marking never-consolidated retained
+                # messages as done. Reset to 0 and reconsolidate the retained
+                # tail (harmless, idempotent) rather than risk that loss.
+                logger.warning(
+                    "mark_consolidated: rotation generation changed %s->%d for "
+                    "%s (rotation during consolidation); resetting "
+                    "last_consolidated to 0 to avoid skipping retained messages",
+                    generation, current_generation, key,
+                )
+                safe_offset = 0
+            elif offset > msg_count:
+                # The file shrank below the captured offset — a rotation fired
+                # during the (slow) LLM await, truncating to the newest messages
+                # and resetting ``last_consolidated`` to 0. The caller's offset
+                # is in the PRE-rotation numbering and is now meaningless.
+                # Clamping it to ``msg_count`` would mark the retained tail —
+                # which now includes brand-new, never-consolidated messages that
+                # arrived after the snapshot — as consolidated, permanently
+                # skipping them (silent history/memory loss). Reset to 0 and let
+                # the retained tail be reconsolidated instead: redoing a handful
+                # of already-processed messages is harmless and idempotent,
+                # whereas dropping new ones is a data-integrity failure.
+                logger.warning(
+                    "mark_consolidated: offset %d exceeds current message count "
+                    "%d for %s (rotation during consolidation); resetting "
+                    "last_consolidated to 0 to avoid skipping post-rotation "
+                    "messages",
+                    offset, msg_count, key,
+                )
+                safe_offset = 0
+            else:
+                safe_offset = offset
+            meta["last_consolidated"] = safe_offset
             meta["updated_at"] = datetime.now().isoformat()
             lines[0] = json.dumps(meta) + "\n"
-            atomic_write(path, "".join(lines), fsync=True)
+            # Reduce lock hold for this one-line metadata rewrite: skip the
+            # fsync (fsync=False). ``last_consolidated`` is recoverable
+            # bookkeeping — if a crash loses it we simply re-consolidate a few
+            # messages — so paying a disk flush while holding the cross-process
+            # lock (blocking every other writer of this session) isn't worth it.
+            atomic_write(path, "".join(lines), fsync=False)
             # Housekeeping bookkeeping — must not advance the session's mtime
             # (see _restore_mtime). Otherwise consolidation floats stale sessions
             # to the top of list_sessions on every gateway restart.
@@ -874,16 +1622,21 @@ class ConversationLog:
             return self._read_messages(key)
         # Guard the lazy build/read of the shared _tab_id_index: this method is
         # reachable from worker threads (chat_persistence restore/save) while the
-        # event loop may clear the index via invalidate_tab_id_cache(). Without
-        # the lock two threads could rebuild concurrently, or one could read a
-        # half-cleared index. Snapshot the key list under the lock, then do the
-        # (potentially slow) per-file reads outside it.
+        # event loop may mark the index stale via invalidate_tab_id_cache().
+        # Without the lock two threads could rebuild concurrently, or one could
+        # read a half-built index. Rebuild only when it is missing/stale
+        # (``None``); a freshly rebuilt index is AUTHORITATIVE, so a tid absent
+        # from it genuinely has no sibling files right now. We deliberately do
+        # NOT plant a permanent ``[]`` sentinel for a missing tid — the old
+        # sentinel suppressed every future rebuild, so a second session opened
+        # later under the same tab_id was never linked into the chain and its
+        # messages silently vanished from recent_chained. Snapshot the key list
+        # under the lock, then do the (potentially slow) per-file reads outside.
         with self._lock:
-            if tid not in self._tab_id_index:
+            if self._tab_id_index is None:
                 self._rebuild_tab_id_index()
-                if tid not in self._tab_id_index:
-                    self._tab_id_index[tid] = []  # sentinel: prevent repeated rebuilds
-            keys = list(self._tab_id_index.get(tid, []))
+            index = self._tab_id_index or {}
+            keys = list(index.get(tid, []))
         if not keys:
             return self._read_messages(key)
         all_msgs: list[dict] = []
@@ -911,19 +1664,62 @@ class ConversationLog:
         self._tab_id_index = index
 
     def invalidate_tab_id_cache(self) -> None:
-        """Clear the tab_id index so it's rebuilt on next chained read."""
+        """Mark the tab_id index stale so it is rebuilt on the next chained read.
+
+        Sets the index to ``None`` (rather than ``.clear()``-ing it) so
+        read_messages_chained can distinguish "stale, must rebuild" from
+        "freshly built, tid legitimately absent" — the distinction the removed
+        ``[]`` sentinel used to get wrong. Guarded by ``self._lock`` so a
+        concurrent rebuild/read on a worker thread can't observe a half-updated
+        index.
+        """
         with self._lock:
-            self._tab_id_index.clear()
+            self._tab_id_index = None
 
     def delete_session(self, key: str) -> bool:
-        """Delete a session file. Returns True if deleted."""
-        path = self._path(key)
-        if path.exists():
-            path.unlink()
+        """Delete a session file. Returns True if a file was removed.
+
+        The existence check and unlink run under ``_locked`` so a concurrent
+        ``append`` / ``rewrite_session`` / ``update_metadata`` in this or any
+        other process cannot race the delete — otherwise a writer holding the
+        lock could complete its ``os.replace`` and resurrect the file we just
+        removed, or we could unlink the file out from under an open descriptor
+        and lose an acknowledged append. ``unlink(missing_ok=True)`` still
+        tolerates a concurrent deletion of the same session (the TOCTOU race
+        between our existence check and the unlink). On a wedged holder the lock
+        acquire raises ``HistoryLockTimeout``; we report "not removed" rather
+        than delete unlocked (the very clobber this lock prevents).
+        """
+        existed = False
+        try:
+            with self._locked(key):
+                path = self._path(key)
+                existed = path.exists()
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    return False
+        except HistoryLockTimeout:
+            logger.warning(
+                "delete_session: lock timeout, not deleting key=%s", key
+            )
+            return False
+        if existed:
             self._invalidate_cache(key)
             self.invalidate_tab_id_cache()
-            return True
-        return False
+        # NB: we deliberately do NOT unlink the ``.lock`` sidecar here. The
+        # sidecar's *inode* is the cross-process mutex: ``_locked`` opens the
+        # path and ``flock``s the resulting fd. Reaping the file re-opens the
+        # exact inode race the lock exists to prevent — after this delete
+        # releases ``_locked``, a concurrent writer can recreate the session
+        # and acquire the surviving sidecar; unlinking it then lets a later
+        # acquirer create a *fresh* sidecar inode and lock that instead, so two
+        # processes hold "the lock" on different inodes and can clobber each
+        # other's writes (lost transcript update). A deleted session therefore
+        # leaves a bounded, zero-byte ``.lock`` trace on purpose; cross-process
+        # -safe reaping (under a separate directory-wide meta-lock that excludes
+        # all session-lock acquisition) is deferred as future work.
+        return existed
 
     def set_title(self, key: str, title: str) -> None:
         """Persist a title into the session's metadata line."""
@@ -932,12 +1728,17 @@ class ConversationLog:
     def update_metadata(self, key: str, fields: dict) -> None:
         """Merge *fields* into the session's metadata line and persist.
 
-        Serialized behind the per-file lock so a concurrent append or rewrite
-        of the same session file can't clobber this metadata edit (and vice
-        versa).
+        Serialized behind the cross-process lock so a concurrent append or
+        rewrite of the same session file — in this or any other process — can't
+        clobber this metadata edit (and vice versa).
         """
-        with self._file_lock(key):
+        with self._locked(key):
             self._update_metadata_locked(key, fields)
+        # A tab_id change re-links this session into (or out of) a chain, so the
+        # cached tab_id→[keys] index is now stale. Invalidate OUTSIDE the lock
+        # (it only touches in-process state) so the next chained read rebuilds.
+        if "tab_id" in fields:
+            self.invalidate_tab_id_cache()
 
     def _update_metadata_locked(self, key: str, fields: dict) -> None:
         """Merge *fields* into the session's metadata line and persist.
@@ -989,7 +1790,12 @@ class ConversationLog:
         try:
             try:
                 _os.write(fd, data)
-                _os.fsync(fd)
+                # Deliberately NO fsync here: this is a one-line metadata edit
+                # (title/agent/folder/tab_id/pin) held under the cross-process
+                # lock. os.replace() below is still crash-atomic (no torn file)
+                # without a flush; fsync would only add power-loss durability,
+                # which isn't worth blocking every other writer of this session
+                # for a disk flush. Metadata is cheaply re-derivable/re-editable.
             finally:
                 _os.close(fd)
             _os.replace(tmp, str(path))
@@ -1000,6 +1806,37 @@ class ConversationLog:
                 pass
             raise
         _restore_mtime(path, prev_mtime)
+        self._invalidate_cache(key)
+
+    def clear_closed(self, key: str) -> None:
+        """Remove the ``closed`` flag from a session's metadata line.
+
+        Serialized behind the cross-process ``_locked`` so a concurrent append /
+        rewrite / metadata edit — in this or any other process — can't clobber
+        this edit (and vice versa). ``update_metadata`` only merges keys, so a
+        dedicated remover is needed to drop ``closed`` when a session is resumed.
+        No-op when the file is absent, unparsable, not flagged, or its first line
+        isn't a metadata line. Housekeeping: the pre-write mtime is preserved so
+        resuming doesn't reorder ``list_sessions``.
+        """
+        path = self._path(key)
+        with self._locked(key):
+            if not path.exists():
+                return
+            prev_mtime = _safe_mtime(path)
+            lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+            if not lines:
+                return
+            try:
+                meta = json.loads(lines[0])
+            except json.JSONDecodeError:
+                return
+            if meta.get("_type") != "metadata" or "closed" not in meta:
+                return
+            meta.pop("closed", None)
+            lines[0] = json.dumps(meta) + "\n"
+            atomic_write(path, "".join(lines), fsync=False)
+            _restore_mtime(path, prev_mtime)
         self._invalidate_cache(key)
 
     def _read_messages(self, key: str) -> list[dict]:
@@ -1291,10 +2128,10 @@ class ConversationLog:
 
     def rewrite_session(self, key: str, messages: list[dict]) -> None:
         """Rewrite session JSONL with only the given messages."""
-        # Serialize the full rewrite against concurrent appends so a live
-        # session's writes aren't lost, and (via atomic_write below) so a crash
-        # can't truncate the transcript.
-        with self._file_lock(key):
+        # Serialize the full rewrite against concurrent appends — in this or
+        # any other process — so a live session's writes aren't lost, and (via
+        # atomic_write below) so a crash can't truncate the transcript.
+        with self._locked(key):
             self._rewrite_session_locked(key, messages)
 
     def _rewrite_session_locked(self, key: str, messages: list[dict]) -> None:
@@ -1333,6 +2170,11 @@ class ConversationLog:
             "last_consolidated": orig_meta.get("last_consolidated", 0),
             "compacted_at": datetime.now().isoformat(),
         }
+        # Carry the rotation generation forward so a compaction (which is NOT a
+        # rotation) doesn't reset it to 0 and spuriously trip the generation
+        # mismatch in mark_consolidated for an in-flight consolidation.
+        if orig_meta.get("rotation_generation"):
+            meta["rotation_generation"] = orig_meta["rotation_generation"]
         if orig_meta.get("memory_mode"):
             meta["memory_mode"] = orig_meta["memory_mode"]
         lines = [json.dumps(meta) + "\n"]
@@ -1343,7 +2185,19 @@ class ConversationLog:
         self._invalidate_cache(key)
 
     def _maybe_rotate(self, path: Path) -> None:
-        """Rotate session file if it exceeds size limit."""
+        """Rotate a session file that exceeds the byte limit.
+
+        Keeps the metadata line plus at most ``_SESSION_KEEP_LINES`` trailing
+        messages. When a file is oversized because of a handful of very large
+        messages — i.e. it has ``<= _SESSION_KEEP_LINES`` lines but still blows
+        the byte budget — it now drops the OLDEST messages until it fits instead
+        of returning early. Previously the ``len(lines) <= _SESSION_KEEP_LINES``
+        guard let such a file grow without bound (a session of a few multi-MB
+        messages would never rotate), defeating the size cap entirely.
+
+        Callers hold the per-session lock (this is invoked from ``append`` under
+        ``_locked``); it does not acquire the lock itself.
+        """
         try:
             if path.stat().st_size <= _SESSION_MAX_BYTES:
                 return
@@ -1353,27 +2207,52 @@ class ConversationLog:
         # append's mtime rather than re-stamping to "now" (see _restore_mtime).
         prev_mtime = _safe_mtime(path)
         lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-        if len(lines) <= _SESSION_KEEP_LINES:
-            return
-        # Keep metadata line + last N message lines
         meta_line = lines[0] if lines and '"_type"' in lines[0] else ""
-        kept = lines[-_SESSION_KEEP_LINES:]
-        dropped_start = 1 if meta_line else 0
-        # Edge case: if len(lines) <= _SESSION_KEEP_LINES + dropped_start, the slice
-        # is empty and _archive_lines returns None (noop). The guard above already
-        # returns when len(lines) <= _SESSION_KEEP_LINES, so this only fires when
-        # there are genuinely more lines than we keep.
+        msg_lines = lines[1:] if meta_line else lines[:]
+        if not msg_lines:
+            return
+        meta_bytes = len(meta_line.encode("utf-8"))
+
+        def _kept_bytes(n: int) -> int:
+            return meta_bytes + sum(len(ln.encode("utf-8")) for ln in msg_lines[-n:])
+
+        # Start from the normal line cap, then shrink further while the retained
+        # tail still exceeds the byte budget — this is what lets a file with
+        # <= _SESSION_KEEP_LINES lines still rotate.
+        keep_count = min(_SESSION_KEEP_LINES, len(msg_lines))
+        while keep_count > 1 and _kept_bytes(keep_count) > _SESSION_MAX_BYTES:
+            keep_count -= 1
+        if keep_count >= len(msg_lines):
+            # Keeping every message would drop nothing — the file is oversized
+            # because of a single message larger than the whole budget, which we
+            # can't split. Leave it rather than pointlessly rewriting.
+            return
+
+        kept = msg_lines[-keep_count:]
+        dropped = msg_lines[:-keep_count]
         try:
-            _archive_lines(path.stem, lines[dropped_start:-_SESSION_KEEP_LINES], reason="rotate", base=self._dir)
+            _archive_lines(path.stem, dropped, reason="rotate", base=self._dir)
         except Exception:
             logger.warning("Failed to archive rotated lines for %s", path.stem, exc_info=True)
 
-        # Reset last_consolidated since offsets are now invalid
+        # Reset last_consolidated since offsets are now invalid, and bump the
+        # rotation generation counter. Resetting the offset to 0 only protects
+        # the case where the file shrank BELOW a stale consolidation snapshot;
+        # a rotation that retains >= the snapshot offset leaves ``offset <=
+        # msg_count`` true while every surviving index has shifted by the number
+        # of dropped lines, so a stale offset written by a concurrent
+        # consolidator would silently mark never-consolidated retained messages
+        # as done. The monotonically-increasing generation lets
+        # ``mark_consolidated`` detect ANY rotation between snapshot and write,
+        # regardless of retained count (absent field == 0 for legacy files).
         if meta_line:
             try:
                 meta = json.loads(meta_line)
                 meta["last_consolidated"] = 0
                 meta["rotated_at"] = datetime.now().isoformat()
+                meta["rotation_generation"] = (
+                    int(meta.get("rotation_generation", 0) or 0) + 1
+                )
                 meta_line = json.dumps(meta) + "\n"
             except json.JSONDecodeError:
                 pass
@@ -1384,7 +2263,12 @@ class ConversationLog:
         # Invalidate cache — offsets changed
         safe = path.stem
         self._invalidate_cache(safe)
-        logger.info("Rotated session file %s (%d → %d lines)", path.name, len(lines), len(kept))
+        logger.info(
+            "Rotated session file %s (%d → %d lines)",
+            path.name,
+            len(lines),
+            len(kept) + (1 if meta_line else 0),
+        )
 
 
 # ── Module-level helpers for auto skill eligibility ──
@@ -1624,7 +2508,23 @@ class HistoryConsolidator:
     async def _consolidate(self, key: str, include_history: bool = True) -> None:
         """Run LLM consolidation for a session."""
         try:
-            unconsolidated, total = self._log.get_unconsolidated(key)
+            # Atomically snapshot the unconsolidated tail, the total message
+            # count (the absolute offset handed to mark_consolidated below), and
+            # the rotation generation under ONE lock hold. Reading them as
+            # separate calls let an append trigger a rotation between them,
+            # pairing a pre-rotation offset with a post-rotation generation —
+            # mark_consolidated would then see matching generations and apply
+            # the stale offset (retained-count fallback misses it too), silently
+            # dropping messages from extraction. Offloaded to a worker thread:
+            # _consolidate runs on the gateway event loop and _locked/file IO is
+            # blocking (same rationale as the mark_consolidated offload below).
+            (
+                unconsolidated,
+                total,
+                generation_at_snapshot,
+            ) = await asyncio.to_thread(
+                self._log.snapshot_for_consolidation, key
+            )
             if not unconsolidated:
                 return
 
@@ -1836,7 +2736,12 @@ class HistoryConsolidator:
             # thread — otherwise a slow filesystem freezes the loop (heartbeats,
             # Slack, dashboard). Same rationale as the offloads above.
             if include_history:
-                await asyncio.to_thread(self._log.mark_consolidated, key, total)
+                await asyncio.to_thread(
+                    self._log.mark_consolidated,
+                    key,
+                    total,
+                    generation_at_snapshot,
+                )
 
         except Exception:
             logger.exception("Consolidation failed for %s", key)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4197,7 +4197,25 @@ class GatewayOrchestrator:
         if self.dashboard_state:
             from kiro_crew.dashboard.chat import save_all_slots_to_history
 
-            save_all_slots_to_history(self.dashboard_state)
+            # save_all_slots_to_history does synchronous per-slot file I/O that
+            # takes the per-session cross-process lock; on the event loop a
+            # contended session would raise HistoryLockTimeout (and a wedged
+            # disk would block the loop). Offload to the bounded
+            # subprocess_executor with a deadline so a slot's final save is
+            # attempted off-loop and cannot stall the shutdown path.
+            try:
+                await asyncio.wait_for(
+                    asyncio.get_running_loop().run_in_executor(
+                        subprocess_executor(),
+                        save_all_slots_to_history,
+                        self.dashboard_state,
+                    ),
+                    timeout=5.0,
+                )
+            except Exception:
+                logger.debug(
+                    "Dashboard slot save before shutdown failed", exc_info=True
+                )
             self.dashboard_state.file_indexes.stop_all()
 
         # Cancel in-flight handler tasks
@@ -4481,7 +4499,24 @@ class GatewayOrchestrator:
                 self.dashboard_state.push_update_progress("restarting", "Restarting server…")
                 from kiro_crew.dashboard.chat import save_all_slots_to_history
 
-                save_all_slots_to_history(self.dashboard_state)
+                # Offload the synchronous per-slot save (per-session lock + disk
+                # I/O) to the bounded subprocess_executor with a deadline so a
+                # contended/wedged session can't stall the auto-update restart
+                # (mirrors the shutdown save above).
+                try:
+                    await asyncio.wait_for(
+                        asyncio.get_running_loop().run_in_executor(
+                            subprocess_executor(),
+                            save_all_slots_to_history,
+                            self.dashboard_state,
+                        ),
+                        timeout=5.0,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Dashboard slot save before auto-update restart failed",
+                        exc_info=True,
+                    )
             if self.sessions:
                 await self.sessions.close_all()
             # Use -m kiro_crew rather than sys.argv[0] so the restart resolves

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -1745,7 +1745,9 @@ async def _handle_slash_command(
             _thread_agents.pop(session_key, None)
             if conversation_log:
                 try:
-                    conversation_log.update_metadata(session_key, {"agent": ""})
+                    await asyncio.to_thread(
+                        conversation_log.update_metadata, session_key, {"agent": ""}
+                    )
                 except Exception:
                     logger.debug("Failed to clear agent in conversation log", exc_info=True)
             sel().log_tool_invocation(
@@ -1770,7 +1772,9 @@ async def _handle_slash_command(
         _thread_agents[session_key] = resolved
         if conversation_log:
             try:
-                conversation_log.update_metadata(session_key, {"agent": resolved})
+                await asyncio.to_thread(
+                    conversation_log.update_metadata, session_key, {"agent": resolved}
+                )
             except Exception:
                 logger.debug("Failed to persist agent to conversation log", exc_info=True)
         sel().log_tool_invocation(
@@ -1808,7 +1812,9 @@ async def _handle_slash_command(
             _thread_projects.pop(session_key, None)
             if conversation_log:
                 try:
-                    conversation_log.update_metadata(session_key, {"project": ""})
+                    await asyncio.to_thread(
+                        conversation_log.update_metadata, session_key, {"project": ""}
+                    )
                 except Exception:
                     logger.debug("Failed to clear project in conversation log", exc_info=True)
             sel().log_tool_invocation(
@@ -1850,7 +1856,9 @@ async def _handle_slash_command(
         _thread_projects[session_key] = resolved
         if conversation_log:
             try:
-                conversation_log.update_metadata(session_key, {"project": resolved})
+                await asyncio.to_thread(
+                    conversation_log.update_metadata, session_key, {"project": resolved}
+                )
             except Exception:
                 logger.debug("Failed to persist project to conversation log", exc_info=True)
         sel().log_tool_invocation(
@@ -1984,7 +1992,9 @@ async def _handle_slash_command(
             _mark_titled(session_key, "manual")
             if conversation_log and not _is_slack_restricted(session_key):
                 try:
-                    conversation_log.set_title(session_key, title_text[:80])
+                    await asyncio.to_thread(
+                        conversation_log.set_title, session_key, title_text[:80]
+                    )
                 except Exception:
                     logger.debug(
                         "Failed to set conversation log title for %s", session_key, exc_info=True
@@ -3846,7 +3856,9 @@ async def _maybe_auto_title_slack(
         await slack.set_thread_title(channel, session_key, title)
         if conversation_log:
             try:
-                conversation_log.set_title(session_key, title)
+                await asyncio.to_thread(
+                    conversation_log.set_title, session_key, title
+                )
             except Exception:
                 logger.debug(
                     "Failed to set conversation log title for %s", session_key, exc_info=True

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -1283,7 +1283,7 @@ async def _route_action_to_session(
 
 async def _import_thread_to_slot(slack: Any, ds: Any, channel: str, thread_ts: str) -> Any:
     """Fetch a Slack thread, redact messages, and import into a new dashboard slot."""
-    from kiro_crew.dashboard.chat import _save_slot_to_history
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 
     # Idempotency: return existing slot if already linked
     existing = ds.get_linked_slot(thread_ts)
@@ -1312,7 +1312,7 @@ async def _import_thread_to_slot(slack: Any, ds: Any, channel: str, thread_ts: s
         text_content, _ = redact_credentials(text_content)
         slot.append(role, text_content, f"msg msg-{'a' if is_bot else 'u'}")
     ds.link_slack(slot.key, thread_ts, channel)
-    _save_slot_to_history(ds, slot)
+    await save_slot_off_loop(ds, slot)
     ds.push_slots_update()
     return slot
 

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1188,14 +1188,46 @@ class TaskRunner:
     def _log_task(self, history_key: str, run: Project, task: Task) -> None:
         if not self._conversation_log:
             return
+        spec_name = Path(run.spec_path).name if run.spec_path else run.task_id
+        user_msg = f"[Task: {spec_name}] Task {task.index}: {task.title}"
+        result_summary = task.result[:2000] if task.result else "Task completed."
+        log = self._conversation_log
+
+        def _do() -> None:
+            # Both appends run on ONE worker thread so they persist IN ORDER —
+            # two independent append_off_loop dispatches could interleave on the
+            # default executor and reorder the transcript — and take the patient
+            # off-loop cross-process lock acquire path.
+            log.append(history_key, "user", user_msg)
+            log.append(history_key, "assistant", result_summary)
+
+        # _log_task is invoked from async task_executor code running ON the
+        # event loop. A direct append there hits _locked's fail-fast on-loop
+        # path (raises HistoryLockTimeout under benign contention, silently
+        # swallowed) and risks a synchronous disk write on the loop. Offload to
+        # a worker thread so it takes the blocking off-loop acquire and can
+        # neither stall the loop nor drop the write under contention.
         try:
-            spec_name = Path(run.spec_path).name if run.spec_path else run.task_id
-            user_msg = f"[Task: {spec_name}] Task {task.index}: {task.title}"
-            self._conversation_log.append(history_key, "user", user_msg)
-            result_summary = task.result[:2000] if task.result else "Task completed."
-            self._conversation_log.append(history_key, "assistant", result_summary)
-        except Exception:
-            logger.debug("Failed to log task to conversation history", exc_info=True)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is None:
+            try:
+                _do()
+            except Exception:
+                logger.debug(
+                    "Failed to log task to conversation history", exc_info=True
+                )
+            return
+
+        def _report(fut: "asyncio.Future[None]") -> None:
+            exc = fut.exception()
+            if exc is not None:
+                logger.debug(
+                    "Failed to log task to conversation history: %r", exc
+                )
+
+        loop.run_in_executor(None, _do).add_done_callback(_report)
 
     # ── Learn from Failures ──
 

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -372,7 +372,9 @@ class TelegramDispatcher:
             # fall through to the except and re-record the successful turn). ──
             self.sessions.record_success(session_key)
             try:
-                self._persist_turn(session_key, text, accumulated, is_new)
+                await asyncio.to_thread(
+                    self._persist_turn, session_key, text, accumulated, is_new
+                )
             except Exception:
                 logger.warning(
                     "Telegram: persist_turn failed session=%s", session_key, exc_info=True

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -23,6 +23,7 @@ Dependency direction is ``webex -> messaging`` (allowed).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -203,7 +204,9 @@ class WebexDispatcher:
             # fall through to the except and re-record the successful turn). ──
             self.sessions.record_success(session_key)
             try:
-                self._persist_turn(session_key, text, accumulated, is_new)
+                await asyncio.to_thread(
+                    self._persist_turn, session_key, text, accumulated, is_new
+                )
             except Exception:
                 logger.warning("Webex: persist_turn failed session=%s", session_key, exc_info=True)
             try:

--- a/src/kiro_crew/wechat/transport_dispatch.py
+++ b/src/kiro_crew/wechat/transport_dispatch.py
@@ -23,6 +23,7 @@ Dependency direction is ``wechat -> messaging`` (allowed).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -218,7 +219,9 @@ class WeComDispatcher:
             # fall through to the except and re-record the successful turn). ──
             self.sessions.record_success(session_key)
             try:
-                self._persist_turn(session_key, text, accumulated, is_new)
+                await asyncio.to_thread(
+                    self._persist_turn, session_key, text, accumulated, is_new
+                )
             except Exception:
                 logger.warning(
                     "WeCom: persist_turn failed session=%s", session_key, exc_info=True

--- a/test/test_chat_slot_mode.py
+++ b/test/test_chat_slot_mode.py
@@ -34,7 +34,7 @@ class TestChatSlotMode:
         slot = _ChatSlot("test")
         assert slot.mode == ""
         state = _mock_state(slot)
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/test/mode",
@@ -51,7 +51,7 @@ class TestChatSlotMode:
         slot = _ChatSlot("test")
         slot.mode = "orchestrator"
         state = _mock_state(slot)
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/test/mode",
@@ -66,7 +66,7 @@ class TestChatSlotMode:
     async def test_invalid_mode_rejected(self):
         slot = _ChatSlot("test")
         state = _mock_state(slot)
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/test/mode",
@@ -80,7 +80,7 @@ class TestChatSlotMode:
     @pytest.mark.asyncio
     async def test_slot_not_found(self):
         state = _mock_state()  # no slot
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/nonexistent/mode",
@@ -93,7 +93,7 @@ class TestChatSlotMode:
         slot = _ChatSlot("test")
         slot.mode = "orchestrator"
         state = _mock_state(slot)
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/test/mode",
@@ -113,7 +113,7 @@ class TestChatSlotMode:
         assert slot.running
         state = _mock_state(slot)
         try:
-            with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
                 async with TestClient(TestServer(_make_app(state))) as client:
                     resp = await client.patch(
                         "/api/chat/slots/test/mode",
@@ -134,7 +134,7 @@ class TestChatSlotMode:
         slot.mode = "orchestrator"
         slot._auto_run = True
         state = _mock_state(slot)
-        with patch("kiro_crew.dashboard.chat_folders._save_slot_to_history"):
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop"):
             async with TestClient(TestServer(_make_app(state))) as client:
                 resp = await client.patch(
                     "/api/chat/slots/test/mode",

--- a/test/test_chat_tags.py
+++ b/test/test_chat_tags.py
@@ -252,7 +252,7 @@ class TestTagVocabulary:
             col = await (await client.post(
                 "/api/chat/tag-columns", json={"tag_ids": [tag["id"], other["id"]], "mode": "any"}
             )).json()
-            with patch("kiro_crew.dashboard.chat_tags._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.delete(f"/api/chat/tags/{tag['id']}")
             assert resp.status == 200
             assert tag["id"] not in {t["id"] for t in state._tags}
@@ -285,7 +285,7 @@ class TestSlotTags:
             t2 = await (await client.post("/api/chat/tags", json={"name": "T2"})).json()
             slot = _ChatSlot("s1")
             state._slots["s1"] = slot
-            with patch("kiro_crew.dashboard.chat_tags._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.put(
                     "/api/chat/slots/s1/tags",
                     json={"tags": [t1["id"], "ghost", t1["id"], t2["id"], 7]},
@@ -512,7 +512,7 @@ class TestDrop:
             col = await (await client.post(
                 "/api/chat/tag-columns", json={"tag_ids": [done["id"]], "mode": "any"}
             )).json()
-            with patch("kiro_crew.dashboard.chat_tags._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
             assert data["ok"] is True
@@ -676,7 +676,7 @@ class TestDropOnMixedColumn:
                 "/api/chat/tag-columns",
                 json={"tag_ids": [done["id"], spike["id"]], "mode": "all"},
             )).json()
-            with patch("kiro_crew.dashboard.chat_tags._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
             assert data["ok"] is True

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -1381,10 +1381,16 @@ class TestInMemoryAuthority:
             log.append("dashboard:s4", "user", f"old msg {i}")
         # Restore truncated to the last 3 in memory; _disk_window_len mirrors
         # what restore sets (those 3 are already the on-disk window tail).
+        # Mirror PRODUCTION restore, which re-appends each window message WITH its
+        # persisted ``ts`` (chat_persistence restore uses
+        # ``slot.append(..., ts=m.get("ts", ""))``). Preserving the ts is what lets
+        # a steady save recognise the on-disk window-region copies as its OWN (a
+        # ts-match) rather than as fresh-ts duplicates — so neither duplicating nor
+        # archiving them.
         slot = state.get_or_create_slot("s4")
-        slot.append("user", "old msg 5")
-        slot.append("user", "old msg 6")
-        slot.append("user", "old msg 7")
+        disk_tail = log.read_messages("dashboard:s4")[5:]
+        for m in disk_tail:
+            slot.append("user", m["content"], ts=m.get("ts", ""))
         slot.drain()
         slot._resumed_count = len(slot.messages)
         slot._disk_window_len = len(slot.messages)
@@ -5382,7 +5388,7 @@ class TestSlotTaskNoneGuard:
         slot.task = asyncio.get_running_loop().create_future()
 
         async with TestClient(TestServer(_make_app(state))) as client:
-            with patch("kiro_crew.dashboard.chat_handlers._save_slot_to_history"):
+            with patch("kiro_crew.dashboard.chat_handlers.save_slot_off_loop"):
                 resp = await client.delete("/api/chat/slots/s1")
             assert resp.status == 200
             assert slot.task.cancelled()
@@ -5544,7 +5550,7 @@ class TestBulkCleanup:
         slot.drain()
 
         with patch(
-            "kiro_crew.dashboard.chat_handlers._save_slot_to_history",
+            "kiro_crew.dashboard.chat_handlers.save_slot_off_loop",
             side_effect=OSError("disk full"),
         ):
             async with TestClient(TestServer(_make_app(state))) as client:
@@ -7189,6 +7195,42 @@ class TestForkSlot:
         visible = [m for m in new_slot.messages if m["role"] in ("user", "assistant")]
         assert len(visible) == 2
         assert visible[-1]["content"] == "reply1"
+
+    @pytest.mark.asyncio
+    async def test_fork_aborts_and_keeps_dirty_when_source_save_fails(self, tmp_path):
+        # Regression (double-persistence data-loss): the fork persists the dirty
+        # source slot before reading it as the source of truth, then clears
+        # `_dirty` (which also disables the periodic retry). If that save is
+        # best-effort it can silently drop the write under a lock timeout / I/O
+        # error, yet `_dirty` would still be cleared — permanently losing the
+        # unwritten source messages on the next restart. The fork must persist
+        # with best_effort=False and, on failure, abort (503) WITHOUT clearing
+        # `_dirty`, so the periodic flush still retries.
+        from unittest.mock import AsyncMock, patch
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.append("user", "unsaved-source-msg", "msg msg-u")
+        slot.append("assistant", "unsaved-reply", "msg msg-a")
+        slot.drain()
+        # Force the save branch: pretend nothing has reached disk yet.
+        slot._dirty = True
+        slot._resumed_count = 0
+
+        failing_save = AsyncMock(side_effect=RuntimeError("lock timeout"))
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with patch(
+                "kiro_crew.dashboard.chat_fork.save_slot_off_loop", failing_save
+            ):
+                resp = await client.post("/api/chat/slots/src/fork", json={})
+                assert resp.status == 503
+
+        # best_effort must be explicitly False so the failure propagated.
+        assert failing_save.await_count == 1
+        assert failing_save.await_args.kwargs.get("best_effort") is False
+        # Slot stays dirty → the periodic flush will retry; messages not lost.
+        assert slot._dirty is True
 
     @pytest.mark.asyncio
     async def test_fork_preserves_meta(self, tmp_path):
@@ -9023,20 +9065,33 @@ class TestEmptyResponseRetry:
             return orig(self_slot, *a, **kw)
 
         with patch.object(_ChatSlot, "queue_insert", spy), patch(
-            "kiro_crew.dashboard.chat_runner._save_slot_to_history"
+            "kiro_crew.dashboard.chat_runner.save_slot_off_loop"
         ) as mock_save, patch(
             "kiro_crew.dashboard.chat_runner._maybe_consolidate"
         ) as mock_consolidate, patch(
             "kiro_crew.dashboard.chat_runner._flush_file_changes"
-        ) as mock_flush:
+        ) as mock_flush, patch(
+            "kiro_crew.dashboard.chat_runner.asyncio.create_task"
+        ) as mock_create_task:
+            # Deterministically neutralize the detached queue-drain task the
+            # finally block spawns after the empty re-queue. Under build-fleet
+            # load the loop can schedule that task (and its own cascading
+            # re-drains) before the assertions run, each calling the patched
+            # _flush_file_changes again (observed flaking as `assert 6 == 1`).
+            # Closing the coroutine and returning a completed future keeps this
+            # turn's behavior (re-queue + single finally flush) while making the
+            # spawn a no-op — no await path, no cascade, no timing dependence.
+            def _no_schedule(coro, *a, **kw):
+                try:
+                    coro.close()
+                except (AttributeError, RuntimeError):
+                    pass
+                fut: asyncio.Future = asyncio.get_event_loop().create_future()
+                fut.set_result(None)
+                return fut
+
+            mock_create_task.side_effect = _no_schedule
             await _run_chat(state, slot, "test message")
-            # The empty-response retry path re-queues the message, and _run_chat's
-            # finally block spawns a detached asyncio task to drain the queue (a
-            # second "attempt 2" turn). Cancel it before asserting: no await has run
-            # since create_task, so the task body has not started, which makes this
-            # safe and deterministic. Under build-fleet load the detached turn would
-            # otherwise race these module-scoped patches (its finally calls the
-            # patched _flush_file_changes a second time), flaking as assert 2 == 1.
             for _bg_task in list(state._background_tasks):
                 _bg_task.cancel()
 

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -124,29 +124,37 @@ class TestPersistsResultToConversationLog:
         state = _make_state()
         job = _make_job(job_id="job1", name="my-cron")
         inject_cron_result_to_dashboard(state, job, "the result")
-        # read_messages probed for dedup, then append called with linked key.
-        assert state.conversation_log.append.call_count == 1
-        args, kwargs = state.conversation_log.append.call_args
+        # Persistence now goes through the atomic append_if_absent (the dup
+        # check runs UNDER the session lock, not as a separate unlocked probe).
+        assert state.conversation_log.append_if_absent.call_count == 1
+        args, kwargs = state.conversation_log.append_if_absent.call_args
         assert args[0] == "cron:job1"
         assert args[1] == "assistant"
         assert "the result" in args[2]
         assert args[2].startswith("# Cron Job Result: my-cron")
+        # The old unlocked append() persist path is gone (dup check is now
+        # atomic inside append_if_absent). NB: read_messages is still called
+        # once to hydrate the fresh slot — that is not the persistence probe.
+        state.conversation_log.append.assert_not_called()
 
-    def test_does_not_persist_when_already_in_log(self):
+    def test_delegates_log_dedup_to_append_if_absent(self):
+        # The log-level duplicate check is now performed ATOMICALLY inside
+        # append_if_absent (under the per-session lock), not as a separate
+        # unlocked read_messages probe at the inject layer. The inject path must
+        # delegate to append_if_absent and no longer do its own log-persist.
+        # (append_if_absent's own skip-on-duplicate behavior is covered by
+        # test_history_locking_remediation::TestAppendIfAbsent.)
         state = _make_state()
         job = _make_job(job_id="job2", name="my-cron")
-        context = "# Cron Job Result: my-cron\n\nthe result"
-        # Conversation log already has this exact message.
-        state.conversation_log.read_messages.return_value = [
-            {"role": "assistant", "content": context}
-        ]
         inject_cron_result_to_dashboard(state, job, "the result")
+        state.conversation_log.append_if_absent.assert_called_once()
         state.conversation_log.append.assert_not_called()
 
     def test_empty_result_does_not_persist(self):
         state = _make_state()
         job = _make_job(job_id="job3")
         inject_cron_result_to_dashboard(state, job, "")
+        state.conversation_log.append_if_absent.assert_not_called()
         state.conversation_log.append.assert_not_called()
 
     def test_no_conversation_log_does_not_crash(self):

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -1365,7 +1365,9 @@ class TestConsolidationDoesNotBlockLoop:
         write_thread_id: dict[str, int] = {}
 
         log = MagicMock()
-        log.get_unconsolidated.return_value = ([{"role": "user", "content": "hi"}], 1)
+        log.snapshot_for_consolidation.return_value = (
+            [{"role": "user", "content": "hi"}], 1, 0
+        )
         log.get_metadata.return_value = {}
 
         memory = MagicMock()
@@ -1410,7 +1412,9 @@ class TestConsolidationDoesNotBlockLoop:
         save_thread_id: dict[str, int] = {}
 
         log = MagicMock()
-        log.get_unconsolidated.return_value = ([{"role": "user", "content": "hi"}], 1)
+        log.snapshot_for_consolidation.return_value = (
+            [{"role": "user", "content": "hi"}], 1, 0
+        )
         log.get_metadata.return_value = {}
 
         memory = MagicMock()

--- a/test/test_history_atomic_rewrite.py
+++ b/test/test_history_atomic_rewrite.py
@@ -62,7 +62,9 @@ class TestMarkConsolidatedOffloaded:
         mark_thread_id: dict[str, int] = {}
 
         log = MagicMock()
-        log.get_unconsolidated.return_value = ([{"role": "user", "content": "hi"}], 1)
+        log.snapshot_for_consolidation.return_value = (
+            [{"role": "user", "content": "hi"}], 1, 0
+        )
         log.get_metadata.return_value = {}
         log.mark_consolidated.side_effect = lambda *a, **k: mark_thread_id.__setitem__(
             "id", threading.get_ident()

--- a/test/test_history_locking_remediation.py
+++ b/test/test_history_locking_remediation.py
@@ -1,0 +1,1708 @@
+"""Regression tests for the Cluster-B ``history.py`` audit remediation.
+
+Each test class reproduces one audited failure scenario:
+
+1. Cross-process advisory ``flock`` covering append / read-rewrite so a writer
+   in ANOTHER process (subagent, cron, CLI) can't silently lose updates.
+2. ``_tab_id_index`` invalidated on append/metadata + removal of the permanent
+   ``[]`` sentinel that hid sessions created after the first chained read.
+3. Consolidation offset recomputed (clamped) when a rotation fired during the
+   LLM await, so post-rotation messages aren't silently skipped.
+4. Oversized files rotate even when they have ``<= _SESSION_KEEP_LINES`` lines
+   (a few huge messages), instead of growing without bound.
+5. ``delete_session`` uses ``unlink(missing_ok=True)`` and tolerates a
+   concurrent removal instead of raising ``FileNotFoundError``.
+6. One-line metadata rewrites no longer ``fsync`` while holding the lock,
+   shrinking the critical section every other writer contends on.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.history import (
+    _SESSION_KEEP_LINES,
+    _SESSION_MAX_BYTES,
+    ConversationLog,
+)
+
+
+# ── Bug 1: cross-process advisory flock ──────────────────────────────────────
+class TestCrossProcessLock:
+    def test_locked_holds_exclusive_flock_cross_fd(self, tmp_path: Path) -> None:
+        """While ``_locked`` is held, a SEPARATE fd on the sidecar lock file
+        (standing in for another process) must NOT be able to grab the exclusive
+        advisory lock. POSIX flock treats independent open file descriptions as
+        competitors even within one process, so this faithfully models the
+        cross-process contention the in-process ``threading.RLock`` cannot cover.
+        """
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        lock_path = log._lock_path("k")
+
+        with log._locked("k"):
+            fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                got = platform_compat.try_acquire_lock(fd, exclusive=True)
+                if got:
+                    platform_compat.release_lock(fd)
+                assert not got, "flock was not held across file descriptions"
+            finally:
+                os.close(fd)
+
+        # Released on exit — now acquirable.
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            assert platform_compat.try_acquire_lock(fd, exclusive=True)
+            platform_compat.release_lock(fd)
+        finally:
+            os.close(fd)
+
+    def test_bounded_acquire_raises_and_never_writes_unlocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When another process holds the sidecar flock, a mutation must NOT
+        block forever AND must NOT proceed with an unlocked write (a concurrent
+        rewrite in the holder could clobber it → silent transcript loss).
+        Instead it polls up to a bounded deadline, then raises
+        ``HistoryLockTimeout`` and leaves the file untouched.
+        """
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+        import kiro_crew.history as history_mod
+
+        monkeypatch.setattr(history_mod, "_FLOCK_ACQUIRE_TIMEOUT_S", 0.2)
+        monkeypatch.setattr(history_mod, "_FLOCK_POLL_INTERVAL_S", 0.02)
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        lock_path = log._lock_path("k")
+
+        # Simulate another process holding the exclusive advisory lock.
+        holder = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            assert platform_compat.try_acquire_lock(holder, exclusive=True)
+            start = time.monotonic()
+            with pytest.raises(history_mod.HistoryLockTimeout):
+                log.append("k", "user", "under-contention")
+            elapsed = time.monotonic() - start
+            # Bounded (not unbounded), and it did fail rather than spin forever.
+            assert elapsed < 2.0, f"append blocked {elapsed:.2f}s despite bounded acquire"
+        finally:
+            platform_compat.release_lock(holder)
+            os.close(holder)
+
+        # CRITICAL: the contended write must NOT have landed unlocked.
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m["content"] for m in fresh._read_messages("k")]
+        assert "under-contention" not in contents
+        assert "seed" in contents
+
+        # After the holder releases, a fresh mutation acquires normally.
+        log.append("k", "user", "after-release")
+        contents2 = [m["content"] for m in ConversationLog(base_dir=tmp_path)._read_messages("k")]
+        assert "after-release" in contents2
+
+    def test_on_loop_acquire_fails_fast_without_blocking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On a running asyncio loop the acquire must make exactly ONE
+        non-blocking attempt and fail fast on contention — never sleep/poll,
+        which would stall the sole event loop."""
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+        import asyncio as _asyncio
+
+        import kiro_crew.history as history_mod
+
+        # A long off-loop budget proves the loop path does NOT fall back to it,
+        # and any _time.sleep on the loop path is a hard failure.
+        monkeypatch.setattr(history_mod, "_FLOCK_ACQUIRE_TIMEOUT_S", 30.0)
+
+        def _no_sleep_on_loop(_secs: float) -> None:
+            raise AssertionError(
+                "on-loop acquire must never sleep/poll (blocks the event loop)"
+            )
+
+        monkeypatch.setattr(history_mod._time, "sleep", _no_sleep_on_loop)
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        holder = os.open(str(log._lock_path("k")), os.O_RDWR | os.O_CREAT, 0o600)
+
+        async def _run() -> float:
+            assert platform_compat.try_acquire_lock(holder, exclusive=True)
+            start = time.monotonic()
+            # This test exercises the low-level on-loop acquire primitive
+            # directly, so it deliberately bypasses the strict off-loop
+            # discipline guard (which would otherwise raise OnLoopPersistError
+            # before the acquire ran).
+            with history_mod.allow_on_loop_persist():
+                with pytest.raises(history_mod.HistoryLockTimeout):
+                    # append runs synchronously on THIS loop thread.
+                    log.append("k", "user", "under-contention")
+            return time.monotonic() - start
+
+        try:
+            elapsed = _asyncio.run(_run())
+            # Single non-blocking attempt: returns effectively immediately and
+            # never used the long off-loop budget.
+            assert elapsed < 1.0, f"on-loop acquire blocked ({elapsed:.2f}s)"
+        finally:
+            platform_compat.release_lock(holder)
+            os.close(holder)
+
+        # CRITICAL: the contended write must NOT have landed unlocked.
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m["content"] for m in fresh._read_messages("k")]
+        assert "under-contention" not in contents
+        assert "seed" in contents
+
+    def test_reentrant_same_thread_same_key(self, tmp_path: Path) -> None:
+        """Nested ``_locked`` for the same key on the same thread must not
+        self-deadlock (it reuses the already-held fd)."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        with log._locked("k"):
+            with log._locked("k"):  # would hang forever without reentrancy
+                log.mark_consolidated("k", 1)
+        assert log.get_metadata("k")["last_consolidated"] == 1
+
+    def test_no_lost_update_across_processes(self, tmp_path: Path) -> None:
+        """A separate PROCESS hammering ``mark_consolidated`` (read-all +
+        rewrite) against a live appender must not drop any appended message.
+
+        Without the cross-process flock, the consolidator process reads N lines,
+        the appender process appends line N+1, then the consolidator's
+        ``os.replace`` writes back its stale N lines — silently losing N+1. The
+        in-process ``threading.RLock`` cannot prevent this because the two
+        actors live in different interpreters.
+        """
+        if not platform_compat.IS_POSIX:
+            pytest.skip("cross-process flock semantics are POSIX-specific")
+        ctx = multiprocessing.get_context("fork")
+        _require_multiprocessing(ctx)
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+
+        n = 200
+        appender = ctx.Process(target=_mp_appender, args=(str(tmp_path), "k", n))
+        consolidator = ctx.Process(
+            target=_mp_consolidator, args=(str(tmp_path), "k", 400)
+        )
+        consolidator.start()
+        appender.start()
+        appender.join(timeout=60)
+        consolidator.join(timeout=60)
+        assert appender.exitcode == 0
+        assert consolidator.exitcode == 0
+
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = {m["content"] for m in fresh._read_messages("k")}
+        missing = [f"a-{i}" for i in range(n) if f"a-{i}" not in contents]
+        assert not missing, f"cross-process rewrite lost {len(missing)} appends"
+
+
+# ── On-loop offload discipline: structurally enforced, not convention-only ────
+class TestOnLoopPersistDiscipline:
+    """The PR routes ~15 on-loop callers off the loop (append_off_loop /
+    save_slot_off_loop / asyncio.to_thread) so ``_locked`` runs off-loop and
+    takes the patient acquire path. Nothing structurally stopped a FUTURE
+    on-loop call-site from calling a raw mutator, which works in every
+    uncontended test yet silently drops the write under real contention
+    (HistoryLockTimeout swallowed by best-effort callers). ``_locked`` now guards
+    that: strict (pytest / dev-mode / env) RAISES ``OnLoopPersistError`` on ANY
+    on-loop entry so the drift fails the suite; production logs it loudly and
+    proceeds via the non-blocking safety-net acquire.
+    """
+
+    def test_raw_on_loop_mutator_raises_in_strict_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With strict enforcement on (``KIROCREW_STRICT_ON_LOOP_PERSIST=1``) a
+        raw mutator call ON the event loop must raise ``OnLoopPersistError`` —
+        the un-offloaded call-site fails the test instead of losing data in
+        production."""
+        import asyncio
+
+        import kiro_crew.history as history_mod
+
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        log = ConversationLog(base_dir=tmp_path)
+
+        async def _run() -> None:
+            # No offload: append enters _locked directly on this loop thread.
+            with pytest.raises(history_mod.OnLoopPersistError):
+                log.append("k", "user", "un-offloaded")
+
+        asyncio.run(_run())
+        # And the guard tripped BEFORE any write landed.
+        fresh = ConversationLog(base_dir=tmp_path)
+        assert "un-offloaded" not in [
+            m["content"] for m in fresh._read_messages("k")
+        ]
+
+    def test_metadata_mutator_on_loop_also_guarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard covers every ``_locked`` mutator, not just ``append`` —
+        e.g. ``update_metadata`` / ``set_title`` / ``delete_session``."""
+        import asyncio
+
+        import kiro_crew.history as history_mod
+
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")  # off-loop seed: allowed
+
+        async def _run() -> None:
+            with pytest.raises(history_mod.OnLoopPersistError):
+                log.set_title("k", "on-loop title")
+
+        asyncio.run(_run())
+
+    def test_dev_mode_also_enables_strict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KIROCREW_DEV_MODE`` (developer gateway) also turns the guard strict,
+        and an explicit falsy ``KIROCREW_STRICT_ON_LOOP_PERSIST`` overrides it so
+        the production-fallback path stays testable even under dev-mode."""
+        import asyncio
+
+        import kiro_crew.history as history_mod
+
+        monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_PERSIST", raising=False)
+        monkeypatch.setenv("KIROCREW_DEV_MODE", "1")
+        assert history_mod._on_loop_persist_strict() is True
+        # Explicit falsy override wins over dev-mode.
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        assert history_mod._on_loop_persist_strict() is False
+
+        log = ConversationLog(base_dir=tmp_path)
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "")
+        monkeypatch.setenv("KIROCREW_DEV_MODE", "1")
+
+        async def _run() -> None:
+            with pytest.raises(history_mod.OnLoopPersistError):
+                log.append("k", "user", "dev-on-loop")
+
+        asyncio.run(_run())
+
+    def test_allow_context_manager_suppresses_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``allow_on_loop_persist()`` is the sanctioned escape hatch for tests
+        exercising the low-level primitive: even in strict mode an on-loop
+        mutator inside it does NOT raise (it proceeds to the real acquire)."""
+        import asyncio
+
+        import kiro_crew.history as history_mod
+
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        log = ConversationLog(base_dir=tmp_path)
+
+        async def _run() -> None:
+            with history_mod.allow_on_loop_persist():
+                # Uncontended, so the single non-blocking acquire succeeds and
+                # the write lands — no OnLoopPersistError.
+                log.append("k", "user", "vetted-on-loop")
+
+        asyncio.run(_run())
+        fresh = ConversationLog(base_dir=tmp_path)
+        assert "vetted-on-loop" in [
+            m["content"] for m in fresh._read_messages("k")
+        ]
+
+    def test_offloaded_call_does_not_trip_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The blessed offload helpers dispatch to a worker thread, so ``_locked``
+        runs OFF the loop and the guard is a no-op — the write lands normally
+        even under strict enforcement."""
+        import asyncio
+
+        from kiro_crew.history import append_off_loop
+
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        log = ConversationLog(base_dir=tmp_path)
+
+        async def _run() -> None:
+            append_off_loop(log, "k", "assistant", "offloaded-ok")
+            for _ in range(50):
+                if any(
+                    m.get("content") == "offloaded-ok"
+                    for m in log.read_messages("k")
+                ):
+                    return
+                await asyncio.sleep(0.02)
+
+        asyncio.run(_run())
+        assert "offloaded-ok" in [m["content"] for m in log.read_messages("k")]
+
+    def test_off_loop_call_never_trips_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plain synchronous (off-loop) mutator — CLI / cron / subagent /
+        worker thread — must never be flagged, even under strict enforcement."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "off-loop-fine")  # no running loop
+        assert "off-loop-fine" in [
+            m["content"] for m in log.read_messages("k")
+        ]
+
+    def test_production_mode_warns_and_proceeds_not_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With strict enforcement explicitly OFF (production gateway: no
+        pytest/dev/env flag), an un-offloaded on-loop call must NOT raise —
+        it degrades to a loud (throttled) warning + the non-blocking safety-net
+        acquire, so shipping never introduces a new hard failure in the field."""
+        import asyncio
+        import logging
+
+        import kiro_crew.history as history_mod
+
+        # Force strict off (simulate a production gateway) and reset the warning
+        # throttle so the diagnostic is observable.
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        monkeypatch.setattr(history_mod, "_on_loop_warn_last", 0.0)
+        log = ConversationLog(base_dir=tmp_path)
+
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = _Capture()
+        history_mod.logger.addHandler(handler)
+
+        async def _run() -> None:
+            # Uncontended: the safety-net acquire succeeds, so this proceeds.
+            log.append("k", "user", "prod-on-loop")
+
+        try:
+            asyncio.run(_run())
+        finally:
+            history_mod.logger.removeHandler(handler)
+
+        # No raise, write landed, and the loud diagnostic fired.
+        fresh = ConversationLog(base_dir=tmp_path)
+        assert "prod-on-loop" in [
+            m["content"] for m in fresh._read_messages("k")
+        ]
+        assert any(
+            "ON the event loop" in r.getMessage() for r in records
+        ), "expected a loud on-loop diagnostic warning in production mode"
+
+    def test_e2e_harness_enables_strict_mode_ci_enforcement(self) -> None:
+        """CI-enforcement guard (arbiter BLOCK item 1): the on-loop persistence
+        discipline must be an ENFORCED invariant, not a dev-only convention.
+
+        Strict mode is deliberately OFF under bare unit pytest (the async harness
+        legitimately drives mutators on the loop as a convenience). To catch a
+        genuinely-new un-offloaded PRODUCTION call-site at PR time, the e2e gate
+        — which spawns a REAL gateway subprocess and drives real chat turns —
+        boots that gateway with ``KIROCREW_STRICT_ON_LOOP_PERSIST=1``, so any
+        raw on-loop ``_locked`` entry raises ``OnLoopPersistError`` and fails CI
+        instead of silently losing transcript data under production contention.
+
+        This test pins that wiring: ``setup.py``'s ``E2eTestCommand`` must export
+        the strict flag into the harness environment (``spawn_feature_gateway``
+        inherits ``os.environ``). If someone removes it, the enforcement silently
+        degrades back to a dev-only convention — so this fails deterministically
+        in the fast unit CI, independent of e2e coverage.
+        """
+        import ast
+        from pathlib import Path as _P
+
+        repo_root = _P(__file__).resolve().parents[1]
+        setup_src = (repo_root / "setup.py").read_text(encoding="utf-8")
+        tree = ast.parse(setup_src)
+
+        # Find E2eTestCommand.run and confirm it assigns
+        # env["KIROCREW_STRICT_ON_LOOP_PERSIST"] = "1" (a truthy string).
+        found = False
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Assign)):
+                continue
+            for tgt in node.targets:
+                if (
+                    isinstance(tgt, ast.Subscript)
+                    and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "env"
+                    and isinstance(tgt.slice, ast.Constant)
+                    and tgt.slice.value == "KIROCREW_STRICT_ON_LOOP_PERSIST"
+                    and isinstance(node.value, ast.Constant)
+                    and str(node.value.value).strip().lower() in {"1", "true", "yes", "on"}
+                ):
+                    found = True
+        assert found, (
+            "setup.py test_e2e must export KIROCREW_STRICT_ON_LOOP_PERSIST=1 into "
+            "the e2e gateway env — the on-loop persistence discipline is a "
+            "CI-enforced invariant, not a dev-only convention (arbiter item 1). "
+            "Do not remove this wiring without an equivalent CI enforcement."
+        )
+
+
+# ── Bug 2: tab_id index invalidation + no permanent [] sentinel ───────────────
+class TestTabIdIndexInvalidation:
+    def test_chain_picks_up_session_created_after_first_read(
+        self, tmp_path: Path
+    ) -> None:
+        """A session opened under an existing tab_id AFTER the chain was first
+        read must be linked in. Previously the append didn't invalidate the
+        cached index, so the second session's messages vanished from
+        ``recent_chained``.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("dashboard_chat-1-1", "user", "a1", tab_id="T")
+
+        # First chained read builds + caches the tab_id index (T -> [A]).
+        first = log.recent_chained("dashboard_chat-1-1", roles={"user"})
+        assert [m["content"] for m in first] == ["a1"]
+
+        # A second session joins tab_id T later. The append MUST invalidate the
+        # cached index so the next chained read rebuilds and sees it.
+        log.append("dashboard_chat-1-2", "user", "b1", tab_id="T")
+
+        again = log.recent_chained("dashboard_chat-1-1", roles={"user"})
+        assert [m["content"] for m in again] == ["a1", "b1"]
+
+    def test_metadata_tab_id_change_invalidates_index(self, tmp_path: Path) -> None:
+        """Setting a session's tab_id via update_metadata must invalidate the
+        index so the session is picked into its chain on the next read."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("dashboard_chat-2-1", "user", "a1", tab_id="G")
+        # Prime the index for tab_id G.
+        assert [m["content"] for m in log.recent_chained("dashboard_chat-2-1")] == [
+            "a1"
+        ]
+
+        # Second session starts WITHOUT the tab_id, then gets linked via metadata.
+        log.append("dashboard_chat-2-2", "user", "b1")
+        log.update_metadata("dashboard_chat-2-2", {"tab_id": "G"})
+
+        chained = log.recent_chained("dashboard_chat-2-1", roles={"user"})
+        assert [m["content"] for m in chained] == ["a1", "b1"]
+
+    def test_no_permanent_negative_sentinel(self, tmp_path: Path) -> None:
+        """A chained read for a tab_id with no dashboard siblings must not poison
+        the cache: a sibling created afterwards is still discovered (the removed
+        ``[]`` sentinel used to suppress every future rebuild)."""
+        log = ConversationLog(base_dir=tmp_path)
+        # slack-style key with a tab_id that the dashboard_chat-* glob misses,
+        # so the first rebuild finds no entry for tab_id S.
+        log.append("slack:123.456", "user", "s1", tab_id="S")
+        first = log.recent_chained("slack:123.456", roles={"user"})
+        assert [m["content"] for m in first] == ["s1"]  # single-file fallback
+
+        # Now a dashboard session joins tab_id S. It must be discoverable.
+        log.append("dashboard_chat-9-9", "user", "d1", tab_id="S")
+        chained = log.recent_chained("dashboard_chat-9-9", roles={"user"})
+        assert "d1" in [m["content"] for m in chained]
+
+
+# ── Bug 3: recompute consolidation offset after rotation-during-await ─────────
+class TestConsolidationOffsetAfterRotation:
+    def test_offset_reset_when_file_shrank(self, tmp_path: Path) -> None:
+        """The consolidator captures ``total`` before a (slow) LLM call. If a
+        rotation truncates the file during that await, the stale absolute offset
+        is in the pre-rotation numbering and is meaningless afterwards. Clamping
+        it to the surviving count would mark the retained tail (which may hold
+        brand-new, never-consolidated messages) as consolidated and skip them.
+        mark_consolidated must instead reset to 0 and let the retained tail be
+        reconsolidated — redoing a few messages is harmless; dropping any is not.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(10):
+            log.append("k", "user", f"m{i}")
+        total_before_llm = len(log._read_messages("k"))
+        assert total_before_llm == 10
+
+        # Rotation fires during the await: file keeps only its newest 3 messages.
+        keep = log._read_messages("k")[-3:]
+        log.rewrite_session("k", keep)
+        assert len(log._read_messages("k")) == 3
+
+        # Consolidator marks the STALE pre-LLM total (10 > surviving 3).
+        log.mark_consolidated("k", total_before_llm)
+
+        meta = log.get_metadata("k")
+        # Reset to 0 rather than clamped to 3: the retained tail is reconsolidated
+        # so nothing that survived rotation is silently marked consolidated.
+        assert meta["last_consolidated"] == 0
+        assert log.unconsolidated_count("k") == 3
+
+    def test_new_message_in_retained_tail_not_skipped(self, tmp_path: Path) -> None:
+        """GPT-flagged race: a NEW message arrives during the LLM await and
+        rotation keeps it in the retained tail. Clamping the stale offset to the
+        surviving count would mark that never-consolidated message as done and
+        permanently drop it. The reset-to-0 path must keep it consolidatable.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(8):
+            log.append("k", "user", f"m{i}")
+        total_before_llm = len(log._read_messages("k"))  # 8 processed by the LLM
+
+        # During the await: a brand-new message arrives, then rotation keeps the
+        # newest 3 — which now INCLUDES that new, never-consolidated message.
+        log.append("k", "user", "brand-new")
+        keep = log._read_messages("k")[-3:]
+        assert keep[-1]["content"] == "brand-new"
+        log.rewrite_session("k", keep)
+
+        log.mark_consolidated("k", total_before_llm)
+
+        # The new message is still pending, not swallowed by a clamp.
+        assert log.get_metadata("k")["last_consolidated"] == 0
+        assert log.unconsolidated_count("k") == 3
+        pending, _ = log.get_unconsolidated("k")
+        assert any(m["content"] == "brand-new" for m in pending)
+
+    def test_offset_unchanged_when_no_rotation(self, tmp_path: Path) -> None:
+        """No rotation: offset is stored verbatim (no reset)."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(5):
+            log.append("k", "user", f"m{i}")
+        log.mark_consolidated("k", 3)
+        assert log.get_metadata("k")["last_consolidated"] == 3
+        assert log.unconsolidated_count("k") == 2
+
+    def test_offset_equal_to_count_stored_verbatim(self, tmp_path: Path) -> None:
+        """offset == current count (all consolidated, no rotation) is stored
+        as-is; only a STRICTLY larger offset (file shrank) triggers the reset."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(4):
+            log.append("k", "user", f"m{i}")
+        log.mark_consolidated("k", 4)
+        assert log.get_metadata("k")["last_consolidated"] == 4
+        assert log.unconsolidated_count("k") == 0
+
+    def test_offset_reset_when_rotation_retains_ge_offset(self, tmp_path: Path) -> None:
+        """The count-only heuristic is INCOMPLETE: a rotation that RETAINS
+        >= the snapshot offset leaves ``offset <= msg_count`` true, so the stale
+        offset sails through and is written verbatim — but every surviving index
+        shifted by the number of dropped lines, silently marking
+        never-consolidated retained messages as done. The rotation GENERATION
+        counter must force the reset regardless of retained count.
+
+        Fails pre-fix: with only ``offset > msg_count`` the offset is <= the
+        retained count and is stored verbatim (data-integrity failure).
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        # ~11 KiB bodies: 100 messages stay under the 2 MiB cap, but appending
+        # ~200 more blows it and triggers a REAL rotation whose retained tail is
+        # still far larger than the offset=100 snapshot below.
+        body = "x" * (11 * 1024)
+        for i in range(100):
+            log.append("k", "user", f"{i}:{body}")
+        # Consolidator snapshots BEFORE the slow LLM call.
+        generation_at_snapshot = log.rotation_generation("k")
+        total_at_snapshot = len(log._read_messages("k"))
+        assert total_at_snapshot == 100
+        assert generation_at_snapshot == 0
+
+        # Slow LLM await: many more messages arrive and trigger a real rotation.
+        for i in range(100, 300):
+            log.append("k", "user", f"{i}:{body}")
+        retained = len(log._read_messages("k"))
+        # The rotation retained MORE messages than the snapshot offset — exactly
+        # the case the count heuristic misses.
+        assert retained >= total_at_snapshot
+        assert log.rotation_generation("k") > generation_at_snapshot
+        # last_consolidated is 0 after the rotation itself…
+        assert log.get_metadata("k")["last_consolidated"] == 0
+
+        # …the consolidator now writes back its stale pre-rotation offset with
+        # the generation it snapshotted. The generation mismatch must force a
+        # reset instead of applying the shifted index.
+        log.mark_consolidated(
+            "k", total_at_snapshot, generation=generation_at_snapshot
+        )
+        assert log.get_metadata("k")["last_consolidated"] == 0
+        assert log.unconsolidated_count("k") == retained
+
+    def test_offset_stored_when_generation_matches(self, tmp_path: Path) -> None:
+        """No rotation between snapshot and write (generation unchanged): the
+        offset is stored verbatim even when supplied with a matching generation.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(6):
+            log.append("k", "user", f"m{i}")
+        gen = log.rotation_generation("k")
+        log.mark_consolidated("k", 4, generation=gen)
+        assert log.get_metadata("k")["last_consolidated"] == 4
+        assert log.unconsolidated_count("k") == 2
+
+    def test_legacy_metadata_absent_generation_reads_zero(self, tmp_path: Path) -> None:
+        """Backward compatibility: a metadata line written before the
+        ``rotation_generation`` field existed reads as generation 0, and a
+        consolidator that snapshotted 0 stores its offset normally."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(5):
+            log.append("k", "user", f"m{i}")
+        # Simulate legacy metadata: strip the generation field entirely.
+        path = log._path("k")
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        import json as _json
+
+        meta = _json.loads(lines[0])
+        meta.pop("rotation_generation", None)
+        lines[0] = _json.dumps(meta) + "\n"
+        path.write_text("".join(lines), encoding="utf-8")
+        log._invalidate_cache("k")
+
+        assert log.rotation_generation("k") == 0
+        log.mark_consolidated("k", 3, generation=0)
+        assert log.get_metadata("k")["last_consolidated"] == 3
+
+    def test_snapshot_for_consolidation_is_atomic_over_rotation(
+        self, tmp_path: Path
+    ) -> None:
+        """``snapshot_for_consolidation`` returns messages, total and generation
+        from ONE consistent point, so the (offset, generation) pair it yields
+        can never straddle a rotation.
+
+        This is the fix for the two-separate-reads race: the OLD pairing
+        (``get_unconsolidated`` then ``rotation_generation``) could read the
+        offset PRE-rotation and the generation POST-rotation, so
+        ``mark_consolidated`` saw a matching generation and applied the stale
+        offset. We assert the snapshot's generation matches the file's actual
+        generation for the same message set, and that feeding the snapshot back
+        into ``mark_consolidated`` stores the offset verbatim (no phantom
+        mismatch) when nothing rotated after it.
+
+        Pre-fix analogue — reading the two values separately with a rotation
+        wedged between them yields a PRE-rotation total paired with a
+        POST-rotation generation; that stale offset is then applied because the
+        generations (post==post) match. The snapshot closes that window.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(6):
+            log.append("k", "user", f"m{i}")
+
+        msgs, total, gen = log.snapshot_for_consolidation("k")
+        assert total == 6
+        assert len(msgs) == 6  # nothing consolidated yet
+        assert gen == log.rotation_generation("k") == 0
+        # The returned list must be an owned copy, not the shared cache object.
+        assert msgs is not log._read_messages("k")
+
+        # Feeding the atomically-captured (total, generation) back stores the
+        # offset verbatim: the pair is internally consistent, so neither the
+        # generation-mismatch nor the count-overflow guard trips.
+        log.mark_consolidated("k", total, generation=gen)
+        assert log.get_metadata("k")["last_consolidated"] == 6
+        assert log.unconsolidated_count("k") == 0
+
+    def test_snapshot_pairs_offset_and_generation_consistently(
+        self, tmp_path: Path
+    ) -> None:
+        """Demonstrates the exact race the snapshot fixes: the OLD two-read
+        pairing can hand mark_consolidated a PRE-rotation offset with a
+        POST-rotation generation, which is then applied because the stored
+        generation also advanced — silently skipping retained messages. The
+        atomic snapshot captures both from the SAME state so the generation it
+        returns always matches the offset it returns.
+        """
+        body = "x" * (11 * 1024)
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(100):
+            log.append("k", "user", f"{i}:{body}")
+
+        # --- OLD PAIRING (simulated): read offset, then a rotation fires, then
+        # read generation. This is what the pre-fix consolidator did. ---
+        stale_offset = len(log._read_messages("k"))  # PRE-rotation total = 100
+        for i in range(100, 300):
+            log.append("k", "user", f"{i}:{body}")  # triggers a real rotation
+        post_rotation_gen = log.rotation_generation("k")  # advanced
+        assert post_rotation_gen > 0
+        retained = len(log._read_messages("k"))
+        assert retained >= stale_offset  # count fallback would miss it
+
+        # Applying the stale offset with the POST-rotation generation: the
+        # generations match (post==post), the offset <= retained count, so the
+        # shifted, meaningless offset is stored verbatim — the data-loss bug.
+        log.mark_consolidated("k", stale_offset, generation=post_rotation_gen)
+        assert log.get_metadata("k")["last_consolidated"] == stale_offset
+
+        # --- NEW: the atomic snapshot never produces that mismatched pair. Its
+        # returned (total, generation) come from one locked read, so the
+        # generation always corresponds to the messages/offset it returned. ---
+        log2 = ConversationLog(base_dir=tmp_path / "other")
+        for i in range(100):
+            log2.append("k", "user", f"{i}:{body}")
+        _, total_s, gen_s = log2.snapshot_for_consolidation("k")
+        # The snapshot's generation matches the file state that produced total_s.
+        assert gen_s == log2.rotation_generation("k")
+        assert total_s == len(log2._read_messages("k"))
+
+
+# ── Bug 4: rotate oversized files even with <= _SESSION_KEEP_LINES lines ──────
+class TestRotateOversizedFewLines:
+    def test_rotates_when_few_but_huge_lines(self, tmp_path: Path) -> None:
+        """A session of a handful of very large messages exceeds the byte cap
+        while having far fewer than ``_SESSION_KEEP_LINES`` lines. It must still
+        rotate (drop oldest) rather than grow unbounded."""
+        log = ConversationLog(base_dir=tmp_path)
+        chunk = 300 * 1024  # 300 KiB per message
+        count = (_SESSION_MAX_BYTES // chunk) + 4  # comfortably over the cap
+        assert count <= _SESSION_KEEP_LINES  # the crux: few lines, big bytes
+        big = "x" * chunk
+        for i in range(count):
+            log.append("k", "user", f"{big}{i}")
+
+        path = log._path("k")
+        assert path.stat().st_size <= _SESSION_MAX_BYTES, "file was never rotated"
+        msgs = log._read_messages("k")
+        assert 0 < len(msgs) < count, "no oldest messages were dropped"
+        # Newest message survives rotation.
+        assert msgs[-1]["content"].endswith(str(count - 1))
+
+    def test_single_message_larger_than_budget_is_kept(self, tmp_path: Path) -> None:
+        """A lone message bigger than the whole budget can't be split, so it is
+        retained (rotation is a no-op) rather than discarded."""
+        log = ConversationLog(base_dir=tmp_path)
+        huge = "y" * (_SESSION_MAX_BYTES + 4096)
+        log.append("k", "user", huge)
+        msgs = log._read_messages("k")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == huge
+
+    def test_small_files_unaffected(self, tmp_path: Path) -> None:
+        """Ordinary small sessions never rotate."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(20):
+            log.append("k", "user", f"m{i}")
+        assert len(log._read_messages("k")) == 20
+
+
+# ── Bug 5: delete_session unlink(missing_ok=True) ─────────────────────────────
+class TestDeleteSessionMissingOk:
+    def test_delete_missing_returns_false(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        assert log.delete_session("never-existed") is False
+
+    def test_toctou_removal_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reproduce the window where the file is reported present by exists()
+        but has been unlinked by another process before our own unlink. With
+        ``missing_ok=True`` this is tolerated; the old bare ``unlink()`` raised
+        ``FileNotFoundError``.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        # Force the existence check to report True even though no file exists.
+        monkeypatch.setattr("kiro_crew.history.Path.exists", lambda self: True)
+        # Must not raise.
+        log.delete_session("ghost")
+
+    def test_delete_existing_returns_true(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m")
+        assert log.delete_session("k") is True
+        assert not log._path("k").exists()
+
+    def test_delete_preserves_sidecar_lock_inode(self, tmp_path: Path) -> None:
+        """A deleted session MUST keep its ``.jsonl.lock`` sidecar. The sidecar
+        inode is the cross-process mutex; unlinking it re-opens the lock-inode
+        race (a recreating writer holds the old inode while a later acquirer
+        creates a fresh sidecar inode, so two processes "hold the lock" on
+        different inodes and can clobber each other). The bounded zero-byte
+        orphan is the deliberate lesser evil.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m")  # first mutation creates the sidecar
+        lock_path = log._lock_path("k")
+        assert lock_path.exists()
+        assert log.delete_session("k") is True
+        assert lock_path.exists(), "sidecar lock inode must be preserved across delete"
+
+    def test_delete_fails_closed_under_contention(self, tmp_path: Path) -> None:
+        """delete_session now runs under ``_locked``. If the cross-process lock
+        cannot be acquired (a wedged holder), it must report "not removed"
+        rather than unlink unlocked — the very clobber the lock prevents. Held
+        from a separate fd to model another process holding the lock.
+        """
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m")
+        # Shrink the acquire budget so the test doesn't wait the full deadline.
+        monkeypatch_budget = 0.2
+        import kiro_crew.history as history_mod
+
+        orig = history_mod._FLOCK_ACQUIRE_TIMEOUT_S
+        history_mod._FLOCK_ACQUIRE_TIMEOUT_S = monkeypatch_budget
+        lock_path = log._lock_path("k")
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            assert platform_compat.try_acquire_lock(fd, exclusive=True)
+            assert log.delete_session("k") is False
+            assert log._path("k").exists(), "file was deleted despite contention"
+        finally:
+            platform_compat.release_lock(fd)
+            os.close(fd)
+            history_mod._FLOCK_ACQUIRE_TIMEOUT_S = orig
+
+
+# ── append_off_loop: on-loop offload / off-loop inline persistence ────────────
+class TestAppendOffLoop:
+    def test_inline_append_when_no_running_loop(self, tmp_path: Path) -> None:
+        """Off the event loop, ``append_off_loop`` persists synchronously."""
+        from kiro_crew.history import append_off_loop
+
+        log = ConversationLog(base_dir=tmp_path)
+        append_off_loop(log, "k", "assistant", "hello", agent="bot")
+        msgs = log.read_messages("k")
+        assert any(m.get("content") == "hello" for m in msgs)
+
+    def test_on_loop_offloads_to_thread_and_persists(self, tmp_path: Path) -> None:
+        """On a running loop the append is dispatched to a worker thread (never
+        run inline on the loop) and still lands. We prove the offload by
+        capturing the thread the append executes on.
+        """
+        import asyncio
+        import threading
+
+        from kiro_crew.history import append_off_loop
+
+        log = ConversationLog(base_dir=tmp_path)
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        real_append = log.append
+
+        def _spy(*args: object, **kwargs: object) -> None:
+            seen["thread"] = threading.get_ident()
+            real_append(*args, **kwargs)  # type: ignore[arg-type]
+
+        log.append = _spy  # type: ignore[method-assign]
+
+        async def _run() -> None:
+            append_off_loop(log, "k", "assistant", "hi")
+            # Let the executor task finish.
+            for _ in range(50):
+                if "thread" in seen:
+                    break
+                await asyncio.sleep(0.02)
+
+        asyncio.run(_run())
+        assert seen.get("thread") is not None
+        assert seen["thread"] != loop_thread, "append ran on the event loop thread"
+        assert any(m.get("content") == "hi" for m in log.read_messages("k"))
+
+
+# ── update_metadata_off_loop: keep flock/os.close off the event loop ──────────
+class TestUpdateMetadataOffLoop:
+    """The cross-process flock acquire + ``os.close`` inside ``_locked`` are
+    ``blocking: true`` under the no-blocking-call-on-event-loop rule: a wedged
+    peer can stall them and freeze chat/WS/heartbeat. ``update_metadata`` (and
+    ``set_title``/``delete_session``) enter ``_locked``, so synchronous on-loop
+    callers must offload. ``update_metadata_off_loop`` is the sync-context
+    escape hatch (mirrors ``append_off_loop``)."""
+
+    def test_inline_update_when_no_running_loop(self, tmp_path: Path) -> None:
+        """Off the event loop the update persists synchronously."""
+        from kiro_crew.history import update_metadata_off_loop
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        update_metadata_off_loop(log, "k", {"title": "hi", "agent": "bot"})
+        meta = ConversationLog(base_dir=tmp_path).get_metadata("k")
+        assert meta["title"] == "hi"
+        assert meta["agent"] == "bot"
+
+    def test_on_loop_offloads_flock_ops_to_thread(self, tmp_path: Path) -> None:
+        """On a running loop the flock/os.close-bearing update_metadata must run
+        on a worker thread, NEVER inline on the event-loop thread, and still
+        persist. We prove the offload by capturing the executing thread id."""
+        import asyncio
+        import threading
+
+        from kiro_crew.history import update_metadata_off_loop
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        real_update = log.update_metadata
+
+        def _spy(*args: object, **kwargs: object) -> None:
+            seen["thread"] = threading.get_ident()
+            real_update(*args, **kwargs)  # type: ignore[arg-type]
+
+        log.update_metadata = _spy  # type: ignore[method-assign]
+
+        async def _run() -> None:
+            update_metadata_off_loop(log, "k", {"title": "async-title"})
+            for _ in range(50):
+                if "thread" in seen:
+                    break
+                await asyncio.sleep(0.02)
+
+        asyncio.run(_run())
+        assert seen.get("thread") is not None
+        assert seen["thread"] != loop_thread, (
+            "update_metadata ran on the event loop thread"
+        )
+        assert (
+            ConversationLog(base_dir=tmp_path).get_metadata("k")["title"]
+            == "async-title"
+        )
+
+
+# ── async handler callers offload _locked ops off the event loop ─────────────
+class TestOnLoopCallersOffload:
+    """The audited async-path callers (``_persist_title`` behind auto-title /
+    manual-title handlers, ``api_session_delete``) enter ``_locked`` via
+    ``set_title`` / ``delete_session``. Running that on the event-loop thread
+    lets a wedged cross-process peer freeze chat/WS/heartbeat. These wiring
+    tests lock in that the ``_locked`` work is dispatched off the loop."""
+
+    def test_persist_title_runs_set_title_off_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+        import threading
+        from unittest.mock import MagicMock
+
+        from kiro_crew.dashboard import chat_title
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("dashboard:t", "user", "seed")
+
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        real_set_title = log.set_title
+
+        def _spy(*args: object, **kwargs: object) -> None:
+            seen["thread"] = threading.get_ident()
+            real_set_title(*args, **kwargs)  # type: ignore[arg-type]
+
+        log.set_title = _spy  # type: ignore[method-assign]
+        monkeypatch.setattr(chat_title, "_history_key_for", lambda _k: "dashboard:t")
+
+        state = MagicMock()
+        state.conversation_log = log
+        slot = MagicMock()
+        slot.key = "t"
+        slot.title = "My Title"
+
+        asyncio.run(chat_title._persist_title(state, slot))
+
+        assert seen.get("thread") is not None
+        assert seen["thread"] != loop_thread, "set_title ran on the event loop thread"
+        assert (
+            ConversationLog(base_dir=tmp_path).get_metadata("dashboard:t")["title"]
+            == "My Title"
+        )
+
+    def test_api_session_delete_runs_delete_off_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+        import threading
+        from unittest.mock import AsyncMock, MagicMock
+
+        from kiro_crew.dashboard.handlers import sessions as sessions_mod
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("gone", "user", "seed")
+
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        real_delete = log.delete_session
+
+        def _spy(*args: object, **kwargs: object) -> bool:
+            seen["thread"] = threading.get_ident()
+            return real_delete(*args, **kwargs)  # type: ignore[arg-type]
+
+        log.delete_session = _spy  # type: ignore[method-assign]
+
+        state = MagicMock()
+        state.conversation_log = log
+        state.push_slots_update = MagicMock()
+        state.push_refresh = MagicMock()
+        monkeypatch.setattr(
+            sessions_mod, "_remove_slot_for_history_key", AsyncMock()
+        )
+
+        request = MagicMock()
+        request.app = {"state": state}
+        request.match_info = {"key": "gone"}
+
+        resp = asyncio.run(sessions_mod.api_session_delete(request))
+
+        assert seen.get("thread") is not None
+        assert seen["thread"] != loop_thread, (
+            "delete_session ran on the event loop thread"
+        )
+        assert b'"ok": true' in resp.body
+        assert not log._path("gone").exists()
+
+
+# ── Bug 6: reduced lock hold — no fsync under lock for one-line metadata ──────
+class TestReducedLockHold:
+    def test_update_metadata_does_not_fsync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A one-line metadata edit must not ``fsync`` while holding the
+        cross-process lock — the flush dominated the critical section every
+        other writer blocked on. The edit must still persist (os.replace is
+        crash-atomic without a flush)."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m")
+
+        calls: list[int] = []
+        monkeypatch.setattr("os.fsync", lambda fd: calls.append(fd))
+
+        log.update_metadata("k", {"title": "hello", "agent": "bob"})
+
+        assert calls == [], "metadata rewrite fsync'd while holding the lock"
+        fresh = ConversationLog(base_dir=tmp_path)
+        meta = fresh.get_metadata("k")
+        assert meta["title"] == "hello"
+        assert meta["agent"] == "bob"
+
+    def test_mark_consolidated_does_not_fsync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """mark_consolidated is likewise a one-line metadata rewrite and must
+        not fsync under the lock, while still persisting the offset and every
+        message."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "m1")
+        log.append("k", "assistant", "m2")
+
+        calls: list[int] = []
+        monkeypatch.setattr("os.fsync", lambda fd: calls.append(fd))
+
+        log.mark_consolidated("k", 2)
+
+        assert calls == [], "mark_consolidated fsync'd while holding the lock"
+        fresh = ConversationLog(base_dir=tmp_path)
+        assert fresh.get_metadata("k")["last_consolidated"] == 2
+        assert [m["content"] for m in fresh._read_messages("k")] == ["m1", "m2"]
+
+
+# ── Multiprocessing workers (module-level so they are picklable under fork) ───
+def _require_multiprocessing(ctx: "multiprocessing.context.BaseContext") -> None:
+    """Skip the test when the sandbox forbids the semaphores multiprocessing
+    needs (some CI/sandbox environments deny ``SemLock`` creation with
+    ``PermissionError``). The flock primitive is still covered by the
+    deterministic single-process ``test_locked_holds_exclusive_flock_cross_fd``.
+    """
+    try:
+        probe = ctx.Process(target=_mp_noop)
+        probe.start()
+        probe.join(timeout=10)
+    except (PermissionError, OSError) as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"multiprocessing unavailable in this environment: {exc}")
+
+
+def _mp_noop() -> None:
+    pass
+
+
+def _mp_appender(dir_str: str, key: str, n: int) -> None:
+    log = ConversationLog(base_dir=Path(dir_str))
+    for i in range(n):
+        log.append(key, "user", f"a-{i}")
+        time.sleep(0.001)
+
+
+def _mp_consolidator(dir_str: str, key: str, iters: int) -> None:
+    log = ConversationLog(base_dir=Path(dir_str))
+    for _ in range(iters):
+        log.mark_consolidated(key, 1)
+        time.sleep(0.0005)
+
+
+# ── Bug 7: dashboard persistence save must hold _locked vs. append_off_loop ──
+class TestDashboardSaveHoldsLock:
+    """``_save_slot_to_history`` (dashboard persistence) does a
+    read-modify-``atomic_write`` of the session JSONL. If it does NOT hold the
+    same per-session ``_locked`` as :meth:`ConversationLog.append`, a concurrent
+    ``append_off_loop`` — e.g. a workflow result appended to the originating
+    dashboard session — can land AFTER the save snapshots the file but BEFORE it
+    replaces the file, so the ``atomic_write`` silently deletes the just-appended
+    (already acknowledged) message.
+
+    This reproduces that interleaving deterministically: a competitor thread
+    appends a message during the save's ``atomic_write``. With the lock the
+    append serializes behind the save and survives; without it the save's
+    file-replace clobbers the append.
+    """
+
+    def _make_state(self, tmp_path: Path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from kiro_crew.dashboard.state import DashboardState
+
+        sessions = MagicMock(count=0)
+        sessions.get_pid = MagicMock(return_value=None)
+        sessions.remove = AsyncMock()
+        return DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+
+    def test_concurrent_append_off_loop_survives_save(self, tmp_path, monkeypatch):
+        import threading
+
+        from kiro_crew.dashboard import chat_persistence
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("locktest")
+        slot.append("user", "m1")
+        slot.append("assistant", "m2")
+        slot.drain()
+        history_key = _history_key_for(slot.key)
+
+        # Seed the on-disk transcript with the current window.
+        _save_slot_to_history(state, slot, force=True)
+
+        # A workflow-result durable copy (exactly what inject_workflow_result
+        # does via append_off_loop) appended while the NEXT save is mid-write.
+        appended = "workflow-result-m3"
+        go = threading.Event()
+        done = threading.Event()
+
+        def _competitor() -> None:
+            # Off the event loop → append takes the patient _locked acquire path.
+            go.wait(5)
+            state.conversation_log.append(history_key, "assistant", appended)
+            done.set()
+
+        competitor = threading.Thread(target=_competitor)
+        competitor.start()
+
+        real_atomic_write = chat_persistence.atomic_write
+
+        def _slow_atomic_write(path, data, **kwargs):
+            # We are now INSIDE the save's critical section. If the save holds
+            # _locked, the competitor's append blocks here until the save's
+            # with-block exits; if it does NOT, the append lands during this
+            # sleep and the real write below clobbers it.
+            go.set()
+            time.sleep(0.5)
+            return real_atomic_write(path, data, **kwargs)
+
+        monkeypatch.setattr(chat_persistence, "atomic_write", _slow_atomic_write)
+
+        # Window is unchanged ([m1, m2]) so a naive save re-writes only those two
+        # lines — the appended m3 exists ONLY on disk and is the loss candidate.
+        _save_slot_to_history(state, slot, force=True)
+
+        assert done.wait(10), "competitor append never completed (deadlock?)"
+        competitor.join(10)
+
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m.get("content") for m in fresh._read_messages(history_key)]
+        assert appended in contents, (
+            "dashboard save clobbered a concurrent append_off_loop message "
+            f"(got {contents!r}) — _save_slot_to_history must hold _locked"
+        )
+        assert contents.count("m1") == 1
+        assert contents.count("m2") == 1
+
+    def test_cross_process_append_before_save_survives(self, tmp_path, monkeypatch):
+        """GPT 5.6 HIGH (chat_persistence.py:793): the ``window`` snapshot is
+        captured BEFORE ``_save_slot_to_history`` takes ``_locked``. A writer in
+        ANOTHER process can fully append + release the lock in that gap; the save
+        then acquires the lock and rewrites ``meta + frozen + window`` from the
+        stale snapshot, permanently deleting the acknowledged append.
+
+        This reproduces it WITHOUT threads: the cross-process append is committed
+        to the file first, then the slot (whose in-memory window never saw it) is
+        saved. The save must merge the on-disk append rather than clobber it.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("staleoverwrite")
+        slot.append("user", "m1")
+        slot.append("assistant", "m2")
+        slot.drain()
+        history_key = _history_key_for(slot.key)
+
+        # Seed the on-disk transcript with the current window ([m1, m2]).
+        _save_slot_to_history(state, slot, force=True)
+
+        # A DIFFERENT process appends an acknowledged message straight to the
+        # file (append holds the same cross-process ``_locked``). This slot's
+        # in-memory window never learns about it (no ``slot.append`` here), so it
+        # is exactly the "landed between snapshot and lock" loss candidate.
+        state.conversation_log.append(history_key, "assistant", "cross-proc-m3")
+
+        # Next slot save: window is still [m1, m2]; a bare meta+frozen+window
+        # replace would drop cross-proc-m3.
+        _save_slot_to_history(state, slot, force=True)
+
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m.get("content") for m in fresh._read_messages(history_key)]
+        assert "cross-proc-m3" in contents, (
+            "slot save deleted a cross-process append that landed between the "
+            f"window snapshot and the file replace (got {contents!r})"
+        )
+        assert contents.count("m1") == 1
+        assert contents.count("m2") == 1
+        assert contents.count("cross-proc-m3") == 1
+
+    def test_repeated_save_after_foreign_append_keeps_it(self, tmp_path, monkeypatch):
+        """GPT 5.6 HIGH (chat_persistence.py:746): the frozen-prefix fast path.
+
+        After a save preserves a cross-process append, it records the resulting
+        file's ``(mtime, size, disk_older)`` in ``slot._frozen_prefix_cache``.
+        The very NEXT save (window and disk both unchanged) then matches that
+        cache and takes the O(window) fast path. If the fast path returns EMPTY
+        foreign lines, the rebuilt ``meta + frozen + window`` payload drops the
+        previously-preserved append — a cron/workflow result followed by two
+        dashboard saves silently loses the transcript line.
+
+        Reproduces the sequence save -> foreign-append -> save -> save -> save
+        with NO writer between the saves, so saves 2..4 all hit the fast path,
+        and asserts the foreign line survives every one exactly once.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("fastpathloss")
+        slot.append("user", "m1")
+        slot.append("assistant", "m2")
+        slot.drain()
+        history_key = _history_key_for(slot.key)
+
+        # Seed the on-disk transcript with the current window ([m1, m2]).
+        _save_slot_to_history(state, slot, force=True)
+
+        # A cron/workflow result lands via the cross-process append path; the
+        # slot's in-memory window never learns about it.
+        state.conversation_log.append(history_key, "assistant", "cron-m3")
+
+        # Save #1: slow path (disk changed since our seed write) detects and
+        # preserves cron-m3, then caches the resulting file metadata + the
+        # preserved foreign line.
+        _save_slot_to_history(state, slot, force=True)
+
+        # Saves #2, #3, #4: disk is byte-identical to save #1's output and the
+        # window is still [m1, m2], so each hits the frozen-prefix fast path.
+        # Before the fix these dropped cron-m3; now the cached foreign line is
+        # re-emitted verbatim on every fast-path save.
+        for _ in range(3):
+            _save_slot_to_history(state, slot, force=True)
+
+        fresh = ConversationLog(base_dir=tmp_path)
+        contents = [m.get("content") for m in fresh._read_messages(history_key)]
+        assert "cron-m3" in contents, (
+            "fast-path save dropped a previously-preserved cross-process append "
+            f"(got {contents!r}) — cached foreign lines must be re-emitted"
+        )
+        assert contents.count("cron-m3") == 1, (
+            f"cron-m3 duplicated across repeated fast-path saves (got {contents!r})"
+        )
+        assert contents.count("m1") == 1
+        assert contents.count("m2") == 1
+
+    def test_slot_save_preserves_rotation_generation(self, tmp_path, monkeypatch):
+        """GPT 5.6 HIGH (chat_persistence.py:793, second half): the rewritten
+        metadata reconstructed a subset and omitted ``rotation_generation``, so a
+        slot save AFTER a rotation reset the generation to 0 — letting a
+        concurrent consolidation apply a stale offset and mark never-consolidated
+        retained messages as done (undoing the rotation-generation fix).
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("rotgen")
+        slot.append("user", "hello")
+        slot.drain()
+        history_key = _history_key_for(slot.key)
+        _save_slot_to_history(state, slot, force=True)
+
+        # Simulate a rotation having bumped the generation counter in metadata.
+        state.conversation_log.update_metadata(history_key, {"rotation_generation": 7})
+        assert state.conversation_log.rotation_generation(history_key) == 7
+
+        # A subsequent slot save must carry the generation forward, not reset it.
+        slot.append("assistant", "world")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        assert state.conversation_log.rotation_generation(history_key) == 7, (
+            "slot save dropped rotation_generation — a stale consolidation "
+            "offset could then be applied against post-rotation messages"
+        )
+
+    def test_foreign_append_content_identity_dedup_semantics(
+        self, tmp_path, monkeypatch
+    ):
+        """Pin the narrowed, timestamp-first foreign-append identity (GPT 5.6
+        HIGH + arbiter long-term item 2).
+
+        ``_frozen_prefix_and_foreign_appends`` classifies a disk window-region
+        line as "ours" (drops it — the window re-serializes it) when EITHER its
+        ``ts`` matches a window entry (in-place edit) OR — as a COUNT-BOUNDED
+        tiebreak — its ``(role, content)`` matches an as-yet-unconsumed window
+        entry (a same-process ``append_if_absent`` copy persisted with a fresh
+        ``ts``). Because the tiebreak is bounded, each window entry absorbs AT
+        MOST one disk copy: a second same-content line with a DISTINCT ts (a
+        genuinely distinct event from another process, e.g. a repeated identical
+        cron/workflow result) is PRESERVED as foreign rather than collapsed. This
+        verifies both no-loss (the distinct event survives) and no-duplication
+        (the append_if_absent fresh-ts copy is folded once, not re-appended).
+        See docs/system-specs/modules/history.md.
+        """
+        import json
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.state.config_dir", lambda: tmp_path
+        )
+        from kiro_crew.dashboard.chat_persistence import (
+            _frozen_prefix_and_foreign_appends,
+        )
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("dedupsem")
+        history_key = _history_key_for(slot.key)
+        path = state.conversation_log._path(history_key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # On-disk: metadata line + window-region message lines.
+        disk_lines = [
+            json.dumps({"_type": "metadata", "created": "2026-01-01T00:00:00Z"}),
+            # ts-match to a window entry (edited in place) → collapsed.
+            json.dumps({"role": "user", "content": "same-ts", "ts": "T1"}),
+            # The window's OWN persisted copy of "windowed" (ts-match) → dropped;
+            # the window re-serializes it.
+            json.dumps({"role": "assistant", "content": "windowed", "ts": "T2"}),
+            # A genuinely DISTINCT event with identical (role, content) but a
+            # different ts — the GPT 5.6 HIGH data-loss case. With the window's
+            # single "windowed" budget already spent by the ts-match above, this
+            # MUST be preserved as foreign, not collapsed.
+            json.dumps({"role": "assistant", "content": "windowed", "ts": "TX"}),
+            # An append_if_absent copy of a window message persisted with a fresh
+            # ts (the window's own copy is NOT on disk at this ts) → folded into
+            # the window by the bounded content tiebreak (no duplication).
+            json.dumps({"role": "assistant", "content": "aif-copy", "ts": "TY"}),
+            # Genuinely distinct content → preserved as foreign.
+            json.dumps({"role": "assistant", "content": "distinct", "ts": "T3"}),
+        ]
+        path.write_text("\n".join(disk_lines) + "\n", encoding="utf-8")
+
+        window_entries = [
+            {"role": "user", "content": "same-ts", "ts": "T1"},
+            {"role": "assistant", "content": "windowed", "ts": "T2"},
+            {"role": "assistant", "content": "aif-copy", "ts": "TZ"},
+        ]
+        slot._frozen_prefix_cache = None
+
+        _prefix, foreign, dedup_dropped = _frozen_prefix_and_foreign_appends(
+            slot, path, 0, window_entries
+        )
+        foreign_contents = [json.loads(ln)["content"] for ln in foreign]
+
+        # ts-match collapsed (window wins on in-place edits / its own copies).
+        assert "same-ts" not in foreign_contents
+        # No-loss: a distinct same-content event with a fresh ts, beyond the
+        # window's single budget for that content, is preserved as foreign.
+        assert foreign_contents.count("windowed") == 1, (
+            "distinct same-content foreign event collapsed — the (role, content) "
+            "dedup must be count-bounded/timestamp-first so two real events are "
+            "not folded into one (GPT 5.6 HIGH data-loss finding)"
+        )
+        # No-duplication: the append_if_absent fresh-ts copy is folded once into
+        # the window (its own budget absorbs it) and NOT re-appended as foreign.
+        assert "aif-copy" not in foreign_contents, (
+            "append_if_absent fresh-ts copy duplicated — the bounded tiebreak "
+            "must fold the window's own copy"
+        )
+        # A genuinely-distinct foreign line is preserved (no data loss).
+        assert "distinct" in foreign_contents
+        # The folded fresh-ts copy is routed through the archive (item 2b) so the
+        # residual ambiguous case loses no data permanently.
+        dropped_contents = [json.loads(ln)["content"] for ln in dedup_dropped]
+        assert dropped_contents == ["aif-copy"], (
+            "fresh-ts content-tiebreak drops must be surfaced for archiving "
+            f"(got {dropped_contents!r})"
+        )
+
+
+class TestBestEffortSaveMarksDirty:
+    """GPT 5.6 HIGH (chat_persistence.py:1087): metadata mutation endpoints
+    (pin / folder / tag / mode) call ``save_slot_off_loop(..., force=True)`` with
+    the default ``best_effort=True``. A lock timeout / I/O error was swallowed and
+    the slot was NOT marked dirty, so the periodic flush never retried — the
+    endpoint returned success but the acknowledged change was lost after restart.
+
+    The fix marks the slot dirty on a swallowed best-effort failure so the 5s
+    flush retries. ``save_slot_off_loop`` is a coroutine, so its body always runs
+    under a running loop and takes the offloaded (executor) branch — that is the
+    path the dashboard metadata endpoints exercise.
+    """
+
+    def _make_state(self, tmp_path: Path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from kiro_crew.dashboard.state import DashboardState
+
+        sessions = MagicMock(count=0)
+        sessions.get_pid = MagicMock(return_value=None)
+        sessions.remove = AsyncMock()
+        return DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+
+    def test_offloaded_best_effort_failure_marks_dirty(self, tmp_path, monkeypatch):
+        import asyncio
+
+        from kiro_crew.dashboard import chat_persistence
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot("beffail")
+        slot.append("user", "m1")
+        slot.drain()
+        slot._dirty = False
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("simulated lock timeout / io error")
+
+        monkeypatch.setattr(chat_persistence, "_save_slot_to_history", _boom)
+
+        async def _run() -> None:
+            # On a running loop → offloaded (executor) branch.
+            await chat_persistence.save_slot_off_loop(state, slot, force=True)
+
+        asyncio.run(_run())
+
+        assert slot._dirty is True, (
+            "a swallowed best-effort save failure must mark the slot dirty so the "
+            "periodic flush retries — otherwise the metadata change is lost"
+        )
+
+
+class TestOnLoopFdCleanupDeferred:
+    """``_locked`` may run synchronously on the event-loop thread (an on-loop
+    caller relying on the single non-blocking acquire safety net). Its cleanup
+    calls ``platform_compat.release_lock`` (``flock(LOCK_UN)``) and ``os.close``,
+    both ``blocking: true`` under the no-blocking-call-on-event-loop rule: a
+    wedged descriptor could freeze chat/WS/heartbeat until watchdog restart.
+    The cleanup must therefore be dispatched OFF the loop, never run inline on
+    the loop thread — while off the loop it still runs inline."""
+
+    def test_off_loop_cleanup_runs_inline(self, tmp_path: Path) -> None:
+        import threading
+
+        seen: list[int] = []
+        real_close = os.close
+
+        def _spy_close(fd: int) -> None:
+            seen.append(threading.get_ident())
+            real_close(fd)
+
+        log = ConversationLog(base_dir=tmp_path)
+        with_patch = os.close
+        try:
+            os.close = _spy_close  # type: ignore[assignment]
+            log.append("k", "user", "seed")
+        finally:
+            os.close = with_patch  # type: ignore[assignment]
+        # Off the loop: the sidecar-fd close ran inline on this (caller) thread.
+        assert seen, "expected the lock fd to be closed"
+        assert all(t == threading.get_ident() for t in seen)
+
+    def test_on_loop_cleanup_deferred_to_worker_thread(self, tmp_path: Path) -> None:
+        import asyncio
+        import threading
+
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")  # create off-loop first
+
+        loop_thread = threading.get_ident()
+        # release_lock is called ONLY for the sidecar lock fd (never the session
+        # file), so the thread it runs on identifies where _locked's descriptor
+        # cleanup executed. release + os.close are one deferred callable, so an
+        # off-loop release proves the close is off-loop too.
+        release_threads: list[int] = []
+        real_release = platform_compat.release_lock
+
+        def _spy_release(fd: int) -> None:
+            release_threads.append(threading.get_ident())
+            real_release(fd)
+
+        async def _run() -> None:
+            platform_compat.release_lock = _spy_release  # type: ignore[assignment]
+            try:
+                # append() enters _locked ON this loop thread; the release+close
+                # must be dispatched to the default executor, not run inline.
+                # This deliberately exercises the low-level on-loop primitive, so
+                # it bypasses the strict off-loop discipline guard.
+                from kiro_crew.history import allow_on_loop_persist
+                with allow_on_loop_persist():
+                    log.append("k", "assistant", "on-loop-append")
+                for _ in range(50):
+                    if release_threads:
+                        break
+                    await asyncio.sleep(0.02)
+            finally:
+                platform_compat.release_lock = real_release  # type: ignore[assignment]
+
+        asyncio.run(_run())
+
+        assert release_threads, "release_lock was never called on the last exit"
+        assert all(t != loop_thread for t in release_threads), (
+            "descriptor release/close ran on the event-loop thread"
+        )
+        # The on-loop append still persisted.
+        assert any(
+            m.get("content") == "on-loop-append"
+            for m in ConversationLog(base_dir=tmp_path)._read_messages("k")
+        )
+
+
+# ── GPT 5.6 HIGH: append_if_absent collapses the workflow/cron double-append ─
+class TestAppendIfAbsent:
+    """``inject_workflow_result`` / ``inject_cron_result_to_dashboard`` reflect
+    a result in the DIRTY in-memory slot (``slot.append``) AND schedule a
+    durable disk copy. If the periodic slot save serializes the message first, a
+    plain follow-up ``append`` writes it a SECOND time and it is replayed twice
+    after restart. ``append_if_absent`` performs the existence check under the
+    SAME per-session lock as the write, collapsing the duplicate to a no-op."""
+
+    def test_appends_when_absent(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        assert log.append_if_absent("k", "assistant", "result-1") is True
+        contents = [m.get("content") for m in log.read_messages("k")]
+        assert contents.count("result-1") == 1
+
+    def test_skips_when_present(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "assistant", "result-1")
+        # A second inject of the same result (e.g. after a slot save already
+        # wrote it) must NOT duplicate it.
+        assert log.append_if_absent("k", "assistant", "result-1") is False
+        contents = [m.get("content") for m in ConversationLog(base_dir=tmp_path).read_messages("k")]
+        assert contents.count("result-1") == 1
+
+    def test_role_sensitive(self, tmp_path: Path) -> None:
+        # Same content under a different role is NOT a duplicate.
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "ping")
+        assert log.append_if_absent("k", "assistant", "ping") is True
+        msgs = ConversationLog(base_dir=tmp_path).read_messages("k")
+        assert [(m["role"], m["content"]) for m in msgs] == [
+            ("user", "ping"), ("assistant", "ping")
+        ]
+
+    def test_check_and_write_are_atomic_under_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The existence check and the append share one ``_locked`` critical
+        section: two concurrent ``append_if_absent`` of the SAME (role, content)
+        must serialize so exactly ONE copy is written. If the check were outside
+        the lock, both would observe "absent" and both would write."""
+        import threading
+
+        if not platform_compat.IS_POSIX:
+            pytest.skip("advisory flock semantics are POSIX-specific")
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("k", "user", "seed")
+        dup = "workflow-result"
+
+        # Slow the in-lock read of the FIRST writer so the second writer is
+        # guaranteed to race the check window (it blocks on _locked until the
+        # first releases, then its own check must see the first's write).
+        real_read = log._read_messages
+        go = threading.Event()
+        slowed_once = threading.Event()
+
+        def _slow_read(key: str) -> list[dict]:
+            res = real_read(key)
+            if key == "k" and not slowed_once.is_set():
+                slowed_once.set()
+                go.set()
+                time.sleep(0.3)
+            return res
+
+        monkeypatch.setattr(log, "_read_messages", _slow_read)
+
+        second_wrote: dict[str, bool] = {}
+
+        def _competitor() -> None:
+            go.wait(5)
+            # Serialized behind the first writer's lock; its check runs AFTER
+            # the first write lands, so it must observe the duplicate and skip.
+            second_wrote["v"] = log.append_if_absent("k", "assistant", dup)
+
+        t = threading.Thread(target=_competitor)
+        t.start()
+        first_wrote = log.append_if_absent("k", "assistant", dup)
+        t.join(10)
+
+        contents = [m.get("content") for m in ConversationLog(base_dir=tmp_path)._read_messages("k")]
+        assert first_wrote is True
+        assert second_wrote.get("v") is False, "second append_if_absent should have skipped"
+        assert contents.count(dup) == 1, f"duplicate result on disk: {contents!r}"
+
+    def test_off_loop_wrapper_dispatches_to_thread(self, tmp_path: Path) -> None:
+        import asyncio
+        import threading
+
+        from kiro_crew.history import append_if_absent_off_loop
+
+        log = ConversationLog(base_dir=tmp_path)
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        real = log.append_if_absent
+
+        def _spy(*a: object, **k: object) -> bool:
+            seen["thread"] = threading.get_ident()
+            return real(*a, **k)  # type: ignore[arg-type]
+
+        log.append_if_absent = _spy  # type: ignore[method-assign]
+
+        async def _run() -> None:
+            append_if_absent_off_loop(log, "k", "assistant", "hi")
+            for _ in range(50):
+                if "thread" in seen:
+                    break
+                await asyncio.sleep(0.02)
+
+        asyncio.run(_run())
+        assert seen.get("thread") is not None
+        assert seen["thread"] != loop_thread, "ran on the event loop thread"
+        assert any(m.get("content") == "hi" for m in log.read_messages("k"))


### PR DESCRIPTION
## Summary

Remediates six concurrency/correctness bugs found by the Cluster-B audit of
`src/kiro_crew/history.py`. Session transcripts are written by multiple
**processes** (gateway, subagents, crons, CLI), but the store previously only
serialized writers *within a single process* via `threading.RLock`. These fixes
add cross-process locking, make rotation/consolidation correct under it, and
tighten a few edge cases.

## Bugs fixed

1. **Cross-process advisory lock over append + read/rewrite paths** — `history.py`
   `append` / `mark_consolidated` / `rewrite_session` / `update_metadata`.
   Added `_locked()` (per-session `.jsonl.lock` sidecar `flock` layered on the
   in-process RLock, reentrant) and routed every create/append/rotate/rewrite/
   metadata mutation through it.
2. **`_tab_id_index` invalidation + removal of permanent `[]` sentinel** —
   `read_messages_chained` / `invalidate_tab_id_cache` / `append` /
   `update_metadata`. Index is now invalidated on append (new tab_id file) and
   metadata tab_id changes; the negative-cache sentinel is gone (index is
   `None` = stale, rebuilt authoritatively).
3. **Recompute consolidation offset when rotation fired during the LLM await** —
   `mark_consolidated` RESETS `last_consolidated` to 0 when the caller's pre-LLM
   `total` exceeds the current message count (a rotation shrank the file), so
   post-rotation messages are reconsolidated (idempotent) rather than silently
   skipped — it does NOT clamp the offset to EOF (clamping would mark the
   post-rotation tail as already-consolidated). Done under the lock.
4. **Rotate oversized files even with `<= 200` lines** — `_maybe_rotate` now
   shrinks the retained tail by bytes, so a session of a few multi-MB messages
   is bounded instead of growing forever.
5. **`delete_session` uses `unlink(missing_ok=True)`** — tolerates a concurrent
   removal instead of raising `FileNotFoundError` on the TOCTOU race.
6. **Reduced lock-hold for one-line metadata rewrites** — `mark_consolidated`
   (`fsync=False`) and `_update_metadata_locked` (dropped the in-lock `fsync`)
   no longer flush to disk while holding the cross-process lock; `os.replace`
   stays crash-atomic without it and the metadata is cheaply re-derivable.

## Failure scenarios addressed

1. A subagent/cron process runs `mark_consolidated` (read-all + `os.replace`)
   while the gateway appends a message → the rewrite clobbers the append; the
   in-process RLock cannot see the other interpreter → **silent lost update**.
2. First chained read caches a tab_id chain (or a `[]` sentinel); a second
   session opened later under the same tab_id is never linked → its messages
   **vanish from `recent_chained`**.
3. Consolidator snapshots `total=N`, awaits the LLM; rotation truncates the file
   to M<N and resets the offset; marking the stale N pushes `last_consolidated`
   past EOF → **every post-rotation message is silently skipped**.
4. A session of a few very large messages exceeds 2 MB but has `<= 200` lines →
   the old `len(lines) <= _SESSION_KEEP_LINES` guard returned early → the file
   **grew without bound**, defeating the size cap.
5. Two actors delete the same session in the exists()→unlink() window → the
   second `unlink()` **raised `FileNotFoundError`**.
6. A one-line metadata edit `fsync`ed a multi-MB file while holding the lock →
   **every other writer of that session blocked on the disk flush**.

## Test evidence

New file `test/test_history_locking_remediation.py` — 16 tests, one class per bug:

- `TestCrossProcessLock` (3): exclusive-flock-held-across-fds,
  reentrant same-key, and a real 2-process appender-vs-consolidator no-lost-update
  test.
- `TestTabIdIndexInvalidation` (3): chain picks up later session, metadata tab_id
  change invalidates, no permanent negative sentinel.
- `TestConsolidationOffsetAfterRotation` (2): offset reset to 0 after shrink; no-op
  when no rotation.
- `TestRotateOversizedFewLines` (3): few-but-huge rotates, single oversize
  message kept, small files untouched.
- `TestDeleteSessionMissingOk` (3): missing→False, TOCTOU no-raise, existing→True.
- `TestReducedLockHold` (2): no `fsync` under lock for `update_metadata` /
  `mark_consolidated`, data still persisted.

## Gate results

- **flake8** `src/kiro_crew/`: **pass** (0 findings).
- **mypy** (CI-parity venv) `src/kiro_crew/`: **pass** — "no issues found in 444 source files".
- **pytest**: **pass** — 16/16 new tests; **1970 passed, 0 failed** across all 48
  history-touching test files under `test/` (`-n 8 --timeout=120`).
  (The stale `tests/` directory — not in `testpaths` — has 17 pre-existing,
  baseline-confirmed failures in unrelated dashboard/context modules; untouched
  by this change.)

