### PR TITLE
feat(ci): publish the Linux AppImage to the distribution CDN

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,6 +95,27 @@ jobs:
       wheel_artifact: cli-wheel
     secrets: inherit
 
+  # ── Linux desktop publish ─────────────────────────────────────────────
+  # Publishes the built AppImage to the distribution CDN (versioned key +
+  # latest alias). Its own lane beside publish-cli, deliberately NOT inside
+  # sign-and-notarize.yml: the Linux artifact takes no part in the macOS
+  # trust chain, and needing only build-desktop means neither a wheel nor a
+  # macOS signing failure can block it (per-platform releases).
+  publish-linux:
+    name: Publish Linux Desktop (nightly channel)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      publish: true
+      appimage_artifact: build-linux-x64
+    secrets: inherit
+
   # Caller job for the reusable sign-and-notarize workflow: a workflow_call
   # callee can never exceed the caller job's permissions, so the caller must
   # grant id-token explicitly. attestations:write covers the sign job's

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -1,0 +1,207 @@
+name: Publish Linux Desktop (reusable)
+
+# Reusable workflow: publish an already-built Linux AppImage to a release
+# channel on the distribution CDN. Called by nightly.yml (channel: nightly)
+# and release.yml (channel: insider | stable) as its own lane BESIDE the
+# macOS sign-and-notarize workflow, mirroring publish-cli.yml: the Linux
+# artifact takes no part in the macOS trust chain (sign -> notarize ->
+# gated publish), so it does not live in that workflow. Depending only on
+# build-desktop at the caller means neither a wheel-build nor a macOS
+# signing failure can block the Linux artifact (per-platform releases).
+#
+# Trust posture: Linux has no Gatekeeper equivalent, so there is no signing
+# gate to wait on. This lane attests its own signed SLSA provenance for the
+# exact bytes it uploads (before anything reaches S3), so a CDN-served
+# AppImage always carries verifiable provenance even when the macOS
+# sign-and-notarize workflow (which independently attests the AppImage from
+# the same build artifact) fails or is cancelled. The same bytes also ship
+# on GitHub Releases.
+#
+# Key properties:
+#   - The versioned key desktop/<channel>/<version>/KiroCrew-x86_64.AppImage
+#     is immutable-cached by CloudFront and is never republished with
+#     different bytes (--if-none-match conditional write; a 412 on a job
+#     re-run keeps the existing object and continues idempotently).
+#   - The mutable alias desktop/<channel>/latest/KiroCrew-x86_64.AppImage
+#     (max-age=300) is written AFTER the versioned key so it never points
+#     at bytes that are not yet live.
+#   - Arch-qualified filename: Linux has no universal binary, so per-arch
+#     filenames are the contract (per-arch, never per-distro). A future
+#     arm64 lane publishes KiroCrew-aarch64.AppImage beside this one.
+#   - Deliberately no feed/<channel>/latest-linux.json yet: the AppImage
+#     has no auto-updater consuming a feed, so the only pointer a human or
+#     a download button needs is the latest alias. The feed lands together
+#     with the Linux updater work.
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Release channel: nightly | insider | stable"
+        required: true
+        type: string
+      version:
+        description: "Version label used in S3 keys"
+        required: true
+        type: string
+      publish:
+        description: "Publish to the public CDN; false skips the job entirely"
+        required: false
+        type: boolean
+        default: true
+      appimage_artifact:
+        description: "Name of the uploaded artifact containing the AppImage"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  publish-linux:
+    name: Publish Linux AppImage (${{ inputs.channel }})
+    # Public-distribution gates: skipped when the caller runs publish-less
+    # or the CDN is not configured (fork). BOTH variables are required --
+    # the bucket receives the upload and the CDN base is baked into the
+    # public URLs and used by the 412 re-run byte-verify; with either one
+    # missing the job skips rather than publishing objects it cannot
+    # verify or address. GitHub Releases still carries the AppImage.
+    if: ${{ inputs.publish && vars.CLI_DIST_BUCKET != '' && vars.CLI_CDN_BASE != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # REQUIRED: the publish role's OIDC trust accepts exactly two subjects,
+    # ref:refs/heads/main and environment:prod. Declaring the environment
+    # keeps tag-triggered (release) runs on the accepted subject, same as
+    # publish-cli.yml and every job in sign-and-notarize.yml.
+    environment: prod
+    env:
+      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      # Pinned published basename, arch-qualified: Linux has no universal
+      # binary, so per-arch filenames are the contract (per-arch, never
+      # per-distro). A future arm64 lane publishes KiroCrew-aarch64.AppImage
+      # beside this one.
+      LINUX_BASENAME: KiroCrew-x86_64
+    steps:
+      - name: Configure AWS credentials
+        if: env.HAS_SIGNING_SECRETS
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Download desktop build artifact
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.appimage_artifact }}
+          path: artifacts
+
+      - name: Locate AppImage
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          mapfile -t APPIMAGES < <(find artifacts -type f -name '*.AppImage')
+          if [ "${#APPIMAGES[@]}" -eq 0 ]; then
+            echo "No AppImage found in build artifacts"; exit 1
+          fi
+          if [ "${#APPIMAGES[@]}" -gt 1 ]; then
+            echo "Expected exactly one AppImage, found ${#APPIMAGES[@]}:"; printf '%s\n' "${APPIMAGES[@]}"; exit 1
+          fi
+          echo "APPIMAGE_PATH=${APPIMAGES[0]}" >> "$GITHUB_ENV"
+          ls -la "${APPIMAGES[0]}"
+
+      # Signed SLSA provenance for the EXACT bytes this lane uploads,
+      # attested before anything reaches S3. This closes the decoupling
+      # gap: sign-and-notarize.yml independently attests the AppImage from
+      # the same build artifact, but that workflow can fail or be cancelled
+      # while this lane still publishes (per-platform releases) -- without
+      # this step, a failed macOS run could leave a CDN-served AppImage
+      # with no verifiable provenance. Placed BEFORE the versioned-key
+      # write so un-attested bytes never go live; if attestation fails,
+      # the job fails and nothing is published.
+      - name: Attest AppImage provenance
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: ${{ env.APPIMAGE_PATH }}
+
+      # Same never-republish discipline as the mac zip/DMG and the cli/*
+      # wheels: the versioned key is immutable-cached by CloudFront and must
+      # never carry different bytes. --if-none-match makes the write
+      # conditional; a 412 on a job re-run keeps the existing object and
+      # continues idempotently.
+      - name: Publish AppImage to distribution bucket
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          APPIMAGE_KEY="desktop/${CHANNEL}/${VERSION}/${LINUX_BASENAME}.AppImage"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${APPIMAGE_KEY}" \
+            --body "${APPIMAGE_PATH}" \
+            --if-none-match '*' \
+            --content-type application/octet-stream \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              # Job re-run: the immutable key already exists. Verify the
+              # published bytes are IDENTICAL to this build before
+              # continuing -- a re-run can rebuild different bytes for the
+              # same version, and proceeding would let the mutable latest
+              # alias (written below) diverge from the immutable versioned
+              # key. Same discipline as publish-cli.yml's 412 path; the
+              # compare goes through the public CDN because the publish
+              # role's S3 read-back grant covers cli/* only.
+              echo "Key already published (job re-run) -- verifying existing bytes match this build: ${APPIMAGE_KEY}"
+              curl -fsSL --retry 3 "${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}" -o /tmp/published.AppImage
+              PUBLISHED_SHA=$(sha256sum /tmp/published.AppImage | awk '{print $1}')
+              LOCAL_SHA=$(sha256sum "${APPIMAGE_PATH}" | awk '{print $1}')
+              rm -f /tmp/published.AppImage
+              if [ "$PUBLISHED_SHA" != "$LOCAL_SHA" ]; then
+                echo "::error::Immutable key ${APPIMAGE_KEY} already holds DIFFERENT bytes (published ${PUBLISHED_SHA}, this build ${LOCAL_SHA}). The version string is burned -- cut a new version instead of re-running. Refusing to repoint the latest alias."
+                exit 1
+              fi
+              echo "Published bytes identical -- keeping existing object and continuing."
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "APPIMAGE_KEY=${APPIMAGE_KEY}" >> "$GITHUB_ENV"
+          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+
+      # Human-clickable permalink to the current AppImage:
+      #   <CDN>/desktop/<channel>/latest/KiroCrew-x86_64.AppImage
+      # Same mutable-alias semantics as the latest-DMG alias: plain
+      # overwrite, max-age=300, written AFTER the versioned key so it never
+      # points at bytes that are not yet live.
+      - name: Update latest AppImage alias
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          LATEST_APPIMAGE_KEY="desktop/${CHANNEL}/latest/${LINUX_BASENAME}.AppImage"
+          aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${LATEST_APPIMAGE_KEY}" \
+            --body "${APPIMAGE_PATH}" \
+            --content-type application/octet-stream \
+            --cache-control "public, max-age=300" > /dev/null
+          echo "LATEST_APPIMAGE_KEY=${LATEST_APPIMAGE_KEY}" >> "$GITHUB_ENV"
+          echo "Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_APPIMAGE_KEY}"
+
+      - name: Summary
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          {
+            echo "## Publish Linux (${CHANNEL})"
+            echo "- Version: ${VERSION}"
+            echo "- Public AppImage: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+            echo "- Latest AppImage alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_APPIMAGE_KEY}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,27 @@ jobs:
       wheel_artifact: cli-wheel
     secrets: inherit
 
