### PR TITLE
fix(overview): scope Vector Memory stat hover accent per card

### DIFF
--- a/website/src/pages/overview/VectorMemoryCard.tsx
+++ b/website/src/pages/overview/VectorMemoryCard.tsx
@@ -314,12 +314,12 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
               { label: 'Episodic', value: stats?.episodic_active ?? 0 },
               { label: 'Embedded', value: stats?.embedded_count ?? stats?.faiss_index_size ?? 0 },
             ].map(s => (
-              <div key={s.label} className="stat-accent bg-bg-elevated rounded-md px-3 py-2 border border-border">
+              <div key={s.label} className="stat-accent relative overflow-hidden bg-bg-elevated rounded-md px-3 py-2 border border-border">
                 <div className="text-muted text-[11px] uppercase tracking-wider">{s.label}</div>
                 <div className="text-lg font-bold text-text-strong">{s.value}</div>
               </div>
             ))}
-            <div className="stat-accent bg-bg-elevated rounded-md px-3 py-2 border border-border">
+            <div className="stat-accent relative overflow-hidden bg-bg-elevated rounded-md px-3 py-2 border border-border">
               <div className="text-muted text-[11px] uppercase tracking-wider">Embeddings</div>
               <div className="text-lg font-bold">
                 {embStatus?.setup_step && embStatus.setup_step !== 'idle' && embStatus.setup_step !== 'done'


### PR DESCRIPTION
Before:
<img width="2264" height="212" alt="Screenshot 2026-07-25 at 2 05 26 AM" src="https://github.com/user-attachments/assets/eaa35844-a98a-4317-bf2e-6bda7c3cd579" />

After: 
<img width="2259" height="210" alt="Screenshot 2026-07-25 at 1 45 23 AM" src="https://github.com/user-attachments/assets/5611c14e-3c36-47ba-b444-2a9eb8fec679" />

Others for reference:
<img width="2008" height="221" alt="Screenshot 2026-07-25 at 1 11 03 AM" src="https://github.com/user-attachments/assets/61cbde9b-b139-47ef-89fc-5709f82c2a86" />


## Summary

The `.stat-accent::after` top-line accent is `position:absolute`, so it anchors to the nearest positioned ancestor. The core `StatCard` (in `ui.tsx`) sets `relative overflow-hidden`, scoping its hover accent to each card individually. The Vector Memory sub-cards omitted these classes, causing the accent to anchor to the whole `Card` — hovering any sub-card highlighted the entire row instead of just that card.

## Changes

Add `relative overflow-hidden` to both Vector Memory stat sub-cards in `VectorMemoryCard.tsx` to match `StatCard` behavior.

## Testing

- TypeScript typecheck passes (`tsc --noEmit`)
- Visual: hover each of the 4 sub-cards (Semantic/Episodic/Embedded/Embeddings) — each now shows its own purple top-line accent independently, matching the Overview top cards (Uptime/Sessions/Messages)