### PR TITLE
fix(dashboard): guard voice-config engine against unhashable JSON values

### DIFF
--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -70,7 +70,9 @@ async def api_voice_config(request: web.Request) -> web.Response:
         _vc.provider = body["provider"]
     if "voice" in body:
         _vc.default_voice = str(body["voice"])
-    if "engine" in body and body["engine"] in VALID_ENGINES:
+    # Same as provider above: ``in VALID_ENGINES`` raises TypeError on an
+    # unhashable JSON value (list/dict), 500ing the PUT — require a str first.
+    if "engine" in body and isinstance(body["engine"], str) and body["engine"] in VALID_ENGINES:
         _vc.default_engine = body["engine"]
     if "rate" in body:
         _vc.default_rate = str(body["rate"])

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -130,6 +130,30 @@ class TestVoiceConfig:
             assert mock_vc.provider == "piper"
 
     @pytest.mark.asyncio
+    async def test_put_config_unhashable_engine_does_not_500(self, tmp_path, monkeypatch):
+        # `body["engine"] in VALID_ENGINES` (a frozenset) raises
+        # TypeError: unhashable type on a JSON list/dict value, 500ing the PUT.
+        # The provider check above was already guarded; engine was missed.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            global_enabled=False, provider="piper", default_voice="Ruth",
+            default_engine="generative", default_rate="100%", default_pitch="0%",
+            aws_profile="", region="", piper_binary="", piper_model="",
+            piper_model_config="", piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({}))
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.config_path", lambda: cfg_path)
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            for bad in ({"engine": ["neural"]}, {"engine": {"x": 1}}):
+                resp = await client.put("/api/voice/config", json=bad)
+                assert resp.status == 200  # not a 500
+            # Unhashable/non-str engine ignored — unchanged
+            assert mock_vc.default_engine == "generative"
+
+    @pytest.mark.asyncio
     async def test_put_config_ignores_invalid_length_scale(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(


### PR DESCRIPTION
## Bug (MEDIUM · crash-on-malformed-input)

`PUT /api/voice/config` did `body["engine"] in VALID_ENGINES` (a `frozenset`) with **no type check**, so a JSON list/dict value (`{"engine": ["neural"]}`) raised `TypeError: unhashable type` and **500'd the request**. The `provider` check directly above was already guarded with `isinstance(str)` (with a comment describing this exact failure mode); `engine` was missed.

## Fix

Mirror the provider guard — require `isinstance(body["engine"], str)` before the membership test, so a bad engine value is ignored (config unchanged) instead of crashing.

## Test

`test_put_config_unhashable_engine_does_not_500` PUTs list- and dict-valued `engine`; **pre-fix** returns 500 (surgical revert), **post-fix** returns 200 and leaves the engine unchanged. Full voice suite (18 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
