### PR TITLE
feat: native Windows support (ConPTY terminal, metrics, process mgmt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ test_plan_atomic_writes_subagent_progress.md
 website/electron/backend-dist/
 website/electron/dist/
 website/electron/node_modules/
+# Generated launcher icon (created from icon.png when making the desktop shortcut)
+website/electron/KiroCrew.ico
 tui/
 mise.toml
 

--- a/docs/WINDOWS_CHANGES.md
+++ b/docs/WINDOWS_CHANGES.md
@@ -1,0 +1,201 @@
+# Windows Changes
+
+This file records the changes made so KiroCrew runs natively on Windows,
+including the Electron desktop app, and explains why each was needed. Every
+change is scoped to Windows or preserves the existing macOS and Linux behavior.
+
+## Environment used
+
+* Windows with CPython 3.13, Node 24, npm 11
+* `kiro-cli` already installed and logged in
+* A repo local virtual environment at `.venv`
+* The React dashboard built with `npm run build` and staged into
+  `src/kiro_crew/static/dist`
+
+## Runtime enablement (user config, not code)
+
+* Set `agent.sandbox_allow_unsandboxed_exec` to true in
+  `~/.kirocrew/config.json`. On Windows there is no OS level sandbox backend
+  (Linux user namespaces and macOS `sandbox-exec` only), so `sandbox.wrap_argv`
+  fails closed and refuses to spawn `kiro-cli`. This is the documented opt in,
+  so chat, model listing, and cron turns work. Without it the dashboard loads
+  but every agent turn errors with "Sandbox backend unavailable".
+
+## Backend changes (`src/kiro_crew`)
+
+* `conpty.py` (new). A Windows pseudo console backend for the dashboard web
+  terminal. It wraps `pywinpty`, the maintained ConPTY binding, and exposes the
+  same small surface the terminal handler needs (`read` returning bytes,
+  `write` taking bytes, `resize`, `isalive`, `terminate`, `pid`). Why. The web
+  terminal used POSIX `pty` and `fork`, which do not exist on Windows, so the
+  panel returned "not supported on Windows". A hand rolled ctypes ConPTY was
+  attempted first but the child never attached to the pseudo console (it printed
+  to the parent console and exited), so the maintained binding was used instead.
+  This module is imported only inside the Windows branch of the terminal
+  handler, so macOS and Linux never load it.
+
+* `platform_compat.py`. Added `system_memory` and `system_cpu_percent`. The
+  first reads total and available physical memory with `GlobalMemoryStatusEx`.
+  The second computes a system wide CPU percentage from a `GetSystemTimes`
+  delta. Both return `None` when the host is not Windows, so POSIX callers fall
+  through to their existing code. Why. The dashboard header read CPU from
+  `/proc/stat` or `ps` and memory from `/proc/meminfo`, none of which exist on
+  Windows, so CPU showed 0 and memory showed blank.
+
+* `dashboard/handlers_system.py`. Added Windows branches for live memory, static
+  total memory, and CPU that call the two new `platform_compat` helpers. The
+  macOS and Linux branches are unchanged. A last known Windows CPU value is kept
+  so the first sample (which has no delta yet) does not flash to zero.
+
+* `dashboard/handlers/terminal.py`. Wired the ConPTY backend into the terminal
+  websocket. On Windows it spawns PowerShell through `conpty.WindowsPty` and
+  routes read, write, and resize through it. Session teardown reaps the whole
+  process tree with `taskkill /T` through `platform_compat` so a background
+  child started in the terminal cannot outlive the closed tab. Added backend
+  agnostic helpers `_sess_alive` and `_sess_pid` that return the same values the
+  old direct process attribute access returned on POSIX. Every Windows path is
+  behind a `winpty` or `IS_WINDOWS` check, so POSIX keeps the original `pty`
+  path.
+
+* `apps/registry.py`. The app install script timeout now reaps through
+  `platform_compat.kill_process_tree_async` instead of a raw `os.killpg`. Why.
+  `os.killpg` does not exist on Windows and raised `AttributeError`, which the
+  `except OSError` guard did not catch, so the process tree leaked and the
+  fallback kill never ran. On POSIX the shim performs the same group kill under
+  the hood, matching how the rest of the codebase already reaps trees.
+
+* `apps/backend.py`. `_pid_alive` now delegates to `platform_compat.pid_exists`.
+  Why. A raw `os.kill(pid, 0)` does not probe liveness on Windows (signal 0 is
+  the console `CTRL_C_EVENT` there), so it misreported liveness in the app
+  backend orphan reaper. The shim uses `OpenProcess` on Windows and the
+  identical `os.kill(pid, 0)` with EPERM treated as alive on POSIX, so POSIX
+  behavior is unchanged.
+
+* `cron_script.py`. Cancelling or timing out a script or command cron now reaps
+  the tree with `platform_compat.kill_process_tree` on Windows. Why. The cancel
+  and escalation paths called `os.getpgid` and `os.killpg`, which do not exist
+  on Windows and raised `AttributeError`. `_resolve_safe_pgid` now returns
+  `None` on Windows and the POSIX group kill logic is left exactly as it was.
+
+* `mcp_discovery.py`. Failed MCP probe cleanup now reaps the probe tree with
+  `taskkill /T` on Windows. Why. The existing reap ran only on POSIX (an
+  `os.killpg` on the probe group), so on Windows the launcher grandchildren
+  (`npx` and `node` shims that start the real MCP server) leaked one tree per
+  failed probe per discovery cycle.
+
+* `dashboard/port_reclaim.py`. Stale gateway port reclaim now works on Windows.
+  The listener lookup routes through `platform_compat.find_listening_pids`,
+  which parses `netstat -ano` on Windows and uses `lsof` on POSIX, and returns
+  a None result (fall back to wait and retry) when the lookup tool is absent.
+  The gateway identity check already resolved the full command line cross
+  platform through WMI, so it needed no change. The terminator now uses
+  `platform_compat.kill_process_tree` (which is `taskkill /T` on Windows and
+  reaps the gateway kiro-cli and MCP children too) while the POSIX branch keeps
+  the original `os.kill` behavior with the portable `platform_compat.SIGTERM`
+  and `platform_compat.SIGKILL` constants (identical to `signal.SIGTERM` and
+  `signal.SIGKILL` on POSIX). Why. It previously identified the holder only with
+  `lsof`, which is absent on Windows, so it returned an unavailable result and
+  never reclaimed the port. Now an unclean previous gateway that still holds the
+  dashboard port is terminated so the next bind rebinds cleanly. The POSIX path
+  is unchanged.
+
+## Frontend and Electron changes (`website/electron`)
+
+* `find-bin.js`. Added Windows candidates that look for `kirocrew.exe` under
+  `Scripts` (the repo `.venv`, the one line installer venv, and bundled
+  layouts), guarded by an injectable `isWindows` parameter, and a Windows aware
+  fallback of `kirocrew.exe`. Why. Node `spawn` does no `PATHEXT` resolution for
+  a bare name on Windows, so the app could not find the backend and fell back to
+  a name it could not launch. POSIX keeps its original candidate list and bare
+  `kirocrew` fallback.
+
+* `main.js`. All of the following are guarded by `IS_WIN` so macOS and Linux are
+  untouched.
+  * Native Windows title bar with real minimize, maximize, and close buttons.
+    An earlier Window Controls Overlay approach was dropped because the caption
+    buttons floated over the dashboard header content.
+  * Auto hide of the application menu bar so it does not add a permanent second
+    strip. Tap Alt to reveal it. All keyboard shortcuts still work.
+  * The window and taskbar icon is set from `icon.png` so an unpackaged run does
+    not show the default Electron icon.
+  * An `AppUserModelId` of `com.amazon.kiro.crew` so the taskbar groups and pins
+    the app as KiroCrew rather than the generic Electron host.
+  * `KIROCREW_PROJECT_DIR` resolves to the repo root (where `agents` and
+    `skills` live) on Windows, because the source layout places them two levels
+    up from the electron folder. macOS and Linux keep the original one level up
+    path.
+  * The window title drops the `[:5476]` port suffix for the primary local
+    window on Windows. macOS and Linux keep the original suffix.
+  * The injected drag region is skipped on Windows since the native title bar
+    already moves the window.
+
+* `test/find-bin.test.js`. Made the fallback test platform deterministic by
+  passing an explicit `isWindows` value and added Windows candidate and fallback
+  cases. All 21 tests pass.
+
+## Backend tests
+
+* `test/test_handlers_system_cpu_pct.py`. Made the `ps` fallback test platform
+  deterministic by pinning the platform to Linux, and added Windows CPU tests
+  that stub `platform_compat.system_cpu_percent`. These run the same on every
+  host.
+
+* `test/test_port_reclaim.py`. Updated the three terminate tests to patch both
+  delivery primitives (`os.kill` for POSIX and `platform_compat.kill_process_tree`
+  for Windows) and to assert against the portable `platform_compat` signal
+  constants, so they validate both platforms. Added two tests for the Windows
+  netstat listener lookup. All 17 pass.
+
+* `test/test_terminal_handler.py`. Made the terminal tests cross platform. The
+  two unit tests and one integration test that asserted the old "not supported
+  on Windows" refusal now exercise the ConPTY path instead (forcing IS_WINDOWS
+  and mocking `WindowsPty`, so the exercised path is identical on Windows and
+  POSIX and needs no pywinpty on the POSIX CI). The spawn and reconnect
+  integration tests read liveness and pid through the backend agnostic
+  `_sess_alive` and `_sess_pid` helpers so they pass for both the pty and ConPTY
+  backends. The genuinely POSIX only tests (foreground title detection via
+  `os.tcgetpgrp`, POSIX fd and proc teardown, and Ctrl+C via PTY SIGINT) are
+  skipped on Windows and still run in full on macOS and Linux. The expanduser
+  test now sets `USERPROFILE` as well as `HOME` so it passes on both. Result on
+  Windows is 80 passed, 13 skipped, 0 failed.
+
+## Packaging
+
+* `setup.cfg`. Added `pywinpty` under a `platform_system == "Windows"` marker,
+  next to `tzdata`. It is never installed or imported on macOS or Linux, which
+  keep the stdlib `pty` and `fork` terminal path.
+
+## Desktop launcher
+
+* Created a Desktop shortcut `KiroCrew.lnk` that starts the Electron app, which
+  in turn starts its own gateway. It targets the Electron executable with the
+  app folder as its argument and uses a generated `website/electron/KiroCrew.ico`
+  icon.
+
+## Cross platform safety
+
+* Backend Windows code is guarded by `platform_compat.IS_WINDOWS` or
+  `sys.platform == "win32"`, or returns `None` off Windows so POSIX callers use
+  their existing code.
+* Electron Windows code is guarded by `IS_WIN` or the `isWindows` parameter.
+* The one shared change in `apps/registry.py` routes through the same
+  `platform_compat` tree kill the rest of the codebase already uses, so the
+  POSIX result is the same group kill as before.
+* Verification done on Windows. `flake8` clean on all changed Python files, the
+  changed modules import cleanly, targeted metric and platform tests pass (86
+  passed), the Electron `find-bin` suite passes (21 of 21), and the live
+  dashboard endpoints returned real data (`/api/models` and `/api/system`).
+
+## Known limitations on Windows
+
+These remain unsupported or degrade gracefully and were not changed.
+
+* Pull request source drawer provider fetch and resolve. The provider CLIs rely
+  on the POSIX OS level sandbox and fail closed with a clear unsupported
+  response.
+* Voice reply through Piper. Upstream ships no Windows binary. Cloud voice works
+  when the `aws` CLI is present.
+* The SSH tunnel for the remote dashboard. It needs an OpenSSH client on the
+  path and a signal handling audit.
+* The optional MCP gateway, which is off by default. It uses an `AF_UNIX` socket
+  and a peer credential check that are POSIX only.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ install_requires =
     # ZoneInfoNotFoundError. The tzdata package supplies it. POSIX uses the
     # system zoneinfo, so scope this to Windows only.
     tzdata>=2024.1; platform_system == "Windows"
