### PR TITLE
feat(website): add theme-option + api-extension seams for downstream editions

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -214,15 +214,20 @@ Builtin apps no longer need manual `NAV_ITEMS` entries. The `builtinRegistry.ts`
 Additive registries let a **downstream edition** (a separate build that composes
 this SPA — e.g. an internal fork) contribute UI without copy-and-shadowing core
 files. The core registers nothing new into them, so every seam is inert in the
-stock build. There are **five** seams:
+stock build. There are **six** registry seams:
 
 | Seam | Module | Registrar → reader |
 |------|--------|--------------------|
 | Builtin page routes | `apps/builtinRegistry.ts` | `registerBuiltinComponents()` → `getBuiltinComponent()` |
 | Nav icons | `apps/builtinIcons.tsx` | `registerBuiltinIcons()` → `getBuiltinIcon()` |
 | Theme branding | `themeBranding.tsx` | `registerThemeBranding()` → `getThemeBranding()` |
+| Theme picker options | `hooks/useTheme.tsx` | `registerTheme()` → `getRegisteredThemes()` |
 | Top-bar widgets | `apps/topBarWidgets.tsx` | `registerTopBarWidgets()` → `getTopBarWidgets()` |
 | Panel nav + migration | `hooks/useKeyboardShortcuts.ts`, `components/MigrationCheck.tsx` | `registerPanelShortcut()`, `registerNonAppPrefix()` |
+
+Plus one **exported-transport** seam for edition-owned API methods (not a
+registry — see "API methods" below): `api/apiTransport.ts` exports `apiTransport`,
+and the edition builds its own typed API module on it.
 
 **Composition root.** `src/extensions.ts` is the one file an edition owns. It is
 imported first in `main.tsx` (before the store/providers/`App`), so all
@@ -251,6 +256,17 @@ chords the handler consumes before panel routing (shortcuts modal, settings,
 focus-input, MRU, chat-jump digits, arrows) — since a panel on one of those would
 be advertised but unreachable. All rejections route through `reportSeamCollision`.
 
