### PR TITLE
feat(dist): cut clients and docs over to the crew.kiro.dev hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ no `npm`, no build step (macOS / Linux / EC2):
 
 ```bash
 # nightly channel (stable/insider channels open once their first release cuts)
-curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh -s -- --channel nightly
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly
 
 # pin an exact version
-curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh -s -- --channel nightly --version 0.1.0.dev20260718
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly --version 0.1.0.dev20260718
 ```
 
 The installer resolves the channel feed, verifies the wheel's SHA-256 against
@@ -57,7 +57,7 @@ pip verifies the hash fail-closed, and no package index is consulted for
 never be selected. Dependencies still resolve from PyPI:
 
 ```bash
-pip install "https://d28nxu9if70cmc.cloudfront.net/cli/nightly/0.1.0.dev20260718/kirocrew-0.1.0.dev20260718-py3-none-any.whl#sha256=2109dd186da999a1f135b4d6da2b36110d6a943e0af229ec259c25f72b73e570"
+pip install "https://download.crew.kiro.dev/cli/nightly/0.1.0.dev20260718/kirocrew-0.1.0.dev20260718-py3-none-any.whl#sha256=2109dd186da999a1f135b4d6da2b36110d6a943e0af229ec259c25f72b73e570"
 ```
 
 The `cli.sh` installer above does exactly this resolution for you (reads the

--- a/cli.sh
+++ b/cli.sh
@@ -2,8 +2,8 @@
 # ──────────────────────────────────────────────────────────────────────
 # KiroCrew CLI installer (channel / wheel based).
 #
-#   curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh
-#   curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh -s -- --channel nightly
+#   curl -fsSL https://download.crew.kiro.dev/cli.sh | sh
+#   curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly
 #
 # Installs the prebuilt `kirocrew` wheel for a release channel. It resolves the
 # channel feed, downloads the wheel over HTTPS from CloudFront, verifies its
@@ -27,7 +27,12 @@ set -eu
 # venv -- producing a broken install (ImportError: No module named 'aiohttp').
 unset PYTHONPATH PYTHONHOME
 
-CDN="${KIROCREW_CDN_BASE:-https://d28nxu9if70cmc.cloudfront.net}"
+# The URL contract splits by class: FEED_BASE serves the mutable pointers
+# (latest-cli.json), ARTIFACT_BASE serves the bytes (wheels, SHA256SUMS).
+# Both are aliases of the same distribution today; --cdn / KIROCREW_CDN_BASE
+# overrides BOTH (test / alternate-CDN escape hatch).
+FEED_BASE="${KIROCREW_CDN_BASE:-https://updates.crew.kiro.dev}"
+ARTIFACT_BASE="${KIROCREW_CDN_BASE:-https://download.crew.kiro.dev}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""
 
@@ -37,14 +42,14 @@ while [ $# -gt 0 ]; do
     --channel=*) CHANNEL="${1#*=}"; shift ;;
     --version) PIN_VERSION="${2:?--version needs a value}"; shift 2 ;;
     --version=*) PIN_VERSION="${1#*=}"; shift ;;
-    --cdn) CDN="${2:?--cdn needs a value}"; shift 2 ;;
-    --cdn=*) CDN="${1#*=}"; shift ;;
+    --cdn) FEED_BASE="${2:?--cdn needs a value}"; ARTIFACT_BASE="$2"; shift 2 ;;
+    --cdn=*) FEED_BASE="${1#*=}"; ARTIFACT_BASE="${1#*=}"; shift ;;
     -h|--help)
       cat <<'EOF'
 KiroCrew CLI installer (channel / wheel based).
 
-  curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh
-  curl -fsSL https://d28nxu9if70cmc.cloudfront.net/cli.sh | sh -s -- --channel nightly
+  curl -fsSL https://download.crew.kiro.dev/cli.sh | sh
+  curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly
 
 Installs the prebuilt `kirocrew` wheel for a release channel: resolves the
 channel feed, downloads the wheel over HTTPS, verifies its SHA-256 against
@@ -61,7 +66,8 @@ EOF
     *) echo "kirocrew-install: unknown argument '$1'" >&2; exit 2 ;;
   esac
 done
-CDN="${CDN%/}"
+FEED_BASE="${FEED_BASE%/}"
+ARTIFACT_BASE="${ARTIFACT_BASE%/}"
 
 # Users say "insider"; the release pipeline publishes that channel under the
 # `beta` prefix (see docs/RELEASE_AUTOMATION.md channel naming). Map the
@@ -109,14 +115,14 @@ if [ -n "$PIN_VERSION" ]; then
   # against the SHA256SUMS published beside it at release time.
   VER="$PIN_VERSION"
   WHEEL_NAME="kirocrew-${VER}-py3-none-any.whl"
-  WHEEL_URL="$CDN/cli/$CHANNEL_PATH/$VER/$WHEEL_NAME"
+  WHEEL_URL="$ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/$WHEEL_NAME"
   echo "Resolving KiroCrew $VER ($CHANNEL channel, pinned) ..."
