### PR TITLE
fix(dashboard): 400 not 500 on non-dict edit-resend body

### DIFF
--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -187,6 +187,11 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    # A valid-JSON but non-object body (array/scalar) has no .get(), so
+    # body.get("index") would raise AttributeError -> 500. Reject it as a 400,
+    # matching the guard in api_chat_slot_switch_variant above.
+    if not isinstance(body, dict):
+        return web.json_response({"error": "invalid JSON"}, status=400)
 
     index = body.get("index")
     ts = body.get("ts")
@@ -201,8 +206,11 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
         msgs = slot.messages
 
         if ts:
-            index = next((i for i, m in enumerate(msgs) if m.get("ts") == ts and m.get("role") == "user"), -1)
-            if index < 0:
+            index = next(
+                (i for i, m in enumerate(msgs) if m.get("ts") == ts and m.get("role") == "user"),
+                -1,
+            )
+            if not isinstance(index, int) or index < 0:
                 return web.json_response({"error": "user message not found for ts"}, status=400)
         elif isinstance(index, int) and 0 <= index < len(msgs):
             if msgs[index].get("role") != "user":

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6913,6 +6913,30 @@ class TestRegenerateAndVariants:
             assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_edit_resend_non_dict_body_is_400_not_500(self, tmp_path, monkeypatch):
+        # api_chat_slot_edit_resend parsed the body but never checked
+        # isinstance(dict); a valid-JSON array/scalar reached body.get("index")
+        # and raised AttributeError -> 500. Must be 400, like switch_variant.
+        from kiro_crew.dashboard.chat import api_chat_slot_edit_resend
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("s1")
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post(
+            "/api/chat/slots/{slot}/edit-resend", api_chat_slot_edit_resend
+        )
+        async with TestClient(TestServer(app)) as client:
+            for bad in ("[1, 2]", '"hi"', "42"):
+                resp = await client.post(
+                    "/api/chat/slots/s1/edit-resend",
+                    data=bad,
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 400, f"body={bad!r} gave {resp.status}"
+
+    @pytest.mark.asyncio
     async def test_regenerate_clears_pending_on_task_error(self, tmp_path, monkeypatch):
         """If _run_chat raises, _pending_variants must be cleared to prevent leak."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)


### PR DESCRIPTION
## Bug (LOW · crash-on-malformed-input)

`api_chat_slot_edit_resend` parsed the JSON body (400 on parse error) but **never checked `isinstance(body, dict)`**; a valid-JSON array or scalar body (`[1,2]` / `"x"` / `42`) reached `body.get("index")` and raised `AttributeError` → **500**. The sibling `api_chat_slot_switch_variant` in the same module already guards this exact case.

## Fix

Add `if not isinstance(body, dict): return 400` right after the parse, mirroring `switch_variant`. The narrower type then surfaced a latent mypy None-safety issue on the `ts`-branch index (`index < 0` when `index` could be `None`) — guarded with `not isinstance(index, int)` (defensive; no behavior change since `next()` returns an int there).

## Test

`TestRegenerateAndVariants::test_edit_resend_non_dict_body_is_400_not_500` posts array/scalar bodies; **pre-fix** returns 500 (surgical revert), **post-fix** 400. Regenerate/variants suite (30 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
