### PR TITLE
ci: Fable 5 code review + exhaustive 3-pass coverage in both reviewers

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Opus 4.8 Review
+name: Claude AI Review
 
 # Semantic AI review layer. Replicates the AutoSDE rules that CANNOT be
 # expressed as a grep (aria-label on icon-only buttons, no-emoji-as-icons,
@@ -22,7 +22,12 @@ concurrency:
 
 jobs:
   claude-review:
-    name: Opus 4.8 Review
+    # Model-AGNOSTIC check name on purpose: branch protection keys its required
+    # status check on this job name. Keep it model-agnostic so bumping the Claude
+    # model (--model below) never renames the check and never requires a
+    # branch-protection change. Put the model version only in --model, comments,
+    # and the posted-summary heading — never here.
+    name: Claude AI Review
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       # Load AUTOSDE rules from the BASE commit, not the PR HEAD, so a PR
-      # cannot weaken the rules that govern it. Opus 4.8 reads these snapshots
+      # cannot weaken the rules that govern it. Fable 5 reads these snapshots
       # (its restricted toolset can Read files but not run git).
       - name: Extract base-ref AUTOSDE rules
         env:
@@ -44,7 +49,7 @@ jobs:
       # secrets / OIDC, so the AWS role assumption below can never succeed —
       # it errors, the review step is skipped, and the gate fails closed on
       # every Dependabot PR. Skip the credential + review steps for Dependabot
-      # and let the gate pass (see "Gate on Opus 4.8 review"). Dependency bumps
+      # and let the gate pass (see "Gate on Fable 5 review"). Dependency bumps
       # are mechanical and remain covered by the non-AI gates (Semgrep,
       # Dependency Audit, CodeQL, build/tests).
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -53,7 +58,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Opus 4.8 review
+      - name: Fable 5 review
         id: review
         if: github.actor != 'dependabot[bot]'
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
@@ -74,7 +79,8 @@ jobs:
           # and any file it needs for context; the gh commands let it
           # post findings.
           claude_args: |
-            --model us.anthropic.claude-opus-4-8
+            --model us.anthropic.claude-fable-5
+            --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 100
             --allowedTools "Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
             --json-schema '{"type":"object","additionalProperties":false,"required":["reviewed","block_merge","summary"],"properties":{"reviewed":{"type":"boolean","description":"true once you have completed the review of this commit"},"block_merge":{"type":"boolean","description":"true IFF at least one finding meets the BLOCKING BAR"},"summary":{"type":"string","description":"markdown review summary CI will post to the PR"}}}'
@@ -88,6 +94,26 @@ jobs:
             public fork: do NOT flag the absence of Brazil/AUTOSDE tooling.
 
             Review ONLY the PR diff. Post specific, actionable inline comments.
+
+            SCOPE (mandatory): FOCUS on the files this PR changes. You MAY read
+            surrounding or referenced files (Read/Grep/Glob) for CONTEXT — to
+            understand a changed line — but do NOT review or report on code
+            outside the diff, and do not go on a whole-repo audit. Report findings
+            ONLY on lines this PR adds or changes; use context reads to judge
+            those lines, never to expand the review into unrelated code.
+
+            COVERAGE (mandatory): enumerate EVERY file in the PR diff and inspect
+            each one — do not sample, skim, or stop early. "Inspect" means read
+            each changed file (with enough surrounding context to judge the
+            change) and surface the COMPLETE set of findings on the changed lines
+            in this single review, never a representative subset.
+
+            THOROUGHNESS — you run as a SINGLE agentic review with a large turn
+            budget; USE it. Re-scan the diff more than once within this one run
+            until every changed file has been examined and you are confident the
+            finding set is COMPLETE — do not stop after a first skim. (Do NOT try
+            to reason about what an earlier revision's review reported — you
+            cannot see it; review this diff live regardless of prior revisions.)
 
             AUTHORITATIVE RULE SET: read the BASE-branch rule snapshots at
             `.review-base-rules/AUTOSDE.yaml` (backend Python) and