+  # ── Linux desktop publish ─────────────────────────────────────────────
+  # Publishes the release AppImage to the distribution CDN (versioned key +
+  # latest alias). Its own lane beside publish-cli, deliberately NOT inside
+  # sign-and-notarize.yml: the Linux artifact takes no part in the macOS
+  # trust chain, and needing only build-desktop means neither a wheel nor a
+  # macOS signing failure can block it (per-platform releases).
+  publish-linux:
+    name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.version }}
+      publish: true
+      appimage_artifact: build-linux-x64
+    secrets: inherit
+
   # Caller job for the reusable sign-and-notarize workflow: a workflow_call
   # callee can never exceed the caller job's permissions, so the caller must
   # grant id-token explicitly. The signing job holds AWS creds (id-token)

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -24,6 +24,9 @@ name: Sign and Notarize macOS (reusable)
 #                instead of repeating two ~30-minute-budget Apple
 #                submissions, and so the expensive macOS runner never burns
 #                minutes on S3 uploads.
+# (Linux publishing is deliberately NOT here: the AppImage takes no part
+# in this trust chain. It ships from publish-linux.yml, its own lane
+# called directly by nightly.yml / release.yml beside publish-cli.yml.)
 #
 # DMG history (2026-07-21): the DMG was briefly withdrawn after a field
 # defect -- hdiutil-created DMGs carry an ADHOC signature, which the Apple

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -70,6 +70,14 @@ class TestNightlyPermissions:
             "id-token": "write",
             "attestations": "write",
         }
