### PR TITLE
fix(dashboard): allow ] inside [OPTIONS:] pill labels

### DIFF
--- a/src/kiro_crew/preview_text.py
+++ b/src/kiro_crew/preview_text.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import re
 
+from kiro_crew.constants import OPTIONS_RE_LINE
+
 # Fenced code blocks — ```lang ... ``` (or unterminated, running to the end
 # of the message). Replaced with a short placeholder; the code body would
 # dominate a 80–120 char preview otherwise.
@@ -24,8 +26,10 @@ _MCWIDGET_RE = re.compile(r"<mcwidget\b[^>]*>[\s\S]*?(?:</mcwidget>|\Z)", re.IGN
 _INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
 _IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
-# Trailing (or embedded) quick-reply block — rendered as buttons, not text.
-_OPTIONS_RE = re.compile(r"\[OPTIONS:[^\]]*\]")
+# Trailing quick-reply block — rendered as buttons, not text. Reuse the canonical
+# ReDoS-hardened, line-anchored parser (constants.OPTIONS_RE_LINE) so this strip
+# can't drift from the dashboard/Slack copies and handles `]` inside a label.
+_OPTIONS_RE = OPTIONS_RE_LINE
 _HEADER_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _BLOCKQUOTE_RE = re.compile(r"^\s*>\s?", re.MULTILINE)
 _BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+", re.MULTILINE)

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -14,15 +14,7 @@ import type { FileChipStyle } from './ChatSettings'
 import { loadChatConfig } from './ChatSettings'
 import { useSmoothStream } from '../../hooks/useSmoothStream'
 import type { PlanStepInput } from '../../api/client'
-
-// Match an [OPTION:] / [OPTIONS:] marker anywhere on a single line. We deliberately
-// do NOT anchor to end-of-string. The model frequently appends a closing line after
-// the marker — a follow-up question, a note, or an auto-inserted comment — and an
-// end-anchored regex then fails to match, leaving the raw "[OPTION: …]" text visible
-// with no buttons (the regression this fixes). The body is single-line ([^\]\n]) so
-// it can't swallow following paragraphs. Global so we can take the LAST marker, which
-// is the actionable gate. Capture group 1 = the optional trailing "S" (multi syntax).
-const OPTION_MARKER_RE = /\[OPTION(S)?:\s*([^\]\n]+?)\s*\]/gi
+import { OPTION_MARKER_RE } from '../../utils/optionsMarker'
 const PLAN_HEADER_RE = /📋\s*Plan for:/i
 const STAGE_RE = /^Stage\s+\d+\s*:/m
 

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -5,6 +5,7 @@ import type { DisplayItem, TurnItem } from './types'
 import { useSearchHighlight } from '../../hooks/SearchHighlightContext'
 import { isWorkflowRunTool } from './WorkflowRunCard'
 import { isWorkflowCompletionMessage } from './WorkflowCompletionCard'
+import { OPTION_MARKER_RE } from '../../utils/optionsMarker'
 
 // A workflow_run launch renders as its own always-visible inline card
 // (WorkflowRunCard), so it must never be folded into the collapsible tool-call
