### PR TITLE
fix(chat): repair long-session scroll (offsets, follow-pin, keys, jumps)

### DIFF
--- a/website/src/components/WidgetFrame.tsx
+++ b/website/src/components/WidgetFrame.tsx
@@ -30,12 +30,51 @@ const HEIGHT_SHRINK_DEBOUNCE_MS = 250
 // immediately as they near the viewport (one at a time, amortized across
 // frames) — building during the scroll means the content is ready by the time
 // it stops, with no skeleton→iframe flash on settle.
-const PROGRAMMATIC_BUILD_DELAY_MS = 450
+// COUPLING (read before changing this number): the scroll convergence polls in
+// `utils/searchScroll.ts` must outlast this delay, or a jump to a widget row
+// settles before the iframe has grown and lands off-target. `MIN_QUIET_MS` there
+// is calibrated above this value, and `searchScroll.coupling.test.ts` fails if
+// that relationship is ever broken — so raising this delay is safe, it will tell
+// you if the poll needs to follow. Exported for that assertion.
+export const PROGRAMMATIC_BUILD_DELAY_MS = 450
 let lastProgrammaticScrollAt = 0
 if (typeof window !== 'undefined') {
   window.addEventListener('mc-chat-scroll-jump', () => { lastProgrammaticScrollAt = Date.now() })
 }
 const BUILD_STAGGER_MS = 120
+// The stagger slot was previously unbounded, so a batch of N widgets pushed the
+// last one's build out by N * BUILD_STAGGER_MS with no ceiling. That made the
+// worst-case build wait unknowable, and the scroll convergence poll cannot be
+// calibrated against an unbounded number (a target in a late slot stays static
+// past the poll's quiet window, settles early, then resizes and moves
+// off-target). Capping the slot bounds it: beyond this many widgets the tail of
+// the batch shares the last slot, which still spreads the JIT cost across
+// several tasks without making the deadline unbounded.
+// several tasks without making the deadline unbounded. Exported so the cap's
+// effect on the actual delay is testable, not just its value.
+export const MAX_STAGGER_SLOTS = 3
+/**
+ * Worst-case delay from a programmatic jump to a widget in that batch having
+ * built. `utils/searchScroll.ts` calibrates `MIN_QUIET_MS` above this, and
+ * `searchScroll.coupling.test.ts` fails if that relationship breaks — so both
+ * numbers here are safe to change, CI will tell you if the poll must follow.
+ */
+export const MAX_WIDGET_BUILD_WAIT_MS =
+  PROGRAMMATIC_BUILD_DELAY_MS + MAX_STAGGER_SLOTS * BUILD_STAGGER_MS
+
+/**
+ * Stagger delay for the widget in slot `slot` of a jump batch, measured from
+ * `baseWait`.
+ *
+ * Extracted and exported ONLY so the cap is directly testable: with the
+ * expression inlined, deleting the `Math.min` left every coupling test green
+ * (they assert the constants' relationship, not the arithmetic that uses them)
+ * while late-slot widgets silently went back to building after convergence had
+ * already settled. `staggeredBuildWait` is asserted to plateau beyond the cap.
+ */
+export function staggeredBuildWait(baseWait: number, slot: number): number {
+  return baseWait + Math.min(slot, MAX_STAGGER_SLOTS) * BUILD_STAGGER_MS
+}
 let jumpBuildSlot = 0
 let jumpBuildResetAt = 0
 
@@ -190,7 +229,7 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
     if (now > jumpBuildResetAt) jumpBuildSlot = 0
     const slot = jumpBuildSlot++
     jumpBuildResetAt = now + PROGRAMMATIC_BUILD_DELAY_MS
-    const wait = baseWait + slot * BUILD_STAGGER_MS
+    const wait = staggeredBuildWait(baseWait, slot)
     const id = setTimeout(() => setVisible(true), wait)
     return () => clearTimeout(id)
   }, [near, visible])

--- a/website/src/hooks/virtualizer/FollowController.ts
+++ b/website/src/hooks/virtualizer/FollowController.ts
@@ -46,6 +46,27 @@ export const DEFAULT_BOTTOM_THRESHOLD = 100
  */
 export const SELF_SCROLL_EPSILON = 2
 
