### PR TITLE
fix(skills): harden skills.sh bundle parsing against malformed registry JSON

### DIFF
--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -172,17 +172,33 @@ class SkillsShProvider:
             return None
         url = f"{self._config.api_base}/download/{urllib.parse.quote(skill_id, safe='/')}"
         data = await _fetch_json(url)
-        if data is None:
+        # skills.sh is untrusted external input: an error/maintenance payload (or
+        # a CDN interposing its SPA HTML) can be valid JSON that is not an object,
+        # so guard the shape before .get() — a bare data.get() on a list/str/number
+        # raises AttributeError and the caller converts a clean not-found into a
+        # misleading 502 + spurious error audit. Mirrors the isinstance guard in
+        # search() above.
+        if not isinstance(data, dict):
             return None
 
-        files = data.get("files", [])
-        if not files:
+        files = data.get("files")
+        if not isinstance(files, list) or not files:
             return None
 
         result: list[tuple[str, str]] = []
         for f in files:
+            # Each entry and its path/contents are attacker-controllable. A
+            # non-dict entry crashes at f.get(); a truthy non-string contents
+            # (e.g. a JSON number) survives the checks below and later blows up
+            # the install handler's `c.encode("utf-8")` with AttributeError; a
+            # non-string path raises TypeError at the `".." in path` check.
+            # Coerce/drop instead of trusting, matching search()'s idiom.
+            if not isinstance(f, dict):
+                continue
             path = f.get("path", "")
             contents = f.get("contents", "")
+            if not isinstance(path, str) or not isinstance(contents, str):
+                continue
             if not path or not contents:
                 continue
             # Skip paths with traversal attempts

--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -77,8 +77,16 @@ class SkillsShProvider:
         if data is None:
             return []
 
-        # skills.sh returns {"skills": [...]} or a flat list — handle both
-        items = data if isinstance(data, list) else data.get("skills", [])
+        # skills.sh returns {"skills": [...]} or a flat list — handle both.
+        # Guard the scalar case too: a JSON string/number body ("maintenance",
+        # an error page) is not a list and has no .get() (AttributeError), and
+        # {"skills": null} yields a non-list -> items[:limit] raises TypeError.
+        # Either way ProviderRegistry.search would swallow it and silently zero
+        # ALL skillsh results. Coerce anything that isn't a list to [] instead.
+        raw_items = data if isinstance(data, list) else (
+            data.get("skills") if isinstance(data, dict) else None
+        )
+        items: list[Any] = raw_items if isinstance(raw_items, list) else []
         results: list[SkillSearchResult] = []
         for item in items[:limit]:
             if not isinstance(item, dict):

--- a/test/test_skill_providers.py
+++ b/test/test_skill_providers.py
@@ -109,6 +109,18 @@ class TestSkillsShProvider:
             assert results == []
 
     @pytest.mark.asyncio
