### PR TITLE
fix(config): stop malformed config values from crashing load()

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -222,11 +222,30 @@ def workspace_root() -> Path:
 
 
 def _safe_int(value: object, default: int) -> int:
-    """Convert *value* to int, returning *default* on failure."""
+    """Convert *value* to int, returning *default* on failure.
+
+    OverflowError: TOML/JSON parse `1e1000` to float("inf"), which int()
+    rejects with OverflowError rather than ValueError — still a malformed
+    config value, still the default.
+    """
     try:
         return int(value)  # type: ignore[call-overload]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
+
+
+def _safe_list(value: object) -> list:
+    """Return *value* if it is a list, else []. Guards list()/comprehensions in
+    config parse against a malformed (non-list) config value that would either
+    crash (int/None) or silently mis-coerce (a string char-splits) — config
+    load must degrade to the default, never raise."""
+    return value if isinstance(value, list) else []
+
+
+def _safe_dict(value: object) -> dict:
+    """Return *value* if it is a dict, else {}. Guards .items()/dict() in config
+    parse against a non-dict config value (which would raise AttributeError)."""
+    return value if isinstance(value, dict) else {}
 
 
 def _safe_float(
@@ -3195,13 +3214,18 @@ class KiroCrewConfig:
                 ),
                 completion_keep_chars=_safe_int(agent_data.get("completion_keep_chars", 3000), 3000),
                 subagent_result_ttl_secs=_safe_int(agent_data.get("subagent_result_ttl_secs", 3600), 3600),
-                subagent_cwd_allowed_roots=list(
-                    agent_data.get(
-                        "subagent_cwd_allowed_roots",
-                        ["~/workspace", "~/workspaces", "~/workplace", "~/workplaces"],
+                subagent_cwd_allowed_roots=(
+                    [r for r in _roots if isinstance(r, str)]
+                    if isinstance(
+                        _roots := agent_data.get("subagent_cwd_allowed_roots"), list
                     )
+                    else ["~/workspace", "~/workspaces", "~/workplace", "~/workplaces"]
                 ),
-                log_level=agent_data.get("log_level", "WARNING").upper(),
+                log_level=(
+                    lvl.upper()
+                    if isinstance(lvl := agent_data.get("log_level", "WARNING"), str)
+                    else "WARNING"
+                ),
                 bot_name=_sanitize_bot_name(agent_data.get("bot_name", "")),
                 max_channels=agent_data.get("max_channels", 1),
                 max_channel_agents=agent_data.get("max_channel_agents", 3),
@@ -3375,7 +3399,9 @@ class KiroCrewConfig:
                 forward_to_agent_callback=str(
                     slack_data.get("forward_to_agent_callback") or ""
                 ).strip(),
-                trusted_bot_ids=set(slack_data.get("trusted_bot_ids", [])),
+                trusted_bot_ids={
+                    b for b in _safe_list(slack_data.get("trusted_bot_ids")) if isinstance(b, str)
+                },
                 allowed_enterprise_ids=[
                     e
                     for e in slack_data.get("allowed_enterprise_ids", [])
@@ -3383,7 +3409,7 @@ class KiroCrewConfig:
                 ],
                 reactions={
                     k: v
-                    for k, v in slack_data.get("reactions", {}).items()
+                    for k, v in _safe_dict(slack_data.get("reactions")).items()
                     if isinstance(k, str) and (v is None or (isinstance(v, str) and v))
                 },
                 reactions_enabled=bool(slack_data.get("reactions_enabled", True)),
@@ -3411,8 +3437,8 @@ class KiroCrewConfig:
                 ],
                 allow_all_users=bool(wechat_data.get("allow_all_users", False)),
                 ws_url=str(wechat_data.get("ws_url", "wss://openws.work.weixin.qq.com")),
-                soft_threshold_pct=int(wechat_data.get("soft_threshold_pct", 80)),
-                hard_threshold_pct=int(wechat_data.get("hard_threshold_pct", 95)),
+                soft_threshold_pct=_safe_int(wechat_data.get("soft_threshold_pct", 80), 80),
+                hard_threshold_pct=_safe_int(wechat_data.get("hard_threshold_pct", 95), 95),
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),
@@ -3548,7 +3574,9 @@ class KiroCrewConfig:
                 auto_refine_on_deviation=bool(skills_data.get("auto_refine_on_deviation", False)),
                 auto_min_tool_calls=_safe_int(skills_data.get("auto_min_tool_calls", 5), 5),
                 auto_similarity_threshold=_safe_float(skills_data.get("auto_similarity_threshold", 0.85), 0.85),