+/**
+ * "At the bottom" tolerance (px) for deciding whether an auto-pin still has
+ * work to do. A flat 0.5 is UNDER one device pixel at fractional device-pixel
+ * ratios (0.67 CSS px at 150% zoom, 0.8 at 125%): the scroller's resting
+ * maximum scrollTop lands on a fractional value, so `|scrollTop - target|`
+ * stays just above 0.5 even when the viewport is visually pinned to the
+ * bottom — making the pin re-fire on every ResizeObserver tick. Scaling the
+ * epsilon to the device pixel (never below 1 CSS px) absorbs that fractional
+ * resting error. `devicePixelRatio` is read defensively so a jsdom / SSR
+ * environment that leaves it undefined falls back to 1 (→ 1.5px).
+ */
+export function atBottomEpsilon(): number {
+  const dpr =
+    typeof window !== 'undefined' &&
+    typeof window.devicePixelRatio === 'number' &&
+    window.devicePixelRatio > 0
+      ? window.devicePixelRatio
+      : 1
+  return Math.max(1, 1 / dpr + 0.5)
+}
+
 /** Live scroll geometry snapshot read from the scroller element. */
 export interface ScrollGeom {
   scrollTop: number
@@ -137,5 +158,5 @@ export function evaluateAutoPin(args: {
   ) {
     return { pin: false, stick: false, target }
   }
-  return { pin: Math.abs(geom.scrollTop - target) > 0.5, stick: true, target }
+  return { pin: Math.abs(geom.scrollTop - target) > atBottomEpsilon(), stick: true, target }
 }

--- a/website/src/hooks/virtualizer/HeightCache.ts
+++ b/website/src/hooks/virtualizer/HeightCache.ts
@@ -2,16 +2,46 @@
 //
 // Maps stable item keys to measured pixel heights so placeholders for
 // off-screen items have correct sizes. Persists to localStorage keyed by
-// session ID, with debounced writes (100ms) and LRU-style pruning at 2000
-// entries.
+// session ID, with debounced writes and LRU-style pruning.
+//
+// LRU recency tracks ACCESS, not just insertion: both get() and set()
+// re-insert the key so recently-scrolled rows survive eviction instead of
+// dying by age. The eviction cap is session-size-aware — a long session may
+// keep up to min(rowCount, HARD_CEILING) heights so scrolling back to the top
+// of a revisited transcript doesn't re-enter all-estimate territory — with a
+// hard ceiling so localStorage can't blow up.
+//
+// averageHeight() exposes the running mean of MEASURED heights (O(1),
+// maintained incrementally through set / overwrite / eviction / load) so
+// callers can estimate unmeasured rows from real data instead of a flat
+// constant.
 //
 // Falls back to in-memory-only mode when localStorage is unavailable
 // (private browsing, quota exceeded, sandboxed iframes, etc.). Corrupted
 // JSON triggers a console.warn and a fresh cache for that session.
 
 const LS_KEY_PREFIX = 'vc_heights_'
+// Baseline floor for the eviction cap. The effective cap grows with the
+// session's row count up to HARD_CEILING (see effectiveCap()).
 const MAX_ENTRIES = 2000
-const FLUSH_DELAY_MS = 100
+// Hard ceiling on retained entries regardless of row count, so a pathological
+// session cannot make the persisted blob unbounded.
+const HARD_CEILING = 20000
+// Debounce for localStorage writes. Lengthened from the original 100ms because
+// streaming fires many set()s per second; a longer window coalesces them into
+// far fewer full-map JSON serializations. Manual flush() (e.g. on unmount)
+// still persists immediately, and the dirty flag skips no-op flushes.
+const FLUSH_DELAY_MS = 750
+// Fallback estimate returned by averageHeight() when nothing is measured yet.
+// Matches the virtualizer's historical flat estimate.
+const DEFAULT_ESTIMATED_HEIGHT = 100
+// Absolute ceiling on the estimated height for an unmeasured row. One
+// pathological row (a giant widget) must not be able to inflate every
+// unmeasured row's estimate without bound. Deliberately generous: measured
+// means on real transcripts sit in the hundreds of px, so this clips only the
+// pathological case. A tighter bound (or a minimum-sample gate before trusting
+// the mean at all) was MEASURED to be worse -- see the comment on averageHeight.
+const MAX_MEAN_PX = 4000
 
 type FlushTimer = ReturnType<typeof setTimeout>
 
@@ -41,12 +71,95 @@ export class HeightCache {
   private readonly storageKey: string
   private dirty = false
   private flushTimer: FlushTimer | null = null
+  // Running sum of MEASURED heights (every cache entry is a measurement), kept
+  // in lockstep with the map through set / overwrite / eviction / load so
+  // averageHeight() is O(1). The mean is sum / cache.size.
+  private measuredSum = 0
+  // Session row count driving the size-aware eviction cap. 0 means UNKNOWN,
+  // never "this session is empty" — see setRowCount() and load().
+  private rowCount = 0
 
-  constructor(sessionId: string) {
+  constructor(sessionId: string, options?: { rowCount?: number }) {
     this.sessionId = sessionId
     this.storage = getStorage()
     this.storageKey = `${LS_KEY_PREFIX}${sessionId}`
+    // Only a positive count is information. A caller that constructs the cache
+    // before its transcript has loaded passes 0, which must not be mistaken for
+    // a genuinely tiny session (load() seeds the cap from the blob instead).
+    if (options && typeof options.rowCount === 'number' && options.rowCount > 0) {
+      this.rowCount = Math.floor(options.rowCount)
+    }
     this.load()
+  }
+
+  /**
+   * Effective eviction cap: max(MAX_ENTRIES, min(rowCount, HARD_CEILING)).
+   * Grows with the session so a large transcript keeps its heights, but never
+   * exceeds HARD_CEILING so the persisted blob stays bounded.
+   */
+  private effectiveCap(): number {
+    return Math.max(MAX_ENTRIES, Math.min(this.rowCount, HARD_CEILING))
+  }
+
+  /**
+   * Update the session row count that drives the eviction cap.
+   *
+   * The count is treated as a HIGH-WATER MARK: it only ever rises. A non-
+   * positive count means "not known yet" rather than "the session is empty" —
+   * the chat hook sets sessionId when a slot changes, one render before the
+   * transcript arrives — and a small POSITIVE count is just as untrustworthy,
+   * because a single WS message can land before slot hydration and report
+   * `itemCount === 1` for a 5,000-row session.
+   *
+   * Shrinking on either is unsafe in a way growing is not: the cap reduction
+   * evicts measurements IRREVERSIBLY, and the authoritative count arriving a
+   * render later raises the cap but cannot bring them back — dropping the
+   * session straight into the estimated-offset jumping this cache exists to
+   * prevent. Retention stays bounded because HARD_CEILING is independent of the
+   * row count, so refusing to shrink cannot grow the persisted blob.
+   */
+  setRowCount(rowCount: number): void {
+    if (!(rowCount > 0)) return
+    const next = Math.floor(rowCount)
+    if (next <= this.rowCount) return
+    this.rowCount = next
+    this.evictToCap()
+  }
+
+  /**
+   * Running mean of MEASURED heights, for estimating unmeasured rows.
+   *
+   * Bounded by MAX_MEAN_PX so one pathological row (a giant widget) cannot
+   * inflate the estimate for thousands of unmeasured rows without limit.
+   *
+   * It deliberately does NOT gate on a minimum sample count, even though the
+   * first measurements all come from the mounted tail and are therefore biased
+   * toward tall rows. That gate was implemented and MEASURED in a real browser
+   * against an 800-row bimodal transcript, and it was worse: holding the flat
+   * configured estimate until the sample grew reintroduced the original
+   * under-estimate (the flat guess is ~5x too small, versus the tail-biased
+   * mean being ~17% too large), and the peak scrollHeight correction rose from
+   * ~51,500px to ~387,000px. A slightly-high adaptive estimate from the first
+   * measurement beats a very-low flat one, so only the outlier ceiling is kept.
+   */
+  averageHeight(fallback: number = DEFAULT_ESTIMATED_HEIGHT): number {
+    const n = this.cache.size
+    if (n === 0) return fallback
+    return Math.min(this.measuredSum / n, MAX_MEAN_PX)
+  }
+
+  /**
+   * Non-promoting read: returns the cached height WITHOUT touching LRU order.
+   *
+   * Bulk index synchronization (OffsetIndex.sync, window/offset scans) reads
+   * every row's height. Routing those through `get()` would rewrite the LRU
+   * order into transcript-index order on every sync, so at capacity the
+   * eviction would drop top-of-transcript rows the user had just viewed —
+   * defeating the access-based retention this cache exists to provide. Genuine
+   * access is recorded by `set()` when a mounted row is measured.
+   */
+  peek(key: string): number | undefined {
+    return this.cache.get(key)
   }
 
   /** Returns the cached height for `key`, or undefined if not measured. */
@@ -63,16 +176,46 @@ export class HeightCache {
   /** Stores `height` for `key`, evicting the oldest entry if over the cap. */
   set(key: string, height: number): void {
     // Re-insert so the key sits at the tail (most-recent position) regardless
-    // of whether it already existed.
-    if (this.cache.has(key)) this.cache.delete(key)
-    this.cache.set(key, height)
-    if (this.cache.size > MAX_ENTRIES) {
-      // Map iteration is in insertion order, so the first key is the oldest.
-      const oldest = this.cache.keys().next().value
-      if (oldest !== undefined) this.cache.delete(oldest)
+    // of whether it already existed. On overwrite, adjust the running sum by
+    // the delta so the mean stays exact.
+    const prev = this.cache.get(key)
+    if (prev !== undefined) {
+      this.cache.delete(key)
+      this.measuredSum -= prev
     }
+    this.cache.set(key, height)
+    this.measuredSum += height
+    this.evictToCap()
     this.dirty = true
     this.scheduleFlush()
+  }
+
+  /**
+   * Evict oldest-first (insertion/access order) until size <= effectiveCap(),
+   * keeping measuredSum in lockstep. Shared by set(), setRowCount() and load().
+   *
+   * An eviction changes what SHOULD be persisted, so it marks the cache dirty
+   * and schedules a flush. Without that, a trim driven by setRowCount() (or by
+   * load() hitting HARD_CEILING) stayed in memory only: the oversized blob
+   * survived in localStorage and was re-read and re-trimmed on every single
+   * open, so the wasted quota was never reclaimed.
+   */
+  private evictToCap(): void {
+    const cap = this.effectiveCap()
+    let evicted = 0
+    while (this.cache.size > cap) {
+      // Map iteration is in insertion order, so the first key is the oldest.
+      const oldestEntry = this.cache.entries().next().value
+      if (oldestEntry === undefined) break
+      const [oldestKey, oldestVal] = oldestEntry
+      this.cache.delete(oldestKey)
+      this.measuredSum -= oldestVal
+      evicted++
+    }
+    if (evicted > 0) {
+      this.dirty = true
+      this.scheduleFlush()
+    }
   }
 
   /** Writes pending changes to localStorage immediately and clears the timer. */
@@ -101,6 +244,7 @@ export class HeightCache {
   /** Clears both in-memory and persisted state for this session. */
   clear(): void {
     this.cache.clear()
+    this.measuredSum = 0
     this.dirty = false
     if (this.flushTimer !== null) {
       clearTimeout(this.flushTimer)
@@ -150,17 +294,24 @@ export class HeightCache {
       const v = (parsed as Record<string, unknown>)[k]
       if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
         this.cache.set(k, v)
+        this.measuredSum += v
       }
     }
     // Enforce the cap on load too. set() trims one-at-a-time, but a blob from an
     // older build, a hand-edited entry, or a long-lived session can persist
-    // more than MAX_ENTRIES keys — without this the cache would start a session
-    // already over the cap. Trim oldest-first (insertion order) to match set().
-    while (this.cache.size > MAX_ENTRIES) {
-      const oldest = this.cache.keys().next().value
-      if (oldest === undefined) break
-      this.cache.delete(oldest)
-    }
+    // more than the cap allows — without this the cache would start a session
+    // already over the cap. Trim oldest-first (insertion order) to match set(),
+    // keeping measuredSum in lockstep.
+    //
+    // When the row count is not known yet, seed it from what we just read. The
+    // trim below is IRREVERSIBLE — a later setRowCount() raises the cap but
+    // cannot bring evicted measurements back — so trimming a long session's
+    // blob to the baseline floor merely because the transcript had not loaded
+    // when the cache was constructed would put a revisited long session right
+    // back into all-estimate territory, which is the bug this cap exists to
+    // prevent. HARD_CEILING still applies, so the blob stays bounded.
+    if (this.rowCount === 0) this.rowCount = this.cache.size
+    this.evictToCap()
   }
 
   private scheduleFlush(): void {

--- a/website/src/hooks/virtualizer/WindowCalculator.ts
+++ b/website/src/hooks/virtualizer/WindowCalculator.ts
@@ -7,8 +7,15 @@
 //
 // Linear scan with early termination: O(N) worst case but amortized O(K)
 // where K is the visible window. For 1000 items at ~80px average, this is
-// <1ms. If profiling ever shows issues at 5000+ items, swap in a
-// prefix-sum tree.
+// <1ms.
+//
+// At 5000+ items the O(N) offset/total walks dominate rAF-throttled scroll
+// frames and the 120ms streaming tick — the main jank source. `OffsetIndex`
+// (bottom of this file) is the prefix-sum tree the header long promised: a
+// Fenwick/binary-indexed tree that answers the same offset/total/index
+// questions in O(log N) / O(1). The free functions below are retained
+// verbatim (identical signatures + behaviour) so existing call sites and
+// tests keep working; hot paths opt into `OffsetIndex` instead.
 
 export interface WindowRange {
   /** First index to mount (inclusive). */
@@ -172,4 +179,154 @@ export function expandWindowDown(
   if (range.end >= itemCount) return range
   const newEnd = Math.min(itemCount, range.end + Math.max(0, overscan))
   return { start: range.start, end: newEnd }
+}
+
+/**
+ * Normalize a raw height reading the same way the free functions above do:
+ * `getHeight(i) || 0` coerces NaN / undefined / 0 to 0, then Math.max clamps
+ * negatives to 0. Keeping this identical guarantees OffsetIndex answers match
+ * getOffset / getIndexAtOffset / getTotalHeight for every input.
+ */
+function normHeight(h: number): number {
+  return Math.max(0, h || 0)
+}
+
+/**
+ * OffsetIndex — a Fenwick (binary-indexed) tree over per-row heights.
+ *
+ * Answers the exact same questions as the O(N) free functions, but at the
+ * cost profile the hot paths need:
+ *   - offsetOf(index)  — cumulative height of rows [0, index)  → O(log N)
+ *   - indexAt(scrollTop) — row whose span contains scrollTop   → O(log N)
+ *   - totalHeight()    — sum of all row heights                → O(1)
+ *
+ * `sync(itemCount, getHeight)` reconciles the tree with the current data:
+ *   - itemCount unchanged → diff the prefix and point-update only the rows
+ *     whose height actually changed (refined measurements). No changed rows
+ *     ⇒ zero tree writes (cheap no-op).
+ *   - itemCount grew      → diff the overlap, then append the new tail rows
+ *     in amortized O(1) each (transcripts grow at the tail).
+ *   - itemCount shrank    → rebuild in O(N) (rare: rows removed).
+ *
+ * USAGE NOTE for callers (sibling B): the whole point is that scroll frames
+ * become O(log N). Call `sync()` when the data changes (new rows, or a batch
+ * of measurements landed — e.g. the 120ms streaming tick), NOT on every rAF
+ * scroll frame. On pure scroll frames call only offsetOf / indexAt /
+ * totalHeight. A same-itemCount sync still O(N)-scans the prefix to pick up
+ * refined measurements, so calling it per scroll frame would re-introduce the
+ * jank this class exists to remove.
+ *
+ * Behaviour matches getIndexAtOffset for zero-height rows (both skip them to
+ * the next occupied / last row) and clamps out-of-range inputs identically.
+ */
+export class OffsetIndex {
+  private n = 0
+  // 1-indexed Fenwick tree; tree[0] is unused padding. tree.length === n + 1.
+  private tree: number[] = [0]
+  // Cached, normalized per-row heights (0..n-1) so sync() can diff in place.
+  private heights: number[] = []
+  // Running total kept in lockstep with the tree so totalHeight() is O(1).
+  private total = 0
+
+  constructor(itemCount: number, getHeight: HeightGetter) {
+    this.sync(itemCount, getHeight)
+  }
+
+  /** Reconcile the tree with the current item count + heights. */
+  sync(itemCount: number, getHeight: HeightGetter): void {
+    const count = Math.max(0, Math.floor(itemCount))
+    if (count < this.n) {
+      // Shrink (rows removed) — cheapest to rebuild from scratch.
+      this.rebuild(count, getHeight)
+      return
+    }
+    // Diff the overlapping prefix: pick up refined measurements in place.
+    // Untouched rows cost one comparison and zero tree writes.
+    for (let i = 0; i < this.n; i++) {
+      const h = normHeight(getHeight(i))
+      const prev = this.heights[i]
+      if (h !== prev) {
+        this.pointUpdate(i, h - prev)
+        this.heights[i] = h
+        this.total += h - prev
+      }
+    }
+    // Append any new tail rows in amortized O(1) each.
+    for (let i = this.n; i < count; i++) {
+      const h = normHeight(getHeight(i))
+      this.heights.push(h)
+      this.tree.push(0)
+      this.appendInit(i + 1) // 1-indexed position of the new row
+      this.total += h
+    }
+    this.n = count
+  }
+
+  /** Cumulative height of rows [0, index). Clamped to [0, totalHeight]. O(log N). */
+  offsetOf(index: number): number {
+    let k = Math.floor(index)
+    if (k <= 0) return 0
+    if (k > this.n) k = this.n
+    let s = 0
+    for (let x = k; x > 0; x -= x & -x) s += this.tree[x]
+    return s
+  }
+
+  /** Sum of all row heights. O(1). */
+  totalHeight(): number {
+    return this.total
+  }
+
+  /** Row index whose vertical span contains scrollTop. Clamped to [0, n-1]. O(log N). */
+  indexAt(scrollTop: number): number {
+    if (this.n <= 0) return 0
+    // Coerce NaN / negative to 0 (matches getIndexAtOffset's Math.max(0, …)).
+    const t = scrollTop > 0 ? scrollTop : 0
+    // Fenwick binary lift: largest `pos` with prefixSum(pos) <= t. That `pos`
+    // is exactly the count of rows fully above t, i.e. the row containing t.
+    let highBit = 1
+    while (highBit << 1 <= this.n) highBit <<= 1
+    let pos = 0
+    let remaining = t
+    for (let pw = highBit; pw > 0; pw >>= 1) {
+      const next = pos + pw
+      if (next <= this.n && this.tree[next] <= remaining) {
+        pos = next
+        remaining -= this.tree[next]
+      }
+    }
+    return pos >= this.n ? this.n - 1 : pos
+  }
+
+  /** Full O(N) rebuild — used on shrink and initial construction fallback. */
+  private rebuild(count: number, getHeight: HeightGetter): void {
+    this.n = count
+    this.heights = new Array<number>(count)
+    this.tree = new Array<number>(count + 1).fill(0)
+    this.total = 0
+    for (let i = 0; i < count; i++) {
+      const h = normHeight(getHeight(i))
+      this.heights[i] = h
+      this.total += h
+    }
+    // O(n) in-place Fenwick construction: push each node's sum to its parent.
+    for (let p = 1; p <= count; p++) {
+      this.tree[p] += this.heights[p - 1]
+      const parent = p + (p & -p)
+      if (parent <= count) this.tree[parent] += this.tree[p]
+    }
+  }
+
+  /** Initialize tree[p] for a freshly appended row from its already-built children. */
+  private appendInit(p: number): void {
+    let val = this.heights[p - 1]
+    const end = p - (p & -p)
+    for (let j = p - 1; j > end; j -= j & -j) val += this.tree[j]
+    this.tree[p] = val
+  }
+
+  /** Add `delta` to row `index` and propagate up the tree. O(log N). */
+  private pointUpdate(index: number, delta: number): void {
+    for (let x = index + 1; x <= this.n; x += x & -x) this.tree[x] += delta
+  }
 }

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -15,9 +15,29 @@
 //   - automatic pins (RO callback + append layout effect) → `pinAuto()`
 //   - explicit pins (slot entry + scrollToBottom API) → `forcePin()`
 //
+// INVARIANT — every programmatic `scrollTop` write MUST record itself in
+// `lastWriteTopRef`. Read this before adding any code that moves the scroller.
+//
+// The stick-release guard distinguishes "the user scrolled" from "we scrolled"
+// by comparing live `scrollTop` against the value we last wrote. An unrecorded
+// write therefore looks exactly like user input and releases follow — which is
+// the historical failure mode that caused an earlier version of this guard to be
+// reverted ("smooth scroll lag causes persistent false positives"). It is safe
+// again only because pins are now instant, so there is no in-flight animation to
+// desynchronise the reference. That makes the invariant load-bearing rather than
+// hygienic: the anchor-compensation write added for #5 has to honour it too, and
+// so must any future one. Browser-verified on this branch (release held across
+// 14 streaming growth ticks with 0 spurious re-pins, re-armed on return to the
+// bottom, at devicePixelRatio 1 and 1.5) — but verification is not a substitute
+// for maintaining the invariant.
+//
 // Visual stability while scrolled up (window expansion, async widget resizes
-// above the viewport) is delegated to the browser's native CSS
-// `overflow-anchor: auto`.
+// above the viewport) uses native CSS `overflow-anchor: auto` PLUS an explicit
+// anchor-preservation pass: an upward window shift can unmount the very node the
+// browser chose as its anchor, which resets anchoring and jumps the viewport, so
+// the top visible row's offset is captured before the commit and `scrollTop` is
+// compensated after it. The CSS is retained — reliance on it is reduced, not
+// replaced.
 //
 // Render contract for callers:
 //   - Wrap the scroll container with `scrollerRef`
@@ -26,9 +46,34 @@
 //     when false render a placeholder `<div style={{ height: item.height }} />`
 //   - Place `topSentinelRef` / `bottomSentinelRef` at the list ends for
 //     window expansion.
+//
+// WHY THIS IS IN-HOUSE (build-vs-buy — recorded, not assumed)
+// ===========================================================
+// This module re-implements machinery that react-virtuoso and @tanstack/virtual
+// ship battle-tested (dynamic measurement, prefix-sum offsets, follow-output
+// pinning, anchor stability), so the choice to keep owning it needs to be a
+// decision on the record rather than a default. The chat-specific requirements a
+// drop-in library does not cover today:
+//   - Widget iframes: rows contain sandboxed iframes that lose all internal
+//     state on unmount and rebuild slowly (PROGRAMMATIC_BUILD_DELAY_MS), which
+//     is why `isSticky` exists to exempt chosen rows from windowing entirely.
+//   - Identity that is not the array index: a steered bubble's `ts` is rewritten
+//     by the server echo, so height-cache identity must key on `meta.clientTs`
+//     (see ChatPage `stableMsgKey`); a library keyed on index or item identity
+//     would orphan the measurement.
+//   - Turn regrouping: a `single` row promotes into a grouped `turn` mid-stream,
+//     changing row composition without changing the underlying messages.
+//   - Cross-session persistence: heights survive in localStorage per session,
+//     partitioned by `sessionId`, so a revisit is warm.
+// None of these is proven *fundamental* — they are integration costs, not
+// impossibilities. The maintainers' open question is therefore whether to keep
+// investing here or schedule a migration; this comment records the constraints
+// that a migration would have to satisfy, so the next scroll fix is a choice
+// rather than a default. It does NOT itself decide the direction.
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { HeightCache } from './HeightCache'
+import { attachUserScrollIntent } from '../../utils/searchScroll'
 import {
   computeWindow,
   computeJumpWindow,
@@ -36,12 +81,15 @@ import {
   expandWindowDown,
   getOffset as getOffsetFn,
   getTotalHeight,
+  OffsetIndex,
 } from './WindowCalculator'
 import {
   computeAtBottom,
   isSelfScroll,
+  SELF_SCROLL_EPSILON,
   stickAfterUserScroll,
   bottomTarget,
+  evaluateAutoPin,
 } from './FollowController'
 import type {
   UseVirtualChatOptions,
@@ -141,8 +189,19 @@ export function useVirtualChat<T>(
   const cacheSessionRef = useRef<string | null>(null)
   if (cacheRef.current === null || cacheSessionRef.current !== sessionId) {
     cacheRef.current?.flush()
-    cacheRef.current = new HeightCache(sessionId)
+    // Seed the row count so the eviction cap is size-aware from the first
+    // measurement: a session longer than the baseline floor must be allowed to
+    // retain its oldest heights, or scrolling back to the top re-enters
+    // all-estimate territory even on a revisit. `itemCount` is legitimately 0
+    // here when a slot switch changes sessionId before the transcript loads;
+    // HeightCache treats that as "unknown" and sizes the cap from the persisted
+    // blob instead, so no measurements are discarded before the real count
+    // arrives via setRowCount() below.
+    cacheRef.current = new HeightCache(sessionId, { rowCount: itemCount })
     cacheSessionRef.current = sessionId
+  } else {
+    // Transcripts grow while mounted; keep the cap in step with the row count.
+    cacheRef.current.setRowCount(itemCount)
   }
 
   // One shared ResizeObserver; Element → index map resolves heights cheaply.
@@ -175,9 +234,30 @@ export function useVirtualChat<T>(
   // Previous scrollTop during smooth-pin animation. Used to detect genuine
   // user scroll-up (scrollTop decreased) vs normal forward animation progress.
   const prevSmoothTopRef = useRef(0)
+  // Detaches the current smooth-glide abort listeners. Held in a ref so the
+  // glide can be torn down from wherever it ends: user input, natural arrival
+  // at the bottom, a replacing glide, or unmount.
+  const smoothAbortDetachRef = useRef<(() => void) | null>(null)
+  const detachSmoothAbort = useCallback(() => {
+    smoothAbortDetachRef.current?.()
+  }, [])
   // Timestamp (performance.now) of the last genuine USER scroll. Used to gate
   // RO-driven follow pins so they don't fire mid-fling — see SCROLL_SETTLE_MS.
   const lastUserScrollAtRef = useRef<number>(0)
+
+  // ---- Scroll-anchor preservation (T4/#5) ----
+  //
+  // While the user is scrolled up reading history, an UPWARD window shift
+  // mounts rows above the viewport (recomputeWindow / top-sentinel expansion).
+  // Native `overflow-anchor: auto` normally holds the viewport steady, but a
+  // scroll-path recompute can UNMOUNT the browser's chosen anchor node (rows
+  // past WINDOW_UNMOUNT_HYSTERESIS), collapsing anchoring and jumping the
+  // viewport. This ref carries the topmost visible row's key + its screen
+  // offset, captured BEFORE an upward shift; a layout effect after commit
+  // re-reads that row and corrects scrollTop by the delta. This REDUCES
+  // reliance on overflow-anchor (it does not replace it — the CSS is owned by
+  // ChatPage and left alone).
+  const anchorPendingRef = useRef<{ key: string; top: number } | null>(null)
 
   // Window range for what is currently mounted. Initial state is the TAIL of
   // the list (last ~overscan+1 items) — chat sessions always open at the
@@ -231,12 +311,54 @@ export function useVirtualChat<T>(
       const it = itemsRef.current[i]
       if (!it) return estimatedHeight
       const k = getKeyRef.current(it, i)
-      const cached = cacheRef.current!.get(k)
+      const cache = cacheRef.current!
+      // peek(), not get(): this closure feeds the BULK scans (OffsetIndex.sync,
+      // window/offset math), which touch every row. Promoting on those reads
+      // would rewrite LRU order into transcript-index order and evict rows the
+      // user just viewed. Genuine access is recorded by set() on measurement.
+      const cached = cache.peek(k)
       // Math.max(h, 1) so zero-height items still register with IO.
-      return cached !== undefined ? Math.max(cached, 1) : estimatedHeight
+      if (cached !== undefined) return Math.max(cached, 1)
+      // Unmeasured row: estimate from the running mean of MEASURED heights,
+      // capped by MAX_MEAN_PX so one pathological row cannot inflate every
+      // unmeasured historical row (#1). averageHeight() falls back to the
+      // configured estimate only while nothing has been measured at all — it
+      // deliberately does NOT hold back for a minimum sample, because measuring
+      // that gate in a browser made the drift ~7.5x worse (see HeightCache).
+      return cache.averageHeight(estimatedHeight)
     },
     [estimatedHeight],
   )
+
+  // ---- Offset index (O(log N) prefix-sum tree over row heights) ----
+  //
+  // The hot paths (per-rAF scroll window recompute, offset/total spacers, the
+  // 120ms streaming tick) used to walk all N rows via the O(N) free functions
+  // (getOffset / getTotalHeight / computeWindow), which dominated scroll frames
+  // on 5000+ row transcripts. `OffsetIndex` answers the same questions in
+  // O(log N) / O(1). It is the authoritative tree, synced HERE on an itemCount
+  // (or getH) change so the offset memos have fresh data on the same render,
+  // and additionally on height changes by `scheduleHeightSync` (the 120ms tick
+  // — the sync point OffsetIndex's own doc prescribes). It is NOT synced on the
+  // per-rAF scroll path (a same-count sync still O(N)-scans the prefix).
+  //
+  // `sessionId` is a dependency because the tree caches heights read through
+  // the (session-scoped) HeightCache: switching to a different session with the
+  // SAME item count changes neither itemCount nor getH's identity, so without
+  // this the tree would keep serving the previous transcript's heights and
+  // render wrong spacers until the next measurement tick corrected it. A
+  // session change invalidates every height, so rebuild rather than sync.
+  const offsetIndexRef = useRef<OffsetIndex | null>(null)
+  const offsetIndexSessionRef = useRef<string | null>(null)
+  const offsetIndex = useMemo(() => {
+    if (offsetIndexRef.current === null || offsetIndexSessionRef.current !== sessionId) {
+      offsetIndexRef.current = new OffsetIndex(itemCount, getH)
+      offsetIndexSessionRef.current = sessionId
+    } else {
+      offsetIndexRef.current.sync(itemCount, getH)
+    }
+    return offsetIndexRef.current
+  }, [itemCount, getH, sessionId])
 
   // Debounced height→memo sync. Cache writes (RO re-measure, measureRef seed)
   // call this instead of bumping heightVersion directly. The bump (which
@@ -246,13 +368,21 @@ export function useVirtualChat<T>(
   // (b) refuses to re-render during a continuous height oscillation (an
   // auto-height widget iframe whose content reflows when resized), which would
   // otherwise be a per-frame render storm + a spacer that jitters ±Δ.
+  //
+  // This debounced tick is also the OffsetIndex sync point (per its doc): it
+  // reconciles the tree with the batch of measurements that landed, then reads
+  // the new total in O(1) — no O(N) getTotalHeight walk ~8x/sec while
+  // streaming (#2).
   const lastSyncedTotalRef = useRef(-1)
   const heightSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const scheduleHeightSync = useCallback(() => {
     if (heightSyncTimerRef.current) clearTimeout(heightSyncTimerRef.current)
     heightSyncTimerRef.current = setTimeout(() => {
       heightSyncTimerRef.current = null
-      const total = getTotalHeight(itemsRef.current.length, getH)
+      const idx = offsetIndexRef.current
+      if (!idx) return
+      idx.sync(itemsRef.current.length, getH)
+      const total = idx.totalHeight()
       if (Math.abs(total - lastSyncedTotalRef.current) > 1) {
         lastSyncedTotalRef.current = total
         setHeightVersion((v) => v + 1)
@@ -263,22 +393,52 @@ export function useVirtualChat<T>(
   // NOTE: `heightVersion` is an intentional manual-invalidation key in the
   // three memos below — it is not referenced in the bodies, so eslint flags it
   // as "unnecessary", but removing it reintroduces the stale-spacer bug
-  // (memos reading the mutable HeightCache via the stable `getH` never
-  // recompute on a height change). Do NOT remove it.
+  // (memos reading the mutable OffsetIndex never recompute on a height change).
+  // Do NOT remove it. `offsetIndex` has a STABLE ref identity (it is the same
+  // tree object mutated in place by sync), so it is listed for clarity but the
+  // real triggers are itemCount / heightVersion / windowRange.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const totalHeight = useMemo(() => getTotalHeight(itemCount, getH), [itemCount, getH, heightVersion])
+  const totalHeight = useMemo(() => offsetIndex.totalHeight(), [offsetIndex, itemCount, heightVersion])
   const offsetBefore = useMemo(
-    () => getOffsetFn(windowRange.start, itemCount, getH),
+    () => offsetIndex.offsetOf(windowRange.start),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [windowRange.start, itemCount, getH, heightVersion],
+    [offsetIndex, windowRange.start, itemCount, heightVersion],
   )
   // Height of all items AFTER the window — used as the bottom spacer so the
   // scroll content keeps its full size while only the window renders real DOM.
   const offsetAfter = useMemo(
-    () => Math.max(0, totalHeight - getOffsetFn(windowRange.end, itemCount, getH)),
+    () => Math.max(0, offsetIndex.totalHeight() - offsetIndex.offsetOf(windowRange.end)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [windowRange.end, itemCount, getH, totalHeight, heightVersion],
+    [offsetIndex, windowRange.end, itemCount, totalHeight, heightVersion],
   )
+
+  // Capture the topmost visible mounted row (smallest index whose bottom edge
+  // is still below the viewport top) and its offset from the scroller's top.
+  // Used by the scroll-anchor preservation path (T4/#5). Returns null when no
+  // mounted row qualifies or the environment has no layout (jsdom).
+  const captureTopAnchor = useCallback((): { key: string; top: number } | null => {
+    const el = scrollerRef.current
+    if (!el || typeof el.getBoundingClientRect !== 'function') return null
+    const srTop = el.getBoundingClientRect().top
+    let bestIdx = Infinity
+    let bestTop = 0
+    let bestKey: string | null = null
+    for (const [node, idx] of elIndexRef.current.entries()) {
+      const rect = (node as HTMLElement).getBoundingClientRect()
+      const top = rect.top - srTop
+      // Skip rows fully above the viewport top — they aren't the anchor the
+      // user is looking at (their screen position is off-screen).
+      if (rect.bottom - srTop <= 0) continue
+      if (idx < bestIdx) {
+        const it = itemsRef.current[idx]
+        if (!it) continue
+        bestIdx = idx
+        bestTop = top
+        bestKey = getKeyRef.current(it, idx)
+      }
+    }
+    return bestKey !== null ? { key: bestKey, top: bestTop } : null
+  }, [scrollerRef])
 
   // ---- Window recomputation (pure; never touches scrollTop) ----
   //
@@ -294,13 +454,36 @@ export function useVirtualChat<T>(
   const recomputeWindow = useCallback((expandOnly = false) => {
     const el = scrollerRef.current
     if (!el) return
-    const next = computeWindow(
-      el.scrollTop,
-      el.clientHeight,
-      itemsRef.current.length,
-      getH,
-      overscan,
-    )
+    const count = itemsRef.current.length
+    const idx = offsetIndexRef.current
+    // Window bounds in O(log N) via the OffsetIndex prefix-sum tree rather than
+    // the O(N) computeWindow linear scan — this is the per-rAF scroll hot path
+    // (#2). Fall back to computeWindow only if the tree is somehow absent.
+    let next: { start: number; end: number }
+    if (count <= 0) {
+      next = { start: 0, end: 0 }
+    } else if (idx) {
+      const top = Math.max(0, el.scrollTop)
+      const bottom = top + Math.max(0, el.clientHeight)
+      const overscanN = Math.max(0, Math.floor(overscan))
+      const firstVisible = idx.indexAt(top)
+      const lastVisible = idx.indexAt(bottom)
+      next = {
+        start: Math.max(0, firstVisible - overscanN),
+        end: Math.min(count, lastVisible + 1 + overscanN),
+      }
+    } else {
+      next = computeWindow(el.scrollTop, el.clientHeight, count, getH, overscan)
+    }
+    // T4/#5: on an upward shift (window start moving up → more rows mount above
+    // the viewport) while the user is scrolled up (stick released), record the
+    // top anchor so the post-commit layout effect can hold the viewport steady.
+    // Skipped while stick is armed — the pin path owns positioning then.
+    const cur = windowRangeRef.current
+    if (next.start < cur.start && !stickRef.current) {
+      const a = captureTopAnchor()
+      if (a) anchorPendingRef.current = a
+    }
     setWindowRange((prev) => {
       let merged: { start: number; end: number }
       if (expandOnly) {
@@ -328,34 +511,145 @@ export function useVirtualChat<T>(
       if (prev.start === merged.start && prev.end === merged.end) return prev
       return merged
     })
-  }, [getH, overscan, scrollerRef])
+  }, [getH, overscan, scrollerRef, captureTopAnchor])
 
   // ---- Pin helpers (the only code that writes el.scrollTop for follow) ----
 
-  // Automatic pin: called when content changed (RO / append). When stick is
-  // armed, always scrolls to the bottom. Stick is released ONLY by the scroll
-  // handler detecting a genuine user scroll-up — never here.
-  const pinAuto = useCallback(() => {
+  // Automatic pin: called when content changed (RO / append / streaming). Now
+  // DELEGATES the decision to FollowController.evaluateAutoPin (T5) — the pure,
+  // unit-tested "race-proof core" that used to be dead code while production
+  // pinAuto implemented a divergent "always pin when stick armed" policy. The
+  // two are reconciled here: evaluateAutoPin reads the LIVE geometry and
+  // (a) never pins when stick is released, (b) releases stick synchronously if
+  // the user has scrolled up since our last write (scrollTop < lastWriteTop and
+  // still away from the bottom — the distance guard tolerates mid-stream
+  // shrink), and (c) otherwise pins to the bottom. Its at-bottom test uses the
+  // DPR-aware epsilon (T3/#4), so this and the delegated core share one gate
+  // instead of the old duplicated `0.5` literals.
+  //
+  // The pin WRITE is INSTANT (behavior:'auto'), not smooth (T3/#4): a streaming
+  // response grows the bottom target every token, and a fresh smooth scroll
+  // CANCELS the in-flight one and restarts toward the moving target, so on a
+  // tall transcript it chases the bottom and never converges. Smooth is
+  // reserved for the explicit "jump to latest" path (scrollToBottom).
+  //
+  // Delegating restored the synchronous scroll-up release that production had
+  // abandoned because SMOOTH-scroll lag produced false positives; with the
+  // instant write there is no animation lag, so scrollTop == lastWriteTop right
+  // after each pin and the guard is reliable again.
+   // ---- The single chokepoint for programmatic scroll writes ----
+  //
+  // Enforces the follow invariant STRUCTURALLY rather than by convention: you
+  // cannot move the scroller without stating how the follow guard should account
+  // for it, because `accounting` is a required argument.
+  //   - 'pin'     — we are pinning; the guard remembers this position, so the
+  //                 resulting scroll event is recognised as our own.
+  //   - 'release' — we are deliberately leaving the bottom (explicit
+  //                 navigation); reset the guard sentinel, follow is off anyway.
+  // An unaccounted write is indistinguishable from user input and would release
+  // follow spuriously — the failure mode that got an earlier version of this
+  // guard reverted. Making the argument mandatory means a future contributor has
+  // to make a choice rather than forget one.
+  const writeScrollTop = useCallback(
+    (
+      el: HTMLDivElement,
+      top: number,
+      behavior: ScrollBehavior,
+      accounting: 'pin' | 'release',
+    ) => {
+      if (typeof el.scrollTo === 'function') el.scrollTo({ top, behavior })
+      else el.scrollTop = top
+      lastWriteTopRef.current = accounting === 'pin' ? top : -1
+      // A SMOOTH pin animates toward `top` over many frames, and every
+      // intermediate scroll event carries a scrollTop that differs from the
+      // recorded target — so the passive listener would read those frames as
+      // user input and release follow, and a mid-animation append would then be
+      // skipped by auto-pin, landing short of the new bottom. Arm the
+      // smooth-pin guard so the listener tolerates the glide (it disarms on
+      // arrival, or on a genuine upward move: see the scroll handler).
+      //
+      // Only the explicit "jump to latest" path is smooth now; the streaming
+      // pin is instant (#4), which is what removed the previous setter for this
+      // guard and left this hole.
+      if (accounting === 'pin' && behavior === 'smooth') {
+        smoothPinActiveRef.current = true
+        prevSmoothTopRef.current = el.scrollTop
+        // ...but the guard must yield to REAL input. Its only other release
+        // condition is "scrollTop moved backward", which a wheel cannot satisfy
+        // while a fast animation is still driving scrollTop forward — so a user
+        // wheeling up mid-glide was ignored and still ended up pinned to the
+        // bottom (verified in a real browser). A one-shot input listener
+        // disarms the guard and releases follow, matching how the jump/search
+        // convergence polls already abort on user input.
+        const abort = () => {
+          // Stale-invocation guard: if the glide already finished, these
+          // listeners are leftovers — detach and do nothing. Without this a
+          // completed jump left handlers behind that a later, unrelated wheel
+          // would fire, releasing follow while no smooth scroll was active.
+          if (!smoothPinActiveRef.current) {
+            detachSmoothAbort()
+            return
+          }
+          smoothPinActiveRef.current = false
+          stickRef.current = false
+          lastUserScrollAtRef.current =
+            typeof performance !== 'undefined' ? performance.now() : Date.now()
+          // Releasing `stick` alone is not enough: the browser's NATIVE smooth
+          // animation keeps running and would still land at the bottom, so the
+          // user's input appears ignored. Re-issuing an instant scroll to the
+          // CURRENT position cancels the in-flight animation and freezes where
+          // they are. lastWriteTop is reset because we are releasing follow.
+          if (typeof el.scrollTo === 'function') el.scrollTo({ top: el.scrollTop, behavior: 'auto' })
+          lastWriteTopRef.current = -1
+          detachSmoothAbort()
+        }
+        // Replace any previous glide's listeners rather than stacking them:
+        // repeated jump-to-latest presses would otherwise accumulate handlers.
+        // attachUserScrollIntent is the shared input set, so a scrollbar drag
+        // or a keyboard scroll aborts the glide too — wheel/touch alone let the
+        // animation override both.
+        detachSmoothAbort()
+        const detachIntent = attachUserScrollIntent(el, abort)
+        smoothAbortDetachRef.current = () => {
+          detachIntent()
+          smoothAbortDetachRef.current = null
+        }
+      }
+    },
+    [detachSmoothAbort],
+  )
+
+ const pinAuto = useCallback(() => {
     const el = scrollerRef.current
     if (!el) return
+    // An in-flight smooth pin is OUR scroll, and mid-glide `scrollTop` sits
+    // below the recorded target while still being meaningfully away from the
+    // bottom — which is exactly evaluateAutoPin's user-scroll-up signature. A
+    // ResizeObserver tick during the glide (streaming output resizes constantly)
+    // therefore released follow and left the rest of the response behind. The
+    // scroll handler already exempts in-flight glides; this path did not.
+    //
+    // Preserve follow and do NOT write: re-issuing a smooth scroll every resize
+    // tick would cancel and restart the animation each time (the restart trap
+    // fix #4 removed). Content appended mid-glide is instead re-targeted the
+    // moment the glide lands — the arrival branch of the scroll handler runs
+    // pinAuto(), which then snaps instantly to the new bottom.
+    if (smoothPinActiveRef.current) return
     const geom = { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
-    const target = Math.max(0, geom.scrollHeight - geom.clientHeight)
-    if (!stickRef.current) return
-    // Always pin when stick is armed. The scroll handler is the sole arbiter of
-    // releasing stick (it detects genuine user scroll-up). Previous approach
-    // tried to release here via a scrollTop-vs-lastWriteTop guard, but smooth
-    // scroll lag causes persistent false positives: the animation hasn't caught
-    // up to the last target when content grows and a new pinAuto fires, so it
-    // looks like "scrollTop < lastWriteTop" even though it's just animation lag.
-    if (Math.abs(geom.scrollTop - target) > 0.5) {
-      smoothPinActiveRef.current = true
-      prevSmoothTopRef.current = geom.scrollTop
-      el.scrollTo({ top: target, behavior: 'smooth' })
-      lastWriteTopRef.current = target
-    } else {
-      lastWriteTopRef.current = target
+    const result = evaluateAutoPin({
+      stick: stickRef.current,
+      geom,
+      lastWriteTop: lastWriteTopRef.current,
+    })
+    stickRef.current = result.stick
+    if (result.pin) {
+      writeScrollTop(el, result.target, 'auto', 'pin')
+    } else if (result.stick) {
+      // Still following but already at the bottom (no write needed) — keep the
+      // self-scroll reference aligned with the current bottom.
+      lastWriteTopRef.current = result.target
     }
-  }, [scrollerRef])
+  }, [scrollerRef, writeScrollTop])
 
   // Forced pin: explicit jump-to-bottom (slot entry, scrollToBottom API,
   // jump-to-latest pill). Always lands at the bottom and (re-)arms follow.
@@ -364,9 +658,8 @@ export function useVirtualChat<T>(
     if (!el) return
     stickRef.current = followOutput
     const target = bottomTarget({ scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight })
-    el.scrollTop = target
-    lastWriteTopRef.current = target
-  }, [followOutput, scrollerRef])
+    writeScrollTop(el, target, 'auto', 'pin')
+  }, [followOutput, scrollerRef, writeScrollTop])
 
   // Keep the tracked scroller element in sync after every commit, so the
   // observer effects below re-attach the moment the node appears (or changes).
@@ -395,7 +688,30 @@ export function useVirtualChat<T>(
       // During a smooth-pin animation, intermediate scroll events are ours —
       // don't treat them as user scrolls.
       if (smoothPinActiveRef.current) {
-        if (atBottom) smoothPinActiveRef.current = false
+        // Arrived: the glide is over, so drop its abort listeners.
+        //
+        // Arrival is measured against the value we actually WROTE
+        // (`lastWriteTopRef`), not `atBottom`. `atBottom` uses the 100px UI
+        // threshold, which the glide enters while the native animation still
+        // has up to 100px to run; disarming there left the remaining animation
+        // un-abortable, so a user grabbing the page inside that band would be
+        // scrolled to the bottom anyway. `isSelfScroll` compares against the
+        // pin target within SELF_SCROLL_EPSILON, so we disarm only once the
+        // animation has genuinely landed. `bottomAnchored` is the fallback for
+        // a pin whose target was clamped by the browser (a shrinking
+        // scrollHeight can leave scrollTop short of the requested value
+        // forever, which would otherwise leak the listeners).
+        const bottomAnchored =
+          geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
+        if (isSelfScroll(el.scrollTop, lastWriteTopRef.current) || bottomAnchored) {
+          smoothPinActiveRef.current = false
+          detachSmoothAbort()
+          // Content appended DURING the glide moved the bottom, and pinAuto
+          // deliberately declined to re-target mid-animation (restarting a
+          // smooth scroll every resize tick stutters). Now that the animation
+          // has landed, correct the shortfall instantly.
+          pinAuto()
+        }
         // If the user grabs the page mid-animation and scrolls up,
         // scrollTop moves backward. Normal forward animation progress
         // always increases scrollTop toward the target.
@@ -403,6 +719,7 @@ export function useVirtualChat<T>(
           smoothPinActiveRef.current = false
           lastUserScrollAtRef.current = performance.now()
           stickRef.current = false
+          detachSmoothAbort()
         }
         prevSmoothTopRef.current = el.scrollTop
       } else if (!isSelfScroll(el.scrollTop, lastWriteTopRef.current)) {
@@ -427,7 +744,7 @@ export function useVirtualChat<T>(
       if (rafId) cancelAnimationFrame(rafId)
       scrollRafScheduledRef.current = false
     }
-  }, [scrollerEl, bottomThreshold, followOutput, recomputeWindow])
+  }, [scrollerEl, bottomThreshold, followOutput, recomputeWindow, detachSmoothAbort, pinAuto])
 
   // ---- ResizeObserver: track mounted-item heights + follow streaming/widgets ----
   // Native overflow-anchor handles visual stability when scrolled up; this
@@ -519,6 +836,19 @@ export function useVirtualChat<T>(
         for (const entry of entries) {
           if (!entry.isIntersecting) continue
           if (entry.target === topSentinelRef.current) {
+            // T4/#5: upward expansion mounts rows above the viewport. Capture
+            // the top anchor first (while stick is released — reading history)
+            // so the compensation layout effect can hold the viewport steady.
+            //
+            // Only when there is actually room to expand: at start === 0
+            // expandWindowUp is a no-op, so a captured anchor would never be
+            // consumed by an upward shift and would instead be applied to the
+            // NEXT layout pass — a downward expansion — yanking the viewport
+            // back to a stale row.
+            if (!stickRef.current && windowRangeRef.current.start > 0) {
+              const a = captureTopAnchor()
+              if (a) anchorPendingRef.current = a
+            }
             setWindowRange((prev) => expandWindowUp(prev, overscan))
           } else if (entry.target === bottomSentinelRef.current) {
             setWindowRange((prev) => expandWindowDown(prev, itemsRef.current.length, overscan))
@@ -531,7 +861,46 @@ export function useVirtualChat<T>(
     if (topSentinelRef.current) io.observe(topSentinelRef.current)
     if (bottomSentinelRef.current) io.observe(bottomSentinelRef.current)
     return () => io.disconnect()
-  }, [overscan, scrollerEl])
+  }, [overscan, scrollerEl, captureTopAnchor])
+
+  // ---- Scroll-anchor preservation: hold the viewport steady across an
+  //      upward window shift (T4/#5) ----
+  //
+  // Runs after every windowRange commit. If recomputeWindow / top-sentinel
+  // expansion captured a top anchor (only on an upward shift while stick is
+  // released), re-read that row's screen position in the freshly-committed DOM
+  // and correct scrollTop by the delta so the row the user is looking at does
+  // not jump when rows mount/unmount above it. Skipped when stick is armed (the
+  // pin path owns positioning) or nothing was captured. The scrollTop write is
+  // recorded in lastWriteTopRef so the passive scroll listener classifies it as
+  // a self-scroll (isSelfScroll / SELF_SCROLL_EPSILON) and does not release
+  // stick or treat it as a user scroll.
+  useLayoutEffect(() => {
+    const pending = anchorPendingRef.current
+    anchorPendingRef.current = null
+    if (!pending) return
+    const el = scrollerRef.current
+    if (!el || stickRef.current || typeof el.getBoundingClientRect !== 'function') return
+    let node: HTMLElement | null = null
+    for (const [n, idx] of elIndexRef.current.entries()) {
+      const it = itemsRef.current[idx]
+      if (it && getKeyRef.current(it, idx) === pending.key) {
+        node = n as HTMLElement
+        break
+      }
+    }
+    if (!node) return
+    const srTop = el.getBoundingClientRect().top
+    const newTop = node.getBoundingClientRect().top - srTop
+    const delta = newTop - pending.top
+    if (Math.abs(delta) > 0.5) {
+      // Instant, and accounted as a 'pin' write: this is our own correction, so
+      // the follow guard must recognise the resulting scroll event as self-scroll
+      // rather than user input. Routed through the chokepoint so the accounting
+      // cannot be forgotten here (see writeScrollTop).
+      writeScrollTop(el, el.scrollTop + delta, 'auto', 'pin')
+    }
+  }, [windowRange, scrollerRef, writeScrollTop])
 
   // ---- Follow-output: pin to bottom when items append ----
   const prevItemCountRef = useRef(itemCount)
@@ -681,14 +1050,12 @@ export function useVirtualChat<T>(
         if (align === 'center') scrollTop = off - el.clientHeight / 2 + itemH / 2
         else if (align === 'end') scrollTop = off - el.clientHeight + itemH
         scrollTop = Math.max(0, Math.min(el.scrollHeight - el.clientHeight, scrollTop))
-        if (typeof el.scrollTo === 'function') el.scrollTo({ top: scrollTop, behavior })
-        else el.scrollTop = scrollTop
         // Jumping to a specific index is an explicit "stop following" intent.
         stickRef.current = false
-        lastWriteTopRef.current = -1
+        writeScrollTop(el, scrollTop, behavior, 'release')
       })
     },
-    [overscan, getH, scrollerRef],
+    [overscan, getH, scrollerRef, writeScrollTop],
   )
 
   // "Human-like" smooth scroll to a (possibly off-window) index. UNLIKE
@@ -735,11 +1102,9 @@ export function useVirtualChat<T>(
       top = Math.max(0, Math.min(el.scrollHeight - el.clientHeight, top))
       // Explicit navigation — stop following.
       stickRef.current = false
-      lastWriteTopRef.current = -1
-      if (typeof el.scrollTo === 'function') el.scrollTo({ top, behavior: 'smooth' })
-      else el.scrollTop = top
+      writeScrollTop(el, top, 'smooth', 'release')
     },
-    [getH, scrollerRef],
+    [getH, scrollerRef, writeScrollTop],
   )
 
   const scrollToBottom = useCallback(
@@ -755,10 +1120,8 @@ export function useVirtualChat<T>(
       stickRef.current = followOutput
       const pinToBottom = (b: ScrollBehavior) => {
         const target = bottomTarget({ scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight })
-        if (typeof el.scrollTo === 'function') el.scrollTo({ top: target, behavior: b })
-        else el.scrollTop = target
         stickRef.current = followOutput
-        lastWriteTopRef.current = target
+        writeScrollTop(el, target, b, 'pin')
       }
       requestAnimationFrame(() => {
         pinToBottom(behavior)
@@ -779,7 +1142,7 @@ export function useVirtualChat<T>(
         requestAnimationFrame(settle)
       })
     },
-    [overscan, followOutput, scrollerRef],
+    [overscan, followOutput, scrollerRef, writeScrollTop],
   )
 
   // Ensure `index` is mounted (in the window) so callers can scroll to an
@@ -924,10 +1287,11 @@ export function useVirtualChat<T>(
 
   useEffect(() => {
     return () => {
+      detachSmoothAbort()
       if (heightSyncTimerRef.current) clearTimeout(heightSyncTimerRef.current)
       cacheRef.current?.flush()
     }
-  }, [])
+  }, [detachSmoothAbort])
 
   return {
     scrollerRef,

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -88,7 +88,7 @@ import { useMessageSearch } from '../hooks/useMessageSearch'
 import SearchHighlightContext, { MessageSearchScope } from '../hooks/SearchHighlightContext'
 import SearchBar from '../components/SearchBar'
 import SearchResultsList from '../components/SearchResultsList'
-import { pickSearchScrollBehavior, scrollCurrentMatchIntoView } from '../utils/searchScroll'
+import { pickSearchScrollBehavior, scrollCurrentMatchIntoView, pollRowSettled, glideOnceStep, attachUserScrollIntent } from '../utils/searchScroll'
 import QueueStack, { SubagentDeliveryProgress, isSystemDelivery } from '../components/QueueStack'
 import { runBelongsToSlot } from '../apps/workflows/runModel'
 import { TipCard, useTipTrigger } from '../components/TipCard'
@@ -202,6 +202,36 @@ export function ChatHeaderMenu({ activeSlot, agent, onReveal, onRename, mode }: 
       </DropdownMenuContent>
     </DropdownMenu>
   )
+}
+
+/** Stable key for a single TurnItem — the leading row of a turn OR a top-level
+ *  single/group. A `single` and the `turn` it leads resolve to the SAME key so
+ *  a mid-stream regroup (single promoted into a grouped turn once it gains
+ *  working steps) does NOT change the row's virtual key → no remount / silent
+ *  re-measure. `msgKey` supplies the per-message identity (clientTs → ts →
+ *  minted id; never the array index — see stableMsgKey). Groups key on their
+ *  first message's start index, which is stable for surviving rows (trailing
+ *  truncation removes later groups whole rather than renumbering earlier ones). */
+export function turnLeadKey(it: TurnItem, msgKey: (m: ChatMessage) => string): string {
+  return it.kind === 'single' ? `row-${msgKey(it.msg)}` : `grp-${it.startIdx}`
+}
+
+/** Virtualizer / HeightCache key for a display row. Pure (identity injected)
+ *  so the steer-reconcile-stability and regroup-stability guarantees are
+ *  unit-testable. A `turn` inherits the key of its leading item so promoting a
+ *  single into a turn (and vice-versa) keeps the row identity — and thus its
+ *  cached height and DOM node — stable. */
+export function virtualKeyFor(
+  it: DisplayItem,
+  index: number,
+  msgKey: (m: ChatMessage) => string,
+): string {
+  if (it.kind === 'turn') {
+    const first = it.items[0]
+    if (!first) return `turn-empty-${index}`
+    return turnLeadKey(first, msgKey)
+  }
+  return turnLeadKey(it, msgKey)
 }
 
 /** Render user message content with file chips and image markdown. Handles:
@@ -1580,6 +1610,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // the newer target (rapid stepping / click-then-click). cancelAnimationFrame(0)
   // is a no-op, so 0 is a safe initial value.
   const navScrollRafRef = useRef(0)
+  // Cancel handle for the in-flight settle poll, so a newer navigation or an
+  // unmount terminates it rather than letting it run to the wall-clock backstop.
+  const navPollCancelRef = useRef<(() => void) | null>(null)
   const navToDisplayIndex = useCallback((
     idx: number,
     opts?: { behavior?: ScrollBehavior; align?: ScrollLogicalPosition; offset?: number },
@@ -1601,20 +1634,62 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // mountIndex queues a React state update (the virtualizer's window range).
     // A FAR jump REPLACES the window, so the target row is NOT painted into the
     // DOM within a single frame — one rAF then a DOM query misses it. Poll for
-    // the row across frames and scroll the instant it mounts: driven by the
-    // row's actual DOM presence (scrollToDisplayIndex returns false until it
-    // exists), not a guessed timer. While the row is missing we do nothing — we
-    // never teleport to top, which was the "far jump jumps to top, second click
-    // works" bug. Near jumps succeed on the first frame; the cap is a safety net.
-    let frames = 0
-    const MAX_FRAMES = 30 // ~0.5s ceiling
-    const attempt = () => {
-      if (scrollToDisplayIndex(idx, { ...opts, behavior })) return
-      if (++frames >= MAX_FRAMES) return
-      navScrollRafRef.current = requestAnimationFrame(attempt)
-    }
-    navScrollRafRef.current = requestAnimationFrame(attempt)
-  }, [scrollToDisplayIndex])
+    // the row and scroll once it mounts, then keep re-scrolling (re-reading the
+    // live offset each frame) until the row's measured height SETTLES — a far
+    // row must mount + measure, and a widget target keeps growing for ~450ms as
+    // its iframe builds (PROGRAMMATIC_BUILD_DELAY_MS). The OLD frame-count
+    // ceiling (~0.5s) gave up before the widget settled, so the jump silently
+    // no-op'd and only worked on a second click once cached. Condition-based
+    // instead: retry until the target reports a stable (non-estimated) height,
+    // with a ~2s wall-clock backstop so a genuinely unreachable target still
+    // terminates instead of spinning. While the row is missing we do NOTHING —
+    // we never teleport to top (the "far jump jumps to top, second click works"
+    // bug). navScrollRafRef holds the in-flight frame so a newer navigation
+    // cancels this loop (rapid stepping / click-then-click).
+    const rowEl = (): HTMLElement | null =>
+      (scrollerRef.current?.querySelector(`[data-display-index="${idx}"]`) as HTMLElement | null) ?? null
+    navPollCancelRef.current?.()
+    // The poll re-scrolls every frame for up to CONVERGE_MAX_MS (~2s). If the
+    // user tries to scroll during that window, continuing to step would drag
+    // the viewport back to the target and fight their input — so user scroll
+    // ABORTS the convergence, exactly as scrollCurrentMatchIntoView does. (The
+    // retired frame-count ceiling was short enough (~0.5s) to mask this; the
+    // longer, condition-based window makes it reachable.) The shared
+    // attachUserScrollIntent covers scrollbar drag and keyboard scrolling too,
+    // not just wheel/touch.
+    const scrollEl = scrollerRef.current
+    const onUserScroll = () => { navPollCancelRef.current?.() }
+    const detachUserScroll = attachUserScrollIntent(scrollEl ?? undefined, onUserScroll)
+    navPollCancelRef.current = pollRowSettled({
+      measure: () => {
+        const el = rowEl()
+        return el ? el.getBoundingClientRect().height : null
+      },
+      // Only the FIRST step may glide — see glideOnceStep. Re-issuing a smooth
+      // scroll cancels and restarts the animation, so stepping every frame
+      // through the quiet window would leave a NEAR jump stuttering until the
+      // poll ends (the same restart trap fix #4 removed from the streaming pin).
+      step: glideOnceStep(
+        (b) => { scrollToDisplayIndex(idx, { ...opts, behavior: b }) },
+        behavior,
+      ),
+      raf: (cb) => (navScrollRafRef.current = requestAnimationFrame(cb)),
+      now: () =>
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? performance.now()
+          : Date.now(),
+      onEnd: () => { detachUserScroll(); navPollCancelRef.current = null },
+    })
+  }, [scrollToDisplayIndex, scrollerRef])
+
+  // Stop any in-flight settle poll on unmount. Without this the loop keeps
+  // ticking rAFs against a null scroller until the ~2s backstop (harmless but
+  // pointless work after the page is gone).
+  useEffect(() => () => {
+    navPollCancelRef.current?.()
+    navPollCancelRef.current = null
+    cancelAnimationFrame(navScrollRafRef.current)
+  }, [])
 
   // "Scroll to previous user message" pill — tracks topmost visible item
   const topmostIdxRef = useRef(0)
@@ -2715,16 +2790,35 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // and append-pin, so the legacy useStreamingScroll/useFollowOutput
   // calls below are no-ops in this configuration but are kept invoked
   // for hook-call stability.
-  const virtualKey = useCallback((it: DisplayItem, _i: number) => {
-    if (it.kind === 'turn') {
-      const first = it.items[0]
-      if (!first) return `turn-empty-${_i}`
-      return first.kind === 'single'
-        ? `turn-${first.msg.ts || first.idx}`
-        : `turn-g-${first.startIdx}`
-    }
-    return it.kind === 'single' ? `s-${it.msg.ts || it.idx}` : `g-${it.startIdx}`
+  // Per-message identity used to derive BOTH the inner bubble key (renderMessage,
+  // ~line 2848) AND the virtualizer/HeightCache key (virtualKey, below). Keeping
+  // them on the SAME identity means the #253 steer-bubble stability fix protects
+  // the virtualizer + HeightCache layer too, not just the bubble:
+  //   1. Prefer meta.clientTs — the steer_push echo overwrites `ts` (client→
+  //      server) mid-stream; keying on `ts` alone would flip the key, orphan the
+  //      cached height, revert the row to the estimate, and lurch the viewport.
+  //   2. Fall back to `ts` for ordinary messages.
+  //   3. For ts-less messages (e.g. an error appended on the send-failure path)
+  //      DON'T fall back to the array index: truncateAfterIndex / regenerate
+  //      would shift the key of every following row → mass remount + a large
+  //      scroll swing. Mint a per-message-instance id instead. Object identity
+  //      is stable across renders under Immer's structural sharing, and survives
+  //      truncation of *later* rows, so the key is stable for the message's life.
+  //      (A durable id stamped in the reducer at append would also survive a full
+  //      refetch/replace — see .scroll-handoff-c.md.)
+  const msgIdSeq = useRef(0)
+  const msgIds = useRef(new WeakMap<ChatMessage, string>())
+  const stableMsgKey = useCallback((m: ChatMessage): string => {
+    const explicit = (m.meta?.clientTs as string | undefined) || m.ts
+    if (explicit) return explicit
+    let id = msgIds.current.get(m)
+    if (!id) { id = `mid-${msgIdSeq.current++}`; msgIds.current.set(m, id) }
+    return id
   }, [])
+  const virtualKey = useCallback(
+    (it: DisplayItem, i: number) => virtualKeyFor(it, i, stableMsgKey),
+    [stableMsgKey],
+  )
 
   // (Sticky widget detection removed — widgets now unmount with the
   // window like any other item. See useVirtualChat call below for the

--- a/website/src/test/ChatPage.dockSearchClose.test.tsx
+++ b/website/src/test/ChatPage.dockSearchClose.test.tsx
@@ -141,7 +141,9 @@ globalThis.fetch = vi.fn().mockResolvedValue({
   json: () => Promise.resolve({}),
 }) as never
 
-import ChatPage from '../pages/ChatPage'
+import ChatPage, { virtualKeyFor, turnLeadKey } from '../pages/ChatPage'
+import type { DisplayItem } from '../pages/chat/types'
+import type { ChatMessage } from '../types'
 
 const ASSISTANT_MSG = {
   role: 'assistant',
@@ -252,5 +254,80 @@ describe('ChatPage – opening a dock panel closes the find pane', () => {
       expect(screen.getByTestId('md-panel')).toBeTruthy()
       expect(screen.queryByPlaceholderText(FIND_PLACEHOLDER)).toBeNull()
     })
+  })
+})
+
+
+// The per-message identity resolver ChatPage feeds virtualKeyFor: prefer the
+// optimistic clientTs (the #253 steer-bubble stability fix), then ts, then a
+// stable minted id for ts-less messages. Mirrors the component's stableMsgKey
+// so these unit tests exercise the real key derivation.
+const makeMsgKey = () => {
+  const ids = new WeakMap<ChatMessage, string>()
+  let seq = 0
+  return (m: ChatMessage): string => {
+    const explicit = (m.meta?.clientTs as string | undefined) || m.ts
+    if (explicit) return explicit
+    let id = ids.get(m)
+    if (!id) { id = `mid-${seq++}`; ids.set(m, id) }
+    return id
+  }
+}
+
+const single = (m: ChatMessage, idx: number): DisplayItem => ({ kind: 'single', msg: m, idx })
+const turnOf = (items: DisplayItem[]): DisplayItem =>
+  ({ kind: 'turn', items: items as never, complete: false })
+
+describe('virtualKeyFor — #253 stability extended to the virtualizer/HeightCache key', () => {
+  it('does NOT change when a steer_push echo overwrites ts with the server ts', () => {
+    const msgKey = makeMsgKey()
+    // Optimistic append: client ts, stashed as meta.clientTs by the reconcile.
+    const optimistic: ChatMessage = { role: 'user', content: 'hi', cls: '', ts: 'client-1', meta: { clientTs: 'client-1', steer: true } }
+    const before = virtualKeyFor(single(optimistic, 3), 3, msgKey)
+    // Echo reconcile swaps ts → server ts but keeps meta.clientTs.
+    const reconciled: ChatMessage = { ...optimistic, ts: 'server-2' }
+    const after = virtualKeyFor(single(reconciled, 3), 3, msgKey)
+    expect(after).toBe(before) // HeightCache entry NOT orphaned, no viewport lurch
+  })
+
+  it('is UNCHANGED when a single promotes into a grouped turn (mid-stream regroup)', () => {
+    const msgKey = makeMsgKey()
+    const lead: ChatMessage = { role: 'assistant', content: 'working…', cls: '', ts: 'a1' }
+    // Before: the assistant renders as a standalone single.
+    const asSingle = virtualKeyFor(single(lead, 5), 5, msgKey)
+    // After: working steps accumulate and collapse into a turn led by the same
+    // assistant message.
+    const tool: ChatMessage = { role: 'tool', content: '🔧 grep', cls: '', ts: 't1' }
+    const tool2: ChatMessage = { role: 'tool', content: '🔧 cat', cls: '', ts: 't2' }
+    const asTurn = virtualKeyFor(turnOf([single(lead, 5), single(tool, 6), single(tool2, 7)]), 5, msgKey)
+    expect(asTurn).toBe(asSingle) // same row identity → no remount / re-measure
+  })
+
+  it('a turn led by a group inherits the group key (stable across regroup)', () => {
+    const msgKey = makeMsgKey()
+    const grp: DisplayItem = { kind: 'group', msgs: [{ role: 'tool', content: '🔧 a', cls: '' }], startIdx: 9 } as never
+    const asGroup = virtualKeyFor(grp, 9, msgKey)
+    const asTurn = virtualKeyFor(turnOf([grp]), 9, msgKey)
+    expect(asTurn).toBe(asGroup)
+    expect(asGroup).toBe('grp-9')
+  })
+
+  it('a ts-less message keys on a stable minted id, NOT the array index', () => {
+    const msgKey = makeMsgKey()
+    // e.g. an error appended on the send-failure path — no ts, no clientTs.
+    const errless: ChatMessage = { role: 'error', content: 'boom', cls: '' }
+    // Same message object at two different positions (later rows truncated →
+    // its display index shifted) must yield the SAME key so the following rows
+    // don't mass-remount.
+    const atFive = virtualKeyFor(single(errless, 5), 5, msgKey)
+    const atNinety = virtualKeyFor(single(errless, 90), 90, msgKey)
+    expect(atNinety).toBe(atFive)
+    expect(atFive.startsWith('row-mid-')).toBe(true)
+  })
+
+  it('turnLeadKey unifies a single and its promoting turn on the same identity', () => {
+    const msgKey = makeMsgKey()
+    const lead: ChatMessage = { role: 'assistant', content: 'x', cls: '', ts: 'z9' }
+    expect(turnLeadKey({ kind: 'single', msg: lead, idx: 0 }, msgKey)).toBe('row-z9')
   })
 })

--- a/website/src/test/ChatPage.navFarJump.test.tsx
+++ b/website/src/test/ChatPage.navFarJump.test.tsx
@@ -1,0 +1,278 @@
+// Feature: chat-virtualizer — a FAR jump whose target mounts slowly still lands
+// on the first navigation, driven through ChatPage.
+//
+// GPT 5.6 HIGH (round 13): `pollRowSettled` has thorough unit tests, but the
+// CALL SITE in ChatPage was untested — reverting it to the retired ~30-frame
+// rAF ceiling left every helper test green while restoring the original bug: the
+// first click on a far target silently no-op'd (the row had not committed to the
+// DOM yet) and only a second click worked, because the row was cached by then.
+//
+// This drives the real production path: a `?msg=` deep link on cold load calls
+// ChatPage's own `navToDisplayIndex`, whose poll must survive the target row
+// being absent for far longer than 30 frames and then scroll to it.
+//
+// jsdom has no layout, so the scroller geometry and per-row rects are faked at
+// the prototype level; what is NOT faked is any part of the poll, the call site,
+// or `scrollToDisplayIndex`, which is DOM-driven and runs for real.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// How many leading rows the virtualizer stub currently has committed. The test
+// raises this to simulate the window-replacement commit landing late.
+let mountedTo = 5
+
+vi.mock('../pages/chat', async () => {
+  const React = await import('react')
+  return {
+    ChatFooter: () => null,
+    McpInfoButton: () => null,
+    UserMessage: () => React.createElement('div', { 'data-testid': 'user-msg' }),
+    AssistantMessage: () => React.createElement('div', { 'data-testid': 'assistant-msg' }),
+  }
+})
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+// Mounts only the first `mountedTo` items, so a far target is genuinely absent
+// from the DOM — the condition the poll exists to survive. mountIndex reports a
+// FAR jump (true) exactly as the real hook does when it replaces its window.
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: (opts: { items?: unknown[]; getKey?: (it: unknown, i: number) => string }) => {
+    const items = opts.items ?? []
+    return {
+      virtualItems: items.slice(0, mountedTo).map((data, index) => ({
+        key: opts.getKey ? opts.getKey(data, index) : String(index),
+        index,
+        mounted: true,
+        data,
+      })),
+      isAtBottom: false,
+      scrollToBottom: vi.fn(),
+      scrollToIndexSmooth: vi.fn(),
+      mountIndex: vi.fn(() => true),
+      measureRef: () => () => {},
+      topSentinelRef: { current: null },
+      bottomSentinelRef: { current: null },
+      offsetBefore: 0,
+      offsetAfter: 0,
+      totalHeight: 4000,
+    }
+  },
+}))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve({}),
+}) as never
+
+import ChatPage from '../pages/ChatPage'
+
+const N = 40
+const TARGET_DISPLAY_INDEX = 35
+const ROW_H = 100
+const CLIENT_H = 400
+const SCROLL_H = N * ROW_H
+const ts = (i: number) => `2026-06-23T20:${String(i).padStart(2, '0')}:00.000Z`
+const mkMessages = () =>
+  Array.from({ length: N }, (_, i) => ({ role: 'user', content: `m${i}`, cls: '', ts: ts(i) }))
+
+interface Recorded { top?: number; behavior?: string }
+
+/**
+ * Fake enough layout for the DOM-driven scroll path: the scroller reports a
+ * viewport and a tall content box, and each row sits at `index * ROW_H`.
+ */
+function installLayout(recorded: Recorded[]) {
+  const proto = HTMLElement.prototype
+  const origRect = proto.getBoundingClientRect
+  const origScrollTo = (proto as unknown as { scrollTo?: unknown }).scrollTo
+  const origClient = Object.getOwnPropertyDescriptor(proto, 'clientHeight')
+  const origScrollH = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
+  const origScrollT = Object.getOwnPropertyDescriptor(proto, 'scrollTop')
+
+  proto.getBoundingClientRect = function (this: HTMLElement): DOMRect {
+    const di = this.getAttribute?.('data-display-index')
+    const top = di !== null && di !== undefined ? Number(di) * ROW_H : 0
+    const height = di !== null && di !== undefined ? ROW_H : CLIENT_H
+    return {
+      top, bottom: top + height, height, left: 0, right: 0, width: 0, x: 0, y: top,
+      toJSON() { return {} },
+    } as DOMRect
+  }
+  Object.defineProperty(proto, 'clientHeight', { configurable: true, get: () => CLIENT_H })
+  Object.defineProperty(proto, 'scrollHeight', { configurable: true, get: () => SCROLL_H })
+  Object.defineProperty(proto, 'scrollTop', { configurable: true, get: () => 0, set: () => {} })
+  ;(proto as unknown as { scrollTo: (o: Recorded) => void }).scrollTo = function (o: Recorded) {
+    recorded.push({ top: o?.top, behavior: o?.behavior })
+  }
+
+  return () => {
+    proto.getBoundingClientRect = origRect
+    ;(proto as unknown as { scrollTo?: unknown }).scrollTo = origScrollTo
+    if (origClient) Object.defineProperty(proto, 'clientHeight', origClient)
+    if (origScrollH) Object.defineProperty(proto, 'scrollHeight', origScrollH)
+    if (origScrollT) Object.defineProperty(proto, 'scrollTop', origScrollT)
+  }
+}
+
+const renderChatPage = (messages: unknown[], msgTs: string) => {
+  const slot = { key: 'chat-1', title: 'chat-1', messages: N, running: false, mode: '', created: '', last_ts: '' }
+  apiMocks.chatSlots = vi.fn().mockResolvedValue([slot])
+  apiMocks.chatSlotDetail = vi.fn().mockResolvedValue({ messages, has_more: false, total: messages.length })
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: false,
+      slots: [slot], approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0,
+      unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as never,
+    chat: {
+      activeSlot: 'chat-1',
+      messages, slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+    } as never,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const { container } = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={[`/chat/chat-1?msg=${encodeURIComponent(msgTs)}`]}>
+            <Routes>
+              <Route path="/chat/:slug?" element={<ChatPage mode="" />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  act(() => { store.dispatch({ type: 'chat/replaceMessages', payload: messages }) })
+  return { store, container }
+}
+
+describe('ChatPage — a far jump whose row mounts late still lands on the first navigation', () => {
+  let frames: FrameRequestCallback[] = []
+  let origRaf: typeof globalThis.requestAnimationFrame
+  let restoreLayout: (() => void) | null = null
+  const recorded: Recorded[] = []
+
+  beforeEach(() => {
+    Object.keys(apiMocks).forEach(k => delete apiMocks[k])
+    mountedTo = 5
+    recorded.length = 0
+    frames = []
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof globalThis.requestAnimationFrame
+    // Only timers are faked: performance.now must stay real so the poll's
+    // wall-clock backstop measures the (near-zero) real duration of the flush
+    // loop rather than the simulated 500ms deep-link delay.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    restoreLayout = installLayout(recorded)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.requestAnimationFrame = origRaf
+    restoreLayout?.()
+    restoreLayout = null
+  })
+
+  /** Run every queued frame once (each may enqueue its successor). */
+  const flushFrames = (n: number) => {
+    for (let i = 0; i < n; i++) {
+      const batch = frames
+      frames = []
+      if (batch.length === 0) return
+      act(() => { batch.forEach((cb) => cb(0)) })
+    }
+  }
+
+  it('keeps polling past 30 frames and scrolls once the row commits', () => {
+    const messages = mkMessages()
+    const { store, container } = renderChatPage(messages, ts(TARGET_DISPLAY_INDEX))
+
+    // The deep-link effect defers the navigation by 500ms.
+    act(() => { vi.advanceTimersByTime(600) })
+    // Only the first 5 rows are committed, so the target genuinely is not there.
+    expect(container.querySelector(`[data-display-index="${TARGET_DISPLAY_INDEX}"]`)).toBeNull()
+
+    recorded.length = 0
+    // Far longer than the retired ~30-frame ceiling.
+    flushFrames(45)
+    // Nothing may have been scrolled while the row was missing — in particular
+    // no teleport to top:0 (the "far jump jumps to the top" bug).
+    expect(recorded.length).toBe(0)
+
+    // The virtualizer's window replacement finally commits.
+    act(() => {
+      mountedTo = N
+      store.dispatch({ type: 'chat/replaceMessages', payload: [...messages] })
+    })
+    const row = container.querySelector(`[data-display-index="${TARGET_DISPLAY_INDEX}"]`)
+    expect(row).not.toBeNull()
+
+    flushFrames(5)
+
+    // The poll found the row and scrolled to it — near its faked offset, not 0.
+    expect(recorded.length).toBeGreaterThan(0)
+    const tops = recorded.map((r) => r.top ?? -1)
+    expect(Math.max(...tops)).toBeGreaterThan(3000)
+  })
+})

--- a/website/src/test/ChatPage.steerKeyIdentity.test.tsx
+++ b/website/src/test/ChatPage.steerKeyIdentity.test.tsx
@@ -1,0 +1,211 @@
+// Feature: chat-virtualizer — row identity survives optimistic steer reconciliation.
+//
+// GPT 5.6 rejected the unit-level key tests in ChatPage.dockSearchClose.test.tsx
+// as self-fulfilling: they hand `virtualKeyFor` a `clientTs` resolver the TEST
+// defines, so reverting ChatPage's own `stableMsgKey` left them green while the
+// real virtualizer key changed again on reconciliation.
+//
+// This exercises the production path instead. ChatPage renders each row as
+// `<div key={vi.key} data-display-index=...>`, where `vi.key` comes from the
+// getKey ChatPage itself passes to the virtualizer. So if the key is stable
+// across reconciliation, React keeps the SAME DOM node; if it changes, React
+// unmounts and remounts the row — which is the actual defect (the row's measured
+// height in HeightCache is orphaned and the viewport lurches). Asserting on node
+// identity therefore tests the real key derivation, with no resolver supplied by
+// the test.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+vi.mock('../pages/chat', async () => {
+  const React = await import('react')
+  return {
+    ChatFooter: () => null,
+    McpInfoButton: () => null,
+    // Rendered content is irrelevant; the row WRAPPER carries the key.
+    UserMessage: () => React.createElement('div', { 'data-testid': 'user-msg' }),
+    AssistantMessage: () => React.createElement('div', { 'data-testid': 'assistant-msg' }),
+  }
+})
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+// The real virtualizer needs IntersectionObserver + layout, so it mounts zero
+// rows in jsdom. This stub mounts every item — but CRUCIALLY it derives each
+// key with `opts.getKey`, i.e. ChatPage's REAL key function. That is what keeps
+// this a test of production behaviour rather than of the stub.
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: (opts: { items?: unknown[]; getKey?: (it: unknown, i: number) => string }) => {
+    const items = opts.items ?? []
+    return {
+      virtualItems: items.map((data, index) => ({
+        key: opts.getKey ? opts.getKey(data, index) : String(index),
+        index,
+        mounted: true,
+        data,
+      })),
+      isAtBottom: true,
+      scrollToBottom: vi.fn(),
+      scrollToIndexSmooth: vi.fn(),
+      mountIndex: vi.fn(),
+      measureRef: () => () => {},
+      topSentinelRef: { current: null },
+      bottomSentinelRef: { current: null },
+      offsetBefore: 0,
+      offsetAfter: 0,
+    }
+  },
+}))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve({}),
+}) as never
+
+import ChatPage from '../pages/ChatPage'
+
+// An optimistic steer bubble: the client stamps its own ts and stashes it in
+// meta.clientTs, because the server will later hand back a DIFFERENT ts.
+const OPTIMISTIC = {
+  role: 'user',
+  content: 'steer me',
+  cls: '',
+  ts: '2026-06-23T20:00:00.000Z',
+  meta: { clientTs: '2026-06-23T20:00:00.000Z', steer: true },
+}
+// The echo reconcile: same logical message, authoritative server ts, clientTs
+// preserved. Anything keyed on `ts` alone sees a brand-new message here.
+const RECONCILED = {
+  ...OPTIMISTIC,
+  ts: '2026-06-23T20:00:04.512Z',
+  meta: { ...OPTIMISTIC.meta },
+}
+
+const renderChatPage = (initial: unknown[]) => {
+  const slot = { key: 'chat-1', title: 'chat-1', messages: 1, running: false, mode: '', created: '', last_ts: '' }
+  apiMocks.chatSlots = vi.fn().mockResolvedValue([slot])
+  apiMocks.chatSlotDetail = vi.fn().mockResolvedValue({ messages: initial, has_more: false, total: initial.length })
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: false,
+      slots: [slot], approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0,
+      unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as never,
+    chat: {
+      activeSlot: 'chat-1',
+      messages: initial, slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+    } as never,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const { container } = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat/chat-1']}>
+            <Routes>
+              <Route path="/chat/:slug?" element={<ChatPage mode="" />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  act(() => { store.dispatch({ type: 'chat/replaceMessages', payload: initial }) })
+  return { store, container }
+}
+
+const rowNode = (container: HTMLElement) =>
+  container.querySelector('[data-display-index="0"]') as HTMLElement | null
+
+describe('ChatPage — the virtualizer row survives steer reconciliation without remounting', () => {
+  beforeEach(() => { Object.keys(apiMocks).forEach(k => delete apiMocks[k]) })
+
+  it('keeps the SAME row DOM node when the server ts replaces the optimistic one', () => {
+    const { store, container } = renderChatPage([OPTIMISTIC])
+    const before = rowNode(container)
+    expect(before).toBeTruthy()
+    // Tag the live node: a remount would create a fresh element without this.
+    ;(before as HTMLElement & { __probe?: string }).__probe = 'kept'
+
+    act(() => { store.dispatch({ type: 'chat/replaceMessages', payload: [RECONCILED] }) })
+
+    const after = rowNode(container)
+    expect(after).toBeTruthy()
+    // Identity, not equality: React reuses the node only if the key is stable.
+    expect(after).toBe(before)
+    expect((after as HTMLElement & { __probe?: string }).__probe).toBe('kept')
+  })
+
+  it('a genuinely different message DOES get its own row node (control)', () => {
+    // Guards against the test passing for a trivial reason — e.g. if row lookup
+    // always returned the same node regardless of key, the assertion above would
+    // be meaningless.
+    const { store, container } = renderChatPage([OPTIMISTIC])
+    const before = rowNode(container)
+    ;(before as HTMLElement & { __probe?: string }).__probe = 'kept'
+    act(() => {
+      store.dispatch({
+        type: 'chat/replaceMessages',
+        payload: [{ role: 'user', content: 'unrelated', cls: '', ts: '2026-06-24T09:00:00.000Z' }],
+      })
+    })
+    const after = rowNode(container)
+    expect(after).toBeTruthy()
+    expect((after as HTMLElement & { __probe?: string }).__probe).toBeUndefined()
+  })
+})

--- a/website/src/test/FollowController.test.ts
+++ b/website/src/test/FollowController.test.ts
@@ -14,6 +14,7 @@ import {
   isSelfScroll,
   stickAfterUserScroll,
   evaluateAutoPin,
+  atBottomEpsilon,
   SELF_SCROLL_EPSILON,
   DEFAULT_BOTTOM_THRESHOLD,
 } from '../hooks/virtualizer/FollowController'
@@ -160,5 +161,65 @@ describe('evaluateAutoPin — the race-proof core', () => {
     expect(distanceFromBottom(geom)).toBeLessThanOrEqual(SELF_SCROLL_EPSILON)
     const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600 })
     expect(r.stick).toBe(true)
+  })
+})
+
+// Feature: chat-virtualizer, T3/#4 — DPR-aware "at bottom" epsilon.
+//
+// A flat 0.5px gate is UNDER one device pixel at fractional device-pixel ratios
+// (0.67 CSS px at 150% zoom), so at the fractional resting scrollTop the pin
+// re-fired on every ResizeObserver tick even though the viewport was visually
+// pinned. atBottomEpsilon() scales to the device pixel (never below 1 CSS px).
+describe('atBottomEpsilon — fractional-DPR resting gate', () => {
+  const desc = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio')
+  const setDpr = (v: number | undefined) => {
+    if (v === undefined) {
+      // Simulate an environment (jsdom/SSR) that leaves it undefined.
+      Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: undefined })
+    } else {
+      Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: v })
+    }
+  }
+  const restore = () => {
+    if (desc) Object.defineProperty(window, 'devicePixelRatio', desc)
+    else setDpr(1)
+  }
+
+  it('at DPR 1.5 the fractional resting max reports at-bottom → no re-pin', () => {
+    setDpr(1.5)
+    try {
+      // eps = max(1, 1/1.5 + 0.5) ≈ 1.167px — covers the 0.67 CSS px error.
+      expect(atBottomEpsilon()).toBeCloseTo(1.1667, 3)
+      // Resting scrollTop lands 0.67px short of the true bottom target (900).
+      const geom = { scrollTop: 900 - 0.67, scrollHeight: 1300, clientHeight: 400 }
+      const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 900 })
+      expect(r.stick).toBe(true)
+      expect(r.pin).toBe(false) // within epsilon — the RO tick does NOT re-fire
+      // The retired flat 0.5 literal WOULD have re-fired here (0.67 > 0.5).
+      expect(0.67).toBeGreaterThan(0.5)
+    } finally {
+      restore()
+    }
+  })
+
+  it('at DPR 1.25 the 0.8px resting error is still within epsilon', () => {
+    setDpr(1.25)
+    try {
+      expect(atBottomEpsilon()).toBeCloseTo(1.3, 5) // 1/1.25 + 0.5
+      const geom = { scrollTop: 600 - 0.8, scrollHeight: 1000, clientHeight: 400 }
+      const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600 })
+      expect(r.pin).toBe(false)
+    } finally {
+      restore()
+    }
+  })
+
+  it('falls back to 1.5px when devicePixelRatio is undefined (jsdom/SSR guard)', () => {
+    setDpr(undefined)
+    try {
+      expect(atBottomEpsilon()).toBe(1.5) // 1/1 + 0.5
+    } finally {
+      restore()
+    }
   })
 })