+    async def test_search_handles_malformed_payload(self):
+        # A scalar JSON body (string/number) is not a list and has no .get()
+        # (AttributeError pre-fix); {"skills": null} yields items=None ->
+        # items[:limit] TypeError. Both must degrade to [] rather than crash.
+        for payload in ("maintenance", 42, {"skills": None}, {"skills": "x"}, {"nope": 1}):
+            with patch(
+                "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+                return_value=payload,
+            ):
+                assert await SkillsShProvider().search("docker") == []
+
+    @pytest.mark.asyncio
     async def test_fetch_content_extracts_skill_md_from_bundle(self):
         bundle = {
             "files": [

--- a/test/test_skill_providers.py
+++ b/test/test_skill_providers.py
@@ -374,6 +374,67 @@ class TestSkillsShDownloadUrl:
         assert calls["n"] == 0  # malformed ids never reach the network
 
 
+class TestSkillsShBundleMalformedInput:
+    """skills.sh is an untrusted external registry: fetch_skill_bundle() must
+    coerce/drop malformed JSON rather than crash. Pre-fix, a non-object top-level
+    payload raised AttributeError at data.get(); a non-dict file entry raised
+    AttributeError at f.get(); a non-string ``path`` raised TypeError at the
+    ``".." in path`` check; and a truthy non-string ``contents`` (e.g. a JSON
+    number) slipped through and later blew up the install handler's
+    ``c.encode("utf-8")``. Each must now yield a clean None / dropped entry."""
+
+    @pytest.mark.asyncio
+    async def test_non_object_payload_returns_none(self):
+        # A list / string / number body (API error, maintenance page, CDN SPA)
+        # must not raise — it should be treated as "no bundle".
+        for payload in ([{"path": "SKILL.md", "contents": "x"}], "html", 42, None):
+            with patch(
+                "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+                return_value=payload,
+            ):
+                assert await SkillsShProvider().fetch_skill_bundle("o/r/s") is None
+
+    @pytest.mark.asyncio
+    async def test_non_list_files_returns_none(self):
+        for files in ("abc", {"a": 1}, 5):
+            with patch(
+                "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+                return_value={"files": files},
+            ):
+                assert await SkillsShProvider().fetch_skill_bundle("o/r/s") is None
+
+    @pytest.mark.asyncio
+    async def test_non_dict_entries_are_dropped(self):
+        payload = {"files": ["not-a-dict", 7, {"path": "SKILL.md", "contents": "ok"}]}
+        with patch(
+            "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+            return_value=payload,
+        ):
+            bundle = await SkillsShProvider().fetch_skill_bundle("o/r/s")
+        assert bundle == [("SKILL.md", "ok")]
+
+    @pytest.mark.asyncio
+    async def test_non_string_path_or_contents_are_dropped(self):
+        # A JSON number in path (TypeError at `".." in path`) or in contents
+        # (survives pre-fix, then 500s the install handler at c.encode()).
+        payload = {
+            "files": [
+                {"path": 5, "contents": "x"},  # non-str path
+                {"path": "BAD.md", "contents": 42},  # non-str contents
+                {"path": "SKILL.md", "contents": "good"},  # valid
+            ]
+        }
+        with patch(
+            "kiro_crew.skill_providers.skillsh._sync_fetch_json",
+            return_value=payload,
+        ):
+            bundle = await SkillsShProvider().fetch_skill_bundle("o/r/s")
+        assert bundle == [("SKILL.md", "good")]
+        # every returned entry is (str, str) so the install handler's
+        # c.encode("utf-8") can never raise.
+        assert all(isinstance(p, str) and isinstance(c, str) for p, c in bundle)
+
+
 class TestIsInternalUrlSSRF:
     """The skills.sh SSRF guard (_is_internal_url), used as both a pre-connect
     check and the redirect gate in _SafeRedirectHandler, must block the alternate


### PR DESCRIPTION
## Bug (HIGH · crash-on-malformed-input)

`skills.sh` is an untrusted external registry, but `fetch_skill_bundle()` trusted the shape of its JSON, so a malformed response crashed the skill install/preview endpoints instead of degrading to a clean not-found:

- **Non-object top-level payload** (a JSON list / string / number — an API error page, a maintenance response, or a CDN interposing its SPA HTML) hit `data.get("files")` → `AttributeError`. The install handler's generic `except` then turned a clean not-found into a misleading **502** + a spurious `outcome=error` SEL audit event.
- **Non-dict file entry** → `AttributeError` at `f.get()`; **non-string `path`** → `TypeError` at the `".." in path` traversal check.
- **Truthy non-string `contents`** (e.g. `{"path": "SKILL.md", "contents": 42}`) slipped through every guard and was returned in the bundle, then blew up the install handler's `sum(len(c.encode("utf-8")) …)` with `AttributeError: 'int' object has no attribute 'encode'` — an unhandled **500** on `POST /api/skills/-/discover/install`.

All fields are attacker-controllable by the remote registry, which this file already treats as untrusted (see the coerce/drop guards in `search()`).

## Fix

Guard the response shape (`isinstance` dict / list) and coerce-or-drop each file entry to `(str, str)`, mirroring `search()`'s existing idiom. Malformed input now yields `None` (clean not-found) or drops the bad entry — no crash.

## Test

`TestSkillsShBundleMalformedInput` in `test/test_skill_providers.py`: non-object payloads, non-list `files`, non-dict entries, and non-string `path`/`contents` each **fail pre-fix** with the exact `AttributeError`/`TypeError` (verified via surgical revert) and **pass post-fix**. Full skillsh suite (45 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
