### PR TITLE
fix(acp): guard the remaining non-dict session update readers

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3669,6 +3669,11 @@ class AcpClient:
         """
         params = msg.params or {}
         update = params.get("update", {})
+        # The update comes straight from the agent process; a non-dict value
+        # (null/list/string) would raise AttributeError here, inside the
+        # prompt-turn dispatch path — same boundary rule as _track_usage_update.
+        if not isinstance(update, dict):
+            return None, False
         kind = update.get("sessionUpdate")
         if kind == UPDATE_AGENT_MESSAGE_CHUNK:
             content = update.get("content", {})
@@ -3896,6 +3901,8 @@ class AcpClient:
         """Track tool calls in stats (used by send_message/send_message_stream)."""
         params = msg.params or {}
         update = params.get("update", {})
+        if not isinstance(update, dict):
+            return
         if update.get("sessionUpdate") == UPDATE_TOOL_CALL:
             title = update.get("title", "unknown")
             kind = update.get("kind", "unknown")
@@ -3905,6 +3912,8 @@ class AcpClient:
     def _extract_tool_event(self, msg: JsonRpcMessage) -> AcpEvent | None:
         params = msg.params or {}
         update = params.get("update", {})
+        if not isinstance(update, dict):
+            return None
         if update.get("sessionUpdate") == UPDATE_TOOL_CALL:
             title = update.get("title", "unknown")
             kind = update.get("kind", "unknown")

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -1439,6 +1439,17 @@ class TestAcpClientExtractChunk:
         )
         assert client._extract_text_chunk(msg) == (None, False)
 
+    @pytest.mark.parametrize("bad_update", [None, "chunk", [1], 7])
+    def test_non_dict_update_returns_none(self, tmp_path, bad_update):
+        """The update value comes straight from the agent process; a non-dict
+        raised AttributeError on update.get() inside the prompt-turn dispatch
+        path, tearing down the whole turn."""
+        client = AcpClient(work_dir=tmp_path)
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(method="session/update", params={"update": bad_update})
+        assert client._extract_text_chunk(msg) == (None, False)  # must not raise
+
 
 class TestAcpClientTrackToolCall:
     def test_tracks_tool_call(self, tmp_path):
@@ -1457,6 +1468,17 @@ class TestAcpClientTrackToolCall:
         )
         client._track_tool_call(msg)
         assert ("tool_use", "execute_bash") in client.last_prompt_stats.tool_calls
+
+    @pytest.mark.parametrize("bad_update", [None, "call", [1], 7])
+    def test_non_dict_update_ignored(self, tmp_path, bad_update):
+        """Same boundary as _extract_text_chunk: non-dict update must be a
+        no-op, not an AttributeError in the dispatch path."""
+        client = AcpClient(work_dir=tmp_path)
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(method="session/update", params={"update": bad_update})
+        client._track_tool_call(msg)  # must not raise
+        assert client.last_prompt_stats.tool_calls == []
 
 
 class TestAcpClientTrackMetadata:
@@ -4266,6 +4288,16 @@ class TestWaitForCompaction:
 
 class TestExtractToolEvent:
     """Tests for _extract_tool_event covering various tool_call shapes."""
+
+    @pytest.mark.parametrize("bad_update", [None, "call", [1], 7])
+    def test_non_dict_update_returns_none(self, bad_update):
+        """Non-dict update raised AttributeError on update.get() in the
+        prompt-turn dispatch path — must be a clean None instead."""
+        client = AcpClient()
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(method="session/update", params={"update": bad_update})
+        assert client._extract_tool_event(msg) is None  # must not raise
 
     def test_basic_tool_call(self):
         client = AcpClient()


### PR DESCRIPTION
## Problem

Three session-update readers in `AcpClient` still trust the agent-supplied `update` value and go straight to `update.get(...)`:

- `_extract_text_chunk` (client.py:3672)
- `_track_tool_call` (client.py:3902)
- `_extract_tool_event` (client.py:3913)

A non-dict `update` (null/list/string) raises `AttributeError` inside the prompt-turn dispatch path (`_dispatch_events` / `send_message_stream`), tearing down the whole turn. Their sibling readers already isinstance-guard exactly this boundary — `_track_usage_update` (`if isinstance(update, dict) else None`), `_extract_tool_call_update` and `_read_config_updates` (`if not isinstance(update, dict): ...`) — so these three are the stragglers, not a new policy.

## Fix

Early-return on non-dict `update` in all three (`(None, False)` / no-op / `None`), matching the established idiom in the same file.

## Test

Parametrized non-dict cases (`None`/`"chunk"`/`[1]`/`7`) for each of the three readers, added to their existing test classes (`TestAcpClientExtractChunk`, `TestAcpClientTrackToolCall`, `TestExtractToolEvent`). Each raised the exact `AttributeError: 'NoneType' object has no attribute 'get'` pre-fix (verified by stash-revert) and is now a clean no-op; the 9 existing positive-path tests in those classes still pass (21 total). `isort`/`flake8`/`mypy` clean.
