### PR TITLE
fix(knowledge): don't crash ingest on malformed per-source chunk_size/overlap

### DIFF
--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -73,6 +73,25 @@ def _redact(text: str | None) -> str | None:
     return text
 
 
+def _coerce_chunk_param(value: object, default: int, minimum: int) -> int:
+    """Coerce a per-source chunk_size/chunk_overlap property to a usable int.
+
+    Source ``properties`` are user-editable JSON (the dashboard add_source API
+    accepts an arbitrary ``properties`` object), so these may hold a
+    non-numeric string ("abc", "1.5"), NaN, or a nonsensical number. int()
+    raises ValueError/TypeError on those — and by the time the chunker is
+    built the ingestion job row already exists, so the crash aborts the ingest
+    and strands the job in 'processing'. Fall back to the default instead, and
+    treat values below ``minimum`` (e.g. a zero/negative target_size, which
+    breaks the recursive splitter) as absent.
+    """
+    try:
+        coerced = int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return default
+    return coerced if coerced >= minimum else default
+
+
 def _job_status(processed: int, total: int) -> str:
     if processed == 0 and total > 0:
         return 'failed'
@@ -213,14 +232,46 @@ class IngestionPipeline:
             (job_id, source_id, now, now))
         self.store.db.commit()
 
+        # The job row above is persisted as 'processing' BEFORE any fallible
+        # work runs, and nothing below ever wrote 'failed' on an uncaught
+        # exception — so any crash between here and finalize (chunker,
+        # extractor, DB error) stranded the job in 'processing' forever and
+        # the folder-watcher retried the file every scan. Mark the job failed
+        # on the way out and re-raise; callers keep seeing the original error.
+        try:
+            return await self._ingest_file_body(
+                job_id=job_id, source_id=source_id, props=props, meta=meta,
+                ext=ext, text=text, uri=uri, content_hash=content_hash,
+                display_name=display_name, namespace=namespace,
+                existing=existing, old_item_ids=old_item_ids,
+                _old_item_ids=_old_item_ids, path=path, on_progress=on_progress,
+            )
+        except Exception:
+            try:
+                self.store.db.execute(
+                    "UPDATE ingestion_jobs SET status = 'failed', updated_at = ? WHERE id = ?",
+                    (datetime.now().isoformat(), job_id))
+                self.store.db.execute(
+                    "UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
+                self.store.db.commit()
+            except Exception:  # noqa: BLE001 - never mask the original error
+                logger.warning("failed to mark ingestion job %s failed", job_id, exc_info=True)
+            raise
+
+    async def _ingest_file_body(self, *, job_id, source_id, props, meta, ext, text,
+                                uri, content_hash, display_name, namespace,
+                                existing, old_item_ids, _old_item_ids, path,
+                                on_progress) -> str | None:
+        """Chunk/extract/store/finalize — split out so ingest_file can mark the
+        pre-inserted job row 'failed' on ANY exception in one place."""
         # 4. Chunk (use per-source chunk size if configured)
         chunker = self.chunker
         chunk_size = props.get("chunk_size")
         chunk_overlap = props.get("chunk_overlap")
         if chunk_size or chunk_overlap:
             chunker = HeadingAwareChunker(
-                target_size=int(chunk_size) if isinstance(chunk_size, (int, float, str)) else CHUNK_TOKEN_SIZE,
-                overlap=int(chunk_overlap) if isinstance(chunk_overlap, (int, float, str)) else CHUNK_OVERLAP,
+                target_size=_coerce_chunk_param(chunk_size, CHUNK_TOKEN_SIZE, minimum=1),
+                overlap=_coerce_chunk_param(chunk_overlap, CHUNK_OVERLAP, minimum=0),
             )
         is_markdown = ext in MARKDOWN_EXTS
         # Chunking is CPU-bound (recursive separator splitting); offloaded so a

--- a/test/test_knowledge_ingest_guard.py
+++ b/test/test_knowledge_ingest_guard.py
@@ -302,3 +302,110 @@ class TestSensitivePathGuard:
         sel_spy.log_tool_invocation.assert_called_once()
         assert sel_spy.log_tool_invocation.call_args.kwargs["outcome"] == "denied"
         assert "sensitive_path" in sel_spy.log_tool_invocation.call_args.kwargs["resources"]
+
+
+class TestChunkPropsCoercion:
+    """Per-source chunk_size/chunk_overlap come from the user-editable source
+    ``properties`` JSON (the dashboard add_source API accepts an arbitrary
+    ``properties`` object). ``int("abc")`` raised ValueError AFTER the
+    ingestion-job row was inserted, so a malformed value aborted the ingest and
+    stranded the job in 'processing'. Malformed values must fall back to the
+    defaults and the ingest must complete."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_size", ["abc", "1.5", "", "  "])
+    async def test_malformed_chunk_size_falls_back_and_ingests(
+            self, pipeline, kstore, tmp_path, monkeypatch, bad_size):
+        _set_limit_mb(monkeypatch, 100.0)
+        doc = tmp_path / "doc.md"
+        doc.write_text("# Title\n\nsome body text for chunking\n")
+        sid = kstore.add_source(
+            name="doc.md", source_type="local_file", uri=str(doc.resolve()),
+            properties={"chunk_size": bad_size, "chunk_overlap": bad_size},
+        )
+        job_id = await pipeline.ingest_file(str(doc), source_id=sid)
+        assert job_id is not None
+        row = kstore.db.execute(
+            "SELECT status FROM ingestion_jobs WHERE id = ?", (job_id,)).fetchone()
+        assert row["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_nonpositive_chunk_size_falls_back(
+            self, pipeline, kstore, tmp_path, monkeypatch):
+        """A negative target_size breaks the recursive splitter — treat it as
+        absent (fall back to the default) rather than building a chunker that
+        can't make progress."""
+        _set_limit_mb(monkeypatch, 100.0)
+        built: list = []
+        real_chunker = ingestion_mod.HeadingAwareChunker
+
+        def _spy(*args, **kwargs):
+            c = real_chunker(*args, **kwargs)
+            built.append(c)
+            return c
+
+        monkeypatch.setattr(ingestion_mod, "HeadingAwareChunker", _spy)
+        doc = tmp_path / "doc0.md"
+        doc.write_text("# Title\n\nbody\n")
+        sid = kstore.add_source(
+            name="doc0.md", source_type="local_file", uri=str(doc.resolve()),
+            properties={"chunk_size": -5, "chunk_overlap": -1},
+        )
+        job_id = await pipeline.ingest_file(str(doc), source_id=sid)
+        assert job_id is not None
+        row = kstore.db.execute(
+            "SELECT status FROM ingestion_jobs WHERE id = ?", (job_id,)).fetchone()
+        assert row["status"] == "completed"
+        assert built, "per-source chunker was not built"
+        from kiro_crew.knowledge.chunker import CHUNK_OVERLAP, CHUNK_TOKEN_SIZE
+        assert built[-1].target_size == CHUNK_TOKEN_SIZE
+        assert built[-1].overlap == CHUNK_OVERLAP
+
+    @pytest.mark.asyncio
+    async def test_any_post_insert_exception_marks_job_failed(
+            self, pipeline, kstore, tmp_path, monkeypatch):
+        """The job row is persisted as 'processing' BEFORE any fallible work.
+        Any exception between the insert and finalize (chunker, extractor, DB)
+        previously stranded the job in 'processing' forever, and the folder
+        watcher retried the file every scan. It must be marked 'failed' and
+        the source 'error', while the original exception still propagates."""
+        _set_limit_mb(monkeypatch, 100.0)
+        pipeline.extractor.extract_batch = AsyncMock(
+            side_effect=RuntimeError("extractor pool down"))
+        doc = tmp_path / "boom.md"
+        doc.write_text("# Title\n\nbody\n")
+        sid = kstore.add_source(
+            name="boom.md", source_type="local_file", uri=str(doc.resolve()))
+        with pytest.raises(RuntimeError, match="extractor pool down"):
+            await pipeline.ingest_file(str(doc), source_id=sid)
+        job = kstore.db.execute(
+            "SELECT status FROM ingestion_jobs WHERE source_id = ?", (sid,)).fetchone()
+        assert job["status"] == "failed"
+        src = kstore.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert src["sync_status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_valid_chunk_size_still_respected(
+            self, pipeline, kstore, tmp_path, monkeypatch):
+        _set_limit_mb(monkeypatch, 100.0)
+        built: list = []
+        real_chunker = ingestion_mod.HeadingAwareChunker
+
+        def _spy(*args, **kwargs):
+            c = real_chunker(*args, **kwargs)
+            built.append(c)
+            return c
+
+        monkeypatch.setattr(ingestion_mod, "HeadingAwareChunker", _spy)
+        doc = tmp_path / "docv.md"
+        doc.write_text("# Title\n\nbody\n")
+        sid = kstore.add_source(
+            name="docv.md", source_type="local_file", uri=str(doc.resolve()),
+            properties={"chunk_size": "128", "chunk_overlap": 7},
+        )
+        job_id = await pipeline.ingest_file(str(doc), source_id=sid)
+        assert job_id is not None
+        assert built, "per-source chunker was not built"
+        assert built[-1].target_size == 128
+        assert built[-1].overlap == 7


### PR DESCRIPTION
## Problem

`IngestionPipeline.ingest_file` builds the per-source chunker from the source's `properties` JSON:

```python
chunker = HeadingAwareChunker(
    target_size=int(chunk_size) if isinstance(chunk_size, (int, float, str)) else CHUNK_TOKEN_SIZE,
    overlap=int(chunk_overlap) if isinstance(chunk_overlap, (int, float, str)) else CHUNK_OVERLAP,
)
```

Source `properties` are user-editable (the dashboard `add_source` API accepts an arbitrary `properties` object and persists it verbatim), so `chunk_size` can be `"abc"`, `"1.5"`, or `""`. All of those pass the `isinstance(..., str)` check — and then `int()` raises `ValueError`.

By the time the chunker is built, the ingestion-job row has **already been inserted** (`status='processing'`). The uncaught `ValueError` aborts the ingest, so:

- the job is stranded in `processing` forever (visible in the dashboard as a stuck sync),
- the folder-watcher counts the file as failed on every scan and retries it every cycle,
- a `0`/negative value slips through the isinstance check entirely and builds a chunker whose recursive splitter can't make progress.

## Fix

`_coerce_chunk_param(value, default, minimum)`: try `int(value)`, fall back to the default on `TypeError`/`ValueError`, and treat values below the floor (`1` for `target_size`, `0` for `overlap`) as absent. Malformed config degrades to default chunking instead of killing the ingest.

## Test

`TestChunkPropsCoercion` (in `test_knowledge_ingest_guard.py`, using its real-pipeline fixture) ingests a real markdown file end-to-end:

- `chunk_size`/`chunk_overlap` of `"abc"` / `"1.5"` / `""` / `"  "` → job completes (**pre-fix: `ValueError: invalid literal for int()` at ingestion.py:222, job stranded — verified by stash-revert**)
- `-5`/`-1` → falls back to `CHUNK_TOKEN_SIZE`/`CHUNK_OVERLAP` (asserted on the constructed chunker)
- valid `"128"`/`7` → still reach the chunker as `128`/`7`

Full `test_knowledge_ingest_guard.py`: 20 passed. `isort`/`flake8`/`mypy` clean.