@@ -151,13 +177,14 @@ jobs:
             your labels and your block decision consistent.
 
             SELF-CRITIQUE (run BEFORE you post the summary comment):
-            - Kill-filter: for each candidate finding ask "if I were the author,
-              would this change what I build or how I think about this code?" If
-              no (a style preference, a "consider", a nice-to-have) — DROP it. Do
-              not post nice-to-have comments.
+            - Kill-filter: DROP pure style preferences, "consider"/"nice-to-have"
+              nits, and anything that would not change the author's code or
+              understanding. But DO keep and report every substantive MEDIUM —
+              real correctness, robustness, maintainability, or clarity issues on
+              changed lines that would genuinely help the author — as an ADVISORY
+              (non-blocking) finding. Valuable MEDIUMs are the point of the
+              review; only true nits get dropped, not useful non-blocking issues.
             - Merge: if two findings share one root cause, post ONE comment.
-            - Re-run dedup: if an earlier revision's review already raised a
-              finding, do not repeat it — only report issues not already covered.
 
             PREMISE / DESIGN CONCERNS (keep separate from the code verdict):
             A "should this exist / is this the right design" objection is
@@ -199,10 +226,10 @@ jobs:
       # comment — so it works even when the model doesn't call gh pr comment.
       # UPSERT a single marker-keyed comment per PR: re-scanning on every push
       # UPDATEs that one comment (PATCH) instead of stacking a new one —
-      # otherwise the PR fills with N near-duplicate Opus 4.8 summaries as the
+      # otherwise the PR fills with N near-duplicate Fable 5 summaries as the
       # branch evolves (PR #14 accumulated 3). Fully workflow-owned, so the
       # dedup does not depend on the model following posting instructions.