+    # Windows web-terminal backend: the dashboard terminal uses a ConPTY
+    # pseudo-console, and pywinpty is the maintained ConPTY binding. Windows
+    # only — POSIX drives the terminal with the stdlib pty/fork instead.
+    pywinpty>=2.0,<4; platform_system == "Windows"
     # Vendored llama-cpp-python runtime imports (in-process embeddings).
     jinja2>=2.11.3
     typing-extensions>=4.5.0
@@ -75,6 +79,7 @@ exclude =
 kiro_crew =
     py.typed
     slack-manifest.yaml
+    model_tokens.json
     model_registry.json
     data/tips_catalog.json
     config/defaults.json

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -1141,16 +1141,13 @@ def _pid_alive(pid: int) -> bool:
     uid — alive, not gone — so it must NOT be conflated with
     ``ProcessLookupError``. Treating EPERM as "gone" would skip the SIGKILL of a
     SIGTERM-ignoring orphan whose credentials changed.
+
+    Routed through ``platform_compat.pid_exists`` — a raw ``os.kill(pid, 0)``
+    on Windows does NOT probe liveness (sig 0 is CTRL_C_EVENT there); the shim
+    uses ``OpenProcess`` on Windows and the identical ``os.kill(pid, 0)`` /
+    EPERM-is-alive logic on POSIX, so POSIX behavior is unchanged.
     """
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
+    return platform_compat.pid_exists(pid)
 
 
 def _read_pidfile() -> dict[str, dict[str, Any]]:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -33,7 +33,6 @@ import os
 import platform as _platform
 import re
 import shutil
-import signal
 import sys
 import time
 from pathlib import Path
@@ -1549,10 +1548,16 @@ async def install_from_registry(
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_SCRIPT_TIMEOUT)
             except asyncio.TimeoutError:
-                # Kill the entire process group (shell + children)
+                # Kill the entire process tree (shell + children). Route through
+                # platform_compat so Windows uses taskkill /T — a raw os.killpg
+                # raises AttributeError there (os.killpg is POSIX-only), which
+                # the OSError guard would NOT catch, leaking the tree and
+                # skipping the proc.kill() fallback.
                 try:
-                    os.killpg(proc.pid, signal.SIGTERM)
-                except OSError:
+                    await platform_compat.kill_process_tree_async(
+                        proc.pid, platform_compat.SIGTERM
+                    )
+                except (OSError, ProcessLookupError):
                     proc.kill()
                 return {
                     "ok": False,

--- a/src/kiro_crew/conpty.py
+++ b/src/kiro_crew/conpty.py
@@ -1,0 +1,90 @@
+"""Windows ConPTY pseudo-terminal backend for the dashboard web terminal.
+
+POSIX drives the terminal with ``pty``/``fork`` (see
+``dashboard/handlers/terminal.py``). Windows has no such primitives; Windows 10
+1809+ ships a real pseudo-console (ConPTY). Rather than hand-roll the fiddly
+Win32 ``CreatePseudoConsole`` + ``STARTUPINFOEX`` dance via ctypes (which is
+notoriously easy to get subtly wrong — the child silently fails to attach to
+the pseudo-console), this wraps **pywinpty**, the maintained ConPTY binding.
+
+pywinpty is a Windows-only dependency (declared under a ``platform_system ==
+"Windows"`` marker in ``setup.cfg``, alongside ``tzdata``); it is never imported
+or installed on macOS/Linux, so POSIX behavior is untouched.
+
+``WindowsPty`` exposes exactly what the terminal handler needs from a PTY:
+``read``/``write`` (blocking; the handler runs them in an executor), ``resize``,
+``isalive``, ``terminate``, and ``pid`` — with byte-oriented read/write so the
+handler's redaction/streaming code is backend-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class WindowsPty:
+    """A ConPTY-backed child process (PowerShell/cmd) via pywinpty."""
+
+    def __init__(
+        self,
+        argv: list[str],
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        cols: int = 80,
+        rows: int = 24,
+    ) -> None:
+        # Imported lazily so a POSIX import of this module (e.g. test collection)
+        # never requires the Windows-only package.
+        from winpty import PtyProcess  # type: ignore[import-not-found]
+
+        self._p = PtyProcess.spawn(argv, cwd=cwd, env=env, dimensions=(rows, cols))
+
+    @property
+    def pid(self) -> int:
+        return int(getattr(self._p, "pid", 0) or 0)
+
+    def read(self, size: int = 4096) -> bytes:
+        """Blocking read of up to *size* bytes; ``b""`` on EOF.
+
+        pywinpty returns ``str`` and raises ``EOFError`` at end-of-stream; the
+        handler works in bytes and treats ``b""`` as EOF, so translate here.
+        """
+        try:
+            data = self._p.read(size)
+        except EOFError:
+            return b""
+        except Exception:
+            return b""
+        if not data:
+            return b""
+        if isinstance(data, bytes):
+            return data
+        return data.encode("utf-8", errors="replace")
+
+    def write(self, data: bytes) -> int:
+        if isinstance(data, bytes):
+            text = data.decode("utf-8", errors="replace")
+        else:
+            text = data
+        self._p.write(text)
+        return len(data)
+
+    def resize(self, cols: int, rows: int) -> None:
+        try:
+            self._p.setwinsize(rows, cols)
+        except Exception:
+            logger.debug("ConPTY resize failed", exc_info=True)
+
+    def isalive(self) -> bool:
+        try:
+            return bool(self._p.isalive())
+        except Exception:
+            return False
+
+    def terminate(self, force: bool = True) -> None:
+        try:
+            self._p.terminate(force=force)
+        except Exception:
+            logger.debug("ConPTY terminate failed", exc_info=True)

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -101,6 +101,10 @@ def _resolve_safe_pgid(proc: subprocess.Popen) -> int | None:
     - The resolved pgid must be > 1 (same ``kill(-1)`` footgun) and must not
       be our own process group (suicide / killing the gateway tree).
     """
+    if not platform_compat.IS_POSIX:
+        # Windows has no process groups (os.getpgid/os.killpg don't exist);
+        # callers fall back to platform_compat.kill_process_tree (taskkill /T).
+        return None
     pid = getattr(proc, "pid", None)
     if type(pid) is not int or pid <= 1:
         logger.error("kill guard: refusing non-int/reserved pid %r", pid)
@@ -137,15 +141,25 @@ def kill_running_process(job_id: str) -> bool:
         except (ProcessLookupError, PermissionError, OSError):
             pgid = None
     if pgid is None:
-        # Already gone (or unsignallable) — fall back to the direct handle.
-        try:
-            proc.terminate()
-        except Exception:
-            # Signal never delivered: clear the cancelled flag so a natural
-            # completion is not misreported as a cancellation.
-            with _PROCS_LOCK:
-                _CANCELLED_PROC_JOBS.discard(job_id)
-            return False
+        # Already gone (or unsignallable) on POSIX; on Windows there are no
+        # process groups, so reap the whole tree via taskkill /T
+        # (platform_compat) before falling back to a single-process terminate.
+        killed_tree = False
+        if not platform_compat.IS_POSIX:
+            try:
+                platform_compat.kill_process_tree(proc.pid, platform_compat.SIGTERM)
+                killed_tree = True
+            except (OSError, ProcessLookupError):
+                killed_tree = False
+        if not killed_tree:
+            try:
+                proc.terminate()
+            except Exception:
+                # Signal never delivered: clear the cancelled flag so a natural
+                # completion is not misreported as a cancellation.
+                with _PROCS_LOCK:
+                    _CANCELLED_PROC_JOBS.discard(job_id)
+                return False
 
     def _escalate() -> None:
         time.sleep(_KILL_ESCALATION_GRACE_SECS)
@@ -165,6 +179,14 @@ def _kill_proc_group(proc: subprocess.Popen) -> None:
             os.killpg(pgid, signal.SIGKILL)
             return
         except (ProcessLookupError, PermissionError, OSError):
+            pass
+    # Windows (pgid is always None there): reap the tree via taskkill /T before
+    # the single-process fallback so children don't orphan.
+    if not platform_compat.IS_POSIX:
+        try:
+            platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
+            return
+        except (OSError, ProcessLookupError):
             pass
     try:
         proc.kill()

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -45,13 +45,6 @@ _MAX_SESSIONS = 12
 _ORPHAN_TIMEOUT_S = 900  # 15 min with no WS → reap PTY (grace window for reload/network drops; in-app nav keeps the WS alive)
 _SCROLLBACK_MAX = 50 * 1024  # 50KB ring buffer per session for reconnect replay
 
-# Fail-fast message + SEL reason for the Windows-unsupported path. Kept as a
-# module constant so the POST create-session handler and the WebSocket open
-# handler return byte-identical wording (avoids drift; CLAUDE.md forbids
-# scattered business-logic string literals).
-_UNSUPPORTED_PLATFORM_MSG = "The web terminal is not supported on Windows."
-_UNSUPPORTED_PLATFORM_REASON = "unsupported_platform"
-
 
 def _redact_terminal(data: bytes | bytearray) -> bytes:
     """Strip credentials/exfiltration URLs from PTY output before it reaches a
