### PR TITLE
fix(knowledge): never let dedup cascade-delete the aggregate artifact source

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -463,10 +463,15 @@ adding a parallel watcher (see `kiro_crew.knowledge.artifact_ingest`):
   SEL audit event), mirroring the folder-watcher file-read guard.
 - **Dedup tie-in.** A file-backed artifact whose `source_path` is also inside a
   synced folder source is the same document under two sources (the aggregate
-  `artifact` source and the folder's `local_file` source). The live Knowledge
-  dedup sweep collapses the pair once both copies share a `content_hash` (the
-  persistent folder copy wins over the artifact copy), so the overlap
-  self-resolves rather than needing special-casing here.
+  `artifact` source and the folder's `local_file` source). The aggregate
+  `artifact` source is **excluded from dedup entirely** (`enumerate_docs` and
+  `_build_doc_for` skip `_AGGREGATE_SOURCE_TYPES`, and `_delete_doc` refuses a
+  cascade on them): treating the whole aggregate as one dedup unit keyed on a
+  single item's hash both misidentified it and — when it lost a pair — cascade-
+  deleted the user's entire artifact library. The artifact↔folder overlap
+  therefore persists (both copies remain retrievable) until per-artifact-slug
+  dedup is built; that is a recorded, intentional trade against silent data
+  loss on the hard-delete path.
 
 ## Companion Chat
 

--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -102,6 +102,7 @@ Base metadata always carries `format`, `title` (file stem), `file_size`, `extens
 - Per-file state lives in the `folder_file_state` table with `status` ∈ `{done, scanning, skipped, failed, deduped}`. `scanning` is written **before** ingest so a crash mid-file is recoverable; `skipped`/`failed`/`deduped` files are not auto-retried (user must retry).
 - **TOCTOU defense**: `_ingest_file` re-resolves symlinks and re-checks `is_sensitive_path` at ingest time; a block writes `status='failed'` and emits an SEL `knowledge.source.file.ingest_denied` (`outcome="denied"`, `reason=sensitive_path_toctou`) audit event.
 - After a successful scan, each newly ingested/changed file gets a **targeted** cross-source dedup (`dedup_document(..., apply=True)`) — O(k·n) over the k changed files rather than a full O(n²) corpus sweep — so a folder copy collapses any matching one-shot upload.
+- **Aggregate sources are not dedup units.** Sources in `_AGGREGATE_SOURCE_TYPES` (currently `artifact` — one source holding many independent documents) are excluded from dedup at every layer: `enumerate_docs` skips them, `_build_doc_for` returns `None` for whole-source builds, and `_delete_doc` refuses a cascade delete on them. A whole-aggregate DocRef keyed on one item's `content_hash` misrepresents the collection, and losing a dedup pair used to cascade-delete the entire artifact library. Per-artifact-slug dedup is future work; until then artifact↔folder overlap is intentionally left in place.
 
 ## 3. LLMPool workers (`llm_pool.py`)
 

--- a/src/kiro_crew/knowledge/dedup.py
+++ b/src/kiro_crew/knowledge/dedup.py
@@ -45,6 +45,17 @@ logger = logging.getLogger(__name__)
 # that source type lands.
 PERSISTENT_SOURCE_TYPES = frozenset({"local_folder", "obsidian_vault", "quip"})
 
+# Aggregate sources bundle MANY logical documents under ONE sources row
+# (auto-ingested artifacts store every artifact's chunks under a single
+# source_type="artifact", file_path=None row, grouped per-slug only in
+# artifact_item_state). They must NOT be treated as one whole-source dedup unit:
+# _build_doc would hash only the FIRST item, and a single artifact matching a
+# watched folder file would make the aggregate the dedup loser, so
+# _delete_doc -> delete_source_cascade would wipe EVERY artifact's KB entry.
+# Excluding them from enumerate_docs is the surgical fix (per-slug dedup is a
+# larger follow-up).
+_AGGREGATE_SOURCE_TYPES = frozenset({"artifact"})
+
 # Tier-2 fuzzy match floor. Validated against a live KB: true duplicates and
 # version-drift copies land at cosine >= 0.95, while same-topic-but-different docs
 # top out around 0.89 -- so 0.95 separates them with margin.
@@ -310,6 +321,10 @@ def enumerate_docs(store) -> list[DocRef]:
             "SELECT id, name, source_type, updated_at FROM sources").fetchall():
         if s["id"] in folder_source_ids:
             continue  # its documents are enumerated per-file above
+        if s["source_type"] in _AGGREGATE_SOURCE_TYPES:
+            # Aggregate row bundling many artifacts — a single whole-source
+            # DocRef here risks delete_source_cascade wiping them all.
+            continue
         item_ids = [r["id"] for r in store.db.execute(
             "SELECT id FROM items WHERE source_id = ?", (s["id"],)).fetchall()]
         doc = _build_doc(
@@ -438,6 +453,15 @@ def find_duplicates(store, docs: list[DocRef], threshold: float) -> list[DedupAc
 
 def _delete_doc(store, doc: DocRef) -> None:
     """Hard-delete a losing document's KB entry. Never touches the file on disk."""
+    if doc.source_type in _AGGREGATE_SOURCE_TYPES:
+        # Belt-and-suspenders: never cascade-delete an aggregate source (it
+        # bundles many artifacts). enumerate_docs already excludes these, but a
+        # future caller building a DocRef directly must not be able to wipe the
+        # whole Artifacts library because one artifact duplicated a folder file.
+        logger.warning(
+            "dedup: refusing to delete aggregate source %s (type=%s)",
+            doc.source_id, doc.source_type)
+        return
     if doc.file_path is None:
         # Whole-source document (upload / chat / manual): remove its source + items.
         store.delete_source_cascade(doc.source_id)
@@ -511,6 +535,15 @@ def _build_doc_for(store, source_id: str, file_path: str | None) -> DocRef | Non
         "SELECT name, source_type, updated_at FROM sources WHERE id = ?",
         (source_id,)).fetchone()
     if not s:
+        return None
+    # Aggregate sources are not dedup units (see enumerate_docs): a whole-
+    # aggregate DocRef keyed on the first item's hash misrepresents the many
+    # artifacts inside. Without this, every artifact save produced phantom
+    # DedupActions that _delete_doc silently refused — and if the aggregate
+    # ever WON a pair, a legitimate upload was hard-deleted against a hash
+    # representing one artifact out of many. Per-item file_path builds are
+    # fine; it is only the whole-source build that lies about identity.
+    if file_path is None and s["source_type"] in _AGGREGATE_SOURCE_TYPES:
         return None
     if file_path is not None:
         row = store.db.execute(

--- a/test/test_knowledge_dedup.py
+++ b/test/test_knowledge_dedup.py
@@ -205,6 +205,37 @@ class TestDedupSweep:
             "SELECT COUNT(*) FROM folder_file_state").fetchone()[0] == 1  # folder kept
         store.db.close()
 
+    def test_artifact_aggregate_source_never_wiped_by_dedup(self, tmp_path):
+        # The auto-ingested "artifact" source bundles EVERY artifact's chunks
+        # under one file_path=None row. Pre-fix, if a single artifact's content
+        # matched a watched folder file, the aggregate lost the dedup and
+        # delete_source_cascade wiped ALL artifacts. It must be excluded from
+        # dedup: the artifact source and all its items survive intact.
+        store = _mk_store(tmp_path)
+        art_sid = store.add_source(
+            name="Artifacts", source_type="artifact", uri="artifact://all"
+        )
+        # Two artifacts under the one aggregate source; the first duplicates a
+        # folder file (same content_hash), the second is unique.
+        store.add_item(
+            title="notes", content="body", item_type="document", source_id=art_sid,
+            content_hash="H1", embedding=floats_to_bytes([1.0, 0.0, 0.0, 0.0]))
+        store.add_item(
+            title="other", content="body2", item_type="document", source_id=art_sid,
+            content_hash="H2", embedding=floats_to_bytes([0.0, 1.0, 0.0, 0.0]))
+        store.db.commit()
+        _add_folder_file(store, "/p/notes.md", "H1", [1.0, 0.0, 0.0, 0.0])
+
+        dedup_sweep(store, apply=True)
+
+        # The aggregate source row and BOTH artifact items still exist.
+        assert store.db.execute(
+            "SELECT COUNT(*) FROM sources WHERE id = ?", (art_sid,)).fetchone()[0] == 1
+        remaining = store.db.execute(
+            "SELECT COUNT(*) FROM items WHERE source_id = ?", (art_sid,)).fetchone()[0]
+        assert remaining == 2, "artifact items must not be cascade-deleted by dedup"
+        store.db.close()
+
     def test_fuzzy_collapses_near_duplicate(self, tmp_path):
         store = _mk_store(tmp_path)
         _add_upload(store, "Plan.docx", "H1", [1.0, 0.0, 0.0, 0.0])
@@ -310,4 +341,37 @@ class TestDedupDocument:
         up_sid, _ = _add_upload(store, "Doc.docx", "H1", [1.0, 0.0, 0.0, 0.0])
         assert dedup_document(store, up_sid, apply=True) == []
         assert _n_uploads(store) == 1
+        store.db.close()
+
+    def test_aggregate_source_is_not_a_dedup_unit_on_ingest_path(self, tmp_path):
+        # dedup_document(source_id) runs on EVERY artifact save (ingestion.py's
+        # per-ingest targeted dedup). _build_doc_for used to construct a whole-
+        # aggregate DocRef keyed on the first item's hash: every duplicating
+        # save produced phantom DedupActions that _delete_doc silently refused,
+        # and if the aggregate ever WON the pair, the legitimate upload was
+        # deleted against a hash representing one artifact of many. The
+        # aggregate must be excluded at the DocRef layer: no actions, and
+        # neither side deleted.
+        store = _mk_store(tmp_path)
+        art_sid = store.add_source(
+            name="Artifacts", source_type="artifact", uri="artifact://all"
+        )
+        store.add_item(
+            title="notes", content="body", item_type="document", source_id=art_sid,
+            content_hash="H1", embedding=floats_to_bytes([1.0, 0.0, 0.0, 0.0]))
+        store.db.commit()
+        # A one-shot upload duplicating that artifact's content. The upload is
+        # OLDER than the aggregate (mtime-like recency), so pre-fix the
+        # aggregate WON the pair and the legitimate upload was hard-deleted.
+        up_sid, _ = _add_upload(store, "notes.md", "H1", [1.0, 0.0, 0.0, 0.0])
+        store.db.execute("UPDATE sources SET updated_at = '2099-01-01T00:00:00' WHERE id = ?",
+                         (art_sid,))
+        store.db.commit()
+
+        # Ingest-path dedup fired FOR the aggregate (as ingestion.py does on
+        # every artifact save): no phantom actions, nothing deleted.
+        assert dedup_document(store, art_sid, apply=True) == []
+        assert _n_uploads(store) == 1, "legitimate upload must survive"
+        assert store.db.execute(
+            "SELECT COUNT(*) FROM items WHERE source_id = ?", (art_sid,)).fetchone()[0] == 1
         store.db.close()


### PR DESCRIPTION
## Bug (HIGH · silent-data-loss)

Auto-ingested artifacts store every artifact's chunks under **ONE aggregate `sources` row** (`source_type="artifact"`, `file_path=None`), grouped per-slug only in `artifact_item_state`. But `enumerate_docs` built a single whole-source `DocRef` for it whose `content_hash` is just the **first** item's hash.

If any one artifact's extracted text matched a watched folder file (identical `content_hash`), `_match_reason` returned `"exact"`, `pick_winner` ranked the persistent folder source above the non-persistent artifact source, and `_delete_doc`'s `file_path is None` branch called `delete_source_cascade(artifact_source_id)` — **silently purging the ENTIRE Artifacts library** (every artifact's items, source_locations, mentions, entity_relations, state) because *one* of them duplicated a folder file. Triggered by the routine `FolderWatcher` end-of-scan dedup and the `knowledge_dedup` sweep — no special trigger needed.

## Fix (surgical, defense-in-depth)

- `enumerate_docs` **skips aggregate sources** (`source_type == "artifact"`) — they must not be treated as one whole-source dedup unit (true per-slug dedup is a larger follow-up).
- `_delete_doc` **refuses `delete_source_cascade` on an aggregate source** as a belt-and-suspenders guard, so no future `DocRef` path can wipe it.

## Test

`test_artifact_aggregate_source_never_wiped_by_dedup` seeds an artifact source with two items (one duplicating a folder file) plus the folder file; **pre-fix** the sweep wipes the whole source (0 items left) via surgical revert, **post-fix** the source and both items survive. Full dedup suite (25 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via the round-2 automated multi-agent bug hunt (adversarially verified + empirically reproduced).