+        # The Linux desktop lane publishes S3 objects (OIDC) and attests
+        # its own SLSA provenance for the exact bytes it uploads -- never
+        # contents:write.
+        assert _permission_block(lines, "  publish-linux:") == {
+            "contents": "read",
+            "id-token": "write",
+            "attestations": "write",
+        }
         # Caller job for the reusable sign-and-notarize workflow: a
         # workflow_call callee can never exceed the caller job's permissions,
         # so the caller must grant id-token explicitly. attestations:write
@@ -96,6 +104,12 @@ class TestReleasePermissions:
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
         assert _permission_block(lines, "  publish-cli:") == {
+            "contents": "read",
+            "id-token": "write",
+            "attestations": "write",
+        }
+        # Linux desktop lane: OIDC + in-lane provenance (see nightly note).
+        assert _permission_block(lines, "  publish-linux:") == {
             "contents": "read",
             "id-token": "write",
             "attestations": "write",


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-linux.yml`: a reusable workflow that publishes the Linux AppImage to the distribution CDN, called directly by `nightly.yml` and `release.yml` as its own lane beside `publish-cli.yml`.

New public URLs (per channel, live after the first green run):

- `https://d28nxu9if70cmc.cloudfront.net/desktop/{channel}/{version}/KiroCrew-x86_64.AppImage` (immutable)
- `https://d28nxu9if70cmc.cloudfront.net/desktop/{channel}/latest/KiroCrew-x86_64.AppImage` (mutable alias, max-age=300)

## Why

The AppImage is currently downloadable only from GitHub Releases, which rate-limits browser downloads. Every other artifact already ships from CloudFront; this closes the Linux desktop gap (both Linux keys 403 on the live CDN today).

## Why its own workflow (not a job in sign-and-notarize.yml)

The Linux artifact takes no part in the macOS trust chain (sign -> notarize -> gated publish), so it does not belong in that workflow. As a standalone lane mirroring `publish-cli.yml`:

- Callers invoke it with `needs: [version, build-desktop]` only, so neither a wheel-build failure nor a macOS signing failure can block the Linux artifact (per-platform releases). Inside `sign-and-notarize.yml` it transitively waited on `build-wheel` via the caller's `needs`.
- The artifact is downloaded by name (`build-linux-x64`) instead of sweeping every artifact in the run.
- `sign-and-notarize.yml` keeps its documented contract: the macOS trust chain, nothing else (a pointer comment marks where Linux went).

## Design notes

- Same never-republish discipline as the zip/DMG on the versioned key (`--if-none-match`); on a re-run 412 the existing bytes are sha256-compared against this build via the public CDN and the job FAILS on mismatch, so the mutable latest alias can never diverge from the immutable versioned key. Alias written after the versioned key.
- Arch-qualified filename (`KiroCrew-x86_64.AppImage`): Linux has no universal binary; per-arch, never per-distro. A future arm64 lane publishes `KiroCrew-aarch64.AppImage` beside it.
- Deliberately no `feed/{channel}/latest-linux.json` yet: no updater consumes it. The feed lands with the Linux updater work.
- Trust posture: the lane attests its own signed SLSA provenance for the exact bytes it uploads, BEFORE anything reaches S3 -- so a CDN-served AppImage always carries verifiable provenance even when the parallel macOS sign-and-notarize workflow (which independently attests the AppImage) fails or is cancelled. No code signature (no Gatekeeper equivalent on Linux); the same bytes also ship on GitHub Releases.
- Workflow permissions: `contents: read` + `id-token: write` + `attestations: write` (for the in-lane provenance), never `contents: write`. `test_workflow_permissions.py` pins the new caller blocks in both nightly and release.
- Publish role already has the `desktop/*` PutObject grant (reconciled in CR-291615658) -- no infrastructure change needed.

## Verification

- YAML parses for all four touched workflows; job graphs verified: `sign-and-notarize.yml` back to `sign, notarize, publish`; `nightly.yml` and `release.yml` both gain `publish-linux` with `needs: [version, build-desktop]`.
- `test_workflow_permissions.py`: 5 passed (including the two new caller-block assertions).
- Post-merge: trigger a manual nightly and curl-verify both URLs (200, correct content-type, alias ETag == versioned ETag).

No screenshots: not a UI change.

