### PR TITLE
feat: complete the edition-seam surface for downstream composition

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -426,7 +426,16 @@ delegates to that same global. Wired sites:
   the pre-seam stub), so a companion that keeps its last URL while
   RECONNECTING/ERROR is not reported as live. `register_callbacks` +
   `status_snapshot` are a v1 addition to the
-  existing `TunnelProvider` Protocol (no `CONTRACT_VERSION` bump). The token-auth
+  existing `TunnelProvider` Protocol (no `CONTRACT_VERSION` bump).
+  **`ensure_available(*, install=True) -> str`** is a further v1 addition (no
+  bump): an idempotent "make the tunnel reachable, provisioning on demand" entry
+  point returning one of `"connected"` / `"starting"` / `"disabled"` /
+  `"unavailable"`. WIRED at `slack/allowlist.py::send_dashboard_link`, which
+  calls it (via `async_safe_context_call`) only when a tunnel URL is wanted for a
+  Slack dashboard link but none is live yet; the `DefaultTunnelProvider` returns
+  `"disabled"`, so the standalone path is unchanged (it still falls back to the
+  local URL). Narrow-only: the method can start/provision a companion tunnel but
+  never bypasses the `tunnel/setup.py` token-auth deny gate. The token-auth
   deny gate in `tunnel/setup.py` is evaluated BEFORE the manager is constructed or
   `start()` reached, so a companion tunnel cannot start without dashboard token
   auth; the connect/disconnect callbacks and `/api/tunnel/status` stay wrapped

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -351,6 +351,11 @@ class DefaultTunnelProvider:
         # standalone ``/api/tunnel/status`` payload is byte-identical to today.
         return None
 
