### PR TITLE
ci: make Arbiter conservative on out-of-scope influence findings

### DIFF
--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -220,6 +220,23 @@ jobs:
             give a cause -> mechanism -> long-term-consequence chain, and a
             concrete suggested fix.
 
+            SCOPE TEST (apply before escalating anything). Many findings flag
+            SIDE EFFECTS on components this PR does not target. Weighing that
+            blast radius is correct and valuable — but a related influence is
+            NOT automatically a blocker. Escalate an out-of-scope /
+            adjacent-component finding ONLY IF this PR itself CREATES or WORSENS
+            the long-term cost AND it is a one-way door — i.e. merging as-is
+            makes it materially harder or costlier to fix later (a persisted
+            schema/contract, a spreading ownership boundary, or a
+            security/data-correctness regression introduced BY this diff). If
+            the concern PRE-EXISTS this PR, is independently reversible in a
+            later change, or the PR merely touches nearby code without deepening
+            the problem, DO NOT block: route it to "Suggested follow-ups" so it
+            is tracked as a new issue instead of gating this PR. When the same
+            item could plausibly be either blocked or followed-up, PREFER the
+            follow-up. Opening a new issue for later is a legitimate outcome, not
+            a failure to act.
+
             FINAL OUTPUT (authoritative — your LAST message, captured verbatim
             from the transcript; do NOT call any tool to post it and write
             nothing after the marker line). The FIRST line is machine-parsed —
@@ -237,8 +254,20 @@ jobs:
             <one line per notable sub-threshold item you deliberately did NOT
             escalate, with the reason — so the author sees the judgment>
 
-            If PASS: write exactly:
+            If PASS, write this line:
             No sub-threshold finding meets the long-term-impact bar.
+
+            Then, under EITHER verdict, if the SCOPE TEST routed any
+            related-influence / sub-threshold items to be tracked without
+            blocking, append this section LAST. It is advisory and NEVER changes
+            the verdict (the machine-parsed verdict line is always the first line
+            above, regardless of what follows):
+
+            ### Suggested follow-ups (open as issues — non-blocking)
+            <one line per related-influence / sub-threshold item worth tracking
+            but NOT worth blocking this PR (per the SCOPE TEST): what it is, why
+            it can safely wait, and where it should be fixed. Omit this heading
+            only if there are genuinely none.>
 
             End with this exact line as proof the review ran for this commit:
             [ARBITER-REVIEWED] ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem

The Long-Term Impact **Arbiter** (`.github/workflows/longterm-arbiter.yml`) is too eager to hard-block. Its influence analysis correctly notices side effects that a change ripples into *adjacent* components, but it then escalates those related-influence findings into merge blockers even when the PR never targeted those components and does not itself deepen the problem. The verdict is strictly binary (`BLOCK`/`PASS`) with no first-class "track this for later" outcome, so authors are forced to either fix out-of-scope concerns in an unrelated PR or reach for the blunt `defer-longterm` label.

## Why it matters

Over-blocking on blast-radius findings stalls otherwise-ready PRs on work that belongs in a separate, scoped change. It trains authors to slap on `defer-longterm` reflexively (eroding the signal) and conflates "this diff introduces a one-way door" with "this diff happens to touch code near a pre-existing concern." The gate should still surface side effects — that analysis is valuable — but be deliberate about which ones actually justify holding the merge.

## Fix (symptoms → root cause → change)

- **Symptom:** legitimate side-effect observations become blockers on components the PR wasn't scoped to change.
- **Root cause:** the escalate rubric had no *scope / one-way-door* test, and the output schema had no non-blocking disposition — so the model's only lever for a real influence was to escalate (→ `BLOCK`).
- **Change (prompt-only; the model stays Read-only, no new permissions/tools):**
  1. Added a **SCOPE TEST** applied before any escalation: an out-of-scope / adjacent-component finding is escalated **only if this PR itself creates or worsens the cost AND it is a one-way door** (persisted schema/contract, spreading ownership boundary, or a security/data-correctness regression introduced *by this diff*). Pre-existing, independently-reversible, or merely-nearby concerns are routed to follow-ups instead of blocking; ties prefer the follow-up. Blast-radius weighing is explicitly retained as valuable.
  2. Added a **`### Suggested follow-ups (open as issues — non-blocking)`** section so routed items are captured as actionable, trackable issues rather than lost. It is emitted **under both verdicts** and always appended **last**, so the machine-parsed `Arbiter-Verdict:` line (always first) is unaffected; the section is explicitly advisory and never changes the verdict. This closes the gap the reviewers flagged where a clean `PASS` — the exact case the SCOPE TEST is designed to produce — would otherwise discard the routed follow-ups.

No change to the gating mechanics, check-run wiring, fail-closed/`waiting` logic, `defer-longterm` override, or verdict parsing (`Arbiter-Verdict: <BLOCK|PASS>` is untouched and remains the first line).

## Tests

N/A — the workflow has no automated test harness; the change is entirely within the model prompt (a YAML block scalar). Verified the workflow YAML still parses cleanly (`yaml.safe_load`). Behavior is exercised by the Arbiter's own runs on subsequent PRs.

## Manual verification

- `yaml.safe_load` of the edited workflow succeeds (no structural break to the block scalar).
- Confirmed `### Suggested follow-ups` is now reachable on both `BLOCK` and `PASS`, and the `Arbiter-Verdict:` header remains the first line of the final message (the only machine-parsed token).
- Diff is scoped to the prompt text only — no logic, permission, or parse changes.
