### PR TITLE
fix(acp): don't tear down the prompt turn on a malformed permission payload

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -326,8 +326,14 @@ def build_permission_event(
         opt_id = o.get("optionId") or o.get("id") or ""
         opt_label = o.get("name") or o.get("label") or ""
         opt_kind = o.get("kind") or ""
-        if not opt_id:
+        # A truthy non-string id would crash opt_id.lower() below (and
+        # non-string label/kind would leak into the typed options list).
+        if not isinstance(opt_id, str) or not opt_id:
             continue
+        if not isinstance(opt_label, str):
+            opt_label = ""
+        if not isinstance(opt_kind, str):
+            opt_kind = ""
         options.append({"id": opt_id, "label": opt_label})
         if not opt_kind:
             opt_kind = _LEGACY_OPTION_KIND.get(opt_id.lower(), "")

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -4222,7 +4222,14 @@ class AcpClient:
     def _build_permission_event(self, msg: JsonRpcMessage) -> AcpEvent:
         request_id = msg.id if msg.id is not None else ""
         params = msg.params or {}
+        # The permission payload comes straight from the agent process. A
+        # malformed toolCall (null/list/string) or options (null/dict/string,
+        # or non-dict entries) would raise AttributeError/TypeError here — and
+        # this runs inside the prompt-turn event generator, so the crash tears
+        # down the whole turn instead of degrading to the default options.
         tool_call = params.get("toolCall", {})
+        if not isinstance(tool_call, dict):
+            tool_call = {}
         title = tool_call.get("title", "unknown")
         # The ACP toolCall carries a `kind` ("execute" for Bash, "read"/"edit"/
         # …). Carry it onto the event as display/telemetry metadata. NOTE: the
@@ -4237,12 +4244,23 @@ class AcpClient:
         # reject_tool can echo the exact id the agent advertised.
         options: list[dict[str, str]] = []
         kind_to_id: dict[str, str] = {}
-        for o in params.get("options", []):
+        raw_options = params.get("options", [])
+        if not isinstance(raw_options, list):
+            raw_options = []
+        for o in raw_options:
+            if not isinstance(o, dict):
+                continue
             opt_id = o.get("optionId") or o.get("id") or ""
             opt_label = o.get("name") or o.get("label") or ""
             opt_kind = o.get("kind") or ""
-            if not opt_id:
+            # A non-string id would crash opt_id.lower() below (and non-string
+            # label/kind would leak into the typed options list) — skip them.
+            if not isinstance(opt_id, str) or not opt_id:
                 continue
+            if not isinstance(opt_label, str):
+                opt_label = ""
+            if not isinstance(opt_kind, str):
+                opt_kind = ""
             options.append({"id": opt_id, "label": opt_label})
             if not opt_kind:
                 # Only synthesize a kind for well-known literals; unknown ids

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -4436,6 +4436,63 @@ class TestBuildPermissionEvent:
         assert len(event.options) == 2
         assert event.options[0]["id"] == "allow_once"
 
+    @pytest.mark.parametrize("bad_options", [None, "allow", 42, {"id": "allow_once"}])
+    def test_non_list_options_degrade_to_defaults(self, bad_options):
+        """The permission payload comes straight from the agent process; a
+        non-list options value made the for-loop raise TypeError (or iterate
+        dict keys), tearing down the prompt-turn event generator instead of
+        degrading to the default allow options."""
+        client = AcpClient()
+        from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            id=12,
+            method="session/requestPermission",
+            params={"toolCall": {"title": "rm"}, "options": bad_options},
+        )
+        event = client._build_permission_event(msg)  # must not raise
+        assert event.kind == EVENT_PERMISSION_REQUEST
+        assert len(event.options) == 2
+        assert event.options[0]["id"] == "allow_once"
+
+    @pytest.mark.parametrize("bad_toolcall", [None, "shell", ["x"], 7])
+    def test_non_dict_toolcall_degrades_to_unknown(self, bad_toolcall):
+        """A non-dict toolCall made tool_call.get(...) raise AttributeError."""
+        client = AcpClient()
+        from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            id=13,
+            method="session/requestPermission",
+            params={"toolCall": bad_toolcall, "options": []},
+        )
+        event = client._build_permission_event(msg)  # must not raise
+        assert event.kind == EVENT_PERMISSION_REQUEST
+        assert event.title == "unknown"
+
+    def test_non_dict_and_non_string_option_entries_skipped(self):
+        """Non-dict entries raised AttributeError on o.get(); an int optionId
+        crashed opt_id.lower() in the legacy-kind synthesis. Both must be
+        skipped while valid entries still parse."""
+        client = AcpClient()
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            id=14,
+            method="session/requestPermission",
+            params={
+                "toolCall": {"title": "shell"},
+                "options": [
+                    "allow",                        # non-dict
+                    None,                           # non-dict
+                    {"id": 42, "label": "int id"},  # non-string id
+                    {"id": "allow_once", "label": "Allow once"},
+                ],
+            },
+        )
+        event = client._build_permission_event(msg)  # must not raise
+        assert event.options == [{"id": "allow_once", "label": "Allow once"}]
+
     def test_cached_tool_input_used(self):
         client = AcpClient()
         from kiro_crew.acp.types import JsonRpcMessage

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -2902,6 +2902,38 @@ def test_build_permission_event_raw_params_none_without_cache():
     assert event.raw_tool_params is None
 
 
