### PR TITLE
fix(agent): self-heal tool_search grant onto existing configs

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1490,8 +1490,26 @@ def _refresh_dynamic_fields(config: dict) -> None:
     if isinstance(bundled_resources, list) and bundled_resources and not config.get("resources"):
         config["resources"] = list(bundled_resources)
 
-    # tools/allowedTools: intentionally not modified on existing configs.
-    # User controls these lists entirely.
+    # tools/allowedTools: user-owned and otherwise NOT modified on existing
+    # configs.  Narrow exception (ADD-only): ensure the ``tool_search`` built-in
+    # grant is present.  kiro-cli only activates MCP Tool Search when the
+    # ToolSearch built-in is in the agent's tools list; without the grant, the
+    # per-session overlay written for AgentConfig.tool_search (enabled +
+    # minPct=0/minTokens=0) is a no-op and full MCP tool specs are sent every
+    # turn.  Existing configs created before ``tool_search`` shipped in
+    # defaults.json never gain it otherwise, because the tools list is preserved
+    # above.  It is a read-only, auto-allowed built-in (permission eval => Allow)
+    # so no ``allowedTools`` entry is needed.  Gated on the shipped template
+    # actually granting it (so an edition that drops it is respected) and scoped
+    # to this single tool; the feature's on/off remains the AgentConfig.tool_search
+    # toggle.  Never removes a tool and never reorders the rest.
+    tools = config.get("tools")
+    if (
+        isinstance(tools, list)
+        and "tool_search" in (bundled.get("tools") or [])
+        and "tool_search" not in tools
+    ):
+        tools.append("tool_search")
 
 
 def get_shipped_tools() -> dict[str, list[str]]:

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1514,8 +1514,91 @@ class TestToolBloatFixes:
 
         path = _run_install(tmp_path, cfg_dir)
         config = json.loads(path.read_text())
+        # Template (_bundled_defaults) does not grant tool_search, so the narrow
+        # seed does not fire and the user's tools list is preserved exactly.
         assert config["tools"] == ["execute_bash", "fs_read", "fs_write", "use_aws", "code"]
         assert config["allowedTools"] == ["fs_read", "use_aws"]
+
+    def _tool_search_defaults(self, tmp_path: Path) -> Path:
+        """Bundled defaults whose template grants the tool_search built-in."""
+        cfg_dir = tmp_path / "config"
+        cfg_dir.mkdir()
+        defaults = {
+            "model": "claude-default",
+            "tools": ["ReadFile", "tool_search"],
+            "allowedTools": ["ReadFile"],
+            "mcpServers": {},
+            "toolsSettings": {"execute_bash": {"deniedCommands": ["rm -rf /"]}},
+            "hooks": {"preToolUse": "audit"},
+        }
+        (cfg_dir / "defaults.json").write_text(json.dumps(defaults))
+        (cfg_dir / "prompt.md").write_text("system prompt")
+        return cfg_dir
+
+    def test_existing_config_seeds_missing_tool_search(self, tmp_path: Path):
+        """Existing config missing tool_search gains it (ADD-only) when the
+        shipped template grants it, appended without disturbing other tools."""
+        cfg_dir = self._tool_search_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        existing = {
+            "model": "claude-user-custom",
+            "tools": ["execute_bash", "fs_read", "code", "@builder-mcp"],
+            "allowedTools": ["fs_read", "@builder-mcp"],
+            "mcpServers": {},
+        }
+        (kiro_dir / "kirocrew.json").write_text(json.dumps(existing))
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text())
+        # tool_search appended at the end; all prior tools preserved in order.
+        assert config["tools"] == [
+            "execute_bash",
+            "fs_read",
+            "code",
+            "@builder-mcp",
+            "tool_search",
+        ]
+        # Read-only auto-allowed built-in: NOT added to allowedTools.
+        assert "tool_search" not in config["allowedTools"]
+        assert config["allowedTools"] == ["fs_read", "@builder-mcp"]
+
+    def test_existing_config_tool_search_idempotent(self, tmp_path: Path):
+        """A config that already grants tool_search is left unchanged (no dup)."""
+        cfg_dir = self._tool_search_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        existing = {
+            "model": "claude-user-custom",
+            "tools": ["execute_bash", "tool_search", "code"],
+            "allowedTools": ["code"],
+            "mcpServers": {},
+        }
+        (kiro_dir / "kirocrew.json").write_text(json.dumps(existing))
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text())
+        assert config["tools"] == ["execute_bash", "tool_search", "code"]
+        assert config["tools"].count("tool_search") == 1
+
+    def test_existing_config_no_tool_search_seed_when_template_omits(self, tmp_path: Path):
+        """When the shipped template does NOT grant tool_search, an existing
+        config's tools are left exactly as-is (seed is template-gated)."""
+        cfg_dir = _bundled_defaults(tmp_path)  # tools == ["ReadFile"], no tool_search
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        existing = {
+            "model": "claude-user-custom",
+            "tools": ["execute_bash", "code"],
+            "allowedTools": ["code"],
+            "mcpServers": {},
+        }
+        (kiro_dir / "kirocrew.json").write_text(json.dumps(existing))
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text())
+        assert config["tools"] == ["execute_bash", "code"]
+        assert "tool_search" not in config["tools"]
 
     def test_existing_config_no_managed_mcp_added(self, tmp_path: Path):
         """Existing configs don't get @managed-mcp refs injected."""