--- a/website/src/test/HeightCache.test.ts
+++ b/website/src/test/HeightCache.test.ts
@@ -123,7 +123,7 @@ describe('HeightCache: LRU eviction', () => {
 })
 
 describe('HeightCache: debounced flush', () => {
-  it('schedules a single flush within 100ms regardless of how many writes', () => {
+  it('schedules a single flush within the debounce window regardless of write count', () => {
     vi.useFakeTimers()
     const c = new HeightCache('debounce')
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
@@ -132,8 +132,12 @@ describe('HeightCache: debounced flush', () => {
     // No flush yet — still inside the debounce window.
     expect(setItemSpy).not.toHaveBeenCalled()
 
+    // Partway through the (lengthened) window: still no flush.
     vi.advanceTimersByTime(100)
-    // One flush, not 50.
+    expect(setItemSpy).not.toHaveBeenCalled()
+
+    // Cross the full debounce window: exactly one flush, not 50.
+    vi.advanceTimersByTime(700)
     expect(setItemSpy).toHaveBeenCalledTimes(1)
     setItemSpy.mockRestore()
   })
@@ -202,7 +206,7 @@ describe('HeightCache: storage failure modes', () => {
 
     const c = new HeightCache('quota')
     c.set('a', 100)
-    vi.advanceTimersByTime(100)
+    vi.advanceTimersByTime(750)
     // The debounced flush actually attempted the persisting write (and threw)…
     expect(setItemSpy).toHaveBeenCalledWith('vc_heights_quota', expect.any(String))
     // …and the cache degraded gracefully to memory-only.
@@ -218,5 +222,322 @@ describe('HeightCache: storage failure modes', () => {
     c.clear()
     expect(c.get('a')).toBeUndefined()
     expect(window.localStorage.getItem('vc_heights_clear-test')).toBeNull()
+  })
+})
+
+describe('HeightCache: averageHeight (running mean of measured heights)', () => {
+  it('returns the fallback estimate when nothing is measured', () => {
+    const c = new HeightCache('avg-empty')
+    // No measurements yet → the historical flat estimate (100).
+    expect(c.averageHeight()).toBe(100)
+  })
+
+  it('is the exact mean of measured heights once past the sample threshold', () => {
+    const c = new HeightCache('avg-basic')
+    c.set('a', 40)
+    c.set('b', 100)
+    c.set('c', 400)
+    // The mean is only trusted at >= MIN_MEAN_SAMPLES (12); pad with knowns so
+    // the expected value stays exact. (Below the threshold the fallback wins —
+    // covered in the small-sample guard block.)
+    for (let i = 0; i < 9; i++) c.set(`pad${i}`, 100)
+    expect(c.averageHeight()).toBeCloseTo((40 + 100 + 400 + 9 * 100) / 12, 10)
+  })
+
+  it('updates the mean correctly on overwrite (no skew)', () => {
+    const c = new HeightCache('avg-overwrite')
+    c.set('a', 100)
+    c.set('b', 200)
+    for (let i = 0; i < 10; i++) c.set(`pad${i}`, 100) // reach the sample threshold
+    expect(c.averageHeight()).toBeCloseTo((100 + 200 + 10 * 100) / 12, 10)
+    // Overwrite 'a' — the mean must reflect only the new value, not both.
+    c.set('a', 400)
+    expect(c.averageHeight()).toBeCloseTo((400 + 200 + 10 * 100) / 12, 10)
+  })
+
+  it('updates the mean correctly on eviction (evicted values leave the sum)', () => {
+    // Small cap (default 2000). Insert 2001 keys of known heights so exactly
+    // the oldest one is evicted, then assert the mean is over the survivors.
+    const c = new HeightCache('avg-evict')
+    // k0 has a huge outlier height; it will be the oldest and get evicted.
+    c.set('k0', 1_000_000)
+    for (let i = 1; i <= 2000; i++) c.set(`k${i}`, 100)
+    // Size capped at 2000, k0 evicted → mean is exactly 100 (all survivors),
+    // NOT skewed by the evicted outlier.
+    expect(c.size()).toBe(2000)
+    expect(c.get('k0')).toBeUndefined()
+    expect(c.averageHeight()).toBeCloseTo(100, 10)
+  })
+
+  it('mean is exact across a random set/overwrite/evict sequence', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.tuple(keyArb, heightArb), { minLength: 1, maxLength: 200 }),
+        (ops) => {
+          const c = new HeightCache(`avg-prop-${Math.random()}`)
+          const expected = new Map<string, number>()
+          for (const [k, h] of ops) {
+            c.set(k, h)
+            expected.set(k, h)
+          }
+          // Default cap is 2000 and keyArb yields far fewer distinct keys, so
+          // no eviction here — the expected map mirrors the cache exactly.
+          const vals = [...expected.values()]
+          const mean = vals.reduce((a, b) => a + b, 0) / vals.length
+          // averageHeight is capped at MAX_MEAN_PX; assert exactness below it.
+          if (mean <= 4000) {
+            expect(c.averageHeight()).toBeCloseTo(mean, 6)
+          } else {
+            expect(c.averageHeight()).toBeGreaterThan(0)
+          }
+        },
+      ),
+      { numRuns: 50 },
+    )
+  })
+})
+
+describe('HeightCache: averageHeight outlier ceiling (GPT MEDIUM)', () => {
+  // GPT flagged that the mean is biased by the tall mounted tail at cold open.
+  // The OUTLIER CEILING is the part adopted. A minimum-sample gate (hold the
+  // flat estimate until the sample grows) was implemented and measured in a real
+  // browser and was WORSE — it reintroduced the ~5x under-estimate and pushed
+  // the peak scrollHeight correction from ~51,500px to ~387,000px — so the mean
+  // is trusted from the first measurement and only clipped at the extreme.
+  it('caps the estimate so one pathological row cannot dominate', () => {
+    const c = new HeightCache('avg-guard-cap')
+    for (let i = 0; i < 12; i++) c.set(`k${i}`, 40)
+    c.set('monster', 5_000_000)
+    // Uncapped this mean would be ~385,000px per unmeasured row.
+    expect(c.averageHeight(100)).toBe(4000)
+  })
+
+  it('leaves a normal transcript mean untouched by the ceiling', () => {
+    const c = new HeightCache('avg-guard-normal')
+    for (let i = 0; i < 20; i++) c.set(`k${i}`, i % 2 === 0 ? 40 : 1200)
+    // Real bimodal transcripts average in the hundreds — well under the cap.
+    expect(c.averageHeight(100)).toBeCloseTo(620, 6)
+  })
+
+  it('adapts from the very FIRST measurement (no sample gate)', () => {
+    const c = new HeightCache('avg-guard-first')
+    c.set('a', 600)
+    // Must NOT hold the flat fallback: that is the original under-estimate bug.
+    expect(c.averageHeight(100)).toBeCloseTo(600, 6)
+  })
+
+  it('honours an explicit fallback only when nothing is measured', () => {
+    const c = new HeightCache('avg-guard-fallback')
+    expect(c.averageHeight(250)).toBe(250)
+    c.set('a', 900)
+    expect(c.averageHeight(250)).toBeCloseTo(900, 6)
+  })
+})
+
+describe('HeightCache: peek() does not disturb LRU order (GPT MEDIUM)', () => {
+  // Regression: OffsetIndex.sync() reads EVERY row's height. Routing that
+  // through get() rewrote LRU order into transcript-index order on each sync,
+  // so at capacity eviction dropped rows the user had just viewed — defeating
+  // the access-based retention the size-aware cap exists to provide.
+  it('peek returns the value without promoting it', () => {
+    const c = new HeightCache('peek-order')
+    for (let i = 0; i < 2000; i++) c.set(`k${i}`, 10)
+    expect(c.peek('k0')).toBe(10) // oldest; peeking must not save it
+    c.set('fresh', 10) // over the 2000 cap → oldest evicted
+    expect(c.peek('k0')).toBeUndefined()
+  })
+
+  it('get() still promotes, so genuine access is protected', () => {
+    const c = new HeightCache('peek-vs-get')
+    for (let i = 0; i < 2000; i++) c.set(`k${i}`, 10)
+    expect(c.get('k0')).toBe(10) // promote k0 to most-recent
+    c.set('fresh', 10)
+    expect(c.peek('k0')).toBe(10) // survived
+    expect(c.peek('k1')).toBeUndefined() // k1 evicted instead
+  })
+
+  it('peek on a missing key is undefined and adds nothing', () => {
+    const c = new HeightCache('peek-missing')
+    expect(c.peek('nope')).toBeUndefined()
+    expect(c.size()).toBe(0)
+  })
+})
+
+describe('HeightCache: size-aware eviction cap', () => {
+  it('defaults to a 2000 floor when no rowCount is supplied', () => {
+    const c = new HeightCache('cap-default')
+    for (let i = 0; i < 2100; i++) c.set(`k${i}`, i)
+    expect(c.size()).toBe(2000)
+  })
+
+  it('grows the cap with rowCount (max(2000, min(rowCount, 20000)))', () => {
+    const c = new HeightCache('cap-grow', { rowCount: 5000 })
+    for (let i = 0; i < 5100; i++) c.set(`k${i}`, i)
+    // Cap = max(2000, min(5000, 20000)) = 5000.
+    expect(c.size()).toBe(5000)
+    expect(c.get('k0')).toBeUndefined()  // oldest 100 evicted
+    expect(c.get('k99')).toBeUndefined()
+    expect(c.get('k100')).toBe(100)
+    expect(c.get('k5099')).toBe(5099)
+  })
+
+  it('a small rowCount still honours the 2000 floor', () => {
+    const c = new HeightCache('cap-floor', { rowCount: 500 })
+    for (let i = 0; i < 2100; i++) c.set(`k${i}`, i)
+    // Cap = max(2000, min(500, 20000)) = 2000.
+    expect(c.size()).toBe(2000)
+  })
+
+  it('honours the 20000 hard ceiling even for an enormous rowCount', () => {
+    const c = new HeightCache('cap-ceiling', { rowCount: 1_000_000 })
+    for (let i = 0; i < 20050; i++) c.set(`k${i}`, i)
+    // Cap = max(2000, min(1_000_000, 20000)) = 20000.
+    expect(c.size()).toBe(20000)
+    expect(c.get('k0')).toBeUndefined()
+    expect(c.get('k49')).toBeUndefined()
+    expect(c.get('k50')).toBe(50)
+    expect(c.get('k20049')).toBe(20049)
+  })
+
+  // setRowCount is a HIGH-WATER MARK: a smaller count never shrinks the cap,
+  // because a transient under-count (one WS message arriving before slot
+  // hydration reports itemCount 1 for a 5,000-row session) would evict
+  // measurements the authoritative count cannot restore. Growth still evicts
+  // oldest-first, which is what bounds retention.
+  it('setRowCount never shrinks the cap, and growth still evicts oldest-first', () => {
+    const c = new HeightCache('cap-shrink', { rowCount: 5000 })
+    for (let i = 0; i < 5000; i++) c.set(`k${i}`, i)
+    expect(c.size()).toBe(5000)
+    // A smaller count is ignored — nothing is discarded.
+    c.setRowCount(2500)
+    expect(c.size()).toBe(5000)
+    expect(c.peek('k0')).toBe(0)
+    expect(c.peek('k4999')).toBe(4999)
+    // The cap is still enforced on the way UP: with the count pinned at 5000,
+    // inserting past it evicts the oldest first.
+    for (let i = 5000; i < 5200; i++) c.set(`k${i}`, i)
+    expect(c.size()).toBe(5000)
+    expect(c.peek('k199')).toBeUndefined()
+    expect(c.peek('k200')).toBe(200)
+    expect(c.peek('k5199')).toBe(5199)
+    // measuredSum stays consistent after the growth evictions: survivors are
+    // k200..k5199.
+    const survivors = 5000
+    const meanExpected =
+      Array.from({ length: survivors }, (_, j) => 200 + j).reduce((a, b) => a + b, 0) /
+      survivors
+    // 2699.5 sits below MAX_MEAN_PX, so the ceiling does not engage here and
+    // measuredSum consistency is asserted directly.
+    expect(meanExpected).toBeLessThan(4000)
+    expect(c.averageHeight()).toBeCloseTo(meanExpected, 6)
+  })
+
+  // Regression: a slot switch sets sessionId one render before the transcript
+  // loads, so the cache is constructed with rowCount 0. Treating that as a real
+  // count trimmed a long session's persisted heights to the 2000 floor at load
+  // time, and the trim is irreversible — the later setRowCount() raises the cap
+  // but cannot restore evicted measurements, so the revisited session fell back
+  // to estimated offsets. 0 must mean "unknown".
+  it('does not trim a long persisted blob when constructed before the count is known', () => {
+    const sid = 'cap-unknown-load'
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < 5000; i++) blob[`k${i}`] = 100
+    window.localStorage.setItem(`vc_heights_${sid}`, JSON.stringify(blob))
+
+    // rowCount 0 == "transcript not loaded yet", NOT "session has no rows".
+    const c = new HeightCache(sid, { rowCount: 0 })
+    expect(c.size()).toBe(5000)
+    expect(c.peek('k0')).toBe(100)
+
+    // The real count arriving later must not discard anything either.
+    c.setRowCount(5000)
+    expect(c.size()).toBe(5000)
+    expect(c.peek('k0')).toBe(100)
+  })
+
+  it('omitting rowCount entirely also preserves a long persisted blob', () => {
+    const sid = 'cap-omitted-load'
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < 3000; i++) blob[`k${i}`] = 100
+    window.localStorage.setItem(`vc_heights_${sid}`, JSON.stringify(blob))
+    expect(new HeightCache(sid).size()).toBe(3000)
+  })
+
+  it('still enforces the hard ceiling on a blob loaded with an unknown count', () => {
+    const sid = 'cap-unknown-ceiling'
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < 20050; i++) blob[`k${i}`] = 100
+    window.localStorage.setItem(`vc_heights_${sid}`, JSON.stringify(blob))
+    // Seeding the cap from the blob must not let it exceed HARD_CEILING.
+    expect(new HeightCache(sid).size()).toBe(20000)
+  })
+
+  it('ignores an under-reported setRowCount instead of shrinking to the floor', () => {
+    const c = new HeightCache('cap-zero-set', { rowCount: 5000 })
+    for (let i = 0; i < 5000; i++) c.set(`k${i}`, 100)
+    expect(c.size()).toBe(5000)
+    // A transient 0 (or NaN) must not be read as "the session emptied".
+    c.setRowCount(0)
+    expect(c.size()).toBe(5000)
+    c.setRowCount(Number.NaN)
+    expect(c.size()).toBe(5000)
+    // Nor a transient POSITIVE under-count: one WS message arriving before slot
+    // hydration reports itemCount 1 for this 5,000-row session, and the trim it
+    // would cause is irreversible.
+    c.setRowCount(1)
+    expect(c.size()).toBe(5000)
+    c.setRowCount(2500)
+    expect(c.size()).toBe(5000)
+    expect(c.peek('k0')).toBe(100)
+    // The authoritative larger count still applies.
+    c.setRowCount(6000)
+    for (let i = 5000; i < 6000; i++) c.set(`k${i}`, 100)
+    expect(c.size()).toBe(6000)
+  })
+
+  // Regression: evictToCap()'s eviction only changed the in-memory map. The
+  // oversized blob stayed in localStorage, so every subsequent open re-read and
+  // re-trimmed it and the wasted quota was never reclaimed. Driven here through
+  // load()'s HARD_CEILING trim, which is the eviction path that does NOT go via
+  // set() — set() dirties the cache on its own, so it cannot discriminate.
+  it('persists the trimmed map after a load-time eviction', () => {
+    const sid = 'cap-load-trim-persist'
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < 20050; i++) blob[`k${i}`] = 100
+    window.localStorage.setItem(`vc_heights_${sid}`, JSON.stringify(blob))
+
+    const c = new HeightCache(sid)
+    expect(c.size()).toBe(20000)
+    // The load-time trim must have dirtied the cache, so flush() writes the
+    // reclaimed blob out rather than treating it as a no-op.
+    c.flush()
+    const persisted = JSON.parse(window.localStorage.getItem(`vc_heights_${sid}`)!)
+    expect(Object.keys(persisted).length).toBe(20000)
+    expect(persisted.k49).toBeUndefined()
+    expect(persisted.k50).toBe(100)
+  })
+})
+
+describe('HeightCache: access-recency eviction', () => {
+  it('recently READ rows survive eviction instead of dying by insertion age', () => {
+    const c = new HeightCache('recency')
+    // Fill to the default 2000-entry cap.
+    for (let i = 0; i < 2000; i++) c.set(`k${i}`, i)
+    // Read the three oldest-by-insertion keys — they should be promoted to MRU.
+    expect(c.get('k0')).toBe(0)
+    expect(c.get('k1')).toBe(1)
+    expect(c.get('k2')).toBe(2)
+    // Insert three new keys → three evictions. The now-oldest are k3,k4,k5,
+    // NOT the freshly-read k0,k1,k2.
+    c.set('n0', 9000)
+    c.set('n1', 9001)
+    c.set('n2', 9002)
+    expect(c.get('k0')).toBe(0)   // survived via read-recency
+    expect(c.get('k1')).toBe(1)
+    expect(c.get('k2')).toBe(2)
+    expect(c.get('k3')).toBeUndefined()  // evicted by age
+    expect(c.get('k4')).toBeUndefined()
+    expect(c.get('k5')).toBeUndefined()
+    expect(c.get('n2')).toBe(9002)
   })
 })

