### PR TITLE
fix(dev): make dev-backend.sh resilient to a custom production KIROCREW_PORT

### DIFF
--- a/dev-backend.sh
+++ b/dev-backend.sh
@@ -4,14 +4,58 @@
 # restart.
 #
 # Usage: ./dev-backend.sh
-#   - Runs on port 6777 (dev port, separate from production on 5476)
-#   - Uses .kirocrew-dev/ as data directory (isolated from ~/.kirocrew/)
-#   - Ctrl+C to stop, re-run to pick up changes
+#   - Runs on a DEDICATED dev port (default 6777), INDEPENDENT of the operator's
+#     production KIROCREW_PORT (which may be customized, e.g. 9999). Override the
+#     dev port with KIROCREW_DEV_PORT.
+#   - Uses .kirocrew-dev/ as data directory (isolated from ~/.kirocrew/); a custom
+#     production KIROCREW_HOME is likewise NOT inherited — override with
+#     KIROCREW_DEV_HOME.
+#   - KIROCREW_DEV_DRYRUN=1 prints the resolved port/home and exits (no launch).
+#   - Ctrl+C to stop, re-run to pick up changes.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+export PYTHONPATH="$SCRIPT_DIR/src"
+export KIROCREW_PROJECT_DIR="$SCRIPT_DIR"
+
+# --- Isolated dev data dir ----------------------------------------------------
+# Do NOT inherit a custom production KIROCREW_HOME, or the throwaway dev gateway
+# would run against real ~/.kirocrew data. Resolve a DEDICATED dev home (override
+# with KIROCREW_DEV_HOME); default .kirocrew-dev.
+KIROCREW_HOME="${KIROCREW_DEV_HOME:-.kirocrew-dev}"
+# Absolutize: config_dir() resolves this against each process's CWD, and MCP
+# subprocesses (mcp-core/mcp-cron) are spawned with session-workspace CWDs —
+# a relative HOME makes them create empty config dirs with no .local_secret,
+# so their gateway IPC calls fail with 403 Forbidden.
+case "$KIROCREW_HOME" in
+    /*) ;;
+    *) KIROCREW_HOME="$SCRIPT_DIR/$KIROCREW_HOME" ;;
+esac
+export KIROCREW_HOME
+
+# --- Dedicated dev port (independent of a custom production KIROCREW_PORT) -----
+# The gateway binds $KIROCREW_PORT. Do NOT inherit the operator's production
+# KIROCREW_PORT — it is commonly customized (e.g. 9999) and reusing it makes the
+# dev instance contend for the LIVE gateway's socket. Resolve an INDEPENDENT dev
+# port instead (override with KIROCREW_DEV_PORT; default 6777). If that port is
+# itself busy (a stale dev run, or a production port equal to the dev default),
+# the gateway reports the conflict on bind — set KIROCREW_DEV_PORT to move it.
+KIROCREW_PORT="${KIROCREW_DEV_PORT:-6777}"
+case "$KIROCREW_PORT" in
+    ''|*[!0-9]*) echo "ERROR: KIROCREW_DEV_PORT must be numeric, got '$KIROCREW_PORT'." >&2; exit 1 ;;
+esac
+export KIROCREW_PORT
+
+# KIROCREW_DEV_DRYRUN=1 -> print the resolved config and exit without launching
+# (confirm which port/home dev-backend would use; needs no venv).
+if [ -n "${KIROCREW_DEV_DRYRUN:-}" ]; then
+    echo "resolved dev config: port=$KIROCREW_PORT home=$KIROCREW_HOME"
+    exit 0
+fi
+
+# --- Runtime interpreter ------------------------------------------------------
 # Find the Python with deps installed: prefer the venv created by install.sh /
 # setup.sh / minimal_install.sh. Override with RUNTIME_PYTHON if needed.
 RUNTIME_PYTHON="${RUNTIME_PYTHON:-}"
@@ -25,19 +69,6 @@ if [ ! -x "$RUNTIME_PYTHON" ]; then
     echo "Run 'bash minimal_install.sh' once to set up the venv, then try again."
     exit 1
 fi
-
-export PYTHONPATH="$SCRIPT_DIR/src"
-export KIROCREW_HOME="${KIROCREW_HOME:-.kirocrew-dev}"
-# Absolutize: config_dir() resolves this against each process's CWD, and MCP
-# subprocesses (mcp-core/mcp-cron) are spawned with session-workspace CWDs —
-# a relative HOME makes them create empty config dirs with no .local_secret,
-# so their gateway IPC calls fail with 403 Forbidden.
-case "$KIROCREW_HOME" in
-    /*) ;;
-    *) KIROCREW_HOME="$SCRIPT_DIR/$KIROCREW_HOME" ;;
-esac
-export KIROCREW_PORT="${KIROCREW_PORT:-6777}"
-export KIROCREW_PROJECT_DIR="$SCRIPT_DIR"
 
 echo "👻 Dev backend starting (live source, port $KIROCREW_PORT)"
 echo "   Python: $RUNTIME_PYTHON"


### PR DESCRIPTION
## Problem
With a customized production `KIROCREW_PORT` (e.g. `9999`) exported in the environment, `./dev-backend.sh` reused that value and contended for the **live** gateway's socket instead of starting the throwaway dev gateway on its own port.

## Why it matters
Launching a local dev preview could collide with — and disrupt — the running production gateway on the same host. This actually happened: a preview launch tried to bind the live `:9999` and logged "port in use — waiting…".

## Fix (symptom → root cause → change)
- **Symptom:** the dev gateway bound (or contended for) the production port.
- **Root cause:** the port was resolved as `${KIROCREW_PORT:-6777}`, which only falls back to `6777` when the variable is **unset** — an exported production value was inherited instead. `KIROCREW_HOME` had the same latent inheritance bug, so the dev gateway could also run against the real `~/.kirocrew` data dir.
- **Change:** resolve a **dedicated** `KIROCREW_DEV_PORT` (default `6777`) and `KIROCREW_DEV_HOME` (default `.kirocrew-dev`), independent of the production `KIROCREW_PORT`/`KIROCREW_HOME`; add a numeric-port guard and a `KIROCREW_DEV_DRYRUN=1` mode that prints the resolved port/home without launching. (An auto-bump-to-next-free-port loop was prototyped and dropped — it duplicated the gateway's own bind-conflict handling and relied on a `/dev/tcp` probe.)

## Tests
Shell script — no unit-test harness. Verified with:
- `bash -n` (syntax) clean.
- Dry-run matrix: ambient production `KIROCREW_PORT=9999` → resolves `6777`; explicit `KIROCREW_DEV_PORT` honored; a custom production `KIROCREW_HOME` is **not** inherited (stays `.kirocrew-dev`); non-numeric `KIROCREW_DEV_PORT` rejected with a clear error.

## Manual verification
Live relaunch with ambient `KIROCREW_PORT=9999`: the dev gateway bound `127.0.0.1:6777` while the live gateway on `:9999` remained untouched, and the dashboard served HTTP 200.
