### PR TITLE
fix(build): restore setup.cfg extras and make first-run robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,19 @@ build: frontend backend
 
 frontend:
 	bash ensure-node.sh || true
+	# `cat ... || true`, not `cat ... &&`: on a first run where ensure-node.sh
+	# could not record a bin dir (no network, unsupported platform, or node
+	# already fine on PATH but the write failed), the marker file is absent and
+	# `cat` exits 1. With `&&` chaining that non-zero exit aborts the whole
+	# recipe line, so the target fails before npm is ever reached. An absent
+	# marker must degrade to "use whatever node is on PATH", not stop the build.
 	cd website && \
-	  NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null)" && \
-	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; } && \
+	  NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null || true)"; \
+	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; }; \
+	  if ! command -v npm >/dev/null 2>&1; then \
+	    echo "ERROR: npm not found. Install Node >= 18 (see ensure-node.sh) and re-run." >&2; \
+	    exit 1; \
+	  fi; \
 	  if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi && \
 	  npm run build
 	rm -rf src/kiro_crew/static/dist
@@ -31,9 +41,19 @@ frontend:
 
 backend:
 	bash ensure-python.sh || true
-	PY="$$(cat $$HOME/.kirocrew/python-bin 2>/dev/null)"; [ -n "$$PY" ] || PY="$(PY)"; \
+	# Same `|| true` reasoning as the frontend target: an absent marker file must
+	# fall back to $(PY), not abort the recipe.
+	PY="$$(cat $$HOME/.kirocrew/python-bin 2>/dev/null || true)"; [ -n "$$PY" ] || PY="$(PY)"; \
 	  if [ -x $(VENV)/bin/python ] && ! $(VENV)/bin/python -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then \
 	    echo "  → recreating $(VENV) (existing interpreter < 3.10)"; rm -rf $(VENV); fi; \
+	  if ! "$$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then \
+	    echo "ERROR: '$$PY' is not Python >= 3.10 (package requires-python is >=3.10)." >&2; \
+	    echo "       Without this gate the venv is built from a too-old interpreter, the" >&2; \
+	    echo "       version guard above deletes it on every run, and the install either" >&2; \
+	    echo "       backtracks forever or crashes at import. Provision 3.10+ first:" >&2; \
+	    echo "         bash ensure-python.sh   # or: make backend PY=python3.12" >&2; \
+	    exit 1; \
+	  fi; \
 	  test -x $(VENV)/bin/python || "$$PY" -m venv $(VENV)
 	$(PIP) install --upgrade pip setuptools wheel
 	# --prefer-binary: on hosts below the modern manylinux baseline (e.g. Amazon
@@ -53,9 +73,16 @@ test: build
 
 # Self-contained pip wheel: builds + stages the dashboard, then produces a
 # wheel that bundles the SPA (see setup.py BuildWithFrontend + MANIFEST.in).
-wheel: frontend
-	$(PY) -m pip install --upgrade build
-	$(PY) -m build --wheel
+#
+# Runs through the venv the `backend` target provisions rather than a bare
+# `$(PY) -m pip install --upgrade build`: on hosts whose system python3 is older
+# than 3.10 (Amazon Linux 2023 ships 3.9) that bare form installs `build` into
+# the *system* interpreter — mutating it without a venv, and tripping PEP 668
+# "externally-managed-environment" where the marker exists. Depending on
+# `backend` guarantees a >= 3.10 venv exists first.
+wheel: frontend backend
+	$(PIP) install --upgrade build
+	$(VENV)/bin/python -m build --wheel
 
 # Frozen standalone backend binary (no system Python needed). Stages the
 # dashboard first so it's embedded in the bundle. Host-arch only (UNIVERSAL=0):
@@ -66,8 +93,16 @@ backend-bin: frontend
 # Full double-clickable desktop app. macOS: ONE universal DMG (arm64 + x86_64,
 # needs an Apple-Silicon host with Rosetta 2 — see docs/DESKTOP_APP.md;
 # UNIVERSAL=0 for a faster host-arch-only build). Linux: AppImage (host arch).