--- a/website/src/test/WindowCalculator.test.ts
+++ b/website/src/test/WindowCalculator.test.ts
@@ -14,6 +14,7 @@ import {
   getOffset,
   getIndexAtOffset,
   getTotalHeight,
+  OffsetIndex,
 } from '../hooks/virtualizer/WindowCalculator'
 
 // Arbitrary: an item heights array of plausible chat message sizes.
@@ -174,5 +175,252 @@ describe('getOffset / getIndexAtOffset', () => {
 
   it('getTotalHeight sums all item heights', () => {
     expect(getTotalHeight(4, (i) => (i + 1) * 10)).toBe(10 + 20 + 30 + 40)
+  })
+})
+
+// ── OffsetIndex (Fenwick/prefix-sum tree) ───────────────────────────────────
+// Correctness contract: OffsetIndex must answer offsetOf / indexAt /
+// totalHeight IDENTICALLY to the O(N) free functions for every input, while
+// scaling sub-linearly (fix #2).
+
+// Mixed height distribution incl. zero-height rows (tool pills → widgets).
+const mixedHeightsArb = fc.array(fc.integer({ min: 0, max: 3000 }), {
+  minLength: 1,
+  maxLength: 300,
+})
+
+describe('OffsetIndex: parity with the O(N) free functions', () => {
+  it('offsetOf(i) === getOffset(i) for every boundary across mixed heights', () => {
+    fc.assert(
+      fc.property(mixedHeightsArb, (heights) => {
+        const getH = (i: number) => heights[i]
+        const oi = new OffsetIndex(heights.length, getH)
+        for (let i = 0; i <= heights.length; i++) {
+          expect(oi.offsetOf(i)).toBe(getOffset(i, heights.length, getH))
+        }
+      }),
+      { numRuns: 100 },
+    )
+  })
+
+  it('totalHeight() === getTotalHeight() and === offsetOf(itemCount)', () => {
+    fc.assert(
+      fc.property(mixedHeightsArb, (heights) => {
+        const getH = (i: number) => heights[i]
+        const oi = new OffsetIndex(heights.length, getH)
+        const total = getTotalHeight(heights.length, getH)
+        expect(oi.totalHeight()).toBe(total)
+        expect(oi.offsetOf(heights.length)).toBe(total)
+      }),
+      { numRuns: 100 },
+    )
+  })
+
+  it('indexAt(scrollTop) === getIndexAtOffset(scrollTop) across the content range', () => {
+    fc.assert(
+      fc.property(
+        mixedHeightsArb,
+        fc.array(fc.integer({ min: 0, max: 1_000_000 }), { minLength: 1, maxLength: 20 }),
+        (heights, probes) => {
+          const getH = (i: number) => heights[i]
+          const oi = new OffsetIndex(heights.length, getH)
+          const total = getTotalHeight(heights.length, getH)
+          for (const raw of probes) {
+            // Sample both inside the content and past the end (clamp branch).
+            const t = total > 0 ? raw % (total + 50) : raw
+            expect(oi.indexAt(t)).toBe(getIndexAtOffset(t, heights.length, getH))
+          }
+          // Exact row boundaries — the round-trip the free functions guarantee.
+          for (let i = 0; i < heights.length; i++) {
+            const off = oi.offsetOf(i)
+            expect(oi.indexAt(off)).toBe(getIndexAtOffset(off, heights.length, getH))
+          }
+        },
+      ),
+      { numRuns: 100 },
+    )
+  })
+
+  it('clamps out-of-range / degenerate inputs like the free functions', () => {
+    const heights = [40, 250, 0, 1200]
+    const getH = (i: number) => heights[i]
+    const oi = new OffsetIndex(heights.length, getH)
+    // offsetOf clamps below 0 and above itemCount.
+    expect(oi.offsetOf(-5)).toBe(0)
+    expect(oi.offsetOf(0)).toBe(0)
+    expect(oi.offsetOf(99)).toBe(getTotalHeight(4, getH))
+    // indexAt clamps negative/NaN → row 0, past-end → last row.
+    expect(oi.indexAt(-100)).toBe(0)
+    expect(oi.indexAt(Number.NaN)).toBe(0)
+    expect(oi.indexAt(9_999_999)).toBe(3)
+    // Empty list.
+    const empty = new OffsetIndex(0, () => 100)
+    expect(empty.totalHeight()).toBe(0)
+    expect(empty.offsetOf(0)).toBe(0)
+    expect(empty.indexAt(500)).toBe(0)
+  })
+})
+
+describe('OffsetIndex: sync (rebuild / extend / refine)', () => {
+  it('append-growth matches a fresh build of the grown array', () => {
+    const heights: number[] = [100, 40, 800, 0, 250]
+    const getH = (i: number) => heights[i]
+    const oi = new OffsetIndex(heights.length, getH)
+    // Grow at the tail (transcript append) five rows at a time.
+    for (let batch = 0; batch < 5; batch++) {
+      for (let k = 0; k < 5; k++) heights.push((batch * 5 + k) * 37 % 900)
+      oi.sync(heights.length, getH)
+      // Every offset + total must match a from-scratch build.
+      const fresh = new OffsetIndex(heights.length, getH)
+      for (let i = 0; i <= heights.length; i++) {
+        expect(oi.offsetOf(i)).toBe(fresh.offsetOf(i))
+      }
+      expect(oi.totalHeight()).toBe(getTotalHeight(heights.length, getH))
+    }
+  })
+
+  it('refining measurements in place (same itemCount) matches a fresh build', () => {
+    const heights = new Array<number>(200).fill(100) // all "estimated"
+    const getH = (i: number) => heights[i]
+    const oi = new OffsetIndex(heights.length, getH)
+    // Rows measure in with their real (varied) heights.
+    for (let i = 0; i < heights.length; i++) heights[i] = (i * 17) % 1500
+    oi.sync(heights.length, getH)
+    for (let i = 0; i <= heights.length; i++) {
+      expect(oi.offsetOf(i)).toBe(getOffset(i, heights.length, getH))
+    }
+    expect(oi.totalHeight()).toBe(getTotalHeight(heights.length, getH))
+  })
+
+  it('shrink (rows removed) rebuilds correctly', () => {
+    const heights = [100, 200, 300, 400, 500, 600]
+    const getH = (i: number) => heights[i]
+    const oi = new OffsetIndex(heights.length, getH)
+    oi.sync(3, getH) // keep first three rows
+    expect(oi.totalHeight()).toBe(600)
+    expect(oi.offsetOf(3)).toBe(600)
+    expect(oi.indexAt(250)).toBe(1)
+  })
+
+  it('a no-op sync (nothing changed) leaves answers identical', () => {
+    const heights = [100, 40, 800, 250]
+    const getH = (i: number) => heights[i]
+    const oi = new OffsetIndex(heights.length, getH)
+    const before = heights.map((_, i) => oi.offsetOf(i))
+    oi.sync(heights.length, getH)
+    heights.forEach((_, i) => expect(oi.offsetOf(i)).toBe(before[i]))
+    expect(oi.totalHeight()).toBe(getTotalHeight(heights.length, getH))
+  })
+})
+
+describe('OffsetIndex: sub-linear scaling benchmark', () => {
+  // Wall-clock micro-benchmarks are noisy, so this test is built to be robust:
+  //  • min-of-N trials (min rejects positive scheduler/GC spikes),
+  //  • enough iterations per trial that each measurement is comfortably
+  //    above timer resolution,
+  //  • assertions are RELATIVE and self-calibrating against the known-linear
+  //    free function measured on the SAME machine — no absolute ms budget that
+  //    could flake on a slow/fast CI box.
+  const makeHeights = (n: number): number[] =>
+    Array.from({ length: n }, (_, i) => 20 + ((i * 131) % 780))
+
+  // Deterministic probe offsets so timing reflects the algorithm, not RNG.
+  const makeProbes = (count: number, span: number): number[] =>
+    Array.from({ length: count }, (_, i) => ((i * 2654435761) % span))
+
+  const bestOf = (trials: number, fn: () => void): number => {
+    let best = Infinity
+    for (let t = 0; t < trials; t++) {
+      const t0 = performance.now()
+      fn()
+      const dt = performance.now() - t0
+      if (dt < best) best = dt
+    }
+    return best
+  }
+
+  it('OffsetIndex.indexAt is far cheaper than the O(N) scan at N=5000', () => {
+    const N = 5000
+    const heights = makeHeights(N)
+    const getH = (i: number) => heights[i]
+    const total = getTotalHeight(N, getH)
+    const oi = new OffsetIndex(N, getH)
+    const ITER = 2000
+    const probes = makeProbes(ITER, total)
+
+    // Warm up both paths (JIT).
+    for (const p of probes) { oi.indexAt(p); getIndexAtOffset(p, N, getH) }
+
+    const oiTime = bestOf(5, () => {
+      for (let i = 0; i < ITER; i++) oi.indexAt(probes[i])
+    })
+    const naiveTime = bestOf(5, () => {
+      for (let i = 0; i < ITER; i++) getIndexAtOffset(probes[i], N, getH)
+    })
+
+    // Fenwick does ~log2(5000)≈12 steps vs the scan's up-to-5000; even with a
+    // generous 3× cushion for constant-factor/noise the tree must win big.
+    expect(oiTime * 3).toBeLessThan(naiveTime)
+  })
+
+  it('per-call cost grows sub-linearly (logarithmically) with N', () => {
+    const sizes = [500, 2000, 5000]
+    // OffsetIndex is so cheap it needs a large iteration count to rise well
+    // above performance.now() resolution — that's what keeps the ratio stable.
+    const ITER = 100_000
+    // The O(N) baseline is expensive PER CALL, so a much smaller count already
+    // yields a stable, well-above-floor measurement (and keeps the test fast).
+    const NAIVE_ITER = 20_000
+
+    // One full measurement pass. Returns the two ratios being compared.
+    const measure = () => {
+      const perCall: Record<number, number> = {}
+      const naivePerCall: Record<number, number> = {}
+      for (const N of sizes) {
+        const heights = makeHeights(N)
+        const getH = (i: number) => heights[i]
+        const total = getTotalHeight(N, getH)
+        const oi = new OffsetIndex(N, getH)
+        const probes = makeProbes(ITER, total)
+        // Warm up.
+        for (let i = 0; i < ITER; i++) oi.indexAt(probes[i])
+        perCall[N] = bestOf(5, () => {
+          for (let i = 0; i < ITER; i++) oi.indexAt(probes[i])
+        }) / ITER
+        // Only measure the linear baseline at the two endpoints we compare.
+        if (N === 500 || N === 5000) {
+          for (let i = 0; i < NAIVE_ITER; i++) getIndexAtOffset(probes[i], N, getH)
+          naivePerCall[N] = bestOf(2, () => {
+            for (let i = 0; i < NAIVE_ITER; i++) getIndexAtOffset(probes[i], N, getH)
+          }) / NAIVE_ITER
+        }
+      }
+      // Self-calibrating: the naive scan is O(N), so its 500→5000 ratio is the
+      // machine's "what linear looks like" (~10×). OffsetIndex (O(log N)) must
+      // scale dramatically better — its 500→5000 ratio should be ~1.4×.
+      return {
+        oiRatio: perCall[5000] / Math.max(perCall[500], 1e-9),
+        naiveRatio: naivePerCall[5000] / Math.max(naivePerCall[500], 1e-9),
+      }
+    }
+
+    // A wall-clock ratio can be distorted when the suite runs in parallel and
+    // an unrelated worker steals CPU mid-measurement. Retry a bounded number of
+    // times and require only that ONE clean pass agrees: a genuine O(N)
+    // regression fails every attempt, while transient contention does not.
+    // The assertions themselves are unchanged.
+    let last = measure()
+    for (let attempt = 1; attempt < 3; attempt++) {
+      if (last.oiRatio < last.naiveRatio && last.oiRatio < 6) break
+      last = measure()
+    }
+    const { oiRatio, naiveRatio } = last
+
+    // Primary, machine-independent signal: OffsetIndex grows far slower than
+    // the known-linear baseline on the SAME hardware.
+    expect(oiRatio).toBeLessThan(naiveRatio)
+    // Absolute backstop: nowhere near linear (which would be ~10×). Generous
+    // enough (6×) to never flake, tight enough to fail an O(N) regression.
+    expect(oiRatio).toBeLessThan(6)
   })
 })

