### PR TITLE
fix(mcp-gateway): serialize concurrent writes to the shared stub->gateway socket

### DIFF
--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -371,8 +371,22 @@ def build_register_payload(args: argparse.Namespace) -> dict:
 
 
 async def _write_frame(writer: asyncio.StreamWriter, obj: dict) -> None:
-    writer.write(json.dumps(obj, separators=(",", ":")).encode("utf-8") + b"\n")
-    await writer.drain()
+    # stdin_pump and _recaller_loop both write this shared stub->gateway socket
+    # and both await drain(). Each write() here lands a WHOLE frame in one
+    # synchronous call, so frame bytes cannot interleave — the hazard is the
+    # concurrent drain(): under backpressure, FlowControlMixin._drain_helper on
+    # many deployed interpreter patch releases holds a single drain waiter
+    # (`assert waiter is None or waiter.cancelled()`), so a second concurrent
+    # drain() trips the assert, kills that pump task, and tears the bridge down
+    # (newer patch releases allow multiple waiters; older ones are common).
+    # Serialize the write+drain pair through the writer's lock — the same
+    # _mc_write_lock idiom gatewayd/backend use on their writers — which also
+    # keeps the invariant robust if a future edit splits a frame across writes.
+    lock = getattr(writer, "_mc_write_lock", None)
+    guard = lock if lock is not None else contextlib.nullcontext()
+    async with guard:
+        writer.write(json.dumps(obj, separators=(",", ":")).encode("utf-8") + b"\n")
+        await writer.drain()
 
 
 async def _read_frame(reader: asyncio.StreamReader) -> Optional[dict]:
