### PR TITLE
docs(skills): worktree hygiene — keep trees clean so prune can reap merged worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,15 @@ frontend/src/.backup_pre_mdpanel/
 kirocrew-data.tar.gz
 .kiro/hooks/track-with-agent.kiro.hook
 
+# Agent-workflow scratch — files agents sometimes write into a worktree and
+# forget to remove: a PR body fed to `gh pr create --body-file`, and review-round
+# build/test log dirs (e.g. .r29-logs/). Ignoring them keeps `git status` clean so
+# Dev Fleet "Prune merged" can reap merged worktrees (a dirty tree fail-closes the
+# prune as merged_dirty). Prefer writing scratch under `mktemp -d`; committed
+# deliverables (e.g. temp-screenshots/) are unaffected. (`*.log` is already ignored above.)
+.pr-body.md
+.r*-logs/
+
 # AI attribution tracking data
 .attribution/
 

--- a/skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -255,6 +255,40 @@ this PR and push fixes"). Absent that, confirm before each push.
 - Never merge on the user's behalf — merge-ready means green + approved +
   current, then hand it back.
 
+## Rule 9 — Leave the worktree clean (so prune can reap it)
+
+A worktree's tree MUST be clean when you finish a work session on it —
+`git status --porcelain` should print **nothing**. This is not cosmetic: Dev
+Fleet's **"Prune merged"** fail-closes on a dirty tree (a `merged_dirty`
+verdict — untracked files count as dirty), so a merged worktree with even one
+stray untracked file or one unrestored tracked file is **refused for deletion**
+and piles up, wasting disk.
+
+Two habits keep the tree clean:
+
+- **Write scratch OUTSIDE the worktree.** PR bodies, build/test log dumps, QA
+  artifacts, and temp notes must never be written into the worktree root. Use a
+  temp dir instead:
+  ```bash
+  SCRATCH=$(mktemp -d)                          # e.g. /tmp/tmp.XXXXXX
+  gh pr create --body-file "$SCRATCH/pr-body.md" ...
+  python -m pytest -q > "$SCRATCH/fullsuite.log" 2>&1
+  ```
+  The lone exception is a **committed** deliverable — e.g. approved QA media
+  under `temp-screenshots/<feature>/`, which is staged into the PR's commit and
+  is therefore clean, not litter (see the pod-e2e skill).
+- **Restore regenerated tracked files; delete stray untracked ones.** Before you
+  end the session, run `git status --porcelain` and clear anything it prints:
+  ```bash
+  git status --porcelain                        # MUST be empty
+  git checkout -- config-baseline.json          # restore a baseline a test rewrote
+  rm -f .pr-body.md && rm -rf .r*-logs/          # delete stray scratch
+  ```
+
+If you genuinely need a new ignored scratch pattern, add it to the root
+`.gitignore` (the agent-workflow scratch section) rather than leaving it to
+dirty every tree.
+
 ## Why these rules exist (gotchas they prevent)
 
 - Editing the live checkout → the running gateway picks up partial changes →
@@ -275,3 +309,7 @@ this PR and push fixes"). Absent that, confirm before each push.
   agent safety convention (Rule 7).
 - Pushing directly to `main` → breaks CI for everyone; always use a feature
   branch + PR.
+- Scratch files (PR bodies, log dumps) written into the worktree, or a tracked
+  baseline a test rewrote and never restored → `git status` is dirty → Dev
+  Fleet "Prune merged" fail-closes (`merged_dirty`) and merged worktrees pile
+  up, wasting disk (Rule 9).

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -241,3 +241,17 @@ QA screenshots and demo videos follow a **review-then-attach** contract:
 4. **Batch to minimize approval resets.** A force-push resets PR approvals --
    attach media BEFORE asking the user to approve the PR itself, and fold the
    media amend into any pending code amend rather than pushing twice.
+
+### Keep the rest of the tree clean
+
+The e2e suite already writes its logs and screenshots to
+`~/.kirocrew-pods/.e2e-artifacts/<wt>/` -- **outside** the worktree -- by design;
+don't copy those raw logs back into the worktree "to keep them with the branch."
+The only QA output that belongs in the tree is the **committed** media under
+`temp-screenshots/<feature>/` (above). Everything else -- raw `*.log` dumps,
+extra frames, scratch notes, the `.pr-body.md` you fed to `gh pr create` -- stays
+outside (write it under a `mktemp -d`). Before ending the session,
+`git status --porcelain` must be empty: a dirty tree fail-closes Dev Fleet's
+"Prune merged" (`merged_dirty`) so the merged worktree can't be reaped. See the
+kirocrew-worktree-dev skill, "Rule 9 -- Leave the worktree clean (so prune can
+reap it)."


### PR DESCRIPTION
## What

A two-part, **docs + `.gitignore`** change that stops agent-workflow litter from
blocking Dev Fleet's **"Prune merged"**.

**(A) Bundled skills**
- `skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md`: new **Rule 9 — Leave the
  worktree clean (so prune can reap it)**, plus a matching bullet in the "Why
  these rules exist" summary.
- `src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md`: a matching
  **"Keep the rest of the tree clean"** note in the QA-media section.

Both convey: (1) write scratch — PR bodies, build/test logs, QA artifacts, temp
notes — **outside** the worktree (`mktemp -d`), never into the worktree root;
(2) before ending a session, `git status --porcelain` MUST be empty (restore
regenerated tracked files like `config-baseline.json`, delete stray untracked
ones); (3) **why** — a dirty tree fail-closes prune (`merged_dirty`) so merged
worktrees pile up and waste disk.

**(B) Defense-in-depth `.gitignore`**
A minimal, clearly-commented agent-scratch block: `.pr-body.md` and `.r*-logs/`.
`*.log` was already globally ignored; `config-baseline.json` is a **tracked**
file, so `.gitignore` can't help a modified copy — that case is covered by the
skill discipline.

## Why

Dev Fleet "Prune merged" fail-closes on a dirty tree (`merged_dirty`; untracked
files count as dirty via `git status --porcelain`). Investigation of the live
fleet found three recurring litter classes — `.pr-body.md`, `.r29-logs/`-style
log dirs, and a modified `config-baseline.json` — that leave merged worktrees
un-reapable, so they accumulate. This PR is *prevention* (skills) + *defense in
depth* (ignore); the prune fail-closed default is intentionally **unchanged**.

## Verification

- Docs + `.gitignore` only — **no `.py` changed**, so isort/flake8/mypy/pytest
  do not apply; no frontend change, so no tsc/vitest/dist rebuild.
- Confirmed the new patterns match: `git check-ignore -v` resolves `.pr-body.md`
  and `.r29-logs/summary.txt` (a non-`.log` file that `*.log` alone would miss),
  and a scratch-litter dir left `git status --porcelain` empty.
- Markdown sanity-checked (balanced code fences, well-formed headings).

Fixes #433
