### PR TITLE
fix(chat): suppress composer autofocus on touch devices (tablet/landscape)

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -20,6 +20,7 @@ import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import TrustDropdown from './TrustDropdown'
 import AutoNudgePopover, { type AutoNudgeLoop } from './AutoNudgePopover'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { isTouchDevice } from '../utils/isTouchDevice'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
 import { isScreenSnipSupported } from '../hooks/useScreenSnip'
 import { useImeGuard } from '../hooks/useImeGuard'
@@ -795,6 +796,15 @@ function ChatInput({
   // closure fresh, but a flip in either (e.g. AI finishes responding -> disabled
   // goes true -> false) MUST NOT steal focus while the user reads or scrolls.
   //
+  // Also bail on touch devices: programmatic .focus() there pops the on-screen
+  // keyboard, so merely tapping a session would cover half the screen before the
+  // user has decided to type. `isMobile` (viewport width < 768px) already covers
+  // portrait phones, but it's a LAYOUT signal — it misses tablets and phones in
+  // landscape (≥768px), which are still touch. `isTouchDevice()` (coarse pointer
+  // / no hover) is the precise keyboard-popping predicate. It's called inline,
+  // not in the dep array, because a device's touch capability is effectively
+  // static for the session (unlike `disabled`/`isMobile`, which flip at runtime).
+  //
   // IMPORTANT: bail on `disabled || isMobile` BEFORE advancing the ref. If a
   // session switch lands while disabled=true (e.g. the user picks a session that
   // is currently stopping), advancing the ref here would consume the focus
@@ -811,7 +821,7 @@ function ChatInput({
       prevAutoFocusKeyRef.current = autoFocusKey
       return
     }
-    if (disabled || isMobile) return
+    if (disabled || isMobile || isTouchDevice()) return
     prevAutoFocusKeyRef.current = autoFocusKey
     const ae = document.activeElement as HTMLElement | null
     if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useNavigationType, useSearchParams } from 're
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { modelListRefetchInterval } from '../providers/modelListHealth'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { isTouchDevice } from '../utils/isTouchDevice'
 import { useSwipeEdge } from '../hooks/useSwipeEdge'
 import type { ResizeInfo } from '../utils/resizeImage'
 import { useAppSelector, useAppDispatch, store } from '../store'
@@ -2154,7 +2155,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       widgetPrefillRef.current = text
       setInput(prev => (prev.trim() ? `${prev.trimEnd()}\n${text}` : text))
       setPrefillHint(true)
-      requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus())
+      // Touch: reveal the pre-filled composer without focusing (focus pops the
+      // soft keyboard); desktop: focus, which scrolls it into view anyway.
+      requestAnimationFrame(() => {
+        const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')
+        if (!ta) return
+        if (isTouchDevice()) { if (typeof ta.scrollIntoView === 'function') ta.scrollIntoView({ block: 'nearest' }) }
+        else ta.focus()
+      })
     }
     window.addEventListener('mc-widget-send', handler)
     return () => window.removeEventListener('mc-widget-send', handler)
@@ -2388,7 +2396,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     })
     // Trigger flying animation
     setFlyingQuote({ text, from: rect })
-    requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus())
+    // Touch: reveal the pre-filled composer without focusing (focus pops the
+    // soft keyboard); desktop: focus, which scrolls it into view anyway.
+    requestAnimationFrame(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')
+      if (!ta) return
+      if (isTouchDevice()) { if (typeof ta.scrollIntoView === 'function') ta.scrollIntoView({ block: 'nearest' }) }
+      else ta.focus()
+    })
   }, [])
 
   const handleEditResend = useCallback((index: number, ts: string, newContent: string) => {

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -31,6 +31,7 @@ import { useSessionActions } from '../hooks/useSessionActions'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { isTouchDevice } from '../utils/isTouchDevice'
 import { safeSetItem } from '../utils/safeStorage'
 import { resolveFolderAgent, resolveFolderProjectDir } from '../utils/folderAgent'
 import ProjectPicker from '../components/ProjectPicker'
@@ -1442,7 +1443,7 @@ function ChatSidebar({
   // Create autopilot session mutation (consistent with useMutation pattern)
   const createAutopilotMutation = useMutation({
     mutationFn: () => dispatch(createSlot({ agent: defaultAgent || undefined, mode: 'orchestrator' })).unwrap(),
-    onSuccess: () => { requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus()) },
+    onSuccess: () => { requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) },
   })
 
   // Create default chat session mutation
@@ -1451,7 +1452,7 @@ function ChatSidebar({
       const effectiveMode = loadChatConfig().defaultAutopilot ? 'orchestrator' : (mode || '')
       return dispatch(createSlot({ agent: defaultAgent || undefined, mode: effectiveMode })).unwrap()
     },
-    onSuccess: () => { requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus()) },
+    onSuccess: () => { requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) },
   })
 
   // Session colors
@@ -2223,7 +2224,7 @@ function ChatSidebar({
                         const walk = (list: ChatFolder[], depth: number) => { for (const f of list) { items.push({ f, depth }); walk(childrenOf(f.id), depth + 1) } }
                         walk(roots, 0)
                         return items.map(({ f, depth }) => (
-                          <DropdownMenuItem key={f.id} style={{ paddingLeft: `${12 + depth * 16}px` }} onClick={() => { createChatInFolder(f.id); requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus()) }}>
+                          <DropdownMenuItem key={f.id} style={{ paddingLeft: `${12 + depth * 16}px` }} onClick={() => { createChatInFolder(f.id); requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) }}>
                             <Folder size={14} className={depth === 0 ? 'text-muted' : 'text-muted/60'} /> {f.name}
                           </DropdownMenuItem>
                         ))