@@ -45,7 +46,7 @@ const isVisibleInline = (it: TurnItem) => isRenderable(it) || isAlwaysVisible(it
 
 /** Strip OPTIONS/markdown formatting and return plain text content length */
 function substantiveLength(text: string): number {
-  return text.replace(/\[OPTION[S]?:.*?\]/gi, '').replace(/[#*_`>\-|]/g, '').trim().length
+  return text.replace(OPTION_MARKER_RE, '').replace(/[#*_`>\-|]/g, '').trim().length
 }
 
 /**

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -284,6 +284,28 @@ describe('parseOptions', () => {
     expect(text).toContain('later')
   })
 
+  // A label may itself contain `]`. The block terminates at the last `]` that ends the
+  // line, so "[OPTIONS: Alpha ] | Bravo ] | Charlie ]]" yields three labels each ending
+  // in `]`. Regression: the old first-`]` regex truncated the block to just "Alpha" and
+  // leaked "| Bravo ] | Charlie ]]" into the rendered text.
+  it('allows `]` inside option labels (terminates at the line-final bracket)', () => {
+    const { options, text } = parseOptions('Here are pills:\n[OPTIONS: Alpha ] | Bravo ] | Charlie ]]')
+    expect(options).toEqual(['Alpha ]', 'Bravo ]', 'Charlie ]'])
+    expect(text).toBe('Here are pills:')
+    expect(text).not.toContain('[OPTIONS:')
+  })
+
+  // ReDoS guard: untrusted model output with thousands of unterminated `[OPTIONS:`
+  // prefixes must not drive quadratic backtracking in the synchronous render path.
+  // The tempered body (utils/optionsMarker.ts) fails in O(1) per prefix.
+  it('does not catastrophically backtrack on adversarial `[OPTIONS:` input', () => {
+    const evil = '[OPTIONS:'.repeat(20000)
+    const start = Date.now()
+    const { options } = parseOptions(evil)
+    expect(options).toEqual([])
+    expect(Date.now() - start).toBeLessThan(500)
+  })
+
   it('shows "Copy link to message" button when messageTs and slotKey are provided', () => {
     render(<AssistantMessage content="Hello" isStreaming={false} slotRunning={false} messageTs="2025-05-13T14:00:00.000Z" slotKey="chat-1" slotTitle="My Chat" />)
     expect(screen.getByTitle('Copy link to message')).toBeInTheDocument()

--- a/website/src/utils/optionsMarker.ts
+++ b/website/src/utils/optionsMarker.ts
@@ -1,0 +1,20 @@
+// Canonical [OPTION(S):] follow-up-pill marker regex — the single source of truth
+// for the frontend, mirroring the backend's ReDoS-hardened OPTIONS_RE_LINE
+// (src/kiro_crew/constants.py). Import this instead of hand-rolling a copy so the
+// grammar can't drift between the dashboard's several parsers.
+//
+// The tempered body `(?:[^[\n]|\[(?!OPTIONS?:))*` matches any run of characters that
+// does NOT begin a fresh `[OPTION(S):` marker, which gives three properties:
+//   1. a label may itself contain `]` — the block ends at the LAST `]` that ends the
+//      line, not the first `]` (so "[OPTIONS: a] | b]]" → ["a]", "b]"]);
+//   2. two same-line markers can't merge into one garbage label;
+//   3. it fails in O(1) per `[OPTIONS:` prefix instead of rescanning the line, so
+//      untrusted model output with thousands of `[OPTIONS:` prefixes can't drive
+//      quadratic (ReDoS-class) backtracking in the synchronous render path.
+// The marker must END ITS LINE (`\][ \t]*$` with the `m` flag) — a trailing note,
+// question, or diff on later lines is left intact. `i` = case-insensitive OPTION(S);
+// `g` = take the LAST marker / strip all. Group 1 = optional "S"; group 2 = labels.
+//
+// Only use with String#matchAll and String#replace (which don't carry the global
+// regex `lastIndex` hazard); do NOT call `.exec`/`.test` on this shared const.
+export const OPTION_MARKER_RE = /\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)\][ \t]*$/gim

--- a/website/src/utils/searchableText.ts
+++ b/website/src/utils/searchableText.ts
@@ -1,10 +1,5 @@
 import type { ChatMessage } from '../types'
-
-// Trailing `[OPTIONS: ...]` blocks are rendered as quick-reply buttons
-// (see parseOptions / OPTIONS_RE in pages/chat/AssistantMessage.tsx) and are
-// stripped from the rendered message body — so they have no text node to
-// highlight. Keep this regex in sync with that one.
-const OPTIONS_RE = /\[OPTIONS:\s*(.+?)\]\s*$/
+import { OPTION_MARKER_RE } from './optionsMarker'
 
 // `<mcwidget>...</mcwidget>` bodies render as a sandboxed iframe (WidgetFrame).
 // Their visible text lives in a separate document the in-chat highlighter's
@@ -26,7 +21,7 @@ const MCWIDGET_RE = /<mcwidget\b[^>]*>[\s\S]*?<\/mcwidget>/gi
  */
 export function searchableText(m: ChatMessage): string {
   if (m.role === 'assistant' || m.role === 'streaming') {
-    return m.content.replace(MCWIDGET_RE, '').replace(OPTIONS_RE, '').trimEnd()
+    return m.content.replace(MCWIDGET_RE, '').replace(OPTION_MARKER_RE, '').trimEnd()
   }
   return m.content
 }


### PR DESCRIPTION
## Problem
Follow-up option pills whose labels contain `]` render broken: only the first pill appears and the rest of the marker leaks into the message body as literal text (e.g. `[OPTIONS: Alpha ] | Bravo ] | Charlie ]]` → one **Alpha** pill + stray `| Bravo ] | Charlie ]]`).

## Why it matters
Any `[OPTIONS:]` label containing a `]` silently corrupts the follow-up bar and dumps raw marker syntax into the chat. The naïve fix also introduces a **ReDoS-class** hazard, so this needs the hardened grammar, not just a wider match.

## Fix (symptom → root cause → change)
- **Symptom:** first-`]` truncation of the pill list + leaked marker text.
- **Root cause:** the frontend `OPTION_MARKER_RE` terminated the label at the **first** `]`; a lazy `[^\n]+?` body would also rescan the line per `[OPTIONS:` prefix — quadratic (ReDoS-class) on untrusted model output.
- **Change:** adopt the backend's canonical, ReDoS-hardened grammar. The tempered body `(?:[^[\n]|\[(?!OPTIONS?:))*` ends at the **last** `]` that ends the line (so a label may contain `]`) and fails in **O(1) per `[OPTIONS:` prefix** (no backtracking blow-up). Mirrors `constants.py:OPTIONS_RE_LINE`.
- **Unify (kills grammar drift):** extract a single frontend source `website/src/utils/optionsMarker.ts`, imported by `AssistantMessage.tsx` (parse), `TurnBlock.tsx` (`substantiveLength`), and `searchableText.ts` (search strip); backend `preview_text.py` now imports the canonical `constants.OPTIONS_RE_LINE`. This removes the first-`]` copies the review flagged, so the leak no longer reproduces in preview/search/strip surfaces.
- **Out of scope:** `voice_reply.py` has a sibling first-`]` strip the review did not flag — left for a follow-up.

## Tests
- Added a `parseOptions` regression: `[OPTIONS: Alpha ] | Bravo ] | Charlie ]]` → `['Alpha ]', 'Bravo ]', 'Charlie ]']`.
- Added an **adversarial ReDoS guard**: 20,000 unterminated `[OPTIONS:` prefixes parse in <500 ms and yield no options.
- 89/89 frontend vitest (`parseOptions` / `deriveFollowUpOptions` / `FollowUpBar` / `searchableText`); `tsc -b` clean; backend `flake8` + `isort` clean; `pytest test_preview_text test_parse_options` → 31 passed.

## Manual verification
Built the SPA and served it from an isolated dev gateway; the `]`-bearing payload renders as three separate pills.
