### PR TITLE
fix(acp): don't crash the prompt turn on non-numeric usage_update used/size

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import difflib
 import json
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
@@ -667,13 +668,38 @@ def parse_session_update(
     return events
 
 
-def parse_usage_update(update: dict[str, Any]) -> tuple[int | None, int | None]:
-    """Parse a ``usage_update`` into ``(used, size)`` token counts.
+def _token_count(value: Any) -> int | float | None:
+    """Validate an agent-supplied token count; None for anything unusable.
+
+    The value comes straight from the agent process. Non-numbers (str/list/
+    bool) would crash comparisons or division downstream; json parses NaN/
+    Infinity literals to non-finite floats that pass isinstance but crash
+    int(); and an arbitrary-precision int beyond float range makes
+    math.isfinite itself raise OverflowError. All of those run inside the
+    prompt-turn dispatch path, so a malformed value must degrade to "absent",
+    never raise.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        if not math.isfinite(value):
+            return None
+    except OverflowError:
+        return None
+    return value
+
+
+def parse_usage_update(update: dict[str, Any]) -> tuple[int | float | None, int | float | None]:
+    """Parse a ``usage_update`` into validated ``(used, size)`` token counts.
 
     kiro-cli's working path (``AcpClient``) reads a FLAT shape (``update.used`` /
     ``update.size``); ``runtime.py`` had drifted to a nested ``update.usage.*``
     read. This reconciles to flat-primary with a nested fallback so both classes
     read identically regardless of which shape kiro emits.
+
+    Values are validated via ``_token_count`` so BOTH consumers
+    (``AcpClient._track_usage_update`` and ``AcpSessionHandle._handle_update``)
+    are safe against malformed payloads at one chokepoint.
     """
     if not isinstance(update, dict):
         return None, None
@@ -686,7 +712,7 @@ def parse_usage_update(update: dict[str, Any]) -> tuple[int | None, int | None]:
                 used = nested.get("used")
             if size is None:
                 size = nested.get("size")
-    return used, size
+    return _token_count(used), _token_count(size)
 
 
 # Re-export the method names so callers can use a single import site for the

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator
 
 from kiro_crew import model_registry, platform_compat
+from kiro_crew.acp._dispatch import parse_usage_update
 from kiro_crew.acp.liveness import VERDICT_UNKNOWN, VERDICT_WORKING, LivenessOracle
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
@@ -3692,8 +3693,12 @@ class AcpClient:
         update = params.get("update", {})
         kind = update.get("sessionUpdate") if isinstance(update, dict) else None
         if kind == UPDATE_USAGE:
-            used = update.get("used")
-            size = update.get("size")
+            # used/size come straight from the agent process; a malformed
+            # value (string, list, bool, NaN/Infinity, bignum beyond float
+            # range) must degrade to "absent" rather than raise mid-turn.
+            # parse_usage_update validates both fields at the shared
+            # chokepoint used by AcpSessionHandle._handle_update too.
+            used, size = parse_usage_update(update)
             if used is not None and size and size > 0:
                 self.last_prompt_stats.context_pct = round((used / size) * 100, 1)
                 # Keep the raw counts so the dashboard token text uses the real

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -1500,6 +1500,45 @@ class TestAcpClientTrackUsageUpdate:
         assert stats.context_used_tokens == 0
         assert stats.context_window_tokens == 0
 
+    @pytest.mark.parametrize(
+        "used,size",
+        [
+            ("50000", "200000"),  # numeric strings: `size > 0` raises TypeError
+            (50000, "200000"),
+            ([50000], 200000),
+            (50000, {"n": 1}),
+            (True, True),  # bools are ints but nonsense as token counts
+            # json parses NaN/Infinity literals to non-finite floats, which
+            # pass an isinstance check but crash int() (ValueError/OverflowError).
+            (float("nan"), 200000),
+            (50000, float("inf")),
+            (float("inf"), float("nan")),
+            # An arbitrary-precision int beyond float range makes
+            # math.isfinite itself raise OverflowError.
+            (10**400, 200000),
+            (50000, 10**400),
+        ],
+    )
+    def test_non_numeric_used_size_treated_as_absent(self, tmp_path, used, size):
+        """used/size come straight from the agent process; a non-numeric value
+        raised TypeError on `size > 0` / `used / size` inside the prompt-turn
+        dispatch path, tearing down the whole turn. Malformed values must be
+        treated like absent ones."""
+        client = AcpClient(work_dir=tmp_path)
+        client._track_usage_update(self._usage_msg(used, size))  # must not raise
+        stats = client.last_prompt_stats
+        assert stats.context_pct == 0.0
+        assert stats.context_used_tokens == 0
+        assert stats.context_window_tokens == 0
+
+    def test_float_used_size_still_tracked(self, tmp_path):
+        client = AcpClient(work_dir=tmp_path)
+        client._track_usage_update(self._usage_msg(50000.0, 200000.0))
+        stats = client.last_prompt_stats
+        assert stats.context_pct == 25.0
+        assert stats.context_used_tokens == 50000
+        assert stats.context_window_tokens == 200000
+
     def test_tokens_carry_forward_across_prompt_reset(self, tmp_path):
         # The per-prompt reset preserves the last known pct + token counts so
         # the dashboard ring/text doesn't flicker to 0 at the start of a turn.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1328,6 +1328,38 @@ async def test_dispatch_usage_update():
         await _stop_reader(task)
 
 
+@pytest.mark.parametrize(
+    "used,size",
+    [
+        ("5000", "10000"),   # numeric strings
+        (float("inf"), 10000),
+        (float("nan"), float("nan")),
+        (10**400, 10000),    # bignum: math.isfinite itself raises OverflowError
+        ([5000], {"n": 1}),
+        (True, True),
+    ],
+)
+def test_handle_update_malformed_usage_is_noop(used, size):
+    """The session-handle path consumes the same agent-supplied usage_update as
+    AcpClient. parse_usage_update validates at the shared chokepoint, so a
+    malformed used/size must be a no-op here too — not a TypeError/
+    OverflowError inside the prompt-turn dispatch."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    msg = JsonRpcMessage(
+        method=METHOD_SESSION_UPDATE,
+        params={
+            "sessionId": "sA",
+            "update": {"sessionUpdate": "usage_update", "used": used, "size": size},
+        },
+    )
+    events = handle._handle_update(msg)  # must not raise
+    assert events == []
+    assert handle.last_prompt_stats.context_pct == 0.0
+    assert handle.last_prompt_stats.context_used_tokens == 0
+
+
 @pytest.mark.asyncio
 async def test_dispatch_metadata_credits():
     """_kiro.dev/metadata meteringUsage(unit=credit) accumulates into last_prompt_stats


### PR DESCRIPTION
## Problem

`AcpClient._track_usage_update` reads `used`/`size` from the agent-supplied `usage_update` session notification and goes straight to arithmetic:

```python
used = update.get("used")
size = update.get("size")
if used is not None and size and size > 0:          # TypeError if size is "200000"/list/dict
    self.last_prompt_stats.context_pct = round((used / size) * 100, 1)  # TypeError if used is a str
```

The payload comes straight from the agent process (kiro-cli, claude-agent-acp, or any third-party ACP agent). An agent that serializes token counts as strings — or sends anything else malformed — raises `TypeError` inside the prompt-turn dispatch path (3 call sites, including the main `_dispatch_events` loop), tearing down the whole turn over a telemetry-only field.

## Fix

isinstance-guard `used`/`size` to real numbers (`bool` excluded — `True` is an `int` subclass but nonsense as a token count) and treat malformed values like absent ones, which already fall through to the existing `logger.debug("usage_update missing used/size")` branch.

## Test

`TestAcpClientTrackUsageUpdate` gains parametrized malformed cases (numeric strings, mixed str/int, list, dict, bools) — each raised `TypeError` pre-fix (verified by stash-revert: `'>' not supported between instances of 'str' and 'int'` at client.py:3697) and now leaves stats untouched. A float-valued case asserts real numeric payloads still track (25.0%, raw counts recorded). Full class: 9 passed. `isort`/`flake8`/`mypy` clean.