@@ -79,7 +72,8 @@ class _TerminalSession:
 
     session_id: str
     master_fd: int
-    proc: asyncio.subprocess.Process
+    proc: "asyncio.subprocess.Process | None" = None
+    winpty: object | None = None  # WindowsPty (ConPTY) backend on Windows
     cols: int = 80
     rows: int = 24
     created_at: float = field(default_factory=time.monotonic)
@@ -213,8 +207,59 @@ def _session_title(sess: "_TerminalSession") -> str | None:
     return None
 
 
+def _sess_alive(sess: "_TerminalSession") -> bool:
+    """Whether the session's child process is still running (either backend)."""
+    if sess.winpty is not None:
+        try:
+            return bool(sess.winpty.isalive())  # type: ignore[attr-defined]
+        except Exception:
+            return False
+    if sess.proc is not None:
+        return sess.proc.returncode is None
+    return False
+
+
+def _sess_pid(sess: "_TerminalSession") -> int | None:
+    """PID of the session's child process (either backend), or None."""
+    if sess.winpty is not None:
+        return getattr(sess.winpty, "pid", None)
+    return sess.proc.pid if sess.proc is not None else None
+
+
 async def _kill_session(sess: _TerminalSession) -> None:
     """Kill PTY process and close FDs for a session."""
+    # Windows ConPTY backend: terminate the pseudo-console child and close its
+    # handles. Offloaded to the subprocess pool so a wedged TerminateProcess /
+    # ClosePseudoConsole can never stall the event loop (same rationale as the
+    # POSIX os.close offload below).
+    if sess.winpty is not None:
+        wp = sess.winpty
+        sess.winpty = None
+        if sess.reader_task is not None:
+            sess.reader_task.cancel()
+            try:
+                await sess.reader_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        loop = asyncio.get_running_loop()
+        pid = getattr(wp, "pid", 0)
+        # Reap the whole console tree (the shell + anything it spawned) via
+        # taskkill /T so a background child can't outlive the closed terminal.
+        if pid:
+            try:
+                await platform_compat.kill_process_tree_async(
+                    pid, platform_compat.SIGTERM
+                )
+            except (OSError, ProcessLookupError):
+                pass
+        # Free the pseudo-console + handles (TerminateProcess is a backstop).
+        try:
+            await loop.run_in_executor(
+                subprocess_executor(), wp.terminate,  # type: ignore[attr-defined]
+            )
+        except (OSError, RuntimeError):
+            pass
+        return
     # Close master_fd first — unblocks reader_task's os.read() in executor.
     #
     # os.close() on a PTY master fd can BLOCK in the kernel: when the far-end
@@ -328,7 +373,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
 
     # Check if reconnecting to existing session
     existing = registry.get(session_id)
-    if existing and existing.proc.returncode is not None:
+    if existing and not _sess_alive(existing):
         # Process died — clean up stale entry
         await _kill_session(existing)
         del registry[session_id]
@@ -376,24 +421,44 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
             operation="terminal.ws.reconnect",
             outcome="ok",
             source="dashboard",
-            resources=f"session={session_id},pid={sess.proc.pid}",
+            resources=f"session={session_id},pid={_sess_pid(sess)}",
         )
-    elif not platform_compat.IS_POSIX:
-        # PTY/fork are POSIX-only; the web terminal is unavailable on Windows.
-        if placeholder:
+    elif platform_compat.IS_WINDOWS:
+        # Windows: spawn a ConPTY-backed shell (PowerShell by default). There is
+        # no POSIX pty/fork; kiro_crew.conpty drives the Win32 pseudo-console via
+        # ctypes (stdlib, no extra dependency).
+        from kiro_crew.conpty import WindowsPty
+
+        shell = str(cfg.get("shell") or "powershell.exe")
+        cwd = _resolve_cwd(cfg, request.query.get("cwd"))
+        if not os.path.isdir(cwd):
+            cwd = os.path.expanduser("~")
+        env = {**os.environ, "KIROCREW_TERMINAL": "1"}
+        argv = [shell, "-NoLogo"] if "powershell" in shell.lower() else [shell]
+        try:
+            wp = WindowsPty(argv, cwd=cwd, env=env, cols=80, rows=24)
+        except Exception as exc:
             registry.pop(session_id, None)  # type: ignore[arg-type]
+            _sel().log_api_access(
+                caller=caller, operation="terminal.ws.open",
+                outcome="error", source="dashboard",
+                resources=f"conpty_spawn_failed={exc}",
+            )
+            if not ws.closed:
+                await ws.send_str(json.dumps(
+                    {"type": "error", "message": f"Failed to start terminal: {exc}"}
+                ))
+                await ws.close()
+            return ws
+        sess = _TerminalSession(
+            session_id=session_id, master_fd=-1, proc=None, winpty=wp, ws=ws,
+        )
+        registry[session_id] = sess
         _sel().log_api_access(
             caller=caller, operation="terminal.ws.open",
-            outcome="denied", source="dashboard",
-            resources=_UNSUPPORTED_PLATFORM_REASON,
+            outcome="ok", source="dashboard",
+            resources=f"session={session_id},pid={wp.pid},shell={shell}",
         )
-        if not ws.closed:
-            await ws.send_str(json.dumps({
-                "type": "error",
-                "message": _UNSUPPORTED_PLATFORM_MSG,
-            }))
-            await ws.close()
-        return ws
     else:
         # Spawn new PTY
         master_fd, worker_fd = _pty.openpty()
@@ -469,11 +534,12 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
     async def read_pty():
         try:
             loop = asyncio.get_running_loop()
+            if sess.winpty is not None:
+                reader = lambda: sess.winpty.read(4096)  # noqa: E731
+            else:
+                reader = lambda: os.read(sess.master_fd, 4096)  # noqa: E731
             while True:
-                data = await loop.run_in_executor(
-                    None,
-                    lambda: os.read(sess.master_fd, 4096),
-                )
+                data = await loop.run_in_executor(None, reader)
                 if not data:
                     break
                 sess.scrollback.extend(data)
@@ -493,12 +559,17 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
         async for msg in ws:
             if msg.type == web.WSMsgType.BINARY:
                 try:
-                    await asyncio.get_running_loop().run_in_executor(
-                        None,
-                        os.write,
-                        sess.master_fd,
-                        msg.data,
-                    )
+                    if sess.winpty is not None:
+                        await asyncio.get_running_loop().run_in_executor(
+                            None, sess.winpty.write, msg.data,
+                        )
+                    else:
+                        await asyncio.get_running_loop().run_in_executor(
+                            None,
+                            os.write,
+                            sess.master_fd,
+                            msg.data,
+                        )
                 except OSError:
                     break
             elif msg.type == web.WSMsgType.TEXT:
@@ -514,14 +585,20 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
                         continue
                     sess.cols = cols
                     sess.rows = rows
-                    try:
-                        fcntl.ioctl(
-                            sess.master_fd,
-                            termios.TIOCSWINSZ,
-                            struct.pack("HHHH", rows, cols, 0, 0),
-                        )
-                    except OSError:
-                        pass
+                    if sess.winpty is not None:
+                        try:
+                            sess.winpty.resize(cols, rows)
+                        except OSError:
+                            pass
+                    else:
+                        try:
+                            fcntl.ioctl(
+                                sess.master_fd,
+                                termios.TIOCSWINSZ,
+                                struct.pack("HHHH", rows, cols, 0, 0),
+                            )
+                        except OSError:
+                            pass
                 elif ctrl.get("type") == "ping":
                     if not ws.closed:
                         async with sess.send_lock:
@@ -564,23 +641,6 @@ async def api_terminal_create(request: web.Request) -> web.Response:
             resources="feature_disabled",
         )
         return web.Response(status=403, text="Terminal panel disabled")
-
-    if platform_compat.IS_WINDOWS:
-        # PTY/fork are POSIX-only; on Windows we fail fast at session-create so
-        # the frontend surfaces the "not supported" error immediately instead of
-        # opening a WebSocket that dies during PTY spawn. Same wording as the WS
-        # handler's error frame so the frontend rendering is uniform. A ConPTY
-        # backend is deferred.
-        _sel().log_api_access(
-            caller=caller, operation="terminal.session.create",
-            outcome="denied", source="dashboard",
-            resources=_UNSUPPORTED_PLATFORM_REASON,
-        )
-        return web.json_response(
-            {"error": _UNSUPPORTED_PLATFORM_MSG,
-             "reason": _UNSUPPORTED_PLATFORM_REASON},
-            status=501,
-        )
 
     registry = _get_registry(request)
     cfg = _get_config(request)
