### PR TITLE
fix(browser): guard patch_mcp_* against a non-object mcp.json

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -632,7 +632,16 @@ def patch_mcp_extension(token: str) -> None:
         return
     try:
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
+        # A user-owned mcp.json may hold valid JSON that isn't an object (e.g.
+        # `[]`/`null`/a string after truncation or a hand-edit), or an
+        # mcpServers that isn't a dict. data.setdefault / servers[...] would
+        # then raise AttributeError/TypeError, which the except below does NOT
+        # catch. Reset a bad shape to {} — matches _migrate_playwright_to_proxy.
+        if not isinstance(data, dict):
+            data = {}
         servers = data.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = data["mcpServers"] = {}
         entry = {
             "command": _kirocrew_bin(),
             "args": ["mcp-playwright-proxy", "--extension"],
@@ -655,7 +664,14 @@ def patch_mcp_headless() -> None:
         return
     try:
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
+        # See patch_mcp_extension: guard a non-object mcp.json / non-dict
+        # mcpServers so setdefault/servers[...] can't raise an uncaught
+        # AttributeError/TypeError.
+        if not isinstance(data, dict):
+            data = {}
         servers = data.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = data["mcpServers"] = {}
         config_path = str(config_dir() / "playwright-config.json")
         entry = {
             "command": _kirocrew_bin(),

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -449,6 +449,31 @@ class TestPatchWritesCanonicalKey:
         assert servers["@playwright/mcp"] == {"command": "npx", "args": ["@playwright/mcp@latest"]}
 
 
+class TestPatchMalformedMcpJson:
+    """A user-owned mcp.json may hold valid JSON that isn't an object, or an
+    mcpServers that isn't a dict. patch_mcp_* guarded only JSONDecodeError/OSError,
+    so data.setdefault / servers[...] raised an uncaught AttributeError/TypeError.
+    The patcher must reset the bad shape and still register the canonical key."""
+
+    @pytest.mark.parametrize("patcher", ["extension", "headless"])
+    @pytest.mark.parametrize("bad", ["[]", "null", '"hi"', "42", '{"mcpServers": []}'])
+    def test_non_object_shape_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, patcher: str, bad: str
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        mcp_json = tmp_path / ".kiro" / "settings" / "mcp.json"
+        mcp_json.parent.mkdir(parents=True, exist_ok=True)
+        mcp_json.write_text(bad)
+        if patcher == "extension":
+            patch_mcp_extension("tok-123")  # must not raise
+        else:
+            patch_mcp_headless()  # must not raise
+        # The bad shape was reset and the canonical proxy key registered.
+        servers = _read_servers(mcp_json)
+        assert _CANONICAL in servers
+
+
 # ── TestMigrateOwnedPlaywrightRegistration ───────────────────────────────────
 
 


### PR DESCRIPTION
## Bug (MEDIUM · crash-on-malformed-input)

`patch_mcp_extension()` and `patch_mcp_headless()` did `data = json.loads(...); servers = data.setdefault("mcpServers", {})` guarded only by `except (JSONDecodeError, OSError)`. A user-owned `~/.kiro/settings/mcp.json` holding valid JSON that isn't an object (`[]`, `null`, a string — after truncation or a hand-edit) made `data.setdefault` raise `AttributeError`; an `{"mcpServers": []}` made `servers[canonical] = entry` raise `TypeError`. Neither is caught, so the patch crashed instead of repairing the file.

## Fix

In both patchers, reset a non-dict `data` to `{}` and a non-dict `servers` to `{}`, matching the `isinstance` idiom in `_migrate_playwright_to_proxy`.

## Test

`TestPatchMalformedMcpJson` parametrizes both patchers over `[]`, `null`, string, number, and `{"mcpServers": []}`; each **fails pre-fix** with the exact `AttributeError`/`TypeError` (surgical revert) and now registers the canonical proxy key. Full browser-setup suite (77 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
