### PR TITLE
ci: re-point Arbiter trigger to renamed Claude AI Review reviewer

### DIFF
--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -1,6 +1,6 @@
 name: Arbiter
 
-# SECOND-ORDER GATE. The line-level reviewers (Opus 4.8 / GPT 5.6) surface Medium
+# SECOND-ORDER GATE. The line-level reviewers (Claude / GPT 5.6) surface Medium
 # findings and the design reviewer surfaces CONCERNS — none of which block,
 # correctly, since most are not blockers. But some carry a real long-term cost
 # (architectural erosion, maintainability debt, latent security/data-correctness
@@ -35,7 +35,7 @@ name: Arbiter
 
 on:
   workflow_run:
-    workflows: ["Opus 4.8 Review", "GPT 5.6 Review", "Design Review"]
+    workflows: ["Claude AI Review", "GPT 5.6 Review", "Design Review"]
     types: [completed]
   pull_request:
     types: [labeled, unlabeled]
@@ -122,7 +122,7 @@ jobs:
             # mis-read per-page). Fail-safe to [] on any error.
             comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
             pick() { printf '%s' "$comments" | jq -r --arg m "$1" '[.[] | select(.user.login=="github-actions[bot]" and (.body|startswith($m)))] | (last.body // "")'; }
-            opus="$(pick '<!-- claude-ai-review -->')"
+            claude="$(pick '<!-- claude-ai-review -->')"
             gpt="$(pick '<!-- codex-ai-review -->')"
             design="$(pick '<!-- design-review -->')"
 
@@ -131,7 +131,7 @@ jobs:
             # this workflow, so its completion re-fires the arbiter — the design
             # comment converges deterministically like the two code reviewers.
             missing=""
-            present "$opus"   || missing="$missing Opus-4.8"
+            present "$claude" || missing="$missing Claude"
             present "$gpt"    || missing="$missing GPT-5.6"
             present "$design" || missing="$missing Design"
 
@@ -141,7 +141,7 @@ jobs:
             else
               {
                 echo "# Sub-threshold reviewer findings for $SHA"
-                echo; echo "## Opus 4.8 Review (line-level; Medium/Low)"; echo; printf '%s\n' "$opus"
+                echo; echo "## Claude AI Review (line-level; Medium/Low)"; echo; printf '%s\n' "$claude"
                 echo; echo "## GPT 5.6 Review (line-level; Medium/Low)"; echo; printf '%s\n' "$gpt"
                 echo; echo "## Design Review (design-level; CONCERNS)"; echo; printf '%s\n' "$design"
               } > /tmp/subthreshold.md
@@ -196,7 +196,7 @@ jobs:
 
             INPUTS:
             - /tmp/subthreshold.md — the Medium/Low findings from the two
-              line-level reviewers (Opus 4.8, GPT 5.6) and the CONCERNS from the
+              line-level reviewers (Claude, GPT 5.6) and the CONCERNS from the
               design reviewer, for this PR and commit.
             - /tmp/pr.diff — the PR diff (may be truncated).
 
@@ -307,7 +307,7 @@ jobs:
             waiting)
               STATUS="in_progress"; CONCLUSION=""
               TITLE="Waiting for reviewers:${MISSING}"
-              BODY="The arbiter runs after all reviewers post for this commit. Missing for \`$SHA\`:${MISSING}. This re-fires as each reviewer (Opus 4.8 / GPT 5.6 / Design) completes; the check stays pending (merge-blocking) until all are in." ;;
+              BODY="The arbiter runs after all reviewers post for this commit. Missing for \`$SHA\`:${MISSING}. This re-fires as each reviewer (Claude / GPT 5.6 / Design) completes; the check stays pending (merge-blocking) until all are in." ;;
             deferred)
               CONCLUSION="success"; TITLE="Deferred via defer-longterm label"
               BODY="An author applied the \`defer-longterm\` label, acknowledging and deferring the long-term items. Policy expects a justification comment on the PR." ;;


### PR DESCRIPTION
## Problem
The **Arbiter** long-term-impact gate appeared to be "removed" — it stopped producing a verdict on recent PRs and could sit stuck as a pending, merge-blocking check.

## Why it matters
The Arbiter is the second-order gate that forces authors to act on genuinely costly sub-threshold findings (architectural erosion, one-way-door contracts, latent security/data-correctness risk). If it silently never converges, either that safety net is gone or PRs get wedged on a check that never resolves.

## Fix (symptom → root cause → change)
- **Symptom:** the `Arbiter — judge from comments` check does not converge; on PRs where the Claude reviewer posts last it stays `in_progress` (pending) indefinitely.
- **Root cause:** PR #405 renamed the Claude reviewer workflow from **"Opus 4.8 Review"** → **"Claude AI Review"** (the Fable 5 switch), but the Arbiter's `workflow_run.workflows` trigger still listed `"Opus 4.8 Review"`. That name no longer exists, so the Claude reviewer's completion no longer re-fires the Arbiter. The Arbiter still fired on GPT/Design completion, but it fail-closes to `waiting` until all three reviewer comments are present — so whenever Claude was the last to post, no subsequent event re-evaluated the gate and it never converged.
- **Change:** re-point the trigger to `"Claude AI Review"`. Also refresh the now-inaccurate `Opus 4.8` naming in the header comment, the model-facing `subthreshold.md` heading, the missing-reviewer label (`Opus-4.8` → `Claude`), and the waiting-state body message, and rename the internal `opus` shell variable to `claude` for clarity. The comment-presence detection already keys off the hidden `<!-- claude-ai-review -->` marker (not the display name), so no detection logic changes — this is purely the stale trigger name plus cosmetics. The `--fallback-model us.anthropic.claude-opus-4-8` pin is intentionally left as-is.

## Tests
N/A — no unit-testable surface; this is a GitHub Actions workflow trigger name. Validated the YAML parses and confirmed the only remaining `opus` token is the legitimate fallback-model pin. Behavioral verification is via CI on this PR (the Arbiter should now fire and converge once all three reviewers post).

## Manual verification
- `ruby -ryaml` load of the workflow: OK.
- `grep -i opus` shows only the `--fallback-model us.anthropic.claude-opus-4-8` line, which is correct.
- On this PR: confirm the Arbiter re-fires after **Claude AI Review** completes and reaches a PASS/BLOCK verdict rather than staying pending.
