### PR TITLE
fix(dashboard): fail-closed /execute audit + native-crew auto-approve gate (CSE G3)

### DIFF
--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -450,6 +450,23 @@ Two guardrails remain intact for a trusted run:
 
 The mid-stream context-overflow check still runs before final approval.
 
+### Provenance gate & fail-closed audit (`_gate_auto_approve`)
+
+Every launch endpoint (`/start`, `/execute`) routes the requested `auto_approve`
+through the shared async `_gate_auto_approve()` provenance gate before honoring
+it. Per-run trust is a human-at-the-dashboard decision, so a grant is honored
+ONLY for a dashboard-context request (`request["app"] == ""`); an app/proxy
+caller cannot mint trust even while claiming `source: "dashboard"`.
+
+The grant decision is **SEL-audited fail-closed**. The audit is written
+`critical=True` (a synchronous, raise-on-failure write) but **offloaded via
+`asyncio.to_thread`** so the synchronous flush does not block the gateway event
+loop while the `await` still surfaces a write failure. The write is contained in
+the gate itself (not per-endpoint), so if the grant cannot be persisted to the
+SEL trail it is **downgraded to denied** — an un-auditable grant is never
+honored — and no unsanitized exception escapes as an HTTP 500 (CWE-755). This
+invariant holds for every current and future launch caller.
+
 Hardening measures scope the trust tightly. It is not the global `SafetyOverride`
 singleton (which would leak trust to every session), but the authoritative grant
 IS held by `SafetyOverride` — as a **task-scoped grant** — so per-run trust is

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1071,6 +1071,32 @@ def _retain_terminal_native(
     return {sid: info for sid, info in terminal}
 
 
+def _native_crew_should_auto_approve(native_tracker, state, slot) -> bool:
+    """Return True only when a native crew subagent is ACTIVE *and* an
+    auto-approve condition holds — otherwise deny (CWE-1188 secure default).
+
+    Active-crew is a NECESSARY precondition: with no live native subagent the
+    parent turn is not blocked on a crew tool, so this path must never
+    auto-approve — regardless of the ``auto_approve_subagent_tools`` hook,
+    ``slot._trust``, or yolo. Only when a crew is active do those signals grant
+    approval; with all three false the tool still falls through to the normal
+    interactive/trust gate rather than being silently approved here.
+    """
+    has_active_crew = bool(native_tracker) and any(
+        not info.get("done") for info in native_tracker.values()
+    )
+    if not has_active_crew:
+        return False
+    return bool(
+        (
+            state.context_builder
+            and state.context_builder.hooks.auto_approve_subagent_tools
+        )
+        or getattr(slot, "_trust", False)
+        or state.is_yolo_active()
+    )
+
+
 def _matches_trusted_pattern(tool_title: str, patterns: set[str]) -> str | None:
     """Return the matched pattern if tool_title matches any trusted pattern.
 
@@ -3121,52 +3147,42 @@ async def _run_chat(
                 # Native crew auto-approve: when a native subagent (crew pipeline)
                 # is active and the session is configured to auto-approve subagent
                 # tools, approve immediately to avoid deadlocking the blocked
-                # parent turn.
-                _has_active_crew = _native_tracker and any(
-                    not info.get("done") for info in _native_tracker.values()
-                )
-                if _has_active_crew:
-                    _should_auto = (
-                        (
-                            state.context_builder
-                            and state.context_builder.hooks.auto_approve_subagent_tools
-                        )
-                        or getattr(slot, "_trust", False)
-                        or state.is_yolo_active()
+                # parent turn. Deny-by-default (CWE-1188): with no active crew this
+                # predicate is False no matter the trust flags, so the tool falls
+                # through to the normal interactive/trust gate below.
+                if _native_crew_should_auto_approve(_native_tracker, state, slot):
+                    logger.debug(
+                        "Native crew auto-approve: %s (request_id=%s)",
+                        event.title,
+                        event.request_id,
                     )
-                    if _should_auto:
-                        logger.debug(
-                            "Native crew auto-approve: %s (request_id=%s)",
-                            event.title,
-                            event.request_id,
-                        )
-                        await client.approve_tool(event.request_id)
-                        _tool_title = _broadcast_auto_tool(state, slot, event)
-                        # Defense-in-depth: re-redact before this second external
-                        # surface (activity feed + sel log). event.title is
-                        # LLM-controlled display text; _broadcast_auto_tool already
-                        # redacts, so both passes are idempotent.
-                        _tool_title, _ = redact_exfiltration_urls(_tool_title)
-                        _tool_title, _ = redact_credentials(_tool_title)
-                        state.broadcast_ws(
-                            "activity_event",
-                            {
-                                "slot": slot.key,
-                                "kind": "permission",
-                                "text": f"Auto-approved (crew): {_tool_title}",
-                            },
-                        )
-                        sel().log_tool_invocation(
-                            session_key=session_key,
-                            agent=slot.agent or "kirocrew",
-                            source="dashboard",
-                            tool_name=_tool_title,
-                            tool_kind=event.tool_kind,
-                            outcome="auto_approved",
-                            request_id=event.request_id,
-                            metadata={"reason": "native_crew"},
-                        )
-                        continue
+                    await client.approve_tool(event.request_id)
+                    _tool_title = _broadcast_auto_tool(state, slot, event)
+                    # Defense-in-depth: re-redact before this second external
+                    # surface (activity feed + sel log). event.title is
+                    # LLM-controlled display text; _broadcast_auto_tool already
+                    # redacts, so both passes are idempotent.
+                    _tool_title, _ = redact_exfiltration_urls(_tool_title)
+                    _tool_title, _ = redact_credentials(_tool_title)
+                    state.broadcast_ws(
+                        "activity_event",
+                        {
+                            "slot": slot.key,
+                            "kind": "permission",
+                            "text": f"Auto-approved (crew): {_tool_title}",
+                        },
+                    )
+                    sel().log_tool_invocation(
+                        session_key=session_key,
+                        agent=slot.agent or "kirocrew",
+                        source="dashboard",
+                        tool_name=_tool_title,
+                        tool_kind=event.tool_kind,
+                        outcome="auto_approved",
+                        request_id=event.request_id,
+                        metadata={"reason": "native_crew"},
+                    )
+                    continue
                 # Session-trusted patterns: auto-approve commands matching user globs.
                 # Security: match against the ACTUAL command from tool_input (not
                 # event.title which is LLM-controlled display text). For shell tools,

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -23,7 +23,7 @@ def _sel():
     return _pkg.sel()
 
 
-def _gate_auto_approve(
+async def _gate_auto_approve(
     request: web.Request, requested: bool, claimed_source, endpoint: str
 ) -> bool:
     """Provenance gate for per-run auto-approve, shared by every launch endpoint.
@@ -48,17 +48,42 @@ def _gate_auto_approve(
     if requested and (request_app != "" or (claimed_source is not None and claimed_source != "dashboard")):
         granted = False
     if requested:
-        _sel().log_tool_invocation(
-            session_key="dashboard",
-            source="taskrunner",
-            tool_name="auto_approve_grant",
-            outcome="granted" if granted else "denied",
-            metadata={
-                "endpoint": endpoint,
-                "claimed_source": str(claimed_source),
-                "request_app": str(request_app),
-            },
-        )
+        try:
+            # Offloaded to a worker thread: critical=True writes SYNCHRONOUSLY and
+            # RAISES on a sink failure (so an unwritable/full SEL store reaches the
+            # except below and fails the grant closed — the default critical=False
+            # only queues the write and would swallow an async failure). Running
+            # that synchronous flush inline would block the gateway event loop
+            # (no-blocking-call-on-event-loop), so it is awaited via to_thread:
+            # off the loop, yet the await still propagates a write failure here.
+            # The whole call — INCLUDING the _sel() lookup (which may lazily
+            # initialize the log) — runs in the worker so nothing touches the loop.
+            await asyncio.to_thread(
+                lambda: _sel().log_tool_invocation(
+                    session_key="dashboard",
+                    source="taskrunner",
+                    tool_name="auto_approve_grant",
+                    outcome="granted" if granted else "denied",
+                    metadata={
+                        "endpoint": endpoint,
+                        "claimed_source": str(claimed_source),
+                        "request_app": str(request_app),
+                    },
+                    critical=True,
+                )
+            )
+        except Exception:
+            # The audit write is a fallible side-effect. Contain it HERE so the
+            # invariant holds for EVERY caller (current and future) rather than
+            # relying on each endpoint to remember to wrap the gate in try/except
+            # (CWE-755 — an unsanitized traceback would otherwise escape as a
+            # 500). Fail closed: a grant we could not audit is downgraded to
+            # denied, never silently honored.
+            logger.exception(
+                "auto_approve grant audit-write failed for endpoint=%s; failing closed",
+                endpoint,
+            )
+            return False
     return granted
 
 
@@ -147,7 +172,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         claimed_source = body.get("source")
         source = claimed_source if claimed_source in allowed_sources else "dashboard"
         # Deny-by-default (`is True`) + shared provenance gate (dashboard-context only).
-        auto_approve = _gate_auto_approve(
+        auto_approve = await _gate_auto_approve(
             request, body.get("auto_approve") is True, claimed_source, endpoint="start"
         )
         task_id = await state.task_runner.start_background(
@@ -566,8 +591,11 @@ async def api_taskrunner_execute_plan(request: web.Request) -> web.Response:
     workspace_dir = body.get("workspace_dir", "")
     # Same provenance gate as /start: an app/proxy-embedded caller cannot mint
     # trust on the resume/execute path either (no source claim here — the run
-    # already exists — so only the dashboard-context check applies).
-    auto_approve = _gate_auto_approve(
+    # already exists — so only the dashboard-context check applies). The gate
+    # contains its own fallible audit write (fails closed to auto_approve=False),
+    # so no CWE-755 try/except is needed at the call site — the invariant lives
+    # in the gate, not here.
+    auto_approve = await _gate_auto_approve(
         request, body.get("auto_approve") is True, None, endpoint="execute"
     )
     try:

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -494,3 +494,43 @@ class TestAutoApproveProvenanceGating:
     async def test_execute_app_embedded_ignored(self) -> None:
         # The /execute endpoint must enforce the SAME gate as /start.
         assert await self._execute_auto_approve_passed(request_app="someapp") is False
+
+    @pytest.mark.asyncio
+    async def test_execute_gate_audit_failure_fails_closed(self) -> None:
+        """A SEL/audit failure inside the provenance gate is CONTAINED in the
+        gate itself (CWE-755): it neither leaks an unsanitized traceback as a 500
+        nor grants trust. The gate fails closed to ``auto_approve=False`` and the
+        plan proceeds without auto-approval.
+
+        Regression guard: the containment invariant lives in ``_gate_auto_approve``
+        (so every current and future caller is protected), NOT in a per-endpoint
+        try/except that a later adopter could forget to add.
+        """
+        runner = MagicMock()
+        runner.execute_plan = AsyncMock(return_value=None)
+        app = web.Application()
+        app["state"] = SimpleNamespace(task_runner=runner)
+        req = make_mocked_request(
+            "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
+            headers={"Content-Length": "32"},
+        )
+        req["app"] = ""  # dashboard context → requested trust is honored, so the gate audits
+        req.json = AsyncMock(return_value={"auto_approve": True})
+
+        boom = MagicMock()
+        boom.log_tool_invocation.side_effect = RuntimeError("sel backend down: SECRET-INTERNAL-DETAIL")
+        with patch("kiro_crew.dashboard.handlers.taskrunner._sel", return_value=boom):
+            resp = await api_taskrunner_execute_plan(req)
+
+        # No unsanitized 500 escapes; the request succeeds.
+        assert resp.status == 200
+        # The raw exception text must not leak to the client.
+        assert "SECRET-INTERNAL-DETAIL" not in resp.body.decode()
+        # Fail closed: trust was NOT granted despite the request asking for it,
+        # and the plan still ran (without auto-approval).
+        runner.execute_plan.assert_called_once()
+        assert runner.execute_plan.call_args.kwargs["auto_approve"] is False
+        # The audit MUST be requested SYNCHRONOUSLY (critical=True) so a real
+        # (async) SEL write failure reaches this fail-closed handler rather than
+        # being swallowed by the background writer after the gate has returned.
+        assert boom.log_tool_invocation.call_args.kwargs["critical"] is True

--- a/test/test_native_subagent_spawn.py
+++ b/test/test_native_subagent_spawn.py
@@ -14,6 +14,7 @@ import pytest
 
 from kiro_crew.dashboard.chat_runner import (
     _append_native_output,
+    _native_crew_should_auto_approve,
     _native_done_result,
     _native_subagent_close_all,
     _native_subagent_sync,
@@ -972,3 +973,73 @@ class TestRetainTerminalNative:
     def test_empty_when_no_done(self):
         tracker = {"r": {"id": "native:r", "done": False, "started": 0.0}}
         assert _retain_terminal_native(tracker) == {}
+
+
+class TestNativeCrewAutoApproveGate:
+    """Gate for the native-crew auto-approve path in chat_runner (CWE-1188).
+
+    Secure default: a tool is auto-approved on this path ONLY when a native crew
+    subagent is ACTIVE *and* at least one trust signal (auto_approve_subagent_tools
+    hook / slot._trust / yolo) is set. With no active crew — or with all signals
+    false — the predicate is False and the tool falls through to the normal
+    interactive/trust gate instead of being silently approved.
+    """
+
+    def _state(self, *, hook=False, yolo=False):
+        state = MagicMock()
+        state.context_builder = MagicMock()
+        state.context_builder.hooks.auto_approve_subagent_tools = hook
+        state.is_yolo_active.return_value = yolo
+        return state
+
+    def _slot(self, *, trust=False):
+        slot = MagicMock()
+        slot._trust = trust
+        return slot
+
+    def test_no_active_crew_all_conditions_false_denies(self):
+        # The core negative case: no crew active AND every trust signal false →
+        # NOT auto-approved.
+        state = self._state(hook=False, yolo=False)
+        slot = self._slot(trust=False)
+        assert _native_crew_should_auto_approve({}, state, slot) is False
+
+    def test_no_active_crew_all_done_denies(self):
+        # A tracker with only finished subagents is not "active".
+        tracker = {"s1": {"done": True}, "s2": {"done": True}}
+        state = self._state(hook=False, yolo=False)
+        slot = self._slot(trust=False)
+        assert _native_crew_should_auto_approve(tracker, state, slot) is False
+
+    def test_no_active_crew_ignores_trust_signals(self):
+        # Active-crew is a NECESSARY precondition: even with yolo/trust/hook all
+        # ON, no active crew means this path must not auto-approve.
+        state = self._state(hook=True, yolo=True)
+        slot = self._slot(trust=True)
+        assert _native_crew_should_auto_approve({}, state, slot) is False
+
+    def test_active_crew_all_conditions_false_denies(self):
+        # Deny-by-default: an active crew alone does not grant approval — a trust
+        # signal must also be present.
+        tracker = {"s1": {"done": False}}
+        state = self._state(hook=False, yolo=False)
+        slot = self._slot(trust=False)
+        assert _native_crew_should_auto_approve(tracker, state, slot) is False
+
+    def test_active_crew_with_hook_approves(self):
+        tracker = {"s1": {"done": False}}
+        state = self._state(hook=True, yolo=False)
+        slot = self._slot(trust=False)
+        assert _native_crew_should_auto_approve(tracker, state, slot) is True
+
+    def test_active_crew_with_slot_trust_approves(self):
+        tracker = {"s1": {"done": False}}
+        state = self._state(hook=False, yolo=False)
+        slot = self._slot(trust=True)
+        assert _native_crew_should_auto_approve(tracker, state, slot) is True
+
+    def test_active_crew_with_yolo_approves(self):
+        tracker = {"s1": {"done": False}}
+        state = self._state(hook=False, yolo=True)
+        slot = self._slot(trust=False)
+        assert _native_crew_should_auto_approve(tracker, state, slot) is True


### PR DESCRIPTION
## Problem
CSE flagged G3 findings on the dashboard **auto-approve** surface:
- **CWE-755 (`/execute` auto-approve gate):** the SEL/audit write ran outside a `try/except`, so a non-`ValueError` leaked a 500 with a traceback, and an audit sink failure could let the grant proceed unrecorded.
- **CWE-1188 (native-crew auto-approve):** the native-subagent path could auto-approve without a live ("active") crew.

## Why it matters
A leaked traceback is a recon aid; auto-approving tools without a live crew, or granting trust with no audit record, are privilege/eventing risks on a security-sensitive path.

## Fix (symptom → root cause → change)
- **CWE-755:** the fallible audit write is now **contained inside `_gate_auto_approve`** (so the invariant holds for every current/future caller, not a per-endpoint `try/except`): on failure it **fails closed to `auto_approve=False`** rather than leaking a 500, and the audit is written **`critical=True`** (synchronous; raises on a sink failure) so an unwritable/full SEL store reaches the fail-closed handler instead of being swallowed by the async writer.
- **CWE-1188:** `_native_crew_should_auto_approve` codifies the pre-existing active-crew precondition (**deny-by-default** without a live crew); behavior-preserving, with credential/URL redaction preserved before the second external surface.

## Scope note — CWE-778 (agent-launcher trust) is risk-accepted, not implemented
An earlier revision added a path-based launcher trust check. It is **removed**: for a personal, single-user tool with tool-approval, launcher substitution is either **out of the threat model** (a same-UID attacker already owns the account; a different local principal / writable-shared-dir writer is out of scope) or requires a **signed / root-owned launcher** — a real integrity mechanism, not a path check. The minimal check added no in-model security value and repeatedly broke common installs (Debian/Homebrew shared dirs, NSS, Windows, BusyBox). The enterprise/multi-tenant hardening + risk-acceptance rationale are tracked in **#417** (needs CSE/maintainer sign-off to close CWE-778 as accepted-risk).

## Tests
- `test/test_auto_approve.py` — the fail-closed audit contract (a SEL failure inside the gate neither leaks a 500 nor grants; asserts `critical=True`).
- `test/test_native_subagent_spawn.py` — native-crew deny-by-default without an active crew.

## Manual verification
N/A — unit coverage is sufficient; both fixes are on covered code paths with regression tests. No user-visible UI change (no screenshots).
