### PR TITLE
fix(dashboard): don't let a corrupt exp brick the refresh-token store

### DIFF
--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -207,12 +207,23 @@ class RefreshStateManager:
             )
             return
         with self._lock:
+            # A single corrupt `exp` (e.g. "abc" or null) must not brick the
+            # store: float() raises TypeError/ValueError, and this runs in the
+            # RefreshStateManager constructor, so an unguarded coercion made
+            # _get_state() — and thus EVERY /api/auth/refresh call — 500 until
+            # the file was hand-repaired. Skip the malformed entry instead.
             for entry in data.get("consumed_jtis", []):
                 if isinstance(entry, dict) and "jti" in entry and "exp" in entry:
-                    self._consumed_jtis[str(entry["jti"])] = float(entry["exp"])
+                    try:
+                        self._consumed_jtis[str(entry["jti"])] = float(entry["exp"])
+                    except (TypeError, ValueError):
+                        logger.warning("refresh_tokens: dropping consumed_jti with bad exp: %r", entry)
             for entry in data.get("revoked_chains", []):
                 if isinstance(entry, dict) and "chain_id" in entry and "exp" in entry:
-                    self._revoked_chains[str(entry["chain_id"])] = float(entry["exp"])
+                    try:
+                        self._revoked_chains[str(entry["chain_id"])] = float(entry["exp"])
+                    except (TypeError, ValueError):
+                        logger.warning("refresh_tokens: dropping revoked_chain with bad exp: %r", entry)
 
     def _persist(self) -> None:
         if self._state_path is None:

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -330,6 +330,38 @@ def test_tr_i_17_corrupted_state_file_starts_empty(tmp_path: Path):
     assert mgr.is_consumed("anything") is False
 
 
+def test_tr_i_17a_malformed_exp_entry_is_skipped_not_fatal(tmp_path: Path):
+    """A single entry with a bad `exp` (valid JSON, non-numeric) must not brick
+    the store. float(exp) raises in the constructor's _load, so an unguarded
+    coercion made _get_state() — and every /api/auth/refresh call — 500 until
+    the file was hand-repaired. The bad entry is dropped; good ones survive."""
+    import json
+
+    state_file = tmp_path / "rt.json"
+    good_exp = time.time() + 86400
+    state_file.write_text(
+        json.dumps(
+            {
+                "consumed_jtis": [
+                    {"jti": "bad", "exp": "not-a-number"},
+                    {"jti": "alsobad", "exp": None},
+                    {"jti": "good", "exp": good_exp},
+                ],
+                "revoked_chains": [
+                    {"chain_id": "badchain", "exp": "nope"},
+                    {"chain_id": "goodchain", "exp": good_exp},
+                ],
+            }
+        )
+    )
+    mgr = RefreshStateManager(state_path=state_file)  # must not raise
+    assert mgr.is_consumed("good") is True
+    assert mgr.is_consumed("bad") is False
+    assert mgr.is_consumed("alsobad") is False
+    assert mgr.is_chain_revoked("goodchain") is True
+    assert mgr.is_chain_revoked("badchain") is False
+
+
 def test_tr_u_18_concurrent_writers(tmp_path: Path):
     """TR-U-18: 10 threads each marking a unique jti — no data loss.
 


### PR DESCRIPTION
## Bug (MEDIUM · crash-on-malformed-input)

`RefreshStateManager._load()` did `float(entry["exp"])` with **no TypeError/ValueError guard** — the enclosing `try` only caught `OSError`/`JSONDecodeError` around the read/parse. A single `refresh_chains.json` entry with `exp="abc"` or `exp=null` made the **constructor raise**, so `_get_state()` failed on every call — **every `/api/auth/refresh` request and `validate_refresh_token()` call 500'd** until the file was hand-repaired.

## Fix

Wrap each per-entry `float()` in `try/except (TypeError, ValueError)` and skip the malformed entry with a warning (coerce-or-drop). Well-formed entries in the same file still load.

## Test

`test_tr_i_17a_malformed_exp_entry_is_skipped_not_fatal` seeds a file with non-numeric and `null` `exp` values alongside good ones; **pre-fix** the constructor raises `ValueError` (surgical revert), **post-fix** the bad entries are dropped and the good ones survive. Full refresh-token suite (36 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
