### PR TITLE
fix(model_registry): register sub-1M cross-vendor model windows

### DIFF
--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -135,12 +135,21 @@ _SUPPLEMENTARY_WINDOWS: dict[str, int] = {
     # cron) that never hits that endpoint would otherwise resolve these to None
     # ⇒ the 1M reference and over-assemble context. Keeping the static window as
     # a floor prevents that over-large-prompt regression on first/headless runs.
-    "deepseek-3.2": 128_000,
+    # Currently-served sub-1M models. Windows are the kiro-cli
+    # `chat --list-models --format json` context_window_tokens as of 2026-07
+    # (the refresh_kiro_windows cache overrides these when seeded).
+    "deepseek-3.2": 164_000,
+    "minimax-m2.5": 196_000,
+    "minimax-m2.1": 196_000,
+    "glm-5": 200_000,
+    "gpt-5.6-sol": 272_000,
+    "gpt-5.6-terra": 272_000,
+    "gpt-5.6-luna": 272_000,
+    "qwen3-coder-next": 256_000,
+    # Legacy / not-currently-served kiro ids, kept as harmless static floors.
     "kimi-k2.5": 256_000,
-    "minimax-m2.1": 200_000,
     "glm-4.7": 200_000,
     "glm-4.7-flash": 128_000,
-    "qwen3-coder-next": 256_000,
     "qwen3-coder-480b": 256_000,
 }
 

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -97,11 +97,19 @@ class TestModelRegistry:
         # static floor a headless start (Slack/cron) that never seeds the
         # kiro-list cache resolves them to None ⇒ the 1M reference and
         # over-assembles context. The supplementary map is the floor.
-        assert mr.model_window("deepseek-3.2") == 128_000
+        # Windows match kiro-cli --list-models context_window_tokens (2026-07).
+        assert mr.model_window("deepseek-3.2") == 164_000
+        assert mr.model_window("minimax-m2.5") == 196_000
+        assert mr.model_window("minimax-m2.1") == 196_000
+        assert mr.model_window("glm-5") == 200_000
+        assert mr.model_window("gpt-5.6-sol") == 272_000
+        assert mr.model_window("gpt-5.6-terra") == 272_000
+        assert mr.model_window("gpt-5.6-luna") == 272_000
         assert mr.model_window("qwen3-coder-next") == 256_000
         assert mr.model_window("qwen3-coder-480b") == 256_000
         assert mr.model_window("glm-4.7-flash") == 128_000
-        for m in ("deepseek-3.2", "qwen3-coder-next", "glm-4.7-flash"):
+        for m in ("deepseek-3.2", "minimax-m2.5", "glm-5", "gpt-5.6-terra",
+                  "qwen3-coder-next", "glm-4.7-flash"):
             assert mr.has_known_window(m) is True
             assert mr.window_source(m) == "supplementary"
 
@@ -135,13 +143,13 @@ class TestModelRegistry:
         try:
             mr._KIRO_WINDOWS.clear()
             assert mr.model_window("auto") == 200_000  # stale registry literal
-            assert mr.model_window("gpt-5.6-terra") is None  # registry doesn't list it
+            assert mr.model_window("unlisted-model-zzz") is None  # neither registry nor supplementary
             # refresh does the in-memory update synchronously and returns True
             # when the cache changed (signalling the async caller to persist).
             changed = mr.refresh_kiro_windows(
                 [
                     {"model_id": "auto", "context_window_tokens": 1000000},
-                    {"model_id": "gpt-5.6-terra", "context_window_tokens": 272000},
+                    {"model_id": "unlisted-model-zzz", "context_window_tokens": 272000},
                     {"model_id": "bad", "context_window_tokens": 0},  # skipped
                     {"model_id": "alsobad"},  # missing field, skipped
                 ]
@@ -149,7 +157,7 @@ class TestModelRegistry:
             assert changed is True
             assert mr.model_window("auto") == 1000000  # cache corrects stale registry 200k
             assert mr.window_source("auto") == "kiro-list"
-            assert mr.model_window("gpt-5.6-terra") == 272000
+            assert mr.model_window("unlisted-model-zzz") == 272000
             assert mr.model_window("bad") is None  # 0 not cached
             # A no-op refresh (same data) returns False — no persist needed.
             assert mr.refresh_kiro_windows([{"model_id": "auto", "context_window_tokens": 1000000}]) is False


### PR DESCRIPTION
# Register sub-1M cross-vendor model windows

## Problem
Cross-vendor subagent seats (e.g. `llm-council`) launched via
`spawn_run(model=<non-Anthropic>)` over-assembled their injected context and
either overflowed the model's window or came back as no-engagement stubs
(the task truncated off the prompt tail). The regression showed up once the
lessons/skills stores grew large enough to saturate the injection caps.

## Why it matters
Any feature that fans out to non-Anthropic models (llm-council, rubber-duck,
cross-vendor review panels) silently degrades: seats can't see their full task,
so their answers are unusable. It affects the smaller-window models most
(deepseek 164k, minimax 196k, glm 200k, gpt-5.6 272k).

## Fix (symptom -> root cause -> change)
The subagent budget scaler resolves a seat's window through
`model_registry.model_window()`:
`live usage > kiro-list cache > registry > _SUPPLEMENTARY_WINDOWS > [1m] heuristic > None`.
The static `_SUPPLEMENTARY_WINDOWS` map is the **floor** used on headless /
cold starts before the kiro-list cache is seeded. It was missing the
currently-served non-Anthropic models, so `model_window()` returned `None` ->
`_effective_window(None)` fell back to the **1M reference** -> the injection
budget was computed for a 1M window and handed to a 128-272k model.

The change completes/corrects the floor with the authoritative kiro-cli
`chat --list-models --format json` `context_window_tokens` (2026-07):

| model | window |
|---|---|
| `deepseek-3.2` | 164,000 (was a stale 128,000) |
| `minimax-m2.5` | 196,000 (added) |
| `minimax-m2.1` | 196,000 (was a stale 200,000) |
| `glm-5` | 200,000 (added) |
| `gpt-5.6-sol` / `-terra` / `-luna` | 272,000 (added) |

Older ids the fleet no longer serves are kept as harmless static floors. On a
host with large stores this cuts a seat's injected-context ceiling ~73-80%
(measured: ~47.6k -> ~9.5k tokens for a 164-200k model, ~13k for 272k),
sizing the budget to each model's real window instead of 1M.

## Tests
- `test_supplementary_windows_cover_headless_non_anthropic_models` extended to
  assert the new/corrected windows and their `supplementary` source.
- `test_refresh_kiro_windows_overrides_and_extends_registry` re-pointed to a
  synthetic unlisted id, since its old `gpt-5.6-terra` example is now a
  registered model (would no longer prove the cache "extends the registry").
- Backend gate green locally: `test_model_registry.py` +
  `test_model_registry_parity.py` (55 passed) + the `test_acp_client` window
  regressions (2 passed); `flake8` clean; `isort` clean. Frontend untouched
  (no JSON/TS change; the parity test compares the two JSON copies and passes).

## Manual verification
Deterministic on-host measurement (worktree code, real large stores, empty
kiro-list cache = the headless condition): confirmed the seat-budget path
`subagent -> window_for_provider_client -> resolve_model_window -> model_window`
now resolves each model to its real window (`supplementary` source) and scales
the injected-context ceiling down 73-80%. A live end-to-end `spawn_run` was
blocked by an unrelated local data-home split (tracked separately), so budget
scaling was verified deterministically rather than via a live model turn.

## Screenshots
N/A -- backend-only change (window data + tests), no user-visible UI.
