### PR TITLE
fix(browser): reject bool/out-of-range screencast frame dimensions

### DIFF
--- a/src/kiro_crew/browser/screencast.py
+++ b/src/kiro_crew/browser/screencast.py
@@ -76,7 +76,12 @@ def build_frame_payload(body: dict[str, Any]) -> dict[str, Any] | None:
     payload: dict[str, Any] = {"data": data, "format": fmt}
     for dim in ("device_width", "device_height"):
         val = body.get(dim)
-        if isinstance(val, int):
+        # bool is an int subclass, so {"device_width": true} would pass a bare
+        # isinstance(int) check and broadcast device_width=True — which the
+        # BrowserLiveView panel treats as 1 in JS aspect/size math (a 1px frame
+        # hint). Also bound it to a sane pixel range, matching the module's
+        # bound-every-field idiom (format allowlist, _B64_RE, _SESSION_KEY_RE).
+        if isinstance(val, int) and not isinstance(val, bool) and 0 < val <= 100_000:
             payload[dim] = val
     # Pass the session key through (bounded) so the panel can label which session
     # it mirrors. The dashboard resolves it to a title from its own slot store.

--- a/test/test_browser_screencast.py
+++ b/test/test_browser_screencast.py
@@ -53,6 +53,18 @@ class TestBuildFramePayload:
         )
         assert out == {"data": "QUJD", "format": "png", "device_width": 1280}
 
+    def test_drops_bool_and_out_of_range_dimensions(self):
+        # bool is an int subclass, so a bare isinstance(int) check let
+        # device_width=True through — the panel then treats it as 1px in JS
+        # aspect math. Non-positive and absurdly large values are dropped too.
+        for bad in (True, False, 0, -5, 100_001):
+            out = build_frame_payload(
+                {"data": "QUJD", "format": "png", "device_width": bad, "device_height": 720}
+            )
+            assert out is not None
+            assert "device_width" not in out, f"device_width={bad!r} leaked"
+            assert out["device_height"] == 720  # a valid sibling still passes
+
     def test_passes_through_valid_session_key(self):
         out = build_frame_payload({"data": "QUJD", "session_key": "chat-Abc_1.2:3"})
         assert out is not None and out["session_key"] == "chat-Abc_1.2:3"


### PR DESCRIPTION
## Bug (LOW · input-validation)

`build_frame_payload` validated `device_width`/`device_height` with `isinstance(val, int)`, but **`bool` is an `int` subclass**, so `{"device_width": true}` passed and the WS frame broadcast to every dashboard client carried `device_width=True`. The `BrowserLiveView` panel then uses it in JS aspect/size math where `True` coerces to `1` — a 1px-wide frame hint. The values were also unbounded (negative / absurdly large).

## Fix

Require `isinstance(int) and not isinstance(bool) and 0 < val <= 100_000`, matching the module's bound-every-field idiom (format allowlist, `_B64_RE`, `_SESSION_KEY_RE`).

## Test

`test_drops_bool_and_out_of_range_dimensions` covers `True`/`False`/`0`/`-5`/`100001`; each **fails pre-fix** (True leaks as a dimension) via surgical revert and is now dropped while a valid sibling still passes. Full screencast suite (40 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via an automated multi-agent bug hunt (adversarially verified + empirically reproduced).