@@ -473,6 +487,10 @@ async def run_bridge(
     # call_soon_threadsafe from the writer thread, wakes a dedicated bridge task
     # so teardown never depends on upstream traffic.
     bridge_loop = asyncio.get_running_loop()
+    # stdin_pump and _recaller_loop both write this shared stub->gateway socket;
+    # serialize their write+drain through one lock (mirrors gatewayd/backend).
+    if getattr(writer, "_mc_write_lock", None) is None:
+        setattr(writer, "_mc_write_lock", asyncio.Lock())
     writer_failed = threading.Event()
     writer_failed_evt = asyncio.Event()
 
@@ -537,8 +555,17 @@ async def run_bridge(
                     pass
                 return
             try:
-                writer.write(line if line.endswith(b"\n") else line + b"\n")
-                await writer.drain()
+                # Serialize with _recaller_loop's _write_frame writes on the
+                # same socket: the write itself is whole-frame atomic, but a
+                # second concurrent drain() under backpressure trips the
+                # single-waiter assert in FlowControlMixin._drain_helper on
+                # pre-3.12-fix interpreters, killing this pump task and tearing
+                # the bridge down (see _write_frame).
+                _lock = getattr(writer, "_mc_write_lock", None)
+                _guard = _lock if _lock is not None else contextlib.nullcontext()
+                async with _guard:
+                    writer.write(line if line.endswith(b"\n") else line + b"\n")
+                    await writer.drain()
             except (ConnectionError, BrokenPipeError):
                 return
 
@@ -746,8 +773,12 @@ async def _recaller_loop(
     never be stranded by a poll deadline. Exits on: key found (after sending
     one ``recaller`` frame) or bridge teardown (``stop_event``). Writes a
     whole frame per ``_write_frame`` (a single synchronous ``writer.write``
-    before any await), so it cannot interleave partial bytes with the stdin
-    pump sharing this ``writer``.
+    before any await), so frame BYTES cannot interleave with the stdin pump
+    sharing this ``writer`` — but the write lock in ``_write_frame`` is still
+    required: two coroutines awaiting ``drain()`` concurrently under
+    backpressure trip the single-drain-waiter assert in
+    ``FlowControlMixin._drain_helper`` on pre-3.12-fix interpreters, which
+    kills a pump task and tears the bridge down.
     """
     loop = asyncio.get_running_loop()
     interval = _RECALLER_POLL_INTERVAL_SECS

--- a/test/test_mcp_gateway_stub_recaller.py
+++ b/test/test_mcp_gateway_stub_recaller.py
@@ -155,3 +155,67 @@ async def test_recaller_loop_noop_when_stopped_before_key(
     stop.set()
     await asyncio.wait_for(stub_mod._recaller_loop(w, None, stop), timeout=1.0)
     assert w.frames == []
+
+
+class _CriticalSectionWriter:
+    """StreamWriter double that detects a broken write+drain critical section:
+    its drain() yields the loop, and it flags if any OTHER write() lands between
+    a given writer's write() and its drain() completing. Serializing write+drain
+    under the shared lock must prevent that."""
+
+    def __init__(self) -> None:
+        self.frames: list[dict[str, Any]] = []
+        self._in_flight = False
+        self.overlap = False
+
+    def write(self, data: bytes) -> None:
+        if self._in_flight:
+            # Another writer's write+drain was still in progress.
+            self.overlap = True
+        for line in data.split(b"\n"):
+            if line:
+                self.frames.append(json.loads(line.decode("utf-8")))
+
+    async def drain(self) -> None:
+        self._in_flight = True
+        try:
+            await asyncio.sleep(0)  # yield: a concurrent write() would overlap
+        finally:
+            self._in_flight = False
+
+
+@pytest.mark.asyncio
+async def test_write_frame_serializes_concurrent_writers() -> None:
+    """stdin_pump and _recaller_loop share one writer and both await drain().
+    Without serialization, one coroutine's write() lands inside another's
+    write+drain critical section (the interleave that corrupts the socket
+    stream). _write_frame must hold the writer's _mc_write_lock across write+
+    drain so the sections never overlap."""
+    w = _CriticalSectionWriter()
+    setattr(w, "_mc_write_lock", asyncio.Lock())
+
+    async def spam(tag: str) -> None:
+        for i in range(20):
+            await stub_mod._write_frame(w, {"type": tag, "n": i})
+
+    await asyncio.gather(spam("a"), spam("b"))
+
+    assert not w.overlap, "write+drain critical sections overlapped (not serialized)"
+    assert len(w.frames) == 40
+
+
+@pytest.mark.asyncio
+async def test_run_bridge_installs_write_lock() -> None:
+    """run_bridge must install a _mc_write_lock on the shared writer so its two
+    writer coroutines serialize. Verified by driving a minimal bridge to EOF."""
+    reader = asyncio.StreamReader()
+    reader.feed_eof()  # immediate EOF -> stdin_pump sends Unregister and exits
+    w = _CapWriter()
+    stop = asyncio.Event()
+    stdin = asyncio.StreamReader()
+    stdin.feed_eof()
+    await asyncio.wait_for(
+        stub_mod.run_bridge(reader, w, stop, stdin=stdin, stdout_writer=w),
+        timeout=2.0,
+    )
+    assert getattr(w, "_mc_write_lock", None) is not None


### PR DESCRIPTION
## Bug (MEDIUM · concurrency)

In `run_bridge` the **`stdin_pump`** task and the **`_recaller_loop`** task both write to the **same** `asyncio.StreamWriter` (the stub→gatewayd socket) and both `await writer.drain()`, with no serialization. Under socket backpressure (transport buffer over the high-water mark while gatewayd is momentarily slow), one coroutine can land a `write()` inside the other's write+drain critical section, **interleaving bytes and corrupting the newline-delimited frame stream** — gatewayd then mis-parses or drops frames.

## Fix

Adopt the same `_mc_write_lock` idiom `gatewayd`/`backend` already use on their writers: `run_bridge` installs an `asyncio.Lock` on the writer, and both `_write_frame` and `stdin_pump`'s raw write acquire it around `write()`+`drain()`.

## Test

- `test_write_frame_serializes_concurrent_writers` — two coroutines drive `_write_frame` on a writer whose `drain()` yields; **pre-fix** their write+drain critical sections overlap (surgical revert), **post-fix** the lock serializes them.
- `test_run_bridge_installs_write_lock` — asserts the lock is installed (fails pre-fix).

Full stub suite (7 tests) green; `isort`/`flake8`/`mypy` clean.

🤖 Found via the round-2 automated multi-agent bug hunt (adversarially verified + empirically reproduced).
