### PR TITLE
fix: green up Windows Backend Tests (history dedup + concurrent-init convergence + auth/credwatch test portability)

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -1,6 +1,6 @@
 # Conversation History Module
 
-Last Updated: 2026-07-24 (on-loop offload discipline enforcement via OnLoopPersistError + CI-enforced strict mode in the e2e gateway job + deferred single-writer-queue alternative; foreign-append timestamp-first bounded dedup with archive of ambiguous drops + creation-time uuid successor identity; agent_usage roster ordering, folder_id in session metadata, _SEARCH_SCAN_WINDOW relevance search; session archive, configurable autocompact)
+Last Updated: 2026-07-25 (foreign-append matcher hardened to a count-bounded, exact-`(ts,role,content)`-first two-pass with ambiguity-guarded ts-only matching — fixes colliding-timestamp duplication on coarse clocks AND the ts-greedy data-loss regression; on-loop offload discipline enforcement via OnLoopPersistError + CI-enforced strict mode in the e2e gateway job + deferred single-writer-queue alternative; foreign-append timestamp-first bounded dedup with archive of ambiguous drops + creation-time uuid successor identity; agent_usage roster ordering, folder_id in session metadata, _SEARCH_SCAN_WINDOW relevance search; session archive, configurable autocompact)
 
 ## Overview
 
@@ -127,26 +127,41 @@ no longer destroy older turns.
   lock in that gap. A bare `meta + frozen + window` replace would then delete
   that acknowledged append, so the save first scans the on-disk WINDOW region
   (the bytes after the frozen prefix) for lines the in-memory window does not
