### PR TITLE
fix(metrics): reap metric-reader daemon thread when telemetry init fails

### DIFF
--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -108,6 +108,12 @@ def _build_recorder() -> MetricsRecorder:
     if not cfg.enabled:
         return MetricsRecorder(None)
 
+    # PeriodicExportingMetricReader starts its daemon ticker thread inside
+    # __init__, so if any later step (MeterProvider construction, etc.) raises,
+    # the reader is already ticking. Hoist it here so the except can reap it —
+    # otherwise the orphaned thread keeps running and spamming export WARNINGs
+    # for the life of the process even though metrics are "disabled".
+    reader = None
     try:
         directory = (
             Path(cfg.local_dir).expanduser()
@@ -137,6 +143,15 @@ def _build_recorder() -> MetricsRecorder:
         return MetricsRecorder(_provider.get_meter(_SCOPE))
     except Exception as exc:
         logger.warning("telemetry init failed; metrics disabled: %s", exc)
+        # Reap the reader's already-started daemon thread if it outlived a
+        # failure in a later init step, so a disabled recorder leaves nothing
+        # ticking behind. shutdown() must never turn the degrade path into a
+        # raise, so swallow anything it throws.
+        if reader is not None:
+            try:
+                reader.shutdown()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                logger.debug("metric reader shutdown after init failure failed", exc_info=True)
         return MetricsRecorder(None)
 
 

--- a/test/metrics/test_provider.py
+++ b/test/metrics/test_provider.py
@@ -44,6 +44,38 @@ def test_recorder_is_cached(monkeypatch):
         reset_for_testing()
 
 
+def test_reader_thread_reaped_when_meterprovider_init_fails(tmp_path, monkeypatch):
+    """PeriodicExportingMetricReader starts its daemon ticker thread in
+    __init__. If a later init step (MeterProvider) raises, the reader is already
+    ticking — the provider must shut it down before degrading, or an orphaned
+    thread spams export WARNINGs for the whole process lifetime."""
+    import kiro_crew.metrics.provider as provider_mod
+
+    reset_for_testing()
+    _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+
+    shutdown_calls = {"n": 0}
+
+    class FakeReader:
+        def __init__(self, *a, **k):
+            pass  # stand-in for the real reader's thread-starting __init__
+
+        def shutdown(self, *a, **k):
+            shutdown_calls["n"] += 1
+
+    def _boom(*a, **k):
+        raise RuntimeError("meter provider init failed")
+
+    monkeypatch.setattr(provider_mod, "PeriodicExportingMetricReader", FakeReader)
+    monkeypatch.setattr(provider_mod, "MeterProvider", _boom)
+    try:
+        rec = get_recorder()
+        assert rec.enabled is False  # degraded to no-op
+        assert shutdown_calls["n"] == 1  # reader was reaped, not orphaned
+    finally:
+        reset_for_testing()
+
+
 def test_degrades_to_noop_when_otel_missing(monkeypatch):
     """with opentelemetry absent from the env closure, the provider
     must degrade to a no-op recorder instead of crashing the eager boot chain."""


### PR DESCRIPTION
## Bug (MEDIUM · resource-leak)

`PeriodicExportingMetricReader` starts its daemon ticker thread inside its own `__init__`. In `_build_recorder()` the reader is constructed **before** the `MeterProvider`; if `MeterProvider` construction (or any later step) raises, the `except` logged *"telemetry init failed; metrics disabled"* and returned a no-op recorder — but **never shut the reader down**. The orphaned thread kept ticking and spamming export `WARNING` logs for the whole process lifetime, even though metrics were "disabled".

## Fix

Hoist `reader = None` above the `try` and call `reader.shutdown()` in the `except` (best-effort — swallows any error so the degrade path never raises).

## Test

`test_reader_thread_reaped_when_meterprovider_init_fails` patches the reader with a shutdown-recording double and forces `MeterProvider` to raise; asserts the recorder degrades to no-op **and** `shutdown()` was called exactly once. **Fails pre-fix** (shutdown never called) via surgical revert. Full metrics suite (76 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
