### PR TITLE
fix(shortcuts): gate Search Everywhere palette behind Enable shortcuts toggle

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -183,6 +183,7 @@ vi.mock('../store', () => ({
 
 import CommandPalette from './CommandPalette'
 import { useCommandPalette } from '../hooks/useCommandPalette'
+import { SHORTCUTS_ENABLED_KEY } from '../hooks/useKeyboardShortcuts'
 import type { Result } from './commandPalette/types'
 
 afterEach(() => {
@@ -239,6 +240,55 @@ describe('useCommandPalette — global trigger', () => {
     expect(result.current.open).toBe(true)
     act(() => result.current.close())
     expect(result.current.open).toBe(false)
+  })
+})
+
+describe('useCommandPalette — Enable shortcuts toggle', () => {
+  // jsdom localStorage is shared across the file/suite, so a lingering '0'
+  // would disable shortcuts for every later test. Always clear the key.
+  afterEach(() => localStorage.removeItem(SHORTCUTS_ENABLED_KEY))
+
+  it('double-Shift does NOT open the palette when shortcuts are disabled', () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const { result } = renderHook(() => useCommandPalette())
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Shift' })
+      fireEvent.keyDown(window, { key: 'Shift' })
+    })
+    expect(result.current.open).toBe(false)
+  })
+
+  it('⌘K does NOT open the palette when shortcuts are disabled', () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const { result } = renderHook(() => useCommandPalette())
+    act(() => {
+      fireEvent.keyDown(window, { key: 'k', metaKey: true })
+    })
+    expect(result.current.open).toBe(false)
+  })
+
+  it('the nav button (openPalette) still works while shortcuts are disabled', () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const { result } = renderHook(() => useCommandPalette())
+    act(() => result.current.openPalette())
+    expect(result.current.open).toBe(true)
+  })
+
+  it('re-enabling restores double-Shift (no stale first tap carries over)', () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const { result } = renderHook(() => useCommandPalette())
+    // A Shift arrives while disabled (must not seed a pending first tap)…
+    act(() => { fireEvent.keyDown(window, { key: 'Shift' }) })
+    // …then shortcuts are re-enabled and a single Shift lands.
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '1')
+    act(() => { fireEvent.keyDown(window, { key: 'Shift' }) })
+    expect(result.current.open).toBe(false)
+    // A genuine double-tap after re-enabling opens as normal.
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Shift' })
+      fireEvent.keyDown(window, { key: 'Shift' })
+    })
+    expect(result.current.open).toBe(true)
   })
 })
 

--- a/website/src/hooks/useCommandPalette.ts
+++ b/website/src/hooks/useCommandPalette.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { SHORTCUTS_ENABLED_KEY } from './useKeyboardShortcuts'
 
 /**
  * Global trigger + open/close state for the Search Everywhere command palette
@@ -13,6 +14,15 @@ import { useState, useEffect, useCallback, useRef } from 'react'
  *    ⌘K is intentionally chosen over reserved combos (⌘P print, ⌘W close tab,
  *    ⌘1–9 tab switch, ⌘⌥← / ⌘⌥→) which Chrome will NOT let a page cancel.
  *
+ * Both keyboard bindings honour the global "Enable shortcuts" toggle
+ * ({@link SHORTCUTS_ENABLED_KEY}, shared with useKeyboardShortcuts /
+ * useInstanceShortcuts and surfaced by the Settings → Shortcuts "Search
+ * Everywhere" row). The flag is read live per keystroke — a Settings change
+ * takes effect without re-registering the listener — so when shortcuts are
+ * off, double-Shift and ⌘K fall through to the browser. The palette stays
+ * reachable via its nav button, which calls `openPalette` directly and is
+ * unaffected by the gate.
+ *
  * The listener is attached to `window` (not an element) so the gesture works
  * regardless of focus — including while a chat textarea or a nav row is
  * focused — matching the "search everywhere" intent.
@@ -25,6 +35,9 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 
 /** Max gap between the two Shift keydowns to count as a double-tap. */
 export const DOUBLE_SHIFT_WINDOW_MS = 400