--- a/website/src/test/searchScroll.coupling.test.ts
+++ b/website/src/test/searchScroll.coupling.test.ts
@@ -1,0 +1,77 @@
+// Feature: chat-virtualizer — cross-module timing coupling.
+//
+// Design Review flagged that the settle-poll constants in `searchScroll.ts` are
+// hand-tuned against a widget-build delay owned by `WidgetFrame.tsx`: two
+// magic numbers in different modules whose relationship is load-bearing but
+// invisible from either side. Rather than create a runtime dependency from a
+// util to a React component (which would drag the component graph into the
+// util), the relationship is asserted here, so drift in EITHER constant fails
+// CI and points at the other one.
+//
+// The relationship: a jump to a widget row must keep converging until the
+// iframe has finished growing. If the poll can settle first, the late resize
+// pushes the target off-centre — the exact first-click miss the condition-based
+// poll was introduced to remove.
+
+import { describe, it, expect } from 'vitest'
+import { MIN_QUIET_MS, CONVERGE_MAX_MS } from '../utils/searchScroll'
+import { PROGRAMMATIC_BUILD_DELAY_MS, MAX_WIDGET_BUILD_WAIT_MS, MAX_STAGGER_SLOTS, staggeredBuildWait } from '../components/WidgetFrame'
+
+describe('searchScroll <-> WidgetFrame timing coupling', () => {
+  it('the settle quiet window outlasts the WORST-CASE widget build wait', () => {
+    // Not just the base delay: a jump can mount a batch of widgets whose builds
+    // are staggered, so the last one to build is the deadline that matters.
+    expect(
+      MIN_QUIET_MS,
+      `MIN_QUIET_MS (${MIN_QUIET_MS}ms) must exceed MAX_WIDGET_BUILD_WAIT_MS ` +
+        `(${MAX_WIDGET_BUILD_WAIT_MS}ms = base ${PROGRAMMATIC_BUILD_DELAY_MS}ms + ` +
+        'capped stagger), or a jump to a widget in a later stagger slot settles ' +
+        'before its iframe grows and lands off-target.',
+    ).toBeGreaterThan(MAX_WIDGET_BUILD_WAIT_MS)
+  })
+
+  it('the worst-case build wait is BOUNDED (stagger is capped)', () => {
+    // If the stagger slot were unbounded, no finite quiet window could be
+    // correct. This pins the fact that it is capped.
+    expect(MAX_WIDGET_BUILD_WAIT_MS).toBeGreaterThan(PROGRAMMATIC_BUILD_DELAY_MS)
+    expect(MAX_WIDGET_BUILD_WAIT_MS).toBeLessThan(CONVERGE_MAX_MS)
+  })
+
+  it('the wall-clock backstop still leaves room for the quiet window', () => {
+    // The backstop terminates a poll whose target never settles. It has to be
+    // comfortably larger than the quiet window, or every poll would time out
+    // instead of settling.
+    expect(CONVERGE_MAX_MS).toBeGreaterThan(MIN_QUIET_MS)
+  })
+
+  it('the backstop also covers mount + build in the worst case', () => {
+    expect(CONVERGE_MAX_MS).toBeGreaterThan(MAX_WIDGET_BUILD_WAIT_MS)
+  })
+
+  // The assertions above compare CONSTANTS, so they stayed green when the
+  // `Math.min` that actually applies the cap was removed — late-slot widgets
+  // would again build after convergence settled while CI reported no problem.
+  // These exercise the arithmetic itself.
+  it('the stagger delay plateaus at the cap instead of growing per widget', () => {
+    const base = 100
+    // Below the cap the delay grows one stagger step per slot.
+    expect(staggeredBuildWait(base, 0)).toBe(base)
+    expect(staggeredBuildWait(base, 1)).toBeGreaterThan(staggeredBuildWait(base, 0))
+    expect(staggeredBuildWait(base, MAX_STAGGER_SLOTS)).toBeGreaterThan(
+      staggeredBuildWait(base, MAX_STAGGER_SLOTS - 1),
+    )
+    // At and beyond the cap it must stop growing, however large the batch.
+    const capped = staggeredBuildWait(base, MAX_STAGGER_SLOTS)
+    expect(staggeredBuildWait(base, MAX_STAGGER_SLOTS + 1)).toBe(capped)
+    expect(staggeredBuildWait(base, 500)).toBe(capped)
+  })
+
+  it('the worst-case wait bound is the one the poll is calibrated against', () => {
+    // Ties MAX_WIDGET_BUILD_WAIT_MS to the function that produces the real
+    // delay, so the published bound cannot drift away from actual behaviour.
+    expect(staggeredBuildWait(PROGRAMMATIC_BUILD_DELAY_MS, 10_000)).toBe(
+      MAX_WIDGET_BUILD_WAIT_MS,
+    )
+    expect(MIN_QUIET_MS).toBeGreaterThan(staggeredBuildWait(PROGRAMMATIC_BUILD_DELAY_MS, 10_000))
+  })
+})

