### PR TITLE
fix(dashboard): stop double ↳↳ arrow on forked session cards

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1801,9 +1801,12 @@ function ChatSidebar({
               ) : null}
             </div>
             <div className="text-[13px] font-semibold leading-snug line-clamp-2 break-words text-text" title={s.title && s.title !== s.key ? s.title : s.key}>
-              {s.forked_from && slots.some(x => x.key === s.forked_from!.replace(/^dashboard:/, '')) && (
-                <span className="text-accent mr-0.5" title="Forked child session">↳</span>
-              )}
+              {/* No separate fork glyph: forked titles already carry the
+                  persisted "↳ " marker (chat_fork.py _FORK_TITLE_MARKER). Keeping
+                  the arrow in the title text — rather than as a UI-only glyph —
+                  means it pre-fills the rename box (setRenameValue at the
+                  onRename handler) so users can edit or drop it when they rename.
+                  A separate ↳ glyph also double-stacked into "↳↳ Fork of …". */}
               {renamingSlot === s.key && renameScope === scope ? (
                 <Input ref={renameInputRef} className="w-full bg-transparent border border-accent rounded px-1 py-0 text-text-strong outline-none text-[13px] select-text" value={renameValue} onChange={e => setRenameValue(e.target.value)} {...ime.bindEnter<HTMLInputElement>({ onEnter: () => { (document.activeElement as HTMLInputElement)?.blur() }, onEscape: () => { cancelRenameRef.current = true; setRenamingSlot(null) }, onBlur: () => { if (!cancelRenameRef.current && renameValue.trim()) { dispatch(sseSlotTitle({ key: s.key, title: renameValue.trim() })); api.renameSlot(s.key, renameValue.trim()).catch(() => { queryClient.invalidateQueries({ queryKey: ['chat-slots'] }) }) } cancelRenameRef.current = false; setRenamingSlot(null) } })} onMouseDown={e => e.stopPropagation()} />
               ) : (s.title && s.title !== s.key ? s.title : s.key)}


### PR DESCRIPTION
## Problem
Forked session cards in the chat sidebar render a double fork arrow — `↳↳ Fork of <parent>` — instead of a single `↳`. It only shows while the parent session is still present in the sidebar list.

## Why it matters
It looks like a rendering bug to users, makes forked titles noisier/wider (worse truncation), and the extra arrow is a UI-only glyph the user cannot edit or remove when renaming the session.

## Fix (symptom → root cause → change)
- **Symptom:** `↳↳` on forked cards, but the raw persisted title only has one `↳`.
- **Root cause:** the arrow has two independent sources. The backend bakes the marker into the persisted title (`chat_fork.py` `_FORK_TITLE_MARKER = "↳ "` → `↳ Fork of <parent>`, which is the tested contract). `ChatSidebar.tsx` *additionally* rendered its own accent `↳` glyph whenever `forked_from` was set and the parent slot was loaded — stacking a second arrow on a title that already began with `↳ `.
- **Change:** remove the redundant UI glyph and let the persisted title marker be the single source of truth. Keeping the arrow in the title text (rather than a UI-only glyph) also means it pre-fills the rename box via the `onRename` handler's `setRenameValue`, so users can edit or drop it when they rename — which the old glyph could not.

## Tests
No new automated test. The removed glyph had no test coverage, and the persisted `↳ Fork of …` marker that now solely owns the arrow is already locked in by backend tests (`test/test_dashboard_chat.py` asserts `↳ Fork of My Chat` and the fork-of-fork case `↳ Fork of Fork of Original`). Full frontend gate re-run on the rebased branch: `tsc --noEmit` clean; eslint clean for this file; vitest 347 files / 3926 passed / 3 skipped / 0 failed.

## Manual verification
1. Fork a session whose parent is still visible in the sidebar → the card shows a single `↳ Fork of <parent>` (previously `↳↳`).
2. Rename that forked session → the rename box pre-fills with `↳ Fork of <parent>`; the `↳` can be edited or removed, and the change persists.
3. Delete/hide the parent → the fork title still shows its single persisted `↳` (unchanged), confirming the marker, not the removed glyph, is the source.