--- a/website/src/test/ChatInput.test.tsx
+++ b/website/src/test/ChatInput.test.tsx
@@ -7,6 +7,12 @@ import ChatInput from '../components/ChatInput'
 import { SlotProvider } from '../providers/SlotContext'
 import type { PasteBlock } from '../utils/pasteTokens'
 
+// isTouchDevice gates the autoFocusKey effect (tapping a session must not pop
+// the soft keyboard). Default false so the desktop-focus tests below behave as
+// before; the touch-device case flips it on per-test.
+const touchEnv = vi.hoisted(() => ({ touch: false }))
+vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => touchEnv.touch }))
+
 const defaultProps = {
   value: '',
   onChange: vi.fn(),
@@ -16,6 +22,7 @@ const defaultProps = {
 beforeEach(() => {
   vi.restoreAllMocks()
   localStorage.clear()
+  touchEnv.touch = false
 })
 
 describe('ChatInput', () => {
@@ -1015,6 +1022,16 @@ describe('ChatInput', () => {
       const ta = screen.getByLabelText('Message input')
       ta.blur()
       rerender(<ChatInput {...defaultProps} autoFocusKey="A" />)
+      expect(ta).not.toHaveFocus()
+    })
+
+    it('does not focus on a touch device, even when the key changes', () => {
+      // Tapping a session on a phone/tablet must not pop the soft keyboard.
+      touchEnv.touch = true
+      const { rerender } = renderWithProviders(<ChatInput {...defaultProps} autoFocusKey="A" />)
+      const ta = screen.getByLabelText('Message input')
+      expect(ta).not.toHaveFocus()
+      rerender(<ChatInput {...defaultProps} autoFocusKey="B" />)
       expect(ta).not.toHaveFocus()
     })
 


### PR DESCRIPTION
## Problem

On touch devices, opening a session (and several other navigation/compose
actions) immediately programmatically focuses the chat composer, which pops the
on-screen keyboard — so merely tapping a session covers half the screen before
the user has decided to type anything.

Portrait phones were **already** protected by the `useIsMobile()` width check
(`max-width: 767px`). The gap this PR closes is **tablets and phones in
landscape** (viewport ≥768px): they are touch devices with a soft keyboard, but
the width check classifies them as desktop, so autofocus still fired and the
keyboard still popped.

## Why it matters

The soft keyboard springing up on every session tap is a jarring mobile
experience — it hides the transcript the user just navigated to and forces an
extra dismiss gesture. On tablets it's especially disruptive (larger keyboard,
and tablets are common for reading/triage where the user often isn't about to
type). It affects the most common interaction: switching between chats.

## Fix (symptom → root cause → change)

- **Symptom:** on a tablet or a phone held in landscape, tapping a session (and
  new-chat / quote / widget actions) pops the soft keyboard. Portrait phones are
  already fine.
- **Root cause:** the composer-focus paths were gated only by `useIsMobile()`,
  which is a **layout** signal (`max-width: 767px`). That covers portrait phones
  but misses tablets and landscape phones (≥768px) — all still touch devices
  where a programmatic `.focus()` pops the keyboard. Viewport width is the wrong
  predicate for "will this open a soft keyboard."
- **Change:** gate the composer-focus paths on the existing, precise
  `isTouchDevice()` predicate (`(pointer: coarse)` / `(hover: none)`) in addition
  to the width check:
  - `ChatInput.tsx` — the session-switch autofocus effect now also bails on
    `isTouchDevice()` (covers single chat and split panes centrally).
  - `ChatSidebar.tsx` — the three new-chat focus paths (default / autopilot /
    new-chat-in-folder) skip focus on touch (empty composer, nothing to reveal).
  - `ChatPage.tsx` — quote and widget-send **pre-fill** the composer, so on touch
    they now scroll the composer into view (`scrollIntoView({ block: 'nearest' })`,
    guarded with `typeof … === 'function'` to match `ProjectPicker`/
    `useListKeyboardNav`) instead of focusing — the inserted text stays visible
    without popping the keyboard.

Desktop behavior is unchanged (`isTouchDevice()` is false there; focus still
runs and scrolls the composer into view naturally).

## Tests

- `ChatInput.test.tsx` — new `autoFocusKey` case: on a touch device the composer
  is **not** focused even when the key changes. Uses a hoisted `isTouchDevice`
  mock (default `false`, matching the existing desktop-focus cases) so the rest
  of the suite is unaffected.
- Full frontend suite green (tsc + vitest, 4441 passed / 3 pre-existing skips).

The quote / widget-send / new-chat sites reuse the same already-tested
`isTouchDevice()` predicate wrapped in a trivial guard; no per-site focus/scroll
assertions were added because asserting focus across `requestAnimationFrame` +
`document.querySelector` in jsdom is flaky, and the existing widget-prefill test
still exercises the (non-touch) pre-fill path unchanged.

## Manual verification

N/A for automated coverage — the observable effect is the OS soft keyboard *not*
appearing, which is an OS artifact that can't be asserted in jsdom and needs a
physical touch device. The predicate itself is unit-tested and the desktop path
is covered by the full suite. Recommended on-device smoke test before/after:
tap a session, tap "New chat", quote a message, tap a widget action — keyboard
should stay down; quote/widget text should be visible in the composer.

## Screenshots

N/A — this is a behavioral change (suppressing a programmatic focus), not a
visual/layout change. There is no static visual diff to capture; the difference
is whether the device soft keyboard appears, which a desktop screenshot cannot
show.