### PR DESCRIPTION
## Summary

MCP Tool Search is enabled by default (`AgentConfig.tool_search=True`, and the
`tool_search` built-in is granted in `config/defaults.json`), so **fresh**
installs defer MCP tool specs correctly. **Existing** installs never gained it:
the refresh path (`_refresh_dynamic_fields`, run when
`~/.kiro/agents/kirocrew.json` already exists) intentionally preserves the
user-owned `tools` list and left `tools`/`allowedTools` untouched.

kiro-cli only activates tool search when the `ToolSearch` built-in is in the
agent's tool list. So for every pre-existing install, the per-session overlay
written for `tool_search` (`enabled` + `minPct=0`/`minTokens=0`) was a **silent
no-op** and full MCP tool specs (including large servers) were sent every turn.

## Fix

A narrow, **ADD-only** self-heal in `_refresh_dynamic_fields`: append
`"tool_search"` to an existing config's `tools` list when the shipped template
grants it and it is absent. This mirrors the existing `includeMcpJson` /
`resources` self-heal pattern for fields that shipped after a user's config was
created.

- Scoped to this **single** built-in (not a general tools reconcile).
- **Gated on the shipped template** granting it, so an edition that drops
  `tool_search` is respected.
- Never removes or reorders other tools; never touches `allowedTools`
  (`tool_search` is a read-only, auto-allowed built-in — permission eval =>
  Allow, so no `allowedTools` entry is needed).
- Feature on/off remains the `AgentConfig.tool_search` toggle.

## Tests

`test/test_agent.py`:
- `test_existing_config_seeds_missing_tool_search` — appended at end, prior
  tools preserved in order, `allowedTools` untouched.
- `test_existing_config_tool_search_idempotent` — already-present is a no-op
  (no duplicate).
- `test_existing_config_no_tool_search_seed_when_template_omits` — template
  without the grant leaves tools exactly as-is.

## Verification

- `test_agent.py`: 125 passed; related install/refresh modules
  (`test_installer_shim_and_cleanup`, `test_mcp_discovery`, `test_mcp_apply`,
  `test_cpp_wiring_enterprise`, `test_heartbeat_cycle_recycle`): 190 passed.
- `flake8 src/kiro_crew/agent.py test/test_agent.py` clean.
- Backend-only; no frontend changes.

## Related upstream context

Feature parity — the fork already shipped the `defaults.json` grant; this PR
closes the existing-install gap:
- https://code.amazon.com/packages/MeshClaw/commits/cbd594fa8be8a6ddb52b6e6cf4afd62358ef1644
- https://code.amazon.com/reviews/CR-290712331