-  curl -fsSL "$CDN/cli/$CHANNEL_PATH/$VER/SHA256SUMS" -o "$TMP/SHA256SUMS" \
-    || err "version '$VER' not found on the $CHANNEL channel (no $CDN/cli/$CHANNEL_PATH/$VER/SHA256SUMS)"
+  curl -fsSL "$ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/SHA256SUMS" -o "$TMP/SHA256SUMS" \
+    || err "version '$VER' not found on the $CHANNEL channel (no $ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/SHA256SUMS)"
   SHA="$(awk -v w="$WHEEL_NAME" '$2==w{print $1}' "$TMP/SHA256SUMS")"
   [ -n "$SHA" ] || err "SHA256SUMS for $VER does not list $WHEEL_NAME"
 else
-  FEED="$CDN/feed/$CHANNEL_PATH/latest-cli.json"
+  FEED="$FEED_BASE/feed/$CHANNEL_PATH/latest-cli.json"
   echo "Resolving KiroCrew ($CHANNEL channel) ..."
   curl -fsSL "$FEED" -o "$TMP/feed.json" \
     || err "channel '$CHANNEL' has no feed at $FEED (try: --channel nightly)"

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -29,8 +29,10 @@ overwritten.
 - `kirocrew-updates-…` (private + CloudFront OAC, public trust domain):
   `cli/{channel}/{version}/`, `desktop/{channel}/{version}/`,
   `feed/{channel}/latest-mac.json`, served at
-  `https://d28nxu9if70cmc.cloudfront.net` (`updates.kirocrew.dev` is not
-  yet provisioned)
+  `https://updates.crew.kiro.dev` (pointers: feeds, pip index) and
+  `https://download.crew.kiro.dev` (artifact bytes) -- aliases of the
+  same distribution; the auto-assigned
+  `https://d28nxu9if70cmc.cloudfront.net` keeps working
 
 **Feed (as built) — static file, no Lambda:** `sign-and-notarize.yml` writes
 `feed/{channel}/latest-mac.json` directly after the spctl gate. There is no
@@ -42,8 +44,8 @@ delta. Schema:
 ```json
 {
   "version": "0.1.0-nightly.20260721061155",
-  "url": "https://d28nxu9if70cmc.cloudfront.net/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip",
-  "dmg": "https://d28nxu9if70cmc.cloudfront.net/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.dmg",
+  "url": "https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip",
+  "dmg": "https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.dmg",
   "name": "0.1.0-nightly.20260721061155",
   "pub_date": "2026-07-21T06:22:13Z"
 }

--- a/docs/RELEASE_PROCESS_DESIGN.md
+++ b/docs/RELEASE_PROCESS_DESIGN.md
@@ -186,9 +186,12 @@ All infrastructure is managed as code (CDK).
 
 ### Download and feed URL design
 
-One CloudFront domain serves everything (currently the auto-assigned
-`d28nxu9if70cmc.cloudfront.net`; the future home is the `crew.kiro.dev`
-subdomain). Every public URL is one of exactly two classes:
+One CloudFront distribution serves everything. The advertised homes are
+`updates.crew.kiro.dev` for pointers and `download.crew.kiro.dev` for
+artifact bytes (one hostname per URL class below, host-scoped inside the
+`crew.kiro.dev` zone so the apex stays free for the product site); the
+auto-assigned `d28nxu9if70cmc.cloudfront.net` keeps serving as an alias.
+Every public URL is one of exactly two classes:
 
 - Immutable versioned keys: long-cached, written once, never republished.
   A version's bytes can never change after publish, so edge caches can
@@ -223,9 +226,9 @@ Rules that make the scheme work:
    index, keeping PyPI available for dependency resolution.
 
 Worked example, stable channel: a human installs from
-`https://d28nxu9if70cmc.cloudfront.net/desktop/stable/latest/KiroCrew.dmg`;
+`https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg`;
 a server installs with `pip install kirocrew --extra-index-url
-https://d28nxu9if70cmc.cloudfront.net/feed/stable/simple/`.
+https://updates.crew.kiro.dev/feed/stable/simple/`.
 
 ### Buckets and CDN
 
@@ -245,18 +248,20 @@ pointers must never be served stale. The distribution speaks HTTP/2 and 3,
 redirects to HTTPS, allows GET/HEAD only, and writes access logs to a
 dedicated bucket with an IA/Glacier/expiry lifecycle.
 
