### PR TITLE
perf(frontend): use vitest v8 coverage provider to speed up CI

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -63,7 +63,7 @@
         "@typescript-eslint/eslint-plugin": "8.58.0",
         "@typescript-eslint/parser": "8.58.0",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-istanbul": "3.2.4",
+        "@vitest/coverage-v8": "3.2.4",
         "autoprefixer": "10.4.27",
         "eslint": "^9.39.4",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -97,6 +97,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -454,6 +468,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -3763,21 +3787,24 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/coverage-istanbul": {
+    "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.4.tgz",
-      "integrity": "sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@istanbuljs/schema": "^0.1.3",
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
         "debug": "^4.4.1",
         "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
         "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^2.0.0"
       },
@@ -3785,7 +3812,13 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
+        "@vitest/browser": "3.2.4",
         "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -4214,6 +4247,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8021,23 +8073,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report": {

--- a/website/package.json
+++ b/website/package.json
@@ -83,7 +83,7 @@
     "@typescript-eslint/eslint-plugin": "8.58.0",
     "@typescript-eslint/parser": "8.58.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-istanbul": "3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
     "autoprefixer": "10.4.27",
     "eslint": "^9.39.4",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -194,7 +194,7 @@ export default defineConfig({
     // ``./coverage/`` would be outside the packaged output and the coverage
     // tool would never see it.
     coverage: {
-      provider: 'istanbul',
+      provider: 'v8',
       reporter: ['text', 'cobertura', 'lcov'],
       reportsDirectory: './build/coverage',
       include: ['src/**/*.{ts,tsx}'],


### PR DESCRIPTION
## Problem
CI feels slow to go green. Timing data from recent runs (per-job wall-clock) shows the **Frontend Tests** job is the long pole at **~14.0–14.4 min**, while the entire backend critical path (slowest 3.12 shard ~8.7m + Coverage Combine ~0.7m) is only ~9.4m. Step-level breakdown of Frontend Tests: install 12s, everything else trivial, and the `vitest run --coverage` step alone is **833s (~13.9 min)**.

## Why it matters
Total PR time-to-green is pinned to the slowest job. Because Frontend Tests runs ~5 min longer than every other job, it single-handedly sets the wall-clock for every push and PR. Adding backend shards does nothing for this; the frontend coverage step must get cheaper.

## Fix (symptom → root cause → change)
- **Symptom:** `vitest run --coverage` takes ~14 min.
- **Root cause:** the vitest config used `provider: 'istanbul'`, which instruments every source file at transform time — the classic reason a coverage run balloons 2–4× over the raw test run.
- **Change:** switch the coverage provider to `v8`, which uses the V8 engine's native coverage (no source instrumentation) and is dramatically cheaper. Reporters (`text`, `cobertura`, `lcov`), `reportsDirectory`, and include/exclude globs are unchanged, so downstream artifacts are identical in shape.

Dependency change (flagged signals):
- `website/package.json`: replace devDependency `@vitest/coverage-istanbul@3.2.4` → `@vitest/coverage-v8@3.2.4` (same version as `vitest`).
- `website/package-lock.json`: regenerated via `npm install` — adds `@vitest/coverage-v8` and its transitives, removes `@vitest/coverage-istanbul`. No runtime deps affected (dev-only).

## Tests
No test logic changed. Verified locally with `npx vitest run --coverage`:
- All frontend tests pass (exit 0).
- Coverage artifacts still emitted: `build/coverage/cobertura-coverage.xml` + `build/coverage/lcov.info`.
- Wall-clock: **102s locally with v8** vs the **~833s istanbul step** observed in CI (~8× lower coverage overhead). Absolute CI time will be higher than local, but Frontend Tests should drop well under the ~9m backend critical path and no longer be the long pole.

The `Coverage Gate` job (`code-review.yml`) enforces a minimum **40%** frontend line-rate, read from the cobertura `line-rate` attribute. The v8 provider produces the same cobertura report, and the local run measured **65.9%** line-rate — comfortably above the 40% floor. v8's line-mapping differs slightly from istanbul's, but not nearly enough to approach the threshold.

## Manual verification
Ran the full frontend coverage suite locally (see Tests). No further manual steps needed — the real CI timing improvement will be visible on this PR's first run.
