### PR TITLE
feat(website): edition-extension seam via KIROCREW_EDITION_DIR (retire the overlay/shadow model)

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -282,16 +282,48 @@ Plus one **exported-transport** seam for edition-owned API methods (not a
 registry — see "API methods" below): `api/apiTransport.ts` exports `apiTransport`,
 and the edition builds its own typed API module on it.
 
-**Composition root.** `src/extensions.ts` is the one file an edition owns. It is
-imported first in `main.tsx` (before the store/providers/`App`), so all
-registration runs before render. The core ships it **empty and must keep it
-empty** — `extensionSeams.test.tsx` asserts the stock body is `export {}` (plus
-comments) and that importing it registers nothing. This guards a silent-erasure
-hazard: the file is core-tracked but edition-owned, so a core registration added
-here would be deleted by an edition's overlay on the next sync with no collision
-and no throw. Put core registrations in the seed maps, never here. Registries are
-read at module-load / first-render and are **not reactive** — register here, not
-after mount.
+**Composition root.** `src/extensions.ts` is **core-owned** and imported first in
+`main.tsx` (before the store/providers/`App`), so all registration runs before
+render. It imports the `virtual:kirocrew-edition` module, which the
+`editionExtensionPlugin` in `vite.config.ts` resolves to:
+- an **inert empty module** in the stock OSS build (`KIROCREW_EDITION_DIR`
+  unset) — the stock build registers nothing, byte-identical to no seam;
+- the **downstream edition's own** `$KIROCREW_EDITION_DIR/extensions.tsx` when
+  that env var points at an edition repo — so the edition injects its
+  `register*()` calls + component imports **by build config**, compiled through
+  the same vite/rollup pass, **without shadowing/overlaying any core file**
+  (the copy-and-shadow erosion the seams exist to eliminate). A misconfigured
+  `KIROCREW_EDITION_DIR` (set but missing `extensions.tsx`/`.ts`) **fails the
+  build loudly** rather than silently degrading to the stock SPA.
+
+**Edition-build safety (fail-closed opt-in):** edition composition is **opt-in
+and fail-closed** — `KIROCREW_EDITION_DIR` alone is NOT enough; the plugin also
+requires **`KIROCREW_ALLOW_EDITION=1`** or it THROWS. So every pipeline
+(including release/publish, and the backend `setup.py` → `build-frontend.sh`
+path) is protected by default: a stray/inherited `KIROCREW_EDITION_DIR` can
+never silently compile proprietary edition sources into `website/dist` (the dist
+staged into the public OSS wheel — a contaminated public release cannot be
+unpublished). Only the edition's own build sets `KIROCREW_ALLOW_EDITION=1`.
+Forgetting the opt-in fails safe (stock); there is no guard var a release job
+must "remember to set." An edition-mode build additionally prints a loud
+`[kirocrew-edition] ⚠ BUILDING WITH EDITION COMPOSITION ROOT` line so the mode
+is unmissable in local + CI logs.
+
+**Edition peer-dependency rule:** an edition dir resolves bare imports from its
+OWN `node_modules`, so any **context-carrying singleton** the core's provider
+tree owns must be de-duplicated or its hooks bind to a second instance
+(`Invalid hook call`, `No QueryClient set`, null router context, silently empty
+data — only at runtime, only in the edition build). `vite.config.ts`
+`resolve.dedupe` covers `react`, `react-dom`, `react-redux`, `react-router`,
+`react-router-dom`, `@tanstack/react-query`, `framer-motion`. **When the core
+adds a new global-context provider, add its package here** (and the edition
+should declare these as peer deps).
+
+The core must register **nothing of its own** in `extensions.ts` —
+`extensionSeams.test.tsx` asserts its stock body is the edition import + `export
+{}` (plus comments). Put core registrations in the seed maps, never here.
+Registries are read at module-load / first-render and are **not reactive** —
+the edition registers via this import path, not after mount.
 
 **Builtin routes.** `registerBuiltinComponents()` accepts only a single, plain
 top-level path segment (`/^\/[A-Za-z0-9][A-Za-z0-9._~-]*$/`) — `BuiltinAppRoute`

