### PR TITLE
feat(knowledge): source-first list view with per-source pagination

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -34,7 +34,7 @@ files / uploads / artifacts / URLs
 | `knowledge/dedup.py` | Cross-source deduplication |
 | `knowledge/connectors/` | `BaseConnector`, `local_folder` source connectors |
 | `mcp_core.py` | `local_knowledge_search` MCP tool + cached store/embedder |
-| `dashboard/handlers/knowledge.py` | Dashboard Knowledge-tab API (sources, ingest, search) |
+| `dashboard/handlers/knowledge.py` | Dashboard Knowledge-tab API (sources, ingest, search, source-scoped list + `/source-counts`) |
 | `agent.py:_install_knowledge_agent` | Installs the `kirocrew-knowledge` kiro-cli agent used by the pool |
 
 ## Constants
@@ -147,6 +147,46 @@ The LLM reaches retrieval through the `kirocrew-core` MCP tool `local_knowledge_
 
 The dashboard Knowledge tab uses the same store via a lazily-initialized `KnowledgeStore` on `DashboardState` (`dashboard/state.py`).
 
+## 5. Source-scoped list API (`dashboard/handlers/knowledge.py`)
+
+The dashboard Knowledge list view is **source-first**: it renders one collapsed
+row per source and pages *within* a source, rather than paging all items globally
+and grouping whatever landed on the page. Two pieces of API surface support this.
+
+### `GET /api/knowledge/items?source_id=<id>`
+
+Scopes the page to a single source. Composes with the existing `type`, `status`,
+`namespace`, `q`, `page`, and `limit` params.
+
+- The reported `total` is **scoped to that source**, not the global count. The
+  in-group pager derives its page count from it, so a global total would break
+  the pager math.
+- `source_id=__none__` selects items with no source (`source_id` NULL or empty).
+- Applied in both branches of `list_items`: as a SQL predicate in the list
+  branch, and via `_matches_source` after ranking in the hybrid-search branch.
+- Because the hybrid-search branch filters *after* the retriever has ranked
+  globally, a scoped search escalates its candidate pool
+  (`_search_until_exhausted`: `_SCOPED_SEARCH_START` doubling to
+  `_SCOPED_SEARCH_MAX`) until the retriever short-reads, so the scoped total is
+  exact rather than truncated by a fixed window. At the cap the total may
+  understate; pushing `source_id` into `HybridRetriever` is the tracked
+  follow-up. Unscoped searches keep the cheap `limit * 3` window.
+
+### `GET /api/knowledge/source-counts`
+
+Returns the item count per source **under the active filters**:
+
+```json
+{ "counts": { "<source_id>": 42, "__none__": 3 }, "total": 45 }
+```
+
+- Accepts `type`, `status`, and `namespace`; the counts reflect them, which is
+  why the list view uses this rather than `/sources.item_count` (a source's
+  unfiltered, all-namespace total that would over-report when filtered).
+- Sourceless items are reported under the `__none__` key.
+- The list view derives its rows from these counts, which is what guarantees
+  every source is visible at once regardless of relative size.
+
 ## Invariants
 
 - **Sensitive paths never ingested** — `FileReader.read`, `FolderWatcher._walk`, `_hash_file`, and `_ingest_file` all gate on `is_sensitive_path()` (with symlink re-resolution at ingest time for TOCTOU).
@@ -156,3 +196,9 @@ The dashboard Knowledge tab uses the same store via a lazily-initialized `Knowle
 - **FTS query input is parameterized** — user query tokens are always double-quoted literals; the user never injects FTS5 operators.
 - **Embedding-dimension mismatches are skipped, not scored** — vector search excludes incomparable-dimension items so a model swap cannot fill the top-K with all-zero ghosts.
 - **The self-heal rebuild path never touches SQLite on the event loop** — `_maybe_reembed_stale`'s stale COUNT, `rebuild_embeddings`' total COUNT / page SELECTs / batch progress commits, and the success-path job finalize all run via `asyncio.to_thread` (`store.db` is a per-thread connection, so each worker thread uses its own connection to the same WAL db). On a large KB (observed: ~1.3GB after an embedder-sig change) an inline COUNT can stall past the 25s loop-watchdog threshold and crash-loop the gateway. The one deliberate exception is the CancelledError finalize in `_run_reembed_job`, which stays inline so cancellation cannot pre-empt the single-flight finalize. When the stale count exceeds `_LARGE_REBUILD_WARN_THRESHOLD` the watcher logs a prominent WARNING before starting the full re-embed.
+- **`__none__` is a shared wire contract** — the no-source sentinel is defined as `_NO_SOURCE` in `dashboard/handlers/knowledge.py` and mirrored as `NO_SOURCE` in `website/src/pages/knowledge/SourceGroup.tsx`. Both sides must change together; it is effectively un-renameable once shipped.
+- **A source-scoped `total` is scoped, never global** — `/items?source_id=` reports the count for that source alone, because the per-source pager computes its page count from it.
+- **Per-source badge counts are filter-aware** — list-view badges come from `/source-counts` (which honours `type`/`status`/`namespace`), not from `/sources.item_count`, so a badge never disagrees with the group's contents under a filter.
+- **The search branch's candidate load runs off the event loop** — a scoped search escalates its candidate pool, so `_load_items_by_id` (batch `SELECT` plus per-row serialization) and the `source_counts` aggregate both run via `asyncio.to_thread`. `store.db` is a per-thread connection, so each worker thread uses its own. Run inline, either can stall the loop past the watchdog threshold on a large KB.
+- **Frontend selection is bounded to on-screen items** — in source-first mode item data lives in per-`SourceGroup` caches, so bulk actions read the items each expanded group reports as rendered, and selected IDs are pruned when a group collapses or pages away. Reading the react-query cache directly would let a bulk Delete reach a retained cache for a source the user can no longer see.
+- **Per-source caches are keyed under the `knowledge-items` prefix** — `['knowledge-items', 'source-items', ...]` and `['knowledge-items', 'source-counts', ...]` so every existing `invalidateQueries(['knowledge-items'])` call site reaches them. Consequently any `setQueriesData` on that prefix must guard on the payload shape, since the counts entry has no `items` array.

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -184,6 +184,70 @@ def _attach_file_paths(store, items: list[dict]) -> None:
             item["_file_path"] = fp
 
 