-                extra_paths=list(skills_data.get("extra_paths", [])),
+                extra_paths=[
+                    p for p in _safe_list(skills_data.get("extra_paths")) if isinstance(p, str)
+                ],
             ),
             slack_channels={
                 ch_id: ChannelConfig.from_dict(ch_data)

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -212,6 +212,64 @@ def test_publish_relocate_roots_parsed_and_round_trips():
     assert reloaded.publish.relocate_roots == ["/srv/shared"]
 
 
+class TestMalformedConfigValuesNeverCrashLoad:
+    """Round-2 hardening: several config parse sites coerced values with a bare
+    .upper()/int()/list()/set()/.items() and no guard. jsonschema is optional
+    (absent in the shipped runtime), so a hand-edited config.json with a wrongly
+    typed value reached the parse and crashed KiroCrewConfig.load() outright —
+    bricking every caller. Each must now degrade to the default instead."""
+
+    def test_non_string_log_level_falls_back(self):
+        # agent.log_level=42 -> "42".upper()? no: 42 has no .upper() -> crash.
+        loaded = _load_from_dict({"agent": {"log_level": 42}})
+        assert loaded.agent.log_level == "WARNING"
+        # a valid string still applies (and uppercases)
+        assert _load_from_dict({"agent": {"log_level": "debug"}}).agent.log_level == "DEBUG"
+
+    def test_non_list_subagent_cwd_allowed_roots_falls_back(self):
+        # The parse-time fallback preserves prior absent-key behavior: the
+        # historical `list(get(default=[4 roots]))` yielded these 4 roots.
+        fallback = ["~/workspace", "~/workspaces", "~/workplace", "~/workplaces"]
+        # int would crash list(); a string would char-split silently.
+        assert _load_from_dict({"agent": {"subagent_cwd_allowed_roots": 5}}).agent.subagent_cwd_allowed_roots == fallback
+        assert _load_from_dict({"agent": {"subagent_cwd_allowed_roots": "abc"}}).agent.subagent_cwd_allowed_roots == fallback
+        # a real list still parses (non-str entries dropped)
+        got = _load_from_dict({"agent": {"subagent_cwd_allowed_roots": ["~/x", 9]}}).agent.subagent_cwd_allowed_roots
+        assert got == ["~/x"]
+
+    def test_non_list_trusted_bot_ids_falls_back(self):
+        # set() on a non-iterable (int) crashes; on a string it char-splits.
+        assert _load_from_dict({"slack": {"trusted_bot_ids": 5}}).slack.trusted_bot_ids == set()
+        assert _load_from_dict({"slack": {"trusted_bot_ids": "B123"}}).slack.trusted_bot_ids == set()
+        assert _load_from_dict({"slack": {"trusted_bot_ids": ["B1", 2]}}).slack.trusted_bot_ids == {"B1"}
+
+    def test_non_dict_reactions_falls_back(self):
+        # .items() on a non-dict (list) crashes.
+        assert _load_from_dict({"slack": {"reactions": ["x"]}}).slack.reactions == {}
+        assert _load_from_dict({"slack": {"reactions": {"eyes": "👀"}}}).slack.reactions == {"eyes": "👀"}
+
+    def test_non_finite_wechat_thresholds_fall_back(self):
+        # JSON/TOML parse 1e1000 to float("inf"); int(inf) raises OverflowError,
+        # not ValueError, so the old _safe_int guard still crashed load().
+        cfg = _load_from_dict(
+            {"wechat": {"soft_threshold_pct": float("inf"), "hard_threshold_pct": float("nan")}}
+        )
+        assert cfg.wechat.soft_threshold_pct == 80
+        # NaN: int(nan) raises ValueError, already caught — pin it anyway.
+        assert cfg.wechat.hard_threshold_pct == 95
+
+    def test_non_numeric_wechat_thresholds_fall_back(self):
+        cfg = _load_from_dict(
+            {"wechat": {"soft_threshold_pct": "lots", "hard_threshold_pct": None}}
+        )
+        assert cfg.wechat.soft_threshold_pct == 80
+        assert cfg.wechat.hard_threshold_pct == 95
+
+    def test_non_list_skills_extra_paths_falls_back(self):
+        assert _load_from_dict({"skills": {"extra_paths": 5}}).skills.extra_paths == []
+        assert _load_from_dict({"skills": {"extra_paths": ["/a", 9]}}).skills.extra_paths == ["/a"]
+
+
 # Hypothesis strategy for safe identifier strings (no control chars, JSON-safe)
 _safe_name_st = st.text(
     alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789_-"),


### PR DESCRIPTION
## Bug (HIGH + MEDIUM cluster · crash-on-malformed-input)

`jsonschema` is optional and **absent from the shipped runtime**, so a hand-edited `config.json` with a wrongly typed value flows straight to the parse in `KiroCrewConfig.load()`. Six sites coerced with a bare `.upper()`/`int()`/`list()`/`set()`/`.items()` and no guard, so **one bad value crashed `load()` outright — bricking every caller** (the gateway, `kirocrew config get/set`, …):

- **`agent.log_level`** — `.get(...).upper()` → `AttributeError` on a non-string *(HIGH)*
- **`agent.subagent_cwd_allowed_roots`** — `list(...)` crashes on int/None, char-splits a string
- **`slack.trusted_bot_ids`** — `set(...)` crashes on int, char-splits a string
- **`slack.reactions`** — `.items()` → `AttributeError` on a non-dict
- **`wechat.soft/hard_threshold_pct`** — bare `int()` → `ValueError` (webex already used `_coerce_int`; this matches it)
- **`skills.extra_paths`** — `list(...)` crashes on int

## Fix

Add `_safe_list` / `_safe_dict` helpers (siblings of the existing `_safe_int`) and route each site through a guard, degrading a malformed value to its default. `agent.subagent_cwd_allowed_roots` preserves the historical absent-key fallback.

## Test

`TestMalformedConfigValuesNeverCrashLoad` — each site **fails pre-fix** with the exact `AttributeError`/`ValueError`/`TypeError` (surgical revert) and now falls back; valid values still parse. Full config suite (148 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via the round-2 automated multi-agent bug hunt (adversarially verified + empirically reproduced).