--- a/website/src/extensions.ts
+++ b/website/src/extensions.ts
@@ -1,33 +1,48 @@
 /**
- * Extension composition root — the ONE file a downstream edition owns.
+ * Extension composition root — the core-owned entry point that pulls in a
+ * downstream edition's registrations.
  *
  * This module is imported for its side effects as the very first line of
- * `main.tsx`, before the store, providers, or `App` are constructed. It is the
- * single, documented place where a downstream edition (or plugin bundle) calls
- * the frontend extension-seam registrars so their contributions are present
- * before the shell renders:
+ * `main.tsx`, before the store, providers, or `App` are constructed, so any
+ * edition contributions are present before the shell renders. The edition's OWN
+ * `extensions.tsx` (in its own repo, at `$KIROCREW_EDITION_DIR`) is where the
+ * frontend extension-seam registrars are called:
  *
- *   import { registerBuiltinComponents } from './apps/builtinRegistry'
- *   import { registerBuiltinIcons }      from './apps/builtinIcons'
- *   import { registerThemeBranding }     from './themeBranding'
- *   import { registerTopBarWidgets }     from './apps/topBarWidgets'
- *   import { registerPanelShortcut }     from './hooks/useKeyboardShortcuts'
- *   import { registerNonAppPrefix }      from './components/MigrationCheck'
- *   import { registerTheme }             from './hooks/useTheme'
- *   import { registerCapsuleSegment }    from './apps/capsuleSegments'
- *   import { registerOverviewStatCards } from './pages/overviewStatCards'
+ *   import { registerBuiltinComponents } from '@/apps/builtinRegistry'
+ *   import { registerBuiltinIcons }      from '@/apps/builtinIcons'
+ *   import { registerThemeBranding }     from '@/themeBranding'
+ *   import { registerTopBarWidgets }     from '@/apps/topBarWidgets'
+ *   import { registerPanelShortcut }     from '@/hooks/useKeyboardShortcuts'
+ *   import { registerNonAppPrefix }      from '@/components/MigrationCheck'
+ *   import { registerTheme }             from '@/hooks/useTheme'
+ *   import { registerCapsuleSegment }    from '@/apps/capsuleSegments'
+ *   import { registerOverviewStatCards } from '@/pages/overviewStatCards'
  *
  * For edition-owned API methods there is no registrar — the edition imports the
- * blessed `apiTransport` (`./api/apiTransport`) and builds its own typed API
+ * blessed `apiTransport` (`@/api/apiTransport`) and builds its own typed API
  * module on it (the core never consumes edition API methods, so a registry would
  * add stringly-typed surface for no composition benefit).
  *
- * The core ships this file EMPTY — the stock build registers nothing and every
- * seam is inert. A downstream edition overlays / owns this one file to inject
- * its registrations, instead of forking `main.tsx` (the copy-and-shadow erosion
- * the seams exist to eliminate). The registries are read at module load /
- * first render, so registering here — before `main.tsx` mounts `App` — is the
- * supported contract; registering later is not reactive and may not appear
- * until an unrelated re-render.
+ * The core OWNS this file and imports the `virtual:kirocrew-edition` module,
+ * which the `editionExtensionPlugin` in `vite.config.ts` resolves to:
+ *   - an INERT empty module in the stock OSS build (`KIROCREW_EDITION_DIR`
+ *     unset) — the stock build registers nothing, byte-identical to no seam;
+ *   - the downstream edition's OWN composition root
+ *     (`$KIROCREW_EDITION_DIR/extensions.tsx`) when that env var points at an
+ *     edition repo — so the edition injects its registrations by CONFIG, never
+ *     by shadowing this file or `main.tsx` (the copy-and-shadow erosion the
+ *     seams exist to eliminate).
+ *
+ * A downstream edition puts its `register*()` calls + component imports in its
+ * own `extensions.tsx`; it does NOT edit this file. The registries are read at
+ * module load / first render, so the edition module runs — before `main.tsx`
+ * mounts `App` — via this import; registering later is not reactive.
+ *
+ * (Edition-owned API methods have no registrar — the edition imports the blessed
+ * `apiTransport` and builds its own typed API module on it.)
  */