+_NO_SOURCE = "__none__"
+
+# Candidate-pool escalation for a source-scoped hybrid search: start here, then
+# double until retrieval is exhausted. Capped so a pathological corpus cannot
+# turn one request into an unbounded scan.
+# Ids bound per `IN (...)` statement. Comfortably under the 999-variable floor
+# of older SQLite builds (SQLITE_MAX_VARIABLE_NUMBER).
+_SQLITE_VARIABLE_CHUNK = 500
+
+_SCOPED_SEARCH_START = 200
+_SCOPED_SEARCH_MAX = 20000
+
+
+async def _search_until_exhausted(retriever, q: str, limit: int) -> list[dict]:
+    """Retrieve hybrid-search candidates until the retriever runs out.
+
+    A source scope is applied *after* ranking, so a fixed window can hide every
+    matching item behind higher-ranked hits from other sources. Growing the
+    window until the retriever returns fewer rows than requested means the
+    caller has seen the whole ranking, so its filtered count is the true total.
+    """
+    want = max(limit * 3, _SCOPED_SEARCH_START)
+    results: list[dict] = []
+    while True:
+        results = await run_in_embed_pool(retriever.search, q, limit=want)
+        # Short read means the ranking is exhausted; nothing further to fetch.
+        if len(results) < want or want >= _SCOPED_SEARCH_MAX:
+            return results
+        want = min(want * 2, _SCOPED_SEARCH_MAX)
+
+
+def _matches_source(item: dict, source_id: str) -> bool:
+    """True when `item` belongs to `source_id`. The `__none__` sentinel matches
+    items with no source (NULL or empty string), mirroring how the list view
+    groups sourceless items into a single 'No source' bucket."""
+    own = item.get("source_id")
+    if source_id == _NO_SOURCE:
+        return not own
+    return own == source_id
+
+
+def _load_items_by_id(store, item_ids: list[str]) -> dict[str, dict]:
+    """Batch-load and serialize items by id, keyed by id.
+
+    Chunked because a source-scoped hybrid search escalates its candidate pool:
+    binding 20k ids into a single `IN (...)` exceeds SQLITE_MAX_VARIABLE_NUMBER
+    (999 on older builds) and fails the request with "too many SQL variables".
+
+    Runs off the event loop: both the SELECT and the per-row serialization can be
+    large enough to stall the gateway if run inline.
+    """
+    out: dict[str, dict] = {}
+    for start in range(0, len(item_ids), _SQLITE_VARIABLE_CHUNK):
+        chunk = item_ids[start:start + _SQLITE_VARIABLE_CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = store.db.execute(
+            f"SELECT * FROM items WHERE id IN ({placeholders})",  # noqa: S608
+            chunk,
+        ).fetchall()
+        for row in rows:
+            out[row["id"]] = store._serialize_item(row)
+    return out
+
+
 async def list_items(request: web.Request) -> web.Response:
     """GET /api/knowledge/items -- list/search with pagination."""
     store = _store(request)
@@ -191,6 +255,10 @@ async def list_items(request: web.Request) -> web.Response:
     item_type = request.query.get("type")
     status = request.query.get("status")
     namespace = request.query.get("namespace")
+    # Scope the page to a single source. The list view pages *within* a source
+    # group, so its pager math must see that source's total, not the global one.
+    # The sentinel "__none__" selects items with no source at all.
+    source_id = request.query.get("source_id")
     try:
         page = max(1, int(request.query.get("page", 1)))
         limit = min(100, max(1, int(request.query.get("limit", 20))))
@@ -206,20 +274,26 @@ async def list_items(request: web.Request) -> web.Response:
         embed_fn = embedder.embed if embedder and await embedder.is_available_async() else None
         retriever = HybridRetriever(store, embedder=embed_fn)
         # mc-embed bulkhead: the search's query embed blocks on Ollama.
-        all_results = await run_in_embed_pool(
-            retriever.search, q, limit=limit * 3
-        )  # over-fetch to allow filtering
-        # Batch fetch all candidate items (avoid N+1)
-        result_ids = [r["id"] for r in all_results]
-        if result_ids:
-            placeholders = ",".join("?" * len(result_ids))
-            rows = store.db.execute(
-                f"SELECT * FROM items WHERE id IN ({placeholders})",  # noqa: S608
-                result_ids
-            ).fetchall()
-            items_by_id = {row["id"]: store._serialize_item(row) for row in rows}
+        # The retriever ranks globally, so post-retrieval filtering can discard
+        # an unbounded share of any fixed window: if enough higher-ranked hits
+        # belong to other sources, a scoped search would report zero matches and
+        # later pages could never reach the real ones. Under a source scope,
+        # escalate the candidate pool until retrieval is exhausted (it returns
+        # fewer rows than asked for), which makes the scoped total exact.
+        # Unscoped searches keep the cheap limit * 3 window.
+        if source_id:
+            all_results = await _search_until_exhausted(retriever, q, limit)
         else:
-            items_by_id = {}
+            all_results = await run_in_embed_pool(
+                retriever.search, q, limit=limit * 3
+            )
+        # Batch fetch all candidate items (avoid N+1). A scoped search escalates
+        # its candidate pool, so this query and the row serialization can both be
+        # large: run them in a worker thread rather than on the event loop.
+        # `store.db` is a thread-local property, so the thread gets its own
+        # connection.
+        result_ids = [r["id"] for r in all_results]
+        items_by_id = await asyncio.to_thread(_load_items_by_id, store, result_ids)
         filtered = []
         for r in all_results:
             item = items_by_id.get(r["id"])
@@ -230,6 +304,8 @@ async def list_items(request: web.Request) -> web.Response:
             if item_type and item.get("item_type") != item_type:
                 continue
             if namespace and item.get("namespace") != namespace:
+                continue
+            if source_id and not _matches_source(item, source_id):
                 continue
             item["_score"] = r["score"]
             item["_match_type"] = r["match_type"]
@@ -250,6 +326,11 @@ async def list_items(request: web.Request) -> web.Response:
         if namespace:
             where.append("i.namespace = ?")
             params.append(namespace)
+        if source_id == _NO_SOURCE:
+            where.append("(i.source_id IS NULL OR i.source_id = '')")
+        elif source_id:
+            where.append("i.source_id = ?")
+            params.append(source_id)
         where_clause = ' AND '.join(where)
         total = store.db.execute(
             f"SELECT COUNT(*) FROM items i WHERE {where_clause}",  # noqa: S608
@@ -448,6 +529,42 @@ async def get_full_graph(request: web.Request) -> web.Response:
 
 
 # ---------- Sources ----------
+
+
+async def source_counts(request: web.Request) -> web.Response:
+    """GET /api/knowledge/source-counts -- item count per source under the
+    active type/status/namespace filters.
+
+    The list view renders one collapsed row per source, so it needs a truthful
+    per-source count *for the current filter set*. `/sources.item_count` is the
+    source's unfiltered, all-namespace total and would over-report whenever a
+    filter is on. Sourceless items are reported under the `__none__` key.
+    """
+    store = _store(request)
+    item_type = request.query.get("type")
+    status = request.query.get("status")
+    namespace = request.query.get("namespace")
+    where, params = ["1=1"], []  # type: list[str], list[object]
+    if item_type:
+        where.append("item_type = ?")
+        params.append(item_type)
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    if namespace:
+        where.append("namespace = ?")
+        params.append(namespace)
+    sql = (
+        f"SELECT COALESCE(NULLIF(source_id, ''), '{_NO_SOURCE}') AS sid, COUNT(*) AS cnt "  # noqa: S608
+        f"FROM items WHERE {' AND '.join(where)} GROUP BY sid"  # noqa: S608
+    )
+    # This is a full aggregate scan over `items`, which grows without bound, so
+    # unlike the point lookups elsewhere in this module it is offloaded rather
+    # than run inline: blocking the event loop here would stall chat and
+    # heartbeat processing on a large knowledge base.
+    rows = await asyncio.to_thread(lambda: store.db.execute(sql, params).fetchall())
+    counts = {r["sid"]: r["cnt"] for r in rows}
+    return web.json_response({"counts": counts, "total": sum(counts.values())})
 
 
 async def list_sources(request: web.Request) -> web.Response:
@@ -1430,6 +1547,7 @@ def setup_knowledge_routes(app: web.Application) -> None:
     app.router.add_get("/api/knowledge/namespaces", list_namespaces)
     app.router.add_get("/api/knowledge/stats", get_stats)
     app.router.add_get("/api/knowledge/sources", list_sources)
+    app.router.add_get("/api/knowledge/source-counts", source_counts)
     app.router.add_post("/api/knowledge/sources", add_source)
     app.router.add_post("/api/knowledge/pick-folder", pick_folder)
     app.router.add_post("/api/knowledge/sources/{id}/sync", sync_source)

--- a/test/test_knowledge_items_source_filter.py
+++ b/test/test_knowledge_items_source_filter.py
@@ -1,0 +1,364 @@
+"""Tests for the `source_id` filter on GET /api/knowledge/items.
+
+The Knowledge Library list view pages *within* a source group, so `list_items`
+must be able to scope a page to one source and report that source's total (not
+the global one). The `__none__` sentinel scopes to items with no source.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.handlers.knowledge import (
+    _load_items_by_id,
+    _matches_source,
+    list_items,
+    source_counts,
+)
+from kiro_crew.knowledge.store import KnowledgeStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "items.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def seeded(store):
+    """Two sources plus a sourceless item.
+
+    alpha has 3 items, beta has 2, and one item has no source at all.
+    """
+    alpha = store.add_source("alpha", "local_folder", "/tmp/alpha")
+    beta = store.add_source("beta", "local_folder", "/tmp/beta")
+    for i in range(3):
+        store.add_item(f"alpha-{i}", f"content alpha {i}", "note", source_id=alpha)
+    for i in range(2):
+        store.add_item(f"beta-{i}", f"content beta {i}", "note", source_id=beta)
+    store.add_item("orphan", "content orphan", "note")
+    return store, alpha, beta
+
+
+def _request(store, query: dict) -> MagicMock:
+    req = MagicMock()
+    req.query = query
+    req.app = {}
+    return req
+
+
+async def _call(store, query: dict) -> dict:
+    req = _request(store, query)
+    with patch(
+        "kiro_crew.dashboard.handlers.knowledge._store", return_value=store
+    ):
+        resp = await list_items(req)
+    return json.loads(resp.body.decode())
+
+
+# ---------------------------------------------------------------------------
+# _matches_source
+# ---------------------------------------------------------------------------
+
+
+def test_matches_source_exact():
+    assert _matches_source({"source_id": "s1"}, "s1") is True
+    assert _matches_source({"source_id": "s1"}, "s2") is False
+
+
+def test_matches_source_none_sentinel_matches_missing_and_empty():
+    assert _matches_source({}, "__none__") is True
+    assert _matches_source({"source_id": None}, "__none__") is True
+    assert _matches_source({"source_id": ""}, "__none__") is True
+    assert _matches_source({"source_id": "s1"}, "__none__") is False
+
+
+# ---------------------------------------------------------------------------
+# list_items?source_id=
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_items_without_source_id_returns_everything(seeded):
+    store, _alpha, _beta = seeded
+    data = await _call(store, {})
+    assert data["total"] == 6
+    assert len(data["items"]) == 6
+
+
+@pytest.mark.asyncio
+async def test_list_items_scopes_to_one_source(seeded):
+    store, alpha, _beta = seeded
+    data = await _call(store, {"source_id": alpha})
+    assert data["total"] == 3
+    assert {i["source_id"] for i in data["items"]} == {alpha}
+
+
+@pytest.mark.asyncio
+async def test_list_items_total_is_scoped_not_global(seeded):
+    """The pager math depends on `total` reflecting the scoped source only."""
+    store, _alpha, beta = seeded
+    data = await _call(store, {"source_id": beta})
+    assert data["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_items_none_sentinel_returns_sourceless_items(seeded):
+    store, _alpha, _beta = seeded
+    data = await _call(store, {"source_id": "__none__"})
+    assert data["total"] == 1
+    assert data["items"][0]["title"] == "orphan"
+    assert not data["items"][0].get("source_id")
+
+
+@pytest.mark.asyncio
+async def test_list_items_unknown_source_id_returns_empty(seeded):
+    store, _alpha, _beta = seeded
+    data = await _call(store, {"source_id": "does-not-exist"})
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_items_source_id_paginates_within_source(seeded):
+    """Paging is scoped: page 2 of a 3-item source at limit 2 yields 1 item."""
+    store, alpha, _beta = seeded
+    page1 = await _call(store, {"source_id": alpha, "page": "1", "limit": "2"})
+    page2 = await _call(store, {"source_id": alpha, "page": "2", "limit": "2"})
+    assert page1["total"] == page2["total"] == 3
+    assert len(page1["items"]) == 2
+    assert len(page2["items"]) == 1
+    ids = {i["id"] for i in page1["items"]} | {i["id"] for i in page2["items"]}
+    assert len(ids) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_items_source_id_composes_with_other_filters(seeded):
+    """source_id narrows alongside type/status/namespace rather than replacing."""
+    store, alpha, _beta = seeded
+    store.add_item("alpha-doc", "a doc", "document", source_id=alpha)
+    data = await _call(store, {"source_id": alpha, "type": "document"})
+    assert data["total"] == 1
+    assert data["items"][0]["title"] == "alpha-doc"
+
+
+@pytest.mark.asyncio
+async def test_list_items_source_id_filters_search_results(seeded):
+    """The hybrid-search branch honours source_id too."""
+    store, alpha, beta = seeded
+
+    results = [{"id": i["id"], "score": 1.0, "match_type": "fts"}
+               for i in store.db.execute("SELECT id FROM items").fetchall()]
+
+    retriever = MagicMock()
+    retriever.search.return_value = results
+    req = _request(store, {"q": "content", "source_id": beta})
+    with (
+        patch("kiro_crew.dashboard.handlers.knowledge._store", return_value=store),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.HybridRetriever",
+            return_value=retriever,
+        ),
+    ):
+        resp = await list_items(req)
+    data = json.loads(resp.body.decode())
+    assert data["total"] == 2
+    assert {i["source_id"] for i in data["items"]} == {beta}
+
+
+# ---------------------------------------------------------------------------
+# source_counts
+# ---------------------------------------------------------------------------
+
+
+async def _counts(store, query: dict) -> dict:
+    req = _request(store, query)
+    with patch(
+        "kiro_crew.dashboard.handlers.knowledge._store", return_value=store
+    ):
+        resp = await source_counts(req)
+    return json.loads(resp.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_source_counts_reports_every_source(seeded):
+    """Every source appears, so none can hide behind pagination."""
+    store, alpha, beta = seeded
+    data = await _counts(store, {})
+    assert data["counts"] == {alpha: 3, beta: 2, "__none__": 1}
+    assert data["total"] == 6
+
+
+@pytest.mark.asyncio
+async def test_source_counts_respects_type_filter(seeded):
+    store, alpha, _beta = seeded
+    store.add_item("alpha-doc", "a doc", "document", source_id=alpha)
+    data = await _counts(store, {"type": "document"})
+    assert data["counts"] == {alpha: 1}
+    assert data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_source_counts_respects_status_filter(seeded):
+    store, alpha, beta = seeded
+    data = await _counts(store, {"status": "active"})
+    assert data["counts"] == {alpha: 3, beta: 2, "__none__": 1}
+    archived = await _counts(store, {"status": "archived"})
+    assert archived["counts"] == {}
+    assert archived["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_source_counts_respects_namespace_filter(seeded):
+    store, alpha, _beta = seeded
+    store.add_item("ns-item", "scoped", "note", source_id=alpha, namespace="team")
+    data = await _counts(store, {"namespace": "team"})
+    assert data["counts"] == {alpha: 1}
+
+
+@pytest.mark.asyncio
+async def test_source_counts_matches_scoped_list_items_total(seeded):
+    """The badge count and the group's own pager total must agree."""
+    store, alpha, _beta = seeded
+    counts = await _counts(store, {})
+    scoped = await _call(store, {"source_id": alpha})
+    assert counts["counts"][alpha] == scoped["total"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_search_escalates_until_retrieval_is_exhausted(seeded):
+    """A source scope is applied after ranking, so the candidate pool grows
+    until the retriever short-reads. Otherwise matches hidden behind
+    higher-ranked hits from other sources would be reported as absent."""
+    store, _alpha, beta = seeded
+    retriever = MagicMock()
+    # Full windows until the pool exceeds 400, then a short read.
+
+    def _search(_q, limit):
+        return [{"id": "x", "score": 1.0, "match_type": "fts"}] * (
+            limit if limit <= 400 else limit - 1
+        )
+    retriever.search.side_effect = _search
+    req = _request(store, {"q": "content", "source_id": beta, "limit": "20"})
+    with (
+        patch("kiro_crew.dashboard.handlers.knowledge._store", return_value=store),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.HybridRetriever",
+            return_value=retriever,
+        ),
+    ):
+        await list_items(req)
+    limits = [c.kwargs["limit"] for c in retriever.search.call_args_list]
+    assert limits == [200, 400, 800]
+
+
+@pytest.mark.asyncio
+async def test_scoped_search_stops_at_the_escalation_cap(seeded):
+    """A corpus that never short-reads must not escalate without bound."""
+    store, _alpha, beta = seeded
+    retriever = MagicMock()
+    retriever.search.side_effect = lambda _q, limit: [
+        {"id": "x", "score": 1.0, "match_type": "fts"}
+    ] * limit
+    req = _request(store, {"q": "content", "source_id": beta, "limit": "20"})
+    with (
+        patch("kiro_crew.dashboard.handlers.knowledge._store", return_value=store),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.HybridRetriever",
+            return_value=retriever,
+        ),
+    ):
+        await list_items(req)
+    limits = [c.kwargs["limit"] for c in retriever.search.call_args_list]
+    assert limits[-1] == 20000
+    assert all(x <= 20000 for x in limits)
+
+
+@pytest.mark.asyncio
+async def test_unscoped_search_keeps_the_narrow_pool(seeded):
+    """Without a source scope the existing limit * 3 window is unchanged."""
+    store, _alpha, _beta = seeded
+    retriever = MagicMock()
+    retriever.search.return_value = []
+    req = _request(store, {"q": "content", "limit": "20"})
+    with (
+        patch("kiro_crew.dashboard.handlers.knowledge._store", return_value=store),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.HybridRetriever",
+            return_value=retriever,
+        ),
+    ):
+        await list_items(req)
+    assert retriever.search.call_args.kwargs["limit"] == 60
+    assert retriever.search.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_candidate_loading_runs_off_the_event_loop(seeded):
+    """A scoped search escalates its candidate pool, so the batch SELECT and
+    row serialization must not run inline on the event loop."""
+    store, _alpha, beta = seeded
+    retriever = MagicMock()
+    retriever.search.return_value = [
+        {"id": r["id"], "score": 1.0, "match_type": "fts"}
+        for r in store.db.execute("SELECT id FROM items").fetchall()
+    ]
+    req = _request(store, {"q": "content", "source_id": beta})
+    with (
+        patch("kiro_crew.dashboard.handlers.knowledge._store", return_value=store),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.HybridRetriever",
+            return_value=retriever,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.knowledge.asyncio.to_thread",
+            wraps=asyncio.to_thread,
+        ) as to_thread,
+    ):
+        resp = await list_items(req)
+    data = json.loads(resp.body.decode())
+    # Still correct, and the load went through to_thread.
+    assert data["total"] == 2
+    assert any(
+        c.args and getattr(c.args[0], "__name__", "") == "_load_items_by_id"
+        for c in to_thread.call_args_list
+    )
+
+
+def test_load_items_by_id_chunks_below_the_sqlite_variable_limit(seeded):
+    """A scoped search can escalate to thousands of candidates. Binding them all
+    into one `IN (...)` exceeds SQLITE_MAX_VARIABLE_NUMBER (999 on older
+    builds), so the load is chunked."""
+    store, alpha, _beta = seeded
+    real_ids = [r["id"] for r in store.db.execute("SELECT id FROM items").fetchall()]
+    # Pad with ids that match nothing so the list crosses several chunks.
+    item_ids = real_ids + [f"missing-{i}" for i in range(2500)]
+
+    seen_sizes = []
+    real_execute = store.db.execute
+
+    def _spy(sql, params=()):
+        if "FROM items WHERE id IN" in sql:
+            seen_sizes.append(len(params))
+        return real_execute(sql, params)
+
+    with patch.object(type(store), "db", property(lambda _self: MagicMock(execute=_spy))):
+        loaded = _load_items_by_id(store, item_ids)
+
+    assert seen_sizes, "expected at least one chunked SELECT"
+    assert max(seen_sizes) <= 999
+    assert len(seen_sizes) > 1
+    # Every real item is still returned exactly once despite the chunking.
+    assert set(loaded) == set(real_ids)
+    assert loaded[real_ids[0]]["id"] == real_ids[0]
+    assert any(i["source_id"] == alpha for i in loaded.values())
+
+
+def test_load_items_by_id_handles_empty_input(seeded):
+    store, _alpha, _beta = seeded
+    assert _load_items_by_id(store, []) == {}