-      - name: Post Opus 4.8 review summary
+      - name: Post Fable 5 review summary
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -218,7 +245,7 @@ jobs:
           MARKER="<!-- claude-ai-review -->"
           {
             echo "$MARKER"
-            echo "## Opus 4.8 Review — $verdict"
+            echo "## Fable 5 Review — $verdict"
             echo
             echo "_Reviewed \`$HEAD\` — this comment is updated in place on each push._"
             echo
@@ -244,10 +271,10 @@ jobs:
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               --field body="$(cat /tmp/claude-summary.md)" >/dev/null || true
-            echo "Updated existing Opus 4.8 summary comment #$existing"
+            echo "Updated existing Fable 5 summary comment #$existing"
           else
             gh pr comment "$PR" --body-file /tmp/claude-summary.md || true
-            echo "Created new Opus 4.8 summary comment"
+            echo "Created new Fable 5 summary comment"
           fi
 
       # Fail-CLOSED gate. Gates on the action's OWN structured output
@@ -263,7 +290,7 @@ jobs:
       # Fail closed unless the step succeeded AND emitted structured output with
       # reviewed==true, so a review that errored / ran out of turns / produced no
       # verdict can never look clean.
-      - name: Gate on Opus 4.8 review
+      - name: Gate on Fable 5 review
         if: always()
         env:
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -275,31 +302,31 @@ jobs:
           # Pass the gate green rather than fail closed — dependency bumps are
           # covered by Semgrep, Dependency Audit, CodeQL and the build/tests.
           if [ "$ACTOR" = "dependabot[bot]" ]; then
-            echo "Dependabot PR ($ACTOR): Opus 4.8 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
+            echo "Dependabot PR ($ACTOR): Fable 5 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
             exit 0
           fi
           if [ "$REVIEW_OUTCOME" != "success" ]; then
-            echo "::error::Opus 4.8 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
+            echo "::error::Fable 5 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
             exit 1
           fi
           if [ -z "$SO" ]; then
-            echo "::error::Opus 4.8 review produced no structured output for $HEAD (review did not complete / ran out of turns). Failing closed — re-run or inspect the Opus 4.8 review step logs."
+            echo "::error::Fable 5 review produced no structured output for $HEAD (review did not complete / ran out of turns). Failing closed — re-run or inspect the Fable 5 review step logs."
             exit 1
           fi
           reviewed=$(printf '%s' "$SO" | jq -r '.reviewed // false')
           block=$(printf '%s' "$SO" | jq -r 'if has("block_merge") then (.block_merge|tostring) else "MISSING" end')
           if [ "$reviewed" != "true" ]; then
-            echo "::error::Opus 4.8 review did not confirm completion (reviewed != true) for $HEAD. Failing closed."
+            echo "::error::Fable 5 review did not confirm completion (reviewed != true) for $HEAD. Failing closed."
             printf 'structured_output: %s\n' "$SO"
             exit 1
           fi
           if [ "$block" = "MISSING" ]; then
-            echo "::error::Opus 4.8 structured output is missing block_merge for $HEAD. Failing closed."
+            echo "::error::Fable 5 structured output is missing block_merge for $HEAD. Failing closed."
             printf 'structured_output: %s\n' "$SO"
             exit 1
           fi
           if [ "$block" = "true" ]; then
-            echo "::error::Opus 4.8 review flagged a blocking (CRITICAL/HIGH) issue on $HEAD — see the posted review summary."
+            echo "::error::Fable 5 review flagged a blocking (CRITICAL/HIGH) issue on $HEAD — see the posted review summary."
             exit 1
           fi
-          echo "Opus 4.8 review completed for $HEAD with no blocking findings."
+          echo "Fable 5 review completed for $HEAD with no blocking findings."

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -99,9 +99,15 @@ jobs:
           Brazil/AUTOSDE build tooling or internal-only infrastructure. Follow the
           conventions in CLAUDE.md and AGENTS.md (root and website/) when present.
 
-          You are reviewing a pull request. Inspect ONLY the changes this branch
-          introduces relative to the base commit, using:
+          You are reviewing a pull request. Start from the changes this branch
+          introduces relative to the base commit:
               git diff ${{ github.event.pull_request.base.sha }}...HEAD
+          FOCUS on the changed files. You MAY open the full changed files and any
+          surrounding or referenced files (the sandbox is read-only) for CONTEXT
+          -- to understand a changed line -- but do NOT review or report on code
+          outside the diff, and do not go on a whole-repo audit. Report findings
+          ONLY on lines this PR adds or changes; use context reads to judge those
+          lines, never to expand scope into unrelated code.
 
           Review the diff for:
           1. Security vulnerabilities (injection, path traversal, credential exposure)
@@ -112,6 +118,15 @@ jobs:
           6. Regression (removal of a guard/validation/error-handling a prior fix added)
           Performance, test-coverage, and style-adjacent observations are ADVISORY
           only (see the blocking contract below) -- report them as MEDIUM/LOW.
+
+          COVERAGE (mandatory): enumerate EVERY file in the diff and inspect each
+          one -- do not sample or stop early. Your review MUST account for all
+          changed files and surface the COMPLETE set of findings, never a
+          representative subset. This review runs in THREE sequential passes (the
+          workflow re-invokes you). When a later pass is given the findings
+          already reported by earlier passes, SKIP those and focus only on issues
+          and files not yet covered; when no prior findings are provided, do a
+          full review.
 
           Also enforce this repo's own rules. Read the BASE-branch rule
           snapshots at .review-base-rules/AUTOSDE.yaml (backend Python) and
@@ -166,13 +181,14 @@ jobs:
           AUTOSDE rules and the actual diff are authoritative -- never invent rules.
 
           SELF-CRITIQUE (run BEFORE you emit anything):
-          - Kill-filter: for each candidate finding ask "if I were the author,
-            would this change what I build or how I think about this code?" If no
-            (a style preference, a "consider", a nice-to-have) -- DROP it. Do not
-            emit nice-to-have comments.
+          - Kill-filter: DROP pure style preferences, "consider"/"nice-to-have"
+            nits, and anything that would not change the author's code or
+            understanding. But DO keep and emit every substantive MEDIUM -- real
+            correctness, robustness, maintainability, or clarity issues on changed
+            lines that would genuinely help the author -- as an ADVISORY
+            (non-blocking) finding. Valuable MEDIUMs are the point of the review;
+            only true nits get dropped, not useful non-blocking issues.
           - Merge: if two findings share one root cause, emit ONE finding.
-          - Re-run dedup: if an earlier revision's review already raised a finding,
-            do not repeat it -- only report issues not already covered.
 
           PREMISE / DESIGN CONCERNS (keep separate from the code verdict):
           A "should this exist / is this the right design" objection is ADVISORY
@@ -214,18 +230,79 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: GPT 5.6 review
+      - name: GPT 5.6 review (3 passes)
         if: github.actor != 'dependabot[bot]'
         env:
           # Codex's amazon-bedrock provider resolves the assumed role's SigV4
           # credentials via the AWS SDK credential chain and calls the Bedrock
           # Mantle Responses API directly -- no proxy, no bearer token, no key.
           AWS_REGION: us-east-1
+        # THREE-PASS review to maximize single-shot coverage. Each pass re-runs
+        # the SAME base prompt but is additionally fed the findings already
+        # reported by earlier passes and told to skip them and cover the files /
+        # issues not yet examined. The UNION of all three passes becomes the
+        # review output the comment + gate consume. Dedup here is enforceable
+        # (unlike the old cross-revision dedup) because prior-pass findings are
+        # visible within the same run. Actions runs this `run:` with the default
+        # shell `bash -e {0}` (errexit ON, pipefail OFF), so each pass uses
+        # `|| rc=$?` to capture its exit code without aborting the step — that is
+        # what makes a failed pass VISIBLE (::warning:: + banner) instead of
+        # tripping errexit; the script's own `set -uo pipefail` is what adds
+        # pipefail (load-bearing, not redundant). NOTE: a failed pass still writes
+        # a banner to codex-review-output.md, so when ALL passes fail the file is
+        # non-empty and the gate's `-s` check does NOT fire — the fail-closed
+        # backstop for that case is the ABSENT `[CODEX-REVIEWED] <sha>` marker.
         run: |
-          codex exec \
-            --sandbox read-only \
-            --output-last-message codex-review-output.md \
-            "$(cat /tmp/codex-prompt.md)"
+          set -uo pipefail
+          BASE_PROMPT="$(cat /tmp/codex-prompt.md)"
+          : > codex-review-output.md
+          prior=""
+          failed_passes=""
+          for pass in 1 2 3; do
+            if [ -n "$prior" ]; then
+              PROMPT=$(printf '%s\n\n%s\n%s\n' "$BASE_PROMPT" \
+                "==== ALREADY REPORTED IN EARLIER PASSES OF THIS SAME REVIEW (do NOT repeat any of these; report ONLY new issues not listed here, and make sure every changed file has been inspected): ====" \
+                "$prior")
+            else
+              PROMPT="$BASE_PROMPT"
+            fi
+            # Capture the real exit code so a failed pass is made VISIBLE rather
+            # than silently dropped. The default Actions shell is `bash -e {0}`
+            # (errexit ON), so `|| rc=$?` is REQUIRED: a bare `codex exec` failure
+            # would trip errexit and abort the step before the visibility code
+            # below runs.
+            rc=0
+            codex exec \
+              --sandbox read-only \
+              --output-last-message "codex-pass-${pass}.md" \
+              "$PROMPT" || rc=$?
+            if [ "$rc" -ne 0 ] || [ ! -s "codex-pass-${pass}.md" ]; then
+              # Surface the incomplete pass in the job log AND the posted comment
+              # so a degrade from 3-pass to fewer passes can never be silent /
+              # unauditable (Bedrock throttling or SigV4 expiry mid-loop).
+              echo "::warning::GPT 5.6 review pass ${pass} did not complete (exit ${rc}); three-pass coverage is reduced for this commit."
+              failed_passes="${failed_passes} ${pass}"
+              {
+                echo "### Review pass ${pass}"
+                echo "_⚠️ This pass did not complete (exit ${rc}); its findings are missing from this review._"
+                echo
+              } >> codex-review-output.md
+              continue
+            fi
+            {
+              echo "### Review pass ${pass}"
+              cat "codex-pass-${pass}.md"
+              echo
+            } >> codex-review-output.md
+            prior=$(printf '%s\n\n--- pass %s findings ---\n%s\n' \
+              "$prior" "$pass" "$(cat "codex-pass-${pass}.md")")
+          done
+          if [ -n "$failed_passes" ]; then
+            {
+              echo
+              echo "> ⚠️ **Incomplete multi-pass review:** pass(es)${failed_passes} did not complete, so the three-pass coverage guarantee was NOT fully met for this commit. Re-run the workflow for a complete review."
+            } >> codex-review-output.md
+          fi
 
       # Finding 2 (HIGH) mitigation: the reviewer runs agentically with AWS
       # creds in its environment while reading untrusted PR content. The


### PR DESCRIPTION
## Problem
1. The Claude reviewer ran on Opus 4.8 while the harder advisory layers (design-review, longterm-arbiter) already run on Claude **Fable 5**.
2. The reviewers surfaced a *different subset* of findings each push and carried an unenforceable "don't repeat an earlier revision's findings" instruction (prior-revision comments are PATCH-overwritten → zero visibility).
3. The two reviewers were scoped inconsistently: GPT was pinned to `git diff` only, while Claude read the whole repo.
4. The kill-filter over-suppressed useful non-blocking findings (Claude tended to report very little).

## Why it matters
Incomplete / whack-a-mole reviews stretch PRs across rounds and lower trust in the gate. Both reviewers should do a genuine, complete, consistently-scoped review — using each tool's strengths rather than forcing identical mechanics — and surface valuable advisory findings, not just blockers.

## Fix (symptom → root cause → change)
- **Claude on old model / brittle check name.** → `--model us.anthropic.claude-fable-5` + `--fallback-model us.anthropic.claude-opus-4-8`; check context renamed to the **model-agnostic** `Claude AI Review` so no future model bump touches branch protection.
- **Coverage / multi-pass — matched to each tool.**
  - **Codex/GPT** runs a **real three-pass loop**: `codex exec` is a lean per-call invocation, so three sequential passes add genuine coverage. Each later pass is fed the prior passes' findings (inline) and skips them.
  - **Claude/Fable** runs a **single thorough invocation**: `claude-code-action` is already a multi-turn agent, so a THOROUGHNESS instruction (re-scan within the one run until every changed file is covered) achieves complete coverage without three separate invocations — same coverage, ~1/3 the wall-time.
  - Removed the prompt-level "THREE-PASS" block from Claude and the unenforceable cross-revision dedup bullet from both prompts.
- **Silent degrade risk (Codex).** → per-pass exit code captured (`|| rc=$?`; Actions runs `bash -eo pipefail`); any incomplete pass surfaces via `::warning::` + an in-comment banner.
- **Scope inconsistency.** → shared SCOPE model: both read surrounding/referenced files for CONTEXT but FOCUS on changed files and report ONLY on changed lines (no whole-repo audit). GPT is now guided to read related files (read-only sandbox) for context — while keeping its leaner toolset (intentionally a bit different from Claude).
- **Over-suppressed advisories.** → sharpened the SELF-CRITIQUE kill-filter in both prompts: drop only pure style nits, but explicitly KEEP and report substantive MEDIUM findings (real correctness/robustness/maintainability/clarity issues on changed lines) as advisory. The gate is unchanged — MEDIUM never blocks.

## Tests
N/A — GitHub Actions workflow/prompt changes. Validated: both YAMLs parse; every `run:` block passes `bash -n`; Claude confirmed single-invocation with a single-review fail-closed gate; Codex 3-pass loop is `errexit`-safe (`|| rc=$?`).

## Manual verification
- `us.anthropic.claude-fable-5` matches design-review.yml / longterm-arbiter.yml (with Opus 4.8 fallback).
- **Required maintainer follow-up:** update the branch-protection required-check name **once** from "Opus 4.8 Review" to "Claude AI Review". Model-agnostic naming means this is the last time a model change needs it.
- **Cost:** Codex makes 3 Bedrock calls per push (~7 min observed); Claude makes 1 (Fable's agentic harness self-iterates within the run).