-  represent and carries them into the payload as `foreign_lines`. A disk line is
-  classified as **ours** (dropped — the window re-serializes it) when EITHER:
-  (a) its `ts` matches a window entry — covers in-place edits that keep `ts` but
-  change content; OR (b) as a **count-bounded** tiebreak, its `(role, content)`
-  matches an **as-yet-unconsumed** window entry — covers a same-process
-  `append_if_absent` durable copy persisted with a fresh `ts` (the workflow/
-  cron-result injectors reflect the message in the slot AND write it via
-  `append_if_absent_off_loop`, so the same message legitimately exists twice with
-  different timestamps and must NOT be double-persisted). Only a line matching
-  NEITHER is foreign and preserved.
-  - **Timestamp-first identity (the fix for GPT 5.6's HIGH data-loss finding).**
-    `ts` is the primary identity; `(role, content)` is only a bounded tiebreak in
-    which **each window entry absorbs at most ONE disk copy**. So if the on-disk
-    window region holds two lines with identical `(role, content)` but distinct
-    timestamps — the window's own persisted copy (ts-matched, dropped) PLUS a
-    *genuinely distinct* event from another process (e.g. a cron that reports the
-    same status text twice) — the first is folded and the **second is preserved
-    as a foreign append**. An earlier plain-`(role, content)`-set match collapsed
-    both real events into one; the bounded, timestamp-first identity fixes it
-    while still folding the common `append_if_absent` fresh-`ts` copy.
+  represent and carries them into the payload as `foreign_lines`. Matching is
+  **count-bounded** (deques of window-entry indices; each disk line matches at
+  most one window entry and each window entry absorbs at most one disk line) and
+  runs in TWO passes so the outcome is independent of disk-line order:
+  - **Pass 1 — exact `(ts, role, content)`** across all disk lines: an unchanged
+    re-serialization, unambiguously **ours** (dropped — the window re-writes it).
+    Resolving these first is what makes a burst of messages sharing ONE `ts`
+    (coarse clocks — notably Windows' ~15 ms tick — stamp rapid appends with an
+    identical `datetime.now().isoformat()`) match one-for-one instead of being
+    mis-classified and duplicated on disk.
+  - **Pass 2**, for each still-unmatched disk line, in order: (a) a **ts-only**
+    match — an in-place edit keeps `ts` but changes content, so the window's
+    version wins and the disk line is dropped — but applied ONLY when the `ts`
+    group is an unambiguous 1:1 (exactly one unmatched window entry AND exactly
+    one unmatched disk line share it); OR (b) a bounded `(role, content)`
+    tiebreak against an as-yet-unconsumed window entry — covers a same-process
+    `append_if_absent` durable copy persisted with a fresh `ts` (the workflow/
+    cron-result injectors reflect the message in the slot AND write it via
+    `append_if_absent_off_loop`, so the same message legitimately exists twice
+    with different timestamps and must NOT be double-persisted). A line matching
+    NEITHER is foreign and preserved.
+  - **Count-bounded, exact-first identity (the fix for GPT 5.6's HIGH data-loss
+    findings).** `(role, content)` is only a bounded tiebreak in which **each
+    window entry absorbs at most ONE disk copy**. So if the on-disk window region
+    holds two lines with identical `(role, content)` but distinct timestamps —
+    the window's own persisted copy PLUS a *genuinely distinct* event from
+    another process (e.g. a cron that reports the same status text twice) — the
+    first is folded and the **second is preserved as a foreign append** (an
+    earlier plain-`(role, content)`-set match collapsed both real events into
+    one). Symmetrically, because colliding timestamps make a ts-only match
+    AMBIGUOUS (a foreign append that happens to share the `ts` is
+    indistinguishable from an edited window entry), ts-only matching is applied
+    ONLY to unambiguous 1:1 `ts` groups; an ambiguous group preserves its disk
+    lines as foreign — favouring a rare stale duplicate over irreversibly
+    dropping an acknowledged cross-process append.
   - **Archive of ambiguous drops (no permanent loss).** A fresh-`ts` copy folded
     by tiebreak (b) is the genuinely ambiguous case (indistinguishable from a
     distinct same-content message without a stable id), so those drops are

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -8,6 +8,7 @@ import logging
 import re
 import time
 import uuid
+from collections import deque
 
 from kiro_crew import model_registry
 from kiro_crew.agent import KIRO_AGENTS_DIR
@@ -802,23 +803,52 @@ def _frozen_prefix_and_foreign_appends(
     # (role, content) used only as a COUNT-BOUNDED tiebreak so each window entry
     # absorbs at most ONE disk copy (see the module docstring / history.md).
     #
-    # ``window_ts`` maps each window entry's ``ts`` to its ``(role, content)`` so
-    # a ts-match can also decrement that entry's content budget — otherwise a
-    # ts-matched entry could ALSO absorb a later same-content disk line and
-    # over-collapse. ``remaining_rc`` is the per-``(role, content)`` budget of
-    # window entries still available to absorb a disk copy.
-    window_ts = {
-        e["ts"]: (e.get("role"), e.get("content", ""))
-        for e in window_entries
-        if e.get("ts")
-    }
-    remaining_rc: dict[tuple[object, object], int] = {}
-    for e in window_entries:
-        _k = (e.get("role"), e.get("content", ""))
-        remaining_rc[_k] = remaining_rc.get(_k, 0) + 1
-    consumed_ts: set[str] = set()
-    foreign: list[str] = []
-    dedup_dropped: list[str] = []
+    # Build COUNT-BOUNDED consumption budgets over the window entries so each
+    # on-disk window-region line is matched to AT MOST ONE window entry and each
+    # window entry absorbs AT MOST ONE disk line. Identity is checked in three
+    # tiers of decreasing confidence:
+    #   (a) exact (ts, role, content) — an unchanged re-serialization (the common
+    #       steady-save case), resolved first across ALL disk lines so a greedy
+    #       edit/tiebreak match can never steal an entry a later exact line needs;
+    #   (b) ts only — an in-place edit (same ``ts``, changed content: window wins);
+    #   (c) (role, content) only — a same-content copy persisted with a FRESH
+    #       ``ts`` (the ``append_if_absent`` case), routed to the archive.
+    # Keying every tier by COUNT (deques of entry indices guarded by a shared
+    # ``consumed`` flag) — rather than a ``ts -> entry`` dict plus a per-``ts``
+    # ``set`` — is what makes this correct when several messages share one ``ts``.
+    # Coarse system clocks (notably Windows' ~15ms tick) can stamp a burst of
+    # rapid appends with an IDENTICAL ``datetime.now().isoformat()``; the old
+    # dict/set collapsed those colliding-``ts`` entries to a single slot, so a
+    # genuine window line was mis-classified as a foreign append and DUPLICATED on
+    # disk. The bounded multiset below matches them one-for-one regardless of
+    # ``ts`` collisions.
+    exact_idx: dict[tuple[object, object, object], "deque[int]"] = {}
+    ts_idx: dict[object, "deque[int]"] = {}
+    rc_idx: dict[tuple[object, object], "deque[int]"] = {}
+    for _i, e in enumerate(window_entries):
+        _ets = e.get("ts")
+        _erole = e.get("role")
+        _econtent = e.get("content", "")
+        if _ets:
+            exact_idx.setdefault((_ets, _erole, _econtent), deque()).append(_i)
+            ts_idx.setdefault(_ets, deque()).append(_i)
+        rc_idx.setdefault((_erole, _econtent), deque()).append(_i)
+    consumed = [False] * len(window_entries)
+
+    def _take(dq: "deque[int] | None") -> bool:
+        """Consume the first not-yet-consumed entry index in ``dq`` (if any)."""
+        if not dq:
+            return False
+        while dq:
+            _idx = dq.popleft()
+            if not consumed[_idx]:
+                consumed[_idx] = True
+                return True
+        return False
+
+    # Parse the on-disk window-region lines once (skipping blank/corrupt/transient
+    # lines exactly as before), so the two matching passes share one parse.
+    disk_msgs: list[tuple[str, object, object, object]] = []  # (norm, ts, role, content)
     for ln in body[disk_older:]:
         if not ln.strip():
             continue
@@ -831,31 +861,72 @@ def _frozen_prefix_and_foreign_appends(
         role = entry.get("role")
         if role is None or role in _TRANSIENT_ROLES:
             continue
-        ts = entry.get("ts")
-        rc = (role, entry.get("content", ""))
         norm = ln if ln.endswith("\n") else ln + "\n"
-        # 1) ts-match: an in-place edit keeps the ``ts`` but changes content, so
-        #    the window's version wins. Consume the matched entry from the
-        #    content budget too so a later same-content line can't re-claim it.
-        if ts and ts in window_ts and ts not in consumed_ts:
-            consumed_ts.add(ts)
-            wkey = window_ts[ts]
-            if remaining_rc.get(wkey, 0) > 0:
-                remaining_rc[wkey] -= 1
-            continue  # same message (possibly edited in place) — window wins
-        # 2) content tiebreak (bounded): a window entry with this exact
-        #    (role, content) that no ts-match already consumed absorbs this disk
-        #    copy — the ``append_if_absent`` fresh-``ts`` case. A drop carrying a
-        #    DISTINCT non-empty ``ts`` is the genuinely ambiguous case (it could
-        #    be a distinct message we cannot tell apart without a stable id), so
-        #    route it through the archive; a ts-less / matching re-serialization
-        #    is a plain window copy and is dropped silently to avoid archive spam.
-        if remaining_rc.get(rc, 0) > 0:
-            remaining_rc[rc] -= 1
+        disk_msgs.append((norm, entry.get("ts"), role, entry.get("content", "")))
+
+    # Pass 1 — exact (ts, role, content): unambiguously our own unchanged
+    # re-serialization. Resolving these first makes the result independent of the
+    # disk-line order (an earlier edit/tiebreak match can no longer consume an
+    # entry that a later exact line requires).
+    handled = [False] * len(disk_msgs)
+    for _j, (_norm, ts, role, content) in enumerate(disk_msgs):
+        if ts and _take(exact_idx.get((ts, role, content))):
+            handled[_j] = True
+
+    foreign: list[str] = []
+    dedup_dropped: list[str] = []
+    # After the exact pass, an in-place EDIT (same ``ts``, changed content) is the
+    # only legitimate reason to drop a still-unmatched disk line by ``ts`` alone.
+    # But under COLLIDING timestamps a ts-only match is AMBIGUOUS: a foreign
+    # cross-process append that happens to share the ``ts`` is indistinguishable
+    # from an edited window entry, and greedily consuming the ts budget would
+    # silently DROP that acknowledged foreign line (data loss) — the exact guard
+    # this scan exists to uphold. So restrict ts-only matching to the UNAMBIGUOUS
+    # singleton case: a ``ts`` carried by EXACTLY ONE still-unmatched window entry
+    # AND EXACTLY ONE still-unmatched disk line. Any ts group with more than one
+    # unmatched line on either side is ambiguous, so its disk lines fall through
+    # to the content tiebreak / foreign preservation below (favouring a rare
+    # duplicate over irreversible data loss). Counts are taken from the
+    # post-exact-pass state and are static for pass 2 (the ``consumed`` guard in
+    # ``_take`` still prevents any double-consumption).
+    w_unmatched_ts: dict[object, int] = {}
+    for _i, e in enumerate(window_entries):
+        _wt = e.get("ts")
+        if _wt and not consumed[_i]:
+            w_unmatched_ts[_wt] = w_unmatched_ts.get(_wt, 0) + 1
+    d_unmatched_ts: dict[object, int] = {}
+    for _j, (_norm, ts, _role, _content) in enumerate(disk_msgs):
+        if ts and not handled[_j]:
+            d_unmatched_ts[ts] = d_unmatched_ts.get(ts, 0) + 1
+
+    # Pass 2 — for still-unmatched disk lines: ts-only (UNAMBIGUOUS in-place edit)
+    # then the bounded (role, content) tiebreak, else genuinely foreign.
+    for _j, (norm, ts, role, content) in enumerate(disk_msgs):
+        if handled[_j]:
+            continue
+        # ts-match: an in-place edit keeps the ``ts`` but changes content, so the
+        # window's version wins and the disk line is dropped silently — but ONLY
+        # when the ``ts`` group is an unambiguous 1:1 (else a colliding foreign
+        # append could be mistaken for the edit and lost).
+        if (
+            ts
+            and w_unmatched_ts.get(ts, 0) == 1
+            and d_unmatched_ts.get(ts, 0) == 1
+            and _take(ts_idx.get(ts))
+        ):
+            continue
+        # content tiebreak (bounded): a window entry with this exact
+        # (role, content) that no match already consumed absorbs this disk copy —
+        # the ``append_if_absent`` fresh-``ts`` case. A drop carrying a DISTINCT
+        # non-empty ``ts`` is the genuinely ambiguous case (it could be a distinct
+        # message we cannot tell apart without a stable id), so route it through
+        # the archive; a ts-less / matching re-serialization is a plain window
+        # copy and is dropped silently to avoid archive spam.
+        if _take(rc_idx.get((role, content))):
             if ts:
                 dedup_dropped.append(norm)
-            continue  # window already carries this content
-        # 3) genuinely foreign → preserve verbatim.
+            continue
+        # genuinely foreign → preserve verbatim.
         foreign.append(norm)
     # Cache the frozen prefix AND the foreign lines together, keyed on the
     # as-read (mtime, size). If this save's atomic_write later fails, the file

--- a/src/kiro_crew/dashboard/token_secret.py
+++ b/src/kiro_crew/dashboard/token_secret.py
@@ -151,6 +151,21 @@ def _load_or_create_secret() -> bytes:
                 existing = key_path.read_bytes()
             except FileNotFoundError:
                 existing = b""
+            except OSError:
+                # A concurrent creator can hold the file open while it writes the
+                # fresh key; on Windows that read raises a sharing violation
+                # (PermissionError / WinError 32). This is TRANSIENT — back off and
+                # retry within the bounded loop rather than letting it propagate to
+                # the outer ephemeral fallback, which would make this racer diverge
+                # from the winner's persisted key (silent auth corruption). POSIX
+                # permits the concurrent read, so this branch is Windows-only; a
+                # genuinely unreadable file still degrades to ephemeral after the
+                # retry budget is exhausted (same as before, ~1s later).
+                logger.debug(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
+                    "token signing key read contended at %s; retrying", key_path
+                )
+                time.sleep(_CREATE_BACKOFF_SECONDS)
+                continue
             if len(existing) >= _MIN_KEY_BYTES:
                 # Re-enforce 0600 at load time, not just at creation: perms may
                 # have been relaxed since (backup restore, manual edit,

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -1407,6 +1407,115 @@ class TestInMemoryAuthority:
         contents = [m["content"] for m in disk]
         assert contents == [f"old msg {i}" for i in range(8)] + ["brand new msg"]
 
+    def test_append_only_colliding_ts_no_duplicate(self, tmp_path, monkeypatch):
+        """Colliding timestamps must not duplicate a genuine message on disk.
+
+        A coarse system clock (notably Windows' ~15ms tick) can stamp a burst of
+        rapid appends with an IDENTICAL ``datetime.now().isoformat()``. The
+        append-safe save must still match each on-disk window-region line to its
+        own window entry one-for-one — never mis-classifying a real window line
+        as a phantom "foreign append" and duplicating it. Regression for the
+        Windows ``Backend Tests`` failure in
+        ``test_append_only_preserves_full_disk_history``.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        # Freeze history.py's clock so every on-disk append shares ONE ts,
+        # reproducing the coarse-clock collision deterministically on any OS.
+        import datetime as _dt
+
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        _FROZEN = _dt.datetime(2026, 7, 25, 0, 0, 0, tzinfo=_dt.timezone.utc)
+
+        class _FrozenDateTime:
+            @classmethod
+            def now(cls, tz=None):
+                return _FROZEN
+
+        monkeypatch.setattr("kiro_crew.history.datetime", _FrozenDateTime)
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        # 8 messages on disk, ALL sharing the frozen ts.
+        for i in range(8):
+            log.append("dashboard:s5c", "user", f"old msg {i}")
+        disk = log.read_messages("dashboard:s5c")
+        # Every on-disk ts is identical — the exact condition that broke matching.
+        assert len({m.get("ts") for m in disk}) == 1
+
+        # Restore truncated to the last 3, re-appending WITH the persisted ts
+        # (mirrors production restore) — so those window entries also collide.
+        slot = state.get_or_create_slot("s5c")
+        for m in disk[5:]:
+            slot.append("user", m["content"], ts=m.get("ts", ""))
+        slot.drain()
+        slot._resumed_count = len(slot.messages)
+        slot._disk_window_len = len(slot.messages)
+        slot._disk_older_count = 5
+        slot.append("user", "brand new msg")
+        slot.drain()
+
+        _save_slot_to_history(state, slot)
+
+        # No phantom foreign append, nothing archived, full history preserved.
+        assert not (tmp_path / "archive").exists()
+        contents = [m["content"] for m in log.read_messages("dashboard:s5c")]
+        assert contents == [f"old msg {i}" for i in range(8)] + ["brand new msg"]
+
+    def test_append_only_colliding_ts_edit_preserves_foreign(self, tmp_path, monkeypatch):
+        """Colliding ts + in-place edit + foreign append must NOT drop the
+        foreign line (regression for GPT 5.6 HIGH on the count-bounded matcher).
+
+        The on-disk window region holds, sharing ONE coarse-clock ts: unchanged
+        ``A``, an acknowledged cross-process foreign append ``X``, and the
+        pre-edit copy of ``B`` — in that adversarial order (foreign BEFORE the
+        pre-edit copy). Memory holds ``A`` and the EDITED ``B'``. A greedy
+        ts-only match would consume ``X`` as if it were ``B``'s in-place edit and
+        silently DROP the acknowledged foreign append. The ambiguity guard must
+        instead preserve ``X`` (favouring a rare stale duplicate over
+        irreversible data loss).
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        import json as _json
+
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        t = "2026-07-25T00:00:00+00:00"  # single colliding timestamp
+
+        def _line(content: str) -> str:
+            return _json.dumps({"role": "user", "content": content, "ts": t}) + "\n"
+
+        # Craft the adversarial on-disk order directly: A, foreign X, pre-edit B.
+        path = log._path("dashboard:s5e")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            _json.dumps({"_type": "metadata", "created_at": t, "last_consolidated": 0})
+            + "\n"
+            + _line("msg A")
+            + _line("msg X (foreign)")
+            + _line("msg B"),
+            encoding="utf-8",
+        )
+
+        # Window: A unchanged, B edited in place (content changes, ts preserved).
+        slot = state.get_or_create_slot("s5e")
+        slot.append("user", "msg A", ts=t)
+        slot.append("user", "msg B (edited in place)", ts=t)
+        slot.drain()
+        slot._resumed_count = len(slot.messages)
+        slot._disk_window_len = len(slot.messages)
+        slot._dirty = True  # an in-place edit marks the slot dirty
+
+        _save_slot_to_history(state, slot)
+
+        contents = [m["content"] for m in log.read_messages("dashboard:s5e")]
+        # The acknowledged foreign append survived (no data loss) ...
+        assert "msg X (foreign)" in contents, "foreign append was dropped (data loss)"
+        # ... and the edited window content is present.
+        assert "msg B (edited in place)" in contents
+
     def test_append_only_no_duplicate_on_resave(self, tmp_path, monkeypatch):
         """Re-saving without new messages must not duplicate the tail on disk."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -331,9 +331,28 @@ class TestRecentFromSource:
         result = log.recent_from_source("dashboard:")
         assert result == []
 
-    def test_recent_from_source_sorted_by_ts(self, tmp_path):
+    def test_recent_from_source_sorted_by_ts(self, tmp_path, monkeypatch):
+        import datetime as _dt
+
+        # history stamps ts with datetime.now().isoformat(); on a coarse clock
+        # (Windows' ~15ms tick) these rapid appends collide, so a ts-only sort
+        # across sessions is ambiguous and the merge order leaks through (the
+        # observed Windows failure: ['first', 'third', 'second']). Drive a
+        # strictly-increasing clock so the chronological order the test asserts is
+        # actually encoded in the timestamps, on every OS.
+        _base = _dt.datetime(2026, 7, 25, 0, 0, 0, tzinfo=_dt.timezone.utc)
+        _tick = {"n": 0}
+
+        class _IncDateTime:
+            @classmethod
+            def now(cls, tz=None):
+                _tick["n"] += 1
+                return _base + _dt.timedelta(seconds=_tick["n"])
+
+        monkeypatch.setattr("kiro_crew.history.datetime", _IncDateTime)
+
         log = ConversationLog(base_dir=tmp_path)
-        # Append in different sessions — timestamps will be ordered
+        # Append in different sessions — timestamps are strictly ordered.
         log.append("dashboard:chat-1-100", "user", "first")
         log.append("dashboard:chat-2-200", "user", "second")
         log.append("dashboard:chat-1-100", "user", "third")

--- a/test/test_mcp_gateway_bluegreen.py
+++ b/test/test_mcp_gateway_bluegreen.py
@@ -564,8 +564,16 @@ async def test_credwatch_no_fire_on_byte_identical_rewrite(tmp_path: Path) -> No
         credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
     )
     await asyncio.sleep(0.05)  # let the baseline establish
-    # Byte-identical rewrite with a forced mtime move.
-    cred.write_bytes(b"secret-v1")
+    # Simulate a no-op refresh (byte-identical content, moved mtime) by touching
+    # ONLY the mtime — do NOT physically rewrite. The watcher's identity is
+    # (mtime, content-hash), so re-writing the SAME bytes is indistinguishable
+    # from an mtime touch; but a real ``write_bytes`` truncates-then-writes
+    # NON-atomically, and the ~10ms poller can read that transient empty/partial
+    # file (digest != baseline -> a spurious fire, then a second fire when the
+    # full bytes reappear). That truncate race — not the property under test — is
+    # what fails this on Windows. An mtime bump alone reproduces the exact
+    # observable state a well-behaved (atomic) refresh daemon leaves behind and is
+    # deterministic on every OS.
     import os
 
     st = cred.stat()

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -878,8 +878,12 @@ def test_signing_secret_persisted_across_loads(tmp_path, monkeypatch) -> None:
     key_file = tmp_path / ta._SECRET_KEY_FILE
     assert key_file.exists()
     assert len(s1) >= 32
-    # Owner-only permissions.
-    assert (key_file.stat().st_mode & 0o777) == 0o600
+    # Owner-only permissions. POSIX enforces this via chmod 0o600; Windows applies
+    # an owner DACL (icacls) that does not surface in st_mode (files report
+    # 0o666), so the POSIX-bit assertion is only meaningful off Windows (the
+    # Windows DACL path is covered by test_platform_compat::TestRestrictToOwner).
+    if os.name != "nt":
+        assert (key_file.stat().st_mode & 0o777) == 0o600
     # Second load returns the SAME secret (persistence).
     s2 = ta._load_or_create_secret()
     assert s1 == s2
@@ -937,8 +941,49 @@ def test_signing_secret_concurrent_first_init_converges(tmp_path, monkeypatch) -
     # Crux: every racer converged on the SINGLE key persisted on disk.
     assert all(r == on_disk for r in results), "concurrent inits diverged from the on-disk key"
     assert len(set(results)) == 1, "more than one distinct signing key was issued"
-    # Winner's create still locked the file down to owner-only.
-    assert (key_file.stat().st_mode & 0o777) == 0o600
+    # Winner's create still locked the file down to owner-only. POSIX enforces
+    # this via chmod 0o600; Windows applies an owner-only DACL (icacls) that does
+    # NOT surface in st_mode (files report 0o666), so the POSIX-bit assertion is
+    # only meaningful off Windows — the Windows DACL path has direct coverage in
+    # test_platform_compat::TestRestrictToOwner.
+    if os.name != "nt":
+        assert (key_file.stat().st_mode & 0o777) == 0o600
+
+
+def test_signing_secret_read_contention_retries_not_ephemeral(tmp_path, monkeypatch) -> None:
+    """A TRANSIENT read failure on the key file — e.g. a Windows sharing
+    violation while a concurrent creator holds it open to write the fresh key —
+    must be RETRIED, not degraded to an ephemeral secret. Otherwise racing
+    first-inits diverge from the persisted key (silent auth corruption). This is
+    the root cause of the flaky Windows `test_signing_secret_concurrent_first_init_converges`
+    divergence; reproduced deterministically here by faulting the first read.
+    """
+    import pathlib
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+    persisted = b"K" * 48  # a valid, already-persisted key (>= 32 bytes)
+    key_file.write_bytes(persisted)
+
+    real_read_bytes = pathlib.Path.read_bytes
+    calls = {"n": 0}
+
+    def _flaky_read(self):  # type: ignore[no-untyped-def]
+        # Fault ONLY the first read of the key file with a sharing-violation-style
+        # PermissionError; the retry (and every other read) hits the real call.
+        if self.name == ts._SECRET_KEY_FILE:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PermissionError("simulated Windows sharing violation")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", _flaky_read)
+
+    got = ts._load_or_create_secret()
+    assert calls["n"] >= 2, "the contended read was not retried"
+    assert got == persisted, "must return the persisted key, not an ephemeral one"
 
 
 def test_signing_secret_existing_file_never_overwritten(tmp_path, monkeypatch) -> None:
@@ -1026,9 +1071,22 @@ def test_signing_secret_write_failure_cleans_up_incomplete_file(
     on_disk = key_file.read_bytes()
     assert len(on_disk) >= ts._MIN_KEY_BYTES, "next init wrote a short/incomplete key"
     assert secret2 == on_disk, "next init did not return the persisted key"
-    assert (key_file.stat().st_mode & 0o777) == 0o600
+    # POSIX-only: Windows locks the key down via an owner DACL, not st_mode bits
+    # (see the concurrent-init test above / test_platform_compat).
+    if os.name != "nt":
+        assert (key_file.stat().st_mode & 0o777) == 0o600
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason=(
+        "Simulates the sibling-substitution race by os.replace()-ing the key "
+        "file while THIS process still holds it open. Windows forbids replacing "
+        "an open handle (WinError 32 sharing violation), so the distinct-inode "
+        "substitution cannot be reproduced. The identity guard's st_dev/st_ino "
+        "logic keeps full coverage on the POSIX matrix."
+    ),
+)
 def test_signing_secret_incomplete_file_not_deleted_if_replaced(
     tmp_path, monkeypatch
 ) -> None:

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -229,7 +229,6 @@ test/test_subagent_sizing.py::TestMacosMemoryProbe::test_zero_page_count_fails_o
 test/test_telegram_config_handlers.py::test_save_persists_token_and_config
 test/test_tips.py::TestStateFilePermissions::test_existing_world_readable_file_corrected_on_rewrite
 test/test_tips.py::TestStateFilePermissions::test_state_file_written_mode_600
-test/test_token_auth.py::test_signing_secret_persisted_across_loads
 test/test_transcribe.py::TestFindWhisper::test_configured_path_not_executable
 test/test_transcribe.py::TestFindWhisper::test_tilde_expansion
 test/test_vector_memory.py::TestSchemaInit::test_file_permissions


### PR DESCRIPTION
## Problem
Tests that fail only on the **Windows** `Backend Tests` matrix. Root cause across most: Windows' coarse (~15 ms) clock and its file-sharing semantics.

- `test_dashboard_chat.py::...::test_append_only_preserves_full_disk_history` — a saved message is **duplicated** on disk.
- `test_token_auth.py::test_signing_secret_concurrent_first_init_converges` — concurrent inits **diverge** from the on-disk key (and a POSIX-mode assertion).
- `test_token_auth.py` — two more `assert st_mode & 0o777 == 0o600` / open-file-replace tests.
- `test_history.py::...::test_recent_from_source_sorted_by_ts` — cross-session order wrong (`['first','third','second']`).
- `test_mcp_gateway_bluegreen.py::test_credwatch_no_fire_on_byte_identical_rewrite` — watcher fires twice on a no-op rewrite.

## Why it matters
Two are genuine bugs: (1) rapid conversation appends can silently **duplicate** a persisted message on Windows; (2) concurrent gateway first-inits can **diverge** on the HMAC signing key on Windows, silently corrupting token/cookie signatures. The rest keep the Windows CI lane red, masking real regressions in the ~16 k tests that already pass there.

## Fix (symptom → root cause → change)
**1. History dedup (product — `chat_persistence.py`).** Colliding `ts` (coarse clock) collapsed the matcher's `ts → entry` dict + per-`ts` `set`, so a real in-window line was mis-classified as a foreign append and re-appended. Replaced with **count-bounded deques** + a **two-pass** match (exact `(ts, role, content)` first, then **unambiguous-only** `ts`-edit → bounded `(role, content)` tiebreak → foreign). The `ts`-edit tier applies only to 1:1 `ts` groups, so a colliding foreign append is never mistaken for an edit and dropped (**data-loss guard** — the HIGH GPT 5.6 raised on rev 1). Spec `history.md` updated.

**2. Concurrent signing-key init (product — `token_secret.py`).** While the `O_EXCL` winner holds the key file open to write, a racer's `read_bytes()` raises a Windows **sharing violation** (`PermissionError`); only `FileNotFoundError` was caught, so it propagated to the ephemeral fallback and that racer signed with a divergent key. Now a transient `OSError` on the fast-path read is **retried within the bounded loop** (POSIX permits the concurrent read, so this is Windows-only; a genuinely unreadable file still degrades after the retry budget).

**3. `recent_from_source` ts-sort (test-only — `test_history.py`).** The asserted cross-session order isn't encoded when timestamps collide. The test now drives a **strictly-increasing clock**, so the chronological order it asserts is real on every OS.

**4. Auth test portability (test-only — `test_token_auth.py`).** Guarded the `st_mode & 0o777 == 0o600` assertions (concurrent-init, write-failure-cleanup, persisted-across-loads) with `os.name != "nt"` (Windows locks via an owner DACL, not mode bits); `skipif(os.name == "nt")` the open-file-replace test (WinError 32); removed the now-fixed `persisted_across_loads` entry from `windows-expected-failures.txt`.

**5. Credential-watcher test portability (test-only — `test_mcp_gateway_bluegreen.py`).** The byte-identical-rewrite test rewrote via `write_bytes` (non-atomic truncate); the 10 ms poller reads the transient empty file on Windows and fires twice. Since the watcher's identity is `(mtime, content-hash)`, the test now bumps **mtime alone** (`os.utime`) — same observable state, no race. Production `credwatch.py` unchanged.

## Tests
- New `test_append_only_colliding_ts_no_duplicate` and `test_append_only_colliding_ts_edit_preserves_foreign` — each **fails on the respective pre-fix matcher** and passes after.
- New `test_signing_secret_read_contention_retries_not_ephemeral` — faults the first key-file read; **fails without the retry fix** (returns ephemeral) and passes after.
- Existing suites retained; auth/credwatch/history tests keep Windows coverage of everything except platform-specific artifacts.

## Manual verification
- `test_dashboard_chat.py` + `test_history_race.py`: **449 passed**. `test_history.py` + `test_token_auth.py`: **368 passed**. `test_mcp_gateway_bluegreen.py`: **32 passed**. 0 regressions.
- All three new regression tests confirmed to **fail on the respective pre-fix code** and pass after.
- `flake8` + `isort` clean on all changed Python files.
- Windows-specific behavior verified by reasoning about the platform semantics (coarse clock, DACL vs mode bits, sharing violations, non-atomic truncate); the fixes are structural, not timing-dependent.