@@ -747,8 +807,8 @@ async def api_terminal_list(request: web.Request) -> web.Response:
         sessions.append(
             {
                 "session_id": sid,
-                "pid": sess.proc.pid if sess.proc else None,
-                "alive": sess.proc.returncode is None if sess.proc else False,
+                "pid": _sess_pid(sess),
+                "alive": _sess_alive(sess),
                 "cols": sess.cols,
                 "rows": sess.rows,
                 "connected": sess.ws is not None and not sess.ws.closed,
@@ -782,7 +842,7 @@ async def reap_orphaned_terminals(app: web.Application) -> None:
                 if sess.last_ws_disconnect and (now - sess.last_ws_disconnect) > _ORPHAN_TIMEOUT_S:
                     to_remove.append(sid)
                 # Reap if process died
-                elif sess.proc.returncode is not None:
+                elif not _sess_alive(sess):
                     to_remove.append(sid)
             for sid in to_remove:
                 removed = registry.pop(sid, None)

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -52,6 +52,10 @@ _proc_cpu_pct: float = 0.0
 _prev_sys_cpu: dict[str, float] = {"busy": 0.0, "total": 0.0}
 _sys_cpu_pct: float = 0.0
 
+# Last-known Windows system CPU % (GetSystemTimes delta returns None on the
+# first sample; reuse the previous value so the header doesn't flash to 0).
+_last_win_cpu_pct: float = 0.0
+
 # Cached static system info (computed once)
 _STATIC_SYSTEM_INFO: dict[str, object] | None = None
 
@@ -229,6 +233,10 @@ def _get_static_system_info() -> dict[str, object]:
                         break
         except Exception:
             pass
+    elif sys.platform == "win32":
+        mem = platform_compat.system_memory()
+        if mem:
+            info["mem_total_gb"] = round(mem[0] / (1024**3), 1)
 
     _STATIC_SYSTEM_INFO = info
     return info
@@ -288,6 +296,15 @@ def _collect_system_metrics() -> dict[str, object]:
             mem_total: float = round(total_bytes / (1024**3), 1)
             data["mem_free_gb"] = mem_free
             data["mem_used_gb"] = round(mem_total - mem_free, 1)
+        elif sys.platform == "win32":
+            mem = platform_compat.system_memory()
+            if mem:
+                total_bytes, avail_bytes = mem
+                mem_total = round(total_bytes / (1024**3), 1)
+                mem_free = round(avail_bytes / (1024**3), 1)
+                data["mem_total_gb"] = mem_total
+                data["mem_free_gb"] = mem_free
+                data["mem_used_gb"] = round(mem_total - mem_free, 1)
         else:
             with open("/proc/meminfo") as f:
                 meminfo: dict[str, int] = {}
@@ -332,16 +349,24 @@ def _collect_system_metrics() -> dict[str, object]:
         pass
     # Prefer the /proc/stat interval delta (no subprocess, counts iowait+steal);
     # fall back to the ps lifetime-average on non-Linux or the first sample.
-    cpu_pct = _system_cpu_pct_from_proc_stat()
-    if cpu_pct is None:
-        try:
-            ps_cpu = subprocess.check_output(
-                ["ps", "-A", "-o", "%cpu"], timeout=2, stderr=subprocess.DEVNULL
-            ).decode()
-            total_cpu = sum(float(x) for x in ps_cpu.strip().splitlines()[1:] if x.strip())
-            cpu_pct = min(100.0, round(total_cpu / cores, 1))
-        except Exception:
-            cpu_pct = 0
+    # Windows has no /proc or ps — use the GetSystemTimes delta via ctypes.
+    if sys.platform == "win32":
+        global _last_win_cpu_pct
+        win_cpu = platform_compat.system_cpu_percent()
+        if win_cpu is not None:
+            _last_win_cpu_pct = win_cpu
+        cpu_pct = _last_win_cpu_pct
+    else:
+        cpu_pct = _system_cpu_pct_from_proc_stat()
+        if cpu_pct is None:
+            try:
+                ps_cpu = subprocess.check_output(
+                    ["ps", "-A", "-o", "%cpu"], timeout=2, stderr=subprocess.DEVNULL
+                ).decode()
+                total_cpu = sum(float(x) for x in ps_cpu.strip().splitlines()[1:] if x.strip())
+                cpu_pct = min(100.0, round(total_cpu / cores, 1))
+            except Exception:
+                cpu_pct = 0
     data["cpu_pct"] = cpu_pct
 
     # Local IP address

--- a/src/kiro_crew/dashboard/port_reclaim.py
+++ b/src/kiro_crew/dashboard/port_reclaim.py
@@ -27,8 +27,9 @@ Safety
 Reclaim is deliberately conservative — it terminates a holder **only** when all
 of these hold:
 
-* the holder is identifiable via ``lsof`` (else we cannot know who to signal →
-  fall back to the old wait/retry);
+* the holder is identifiable via the port->PID lookup (``lsof`` on POSIX,
+  ``netstat -ano`` on Windows) — else we cannot know who to signal → fall back
+  to the old wait/retry;
 * the holder is a *KiroCrew gateway* process — reusing the same structural
   command-line check that gates ``kirocrew stop`` (:func:`_is_kirocrew_process`)
   so we never signal an unrelated process that merely grabbed the port; and
@@ -51,9 +52,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import signal
 import subprocess
 from collections.abc import Awaitable, Callable
+
+from kiro_crew import platform_compat
 
 logger = logging.getLogger("kiro_crew.dashboard.port_reclaim")
 
@@ -67,12 +69,21 @@ RECLAIM_FAILED = "reclaim_failed"  # holder identified as stale but could not be
 
 
 def _listeners_on_port(port: int) -> list[int] | None:
-    """PIDs holding a ``LISTEN`` socket on *port*, via ``lsof``.
+    """PIDs holding a ``LISTEN`` socket on *port*.
 
     Returns the (de-duplicated) list of PIDs, an empty list when nothing is
-    listening, or ``None`` when ``lsof`` is unavailable so the caller can fall
-    back to plain wait/retry instead of guessing.
+    listening, or ``None`` when the lookup tool is unavailable so the caller can
+    fall back to plain wait/retry instead of guessing. POSIX uses ``lsof``;
+    Windows has no ``lsof`` and parses ``netstat -ano`` through
+    ``platform_compat.find_listening_pids`` instead.
     """
+    if platform_compat.IS_WINDOWS:
+        # ``find_listening_pids`` folds a missing tool into an empty list, so
+        # distinguish "netstat absent" (None -> wait/retry) from "genuinely no
+        # listener" ([]), mirroring the lsof-missing branch below.
+        if not platform_compat.listening_pid_tool_available():
+            return None
+        return platform_compat.find_listening_pids(port)
     try:
         out = subprocess.check_output(
             ["lsof", "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
@@ -157,6 +168,23 @@ async def _terminate_pids(
     from kiro_crew.cli_server import _pid_exited
 
     def _signal(pid: int, sig: int) -> bool:
+        if platform_compat.IS_WINDOWS:
+            # No POSIX signals for a detached console-less gateway. taskkill /T
+            # (kill_process_tree) reaps the gateway's kiro-cli / MCP children too
+            # — a single-PID kill would orphan them and leak trees. Mirrors the
+            # Windows branch of `kirocrew stop`.
+            try:
+                platform_compat.kill_process_tree(pid, sig)
+            except ProcessLookupError:
+                pass  # already gone — success for our purposes
+            except PermissionError:
+                return False
+            except OSError:
+                # Generic taskkill failure — re-check liveness rather than
+                # guessing denied vs already-exited.
+                if platform_compat.pid_exists(pid):
+                    return False
+            return True
         try:
             os.kill(pid, sig)
         except ProcessLookupError:
@@ -166,14 +194,14 @@ async def _terminate_pids(
         return True
 
     for pid in pids:
-        if not _signal(pid, signal.SIGTERM):
+        if not _signal(pid, platform_compat.SIGTERM):
             return False
     if await _wait_all_exited(pids, term_wait, poll, _pid_exited):
         return True
 
     # Escalate to SIGKILL for any survivor.
     for pid in pids:
-        if not _pid_exited(pid) and not _signal(pid, signal.SIGKILL):
+        if not _pid_exited(pid) and not _signal(pid, platform_compat.SIGKILL):
             return False
     return await _wait_all_exited(pids, kill_wait, poll, _pid_exited)
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -913,6 +913,19 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
                         probe_pid,
                         exc_info=True,
                     )
+        elif proc is not None and platform_compat.IS_WINDOWS:
+            # Windows has no process groups; reap the probe's whole tree via
+            # taskkill /T so the launcher's grandchildren (npx/node -> real MCP
+            # server) don't leak one tree per failed probe per discovery cycle.
+            probe_pid = proc.pid
+            if isinstance(probe_pid, int) and probe_pid > 1:
+                try:
+                    platform_compat.kill_process_tree(probe_pid, platform_compat.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    logger.debug(
+                        "Probe tree reap failed for %s (pid %s)",
+                        server.name, probe_pid, exc_info=True,
+                    )
         if sandbox_cleanup:
             Path(sandbox_cleanup).unlink(missing_ok=True)
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1071,6 +1071,91 @@ def proc_cpu_seconds() -> float:
 
 
 # ---------------------------------------------------------------------------
+# System-wide metrics (Windows). POSIX callers read /proc or sysctl directly;
+# Windows has neither, so route through Win32 via ctypes.
+# ---------------------------------------------------------------------------
+
+# Prev-sample state for the Windows system-CPU delta (GetSystemTimes).
+_prev_win_sys_cpu: dict[str, float] = {"idle": 0.0, "total": 0.0}
+
+
+def system_memory() -> "tuple[int, int] | None":
+    """Return (total_bytes, available_bytes) of physical RAM on Windows.
+
+    Uses ``GlobalMemoryStatusEx``. Returns ``None`` on non-Windows (POSIX
+    callers read ``/proc/meminfo`` or ``sysctl hw.memsize`` themselves) or on
+    any failure, so the caller can fall back.
+    """
+    if not IS_WINDOWS:
+        return None
+    try:
+
+        class MEMORYSTATUSEX(ctypes.Structure):  # noqa: N801 — Windows struct
+            _fields_ = [
+                ("dwLength", wintypes.DWORD),
+                ("dwMemoryLoad", wintypes.DWORD),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return int(stat.ullTotalPhys), int(stat.ullAvailPhys)
+        return None
+    except Exception:
+        return None
+
+
+def system_cpu_percent() -> "float | None":
+    """Return system-wide CPU utilization percent since the previous call.
+
+    Windows only, via ``GetSystemTimes`` (idle/kernel/user FILETIMEs; the
+    kernel time INCLUDES idle). Returns ``None`` on non-Windows, the first
+    (pre-delta) sample, or failure. Stateful — keeps the previous sample in a
+    module global, so callers should poll it periodically.
+    """
+    if not IS_WINDOWS:
+        return None
+    try:
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        idle = wintypes.FILETIME()
+        kernel = wintypes.FILETIME()
+        user = wintypes.FILETIME()
+        if not kernel32.GetSystemTimes(
+            ctypes.byref(idle), ctypes.byref(kernel), ctypes.byref(user)
+        ):
+            return None
+
+        def _ticks(ft: "wintypes.FILETIME") -> float:
+            return float((ft.dwHighDateTime << 32) | ft.dwLowDateTime)
+
+        idle_t = _ticks(idle)
+        # kernel already includes idle, so kernel+user is the full busy+idle.
+        total_t = _ticks(kernel) + _ticks(user)
+        prev_idle = _prev_win_sys_cpu["idle"]
+        prev_total = _prev_win_sys_cpu["total"]
+        _prev_win_sys_cpu["idle"] = idle_t
+        _prev_win_sys_cpu["total"] = total_t
+        if prev_total <= 0:
+            return None  # first sample, no delta yet
+        dtotal = total_t - prev_total
+        if dtotal <= 0:
+            return None
+        busy = dtotal - (idle_t - prev_idle)
+        return min(100.0, max(0.0, round(busy / dtotal * 100.0, 1)))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # strftime portability
 # ---------------------------------------------------------------------------
 

--- a/test/test_handlers_system_cpu_pct.py
+++ b/test/test_handlers_system_cpu_pct.py
@@ -91,9 +91,34 @@ class TestCollectSystemMetricsCpuFallback:
         back to the ps lifetime-average to populate cpu_pct."""
         _reset()
         with (
+            patch.object(hs.sys, "platform", "linux"),
             patch.object(hs, "_system_cpu_pct_from_proc_stat", return_value=None),
             patch.object(hs.subprocess, "check_output", return_value=b"%CPU\n10.0\n5.0\n"),
             patch.object(hs.os, "cpu_count", return_value=1),
         ):
             data = hs._collect_system_metrics()
         assert data["cpu_pct"] == 15.0
+
+    def test_windows_uses_getsystemtimes(self) -> None:
+        """On Windows the handler uses platform_compat.system_cpu_percent
+        (GetSystemTimes delta) instead of /proc/stat or ps."""
+        _reset()
+        hs._last_win_cpu_pct = 0.0
+        with (
+            patch.object(hs.sys, "platform", "win32"),
+            patch.object(hs.platform_compat, "system_cpu_percent", return_value=42.0),
+        ):
+            data = hs._collect_system_metrics()
+        assert data["cpu_pct"] == 42.0
+
+    def test_windows_reuses_last_on_first_none_sample(self) -> None:
+        """The first GetSystemTimes sample returns None (no delta); the handler
+        reuses the last-known value rather than flashing to 0."""
+        _reset()
+        hs._last_win_cpu_pct = 17.0
+        with (
+            patch.object(hs.sys, "platform", "win32"),
+            patch.object(hs.platform_compat, "system_cpu_percent", return_value=None),
+        ):
+            data = hs._collect_system_metrics()
+        assert data["cpu_pct"] == 17.0

--- a/test/test_port_reclaim.py
+++ b/test/test_port_reclaim.py
@@ -240,7 +240,13 @@ async def test_probe_healthy_false_for_wedged_socket() -> None:
 @pytest.mark.asyncio
 async def test_terminate_returns_true_when_already_gone(monkeypatch) -> None:
     signals: list[tuple[int, int]] = []
+    # Patch BOTH delivery primitives so the test is platform agnostic: POSIX
+    # _signal calls os.kill, Windows _signal calls kill_process_tree.
     monkeypatch.setattr(pr.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+    monkeypatch.setattr(
+        pr.platform_compat, "kill_process_tree",
+        lambda pid, sig: signals.append((pid, sig)),
+    )
     # Patch the liveness check used inside _terminate_pids.
     import kiro_crew.cli_server as cli_server
 
@@ -249,13 +255,12 @@ async def test_terminate_returns_true_when_already_gone(monkeypatch) -> None:
     ok = await pr._terminate_pids([1234], term_wait=0.1, kill_wait=0.1, poll=0.01)
     assert ok is True
     # Only SIGTERM sent; no escalation needed.
-    assert signals == [(1234, pr.signal.SIGTERM)]
+    assert signals == [(1234, pr.platform_compat.SIGTERM)]
 
 
 @pytest.mark.asyncio
 async def test_terminate_escalates_to_sigkill(monkeypatch) -> None:
     signals: list[tuple[int, int]] = []
-    monkeypatch.setattr(pr.os, "kill", lambda pid, sig: signals.append((pid, sig)))
     import kiro_crew.cli_server as cli_server
 
     # Survives SIGTERM, dies after SIGKILL is issued.
@@ -266,16 +271,17 @@ async def test_terminate_escalates_to_sigkill(monkeypatch) -> None:
 
     def _kill(pid: int, sig: int) -> None:
         signals.append((pid, sig))
-        if sig == pr.signal.SIGKILL:
+        if sig == pr.platform_compat.SIGKILL:
             state["alive"] = False
 
     monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_process_tree", _kill)
     monkeypatch.setattr(cli_server, "_pid_exited", _exited)
 
     ok = await pr._terminate_pids([1234], term_wait=0.05, kill_wait=0.2, poll=0.01)
     assert ok is True
-    assert (1234, pr.signal.SIGTERM) in signals
-    assert (1234, pr.signal.SIGKILL) in signals
+    assert (1234, pr.platform_compat.SIGTERM) in signals
+    assert (1234, pr.platform_compat.SIGKILL) in signals
 
 
 @pytest.mark.asyncio
@@ -284,5 +290,28 @@ async def test_terminate_returns_false_on_permission_error(monkeypatch) -> None:
         raise PermissionError("not allowed")
 
     monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_process_tree", _kill)
     ok = await pr._terminate_pids([1], term_wait=0.05, kill_wait=0.05, poll=0.01)
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _listeners_on_port - cross-platform lookup (POSIX lsof / Windows netstat)
+# ---------------------------------------------------------------------------
+
+
+def test_listeners_windows_uses_find_listening_pids(monkeypatch) -> None:
+    """On Windows the listener lookup routes through
+    platform_compat.find_listening_pids (netstat -ano), not lsof."""
+    monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(pr.platform_compat, "listening_pid_tool_available", lambda: True)
+    monkeypatch.setattr(pr.platform_compat, "find_listening_pids", lambda port: [4242])
+    assert pr._listeners_on_port(5476) == [4242]
+
+
+def test_listeners_windows_tool_absent_returns_none(monkeypatch) -> None:
+    """When netstat is unavailable on Windows the lookup returns None so the
+    caller degrades to wait/retry rather than mis-reporting no holder."""
+    monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(pr.platform_compat, "listening_pid_tool_available", lambda: False)
+    assert pr._listeners_on_port(5476) is None

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -106,7 +106,10 @@ class TestResolveCwd:
         assert terminal._resolve_cwd({"cwd": "/etc"}, str(tmp_path)) == str(tmp_path)
 
     def test_expands_user_in_requested(self, tmp_path, monkeypatch):
+        # POSIX expanduser reads HOME; Windows reads USERPROFILE — set both so
+        # the test is platform agnostic.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         assert terminal._resolve_cwd({}, "~") == str(tmp_path)
 
     def test_invalid_requested_falls_back_to_config_cwd(self, tmp_path):
@@ -244,6 +247,10 @@ class TestKillSession:
         # Cleared BEFORE the await, so cancellation cannot leave a stale fd.
         assert sess.master_fd == -1
 
+    @pytest.mark.skipif(
+        terminal.platform_compat.IS_WINDOWS,
+        reason="POSIX master_fd/proc teardown; Windows sessions use the ConPTY backend",
+    )
     @pytest.mark.asyncio
     async def test_handles_runtime_error_on_close_when_pool_shutdown(self):
         """If subprocess_executor was torn down, run_in_executor's submit raises
@@ -344,7 +351,9 @@ class TestApiTerminalCreateWindowsFailFast:
     """
 
     @pytest.mark.asyncio
-    async def test_windows_returns_501_with_error_and_reason(self, monkeypatch):
+    async def test_windows_returns_session_id(self, monkeypatch):
+        # Windows now spawns a ConPTY-backed shell, so create SUCCEEDS (returns
+        # a session_id) instead of the old 501 "unsupported" refusal.
         registry: dict = {}
         req = _make_request(registry=registry)
         monkeypatch.setattr(terminal.platform_compat, "IS_WINDOWS", True)
@@ -352,47 +361,14 @@ class TestApiTerminalCreateWindowsFailFast:
              patch.object(terminal, "_sel") as mock_sel:
             mock_sel.return_value.log_api_access = MagicMock()
             resp = await terminal.api_terminal_create(req)
-        assert resp.status == 501
+        assert resp.status == 200
         body = json.loads(resp.body)
-        assert body["error"] == terminal._UNSUPPORTED_PLATFORM_MSG
-        assert body["reason"] == terminal._UNSUPPORTED_PLATFORM_REASON
-        # No session was created; registry stays untouched.
-        assert registry == {}
-
-    @pytest.mark.asyncio
-    async def test_windows_logs_denied_unsupported_platform(self, monkeypatch):
-        req = _make_request()
-        monkeypatch.setattr(terminal.platform_compat, "IS_WINDOWS", True)
-        with patch.object(terminal, "_get_config", return_value={"enabled": True}), \
-             patch.object(terminal, "_sel") as mock_sel:
-            log = MagicMock()
-            mock_sel.return_value.log_api_access = log
-            await terminal.api_terminal_create(req)
-        # Denied audit event with the shared reason string, so the reason is
-        # a single source of truth across the WS and REST paths.
-        assert log.called
-        kwargs = log.call_args.kwargs
-        assert kwargs.get("operation") == "terminal.session.create"
-        assert kwargs.get("outcome") == "denied"
-        assert kwargs.get("resources") == terminal._UNSUPPORTED_PLATFORM_REASON
-
-    @pytest.mark.asyncio
-    async def test_windows_gate_runs_before_max_sessions(self, monkeypatch):
-        # Even at capacity, Windows must return 501 (unsupported) rather than
-        # 429 (busy) — the platform gate is unconditional and takes precedence.
-        registry = {"s1": _make_session(), "s2": _make_session(), "s3": _make_session()}
-        req = _make_request(registry=registry)
-        monkeypatch.setattr(terminal.platform_compat, "IS_WINDOWS", True)
-        with patch.object(terminal, "_get_config", return_value={"enabled": True}), \
-             patch.object(terminal, "_sel") as mock_sel:
-            mock_sel.return_value.log_api_access = MagicMock()
-            resp = await terminal.api_terminal_create(req)
-        assert resp.status == 501
+        assert "session_id" in body
 
     @pytest.mark.asyncio
     async def test_windows_gate_still_requires_auth(self, monkeypatch):
         # Authentication is still enforced first — an unauthenticated request
-        # must not learn platform capabilities. 401 wins over 501.
+        # must not create a session. 401 regardless of platform.
         req = _make_request(user=None)
         monkeypatch.setattr(terminal.platform_compat, "IS_WINDOWS", True)
         resp = await terminal.api_terminal_create(req)
@@ -418,25 +394,18 @@ class TestApiTerminalCreateWindowsFailFast:
            "covers the same code path on Linux CI.",
 )
 class TestApiTerminalCreateWindowsUnmocked:
-    """Windows-only unmocked coverage of the fail-fast gate.
-
-    Runs against the real ``platform_compat.IS_WINDOWS`` constant (no
-    monkeypatch), so a regression that skips the guard or wires the constant
-    wrong on Windows would be caught here even if the Linux monkeypatch suite
-    passed. Skipped on POSIX to keep CI green — pattern mirrors the umbrella's
-    other ``skipif(not IS_WINDOWS)`` classes.
-    """
+    """Windows-only unmocked coverage: create succeeds (ConPTY-backed)."""
 
     @pytest.mark.asyncio
-    async def test_real_windows_returns_501(self):
+    async def test_real_windows_returns_session_id(self):
         req = _make_request()
         with patch.object(terminal, "_get_config", return_value={"enabled": True}), \
              patch.object(terminal, "_sel") as mock_sel:
             mock_sel.return_value.log_api_access = MagicMock()
             resp = await terminal.api_terminal_create(req)
-        assert resp.status == 501
+        assert resp.status == 200
         body = json.loads(resp.body)
-        assert body["reason"] == terminal._UNSUPPORTED_PLATFORM_REASON
+        assert "session_id" in body
 
 
 # ── api_terminal_delete ──
@@ -663,21 +632,24 @@ class TestApiTerminalWs:
         assert registry.get("abc123") is not dead_sess
 
     @pytest.mark.asyncio
-    async def test_refuses_new_session_on_non_posix(self, monkeypatch):
-        """On a non-POSIX host, a new WS session is refused (no PTY spawned).
-
-        PTY/fork are POSIX-only, so the ``elif not platform_compat.IS_POSIX``
-        branch pops the reserved placeholder, logs the denial, sends an error
-        frame, closes the socket, and returns it. ``WebSocketResponse`` is
-        mocked so ``return ws`` is exercised deterministically.
+    async def test_windows_conpty_spawn_failure_sends_error(self, monkeypatch):
+        """On Windows a new WS session spawns a ConPTY shell (kiro_crew.conpty);
+        the old 'not supported on Windows' refusal no longer exists. If the
+        spawn fails, the handler pops the placeholder, sends an error frame, and
+        closes. WindowsPty is mocked to raise so ``return ws`` is exercised
+        without a real pseudo-console (and without needing pywinpty on POSIX CI).
         """
         registry: dict = {}
         req = _make_request(registry=registry, session_id="win-sess")
+        req.query = MagicMock()
+        req.query.get = lambda *a, **k: None
 
         ws = AsyncMock()
         ws.closed = False
 
         with patch.object(terminal.platform_compat, "IS_POSIX", False), \
+             patch.object(terminal.platform_compat, "IS_WINDOWS", True), \
+             patch("kiro_crew.conpty.WindowsPty", side_effect=RuntimeError("boom")), \
              patch.object(terminal, "_get_config", return_value={"enabled": True}), \
              patch.object(terminal.web, "WebSocketResponse", return_value=ws), \
              patch.object(terminal, "_sel") as mock_sel:
@@ -685,26 +657,28 @@ class TestApiTerminalWs:
             resp = await terminal.api_terminal_ws(req)
 
         assert resp is ws
-        # Placeholder reservation was rolled back; no PTY session registered.
         assert "win-sess" not in registry
-        ws.prepare.assert_awaited_once()
         ws.send_str.assert_awaited_once()
         sent = json.loads(ws.send_str.call_args.args[0])
         assert sent["type"] == "error"
-        assert "not supported on Windows" in sent["message"]
+        assert "Failed to start terminal" in sent["message"]
         ws.close.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_non_posix_skips_send_when_ws_already_closed(self, monkeypatch):
-        """If the socket is already closed, the non-POSIX branch skips the
-        error frame and close (covers the ``if not ws.closed`` false path)."""
+    async def test_windows_conpty_spawn_failure_skips_send_when_ws_closed(self, monkeypatch):
+        """If the socket is already closed, the Windows spawn-failure path skips
+        the error frame and close (covers the ``if not ws.closed`` false path)."""
         registry: dict = {}
         req = _make_request(registry=registry, session_id="win-closed")
+        req.query = MagicMock()
+        req.query.get = lambda *a, **k: None
 
         ws = AsyncMock()
         ws.closed = True
 
         with patch.object(terminal.platform_compat, "IS_POSIX", False), \
+             patch.object(terminal.platform_compat, "IS_WINDOWS", True), \
+             patch("kiro_crew.conpty.WindowsPty", side_effect=RuntimeError("boom")), \
              patch.object(terminal, "_get_config", return_value={"enabled": True}), \
              patch.object(terminal.web, "WebSocketResponse", return_value=ws), \
              patch.object(terminal, "_sel") as mock_sel:
@@ -928,7 +902,7 @@ class TestTerminalWsIntegration:
                 # Session should be registered
                 assert "test-sess-1" in registry
                 sess = registry["test-sess-1"]
-                assert sess.proc.returncode is None  # alive
+                assert terminal._sess_alive(sess)  # alive (pty or ConPTY backend)
                 await ws.close()
 
             # After WS close, session stays (orphan reaper handles cleanup)
@@ -1044,13 +1018,13 @@ class TestTerminalWsIntegration:
                 await ws.close()
 
             sess = registry["recon-sess"]
-            original_pid = sess.proc.pid
+            original_pid = terminal._sess_pid(sess)
             assert sess.ws is None  # disconnected
 
             # Reconnect
             async with client.ws_connect("/api/ws/terminal/recon-sess") as ws:
                 sess = registry["recon-sess"]
-                assert sess.proc.pid == original_pid  # same PTY
+                assert terminal._sess_pid(sess) == original_pid  # same PTY
                 assert sess.ws is not None  # reconnected
                 assert sess.last_ws_disconnect is None
                 await ws.close()
@@ -1087,19 +1061,40 @@ class TestTerminalWsIntegration:
             await terminal._kill_session(registry["json-sess"])
 
     @pytest.mark.asyncio
-    async def test_ws_unsupported_platform_on_non_posix(self, monkeypatch, tmp_path):
-        """When the platform is not POSIX, opening a new WS session is refused.
-
-        Exercises the ``elif not platform_compat.IS_POSIX`` branch by forcing
-        ``IS_POSIX`` False (PTY/fork are POSIX-only). No PTY is spawned: the
-        handler pops the reserved placeholder, emits an error frame, and closes
-        the socket. Runs on a real TestServer so ``ws.prepare`` succeeds.
+    async def test_ws_windows_spawns_conpty(self, monkeypatch, tmp_path):
+        """On Windows a new WS session spawns a ConPTY-backed shell instead of
+        the old 'not supported' refusal. WindowsPty is mocked so the test needs
+        no real pseudo-console (and runs on POSIX CI without pywinpty); forcing
+        IS_WINDOWS makes the exercised code path identical on Windows and POSIX.
         """
         cfg_file = tmp_path / "config.json"
         cfg_file.write_text(json.dumps({"dashboard": {"terminal": {"enabled": True}}}))
         monkeypatch.setattr(terminal, "config_path", lambda: cfg_file)
         monkeypatch.setattr(terminal, "_sel", lambda: MagicMock())
         monkeypatch.setattr(terminal.platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(terminal.platform_compat, "IS_WINDOWS", True)
+
+        class _FakeWinPty:
+            def __init__(self, argv, cwd=None, env=None, cols=80, rows=24):
+                self.pid = 4321
+                self._alive = True
+
+            def read(self, size=4096):
+                return b""  # EOF: the reader loop exits cleanly
+
+            def write(self, data):
+                return len(data)
+
+            def resize(self, cols, rows):
+                pass
+
+            def isalive(self):
+                return self._alive
+
+            def terminate(self, force=True):
+                self._alive = False
+
+        monkeypatch.setattr("kiro_crew.conpty.WindowsPty", _FakeWinPty)
 
         registry: dict = {}
         app = _make_app(registry=registry)
@@ -1107,72 +1102,21 @@ class TestTerminalWsIntegration:
         from aiohttp.test_utils import TestClient, TestServer
 
         async with TestClient(TestServer(app)) as client:
-            async with client.ws_connect("/api/ws/terminal/winnope-sess") as ws:
-                # First frame is the JSON error message.
-                msg = await ws.receive(timeout=5)
-                assert msg.type == web.WSMsgType.TEXT
-                data = json.loads(msg.data)
-                assert data["type"] == "error"
-                assert "not supported on Windows" in data["message"]
-                # Server closes the socket after sending the error.
-                closing = await ws.receive(timeout=5)
-                assert closing.type in (
-                    web.WSMsgType.CLOSE,
-                    web.WSMsgType.CLOSING,
-                    web.WSMsgType.CLOSED,
-                )
+            async with client.ws_connect("/api/ws/terminal/winok-sess") as ws:
+                # A ConPTY session is registered (not refused).
+                assert "winok-sess" in registry
+                sess = registry["winok-sess"]
+                assert sess.winpty is not None
+                assert sess.proc is None  # Windows backend has no asyncio proc
+                await ws.close()
 
-            # No PTY session was registered; the reserved placeholder was popped.
-            assert "winnope-sess" not in registry
+        if "winok-sess" in registry:
+            await terminal._kill_session(registry["winok-sess"])
 
-    @pytest.mark.asyncio
-    async def test_ws_unsupported_platform_logs_shared_reason_constant(
-        self, monkeypatch, tmp_path
-    ):
-        """The WS-denied audit event must carry the SAME ``_UNSUPPORTED_PLATFORM_REASON``
-        string the REST path emits (see ``test_windows_logs_denied_unsupported_platform``).
-        Keeping a single source of truth means auditors filtering on
-        ``resources == "unsupported_platform"`` catch both surfaces at once —
-        if a future refactor inlines a different string here, this assertion
-        fires.
-        """
-        cfg_file = tmp_path / "config.json"
-        cfg_file.write_text(json.dumps({"dashboard": {"terminal": {"enabled": True}}}))
-        monkeypatch.setattr(terminal, "config_path", lambda: cfg_file)
-        sel_mock = MagicMock()
-        sel_mock.log_api_access = MagicMock()
-        monkeypatch.setattr(terminal, "_sel", lambda: sel_mock)
-        monkeypatch.setattr(terminal.platform_compat, "IS_POSIX", False)
-
-        registry: dict = {}
-        app = _make_app(registry=registry)
-
-        from aiohttp.test_utils import TestClient, TestServer
-
-        async with TestClient(TestServer(app)) as client:
-            async with client.ws_connect("/api/ws/terminal/audit-sess") as ws:
-                # Drain the error frame + close (mirrors the sibling test).
-                msg = await ws.receive(timeout=5)
-                assert msg.type == web.WSMsgType.TEXT
-                closing = await ws.receive(timeout=5)
-                assert closing.type in (
-                    web.WSMsgType.CLOSE,
-                    web.WSMsgType.CLOSING,
-                    web.WSMsgType.CLOSED,
-                )
-
-        # Find the denied audit event (there may be earlier "allowed" logs;
-        # scan for the one this test is guarding).
-        denied_calls = [
-            c for c in sel_mock.log_api_access.call_args_list
-            if c.kwargs.get("outcome") == "denied"
-        ]
-        assert denied_calls, "expected at least one denied audit event"
-        kwargs = denied_calls[-1].kwargs
-        assert kwargs["operation"] == "terminal.ws.open"
-        assert kwargs["outcome"] == "denied"
-        assert kwargs["resources"] == terminal._UNSUPPORTED_PLATFORM_REASON
-
+    @pytest.mark.skipif(
+        terminal.platform_compat.IS_WINDOWS,
+        reason="POSIX SIGINT via PTY; on Windows Ctrl+C is handled inside ConPTY",
+    )
     @pytest.mark.asyncio
     async def test_ws_ctrl_c_delivers_sigint(self, monkeypatch, tmp_path):
         """Send \\x03 (Ctrl+C) and verify the child process receives SIGINT.
@@ -1289,6 +1233,12 @@ class TestTerminalWsIntegration:
         cfg_file.write_text(json.dumps({"dashboard": {"terminal": {"enabled": True}}}))
         monkeypatch.setattr(terminal, "config_path", lambda: cfg_file)
         monkeypatch.setattr(terminal, "_sel", lambda: MagicMock())
+        # This test seeds a mock session (proc.pid=12345) and deletes it. Stub the
+        # tree-kill so teardown does no real process signalling: on POSIX
+        # os.killpg(getpgid(12345)) fails fast, but on Windows taskkill /T /PID
+        # 12345 targets a real system PID (slow timeout / could kill it). Real
+        # teardown is covered by the ConPTY integration test.
+        monkeypatch.setattr(terminal.platform_compat, "kill_process_tree_async", AsyncMock())
 
         app = _make_app()
 
@@ -1396,6 +1346,11 @@ class TestProcHelpers:
 # ── _session_title ──
 
 
+@pytest.mark.skipif(
+    terminal.platform_compat.IS_WINDOWS,
+    reason="foreground-command detection uses os.tcgetpgrp (POSIX-only); "
+    "_session_title returns None on Windows",
+)
 class TestSessionTitle:
     """The tab-title label: foreground command name while one runs, else the
     shell's cwd basename. _proc_comm/_proc_cwd and os.tcgetpgrp are patched so

--- a/website/electron/find-bin.js
+++ b/website/electron/find-bin.js
@@ -18,9 +18,23 @@ const ARCH_DIR_SUFFIX = { arm64: "arm64", x64: "x64" };
  * @param {string} dirname - `__dirname` of the calling module
  * @param {string} [arch] - CPU arch selecting the backend tree in universal
  *   bundles (defaults to `process.arch`)
- * @returns {string} Absolute path to the binary, or `"kirocrew"`
+ * @param {boolean} [isWindows] - whether the host is Windows (defaults to
+ *   `process.platform === "win32"`). On Windows the backend ships as a real
+ *   `kirocrew.exe` console script under `Scripts\` (venv) — Node's `spawn()`
+ *   does no PATHEXT resolution for a bare name, so an absolute `.exe` path is
+ *   required.
+ * @returns {string} Absolute path to the binary, or `"kirocrew"` /
+ *   `"kirocrew.exe"` (Windows) as a PATH fallback
  */
-function findKirocrewBin(fs, os, path, resourcesPath, dirname, arch = process.arch) {
+function findKirocrewBin(
+  fs,
+  os,
+  path,
+  resourcesPath,
+  dirname,
+  arch = process.arch,
+  isWindows = process.platform === "win32"
+) {
   const home = os.homedir();
   const candidates = [];
   // 0. Universal-bundle layout: arch-suffixed backend trees, selected by the
@@ -33,6 +47,26 @@ function findKirocrewBin(fs, os, path, resourcesPath, dirname, arch = process.ar
     candidates.push(
       path.join(resourcesPath || "", "backend-dist", archBackend, "bin", "kirocrew"),
       path.resolve(dirname, "backend-dist", archBackend, "bin", "kirocrew")
+    );
+  }
+  // 0b. Windows layout: a pip/venv install exposes `kirocrew.exe` under
+  //     `Scripts\` (not the POSIX `bin/kirocrew` launcher). Probed before the
+  //     POSIX candidates so a native Windows source install resolves to an
+  //     absolute `.exe` that `spawn()` can launch without a shell. On POSIX
+  //     these are skipped entirely so mac/Linux behavior is unchanged.
+  if (isWindows) {
+    candidates.push(
+      // Bundled Windows backend (python-build-standalone → Scripts\kirocrew.exe)
+      path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
+      path.resolve(dirname, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
+      // Source checkout: repo-root `.venv` — electron/ is <repo>/website/electron,
+      // so the venv is two levels up; one level up covers a <repo>/website venv.
+      path.resolve(dirname, "..", "..", ".venv", "Scripts", "kirocrew.exe"),
+      path.resolve(dirname, "..", ".venv", "Scripts", "kirocrew.exe"),
+      // One-liner installer venv, and toolbox / local pip Scripts dirs.
+      path.join(home, ".kirocrew-app", ".venv", "Scripts", "kirocrew.exe"),
+      path.join(home, ".toolbox", "bin", "kirocrew.exe"),
+      path.join(home, ".local", "bin", "kirocrew.exe")
     );
   }
   candidates.push(
@@ -62,7 +96,7 @@ function findKirocrewBin(fs, os, path, resourcesPath, dirname, arch = process.ar
       if (e.code !== "ENOENT") console.warn(`kirocrew candidate ${bin}: ${e.code}`);
     }
   }
-  return "kirocrew"; // fall back to PATH
+  return isWindows ? "kirocrew.exe" : "kirocrew"; // fall back to PATH
 }
 
 module.exports = { findKirocrewBin };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -84,6 +84,7 @@ const HEALTH_URL = `${BACKEND_URL}/api/status`;
 const POLL_INTERVAL_MS = 500;
 const MAX_WAIT_MS = 30_000; // 30s max wait for backend
 const IS_MAC = process.platform === "darwin";
+const IS_WIN = process.platform === "win32";
 // The dashboard view fills the whole content area on all platforms. On macOS
 // the window is frameless (titleBarStyle:"hidden") and the dashboard's own
 // 42px header doubles as the title bar: an injected drag region makes it
@@ -96,6 +97,17 @@ const { attachContextMenu } = require("./context-menu");
 // Set app name for macOS menu bar and dock. Nightly ships as a separate
 // side-by-side app, so its menu bar must say so.
 app.name = identityFamily(app.getVersion()) === "nightly" ? "Kiro Crew Nightly" : "Kiro Crew";
+
+// Windows taskbar identity. Without an explicit AppUserModelID, Windows groups
+// the app under the generic Electron host (wrong icon in the taskbar/jumplist,
+// pinning targets Electron rather than KiroCrew). Match the packaged appId
+// (build.appId = "com.amazon.kiro.crew"); nightly gets a distinct id so it
+// pins/groups side-by-side with stable, mirroring the app.name split above.
+if (IS_WIN) {
+  const appUserModelId = identityFamily(app.getVersion()) === "nightly"
+    ? "com.amazon.kiro.crew.nightly" : "com.amazon.kiro.crew";
+  app.setAppUserModelId(appUserModelId);
+}
 
 // Single-instance lock. On macOS LaunchServices reuses the already-running .app
 // when the user relaunches from the Dock / Spotlight, so a second instance is
@@ -284,6 +296,28 @@ function startGateway() {
   });
 }
 
+// Resolve the KiroCrew project root (the tree that ships `agents/` + `skills/`)
+// for the gateway's KIROCREW_PROJECT_DIR. The bundled app keeps these alongside
+// the Electron files (Resources/), i.e. one level up from `electron/`; a source
+// checkout has them at the repo root, two levels up (<repo>/website/electron).
+// Probe both and pick the first that actually contains the markers so a source
+// run doesn't mis-point at `website/`. Falls back to the legacy one-level-up
+// path when neither has markers (preserves prior behavior).
+function resolveProjectDir() {
+  const candidates = [
+    path.resolve(__dirname, ".."),
+    path.resolve(__dirname, "..", ".."),
+  ];
+  for (const c of candidates) {
+    try {
+      if (fs.existsSync(path.join(c, "agents")) && fs.existsSync(path.join(c, "skills"))) {
+        return c;
+      }
+    } catch { /* ignore and try next */ }
+  }
+  return path.resolve(__dirname, "..");
+}
+
 function spawnGateway(resolve) {
         // Ensure ~/.kirocrew/ directory exists before starting gateway
         // (gateway generates .local_secret itself on startup via O_CREAT|O_TRUNC)
@@ -323,7 +357,10 @@ function spawnGateway(resolve) {
           detached: false,
           env: {
             ...cleanEnv,
-            KIROCREW_PROJECT_DIR: path.resolve(__dirname, ".."),
+            // Windows source layout puts agents/ + skills/ at the repo root
+            // (two levels up from electron/), so resolve by markers there.
+            // macOS/Linux keep the original one-level-up path unchanged.
+            KIROCREW_PROJECT_DIR: IS_WIN ? resolveProjectDir() : path.resolve(__dirname, ".."),
             // Keep CPython bytecode caches OUT of the signed app bundle.
             // Without this, the embedded interpreter writes __pycache__/*.pyc
             // next to the bundled sources on first import, breaking the
@@ -602,8 +639,19 @@ function setupWindowContents(win, backendUrl) {
   win.webContents = view.webContents;
 
   function applyTitle() {
-    const suffix = customName || getRemoteHostConfig(store, port)?.defaultName || `[:${port}]`;
-    win.setTitle(`Kiro Crew ${suffix}`);
+    const remoteName = getRemoteHostConfig(store, port)?.defaultName;
+    if (!IS_WIN) {
+      // macOS/Linux behavior unchanged: always show the [:port] suffix.
+      const suffix = customName || remoteName || `[:${port}]`;
+      win.setTitle(`Kiro Crew ${suffix}`);
+      return;
+    }
+    // Windows: the bare "[:5476]" read as part of the product name and confused
+    // users, so the primary local window is just "Kiro Crew"; keep the suffix
+    // only for a non-default (remote/secondary) window.
+    let suffix = customName || remoteName || "";
+    if (!suffix && port && String(port) !== "5476") suffix = `[:${port}]`;
+    win.setTitle(suffix ? `Kiro Crew ${suffix}` : "Kiro Crew");
   }
 
   win._mcSetCustomName = (name) => { customName = name; applyTitle(); };
@@ -637,27 +685,33 @@ function setupWindowContents(win, backendUrl) {
   view.webContents.on("page-title-updated", (e) => { e.preventDefault(); applyTitle(); });
 
   view.webContents.on("did-finish-load", () => {
-    view.webContents.insertCSS(`
-      #electron-drag-bar {
-        position: fixed;
-        top: 0; left: 0; right: 0;
-        height: 42px;
-        -webkit-app-region: drag;
-        z-index: 99999;
-        pointer-events: none;
-      }
-      a, button, input, select, textarea,
-      [role="button"], [tabindex], iframe {
-        -webkit-app-region: no-drag;
-      }
-    `);
-    view.webContents.executeJavaScript(`
-      if (!document.getElementById('electron-drag-bar')) {
-        const bar = document.createElement('div');
-        bar.id = 'electron-drag-bar';
-        document.body.prepend(bar);
-      }
-    `);
+    // macOS + Linux only: the frameless window needs an injected drag region so
+    // the dashboard header can move the window. Windows uses a native title bar,
+    // which already provides dragging — injecting an app-region bar over the
+    // header would only risk swallowing clicks, so skip it there.
+    if (!IS_WIN) {
+      view.webContents.insertCSS(`
+        #electron-drag-bar {
+          position: fixed;
+          top: 0; left: 0; right: 0;
+          height: 42px;
+          -webkit-app-region: drag;
+          z-index: 99999;
+          pointer-events: none;
+        }
+        a, button, input, select, textarea,
+        [role="button"], [tabindex], iframe {
+          -webkit-app-region: no-drag;
+        }
+      `);
+      view.webContents.executeJavaScript(`
+        if (!document.getElementById('electron-drag-bar')) {
+          const bar = document.createElement('div');
+          bar.id = 'electron-drag-bar';
+          document.body.prepend(bar);
+        }
+      `);
+    }
     // Sync window background to theme color (visible in tab bar padding area)
     view.webContents.executeJavaScript(
       `getComputedStyle(document.documentElement).getPropertyValue('--bg').trim()`
@@ -754,9 +808,23 @@ function createWindow() {
     height: state.height,
     minWidth: 550,
     minHeight: 600,
-    titleBarStyle: "hidden",
     backgroundColor: "#0f1117",
   };
+  // macOS + Linux: frameless — the dashboard's 42px header doubles as the title
+  // bar (drag region injected below; macOS insets the native traffic lights).
+  // Windows: use the STANDARD native title bar + caption buttons (a Window
+  // Controls Overlay floats its buttons over the header content).
+  if (!IS_WIN) opts.titleBarStyle = "hidden";
+  if (IS_WIN) opts.autoHideMenuBar = true;
+  // Window + taskbar icon (Windows only): running unpackaged (`electron .`)
+  // otherwise shows the default Electron icon. macOS takes its icon from the
+  // .app bundle and Linux from the .desktop/AppImage, so leave those untouched.
+  if (IS_WIN) {
+    const iconFile = identityFamily(app.getVersion()) === "nightly"
+      && fs.existsSync(path.join(__dirname, "icon-nightly.png"))
+      ? "icon-nightly.png" : "icon.png";
+    opts.icon = path.join(__dirname, iconFile);
+  }
   // Inset the native traffic lights into the dashboard's 42px header row.
   // Kept in sync with zoom by positionTrafficLights().
   if (IS_MAC) opts.trafficLightPosition = trafficLightPositionForZoom(1);

--- a/website/electron/test/find-bin.test.js
+++ b/website/electron/test/find-bin.test.js
@@ -74,9 +74,40 @@ describe("findKirocrewBin", () => {
     assert.equal(result, binPath);
   });
 
-  it("falls back to bare 'kirocrew' when no candidates are executable", () => {
-    const result = findKirocrewBin(none, fakeOs, path, RESOURCES, DIRNAME);
+  it("falls back to bare 'kirocrew' when no candidates are executable (POSIX)", () => {
+    const result = findKirocrewBin(none, fakeOs, path, RESOURCES, DIRNAME, "x64", false);
     assert.equal(result, "kirocrew");
+  });
+
+  it("falls back to bare 'kirocrew.exe' when no candidates are executable (Windows)", () => {
+    const result = findKirocrewBin(none, fakeOs, path, RESOURCES, DIRNAME, "x64", true);
+    assert.equal(result, "kirocrew.exe");
+  });
+
+  it("finds the venv Scripts\\kirocrew.exe two levels up from electron/ on Windows", () => {
+    const venvExe = path.resolve(DIRNAME, "..", "..", ".venv", "Scripts", "kirocrew.exe");
+    const fakeFs = only(venvExe);
+    const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME, "x64", true);
+    assert.equal(result, venvExe);
+  });
+
+  it("finds the bundled Windows backend Scripts\\kirocrew.exe on Windows", () => {
+    const bundledExe = path.join(
+      RESOURCES, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"
+    );
+    const fakeFs = only(bundledExe);
+    const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME, "x64", true);
+    assert.equal(result, bundledExe);
+  });
+
+  it("does not probe Windows .exe candidates on POSIX", () => {
+    const probed = [];
+    const fakeFs = {
+      accessSync: (p) => { probed.push(p); throw new Error("ENOENT"); },
+      constants: { X_OK: fs.constants.X_OK },
+    };
+    findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME, "x64", false);
+    assert.deepStrictEqual(probed.filter((p) => p.endsWith(".exe")), []);
   });
 
   it("returns first match when multiple candidates exist", () => {


### PR DESCRIPTION
Make the dashboard, chat, terminal, and desktop app work natively on Windows without changing macOS/Linux behavior.

- terminal: ConPTY-backed web terminal via a new stdlib-interfaced backend (kiro_crew/conpty.py wrapping pywinpty, a Windows-only dep) replacing the POSIX pty/fork path; session teardown reaps the tree with taskkill /T
- platform_compat: add system_memory (GlobalMemoryStatusEx) and system_cpu_percent (GetSystemTimes) so the dashboard CPU/MEM header works
- handlers_system: Windows branches for live/static memory and CPU
- process mgmt: route Windows-incompatible os.killpg/os.getpgid/os.kill(pid,0) through platform_compat in apps/registry, apps/backend, cron_script, mcp_discovery, and dashboard/port_reclaim (netstat -ano listener lookup)
- electron: find-bin resolves kirocrew.exe under Scripts\; main.js uses a native title bar + auto-hidden menu + window icon + AppUserModelId and points KIROCREW_PROJECT_DIR at the repo root — all guarded to Windows
- setup.cfg: pywinpty under a platform_system == Windows marker
- tests: make terminal/port_reclaim/cpu tests cross-platform (exercise the ConPTY path, skip genuinely POSIX-only behaviors on Windows)
- docs/WINDOWS_CHANGES.md: full rationale

All changes are guarded by IS_WINDOWS/IS_POSIX or return None off Windows, so POSIX paths are unchanged.

## Description

<!-- What does this PR do? Why is it needed? -->

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Testing

- [ ] Existing tests pass (`make test`)
- [ ] New tests added for new functionality
- [ ] Manual verification performed (describe below if applicable)

## Checklist

- [ ] Code follows the project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