-The domain is the auto-assigned `*.cloudfront.net`, exported to CI as the
-`CLI_CDN_BASE` variable. The public home will be the `crew.kiro.dev`
-subdomain, following the convention Kiro's other distribution surfaces
-use (`cli.kiro.dev` is the closest analog). KiroCrew owns the
-`crew.kiro.dev` hosted zone and iterates on its records freely; the
-kiro.dev apex carries a one-line NS delegation to the zone's
-nameservers. Rollout is phased: the zone and alias records first, then
-(once the delegation resolves) the DNS-validated certificate in
-us-east-1 and the domain attach on the distribution. The scheme is
-base-URL-agnostic (the client's feed base is configurable and CI reads
-the base from a variable), so the cutover changes no path shapes and the
-`*.cloudfront.net` URLs keep working.
+The advertised hostnames are `updates.crew.kiro.dev` (pointers) and
+`download.crew.kiro.dev` (artifact bytes), following the convention
+Kiro's other distribution surfaces use (`cli.kiro.dev` is the closest
+analog). KiroCrew owns the `crew.kiro.dev` hosted zone and iterates on
+its records freely; the kiro.dev apex carries a one-line NS delegation
+to the zone's nameservers, and a DNS-validated certificate covering the
+zone's apex and wildcard is attached to the distribution. Splitting the
+two URL classes across hostnames means future protective policy on the
+byte surface (rate rules, geo/redirect layers) or a physical origin
+split can never touch the availability-critical feed path, with no
+client-visible migration. The scheme stays base-URL-agnostic (the
+client's feed base is configurable and CI reads its artifact base from
+the `CLI_CDN_BASE` variable), so no path shape ever changed and the
+auto-assigned `*.cloudfront.net` URLs keep working as aliases.
 
 ### Identity and trust boundaries
 

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -14,16 +14,17 @@
  * stays testable without an Electron runtime.
  */
 
-// Default update feed host: the public distribution CDN (CloudFront + OAC
-// over the kirocrew-updates bucket). The feed is a STATIC JSON file at
-// <base>/<channel>/latest-mac.json written by CI after notarization; the
-// artifact it points at lives under desktop/<channel>/<version>/ on the
-// same CDN. There is no 200/204 server endpoint: safeCheck() fetches the
-// feed itself and compares versions CLIENT-SIDE, engaging Squirrel.Mac only
-// when the feed version differs from the running app. (Squirrel treats any
-// 200 feed response as "update available", so gating on the client compare
-// is what prevents a re-download loop against a static file.)
-const DEFAULT_FEED_BASE = "https://d28nxu9if70cmc.cloudfront.net/feed";
+// Default update feed host: updates.crew.kiro.dev, the pointer hostname of
+// the public distribution CDN (CloudFront + OAC over the kirocrew-updates
+// bucket). The feed is a STATIC JSON file at <base>/<channel>/latest-mac.json
+// written by CI after notarization; the artifact URLs inside it point at the
+// byte hostname (download.crew.kiro.dev, CI's CLI_CDN_BASE). There is no
+// 200/204 server endpoint: safeCheck() fetches the feed itself and compares
+// versions CLIENT-SIDE, engaging Squirrel.Mac only when the feed version
+// differs from the running app. (Squirrel treats any 200 feed response as
+// "update available", so gating on the client compare is what prevents a
+// re-download loop against a static file.)
+const DEFAULT_FEED_BASE = "https://updates.crew.kiro.dev/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
 const FORCE_EXIT_AFTER_MS = 5 * 1000; // failsafe: guarantee exit after quitAndInstall


### PR DESCRIPTION
## What

Cuts every client default and doc reference from the auto-assigned `d28nxu9if70cmc.cloudfront.net` to the owned hostnames, one per URL class:

| Hostname | Serves | Changed here |
|---|---|---|
| `updates.crew.kiro.dev` | Pointers: update feeds, PEP 503 index | `auto-update.js` `DEFAULT_FEED_BASE`, `cli.sh` feed resolution, pip index docs |
| `download.crew.kiro.dev` | Bytes: DMG/zip/AppImage, wheels, `cli.sh` itself | `cli.sh` pinned-wheel + SHA256SUMS fetches, README install URLs |

The CI side is already flipped: the `CLI_CDN_BASE` repo variable now holds `https://download.crew.kiro.dev`, so feed bodies and the PEP 503 index emit byte-hostname URLs from each channel's next publish.

## Why

Both hostnames are live aliases of the distribution (wildcard-cert, ETag-verified byte-identical to the cloudfront.net name). Splitting pointers from bytes means future protective policy on the byte surface (rate limiting, geo/redirect) or a physical origin split can never touch the availability-critical feed path -- and baking the split into clients/feeds now makes any such future change client-invisible.

## Compatibility

Nothing breaks in either direction: the cloudfront.net URLs keep serving forever (old feeds, old clients, old docs all keep working), and `cli.sh`'s `--cdn` / `KIROCREW_CDN_BASE` override still covers both bases for tests and mirrors.

## Verification

- Electron updater suite passes (feed-base tests are base-parameterized; no test pinned the old domain)
- `sh -n cli.sh` clean; no stray `$CDN` references
- Remaining `d28nxu` mentions are deliberate: the T3 historical record and two 'keeps working as an alias' notes
- Both hostnames live-verified today: feed 200/TLS-valid on `updates.`, DMG 200 + wheel 200 on `download.`, ETags byte-identical across all hostnames

No screenshots: no user-visible UI change.