+def test_build_permission_event_non_string_option_entries_skipped():
+    """The shared parser feeds AcpSessionHandle's prompt event generator; a
+    truthy non-string id (e.g. {"id": 42}) crashed opt_id.lower() in the
+    legacy-kind synthesis, tearing down the turn on the shared-runtime
+    transport — the same class of crash AcpClient's copy guards against.
+    Non-dict entries and non-string label/kind must be skipped/coerced while
+    valid entries still parse."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    msg = JsonRpcMessage.from_dict({
+        "id": 7,
+        "method": METHOD_REQUEST_PERMISSION,
+        "params": {
+            "toolCall": {"toolCallId": "tc-y", "title": "shell"},
+            "options": [
+                "allow",                          # non-dict
+                None,                             # non-dict
+                {"id": 42, "label": "int id"},    # non-string id → skipped
+                {"id": "allow_once", "label": 7, "kind": ["x"]},  # coerced
+                {"id": "allow_always", "label": "Always"},
+            ],
+        },
+    })
+    event, recorded = build_permission_event(msg, raw_params_cache={})  # must not raise
+    assert event.options == [
+        {"id": "allow_once", "label": ""},
+        {"id": "allow_always", "label": "Always"},
+    ]
+    assert recorded is not None
+
+
 def test_mark_dead_unregisters_protected_pid():
     """Regression (PR #21 follow-up): _mark_dead must release the sweep-protection
     shield on ANY death path (not just kill()), else the dead PID lingers in


### PR DESCRIPTION
## Problem

`AcpClient._build_permission_event` trusts the shape of the agent-supplied `session/requestPermission` params:

```python
tool_call = params.get("toolCall", {})
title = tool_call.get("title", "unknown")          # AttributeError if toolCall is null/list/str
...
for o in params.get("options", []):                 # TypeError if options is null/int; iterates keys if dict
    opt_id = o.get("optionId") or o.get("id") or "" # AttributeError if entry is non-dict
    ...
    opt_kind = _LEGACY_OPTION_KIND.get(opt_id.lower(), "")  # AttributeError if id is an int
```

The permission payload comes straight from the agent process (kiro-cli, claude-agent-acp, or any third-party ACP agent). The builder runs inside the prompt-turn event generator (`_prompt_events`), so any of these exceptions **tears down the entire turn** — the user sees a dead chat instead of a permission card with the default allow options.

## Fix

isinstance-guard at the boundary, matching how the rest of the payload is already treated as untrusted:

- non-dict `toolCall` → `{}` (title degrades to `"unknown"`)
- non-list `options` → `[]` (falls through to the existing default allow-options path)
- non-dict option entries and non-string ids → skipped; non-string label/kind → `""`

A fully malformed payload now degrades to the same default-options path that an *empty* options list already takes.

## Test

`TestBuildPermissionEvent` gains parametrized cases: non-list `options` (`None`/`"allow"`/`42`/dict), non-dict `toolCall` (`None`/`"shell"`/`["x"]`/`7`), and mixed non-dict + int-id option entries. Each raised the exact `TypeError`/`AttributeError` pre-fix (verified by stash-revert: `TypeError: 'NoneType' object is not iterable` at client.py:4240, `AttributeError: 'str' object has no attribute 'get'` at :4241) and now yields a valid `EVENT_PERMISSION_REQUEST`. Full class: 19 passed. `isort`/`flake8`/`mypy` clean.