--- a/website/src/test/searchScroll.test.ts
+++ b/website/src/test/searchScroll.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
-import { pickSearchScrollBehavior, RAPID_STEP_MS, scrollCurrentMatchIntoView } from '../utils/searchScroll'
+import {
+  pickSearchScrollBehavior,
+  RAPID_STEP_MS,
+  scrollCurrentMatchIntoView,
+  pollRowSettled,
+  glideOnceStep,
+  attachUserScrollIntent,
+} from '../utils/searchScroll'
 
 describe('pickSearchScrollBehavior', () => {
   it('snaps (auto) when stepping faster than the threshold', () => {
@@ -22,19 +29,528 @@ describe('pickSearchScrollBehavior', () => {
   })
 })
 
+// A deterministic frame scheduler + clock so the condition-based converge loops
+// can be driven one frame at a time without real rAF / timers.
+function makeDriver() {
+  let queue: Array<() => void> = []
+  let t = 0
+  return {
+    raf: (cb: () => void) => { queue.push(cb); return queue.length },
+    now: () => t,
+    advance: (ms: number) => { t += ms },
+    pending: () => queue.length,
+    /** Run up to `n` queued frames (each may re-queue the next). */
+    flush: (n = 1) => {
+      for (let i = 0; i < n; i++) {
+        const cb = queue.shift()
+        if (!cb) break
+        cb()
+      }
+    },
+    drain: (maxFrames = 500, msPerFrame = 8) => {
+      for (let i = 0; i < maxFrames && queue.length; i++) {
+        t += msPerFrame
+        const cb = queue.shift()
+        cb?.()
+      }
+    },
+  }
+}
+
+describe('pollRowSettled: nested scroll ownership (GPT MEDIUM round 13)', () => {
+  // Navigating to a search result starts a ROW-level convergence (centre
+  // display index N); once that row mounts, the message component starts a
+  // finer MARK-level convergence (centre the exact occurrence inside it). The
+  // row poll re-scrolls every frame for the whole quiet window, so without a
+  // handoff it repeatedly undid the mark centring and the viewport ended up on
+  // the containing turn rather than on the match.
+  it('a newer poll retires an older one that has already stepped', () => {
+    const d = makeDriver()
+    const rowSteps: number[] = []
+    const rowEnd: string[] = []
+    pollRowSettled({
+      measure: () => 10,
+      step: () => rowSteps.push(1),
+      raf: d.raf,
+      now: d.now,
+      onEnd: (r) => rowEnd.push(r),
+    })
+    d.flush(1)
+    expect(rowSteps.length).toBe(1)
+    expect(rowEnd).toEqual([])
+
+    // The nested mark-level poll claims ownership.
+    const markSteps: number[] = []
+    pollRowSettled({
+      measure: () => 20,
+      step: () => markSteps.push(1),
+      raf: d.raf,
+      now: d.now,
+    })
+    expect(rowEnd).toEqual(['cancelled'])
+
+    // The retired poll must stop stepping; the new one keeps going.
+    const rowStepsAtHandoff = rowSteps.length
+    d.drain(20)
+    expect(rowSteps.length).toBe(rowStepsAtHandoff)
+    expect(markSteps.length).toBeGreaterThan(0)
+  })
+
+  // The row poll's first step is what MOUNTS the nested target. Retiring it
+  // before that step would mean the mark never appears and NEITHER scroll
+  // happens — the far-jump no-op this PR exists to fix.
+  it('defers retirement until the superseded poll has stepped once', () => {
+    const d = makeDriver()
+    let rowPresent = false
+    const rowSteps: number[] = []
+    const rowEnd: string[] = []
+    pollRowSettled({
+      measure: () => (rowPresent ? 10 : null),
+      step: () => rowSteps.push(1),
+      raf: d.raf,
+      now: d.now,
+      onEnd: (r) => rowEnd.push(r),
+    })
+    d.flush(2)
+    expect(rowSteps.length).toBe(0)
+
+    // A nested poll claims ownership while the row is still unmounted.
+    pollRowSettled({ measure: () => null, step: () => {}, raf: d.raf, now: d.now })
+    // Not retired yet — it still owes its mounting step.
+    expect(rowEnd).toEqual([])
+
+    rowPresent = true
+    d.flush(1)
+    expect(rowSteps.length).toBe(1)
+    expect(rowEnd).toEqual(['cancelled'])
+  })
+
+  it('a retired poll\'s teardown cannot revoke the newer poll\'s claim', () => {
+    const d = makeDriver()
+    const cancelA = pollRowSettled({ measure: () => 10, step: () => {}, raf: d.raf, now: d.now })
+    d.flush(1)
+    const bSteps: number[] = []
+    pollRowSettled({
+      measure: () => 10,
+      step: () => bSteps.push(1),
+      raf: d.raf,
+      now: d.now,
+    })
+    // Let B actually step, so C's claim retires it immediately rather than
+    // deferring (the deferral case is covered by the test above).
+    d.flush(3)
+    // A late cancel() on the already-retired poll A must not clear B's claim —
+    // otherwise C would find no owner to supersede and both would run at once.
+    cancelA()
+    const bStepsBeforeC = bSteps.length
+    expect(bStepsBeforeC).toBeGreaterThan(0)
+    const cSteps: number[] = []
+    pollRowSettled({
+      measure: () => 10,
+      step: () => cSteps.push(1),
+      raf: d.raf,
+      now: d.now,
+    })
+    d.drain(20)
+    expect(cSteps.length).toBeGreaterThan(0)
+    // B was superseded by C, so it stopped stepping.
+    expect(bSteps.length).toBe(bStepsBeforeC)
+  })
+})
+
+describe('glideOnceStep (GPT MEDIUM round 3)', () => {
+  // Re-issuing a smooth scroll cancels the in-flight animation and restarts it.
+  // A convergence poll steps once per frame, so a NEAR jump that kept
+  // behavior:'smooth' on every step stuttered/stalled until the poll ended.
+  it('uses the requested behavior once, then snaps instantly', () => {
+    const seen: ScrollBehavior[] = []
+    const step = glideOnceStep((b) => seen.push(b), 'smooth')
+    step(); step(); step(); step()
+    expect(seen).toEqual(['smooth', 'auto', 'auto', 'auto'])
+  })
+
+  it('passes an already-instant behavior straight through', () => {
+    const seen: ScrollBehavior[] = []
+    const step = glideOnceStep((b) => seen.push(b), 'auto')
+    step(); step()
+    expect(seen).toEqual(['auto', 'auto'])
+  })
+
+  it('each call site gets its own latch (a new jump may glide again)', () => {
+    const a: ScrollBehavior[] = []
+    const b: ScrollBehavior[] = []
+    const stepA = glideOnceStep((x) => a.push(x), 'smooth')
+    const stepB = glideOnceStep((x) => b.push(x), 'smooth')
+    stepA(); stepA(); stepB()
+    expect(a).toEqual(['smooth', 'auto'])
+    expect(b).toEqual(['smooth'])
+  })
+
+  it('under a real poll, exactly ONE smooth scroll is issued across the quiet window', () => {
+    const d = makeDriver()
+    const seen: ScrollBehavior[] = []
+    pollRowSettled({
+      measure: () => 300, // stable, so the 500ms quiet window is what keeps it alive
+      step: glideOnceStep((b) => seen.push(b), 'smooth'),
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+    })
+    d.drain(500, 8)
+    // Many steps across the quiet window, but only the first animated.
+    expect(seen.length).toBeGreaterThan(2)
+    expect(seen.filter((b) => b === 'smooth')).toHaveLength(1)
+    expect(seen[0]).toBe('smooth')
+  })
+})
+
+describe('pollRowSettled: user scroll aborts convergence (GPT MEDIUM round 2)', () => {
+  // The poll re-scrolls every frame for up to ~2s. If the user wheels during
+  // that window, continuing to step drags the viewport back to the target and
+  // fights their input. navToDisplayIndex now cancels on wheel/touchmove and
+  // detaches the listeners when the poll ends; these assertions pin the
+  // contract that makes that wiring correct.
+  it('cancel() stops all further step() calls mid-flight', () => {
+    const d = makeDriver()
+    const step = vi.fn()
+    let reason = ''
+    // A target that never settles, so only a cancel can end the loop.
+    let h = 100
+    const cancel = pollRowSettled({
+      measure: () => (h += 10),
+      step,
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain(5, 8)
+    const callsBefore = step.mock.calls.length
+    expect(callsBefore).toBeGreaterThan(0)
+
+    cancel() // simulates the wheel/touchmove handler firing
+    expect(reason).toBe('cancelled')
+
+    d.drain(20, 8)
+    expect(step.mock.calls.length).toBe(callsBefore) // no further scrolling
+  })
+
+  it('onEnd fires exactly once on cancel, so listener cleanup cannot double-run', () => {
+    const d = makeDriver()
+    const onEnd = vi.fn()
+    const cancel = pollRowSettled({
+      measure: () => 100,
+      step: () => {},
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      minQuietMs: 999_999, // never settles naturally
+      onEnd,
+    })
+    d.drain(3, 8)
+    cancel()
+    cancel() // idempotent
+    d.drain(10, 8)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith('cancelled')
+  })
+
+  it('onEnd also fires on natural settle, so listeners are detached without a cancel', () => {
+    const d = makeDriver()
+    const onEnd = vi.fn()
+    pollRowSettled({
+      measure: () => 100,
+      step: () => {},
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      onEnd,
+    })
+    d.drain(500, 8)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith('settled')
+  })
+})
+
+describe('pollRowSettled: delayed widget growth (GPT MEDIUM)', () => {
+  it('does NOT settle on a 2-frame streak when growth starts after the widget build delay', () => {
+    const d = makeDriver()
+    // A widget row: static 120px until its ~450ms iframe build lands, then it
+    // grows to its real height. A frame-count-only settle would declare victory
+    // at ~16-32ms, stop stepping, and let the later growth push the match
+    // off-centre — the exact first-click miss this poll exists to prevent.
+    const GROW_AT_MS = 450
+    const FINAL = 900
+    let lastStepHeight = 0
+    let reason = ''
+    pollRowSettled({
+      measure: () => (d.now() >= GROW_AT_MS ? FINAL : 120),
+      step: () => { lastStepHeight = d.now() >= GROW_AT_MS ? FINAL : 120 },
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      settleFrames: 2,
+      onEnd: (r) => { reason = r },
+    })
+    // Run a handful of frames — enough for a 2-frame streak, nowhere near the
+    // quiet window. The poll must still be alive and must not have settled.
+    d.drain(6, 8) // ~48ms
+    expect(reason).toBe('')
+    // Carry on past the growth point and let it genuinely settle.
+    d.drain(400, 8)
+    expect(reason).toBe('settled')
+    // Critically, the final step ran against the POST-growth height.
+    expect(lastStepHeight).toBe(FINAL)
+  })
+
+  it('still settles promptly once the measurement is genuinely quiet', () => {
+    const d = makeDriver()
+    let reason = ''
+    pollRowSettled({
+      measure: () => 200, // stable from the very first frame
+      step: () => {},
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain(500, 8)
+    expect(reason).toBe('settled')
+  })
+
+  it('an explicit minQuietMs of 0 restores pure frame-streak settling', () => {
+    const d = makeDriver()
+    let reason = ''
+    pollRowSettled({
+      measure: () => 200,
+      step: () => {},
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      settleFrames: 2,
+      minQuietMs: 0,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain(4, 8) // ~32ms — would NOT be enough with the default quiet window
+    expect(reason).toBe('settled')
+  })
+})
+
+describe('pollRowSettled', () => {
+  it('waits for a target that mounts AFTER the old 30-frame ceiling, then settles', () => {
+    const d = makeDriver()
+    let frame = 0
+    const mountAt = 40 // well past the retired MAX_FRAMES = 30 ceiling
+    const step = vi.fn()
+    let reason = ''
+    // Row is absent (null) until frame 40, then a stable measured height.
+    pollRowSettled({
+      measure: () => (++frame >= mountAt ? 100 : null),
+      step,
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      settleFrames: 2,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain()
+    // It did NOT bail early: the scroll ran only once the row mounted (>30
+    // frames in), and the loop converged rather than silently no-op'ing.
+    expect(step).toHaveBeenCalled()
+    expect(reason).toBe('settled')
+    expect(d.pending()).toBe(0) // terminated — not spinning
+  })
+
+  it('re-reads/re-scrolls while a widget target keeps growing, settling once stable', () => {
+    const d = makeDriver()
+    // Height climbs (widget iframe building) then holds — mimics the ~450ms
+    // PROGRAMMATIC_BUILD_DELAY_MS growth the frame-count cap used to miss.
+    const heights = [50, 60, 90, 140, 140, 140]
+    let i = 0
+    const step = vi.fn()
+    let reason = ''
+    pollRowSettled({
+      measure: () => heights[Math.min(i++, heights.length - 1)],
+      step,
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      settleFrames: 2,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain()
+    // Scrolled on every present frame while growing (re-reading the offset),
+    // and only stopped once the height stopped moving.
+    expect(step.mock.calls.length).toBeGreaterThanOrEqual(4)
+    expect(reason).toBe('settled')
+  })
+
+  it('terminates via the wall-clock backstop when the target never mounts', () => {
+    const d = makeDriver()
+    const step = vi.fn()
+    let reason = ''
+    pollRowSettled({
+      measure: () => null, // never present
+      step,
+      raf: d.raf,
+      now: d.now,
+      maxMs: 100,
+      onEnd: (r) => { reason = r },
+    })
+    d.drain(500, 16) // 16ms/frame → crosses the 100ms backstop quickly
+    expect(step).not.toHaveBeenCalled()
+    expect(reason).toBe('timeout')
+    expect(d.pending()).toBe(0) // did not spin forever
+  })
+
+  it('cancel() stops the loop and fires onEnd exactly once', () => {
+    const d = makeDriver()
+    const step = vi.fn()
+    const onEnd = vi.fn()
+    const cancel = pollRowSettled({
+      measure: () => 100,
+      step,
+      raf: d.raf,
+      now: d.now,
+      maxMs: 5000,
+      onEnd,
+    })
+    d.flush(1)               // one frame runs (scrolls once)
+    const before = step.mock.calls.length
+    cancel()
+    d.flush(5)               // any queued frames must no-op after cancel
+    expect(step.mock.calls.length).toBe(before)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith('cancelled')
+    cancel()                 // idempotent
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('scrollCurrentMatchIntoView', () => {
   it('returns a cancel function so callers can abort the converge loop', () => {
-    const cancel = scrollCurrentMatchIntoView(document.body, 2)
+    const cancel = scrollCurrentMatchIntoView(document.body, { maxMs: 50 })
     expect(typeof cancel).toBe('function')
+    cancel()
   })
 
   it('cancel is idempotent and safe to call (no throw, removes listeners)', () => {
     const remove = vi.spyOn(window, 'removeEventListener')
-    const cancel = scrollCurrentMatchIntoView(document.body, 5)
+    const cancel = scrollCurrentMatchIntoView(document.body, { maxMs: 50 })
     expect(() => { cancel(); cancel() }).not.toThrow()
     // cancel() tears down the wheel/touchmove listeners it registered.
     expect(remove).toHaveBeenCalledWith('wheel', expect.any(Function))
     expect(remove).toHaveBeenCalledWith('touchmove', expect.any(Function))
     remove.mockRestore()
+  })
+
+  it('aborts (tears down listeners) when the user scrolls with the wheel', () => {
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const cancel = scrollCurrentMatchIntoView(document.body, { maxMs: 5000 })
+    // User takes over — the loop must bail so it never fights them.
+    window.dispatchEvent(new Event('wheel'))
+    expect(remove).toHaveBeenCalledWith('wheel', expect.any(Function))
+    expect(remove).toHaveBeenCalledWith('touchmove', expect.any(Function))
+    cancel()
+    remove.mockRestore()
+  })
+
+  it('aborts on touchmove', () => {
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const cancel = scrollCurrentMatchIntoView(document.body, { maxMs: 5000 })
+    window.dispatchEvent(new Event('touchmove'))
+    expect(remove).toHaveBeenCalledWith('touchmove', expect.any(Function))
+    cancel()
+    remove.mockRestore()
+  })
+})
+
+// Regression: the abort listened only for wheel/touchmove, so dragging the
+// scrollbar or scrolling with the keyboard did not stop convergence and the
+// user was recentered for up to CONVERGE_MAX_MS. The same gap existed
+// independently in ChatPage, which is why this now lives in one shared helper.
+describe('attachUserScrollIntent', () => {
+  function harness() {
+    const el = document.createElement('div')
+    const onUser = vi.fn()
+    const detach = attachUserScrollIntent(el, onUser)
+    return { el, onUser, detach }
+  }
+
+  it('fires on a scrollbar drag (pointerdown), not just wheel and touch', () => {
+    const { el, onUser, detach } = harness()
+    el.dispatchEvent(new Event('pointerdown'))
+    expect(onUser).toHaveBeenCalledTimes(1)
+    el.dispatchEvent(new Event('wheel'))
+    el.dispatchEvent(new Event('touchmove'))
+    expect(onUser).toHaveBeenCalledTimes(3)
+    detach()
+  })
+
+  it('fires on scrolling keys', () => {
+    const { el, onUser, detach } = harness()
+    for (const key of ['ArrowDown', 'PageUp', 'Home', 'End', ' ']) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key }))
+    }
+    expect(onUser).toHaveBeenCalledTimes(5)
+    detach()
+  })
+
+  it('ignores typing, so searching does not cancel its own convergence', () => {
+    const { el, onUser, detach } = harness()
+    for (const key of ['a', 'Z', '1', 'Shift', 'Enter', 'Backspace']) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key }))
+    }
+    expect(onUser).not.toHaveBeenCalled()
+    detach()
+  })
+
+  it('detaches every listener it attached', () => {
+    const { el, onUser, detach } = harness()
+    detach()
+    el.dispatchEvent(new Event('wheel'))
+    el.dispatchEvent(new Event('touchmove'))
+    el.dispatchEvent(new Event('pointerdown'))
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+    expect(onUser).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op with no target and its detach is safe to call', () => {
+    const detach = attachUserScrollIntent(undefined, () => { throw new Error('unreachable') })
+    expect(() => detach()).not.toThrow()
+  })
+
+  it('a scrollbar drag aborts a real convergence poll', () => {
+    // Synchronous, manually-pumped rAF so no timers are involved: each pump
+    // runs at most one queued frame, which is what makes "no further steps
+    // after the abort" a real assertion rather than a timing artifact.
+    let queued: (() => void) | null = null
+    const raf = (cb: () => void) => { queued = cb; return 1 }
+    const pump = () => { const c = queued; queued = null; c?.() }
+    const step = vi.fn()
+    let t = 0
+    const cancel = pollRowSettled({
+      // A changing measurement keeps the poll alive (never settles), so the
+      // only thing that can end it is the abort under test.
+      measure: () => (t += 7),
+      step,
+      raf,
+      now: () => (t += 16),
+      maxMs: 100_000,
+    })
+    pump()
+    pump()
+    expect(step.mock.calls.length).toBeGreaterThan(0)
+
+    // Wire the shared helper the way the production sites do.
+    const el = document.createElement('div')
+    const detach = attachUserScrollIntent(el, cancel)
+    el.dispatchEvent(new Event('pointerdown'))
+    const callsAtAbort = step.mock.calls.length
+    pump()
+    pump()
+    expect(step.mock.calls.length).toBe(callsAtAbort)
+    detach()
+    cancel()
   })
 })

--- a/website/src/test/useVirtualChat.integration.test.tsx
+++ b/website/src/test/useVirtualChat.integration.test.tsx
@@ -14,9 +14,13 @@
 // is intentionally undefined in the test env, so the RO auto-pin never fires and
 // can't perturb the result.)
 
-import { describe, it, expect, beforeEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import type { RefObject } from 'react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, render as rtlRender, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { readFileSync } from 'node:fs'
+
+// Resolved from the vitest cwd (website/), used by the chokepoint source guard.
+const HOOK_SRC = 'src/hooks/virtualizer/useVirtualChat.ts'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
 import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
 
@@ -253,6 +257,41 @@ describe('useVirtualChat integration: follow / pin wiring', () => {
     expect(el.scrollTop).toBe(300)
   })
 
+  it('streaming growth across many ticks issues INSTANT pins landing exactly on bottomTarget', () => {
+    // T3/#4: while following, each streamed chunk grows the bottom target. The
+    // pin must be INSTANT (behavior:'auto') and land EXACTLY on the new bottom
+    // — a smooth pin would be cancelled/restarted by the next chunk and chase a
+    // moving target, never converging on a tall transcript.
+    const { el, state, view } = render(
+      { scrollTop: 0, scrollHeight: 400, clientHeight: 400 },
+      mkItems(3),
+      'stream-instant',
+    )
+    expect(el.scrollTop).toBe(0)
+
+    // Record how the scroller is driven from here.
+    const behaviors: (string | undefined)[] = []
+    ;(el as unknown as { scrollTo: (o: { top: number; behavior?: string }) => void }).scrollTo = (o) => {
+      behaviors.push(o.behavior)
+      state.scrollTop = o.top
+    }
+
+    let count = 3
+    for (let h = 700; h <= 4000; h += 300) {
+      count += 1
+      act(() => {
+        state.scrollHeight = h
+        view.rerender({ items: mkItems(count), sessionId: 'stream-instant', getKey, externalScrollerRef: { current: el } })
+      })
+      // Landed EXACTLY on bottomTarget (scrollHeight - clientHeight).
+      expect(el.scrollTop).toBe(h - 400)
+    }
+
+    // Every streaming pin was instant — no smooth animation to chase the target.
+    expect(behaviors.length).toBeGreaterThan(0)
+    expect(behaviors.every((b) => b === 'auto')).toBe(true)
+  })
+
   it('does NOT yank when the user scrolls up between the bulk pin and its settle frame', () => {
     // rAF is queued by the bulk path's settle pin — capture it so the test
     // controls exactly when the frame fires.
@@ -294,6 +333,728 @@ describe('useVirtualChat integration: follow / pin wiring', () => {
       el.remove()
     } finally {
       globalThis.requestAnimationFrame = origRaf
+    }
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+// T4/#5 — scroll-anchor preservation across an upward window shift.
+//
+// jsdom has no layout, so this suite installs a tiny deterministic "layout
+// engine": getBoundingClientRect walks the scroller's children summing their
+// heights (spacers use their inline style.height; rows use a per-index real
+// height) minus scrollTop, and offsetHeight reports the same real height so
+// measureRef seeds the cache. The virtualizer's offset spacer is sized from
+// the OffsetIndex, which cold-starts at the flat estimate (80) — so when an
+// upward scroll mounts rows that actually render taller (100), the content
+// above the viewport grows and the row the user is looking at would JUMP down.
+// The anchor-preservation layout effect must cancel that jump by correcting
+// scrollTop, keeping the visible top row's screen position stable.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: every scroll write goes through the one chokepoint', () => {
+  // Design finding: follow-release correctness rested on a comment-enforced
+  // invariant ("every programmatic scrollTop write must record itself in
+  // lastWriteTopRef") that had already failed once in this codebase. It is now
+  // structural: all writes funnel through `writeScrollTop`, whose `accounting`
+  // argument is REQUIRED, so tsc rejects a write that does not state how the
+  // follow guard should treat it.
+  //
+  // This is a SOURCE guard rather than a behavioural one, deliberately. The
+  // failure it prevents is a future contributor adding a raw `el.scrollTop = x`
+  // that skips the bookkeeping; that is a property of the code, and attempts to
+  // express it behaviourally in jsdom did not discriminate (the mocked geometry
+  // cannot reproduce the browser's scroll-event ordering that makes the guard
+  // load-bearing). Asserting it at the source level does discriminate: adding a
+  // raw write fails this test immediately.
+  it('has no raw scrollTop / scrollTo writes outside writeScrollTop', () => {
+    const src = readFileSync(HOOK_SRC, 'utf8')
+    // Isolate the chokepoint body — the one place raw writes are allowed.
+    const chokeStart = src.indexOf('const writeScrollTop = useCallback(')
+    expect(chokeStart).toBeGreaterThan(-1)
+    const chokeEnd = src.indexOf('\n  )', chokeStart)
+    const outside = src.slice(0, chokeStart) + src.slice(chokeEnd)
+
+    const rawWrites = outside
+      .split('\n')
+      .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+      .filter(({ line }) => !line.startsWith('//'))
+      .filter(({ line }) => /\.scrollTop\s*(=|\+=|-=)/.test(line) || /\.scrollTo\(\{/.test(line))
+
+    expect(
+      rawWrites.map((r) => r.line),
+      'raw scroll writes must go through writeScrollTop(el, top, behavior, accounting)',
+    ).toEqual([])
+  })
+
+  it('states an accounting disposition at every call site', () => {
+    const src = readFileSync(HOOK_SRC, 'utf8')
+    const calls = [...src.matchAll(/writeScrollTop\(\s*el[^)]*\)/g)].map((m) => m[0])
+    // Every call site (excluding the declaration) passes 'pin' or 'release'.
+    expect(calls.length).toBeGreaterThanOrEqual(5)
+    for (const c of calls) {
+      expect(c, `call site missing accounting: ${c}`).toMatch(/'(pin|release)'/)
+    }
+  })
+})
+
+describe('useVirtualChat: smooth-pin guard (GPT MEDIUM round 4)', () => {
+  // scrollToBottom defers its write into a rAF; this suite otherwise avoids rAF,
+  // so run it synchronously to keep these assertions deterministic.
+  let realRaf: typeof globalThis.requestAnimationFrame
+  beforeEach(() => {
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof globalThis.requestAnimationFrame
+  })
+  afterEach(() => { globalThis.requestAnimationFrame = realRaf })
+
+  // NOTE: the positive case (a smooth pin's intermediate animation frames must
+  // not be read as user input) is verified in a REAL BROWSER, not here. jsdom has
+  // no scroll animation, so reproducing it requires hand-faking the frame
+  // sequence AND the append-pin path; two attempts at that produced a test that
+  // failed for reasons unrelated to the guard. Rather than ship an assertion I
+  // do not trust, the behaviour is measured with the Chromium harness (see the
+  // PR disposition). What IS asserted here is the inverse, which jsdom models
+  // faithfully: an instant pin must not leave the guard armed and swallow real
+  // user input.
+  it('an INSTANT pin does not arm the smooth guard', () => {
+    const { el, state } = makeScroller({ scrollTop: 2500, scrollHeight: 3000, clientHeight: 500 })
+    const ref = { current: el } as RefObject<HTMLDivElement>
+    const { result } = renderHook(() =>
+      useVirtualChat<Item>({
+        items: mkItems(30),
+        getKey,
+        sessionId: 'instant-pin-guard',
+        externalScrollerRef: ref,
+      } as UseVirtualChatOptions<Item>),
+    )
+    act(() => { result.current.scrollToBottom('auto') })
+    // A genuine user scroll-up right after an instant pin must still release
+    // follow — the guard must not be left armed and swallowing real input.
+    act(() => {
+      state.scrollTop = 800
+      el.dispatchEvent(new Event('scroll'))
+    })
+    expect(result.current.isAtBottom).toBe(false)
+  })
+
+  // The NOTE above still holds for the *animation* itself. What the following
+  // tests cover is the pure bookkeeping around it — which scroll positions arm,
+  // hold, and disarm the guard — and jsdom models that faithfully, because it is
+  // only scrollTop values and scroll events. The observable signal for "guard
+  // still armed" is the abort's side effect: a wheel while armed re-issues an
+  // INSTANT scrollTo to freeze the glide (releasing stick alone would let the
+  // native animation finish). If the guard is already disarmed, a wheel does
+  // nothing. That distinction is what these assert.
+  function smoothPinHarness(sessionId: string) {
+    // bottomTarget = scrollHeight - clientHeight = 2500.
+    const { el, state } = makeScroller({ scrollTop: 1000, scrollHeight: 3000, clientHeight: 500 })
+    const behaviors: (string | undefined)[] = []
+    ;(el as unknown as { scrollTo: (o: { top: number; behavior?: string }) => void }).scrollTo =
+      (o) => {
+        behaviors.push(o.behavior)
+        // A SMOOTH write does not teleport scrollTop — that is what makes it a
+        // glide. The animation is then simulated by the explicit scrollTo()
+        // steps below, which is exactly the frame sequence the guard reads.
+        if (o.behavior !== 'smooth') state.scrollTop = o.top
+      }
+    const ref = { current: el } as RefObject<HTMLDivElement>
+    const { result } = renderHook(() =>
+      useVirtualChat<Item>({
+        items: mkItems(30),
+        getKey,
+        sessionId,
+        externalScrollerRef: ref,
+      } as UseVirtualChatOptions<Item>),
+    )
+    const scrollTo = (top: number) => {
+      act(() => {
+        state.scrollTop = top
+        el.dispatchEvent(new Event('scroll'))
+      })
+    }
+    // Real scenario: mount auto-pins to the bottom, the user scrolls UP, then
+    // presses jump-to-latest — so the glide starts from where they are, not from
+    // the bottom. Without this the mount pin leaves scrollTop at the target and
+    // every simulated glide frame reads as backward (user) motion instead.
+    scrollTo(1000)
+    act(() => { result.current.scrollToBottom('smooth') })
+    // Returns true if the wheel was still able to abort, i.e. the guard was armed.
+    const wheelAborts = () => {
+      const before = behaviors.length
+      act(() => { el.dispatchEvent(new Event('wheel')) })
+      return behaviors.length > before && behaviors[behaviors.length - 1] === 'auto'
+    }
+    return { el, state, behaviors, result, scrollTo, wheelAborts }
+  }
+
+  it('holds the guard through intermediate glide frames, and they do not release follow', () => {
+    const h = smoothPinHarness('smooth-intermediate')
+    // Forward progress toward the target: these events are OURS, not the user's.
+    h.scrollTo(1400)
+    h.scrollTo(1900)
+    expect(h.result.current.isAtBottom).toBe(false) // still short of the target
+    expect(h.wheelAborts()).toBe(true)
+  })
+
+  // Regression for the arrival condition. It used to be `atBottom`, i.e. the
+  // 100px bottomThreshold: the glide entered that band while the native
+  // animation still had up to 100px to run, the guard disarmed early, and a user
+  // grabbing the page inside the band was carried to the bottom anyway.
+  it('does NOT disarm merely because the glide entered the 100px bottom band', () => {
+    const h = smoothPinHarness('smooth-band')
+    // 3000 - (2450 + 500) = 50px from the bottom → inside the 100px UI band,
+    // but 50px short of the value we actually wrote (2500).
+    h.scrollTo(2450)
+    expect(h.wheelAborts()).toBe(true)
+  })
+
+  it('disarms once the glide reaches the value actually written', () => {
+    const h = smoothPinHarness('smooth-arrived')
+    h.scrollTo(2500) // exactly lastWriteTop
+    // Arrived → listeners dropped, so a later unrelated wheel must be inert.
+    expect(h.wheelAborts()).toBe(false)
+    expect(h.result.current.isAtBottom).toBe(true)
+  })
+
+  it('disarms when the scroller is bottom-anchored even if the write was clamped', () => {
+    const h = smoothPinHarness('smooth-clamped')
+    // Content shrank mid-glide: the written target 2500 is now unreachable, but
+    // we ARE at the bottom. Without the bottom-anchored fallback the guard (and
+    // its listeners) would stay armed forever.
+    act(() => {
+      h.state.scrollHeight = 2400
+      h.state.scrollTop = 1900 // 2400 - 500 = 1900 → exactly bottom
+      h.el.dispatchEvent(new Event('scroll'))
+    })
+    expect(h.wheelAborts()).toBe(false)
+  })
+
+  it('a backward scroll mid-glide releases follow and disarms', () => {
+    const h = smoothPinHarness('smooth-backward')
+    h.scrollTo(1400)
+    h.scrollTo(900) // user grabbed the page: scrollTop moved backward
+    expect(h.result.current.isAtBottom).toBe(false)
+    expect(h.wheelAborts()).toBe(false) // already disarmed by the backward move
+  })
+
+  it('a wheel abort freezes the glide in place instead of only releasing stick', () => {
+    const h = smoothPinHarness('smooth-freeze')
+    h.scrollTo(1400)
+    act(() => { h.el.dispatchEvent(new Event('wheel')) })
+    // The instant re-issue is what cancels the browser's native animation.
+    expect(h.behaviors[h.behaviors.length - 1]).toBe('auto')
+    expect(h.state.scrollTop).toBe(1400)
+    expect(h.result.current.isAtBottom).toBe(false)
+  })
+
+  // GPT MEDIUM round 13: the abort listened for `wheel`/`touchmove` only, so a
+  // scrollbar drag or a keyboard scroll during the glide was overridden by the
+  // continuing animation. attachUserScrollIntent is the shared input set.
+  it('a scrollbar drag (pointerdown) aborts the glide', () => {
+    const h = smoothPinHarness('smooth-pointer')
+    h.scrollTo(1400)
+    act(() => { h.el.dispatchEvent(new Event('pointerdown')) })
+    expect(h.behaviors[h.behaviors.length - 1]).toBe('auto')
+    expect(h.state.scrollTop).toBe(1400)
+    expect(h.result.current.isAtBottom).toBe(false)
+  })
+
+  it('a scrolling keypress aborts the glide, but ordinary typing does not', () => {
+    const h = smoothPinHarness('smooth-keys')
+    h.scrollTo(1400)
+    // Typing in the search box while a glide runs is not scroll intent.
+    act(() => { h.el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' })) })
+    expect(h.behaviors[h.behaviors.length - 1]).toBe('smooth')
+    act(() => { h.el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' })) })
+    expect(h.behaviors[h.behaviors.length - 1]).toBe('auto')
+    expect(h.result.current.isAtBottom).toBe(false)
+  })
+
+  // GPT MEDIUM round 13: pinAuto (RO tick / append layout effect) read the
+  // glide's own mid-flight scrollTop as a user scroll-up — scrollTop sits below
+  // the recorded target AND meaningfully away from the bottom, which is exactly
+  // evaluateAutoPin's release signature. Streaming output resizes constantly, so
+  // an append during an explicit jump-to-latest killed follow for the rest of
+  // the response.
+  function appendDuringGlide(sessionId: string) {
+    const { el, state } = makeScroller({ scrollTop: 1000, scrollHeight: 3000, clientHeight: 500 })
+    const behaviors: (string | undefined)[] = []
+    ;(el as unknown as { scrollTo: (o: { top: number; behavior?: string }) => void }).scrollTo =
+      (o) => {
+        behaviors.push(o.behavior)
+        if (o.behavior !== 'smooth') state.scrollTop = o.top
+      }
+    const ref = { current: el } as RefObject<HTMLDivElement>
+    const base = {
+      items: mkItems(30),
+      getKey,
+      sessionId,
+      externalScrollerRef: ref,
+    } as UseVirtualChatOptions<Item>
+    const view = renderHook((props: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(props), {
+      initialProps: base,
+    })
+    // User scrolled up, then pressed jump-to-latest: the glide starts from where
+    // they are and targets the CURRENT bottom (3000 - 500 = 2500).
+    act(() => { state.scrollTop = 1000; el.dispatchEvent(new Event('scroll')) })
+    act(() => { view.result.current.scrollToBottom('smooth') })
+    const writesBeforeAppend = behaviors.length
+    // Streaming appends mid-glide: the bottom moves to 4000 - 500 = 3500.
+    act(() => {
+      state.scrollHeight = 4000
+      view.rerender({ ...base, items: mkItems(31) })
+    })
+    return { el, state, behaviors, view, writesBeforeAppend }
+  }
+
+  it('a mid-glide append does not release follow, and lands on the NEW bottom on arrival', () => {
+    const h = appendDuringGlide('smooth-append-follow')
+    // Simulate the animation reaching the value we wrote (2500) — short of the
+    // new bottom, because the content grew after the write.
+    act(() => { h.state.scrollTop = 2500; h.el.dispatchEvent(new Event('scroll')) })
+    // Arrival disarms the guard and re-targets instantly to the new bottom.
+    expect(h.state.scrollTop).toBe(3500)
+    // The re-target is itself a scroll write; the browser emits a scroll event
+    // for it, which is what refreshes the exposed isAtBottom state (it was
+    // computed from the geometry read BEFORE the write).
+    act(() => { h.el.dispatchEvent(new Event('scroll')) })
+    expect(h.view.result.current.isAtBottom).toBe(true)
+  })
+
+  it('does not re-issue a smooth write for a mid-glide append (no animation restart)', () => {
+    const h = appendDuringGlide('smooth-append-norestart')
+    // Re-targeting mid-animation would cancel and restart the glide every resize
+    // tick — the restart trap fix #4 removed from the streaming pin.
+    expect(h.behaviors.length).toBe(h.writesBeforeAppend)
+  })
+})
+
+describe('useVirtualChat: adaptive height estimate is wired into the offsets (GPT HIGH round 13)', () => {
+  // HeightCache.averageHeight() is unit-tested in isolation, but reverting the
+  // hook's `getH` back to the flat `estimatedHeight` left every one of those
+  // tests green while restoring the original bug: a long transcript's unmeasured
+  // rows are sized by a fixed 80px guess, so total height and the spacer offsets
+  // are wildly short and scrolling up lands in the wrong place. This asserts the
+  // WIRING — that measured heights feed the estimate for UNMEASURED rows.
+  beforeEach(() => localStorage.clear())
+
+  const seed = (sid: string, keys: string[], h: number) => {
+    const blob: Record<string, number> = {}
+    for (const k of keys) blob[k] = h
+    localStorage.setItem(`vc_heights_${sid}`, JSON.stringify(blob))
+  }
+
+  it('sizes unmeasured rows from the measured mean, not the flat estimate', () => {
+    const sid = 'estimate-wiring'
+    const N = 200
+    // Ten rows measured at 500px; the other 190 have never been measured.
+    seed(sid, Array.from({ length: 10 }, (_, i) => `m${i}`), 500)
+    const { view } = render({ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }, mkItems(N), sid)
+
+    // Flat 80px estimate would give 10*500 + 190*80 = 20,200. The adaptive mean
+    // (500) gives 200*500 = 100,000.
+    expect(view.result.current.totalHeight).toBe(N * 500)
+    expect(view.result.current.totalHeight).toBeGreaterThan(20_200 * 2)
+  })
+
+  it('the spacer offsets follow the adaptive estimate too', () => {
+    const sid = 'estimate-wiring-spacers'
+    seed(sid, Array.from({ length: 10 }, (_, i) => `m${i}`), 500)
+    const { view } = render({ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }, mkItems(200), sid)
+    // offsetBefore + rendered window + offsetAfter must reconstruct the total,
+    // so an under-estimate anywhere would show up as a mismatch.
+    const v = view.result.current
+    expect(v.offsetBefore + v.offsetAfter).toBeLessThanOrEqual(v.totalHeight)
+    // With the window pinned at the top, everything below it is estimated —
+    // the flat guess would make offsetAfter an order of magnitude smaller.
+    expect(v.offsetAfter).toBeGreaterThan(20_000)
+  })
+
+  it('falls back to the configured estimate only when nothing is measured', () => {
+    const { view } = render(
+      { scrollTop: 0, scrollHeight: 1000, clientHeight: 400 },
+      mkItems(50),
+      'estimate-wiring-empty',
+    )
+    expect(view.result.current.totalHeight).toBe(50 * 80)
+  })
+})
+
+describe('useVirtualChat: OffsetIndex is rebuilt on session switch (GPT MEDIUM)', () => {
+  // Regression: the offsetIndex memo depended only on [itemCount, getH]. getH's
+  // identity is stable across a session change (deps: [estimatedHeight]), so
+  // switching to a DIFFERENT session with the SAME item count rebuilt nothing —
+  // the Fenwick tree kept serving the previous transcript's heights and rendered
+  // wrong spacers until a measurement tick corrected it.
+  const seedHeights = (sessionId: string, n: number, h: number) => {
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < n; i++) blob[`m${i}`] = h
+    window.localStorage.setItem(`vc_heights_${sessionId}`, JSON.stringify(blob))
+  }
+
+  it('reports the NEW session\'s offsets when both sessions have equal item counts', () => {
+    const N = 40
+    // Two sessions, same row count, very different per-row heights.
+    seedHeights('offidx-a', N, 100)
+    seedHeights('offidx-b', N, 500)
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 1000, clientHeight: 500 })
+    const ref = { current: el } as RefObject<HTMLDivElement>
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string }) =>
+        useVirtualChat<Item>({
+          items: mkItems(N),
+          getKey,
+          sessionId: sid,
+          externalScrollerRef: ref,
+        } as UseVirtualChatOptions<Item>),
+      { initialProps: { sid: 'offidx-a' } },
+    )
+    const totalA = result.current.totalHeight
+    expect(totalA).toBe(N * 100)
+
+    // Same item count, different session — the tree MUST be rebuilt.
+    rerender({ sid: 'offidx-b' })
+    expect(result.current.totalHeight).toBe(N * 500)
+    expect(result.current.totalHeight).not.toBe(totalA)
+
+    window.localStorage.removeItem('vc_heights_offidx-a')
+    window.localStorage.removeItem('vc_heights_offidx-b')
+  })
+})
+
+describe('useVirtualChat: height-cache eviction cap is wired to the row count', () => {
+  // Regression: HeightCache grew a session-size-aware eviction cap, and
+  // HeightCache.test.ts proved the cap arithmetic correct — but the hook
+  // constructed `new HeightCache(sessionId)` without ever supplying rowCount,
+  // so the cap stayed pinned at the 2000 floor and long sessions still evicted
+  // their oldest heights. Every unit test passed; only a browser run at 3000
+  // rows exposed it. These assertions cover the WIRING, not the arithmetic.
+  //
+  // Public surface used: HeightCache enforces the cap when it LOADS a persisted
+  // blob, so a pre-seeded localStorage entry of n > 2000 heights survives mount
+  // only if the hook told the cache the session is n rows long.
+  const CAP_FLOOR = 2000
+  const SIDS = ['cap-wiring-seed', 'cap-wiring-short', 'cap-wiring-ceiling']
+  // These tests deliberately write persisted height blobs. Clear them around
+  // every case so they can't leak into suites that enumerate localStorage
+  // (an order-dependent flake source).
+  const clearSeeds = () => {
+    for (const sid of SIDS) window.localStorage.removeItem(`vc_heights_${sid}`)
+  }
+  beforeEach(clearSeeds)
+  afterEach(clearSeeds)
+  const seed = (sessionId: string, n: number) => {
+    const blob: Record<string, number> = {}
+    for (let i = 0; i < n; i++) blob[`m${i}`] = 40 + (i % 5)
+    window.localStorage.setItem(`vc_heights_${sessionId}`, JSON.stringify(blob))
+  }
+  const persistedCount = (sessionId: string) => {
+    const raw = window.localStorage.getItem(`vc_heights_${sessionId}`)
+    return raw ? Object.keys(JSON.parse(raw) as Record<string, number>).length : 0
+  }
+  // Mount, then push ONE real measurement through the hook's own measure path.
+  // That matters: flush() skips when the cache isn't dirty, so without a write
+  // the stale seeded blob would be read straight back and the assertion would
+  // pass even with the cap left at the floor (a vacuous test).
+  const mountMeasureUnmount = (sessionId: string, n: number) => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 1000, clientHeight: 500 })
+    const ref = { current: el } as RefObject<HTMLDivElement>
+    const { result, unmount } = renderHook(() =>
+      useVirtualChat<Item>({
+        items: mkItems(n),
+        getKey,
+        sessionId,
+        externalScrollerRef: ref,
+      } as UseVirtualChatOptions<Item>),
+    )
+    act(() => {
+      const node = document.createElement('div')
+      Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => 44 })
+      result.current.measureRef(0)(node)
+    })
+    unmount() // flushes the (now dirty) cache to localStorage
+  }
+
+  it('keeps more than the 2000 floor for a 3000-row session (cap seeded from row count)', () => {
+    const sid = 'cap-wiring-seed'
+    seed(sid, 3000)
+    mountMeasureUnmount(sid, 3000)
+    // With the cap left at the floor this trims to exactly 2000 and m0 is gone.
+    expect(persistedCount(sid)).toBeGreaterThan(CAP_FLOOR)
+    const blob = JSON.parse(window.localStorage.getItem(`vc_heights_${sid}`)!)
+    expect(blob.m0).toBeDefined() // oldest entry survived
+  })
+
+  it('still trims a stale oversized blob down to the floor for a short session', () => {
+    const sid = 'cap-wiring-short'
+    seed(sid, 2600) // stale oversized blob, but the session is only 100 rows
+    mountMeasureUnmount(sid, 100)
+    expect(persistedCount(sid)).toBe(CAP_FLOOR)
+  })
+
+  it('honours the hard ceiling rather than tracking row count without bound', () => {
+    const sid = 'cap-wiring-ceiling'
+    seed(sid, 300)
+    mountMeasureUnmount(sid, 1_000_000)
+    // Cap is min(rowCount, 20000); the seeded 300 all survive and nothing blows up.
+    expect(persistedCount(sid)).toBeGreaterThanOrEqual(300)
+    expect(persistedCount(sid)).toBeLessThanOrEqual(20000)
+  })
+})
+
+describe('useVirtualChat: scroll-anchor preservation (T4/#5)', () => {
+  const REAL_H = 100 // every mounted row renders this tall…
+  // …while the OffsetIndex spacer cold-starts at estimatedHeight (80), so each
+  // newly-mounted row above the viewport adds REAL_H - 80 = 20px of drift.
+
+  let restore: (() => void) | null = null
+
+  function rect(top: number, height: number): DOMRect {
+    return {
+      top, bottom: top + height, height, left: 0, right: 0, width: 0, x: 0, y: top,
+      toJSON() { return {} },
+    } as DOMRect
+  }
+
+  function installFakeLayout(scroller: HTMLElement, clientHeight: number) {
+    const proto = HTMLElement.prototype
+    const origRect = proto.getBoundingClientRect
+    const origOffsetH = Object.getOwnPropertyDescriptor(proto, 'offsetHeight')
+
+    const childHeight = (child: Element): number => {
+      const di = (child as HTMLElement).getAttribute('data-index')
+      if (di !== null) return REAL_H
+      const h = (child as HTMLElement).style?.height
+      return h ? parseFloat(h) : 0
+    }
+
+    proto.getBoundingClientRect = function (this: HTMLElement): DOMRect {
+      if (this === scroller) return rect(0, clientHeight)
+      if (this.parentElement === scroller) {
+        let y = 0
+        for (const sib of Array.from(scroller.children)) {
+          if (sib === this) break
+          y += childHeight(sib)
+        }
+        return rect(y - scroller.scrollTop, childHeight(this))
+      }
+      return origRect.call(this)
+    }
+    Object.defineProperty(proto, 'offsetHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.getAttribute('data-index') !== null ? REAL_H : 0
+      },
+    })
+
+    restore = () => {
+      proto.getBoundingClientRect = origRect
+      if (origOffsetH) Object.defineProperty(proto, 'offsetHeight', origOffsetH)
+      else delete (proto as unknown as Record<string, unknown>).offsetHeight
+    }
+  }
+
+  afterEach(() => {
+    restore?.()
+    restore = null
+  })
+
+  function AnchorHarness({ items, scrollerRef }: {
+    items: Item[]
+    scrollerRef: RefObject<HTMLDivElement | null>
+  }) {
+    const v = useVirtualChat<Item>({
+      items, sessionId: 'anchor', getKey, overscan: 2, externalScrollerRef: scrollerRef,
+    })
+    return (
+      <div ref={scrollerRef as RefObject<HTMLDivElement>} data-scroller>
+        <div ref={v.topSentinelRef} data-sentinel="top" />
+        <div data-spacer="before" style={{ height: v.offsetBefore }} />
+        {v.virtualItems.map((it) => (
+          <div key={it.key} data-index={it.index} ref={v.measureRef(it.index)} />
+        ))}
+        <div data-spacer="after" style={{ height: v.offsetAfter }} />
+        <div ref={v.bottomSentinelRef} data-sentinel="bottom" />
+      </div>
+    )
+  }
+
+  it('holds the top visible row steady when an upward shift mounts rows above it', () => {
+    // Deterministic rAF: capture frames so we control exactly when the
+    // scroll-driven window recompute runs.
+    const frames: FrameRequestCallback[] = []
+    const origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof requestAnimationFrame
+
+    // Fake IntersectionObserver: capture instances so the test can fire the
+    // top-sentinel intersection deterministically (jsdom has none).
+    interface FakeIOInst { cb: IntersectionObserverCallback }
+    const ioInstances: FakeIOInst[] = []
+    class FakeIO {
+      cb: IntersectionObserverCallback
+      constructor(cb: IntersectionObserverCallback) { this.cb = cb; ioInstances.push(this) }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return [] }
+      root: Element | null = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    const origIO = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = FakeIO as unknown as typeof IntersectionObserver
+
+    const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
+    try {
+      const N = 30
+      let scrollTop = 0
+      const CLIENT = 400
+      const SCROLL_HEIGHT = 3000
+
+      rtlRender(<AnchorHarness items={mkItems(N)} scrollerRef={scrollerRef} />)
+      const el = scrollerRef.current!
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
+      })
+      Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => CLIENT })
+      Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => SCROLL_HEIGHT })
+      installFakeLayout(el, CLIENT)
+
+      // Drain the mount pins (slot-entry / bulk forcePin rAFs) at the real
+      // geometry so they don't fire mid-test, then discard their frames.
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+      // Scroll so the OffsetIndex (80px/row) places the window near the bottom:
+      // indexAt(2160)=27 → window {25..30}. The scroll releases stick and
+      // schedules a recompute; flush that one frame.
+      act(() => { scrollTop = 2160; el.dispatchEvent(new Event('scroll')) })
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+      // Topmost visible mounted row + its screen top, computed the same way the
+      // hook's captureTopAnchor does.
+      const topVisible = () => {
+        const srTop = el.getBoundingClientRect().top
+        let best: { idx: number; top: number } | null = null
+        el.querySelectorAll('[data-index]').forEach((node) => {
+          const r = (node as HTMLElement).getBoundingClientRect()
+          if (r.bottom - srTop <= 0) return
+          const idx = Number((node as HTMLElement).getAttribute('data-index'))
+          if (!best || idx < best.idx) best = { idx, top: r.top - srTop }
+        })
+        return best
+      }
+      const before = topVisible()!
+      expect(before).not.toBeNull()
+
+      // Fire the top-sentinel intersection: expandWindowUp shifts start down by
+      // overscan (25 → 23), mounting rows 23,24 which render at REAL_H (100)
+      // while the shrunk offsetBefore spacer only credits them 80 each — a
+      // per-row drift that would push `before` down without compensation.
+      const topSentinel = el.querySelector('[data-sentinel="top"]') as HTMLElement
+      act(() => {
+        ioInstances[0].cb(
+          [{ isIntersecting: true, target: topSentinel } as unknown as IntersectionObserverEntry],
+          ioInstances[0] as unknown as IntersectionObserver,
+        )
+      })
+
+      // The same row's screen position must be preserved (compensation moved
+      // scrollTop by the drift), keeping the transcript visually stable.
+      const afterNode = el.querySelector(`[data-index="${before.idx}"]`) as HTMLElement | null
+      expect(afterNode).not.toBeNull()
+      const afterTop = afterNode!.getBoundingClientRect().top - el.getBoundingClientRect().top
+      expect(Math.abs(afterTop - before.top)).toBeLessThanOrEqual(1)
+      // Compensation held the anchor by pushing scrollTop DOWN by the drift the
+      // newly-mounted (taller-than-estimated) rows introduced above it.
+      expect(scrollTop).toBeGreaterThan(2160)
+    } finally {
+      globalThis.requestAnimationFrame = origRaf
+      globalThis.IntersectionObserver = origIO
+    }
+  })
+
+  // GPT MEDIUM round 13: at start === 0 expandWindowUp is a NO-OP, but the
+  // anchor was captured anyway. Nothing upward ever consumed it, so it sat
+  // pending until the next unrelated commit — which then "corrected" scrollTop
+  // back to where the anchored row used to be, yanking the user toward the top.
+  it('does not capture a top anchor when the window is already at index 0', () => {
+    const frames: FrameRequestCallback[] = []
+    const origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof requestAnimationFrame
+
+    interface FakeIOInst { cb: IntersectionObserverCallback }
+    const ioInstances: FakeIOInst[] = []
+    class FakeIO {
+      cb: IntersectionObserverCallback
+      constructor(cb: IntersectionObserverCallback) { this.cb = cb; ioInstances.push(this) }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return [] }
+      root: Element | null = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    const origIO = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = FakeIO as unknown as typeof IntersectionObserver
+
+    const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
+    try {
+      let scrollTop = 0
+      const CLIENT = 400
+      rtlRender(<AnchorHarness items={mkItems(30)} scrollerRef={scrollerRef} />)
+      const el = scrollerRef.current!
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
+      })
+      Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => CLIENT })
+      Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => 3000 })
+      installFakeLayout(el, CLIENT)
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+      // Near the very top: the window's start is already 0, and the scroll
+      // releases stick (the condition the capture was gated on).
+      act(() => { scrollTop = 50; el.dispatchEvent(new Event('scroll')) })
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+      // Top sentinel fires (it is permanently in view at the top of the list).
+      const topSentinel = el.querySelector('[data-sentinel="top"]') as HTMLElement
+      act(() => {
+        ioInstances[0].cb(
+          [{ isIntersecting: true, target: topSentinel } as unknown as IntersectionObserverEntry],
+          ioInstances[0] as unknown as IntersectionObserver,
+        )
+      })
+
+      // The user now scrolls DOWN a little, then any commit lands (here the
+      // bottom sentinel extending the window). A pending anchor from the no-op
+      // upward expansion would be applied on that commit and drag scrollTop back
+      // to 50.
+      act(() => { scrollTop = 150; el.dispatchEvent(new Event('scroll')) })
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+      const bottomSentinel = el.querySelector('[data-sentinel="bottom"]') as HTMLElement
+      act(() => {
+        ioInstances[0].cb(
+          [{ isIntersecting: true, target: bottomSentinel } as unknown as IntersectionObserverEntry],
+          ioInstances[0] as unknown as IntersectionObserver,
+        )
+      })
+      act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+      expect(scrollTop).toBe(150)
+    } finally {
+      globalThis.requestAnimationFrame = origRaf
+      globalThis.IntersectionObserver = origIO
     }
   })
 })

