### PR TITLE
fix(dashboard): don't crash gateway boot on a malformed dashboard.url

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -529,6 +529,8 @@ Returns the effective config for a channel:
 
 The `dashboard.url` field controls where the dashboard is reachable. From it, the system derives the port to bind on, the bind address (`0.0.0.0` for non-loopback hosts, `127.0.0.1` otherwise), and the allowed origins for CSRF/WebSocket checks. When omitted, defaults to `localhost:5476`.
 
+A **malformed** `dashboard.url` (e.g. an unterminated IPv6 literal `http://[::1` or a non-numeric port `http://host:notaport`) does **not** abort startup: `parse_dashboard_url` degrades to the defaults (`""` host, port `5476`) and logs a warning, so a single typo in the config can never take the gateway down on boot. `KIROCREW_PORT` still overrides the port regardless.
+
 ## Model Resolution Chain
 
 When `agent.model` is `"auto"` (default):

--- a/src/kiro_crew/dashboard/origin.py
+++ b/src/kiro_crew/dashboard/origin.py
@@ -145,9 +145,19 @@ def parse_dashboard_url(url: str) -> tuple[str, int]:
         host, port = "", _DEFAULT_PORT
     else:
         url = _ensure_scheme(url)
-        parsed = urlparse(url)
-        host = parsed.hostname or ""
-        port = parsed.port or _DEFAULT_PORT
+        # urlparse raises ValueError on a malformed IPv6 literal
+        # ("http://[::1"), and .port raises ValueError on a non-integer port
+        # ("http://host:notaport"). dashboard.url is a user-editable config
+        # field parsed unguarded during gateway startup (SlackGateway.
+        # _init_dashboard, cli_server, cli_doctor, mcp_core), so one typo aborted
+        # the whole boot. Degrade to defaults instead — mirrors dashboard_origin().
+        try:
+            parsed = urlparse(url)
+            host = parsed.hostname or ""
+            port = parsed.port or _DEFAULT_PORT
+        except ValueError:
+            logger.warning("Ignoring malformed dashboard_url: %s", url)
+            host, port = "", _DEFAULT_PORT
     env_port = os.environ.get("KIROCREW_PORT")
     if env_port:
         try:

--- a/test/test_dashboard_origin.py
+++ b/test/test_dashboard_origin.py
@@ -132,6 +132,30 @@ class TestSchemeAgreement:
         assert origin == f"http://{host}:9090"
 
 
+class TestParseDashboardUrlMalformed:
+    """A typo in the user-editable dashboard.url config field must not abort
+    gateway startup. parse_dashboard_url is called unguarded during boot, and
+    urlparse()/.port raise ValueError on a malformed IPv6 literal or a
+    non-integer port — those must degrade to defaults, not propagate."""
+
+    def test_malformed_ipv6_falls_back_to_defaults(self) -> None:
+        # urlparse("http://[::1") raises ValueError('Invalid IPv6 URL').
+        host, port = parse_dashboard_url("http://[::1")
+        assert host == ""
+        assert port == 5476  # _DEFAULT_PORT
+
+    def test_non_integer_port_falls_back_to_defaults(self) -> None:
+        # parsed.port raises ValueError on a non-numeric port.
+        host, port = parse_dashboard_url("http://myhost:notaport")
+        assert host == ""
+        assert port == 5476
+
+    def test_valid_url_still_parses(self) -> None:
+        host, port = parse_dashboard_url("http://myhost:9090")
+        assert host == "myhost"
+        assert port == 9090
+
+
 _MOD = "kiro_crew.dashboard.origin"
 
 


### PR DESCRIPTION
## Bug (HIGH · crash-on-malformed-input / boot crash)

`parse_dashboard_url()` called `urlparse(url)` and read `parsed.port` with **no ValueError guard**:

- `urlparse("http://[::1")` raises `ValueError('Invalid IPv6 URL')`
- `parsed.port` raises `ValueError` on a non-integer port (`"http://host:notaport"`)

The function runs **unguarded during gateway startup** (`SlackGateway._init_dashboard`, `cli_server`, `cli_doctor`, `mcp_core`), so a single typo in the user-editable `config.json` `dashboard.url` field **aborts the entire gateway boot**.

## Fix

Wrap the parse in `try/except ValueError` and fall back to `("", _DEFAULT_PORT)` with a warning — mirroring the guard `dashboard_origin()` already uses on the same parse.

## Test

`TestParseDashboardUrlMalformed`: malformed IPv6 and non-integer port each **fail pre-fix** with the exact `ValueError` (surgical revert) and now degrade to defaults; a valid URL still parses. Full origin suite (86 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
