### PR TITLE
fix(skills): clamp discover `limit` query param to >= 1

### DIFF
--- a/src/kiro_crew/dashboard/handlers/discover.py
+++ b/src/kiro_crew/dashboard/handlers/discover.py
@@ -97,7 +97,10 @@ async def api_skills_discover(request: web.Request) -> web.Response:
     query = request.query.get("q", "").strip()
     provider_filter = request.query.get("provider", "").strip() or None
     try:
-        limit = min(int(request.query.get("limit", "20")), 50)
+        # Clamp BOTH ends: the upper-only min() let limit<=0 through, where
+        # merged[:limit] / items[:limit] silently drop results (limit=-1) or
+        # return nothing (limit=0), and &limit=-1 hit the provider URL.
+        limit = max(1, min(int(request.query.get("limit", "20")), 50))
     except ValueError:
         limit = 20
 

--- a/test/test_skill_discover.py
+++ b/test/test_skill_discover.py
@@ -287,3 +287,36 @@ class TestDiscoverSearch:
             assert data["results"][0]["installs"] == 4321
         finally:
             await client.close()
+
+    async def test_limit_query_is_clamped_to_at_least_one(self, fake_home, reset_registry):
+        """`limit` was clamped only on the upper end (min(..., 50)); a
+        <=0 value survived, and merged[:limit] then silently dropped the last
+        result (limit=-1) or returned nothing (limit=0), and &limit=-1 hit the
+        provider URL. The handler must now clamp to >=1."""
+        seen = {}
+
+        class RecordingProvider(FakeProvider):
+            async def search(self, query, *, limit=20):
+                seen["limit"] = limit
+                return self._results
+
+        state, _ = _state_with_skills_loader(fake_home)
+        app = _make_app(state, RecordingProvider())
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        try:
+            for raw in ("-1", "0"):
+                seen.clear()
+                resp = await client.get(
+                    "/api/skills/-/discover", params={"q": "fake", "limit": raw}
+                )
+                assert resp.status == 200
+                assert seen["limit"] >= 1, f"limit={raw!r} not clamped: {seen}"
+            # upper bound still enforced
+            seen.clear()
+            await client.get(
+                "/api/skills/-/discover", params={"q": "fake", "limit": "999"}
+            )
+            assert seen["limit"] == 50
+        finally:
+            await client.close()


### PR DESCRIPTION
## Bug (LOW · input-validation)

`GET /api/skills/-/discover` clamped the `limit` query param only on the upper end — `min(int(request.query.get("limit","20")), 50)` — so a non-positive value slipped through:

- `limit=-1` → `merged[:limit]` (registry) and `items[:limit]` (provider) become `[:-1]` and **silently drop the last result**; `&limit=-1` also reached the skills.sh request URL (undefined behavior).
- `limit=0` → an always-empty result set that reads as "no matches".

## Fix

`limit = max(1, min(int(...), 50))` — clamp both ends, keeping the existing `except ValueError: limit = 20` fallback. 0 and negatives are neutralized before they reach `ProviderRegistry.search` or the provider URL.

## Test

`TestDiscoverSearch::test_limit_query_is_clamped_to_at_least_one` records the `limit` the provider receives and asserts it's `>=1` for `limit=-1`/`0`, still capped at `50`. Fails pre-fix (limit=-1 passes through) via surgical revert; passes post-fix. Full discover suite (10 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