--- a/website/src/utils/searchScroll.ts
+++ b/website/src/utils/searchScroll.ts
@@ -2,6 +2,33 @@
  * "rapid stepping" and snap instantly instead of smooth-scrolling. */
 export const RAPID_STEP_MS = 250
 
+/** Default wall-clock backstop (ms) for the converge polls below. A far row
+ * that is off-window must mount + measure, and a widget target needs ~450ms
+ * for its iframe build alone (PROGRAMMATIC_BUILD_DELAY_MS in WidgetFrame), so
+ * a short frame-count ceiling gave up before the target ever settled — the
+ * jump silently no-op'd and only worked on a second click once cached. ~2s is
+ * comfortably past mount + measure + widget build while still guaranteeing a
+ * genuinely unreachable target terminates instead of spinning forever. */
+export const CONVERGE_MAX_MS = 2000
+
+/** Minimum time (ms) a measurement must stay UNCHANGED before the converge
+ * polls accept it as settled. A frame-count streak alone is not sufficient: a
+ * widget row reports a static height until its iframe build lands, so a couple
+ * of equal frames (~32ms) would end the poll before the growth even started,
+ * letting the late resize push the target back off-centre.
+ *
+ * Calibrated above `MAX_WIDGET_BUILD_WAIT_MS` in WidgetFrame — the worst case
+ * for a jump, which is the base build delay PLUS the capped per-widget stagger
+ * (an earlier value only cleared the base delay, so a widget in a later stagger
+ * slot still settled early). `searchScroll.coupling.test.ts` asserts the
+ * relationship, so raising either constant fails CI rather than silently
+ * regressing the first-click jump. Still comfortably inside CONVERGE_MAX_MS.
+ *
+ * Note this delays only the "settled" DECLARATION, not the visible movement:
+ * the first step scrolls immediately and later steps merely re-correct, so a
+ * longer quiet window costs a few extra rAFs, not perceived latency. */
+export const MIN_QUIET_MS = 900
+
 /**
  * Decide how the chat should scroll when the search match changes.
  *
@@ -18,42 +45,287 @@ export function pickSearchScrollBehavior(
   return now - lastStepAt < thresholdMs ? 'auto' : 'smooth'
 }
 
+const defaultNow = (): number =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+
+const defaultRaf: (cb: () => void) => number =
+  typeof requestAnimationFrame === 'function'
+    ? (cb) => requestAnimationFrame(cb)
+    : (cb) => setTimeout(cb, 16) as unknown as number
+
+/**
+ * Injectable dependencies for the generic converge poll.
+ *
+ * The poll is CONDITION-based, not frame-count based. Each frame it reads a
+ * monitored quantity via `measure()` (e.g. the target row's height, or the
+ * active mark's viewport position):
+ *   - `null`  → the target is not mounted yet. The poll waits (runs no `step`)
+ *               but the wall-clock backstop keeps ticking, so an absent /
+ *               never-mounting target still terminates.
+ *   - number  → the target IS present. `step()` runs (e.g. scroll it into
+ *               view, re-reading the live offset), and the value is compared
+ *               to the previous frame. When it stops moving for `settleFrames`
+ *               consecutive frames the row is measured (non-estimated) and the
+ *               loop stops. A widget that keeps growing during its build resets
+ *               the streak every frame, so the poll naturally re-reads the
+ *               offset after the widget-build delay and only settles once done.
+ */
+export interface SettlePollDeps {
+  /** Monitored quantity this frame, or `null` when the target is absent. */
+  measure: () => number | null
+  /** Side effect to run each frame the target is present (e.g. scroll). */
+  step: () => void
+  /** Schedule the next frame. */
+  raf?: (cb: () => void) => number
+  /** Monotonic clock in ms. */
+  now?: () => number
+  /** Wall-clock backstop in ms. Default `CONVERGE_MAX_MS`. */
+  maxMs?: number
+  /** Consecutive equal measurements that count as "settled". Default 2. */
+  settleFrames?: number
+  /**
+   * Minimum time in ms the measurement must stay quiet before "settled" is
+   * accepted. Default `MIN_QUIET_MS`. A frame-count streak alone is not enough:
+   * a widget row reports a static height until its build delay elapses
+   * (`PROGRAMMATIC_BUILD_DELAY_MS`, ~450ms), so two equal frames (~32ms) would
+   * declare victory, stop polling, and let the later growth push the target
+   * back off-centre — reproducing the miss this poll exists to prevent.
+   */
+  minQuietMs?: number
+  /** Invoked exactly once when the loop terminates. */
+  onEnd?: (reason: 'settled' | 'timeout' | 'cancelled') => void
+}
+
+/**
+ * The single in-flight programmatic scroll convergence, if any.
+ *
+ * Convergence polls are mutually exclusive by nature: they all drive the same
+ * scroller, so two running at once fight each other frame by frame. They are
+ * also NESTED in practice — navigating to a search result starts a ROW-level
+ * poll (centre display index N), and once that row mounts the message component
+ * starts a finer MARK-level poll (centre the exact occurrence inside it). The
+ * row poll re-scrolls every frame for the whole quiet window, so without a
+ * handoff it repeatedly undid the mark centring and left the viewport on the
+ * containing turn instead of the match.
+ */
+let activeScrollOwner: (() => void) | null = null
+
+/**
+ * Install `supersede` as the active convergence owner, notifying the previous
+ * owner that it has been taken over. Returns a release function that clears
+ * ownership only if this owner is still the active one (so a stale poll's
+ * teardown can never revoke a newer poll's claim).
+ */
+function claimScrollOwnership(supersede: () => void): () => void {
+  const prev = activeScrollOwner
+  // Install FIRST: `prev()` may synchronously run its own teardown, whose
+  // release must compare against `prev` and therefore no-op.
+  activeScrollOwner = supersede
+  if (prev && prev !== supersede) prev()
+  return () => {
+    if (activeScrollOwner === supersede) activeScrollOwner = null
+  }
+}
+
+/**
+ * Frame-driven poll that runs `step()` until the monitored `measure()` value
+ * has settled (measured, not estimated), with a wall-clock backstop so a
+ * never-present target can't spin. Returns a `cancel()` — idempotent and safe
+ * to call after natural termination. Extracted as a pure function (clock, rAF,
+ * and DOM access all injected) so the convergence + termination guarantees are
+ * unit-testable without a live virtualizer.
+ *
+ * Starting a poll CLAIMS scroll ownership (see `activeScrollOwner`), so a nested
+ * finer-grained poll retires the coarser one that led to it. The retirement is
+ * deferred until the superseded poll has completed at least one step, because
+ * that first step is what MOUNTS the nested target: cancelling before it would
+ * mean the finer poll's element never appears and neither scroll happens.
+ */
+export function pollRowSettled(deps: SettlePollDeps): () => void {
+  const {
+    measure,
+    step,
+    raf = defaultRaf,
+    now = defaultNow,
+    maxMs = CONVERGE_MAX_MS,
+    settleFrames = 2,
+    minQuietMs = MIN_QUIET_MS,
+  } = deps
+  const start = now()
+  let last: number | null = null
+  let stable = 0
+  // When the measurement last CHANGED — the quiet window is timed from here.
+  let lastChangeAt = start
+  let done = false
+  // Whether a step has actually run. A superseding owner waits for this,
+  // because the first step is what mounts the nested target.
+  let hasStepped = false
+  let superseded = false
+  let releaseOwnership: () => void = () => {}
+  const finish = (reason: 'settled' | 'timeout' | 'cancelled') => {
+    if (done) return
+    done = true
+    releaseOwnership()
+    deps.onEnd?.(reason)
+  }
+  releaseOwnership = claimScrollOwnership(() => {
+    if (hasStepped) finish('cancelled')
+    else superseded = true
+  })
+  const tick = () => {
+    if (done) return
+    const v = measure()
+    if (v != null) {
+      step()
+      hasStepped = true
+      // A finer-grained poll is waiting to take over; the target it needs is
+      // now mounted and scrolled into place, so stand down.
+      if (superseded) return finish('cancelled')
+      if (last != null && Math.abs(v - last) < 1) {
+        // Require BOTH a frame streak and a real quiet duration, so a row whose
+        // growth starts after the streak still converges.
+        if (++stable >= settleFrames && now() - lastChangeAt >= minQuietMs) {
+          return finish('settled')
+        }
+      } else {
+        stable = 0
+        lastChangeAt = now()
+      }
+      last = v
+    }
+    if (now() - start >= maxMs) return finish('timeout')
+    raf(tick)
+  }
+  raf(tick)
+  return () => finish('cancelled')
+}
+
+/**
+ * Wraps a scroll callback so only the FIRST invocation may use an animated
+ * behavior and every later one snaps instantly.
+ *
+ * Convergence polls call `step()` once per frame. Re-issuing a smooth scroll
+ * cancels the in-flight animation and restarts it from the current position, so
+ * a repeatedly-stepped smooth scroll stutters or stalls instead of gliding —
+ * the same restart trap that was removed from the streaming follow pin. The
+ * later corrections are sub-pixel-to-few-pixel adjustments as the target row
+ * measures in, so making them instant is visually invisible while keeping the
+ * initial user-visible movement smooth.
+ */
+export function glideOnceStep(
+  scroll: (behavior: ScrollBehavior) => void,
+  firstBehavior: ScrollBehavior,
+): () => void {
+  let stepped = false
+  return () => {
+    scroll(stepped ? 'auto' : firstBehavior)
+    stepped = true
+  }
+}
+
 /**
  * Center the active search occurrence (`mark.search-current`) in the viewport,
- * re-applying across animation frames so it CONVERGES as the target settles.
- * A far jump mounts an unmeasured virtualized row, and a match inside a
- * collapsed turn triggers a ~300ms expand animation — both keep shifting layout
- * after an initial scroll, so a single (or short) attempt lands on a stale
- * offset (often top-of-list). Re-centering for ~600ms tracks the mark through
- * measurement + expansion and ends on the correct spot on the first click. The
- * loop bails immediately if the user scrolls (wheel/touch) so it never fights
- * them, and each call is a no-op once the position is stable. Instant — no
- * animation of its own.
+ * re-applying across frames so it CONVERGES as the target settles. A far jump
+ * mounts an unmeasured virtualized row, a match inside a collapsed turn
+ * triggers a ~300ms expand animation, and a match near a widget shifts as the
+ * widget builds (~450ms) — all keep moving layout after an initial scroll, so a
+ * single (or short frame-capped) attempt lands on a stale offset (often
+ * top-of-list). This re-centers until the mark's viewport position stops moving
+ * (row measured, expansion + build finished), then stops — landing on the
+ * correct spot on the FIRST click. A ~2s wall-clock backstop guarantees a
+ * genuinely unreachable match still terminates rather than spinning.
  *
- * Returns a `cancel()` function so callers (e.g. a useEffect that re-runs on
- * every active-occurrence change) can abort the previous loop before starting a
- * new one and on unmount — otherwise rapid navigation accumulates concurrent
- * loops, each with its own window listeners, some running against detached DOM.
+ * The loop bails immediately on any user scroll intent — wheel, touch,
+ * scrollbar drag, or a scrolling keypress (see attachUserScrollIntent) — so it
+ * never fights them. Returns a `cancel()` so callers (e.g. a useEffect that
+ * re-runs
+ * on every active-occurrence change) can abort the previous loop before
+ * starting a new one and on unmount — otherwise rapid navigation accumulates
+ * concurrent loops, each with its own window listeners, some against detached
+ * DOM.
  */
