### PR TITLE
fix(knowledge): make the sources page usable on mobile

### DIFF
--- a/website/src/pages/knowledge/SourcesList.tsx
+++ b/website/src/pages/knowledge/SourcesList.tsx
@@ -12,11 +12,11 @@ export function SourceSummaryDisplay({ source }: { source: Source }) {
   if (!source.summary_topic) return null
   const themes: string[] = (() => { try { return JSON.parse(source.summary_themes || '[]') } catch { return [] } })()
   return (
-    <div className="mt-1">
+    <div className="mt-1 min-w-0">
       <p className="text-[12px] text-muted leading-relaxed line-clamp-1">{source.summary_topic}</p>
       {themes.length > 0 && (
         <div className="flex gap-1 flex-wrap mt-0.5">
-          {themes.map((t, i) => <span key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-bg border border-border text-muted">{t}</span>)}
+          {themes.map((t, i) => <span key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-bg border border-border text-muted whitespace-nowrap max-w-full truncate">{t}</span>)}
         </div>
       )}
     </div>
@@ -78,7 +78,7 @@ function StalenessIndicator({ lastSynced }: { lastSynced?: string }) {
   const daysSince = Math.floor((Date.now() - new Date(lastSynced).getTime()) / (1000 * 60 * 60 * 24))
   const stale = daysSince > 30
   return (
-    <span className={`text-[11px] ${stale ? 'text-warn' : 'text-muted'}`}>
+    <span className={`text-[11px] whitespace-nowrap ${stale ? 'text-warn' : 'text-muted'}`}>
       {stale && <AlertCircle size={10} className="inline mr-0.5" />}
       {formatRelativeDate(lastSynced)}
     </span>
@@ -440,14 +440,16 @@ export default function SourcesList({ onIngest, uploadNamespace, setUploadNamesp
           const isPending = s.sync_status === 'pending_confirmation'
           return (
           <div key={s.id} className={`border border-border rounded-lg p-3 hover:border-border-strong transition-all ${isDeleting ? 'opacity-50' : ''}`}>
-            <div className="flex items-center gap-3">
+            {/* Stacks on narrow viewports: identity block on top, meta + actions below. */}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+              <div className="flex items-start sm:items-center gap-2 sm:gap-3 min-w-0 flex-1">
               {isFolderType ? (
-                <button onClick={() => setExpandedSource(isExpanded ? null : s.id)} className="text-muted shrink-0"
+                <button onClick={() => setExpandedSource(isExpanded ? null : s.id)} className="text-muted shrink-0 mt-0.5 sm:mt-0"
                   aria-label={isExpanded ? 'Collapse folder details' : 'Expand folder details'}>
                   {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                 </button>
               ) : (
-                <FolderSync size={16} className="text-muted shrink-0" />
+                <FolderSync size={16} className="text-muted shrink-0 mt-0.5 sm:mt-0" />
               )}
               <div className="flex-1 min-w-0">
                 {editingId === s.id ? (
@@ -465,24 +467,29 @@ export default function SourcesList({ onIngest, uploadNamespace, setUploadNamesp
                   <div className="flex items-center gap-1 min-w-0 group/name">
                     <span className="text-sm font-medium text-text-strong truncate">{s.name}</span>
                     <button aria-label="Rename source" onClick={() => startRename(s)}
-                      className="text-muted shrink-0 p-0.5 rounded opacity-0 group-hover/name:opacity-100 hover:text-text transition-opacity"><Pencil size={12} /></button>
+                      className="text-muted shrink-0 p-0.5 rounded opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 hover:text-text transition-opacity"><Pencil size={12} /></button>
                   </div>
                 )}
-                <div className="text-[11px] text-muted flex items-center gap-1.5">
-                  {s.source_type}{s.uri ? ` · ${s.uri}` : ''}
+                <div className="text-[11px] text-muted flex items-center gap-1.5 min-w-0">
+                  <span className="truncate" title={s.uri || s.source_type}>
+                    {s.source_type}{s.uri ? ` · ${s.uri}` : ''}
+                  </span>
                   {s.source_type === 'local_file'
-                    ? <span className="inline-flex items-center gap-0.5 text-ok" title="Auto-watches for file changes every 5 min">● auto</span>
+                    ? <span className="inline-flex items-center gap-0.5 text-ok shrink-0" title="Auto-watches for file changes every 5 min">● auto</span>
                     : isFolderType
-                    ? <span className={`inline-flex items-center gap-0.5 ${isPaused ? 'text-warn' : isPending ? 'text-muted' : 'text-ok'}`} title={isPaused ? 'Paused' : isPending ? 'Awaiting confirmation' : 'Watching folder'}>● {isPaused ? 'paused' : isPending ? 'pending' : 'folder'}</span>
-                    : <span className="inline-flex items-center gap-0.5 text-muted" title="Use Sync button to update">○ manual</span>}
+                    ? <span className={`inline-flex items-center gap-0.5 shrink-0 ${isPaused ? 'text-warn' : isPending ? 'text-muted' : 'text-ok'}`} title={isPaused ? 'Paused' : isPending ? 'Awaiting confirmation' : 'Watching folder'}>● {isPaused ? 'paused' : isPending ? 'pending' : 'folder'}</span>
+                    : <span className="inline-flex items-center gap-0.5 text-muted shrink-0" title="Use Sync button to update">○ manual</span>}
                 </div>
                 <SourceSummaryDisplay source={s} />
               </div>
+              </div>
+              {/* Meta + actions: wraps under the identity block on narrow viewports. */}
+              <div className="flex items-center gap-2 sm:gap-3 flex-wrap sm:flex-nowrap shrink-0 pl-6 sm:pl-0">
               {isDeleting ? <Badge variant="warn">Deleting...</Badge> : (
                 <Badge variant={s.sync_status === 'synced' || s.sync_status === 'active' ? 'ok' : s.sync_status === 'error' ? 'err' : s.sync_status === 'paused' ? 'warn' : 'aim'}>{s.sync_status}</Badge>
               )}
-              <span className="text-[11px] text-muted">{s.item_count ?? 0} items</span>
-              {(() => { const { wordCount: wc } = parseSourceProps(s); if (!shouldShowWordCount(wc)) return null; return <span className="text-[11px] text-muted">{wc! < 1000 ? `${wc} words` : `~${Math.round(wc! / 1000)}k words`}</span> })()}
+              <span className="text-[11px] text-muted whitespace-nowrap">{s.item_count ?? 0} items</span>
+              {(() => { const { wordCount: wc } = parseSourceProps(s); if (!shouldShowWordCount(wc)) return null; return <span className="text-[11px] text-muted whitespace-nowrap">{wc! < 1000 ? `${wc} words` : `~${Math.round(wc! / 1000)}k words`}</span> })()}
               <StalenessIndicator lastSynced={s.last_synced} />
               {/* Pause/Resume/Confirm for folder sources */}
               {isFolderType && isPending && (
@@ -518,6 +525,7 @@ export default function SourcesList({ onIngest, uploadNamespace, setUploadNamesp
                 className="px-2 py-1 text-[11px] border border-border rounded hover:bg-bg-elevated text-danger/70 hover:text-danger disabled:opacity-50 flex items-center gap-0.5">
                 {isDeleting ? <RefreshCw size={12} className="animate-spin" /> : <X size={12} />}
               </button>
+              </div>
             </div>
             {/* Inline expandable progress for folder sources */}
             {isFolderType && isExpanded && <FolderProgress sourceId={s.id} />}

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -449,14 +449,16 @@ export default function KnowledgePage() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-end justify-between gap-4 px-6 pt-4 pb-3">
-        <div>
-          <div className="text-2xl font-bold tracking-tight text-text-strong flex items-center gap-2">
-            <BookOpen size={22} /> Knowledge Library
+      <div className="flex items-start sm:items-end justify-between gap-3 sm:gap-4 px-4 sm:px-6 pt-4 pb-3">
+        <div className="min-w-0">
+          <div className="text-xl sm:text-2xl font-bold tracking-tight text-text-strong flex items-center gap-2">
+            <BookOpen size={22} className="shrink-0" /> Knowledge Library
           </div>
-          <div className="text-muted text-sm mt-1">Search, explore, and manage your knowledge base</div>
+          <div className="text-muted text-[13px] sm:text-sm mt-1">Search, explore, and manage your knowledge base</div>
         </div>
-        <Btn onClick={() => setShowHelp(true)}><HelpCircle size={14} /> Help</Btn>
+        <div className="shrink-0">
+          <Btn onClick={() => setShowHelp(true)}><HelpCircle size={14} /> Help</Btn>
+        </div>
       </div>
 
       {showHelp && (
@@ -483,17 +485,18 @@ export default function KnowledgePage() {
         </Clickable>
       )}
 
-      {/* Tabs */}
-      <div className="flex gap-1 px-6 border-b border-border">
+      {/* Tabs — horizontally scrollable on narrow viewports so the active
+          underline never spills past the container. */}
+      <div className="flex gap-1 px-4 sm:px-6 border-b border-border overflow-x-auto">
         {TABS.map(t => (
           <button key={t} onClick={() => { setTab(t); setSelectedId(null); setSelectedItems(new Set()) }}
-            className={`flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium border-b-2 transition-all bg-transparent cursor-pointer ${tab === t ? 'border-accent text-text font-semibold' : 'border-transparent text-muted hover:text-text'}`}>
+            className={`flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium border-b-2 transition-all bg-transparent cursor-pointer shrink-0 whitespace-nowrap ${tab === t ? 'border-accent text-text font-semibold' : 'border-transparent text-muted hover:text-text'}`}>
             {TAB_META[t].icon} {TAB_META[t].label}
           </button>
         ))}
       </div>
 
-      <div className={`flex-1 px-6 py-4 min-h-0 ${tab === 'graph' ? 'flex flex-col' : 'overflow-y-auto'}`} ref={listContainerRef}>
+      <div className={`flex-1 px-4 sm:px-6 py-4 min-h-0 ${tab === 'graph' ? 'flex flex-col' : 'overflow-y-auto'}`} ref={listContainerRef}>
         <EmbeddingStatus />
         {isEmpty && tab === 'list' ? (
           <div className="flex flex-col items-center justify-center py-12 animate-rise">
@@ -619,19 +622,19 @@ export default function KnowledgePage() {
 
       {/* Stats bar */}
       {stats && (
-        <div className="border-t border-border px-6 py-2 flex gap-4 text-[12px] text-muted shrink-0">
-          <span>{stats.items} items</span>
-          <span>{stats.entities} entities</span>
-          <span>{stats.relations} relations</span>
-          <span>{stats.sources} sources</span>
+        <div className="border-t border-border px-4 sm:px-6 py-2 flex gap-x-3 gap-y-0.5 sm:gap-4 flex-wrap text-[11px] sm:text-[12px] text-muted shrink-0">
+          <span className="whitespace-nowrap">{stats.items} items</span>
+          <span className="whitespace-nowrap">{stats.entities} entities</span>
+          <span className="whitespace-nowrap">{stats.relations} relations</span>
+          <span className="whitespace-nowrap">{stats.sources} sources</span>
           {stats.embeddings?.enabled ? (
-            <span className={stats.embeddings.available ? 'text-ok' : 'text-warn'} title={stats.embeddings.available ? `${stats.embeddings.model} — ${stats.embeddings.embedded_items} embedded` : `Embedding model loading (${stats.embeddings.model})`}>
+            <span className={`whitespace-nowrap ${stats.embeddings.available ? 'text-ok' : 'text-warn'}`} title={stats.embeddings.available ? `${stats.embeddings.model} — ${stats.embeddings.embedded_items} embedded` : `Embedding model loading (${stats.embeddings.model})`}>
               ● {stats.embeddings.available ? `embeddings (${stats.embeddings.embedded_items})` : 'embeddings loading'}
             </span>
           ) : (
-            <span className="text-muted" title="Embedding model is downloading in the background">○ embeddings initializing</span>
+            <span className="text-muted whitespace-nowrap" title="Embedding model is downloading in the background">○ embeddings initializing</span>
           )}
-          {tab === 'list' && <span className="ml-auto text-[10px]">/ to search, Esc to back, &larr;&rarr; to page</span>}
+          {tab === 'list' && <span className="ml-auto text-[10px] hidden sm:inline">/ to search, Esc to back, &larr;&rarr; to page</span>}
         </div>
       )}
     </div>

--- a/website/src/test/SourcesList.responsive.test.tsx
+++ b/website/src/test/SourcesList.responsive.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import SourcesList from '../pages/knowledge/SourcesList'
+import * as api from '../pages/knowledge/api'
+import type { Source } from '../pages/knowledge/types'
+
+vi.mock('../pages/knowledge/api', () => ({ knowledgeApi: vi.fn() }))
+
+const LONG_URI = '/home/user/workplace/AVeryLongPackageName/src/AVeryLongPackageName/deeply/nested/notes'
+
+const sources: Source[] = [
+  {
+    id: 's1',
+    name: 'Private Package Notes',
+    source_type: 'local_folder',
+    uri: LONG_URI,
+    sync_status: 'synced',
+    item_count: 378,
+    summary_topic: 'Employment dates',
+    summary_themes: JSON.stringify([
+      'employment-dates', 'override-management', 'data-materialization',
+      'backfill-architecture', 'ps-integration',
+    ]),
+  },
+  {
+    id: 's2',
+    name: 'Artifacts',
+    source_type: 'artifact',
+    uri: 'artifact://',
+    sync_status: 'synced',
+    item_count: 33,
+  },
+]
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+function renderList() {
+  return render(
+    <SourcesList onIngest={() => {}} uploadNamespace="" setUploadNamespace={() => {}} namespaces={[]} ingestionJobs={[]} />,
+    { wrapper },
+  )
+}
+
+beforeEach(() => {
+  queryClient.clear()
+  vi.mocked(api.knowledgeApi).mockReset()
+  vi.mocked(api.knowledgeApi).mockImplementation(async (path: string) => {
+    if (path === '/sources') return sources as unknown as never
+    return { ok: true } as unknown as never
+  })
+})
+
+describe('SourcesList — mobile layout', () => {
+  it('stacks the row on narrow viewports and keeps it a row from sm up', async () => {
+    renderList()
+    const name = await screen.findByText('Private Package Notes')
+    // name span → identity inner → identity outer → row wrapper
+    const row = name.closest('div')!.parentElement!.parentElement!.parentElement!
+    expect(row.className).toContain('flex-col')
+    expect(row.className).toContain('sm:flex-row')
+  })
+
+  it('truncates a long source URI instead of overflowing the card', async () => {
+    renderList()
+    const uri = await screen.findByTitle(LONG_URI)
+    expect(uri.className).toContain('truncate')
+    expect(uri.parentElement!.className).toContain('min-w-0')
+  })
+
+  it('keeps the source name truncated so long names cannot push actions offscreen', async () => {
+    renderList()
+    const name = await screen.findByText('Private Package Notes')
+    expect(name.className).toContain('truncate')
+  })
+
+  it('renders theme chips on a single line each so they wrap instead of stacking tall', async () => {
+    renderList()
+    const chip = await screen.findByText('employment-dates')
+    expect(chip.className).toContain('whitespace-nowrap')
+    expect(chip.parentElement!.className).toContain('flex-wrap')
+  })
+
+  it('allows the meta/action cluster to wrap on mobile but not from sm up', async () => {
+    renderList()
+    const items = await screen.findByText('378 items')
+    const cluster = items.parentElement!
+    expect(cluster.className).toContain('flex-wrap')
+    expect(cluster.className).toContain('sm:flex-nowrap')
+  })
+
+  it('keeps item counts and sync dates on one line', async () => {
+    renderList()
+    expect((await screen.findByText('378 items')).className).toContain('whitespace-nowrap')
+    expect((await screen.findByText('33 items')).className).toContain('whitespace-nowrap')
+  })
+
+  it('shows the rename affordance without hover on touch viewports', async () => {
+    renderList()
+    await screen.findByText('Private Package Notes')
+    const pencil = screen.getAllByLabelText('Rename source')[0]
+    expect(pencil.className).toContain('opacity-100')
+    expect(pencil.className).toContain('sm:opacity-0')
+  })
+})


### PR DESCRIPTION
## Problem

The Knowledge Library **Sources** tab was broken on mobile.

Each source row was a single unbreakable `flex items-center` line, and the folder path had no `min-w-0`/`truncate`. A long URI therefore pushed the sync badge, item count, staleness date, Pause and delete buttons off the right edge of the card. With the remaining width squeezed to nothing, the summary theme chips collapsed into a tall one-word-per-line column, making a single source row taller than half the viewport. The tab bar had no overflow handling either, so the active underline spilled past the container.

## Changes

- Source rows stack below `sm` (identity block on top, meta and actions below) and stay a single row from `sm` up.
- Long URIs truncate with a `title` tooltip instead of overflowing; status pills are `shrink-0`.
- Theme chips are `whitespace-nowrap` so they wrap horizontally instead of stacking vertically.
- Meta/action cluster wraps on mobile, `sm:flex-nowrap` above; item counts and sync dates no longer break mid-token.
- Page header shrinks type and drops to `px-4` on mobile; the Help button no longer shrinks.
- Tab bar is horizontally scrollable with non-shrinking, non-wrapping tabs.
- Stats footer wraps cleanly; the keyboard-shortcut hint is hidden below `sm`.
- The rename pencil is visible without hover on touch viewports, where hover never fires.

Purely presentational: no API, data-flow, or behavioural change, so no module spec update is required.

## Testing

- 7 new tests in `website/src/test/SourcesList.responsive.test.tsx` covering row stacking, URI truncation, name truncation, chip wrapping, action-cluster wrap behaviour, nowrap counts, and the touch-visible rename affordance.
- Full frontend suite: 3902 passed, 3 skipped.
- `npx tsc -b --force` clean.
- `./scripts/scrub-lint.sh --no-history` clean.

### Before
<img width="682" height="1266" alt="image" src="https://github.com/user-attachments/assets/7f168528-695a-456d-81c5-d83782d0cfec" />


### After
<img width="680" height="1472" alt="image" src="https://github.com/user-attachments/assets/552c1a86-f362-4110-bf09-c9fdf870c43e" />