+**Theme picker options.** `registerTheme([{ value, label }])` adds a built-in
+theme to the picker; `useTheme` reads it via `allThemes = [...THEMES,
+...registered, ...customThemes]`. The theme's CSS block ships in the edition's
+overlay — this seam only contributes the picker entry. A `value` already in
+`THEMES` or previously registered is rejected via `reportSeamCollision` (core
+wins).
+
+**API methods.** There is no registrar. An edition imports `apiTransport` from
+`api/apiTransport.ts` and writes its own fully-typed API module on it — see the
+"API methods (exported transport, not a registry)" note below for why.
+
 **Collision policy (`apps/seamCollision.ts`).** A registration whose key collides
 with a core (or already-registered) entry is resolved core-wins. It is
 **fail-loud in dev/test** (`reportSeamCollision` throws under
@@ -258,11 +274,40 @@ with a core (or already-registered) entry is resolved core-wins. It is
 and **degrades safe in production** (warn + ignore) so a shipped app never
 white-screens over a duplicate.
 
-**No API-client seam.** A `registerApiExtensions()`/`apiExt` seam was considered
-and **dropped**: unlike the five above, the core never consumes it (it would be
-written and read only by the edition), so it added public, stringly-typed surface
-for zero composition benefit. An edition's widgets define their own typed API
-helpers in their own module instead.
+**API methods (exported transport, not a registry).** Unlike the six registry
+seams, the core never *consumes* edition API methods — they are written and read
+only by the edition. A registry the core never reads would add public,
+stringly-typed (`unknown`-cast) seam surface for zero composition benefit. So
+instead of a registrar, `api/apiTransport.ts` **exports** the blessed
+`apiTransport` — the same `get`/`post`/`put`/`del`/`patch` + `j`/`jNullable` the
+core methods use (`client.ts` installs them via `installApiTransport` at module
+load). An edition builds its OWN fully-typed API module on `apiTransport`:
+
+```ts
+import { apiTransport as t } from '../api/apiTransport'
+export const editionApi = {
+  midwayTtl: () => t.get('/api/midway-ttl').then(t.j) as Promise<MidwayTtl>,
+}
+```
+
+This gives the edition the one thing it needs — the `X-Session-Key` header (the
+fail-open ephemeral-gate guard) and the auth-recovery/`ApiError` pipeline by
+construction — with full static types on the edition side and **no new *registry*
+contract**. It never forks `client.ts` and never writes raw `fetch` (which would
+silently drop the session key).
+
+`ApiTransport` (the seven helper signatures + the `j`/`jNullable` semantics) **is**
+a small, **intentionally-frozen** downstream contract — a separately-built edition
+compiles against it. There is no `CONTRACT_VERSION`-style guard on this frontend
+seam, so treat it like the backend's "CONTRACT_VERSION pinned at 1 pre-launch":
+changing a request helper's shape or `j`'s error behavior is **edition-breaking**
+(the stock build stays green — the seam is inert — so breakage surfaces only at
+runtime in the out-of-repo edition), not a free refactor. Evolve additively. Each
+`apiTransport` method is a stable wrapper that resolves the installed helper at
+call time, so an edition may import/destructure it at module-init without an
+ordering hazard vs. `extensions.ts`. Trust boundary: the transport carries the
+session key — it is for the edition composition root, **never**
+app/plugin-contributed frontend code.
 
 **`onActivate` timing.** A theme branding's `onActivate` side-effect fires on the
 first render for the initially-active theme (not only on a later switch); keep it

--- a/website/src/api/apiTransport.ts
+++ b/website/src/api/apiTransport.ts
@@ -1,0 +1,94 @@
+/**
+ * Blessed API transport — the shared, session-key-authenticated request helpers.
+ *
+ * `api/client.ts` defines the low-level helpers (`get`/`post`/`put`/`del`/
+ * `patch` + the `j`/`jNullable` response parsers) and installs them here via
+ * `installApiTransport`. A downstream edition that ships its own backend routes
+ * imports `apiTransport` and builds its OWN fully-typed API module on top of it,
+ * instead of forking `api/client.ts` (the whole-file-shadow erosion the seams
+ * exist to eliminate) or writing methods on raw `fetch`.
+ *
+ * Why an exported transport and NOT a `registerApiExtensions()` registry: unlike
+ * the other seams (builtin routes/icons/theme branding/top-bar widgets/panel
+ * shortcuts/theme options), the core never CONSUMES edition API methods — they
+ * are written and read only by the edition. A registry the core never reads adds
+ * public, stringly-typed (`unknown`-cast) seam surface for zero composition
+ * benefit (the reason such a seam was declined in the original seam PR). Exporting
+ * the blessed transport gives an edition the one thing it actually needs —
+ * `X-Session-Key` + the auth-recovery/`ApiError` pipeline by construction — while
+ * letting it keep full static types in its own module and adding no new
+ * *registry* contract.
+ *
+ * ## `ApiTransport` IS a small, intentionally-FROZEN downstream contract
+ *
+ * A separately-built edition compiles against the seven signatures below and the
+ * `j`/`jNullable` semantics (the session-expiry / auth-banner / `ApiError`
+ * recovery pipeline). Nothing analogous to the backend's `CONTRACT_VERSION`
+ * guards this frontend seam, so **treat these signatures as frozen** — like the
+ * backend's "CONTRACT_VERSION pinned at 1 pre-launch": a change to a request
+ * helper's shape or to `j`'s error behavior is **edition-breaking**, not a free
+ * internal refactor (the stock build stays green — the seam is inert — and the
+ * breakage surfaces only at runtime in the out-of-repo edition, on auth-adjacent
+ * surface since the transport carries `X-Session-Key`). Evolve additively.
+ *
+ * Trust boundary: this transport carries the session-key header; it is for the
+ * edition composition root, NOT for app/plugin-contributed frontend code.
+ */
+
+/**
+ * The session-key-authenticated request helpers, identical to those the core
+ * `api` methods use. `get`/`post`/`put`/`del`/`patch` issue the request with the
+ * `X-Session-Key` header; `j`/`jNullable` parse the `Response` and run the
+ * session-expiry / auth-banner / `ApiError` recovery pipeline.
+ *
+ * Intentionally frozen — see the module header. Add methods, never change these.
+ */
+export interface ApiTransport {
+  get: (url: string) => Promise<Response>
+  post: (url: string, body?: object) => Promise<Response>
+  put: (url: string, body: object) => Promise<Response>
+  del: (url: string, body?: object) => Promise<Response>
+  patch: (url: string, body: object) => Promise<Response>
+  j: (r: Response) => Promise<unknown>
+  jNullable: (r: Response) => Promise<unknown>
+}
+
+// Installed once by client.ts (which owns the helpers) at its module load.
+let _installed: ApiTransport | null = null
+
+/**
+ * Install the blessed transport. Called once by `api/client.ts`. Not part of the
+ * downstream-facing contract — editions read `apiTransport`, they never install.
+ */
+export function installApiTransport(transport: ApiTransport): void {
+  _installed = transport
+}
+
+function _resolve(): ApiTransport {
+  if (!_installed) {
+    // client.ts installs at its own module load. Any real request happens well
+    // after app startup, by which point client.ts has been imported (it is
+    // pulled in transitively by the store/providers/App). This guards only the
+    // impossible-in-practice case of a call before that.
+    throw new Error('apiTransport used before api/client installed it')
+  }
+  return _installed
+}
+
+/**
+ * The blessed transport. Each method is a STABLE wrapper that resolves the
+ * installed helper at CALL time — so an edition may `import { apiTransport }`
+ * and even destructure it at module-init (before `client.ts` installs the real
+ * helpers) without throwing; the wrappers just forward once actually invoked,
+ * which is always after startup. This deliberately avoids any import-ordering
+ * coupling with `extensions.ts` (imported first in `main.tsx`).
+ */
+export const apiTransport: ApiTransport = {
+  get: (url) => _resolve().get(url),
+  post: (url, body) => _resolve().post(url, body),
+  put: (url, body) => _resolve().put(url, body),
+  del: (url, body) => _resolve().del(url, body),
+  patch: (url, body) => _resolve().patch(url, body),
+  j: (r) => _resolve().j(r),
+  jNullable: (r) => _resolve().jNullable(r),
+}

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   SessionDoc,
 } from '../types'
 import { refreshOnce, __resetRefreshOnceForTests } from './refreshOnce'