-export function scrollCurrentMatchIntoView(root?: Element | null, maxFrames = 36): () => void {
-  let frame = 0
-  let cancelled = false
+/**
+ * Keys that scroll the page. A `keydown` abort must filter on these: the search
+ * box is focused while matches are navigated, so aborting on *any* keystroke
+ * would cancel convergence on every character the user types.
+ */
+const SCROLLING_KEYS = new Set([
+  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+  'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
+])
+
+/**
+ * Attach a one-shot "the user is trying to scroll" listener set and return a
+ * detach function.
+ *
+ * `wheel` + `touchmove` alone miss three real input paths that all move the
+ * scroller: dragging the scrollbar (pointer events, no wheel), keyboard
+ * scrolling (arrows / PageUp / Home / space), and assistive technology driving
+ * either of those. Missing them meant a user who dragged the scrollbar during
+ * convergence was silently recentered for up to CONVERGE_MAX_MS.
+ *
+ * Shared so every scroll-abort site (this module's convergence poll and
+ * ChatPage's navigation settle) reacts to the same input set — the previous
+ * per-site duplication is exactly how the gap survived in two places at once.
+ */
+export function attachUserScrollIntent(
+  target: EventTarget | undefined,
+  onUser: () => void,
+): () => void {
+  if (!target) return () => {}
+  const onKey = (e: Event) => {
+    const key = (e as KeyboardEvent).key
+    // A bare modifier press is not scroll intent; an unknown key is not either.
+    if (typeof key === 'string' && SCROLLING_KEYS.has(key)) onUser()
+  }
+  const passive = { passive: true } as const
+  target.addEventListener('wheel', onUser, passive)
+  target.addEventListener('touchmove', onUser, passive)
+  // pointerdown fires when the scrollbar thumb is grabbed, before any scroll
+  // event arrives, so the abort lands ahead of the first drag movement.
+  target.addEventListener('pointerdown', onUser, passive)
+  target.addEventListener('keydown', onKey, passive)
+  return () => {
+    target.removeEventListener('wheel', onUser)
+    target.removeEventListener('touchmove', onUser)
+    target.removeEventListener('pointerdown', onUser)
+    target.removeEventListener('keydown', onKey)
+  }
+}
+
+export function scrollCurrentMatchIntoView(
+  root?: Element | null,
+  opts: { maxMs?: number; now?: () => number; raf?: (cb: () => void) => number } = {},
+): () => void {
+  const { maxMs = CONVERGE_MAX_MS, now = defaultNow, raf = defaultRaf } = opts
   const target: EventTarget | undefined =
     typeof window !== 'undefined' ? window : undefined
-  const cleanup = () => {
-    target?.removeEventListener('wheel', cancel)
-    target?.removeEventListener('touchmove', cancel)
-  }
-  const cancel = () => { cancelled = true; cleanup() }
-  target?.addEventListener('wheel', cancel, { passive: true })
-  target?.addEventListener('touchmove', cancel, { passive: true })
-  const tick = () => {
-    if (cancelled) return
-    const mark = (root ?? document).querySelector('mark.search-current') as HTMLElement | null
-    mark?.scrollIntoView?.({ block: 'center' })
-    if (++frame < maxFrames) requestAnimationFrame(tick)
-    else cleanup()
-  }
-  requestAnimationFrame(tick)
-  return cancel
+  const scope: ParentNode | null =
+    root ?? (typeof document !== 'undefined' ? document : null)
+  let mark: HTMLElement | null = null
+  // Hoisted so `cleanup` (referenced by pollRowSettled's onEnd) can name it.
+  function onUser() { stop() }
+  let detachUser: () => void = () => {}
+  const cleanup = () => { detachUser() }
+  const stop = pollRowSettled({
+    // Reading the mark's position IS the convergence signal; scrolling is the
+    // step. While the mark is absent (off-window row not mounted), measure
+    // returns null and the poll idles until the backstop.
+    measure: () => {
+      mark = (scope?.querySelector('mark.search-current') as HTMLElement | null) ?? null
+      if (!mark) return null
+      return typeof mark.getBoundingClientRect === 'function'
+        ? mark.getBoundingClientRect().top
+        : 0
+    },
+    step: () => { mark?.scrollIntoView?.({ block: 'center' }) },
+    raf,
+    now,
+    maxMs,
+    onEnd: cleanup,
+  })
+  detachUser = attachUserScrollIntent(target, onUser)
+  return () => { stop(); cleanup() }
 }


### PR DESCRIPTION
## Problem

Long chat sessions (500+ messages) exhibited several distinct scroll defects: the scrollbar thumb was the wrong size and lurched while scrolling up, scrolling was janky, the viewport jumped seemingly at random, the view rubber-banded at the bottom during streaming, and clicking a far search result or the "jump to previous user message" pill silently did nothing (then worked on a second click).

A three-track investigation established that this is **not** a pagination or lazy-load bug. The backend ships the entire transcript in one response (`api_chat_slot_detail` returns `older + slot.messages` with `has_more=False`) and `loadOlderMessages` is dormant — never wired to a scroll trigger. Every symptom traces to the frontend virtualizer's height model, whose error scales with a single factor: **the number of unmeasured rows above the viewport**. That is why the causes compound rather than appearing in isolation.

## Fixes

**1. Estimated-height drift.** Unmeasured rows returned a flat `estimatedHeight: 100` while real rows span ~40px (tool pill) to thousands (assistant turn + widget), so `offsetBefore` / `totalHeight` were dominated by estimate error on any long session opened at the bottom. `HeightCache` now exposes `averageHeight()` (an O(1) running mean of measured rows) and the virtualizer estimates unmeasured rows from it, falling back to `estimatedHeight` only when there are zero measurements, so cold start is unchanged.

**2. O(N) scans per scroll frame.** `getOffset` / `getTotalHeight` / `computeWindow` walked from index 0 on every rAF-throttled scroll event and every 120ms streaming tick. The "amortized O(K)" property only held near the top of the list — parked near the bottom, which is the normal chat state, the scan walked nearly all N rows. Added `OffsetIndex`, a prefix-sum structure with O(log N) `offsetOf` / `indexAt` and O(1) `totalHeight`, and rewired the hot paths to it. This is the fix the `WindowCalculator` header had explicitly deferred. Every pre-existing export keeps an identical signature.

**3. Divergent React key systems.** The inner message key already preferred `meta.clientTs` (the #253 steer-bubble fix), but `virtualKey` — which is *also* the `HeightCache` lookup key and the React key on the windowed row wrapper — used mutable `m.ts` or the array index. So a steer echo flipping `ts` client→server, or a `single`→`turn` regroup mid-stream, orphaned the cached height and lurched the viewport; and `ts`-less messages keyed positionally, so `truncateAfterIndex` / regenerate remounted every following row. Keys are now unified through `stableMsgKey`, and a turn inherits its lead item's key so a regroup is key-stable. The #253 fix now protects the layer that actually owns scroll position.

**4. Streaming auto-pin never converged.** The pin used `behavior:'smooth'`; issuing a new smooth scroll cancels the in-flight one and restarts it toward a target that grows on every streamed delta, so on a tall transcript it chased the bottom indefinitely. Streaming pins are now instant, with smooth reserved for explicit user "jump to latest". Separately, the `> 0.5` at-bottom epsilon is smaller than one device pixel at fractional DPR (0.67 CSS px at 150%, 0.8 at 125%), so `pinAuto` believed it was not at bottom even when it visually was and re-fired on every ResizeObserver tick — the epsilon is now DPR-aware.

**5. Anchor stability depended on a node the windowing could unmount.** The RO re-pin is deliberately gated off once stick releases, deferring all stability to native `overflow-anchor`. But `recomputeWindow` unmounts rows past the hysteresis, and if the browser's chosen anchor node is one of them, anchoring resets and the viewport jumps. Added explicit anchor preservation across upward window shifts: record the topmost visible row and its viewport-relative offset, then compensate `scrollTop` after commit. `overflow-anchor` is retained — this reduces reliance on it rather than replacing it. The compensating write is classified as a self-scroll so it cannot release stick.

**6. HeightCache eviction.** A fixed 2000-entry cap evicting oldest-first meant sessions above 2000 display rows dropped their oldest heights, so scrolling to the top re-entered all-estimate territory even on a revisit. The cap is now session-size aware with a hard ceiling, and LRU recency tracks access rather than insertion so recently-scrolled regions survive.

**7. Fixed-frame poll ceilings.** `navToDisplayIndex` gave up after 30 frames (~0.5s) and `scrollCurrentMatchIntoView` after 36 (~0.6s) — less than the 450ms a widget needs for its build alone. A far jump whose target was still mounting silently no-opped. Both polls are now condition-based on the target row's height settling, with a ~2s wall-clock backstop, and still terminate on a genuinely unreachable target. The existing user-interrupt behaviour (bail on wheel/touchmove) is preserved.

**Correctness trap also resolved:** `FollowController.evaluateAutoPin` was tested but dead — production `pinAuto` implemented a different policy, so the green follow-controller tests were validating logic that did not govern the app. Any assertion about follow behaviour now runs against the real path.

## Verification

All gates green locally on the rebased commit:

| Gate | Result |
|---|---|
| `tsc -b` | clean |
| `vitest run` | 383 files, 4455 passed, 0 failed |
| `flake8 -j1 src/ test/` | clean |
| `isort --check-only` | clean |
| `mypy 1.14.1` (CI-parity venv) | 472 files, no issues |
| `pytest -n 8` | 16468 passed |

The 10 pytest failures observed locally (9 in `test_sandbox_argv.py`, 1 hardlink test in `test_deploy_round30_fixes.py`) are pre-existing host-environment failures, not regressions: this diff contains **zero** Python files, so the backend is byte-identical to `main`.

New regression coverage (plus the review-round tests listed further down): prefix-sum offsets match a naive linear sum across mixed height distributions; per-call cost does not scale linearly from N=500 to N=5000; `averageHeight` correctness across set/overwrite/evict; access-recency eviction; `virtualKey` stability across a `steer_push` reconcile and across a single→turn regroup; instant pins landing exactly on `bottomTarget`; at-bottom detection at `devicePixelRatio=1.5`; anchor stability across an unmount boundary; and a far jump that mounts after more than 30 frames completing instead of bailing.

## Browser verification (replaces this PR's earlier "Not verified" section)

The repro harness described below has now been **run in real headless Chromium** against the real `useVirtualChat` hook with an 800-row and 3000-row bimodal transcript (short user rows plus tall assistant rows with 30-line code blocks; a uniform distribution masks estimate drift). Cold cache forced by clearing `vc_heights_*`.

**It found a real bug, which is fixed in this PR:** fix #6 was dead code. `useVirtualChat` constructed `new HeightCache(sessionId)` and never supplied `rowCount` or called `setRowCount()`, so the session-size-aware eviction cap never left its 2000 floor. At 3000 rows the harness reported `measured: 2000` with exactly 2000 entries persisted. `HeightCache.test.ts` proved the cap arithmetic correct — which is precisely why the unit suite passed while the behaviour was entirely absent. The cap is now seeded at construction and updated as the transcript grows, with integration tests covering the **wiring** rather than the arithmetic.

Measured results on the current head:

| Claim | Result |
|---|---|
| #5 anchor preservation | Across 40 real wheel-ups, visible content moved **600.0px mean for a 600px wheel, max error 1.2px**, while `scrollTop`/`scrollHeight` churned together by up to ±52,104px — the compensation absorbing estimate corrections almost exactly |
| #4 streaming pin | `distFromBottom` = 0.00 across every growth tick; gap to `bottomTarget` 0.0000px; exactly 1 distinct `scrollTop` while idle at bottom (no re-pin storm) |
| #4 DPR epsilon | Identical clean behaviour at `deviceScaleFactor` 1.5 |
| #1 adaptive estimate | Unmeasured rows estimate ~633px from the running mean against an actual ~541px average. The old flat 100px modelled 800 rows as ~80k px against an actual ~433k — off 5.4× |
| #6 size-aware cache | Was broken (2000/3000); now 3000/3000 retained |
| Console/page errors | 0 throughout, at both DPRs |

**Stick-release under active streaming** (the reinstated previously-reverted follow policy — Design CONCERN #1, the largest disclosed unknown): verified in real Chromium. Follow tracks the bottom while at rest; a wheel-up mid-stream releases it (`isAtBottom` false, distance 1500px); across **14 further streaming growth ticks the release HELD with 0 spurious re-pins**, distance growing monotonically 1542 → 2088px as the tail appended; returning to the bottom **re-armed** follow, which then held at 0.00 across 5 more ticks. Confirmed at `devicePixelRatio` 1 and 1.5.

### Still not verified in a browser

- **#7 condition-based polls** — the harness drives `virt.scrollToIndex` directly, not ChatPage's `navToDisplayIndex` + `pollRowSettled`. Covered by unit tests only.
- **#3 key unification** — needs a real steer echo / turn regroup the harness cannot produce. Unit tests only.
- **#2 prefix-sum** — non-discriminating: frame time was vsync-bound at 16.5ms for both 800 and 3000 rows, with 0 long tasks at 3000. No jank observed, but this does not isolate the O(N) claim.

### Known residual

`scrollHeight` still swings by up to 51,504px in a single step as rows measure in. Visible content stays steady (that is #5 working), but the **scrollbar thumb still moves** while scrolling up a long session. Estimate drift is reduced roughly 5× rather than eliminated; closing it fully means eager measurement or a persisted per-role height profile.

## Behaviour changes not among the seven numbered fixes

`HeightCache.FLUSH_DELAY_MS` changes **100ms → 750ms**. Streaming fires many `set()` calls per second and each flush serialized the whole map; the longer window coalesces them. Consequence: a hard tab kill inside the window loses more unsaved height measurements than before, yielding a slightly colder cache on next open — self-healing via the new `averageHeight()` fallback. Manual `flush()` (e.g. on unmount) still persists immediately, and a dirty flag skips no-op flushes. Disclosed here per Design CONCERN #3.

`WidgetFrame`'s build stagger gains a ceiling: `MAX_STAGGER_SLOTS = 3` caps the per-widget stagger slot, where it was previously unbounded. Before, a batch of N widgets pushed the last one's build out by `N * BUILD_STAGGER_MS` (120ms) with no limit, so the worst-case build wait was unknowable — and fix #7's convergence poll cannot be calibrated against an unbounded number (a target in a late slot stays static past the quiet window, settles early, then resizes and lands off-target). Consequence: in a batch of more than 3 widgets the tail now shares the last slot, so the JIT build cost is spread across fewer tasks than before — still staggered, but less finely for large batches. This is what makes `MAX_WIDGET_BUILD_WAIT_MS` (450 + 3x120 = 810ms) a finite bound that `MIN_QUIET_MS` (900ms) can sit above, enforced by `searchScroll.coupling.test.ts`. Disclosed here per Design finding #4.

## Review round 1 — all findings addressed

- **GPT MEDIUM** (`useVirtualChat.ts` offsetIndex memo): deps were `[itemCount, getH]`, and `getH`'s identity is stable across a session change, so switching to a different session with an identical item count rebuilt nothing and the Fenwick tree kept serving the previous transcript's heights. Now rebuilds on `sessionId` change. Regression test verified non-vacuous by reverting the fix.
- **GPT MEDIUM** (`searchScroll.ts` settle): a 2-frame streak (~32ms) could be accepted as settled before a widget's ~450ms build started growing the row, letting the late resize push the match off-centre. Settling now additionally requires a minimum quiet **duration** (`MIN_QUIET_MS` = 900ms, inside the 2s backstop). `minQuietMs: 0` restores pure frame-streak behaviour for callers that want it.
- **Opus LOW** (`ChatPage.navToDisplayIndex`): the `cancel()` returned by `pollRowSettled` was discarded, so an in-flight loop kept ticking to the 2s backstop after unmount. The handle is now retained, cancelled by a newer navigation, and cleared on unmount.
- **Design CONCERN #1**: closed by the browser run above.
- **Design CONCERN #3**: disclosed above.
- **Design CONCERN #2** (bespoke virtualizer has crossed the build-vs-buy line): no code change requested in this PR by the reviewer. Worth a separate ADR/issue decision on whether the in-house virtualizer is a deliberate investment or a migration to TanStack Virtual / react-virtuoso should be scheduled — flagged for the maintainers rather than decided here.

Also de-flaked `WindowCalculator`'s scaling benchmark, which failed under parallel CI-like load but passed in isolation. Made contention-resistant with bounded retries rather than looser thresholds, so a genuine O(N) regression still fails every attempt.

## Follow-up (deliberately out of scope)

`smoothPinActiveRef` / `prevSmoothTopRef` in `useVirtualChat.ts` were briefly dormant during this PR (making the streaming pin instant removed their only setter) and are **live again at HEAD**. Review caught that `scrollToBottom('smooth')` — the explicit jump-to-latest — still animates and therefore still needs the guard: unarmed, each intermediate animation frame read as user input and released follow. The chokepoint now arms it for smooth pins, and a one-shot `wheel`/`touchmove` abort cancels the in-flight animation so the guard cannot swallow genuine input. Nothing is dormant and nothing here is deferred.

The real deferred items are tracked as issues rather than left in this description: **#411** (stamp a stable client id for `ts`-less messages in the reducer, closing the identity guarantee the `WeakMap` only narrows) and **#412** (the build-vs-buy decision for the in-house virtualizer, plus consolidating the height seam so `OffsetIndex` is the single read surface).

Additionally, the `ts`-less key fallback currently mints a per-message id in a `WeakMap` keyed on object identity, which is stable across renders and survives truncation of later rows but not a full list replace/refetch. The durable fix is to stamp a stable client id in the reducer when appending a `ts`-less message, which would let the key survive refetch too.

## Migration note

Persisted `HeightCache` entries written under the old key scheme go stale on first load after deploy, causing a one-time re-measure via the `averageHeight()` fallback. This is expected and self-healing.



