### PR TITLE
fix(dashboard): 400 not 500 on non-integer autonudge idle_secs/max_cycles

### DIFF
--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -65,13 +65,24 @@ async def api_autonudge_start(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    # idle_secs/max_cycles come straight from the request body: int() raises
+    # ValueError on "abc" and TypeError on null/list, which would surface as a
+    # 500 instead of a 400. Coerce up front and reject bad input, matching the
+    # sibling handlers_instances.api_instances_add guard on the same pattern.
+    try:
+        idle_secs = int(body.get("idle_secs", 60))
+        max_cycles = int(body.get("max_cycles", 0))
+    except (TypeError, ValueError):
+        return web.json_response(
+            {"error": "idle_secs and max_cycles must be integers"}, status=400
+        )
     loop, error, status = await authorize_and_add_nudge(
         svc=svc,
         state=state,
         slot_key=(body.get("session_key") or body.get("slot_key") or ""),
         message=(body.get("message") or ""),
-        idle_secs=int(body.get("idle_secs", 60)),
-        max_cycles=int(body.get("max_cycles", 0)),
+        idle_secs=idle_secs,
+        max_cycles=max_cycles,
         stop_sentinel_path=(body.get("stop_sentinel_path") or ""),
         source="dashboard",
         caller=request.remote or "",

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -562,3 +562,66 @@ async def test_dashboard_loop_does_not_self_rearm(svc, monkeypatch):
     # No new timer was armed — the finished task is still the registered one.
     assert svc._timers.get(loop.id) is timer1
     svc.stop()
+
+
+class TestAutonudgeStartIntCoercion:
+    """POST /api/autonudge passed idle_secs/max_cycles through int() with no
+    guard, so a non-numeric ("abc"), null, or list value 500'd instead of
+    returning 400 — unlike the sibling api_instances_add which guards the same
+    int(body.get(...)) pattern. These drive the real handler over aiohttp."""
+
+    def _app(self, monkeypatch, fake_svc):
+        from unittest.mock import MagicMock
+
+        from aiohttp import web
+
+        from kiro_crew.dashboard.handlers import autonudge as _handler
+
+        monkeypatch.setattr(_handler, "_autonudge_get", lambda: fake_svc)
+        state = MagicMock()
+        state._slots = {"chat-1-123": MagicMock(workspace="default")}
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/autonudge", _handler.api_autonudge_start)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_non_integer_idle_secs_is_400_not_500(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        fake_svc = MagicMock()
+        fake_svc.add = AsyncMock()  # must NOT be called on bad input
+        app = self._app(monkeypatch, fake_svc)
+        async with TestClient(TestServer(app)) as client:
+            for bad in ("abc", None, ["x"]):
+                resp = await client.post(
+                    "/api/autonudge",
+                    json={"slot_key": "chat-1-123", "message": "go", "idle_secs": bad},
+                )
+                assert resp.status == 400, f"idle_secs={bad!r} gave {resp.status}"
+        fake_svc.add.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_valid_integers_still_start(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        fake_svc = MagicMock()
+        fake_svc.add = AsyncMock(
+            return_value=NudgeLoop(
+                id="loop-1", slot_key="chat-1-123", message="go", idle_secs=30, max_cycles=2
+            )
+        )
+        app = self._app(monkeypatch, fake_svc)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/autonudge",
+                json={"slot_key": "chat-1-123", "message": "go", "idle_secs": 30, "max_cycles": 2},
+            )
+            assert resp.status == 200
+        fake_svc.add.assert_awaited_once()
+        assert fake_svc.add.await_args.kwargs["idle_secs"] == 30
+        assert fake_svc.add.await_args.kwargs["max_cycles"] == 2


### PR DESCRIPTION
## Bug (MEDIUM · input-validation)

`api_autonudge_start` passed `idle_secs=int(body.get("idle_secs", 60))` and `max_cycles=int(body.get("max_cycles", 0))` straight from the request body with **no try/except**: `"abc"` raises `ValueError`, `null`/list raise `TypeError` — all surfacing as a **500 instead of a 400**. The sibling handler `handlers_instances.api_instances_add` already wraps the identical `int(body.get(...))` coercion in try/except and returns 400.

## Fix

Coerce both up front in `try/except (TypeError, ValueError)` and return `400` with a clear message; the `svc.add` call uses the validated locals.

## Test

`TestAutonudgeStartIntCoercion` drives the **real handler over aiohttp**: non-integer `idle_secs` (`"abc"`/`null`/list) returns 400 (**pre-fix: 500**, surgical revert) and never calls `svc.add`; valid integers still start the loop and reach `svc.add` with the right values. Full autonudge suite (24 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