--- a/website/src/pages/knowledge/ItemCard.tsx
+++ b/website/src/pages/knowledge/ItemCard.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { Tag, Copy, ChevronDown, ChevronRight, FileText } from 'lucide-react'
+import { Btn, Badge } from '../../components/ui'
+import Clickable from '../../components/Clickable'
+import { typeBadgeVariant, formatDate, useCopy } from './helpers'
+import type { KnowledgeItem } from './types'
+
+export function ItemCard({ item, onClick, selected, onSelect }: {
+  item: KnowledgeItem
+  onClick: () => void
+  selected: boolean
+  onSelect: (checked: boolean) => void
+}) {
+  const { copied, copy } = useCopy()
+  return (
+    <div className="flex items-start gap-2 animate-rise">
+      <input type="checkbox" aria-label={`Select ${item.title || 'Untitled'}`} checked={selected} onChange={e => onSelect(e.target.checked)}
+        className="mt-3.5 shrink-0 accent-accent" onClick={e => e.stopPropagation()} />
+      <Clickable onClick={onClick} className="flex-1 border border-border rounded-lg p-3.5 hover:border-border-strong hover:bg-bg-hover cursor-pointer transition-all">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-text-strong truncate">{item.title || 'Untitled'}</div>
+            {item.summary && <div className="text-[13px] text-muted mt-1 line-clamp-2">{item.summary}</div>}
+          </div>
+          <Badge variant={typeBadgeVariant(item.item_type)}>{item.item_type.replace(/_/g, ' ')}</Badge>
+        </div>
+        <div className="flex items-center gap-3 mt-2 text-[11px] text-muted">
+          <span>{formatDate(item.updated_at)}</span>
+          {item.namespace && item.namespace !== 'default' && <span className="bg-accent/10 text-accent px-1.5 py-0.5 rounded text-[10px]">{item.namespace}</span>}
+          {item.tags && <span className="flex items-center gap-0.5"><Tag size={10} />{typeof item.tags === 'string' ? item.tags : ''}</span>}
+          {item._score !== undefined && <span className="text-[10px] text-accent/70">{item._match_type}</span>}
+          <Btn className="ml-auto !px-1.5 !py-0.5 !text-[11px]" onClick={e => { e.stopPropagation(); copy(item.summary || item.title) }}><Copy size={10} /> {copied ? 'Copied!' : 'Copy'}</Btn>
+        </div>
+      </Clickable>
+    </div>
+  )
+}
+
+export function FileSubGroup({ filePath, items, onItemClick, selectedItems, onSelect }: {
+  filePath: string
+  items: KnowledgeItem[]
+  onItemClick: (id: string) => void
+  selectedItems: Set<string>
+  onSelect: (id: string, checked: boolean) => void
+}) {
+  const [open, setOpen] = useState(true)
+  const fileName = filePath === '__ungrouped__' ? 'Other' : filePath.split('/').pop() || filePath
+
+  return (
+    <div className="ml-2 border-l-2 border-border pl-2">
+      <button onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 py-1 text-left bg-transparent border-none cursor-pointer w-full">
+        {open ? <ChevronDown size={12} className="text-muted" /> : <ChevronRight size={12} className="text-muted" />}
+        <FileText size={12} className="text-muted" />
+        <span className="text-[12px] text-text truncate">{fileName}</span>
+        <span className="text-[10px] text-muted">({items.length})</span>
+      </button>
+      {open && (
+        <div className="space-y-1 mt-0.5">
+          {items.map(item => (
+            <ItemCard key={item.id} item={item} onClick={() => onItemClick(item.id)}
+              selected={selectedItems.has(item.id)}
+              onSelect={(checked) => onSelect(item.id, checked)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/website/src/pages/knowledge/SourceGroup.tsx
+++ b/website/src/pages/knowledge/SourceGroup.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, ChevronRight, FileText, FolderOpen } from 'lucide-react'
+import { Btn, Badge, ContentSkeleton } from '../../components/ui'
+import { knowledgeApi } from './api'
+import { ItemCard, FileSubGroup } from './ItemCard'
+import type { KnowledgeItem, Source } from './types'
+
+// Items fetched per expansion. The backend caps page size at 100
+// (dashboard/handlers/knowledge.py list_items), so requesting more would
+// silently truncate and break the in-group pager math.
+export const GROUP_PAGE_SIZE = 100
+
+// Sentinel source id for items that belong to no source. Mirrors the backend
+// `_NO_SOURCE` constant used by /items?source_id= and /source-counts.
+export const NO_SOURCE = '__none__'
+
+export interface SourceGroupProps {
+  /** Source id, or NO_SOURCE for the sourceless bucket. */
+  sourceId: string
+  source: Source | undefined
+  /** Item count for this source under the active filters. */
+  count: number
+  onItemClick: (id: string) => void
+  selectedItems: Set<string>
+  onSelect: (id: string, checked: boolean) => void
+  /** Filters currently applied to the list, forwarded to the scoped fetch. */
+  filters: { type?: string; status?: string; namespace?: string }
+  /**
+   * Reports the items this group currently renders, or null when it renders
+   * none (collapsed or unmounted). The page uses this to bound selection-wide
+   * actions to visible items only: reading the query cache directly would also
+   * pick up retained caches for groups that are no longer on screen, and a
+   * bulk Delete would then destroy items the user cannot see.
+   */
+  onVisibleItemsChange?: (sourceId: string, items: KnowledgeItem[] | null) => void
+  defaultOpen?: boolean
+}
+
+/**
+ * One collapsed row per source. Items are fetched only when the row is
+ * expanded, and the pager inside the row walks that source alone, so a large
+ * source can never push a smaller one onto a later page of a shared pager.
+ */
+export function SourceGroup({
+  sourceId, source, count, onItemClick, selectedItems, onSelect, filters,
+  onVisibleItemsChange, defaultOpen = false,
+}: SourceGroupProps) {
+  const [open, setOpen] = useState(defaultOpen)
+  const [page, setPage] = useState(1)
+
+  const isNoSource = sourceId === NO_SOURCE
+  const name = isNoSource ? 'No source' : (source?.name || 'Unknown source')
+  const subtitle = isNoSource ? 'Items added directly' : (source?.uri || '')
+  const isFolder = source?.source_type === 'local_folder' || source?.source_type === 'obsidian_vault'
+  const isArtifact = source?.source_type === 'artifact'
+  // Sub-group items: folder/vault sources group by file path; the aggregate
+  // "artifact" source groups per-artifact (label = artifact name).
+  const isGrouped = isFolder || isArtifact
+  const Icon = isFolder ? FolderOpen : FileText
+
+  // A filter change can shrink a source below the current page. The group stays
+  // mounted (keyed by sourceId), so without this the user sees an empty page.
+  useEffect(() => { setPage(1) }, [filters])
+
+  const { data, isLoading } = useQuery({
+    // Keyed under the shared 'knowledge-items' prefix so every existing
+    // invalidateQueries(['knowledge-items']) call site reaches this cache too.
+    queryKey: ['knowledge-items', 'source-items', sourceId, page, filters],
+    queryFn: () => {
+      const params = new URLSearchParams({
+        source_id: sourceId,
+        page: String(page),
+        limit: String(GROUP_PAGE_SIZE),
+      })
+      if (filters.type) params.set('type', filters.type)
+      if (filters.status) params.set('status', filters.status)
+      if (filters.namespace) params.set('namespace', filters.namespace)
+      return knowledgeApi<{ items: KnowledgeItem[]; total: number }>(`/items?${params}`)
+    },
+    // Lazy: nothing is requested until the user opens the row.
+    enabled: open,
+  })
+
+  const items = useMemo(() => data?.items ?? [], [data])
+  // Fall back to the badge count until the scoped fetch resolves, so the pager
+  // does not flicker between 1 page and its real page count.
+  const total = data?.total ?? count
+  const totalPages = Math.ceil(total / GROUP_PAGE_SIZE)
+
+  // Publish what is on screen, and retract it when this group stops rendering
+  // items so a later select-all cannot reach it.
+  useEffect(() => {
+    if (!onVisibleItemsChange) return
+    onVisibleItemsChange(sourceId, open ? items : null)
+    return () => onVisibleItemsChange(sourceId, null)
+  }, [onVisibleItemsChange, sourceId, open, items])
+
+  const fileGroups = useMemo(() => {
+    if (!isGrouped) return null
+    const groups = new Map<string, KnowledgeItem[]>()
+    for (const item of items) {
+      const key = item._file_path || '__ungrouped__'
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key)!.push(item)
+    }
+    return groups.size > 0 ? groups : null
+  }, [items, isGrouped])
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className="w-full flex items-center gap-2 px-3 py-2.5 bg-bg-elevated hover:bg-bg-hover text-left border-none cursor-pointer transition-colors"
+      >
+        {open ? <ChevronDown size={14} className="text-muted shrink-0" /> : <ChevronRight size={14} className="text-muted shrink-0" />}
+        <Icon size={14} className={isFolder ? 'text-amber-500 shrink-0' : 'text-accent shrink-0'} />
+        <span className="text-[13px] font-medium text-text-strong truncate">{name}</span>
+        <Badge variant="ok">{count}</Badge>
+        {source?.summary_topic && <span className="text-[11px] text-muted truncate max-w-[300px]">{source.summary_topic}</span>}
+        {subtitle && <span className="text-[11px] text-muted truncate ml-auto max-w-[200px]">{subtitle}</span>}
+      </button>
+      {open && (
+        <div className="space-y-1.5 p-2 pt-1">
+          {isLoading && !items.length ? <ContentSkeleton /> : fileGroups ? (
+            Array.from(fileGroups.entries()).map(([filePath, fileItems]) => (
+              <FileSubGroup key={filePath} filePath={filePath} items={fileItems}
+                onItemClick={onItemClick} selectedItems={selectedItems} onSelect={onSelect} />
+            ))
+          ) : (
+            items.map(item => (
+              <ItemCard key={item.id} item={item} onClick={() => onItemClick(item.id)}
+                selected={selectedItems.has(item.id)}
+                onSelect={(checked) => onSelect(item.id, checked)}
+              />
+            ))
+          )}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-3 pt-2 mt-1 border-t border-border">
+              <Btn disabled={page <= 1} onClick={() => setPage(p => p - 1)}>&larr; Prev</Btn>
+              <span className="text-[12px] text-text">Page {page} of {totalPages}</span>
+              <span className="text-[11px] text-muted">({total} items)</span>
+              <Btn disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}>Next &rarr;</Btn>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SourceGroup

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Search, BookOpen, Network, FolderSync, HelpCircle, FileText, Tag, X, Copy, ChevronDown, ChevronRight, FolderOpen } from 'lucide-react'
+import { Search, BookOpen, Network, FolderSync, HelpCircle, FileText, X, Copy } from 'lucide-react'
 import { Btn, SearchInput, Badge, EmptyState, ContentSkeleton } from '../../components/ui'
 import Clickable from '../../components/Clickable'
 import { knowledgeApi } from './api'
-import { typeBadgeVariant, formatDate, useCopy, ITEM_TYPES, STATUSES, ONBOARDING } from './helpers'
+import { useCopy, ITEM_TYPES, STATUSES, ONBOARDING } from './helpers'
 import DetailView from './DetailView'
 import SourcesList from './SourcesList'
+import { ItemCard } from './ItemCard'
+import { SourceGroup, NO_SOURCE } from './SourceGroup'
 import { EmbeddingStatus } from './EmbeddingStatus'
 import type { KnowledgeItem, Entity, Source, NamespaceInfo, IngestionJob } from './types'
 
@@ -55,32 +57,6 @@ function EntityAutocomplete({ query, onSelect }: { query: string; onSelect: (nam
   )
 }
 
-function ItemCard({ item, onClick, selected, onSelect }: { item: KnowledgeItem; onClick: () => void; selected: boolean; onSelect: (checked: boolean) => void }) {
-  const { copied, copy } = useCopy()
-  return (
-    <div className="flex items-start gap-2 animate-rise">
-      <input type="checkbox" aria-label={`Select ${item.title || 'Untitled'}`} checked={selected} onChange={e => onSelect(e.target.checked)}
-        className="mt-3.5 shrink-0 accent-accent" onClick={e => e.stopPropagation()} />
-      <Clickable onClick={onClick} className="flex-1 border border-border rounded-lg p-3.5 hover:border-border-strong hover:bg-bg-hover cursor-pointer transition-all">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium text-text-strong truncate">{item.title || 'Untitled'}</div>
-            {item.summary && <div className="text-[13px] text-muted mt-1 line-clamp-2">{item.summary}</div>}
-          </div>
-          <Badge variant={typeBadgeVariant(item.item_type)}>{item.item_type.replace(/_/g, ' ')}</Badge>
-        </div>
-        <div className="flex items-center gap-3 mt-2 text-[11px] text-muted">
-          <span>{formatDate(item.updated_at)}</span>
-          {item.namespace && item.namespace !== 'default' && <span className="bg-accent/10 text-accent px-1.5 py-0.5 rounded text-[10px]">{item.namespace}</span>}
-          {item.tags && <span className="flex items-center gap-0.5"><Tag size={10} />{typeof item.tags === 'string' ? item.tags : ''}</span>}
-          {item._score !== undefined && <span className="text-[10px] text-accent/70">{item._match_type}</span>}
-          <Btn className="ml-auto !px-1.5 !py-0.5 !text-[11px]" onClick={e => { e.stopPropagation(); copy(item.summary || item.title) }}><Copy size={10} /> {copied ? 'Copied!' : 'Copy'}</Btn>
-        </div>
-      </Clickable>
-    </div>
-  )
-}
-
 function BulkActions({ selectedIds, items, onDone }: { selectedIds: Set<string>; items: KnowledgeItem[]; onDone: () => void }) {
   const queryClient = useQueryClient()
 
@@ -93,9 +69,13 @@ function BulkActions({ selectedIds, items, onDone }: { selectedIds: Set<string>;
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: ['knowledge-items'] })
       const prev = queryClient.getQueriesData({ queryKey: ['knowledge-items'] })
-      queryClient.setQueriesData<{ items: KnowledgeItem[]; total: number }>({ queryKey: ['knowledge-items'] }, old =>
-        old ? { ...old, items: old.items.filter(i => !selectedIds.has(i.id)), total: old.total - selectedIds.size } : old
-      )
+      // The 'knowledge-items' prefix now also covers the source-counts cache,
+      // whose payload has no `items` array. Only rewrite item-shaped entries.
+      queryClient.setQueriesData<{ items: KnowledgeItem[]; total: number }>({ queryKey: ['knowledge-items'] }, old => {
+        if (!old || !Array.isArray(old.items)) return old
+        const kept = old.items.filter(i => !selectedIds.has(i.id))
+        return { ...old, items: kept, total: old.total - (old.items.length - kept.length) }
+      })
       return { prev }
     },
     onError: (_err, _vars, ctx) => {
@@ -117,9 +97,13 @@ function BulkActions({ selectedIds, items, onDone }: { selectedIds: Set<string>;
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: ['knowledge-items'] })
       const prev = queryClient.getQueriesData({ queryKey: ['knowledge-items'] })
-      queryClient.setQueriesData<{ items: KnowledgeItem[]; total: number }>({ queryKey: ['knowledge-items'] }, old =>
-        old ? { ...old, items: old.items.filter(i => !selectedIds.has(i.id)), total: old.total - selectedIds.size } : old
-      )
+      // The 'knowledge-items' prefix now also covers the source-counts cache,
+      // whose payload has no `items` array. Only rewrite item-shaped entries.
+      queryClient.setQueriesData<{ items: KnowledgeItem[]; total: number }>({ queryKey: ['knowledge-items'] }, old => {
+        if (!old || !Array.isArray(old.items)) return old
+        const kept = old.items.filter(i => !selectedIds.has(i.id))
+        return { ...old, items: kept, total: old.total - (old.items.length - kept.length) }
+      })
       return { prev }
     },
     onError: (_err, _vars, ctx) => {
@@ -152,105 +136,6 @@ function BulkActions({ selectedIds, items, onDone }: { selectedIds: Set<string>;
   )
 }
 
-function FileSubGroup({ filePath, items, onItemClick, selectedItems, onSelect }: {
-  filePath: string; items: KnowledgeItem[]
-  onItemClick: (id: string) => void; selectedItems: Set<string>; onSelect: (id: string, checked: boolean) => void
-}) {
-  const [open, setOpen] = useState(true)
-  const fileName = filePath === '__ungrouped__' ? 'Other' : filePath.split('/').pop() || filePath
-
-  return (
-    <div className="ml-2 border-l-2 border-border pl-2">
-      <button onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 py-1 text-left bg-transparent border-none cursor-pointer w-full">
-        {open ? <ChevronDown size={12} className="text-muted" /> : <ChevronRight size={12} className="text-muted" />}
-        <FileText size={12} className="text-muted" />
-        <span className="text-[12px] text-text truncate">{fileName}</span>
-        <span className="text-[10px] text-muted">({items.length})</span>
-      </button>
-      {open && (
-        <div className="space-y-1 mt-0.5">
-          {items.map(item => (
-            <ItemCard key={item.id} item={item} onClick={() => onItemClick(item.id)}
-              selected={selectedItems.has(item.id)}
-              onSelect={(checked) => onSelect(item.id, checked)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-interface SourceGroupProps {
-  source: Source | undefined
-  items: KnowledgeItem[]
-  onItemClick: (id: string) => void
-  selectedItems: Set<string>
-  onSelect: (id: string, checked: boolean) => void
-  defaultOpen?: boolean
-  // When true, the badge shows the source's true total (source.item_count) rather than the
-  // count of items on the current page, which is capped at MAX_PAGE_SIZE by the backend.
-  showSourceTotal?: boolean
-}
-
-function SourceGroup({ source, items, onItemClick, selectedItems, onSelect, defaultOpen = false, showSourceTotal = false }: SourceGroupProps) {
-  const [open, setOpen] = useState(defaultOpen)
-  const name = source?.name || 'Unknown source'
-  const subtitle = source?.uri || ''
-  const isFolder = source?.source_type === 'local_folder' || source?.source_type === 'obsidian_vault'
-  const isArtifact = source?.source_type === 'artifact'
-  // Sub-group items: folder/vault sources group by file path; the aggregate
-  // "artifact" source groups per-artifact (label = artifact name).
-  const isGrouped = isFolder || isArtifact
-  const Icon = isFolder ? FolderOpen : FileText
-
-  // Sub-group by file/artifact for grouped sources
-  const fileGroups = useMemo(() => {
-    if (!isGrouped) return null
-    const groups = new Map<string, KnowledgeItem[]>()
-    for (const item of items) {
-      const key = item._file_path || '__ungrouped__'
-      if (!groups.has(key)) groups.set(key, [])
-      groups.get(key)!.push(item)
-    }
-    return groups.size > 0 ? groups : null
-  }, [items, isGrouped])
-
-  return (
-    <div className="border border-border rounded-lg overflow-hidden">
-      <button
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center gap-2 px-3 py-2.5 bg-bg-elevated hover:bg-bg-hover text-left border-none cursor-pointer transition-colors"
-      >
-        {open ? <ChevronDown size={14} className="text-muted shrink-0" /> : <ChevronRight size={14} className="text-muted shrink-0" />}
-        <Icon size={14} className={isFolder ? "text-amber-500 shrink-0" : "text-accent shrink-0"} />
-        <span className="text-[13px] font-medium text-text-strong truncate">{name}</span>
-        <Badge variant="ok">{showSourceTotal ? (source?.item_count ?? items.length) : items.length}</Badge>
-        {source?.summary_topic && <span className="text-[11px] text-muted truncate max-w-[300px]">{source.summary_topic}</span>}
-        {subtitle && <span className="text-[11px] text-muted truncate ml-auto max-w-[200px]">{subtitle}</span>}
-      </button>
-      {open && (
-        <div className="space-y-1.5 p-2 pt-1">
-          {fileGroups ? (
-            Array.from(fileGroups.entries()).map(([filePath, fileItems]) => (
-              <FileSubGroup key={filePath} filePath={filePath} items={fileItems}
-                onItemClick={onItemClick} selectedItems={selectedItems} onSelect={onSelect} />
-            ))
-          ) : (
-            items.map(item => (
-              <ItemCard key={item.id} item={item} onClick={() => onItemClick(item.id)}
-                selected={selectedItems.has(item.id)}
-                onSelect={(checked) => onSelect(item.id, checked)}
-              />
-            ))
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
 export default function KnowledgePage() {
   const queryClient = useQueryClient()
   const [tab, setTab] = useState<Tab>('list')
@@ -267,12 +152,21 @@ export default function KnowledgePage() {
   const [uploadNamespace, setUploadNamespace] = useState('default')
   const [showAutocomplete, setShowAutocomplete] = useState(false)
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set())
+  // Items currently rendered by each expanded SourceGroup. Selection-wide
+  // actions read this instead of the react-query cache, so they can never reach
+  // an item that is not on screen (a retained cache from a previously expanded
+  // source would otherwise be swept into a bulk Delete).
+  const [visibleBySource, setVisibleBySource] = useState<Record<string, KnowledgeItem[]>>({})
   const searchRef = useRef<HTMLDivElement>(null)
   const entitySectionRef = useRef<HTMLDivElement>(null)
   const listContainerRef = useRef<HTMLDivElement>(null)
   const limit = query ? 20 : MAX_PAGE_SIZE
+  // Source-first list: when nothing is searched the top level renders one row
+  // per source and each row pages within itself, so the item-level query below
+  // is only used for flat search results.
+  const sourceFirst = !query
 
-  const { data: itemsData, isLoading: loading } = useQuery({
+  const { data: itemsData, isLoading: itemsLoading } = useQuery({
     queryKey: ['knowledge-items', { page, query, typeFilter, statusFilter, namespaceFilter, limit }],
     queryFn: () => {
       const params = new URLSearchParams({ page: String(page), limit: String(limit) })
@@ -282,17 +176,32 @@ export default function KnowledgePage() {
       if (namespaceFilter) params.set('namespace', namespaceFilter)
       return knowledgeApi<{ items: KnowledgeItem[]; total: number }>(`/items?${params}`)
     },
+    enabled: !sourceFirst,
   })
+
+  // Per-source counts under the active filters. This is what makes every source
+  // visible at once: the rows come from these counts, not from whichever items
+  // happened to land on a shared page.
+  const { data: countsData, isLoading: countsLoading } = useQuery({
+    // Shared 'knowledge-items' prefix: see SourceGroup for the rationale.
+    queryKey: ['knowledge-items', 'source-counts', { typeFilter, statusFilter, namespaceFilter }],
+    queryFn: () => {
+      const params = new URLSearchParams()
+      if (typeFilter) params.set('type', typeFilter)
+      if (statusFilter) params.set('status', statusFilter)
+      if (namespaceFilter) params.set('namespace', namespaceFilter)
+      const qs = params.toString()
+      return knowledgeApi<{ counts: Record<string, number>; total: number }>(`/source-counts${qs ? `?${qs}` : ''}`)
+    },
+    enabled: sourceFirst,
+  })
+
   // Memoize so the `?? []` fallback doesn't create a new array reference on
-  // every render — that reference feeds the groupedItems useMemo and the
-  // keyboard-shortcut useEffect below, and an unstable identity would make them
-  // recompute/re-subscribe each render.
+  // every render — that reference feeds the keyboard-shortcut useEffect below,
+  // and an unstable identity would make it re-subscribe each render.
   const items = useMemo(() => itemsData?.items ?? [], [itemsData])
-  const total = itemsData?.total ?? 0
-  // Source-group badges show the source's true item_count only when the list is unfiltered.
-  // Under a search/type/namespace filter the badge falls back to the matched count on the page,
-  // since item_count (from /sources) is the source's unfiltered, all-namespace total.
-  const showSourceTotals = !query && !typeFilter && !namespaceFilter
+  const total = sourceFirst ? (countsData?.total ?? 0) : (itemsData?.total ?? 0)
+  const loading = sourceFirst ? countsLoading : itemsLoading
 
   const { data: stats } = useQuery({
     queryKey: ['knowledge-stats'],
@@ -345,22 +254,34 @@ export default function KnowledgePage() {
     enabled: !!selectedEntity,
   })
 
-  const sourcesMap = useMemo(() => {
-    const map = new Map<string, Source>()
-    for (const s of sources) map.set(s.id, s)
-    return map
-  }, [sources])
-
-  const groupedItems = useMemo(() => {
-    if (query) return null // flat mode on search
-    const groups = new Map<string, KnowledgeItem[]>()
-    for (const item of items) {
-      const key = item.source_id || '__none__'
-      if (!groups.has(key)) groups.set(key, [])
-      groups.get(key)!.push(item)
+  // One row per source that has at least one matching item, ordered the way the
+  // Sources tab orders them (most recently updated first) with the sourceless
+  // bucket last. Derived from /source-counts, so a source is never hidden just
+  // because its items fell on a later page.
+  const sourceRows = useMemo(() => {
+    if (!sourceFirst) return null
+    const counts = countsData?.counts ?? {}
+    // Explicit element type: rows for unknown or sourceless buckets carry no
+    // Source record, which inference from the first map alone would reject.
+    const rows: { sourceId: string; source: Source | undefined; count: number }[] = sources
+      .filter(s => (counts[s.id] ?? 0) > 0)
+      .map(s => ({ sourceId: s.id, source: s as Source | undefined, count: counts[s.id] }))
+    // Sources present in counts but missing from /sources (deleted row, stale
+    // cache) still get a row so their items remain reachable.
+    const known = new Set(sources.map(s => s.id))
+    for (const [sid, count] of Object.entries(counts)) {
+      if (sid !== NO_SOURCE && !known.has(sid)) rows.push({ sourceId: sid, source: undefined, count })
     }
-    return groups
-  }, [items, query])
+    if (counts[NO_SOURCE]) rows.push({ sourceId: NO_SOURCE, source: undefined, count: counts[NO_SOURCE] })
+    return rows
+  }, [sourceFirst, countsData, sources])
+
+  // Filters forwarded to each group's scoped item fetch. Memoized because it is
+  // part of the group query key.
+  const groupFilters = useMemo(
+    () => ({ type: typeFilter, status: statusFilter, namespace: namespaceFilter }),
+    [typeFilter, statusFilter, namespaceFilter]
+  )
 
   const ingestMutation = useMutation({
     mutationFn: async ({ files, namespace }: { files: File[]; namespace: string }) => {
@@ -393,6 +314,25 @@ export default function KnowledgePage() {
     ingestMutation.mutate({ files, namespace: uploadNamespace || 'default' })
   }
 
+  // In flat search mode the page owns the items; in source-first mode the
+  // expanded groups do.
+  const visibleItems = useMemo(
+    () => (sourceFirst ? Object.values(visibleBySource).flat() : items),
+    [sourceFirst, visibleBySource, items]
+  )
+
+  // Selection is bounded to what is on screen. A group collapsing or paging
+  // away removes its items from `visibleItems`, so drop their IDs here too:
+  // otherwise a bulk Delete would act on items the user can no longer see.
+  useEffect(() => {
+    setSelectedItems(prev => {
+      if (prev.size === 0) return prev
+      const visible = new Set(visibleItems.map(i => i.id))
+      const kept = new Set([...prev].filter(id => visible.has(id)))
+      return kept.size === prev.size ? prev : kept
+    })
+  }, [visibleItems])
+
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -414,19 +354,22 @@ export default function KnowledgePage() {
         else if (selectedId) { setSelectedId(null); e.preventDefault() }
         else if (selectedItems.size > 0) { setSelectedItems(new Set()); e.preventDefault() }
       } else if (e.key === 'ArrowRight' && !e.altKey && !e.ctrlKey) {
-        if (!selectedId && page < Math.ceil(total / limit)) { setPage(p => p + 1); e.preventDefault() }
+        // Arrow paging drives the flat search pager only; in source-first mode
+        // each group owns its own pager and `page` is unread.
+        if (!sourceFirst && !selectedId && page < Math.ceil(total / limit)) { setPage(p => p + 1); e.preventDefault() }
       } else if (e.key === 'ArrowLeft' && !e.altKey && !e.ctrlKey) {
-        if (!selectedId && page > 1) { setPage(p => p - 1); e.preventDefault() }
+        if (!sourceFirst && !selectedId && page > 1) { setPage(p => p - 1); e.preventDefault() }
       } else if (e.key === 'a' && (e.ctrlKey || e.metaKey) && tab === 'list' && !selectedId) {
         if (listContainerRef.current?.contains(document.activeElement || target)) {
           e.preventDefault()
-          setSelectedItems(new Set(items.map(i => i.id)))
+          // Only what is on screen: never a retained cache for a collapsed source.
+          setSelectedItems(new Set(visibleItems.map(i => i.id)))
         }
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [selectedId, page, total, limit, items, tab, selectedItems.size, showHelp])
+  }, [selectedId, page, total, limit, tab, selectedItems.size, showHelp, sourceFirst, visibleItems])
 
   useEffect(() => {
     setSelectedItems(new Set())
@@ -437,6 +380,19 @@ export default function KnowledgePage() {
       entitySectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }
   }, [selectedEntity])
+
+  const handleVisibleItemsChange = useCallback((sourceId: string, groupItems: KnowledgeItem[] | null) => {
+    setVisibleBySource(prev => {
+      if (groupItems === null) {
+        if (!(sourceId in prev)) return prev
+        const next = { ...prev }
+        delete next[sourceId]
+        return next
+      }
+      if (prev[sourceId] === groupItems) return prev
+      return { ...prev, [sourceId]: groupItems }
+    })
+  }, [])
 
   const handleEntitySelect = useCallback((name: string) => {
     setTab('graph')
@@ -535,32 +491,41 @@ export default function KnowledgePage() {
               </div>
 
               {selectedItems.size > 0 && (
-                <BulkActions selectedIds={selectedItems} items={items} onDone={() => setSelectedItems(new Set())} />
+                <BulkActions selectedIds={selectedItems} items={visibleItems} onDone={() => setSelectedItems(new Set())} />
               )}
 
-              {loading ? <ContentSkeleton /> : !items.length ? (
+              {loading ? <ContentSkeleton /> : sourceRows ? (
+                !sourceRows.length ? (
+                  <EmptyState icon={<Search size={40} />} title="No items match your filters" subtitle="Try a different type, status, or namespace" />
+                ) : (
+                  <div className="space-y-2 mt-3">
+                    {sourceRows.map(row => (
+                      <SourceGroup
+                        key={row.sourceId}
+                        sourceId={row.sourceId}
+                        source={row.source}
+                        count={row.count}
+                        filters={groupFilters}
+                        onVisibleItemsChange={handleVisibleItemsChange}
+                        // A single source is opened by default: there is nothing
+                        // to choose between, so an extra click buys nothing.
+                        defaultOpen={sourceRows.length === 1}
+                        onItemClick={(id) => setSelectedId(id)}
+                        selectedItems={selectedItems}
+                        onSelect={(id, checked) => {
+                          setSelectedItems(prev => {
+                            const next = new Set(prev)
+                            if (checked) next.add(id)
+                            else next.delete(id)
+                            return next
+                          })
+                        }}
+                      />
+                    ))}
+                  </div>
+                )
+              ) : !items.length ? (
                 <EmptyState icon={<Search size={40} />} title="No items match your search" subtitle="Try different keywords or filters" />
-              ) : groupedItems ? (
-                <div className="space-y-2 mt-3">
-                  {Array.from(groupedItems.entries()).map(([sourceId, groupItems]) => (
-                    <SourceGroup
-                      key={sourceId}
-                      source={sourcesMap.get(sourceId)}
-                      items={groupItems}
-                      showSourceTotal={showSourceTotals}
-                      onItemClick={(id) => setSelectedId(id)}
-                      selectedItems={selectedItems}
-                      onSelect={(id, checked) => {
-                        setSelectedItems(prev => {
-                          const next = new Set(prev)
-                          if (checked) next.add(id)
-                          else next.delete(id)
-                          return next
-                        })
-                      }}
-                    />
-                  ))}
-                </div>
               ) : (
                 <div className="space-y-2 mt-3">
                   {items.map(item => (
@@ -578,7 +543,9 @@ export default function KnowledgePage() {
                   ))}
                 </div>
               )}
-              {totalPages > 1 && (
+              {/* Top-level pager exists only for flat search results. In
+                  source-first mode each group owns its own pager. */}
+              {!sourceFirst && totalPages > 1 && (
                 <div className="flex items-center justify-center gap-3 mt-4 py-3 border-t border-border">
                   <Btn disabled={page <= 1} onClick={() => setPage(p => p - 1)}>&larr; Prev</Btn>
                   <span className="text-[13px] text-text font-medium">Page {page} of {totalPages}</span>

--- a/website/src/test/KnowledgeListView.test.tsx
+++ b/website/src/test/KnowledgeListView.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 
-// Mock the knowledge API so we control /items and /sources responses
+// Mock the knowledge API so we control /items, /sources and /source-counts.
 const mockKnowledgeApi = vi.fn()
 vi.mock('../pages/knowledge/api', () => ({
   knowledgeApi: (...args: unknown[]) => mockKnowledgeApi(...args),
@@ -19,45 +20,191 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
   </MemoryRouter>
 )
 
-// One source with 436 total items, but the page only returns a 3-item slice and a
-// grand total of 482 — mirrors the real bug (backend caps the page at 100).
-const pageItems = [
-  { id: 'i1', title: 'A', item_type: 'document', status: 'active', source_id: 's1', created_at: '2026-01-01', updated_at: '2026-01-01' },
-  { id: 'i2', title: 'B', item_type: 'document', status: 'active', source_id: 's1', created_at: '2026-01-01', updated_at: '2026-01-01' },
-  { id: 'i3', title: 'C', item_type: 'document', status: 'active', source_id: 's1', created_at: '2026-01-01', updated_at: '2026-01-01' },
+// Reproduces the reported bug shape: three sources of wildly different sizes.
+// Under the old shared item pager, `Artifacts` (11 items) only appeared on
+// whichever page its items happened to land on -- page 5 of 10 -- so it was
+// invisible from page 1.
+const SOURCES = [
+  { id: 's1', name: 'PersonalKnowledgeBase', source_type: 'local_folder', uri: '/pkb', sync_status: 'synced', item_count: 378 },
+  { id: 's2', name: 'WorkforceEmploymentKnowledgeBase', source_type: 'local_folder', uri: '/wfe', sync_status: 'synced', item_count: 542 },
+  { id: 's3', name: 'Artifacts', source_type: 'artifact', uri: 'artifact://', sync_status: 'synced', item_count: 11 },
 ]
+
+const COUNTS = { s1: 378, s2: 542, s3: 11, __none__: 22 }
+
+function item(id: string, sourceId: string, title: string) {
+  return {
+    id, title, item_type: 'document', status: 'active', source_id: sourceId,
+    created_at: '2026-01-01', updated_at: '2026-01-01',
+  }
+}
+
+let itemCalls: string[] = []
 
 beforeEach(() => {
   vi.clearAllMocks()
   qc.clear()
+  itemCalls = []
   mockKnowledgeApi.mockImplementation((path: string) => {
-    if (path.startsWith('/items')) return Promise.resolve({ items: pageItems, total: 482 })
-    if (path === '/sources') return Promise.resolve([
-      { id: 's1', name: 'Opportunity Planner', source_type: 'local_folder', uri: '/op', sync_status: 'synced', item_count: 436 },
-    ])
-    if (path === '/stats') return Promise.resolve({ items: 482, entities: 0, relations: 0, sources: 1 })
-    if (path === '/namespaces') return Promise.resolve([])
+    const p = String(path)
+    if (p.startsWith('/items')) {
+      itemCalls.push(p)
+      const sid = new URLSearchParams(p.split('?')[1]).get('source_id')
+      if (sid) {
+        const total = COUNTS[sid as keyof typeof COUNTS] ?? 0
+        return Promise.resolve({ items: [item(`${sid}-a`, sid, `${sid} item A`)], total })
+      }
+      // Flat search branch
+      return Promise.resolve({ items: [item('f1', 's1', 'search hit')], total: 1 })
+    }
+    if (p.startsWith('/source-counts')) {
+      return Promise.resolve({ counts: COUNTS, total: 953 })
+    }
+    if (p === '/sources') return Promise.resolve(SOURCES)
+    if (p === '/stats') return Promise.resolve({ items: 953, entities: 0, relations: 0, sources: 3 })
+    if (p === '/namespaces') return Promise.resolve([])
+    if (p === '/config') return Promise.resolve({ enabled: true, supported_formats: ['.md'] })
     return Promise.resolve([])
   })
 })
 
-describe('Knowledge List View — pagination math + per-source badge total', () => {
-  it('badge shows the source total (item_count), not the loaded page slice', async () => {
+describe('Knowledge List View — source-first rows', () => {
+  it('shows every source at once, no scrolling through a shared pager', async () => {
     render(<KnowledgePage />, { wrapper: Wrapper })
-    // With the fix the badge reflects source.item_count (436). Pre-fix it would render the
-    // 3-item page slice, so 436 never appears.
-    expect(await screen.findByText('Opportunity Planner')).toBeInTheDocument()
-    expect(await screen.findByText('436')).toBeInTheDocument()
+    expect(await screen.findByText('PersonalKnowledgeBase')).toBeInTheDocument()
+    expect(await screen.findByText('WorkforceEmploymentKnowledgeBase')).toBeInTheDocument()
+    // The 11-item source used to be stranded on page 5. It is now on the first screen.
+    expect(await screen.findByText('Artifacts')).toBeInTheDocument()
   })
 
-  it('requests the backend page cap (limit=100) so pagination math is correct', async () => {
+  it('renders a bucket for items that belong to no source', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    expect(await screen.findByText('No source')).toBeInTheDocument()
+    expect(await screen.findByText('22')).toBeInTheDocument()
+  })
+
+  it('badges show the per-source count from /source-counts', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    expect(await screen.findByText('378')).toBeInTheDocument()
+    expect(await screen.findByText('542')).toBeInTheDocument()
+    expect(await screen.findByText('11')).toBeInTheDocument()
+  })
+
+  it('does not render a top-level pager in source-first mode', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await screen.findByText('PersonalKnowledgeBase')
+    // 953 items / 100 would have been "Page 1 of 10" under the old shared pager.
+    expect(screen.queryByText(/^Page 1 of 10$/)).not.toBeInTheDocument()
+  })
+
+  it('fetches no items until a source row is expanded', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await screen.findByText('PersonalKnowledgeBase')
+    await waitFor(() => expect(mockKnowledgeApi).toHaveBeenCalled())
+    expect(itemCalls).toHaveLength(0)
+  })
+
+  it('expanding a source fetches only that source, scoped and paged', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const row = await screen.findByText('Artifacts')
+    await userEvent.click(row)
+    await waitFor(() => expect(itemCalls.length).toBeGreaterThan(0))
+    expect(itemCalls[0]).toContain('source_id=s3')
+    expect(itemCalls[0]).toContain('limit=100')
+    expect(itemCalls[0]).toContain('page=1')
+  })
+
+  it('shows an in-group pager scoped to the expanded source total', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByText('PersonalKnowledgeBase'))
+    // 378 items at 100/page -> 4 pages, from this source alone (not 953/100 = 10).
+    expect(await screen.findByText('Page 1 of 4')).toBeInTheDocument()
+  })
+
+  it('a small source gets no in-group pager', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByText('Artifacts'))
+    await waitFor(() => expect(itemCalls.length).toBeGreaterThan(0))
+    // 11 items fit on one page.
+    expect(screen.queryByText(/^Page 1 of 1$/)).not.toBeInTheDocument()
+  })
+
+  it('forwards active filters to /source-counts so badges stay truthful', async () => {
     render(<KnowledgePage />, { wrapper: Wrapper })
     await waitFor(() => {
-      const itemsCall = mockKnowledgeApi.mock.calls.find(c => String(c[0]).startsWith('/items'))
-      expect(itemsCall).toBeTruthy()
-      expect(String(itemsCall![0])).toContain('limit=100')
+      const call = mockKnowledgeApi.mock.calls.find(c => String(c[0]).startsWith('/source-counts'))
+      expect(call).toBeTruthy()
+      // statusFilter defaults to 'active'
+      expect(String(call![0])).toContain('status=active')
     })
-    // total 482 / 100 = 5 pages -> the pager renders and reports the right page count
-    expect(await screen.findByText('Page 1 of 5')).toBeInTheDocument()
+  })
+
+  it('copies content of items selected inside a group', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByText('Artifacts'))
+    // Check the group's item, then use the page-level bulk action.
+    await userEvent.click(await screen.findByLabelText(/^Select s3 item A$/))
+    await userEvent.click(await screen.findByText(/Copy Content/))
+    // Regression: `items` is empty in source-first mode, so a page-array-based
+    // implementation copied an empty string here.
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    expect(writeText.mock.calls[0][0]).toContain('s3 item A')
+  })
+
+  it('select-all reaches only items rendered on screen', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    // Expand one source, then collapse it: its react-query cache is retained.
+    const artifacts = await screen.findByText('Artifacts')
+    await userEvent.click(artifacts)
+    await screen.findByLabelText(/^Select s3 item A$/)
+    await userEvent.click(artifacts)
+    await waitFor(() => expect(screen.queryByLabelText(/^Select s3 item A$/)).not.toBeInTheDocument())
+    // Expand a different source and select all.
+    await userEvent.click(await screen.findByText('PersonalKnowledgeBase'))
+    await screen.findByLabelText(/^Select s1 item A$/)
+    await userEvent.keyboard('{Control>}a{/Control}')
+    // Regression: reading the query cache would also select the collapsed
+    // source's retained item, which a bulk Delete would then destroy unseen.
+    await waitFor(() => expect(screen.getByText(/\d+ selected/)).toBeInTheDocument())
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+  })
+
+  it('drops selected IDs when their source collapses off screen', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const artifacts = await screen.findByText('Artifacts')
+    await userEvent.click(artifacts)
+    await userEvent.click(await screen.findByLabelText(/^Select s3 item A$/))
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+    // Collapsing hides the item. Regression: keeping its ID in the selection
+    // let a bulk Delete destroy an item the user could no longer see.
+    await userEvent.click(artifacts)
+    await waitFor(() => expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument())
+  })
+
+  it('keys per-source queries under the knowledge-items prefix so mutations invalidate them', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByText('Artifacts'))
+    await waitFor(() => expect(itemCalls.length).toBeGreaterThan(0))
+    const keys = qc.getQueryCache().getAll().map(q => q.queryKey)
+    // Both new caches must sit under the prefix every existing
+    // invalidateQueries(['knowledge-items']) call site already targets.
+    expect(keys.some(k => k[0] === 'knowledge-items' && k[1] === 'source-items')).toBe(true)
+    expect(keys.some(k => k[0] === 'knowledge-items' && k[1] === 'source-counts')).toBe(true)
+    // Confirm a prefix invalidation matches them.
+    const matched = qc.getQueryCache().findAll({ queryKey: ['knowledge-items'] })
+    expect(matched.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('searching falls back to a flat list with a top-level pager', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const input = await screen.findByPlaceholderText(/Search knowledge/i)
+    await userEvent.type(input, 'hit{Enter}')
+    // Flat mode: the search branch is queried without a source_id scope.
+    await waitFor(() => {
+      expect(itemCalls.some(c => c.includes('q=hit') && !c.includes('source_id='))).toBe(true)
+    })
+    expect(await screen.findByText('search hit')).toBeInTheDocument()
   })
 })

--- a/website/src/test/KnowledgeSourceGroup.test.tsx
+++ b/website/src/test/KnowledgeSourceGroup.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockKnowledgeApi = vi.fn()
+vi.mock('../pages/knowledge/api', () => ({
+  knowledgeApi: (...args: unknown[]) => mockKnowledgeApi(...args),
+}))
+
+const { SourceGroup, NO_SOURCE, GROUP_PAGE_SIZE } = await import('../pages/knowledge/SourceGroup')
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+)
+
+const FOLDER_SOURCE = {
+  id: 's1', name: 'PersonalKnowledgeBase', source_type: 'local_folder',
+  uri: '/home/me/pkb', sync_status: 'synced', item_count: 378,
+}
+
+function item(id: string, filePath?: string) {
+  return {
+    id, title: `Item ${id}`, item_type: 'document', status: 'active',
+    source_id: 's1', created_at: '2026-01-01', updated_at: '2026-01-01',
+    ...(filePath ? { _file_path: filePath } : {}),
+  }
+}
+
+let calls: string[] = []
+let respond: (path: string) => unknown
+
+function renderGroup(props: Record<string, unknown> = {}) {
+  return render(
+    <SourceGroup
+      sourceId="s1"
+      source={FOLDER_SOURCE}
+      count={378}
+      filters={{ status: 'active' }}
+      onItemClick={() => {}}
+      selectedItems={new Set()}
+      onSelect={() => {}}
+      {...props}
+    />,
+    { wrapper: Wrapper }
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  qc.clear()
+  calls = []
+  respond = () => ({ items: [item('a'), item('b')], total: 378 })
+  mockKnowledgeApi.mockImplementation((path: string) => {
+    calls.push(String(path))
+    return Promise.resolve(respond(String(path)))
+  })
+})
+
+describe('SourceGroup', () => {
+  it('renders the source name and its filter-aware count while collapsed', () => {
+    renderGroup()
+    expect(screen.getByText('PersonalKnowledgeBase')).toBeInTheDocument()
+    expect(screen.getByText('378')).toBeInTheDocument()
+  })
+
+  it('fetches nothing while collapsed', () => {
+    renderGroup()
+    expect(mockKnowledgeApi).not.toHaveBeenCalled()
+  })
+
+  it('fetches items scoped to its own source on expand', async () => {
+    renderGroup()
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0]).toContain('source_id=s1')
+    expect(calls[0]).toContain(`limit=${GROUP_PAGE_SIZE}`)
+  })
+
+  it('forwards active filters to the scoped fetch', async () => {
+    renderGroup({ filters: { type: 'document', status: 'archived', namespace: 'team' } })
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0]).toContain('type=document')
+    expect(calls[0]).toContain('status=archived')
+    expect(calls[0]).toContain('namespace=team')
+  })
+
+  it('pages within its own source only', async () => {
+    renderGroup()
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    // 378 / 100 = 4 pages for this source alone
+    expect(await screen.findByText('Page 1 of 4')).toBeInTheDocument()
+    await userEvent.click(screen.getByText(/Next/))
+    await waitFor(() => expect(calls.some(c => c.includes('page=2'))).toBe(true))
+    expect(await screen.findByText('Page 2 of 4')).toBeInTheDocument()
+    // Every request stayed scoped to this source.
+    expect(calls.every(c => c.includes('source_id=s1'))).toBe(true)
+  })
+
+  it('hides the pager when the source fits on one page', async () => {
+    respond = () => ({ items: [item('a')], total: 3 })
+    renderGroup({ count: 3 })
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(screen.queryByText(/^Page /)).not.toBeInTheDocument()
+  })
+
+  it('uses the badge count for pager math until the fetch resolves', async () => {
+    // Never resolves: the pager must still derive 4 pages from `count`.
+    mockKnowledgeApi.mockImplementation(() => new Promise(() => {}))
+    renderGroup()
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    expect(await screen.findByText('Page 1 of 4')).toBeInTheDocument()
+  })
+
+  it('sub-groups folder-source items by file path', async () => {
+    respond = () => ({
+      items: [item('a', '/home/me/pkb/notes.md'), item('b', '/home/me/pkb/notes.md'), item('c', '/home/me/pkb/todo.md')],
+      total: 3,
+    })
+    renderGroup({ count: 3 })
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    expect(await screen.findByText('notes.md')).toBeInTheDocument()
+    expect(screen.getByText('todo.md')).toBeInTheDocument()
+    expect(screen.getByText('(2)')).toBeInTheDocument()
+  })
+
+  it('renders flat item cards for non-folder sources', async () => {
+    respond = () => ({ items: [item('a')], total: 1 })
+    renderGroup({
+      count: 1,
+      source: { ...FOLDER_SOURCE, source_type: 'local_file' },
+    })
+    await userEvent.click(screen.getByText('PersonalKnowledgeBase'))
+    expect(await screen.findByText('Item a')).toBeInTheDocument()
+    expect(screen.queryByText('notes.md')).not.toBeInTheDocument()
+  })
+
+  it('labels the sourceless bucket and queries it with the __none__ sentinel', async () => {
+    respond = () => ({ items: [item('a')], total: 1 })
+    renderGroup({ sourceId: NO_SOURCE, source: undefined, count: 1 })
+    expect(screen.getByText('No source')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('No source'))
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0]).toContain(`source_id=${encodeURIComponent(NO_SOURCE)}`)
+  })
+
+  it('resets to page 1 when the filters change', async () => {
+    const { rerender } = renderGroup({ defaultOpen: true })
+    await screen.findByText('Page 1 of 4')
+    await userEvent.click(screen.getByText(/Next/))
+    expect(await screen.findByText('Page 2 of 4')).toBeInTheDocument()
+    // A filter change can shrink the source below the current page; without a
+    // reset the still-mounted group would sit on an out-of-range page.
+    rerender(
+      <SourceGroup
+        sourceId="s1"
+        source={FOLDER_SOURCE}
+        count={378}
+        filters={{ status: 'archived' }}
+        onItemClick={() => {}}
+        selectedItems={new Set()}
+        onSelect={() => {}}
+        defaultOpen
+      />
+    )
+    expect(await screen.findByText('Page 1 of 4')).toBeInTheDocument()
+  })
+
+  it('opens pre-expanded when defaultOpen is set', async () => {
+    renderGroup({ defaultOpen: true })
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
The Knowledge Library list view paginated items globally and then grouped
whichever items landed on the current page by source. A large source spanned
several pages, so smaller sources were invisible until you happened to page
onto them: with 953 items across four sources, an 11-item source only appeared
on page 5 of 10. The group badge also showed the source's true total while the
expanded body held only that page's slice.

The top level now renders one collapsed row per source, derived from per-source
counts rather than from a shared page. Expanding a row lazily fetches that
source's items and pages within that source alone.

Backend:
- list_items accepts source_id, with a __none__ sentinel for sourceless items,
  applied in both the SQL branch and the hybrid-search branch. The reported
  total is scoped, so a group's pager math is correct.
- New GET /api/knowledge/source-counts returns per-source counts under the
  active type/status/namespace filters, so badges stay truthful when filtered.

Frontend:
- ItemCard and FileSubGroup extracted to ItemCard.tsx for reuse.
- New SourceGroup.tsx: lazy scoped fetch on expand plus an in-group pager.
- index.tsx drives rows off /source-counts and keeps the flat list with a
  top-level pager for search results only.

Tests: 15 backend, 21 frontend. Full frontend suite 4421 passed, backend
knowledge tests 314 passed, typecheck and eslint clean.

### Before

https://github.com/user-attachments/assets/fd839c24-a032-4379-aa8e-d2835ba100e8



### After


https://github.com/user-attachments/assets/f203ea6b-d1f0-4144-9506-1fa743fadf44