+    async def ensure_available(self, *, install: bool = True) -> str:
+        # Standalone never auto-provisions a tunnel — pure no-op, so a shared
+        # dashboard link falls back to the local host:port exactly as today.
+        return "disabled"
+
 
 class DefaultTelemetryProvider:
     """No-op telemetry; RUM stays disabled (frontend shim already no-op)."""

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -698,6 +698,30 @@ class TunnelProvider(Protocol):
         """
         ...
 
+    async def ensure_available(self, *, install: bool = True) -> str:
+        """Zero-touch provision: ensure a tunnel CAN serve a remote link, then
+        report the resulting state. Distinct from ``start()`` (which only starts
+        an ALREADY-enabled tunnel) — this may install the tunnel toolchain and
+        flip enablement before starting, for surfaces that mint a remote link on
+        demand (the ``/kirocrew dashboard`` command, the setup wizard).
+
+        WIRED: ``slack/allowlist.py::send_dashboard_link`` calls this (via
+        ``safe_context_call``) when the box is localhost-only and no live public
+        URL exists, so a shared dashboard link can bring the tunnel up on first
+        use. Returns a state string: ``"connected"`` (URL live), ``"starting"``
+        (provisioning in progress), ``"disabled"`` (not configured / opted out),
+        or ``"unavailable"`` (install or start failed). ``install=False`` skips
+        any toolchain install (start-only). Only ``"connected"`` guarantees a
+        live public URL — the caller adopts a tunnel URL solely on ``"connected"``
+        and otherwise keeps the local link, re-issuing later once connected.
+
+        Public default = ``"disabled"`` — a pure no-op, so the standalone build
+        never provisions anything and behaves byte-identically. A companion
+        drives its real install-and-enable pipeline here (v1 addition; no
+        ``CONTRACT_VERSION`` bump).
+        """
+        ...
+
 
 class TelemetryProvider(Protocol):
     """Backend telemetry sink + the frontend RUM config blob.

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3172,7 +3172,9 @@ def _exfil_exempt_hosts() -> frozenset[str]:
 
 
 def _exfil_url_warning(
-    domain: str, path_and_query: str, exempt_hosts: frozenset[str]
+    domain: str,
+    path_and_query: str,
+    exempt_hosts: frozenset[str],
 ) -> str | None:
     """Classify one matched URL — the single per-URL exfil verdict.
 
@@ -3225,7 +3227,9 @@ def _exfil_url_warning(
     # decode-and-scan just above catches ENCODED credentials on every host, and
     # the heavy percent-encoding detector below runs even for exempted hosts, so
     # an encoded exfil payload to a trusted tenant is still caught.
-    if domain.lower() not in exempt_hosts:
+    _dom = domain.lower()
+    _exempt = _dom in exempt_hosts
+    if not _exempt:
         # (Valid S3 presigned URLs were already exempted at the top, so no
         # _is_safe_presigned re-check is needed here.)
         if len(query) >= _EXFIL_QUERY_MIN_LEN:

--- a/src/kiro_crew/slack/allowlist.py
+++ b/src/kiro_crew/slack/allowlist.py
@@ -216,6 +216,29 @@ async def send_dashboard_link(
     # Tunnel URL is only used when explicitly opted in via slack.use_tunnel_url
     # (default false until tunnel mechanism is scaled for general use).
     tunnel_url = get_tunnel_url() if cfg.slack.use_tunnel_url else ""
+    # Zero-touch provisioning seam: when opted into the tunnel URL, the box is
+    # localhost-only, and no tunnel is live yet, give a composed edition a chance
+    # to provision one on demand (install + enable + start), then re-read the URL.
+    # The public Default's ensure_available() returns "disabled" (no-op), so the
+    # standalone path is byte-identical — this block only does work for an edition
+    # that implements the seam. PlatformCompositionError is re-raised (fail-closed).
+    if cfg.slack.use_tunnel_url and local_only and not tunnel_url:
+        from kiro_crew.platform import current_context
+        from kiro_crew.platform.context import async_safe_context_call
+
+        state = await async_safe_context_call(
+            lambda: current_context().tunnel.ensure_available(),
+            fallback="disabled",
+            log_message="tunnel.ensure_available failed; falling back to local link",
+        )
+        # Only adopt a tunnel URL once the tunnel is actually CONNECTED — a
+        # "starting" tunnel has no public URL live yet, so re-reading it would
+        # yield "" and we would (correctly) fall through to the local link
+        # anyway; gating on "connected" makes that explicit and never risks
+        # sending a half-provisioned/localhost link as if it were the tunnel.
+        # The edition can re-issue the link on a later message once connected.
+        if state == "connected":
+            tunnel_url = get_tunnel_url() or tunnel_url
     if tunnel_url:
         url = f"{tunnel_url}/?token={token}"
     else:

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -214,7 +214,7 @@ Builtin apps no longer need manual `NAV_ITEMS` entries. The `builtinRegistry.ts`
 Additive registries let a **downstream edition** (a separate build that composes
 this SPA — e.g. an internal fork) contribute UI without copy-and-shadowing core
 files. The core registers nothing new into them, so every seam is inert in the
-stock build. There are **six** registry seams:
+stock build. There are **eight** registry seams:
 
 | Seam | Module | Registrar → reader |
 |------|--------|--------------------|
@@ -223,6 +223,8 @@ stock build. There are **six** registry seams:
 | Theme branding | `themeBranding.tsx` | `registerThemeBranding()` → `getThemeBranding()` |
 | Theme picker options | `hooks/useTheme.tsx` | `registerTheme()` → `getRegisteredThemes()` |
 | Top-bar widgets | `apps/topBarWidgets.tsx` | `registerTopBarWidgets()` → `getTopBarWidgets()` |
+| Readout-capsule segments | `apps/capsuleSegments.tsx` | `registerCapsuleSegment()` → `getCapsuleSegments()` |
+| Overview status cards | `pages/overviewStatCards.tsx` | `registerOverviewStatCards()` → `getOverviewStatCards()` |
 | Panel nav + migration | `hooks/useKeyboardShortcuts.ts`, `components/MigrationCheck.tsx` | `registerPanelShortcut()`, `registerNonAppPrefix()` |
 
 Plus one **exported-transport** seam for edition-owned API methods (not a
@@ -262,6 +264,25 @@ theme to the picker; `useTheme` reads it via `allThemes = [...THEMES,
 overlay — this seam only contributes the picker entry. A `value` already in
 `THEMES` or previously registered is rejected via `reportSeamCollision` (core
 wins).
+
+**Readout-capsule segments.** `registerCapsuleSegment([{ id, order?, component,
+hideOnMobile? }])` mounts a status segment INSIDE the header's readout capsule
+(sharing its border, `|` dividers, and offline tint), not as a standalone sibling
+pill — use this over `registerTopBarWidgets` when the readout must join that
+grouping (e.g. a credential-TTL or spend segment). App.tsx splices registered
+segments after the core segments in `order`; each renders with an `offline` prop
+and is isolated in its own `ErrorBoundary`.
+
+**Overview status cards.** `registerOverviewStatCards([{ id, order?, component }])`
+adds a self-contained `StatCard` (owning its own query/state, like the core
+`TunnelStatus`) to the Settings → Overview grid, after the core cards. Each
+receives a `delay` prop for the grid's stagger animation and is `ErrorBoundary`-
+isolated.
+
+**Theme branding reaches two consumers.** `getThemeBranding(colorTheme)` drives
+both the App.tsx shell chrome AND `WelcomeView.tsx` (the new-session/welcome
+screen brand mark) — a registered theme's `logo` shows in both, falling back to
+the stock `KiroGhost` when the theme registers none.
 
 **API methods.** There is no registrar. An edition imports `apiTransport` from
 `api/apiTransport.ts` and writes its own fully-typed API module on it — see the

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -80,6 +80,7 @@ import BuiltinAppRoute from './apps/BuiltinAppRoute'
 import { getBuiltinIcon } from './apps/builtinIcons'
 import { getThemeBranding } from './themeBranding'
 import { getTopBarWidgets } from './apps/topBarWidgets'
+import { getCapsuleSegments } from './apps/capsuleSegments'
 import { FEATURE_REQUEST_PROMPT } from './prompts/featureRequest'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useInstanceShortcuts } from './hooks/useInstanceShortcuts'
@@ -1492,6 +1493,25 @@ export default function App() {
                 </button>)
               }
             }
+            }
+            // Extension slot: downstream-registered capsule segments (e.g. an
+            // edition credential-TTL or spend segment) join the capsule INSIDE
+            // its border/dividers/offline-tint, after the core segments, in
+            // `order`. Each is isolated in its own ErrorBoundary (fallback=null)
+            // so a throwing segment disables only itself. Empty in stock build.
+            // Gated on !capsuleCollapsed exactly like the core readouts, so
+            // collapsing reduces the capsule to the bare connection dot rather
+            // than leaving extension segments + their dividers visible.
+            if (!capsuleCollapsed) {
+              for (const cs of getCapsuleSegments()) {
+                if (cs.hideOnMobile && isMobile) continue
+                const SegComp = cs.component
+                segments.push(
+                  <ErrorBoundary key={cs.id} scope={`capsule-segment:${cs.id}`} fallback={null}>
+                    <SegComp offline={offline} />
+                  </ErrorBoundary>
+                )
+              }
             }
             return (
               /* layout + tween (not spring: springs bounced in a prior

--- a/website/src/apps/capsuleSegments.tsx
+++ b/website/src/apps/capsuleSegments.tsx
@@ -1,0 +1,57 @@
+/**
+ * Readout-capsule segment registry.
+ *
+ * The header's "readout capsule" (the bordered pill holding the connection dot,
+ * system-metrics, and usage segments, divided by `|` separators and tinted red
+ * when offline) is an extension slot for status readouts that must live INSIDE
+ * that grouping — e.g. a credential-TTL segment or a spend segment that should
+ * share the capsule's border, dividers, and offline tint rather than float as a
+ * separate sibling pill (which is what `topBarWidgets` provides).
+ *
+ * A downstream edition registers segments here from its entry module; App.tsx
+ * splices them into the capsule's `segments[]` array in `order` (ascending),
+ * after the core segments. The core registers none, so the capsule is unchanged
+ * in the stock build.
+ *
+ * Each segment component is rendered with an `offline` prop so it can match the
+ * capsule's connection-state styling. Registration is expected at module-load
+ * time (edition composition), before App mounts — this registry is not reactive.
+ *
+ * Choosing between the two slots:
+ *  - inside the capsule (border/divider/offline-tint grouping) → this seam.
+ *  - a standalone pill next to the capsule → `registerTopBarWidgets`.
+ */
+import type { ComponentType } from 'react'
+import { reportSeamCollision } from './seamCollision'
+
+export interface CapsuleSegment {
+  /** Stable key for React reconciliation + de-dup. */
+  id: string
+  /** Ascending sort key for placement among registered segments (default 0). */
+  order?: number
+  /** Hide on narrow (mobile) viewports. Default false. */
+  hideOnMobile?: boolean
+  /** The segment. Rendered with the capsule's `offline` state so it can match tint. */
+  component: ComponentType<{ offline: boolean }>
+}
+
+const CAPSULE_SEGMENTS: CapsuleSegment[] = []
+
+/**
+ * Register one or more readout-capsule segments. A duplicate `id` is ignored and
+ * logs a warning, so re-entrant registration (e.g. HMR) stays idempotent.
+ */
+export function registerCapsuleSegment(segments: CapsuleSegment[]): void {
+  for (const s of segments) {
+    if (CAPSULE_SEGMENTS.some(existing => existing.id === s.id)) {
+      reportSeamCollision('capsuleSegments', `segment ${s.id} already registered; ignoring duplicate`)
+      continue
+    }
+    CAPSULE_SEGMENTS.push(s)
+  }
+}
+
+/** All registered capsule segments, sorted by `order` (ascending, stable). */
+export function getCapsuleSegments(): readonly CapsuleSegment[] {
+  return [...CAPSULE_SEGMENTS].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+}

--- a/website/src/components/WelcomeView.tsx
+++ b/website/src/components/WelcomeView.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom'
 import { Droplet, EyeOff, Ghost, RefreshCw, Undo2, VenetianMask } from 'lucide-react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { KiroGhost } from './KiroGhost'
+import { useTheme } from '../hooks/useTheme'
+import { getThemeBranding } from '../themeBranding'
 import { api } from '../api/client'
 
 interface WelcomeViewProps {
@@ -97,12 +99,22 @@ export default function WelcomeView({
 
   const currentMode = (memoryMode ?? 'persistent') as 'persistent' | 'incognito' | 'temporary'
 
+  // Per-theme brand mark: a registered theme (via the themeBranding seam) may
+  // supply its own logo — render it here too, not just in the App shell, so the
+  // welcome screen matches the active theme. Falls back to the stock KiroGhost
+  // when the theme registers no logo (the standalone build always does).
+  const { colorTheme } = useTheme()
+  const brandLogo = getThemeBranding(colorTheme)?.logo
+  const brandMark = brandLogo
+    ? <img src={brandLogo} alt="" aria-hidden="true" className="w-16 h-16 drop-shadow-lg shrink-0 animate-float rounded-md object-contain" />
+    : <KiroGhost size={64} className="drop-shadow-lg shrink-0 animate-float" />
+
   return (
     <div className="flex flex-col items-center w-full gap-6 px-8">
-      {mode === 'orchestrator' && <KiroGhost size={64} className="drop-shadow-lg shrink-0 animate-float" />}
+      {mode === 'orchestrator' && brandMark}
       <div className="text-center">
         <div className="flex items-center justify-center gap-4">
-          {mode !== 'orchestrator' && <KiroGhost size={64} className="drop-shadow-lg shrink-0 animate-float" />}
+          {mode !== 'orchestrator' && brandMark}
           <h2 className="text-5xl font-light text-text-strong tracking-tight">{mode === 'orchestrator' ? 'Autopilot' : 'What can I do for you?'}</h2>
           {mode !== 'orchestrator' && <div className="w-[64px] shrink-0" />}
         </div>

--- a/website/src/extensions.ts
+++ b/website/src/extensions.ts
@@ -14,6 +14,8 @@
  *   import { registerPanelShortcut }     from './hooks/useKeyboardShortcuts'
  *   import { registerNonAppPrefix }      from './components/MigrationCheck'
  *   import { registerTheme }             from './hooks/useTheme'
+ *   import { registerCapsuleSegment }    from './apps/capsuleSegments'
+ *   import { registerOverviewStatCards } from './pages/overviewStatCards'
  *
  * For edition-owned API methods there is no registrar — the edition imports the
  * blessed `apiTransport` (`./api/apiTransport`) and builds its own typed API

--- a/website/src/pages/OverviewPage.tsx
+++ b/website/src/pages/OverviewPage.tsx
@@ -5,6 +5,8 @@ import { useUptime } from '../hooks/useUptime'
 import { api } from '../api/client'
 import { StatCard } from '../components/ui'
 import { TunnelStatus } from '../components/TunnelStatus'
+import ErrorBoundary from '../components/ErrorBoundary'
+import { getOverviewStatCards } from './overviewStatCards'
 import { MemoryTab, AgentCfgTab, KiroCrewCfgTab, UsageTab, PortabilityTab } from './overview'
 
 const tabs = ['memory', 'usage', 'kirocrewcfg', 'agentcfg', 'portability']
@@ -32,6 +34,17 @@ export default function OverviewPage() {
           <StatCard key={s.label} label={s.label} value={s.value} accent={s.accent} delay={i * 60} />
         ))}
         <TunnelStatus delay={6 * 60} />
+        {/* Extension slot: downstream-registered status cards (e.g. an edition
+            credential-TTL card). Empty in the stock build. Each is isolated in
+            its own ErrorBoundary so a throwing card disables only itself. */}
+        {getOverviewStatCards().map((c, i) => {
+          const CardComp = c.component
+          return (
+            <ErrorBoundary key={c.id} scope={`overview-stat-card:${c.id}`} fallback={null}>
+              <CardComp delay={(7 + i) * 60} />
+            </ErrorBoundary>
+          )
+        })}
       </div>
         <div className="flex gap-1 mb-4 border-b border-border">
           {tabs.map(t => (

--- a/website/src/pages/overviewStatCards.tsx
+++ b/website/src/pages/overviewStatCards.tsx
@@ -1,0 +1,51 @@
+/**
+ * Overview status-card registry.
+ *
+ * The Settings → Overview status grid is a fixed row of `StatCard`s (Uptime,
+ * Sessions, …) followed by the built-in `TunnelStatus` card. A downstream
+ * edition contributes its own status cards — e.g. a credential-TTL card that
+ * polls an edition endpoint — by registering a component here from its entry
+ * module, instead of editing OverviewPage.tsx on every upstream sync.
+ *
+ * Each registered entry is a self-contained component (like the core
+ * `TunnelStatus`): it renders its own `StatCard` and owns its own query/state,
+ * and receives a `delay` prop so it can match the grid's staggered rise-in
+ * animation. OverviewPage renders them after the core cards, in `order`
+ * (ascending). The core registers none, so the grid is unchanged in the stock
+ * build.
+ *
+ * Registration is expected at module-load time (edition composition), before
+ * the page renders — this registry is not reactive.
+ */
+import type { ComponentType } from 'react'
+import { reportSeamCollision } from '../apps/seamCollision'
+
+export interface OverviewStatCard {
+  /** Stable key for React reconciliation + de-dup. */
+  id: string
+  /** Ascending sort key for placement among registered cards (default 0). */
+  order?: number
+  /** Self-contained card component. Rendered with a `delay` for stagger animation. */
+  component: ComponentType<{ delay?: number }>
+}
+
+const OVERVIEW_STAT_CARDS: OverviewStatCard[] = []
+
+/**
+ * Register one or more overview status cards. A duplicate `id` is ignored and
+ * logs a warning, so re-entrant registration (e.g. HMR) stays idempotent.
+ */
+export function registerOverviewStatCards(cards: OverviewStatCard[]): void {
+  for (const c of cards) {
+    if (OVERVIEW_STAT_CARDS.some(existing => existing.id === c.id)) {
+      reportSeamCollision('overviewStatCards', `stat card ${c.id} already registered; ignoring duplicate`)
+      continue
+    }
+    OVERVIEW_STAT_CARDS.push(c)
+  }
+}
+
+/** All registered overview status cards, sorted by `order` (ascending, stable). */
+export function getOverviewStatCards(): readonly OverviewStatCard[] {
+  return [...OVERVIEW_STAT_CARDS].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+}

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -32,6 +32,8 @@ import {
   RESERVED_PANEL_CODES,
 } from '../hooks/useKeyboardShortcuts'
 import { registerTheme, getRegisteredThemes } from '../hooks/useTheme'
+import { registerCapsuleSegment, getCapsuleSegments } from '../apps/capsuleSegments'
+import { registerOverviewStatCards, getOverviewStatCards } from '../pages/overviewStatCards'
 import { apiTransport } from '../api/apiTransport'
 // Importing the client installs the blessed transport (installApiTransport runs
 // at client module load), so `apiTransport` is populated for the test below.
@@ -249,6 +251,40 @@ describe('apiTransport — exported blessed transport (not a registry)', () => {
   })
 })
 
+describe('capsuleSegments — in-capsule segment seam', () => {
+  it('registers segments and returns them sorted by order', () => {
+    registerCapsuleSegment([{ id: 'testseg:b', order: 2, component: () => null }])
+    registerCapsuleSegment([{ id: 'testseg:a', order: 1, component: () => null }])
+    const ids = getCapsuleSegments().filter(s => s.id.startsWith('testseg:')).map(s => s.id)
+    expect(ids).toEqual(['testseg:a', 'testseg:b'])
+  })
+
+  it('throws on a duplicate id in dev/test', () => {
+    registerCapsuleSegment([{ id: 'testseg:dup', component: () => null }])
+    expect(() => registerCapsuleSegment([{ id: 'testseg:dup', component: () => null }])).toThrow(
+      /already registered/,
+    )
+    expect(getCapsuleSegments().filter(s => s.id === 'testseg:dup').length).toBe(1)
+  })
+})
+
+describe('overviewStatCards — settings status-card seam', () => {
+  it('registers cards and returns them sorted by order', () => {
+    registerOverviewStatCards([{ id: 'testcard:b', order: 2, component: () => null }])
+    registerOverviewStatCards([{ id: 'testcard:a', order: 1, component: () => null }])
+    const ids = getOverviewStatCards().filter(c => c.id.startsWith('testcard:')).map(c => c.id)
+    expect(ids).toEqual(['testcard:a', 'testcard:b'])
+  })
+
+  it('throws on a duplicate id in dev/test', () => {
+    registerOverviewStatCards([{ id: 'testcard:dup', component: () => null }])
+    expect(() =>
+      registerOverviewStatCards([{ id: 'testcard:dup', component: () => null }]),
+    ).toThrow(/already registered/)
+    expect(getOverviewStatCards().filter(c => c.id === 'testcard:dup').length).toBe(1)
+  })
+})
+
 describe('builtinRegistry — route-shape guard', () => {
   // BuiltinAppRoute resolves /:builtinApp from ONE pathname segment and never
   // the query/hash — so anything that isn't a bare plain segment registers but
@@ -330,6 +366,11 @@ describe('composition root — stock extensions.ts is empty', () => {
       .replace(/^\s*\/\/.*$/gm, '') // line comments
       .trim()
     expect(code).toBe('export {}')
+  })
+
+  it('capsule-segment + overview-stat-card seams are empty in the stock build', () => {
+    expect(getCapsuleSegments().every(s => !s.id.startsWith('edition:'))).toBe(true)
+    expect(getOverviewStatCards().every(c => !c.id.startsWith('edition:'))).toBe(true)
   })
 
   it('importing it adds no registrations beyond the seeded core state', async () => {


### PR DESCRIPTION
## What

A cross-verification of the internal edition against the composed platform seams (MeshClaw beta vs KiroCrew core, backend + frontend) found surfaces where a downstream edition still had to edit a core file — no register hook existed. This closes them so the edition composes **purely additively**. Every addition is inert in the stock build.

| # | Seam | Kind |
|---|------|------|
| 1 | `WelcomeView` consumes existing `getThemeBranding` | clear win — reach an existing seam to a 2nd consumer, no new contract |
| 2 | `TunnelProvider.ensure_available()` | new backend Protocol method |
| 3 | `registerCapsuleSegment` | new frontend registry |
| 4 | `registerOverviewStatCards` | new frontend registry |

## Backend

- **`TunnelProvider.ensure_available(*, install=True) -> str`** — zero-touch provisioning, distinct from `start()` (which only starts an already-enabled tunnel). Wired into `slack/allowlist.send_dashboard_link` (localhost-only + no live URL) via `async_safe_context_call`. Returns `"connected"`/`"starting"`/`"disabled"`/`"unavailable"`; the caller adopts a tunnel URL **only on `"connected"`** (a `"starting"` tunnel has no live URL yet) and otherwise keeps the local link. Default returns `"disabled"` (no-op) → standalone falls back to the local `host:port` exactly as today.

## Frontend

- **`registerCapsuleSegment`** (`apps/capsuleSegments.tsx`) — mount a status segment **inside** the header readout capsule (its border / `|` dividers / offline tint), vs `registerTopBarWidgets` which only appends a sibling pill. Gated on `!capsuleCollapsed` exactly like the core readouts, so collapsing reduces the capsule to the bare connection dot. This is the one residue that blocked a downstream edition from fully collapsing its `App.tsx` shadow onto seams.
- **`registerOverviewStatCards`** (`pages/overviewStatCards.tsx`) — contribute a self-contained `StatCard` (owning its own query, like the core `TunnelStatus`) to the Settings → Overview grid.
- **`WelcomeView`** now reads the existing `getThemeBranding` seam so a registered theme's logo/name shows on the welcome screen, not just the shell chrome.

All registries follow the established seam conventions: core-wins `reportSeamCollision` (fail-loud in dev/test, warn in prod), read at module load, registered from the `extensions.ts` composition root, per-slot `ErrorBoundary` isolation.

## Not included: exfil host-suffix exemption

An earlier revision added a fifth seam — `CredentialPolicy.exempt_host_suffixes()`, an exfil-heuristic exemption by parent domain. **It was removed.** A suffix exemption cannot be validated as edition-controlled without a full, maintained Public Suffix List: a partial embedded denylist (any missed multi-tenant apex like `blogspot.com` re-opens the hole) is not a defensible security boundary on the credential-egress path, and pulling in a PSL dependency is out of scope. The companion enumerates its trusted tenants through the **existing** exact-host seam (`exempt_exact_hosts`) instead, so the exfil floor stays **exact-match only** — the pre-PR behavior, unchanged.

## Testing

- **Backend:** exfil suite green with exact-host-only matching (59 exfil cases); `mypy`/`flake8`/`black` clean.
- **Frontend:** seam tests (register/get, order-sort, duplicate-throws) for the two new registries — 43 pass; `tsc` + production build clean.
- **Specs (same commit):** `docs/system-specs/modules/platform-context.md` documents `ensure_available()`'s states + wiring; `website/AGENTS.md` frontend seam table updated; backend Protocol docstrings updated.

## Provenance

Gaps surfaced by a 5-agent cross-verification fleet; the other backend/frontend domains (apps/dashboard, memory/knowledge, jail/mcp/providers publish, identity/telemetry) were confirmed **fully seamed**.