+// Resolved by editionExtensionPlugin (vite.config.ts): inert in the stock build,
+// the edition's composition root when KIROCREW_EDITION_DIR is set.
+import 'virtual:kirocrew-edition'
+
 export {}

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -352,20 +352,22 @@ describe('extension slot isolation', () => {
 })
 
 describe('composition root — stock extensions.ts is empty', () => {
-  // extensions.ts is core-tracked but contractually edition-owned: a downstream
-  // build overlays it to inject registrations. If the CORE ever registers
-  // something in it, an edition's overlay would silently delete that core
-  // feature on the next sync (no key collision -> no throw). Guard the
-  // invariant so the stock file stays a no-op: its body is `export {}` (plus
-  // comments), and importing it registers nothing.
-  it('has an empty body (export {} + comments only)', () => {
+  // extensions.ts is core-OWNED: it imports the `virtual:kirocrew-edition`
+  // module (resolved by editionExtensionPlugin to an inert stub in the stock
+  // build, or the edition's own composition root when KIROCREW_EDITION_DIR is
+  // set). The core must register NOTHING of its own here — its only body is the
+  // edition import + `export {}` (plus comments). If the core ever added a
+  // registration here, the stock build would stop being a pure no-op. Guard
+  // that invariant.
+  it('has an empty body (edition import + export {} + comments only)', () => {
     // vitest runs with cwd = website/; extensions.ts lives at src/extensions.ts.
     const src = readFileSync(resolve(process.cwd(), 'src/extensions.ts'), 'utf-8')
     const code = src
+      .replace(/\r\n/g, '\n') // normalize CRLF (Windows checkout) before comparing
       .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
       .replace(/^\s*\/\/.*$/gm, '') // line comments
       .trim()
-    expect(code).toBe('export {}')
+    expect(code).toBe("import 'virtual:kirocrew-edition'\n\nexport {}")
   })
 
   it('capsule-segment + overview-stat-card seams are empty in the stock build', () => {

--- a/website/src/vite-env.d.ts
+++ b/website/src/vite-env.d.ts
@@ -1,3 +1,8 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string
+
+// Resolved by the `editionExtensionPlugin` in vite.config.ts: an inert empty
+// module in the stock build, or the downstream edition's composition root when
+// KIROCREW_EDITION_DIR is set. Imported once by src/extensions.ts.
+declare module 'virtual:kirocrew-edition' {}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig, type Plugin } from 'vite'
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react'
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { execSync } from 'child_process'
 import http from 'http'
 import path from 'path'
@@ -160,12 +160,133 @@ function swVersionPlugin(): Plugin {
   }
 }
 
+/**
+ * Edition-extension seam: resolves the virtual module `virtual:kirocrew-edition`
+ * — imported once by `src/extensions.ts` — to a downstream edition's own
+ * composition-root module, WITHOUT the edition having to overlay/shadow any core
+ * file.
+ *
+ * - `KIROCREW_EDITION_DIR` unset (the stock OSS build): resolves to an INERT
+ *   empty module (`export {}`), so the stock build registers nothing and is
+ *   byte-identical to having no seam at all.
+ * - `KIROCREW_EDITION_DIR=<abs path>` set (a downstream edition build): resolves
+ *   to `<dir>/extensions.tsx` (or `.ts`) — the edition's own file, living in the
+ *   edition's own repo. Its `register*()` calls + component imports compile into
+ *   the SPA through the SAME vite/rollup pass as the core, so the edition never
+ *   copies a core file. The edition dir is added to the watch/allow list so its
+ *   sources resolve.
+ *
+ * This is the frontend analogue of the backend CPP seam: one core, two editions,
+ * the core never importing an edition — the edition is injected by config at
+ * build time, never by shadowing `main.tsx`/`extensions.ts`.
+ */
+function editionExtensionPlugin(): Plugin {
+  const VIRTUAL_ID = 'virtual:kirocrew-edition'
+  const RESOLVED_ID = '\0' + VIRTUAL_ID
+  const editionDir = process.env.KIROCREW_EDITION_DIR
+  // FAIL-CLOSED by default: composing a downstream edition (which compiles that
+  // edition's proprietary sources into website/dist — the dist staged into the
+  // public OSS wheel) requires an EXPLICIT opt-in, KIROCREW_ALLOW_EDITION=1.
+  // Every pipeline — including release/publish — is therefore protected by
+  // default with NO "remember to set a guard var" dependency: an inherited
+  // KIROCREW_EDITION_DIR without the opt-in FAILS THE BUILD rather than
+  // silently contaminating a public artifact (a one-way door — a published
+  // release cannot be unpublished). Only the edition's own build.sh sets the
+  // opt-in. Unsetting the opt-in can never weaken this; forgetting to set it
+  // only ever fails safe (stock).
+  if (editionDir && process.env.KIROCREW_ALLOW_EDITION !== '1') {
+    throw new Error(
+      `KIROCREW_EDITION_DIR is set to '${editionDir}' but KIROCREW_ALLOW_EDITION=1 is not. ` +
+        'Edition composition is opt-in (fail-closed) so a stray env var cannot contaminate a ' +
+        'stock/release build. Set KIROCREW_ALLOW_EDITION=1 in the edition build, or unset ' +
+        'KIROCREW_EDITION_DIR for a stock build.'
+    )
+  }
+  // Resolve the edition's composition root eagerly so a MISCONFIGURED dir
+  // (set but missing the file) fails the build loudly rather than silently
+  // degrading to the stock SPA — a silent degrade would ship an edition build
+  // with none of its edition behavior.
+  let editionEntry: string | null = null
+  if (editionDir) {
+    const abs = path.resolve(editionDir)
+    const candidate = ['extensions.tsx', 'extensions.ts'].map((f) => path.join(abs, f)).find(existsSync)
+    if (!candidate) {
+      throw new Error(
+        `KIROCREW_EDITION_DIR is set to '${editionDir}' but no extensions.tsx/.ts exists there. ` +
+          'Unset it for the stock build, or point it at the edition composition root.'
+      )
+    }
+    editionEntry = candidate
+    // Loud, unmissable self-identification: an inherited KIROCREW_EDITION_DIR
+    // would otherwise SILENTLY compile a downstream edition's (proprietary)
+    // sources into website/dist — which is staged into the Python package. In
+    // this public OSS repo that is an IP-contamination hazard with no trace, so
+    // every edition-mode build/test run must announce itself in local + CI logs.
+    console.warn(
+      `\n[kirocrew-edition] ⚠ BUILDING WITH EDITION COMPOSITION ROOT: ${editionEntry}\n` +
+        '[kirocrew-edition] the resulting dist is EDITION-composed, NOT a stock OSS build. ' +
+        'Unset KIROCREW_EDITION_DIR for a stock build.\n'
+    )
+  }
+  return {
+    name: 'kirocrew-edition-extension',
+    enforce: 'pre',
+    config() {
+      if (editionDir) {
+        // Let vite's dev server serve/resolve files from outside the project
+        // root (the edition dir lives in a sibling repo). ADD the edition dir to
+        // the allow list — include the core project root explicitly because
+        // providing a custom `server.fs.allow` DISABLES vite's workspace-root
+        // auto-detection (per the vite docs), which would otherwise stop core
+        // `website/` files from resolving in dev.
+        return { server: { fs: { allow: [__dirname, path.resolve(editionDir)] } } }
+      }
+      return {}
+    },
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID
+      return null
+    },
+    load(id) {
+      if (id !== RESOLVED_ID) return null
+      if (editionEntry) {
+        // Re-export the edition's composition root so its module-load
+        // side effects (the register*() calls) run exactly once. Emit a
+        // forward-slash path: on Windows editionEntry contains backslashes
+        // (path.resolve/join), which are invalid escape sequences in a JS
+        // import specifier — normalize to posix separators.
+        const spec = editionEntry.split(path.sep).join('/')
+        return `import ${JSON.stringify(spec)}\nexport {}\n`
+      }
+      // Stock OSS build: inert.
+      return 'export {}\n'
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), tailwindRuntimePlugin(), swVersionPlugin()],
+  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), tailwindRuntimePlugin(), swVersionPlugin(), editionExtensionPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Force a SINGLE instance of every CONTEXT-CARRYING singleton across the
+    // bundle. A KIROCREW_EDITION_DIR in a separate repo may resolve these from
+    // ITS OWN node_modules; a second copy binds an edition component's hooks to
+    // a DIFFERENT context instance than the core's providers — "Invalid hook
+    // call" (react), "No QueryClient set" / null router context / silently empty
+    // data (the rest) — only at runtime, only in the out-of-repo edition build.
+    // Dedupe the libraries the core's provider tree owns; harmless in the stock
+    // single-node_modules build. (See website/AGENTS.md — edition peer-dep rule.)
+    dedupe: [
+      'react',
+      'react-dom',
+      'react-redux',
+      'react-router',
+      'react-router-dom',
+      '@tanstack/react-query',
+      'framer-motion',
+    ],
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Problem

A downstream edition (or plugin bundle) that wants to add frontend features — routes, theme brandings, top-bar widgets, its own React components — currently has only the `register*()` seams plus a core-tracked-but-"edition-owned" `src/extensions.ts`. That works for *registration*, but it does not solve **how the edition's own component source files get into the Vite build**: today an edition must physically overlay/copy files into the core `website/src/` tree (a build-time rsync), which shadows core files, drifts on every sync, and is exactly the copy-and-shadow erosion the seams were meant to eliminate.

## Why it matters

The `extensions.ts`-is-edition-owned contract also carries a silent-erasure hazard: it is core-tracked but expected to be overwritten downstream, so any core registration added there would be deleted by an edition's overlay on the next sync with no collision and no throw. An edition needs a way to inject **both** its registrations and its component sources **by build configuration**, without touching a single core file.

## Fix (symptom → root cause → change)

- **Symptom:** editions overlay/shadow core `website/src/` files to get their components into the bundle.
- **Root cause:** there is no build-config seam that lets the edition's sources live in the edition's own repo yet compile through the core's Vite pass.
- **Change:** add `editionExtensionPlugin` to `vite.config.ts`. `src/extensions.ts` (now unambiguously **core-owned**) imports a virtual module `virtual:kirocrew-edition`, which the plugin resolves to:
  - an **inert empty module** in the stock build (`KIROCREW_EDITION_DIR` unset) — registers nothing, byte-identical to no seam;
  - the downstream edition's own `$KIROCREW_EDITION_DIR/extensions.tsx` (or `.ts`) when that env var points at an edition repo — the edition's `register*()` calls + component imports compile into the SPA through the **same** Vite/rollup pass, so the edition never copies or shadows a core file. The edition dir is added to Vite's `server.fs.allow`.
  - a **misconfigured** `KIROCREW_EDITION_DIR` (set but no `extensions.tsx`/`.ts` there) **fails the build loudly**, rather than silently degrading to the stock SPA (which would ship an "edition" build with none of its edition behavior).

This is the frontend analogue of the backend Composed Platform Providers seam: one core, two editions, the core never importing an edition — the edition is injected by config at build time, never by shadowing `main.tsx`/`extensions.ts`.

## Tests

- `extensionSeams.test.tsx` — updated the composition-root invariant: the stock `extensions.ts` body is now the edition import + `export {}` (plus comments), and the core still registers nothing of its own. All 43 seam tests pass.
- Ambient module declaration for `virtual:kirocrew-edition` added to `vite-env.d.ts` so `tsc` resolves the import.

## Manual verification

- **Stock build** (no `KIROCREW_EDITION_DIR`): `npm run build` green; `tsc -b` clean; the virtual module is `export {}` — byte-identical behavior to before.
- **Edition build** (`KIROCREW_EDITION_DIR=<throwaway dir with an extensions.tsx that logs a marker>`): `npm run build` green and the edition module's marker is present in the emitted `dist/assets/*.js` — i.e. the edition source compiled into the SPA with zero core-file changes.
- **Misconfigured dir** (set but no `extensions.tsx`): build fails with a clear, actionable error.
- `eslint` clean on the changed files.

## Screenshots

N/A — build-config / module-resolution seam, no user-visible UI change.
