### PR TITLE
feat: add pre-canned schedule cards to Schedule empty state

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -133,6 +133,12 @@ Default response is a compact one-line-per-job summary (id, name, status, schedu
 
 Security: sanitize-then-truncate ordering enforced for all user-controlled fields (message <=80 chars, last_error <=200 chars, last_result <=120 chars) so credentials straddling truncation boundaries cannot leak as partial fragments.
 
+### Schedule Page Empty-State Templates
+
+When the Schedule page (`/schedule`, `SchedulePage.tsx`) has **no jobs**, the empty state renders a bottom-pinned "Start from a pre-made schedule" row of four pre-canned template cards (`SCHEDULE_PRESETS` in `frontend/src/utils/schedulePresets.tsx`): **Dependency Guardian** (weekly, Mondays 06:00), **Nightly Build Watch** (cron `0 2 * * *`), **Error Digest** (interval, every 6 hours), and **Standup Brief** (cron `45 8 * * 1-5`). Each preset carries a `CronPrefill` payload (name, message, and schedule mode + values).
+
+Clicking a card opens the **existing** create panel with those fields pre-filled — it does **not** create a job directly. This is driven by an optional `prefill?: CronPrefill` prop on `JobForm`: in **create mode** (no `job`) the prefill seeds the initial form state (name, message, `schedMode`, interval, `weekDays`, `weekTime`, `cronExpr`); in **edit mode** (a `job` is present) `prefill` is ignored. The user reviews and saves through the normal `createCron` path, so a preset-seeded job is an ordinary cron job with no special lineage. `CronPrefill.weekDays` uses JobForm's grid convention (Mon=1 … Sun=7); a test pins the weekly preset to a Monday (`dow=1`) cron so a future change to that mapping fails loudly. Cards are rendered as accessible `Clickable` elements, hug their content, and equalize to the tallest via CSS-grid stretch. In the empty state only, the scroll container uses an 8px bottom pad (`pb-2`) instead of the default `pb-8` so the card row's bottom lines up with the left-nav panel's `m-2` bottom edge; the list/table view retains the standard `pb-8`.
+
 ## Dashboard (`dashboard/`)
 
 Modular aiohttp package at `127.0.0.1:5476` (configurable). Split into:

--- a/website/src/components/JobForm.tsx
+++ b/website/src/components/JobForm.tsx
@@ -5,6 +5,7 @@ import { Input, SendBtn } from './ui'
 import { SettingsToggle } from './settings'
 import AgentSelector, { type KiroCrewAgent } from './AgentSelector'
 import type { CronJob } from '../types'
+import type { CronPrefill } from '../utils/schedulePresets'
 import { SaveCreateLabel, CRON_SEL, expandDow } from '../utils/cronUtils'
 
 export const TIMEZONES = ['America/Los_Angeles','America/Phoenix','America/Denver','America/Chicago','America/New_York','America/Sao_Paulo','Europe/London','Europe/Berlin','Europe/Paris','Asia/Kolkata','Asia/Shanghai','Asia/Tokyo','Australia/Sydney','Pacific/Auckland','UTC']
@@ -93,6 +94,8 @@ function buildBody(
 
 interface Props {
   job?: CronJob // if provided, edit mode
+  /** Seed values for a NEW job (create mode). Ignored when `job` is set. */
+  prefill?: CronPrefill
   agents: KiroCrewAgent[]
   defaultAgent: string
   onSaved: () => void
@@ -106,10 +109,25 @@ interface Props {
   onSavingChange?: (saving: boolean) => void
 }
 
-export default function JobForm({ job, agents, defaultAgent, onSaved, layout = 'horizontal', externalSubmit, submitRef, onSavingChange }: Props) {
+export default function JobForm({ job, prefill, agents, defaultAgent, onSaved, layout = 'horizontal', externalSubmit, submitRef, onSavingChange }: Props) {
   const defaults = parseJobDefaults(job)
-  const [name, setName] = useState(defaults.name)
-  const [msg, setMsg] = useState(defaults.message)
+  // In create mode (no job), a preset can seed the prompt + schedule fields.
+  // Edit mode always reflects the job as-stored and ignores any prefill.
+  const init = !job && prefill
+    ? {
+      ...defaults,
+      name: prefill.name,
+      message: prefill.message,
+      schedMode: prefill.schedMode,
+      intVal: prefill.intVal ?? defaults.intVal,
+      intUnit: prefill.intUnit ?? defaults.intUnit,
+      weekDays: prefill.weekDays ?? defaults.weekDays,
+      weekTime: prefill.weekTime ?? defaults.weekTime,
+      cronExpr: prefill.cronExpr ?? defaults.cronExpr,
+    }
+    : defaults
+  const [name, setName] = useState(init.name)
+  const [msg, setMsg] = useState(init.message)
   const [agent, setAgent] = useState(defaults.agent)
   const [model, setModel] = useState(defaults.model)
   const { data: modelList = [] } = useQuery<{ name: string; description?: string }[]>({
@@ -124,13 +142,13 @@ export default function JobForm({ job, agents, defaultAgent, onSaved, layout = '
   const [silent, setSilent] = useState(defaults.silent)
   const [strictSchedule, setStrictSchedule] = useState(defaults.strictSchedule)
   const [hideInChat, setHideInChat] = useState(defaults.hideInChat)
-  const [schedMode, setSchedMode] = useState(defaults.schedMode)
-  const [intVal, setIntVal] = useState(defaults.intVal)
-  const [intUnit, setIntUnit] = useState(defaults.intUnit)
-  const [weekDays, setWeekDays] = useState(defaults.weekDays)
-  const [weekTime, setWeekTime] = useState(defaults.weekTime)
+  const [schedMode, setSchedMode] = useState(init.schedMode)
+  const [intVal, setIntVal] = useState(init.intVal)
+  const [intUnit, setIntUnit] = useState(init.intUnit)
+  const [weekDays, setWeekDays] = useState(init.weekDays)
+  const [weekTime, setWeekTime] = useState(init.weekTime)
   const [tz, setTz] = useState(() => job ? (job.timezone || 'UTC') : Intl.DateTimeFormat().resolvedOptions().timeZone)
-  const [cronExpr, setCronExpr] = useState(defaults.cronExpr)
+  const [cronExpr, setCronExpr] = useState(init.cronExpr)
   const [error, setError] = useState('')
   const [saving, setSavingState] = useState(false)
   const setSaving = (v: boolean) => { setSavingState(v); onSavingChange?.(v) }

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -2,7 +2,7 @@ import { safeSetItem } from '../utils/safeStorage'
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import Clickable from '../components/Clickable'
 import { AnimatePresence, motion } from 'framer-motion'
-import { List, CalendarDays, ClipboardList, ChevronRight, Globe, Check, History, Trash2 } from 'lucide-react'
+import { List, CalendarDays, CalendarClock, Plus, ClipboardList, ChevronRight, Globe, Check, History, Trash2 } from 'lucide-react'
 import { api } from '../api/client'
 import { PageHeader, Card, CardTitle, Btn, SendBtn, Badge, SearchInput, EmptyState, Skeleton } from '../components/ui'
 import SegmentedControl from '../components/SegmentedControl'
@@ -21,6 +21,7 @@ import { useSortableTable } from '../hooks/useSortableTable'
 import SortableHeader from '../components/SortableHeader'
 import ExecutionsView from '../components/ExecutionsView'
 import { sanitizeLlmOutput } from '../utils/sanitize'
+import { SCHEDULE_PRESETS, type CronPrefill } from '../utils/schedulePresets'
 
 const RENDER_TZ_STORAGE_KEY = 'kirocrew.schedule.renderTz'
 /**
@@ -81,6 +82,7 @@ export default function SchedulePage() {
   const [cronFilter, setCronFilter] = useState('')
   const [selected, setSelected] = useState<CronJob | null>(null)
   const [creating, setCreating] = useState(false)
+  const [prefill, setPrefill] = useState<CronPrefill | null>(null)
   const [jobsView, setJobsView] = useState<'list' | 'calendar' | 'executions'>('list')
   const [renderTz, setRenderTz] = useState<string>(() => {
     try {
@@ -216,11 +218,21 @@ export default function SchedulePage() {
   }, [selectedIds, load])
   const confirmArmed = confirmText.trim().toLowerCase() === 'delete'
 
+  // Open the create panel blank (from "Create your first job" / "Add Job").
+  const openBlankCreate = useCallback(() => { setSelected(null); setPrefill(null); setCreating(true) }, [])
+  // Open the create panel seeded from a pre-canned schedule card.
+  const openPreset = useCallback((p: CronPrefill) => { setSelected(null); setPrefill(p); setCreating(true) }, [])
+
+  // When the templates empty state is showing, use an 8px bottom pad (matching
+  // the left-nav panel's m-2 edge) so the card row's bottom lines up with the
+  // sidebar's bottom. The list/table view keeps the standard pb-8.
+  const showEmptyState = !loading && !loadError && jobs.length === 0 && !creating
+
   return (
     <div className="flex flex-1 min-h-0 overflow-hidden">
       <div className="flex-1 min-w-0 flex flex-col min-h-0">
         <PageHeader title="Schedule" subtitle="Manage recurring cron jobs and scheduled tasks" />
-        <div className="flex-1 overflow-y-auto px-6 pb-8 min-h-0">
+        <div className={`flex-1 overflow-y-auto px-6 min-h-0 ${showEmptyState ? 'pb-2' : 'pb-8'}`}>
           {loadError ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <p className="text-danger text-sm mb-3">{loadError}</p>
@@ -229,23 +241,39 @@ export default function SchedulePage() {
           ) : loading ? (
             <div className="flex items-center justify-center py-20"><Skeleton className="h-6 w-32 rounded" /></div>
           ) : jobs.length === 0 && !creating ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <svg className="w-16 h-16 stroke-current fill-none text-muted/20 mb-4" viewBox="0 0 24 24" strokeWidth={1} strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
-                <line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/>
-                <line x1="3" y1="10" x2="21" y2="10"/>
-                <circle cx="12" cy="15" r="1.5"/>
-                <path d="M9.5 15h-2M16.5 15h-2"/>
-              </svg>
-              <div className="text-muted text-sm font-medium">No scheduled jobs yet</div>
-              <p className="text-sm text-muted max-w-[360px] mb-5 mt-2">Schedule recurring tasks to run automatically — check pipelines, generate reports, monitor services, or anything your agent can do.</p>
-              <SendBtn onClick={() => { setSelected(null); setCreating(true) }}>
-                <span className="flex items-center gap-1.5">
-                  <svg className="w-3.5 h-3.5 stroke-current fill-none" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                  Create your first job
-                </span>
-              </SendBtn>
-              <p className="text-[12px] text-muted mt-3">or <a href="/chat" className="text-accent hover:underline">ask in chat</a> — try "remind me to check my pipeline every morning"</p>
+            <div className="flex flex-col h-full min-h-0">
+              <div className="flex-1 flex flex-col items-center justify-center text-center min-h-0 py-8">
+                <CalendarClock className="w-16 h-16 text-muted/20 mb-4" strokeWidth={1} aria-hidden="true" />
+                <div className="text-muted text-sm font-medium">No scheduled jobs yet</div>
+                <p className="text-sm text-muted max-w-[360px] mb-5 mt-2">Schedule recurring tasks to run automatically — check pipelines, generate reports, monitor services, or anything your agent can do.</p>
+                <SendBtn onClick={openBlankCreate}>
+                  <span className="flex items-center gap-1.5">
+                    <Plus size={14} aria-hidden="true" />
+                    Create your first job
+                  </span>
+                </SendBtn>
+                <p className="text-[12px] text-muted mt-3">or <a href="/chat" className="text-accent hover:underline">ask in chat</a> — try "remind me to check my pipeline every morning"</p>
+              </div>
+
+              {/* Pre-canned schedules pinned to the bottom: click to open the
+                  create flow pre-filled. */}
+              <div className="w-full shrink-0 pt-6">
+                <div className="text-left text-[12px] font-medium uppercase tracking-[.04em] text-muted mb-3">Start from a pre-made schedule</div>
+                <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
+                  {SCHEDULE_PRESETS.map(p => (
+                    <Clickable
+                      key={p.id}
+                      onClick={() => openPreset(p.prefill)}
+                      className="group flex flex-col items-start gap-2 text-left px-5 py-5 rounded-[20px] bg-card border border-border hover:border-accent/50 hover:bg-bg-hover transition-colors focus-ring cursor-pointer"
+                    >
+                      <span className="text-accent shrink-0">{p.icon}</span>
+                      <span className="text-[15px] font-semibold text-text-strong leading-snug">{p.title}</span>
+                      <span className="text-[13px] leading-[18px] text-muted">{p.description}</span>
+                      <span className="text-[12px] text-muted/80 font-medium mt-auto">{p.cadence}</span>
+                    </Clickable>
+                  ))}
+                </div>
+              </div>
             </div>
           ) : (<>
           <div className="flex items-center gap-2 px-3 py-2.5 mb-4 rounded-lg bg-accent-subtle border border-accent/20 text-[13px] text-text">
@@ -258,7 +286,7 @@ export default function SchedulePage() {
             <div className="flex items-center justify-between w-full">
               <span className="flex items-center gap-1.5">Jobs <InfoTip text="Scheduled jobs run on the configured interval or cron expression." /></span>
               <div className="flex items-center gap-2">
-                <SendBtn onClick={() => { setSelected(null); setCreating(true) }}>
+                <SendBtn onClick={openBlankCreate}>
                   <span className="flex items-center gap-1.5">
                     <svg className="w-3.5 h-3.5 stroke-current fill-none" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                     Add Job
@@ -381,12 +409,13 @@ export default function SchedulePage() {
             className="shrink-0 overflow-hidden h-full"
           >
             <JobDetailPanel
-              key={selected?.id || 'new'}
+              key={selected?.id || prefill?.name || 'new'}
               job={selected || undefined}
+              prefill={!selected ? prefill || undefined : undefined}
               agents={agents}
               defaultAgent={defaultAgent}
-              onClose={() => { setSelected(null); setCreating(false) }}
-              onSaved={() => { load(); setSelected(null); setCreating(false) }}
+              onClose={() => { setSelected(null); setCreating(false); setPrefill(null) }}
+              onSaved={() => { load(); setSelected(null); setCreating(false); setPrefill(null) }}
             />
           </motion.div>
         )}
@@ -450,8 +479,8 @@ export default function SchedulePage() {
 // flex row and reflow content off-screen (mirrors DetailPanel's reserveWidth).
 const JOB_LIST_MIN = 360
 
-function JobDetailPanel({ job, agents, defaultAgent, onClose, onSaved }: {
-  job?: CronJob; agents: KiroCrewAgent[]; defaultAgent: string; onClose: () => void; onSaved: () => void
+function JobDetailPanel({ job, prefill, agents, defaultAgent, onClose, onSaved }: {
+  job?: CronJob; prefill?: CronPrefill; agents: KiroCrewAgent[]; defaultAgent: string; onClose: () => void; onSaved: () => void
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -514,7 +543,7 @@ function JobDetailPanel({ job, agents, defaultAgent, onClose, onSaved }: {
         <div className="w-[2px] h-full bg-transparent group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-colors duration-200" />
       </div>
       <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-        <span className="text-base font-semibold text-text-strong truncate">{job ? job.name : 'New Job'}</span>
+        <span className="text-base font-semibold text-text-strong truncate">{job ? job.name : (prefill?.name || 'New Job')}</span>
         <Btn aria-label="Close" onClick={onClose}>
           <svg className="w-4 h-4 stroke-current fill-none" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </Btn>
@@ -549,7 +578,7 @@ function JobDetailPanel({ job, agents, defaultAgent, onClose, onSaved }: {
           <JobLogsView jobId={job.id} isRunning={job.is_running} runningSince={job.running_since} cancelError={panelError} onCancel={async () => { setPanelError(null); try { await api.cancelCron(job.id); onSaved() } catch (e: unknown) { setPanelError(e instanceof Error ? e.message : 'Failed') } }} />
         ) : (
           <>
-            <JobForm job={job} agents={agents} defaultAgent={defaultAgent} onSaved={onSaved} layout="vertical" externalSubmit submitRef={submitRef} onSavingChange={setSaving} />
+            <JobForm job={job} prefill={prefill} agents={agents} defaultAgent={defaultAgent} onSaved={onSaved} layout="vertical" externalSubmit submitRef={submitRef} onSavingChange={setSaving} />
             {panelError && <div className="text-danger text-[13px]">{panelError}</div>}
             {job?.script && (job.last_result || job.last_error) && (
               <div className="flex flex-col gap-1.5">

--- a/website/src/test/SchedulePage.test.tsx
+++ b/website/src/test/SchedulePage.test.tsx
@@ -24,6 +24,8 @@ vi.mock('../api/client', () => ({
     crons: vi.fn(),
     deleteCron: vi.fn(),
     batchDeleteCron: vi.fn(),
+    createCron: vi.fn().mockResolvedValue({}),
+    models: vi.fn().mockResolvedValue([]),
     updateCron: vi.fn().mockResolvedValue({}),
     toggleCron: vi.fn().mockResolvedValue({}),
     runCron: vi.fn().mockResolvedValue({}),
@@ -188,5 +190,59 @@ describe('SchedulePage batch select + bulk delete', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     await waitFor(() =>
       expect(screen.getByRole('checkbox', { name: 'Select Weekly digest' })).toBeChecked())
+  })
+})
+
+describe('SchedulePage empty-state preset cards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the 4 pre-canned schedule cards when there are no jobs', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({ jobs: [] })
+
+    renderWithProviders(<SchedulePage />)
+
+    await waitFor(() => expect(screen.getByText('Dependency Guardian')).toBeInTheDocument())
+    expect(screen.getByText('Nightly Build Watch')).toBeInTheDocument()
+    expect(screen.getByText('Error Digest')).toBeInTheDocument()
+    expect(screen.getByText('Standup Brief')).toBeInTheDocument()
+  })
+
+  it('clicking a preset card opens the create panel with the prompt + name prefilled', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({ jobs: [] })
+
+    renderWithProviders(<SchedulePage />)
+    await waitFor(() => expect(screen.getByText('Error Digest')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Error Digest'))
+
+    const nameInput = (await screen.findByLabelText('Name')) as HTMLInputElement
+    expect(nameInput.value).toBe('Error Digest')
+    const msgInput = screen.getByLabelText('Message') as HTMLTextAreaElement
+    expect(msgInput.value).toContain('production errors')
+  })
+
+  it('weekly preset (Dependency Guardian) creates a Monday cron', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({ jobs: [] })
+    vi.mocked(api).createCron.mockResolvedValue({})
+
+    renderWithProviders(<SchedulePage />)
+    await waitFor(() => expect(screen.getByText('Dependency Guardian')).toBeInTheDocument())
+
+    // Open the prefilled create panel, then save via the normal create path.
+    fireEvent.click(screen.getByText('Dependency Guardian'))
+    const createBtn = await screen.findByRole('button', { name: 'Create' })
+    fireEvent.click(createBtn)
+
+    await waitFor(() => expect(api.createCron).toHaveBeenCalled())
+    const body = vi.mocked(api).createCron.mock.calls[0][0] as Record<string, unknown>
+    // Pins JobForm's grid weekday convention (Mon=1): the Dependency Guardian
+    // preset (weekDays: [1], 06:00) must map to a Monday cron. If JobForm's
+    // day-numbering changes, this fails loudly instead of silently shifting.
+    expect(body.cron).toBe('0 6 * * 1')
   })
 })

--- a/website/src/utils/schedulePresets.tsx
+++ b/website/src/utils/schedulePresets.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react'
+import { ShieldCheck, Moon, AlertTriangle, Sunrise } from 'lucide-react'
+
+/**
+ * Prefill payload for the "New Job" creation flow. Field names mirror
+ * JobForm's internal schedule state so the form can seed itself directly.
+ * weekDays use the grid convention (Mon=1 … Sun=7), matching JobForm's
+ * DAY_NAMES / toggleDay ordering.
+ */
+export interface CronPrefill {
+  name: string
+  message: string
+  schedMode: 'interval' | 'weekly' | 'cron'
+  intVal?: number
+  intUnit?: 'minutes' | 'hours' | 'days'
+  weekDays?: number[]
+  weekTime?: string
+  cronExpr?: string
+}
+
+export interface SchedulePreset {
+  id: string
+  icon: ReactNode
+  title: string
+  description: string
+  /** Human-readable cadence shown on the card (mirrors the schedule prefill). */
+  cadence: string
+  prefill: CronPrefill
+}
+
+const ICON_SIZE = 22
+
+/**
+ * Four pre-canned schedules surfaced on the empty Schedule page. Clicking a
+ * card opens the standard create flow with the prompt + schedule pre-filled;
+ * the user reviews and saves like any other job.
+ */
+export const SCHEDULE_PRESETS: SchedulePreset[] = [
+  {
+    id: 'dependency-guardian',
+    icon: <ShieldCheck size={ICON_SIZE} />,
+    title: 'Dependency Guardian',
+    description: 'Upgrades packages, runs tests, and opens a PR only when green.',
+    cadence: 'Weekly · Mondays 6:00am',
+    prefill: {
+      name: 'Dependency Guardian',
+      message:
+        'Check this project for outdated dependencies. Upgrade them, run the full test suite, and fix anything that breaks. Only open a pull request if all tests pass green — otherwise report what failed.',
+      schedMode: 'weekly',
+      weekDays: [1],
+      weekTime: '06:00',
+    },
+  },
+  {
+    id: 'nightly-build-watch',
+    icon: <Moon size={ICON_SIZE} />,
+    title: 'Nightly Build Watch',
+    description: 'Builds and tests main overnight; reports failures and likely fixes.',
+    cadence: 'Every 24 hours · 2:00am',
+    prefill: {
+      name: 'Nightly Build Watch',
+      message:
+        'Build and test the main branch. If anything fails, report exactly what failed, the likely root cause, and a suggested fix.',
+      schedMode: 'cron',
+      cronExpr: '0 2 * * *',
+    },
+  },
+  {
+    id: 'error-digest',
+    icon: <AlertTriangle size={ICON_SIZE} />,
+    title: 'Error Digest',
+    description: 'Clusters new production errors with a suspected cause for each.',
+    cadence: 'Every 6 hours',
+    prefill: {
+      name: 'Error Digest',
+      message:
+        'Review new production errors since the last run. Cluster them by type, and for each cluster give a short summary and a suspected cause.',
+      schedMode: 'interval',
+      intVal: 6,
+      intUnit: 'hours',
+    },
+  },
+  {
+    id: 'standup-brief',
+    icon: <Sunrise size={ICON_SIZE} />,
+    title: 'Standup Brief',
+    description: 'Your commits, PRs, CI status, and blockers before standup.',
+    cadence: 'Every weekday · 8:45am',
+    prefill: {
+      name: 'Standup Brief',
+      message:
+        "Summarize my recent commits, open pull requests, CI status, and any blockers for today's standup. Keep it concise and deliver it before the meeting.",
+      schedMode: 'cron',
+      cronExpr: '45 8 * * 1-5',
+    },
+  },
+]


### PR DESCRIPTION
## Summary

Adds four ready-to-use **schedule templates** to the empty Schedule page. Clicking a card opens the existing create flow with the prompt, name, and time/interval/cron trigger **pre-filled**, so the user reviews and saves like any other job.

Templates:

| Card | Prompt intent | Trigger |
|------|---------------|---------|
| **Dependency Guardian** | Upgrade deps, run tests, open a PR when green | Weekly · Mondays 6:00am |
| **Nightly Build Watch** | Build/test main overnight, report failures | Daily `0 2 * * *` |
| **Error Digest** | Cluster new prod errors with a suspected cause | Every 6 hours |
| **Standup Brief** | Commits, PRs, CI status, blockers before standup | Weekdays `45 8 * * 1-5` |

## Changes

- `JobForm`: new optional `prefill` prop seeds create-mode state (name, message, schedule mode + values). Edit mode is unaffected — prefill is ignored when a `job` is present.
- `schedulePresets.tsx`: new module holding the `CronPrefill` / `SchedulePreset` types and the four preset definitions (icon, copy, cadence, prefill payload).
- `SchedulePage`: renders the "Start from a pre-made schedule" row in the empty state, pinned to the bottom and aligned with the left-nav panel's bottom edge. Cards hug their content and equalize to the tallest via CSS-grid stretch; the row is responsive (1 → 2 → 4 columns).

## Testing

- `tsc --noEmit` clean
- `eslint` — 0 errors (pre-existing warnings only)
- `vitest` — new empty-state tests (cards render; clicking a card opens the create panel prefilled) + existing SchedulePage / JobForm suites pass (23 tests)
- `npm run build` succeeds

## Screenshots
<img width="1724" height="900" alt="image" src="https://github.com/user-attachments/assets/8b7f5a5a-4e9b-419e-9a2b-0efc5a9b40ff" />

