### PR TITLE
fix(slack): correct to_slack_mrkdwn truncation that left oversized messages

### DIFF
--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -143,7 +143,14 @@ def to_slack_mrkdwn(text: str, *, keep_tables: bool = False) -> str:
     text = _strip_ansi(text)
 
     if len(text) > SLACK_MAX_TEXT:
-        cut = text[:SLACK_MAX_TEXT].rfind("\n") or SLACK_MAX_TEXT
+        # rfind returns -1 (no newline in window) or the last newline's index —
+        # NOT a bool. `rfind(...) or SLACK_MAX_TEXT` mishandles both: -1 is
+        # truthy so text[:-1] keeps ~39000 chars (Slack then rejects the
+        # message), and a newline at index 0 falls through to the cap. Use the
+        # explicit -1 check already used by split_message().
+        cut = text[:SLACK_MAX_TEXT].rfind("\n")
+        if cut <= 0:
+            cut = SLACK_MAX_TEXT
         text = f"{text[:cut]}\n\n_…truncated ({len(text)} chars total)_"
 
     if not keep_tables:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -2229,6 +2229,38 @@ class TestContextFooter:
         assert "ctx" not in text
 
 
+class TestToSlackMrkdwnTruncation:
+    """The >SLACK_MAX_TEXT truncation used `rfind("\\n") or SLACK_MAX_TEXT`,
+    which misreads rfind's int return: -1 (no newline) is truthy so text[:-1]
+    keeps ~39000 chars and Slack rejects the message; a newline at index 0
+    falls through to the cap. The result must always be safely under the limit."""
+
+    def test_no_newline_long_text_truncates_under_limit(self):
+        from kiro_crew.slack.format import SLACK_MAX_TEXT, to_slack_mrkdwn
+
+        # A single long line with NO newline (minified JSON / base64 / long URL).
+        text = "x" * (SLACK_MAX_TEXT + 5000)
+        out = to_slack_mrkdwn(text)
+        # Pre-fix: rfind -> -1, text[:-1] leaves ~SLACK_MAX_TEXT+4999 chars.
+        assert len(out) < SLACK_MAX_TEXT + 200  # body cut to cap + short notice
+        assert "truncated" in out
+
+    def test_leading_newline_does_not_truncate_to_empty(self):
+        from kiro_crew.slack.format import SLACK_MAX_TEXT, to_slack_mrkdwn
+
+        # Newline only at index 0 of the window: rfind -> 0, `0 or CAP` -> CAP
+        # pre-fix (accidentally correct), but the explicit check keeps it robust.
+        text = "\n" + "y" * (SLACK_MAX_TEXT + 1000)
+        out = to_slack_mrkdwn(text)
+        assert len(out) < SLACK_MAX_TEXT + 200
+        assert "truncated" in out
+
+    def test_short_text_is_untouched(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        assert to_slack_mrkdwn("hello world") == "hello world"
+
+
 class TestToSlackMrkdwnKeepTables:
     """Tests for the keep_tables parameter in to_slack_mrkdwn."""
 


### PR DESCRIPTION
## Bug (HIGH · correctness)

`to_slack_mrkdwn`'s `>SLACK_MAX_TEXT` truncation used:
```python
cut = text[:SLACK_MAX_TEXT].rfind("\n") or SLACK_MAX_TEXT
```
which misreads `rfind`'s **int** return value:

- `rfind` returns **`-1`** when there's no newline in the window (common for minified JSON, base64 blobs, single-line logs, long URLs) — and `-1` is truthy, so `-1 or SLACK_MAX_TEXT` evaluates to `-1` and `text[:-1]` keeps **~39000 chars**, leaving the message over Slack's limit → **Slack rejects the post**.
- A newline at index `0` hits the `0 or CAP` case.

## Fix

Use the explicit `-1` check already used by `split_message()`:
```python
cut = text[:SLACK_MAX_TEXT].rfind("\n")
if cut <= 0:
    cut = SLACK_MAX_TEXT
```

## Test

`TestToSlackMrkdwnTruncation` — a long no-newline body is now cut under the limit (**pre-fix it stayed ~44000 chars**, surgical revert); leading-newline and short-text paths covered. Relevant mrkdwn/split tests (32) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via the round-2 automated multi-agent bug hunt (adversarially verified + empirically reproduced).
