### PR TITLE
fix(notifications): stop app meta from smuggling broadcast-envelope keys

### DIFF
--- a/src/kiro_crew/notifications/bus.py
+++ b/src/kiro_crew/notifications/bus.py
@@ -68,6 +68,10 @@ _RESERVED_NOTE_KEYS = frozenset(
         "url",
         "icon",
         "ttl",
+        # Sink/frontend-owned status fields: a caller must not be able to
+        # pre-suppress or pre-acknowledge a note it is pushing.
+        "silenced",
+        "acked",
     }
 )
 
@@ -283,11 +287,24 @@ class NotificationBus:
         if payload.meta:
             # Meta keys merge flat into the note (legacy behavior — the
             # frontend reads note.job_id / note.slot / note.session_key
-            # directly). Reserved schema keys are skipped entirely so meta
-            # can neither clobber them nor smuggle unvalidated values into
-            # unset schema fields (see _RESERVED_NOTE_KEYS).
+            # directly). The merge is default-safe: a meta key is admitted only
+            # if it clears THREE independent guards, so no single denylist has
+            # to be kept perfectly in sync as the schema grows:
+            #   1. not already in `note` — every field the builder above wrote
+            #      (kind/source/.../group_key/actions/url/icon/ttl, present or
+            #      added in future) is off-limits by construction, closing the
+            #      "unset schema field" smuggle vector without re-listing them.
+            #   2. not underscore-prefixed — all internal broadcast-envelope
+            #      keys (DashboardState._broadcast branches on note["_type"] and
+            #      reads companion keys like slot/role/content once it is set)
+            #      are private by convention; blocking the whole `_`-namespace
+            #      neutralizes envelope hijacking for current AND future keys.
+            #   3. not in _RESERVED_NOTE_KEYS — the residual sink/frontend-owned
+            #      fields that are NOT underscore-prefixed and are set LATER than
+            #      this merge (silenced/acked), so guards 1-2 can't catch them.
             for key, value in payload.meta.items():
-                if key not in _RESERVED_NOTE_KEYS:
-                    note.setdefault(key, value)
+                if key in note or key.startswith("_") or key in _RESERVED_NOTE_KEYS:
+                    continue
+                note[key] = value
         self._sink(note)
         return note

--- a/test/test_notification_bus.py
+++ b/test/test_notification_bus.py
@@ -231,6 +231,26 @@ class TestNoteShape:
         assert note["title"] == "t"  # reserved key not clobbered by meta
         assert note["channel"] == "system.cron"
 
+    def test_meta_cannot_clobber_a_builder_set_field(self):
+        # Default-safe guard: any key the builder already wrote to the note is
+        # off-limits to meta by construction (the "key in note" check), so a new
+        # schema field is protected without having to be re-listed in a denylist.
+        # group_key is a builder-set optional field that is not underscore-
+        # prefixed.
+        bus, _ = _make_bus()
+        note = bus.push(
+            NotificationPayload(
+                source="system",
+                channel="system.cron",
+                title="t",
+                body="b",
+                group_key="real-group",
+                meta={"group_key": "EVIL", "job_id": "j1"},
+            )
+        )
+        assert note["group_key"] == "real-group"
+        assert note["job_id"] == "j1"
+
     def test_meta_cannot_smuggle_unset_schema_fields(self):
         # meta={"url": ...} must not inject an unvalidated URL into the note
         # when payload.url is None (validation only runs on payload fields).
@@ -246,6 +266,47 @@ class TestNoteShape:
         )
         assert "url" not in note
         assert "ttl" not in note
+        assert note["job_id"] == "j1"
+
+    def test_meta_cannot_smuggle_broadcast_envelope_keys(self):
+        # DashboardState._broadcast branches on note["_type"] (and reads
+        # companion keys like slot/role/content once set) to decide the WS
+        # frame. Caller-supplied meta must not be able to inject "_type" (or any
+        # underscore-prefixed key) and hijack the envelope.
+        bus, _ = _make_bus()
+        note = bus.push(
+            NotificationPayload(
+                source="system",
+                channel="system.cron",
+                title="t",
+                body="b",
+                meta={
+                    "_type": "slot_update",
+                    "slot": "victim",
+                    "content": "spoofed",
+                    "job_id": "j1",
+                },
+            )
+        )
+        assert "_type" not in note
+        assert note.get("_type", "notification") == "notification"
+        assert note["job_id"] == "j1"  # non-private meta still merges
+
+    def test_meta_cannot_preset_status_fields(self):
+        # 'silenced'/'acked' are sink/frontend-owned; a caller must not
+        # pre-suppress or pre-ack a note it is pushing.
+        bus, _ = _make_bus()
+        note = bus.push(
+            NotificationPayload(
+                source="system",
+                channel="system.cron",
+                title="t",
+                body="b",
+                meta={"silenced": True, "acked": True, "job_id": "j1"},
+            )
+        )
+        assert "silenced" not in note
+        assert "acked" not in note
         assert note["job_id"] == "j1"
 
     def test_optional_fields_omitted_when_unset(self):


### PR DESCRIPTION
## Bug (HIGH · privilege / envelope-smuggling)

`NotificationBus.push()` merges caller-supplied `meta` flat into the note, skipping only `_RESERVED_NOTE_KEYS` (the schema fields). That set omitted:

- the internal broadcast-envelope discriminator **`_type`** (and companion keys `slot`/`role`/`content`/… that `DashboardState._broadcast` reads once `_type` is set), and
- the sink/frontend-owned status keys **`silenced`** / **`acked`**.

So an authenticated app-push could set `meta={"_type": "slot_update", "slot": …, "content": …}` to **hijack the WS frame** the dashboard renders, or `meta={"silenced": true}` / `{"acked": true}` to pre-suppress or pre-ack its own notification.

## Fix

- Drop any **underscore-prefixed** meta key in the merge loop (neutralizes `_type` and every companion envelope key — the WS translation only branches once `_type` is present).
- Add `silenced` and `acked` to `_RESERVED_NOTE_KEYS`.

Non-private meta (`job_id`, plain `slot`, …) still merges as before.

## Test

`TestNoteShape::test_meta_cannot_smuggle_broadcast_envelope_keys` and `::test_meta_cannot_preset_status_fields` — both **fail pre-fix** (the keys land in the note) via surgical revert, pass post-fix. Full bus suite (50 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