+
+/** Live read of the global shortcuts toggle (default on; '0' means disabled). */
+const shortcutsEnabled = () => localStorage.getItem(SHORTCUTS_ENABLED_KEY) !== '0'
 
 export interface UseCommandPalette {
   /** Whether the palette is currently shown. */
@@ -49,6 +62,16 @@ export function useCommandPalette(): UseCommandPalette {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // Honour the global "Enable shortcuts" toggle. Read live so a Settings
+      // change applies without re-registering. When off, both bindings fall
+      // through to the browser; the palette's nav button (openPalette) is
+      // unaffected. Reset any pending first Shift tap so re-enabling can't
+      // resume a half-formed double-tap from across the disabled window.
+      if (!shortcutsEnabled()) {
+        lastShiftRef.current = 0
+        return
+      }
+
       // ⌘K / Ctrl+K alias — toggle. Require no other modifiers so it doesn't
       // swallow richer combos. Cancelable in a real Chrome tab.
       if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {


### PR DESCRIPTION
## Problem

The "Enable shortcuts" toggle (Settings → Shortcuts, and the Alt+K modal) does
**not** disable the Search Everywhere command palette. Pressing **Shift twice**
(or ⌘K / Ctrl+K) still opens the palette even with shortcuts turned off. The
Settings → Shortcuts page already lists a **"Search Everywhere"** row, so the
toggle *appears* to govern the palette — but it never did.

## Why it matters

Users who turn shortcuts off want a quiet keyboard — no chords firing
unexpectedly. Double‑Shift is easy to trigger by accident (e.g. typing two
capitals in quick succession), and there was no way to stop it. The UI
advertised control it didn't deliver, so "off" wasn't actually off.

## Fix (symptom → root cause → change)

- **Symptom:** double‑Shift / ⌘K opens the palette regardless of the toggle.
- **Root cause:** the palette's global bindings live in `useCommandPalette`,
  which attaches its own `window` keydown listener and never read the shared
  `mc-keyboard-shortcuts` flag. That flag is only consulted by the Alt‑based
  `useKeyboardShortcuts` handler and by `useInstanceShortcuts` — the palette
  hook was simply outside the gate.
- **Change:** `useCommandPalette` now reads the same flag **live per keystroke**
  (mirroring `useInstanceShortcuts`, so a Settings change applies without
  re‑registering the listener) and bails before **both** bindings when
  shortcuts are disabled. The pending first‑Shift tap is reset on the disabled
  path so re‑enabling can't resume a half‑formed double‑tap from across the
  disabled window.
- **Deliberately unaffected:** the palette's **nav button** (`openPalette`)
  still opens it while shortcuts are off, and the **Alt+K** (shortcuts modal) /
  **Alt+,** (settings) escape hatches remain ungated so the toggle is always
  reachable to re‑enable.

Scope is intentionally limited to the palette (the double‑Shift binding the
user reported). Two other global chords bypass the toggle — ⌘F in‑chat message
search and ⌘D split mode — and are left as‑is for a separate decision.

## Tests

Added four cases to `CommandPalette.test.tsx` under a new
"Enable shortcuts toggle" describe block:

- double‑Shift does **not** open the palette when the flag is `0`.
- ⌘K does **not** open the palette when the flag is `0`.
- `openPalette()` (nav button) **still** opens it while disabled.
- re‑enabling restores double‑Shift with **no stale first tap** carried over.

The block clears the `mc-keyboard-shortcuts` key in `afterEach` — jsdom
localStorage is shared across the suite, so a lingering `0` would disable
shortcuts for later tests.

## Manual verification

N/A — unit coverage is sufficient. The behavior is pure keyboard‑event logic
fully exercised by the new tests; there is no visual change to click through.

## Screenshots

N/A — no user‑visible UI change. The Settings → Shortcuts "Search Everywhere"
row already existed and is untouched; this PR only changes whether the keyboard
bindings fire.
