### PR TITLE
fix(acp): don't kill the multiplexed demux on a non-numeric response id

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -662,7 +662,20 @@ class AcpRuntime:
 
                 # Route responses
                 if msg.id is not None and (msg.result is not None or msg.error is not None):
-                    req_id = msg.id if isinstance(msg.id, int) else int(msg.id)
+                    # JSON-RPC allows string ids, and this runtime only ever
+                    # issues int ids — but the id in the response is agent-
+                    # controlled. int("req-1") / int([...]) raises ValueError/
+                    # TypeError, which the catch-all below turns into
+                    # _mark_dead, poisoning EVERY multiplexed session over one
+                    # unmatched frame. Same invariant as the non-dict guard
+                    # above: skip the frame, don't kill the demux.
+                    try:
+                        req_id = msg.id if isinstance(msg.id, int) else int(msg.id)
+                    except (TypeError, ValueError, OverflowError):
+                        # OverflowError: json parses 1e9999 to float("inf"),
+                        # which int() rejects differently from a bad string.
+                        logger.debug("Response with non-numeric id %r dropped", msg.id)
+                        continue
 
                     # Check awaited requests first (init, session/new, set_mode)
                     future = self._pending_requests.pop(req_id, None)

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -159,6 +159,52 @@ async def test_awaited_response_resolves_pending_future():
 
 
 @pytest.mark.asyncio
+async def test_non_numeric_response_id_dropped_without_killing_demux():
+    """The id in a response frame is agent-controlled. int("req-1") raised
+    ValueError, which the reader's catch-all turned into _mark_dead — poisoning
+    EVERY multiplexed session over one unmatched frame. The frame must be
+    dropped and the reader must keep routing."""
+    rt, reader, _ = _make_runtime()
+    q = _register(rt, "sA")
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    rt._pending_requests[7] = fut
+    task = await _start_reader(rt)
+    try:
+        # String / list / overflow ids: none int() coercible. json parses
+        # 1e9999 to float("inf"), which raises OverflowError (not ValueError).
+        _feed(reader, {"id": "req-1", "result": {"ok": True}})
+        _feed(reader, {"id": [1], "error": {"code": -1}})
+        reader.feed_data(b'{"id": 1e9999, "result": {}}\n')
+        # The reader must still be alive: a valid response and a routed
+        # notification must both be delivered after the bad frames.
+        _feed(reader, {"id": 7, "result": {"sessionId": "new1"}})
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        result = await asyncio.wait_for(fut, timeout=1.0)
+        assert result == {"sessionId": "new1"}
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=1.0)
+        assert msg.params["sessionId"] == "sA"
+        assert not rt._dead
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_numeric_string_response_id_still_coerced():
+    """A digit-string id ("7") keeps working — it was int()-coerced before and
+    must keep matching the pending int key after the guard."""
+    rt, reader, _ = _make_runtime()
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    rt._pending_requests[7] = fut
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"id": "7", "result": {"ok": 1}})
+        result = await asyncio.wait_for(fut, timeout=1.0)
+        assert result == {"ok": 1}
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
 async def test_error_response_sets_exception_on_future():
     rt, reader, _ = _make_runtime()
     fut: asyncio.Future = asyncio.get_event_loop().create_future()


### PR DESCRIPTION
## Problem

`AcpRuntime._reader_loop` — the **single owner of stdout** that demultiplexes one agent process across all concurrent sessions — coerces response ids like this:

```python
if msg.id is not None and (msg.result is not None or msg.error is not None):
    req_id = msg.id if isinstance(msg.id, int) else int(msg.id)
```

JSON-RPC explicitly allows string ids, and the id in a response frame is agent-controlled. `int("req-1")` raises `ValueError` (a list id raises `TypeError`), which the loop's catch-all converts into `_mark_dead` — failing every pending future and poisoning **every** multiplexed session's queue. One stray frame from the agent kills every active chat on that runtime.

The loop already defends exactly this invariant for non-dict JSON lines (the `isinstance(data, dict)` guard a few lines above, added so "one stray line can't kill the demux"). This is the same hole one branch later.

## Fix

Wrap the coercion in `try/except (TypeError, ValueError)`, drop the frame at debug level, keep reading. Digit-string ids (`"7"`) still coerce and match their pending int key exactly as before.

## Test

Driven through the real `_reader_loop` with a real `asyncio.StreamReader` (the file's existing harness):

- `test_non_numeric_response_id_dropped_without_killing_demux` — feeds `{"id": "req-1", ...}` and `{"id": [1], ...}`, then proves the reader **still** resolves a pending future, still routes a session notification, and `rt._dead` is False. Pre-fix: `ValueError: invalid literal for int() with base 10: 'req-1'` crashed the reader (verified by stash-revert).
- `test_numeric_string_response_id_still_coerced` — pins the legacy `"7"` → `7` behavior.

Full `test_acp_runtime.py`: 133 passed. `isort`/`flake8`/`mypy` clean.
