### PR TITLE
style(follow-up): send-arrow icon + 'Send now' tooltip on quick-send chip

### DIFF
--- a/website/src/components/FollowUpBar.tsx
+++ b/website/src/components/FollowUpBar.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef, useState, useEffect, useCallback } from 'react'
-import { ChevronLeft, ChevronRight, Zap } from 'lucide-react'
+import { ChevronLeft, ChevronRight, ArrowUp } from 'lucide-react'
 
 export type FollowUpLayout = 'multiline' | 'scroll'
 
@@ -130,13 +130,13 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
       {mainChip}
       <button
         type="button"
-        aria-label={`Send "${option}" now`}
-        title={`Send "${option}" now`}
+        aria-label={`Send now: ${option}`}
+        title="Send now"
         onMouseDown={(e) => e.preventDefault()}
         onClick={(e) => { e.stopPropagation(); if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }; onSend?.(isPicked ? undefined : option) }}
         className={sendSegmentClassName(isPicked)}
       >
-        <Zap size={13} />
+        <ArrowUp size={13} />
       </button>
     </span>
   )

--- a/website/src/test/FollowUpBar.test.tsx
+++ b/website/src/test/FollowUpBar.test.tsx
@@ -157,24 +157,24 @@ describe('FollowUpBar', () => {
 
   // ─── Split-button "send now" segment ─────────────────────────
   // Discoverable form of the double-click-to-send gesture: a distinct
-  // lightning-bolt segment next to the chip body that sends immediately.
+  // send-arrow segment next to the chip body that sends immediately.
   describe('send-now split segment', () => {
     it('renders a distinct "Send" button alongside the chip when onSend is provided', () => {
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={() => {}} onSend={() => {}} />)
       expect(screen.getByRole('button', { name: 'Go' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Send "Go" now' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Send now: Go' })).toBeInTheDocument()
     })
 
     it('does not render the send segment without onSend (legacy callers)', () => {
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={() => {}} />)
-      expect(screen.queryByRole('button', { name: 'Send "Go" now' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Send now: Go' })).not.toBeInTheDocument()
     })
 
     it('clicking the send segment calls onSend(option) directly and skips onSelect', () => {
       const onSelect = vi.fn()
       const onSend = vi.fn()
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={onSelect} onSend={onSend} />)
-      fireEvent.click(screen.getByRole('button', { name: 'Send "Go" now' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
       expect(onSend).toHaveBeenCalledTimes(1)
       expect(onSend).toHaveBeenCalledWith('Go')
       expect(onSelect).not.toHaveBeenCalled()
@@ -184,7 +184,7 @@ describe('FollowUpBar', () => {
       const onSelect = vi.fn()
       const onSend = vi.fn()
       render(<FollowUpBar options={['Go']} picked={new Set(['Go'])} onSelect={onSelect} onSend={onSend} />)
-      fireEvent.click(screen.getByRole('button', { name: 'Send "Go" now' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
       expect(onSend).toHaveBeenCalledWith(undefined)
     })
 
@@ -194,7 +194,7 @@ describe('FollowUpBar', () => {
       const onSend = vi.fn()
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={onSelect} onSend={onSend} />)
       fireEvent.click(screen.getByRole('button', { name: 'Go' }), { detail: 1 })
-      fireEvent.click(screen.getByRole('button', { name: 'Send "Go" now' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
       act(() => { vi.advanceTimersByTime(250) })
       expect(onSend).toHaveBeenCalledTimes(1)
       expect(onSelect).not.toHaveBeenCalled()
@@ -203,12 +203,12 @@ describe('FollowUpBar', () => {
 
     it('suppresses the send segment in quickSend instant-send state (single click already sends)', () => {
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={() => {}} onSend={() => {}} quickSend />)
-      expect(screen.queryByRole('button', { name: 'Send "Go" now' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Send now: Go' })).not.toBeInTheDocument()
     })
 
     it('shows the send segment once a pick exists even with quickSend on (debounced path)', () => {
       render(<FollowUpBar options={['Go']} picked={new Set(['First'])} onSelect={() => {}} onSend={() => {}} quickSend />)
-      expect(screen.getByRole('button', { name: 'Send "Go" now' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Send now: Go' })).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Problem
The follow-up option chips have a quick-send segment (the split button on the right of each chip that fires the option immediately). It used the `Zap` (lightning) icon, which reads as "fast/instant" rather than "send", and the hover tooltip interpolated the full option text (`Send "<long option>" now`), which read awkwardly.

## Why it matters
The quick-send segment is a send affordance but didn't look like the app's other send controls, and the verbose tooltip was hard to parse for long option labels — small but real friction on a frequently-seen control.

## Fix (symptom → root cause → change)
- Icon mismatch → the segment used `Zap`, unrelated to sending → swap to `ArrowUp`, matching the **primary composer send button** (`ChatInput.tsx` `<ArrowUp size={18} />`, aria-label "Send"). Size 13 to fit the compact segment.
- Awkward tooltip → the `title` interpolated the option text → simplify the visible tooltip to a clean **`Send now`**; the `aria-label` still carries the option text (`Send now: <option>`) for screen-reader context.

## Tests
- `website/src/test/FollowUpBar.test.tsx` — updated the send-now segment's accessible-name assertions to `Send now: Go` (25/25 pass).

## Manual verification
- `npx tsc -b` clean; hard-refreshed the dashboard and confirmed the arrow renders in unpicked/hover/picked states.
- A rendered screenshot of the three states was reviewed during development; not committed to the tree (per Design review — one-off PR screenshots belong on the PR's attachment CDN, not the repo.
EOF
)