+#
+# build-desktop.sh runs `npm ci` / `npm run build` itself, so it needs node on
+# PATH. It provisions its own uv + PBS interpreter but NOT node, so bootstrap
+# node here — otherwise a first `make desktop` on a node-less host dies at the
+# script's npm step instead of installing it like every other target does.
 desktop:
-	bash packaging/build-desktop.sh
+	bash ensure-node.sh || true
+	NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null || true)"; \
+	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; }; \
+	  bash packaging/build-desktop.sh
 
 clean:
 	rm -rf build dist *.egg-info src/*.egg-info \

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -483,7 +483,7 @@ feed/{channel}/latest-cli.json
   "wheel_url": "https://updates.kirocrew.dev/cli/beta/0.2.0/kirocrew-0.2.0-py3-none-any.whl",
   "sha256": "…",
   "sig_url": "https://updates.kirocrew.dev/cli/beta/0.2.0/kirocrew-0.2.0-py3-none-any.whl.sig",
-  "python_requires": ">=3.9",
+  "python_requires": ">=3.10",
   "pub_date": "2026-07-18T06:15:00Z"
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,12 @@ readme = "README.md"
 # requires-python from here (not setup.cfg), and an absent value makes the
 # build backend raise SpecifierSet(None) -> TypeError during wheel builds.
 requires-python = ">=3.10"
-dynamic = ["dependencies"]
+# optional-dependencies must be listed here too: the extras live in setup.cfg
+# ([options.extras_require]), and once a [project] table exists setuptools
+# ignores setup.cfg metadata unless the field is declared dynamic. Omitting it
+# silently drops every extra — `pip install -e ".[dev]"` then reports
+# "does not provide the extra 'dev'" and installs no test tooling.
+dynamic = ["dependencies", "optional-dependencies"]
 
 [project.urls]
 Homepage = "https://github.com/kirodotdev/KiroCrew"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,14 @@
 zip_safe = True
 include_package_data = True
 # macOS (x86_64 + arm64), Linux (x86_64 + aarch64), and Windows, CPython
-# 3.9-3.13. Declaring this gives pip a clear, early error on an unsupported
+# 3.10-3.13. Declaring this gives pip a clear, early error on an unsupported
 # interpreter instead of a late syntax/dependency failure.
-python_requires = >=3.9
+#
+# Must match pyproject.toml's requires-python: that [project] value is the one
+# that actually lands in the built metadata, so a looser bound here is dead
+# config that misleads readers into thinking 3.9 is supported (it is not — the
+# code uses contextlib.aclosing, added in 3.10).
+python_requires = >=3.10
 package_dir =
     = src
 packages = find:
@@ -60,16 +65,25 @@ desktop =
     pyinstaller>=6,<7
 # Development and test tooling:
 #   pip install -e ".[dev]"
+# Keep in sync with [dependency-groups] dev in pyproject.toml, which CI
+# installs via `--group dev`; this extra is what `make build` uses.
+# The formatter/linter/type-checker are pinned to the exact versions CI runs:
+# black and mypy change their output across minor releases, so a floating range
+# makes a local `make build` venv disagree with CI (black 26 reformats ~680
+# files that black 24 accepts). Bump these in lockstep with pyproject.toml.
 dev =
+    pytest>=8,<9
     pytest-cov>=4,<7
     pytest-asyncio>=0.21
     pytest-xdist>=3
     pytest-timeout>=2
     pytest-testmon>=2
-    black>=24
-    isort>=5
-    flake8>=7
-    mypy>=1
+    # Imported unconditionally by test/conftest.py.
+    hypothesis>=6
+    black==24.10.0
+    isort==6.0.0
+    flake8==7.1.0
+    mypy==1.14.1
 
 [options.packages.find]
 where = src

--- a/test/test_pip_deps_consistency.py
+++ b/test/test_pip_deps_consistency.py
@@ -146,6 +146,106 @@ def test_otlp_extra_declares_exact_http_exporter_version():
     assert requirements == ["opentelemetry-exporter-otlp-proto-http==1.44.0"]
 
 
+def _pyproject_path() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _pyproject_text() -> str:
+    return _pyproject_path().read_text(encoding="utf-8")
+
+
+def test_pyproject_declares_optional_dependencies_dynamic():
+    """``optional-dependencies`` MUST be in pyproject's ``[project] dynamic``.
+
+    The extras (voice/desktop/dev/otlp) live in setup.cfg
+    ``[options.extras_require]``. Once a ``[project]`` table exists, setuptools
+    ignores setup.cfg metadata for any field not declared dynamic — so dropping
+    this entry silently strips EVERY extra from the built metadata. pip then
+    treats ``pip install -e ".[dev]"`` as a plain install and exits 0 with only
+    a warning ("does not provide the extra 'dev'"), so no test tooling is
+    installed and ``make test`` dies on a missing ``.venv/bin/pytest``. The same
+    omission also broke the published wheel's ``kirocrew[voice]`` install path.
+    """
+    text = _pyproject_text()
+    dynamic_lines = [
+        ln for ln in text.splitlines() if ln.strip().startswith("dynamic")
+    ]
+    assert dynamic_lines, "pyproject.toml [project] declares no `dynamic` field"
+    joined = " ".join(dynamic_lines)
+    assert "optional-dependencies" in joined, (
+        "pyproject.toml [project].dynamic must include "
+        '"optional-dependencies", otherwise setuptools drops every extra '
+        "declared in setup.cfg [options.extras_require] and "
+        'pip install ".[dev]" / ".[voice]" becomes a silent no-op.\n'
+        f"Found: {joined.strip()}"
+    )
+
+
+def test_declared_extras_match_setup_cfg():
+    """Every setup.cfg extra stays reachable; guards the dynamic wiring above."""
+    cfg = configparser.ConfigParser()
+    cfg.read(_setup_cfg_path())
+    assert cfg.has_section("options.extras_require")
+    extras = set(cfg.options("options.extras_require"))
+    # These four are referenced by docs, CI, and the Makefile; losing any of
+    # them breaks a documented install path.
+    assert {"otlp", "voice", "desktop", "dev"} <= extras, (
+        f"expected the documented extras to exist in setup.cfg; got {sorted(extras)}"
+    )
+
+
+def _extra_requirements(extra: str) -> list[str]:
+    cfg = configparser.ConfigParser()
+    cfg.read(_setup_cfg_path())
+    return [
+        line.strip()
+        for line in cfg.get("options.extras_require", extra).splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_dev_extra_covers_test_imports():
+    """``[dev]`` MUST install everything ``test/conftest.py`` imports.
+
+    conftest.py imports hypothesis unconditionally at module scope, so a `[dev]`
+    install missing it makes the ENTIRE suite fail at collection with
+    ModuleNotFoundError — not one test, all of them.
+    """
+    declared = " ".join(_extra_requirements("dev")).lower()
+    for required in ("pytest", "hypothesis"):
+        assert required in declared, (
+            f"setup.cfg [options.extras_require] dev must declare {required!r} — "
+            "test/conftest.py imports it at module scope, so the whole suite "
+            f"fails to collect without it. Declared: {declared}"
+        )
+
+
+def test_python_requires_agrees_between_pyproject_and_setup_cfg():
+    """setup.cfg ``python_requires`` must match pyproject ``requires-python``.
+
+    pyproject's value is the one that lands in the built metadata, so a looser
+    bound in setup.cfg is dead config that advertises support for interpreters
+    the package cannot actually run on.
+    """
+    cfg = configparser.ConfigParser()
+    cfg.read(_setup_cfg_path())
+    cfg_req = cfg.get("options", "python_requires", fallback="").strip()
+
+    proj_req = ""
+    for line in _pyproject_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("requires-python"):
+            proj_req = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+            break
+
+    assert proj_req, "pyproject.toml declares no requires-python"
+    assert cfg_req == proj_req, (
+        "python_requires disagreement: setup.cfg says "
+        f"{cfg_req!r} but pyproject.toml requires-python says {proj_req!r}. "
+        "pyproject wins in the built metadata, so keep them identical."
+    )
+
+
 def _collect_unguarded_imports(filepath: pathlib.Path) -> list[tuple[str, str]]:
     """Unguarded module-level third-party imports in a single file."""
     source = filepath.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Problem

`make test` fails on a first run:

```
bash packaging/resign-macos-libs.sh .venv/bin/python
.venv/bin/pytest -q
make: .venv/bin/pytest: No such file or directory
make: *** [Makefile:50: test] Error 127
```

It reads like a Makefile path bug, but the path is right — **nothing was ever installed there.** `pip install -e ".[dev]"` was silently a no-op:

```console
$ pip install --dry-run -e ".[dev]"
WARNING: kirocrew 0.1.0 does not provide the extra 'dev'
```

pip treated it as a plain install, exited **0**, and `make` walked on to a `pytest` that didn't exist.

## Why it matters

The blast radius is wider than the local test target. A wheel built from the pre-fix tree ships **zero** extras:

| Wheel built from | `Provides-Extra` |
|---|---|
| pre-fix `main` | *(none)* |
| this branch | `otlp`, `voice`, `desktop`, `dev` |

So the documented, published `pip install kirocrew[voice]` path was broken for end users too — installing the extra quietly got them a package with no STT dependencies, failing later at import instead of at install. Same for `[otlp]` and `[desktop]`.

CI stayed green throughout because it installs dev tooling via `--group dev` (pyproject `[dependency-groups]`), a completely separate mechanism that never consults the extras. Nothing was watching this.

## Fix (symptoms → root cause → change)

**Symptom:** `.venv/bin/pytest` missing → **pip installed no dev tooling** → **pip reported the `dev` extra doesn't exist** → **the extras were absent from the built metadata**.

Root cause: `pyproject.toml` declared

```toml
dynamic = ["dependencies"]          # "optional-dependencies" missing
```

Every extra lives in `setup.cfg [options.extras_require]`. Once a `[project]` table exists, setuptools **ignores setup.cfg metadata for any field not declared dynamic** — so all four extras were dropped on the floor. The `requires-python` line directly above carries a comment about this exact setuptools precedence rule, so it was simply missed in 3b76f971.

Fix: add `"optional-dependencies"` to `dynamic`.

While auditing every `make` target for first-run robustness (with and without preexisting tooling), four more first-run breaks surfaced:

- **`frontend`** — `NBD="$(cat …/node-bin-dir 2>/dev/null) && …`: when the marker file is absent (first run, or `ensure-node.sh` couldn't write it) `cat` exits 1, and `&&` chaining aborts the recipe line **before npm ever runs**. Reproduced with real `make`:
  ```
  make: *** [Makefile:2: frontend] Error 1
  ```
  Changed to `|| true` so an absent marker degrades to "use node on PATH", plus an explicit error when npm genuinely isn't installed (previously a confusing `cat` failure).
- **`backend`** — an absent marker fell back to `$(PY)` with no version gate. On hosts whose `python3` is < 3.10 (AL2023 ships 3.9; this dev host too) that builds a too-old venv, which the *existing* `>= 3.10` guard then deletes on every subsequent run, while pip backtracks indefinitely resolving deps for an unsupported interpreter. Now gated with an actionable error.
- **`wheel`** — ran `$(PY) -m pip install --upgrade build`, i.e. installed into the **system interpreter**, mutating it outside any venv and tripping PEP 668 `externally-managed-environment` where the marker exists. Now routed through the `backend` venv (also guaranteeing a ≥ 3.10 interpreter).
- **`desktop`** — `build-desktop.sh` runs `npm ci` / `npm run build` itself and bootstraps uv + a PBS interpreter, but **not node**, so a first `make desktop` on a node-less host died at its npm step. Now bootstraps node like every other target.

Two consistency fixes in the same class (dead config that misleads):

- `setup.cfg python_requires = >=3.9` was **silently ignored** — pyproject's `>=3.10` is what lands in the metadata — and advertised an interpreter the code can't run on (`contextlib.aclosing` needs 3.10). Aligned to `>=3.10`, plus the stale `">=3.9"` sample in `docs/RELEASE_AUTOMATION.md` (the workflow reads the real value from wheel metadata, so only the doc was wrong).
- The `[dev]` extra was missing **`pytest`** and **`hypothesis`** — the latter imported at module scope by `test/conftest.py`, so its absence fails collection of the *entire* suite, not one test. Its loose `black>=24` / `mypy>=1` bounds, never exercised while extras were broken, resolved to black 26 / mypy 2.3 / pytest 9 against CI's pinned 24.10.0 / 1.14.1 — a local `make build` venv that disagrees with CI. Pinned to match `[dependency-groups]`.

## Tests

Four regression tests in `test/test_pip_deps_consistency.py` (the existing packaging-gate module, which already guards the `otlp` extra):

| Test | Locks in |
|---|---|
| `test_pyproject_declares_optional_dependencies_dynamic` | `optional-dependencies` stays in `[project].dynamic` — the root cause |
| `test_declared_extras_match_setup_cfg` | all four documented extras remain declared |
| `test_dev_extra_covers_test_imports` | `[dev]` keeps `pytest` + `hypothesis`, so collection can't break |
| `test_python_requires_agrees_between_pyproject_and_setup_cfg` | the two `requires-python` values can't drift apart again |

Each was **mutation-verified** — reverting the corresponding fix makes exactly that test fail, and only that one:

```
MUTATION 1 (revert `dynamic`):        FAILED …test_pyproject_declares_optional_dependencies_dynamic  → 1 failed, 6 passed
MUTATION 2 (drop hypothesis):         FAILED …test_dev_extra_covers_test_imports                     → 1 failed, 6 passed
MUTATION 3 (python_requires → 3.9):   FAILED …test_python_requires_agrees_between_pyproject_and_setup_cfg → 1 failed, 6 passed
RESTORED:                             7 passed
```

Full suite: **16475 passed, 72 skipped, 5 xfailed** (up from 16471 — the 4 new tests). `flake8` clean, `isort` clean, `mypy` clean (469 files), `scripts/scrub-lint.sh` passes.

## Manual verification

The Makefile changes are shell control-flow that unit tests can't reach, so each was exercised directly on Linux/aarch64:

- **`make test`** — the originally-failing command — now completes: `16475 passed … in 147s`.
- **`make wheel`** — builds end-to-end; the wheel carries all 4 `Provides-Extra`, `Requires-Python: >=3.10`, and 303 bundled dashboard files incl. `static/dist/index.html`.
- **`make backend-bin`** — passes its own self-containment gate (`python -m kiro_crew --version` under `PYTHONNOUSERSITE=1`) and the `find-bin.js` resolver-agreement gate.
- **`make clean`** — exits 0 on a pristine tree and is idempotent across repeat runs.
- **`frontend` recipe** — reproduced the `Error 1` failure with real `make` + an empty `HOME`, confirmed the fix reaches the npm step, and confirmed a node-less PATH now yields the explicit error rather than a `cat` failure.
- **`backend` recipe** — verified all three interpreter cases: too-old `$(PY)` fails fast with the hint; an explicit `PY=python3.11` proceeds; the recorded marker path proceeds.
- **Pre/post-fix wheel metadata compared** directly (built both, diffed `Provides-Extra`) to prove the end-user `[voice]` regression.

Not verified on macOS or Windows: no changes are platform-specific — `packaging/resign-macos-libs.sh` is untouched and remains a no-op off macOS, and the `desktop`/`backend-bin` macOS-universal branches are unchanged. `make desktop`'s full electron-builder leg wasn't run here (needs a DMG/AppImage toolchain); its node-bootstrap addition is the same two lines already proven in the `frontend` target.
