### PR TITLE
fix(browser): make the Netscape cookie-jar parser tolerant of bad input

### DIFF
--- a/src/kiro_crew/browser/auth.py
+++ b/src/kiro_crew/browser/auth.py
@@ -106,7 +106,10 @@ def parse_netscape_cookies(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     cookies: list[dict[str, Any]] = []
-    for line in path.read_text().splitlines():
+    # errors="replace": a single non-UTF-8 byte anywhere in the jar would
+    # otherwise raise UnicodeDecodeError and abort parsing of ALL cookies.
+    # Degrade the bad byte to U+FFFD on its line instead.
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -129,8 +132,15 @@ def parse_netscape_cookies(path: Path) -> list[dict[str, Any]]:
             "httpOnly": http_only,
             "sameSite": "None" if is_secure else "Lax",
         }
-        expires = parts[4]
-        cookie["expires"] = int(expires) if expires.isdigit() and int(expires) > 0 else -1
+        # str.isdigit() is True for unicode digits ("²", "٣") that int()
+        # rejects, so the old `isdigit() and int(...)` gate still raised
+        # ValueError on those. Guard the coercion and degrade a malformed or
+        # non-positive expiry to a session cookie (-1).
+        try:
+            parsed_exp = int(parts[4])
+        except ValueError:
+            parsed_exp = -1
+        cookie["expires"] = parsed_exp if parsed_exp > 0 else -1
         cookies.append(cookie)
     return cookies
 

--- a/test/test_browser_auth.py
+++ b/test/test_browser_auth.py
@@ -1,0 +1,65 @@
+"""Tests for the Netscape cookie-jar parser (kiro_crew.browser.auth)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.browser.auth import parse_netscape_cookies
+
+# A tab-separated Netscape cookie line: domain, incl_subdomains, path,
+# secure, expires, name, value.
+_GOOD = "example.com\tTRUE\t/\tFALSE\t1999999999\tsid\tabc123"
+
+
+def test_parses_a_valid_cookie(tmp_path: Path):
+    jar = tmp_path / "cookies.txt"
+    jar.write_text(_GOOD + "\n")
+    cookies = parse_netscape_cookies(jar)
+    assert len(cookies) == 1
+    assert cookies[0]["name"] == "sid"
+    assert cookies[0]["value"] == "abc123"
+    assert cookies[0]["expires"] == 1999999999
+
+
+def test_non_utf8_byte_does_not_abort_the_whole_jar(tmp_path: Path):
+    """A single non-UTF-8 byte anywhere in the jar previously raised
+    UnicodeDecodeError from path.read_text() and dropped EVERY cookie. It must
+    now degrade to U+FFFD on that line and still parse the good cookies."""
+    jar = tmp_path / "cookies.txt"
+    # A valid line, then a line with a raw 0xFF byte, then another valid line.
+    good2 = "example.org\tTRUE\t/\tFALSE\t1999999999\ttok\txyz"
+    jar.write_bytes(
+        (_GOOD + "\n").encode("utf-8")
+        + b"example.net\tTRUE\t/\tFALSE\t1999999999\tbad\t\xffval\n"
+        + (good2 + "\n").encode("utf-8")
+    )
+    cookies = parse_netscape_cookies(jar)
+    names = {c["name"] for c in cookies}
+    # Both clean cookies survive; the mangled line is still parsed (not fatal).
+    assert "sid" in names
+    assert "tok" in names
+    assert len(cookies) == 3
+
+
+def test_unicode_digit_expiry_degrades_to_session_cookie(tmp_path: Path):
+    """str.isdigit() is True for unicode digits ("²", "٣") that int() rejects,
+    so the old gate still raised ValueError. A malformed expiry must degrade to
+    a session cookie (-1), not crash the parser."""
+    jar = tmp_path / "cookies.txt"
+    jar.write_text(
+        "example.com\tTRUE\t/\tFALSE\t²\tsid\tabc\n"  # superscript-2 expiry
+        "example.com\tTRUE\t/\tFALSE\tnotanum\ttok\txyz\n"
+    )
+    cookies = parse_netscape_cookies(jar)
+    assert len(cookies) == 2
+    assert all(c["expires"] == -1 for c in cookies)
+
+
+def test_negative_and_zero_expiry_become_session(tmp_path: Path):
+    jar = tmp_path / "cookies.txt"
+    jar.write_text(
+        "example.com\tTRUE\t/\tFALSE\t-5\tsid\tabc\n"
+        "example.com\tTRUE\t/\tFALSE\t0\ttok\txyz\n"
+    )
+    cookies = parse_netscape_cookies(jar)
+    assert all(c["expires"] == -1 for c in cookies)


### PR DESCRIPTION
## Bug (MEDIUM · crash-on-malformed-input)

`parse_netscape_cookies()` had two crash paths, both of which escaped the function and — via `refresh_storage_state`'s blanket `except Exception: pass` — **silently dropped the user's entire cookie jar**:

1. `path.read_text()` defaults to strict UTF-8, so a single non-UTF-8 byte anywhere in the file raised `UnicodeDecodeError` and aborted parsing of **all** cookies.
2. `int(expires) if expires.isdigit() ...` — `str.isdigit()` is `True` for unicode digits (`"²"`, `"٣"`) that `int()` rejects, so `int()` still raised `ValueError`.

## Fix

1. Decode with `errors="replace"` — one bad byte degrades to `U+FFFD` on its line instead of nuking the jar.
2. Replace the `isdigit()` gate with a `try/except`, degrading a malformed or non-positive expiry to a session cookie (`-1`).

## Test

`test_browser_auth.py` — non-UTF-8 byte and unicode-digit expiry each **fail pre-fix** with the exact `UnicodeDecodeError`/`ValueError` (surgical revert) and now parse cleanly; valid, negative, and zero expiries also covered. `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