+import { installApiTransport } from './apiTransport'
 import { queryClient } from './queryClient'
 
 export type McpPoolableServer = {
@@ -403,6 +404,12 @@ const del = (url: string, body?: object) =>
   fetch(url, { method: 'DELETE', headers: body ? { 'Content-Type': 'application/json', ..._sk } : _sk, body: body ? JSON.stringify(body) : undefined })
 const patch = (url: string, body: object) =>
   fetch(url, { method: 'PATCH', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify(body) })
+
+// Publish the blessed transport so a downstream edition can build its OWN typed
+// API module on the SAME session-key-authenticated helpers as core methods
+// (inheriting X-Session-Key + auth-recovery + ApiError), instead of forking this
+// file or writing methods on raw fetch. See api/apiTransport.ts.
+installApiTransport({ get, post, put, del, patch, j, jNullable })
 
 export interface InstanceTunnelStatus {
   instance_id: string

--- a/website/src/extensions.ts
+++ b/website/src/extensions.ts
@@ -13,6 +13,12 @@
  *   import { registerTopBarWidgets }     from './apps/topBarWidgets'
  *   import { registerPanelShortcut }     from './hooks/useKeyboardShortcuts'
  *   import { registerNonAppPrefix }      from './components/MigrationCheck'
+ *   import { registerTheme }             from './hooks/useTheme'
+ *
+ * For edition-owned API methods there is no registrar — the edition imports the
+ * blessed `apiTransport` (`./api/apiTransport`) and builds its own typed API
+ * module on it (the core never consumes edition API methods, so a registry would
+ * add stringly-typed surface for no composition benefit).
  *
  * The core ships this file EMPTY — the stock build registers nothing and every
  * seam is inert. A downstream edition overlays / owns this one file to inject

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { api } from '../api/client'
+import { reportSeamCollision } from '../apps/seamCollision'
 import { sanitizeCssValue } from '../lib/cssSanitize'
 import { safeSetItem } from '../utils/safeStorage'
 
@@ -145,6 +146,46 @@ export const THEMES: ThemeEntry[] = [
 
 /** Default color theme applied on first run when no preference is persisted. */
 export const DEFAULT_COLOR_THEME: ColorTheme = 'kiro'
+
+/**
+ * Downstream-registered built-in themes.
+ *
+ * Extension seam: a downstream edition (or plugin bundle) adds its own theme
+ * options to the theme picker via `registerTheme()` from its entry module,
+ * instead of editing the `THEMES` array on every upstream sync. These are
+ * built-in (non-`custom`) themes — the theme's CSS block ships with the
+ * edition's overlay; this registry only contributes the picker entry (value +
+ * label). The core registers none, so the stock picker shows only `THEMES`.
+ *
+ * Read via `allThemes` (`[...THEMES, ...registered, ...customThemes]`), so a
+ * registered theme appears in the picker without touching this file. Registration
+ * is expected at module-load time (edition composition), before the picker
+ * renders — this registry is not reactive.
+ */
+const REGISTERED_THEMES: ThemeEntry[] = []
+
+/**
+ * Register additional built-in theme picker entries at runtime. A duplicate
+ * `value` (already in `THEMES` or previously registered) is ignored and logs a
+ * warning, so re-entrant registration (e.g. HMR) stays idempotent.
+ */
+export function registerTheme(entries: ThemeEntry[]): void {
+  for (const entry of entries) {
+    if (
+      THEMES.some((t) => t.value === entry.value) ||
+      REGISTERED_THEMES.some((t) => t.value === entry.value)
+    ) {
+      reportSeamCollision('theme', `theme ${entry.value} already registered; ignoring duplicate`)
+      continue
+    }
+    REGISTERED_THEMES.push(entry)
+  }
+}
+
+/** All registered downstream themes, in insertion order. */
+export function getRegisteredThemes(): readonly ThemeEntry[] {
+  return REGISTERED_THEMES
+}
 
 const SYNC_EVENT = 'mc-theme-sync'
 export const CUSTOM_THEMES_CHANGED_EVENT = 'mc-custom-themes-changed'
@@ -376,7 +417,7 @@ function useThemeState(): ThemeContextValue {
   }, [colorTheme, setColorTheme, loadCustomThemes])
 
   // Combined themes list: built-in + custom
-  const allThemes: ThemeEntry[] = [...THEMES, ...customThemes]
+  const allThemes: ThemeEntry[] = [...THEMES, ...REGISTERED_THEMES, ...customThemes]
 
   const markOnboarded = useCallback(() => {
     safeSetItem('mc-onboarded', '1')

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -31,6 +31,11 @@ import {
   DEFAULT_SHORTCUTS,
   RESERVED_PANEL_CODES,
 } from '../hooks/useKeyboardShortcuts'
+import { registerTheme, getRegisteredThemes } from '../hooks/useTheme'
+import { apiTransport } from '../api/apiTransport'
+// Importing the client installs the blessed transport (installApiTransport runs
+// at client module load), so `apiTransport` is populated for the test below.
+import '../api/client'
 
 const Dummy = () => null
 
@@ -196,6 +201,51 @@ describe('panel shortcut — nav seam', () => {
     // And every code the parser DID recover must be reserved.
     const missing = [...consumed].filter(c => !RESERVED_PANEL_CODES.has(c))
     expect(missing).toEqual([])
+  })
+})
+
+describe('theme — picker-option seam', () => {
+  it('is empty in the stock build until registered', () => {
+    const before = getRegisteredThemes().length
+    registerTheme([{ value: 'seam-theme-opt', label: '🧪 Seam Theme' }])
+    expect(getRegisteredThemes().length).toBe(before + 1)
+    expect(getRegisteredThemes().some(t => t.value === 'seam-theme-opt')).toBe(true)
+  })
+
+  it('throws on a value already in core THEMES; core wins', () => {
+    expect(() => registerTheme([{ value: 'kiro', label: 'Hijack' }])).toThrow(/already registered/)
+  })
+
+  it('throws on a duplicate registered value in dev/test', () => {
+    registerTheme([{ value: 'seam-theme-dup', label: '🧪 Dup' }])
+    expect(() => registerTheme([{ value: 'seam-theme-dup', label: '🧪 Dup2' }])).toThrow(
+      /already registered/,
+    )
+    expect(getRegisteredThemes().filter(t => t.value === 'seam-theme-dup').length).toBe(1)
+  })
+})
+
+describe('apiTransport — exported blessed transport (not a registry)', () => {
+  it('exposes the core session-key helpers an edition builds its API module on', () => {
+    // These are the same helpers the core `api` methods use, so an edition
+    // method built on them inherits X-Session-Key + auth-recovery + ApiError by
+    // construction (never raw fetch, which would drop the session key). `put`
+    // must be present — an edition PUT route otherwise falls back to raw fetch.
+    for (const key of ['get', 'post', 'put', 'del', 'patch', 'j', 'jNullable'] as const) {
+      expect(typeof apiTransport[key]).toBe('function')
+    }
+  })
+
+  it('methods are stable wrappers — destructuring at module-init must not throw', () => {
+    // extensions.ts is imported before client.ts in main.tsx, so an edition
+    // that destructures the transport at its own module-init could reach it
+    // before install. The wrappers resolve at CALL time, so destructuring is
+    // always safe (no import-ordering hazard); only calling before install
+    // would error, which never happens after startup.
+    expect(() => {
+      const { get, post, put } = apiTransport
+      return [get, post, put]
+    }).not.toThrow()
   })
 })
 


### PR DESCRIPTION
## What

Adds the final two frontend extension points so a downstream edition (a separate build that composes this SPA — e.g. an internal fork) can contribute **theme picker options** and **edition-owned API client methods** without copy-and-shadowing core files. This completes the seam set from #296 — those two capabilities were the only remaining reasons an edition still had to whole-file-shadow `hooks/useTheme.tsx` and `api/client.ts`.

| Extension point | Module | Shape |
|-----------------|--------|-------|
| Theme picker options | `hooks/useTheme.tsx` | **registry** — `registerTheme()` → `getRegisteredThemes()` (core consumes it via `allThemes`) |
| API methods | `api/apiTransport.ts` (new) | **exported transport** — `apiTransport`; the edition builds its own typed API module on it (no registrar) |

## Why the API seam is an exported transport, NOT a registry

Unlike the six registry seams, the core never **consumes** edition API methods — they are written and read only by the edition. A registrar the core never reads would just re-add the stringly-typed (`unknown`-cast) public surface that was declined for exactly this reason in #296. So instead `api/apiTransport.ts` **exports** the blessed `apiTransport` — the same `get`/`post`/`put`/`del`/`patch` + `j`/`jNullable` helpers the core methods use (`client.ts` installs them at module load). The edition builds its own fully-typed module on it:

```ts
import { apiTransport as t } from '../api/apiTransport'
export const editionApi = {
  midwayTtl: () => t.get('/api/midway-ttl').then(t.j) as Promise<MidwayTtl>,
}
```

This gives the edition the one thing it needs — `X-Session-Key` (the fail-open ephemeral-gate guard) + the auth-recovery/`ApiError` pipeline **by construction** — with full static types on the edition side, never raw `fetch` (which would drop the session key), and no new registry contract.

`ApiTransport` **is** a small, **intentionally-frozen** downstream contract (seven signatures + `j`/`jNullable` semantics): a separately-built edition compiles against it and there is no `CONTRACT_VERSION`-style guard, so a change to a helper's shape is edition-breaking, not a free refactor — documented as such in `apiTransport.ts` and `AGENTS.md`. Each `apiTransport` method is a **stable wrapper** that resolves the installed helper at call time, so an edition may import/destructure it at module-init (before `client.ts` installs) without any ordering hazard vs. `extensions.ts` (imported first in `main.tsx`). Trust boundary: composition root only, never app/plugin code.

`registerTheme()` stays a registry (that one the core *does* consume), following the established core-wins collision policy.

## Testing

- `extensionSeams.test.tsx`: 3 new `registerTheme` tests + 2 `apiTransport` tests (helpers incl. `put` present; destructure-at-init safe) — **38 pass** total.
- `tsc -b`, `eslint`, and the full production build are clean.
- `website/AGENTS.md` updated (six registry seams + the transport export; the stale "No API-client seam … dropped" section replaced with the resolved rationale).