### PR TITLE
fix(dashboard): stop approval cards outliving their approval future

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -203,6 +203,29 @@ Streaming chunks are cleaned up after each response (only final assistant messag
 
 **Agent Config**: PUT saves to `~/.kiro/agents/kirocrew.json` and auto-restarts all kiro-cli sessions so changes take effect immediately.
 
+### Tool-Approval Resolution Persistence
+
+A pending tool approval has **two** pieces of state that must stay in lockstep: the in-memory `asyncio.Future` in `slot._approval_futures[request_id]`, which the chat runner awaits, and the `permission` message in `slot.messages`, whose `cls` JSON is what the UI renders the approval bar from. The message is the durable half — it is the only piece that survives a history reload.
+
+**Invariant: every path that resolves or discards an approval future MUST also mark the message.** A future resolved without marking leaves a card that renders as pending while nothing is listening: the UI keeps showing live Allow once / Trust / Reject buttons, `POST /api/chat/slots/{slot}/approve` answers `404 no pending approval` for all of them, and a reload resurrects the card. The resolution paths and their markers:
+
+| Path | Marker |
+|---|---|
+| HTTP `POST /api/chat/slots/{slot}/approve` | `api_chat_slot_approve` marks `"trust"` / `"trust_reads"` verbatim (the UI renders those distinctly), everything else as the coerced `"approved"` / `"approved_trust_reads"` / `"rejected"` |
+| Slack approval click | `DashboardState.resolve_approval` marks `"approved"`/`"rejected"` |
+| Bulk trust/yolo mode switch | `api_chat_mode` marks with the mode name (`"trust"` / `"yolo"`) |
+| Stop / interrupt | `_reject_pending_approvals` marks `"rejected"` |
+| Chat runner's own exits — 2h `wait_for` timeout, Slack delivery-failure auto-reject, task cancellation | the `finally` backstop in `_run_chat` marks with `only_if_pending=True` |
+| Turn-start sweep (repairs orphans from prior turns) | `_sweep_stale_permissions` marks `"stale"` |
+
+**`resolved` field values** (`cls.resolved`): `"approved"`, `"approved_trust_reads"`, `"rejected"`, `"trust"`, `"trust_reads"`, `"yolo"`, `"stale"`. Presence of the key — not its value — is what makes a permission message non-pending; `selectSlotPendingApproval` in the SPA and the `only_if_pending` guard both key off presence alone. The frontend additionally writes `"stale"` locally when a decision 404s, which clears the orphaned card in that tab; it is a display-layer dismissal, not a backend write, so orphans persisted before the marking paths existed converge only via the next turn's sweep.
+
+**`only_if_pending` guard**: `_mark_permission_resolved(..., only_if_pending=True)` returns `False` and writes nothing when `resolved` is already present. The runner's backstop uses it so it cannot flatten a richer decision a primary resolver already recorded — `"trust"` renders as *"Trusted — auto-approving future calls"* and would otherwise be downgraded to a bare `"approved"`. It also suppresses a duplicate `approval_resolved` WS broadcast on the paths where the primary resolver already sent one.
+
+**`slot._dirty` obligation**: `_mark_permission_resolved` mutates `slot.messages` in place and returns `True` when it wrote. The periodic flush (`_flush_dirty_slots`, every 5s) **skips slots whose `_dirty` is `False`**, so a caller that marks without flagging the slot can lose the write on restart and resurrect the card. Every call site holding the owning slot sets `slot._dirty = True` on a `True` return. This invariant is enforced by convention at each call site, not by an owning helper — a new future-resolution path must honor both halves.
+
+**Runner backstop totality**: `outcome` is pre-seeded to `"rejected"` before the approval `await`, because the `finally` runs on *every* exit including `CancelledError` (slot deletion and cleanup endpoints cancel `slot.task`). Assigning it only inside `try`/`except` would raise `UnboundLocalError` from the `finally`, replacing the cancellation with a spurious exception and skipping both the message marking and the Slack prompt cleanup.
+
 ### Key Endpoints
 
 **Status/System**: `/api/status`, `/api/system` (live metrics, 1s refresh, static fields cached), `/api/stream` (SSE), `/api/ws` (WebSocket — single multiplexed connection replacing SSE + polling for React SPA)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -713,10 +713,18 @@ def _reject_pending_approvals(slot: _ChatSlot) -> None:
     approval, the chat runner is suspended on the approval future. Without
     resolving it, the stream generator stays paused, _turn_done never fires,
     and the cooperative cancel times out — forcing a hard kill.
+
+    Resolving the future is not enough on its own: the ``permission`` message
+    the UI renders the approval bar from must ALSO be marked resolved.
+    Otherwise the future is gone while the message still reads pending, so the
+    bar survives a history reload and every button on it answers
+    ``404 no pending approval`` — an approval card the user cannot action.
     """
     for aid, fut in list(slot._approval_futures.items()):
         if not fut.done():
             fut.set_result("rejected")
+            if _mark_permission_resolved(slot.messages, aid, "rejected"):
+                slot._dirty = True
             sel().log_tool_invocation(
                 session_key=_history_key_for(slot.key),
                 agent=getattr(slot, "agent", "") or "kirocrew",
@@ -2102,8 +2110,11 @@ async def api_chat_mode(request: web.Request) -> web.Response:
             for aid, fut in list(slot._approval_futures.items()):
                 if not fut.done():
                     fut.set_result("approved")
-                    # Persist resolved state into the permission message
-                    _mark_permission_resolved(slot.messages, aid, mode)
+                    # Persist resolved state into the permission message. The
+                    # periodic flush skips non-dirty slots, so the mark must
+                    # flag the slot or the write can be lost on restart.
+                    if _mark_permission_resolved(slot.messages, aid, mode):
+                        slot._dirty = True
                     state.broadcast_ws("approval_resolved", {"id": aid, "approved": True})
                     try:
                         sel().log_api_access(
@@ -2304,12 +2315,15 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
     fut.set_result(resolved)
     # Persist resolved state into the permission message so it survives tab
     # switches — on the owner slot, whose messages hold the permission card.
+    # Flagging the slot dirty is required for it to survive a RESTART too: the
+    # periodic flush skips non-dirty slots.
     if request_id:
-        _mark_permission_resolved(
+        if _mark_permission_resolved(
             owner.messages,
             request_id,
             original_action if original_action in ("trust", "trust_reads") else resolved,
-        )
+        ):
+            owner._dirty = True
     # Broadcast first to ensure frontend is unblocked
     if request_id:
         state.broadcast_ws(

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -93,6 +93,7 @@ from kiro_crew.dashboard.state import (
     TOOL_STALL_RECOVERY_PREFIX,
     DashboardState,
     _ChatSlot,
+    _mark_permission_resolved,
     build_refusal_recovery_prompt,
     build_stale_recovery_prompt,
     build_tool_stall_recovery_prompt,
@@ -3424,12 +3425,45 @@ async def _run_chat(
                         )
                         if not fut.done():
                             fut.set_result("rejected")
+                # Pre-seeded so the `finally` backstop below is total over EVERY
+                # exit from the await — including CancelledError, which slot
+                # deletion / cleanup endpoints raise by cancelling slot.task.
+                # Assigning only inside try/except would leave `outcome` unbound
+                # on that path: the finally would raise UnboundLocalError,
+                # replacing the CancelledError with a spurious exception and
+                # skipping both the message marking and the Slack cleanup —
+                # reintroducing this PR's own orphan-card bug on the cancel path.
+                # "rejected" is the correct reading: a cancelled turn never
+                # obtained consent.
+                outcome = "rejected"
                 try:
                     outcome = await asyncio.wait_for(fut, timeout=7200.0)
                 except asyncio.TimeoutError:
                     outcome = "rejected"
                 finally:
                     slot._approval_futures.pop(str(event.request_id), None)
+                    # Backstop: the future is now gone, so the permission
+                    # message MUST NOT be left reading pending — the UI would
+                    # keep rendering an approval bar whose every button answers
+                    # 404, and a history reload would resurrect it. The primary
+                    # resolvers (HTTP slot-approve, Slack click) already mark it
+                    # and record richer decisions like "trust"/"yolo", so only
+                    # write when still pending. This is the sole marker for the
+                    # paths that resolve the future in-process: the 2h timeout
+                    # above and the Slack-delivery auto-reject branches.
+                    _approved = outcome in ("approved", "approved_trust_reads")
+                    if _mark_permission_resolved(
+                        slot.messages,
+                        str(event.request_id),
+                        "approved" if _approved else "rejected",
+                        only_if_pending=True,
+                    ):
+                        slot._dirty = True
+                        state.broadcast_ws(
+                            "approval_resolved",
+                            {"id": str(event.request_id), "approved": _approved},
+                        )
+                        state.push_slots_update()
                     # Clean up the Slack prompt: remove the registry entry and
                     # delete the buttons message now the decision is in.
                     if _slack_approval_ts is not None:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -317,18 +317,43 @@ def parse_cls_meta(cls_val: str) -> dict | None:
     return meta
 
 
-def _mark_permission_resolved(messages: list[dict], request_id: str, decision: str) -> None:
-    """Persist a resolved decision into a permission message's cls JSON."""
+def _mark_permission_resolved(
+    messages: list[dict],
+    request_id: str,
+    decision: str,
+    *,
+    only_if_pending: bool = False,
+) -> bool:
+    """Persist a resolved decision into a permission message's cls JSON.
+
+    Returns True when a permission message was written. Callers holding the
+    owning slot MUST set ``slot._dirty = True`` on a True return — the periodic
+    flush skips non-dirty slots, so an unflagged in-place mutation can be lost
+    on restart and the card comes back as an unanswerable orphan.
+
+    ``only_if_pending`` leaves an already-resolved message untouched (and
+    returns False). Use it for backstop callers that must not clobber a richer
+    decision already recorded by the primary resolver — e.g. "trust"/"yolo",
+    which the UI renders as "Trusted — auto-approving future calls" and would
+    otherwise be flattened to a bare "approved".
+    """
     for msg in reversed(messages):
         if msg.get("role") == "permission":
             try:
                 cls = json.loads(msg.get("cls", "{}"))
+                if not isinstance(cls, dict):
+                    # Valid JSON but not an object — cannot carry "resolved".
+                    # Mirrors parse_cls_meta() / _sweep_stale_permissions().
+                    continue
                 if cls.get("request_id") == request_id:
+                    if only_if_pending and "resolved" in cls:
+                        return False
                     cls["resolved"] = decision
                     msg["cls"] = json.dumps(cls)
-                    return
+                    return True
             except (json.JSONDecodeError, TypeError):
                 pass
+    return False
 
 
 # ── Constants ──
@@ -1798,7 +1823,11 @@ class DashboardState:
             fut = slot._approval_futures.get(approval_id)
             if fut and not fut.done():
                 fut.set_result(decision)
-                _mark_permission_resolved(slot.messages, approval_id, decision)
+                if _mark_permission_resolved(slot.messages, approval_id, decision):
+                    # The periodic flush skips non-dirty slots; without this the
+                    # in-place mutation can be lost and the answered card comes
+                    # back on reload with a future that no longer exists.
+                    slot._dirty = True
                 self._audit_and_broadcast_approval(slot.key, approval_id, approved)
                 self.push_slots_update()
                 return True

--- a/test/test_mark_permission_resolved.py
+++ b/test/test_mark_permission_resolved.py
@@ -75,3 +75,63 @@ class TestMarkPermissionResolved:
         _mark_permission_resolved(msgs, "abc", "approved")
         assert "resolved" not in json.loads(msgs[0]["cls"])
         assert json.loads(msgs[2]["cls"])["resolved"] == "approved"
+
+    def test_non_dict_cls_skipped(self) -> None:
+        """Valid JSON that isn't an object cannot carry "resolved" — skip, don't raise."""
+        msgs = [
+            {"role": "permission", "content": "shell", "cls": "[]", "ts": "1"},
+            {"role": "permission", "content": "shell", "cls": "123", "ts": "2"},
+            {"role": "permission", "content": "read", "cls": json.dumps({"request_id": "abc"}), "ts": "3"},
+        ]
+        assert _mark_permission_resolved(msgs, "abc", "approved") is True
+        assert json.loads(msgs[2]["cls"])["resolved"] == "approved"
+
+    def test_returns_whether_it_wrote(self) -> None:
+        msgs = [
+            {"role": "permission", "content": "shell", "cls": json.dumps({"request_id": "abc"}), "ts": "1"},
+        ]
+        assert _mark_permission_resolved(msgs, "abc", "approved") is True
+        assert _mark_permission_resolved(msgs, "nope", "approved") is False
+
+
+class TestMarkPermissionResolvedOnlyIfPending:
+    """The backstop guard: never clobber a decision the primary resolver wrote."""
+
+    def test_skips_already_resolved(self) -> None:
+        msgs = [
+            {
+                "role": "permission",
+                "content": "shell",
+                "cls": json.dumps({"request_id": "abc", "resolved": "trust"}),
+                "ts": "1",
+            },
+        ]
+        assert (
+            _mark_permission_resolved(msgs, "abc", "approved", only_if_pending=True)
+            is False
+        )
+        # "trust" renders as "Trusted — auto-approving future calls"; flattening it
+        # to a bare "approved" would silently downgrade the UI's account of events.
+        assert json.loads(msgs[0]["cls"])["resolved"] == "trust"
+
+    def test_writes_when_still_pending(self) -> None:
+        msgs = [
+            {"role": "permission", "content": "shell", "cls": json.dumps({"request_id": "abc"}), "ts": "1"},
+        ]
+        assert (
+            _mark_permission_resolved(msgs, "abc", "rejected", only_if_pending=True)
+            is True
+        )
+        assert json.loads(msgs[0]["cls"])["resolved"] == "rejected"
+
+    def test_overwrites_when_guard_off(self) -> None:
+        msgs = [
+            {
+                "role": "permission",
+                "content": "shell",
+                "cls": json.dumps({"request_id": "abc", "resolved": "stale"}),
+                "ts": "1",
+            },
+        ]
+        assert _mark_permission_resolved(msgs, "abc", "approved") is True
+        assert json.loads(msgs[0]["cls"])["resolved"] == "approved"

--- a/test/test_orphaned_approval_card.py
+++ b/test/test_orphaned_approval_card.py
@@ -1,0 +1,262 @@
+"""Regression tests: an approval bar must never outlive its approval future.
+
+The bug: paths that resolved the approval future *in-process* — a stop/interrupt
+(``_reject_pending_approvals``) and the chat runner's own 2h timeout / Slack
+delivery-failure auto-reject — dropped the future without marking the
+``permission`` message resolved. The UI keys its approval bar off that message,
+so the bar survived a history reload while the future it pointed at was gone:
+every button (Allow once, Trust, Reject) answered ``404 no pending approval``
+and the card could not be dismissed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeSlot:
+    """Minimal ChatSlot stand-in carrying approval futures + messages."""
+
+    def __init__(self) -> None:
+        self.key = "test-slot"
+        self.agent = "kirocrew"
+        self.messages: list[dict] = []
+        self._dirty = False
+        self._approval_futures: dict[str, asyncio.Future] = {}
+
+    def add_pending_approval(self, request_id: str) -> asyncio.Future:
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._approval_futures[request_id] = fut
+        self.messages.append(
+            {
+                "role": "permission",
+                "content": "Running: gh pr view 297",
+                "cls": json.dumps({"request_id": request_id}),
+                "ts": "1",
+            }
+        )
+        return fut
+
+    def resolved_for(self, request_id: str) -> str | None:
+        for msg in self.messages:
+            if msg.get("role") != "permission":
+                continue
+            cls = json.loads(msg["cls"])
+            if cls.get("request_id") == request_id:
+                return cls.get("resolved")
+        return None
+
+
+class TestRejectPendingApprovalsMarksMessage:
+    """Stop/interrupt path — chat_handlers._reject_pending_approvals."""
+
+    @pytest.mark.asyncio
+    async def test_marks_permission_resolved(self) -> None:
+        from kiro_crew.dashboard.chat_handlers import _reject_pending_approvals
+
+        slot = _FakeSlot()
+        fut = slot.add_pending_approval("ap-1")
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel", return_value=MagicMock()):
+            _reject_pending_approvals(slot)  # type: ignore[arg-type]
+
+        assert fut.done() and fut.result() == "rejected"
+        # Without this the card outlives the future and 404s on every click.
+        assert slot.resolved_for("ap-1") == "rejected"
+        # The periodic flush skips non-dirty slots, so the mark must set it or
+        # the orphan returns after a restart.
+        assert slot._dirty is True
+
+    @pytest.mark.asyncio
+    async def test_marks_every_pending_approval(self) -> None:
+        from kiro_crew.dashboard.chat_handlers import _reject_pending_approvals
+
+        slot = _FakeSlot()
+        slot.add_pending_approval("ap-1")
+        slot.add_pending_approval("ap-2")
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel", return_value=MagicMock()):
+            _reject_pending_approvals(slot)  # type: ignore[arg-type]
+
+        assert slot.resolved_for("ap-1") == "rejected"
+        assert slot.resolved_for("ap-2") == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_future_untouched(self) -> None:
+        """A future the user already answered keeps its recorded decision."""
+        from kiro_crew.dashboard.chat_handlers import _reject_pending_approvals
+        from kiro_crew.dashboard.state import _mark_permission_resolved
+
+        slot = _FakeSlot()
+        fut = slot.add_pending_approval("ap-1")
+        fut.set_result("approved")
+        _mark_permission_resolved(slot.messages, "ap-1", "trust")
+        slot._dirty = False
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel", return_value=MagicMock()):
+            _reject_pending_approvals(slot)  # type: ignore[arg-type]
+
+        assert slot.resolved_for("ap-1") == "trust"
+        assert slot._dirty is False
+
+
+class TestRunnerBackstopContract:
+    """The runner-side backstop for futures it consumes itself.
+
+    Exercising the real ``_run_chat`` approval branch needs a full ACP stream
+    harness; these lock the contract the backstop depends on so a refactor that
+    breaks the guard fails here rather than silently reintroducing the orphan.
+    """
+
+    def test_outcome_is_preseeded_before_the_await(self) -> None:
+        """`outcome` must be assigned BEFORE the try, not only inside it.
+
+        The `finally` reads `outcome`, and it runs on every exit from the await
+        — including `CancelledError`, which slot deletion / cleanup endpoints
+        raise by cancelling `slot.task`. If the only assignments were inside
+        `try`/`except asyncio.TimeoutError`, that path would raise
+        `UnboundLocalError` from the `finally`: the cancellation would be
+        replaced by a spurious exception, and everything after the read —
+        the message marking AND the pre-existing Slack prompt cleanup — would
+        be skipped, reintroducing the orphan card on exactly that path.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        # The pre-seed must appear before the guarded await that follows it.
+        preseed = src.index('outcome = "rejected"')
+        await_idx = src.index("await asyncio.wait_for(fut, timeout=7200.0)")
+        assert preseed < await_idx, (
+            "outcome must be pre-seeded before the approval await so the "
+            "finally backstop is total over cancellation"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_shape_marks_and_reraises(self) -> None:
+        """Mirror of the runner's try/finally under cancellation.
+
+        Proves the pre-seeded shape both marks the message and lets the
+        CancelledError propagate — the two things the unbound read broke.
+        """
+        from kiro_crew.dashboard.state import _mark_permission_resolved
+
+        slot = _FakeSlot()
+        fut = slot.add_pending_approval("ap-1")
+
+        async def approval_branch() -> None:
+            outcome = "rejected"
+            try:
+                outcome = await asyncio.wait_for(fut, timeout=7200.0)
+            except asyncio.TimeoutError:
+                outcome = "rejected"
+            finally:
+                slot._approval_futures.pop("ap-1", None)
+                approved = outcome in ("approved", "approved_trust_reads")
+                if _mark_permission_resolved(
+                    slot.messages,
+                    "ap-1",
+                    "approved" if approved else "rejected",
+                    only_if_pending=True,
+                ):
+                    slot._dirty = True
+
+        task = asyncio.ensure_future(approval_branch())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert slot.resolved_for("ap-1") == "rejected"
+        assert slot._dirty is True
+        assert "ap-1" not in slot._approval_futures
+
+    def test_timeout_marks_rejected_when_pending(self) -> None:
+        from kiro_crew.dashboard.state import _mark_permission_resolved
+
+        slot = _FakeSlot()
+        slot.messages.append(
+            {
+                "role": "permission",
+                "content": "Running: gh pr view 297",
+                "cls": json.dumps({"request_id": "ap-1"}),
+                "ts": "1",
+            }
+        )
+        wrote = _mark_permission_resolved(
+            slot.messages, "ap-1", "rejected", only_if_pending=True
+        )
+        assert wrote is True
+        assert slot.resolved_for("ap-1") == "rejected"
+
+    def test_backstop_does_not_clobber_http_decision(self) -> None:
+        """HTTP slot-approve already recorded "yolo"/"trust" — keep it."""
+        from kiro_crew.dashboard.state import _mark_permission_resolved
+
+        slot = _FakeSlot()
+        slot.messages.append(
+            {
+                "role": "permission",
+                "content": "Running: gh pr view 297",
+                "cls": json.dumps({"request_id": "ap-1", "resolved": "yolo"}),
+                "ts": "1",
+            }
+        )
+        wrote = _mark_permission_resolved(
+            slot.messages, "ap-1", "approved", only_if_pending=True
+        )
+        assert wrote is False
+        assert slot.resolved_for("ap-1") == "yolo"
+
+
+class TestResolveApprovalFlushes:
+    """state.resolve_approval must flag the slot dirty when it marks."""
+
+    def test_every_call_site_flags_dirty(self) -> None:
+        """The mark-then-flag invariant is convention, so assert it structurally.
+
+        `_flush_dirty_slots` skips slots whose `_dirty` is False, so a call site
+        that marks without flagging can lose the write on restart and resurrect
+        the card. Guard every current site so a new one is caught in review.
+        """
+        import re
+        from pathlib import Path
+
+        import kiro_crew.dashboard as pkg
+
+        root = Path(pkg.__file__).parent
+        for name in ("chat_handlers.py", "chat_runner.py", "state.py"):
+            src = (root / name).read_text()
+            for match in re.finditer(r"_mark_permission_resolved\(", src):
+                # Skip the definition itself.
+                if src[: match.start()].rstrip().endswith("def"):
+                    continue
+                window = src[match.start() : match.start() + 600]
+                assert "_dirty = True" in window, (
+                    f"{name}: a _mark_permission_resolved call site does not set "
+                    "_dirty — the periodic flush will skip it"
+                )
+
+    @pytest.mark.asyncio
+    async def test_marks_slot_dirty(self) -> None:
+        from kiro_crew.dashboard.state import DashboardState
+
+        slot = _FakeSlot()
+        fut = slot.add_pending_approval("ap-1")
+
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"test-slot": slot}
+        state._approval_futures = {}
+        state.resolve_state_approval = MagicMock(return_value=False)
+        state._audit_and_broadcast_approval = MagicMock()
+        state.push_slots_update = MagicMock()
+
+        assert DashboardState.resolve_approval(state, "ap-1", True) is True
+        assert fut.result() == "approved"
+        assert slot.resolved_for("ap-1") == "approved"
+        assert slot._dirty is True

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -10,7 +10,7 @@ import { resolveByApprovalId, openActivityToTool, openActivityToTab, selectSlotP
 import { useSlotId } from '../providers/SlotContext'
 import { useToolPillVisible } from '../store/toolPillRegistry'
 import { ToolDetails } from '../pages/chat/ToolDetails'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import { safeSetItem } from '../utils/safeStorage'
 import { offlineProps } from '../utils/offline'
 import { shallowEqual } from 'react-redux'
@@ -443,6 +443,9 @@ function ChatInput({
   const pendingApproval = useAppSelector(s => selectSlotPendingApproval(s, slotId), shallowEqual)
   const hasApproval = !!pendingApproval
   const [approvalSubmitting, setApprovalSubmitting] = useState(false)
+  // Non-null while the last approval decision failed. Rendered as a one-line
+  // strip under the composer; auto-clears so it cannot become permanent chrome.
+  const [approvalNotice, setApprovalNotice] = useState<string | null>(null)
 
   const activeSlot = slotId
   const approvalMeta = pendingApproval?.meta as Record<string, unknown> | undefined
@@ -489,6 +492,14 @@ function ChatInput({
   }, [approvalToolCallId])
 
   const showGhost = !!pendingApproval && !pillVisible && ghostSettled
+
+  // Auto-dismiss the failure notice. Bounded lifetime keeps a transient
+  // backend hiccup from leaving a permanent banner over the composer.
+  useEffect(() => {
+    if (!approvalNotice) return
+    const t = setTimeout(() => setApprovalNotice(null), 8000)
+    return () => clearTimeout(t)
+  }, [approvalNotice])
   const showInChat = useCallback(() => {
     if (approvalToolCallId) dispatch(openActivityToTool(approvalToolCallId))
   }, [approvalToolCallId, dispatch])
@@ -499,14 +510,25 @@ function ChatInput({
   const handleApprovalAction = useCallback((decision: string, pattern?: string) => {
     if (!approvalId) return
     setApprovalSubmitting(true)
+    setApprovalNotice(null)
     const finish = () => {
       dispatch(resolveByApprovalId({ id: approvalId, decision }))
       setApprovalSubmitting(false)
     }
     const fail = (err: unknown) => {
+      setApprovalSubmitting(false)
+      // 404 means the backend no longer holds a future for this id — the turn
+      // was stopped, timed out, or the process was replaced. The card is an
+      // orphan: leaving it up makes every button look broken (the original
+      // bug), so clear it and say why instead of only logging to the console.
+      if (err instanceof ApiError && err.status === 404) {
+        dispatch(resolveByApprovalId({ id: approvalId, decision: 'stale' }))
+        setApprovalNotice('That approval expired — the turn it belonged to is no longer waiting.')
+        return
+      }
       // eslint-disable-next-line no-console -- surface real approval-resolution failures to the dev console
       console.error('Approval failed:', err)
-      setApprovalSubmitting(false)
+      setApprovalNotice('Could not submit that decision — see the console for details.')
     }
     if (['trust_command', 'trust_base', 'trust', 'trust_reads'].includes(decision) && activeSlot) {
       const extra: Record<string, string> = { request_id: approvalId }
@@ -1787,7 +1809,15 @@ function ChatInput({
         )}
       </AnimatePresence>
 
-
+      {approvalNotice && (
+        <div
+          role="status"
+          className="flex items-center gap-2 px-4 py-2 mb-1 bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] rounded-lg"
+        >
+          <Lock size={12} className="text-warn shrink-0" />
+          <span className="text-muted text-[13px]">{approvalNotice}</span>
+        </div>
+      )}
 
       {!showGhost && prefillHint && (
         <div className="flex items-center gap-2 px-4 py-2 mb-1 bg-accent/10 rounded-lg">

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -6,15 +6,32 @@ vi.mock("@radix-ui/react-popover", async () => await import("./__mocks__/@radix-
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders, createTestStore } from './helpers'
 import ChatInput from '../components/ChatInput'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import type { RootState } from '../store'
 
-vi.mock('../api/client', () => ({
-  api: {
-    resolveApproval: vi.fn(() => Promise.resolve({})),
-    approveChatSlot: vi.fn(() => Promise.resolve({})),
-  },
-}))
+vi.mock('../api/client', () => {
+  // Declared INSIDE the factory: vi.mock is hoisted above module-level
+  // declarations, so a top-level class here would be a TDZ error.
+  //
+  // Must be a real class: ChatInput narrows the rejection with
+  // `err instanceof ApiError` to tell an orphaned approval (404) from a
+  // genuine transport failure. A bare object stub makes that check false.
+  class MockApiError extends Error {
+    readonly status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+    }
+  }
+  return {
+    api: {
+      resolveApproval: vi.fn(() => Promise.resolve({})),
+      approveChatSlot: vi.fn(() => Promise.resolve({})),
+    },
+    ApiError: MockApiError,
+  }
+})
 
 const defaultProps = {
   value: '',
@@ -264,6 +281,61 @@ describe('ChatInput approval flow', () => {
     fireEvent.click(screen.getByText('Trust'))
     const buttons = screen.getAllByRole('menuitem')
     expect(buttons.some(b => b.textContent?.includes('commands'))).toBe(false)
+  })
+})
+
+/**
+ * Orphaned approval cards: the backend no longer holds a future for the id
+ * (turn stopped / timed out / process replaced), so it answers 404. The card
+ * used to stay on screen with every button dead — clicks looked ignored.
+ */
+describe('ChatInput orphaned approval (404)', () => {
+  const notFound = () => new ApiError(404, 'no pending approval')
+
+  it('clears the approval bar when Trust 404s', async () => {
+    vi.mocked(api.approveChatSlot).mockRejectedValueOnce(notFound())
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Trust'))
+    fireEvent.click(screen.getByText('Trust all tools'))
+    await waitFor(() => {
+      expect(screen.queryByText('Allow once')).not.toBeInTheDocument()
+    })
+    expect(store.getState().chat.messages[1].meta!.resolved).toBe('stale')
+  })
+
+  it('clears the approval bar when Allow once 404s', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValueOnce(notFound())
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Allow once'))
+    await waitFor(() => {
+      expect(screen.queryByText('Allow once')).not.toBeInTheDocument()
+    })
+  })
+
+  it('explains why the click did nothing instead of failing silently', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValueOnce(notFound())
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Reject'))
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/expired/i)
+    })
+  })
+
+  it('keeps the bar up on a non-404 failure so the user can retry', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValueOnce(new ApiError(503, 'busy'))
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Allow once'))
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+    // A transient server error is not evidence the approval is gone — the
+    // buttons must remain live rather than dismissing a still-valid request.
+    expect(screen.getByText('Allow once')).toBeInTheDocument()
+    expect(store.getState().chat.messages[1].meta!.resolved).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Problem

A tool-approval bar could remain on screen after the backend had already
destroyed the future behind it. Every button on that card — **Allow once**,
**Trust**, **Reject** — then answered `404 no pending approval`, and the
frontend swallowed the response. From the user's side the buttons simply did
nothing, with no way to dismiss the card.

Reported from a live session: a cron-injected approval (`[cron] Running: gh pr …`)
sat in the composer after the turn was stopped. Clicking Trust appeared to be
ignored.

## Root cause

Three paths resolved the approval future without marking the `permission`
message that the UI keys its approval bar off:

| Path | Behaviour |
|---|---|
| `_reject_pending_approvals` (stop / interrupt) | set the future to `rejected`, never marked the message → card returned on history reload |
| Chat runner's 2h `wait_for` timeout, and the Slack delivery-failure auto-reject branches | popped the future with no marker at all |
| `state.resolve_approval` | marked the message but left `slot._dirty` false; the periodic flush skips non-dirty slots, so the write could be lost on restart |

The turn-start sweep (`_sweep_stale_permissions`) eventually cleans these up,
which is why sending a new message unstuck it — but until then the card was
live and unanswerable.

## Fix

**Backend**
- `_reject_pending_approvals` marks the permission message `rejected` and flags
  the slot dirty.
- The chat runner marks the message in the `finally` that pops the future,
  covering both the timeout and the Slack auto-reject branches. It passes
  `only_if_pending=True` so it cannot flatten a richer decision already recorded
  by the HTTP or Slack resolver — `"trust"` / `"yolo"` render as
  *"Trusted — auto-approving future calls"* and would otherwise be downgraded to
  a bare `"approved"`. It also broadcasts `approval_resolved` so open tabs clear
  without a reload.
- `state.resolve_approval` now sets `slot._dirty` when it marks.
- `_mark_permission_resolved` gained the `only_if_pending` guard, a `bool`
  return, and a non-dict `cls` skip matching `parse_cls_meta()` /
  `_sweep_stale_permissions()`.

**Frontend**
- A 404 clears the orphaned card and shows a one-line notice explaining the
  approval expired, instead of only reaching `console.error`.
- Non-404 failures keep the bar up and say the decision could not be submitted —
  a transient server error is not evidence the request is gone, so the buttons
  stay live for a retry.
- The notice auto-dismisses after 8s so a hiccup cannot leave permanent chrome.

## Tests

- **Frontend (4 new):** 404 clears the card via both `resolveApproval` and
  `approveChatSlot`; the notice is surfaced; a 503 leaves the bar and the
  unresolved meta intact. The `../api/client` mock now exports a real `ApiError`
  class — the component narrows with `instanceof`, which a plain object stub
  would silently defeat.
- **Backend (12 new):** stop path marks every pending approval and sets
  `_dirty`; an already-answered future keeps its decision; the `only_if_pending`
  guard both writes when pending and refuses to clobber; `resolve_approval`
  flags the slot dirty; non-dict `cls` is skipped.

## Verification

All gates run locally from the worktree:

| Gate | Result |
|---|---|
| `flake8 -j1 src/ test/` | clean |
| `isort --check-only` | clean |
| `mypy src/kiro_crew/` (CI-parity venv, 1.14.1, no faiss) | 469 files, no issues |
| `npx tsc -b` | clean |
| `npx vitest run` | 374 files, 4294 passed / 3 skipped |
| `pytest -n 8` | 16,461 passed, 19 failed |

The 19 backend failures are pre-existing host-environment failures in
`test_sandbox_*.py` and `test_deploy_round30_fixes.py` — confirmed identical on
an untouched `origin/main` worktree at the same base commit (`ba3d87d6`), and in
files this change does not touch.

Not verified: the live dashboard interaction. The orphan states need a stopped
turn or a 2h timeout to reproduce by hand, so they are covered by unit
regressions rather than a manual click-through.
