### PR TITLE
fix(chat): put credits before elapsed time in the turn-stats footer

### DIFF
--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -220,10 +220,22 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
     )}
     {!isStreaming && showFooter && turnStats && turnStats.elapsed_ms > 0 && (
       <div className="flex items-center gap-1 mt-1 text-[11px] text-muted/60 font-mono tabular-nums" data-testid="turn-stats" title={`Turn took ${fmtTurnElapsed(turnStats.elapsed_ms)}${(turnStats.credits ?? 0) > 0 ? ` and used ${fmtCredits(turnStats.credits!)} credits` : ''}${(turnStats.cost_usd ?? 0) > 0 ? ` ($${turnStats.cost_usd!.toFixed(4)} API cost)` : ''}`}>
-        <Clock size={11} aria-hidden="true" />
-        <span>{fmtTurnElapsed(turnStats.elapsed_ms)}</span>
-        {(turnStats.credits ?? 0) > 0 && <span>· {fmtCredits(turnStats.credits!)} credits</span>}
-        {!(turnStats.credits ?? 0) && (turnStats.cost_usd ?? 0) > 0 && <span>· ${turnStats.cost_usd!.toFixed(turnStats.cost_usd! < 0.01 ? 4 : 2)}</span>}
+        {/* Cost leads, elapsed trails: credits are the scarce resource users
+            actually budget, so they read first. The clock icon travels WITH the
+            elapsed value (never leads the line) so it never appears to label
+            the credit figure. */}
+        {(() => {
+          const credits = turnStats.credits ?? 0
+          const cost = turnStats.cost_usd ?? 0
+          const billed = credits > 0
+            ? `${fmtCredits(credits)} credits`
+            : cost > 0 ? `$${cost.toFixed(cost < 0.01 ? 4 : 2)}` : ''
+          return <>
+            {billed && <span>{billed} ·</span>}
+            <Clock size={11} aria-hidden="true" />
+            <span>{fmtTurnElapsed(turnStats.elapsed_ms)}</span>
+          </>
+        })()}
       </div>
     )}
     {!isStreaming && showFooter && (

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -319,6 +319,19 @@ describe('turn stats footer (elapsed time + credits)', () => {
     expect(stats).toHaveTextContent('2.50 credits')
   })
 
+  it('puts the billed amount before the elapsed time', () => {
+    render(<AssistantMessage content="done" isStreaming={false} slotRunning={false} turnStats={{ elapsed_ms: 84_000, credits: 2.5 }} />)
+    // Collapse whitespace: the cost must read first, elapsed second.
+    const text = screen.getByTestId('turn-stats').textContent!.replace(/\s+/g, ' ').trim()
+    expect(text).toMatch(/^2\.50 credits ·\s*1m 24s$/)
+  })
+
+  it('puts the dollar cost before the elapsed time too', () => {
+    render(<AssistantMessage content="done" isStreaming={false} slotRunning={false} turnStats={{ elapsed_ms: 8_400, cost_usd: 0.0231 }} />)
+    const text = screen.getByTestId('turn-stats').textContent!.replace(/\s+/g, ' ').trim()
+    expect(text).toMatch(/^\$0\.02 ·\s*8\.4s$/)
+  })
+
   it('renders cost_usd when the provider bills in dollars (no credits)', () => {
     render(<AssistantMessage content="done" isStreaming={false} slotRunning={false} turnStats={{ elapsed_ms: 8_400, cost_usd: 0.0231 }} />)
     const stats = screen.getByTestId('turn-stats')


### PR DESCRIPTION
## What

The per-turn stats footer under completed assistant messages read
`8m 21s · 10.2 credits` — elapsed wall clock first. This flips it to
`10.2 credits · 8m 21s`.

Credits are the resource users actively budget against their plan; elapsed
time is the secondary signal. Leading with cost matches how the number is
actually scanned.

## Details

- The `Clock` icon moves from the head of the line to immediately before the
  elapsed value, so it no longer looks like it labels the credit figure.
- Dollar-billed turns (`claude_code` / `cost_usd`) flip the same way.
- The elapsed-only case (nothing billed) is visually unchanged — icon then time.
- The hover tooltip is untouched; it was already prose (`Turn took … and used …`).

## Testing

- `npx tsc --noEmit` — clean
- Full Vitest suite: **4320 passed / 3 skipped** across 376 files
- Two new order assertions in `AssistantMessage.test.tsx` pin credits-then-elapsed
  for both the credits and the `cost_usd` branch

Frontend-only; no Python touched.
