### PR TITLE
feat(chat): support folder references in the @-mention picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,12 +633,23 @@ The subagent completed but injection timed out. Result is on disk — use `read`
 
 ## File Attachments
 
-Users attach files via `@filename` syntax in chat input. The file picker searches the active project directory.
+Users attach files via `@filename` syntax in chat input. The file picker searches the active project directory and matches both files and directories.
 
 - `@relative/path` tokens resolved to full paths
 - Image files rendered inline as markdown `![image](path)`
 - Non-image files sent as `[attached_file N] /full/path`
+- Directories sent as `[attached_dir N] /full/path` — see below
 - The `[PROJECT]` context entry tells you which directory is active
+
+### Folder references
+
+A folder mention is a **path reference, not an attachment**. The marker names a
+directory you may explore; no contents are inlined.
+
+- `[attached_dir N] /full/path` means the user pointed you at that directory
+- Do NOT call a file-read tool on the path: it is a directory, and the read will fail
+- Explore it with your own tools: glob for a listing, grep to search contents, read individual files once you know their paths
+- `[attached_file N]` and `[attached_dir N]` number independently, so one message can carry both `[attached_file 1]` and `[attached_dir 1]`
 
 ## Widget Protocol
 

--- a/docs/system-specs/index.md
+++ b/docs/system-specs/index.md
@@ -14,6 +14,7 @@ Load relevant module specs before making changes to that component. Read common 
 | [channel-history](modules/channel-history.md) | Group conversation context buffer |
 | [config](modules/config.md) | Dataclass config schema and loader |
 | [cli](modules/cli.md) | argparse CLI commands (chat, gateway, doctor, setup, manifest) |
+| [file-search](modules/file-search.md) | `@`-mention file and folder search: `/api/file-search` with `kind`/`kinds`, FileIndex directory entries, `[attached_file N]` and `[attached_dir N]` prompt markers |
 | [heartbeat](modules/heartbeat.md) | Periodic background tasks |
 | [history](modules/history.md) | Persistent conversation history with LLM consolidation |
 | [knowledge](modules/knowledge.md) | Knowledge Library ingest (FileReader/SUPPORTED formats incl. .org), folder watcher, LLMPool workers (sweep-shielded) |

--- a/docs/system-specs/modules/file-search.md
+++ b/docs/system-specs/modules/file-search.md
@@ -1,0 +1,240 @@
+# File Search Module
+
+Last Updated: 2026-07-25
+
+## Overview
+
+File search backs the `@`-mention picker in the dashboard chat composer. A user
+types `@` followed by 2+ characters, picks a result, and the composer inserts a
+token that serializes into the prompt as an attachment marker.
+
+Results cover both **files** and **directories**. A file is an attachment whose
+content reaches the agent. A directory is a **path reference only**: the agent
+receives the path and explores it with its own glob/grep/read tools. No
+directory listing or recursive content is inlined.
+
+## API
+
+### `GET /api/file-search`
+
+| Param | Required | Description |
+|---|---|---|
+| `q` | yes | Query string. Fewer than 2 characters returns an empty result set. |
+| `project` | no | Absolute project path to scope the search to. |
+| `workspace` | no | Workspace name to scope the search to, when `project` is absent. |
+| `kinds` | no | `all` (default), `files`, or `dirs`. Unrecognized values fall back to `all`. |
+
+Response:
+
+```json
+{
+  "results": [
+    {"path": "/repo/src/pages", "name": "pages", "kind": "dir",  "size": 0,    "mtime": 1750000000},
+    {"path": "/repo/src/app.ts", "name": "app.ts", "kind": "file", "size": 2048, "mtime": 1750000000}
+  ],
+  "root": "/repo"
+}
+```
+
+- `kind` is `"file"` or `"dir"`. Directory entries always report `size: 0`.
+- At most 15 results are returned.
+- Ranking is by fuzzy score, then **files before directories** on an equal
+  score, then shorter name, then recency. The file bias keeps directory entries
+  from crowding out the file a user is most likely searching for.
+
+### Result sourcing
+
+Two paths produce results:
+
+1. **In-memory index fast path.** Used when the request is scoped to a single
+   project and that project's `FileIndex` is ready and untruncated.
+2. **Per-request walk fallback.** Used otherwise, bounded by a scan budget
+   (50k entries scoped, 5k unscoped) and a collection cap. Files and directories
+   are collected into separate candidate lists, each with its own cap, and files
+   are scanned first at each level. A shared cap let a burst of matching
+   directories fill it before the files in the same directory were examined, so
+   the file-before-directory tie-break never got the chance to run.
+
+Both paths apply the same exclusions: dot-prefixed names, a skip set
+(`node_modules`, `__pycache__`, `dist`, `build`, `venv`, `env`, `out`,
+`target`), and `is_sensitive_path`.
+
+## Security
+
+Both file and directory candidates are resolved with `os.path.realpath`
+**before** the `is_sensitive_path` check, so a symlink pointing into a sensitive
+tree is rejected on its real path rather than its link path. This matches the
+existing precedent in `api_browse_dirs` / `api_browse_files`. The two branches
+are deliberately symmetrical: a divergence would let a sensitive target be
+reachable as a file but not as a directory, or the reverse.
+
+## FileIndex
+
+`FileIndex` keeps an in-memory list of entries per project root, rebuilt every
+30 seconds on a background task, capped at 100,000 entries.
+
+Each entry is a 6-tuple: `(path, name, relpath, size, mtime, kind)` where `kind`
+is `"file"` or `"dir"` and directory entries carry `size: 0`.
+
+Directories are collected during the walk rather than derived from file paths,
+so an **empty** directory is still indexed and searchable. Both files and
+directories count toward the entry cap; once the cap is hit the index is marked
+truncated and the fast path is disabled for that root, falling back to the
+per-request walk.
+
+`FileIndex.search(query, scorer, max_results, kinds)` applies the same
+`kinds` filter and file-before-directory tie-break as the endpoint.
+
+## Prompt markers
+
+The composer serializes picked entries into two independent marker families:
+
+| Marker | Meaning |
+|---|---|
+| `![image](/full/path)` | Image attachment, inlined as markdown |
+| `[attached_file N] /full/path` | Non-image file attachment |
+| `[attached_dir N] /full/path` | Directory path reference |
+
+Numbering is **per family**: `N` in `[attached_file N]` indexes the ordered file
+list, `N` in `[attached_dir N]` indexes the ordered directory list. A single
+message can therefore contain both `[attached_file 1]` and `[attached_dir 1]`
+referring to different things. Within each family, entries referenced inline in
+the user's text are numbered before unreferenced ones.
+
+Path resolution is lossless: because `N` indexes the original ordered list, a
+path containing spaces still resolves exactly, and the whitespace-bounded
+capture is only a fallback for history replay without metadata.
+
+For that index to survive a round trip, the sender persists the ordered lists on
+message metadata: `meta.files` for the file family and `meta.dirs` for the
+directory family. Both are required, not optional. The server stores the
+LLM-facing token form in `content` while keeping this metadata alongside it, so
+replay reads the index from metadata rather than re-parsing the text. Omitting
+`meta.dirs` silently degrades folder replay to the whitespace fallback, which
+truncates any path containing a space. Mid-turn steering renders its own
+optimistic bubble from the same tokenized text, so it carries the same metadata.
+
+Folder tokens are inserted with a trailing slash (`@src/pages/`) so a folder
+mention is visually distinct from a file mention in the composer. Matching
+tolerates the token with or without that slash.
+
+The agent-facing contract for these markers is documented in `AGENTS.md`
+under "File Attachments". Directories must not be passed to a file-read tool.
+
+## Rendering
+
+A resolved marker becomes either an inline chip or a block card depending on
+**position**, not on metadata:
+
+- A marker embedded in a line with other text renders as an inline `@label`
+  chip. Folder chips carry a trailing slash. File chips are clickable and open
+  the file viewer; folder chips are not, so the resolver keeps them in a separate
+  `dirMentionMap` rather than the file `mentionMap` that drives the click handler.
+- A marker alone on its line renders as a block card. File cards are clickable
+  and open the file viewer; folder cards are not clickable, because a directory
+  has nothing to open.
+
+Folder token matching tolerates either path separator and an optional trailing
+one, so a native Windows path inserted as `@src\pages/` still resolves. Without
+that, the mention stayed as raw text and a duplicate marker was appended. Chip
+and card labels are derived the same way: the basename split accepts either
+separator, so a native Windows path shows its folder name rather than the whole
+absolute path, and duplicate names still disambiguate on their parent segment.
+
+The preview strip renders whenever either family is staged, and the composer's
+manual-height compensation keys off both. A folders-only strip would otherwise
+appear with no wrapper allowance and overlap the textarea.
+
+Attachments never referenced anywhere in the message text are rendered exactly
+once at message level, so a message split across multiple paste segments cannot
+duplicate them.
+
+Chat titles strip both marker families before prompt construction, so neither a
+file path nor a folder path leaks into a generated title.
+
+## Composer state
+
+Staged files and staged folders are tracked in separate state (`pendingFiles`,
+`pendingDirs`) so a directory never reaches the upload, thumbnail, or
+`attached_file` paths.
+
+Both are persisted **per chat slot**, files via `chatFileDrafts` and folders via
+`chatDirDrafts`, each in sessionStorage under its own key. On a slot switch the
+outgoing slot's staged entries are written to its draft and the incoming slot's
+are restored. Restoring is what keeps the two isolated: without an explicit
+reset, a folder picked in one chat would remain staged and ride along on the next
+send in a different chat.
+
+When a send fails on a connection error the composer is restored from the
+**pre-serialization** state: the raw typed text plus both staged families. The
+restored file list is the union of images and non-images, since
+`prepareSendPayload` splits those apart for the LLM payload and an image exists
+only in `pendingFiles` — restoring the non-image list alone dropped it, so a
+retry would have sent the message without the image.
+
+Mid-turn steering carries the same metadata, on both the optimistic bubble and
+the server-persisted entry: `steerChat` forwards `meta` in the request body and
+the steer branch merges it into the appended history entry. The `steer` marker is
+applied server-side last, so a client cannot spoof it. Without server-side
+persistence the metadata lived only in the live session, and a reload fell back
+to the content scan and truncated any path containing a space.
+
+The `steer_push` WebSocket echo carries that same `meta` and the client consumes
+it. Other open tabs render the steered bubble from the echo alone, so an echo
+without the ordered lists left them showing a space-truncated path until the
+next reload.
+
+The **queue** is the third path a message with attachments can take (mid-turn
+without a live steer channel, or held while sub-agents run). `queue_append`
+accepts the redacted `meta`, and the drain in `chat_runner` persists it onto the
+appended entry — otherwise a queued message kept its markers but lost the lists.
+A metadata-bearing entry is never folded into a `[N queued messages merged]`
+turn: marker numbers index the message's own list, so concatenating two such
+messages would resolve the second message's markers against the first's paths.
+It breaks the merge and drains alone.
+
+`meta.files` / `meta.dirs` arrive from an untrusted payload, so `metaPathList`
+validates them at the boundary. Invalid members are **blanked in place, never
+dropped**: the marker number is a positional index into this list, so filtering
+would shift every later path down a slot and a spaced path following an invalid
+entry would resolve against the wrong element (or past the end) and fall through
+to the truncating scan. A blank is an alignment placeholder only — it is filtered
+out of the chip/card and unreferenced-attachment outputs so it can never render
+as an empty attachment.
+
+Both write paths roll back on rejection. A failed steer removes its optimistic
+bubble (`removeOptimisticMessage`, scoped to `meta.optimistic` so a
+server-confirmed message with the same timestamp is never deleted) and re-stages
+the composer; a rejected `createSlot` during send restores the captured text,
+files (images included) and folders instead of letting `.unwrap()` throw past the
+restore path.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `src/kiro_crew/dashboard/handlers/files.py` | `api_file_search` endpoint, fuzzy scorer, walk fallback |
+| `src/kiro_crew/dashboard/file_index.py` | `FileIndex`, `FileIndexRegistry` |
+| `src/kiro_crew/dashboard/chat_title.py` | Marker stripping for title generation |
+| `website/src/components/FilePickerMenu.tsx` | Picker UI, `kind` propagation, trailing-slash insertion |
+| `website/src/components/ChatInput.tsx` | Composer wiring, pending file/folder preview strip |
+| `website/src/utils/fileTokens.ts` | Marker serialization and resolution |
+| `website/src/utils/chatDirDrafts.ts` | Per-slot staged folder-reference persistence |
+| `website/src/pages/ChatPage.tsx` | Pending state, send payload, message rendering |
+
+## Tests
+
+| File | Coverage |
+|---|---|
+| `test/test_file_search.py` | Endpoint behaviour, scoring, exclusions |
+| `test/test_file_index.py` | Index build, refresh, registry refcounting |
+| `test/test_file_search_dirs.py` | Directory results, `kinds` filter, symlink security |
+| `test/test_chat_title_dirs.py` | Marker stripping for both families |
+| `website/src/test/FilePickerMenu.dirs.test.tsx` | Folder rows, selection payloads |
+| `website/src/test/fileTokens.dirs.test.ts` | `[attached_dir N]` serialization and numbering |
+| `website/src/test/renderUserContent.dirs.test.tsx` | Folder chips and cards |
+| `website/src/test/chatDirDrafts.test.ts` | Per-slot folder-draft store |
+| `website/src/test/ChatPageDrafts.test.tsx` | Draft isolation, `meta.dirs` persistence guards, send-failure attachment restore, createSlot/steer rejection restore |
+| `website/src/test/chatSlice.removeOptimistic.test.ts` | Optimistic-bubble rollback stays scoped to unconfirmed messages |
+| `website/src/test/ChatInput.dirStripHeight.test.tsx` | Preview-strip height compensation for a folders-only strip |
+| `test/test_chat_steer.py` | Steered messages persist `meta.files` / `meta.dirs`; `steer` marker is not spoofable; `steer_push` echoes meta; queued sends carry meta to the drain and never merge |

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -266,12 +266,21 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                     # (dirty-flush picks it up on next save cycle). Store the
                     # sanitized form — raw content must never reach an external
                     # surface (security-controls).
+                    #
+                    # Carry the client's attachment metadata through, same as the
+                    # queue path at the bottom of this handler. Without it the
+                    # persisted steer keeps only `steer: True`, so on reload
+                    # `parseFiles`/`parseDirs` fall back to scanning the content
+                    # for markers and truncate any path containing a space. The
+                    # `steer` flag is set last so a client cannot spoof it.
+                    _steer_meta = dict(_redact_meta(user_meta)) if user_meta else {}
+                    _steer_meta["steer"] = True
                     slot.append(
                         "user",
                         _sanitized,
                         "msg msg-u",
                         ts=_ts,
-                        meta={"steer": True},
+                        meta=_steer_meta,
                     )
                     state.broadcast_ws(
                         "steer_push",
@@ -279,6 +288,12 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                             "slot": slot.key,
                             "content": _redacted,
                             "ts": _ts,
+                            # Mirror the persisted metadata to every other open
+                            # client. The echo is what a second tab renders from,
+                            # so without the ordered lists that tab falls back to
+                            # the whitespace scan and shows `/repo/my` for
+                            # `/repo/my docs` until a reload re-fetches history.
+                            "meta": _steer_meta,
                         },
                     )
                     return web.json_response({"ok": True, "steered": True})
@@ -287,7 +302,10 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # The existing SSE reader will pick up queued messages as _run_chat
         # processes the queue in its finally block.
         if message:
-            qid = slot.queue_append(message)
+            # Carry the attachment metadata into the queue entry so the drain can
+            # persist it (see queue_append / _dequeue_next_message). Redacted at
+            # the boundary, exactly like the non-queued send path below.
+            qid = slot.queue_append(message, meta=_redact_meta(user_meta) if user_meta else None)
             _c, _ = redact_exfiltration_urls(message)
             _c, _ = redact_credentials(_c)
             _redacted = _redact_for_display(_c)
@@ -319,7 +337,7 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         and state.subagents is not None
         and state.subagents.running_agents_for(f"dashboard:{slot.key}")
     ):
-        qid = slot.queue_append(message)
+        qid = slot.queue_append(message, meta=_redact_meta(user_meta) if user_meta else None)
         _c, _ = redact_exfiltration_urls(message)
         _c, _ = redact_credentials(_c)
         _redacted = _redact_for_display(_c)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4657,6 +4657,19 @@ async def _run_chat(
             cron_label = _m.group(1) if _m else "cron"
             cron_label, _ = redact_exfiltration_urls(cron_label)
             cron_label, _ = redact_credentials(cron_label)
+            # Carry a queued user message's attachment metadata onto the
+            # persisted entry. `_dequeue_next_message` never merges a
+            # metadata-bearing item, so `consumed` holds exactly it and there is
+            # no ambiguity about which lists belong to this content. Without
+            # this the drained message keeps its `[attached_dir N]` markers but
+            # loses the ordered lists, and replay truncates any path containing
+            # a space at the first space. Only plain user messages carry it —
+            # cron/subagent/recovery injections have no attachments.
+            _queued_meta = (
+                consumed[0].get("meta")
+                if (len(consumed) == 1 and not (is_cron or is_subagent or is_recovery))
+                else None
+            )
             slot.append(
                 "subagent"
                 if is_subagent
@@ -4669,6 +4682,7 @@ async def _run_chat(
                 else "msg msg-inject"
                 if is_recovery
                 else "msg msg-u",
+                meta=_queued_meta or None,
             )
 
             task = asyncio.create_task(

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -28,9 +28,21 @@ _TITLE_MAX_ATTEMPTS = 5
 _TITLE_TEXT_LIMIT = 16_384
 _TITLE_MAX_ATTACHMENT_FILES = 20
 _TITLE_MAX_ATTACHMENT_PATH_LENGTH = 4_096
-_TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + _TITLE_MAX_ATTACHMENT_FILES * (
-    _TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32
-)
+# Two marker families each get the full per-family allowance (files and folders
+# are counted separately), so the scan budget must cover BOTH. Budgeting for one
+# family would let a message carrying long file AND folder paths be truncated
+# before its user text, leaving title generation with an empty transcript.
+_TITLE_ATTACHMENT_FAMILIES = 2
+# Total budget for ALL substituted attachment labels in one message, and the cap
+# on any single one. The transcript line fed to the titler is itself capped, so
+# without these a message carrying many (or one pathological) attachment name
+# would spend the whole line on names and truncate away the user's caption --
+# the same failure mode as dropping the names entirely.
+_TITLE_MAX_ATTACHMENT_LABEL_BUDGET = 80
+_TITLE_MAX_ATTACHMENT_LABEL_LENGTH = _TITLE_MAX_ATTACHMENT_LABEL_BUDGET // 2
+_TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + (
+    _TITLE_ATTACHMENT_FAMILIES * _TITLE_MAX_ATTACHMENT_FILES
+) * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32)
 
 # Titling is a trivial 3-6 word task, so run it on the cheapest/fastest model
 # (Haiku) rather than the kirocrew-lite default (Opus 4.6 on the kiro-cli path).
@@ -107,21 +119,75 @@ def _strip_markdown_images(content: str, *, drop_trailing_partial: bool = False)
     return "".join(chunks)
 
 
+def _trailing_segment(path: str) -> str:
+    """Last path segment, separator-agnostic, capped to the per-label limit."""
+    base = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    return base[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+
+
+def _attachment_labels(*path_groups: tuple[str, ...]) -> dict[str, str]:
+    """Map each attachment path to its title label: the trailing path segment.
+
+    Titles keep the name rather than the full path: the path is noise and can
+    leak a directory layout, but the name is usually the whole topic. A label is
+    widened to the last two segments when its basename collides, because three
+    folders all named ``docs`` would otherwise read as "docs and docs and docs"
+    -- which the titling model rejects as SKIP, the very failure this substitution
+    exists to fix. Mirrors the disambiguation the composer applies to chips.
+
+    Groups are labelled together so a file and a folder sharing a basename are
+    disambiguated against each other too.
+    """
+    normalized = {
+        p: p.replace("\\", "/").rstrip("/") for group in path_groups for p in group if p
+    }
+    basenames = [n.rsplit("/", 1)[-1] for n in normalized.values()]
+    dupes = {b for b in basenames if basenames.count(b) > 1}
+    labels: dict[str, str] = {}
+    for original, norm in normalized.items():
+        segments = norm.split("/")
+        label = (
+            "/".join(segments[-2:])
+            if segments[-1] in dupes and len(segments) > 1
+            else segments[-1]
+        )
+        labels[original] = label[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+
+    return labels
+
+
 def _strip_attached_file_tokens(
     content: str,
     attached_files: tuple[str, ...] = (),
     *,
     drop_trailing_partial: bool = False,
+    prefix: str = "[attached_file ",
+    labels: dict[str, str] | None = None,
+    budget: list[int] | None = None,
 ) -> str:
-    """Remove dashboard-generated ``[attached_file N] path`` references.
+    """Replace dashboard-generated ``[attached_file N] path`` references.
+
+    The marker and its full path are replaced by the attachment's BASENAME, not
+    dropped. Dropping them left an attachment-only message with no content at
+    all: "tell me about [attached_dir 1] /long/path/docs and [attached_dir 2]
+    /long/path/website/docs" collapsed to "tell me about and", so the titling
+    model correctly answered SKIP and every such chat fell back to a truncated
+    name. The basename preserves the topic while still keeping the full path out
+    of the title.
 
     Current dashboard messages store paths in token-index order, making each
     lookup constant-time. The whitespace-delimited fallback preserves support
     for older messages without metadata.
+
+    ``prefix`` selects the marker family. Folder references use the sibling
+    ``[attached_dir N] path`` marker with its own index space, so the caller
+    passes the matching ordered path tuple for whichever prefix it scans.
     """
-    prefix = "[attached_file "
     chunks: list[str] = []
     cursor = 0
+    # A single-element list carries the label budget so it is shared across both
+    # marker-family passes over the same message.
+    remaining = budget if budget is not None else [0]
     while True:
         token_start = content.find(prefix, cursor)
         if token_start < 0:
@@ -169,7 +235,24 @@ def _strip_attached_file_tokens(
             continue
 
         chunks.append(content[cursor:token_start])
-        chunks.append(" ")
+        # Substitute the name rather than dropping it: an attachment-only message
+        # would otherwise be left with no content for the titler to name. Once
+        # the shared budget is spent, the rest collapse to a bare space so the
+        # user's own text keeps its place in the transcript line. ``labels=None``
+        # opts out entirely (the truncated fallback does this).
+        if labels is None:
+            label = ""
+        elif expected_path:
+            label = labels.get(expected_path, "")
+        else:
+            # Older messages carry no metadata and so no ordered path to look up;
+            # derive the label from the text the whitespace scan captured.
+            label = _trailing_segment(content[path_start:path_end])
+        if label and len(label) <= remaining[0]:
+            remaining[0] -= len(label)
+            chunks.append(f" {label} ")
+        else:
+            chunks.append(" ")
         cursor = path_end
 
     return "".join(chunks)
@@ -189,22 +272,67 @@ def _message_attachment_paths(message: dict[str, Any]) -> tuple[str, ...]:
     )
 
 
-def _title_text(content: str, attached_files: tuple[str, ...] = ()) -> str:
+def _message_dir_paths(message: dict[str, Any]) -> tuple[str, ...]:
+    """Return bounded, index-preserving folder paths from message metadata."""
+    meta = message.get("meta")
+    if not isinstance(meta, dict):
+        return ()
+    dirs = meta.get("dirs")
+    if not isinstance(dirs, list):
+        return ()
+    return tuple(
+        path if isinstance(path, str) and 0 < len(path) <= _TITLE_MAX_ATTACHMENT_PATH_LENGTH else ""
+        for path in dirs[:_TITLE_MAX_ATTACHMENT_FILES]
+    )
+
+
+def _title_text(
+    content: str,
+    attached_files: tuple[str, ...] = (),
+    attached_dirs: tuple[str, ...] = (),
+    *,
+    keep_attachment_names: bool = True,
+) -> str:
     """Return bounded message text suitable for title generation.
 
     A bounded allowance large enough for every accepted attachment is sanitized
     first, so generated paths cannot crowd later user text out of the retained
     title input. The normalized user text is capped separately.
+
+    ``keep_attachment_names`` substitutes each attachment's basename so the LLM
+    has something to name. The truncated fallback passes False: an
+    attachment-only message must stay unnameable there, because titling it
+    "report.txt" would lock a filename in as the permanent title and prevent a
+    later real title from replacing it.
     """
     source_was_truncated = len(content) > _TITLE_SOURCE_SCAN_LIMIT
     content = content[:_TITLE_SOURCE_SCAN_LIMIT]
     if content.startswith("[BROWSE] "):
         content = content[len("[BROWSE] ") :]
     content = _strip_markdown_images(content, drop_trailing_partial=source_was_truncated)
+    # One label map and one budget shared by both passes, so a file and a folder
+    # with the same basename disambiguate against each other and their names
+    # cannot together crowd out the user's text.
+    labels = (
+        _attachment_labels(attached_files, attached_dirs) if keep_attachment_names else None
+    )
+    budget = [_TITLE_MAX_ATTACHMENT_LABEL_BUDGET]
     content = _strip_attached_file_tokens(
         content,
         attached_files,
         drop_trailing_partial=source_was_truncated,
+        labels=labels,
+        budget=budget,
+    )
+    # Folder references carry their own marker and index space, so they need a
+    # second pass with the matching ordered paths.
+    content = _strip_attached_file_tokens(
+        content,
+        attached_dirs,
+        drop_trailing_partial=source_was_truncated,
+        prefix="[attached_dir ",
+        labels=labels,
+        budget=budget,
     )
     return " ".join(content.split())[:_TITLE_TEXT_LIMIT]
 
@@ -214,7 +342,11 @@ def _build_title_prompt(messages: list[dict[str, Any]]) -> str | None:
     lines: list[str] = []
     for m in messages[:10]:
         role = m.get("role", "")
-        content = _title_text(m.get("content", ""), _message_attachment_paths(m))
+        content = _title_text(
+            m.get("content", ""),
+            _message_attachment_paths(m),
+            _message_dir_paths(m),
+        )
         if role in ("user", "assistant") and content:
             lines.append(f"{role}: {content[:200]}")
     if not lines:
@@ -361,7 +493,14 @@ def _fallback_title_from_messages(messages: list[dict[str, Any]]) -> str:
             text
             for m in messages
             if m.get("role") == "user"
-            and (text := _title_text(m.get("content", ""), _message_attachment_paths(m)))
+            and (
+                text := _title_text(
+                    m.get("content", ""),
+                    _message_attachment_paths(m),
+                    _message_dir_paths(m),
+                    keep_attachment_names=False,
+                )
+            )
         ),
         "",
     )

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -593,6 +593,15 @@ def _dequeue_next_message(slot, merge_enabled: bool) -> tuple:
         for item in list(slot._queue):
             if is_system_injection_item(item):
                 break
+            # An attachment-bearing entry must drain ALONE. Its `meta.files` /
+            # `meta.dirs` are ordered lists indexed by the `[attached_file N]` /
+            # `[attached_dir N]` markers in its own content; concatenating two
+            # such messages would put two independent index spaces in one body
+            # with only one metadata list, so the second message's markers would
+            # resolve against the first's paths. Break the merge here and let it
+            # drain on its own turn with its metadata intact.
+            if item.get("meta"):
+                break
             to_merge.append(item)
         if len(to_merge) > 1:
             del slot._queue[:len(to_merge)]

--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -21,6 +21,10 @@ _SKIP_DIRS = frozenset({
 _REFRESH_SECS = 30
 _MAX_ENTRIES = 100_000
 
+# (path, name, relpath, size, mtime, kind) where kind is "file" or "dir".
+# Directory entries carry size 0.
+_Entry = tuple[str, str, str, int, int, str]
+
 
 class FileIndex:
     """In-memory file index for a single project root.
@@ -33,7 +37,7 @@ class FileIndex:
 
     def __init__(self, root: str) -> None:
         self.root = root
-        self._entries: list[tuple[str, str, str, int, int]] = []  # (path, name, relpath, size, mtime)
+        self._entries: list[_Entry] = []
         self._task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._ready = asyncio.Event()
         self._truncated = False
@@ -62,25 +66,43 @@ class FileIndex:
     def truncated(self) -> bool:
         return self._truncated
 
-    def search(self, query: str, scorer, max_results: int = 15) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        scorer,
+        max_results: int = 15,
+        kinds: str = "all",
+    ) -> list[dict]:
         """Search the index using the provided scorer function.
 
         Args:
             query: lowercased search query (min 2 chars).
             scorer: callable(query, filename, relpath) -> float. 0 = no match.
             max_results: cap on returned results.
+            kinds: ``"all"`` (default), ``"files"``, or ``"dirs"``.
         """
+        want_files = kinds in ("all", "files")
+        want_dirs = kinds in ("all", "dirs")
         hits: list[dict] = []
-        for fpath, fname, rel, size, mtime in self._entries:
+        for fpath, fname, rel, size, mtime, kind in self._entries:
+            if kind == "dir":
+                if not want_dirs:
+                    continue
+            elif not want_files:
+                continue
             sc = scorer(query, fname, rel)
             if sc <= 0:
                 continue
             hits.append({
-                "path": fpath, "name": fname,
+                "path": fpath, "name": fname, "kind": kind,
                 "size": size, "mtime": mtime, "_score": sc,
             })
         now = time.time()
-        hits.sort(key=lambda r: (-r["_score"], len(r["name"]), now - r["mtime"]))
+        # Files rank above dirs on an otherwise equal score so directory
+        # entries never crowd out the file the user is most likely after.
+        hits.sort(key=lambda r: (
+            -r["_score"], r["kind"] == "dir", len(r["name"]), now - r["mtime"],
+        ))
         return hits[:max_results]
 
     async def _rebuild(self) -> None:
@@ -89,14 +111,33 @@ class FileIndex:
         self._truncated = truncated
         logger.debug("FileIndex rebuilt for %s: %d entries%s", self.root, len(entries), " (truncated)" if truncated else "")
 
-    def _walk(self) -> tuple[list[tuple[str, str, str, int, int]], bool]:
-        entries: list[tuple[str, str, str, int, int]] = []
+    def _walk(self) -> tuple[list[_Entry], bool]:
+        entries: list[_Entry] = []
         truncated = False
         for dirpath, dirnames, filenames in os.walk(self.root):
             dirnames[:] = [
                 d for d in dirnames
                 if not d.startswith(".") and d not in _SKIP_DIRS
             ]
+            for dname in dirnames:
+                if len(entries) >= _MAX_ENTRIES:
+                    truncated = True
+                    break
+                dfull = os.path.join(dirpath, dname)
+                # Resolve symlinks before the sensitivity check so a link
+                # pointing into a sensitive tree cannot slip through.
+                if is_sensitive_path(os.path.realpath(dfull)):
+                    continue
+                try:
+                    st = os.stat(dfull)
+                except OSError:
+                    continue
+                entries.append((
+                    dfull, dname, os.path.relpath(dfull, self.root),
+                    0, int(st.st_mtime), "dir",
+                ))
+            if truncated:
+                break
             for fname in filenames:
                 if len(entries) >= _MAX_ENTRIES:
                     truncated = True
@@ -104,13 +145,16 @@ class FileIndex:
                 if fname.startswith("."):
                     continue
                 fpath = os.path.join(dirpath, fname)
-                if is_sensitive_path(fpath):
+                if is_sensitive_path(os.path.realpath(fpath)):
                     continue
                 try:
                     st = os.stat(fpath)
                 except OSError:
                     continue
-                entries.append((fpath, fname, os.path.relpath(fpath, self.root), st.st_size, int(st.st_mtime)))
+                entries.append((
+                    fpath, fname, os.path.relpath(fpath, self.root),
+                    st.st_size, int(st.st_mtime), "file",
+                ))
             if truncated:
                 break
         return entries, truncated

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1859,6 +1859,14 @@ async def api_file_search(request: web.Request) -> web.Response:
 
     max_results = 15
 
+    # kinds: "all" (default) returns both files and directories; "files" or
+    # "dirs" restricts the result set. Unknown values fall back to "all".
+    kinds = request.query.get("kinds", "all").strip().lower()
+    if kinds not in ("all", "files", "dirs"):
+        kinds = "all"
+    want_files = kinds in ("all", "files")
+    want_dirs = kinds in ("all", "dirs")
+
     # Scope search to project (arbitrary path) or workspace
     project = request.query.get("project", "")
     ws_name = request.query.get("workspace", "")
@@ -1907,9 +1915,9 @@ async def api_file_search(request: web.Request) -> web.Response:
     if scoped and len(safe_roots) == 1:
         idx = state.file_indexes.get(safe_roots[0])
         if idx and idx.is_ready and not idx.truncated:
-            results = await asyncio.to_thread(idx.search, query, _fuzzy_score, max_results)
+            results = await asyncio.to_thread(idx.search, query, _fuzzy_score, max_results, kinds)
             trimmed = [{k: v for k, v in r.items() if k != "_score"} for r in results]
-            _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} indexed=true entries={idx.entry_count} results={len(trimmed)}")
+            _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} kinds={kinds} indexed=true entries={idx.entry_count} results={len(trimmed)}")
             return web.json_response({"results": trimmed, "root": safe_roots[0]})
 
     # Fallback: walk filesystem per request
@@ -1923,49 +1931,93 @@ async def api_file_search(request: web.Request) -> web.Response:
     max_collect = max_results * 10  # collect enough candidates for good scoring, then stop
 
     def _walk_file_search() -> list[dict]:
-        """Blocking file-system walk — offloaded via asyncio.to_thread."""
-        results: list[dict] = []
-        walked = 0
+        """Blocking file-system walk — offloaded via asyncio.to_thread.
+
+        Files and directories are collected into SEPARATE candidate lists, each
+        with its own ``max_collect`` allowance. A shared list would let a burst
+        of matching directories fill the cap before the files in the same
+        directory are even examined, dropping the likely target before the
+        file-before-dir tie-break ever runs. Files are also scanned first at each
+        level, so under a tight scan budget the file candidates are the ones that
+        survive.
+        """
+        # Per-kind state: [candidates, walked]. The budgets are deliberately
+        # independent -- a single shared counter let one kind exhaust the whole
+        # allowance before the other was examined, so a root with 50,000 files
+        # starved directory results entirely (and vice versa for the candidate
+        # cap, which dropped the likely file target before the file-before-dir
+        # tie-break could run).
+        found: dict[str, list[dict]] = {"file": [], "dir": []}
+        walked: dict[str, int] = {"file": 0, "dir": 0}
+        wanted = {"file": want_files, "dir": want_dirs}
+
+        def _done(kind: str) -> bool:
+            return (
+                not wanted[kind]
+                or walked[kind] >= max_scan
+                or len(found[kind]) >= max_collect
+            )
+
+        def _full() -> bool:
+            return _done("file") and _done("dir")
+
+        def _collect(kind: str, dirpath: str, names: list[str], root_dir: str) -> None:
+            """Score and collect one kind of entry from a single directory level."""
+            for name in names:
+                if _done(kind):
+                    return
+                walked[kind] += 1
+                if kind == "file" and name.startswith("."):
+                    continue
+                full = os.path.join(dirpath, name)
+                score = _fuzzy_score(query, name, os.path.relpath(full, root_dir))
+                if score <= 0:
+                    continue
+                # Resolve symlinks before the sensitivity check so a link into a
+                # sensitive tree cannot slip through.
+                if is_sensitive_path(os.path.realpath(full)):
+                    continue
+                try:
+                    st = os.stat(full)
+                except OSError:
+                    continue
+                found[kind].append({
+                    "path": full,
+                    "name": name,
+                    "kind": kind,
+                    "size": st.st_size if kind == "file" else 0,
+                    "mtime": int(st.st_mtime),
+                    "_score": score,
+                })
+
         for root_dir in safe_roots:
-            if walked >= max_scan or len(results) >= max_collect:
+            if _full():
                 break
             for dirpath, dirnames, filenames in os.walk(root_dir):
                 dirnames[:] = [
                     d for d in dirnames
                     if not d.startswith(".") and d not in skip_dirs
                 ]
-                for fname in filenames:
-                    if walked >= max_scan or len(results) >= max_collect:
-                        break
-                    walked += 1
-                    if fname.startswith("."):
-                        continue
-                    fpath = os.path.join(dirpath, fname)
-                    rel = os.path.relpath(fpath, root_dir)
-                    sc = _fuzzy_score(query, fname, rel)
-                    if sc <= 0:
-                        continue
-                    if is_sensitive_path(fpath):
-                        continue
-                    try:
-                        st = os.stat(fpath)
-                    except OSError:
-                        continue
-                    results.append({"path": fpath, "name": fname, "size": st.st_size, "mtime": int(st.st_mtime), "_score": sc})
-                if walked >= max_scan or len(results) >= max_collect:
+                # Files first: under a tight scan budget the file candidates are
+                # the ones that survive.
+                _collect("file", dirpath, filenames, root_dir)
+                _collect("dir", dirpath, dirnames, root_dir)
+                if _full():
                     break
-        return results
+        return found["file"] + found["dir"]
 
     results = await asyncio.to_thread(_walk_file_search)
 
-    # Sort by score descending, then shorter name, then recency
+    # Sort by score descending, files before dirs on a tie, then shorter name, then recency
     now = time.time()
-    results.sort(key=lambda r: (-r["_score"], len(r["name"]), now - r["mtime"]))
+    results.sort(key=lambda r: (
+        -r["_score"], r["kind"] == "dir", len(r["name"]), now - r["mtime"],
+    ))
 
     # Strip internal scoring field before response
     trimmed = [{k: v for k, v in r.items() if k != "_score"} for r in results[:max_results]]
 
-    _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} roots={len(safe_roots)} results={len(trimmed)}")
+    _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} kinds={kinds} roots={len(safe_roots)} results={len(trimmed)}")
     return web.json_response({
         "results": trimmed,
         "root": safe_roots[0] if scoped and safe_roots else "",

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1057,7 +1057,7 @@ class _ChatSlot:
 
     # ── Queue helpers (dict-based queue items) ──
 
-    def queue_append(self, content: str, kind: str = "") -> str:
+    def queue_append(self, content: str, kind: str = "", meta: dict | None = None) -> str:
         """Append a message to the queue. Returns the generated queue ID.
 
         ``kind`` is a structural origin tag (e.g. ``"synthetic_recovery"`` for
@@ -1065,9 +1065,21 @@ class _ChatSlot:
         not by content equality — survives queue transformations and cannot
         collide with user-typed text that happens to match an internal string.
         Empty string = plain user/system content (default).
+
+        ``meta`` carries the (already-redacted) attachment metadata of a queued
+        user message — ``meta.files`` / ``meta.dirs``. It must survive the queue
+        because those ordered lists are what let a path containing a space
+        replay losslessly; without it the drain persists the message with
+        markers but no lists, and ``parseFiles``/``parseDirs`` fall back to the
+        whitespace scan that truncates ``/repo/my docs`` to ``/repo/my``.
         """
         qid = uuid.uuid4().hex[:12]
-        self._queue.append({"id": qid, "content": content, "kind": kind})
+        item: dict = {"id": qid, "content": content, "kind": kind}
+        # Only set when present so existing queue-shape assertions (which
+        # compare against the 3-key dict) stay valid for unattached messages.
+        if meta:
+            item["meta"] = meta
+        self._queue.append(item)
         return qid
 
     def queue_insert(self, index: int, content: str, kind: str = "") -> str:

--- a/test/test_acp_send_prompt_dirs.py
+++ b/test/test_acp_send_prompt_dirs.py
@@ -1,0 +1,99 @@
+"""_send_prompt must leave `[attached_dir N]` folder paths untouched.
+
+Image attachments are extracted from the prompt text and inlined as base64
+`image` content blocks. Folder references are plain paths with no image
+extension and are not files, so they must survive verbatim in the text block —
+otherwise the agent would receive a mangled path it cannot explore.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiro_crew.acp.client import AcpClient
+
+
+async def _captured_prompt(message: str) -> list[dict]:
+    """Run _send_prompt with the transport stubbed; return the prompt blocks."""
+    client = AcpClient()
+    client._session_id = "s1"
+    client._send_request = AsyncMock(return_value=1)
+    await client._send_prompt(message)
+    return client._send_request.call_args[0][1]["prompt"]
+
+
+def _text_of(prompt: list[dict]) -> str:
+    return next(b["text"] for b in prompt if b["type"] == "text")
+
+
+class TestSendPromptDirPaths:
+    @pytest.mark.asyncio
+    async def test_dir_marker_survives_verbatim(self, tmp_path):
+        d = tmp_path / "pages"
+        d.mkdir()
+        msg = f"review [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert not [b for b in prompt if b["type"] == "image"]
+
+    @pytest.mark.asyncio
+    async def test_dir_named_like_an_image_is_not_inlined(self, tmp_path):
+        """A DIRECTORY whose name ends in .png must not be read as an image.
+
+        The path regex matches the extension, so the is_file() guard is the only
+        thing preventing an attempt to base64 a directory.
+        """
+        d = tmp_path / "screenshots.png"
+        d.mkdir()
+        msg = f"see [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert str(d) in _text_of(prompt)
+        assert not [b for b in prompt if b["type"] == "image"]
+
+    @pytest.mark.asyncio
+    async def test_dir_path_with_spaces_survives(self, tmp_path):
+        d = tmp_path / "my docs"
+        d.mkdir()
+        msg = f"check [attached_dir 1] {d} please"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "_send_prompt's image path regex is anchored to a leading '/', so it "
+            "never matches a native Windows path. That POSIX-only extraction "
+            "predates folder support; this test asserts a dir reference coexists "
+            "with an inlined image, which requires extraction to fire."
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_image_still_inlined_alongside_a_dir_reference(self, tmp_path):
+        d = tmp_path / "pages"
+        d.mkdir()
+        img = tmp_path / "shot.png"
+        # 1x1 PNG header bytes are enough: the client only base64s the content.
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        msg = f"look at {img} and [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        images = [b for b in prompt if b["type"] == "image"]
+        assert len(images) == 1
+        assert images[0]["mimeType"] == "image/png"
+        text = _text_of(prompt)
+        # The image path is replaced by a placeholder; the dir path is not.
+        assert "[image: shot.png]" in text
+        assert str(d) in text
+        assert str(img) not in text
+
+    @pytest.mark.asyncio
+    async def test_file_marker_unchanged_by_dir_support(self, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n")
+        msg = f"read [attached_file 1] {f}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert not [b for b in prompt if b["type"] == "image"]

--- a/test/test_chat_steer.py
+++ b/test/test_chat_steer.py
@@ -105,3 +105,196 @@ class TestApiChatSteer:
             assert data.get("steered") is not True
 
         client_mock.steer.assert_awaited_once()
+
+
+class TestSteerPersistsAttachmentMeta:
+    """A steered message must persist the ordered attachment lists.
+
+    Without them a reload falls back to scanning the content for markers, which
+    is bounded by whitespace and so truncates any path containing a space.
+    """
+
+    @pytest.mark.asyncio
+    async def test_steer_persists_files_and_dirs(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        spaced_dir = "/repo/my docs"
+        spaced_file = "/repo/my notes.txt"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir} and [attached_file 1] {spaced_file}",
+                    "steer": True,
+                    "meta": {"files": [spaced_file], "dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        persisted = [m for m in slot.messages if m.get("role") == "user"]
+        assert persisted, "the steered message was not persisted"
+        meta = persisted[-1].get("meta") or {}
+        assert meta.get("steer") is True, "the steer marker must survive"
+        assert meta.get("dirs") == [spaced_dir], "spaced folder path lost from meta.dirs"
+        assert meta.get("files") == [spaced_file], "spaced file path lost from meta.files"
+
+    @pytest.mark.asyncio
+    async def test_steer_without_meta_still_marks_steer(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "plain steer", "steer": True}
+            )
+            assert resp.status == 200
+
+        persisted = [m for m in slot.messages if m.get("role") == "user"]
+        assert (persisted[-1].get("meta") or {}).get("steer") is True
+
+    @pytest.mark.asyncio
+    async def test_client_cannot_spoof_the_steer_marker(self, tmp_path, monkeypatch, _patch_sel):
+        """`steer` is set server-side last, so a client value cannot override it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "sneaky",
+                    "steer": True,
+                    "meta": {"steer": False, "dirs": ["/repo/docs"]},
+                },
+            )
+            assert resp.status == 200
+
+        meta = [m for m in slot.messages if m.get("role") == "user"][-1].get("meta") or {}
+        assert meta.get("steer") is True
+        assert meta.get("dirs") == ["/repo/docs"]
+
+    @pytest.mark.asyncio
+    async def test_steer_push_echo_carries_meta(self, tmp_path, monkeypatch, _patch_sel):
+        """The WS echo must mirror the metadata, not just the content.
+
+        A second open tab renders the steered bubble from this event. Without the
+        ordered lists it falls back to the whitespace-bounded content scan and
+        shows `/repo/my` for `/repo/my docs` until the page is reloaded.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        spaced_dir = "/repo/my docs"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir}",
+                    "steer": True,
+                    "meta": {"dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+
+        pushes = [c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "steer_push"]
+        assert pushes, "no steer_push event was broadcast"
+        payload = pushes[-1].args[1]
+        assert payload.get("meta", {}).get("dirs") == [spaced_dir], "steer_push dropped meta.dirs"
+        assert payload.get("meta", {}).get("steer") is True
+
+
+class TestQueuedSendPersistsAttachmentMeta:
+    """A queued (mid-turn / held) send must carry its attachment lists too.
+
+    The queue is the other path a message with attachments can take. It used to
+    store only `{id, content, kind}`, so the drain persisted the markers without
+    the ordered lists and a spaced path truncated on replay — the same defect as
+    the steer path, one layer down.
+    """
+
+    @pytest.mark.asyncio
+    async def test_queued_message_carries_meta_to_the_drain(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        # No live ACP client -> steer is unavailable -> falls through to the queue.
+        slot._acp_client = None
+
+        spaced_dir = "/repo/my docs"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir}",
+                    "meta": {"dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        assert slot._queue, "the message was not queued"
+        assert slot._queue[-1].get("meta", {}).get("dirs") == [spaced_dir], (
+            "queue entry dropped meta.dirs, so the drain cannot persist it"
+        )
+
+    def test_queue_append_omits_meta_key_when_absent(self, tmp_path, monkeypatch):
+        """An unattached message keeps the original 3-key queue shape."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        slot.queue_append("plain text")
+        assert set(slot._queue[-1]) == {"id", "content", "kind"}
+
+    def test_attachment_bearing_entry_is_never_merged(self, tmp_path, monkeypatch):
+        """Merging would put two marker index spaces under one metadata list.
+
+        `[attached_dir 1]` in the second message would resolve against the first
+        message's `meta.dirs`, so an attachment-bearing entry must drain alone.
+        """
+        from kiro_crew.dashboard.chat_utils import _dequeue_next_message
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        slot.queue_append("plain one")
+        slot.queue_append("plain two")
+        slot.queue_append("with folder [attached_dir 1] /repo/my docs", meta={"dirs": ["/repo/my docs"]})
+
+        msg, consumed = _dequeue_next_message(slot, merge_enabled=True)
+        assert len(consumed) == 2, "the merge must stop at the attachment-bearing entry"
+        assert "with folder" not in msg
+
+        msg2, consumed2 = _dequeue_next_message(slot, merge_enabled=True)
+        assert len(consumed2) == 1
+        assert consumed2[0]["meta"]["dirs"] == ["/repo/my docs"]

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -78,6 +78,7 @@ def test_prompt_strips_non_image_attachment_before_truncation():
     prompt = _build_title_prompt([{"role": "user", "content": f"{attachment}\nreview this config"}])
 
     assert prompt is not None
+    # The basename is substituted but capped, so the caption still survives.
     assert "review this config" in prompt
     assert "attached_file" not in prompt
     assert "/uploads/" not in prompt
@@ -97,7 +98,9 @@ def test_prompt_strips_non_image_attachment_path_with_spaces_from_metadata():
 
     assert prompt is not None
     assert "summarize the findings" in prompt
-    assert "quarterly report final.txt" not in prompt
+    # The basename (with its spaces) is kept; the parent path is not.
+    assert "quarterly report final.txt" in prompt
+    assert "/Users/example/uploads/" not in prompt
 
 
 def test_title_text_bounds_source_scanning():
@@ -125,6 +128,7 @@ def test_prompt_strips_multiple_near_limit_attachments_before_text_cap():
     prompt = _build_title_prompt([{"role": "user", "content": content, "meta": {"files": paths}}])
 
     assert prompt is not None
+    # Each substituted label is capped, so five of them cannot crowd out the text.
     assert "summarize the quarterly findings" in prompt
     assert "attached_file" not in prompt
     assert "/tmp/" not in prompt
@@ -160,8 +164,10 @@ def test_prompt_strips_mixed_attachments_and_keeps_caption():
 
     assert prompt is not None
     assert "compare these outputs" in prompt
+    # Images are still dropped entirely; file attachments keep their basename.
     assert "screenshot.png" not in prompt
-    assert "results.csv" not in prompt
+    assert "results.csv" in prompt
+    assert "/tmp/results.csv" not in prompt
 
 
 def test_prompt_preserves_escaped_and_code_quoted_markdown_images():

--- a/test/test_chat_title_dirs.py
+++ b/test/test_chat_title_dirs.py
@@ -1,0 +1,244 @@
+"""Tests for folder-reference stripping in auto-title text (chat_title)."""
+
+from __future__ import annotations
+
+from kiro_crew.dashboard.chat_title import (
+    _TITLE_MAX_ATTACHMENT_FILES,
+    _TITLE_MAX_ATTACHMENT_PATH_LENGTH,
+    _TITLE_SOURCE_SCAN_LIMIT,
+    _TITLE_TEXT_LIMIT,
+    _build_title_prompt,
+    _fallback_title_from_messages,
+    _message_dir_paths,
+    _title_text,
+)
+
+DIR = "/repo/src/pages"
+FILE = "/repo/data.csv"
+
+
+class TestTitleTextDirTokens:
+    def test_strips_standalone_dir_token(self):
+        out = _title_text(f"[attached_dir 1] {DIR}", (), (DIR,))
+        assert "attached_dir" not in out
+        assert DIR not in out
+        # The basename survives: an attachment-only message would otherwise have
+        # no content left for the titler to name.
+        assert out == "pages"
+
+    def test_keeps_surrounding_user_text(self):
+        out = _title_text(f"review [attached_dir 1] {DIR} today", (), (DIR,))
+        assert "attached_dir" not in out
+        assert out == "review pages today"
+
+    def test_strips_dir_token_without_metadata(self):
+        """History replay: no meta, so the whitespace fallback must handle it."""
+        out = _title_text(f"review [attached_dir 1] {DIR} today")
+        assert "attached_dir" not in out
+        assert DIR not in out
+        assert out == "review pages today"
+
+    def test_strips_both_marker_families(self):
+        content = f"look at [attached_file 1] {FILE} and [attached_dir 1] {DIR} please"
+        out = _title_text(content, (FILE,), (DIR,))
+        assert "attached_file" not in out
+        assert "attached_dir" not in out
+        assert FILE not in out
+        assert DIR not in out
+        assert out == "look at data.csv and pages please"
+
+    def test_same_numbered_markers_resolve_against_own_lists(self):
+        """[attached_file 1] and [attached_dir 1] index different tuples."""
+        content = f"[attached_file 1] {FILE} [attached_dir 1] {DIR} end"
+        out = _title_text(content, (FILE,), (DIR,))
+        assert out == "data.csv pages end"
+
+    def test_strips_dir_path_containing_spaces(self):
+        spaced = "/repo/my docs"
+        out = _title_text(f"check [attached_dir 1] {spaced} now", (), (spaced,))
+        assert "attached_dir" not in out
+        assert "/repo/my docs" not in out
+        # The basename keeps its internal space; only the parent path is dropped.
+        assert out == "check my docs now"
+
+    def test_file_only_message_unaffected(self):
+        out = _title_text(f"see [attached_file 1] {FILE} ok", (FILE,))
+        assert "attached_file" not in out
+        assert out == "see data.csv ok"
+
+    def test_plain_text_unaffected(self):
+        assert _title_text("just a normal message") == "just a normal message"
+
+    def test_unknown_dir_index_falls_back_to_whitespace_capture(self):
+        """A token numbered beyond the tuple still gets stripped."""
+        out = _title_text(f"a [attached_dir 9] {DIR} b", (), (DIR,))
+        assert "attached_dir" not in out
+        assert DIR not in out
+
+
+class TestMessageDirPaths:
+    def test_reads_meta_dirs_in_order(self):
+        msg = {"meta": {"dirs": [DIR, "/repo/docs"]}}
+        assert _message_dir_paths(msg) == (DIR, "/repo/docs")
+
+    def test_missing_meta_returns_empty(self):
+        assert _message_dir_paths({}) == ()
+
+    def test_non_dict_meta_returns_empty(self):
+        assert _message_dir_paths({"meta": "nope"}) == ()
+
+    def test_non_list_dirs_returns_empty(self):
+        assert _message_dir_paths({"meta": {"dirs": "nope"}}) == ()
+
+    def test_caps_the_number_of_dirs(self):
+        many = [f"/repo/d{i}" for i in range(_TITLE_MAX_ATTACHMENT_FILES + 5)]
+        assert len(_message_dir_paths({"meta": {"dirs": many}})) == _TITLE_MAX_ATTACHMENT_FILES
+
+    def test_blanks_overlong_paths_preserving_index(self):
+        long_path = "/repo/" + "x" * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 10)
+        got = _message_dir_paths({"meta": {"dirs": [long_path, DIR]}})
+        assert got == ("", DIR), "index order must be preserved so token N still resolves"
+
+    def test_blanks_non_string_entries(self):
+        assert _message_dir_paths({"meta": {"dirs": [None, DIR]}}) == ("", DIR)
+
+
+class TestTitlePromptWithDirs:
+    def test_prompt_body_has_no_dir_marker(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": f"summarize [attached_dir 1] {DIR} for me",
+                "meta": {"dirs": [DIR]},
+            },
+        ]
+        prompt = _build_title_prompt(msgs)
+        assert prompt is not None
+        assert "attached_dir" not in prompt
+        assert DIR not in prompt
+        assert "summarize" in prompt
+
+    def test_dir_only_message_yields_the_folder_name(self):
+        """A folder-only message is titled from the folder name.
+
+        It previously produced no transcript at all, so the titler had nothing to
+        name and answered SKIP.
+        """
+        msgs = [
+            {"role": "user", "content": f"[attached_dir 1] {DIR}", "meta": {"dirs": [DIR]}},
+        ]
+        prompt = _build_title_prompt(msgs)
+        assert prompt is not None
+        assert "user: pages" in prompt
+        assert DIR not in prompt
+
+
+class TestTitleScanBudgetCoversBothFamilies:
+    def test_scan_limit_budgets_for_two_families(self):
+        """Each family gets its own 20-entry allowance, so the budget covers both.
+
+        A one-family budget would let a message carrying long file AND folder
+        paths be truncated before its user text.
+        """
+        per_family = _TITLE_MAX_ATTACHMENT_FILES * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32)
+        assert _TITLE_SOURCE_SCAN_LIMIT >= _TITLE_TEXT_LIMIT + 2 * per_family
+
+    def test_user_text_survives_a_full_pair_of_attachment_families(self):
+        """Max-length paths in both families must not crowd out the user text."""
+        long_dirs = [f"/d{i}/" + "x" * 3_000 for i in range(_TITLE_MAX_ATTACHMENT_FILES)]
+        long_files = [f"/f{i}/" + "y" * 3_000 for i in range(_TITLE_MAX_ATTACHMENT_FILES)]
+        tokens = "\n".join(
+            [f"[attached_file {i + 1}] {p}" for i, p in enumerate(long_files)]
+            + [f"[attached_dir {i + 1}] {p}" for i, p in enumerate(long_dirs)]
+        )
+        content = f"{tokens}\nplease summarize this"
+        text = _title_text(content, tuple(long_files), tuple(long_dirs))
+        assert "please summarize this" in text
+        assert "attached_file" not in text
+        assert "attached_dir" not in text
+        # Full paths are still excluded; only basenames are substituted.
+        assert long_dirs[0] not in text
+        assert long_files[0] not in text
+
+
+class TestFallbackTitleWithDirs:
+    def test_fallback_title_strips_the_folder_marker(self):
+        """The fallback path (LLM titler unavailable) must strip dir markers too.
+
+        It previously passed only the file paths, so a folder mention surfaced
+        raw as "Tell me about [attached_dir 1] /repo/docs" in the chat title.
+        """
+        msgs = [
+            {
+                "role": "user",
+                "content": f"Tell me about [attached_dir 1] {DIR}",
+                "meta": {"dirs": [DIR]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_dir" not in title
+        assert DIR not in title
+        assert title.startswith("Tell me about")
+
+    def test_fallback_title_strips_both_families(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": f"compare [attached_file 1] {FILE} with [attached_dir 1] {DIR}",
+                "meta": {"files": [FILE], "dirs": [DIR]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_file" not in title
+        assert "attached_dir" not in title
+        assert "compare" in title
+
+    def test_fallback_title_strips_a_spaced_folder_path(self):
+        spaced = "/repo/my docs"
+        msgs = [
+            {
+                "role": "user",
+                "content": f"summarize [attached_dir 1] {spaced} please",
+                "meta": {"dirs": [spaced]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_dir" not in title
+        assert spaced not in title
+        assert "summarize" in title
+        # The fallback drops attachment names entirely (only the LLM prompt keeps
+        # them), so no part of the spaced path may survive. Without the ordered
+        # dir paths the whitespace fallback would stop at the space and leak the
+        # tail "docs" into the title.
+        assert "docs" not in title, "the spaced path tail leaked into the title"
+
+
+class TestAttachmentLabelBudget:
+    def test_many_folder_labels_do_not_crowd_out_the_caption(self):
+        """The shared label budget protects the user's own text.
+
+        Substituting a name per attachment is only safe while the total stays
+        bounded: the transcript line handed to the titler is itself capped, so
+        20 long folder names would push the caption out entirely.
+        """
+        dirs = [f"/repo/{'d' * 30}{i}" for i in range(20)]
+        content = (
+            " ".join(f"[attached_dir {i + 1}] {p}" for i, p in enumerate(dirs))
+            + " please summarize these"
+        )
+        text = _title_text(content, (), tuple(dirs))
+        assert "please summarize these" in text
+        assert "attached_dir" not in text
+        assert len(text) < 400, "labels consumed an unbounded share of the line"
+
+    def test_colliding_folder_names_are_disambiguated(self):
+        """Three folders all named docs must not read as "docs and docs and docs"."""
+        dirs = ["/repo/docs", "/repo/website/docs", "/repo/src/kiro_crew/docs"]
+        content = (
+            f"tell me about [attached_dir 1] {dirs[0]} and [attached_dir 2] {dirs[1]}"
+            f" and [attached_dir 3] {dirs[2]}"
+        )
+        text = _title_text(content, (), tuple(dirs))
+        assert "repo/docs" in text
+        assert "website/docs" in text
+        assert "kiro_crew/docs" in text

--- a/test/test_file_search.py
+++ b/test/test_file_search.py
@@ -172,7 +172,13 @@ class TestFileSearch:
         (sub / "utils.py").write_text("x")          # path matches "myfeature"
         (tmp_path / "myfeature.py").write_text("x")  # filename matches "myfeature"
         async with TestClient(TestServer(_make_app())) as client:
-            resp = await client.get(f"/api/file-search?q=myfeature&project={tmp_path}")
+            # kinds=files: this asserts name-match vs path-match ranking among
+            # files. The "myfeature" directory itself is a legitimate hit under
+            # the default kinds=all, so it is excluded here to keep the
+            # assertion about the ranking rule under test.
+            resp = await client.get(
+                f"/api/file-search?q=myfeature&kinds=files&project={tmp_path}"
+            )
             results = (await resp.json())["results"]
             assert results[0]["name"] == "myfeature.py"  # filename match ranked first
             assert any(r["name"] == "utils.py" for r in results)  # path match included

--- a/test/test_file_search_dirs.py
+++ b/test/test_file_search_dirs.py
@@ -1,0 +1,329 @@
+"""Tests for directory results in FileIndex and /api/file-search.
+
+Covers the folder @-mention feature: directory entries carry ``kind: "dir"``,
+the ``kinds`` query param filters the result set, files outrank directories on
+an otherwise equal score, and symlinked directories are resolved before the
+sensitivity check.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.file_index import FileIndex
+from kiro_crew.dashboard.handlers import api_file_search
+
+
+def _make_app(index=None) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/file-search", api_file_search)
+    state = MagicMock()
+    state.file_indexes.get.return_value = index
+    app["state"] = state
+    return app
+
+
+@pytest.fixture()
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+def _populate(tmp_path):
+    """Tree with directories and files sharing the "widget" stem."""
+    (tmp_path / "widgets.py").write_text("x")
+    wdir = tmp_path / "widgets"
+    wdir.mkdir()
+    (wdir / "button.py").write_text("y")
+    nested = wdir / "widgetsinner"
+    nested.mkdir()
+    (nested / "leaf.py").write_text("z")
+    # An empty directory: proof dirs are walked, not derived from file paths.
+    (tmp_path / "widgetsempty").mkdir()
+    # Excluded: dot-prefixed and skip-listed dirs
+    (tmp_path / ".widgetshidden").mkdir()
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / "widgetsdep").mkdir()
+
+
+def _scorer(q, name, rel):
+    nl = name.lower()
+    if q in nl:
+        return 10.0
+    if q in rel.lower():
+        return 5.0
+    return 0.0
+
+
+class TestFileIndexDirs:
+    @pytest.mark.asyncio
+    async def test_index_includes_dir_entries(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            results = idx.search("widgets", _scorer)
+            by_name = {r["name"]: r for r in results}
+            assert by_name["widgets"]["kind"] == "dir"
+            assert by_name["widgets.py"]["kind"] == "file"
+            # Directory entries report size 0 and a real mtime.
+            assert by_name["widgets"]["size"] == 0
+            assert by_name["widgets"]["mtime"] > 0
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_includes_empty_dir(self, tmp_path):
+        """An empty dir has no files, so it can only appear if dirs are walked."""
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            names = {r["name"] for r in idx.search("widgetsempty", _scorer)}
+            assert "widgetsempty" in names
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_kinds_filter(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            dirs = idx.search("widgets", _scorer, 15, "dirs")
+            assert dirs, "expected at least one directory hit"
+            assert all(r["kind"] == "dir" for r in dirs)
+
+            files = idx.search("widgets", _scorer, 15, "files")
+            assert files, "expected at least one file hit"
+            assert all(r["kind"] == "file" for r in files)
+
+            both = {r["kind"] for r in idx.search("widgets", _scorer, 15, "all")}
+            assert both == {"dir", "file"}
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_excludes_hidden_and_skip_dirs(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            names = {r["name"] for r in idx.search("widgets", _scorer, 50, "dirs")}
+            assert ".widgetshidden" not in names
+            assert "widgetsdep" not in names
+            assert "node_modules" not in names
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_files_outrank_dirs_on_equal_score(self, tmp_path):
+        """Equal score and equal name length: the file must sort first."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha.x").write_text("x")
+
+        def flat_scorer(q, name, rel):
+            return 10.0 if q in name.lower() else 0.0
+
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            results = idx.search("alpha", flat_scorer)
+            kinds = [r["kind"] for r in results]
+            assert kinds[0] == "file", f"expected file first, got {results}"
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_dir_symlink_resolved_before_sensitive_check(self, tmp_path):
+        """A symlink into a sensitive tree must be rejected on its real path."""
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink"
+        os.symlink(str(tmp_path / "widgets"), str(link))
+
+        idx = FileIndex(str(tmp_path))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch("kiro_crew.dashboard.file_index.is_sensitive_path", side_effect=fake_sensitive):
+            entries, _ = idx._walk()
+        names = {e[1] for e in entries if e[5] == "dir"}
+        assert "widgetslink" not in names
+        assert "widgets" not in names, "the symlink target shares the real path and must also be filtered"
+
+    @pytest.mark.asyncio
+    async def test_index_file_symlink_resolved_before_sensitive_check(self, tmp_path):
+        """A symlinked FILE into a sensitive tree is rejected on its real path."""
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink.py"
+        os.symlink(str(tmp_path / "widgets.py"), str(link))
+
+        idx = FileIndex(str(tmp_path))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch("kiro_crew.dashboard.file_index.is_sensitive_path", side_effect=fake_sensitive):
+            entries, _ = idx._walk()
+        names = {e[1] for e in entries if e[5] == "file"}
+        assert "widgetslink.py" not in names
+        assert "widgets.py" not in names, "the symlink target shares the real path"
+
+
+class TestApiFileSearchDirs:
+    @pytest.mark.asyncio
+    async def test_walk_fallback_returns_dirs(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            assert resp.status == 200
+            results = (await resp.json())["results"]
+            by_name = {r["name"]: r for r in results}
+            assert by_name["widgets"]["kind"] == "dir"
+            assert by_name["widgets"]["size"] == 0
+            assert by_name["widgets.py"]["kind"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_kinds_dirs_only(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+            )
+            results = (await resp.json())["results"]
+            assert results
+            assert all(r["kind"] == "dir" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_kinds_files_only(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=files&project={tmp_path}"
+            )
+            results = (await resp.json())["results"]
+            assert results
+            assert all(r["kind"] == "file" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_unknown_kinds_value_falls_back_to_all(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=bogus&project={tmp_path}"
+            )
+            assert resp.status == 200
+            kinds = {r["kind"] for r in (await resp.json())["results"]}
+            assert kinds == {"dir", "file"}
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_excludes_hidden_and_skip_dirs(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+            )
+            names = {r["name"] for r in (await resp.json())["results"]}
+            assert ".widgetshidden" not in names
+            assert "widgetsdep" not in names
+
+    @pytest.mark.asyncio
+    async def test_index_fast_path_forwards_kinds(self, tmp_path, mock_sel):
+        """The fast path must pass the kinds param through to FileIndex.search."""
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            app = _make_app(index=idx)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get(
+                    f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+                )
+                data = await resp.json()
+                assert data["root"] == os.path.realpath(str(tmp_path))
+                assert data["results"]
+                assert all(r["kind"] == "dir" for r in data["results"])
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_file_symlink_resolved_before_sensitive_check(
+        self, tmp_path, mock_sel
+    ):
+        """A symlinked FILE into a sensitive tree is rejected on its real path.
+
+        The directory branch already resolved symlinks first; files must match so
+        the two branches cannot disagree about what counts as sensitive.
+        """
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink.py"
+        os.symlink(str(tmp_path / "widgets.py"), str(link))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch(
+            # api_file_search imports is_sensitive_path locally from
+            # kiro_crew.security, so the source module is the patch target.
+            "kiro_crew.security.is_sensitive_path",
+            side_effect=fake_sensitive,
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(
+                    f"/api/file-search?q=widgets&kinds=files&project={tmp_path}"
+                )
+                names = {r["name"] for r in (await resp.json())["results"]}
+        assert "widgetslink.py" not in names
+        assert "widgets.py" not in names, "the symlink target shares the real path"
+
+    @pytest.mark.asyncio
+    async def test_many_matching_dirs_do_not_starve_files(self, tmp_path, mock_sel):
+        """Directories must not consume the whole candidate budget.
+
+        A shared collection cap let a burst of matching directories fill it
+        before any file was examined, so the best-scoring file was never even a
+        candidate. The directories here score LOWER than the file, so a correct
+        implementation returns the file regardless of ranking: the only way to
+        lose it is to never collect it.
+        """
+        # max_collect is max_results * 10 = 150, so 400 matching directories
+        # would previously exhaust it before the file was reached.
+        for i in range(400):
+            (tmp_path / f"zzz_widgets{i:03d}").mkdir()
+        (tmp_path / "widgets.py").write_text("x")
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            results = (await resp.json())["results"]
+        names = [r["name"] for r in results]
+        assert "widgets.py" in names, "the file was crowded out by directory candidates"
+
+    @pytest.mark.asyncio
+    async def test_files_and_dirs_have_independent_scan_budgets(self, tmp_path, mock_sel):
+        """A file-heavy root must not starve the directory scan.
+
+        A single shared scan counter let files spend the whole budget before any
+        directory was examined, so directory search returned nothing even though
+        it was enabled. Non-matching files are used so only the SCAN budget (not
+        the candidate cap) is under test.
+        """
+        for i in range(5_000):
+            (tmp_path / f"zz{i:04d}.py").write_text("x")
+        (tmp_path / "widgets_dir").mkdir()
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            results = (await resp.json())["results"]
+        names = [r["name"] for r in results]
+        assert "widgets_dir" in names, "directory candidates were starved by the file scan"

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -862,8 +862,12 @@ export const api = {
   // Mid-turn steer: inject into the RUNNING turn instead of queueing. Fire-and-forget
   // JSON response ({ok, steered}); the backend falls back to queue if steer is
   // unavailable so the text is never dropped.
-  steerChat: (message: string, slot?: string) =>
-    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true }) }).then(j),
+  // `meta` carries the ordered attachment lists (files/dirs). The server
+  // persists them on the steered history entry, so a path containing a space
+  // still resolves after a reload instead of being truncated by the
+  // content-scan fallback.
+  steerChat: (message: string, slot?: string, meta?: Record<string, unknown>) =>
+    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true, ...(meta ? { meta } : {}) }) }).then(j),
   sessionsHealth: () => fetch('/api/sessions/health').then(j),
   // Knowledge
   knowledgeSearch: (q: string) => get(`/api/knowledge/search-for-context?q=${encodeURIComponent(q)}`).then(j),
@@ -959,11 +963,11 @@ export const api = {
   simulateUpdate: (opts?: { delay?: number; fail_at?: string }) => post('/api/update/simulate', opts || {}).then(j),
   pickFiles: () => post('/api/upload').then(j) as Promise<{ paths: string[] }>,
   fileDiff: (path: string) => fetch('/api/file-diff?path=' + encodeURIComponent(path)).then(j) as Promise<{ diff: string; original: string; status?: 'clean' | 'modified' | 'untracked' | 'not_git' }>,
-  /** Fuzzy file search for @-mention picker */
+  /** Fuzzy file search for @-mention picker. `kind` distinguishes folder hits from files. */
   fileSearch: (q: string, project?: string, signal?: AbortSignal) => {
     const p = new URLSearchParams({ q })
     if (project) p.set('project', project)
-    return fetch(`/api/file-search?${p}`, signal ? { signal } : undefined).then(j) as Promise<{ results: Array<{ path: string; name: string; size: number; mtime: number }>; root: string }>
+    return fetch(`/api/file-search?${p}`, signal ? { signal } : undefined).then(j) as Promise<{ results: Array<{ path: string; name: string; size: number; mtime: number; kind?: 'file' | 'dir' }>; root: string }>
   },
   /** Upload files via browser File API (cross-platform) */
   uploadFiles: async (files: File[]) => {

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
-import { ArrowUpFromLine, ArrowUp, Loader2, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
+import { ArrowUpFromLine, ArrowUp, Loader2, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, Folder, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
 import { Toggle } from './ui'
 import VoiceStatusBar from './VoiceStatusBar'
 import { createPortal } from 'react-dom'
@@ -64,6 +64,7 @@ export {
 import { effortLabel } from '../lib/effort'
 import SlashCommandMenu from './SlashCommandMenu'
 import FilePickerMenu from './FilePickerMenu'
+import type { FileKind } from './FilePickerMenu'
 import SkillPickerMenu from './SkillPickerMenu'
 import { matchFileToken, matchSkillToken, replaceTokenAtCaret } from './composerTokens'
 import { useStopEscapeHatch } from '../hooks/useStopEscapeHatch'
@@ -184,10 +185,14 @@ interface ChatInputProps {
   uploading?: boolean
   /** Pending file paths (images + non-images) for preview strip */
   pendingFiles?: string[]
+  /** Pending directory references for the preview strip (path handed to the agent, not an upload) */
+  pendingDirs?: string[]
   /** Resize details keyed by pending-file path; renders a badge on the chip */
   resizedInfo?: Record<string, ResizeInfo>
   /** Remove a pending file by path */
   onRemoveFile?: (path: string) => void
+  /** Remove a pending directory reference by path */
+  onRemoveDir?: (path: string) => void
   /** Show macOS-only buttons (screenshot) */
   isMac?: boolean
   /** Drag-and-drop handler for the entire input bar */
@@ -228,7 +233,8 @@ interface ChatInputProps {
   reasoningEffort?: string
   onReasoningEffortClick?: (rect: DOMRect) => void
   providerId?: string
-  onFileSelect?: (path: string) => void
+  /** Invoked when an @-mention picks a file or directory. `kind` defaults to 'file'. */
+  onFileSelect?: (path: string, kind?: FileKind) => void
   onFileOpen?: (path: string) => void
   project?: string
   memoryMode?: string
@@ -313,10 +319,10 @@ function ResizeBadge({ resize }: { resize: ResizeInfo }) {
   )
 }
 
-function FilePreviewStrip({ files, resizedInfo, onRemove }: { files: string[]; resizedInfo?: Record<string, ResizeInfo>; onRemove?: (path: string) => void }) {
+function FilePreviewStrip({ files, dirs = [], resizedInfo, onRemove, onRemoveDir }: { files: string[]; dirs?: string[]; resizedInfo?: Record<string, ResizeInfo>; onRemove?: (path: string) => void; onRemoveDir?: (path: string) => void }) {
   const imgs = files.filter(p => IMG_EXT.test(p))
   const nonImgs = files.filter(p => !IMG_EXT.test(p))
-  if (!imgs.length && !nonImgs.length) return null
+  if (!imgs.length && !nonImgs.length && !dirs.length) return null
   return (
     // NOTE: rendered height must match FILE_PREVIEW_H constant, update both together
     <div className="flex gap-2 px-5 py-2 border-t border-border bg-chrome/50 overflow-x-auto items-end" data-image-scope="">
@@ -354,6 +360,22 @@ function FilePreviewStrip({ files, resizedInfo, onRemove }: { files: string[]; r
           )}
         </div>
       ))}
+      {/* Folder references: a path handed to the agent, not an upload. No
+          /api/file-raw thumbnail is fetched — there is no content to preview. */}
+      {dirs.map(path => (
+        <div
+          key={path}
+          data-dir-chip=""
+          title={path}
+          className="relative group/preview shrink-0 flex items-center gap-1.5 px-2 py-1 rounded border border-border bg-bg-hover text-[12px] text-text"
+        >
+          <Folder size={12} aria-label="Folder" className="shrink-0 lucide-inline" />
+          <span>{(path.replace(/[/\\]+$/, '').split(/[/\\]/).pop() || path) + '/'}</span>
+          {onRemoveDir && (
+            <button aria-label="Remove folder" className="text-muted hover:text-danger cursor-pointer bg-transparent border-none p-0" onClick={() => onRemoveDir(path)} title="Remove"><X size={12} /></button>
+          )}
+        </div>
+      ))}
     </div>
   )
 }
@@ -373,8 +395,10 @@ function ChatInput({
   onUploadFiles,
   uploading = false,
   pendingFiles = [],
+  pendingDirs = [],
   resizedInfo,
   onRemoveFile,
+  onRemoveDir,
   isMac = false,
   onDrop,
   dragOver = false,
@@ -1643,7 +1667,10 @@ function ChatInput({
     e.target.value = '' // reset so same file can be re-selected
   }, [onUploadFiles])
 
-  const hasFiles = pendingFiles.length > 0
+  // The preview strip renders for folder references too, so height
+  // compensation must key off both staged families — otherwise a dirs-only
+  // strip appears with no wrapper expansion and eats into the textarea.
+  const hasFiles = pendingFiles.length > 0 || pendingDirs.length > 0
   const prevHadFiles = useRef(hasFiles)
   const dragMinH = hasFiles ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H
   const dragMinHRef = useRef(dragMinH)
@@ -1662,7 +1689,7 @@ function ChatInput({
   return (
     // 'input-area' is a stable theming hook — see website/docs/theming-contract.md
     <div className={`input-area px-5 pb-1 ${hasApproval ? 'pt-0' : 'pt-1'} mx-auto w-full flex flex-col`}
-      style={{ maxWidth: 'var(--mc-input-width, 900px)', ...(manualHeight !== null ? { minHeight: (pendingFiles.length > 0 ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H) + 'px' } : {}) }}>
+      style={{ maxWidth: 'var(--mc-input-width, 900px)', ...(manualHeight !== null ? { minHeight: (hasFiles ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H) + 'px' } : {}) }}>
 
       {aboveComposer}
 
@@ -1840,10 +1867,13 @@ function ChatInput({
           open={filePickerOpen}
           project={project}
           onFileOpen={onFileOpen}
-          onSelect={({ path, relativePath }) => {
+          onSelect={({ path, relativePath, kind }) => {
+            // relativePath already carries a trailing slash for directories
+            // (see selectionFor in FilePickerMenu), so the inserted token reads
+            // as e.g. "@src/pages/ " and is unambiguously a folder.
             applyPickedToken(/(^|[\s])@\S*$/, `@${relativePath} `)
             setFilePickerOpen(false); setFileQuery('')
-            onFileSelect(path)
+            onFileSelect(path, kind)
           }}
           onClose={() => { setFilePickerOpen(false); setFileQuery('') }}
         />
@@ -1887,7 +1917,7 @@ function ChatInput({
         onDragLeave={onDragLeave}
         onDrop={onDrop}
       >
-        <FilePreviewStrip files={pendingFiles} resizedInfo={resizedInfo} onRemove={onRemoveFile} />
+        <FilePreviewStrip files={pendingFiles} dirs={pendingDirs} resizedInfo={resizedInfo} onRemove={onRemoveFile} onRemoveDir={onRemoveDir} />
 
         <VoiceStatusBar recording={voiceRecording} level={voiceLevel} deviceLabel={voiceDeviceLabel} error={voiceError} onDismissError={onClearVoiceError} />
 

--- a/website/src/components/FilePickerMenu.tsx
+++ b/website/src/components/FilePickerMenu.tsx
@@ -1,16 +1,20 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
-import { FileText, Eye } from 'lucide-react'
+import { FileText, Folder, Eye } from 'lucide-react'
 import { api } from '../api/client'
 import { useListKeyboardNav } from '../hooks/useListKeyboardNav'
 import { menuGeometry, bottomUpOrder } from '../lib/pickerMenu'
+
+export type FileKind = 'file' | 'dir'
 
 interface FileResult {
   path: string
   name: string
   size: number
   mtime: number
+  /** Absent on responses from older backends — treated as 'file'. */
+  kind?: FileKind
 }
 
 interface FileSearchResponse {
@@ -22,7 +26,7 @@ interface Props {
   query: string
   anchorRef: React.RefObject<HTMLElement | null>
   open: boolean
-  onSelect: (info: { path: string; relativePath: string }) => void
+  onSelect: (info: { path: string; relativePath: string; kind: FileKind }) => void
   onClose: () => void
   onFileOpen?: (path: string) => void
   project?: string
@@ -42,10 +46,40 @@ function formatAge(mtime: number): string {
   return new Date(mtime * 1000).toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
-function makeRelative(path: string, root: string): string {
+/**
+ * Strip the project root prefix so the inserted token is a short relative path.
+ *
+ * Separator-aware: on native Windows the search result and the root both use
+ * backslashes, and a `/`-only prefix check never matched, so the picker inserted
+ * the ABSOLUTE path. For folders that then failed to resolve on send, because
+ * the suffix walk in buildDirRelMap only produces suffixes after a separator and
+ * never the full path, leaving the raw mention plus a duplicate marker.
+ */
+export function makeRelative(path: string, root: string): string {
   if (!root) return path
-  const r = root.endsWith('/') ? root : root + '/'
+  const r = /[/\\]$/.test(root) ? root : root + (root.includes('\\') && !root.includes('/') ? '\\' : '/')
   return path.startsWith(r) ? path.slice(r.length) : path
+}
+
+/** Normalize a possibly-absent kind from the search response. */
+export function resultKind(f: { kind?: FileKind }): FileKind {
+  return f.kind === 'dir' ? 'dir' : 'file'
+}
+
+/**
+ * Build the payload handed to onSelect. Directory paths get a trailing slash on
+ * the relative form so the inserted @-token reads unambiguously as a folder.
+ */
+export function selectionFor(f: FileResult, root: string): { path: string; relativePath: string; kind: FileKind } {
+  const kind = resultKind(f)
+  const rel = makeRelative(f.path, root)
+  return {
+    path: f.path,
+    // `endsWith` covers either separator so a Windows path is not given a second
+    // one; the inserted token still ends in `/`, which dirTokenRegex tolerates.
+    relativePath: kind === 'dir' && !/[/\\]$/.test(rel) ? rel + '/' : rel,
+    kind,
+  }
 }
 
 export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClose, onFileOpen, project }: Props) {
@@ -90,10 +124,13 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
   // Open the highlighted file in the viewer (the eye/preview action) instead of
   // inserting an @-mention. Shared by the Cmd/Ctrl+Enter path (via onChoose's
   // withModifier flag) and the Alt+Enter path (via onAltEnter). Returns true so
-  // the hook knows the default choose was superseded.
+  // the hook knows the default choose was superseded. Directories have nothing
+  // to preview, so they fall through to the normal insert.
   const openInViewer = useCallback((idx: number): boolean => {
     const f = resultsRef.current[idx]
-    if (f && onFileOpenRef.current) { onFileOpenRef.current(f.path); onClose(); return true }
+    if (f && resultKind(f) === 'file' && onFileOpenRef.current) {
+      onFileOpenRef.current(f.path); onClose(); return true
+    }
     return false
   }, [onClose])
 
@@ -106,7 +143,7 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
     const f = r[eff]
     if (!f) return
     if (withModifier && openInViewer(eff)) return
-    onSelect({ path: f.path, relativePath: makeRelative(f.path, rootRef.current) })
+    onSelect(selectionFor(f, rootRef.current))
   }, [onSelect, openInViewer])
 
   // Shared Arrow/Enter/Tab/Escape + scroll-into-view (see useListKeyboardNav).
@@ -153,25 +190,33 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
       role="listbox"
       style={{ top, left, width: Math.min(width, 420), maxHeight }}
     >
-      {results.length === 0 ? empty : results.map((f, i) => (
+      {results.length === 0 ? empty : results.map((f, i) => {
+        const kind = resultKind(f)
+        const isDir = kind === 'dir'
+        return (
         <div
           role="option"
           aria-selected={i === selected}
+          data-kind={kind}
           tabIndex={-1}
           key={f.path}
           ref={el => { itemRefs.current[i] = el }}
           className={`w-full text-left px-3 py-2 flex items-center gap-3 cursor-pointer transition-colors ${i === selected ? 'bg-accent-subtle text-text' : 'text-muted hover:bg-bg-hover hover:text-text'}`}
           title={f.path}
           onMouseEnter={() => setSelected(i)}
-          onMouseDown={e => { e.preventDefault(); onSelect({ path: f.path, relativePath: makeRelative(f.path, rootRef.current) }) }}
+          onMouseDown={e => { e.preventDefault(); onSelect(selectionFor(f, rootRef.current)) }}
         >
-          <FileText size={14} className="shrink-0 lucide-inline" />
+          {isDir
+            ? <Folder size={14} aria-label="Folder" className="shrink-0 lucide-inline" />
+            : <FileText size={14} className="shrink-0 lucide-inline" />}
           <div className="flex-1 min-w-0">
-            <div className="text-[13px] font-mono font-semibold truncate">{f.name}</div>
+            <div className="text-[13px] font-mono font-semibold truncate">{isDir ? f.name + '/' : f.name}</div>
             <div className="text-[11px] text-muted truncate">{f.path}</div>
           </div>
-          <span className="text-[11px] text-muted shrink-0 whitespace-nowrap">{formatSize(f.size)} · {formatAge(f.mtime)}</span>
-          {onFileOpen && (
+          <span className="text-[11px] text-muted shrink-0 whitespace-nowrap">
+            {isDir ? `folder · ${formatAge(f.mtime)}` : `${formatSize(f.size)} · ${formatAge(f.mtime)}`}
+          </span>
+          {onFileOpen && !isDir && (
             <button
               type="button"
               aria-label="Open in viewer"
@@ -184,7 +229,8 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
             </button>
           )}
         </div>
-      ))}
+        )
+      })}
     </div>,
     document.body
   )

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -413,9 +413,17 @@ export function useWebSocket() {
             // target slot's transcript. Uses appendSlotMessage so the bubble
             // appears whether or not the slot is currently active (background
             // tabs). Persisted server-side — survives page reload.
+            //
+            // Consume the server's `meta` (the redacted attachment lists plus
+            // the server-set `steer` flag) rather than hardcoding `{steer:true}`:
+            // the ordered `files`/`dirs` lists are what let a path containing a
+            // space render losslessly, so a second open tab would otherwise
+            // fall back to the whitespace scan and truncate it until reload.
+            // `steer: true` is re-asserted locally so the bubble still styles
+            // as a steer even against an older backend that sends no meta.
             dispatch(appendSlotMessage({
               slot: (data as { slot?: string }).slot || store.getState().chat.activeSlot || '',
-              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { steer: true }, ts: (data as { ts?: string }).ts },
+              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { ...((data as { meta?: Record<string, unknown> }).meta || {}), steer: true }, ts: (data as { ts?: string }).ts },
             }))
             break
           case 'queue_cancel':

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -12,7 +12,7 @@ import { useConnected } from '../hooks/useConnected'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import {
   switchSlot, createSlot, deleteSlot, fetchHistory,
-  appendMessage, resumeFromHistory, forkSlot,
+  appendMessage, removeOptimisticMessage, resumeFromHistory, forkSlot,
   setSlotRunning, startLocalTurn, syncSlotRunningFromServer, setPendingInput, resolveByApprovalId, clearPendingPermissions, cancelQueuedMessage, editQueuedMessage,
   selectComposerBusy,
   setVoiceAudio,
@@ -43,7 +43,7 @@ import ThinkingBlock from './chat/ThinkingBlock'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
+import { parseFiles, parseDirs, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments, findUnreferencedDirs } from '../utils/fileTokens'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
@@ -100,6 +100,7 @@ import ChatSidebar, { SIDEBAR_MIN, SIDEBAR_MAX } from './ChatSidebar'
 import { toSlug } from '../utils/shareUrl'
 import { DRAFT_SAVE_DEBOUNCE_MS, loadDrafts, saveDrafts as persistDrafts, setDraft } from '../utils/chatDrafts'
 import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } from '../utils/chatFileDrafts'
+import { loadDirDrafts, saveDirDrafts as persistDirDrafts, setDirDraft } from '../utils/chatDirDrafts'
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { findPrevUserMsgDisplayIdx } from '../utils/findPrevUserMsgDisplayIdx'
 import {
@@ -113,7 +114,7 @@ import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { BookOpen, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, PanelRight, Paperclip } from 'lucide-react'
+import { BookOpen, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, PanelRight, Paperclip, Folder } from 'lucide-react'
 
 import InfoTip from '../components/InfoTip'
 import { FileCard } from '../components/FileCard'
@@ -305,12 +306,18 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
   // source of truth; token N indexes the original list, not image-filtered).
   const orderedFiles = parseFiles(text, meta)
   const unreferenced = orderedFiles.length ? findUnreferencedAttachments(text, orderedFiles) : []
-  if (unreferenced.length) {
+  const orderedDirs = parseDirs(text, meta)
+  const unreferencedDirs = orderedDirs.length ? findUnreferencedDirs(text, orderedDirs) : []
+  if (unreferenced.length || unreferencedDirs.length) {
     const labels = buildFileLabels(unreferenced)
+    const dirLabels = buildFileLabels(unreferencedDirs)
     out.push(
       <div key="msg-cards" className="flex flex-col gap-1.5 mt-1">
         {unreferenced.map((p, i) => (
           <FileAttachmentCard key={`msg-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
+        ))}
+        {unreferencedDirs.map((p, i) => (
+          <DirAttachmentCard key={`msg-d${i}`} fullPath={p} label={dirLabels.get(p) || p} />
         ))}
       </div>,
     )
@@ -323,7 +330,8 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
  *  whitespace-preserving span (no markdown). */
 function renderInlineSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string) {
   const parsedFiles = parseFiles(content, meta)
-  if (!parsedFiles.length) {
+  const parsedDirs = parseDirs(content, meta)
+  if (!parsedFiles.length && !parsedDirs.length) {
     return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
   }
   // Inline-flow variant (adjacent to a paste chip): keep everything inline.
@@ -331,18 +339,23 @@ function renderInlineSegment(content: string, meta: Record<string, unknown> | un
   // standalone-token upload in this segment also renders as an inline chip
   // appended to it (this path can't host block cards without breaking the
   // inline flow). Never-referenced attachments are handled once at message
-  // level. Pass the ORIGINAL ordered list so token indices line up.
-  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
-  if (!mentionMap.size && !cardPaths.length) {
+  // level. Pass the ORIGINAL ordered lists so token indices line up.
+  const { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels } = resolveFileSegment(content, parsedFiles, parsedDirs)
+  if (!mentionMap.size && !dirMentionMap.size && !cardPaths.length && !dirCardPaths.length) {
     return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{display}</span>
   }
+  const dirLabels = buildFileLabels(dirCardPaths)
 
+  // Both families are split out of the text in one pass, but only file tokens
+  // resolve to a clickable chip: a folder has nothing to open in the viewer.
   const keys = [...mentionMap.keys()].slice(0, 20)
-  const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const dirKeys = [...dirMentionMap.keys()].slice(0, 20)
+  const tokPattern = [...keys, ...dirKeys].map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const parts = tokPattern
     ? display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
     : [display]
   const chipCls = 'inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors'
+  const dirChipCls = 'inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono'
   return (
     <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>
       {parts.map((part, i) => {
@@ -353,10 +366,19 @@ function renderInlineSegment(content: string, meta: Record<string, unknown> | un
             <Clickable key={`${keyBase}-f${i}`} className={chipCls} title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
           )
         }
+        const dirPath = tok && dirMentionMap.get(tok)
+        if (dirPath) {
+          return <span key={`${keyBase}-fd${i}`} className={dirChipCls} title={dirPath}>@{tok}</span>
+        }
         return <span key={`${keyBase}-p${i}`}>{part}</span>
       })}
       {cardPaths.map((p, i) => (
         <Clickable key={`${keyBase}-uc${i}`} className={chipCls} title={p} onClick={() => onFileOpen(p)} aria-label={`Open file ${p}`}>@{labels.get(p) || p}</Clickable>
+      ))}
+      {/* Folder chips: not clickable — a directory has nothing to open in the
+          file viewer, so this is a label, not a link. */}
+      {dirCardPaths.map((p, i) => (
+        <span key={`${keyBase}-ud${i}`} className={dirChipCls} title={p}>@{(dirLabels.get(p) || p)}/</span>
       ))}
     </span>
   )
@@ -380,6 +402,21 @@ function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string;
   )
 }
 
+/** Block card for a folder reference. Visually distinct from a file card: a
+ *  folder is a path handed to the agent, not an upload, and there is nothing to
+ *  open in the file viewer, so it is not clickable. */
+function DirAttachmentCard({ fullPath, label }: { fullPath: string; label: string }) {
+  return (
+    <div
+      className="flex items-center gap-2.5 max-w-full bg-card border border-border rounded-lg px-3 py-2 text-sm text-text animate-scale-in"
+      title={fullPath}
+    >
+      <Folder size={15} className="shrink-0 text-muted" aria-label="Folder" />
+      <span className="font-medium truncate">{label}/</span>
+    </div>
+  )
+}
+
 /** File-card + markdown rendering for a text segment (no paste tokens inside).
  *
  *  Attachment display is resolved by the shared resolveFileSegment helper
@@ -393,16 +430,18 @@ function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string;
  *  Images keep their inline `![image](path)` markdown and are excluded here. */
 function renderFileSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string) {
   const parsedFiles = parseFiles(content, meta)
+  const parsedDirs = parseDirs(content, meta)
 
   // No attachments — plain markdown (bold, code, links, etc.).
   // softBreaks: preserve Shift+Enter line breaks as <br> (see MarkdownRenderer).
-  if (!parsedFiles.length) {
+  if (!parsedFiles.length && !parsedDirs.length) {
     return <MarkdownRenderer content={content} softBreaks />
   }
 
-  // Pass the ORIGINAL ordered list (images included) so [attached_file N] token
-  // indices line up; resolveFileSegment filters images out of its output.
-  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
+  // Pass the ORIGINAL ordered lists (images included) so [attached_file N] and
+  // [attached_dir N] token indices line up; each marker numbers into its own
+  // list. resolveFileSegment filters images out of its output.
+  const { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels } = resolveFileSegment(content, parsedFiles, parsedDirs)
 
   // renderFileSegment handles the WHOLE message (non-paste path), so every
   // attachment belongs to this segment. Cards = standalone-upload tokens in the
@@ -415,17 +454,27 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
     ...cardPaths,
     ...findUnreferencedAttachments(display, parsedFiles).filter(p => !carded.has(p)),
   ]
+  const cardedDirs = new Set(dirCardPaths)
+  const allDirCardPaths = [
+    ...dirCardPaths,
+    ...findUnreferencedDirs(display, parsedDirs).filter(p => !cardedDirs.has(p)),
+  ]
+  const dirLabels = buildFileLabels(allDirCardPaths)
 
-  const cards = allCardPaths.length ? (
+  const cards = allCardPaths.length || allDirCardPaths.length ? (
     <div key={`${keyBase}-cards`} className="flex flex-col gap-1.5 mt-1 first:mt-0">
       {allCardPaths.map((p, i) => (
         <FileAttachmentCard key={`${keyBase}-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
       ))}
+      {allDirCardPaths.map((p, i) => (
+        <DirAttachmentCard key={`${keyBase}-d${i}`} fullPath={p} label={dirLabels.get(p) || p} />
+      ))}
     </div>
   ) : null
 
-  // No inline @-mentions: caption (if any) is plain markdown, then the cards.
-  if (!mentionMap.size) {
+  // No inline @-mentions of either family: caption (if any) is plain markdown,
+  // then the cards.
+  if (!mentionMap.size && !dirMentionMap.size) {
     const caption = display.trim()
     return <>{caption ? <MarkdownRenderer key={`${keyBase}-cap`} content={caption} softBreaks /> : null}{cards}</>
   }
@@ -438,7 +487,8 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   // literal text — a rare combination, same trade-off as renderInlineSegment.
   // Cap tokens to prevent ReDoS from many alternations.
   const keys = [...mentionMap.keys()].slice(0, 20)
-  const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const dirKeys = [...dirMentionMap.keys()].slice(0, 20)
+  const tokPattern = [...keys, ...dirKeys].map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const parts = display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
   const body = (
     <span key={`${keyBase}-body`} style={{ whiteSpace: 'pre-wrap' }}>
@@ -449,6 +499,15 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
           return (
             <Clickable key={`${keyBase}-f${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors"
               title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
+          )
+        }
+        // A folder chip is a label, not a link: the file viewer cannot open a
+        // directory, so it gets no click handler and no cursor affordance.
+        const dirPath = tok && dirMentionMap.get(tok)
+        if (dirPath) {
+          return (
+            <span key={`${keyBase}-fd${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono"
+              title={dirPath}>@{tok}</span>
           )
         }
         return part ? <span key={`${keyBase}-p${i}`}>{part}</span> : null
@@ -585,13 +644,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   if (drafts.current === null) drafts.current = loadDrafts()
   const fileDrafts = useRef<Record<string, string[]>>(null!)
   if (fileDrafts.current === null) fileDrafts.current = loadFileDrafts()
+  // Per-slot staged folder references, persisted alongside file attachments so a
+  // picked folder neither vanishes on slot switch nor leaks into another slot.
+  const dirDrafts = useRef<Record<string, string[]>>(null!)
+  if (dirDrafts.current === null) dirDrafts.current = loadDirDrafts()
   // Per-slot collapsed-paste blocks backing the `[ Paste #N · M lines ]` tokens
   // in `input`. Persisted (localStorage, same TTL as text drafts) so the chip
   // survives slot switches / refresh instead of degrading to literal text.
   const pasteDrafts = useRef<Record<string, PasteBlock[]>>(null!)
   if (pasteDrafts.current === null) pasteDrafts.current = loadPasteDrafts()
   const saveDraftsTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const saveDrafts = useCallback(() => { persistDrafts(drafts.current); persistFileDrafts(fileDrafts.current); persistPasteDrafts(pasteDrafts.current) }, [])
+  const saveDrafts = useCallback(() => { persistDrafts(drafts.current); persistFileDrafts(fileDrafts.current); persistDirDrafts(dirDrafts.current); persistPasteDrafts(pasteDrafts.current) }, [])
   const saveDraftsDebounced = useCallback(() => {
     if (saveDraftsTimer.current) clearTimeout(saveDraftsTimer.current)
     saveDraftsTimer.current = setTimeout(() => { saveDraftsTimer.current = null; saveDrafts() }, DRAFT_SAVE_DEBOUNCE_MS)
@@ -722,7 +785,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // Mid-turn steer is a POST write, so it goes through useMutation for
   // consistent error/loading-state handling (fire-and-forget: no onSuccess).
   const steerMutation = useMutation({
-    mutationFn: (text: string) => api.steerChat(text, activeSlot!),
+    mutationFn: ({ text, meta }: { text: string; meta?: Record<string, unknown> }) =>
+      api.steerChat(text, activeSlot!, meta),
     onError: (e) => { console.error('steer failed', e) },
   })
   const [reasoningEffortDropdown, setReasoningEffortDropdown] = useState(false)
@@ -960,10 +1024,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     for (const [k, v] of Object.entries(stored)) { if (!(k in drafts.current)) drafts.current[k] = v }
     const storedFiles = loadFileDrafts()
     for (const [k, v] of Object.entries(storedFiles)) { if (!(k in fileDrafts.current)) fileDrafts.current[k] = v }
+    const storedDirs = loadDirDrafts()
+    for (const [k, v] of Object.entries(storedDirs)) { if (!(k in dirDrafts.current)) dirDrafts.current[k] = v }
     const storedPastes = loadPasteDrafts()
     for (const [k, v] of Object.entries(storedPastes)) { if (!(k in pasteDrafts.current)) pasteDrafts.current[k] = v }
     if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
     if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+    if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
     if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
     prevSlot.current = activeSlot
     const raw = sessionStorage.getItem(PREFILL_STORAGE_KEY)
@@ -979,6 +1046,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // Restore the incoming slot's staged file attachments (copy so the
     // live state array and the stored draft don't share a reference).
     setPendingFiles(activeSlot ? (fileDrafts.current[activeSlot] ?? []).slice() : [])
+    // Same for staged folder references. Without this reset a folder picked in
+    // one chat would ride along on the next send in a different chat.
+    setPendingDirs(activeSlot ? (dirDrafts.current[activeSlot] ?? []).slice() : [])
     // Restore the incoming slot's collapsed-paste blocks (deep copy so the live
     // state and the stored draft don't share references). Without this the
     // token text rehydrates from the text draft but its backing block is gone,
@@ -995,6 +1065,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (saveDraftsTimer.current) { clearTimeout(saveDraftsTimer.current); saveDraftsTimer.current = null }
     if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
     if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+    if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
     if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
     flushDrafts()
   }, [flushDrafts])
@@ -1003,6 +1074,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     const h = () => {
       if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
       if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+      if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
       if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
       flushDrafts()
     }
@@ -1033,8 +1105,23 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const [dragOver, setDragOver] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<string[]>([])
+  // Folder references picked via @-mention. Kept separate from pendingFiles so
+  // a directory never reaches the upload/thumbnail/attached_file paths.
+  const [pendingDirs, setPendingDirs] = useState<string[]>([])
   const [snipFrame, setSnipFrame] = useState<HTMLCanvasElement | null>(null)
   const pendingFilesRef = useRef(pendingFiles)
+  const pendingDirsRef = useRef(pendingDirs)
+  useEffect(() => {
+    pendingDirsRef.current = pendingDirs
+    // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
+    const s = composerSlotRef.current
+    if (s) {
+      setDirDraft(dirDrafts.current, s, pendingDirs)
+      saveDraftsDebounced()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- draft key is
+    // composerSlotRef; slot-change effect handles that transition
+  }, [pendingDirs, saveDraftsDebounced])
   useEffect(() => {
     pendingFilesRef.current = pendingFiles
     // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
@@ -1927,7 +2014,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     try {
       await dispatch(resumeFromHistory({ key, title })).unwrap()
       if (activeSlot && activeSlot !== key) {
-        delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]; prevSlot.current = null; saveDrafts()
+        delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete dirDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]; prevSlot.current = null; saveDrafts()
         dispatch(deleteSlot(activeSlot)).unwrap().catch(() => {})
       }
     } catch { /* resume failed — keep current slot */ }
@@ -1953,7 +2040,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // widget action pre-filled. Cleared on every send so it can't go stale.
     const widgetOrigin = !!widgetPrefillRef.current && raw.includes(widgetPrefillRef.current)
     widgetPrefillRef.current = null
-    if (!raw && !pendingFilesRef.current.length) return
+    if (!raw && !pendingFilesRef.current.length && !pendingDirsRef.current.length) return
 
     // The session actually on screen at send time. Read from the ref (fresh
     // every render), not the closure `activeSlot` (stale until send() is
@@ -1979,7 +2066,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       return
     }
 
-    const { txt, displayTxt, filePaths } = prepareSendPayload(raw, pendingFilesRef.current)
+    const { txt, displayTxt, filePaths, imgPaths, dirPaths } = prepareSendPayload(raw, pendingFilesRef.current, pendingDirsRef.current)
+    // Images are split out of `filePaths` for the LLM payload, but for
+    // draft/restore purposes the composer's staged list is the union: an image
+    // lives only in `pendingFiles` (never in `raw`), so restoring `filePaths`
+    // alone on a send failure would silently drop it.
+    const stagedFiles = [...imgPaths, ...filePaths]
     // Expand paste tokens for the LLM; UI-facing displayTxt keeps the tokens
     // intact so the user bubble can render them as clickable chips.
     const activePastes = pasteBlocksRef.current
@@ -1997,7 +2089,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
     setPrefillHint(false)
     if (!optionText) {
-      setInput(''); setPendingFiles([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
+      setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete dirDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
       // The challenge-handoff prompt is seeded into PREFILL_STORAGE_KEY and the
       // slot-restore effect re-applies it on slot changes. Once that prompt is
       // sent, clear the seed so a later slot-restore can't re-fill the (now
@@ -2017,7 +2109,37 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     }
     if (!slot || forceNew) {
       sendingRef.current = true;
-      const result = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap();
+      let result: { key: string }
+      try {
+        result = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap();
+      } catch (e) {
+        // `.unwrap()` rethrows a rejected createSlot, and the composer was
+        // already cleared above — so without this the staged text, files and
+        // folders are gone for good and the user has nothing to retry with.
+        // Re-stage the captured pre-clear state and surface the failure. Mirrors
+        // the send-failure restore below (same helpers, same stagedFiles union
+        // so a staged image is not dropped), but keyed to the slot on screen
+        // since no new slot exists to attribute the draft to.
+        sendingRef.current = false
+        if (!optionText && uiSlot) {
+          setDraft(drafts.current, uiSlot, raw)
+          setFileDraft(fileDrafts.current, uiSlot, stagedFiles)
+          setDirDraft(dirDrafts.current, uiSlot, dirPaths)
+          setPasteDraft(pasteDrafts.current, uiSlot, activePastes)
+          saveDrafts()
+          if (uiSlot === activeSlotRef.current) {
+            setInput(raw)
+            setPendingFiles(stagedFiles)
+            setPendingDirs(dirPaths)
+            setPasteBlocks(activePastes)
+          }
+        }
+        dispatch(setSlotRunning(false))
+        dispatch(appendMessage({ role: 'error', content: 'Could not start a new session — your message and attachments were restored.', cls: '' }))
+        // eslint-disable-next-line no-console -- surface session-create failures for debugging
+        console.error('createSlot failed', e)
+        return
+      }
       slot = result.key;
       if (pendingProjectRef.current) {
         await api.chatSlotProject(result.key, pendingProjectRef.current).catch(e => {
@@ -2030,6 +2152,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // Build meta for persistence (knowledge, files, pastes)
     const meta: Record<string, unknown> = {}
     if (filePaths.length) meta.files = filePaths
+    // Folder references need the same index-preserving metadata as files: the
+    // content-scan fallback splits on whitespace, so a path containing a space
+    // would be truncated on replay without this.
+    if (dirPaths.length) meta.dirs = dirPaths
     if (bubblePastes.length) meta.pastes = bubblePastes
     if (knowledgeBlock) meta.knowledge = { items: knowledgeBlock.items.length, tokens: knowledgeBlock.totalTokens, titles: knowledgeBlock.items.map(i => i.title), content: knowledgeBlock.items.map(i => ({ title: i.title, text: i.content.slice(0, 2000) })) }
     if (widgetOrigin) meta.origin = 'widget'
@@ -2064,8 +2190,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
         dispatch(setSlotRunning(false))
         dispatch(appendMessage({ role: 'error', content: 'Connection error', cls: '' }))
         // Restore draft so the user doesn't lose their message.
-        // Also restore the paste blocks backing any tokens in `txt`, otherwise
-        // the restored text shows a dead `[ Paste #N · M lines ]` literal.
+        // Restore the PRE-SERIALIZATION text (`raw`, with its @-mentions) and
+        // re-stage the attachments, rather than the serialized `txt`. Restoring
+        // `txt` put the generated `[attached_file N] / [attached_dir N]` markers
+        // into the composer with no backing pending lists, so a retry sent
+        // marker text stripped of its index-preserving metadata and a folder or
+        // file path containing a space truncated on replay. Re-staging cannot
+        // duplicate markers either: `raw` carries @-mentions, which the next
+        // prepareSendPayload rewrites in place.
+        // Also restore the paste blocks backing any tokens in the text,
+        // otherwise it shows a dead `[ Paste #N · M lines ]` literal.
         // Persist for `slot` unconditionally (recoverable on disk), but only
         // touch the live input/blocks when `slot` is the one on screen. Compare
         // against activeSlotRef.current, NOT the closure's `activeSlot`: a
@@ -2076,10 +2210,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
         // visibly for a new-session failure while still not splicing a targeted
         // send's text into an unrelated slot the user is looking at.
         if (slot) {
-          setDraft(drafts.current, slot, txt)
+          setDraft(drafts.current, slot, raw)
+          setFileDraft(fileDrafts.current, slot, stagedFiles)
+          setDirDraft(dirDrafts.current, slot, dirPaths)
           setPasteDraft(pasteDrafts.current, slot, activePastes)
           saveDrafts()
-          if (slot === activeSlotRef.current) { setInput(txt); setPasteBlocks(activePastes) }
+          if (slot === activeSlotRef.current) {
+            setInput(raw)
+            setPendingFiles(stagedFiles)
+            setPendingDirs(dirPaths)
+            setPasteBlocks(activePastes)
+          }
         }
       }
     }
@@ -2643,8 +2784,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (!activeSlot) return
     const raw = inputRef.current.trim()
     const files = pendingFilesRef.current
-    if (!raw && !files.length) return
-    const { txt } = prepareSendPayload(raw, files)
+    const dirs = pendingDirsRef.current
+    if (!raw && !files.length && !dirs.length) return
+    const { txt, filePaths, dirPaths } = prepareSendPayload(raw, files, dirs)
     const activePastes = pasteBlocksRef.current
     const llmTxt = activePastes.length ? expandPasteTokens(txt, activePastes) : txt
     // Optimistically show the steered text immediately. Since steer became the
@@ -2654,10 +2796,50 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // WS event, making it look like nothing happened until the response resumed.
     // Tagged meta.optimistic so the echo reconciles this bubble in place
     // (appendSlotMessage) instead of rendering a duplicate.
-    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true } }))
-    steerMutation.mutate(llmTxt)
-    setInput(''); setPendingFiles([]); setPasteBlocks([])
-    delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]
+    // The attachment lists ride along for the same reason send() carries them:
+    // the bubble renders the tokenized text, and without the ordered lists a
+    // path containing a space falls back to the whitespace scan and truncates.
+    const steerMeta: Record<string, unknown> = { steer: true, optimistic: true }
+    if (filePaths.length) steerMeta.files = filePaths
+    if (dirPaths.length) steerMeta.dirs = dirPaths
+    const optimisticTs = new Date().toISOString()
+    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: optimisticTs, meta: steerMeta }))
+    // Send the attachment lists to the server too, so the persisted steer
+    // carries them and a spaced path survives a reload. `optimistic` is a
+    // client-only marker and `steer` is set server-side, so neither is sent.
+    const serverMeta: Record<string, unknown> = {}
+    if (filePaths.length) serverMeta.files = filePaths
+    if (dirPaths.length) serverMeta.dirs = dirPaths
+    // Capture the pre-clear composer state so a rejected POST can put it back.
+    // The clears below are unconditional (text and attachments must clear
+    // atomically), so without this a failed steer leaves an optimistic bubble
+    // on screen while the staged folders/files/pastes are gone — the user's
+    // attachment selection is unrecoverable and the bubble is a lie about what
+    // the agent received.
+    const restore = { raw, files, dirs, pastes: activePastes, slot: activeSlot }
+    steerMutation.mutate(
+      { text: llmTxt, meta: Object.keys(serverMeta).length ? serverMeta : undefined },
+      {
+        onError: () => {
+          // Drop the optimistic bubble — nothing was steered — and re-stage the
+          // composer exactly as it was so the user can retry.
+          dispatch(removeOptimisticMessage({ slot: restore.slot, ts: optimisticTs }))
+          setDraft(drafts.current, restore.slot, restore.raw)
+          setFileDraft(fileDrafts.current, restore.slot, restore.files)
+          setDirDraft(dirDrafts.current, restore.slot, restore.dirs)
+          setPasteDraft(pasteDrafts.current, restore.slot, restore.pastes)
+          saveDrafts()
+          if (restore.slot === activeSlotRef.current) {
+            setInput(restore.raw)
+            setPendingFiles(restore.files)
+            setPendingDirs(restore.dirs)
+            setPasteBlocks(restore.pastes)
+          }
+        },
+      },
+    )
+    setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([])
+    delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete dirDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]
     saveDrafts()
   }, [activeSlot, steerMutation, saveDrafts, dispatch])
 
@@ -3544,9 +3726,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               onUploadFiles={uploadFiles}
               uploading={uploading}
               pendingFiles={pendingFiles}
+              pendingDirs={pendingDirs}
               resizedInfo={resizedInfo}
               onRemoveFile={p => setPendingFiles(prev => prev.filter(x => x !== p))}
-              onFileSelect={path => setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])}
+              onRemoveDir={p => setPendingDirs(prev => prev.filter(x => x !== p))}
+              onFileSelect={(path, kind) => {
+                // A folder mention is a path reference, not an upload: it goes
+                // to pendingDirs so it serializes as [attached_dir N].
+                if (kind === 'dir') setPendingDirs(prev => prev.includes(path) ? prev : [...prev, path])
+                else setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])
+              }}
               onFileOpen={handleFileOpen}
               project={currentSlot?.project || ''}
               isMac={isMac}

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -804,6 +804,20 @@ const chatSlice = createSlice({
     },
     removeThinking(state) { state.messages = state.messages.filter(m => m.role !== 'thinking') },
     removeByApprovalId(state, action: PayloadAction<string>) { state.messages = state.messages.filter(m => m.meta?.approval_id !== action.payload) },
+    /** Drop an optimistic user bubble whose write was rejected.
+     *
+     * Keyed on the client ts stamped at dispatch time AND `meta.optimistic`, so
+     * it can only ever remove a not-yet-confirmed bubble — never a message the
+     * server has echoed (the steer echo reconciles in place and clears the
+     * optimistic marker). Sweeps the active list and the per-slot list because
+     * a steer can be dispatched into a background slot. */
+    removeOptimisticMessage(state, action: PayloadAction<{ slot?: string; ts: string }>) {
+      const { slot, ts } = action.payload
+      const keep = (m: { ts?: string; meta?: Record<string, unknown> | null }) =>
+        !(m.ts === ts && Boolean(m.meta?.optimistic))
+      state.messages = state.messages.filter(keep)
+      if (slot && state.slotMessages[slot]) state.slotMessages[slot] = state.slotMessages[slot].filter(keep)
+    },
     resolveByApprovalId(state, action: PayloadAction<{ id: string; decision?: string }>) {
       const decision = action.payload.decision || 'approved'
       let m = state.messages.find(m => m.meta?.approval_id === action.payload.id)
@@ -1902,7 +1916,7 @@ const chatSlice = createSlice({
 
 export const {
   setActiveSlot, clearSlotState, setPendingInput, setQuestionCard, clearQuestionCard, appendMessage, appendSlotMessage, updateStreamingMessage, finalizeAssistant,
-  removeThinking, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage,
+  removeThinking, removeByApprovalId, removeOptimisticMessage, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage,
   sseContextUsage, setVoicePlaying, setVoiceAudio,
   toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone,
   sseSubagentBatchUpdate, sseSubagentBatchChunks, selectSubagent, clearTerminalSubagents,

--- a/website/src/test/ChatInput.dirStripHeight.test.tsx
+++ b/website/src/test/ChatInput.dirStripHeight.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+// The attachment preview strip now renders for folder references too, but the
+// composer's manual-height compensation used to key off `pendingFiles` alone.
+// With a manually resized composer and only a folder staged, the strip appeared
+// without the FILE_PREVIEW_H allowance, so it ate into the textarea instead of
+// expanding the wrapper.
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+}
+
+// Must match ChatInput's own constants.
+const INPUT_DRAG_MIN_H = 93
+const FILE_PREVIEW_H = 81
+const MANUAL_H = 300
+
+const outerOf = () => screen.getByLabelText('Message input').closest('.input-area') as HTMLElement
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+  // A persisted manual height is what activates the minHeight compensation.
+  localStorage.setItem('mc-input-height', String(MANUAL_H))
+})
+
+describe('ChatInput preview-strip height compensation', () => {
+  it('compensates for a dirs-only preview strip', () => {
+    renderWithProviders(<ChatInput {...defaultProps} pendingDirs={['/repo/website/docs']} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H + FILE_PREVIEW_H}px`)
+  })
+
+  it('compensates for a files-only preview strip (unchanged)', () => {
+    renderWithProviders(<ChatInput {...defaultProps} pendingFiles={['/tmp/a.txt']} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H + FILE_PREVIEW_H}px`)
+  })
+
+  it('does not compensate when nothing is staged', () => {
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H}px`)
+  })
+})

--- a/website/src/test/ChatPageDrafts.test.tsx
+++ b/website/src/test/ChatPageDrafts.test.tsx
@@ -127,7 +127,7 @@ beforeEach(() => {
 // someone reorders the effects or moves the advance up. All three persist
 // writes are asserted (not just text) because the advance now guards all three.
 describe('ChatPage composerSlotRef effect ordering', () => {
-  it('declares all three composer-persist effects before advancing composerSlotRef', () => {
+  it('declares all four composer-persist effects before advancing composerSlotRef', () => {
     // Deliberately brittle: this matches exact code substrings from ChatPage.tsx
     // to lock a load-bearing effect-declaration order. An innocuous rename/reformat
     // will trip it. The fix is to UPDATE the substrings below to the new form,
@@ -136,19 +136,121 @@ describe('ChatPage composerSlotRef effect ordering', () => {
     const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
     const textIdx = src.indexOf('setDraft(drafts.current, s, input)')
     const fileIdx = src.indexOf('setFileDraft(fileDrafts.current, s, pendingFiles)')
+    const dirIdx = src.indexOf('setDirDraft(dirDrafts.current, s, pendingDirs)')
     const pasteIdx = src.indexOf('setPasteDraft(pasteDrafts.current, s, pasteBlocks)')
     const advanceIdx = src.indexOf('composerSlotRef.current = activeSlot')
     expect(textIdx, 'text-persist effect (setDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(fileIdx, 'file-persist effect (setFileDraft off composerSlotRef) not found').toBeGreaterThan(-1)
+    expect(dirIdx, 'dir-persist effect (setDirDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(pasteIdx, 'paste-persist effect (setPasteDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(advanceIdx, 'composerSlotRef advance not found').toBeGreaterThan(-1)
     const order = 'persist effect must be declared BEFORE the composerSlotRef advance (draft-smear guard). If effects moved, UPDATE the substrings; do not delete this guard.'
     expect(textIdx, order).toBeLessThan(advanceIdx)
     expect(fileIdx, order).toBeLessThan(advanceIdx)
+    expect(dirIdx, order).toBeLessThan(advanceIdx)
     expect(pasteIdx, order).toBeLessThan(advanceIdx)
   })
 
-  // Symptom B (send routing to the slot the user already left) can't be covered
+  // The folder-leak fix: the slot-change effect must RESET pendingDirs from the
+  // incoming slot's draft. Without it a folder picked in chat A rides along on
+  // the next send in chat B. Behaviorally awkward to reach (needs a real picker
+  // selection), so guard the reset line statically.
+  it('resets pendingDirs from the incoming slot draft on slot change', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'slot change must restore pendingDirs from dirDrafts').toContain(
+      "setPendingDirs(activeSlot ? (dirDrafts.current[activeSlot] ?? []).slice() : [])",
+    )
+  })
+
+  // The replay fix: send() must persist dirPaths on meta.dirs, otherwise a
+  // folder path containing a space is truncated by the content-scan fallback.
+  it('persists folder paths on meta.dirs', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'send() must destructure dirPaths from prepareSendPayload').toMatch(
+      /const \{[^}]*dirPaths[^}]*\} = prepareSendPayload\(/,
+    )
+    expect(src, 'send() must set meta.dirs').toContain('if (dirPaths.length) meta.dirs = dirPaths')
+  })
+
+  // steer() renders its own optimistic bubble from the tokenized text, so it
+  // needs the same ordered lists as send() or a spaced path truncates there too.
+  it('persists attachment metadata on the steered optimistic bubble', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'steer() must set files on the bubble meta').toContain(
+      'if (filePaths.length) steerMeta.files = filePaths',
+    )
+    expect(src, 'steer() must set dirs on the bubble meta').toContain(
+      'if (dirPaths.length) steerMeta.dirs = dirPaths',
+    )
+    expect(src, 'steer() must not discard the payload lists').not.toContain(
+      'const { txt } = prepareSendPayload(raw, files, dirs)',
+    )
+  })
+
+  // The optimistic bubble alone is not enough: the SERVER must persist the
+  // ordered lists too, or the spaced path is truncated by the content-scan
+  // fallback after a reload. Guarded statically because the assertion is about
+  // what crosses the network boundary, and the mutation is fire-and-forget.
+  it('sends attachment metadata to the server on steer', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'steer() must send the lists, not just the text').toMatch(
+      /steerMutation\.mutate\(\s*\{\s*text:\s*llmTxt,\s*meta:/,
+    )
+    expect(src, 'steer() must put files on the server meta').toContain(
+      'if (filePaths.length) serverMeta.files = filePaths',
+    )
+    expect(src, 'steer() must put dirs on the server meta').toContain(
+      'if (dirPaths.length) serverMeta.dirs = dirPaths',
+    )
+    const client = readFileSync(resolve(here, '../api/client.ts'), 'utf8')
+    expect(client, 'steerChat must forward meta in the request body').toMatch(
+      /steer:\s*true,\s*\.\.\.\(meta\s*\?\s*\{\s*meta\s*\}\s*:\s*\{\}\)/,
+    )
+  })
+
+  // Two write paths can reject AFTER the composer has been cleared, and the
+  // clears are unconditional (text + attachments must clear atomically). Both
+  // must capture the pre-clear state and put it back, or the user's staged
+  // folders/files are unrecoverable while a bubble claims they were sent.
+  // Static guards: both are rejection paths on a fire-and-forget write, so the
+  // assertion is about the code shape, not observable render output.
+  it('restores the composer when createSlot rejects mid-send', () => {
+    // Brittle by design: if these lines are renamed, UPDATE the substrings —
+    // do not delete the guard.
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'the unwrapped createSlot must be inside a try').toMatch(
+      /try\s*\{\s*result = await dispatch\(createSlot\(/,
+    )
+    expect(src, 'a rejected createSlot must re-stage the staged files (images included)').toContain(
+      'setFileDraft(fileDrafts.current, uiSlot, stagedFiles)',
+    )
+    expect(src, 'a rejected createSlot must re-stage the staged dirs').toContain(
+      'setDirDraft(dirDrafts.current, uiSlot, dirPaths)',
+    )
+    expect(src, 'a rejected createSlot must not fall through to the send').toMatch(
+      /console\.error\('createSlot failed', e\)\s*\n\s*return/,
+    )
+  })
+
+  it('rolls back the optimistic bubble and restores drafts when steer rejects', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'steer must pass an onError handler to the mutation').toMatch(
+      /steerMutation\.mutate\([\s\S]{0,400}onError:/,
+    )
+    expect(src, 'a failed steer must drop its optimistic bubble').toContain(
+      'dispatch(removeOptimisticMessage({ slot: restore.slot, ts: optimisticTs }))',
+    )
+    expect(src, 'a failed steer must re-stage the staged dirs').toContain(
+      'setDirDraft(dirDrafts.current, restore.slot, restore.dirs)',
+    )
+  })
+
   // behaviorally: the ref-vs-closure divergence it fixes is a same-tick race
   // between the reducer's activeSlot flip and send()'s re-memoization, and RTL
   // flushes a render between any dispatch and the Enter event, so the closure
@@ -462,6 +564,43 @@ describe('ChatPage draft persistence', { timeout: 15_000 }, () => {
       return s
     })
     expect(saved['new-slot']).toBeUndefined()
+  })
+
+  it('restores a staged image after a failed send, not just non-image files', async () => {
+    // Images are filtered out of prepareSendPayload's `filePaths` (they go into
+    // `imgPaths` and become `![image](...)` markdown), so restoring `filePaths`
+    // alone silently dropped the image: it lives only in pendingFiles, never in
+    // the raw text, so a retry would have sent the message without it.
+    const { api } = await import('../api/client')
+    vi.mocked(api.uploadFiles).mockResolvedValueOnce({ paths: ['/tmp/shot.png', '/tmp/notes.txt'] })
+    vi.mocked(api.sendChat).mockRejectedValueOnce(new Error('Network error'))
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    const dropTarget = input.closest('div') as HTMLElement
+    await act(async () => {
+      fireEvent.drop(dropTarget, {
+        dataTransfer: {
+          files: [new File(['x'], 'shot.png', { type: 'image/png' }), new File(['y'], 'notes.txt', { type: 'text/plain' })],
+          types: ['Files'],
+        },
+      })
+    })
+    await waitFor(() => {
+      const saved = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(saved['slot-a']).toEqual(['/tmp/shot.png', '/tmp/notes.txt'])
+    })
+
+    await act(async () => { fireEvent.change(input, { target: { value: 'look at this' } }) })
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+
+    await waitFor(() => {
+      const saved = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(saved['slot-a'], 'the image must survive the send-failure restore')
+        .toEqual(['/tmp/shot.png', '/tmp/notes.txt'])
+    })
   })
 
   it('restores draft to localStorage on connection error', async () => {

--- a/website/src/test/FilePickerMenu.dirs.test.tsx
+++ b/website/src/test/FilePickerMenu.dirs.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRef } from 'react'
+
+/* ── Mock api/client BEFORE the component imports ── */
+const mockApi = vi.hoisted(() => ({
+  fileSearch: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import FilePickerMenu, { resultKind, selectionFor, makeRelative } from '../components/FilePickerMenu'
+
+const ROOT = '/repo'
+const NOW = Math.floor(Date.now() / 1000)
+
+const RESULTS = [
+  { path: '/repo/src/widgets', name: 'widgets', size: 0, mtime: NOW - 120, kind: 'dir' as const },
+  { path: '/repo/src/widgets.ts', name: 'widgets.ts', size: 2048, mtime: NOW - 120, kind: 'file' as const },
+]
+
+function Harness({
+  query, open, onSelect = vi.fn(), onClose = vi.fn(), onFileOpen,
+}: {
+  query: string
+  open: boolean
+  onSelect?: (i: { path: string; relativePath: string; kind: 'file' | 'dir' }) => void
+  onClose?: () => void
+  onFileOpen?: (p: string) => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={qc}>
+      <div>
+        <div ref={ref} data-testid="anchor">anchor</div>
+        <FilePickerMenu
+          query={query}
+          anchorRef={ref}
+          open={open}
+          onSelect={onSelect}
+          onClose={onClose}
+          onFileOpen={onFileOpen}
+        />
+      </div>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockApi.fileSearch.mockResolvedValue({ results: RESULTS, root: ROOT })
+})
+
+describe('selectionFor', () => {
+  it('appends a trailing slash to directory relative paths', () => {
+    expect(selectionFor(RESULTS[0], ROOT)).toEqual({
+      path: '/repo/src/widgets',
+      relativePath: 'src/widgets/',
+      kind: 'dir',
+    })
+  })
+
+  it('leaves file relative paths untouched', () => {
+    expect(selectionFor(RESULTS[1], ROOT)).toEqual({
+      path: '/repo/src/widgets.ts',
+      relativePath: 'src/widgets.ts',
+      kind: 'file',
+    })
+  })
+
+  it('does not double up an existing trailing slash', () => {
+    const withSlash = { ...RESULTS[0], path: '/repo/src/widgets/' }
+    expect(selectionFor(withSlash, ROOT).relativePath).toBe('src/widgets/')
+  })
+
+  it('falls back to the absolute path when no root is known', () => {
+    expect(selectionFor(RESULTS[0], '').relativePath).toBe('/repo/src/widgets/')
+  })
+})
+
+describe('resultKind', () => {
+  it('treats a missing kind as file for backward compatibility', () => {
+    expect(resultKind({})).toBe('file')
+  })
+
+  it('reads an explicit dir kind', () => {
+    expect(resultKind({ kind: 'dir' })).toBe('dir')
+  })
+})
+
+describe('FilePickerMenu directory rows', () => {
+  it('renders a directory name with a trailing slash', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByText('widgets/')).toBeInTheDocument()
+    expect(screen.getByText('widgets.ts')).toBeInTheDocument()
+  })
+
+  it('marks rows with their kind', async () => {
+    render(<Harness query="widgets" open />)
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(2))
+    const kinds = screen.getAllByRole('option').map(o => o.getAttribute('data-kind'))
+    expect(kinds).toContain('dir')
+    expect(kinds).toContain('file')
+  })
+
+  it('shows a folder label instead of a byte size for directories', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByText(/^folder · /)).toBeInTheDocument()
+    expect(screen.getByText(/^2KB · /)).toBeInTheDocument()
+  })
+
+  it('renders a Folder icon for directories', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByLabelText('Folder')).toBeInTheDocument()
+  })
+
+  it('suppresses the preview button on directory rows', async () => {
+    const onFileOpen = vi.fn()
+    render(<Harness query="widgets" open onFileOpen={onFileOpen} />)
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(2))
+    // One eye button only: the file row. The dir row has nothing to preview.
+    expect(screen.getAllByLabelText('Open in viewer')).toHaveLength(1)
+  })
+
+  it('emits kind=dir with a trailing-slash relative path on click', async () => {
+    const onSelect = vi.fn()
+    render(<Harness query="widgets" open onSelect={onSelect} />)
+    const dirRow = await waitFor(() => {
+      const row = screen.getAllByRole('option').find(o => o.getAttribute('data-kind') === 'dir')
+      expect(row).toBeTruthy()
+      return row!
+    })
+    fireEvent.mouseDown(dirRow)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/src/widgets',
+      relativePath: 'src/widgets/',
+      kind: 'dir',
+    })
+  })
+
+  it('emits kind=file for file rows', async () => {
+    const onSelect = vi.fn()
+    render(<Harness query="widgets" open onSelect={onSelect} />)
+    const fileRow = await waitFor(() => {
+      const row = screen.getAllByRole('option').find(o => o.getAttribute('data-kind') === 'file')
+      expect(row).toBeTruthy()
+      return row!
+    })
+    fireEvent.mouseDown(fileRow)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/src/widgets.ts',
+      relativePath: 'src/widgets.ts',
+      kind: 'file',
+    })
+  })
+
+  it('treats a result with no kind field as a file', async () => {
+    mockApi.fileSearch.mockResolvedValue({
+      results: [{ path: '/repo/legacy.ts', name: 'legacy.ts', size: 10, mtime: NOW }],
+      root: ROOT,
+    })
+    const onSelect = vi.fn()
+    render(<Harness query="legacy" open onSelect={onSelect} />)
+    const row = await waitFor(() => {
+      const r = screen.getAllByRole('option')[0]
+      expect(r).toBeTruthy()
+      return r
+    })
+    expect(row.getAttribute('data-kind')).toBe('file')
+    fireEvent.mouseDown(row)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/legacy.ts',
+      relativePath: 'legacy.ts',
+      kind: 'file',
+    })
+  })
+})
+
+describe('makeRelative — separator awareness', () => {
+  it('strips a POSIX root', () => {
+    expect(makeRelative('/repo/src/pages', '/repo')).toBe('src/pages')
+  })
+
+  it('strips a Windows root', () => {
+    // A '/'-only prefix check left the ABSOLUTE path here, which then failed to
+    // resolve as a folder mention on send.
+    expect(makeRelative('C:\\repo\\src\\pages', 'C:\\repo')).toBe('src\\pages')
+  })
+
+  it('strips a Windows root that already ends in a separator', () => {
+    expect(makeRelative('C:\\repo\\src', 'C:\\repo\\')).toBe('src')
+  })
+
+  it('returns the path unchanged when the root does not match', () => {
+    expect(makeRelative('/other/src', '/repo')).toBe('/other/src')
+  })
+
+  it('returns the path unchanged with an empty root', () => {
+    expect(makeRelative('/repo/src', '')).toBe('/repo/src')
+  })
+
+  it('inserts a relative folder token for a Windows root', () => {
+    const sel = selectionFor(
+      { path: 'C:\\repo\\src\\pages', name: 'pages', size: 0, mtime: 0, kind: 'dir' },
+      'C:\\repo',
+    )
+    expect(sel.relativePath).toBe('src\\pages/')
+  })
+})

--- a/website/src/test/chatDirDrafts.test.ts
+++ b/website/src/test/chatDirDrafts.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DIR_DRAFTS_KEY, loadDirDrafts, saveDirDrafts, setDirDraft } from '../utils/chatDirDrafts'
+import { FILE_DRAFTS_KEY } from '../utils/chatFileDrafts'
+
+describe('chatDirDrafts', () => {
+  beforeEach(() => { sessionStorage.clear() })
+
+  it('roundtrips dir drafts through sessionStorage', () => {
+    const drafts = {
+      'chat-1-100': ['/repo/src/pages', '/repo/docs'],
+      'chat-2-200': ['/repo/my docs'],
+    }
+    saveDirDrafts(drafts)
+    expect(loadDirDrafts()).toEqual(drafts)
+    expect(sessionStorage.getItem(DIR_DRAFTS_KEY)).toBe(JSON.stringify(drafts))
+  })
+
+  it('uses a storage key distinct from the file drafts key', () => {
+    // A shared key would smear folder references into the file-attachment list,
+    // putting a directory back on the upload/thumbnail path.
+    expect(DIR_DRAFTS_KEY).not.toBe(FILE_DRAFTS_KEY)
+  })
+
+  it('returns {} on missing, corrupt, or non-object storage', () => {
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, 'not json')
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, '[]')
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, 'null')
+    expect(loadDirDrafts()).toEqual({})
+  })
+
+  it('filters out non-array and non-string-element values (corruption guard)', () => {
+    sessionStorage.setItem(DIR_DRAFTS_KEY, JSON.stringify({
+      'good': ['/repo/src'],
+      'string-value': 'not-an-array',
+      'number-value': 42,
+      'null-value': null,
+      'mixed-array': ['/repo/a', 42, null, '/repo/b'],
+      'empty-array': [],
+    }))
+    expect(loadDirDrafts()).toEqual({
+      'good': ['/repo/src'],
+      'mixed-array': ['/repo/a', '/repo/b'],
+    })
+  })
+
+  it('setDirDraft stores non-empty and deletes empty', () => {
+    const d: Record<string, string[]> = { 'chat-1-100': ['/repo/old'] }
+    setDirDraft(d, 'chat-1-100', ['/repo/new1', '/repo/new2'])
+    expect(d).toEqual({ 'chat-1-100': ['/repo/new1', '/repo/new2'] })
+    setDirDraft(d, 'chat-1-100', [])
+    expect(d).toEqual({})
+  })
+
+  it('setDirDraft stores a defensive copy so caller mutations do not leak', () => {
+    const d: Record<string, string[]> = {}
+    const live: string[] = ['/repo/a']
+    setDirDraft(d, 'chat-1', live)
+    live.push('/repo/b')
+    expect(d['chat-1']).toEqual(['/repo/a'])
+  })
+
+  it('keeps per-slot entries isolated', () => {
+    const d: Record<string, string[]> = {}
+    setDirDraft(d, 'chat-a', ['/repo/src/pages'])
+    setDirDraft(d, 'chat-b', ['/repo/docs'])
+    expect(d['chat-a']).toEqual(['/repo/src/pages'])
+    expect(d['chat-b']).toEqual(['/repo/docs'])
+  })
+
+  it('preserves a path containing spaces', () => {
+    const d: Record<string, string[]> = {}
+    setDirDraft(d, 'chat-1', ['/repo/my docs'])
+    saveDirDrafts(d)
+    expect(loadDirDrafts()['chat-1']).toEqual(['/repo/my docs'])
+  })
+})

--- a/website/src/test/chatSlice.removeOptimistic.test.ts
+++ b/website/src/test/chatSlice.removeOptimistic.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for removeOptimisticMessage — rollback of an optimistic user bubble
+ * whose write was rejected.
+ *
+ * A mid-turn steer renders its bubble immediately and POSTs fire-and-forget. If
+ * the POST fails, that bubble is a lie: it claims the agent received text and
+ * attachments it never got. Rollback must be surgical — it may only ever remove
+ * a still-unconfirmed bubble, never one the server has already echoed (the
+ * steer echo reconciles in place and drops the `optimistic` marker), and it must
+ * reach the per-slot list because a steer can target a background slot.
+ */
+import { describe, it, expect } from 'vitest'
+import reducer, { removeOptimisticMessage } from '../store/chatSlice'
+import type { ChatMessage } from '../types'
+
+const SLOT = 'slot-a'
+const TS = '2026-07-26T09:00:00.000Z'
+
+function stateWith(messages: ChatMessage[], slotMessages?: ChatMessage[]) {
+  const base = reducer(undefined, { type: '@@INIT' })
+  return {
+    ...base,
+    activeSlot: SLOT,
+    messages,
+    slotMessages: slotMessages ? { [SLOT]: slotMessages } : base.slotMessages,
+  }
+}
+
+const optimistic: ChatMessage = {
+  role: 'user', content: 'steered text', cls: 'msg msg-u', ts: TS,
+  meta: { steer: true, optimistic: true, dirs: ['/repo/my docs'] },
+}
+
+describe('removeOptimisticMessage', () => {
+  it('removes the optimistic bubble matching the ts', () => {
+    const next = reducer(stateWith([optimistic]), removeOptimisticMessage({ slot: SLOT, ts: TS }))
+    expect(next.messages).toHaveLength(0)
+  })
+
+  it('also removes it from the per-slot list (steer into a background slot)', () => {
+    const next = reducer(stateWith([], [optimistic]), removeOptimisticMessage({ slot: SLOT, ts: TS }))
+    expect(next.slotMessages[SLOT]).toHaveLength(0)
+  })
+
+  it('leaves a CONFIRMED message with the same ts untouched', () => {
+    // The steer echo reconciles the bubble in place and clears `optimistic`.
+    // A late-arriving rejection must not then delete the real, server-persisted
+    // message — that would silently erase history the agent actually received.
+    const confirmed: ChatMessage = { ...optimistic, meta: { steer: true, dirs: ['/repo/my docs'] } }
+    const next = reducer(stateWith([confirmed]), removeOptimisticMessage({ slot: SLOT, ts: TS }))
+    expect(next.messages).toHaveLength(1)
+  })
+
+  it('leaves other optimistic messages with a different ts untouched', () => {
+    const other: ChatMessage = { ...optimistic, ts: '2026-07-26T09:00:01.000Z', content: 'a later steer' }
+    const next = reducer(stateWith([optimistic, other]), removeOptimisticMessage({ slot: SLOT, ts: TS }))
+    expect(next.messages).toHaveLength(1)
+    expect(next.messages[0].content).toBe('a later steer')
+  })
+
+  it('is a no-op for an unknown slot', () => {
+    const next = reducer(stateWith([], [optimistic]), removeOptimisticMessage({ slot: 'nope', ts: TS }))
+    expect(next.slotMessages[SLOT]).toHaveLength(1)
+  })
+})

--- a/website/src/test/fileTokens.dirs.test.ts
+++ b/website/src/test/fileTokens.dirs.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest'
+import { prepareSendPayload, buildDirRelMap, replaceDirTokens, resolveFileSegment, parseDirs, parseFiles, buildFileLabels, findUnreferencedDirs } from '../utils/fileTokens'
+
+describe('buildDirRelMap', () => {
+  it('matches a token written with the inserted trailing slash', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/ please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('matches a token written without a trailing slash', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('matches a token at end of input', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('does not match a longer sibling path', () => {
+    const map = buildDirRelMap(['/repo/src/page'], 'look at @src/pages/ please')
+    expect(map.size).toBe(0)
+  })
+})
+
+describe('replaceDirTokens', () => {
+  it('replaces the token including its trailing slash', () => {
+    const dirs = ['/repo/src/pages']
+    const map = buildDirRelMap(dirs, 'in @src/pages/ now')
+    const out = replaceDirTokens(map.size ? 'in @src/pages/ now' : '', dirs, map, p => `<${p}>`)
+    expect(out).toBe('in </repo/src/pages> now')
+  })
+})
+
+describe('prepareSendPayload with directories', () => {
+  it('emits an attached_dir token for an inline folder mention', () => {
+    const r = prepareSendPayload('review @src/pages/ for me', [], ['/repo/src/pages'])
+    expect(r.txt).toBe('review [attached_dir 1] /repo/src/pages for me')
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('appends an attached_dir token for an unreferenced folder', () => {
+    const r = prepareSendPayload('take a look', [], ['/repo/src/pages'])
+    expect(r.txt).toBe('take a look\n[attached_dir 1] /repo/src/pages')
+  })
+
+  it('never uses the attached_file marker for a directory', () => {
+    const r = prepareSendPayload('review @src/pages/', [], ['/repo/src/pages'])
+    expect(r.txt).not.toContain('attached_file')
+  })
+
+  it('keeps directories out of filePaths and imgPaths', () => {
+    const r = prepareSendPayload('see @src/pages/', [], ['/repo/src/pages'])
+    expect(r.filePaths).toEqual([])
+    expect(r.imgPaths).toEqual([])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('normalizes a trailing slash on the incoming pending dir path', () => {
+    const r = prepareSendPayload('see @src/pages/', [], ['/repo/src/pages/'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+    expect(r.txt).toBe('see [attached_dir 1] /repo/src/pages')
+  })
+
+  it('deduplicates repeated pending dirs', () => {
+    const r = prepareSendPayload('hi', [], ['/repo/src', '/repo/src/', '/repo/src'])
+    expect(r.dirPaths).toEqual(['/repo/src'])
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+
+  it('numbers directories independently of files', () => {
+    const r = prepareSendPayload(
+      'compare @src/pages/ with @data.csv',
+      ['/repo/data.csv'],
+      ['/repo/src/pages'],
+    )
+    // Both start at 1: the two marker namespaces are separate.
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).toContain('[attached_file 1] /repo/data.csv')
+    expect(r.filePaths).toEqual(['/repo/data.csv'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('numbers referenced dirs before unreferenced ones', () => {
+    const r = prepareSendPayload(
+      'only @src/pages/ is mentioned',
+      [],
+      ['/repo/docs', '/repo/src/pages'],
+    )
+    expect(r.dirPaths).toEqual(['/repo/src/pages', '/repo/docs'])
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).toContain('[attached_dir 2] /repo/docs')
+  })
+
+  it('does not consume a file path that sits beneath a mentioned dir', () => {
+    // The dir pass runs first, but "@src/pages/list.tsx" must resolve to the
+    // FILE, not to the dir prefix plus stray text.
+    const r = prepareSendPayload(
+      'open @src/pages/list.tsx',
+      ['/repo/src/pages/list.tsx'],
+      ['/repo/src/pages'],
+    )
+    expect(r.txt).toContain('[attached_file 1] /repo/src/pages/list.tsx')
+    // The dir was not mentioned on its own, so its token is appended.
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).not.toContain('[attached_dir 1] /repo/src/pages/list.tsx')
+  })
+
+  it('handles a folder name containing spaces', () => {    const r = prepareSendPayload('check @my docs/', [], ['/repo/my docs'])
+    expect(r.dirPaths).toEqual(['/repo/my docs'])
+    expect(r.txt).toContain('[attached_dir 1] /repo/my docs')
+  })
+
+  it('places dir tokens after file tokens when both are unreferenced', () => {
+    const r = prepareSendPayload('hello', ['/repo/data.csv'], ['/repo/src'])
+    expect(r.txt).toBe('hello\n[attached_file 1] /repo/data.csv\n[attached_dir 1] /repo/src')
+  })
+
+  it('leaves displayTxt free of dir markers', () => {
+    const r = prepareSendPayload('review @src/pages/ please', [], ['/repo/src/pages'])
+    expect(r.displayTxt).toBe('review @src/pages/ please')
+    expect(r.displayTxt).not.toContain('attached_dir')
+  })
+
+  it('is a no-op when no dirs are pending (back-compat with the 2-arg call)', () => {
+    const withArg = prepareSendPayload('hello', ['/repo/data.csv'], [])
+    const withoutArg = prepareSendPayload('hello', ['/repo/data.csv'])
+    expect(withoutArg.txt).toBe(withArg.txt)
+    expect(withoutArg.dirPaths).toEqual([])
+    expect(withoutArg.txt).not.toContain('attached_dir')
+  })
+
+  it('coexists with an image attachment', () => {
+    const r = prepareSendPayload('see @src/pages/', ['/repo/shot.png'], ['/repo/src/pages'])
+    expect(r.txt).toContain('![image](/repo/shot.png)')
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.imgPaths).toEqual(['/repo/shot.png'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+})
+
+describe('buildDirRelMap — Windows separators', () => {
+  it('resolves an absolute-path mention (unstripped root)', () => {
+    // If the root could not be stripped, the picker inserts the absolute path.
+    // A suffix-only walk never matched it, so the raw mention survived and a
+    // duplicate marker was appended.
+    const map = buildDirRelMap(['C:\\repo\\src'], 'look at @C:\\repo\\src/ please')
+    expect(map.get('C:\\repo\\src')).toBe('C:\\repo\\src')
+  })
+
+  it('prefers the short suffix over the full path when both could match', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/ please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+    expect(map.has('/repo/src/pages')).toBe(false)
+  })
+
+  it('serializes an absolute-path mention to exactly one marker', () => {
+    const r = prepareSendPayload('review @C:\\repo\\src/ please', [], ['C:\\repo\\src'])
+    expect(r.txt).toBe('review [attached_dir 1] C:\\repo\\src please')
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+
+  it('matches a backslash path mention', () => {
+    // On native Windows the picker inserts the backslash path with a trailing
+    // slash. Splitting on '/' alone yielded one segment, so no suffix matched
+    // and the raw @-text survived alongside a duplicate marker.
+    const map = buildDirRelMap(['C:\\repo\\src\\pages'], 'look at @src\\pages/ please')
+    expect(map.get('src\\pages')).toBe('C:\\repo\\src\\pages')
+  })
+
+  it('matches a backslash mention with a trailing backslash', () => {
+    const map = buildDirRelMap(['C:\\repo\\src\\pages'], 'look at @src\\pages\\ please')
+    expect(map.get('src\\pages')).toBe('C:\\repo\\src\\pages')
+  })
+
+  it('serializes a backslash folder mention to exactly one marker', () => {
+    const r = prepareSendPayload('review @src\\pages/ please', [], ['C:\\repo\\src\\pages'])
+    expect(r.txt).toBe('review [attached_dir 1] C:\\repo\\src\\pages please')
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+    expect(r.dirPaths).toEqual(['C:\\repo\\src\\pages'])
+  })
+
+  it('normalizes a trailing backslash before dedup', () => {
+    const r = prepareSendPayload('', [], ['C:\\repo\\src', 'C:\\repo\\src\\'])
+    expect(r.dirPaths).toEqual(['C:\\repo\\src'])
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+})
+
+describe('resolveFileSegment — folder mentions are kept out of mentionMap', () => {
+  it('routes an embedded folder token to dirMentionMap only', () => {
+    // mentionMap entries render as clickable "Open file" chips; a directory has
+    // nothing for the file viewer to open, so it must not land there.
+    const r = resolveFileSegment('review [attached_dir 1] /repo/src/pages today', [], ['/repo/src/pages'])
+    expect(r.mentionMap.size).toBe(0)
+    expect(r.dirMentionMap.get('pages/')).toBe('/repo/src/pages')
+  })
+
+  it('keeps the two maps separate for a mixed message', () => {
+    const r = resolveFileSegment(
+      'see [attached_file 1] /repo/data.csv and [attached_dir 1] /repo/src/pages now',
+      ['/repo/data.csv'],
+      ['/repo/src/pages'],
+    )
+    expect(r.mentionMap.get('data.csv')).toBe('/repo/data.csv')
+    expect(r.mentionMap.has('pages/')).toBe(false)
+    expect(r.dirMentionMap.get('pages/')).toBe('/repo/src/pages')
+  })
+
+  it('routes an optimistic-form folder mention to dirMentionMap', () => {
+    const r = resolveFileSegment('review @src/pages/ please', [], ['/repo/src/pages'])
+    expect(r.mentionMap.size).toBe(0)
+    expect(r.dirMentionMap.get('src/pages/')).toBe('/repo/src/pages')
+  })
+})
+
+describe('parseDirs / parseFiles — untrusted meta', () => {
+  it('falls back to the content scan when meta.dirs is a string', () => {
+    // /api/chat accepts any dict as meta, so this shape is reachable. An
+    // unvalidated cast reached buildFileLabels, where p.split() threw and the
+    // whole message failed to render.
+    const content = '[attached_dir 1] /repo/src'
+    expect(parseDirs(content, { dirs: 'nope' } as Record<string, unknown>)).toEqual(['/repo/src'])
+  })
+
+  it('blanks non-string members of meta.dirs in place, preserving marker indices', () => {
+    // Blanked, NOT dropped: marker N indexes this list positionally, so
+    // filtering would shift later paths down a slot (see the spaced-path test
+    // below for the user-visible consequence).
+    const dirs = ['/repo/src', 42, null, '', '/repo/docs'] as unknown
+    expect(parseDirs('', { dirs } as Record<string, unknown>)).toEqual(['/repo/src', '', '', '', '/repo/docs'])
+  })
+
+  it('resolves a spaced path whose marker follows an INVALID meta entry', () => {
+    // Regression: with `.filter()`, the bad entry at index 0 shifted
+    // '/repo/my docs' from slot 2 to slot 1, so `[attached_dir 2]` indexed past
+    // the end, fell through to the whitespace-bounded scan, and truncated the
+    // path at the space — rendering '/repo/my' and losing '/docs'.
+    const content = 'check [attached_dir 2] /repo/my docs please'
+    const dirs = parseDirs(content, { dirs: [42, '/repo/my docs'] } as unknown as Record<string, unknown>)
+    expect(dirs).toEqual(['', '/repo/my docs'])
+    const { display, dirMentionMap } = resolveFileSegment(content, [], dirs)
+    // The full spaced path survives as a chip, not truncated at the space.
+    expect([...dirMentionMap.values()]).toContain('/repo/my docs')
+    expect(display).not.toContain('/repo/my docs')
+    expect(display).not.toMatch(/\[attached_dir 2\]/)
+  })
+
+  it('does not surface a blank placeholder as an attachment card', () => {
+    // A blank is an index-alignment placeholder, never a real path — it must not
+    // reach findUnreferencedDirs and render an empty card.
+    expect(findUnreferencedDirs('no markers here', ['', '/repo/docs'])).toEqual(['/repo/docs'])
+  })
+
+  it('falls back to the content scan when every meta.dirs member is invalid', () => {
+    // All-blank carries no usable path, so `.length` must stay falsy for the
+    // caller's fallback rather than yielding ['', ''].
+    expect(parseDirs('[attached_dir 1] /repo/src', { dirs: [1, 2] } as unknown as Record<string, unknown>))
+      .toEqual(['/repo/src'])
+  })
+
+  it('falls back when meta.dirs is an object', () => {
+    expect(parseDirs('[attached_dir 1] /repo/src', { dirs: { a: 1 } } as Record<string, unknown>))
+      .toEqual(['/repo/src'])
+  })
+
+  it('applies the same validation to meta.files', () => {
+    expect(parseFiles('[attached_file 1] /repo/a.csv', { files: 'nope' } as Record<string, unknown>))
+      .toEqual(['/repo/a.csv'])
+    expect(parseFiles('', { files: ['/repo/a.csv', 7] } as unknown as Record<string, unknown>))
+      .toEqual(['/repo/a.csv', ''])
+  })
+
+  it('resolveFileSegment survives malformed meta-derived lists', () => {
+    const dirs = parseDirs('review [attached_dir 1] /repo/src/pages now', { dirs: 99 } as Record<string, unknown>)
+    expect(() => resolveFileSegment('review [attached_dir 1] /repo/src/pages now', [], dirs)).not.toThrow()
+  })
+})
+
+describe('buildFileLabels with Windows separators', () => {
+  it('takes the basename of a backslash path', () => {
+    // Splitting on `/` alone left the whole absolute path as the "basename", so
+    // every chip and card displayed the full native Windows path.
+    const map = buildFileLabels(['C:\\repo\\website\\docs'])
+    expect(map.get('C:\\repo\\website\\docs')).toBe('docs')
+  })
+
+  it('disambiguates duplicate names across backslash paths', () => {
+    const paths = ['C:\\repo\\docs', 'C:\\repo\\website\\docs']
+    const map = buildFileLabels(paths)
+    expect(map.get(paths[0])).toBe('repo/docs')
+    expect(map.get(paths[1])).toBe('website/docs')
+  })
+
+  it('still handles POSIX paths unchanged', () => {
+    const paths = ['/repo/docs', '/repo/website/docs', '/repo/a.txt']
+    const map = buildFileLabels(paths)
+    expect(map.get('/repo/docs')).toBe('repo/docs')
+    expect(map.get('/repo/website/docs')).toBe('website/docs')
+    expect(map.get('/repo/a.txt')).toBe('a.txt')
+  })
+})

--- a/website/src/test/renderUserContent.dirs.test.tsx
+++ b/website/src/test/renderUserContent.dirs.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { renderUserContent } from '../pages/ChatPage'
+
+const noop = () => {}
+
+/** The persisted shape: server stores the LLM-facing token form in content AND
+ *  keeps meta alongside it. Tests cover both meta-present and no-meta replay. */
+const DIR = '/repo/src/pages'
+const FILE = '/repo/data.csv'
+
+describe('renderUserContent — folder references', () => {
+  it('renders a standalone folder token as a folder card, not raw text', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('pages/')
+  })
+
+  it('renders the folder card with a Folder icon', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelector('[aria-label="Folder"]')).toBeInTheDocument()
+  })
+
+  it('exposes the full path as the folder card title', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelector(`[title="${DIR}"]`)).toBeInTheDocument()
+  })
+
+  it('does not make the folder card clickable', () => {
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const card = container.querySelector(`[title="${DIR}"]`)!
+    expect(card.tagName.toLowerCase()).not.toBe('a')
+    expect(card.tagName.toLowerCase()).not.toBe('button')
+  })
+
+  it('renders an embedded folder token as an inline chip with a trailing slash', () => {
+    const { container } = render(
+      <>{renderUserContent(`please review [attached_dir 1] ${DIR} today`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('please review')
+    expect(container).toHaveTextContent('@pages/')
+    expect(container).toHaveTextContent('today')
+  })
+
+  it('keeps an embedded folder mention on one line with the surrounding text', () => {
+    const { container } = render(
+      <>{renderUserContent(`check [attached_dir 1] ${DIR} now`, { dirs: [DIR] }, noop)}</>,
+    )
+    // A block <p> per run would break the line around the chip.
+    expect(container.querySelectorAll('p')).toHaveLength(0)
+  })
+
+  it('replays a folder token with no meta (history replay path)', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, undefined, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('pages/')
+  })
+
+  it('renders a file card and a folder card together', () => {
+    const content = `hello\n[attached_file 1] ${FILE}\n[attached_dir 1] ${DIR}`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_file')
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('data.csv')
+    expect(container).toHaveTextContent('pages/')
+    expect(container).toHaveTextContent('hello')
+  })
+
+  it('resolves same-numbered file and dir tokens against their own lists', () => {
+    // Both markers are numbered 1: each must index its OWN ordered list.
+    const content = `see [attached_file 1] ${FILE} and [attached_dir 1] ${DIR}`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).toHaveTextContent('@data.csv')
+    expect(container).toHaveTextContent('@pages/')
+  })
+
+  it('does not make an embedded folder chip clickable', () => {
+    // A mentionMap entry renders as an "Open file" chip that calls onFileOpen.
+    // A folder must not reach that path: the viewer cannot open a directory.
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent(`please review [attached_dir 1] ${DIR} today`, { dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const chip = container.querySelector(`[title="${DIR}"]`)!
+    expect(chip).toBeInTheDocument()
+    expect(chip.tagName.toLowerCase()).not.toBe('a')
+    expect(chip.tagName.toLowerCase()).not.toBe('button')
+    expect(chip.getAttribute('aria-label') ?? '').not.toMatch(/open file/i)
+    expect(chip.className).not.toContain('cursor-pointer')
+  })
+
+  it('keeps an embedded file chip clickable alongside a folder chip', () => {
+    const onFileOpen = vi.fn()
+    const content = `see [attached_file 1] ${FILE} and [attached_dir 1] ${DIR} now`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const fileChip = container.querySelector(`[aria-label="Open file ${FILE}"]`)
+    expect(fileChip).toBeInTheDocument()
+    const dirChip = container.querySelector(`[title="${DIR}"]`)!
+    expect(dirChip.getAttribute('aria-label') ?? '').not.toMatch(/open file/i)
+  })
+
+  it('handles a folder path containing spaces', () => {
+    const spaced = '/repo/my docs'
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${spaced}`, { dirs: [spaced] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container.querySelector(`[title="${spaced}"]`)).toBeInTheDocument()
+    expect(container).toHaveTextContent('my docs/')
+  })
+
+  it('resolves a spaced folder path from the meta the sender actually persists', () => {
+    // Regression guard: send() must put dirPaths on meta.dirs. Without it this
+    // message replays through the whitespace-splitting content fallback, which
+    // truncates the path at the first space.
+    const spaced = '/repo/my docs'
+    const content = `look at [attached_dir 1] ${spaced} please`
+    const withMeta = render(
+      <>{renderUserContent(content, { dirs: [spaced] }, noop)}</>,
+    )
+    expect(withMeta.container).toHaveTextContent('@my docs/')
+    expect(withMeta.container).toHaveTextContent('please')
+    expect(withMeta.container).not.toHaveTextContent('attached_dir')
+    // Same content with no meta is the degraded path: the fallback can only see
+    // up to the space, so the tail leaks as text. This asserts the difference is
+    // real, which is why meta.dirs must be persisted.
+    const noMeta = render(<>{renderUserContent(content, undefined, noop)}</>)
+    expect(noMeta.container).toHaveTextContent('docs')
+  })
+
+  it('renders the optimistic bubble form (@relative, no token yet)', () => {
+    const { container } = render(
+      <>{renderUserContent('review @src/pages/ please', { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).toHaveTextContent('review')
+    expect(container).toHaveTextContent('please')
+    expect(container).toHaveTextContent('src/pages/')
+  })
+
+  it('renders a folder card exactly once, not per segment', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelectorAll(`[title="${DIR}"]`)).toHaveLength(1)
+  })
+
+  it('leaves a message with no attachments untouched', () => {
+    const { container } = render(
+      <>{renderUserContent('plain **bold** message', undefined, noop)}</>,
+    )
+    expect(container.querySelector('strong')).toHaveTextContent('bold')
+  })
+
+  it('still renders a file-only message exactly as before (no dir regression)', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_file 1] ${FILE}`, { files: [FILE] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_file')
+    expect(container).toHaveTextContent('data.csv')
+    expect(container.querySelector('[aria-label="Folder"]')).not.toBeInTheDocument()
+  })
+})

--- a/website/src/utils/chatDirDrafts.ts
+++ b/website/src/utils/chatDirDrafts.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-slot pending-folder-reference persistence (directory paths staged in the
+ * compose box before send). Thin instance of `createSlotDraftStore`, mirroring
+ * `chatFileDrafts`.
+ *
+ * A folder reference is a path handed to the agent, not an upload, so nothing
+ * server-side can garbage-collect it. It is still kept in sessionStorage rather
+ * than localStorage to match the file-attachment lifetime: a staged reference
+ * belongs to the composing session, and a path that is valid today may not
+ * exist after a tab-close-and-return.
+ */
+import { createSlotDraftStore } from './slotDraftStore'
+
+export const DIR_DRAFTS_KEY = 'mc-chat-dir-drafts'
+
+export type DirDrafts = Record<string, string[]>
+
+/** Coerce to a non-empty string[] (dropping non-string members), or null. The
+ *  returned copy isolates the store from caller mutations and vice versa. */
+const sanitizePaths = (v: unknown): string[] | null => {
+  if (!Array.isArray(v)) return null
+  const arr = v.filter((x): x is string => typeof x === 'string')
+  return arr.length ? arr.slice() : null
+}
+
+const store = createSlotDraftStore<string[]>({
+  key: DIR_DRAFTS_KEY,
+  storage: 'session',
+  sanitize: sanitizePaths,
+})
+
+export const loadDirDrafts = store.load
+export const saveDirDrafts = store.save
+export const setDirDraft = store.set

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -8,9 +8,37 @@ function tokenRegex(token: string, flags = ''): RegExp {
   return new RegExp(`@${escaped}(?=\\s|$)`, flags)
 }
 
+/**
+ * Coerce an untrusted `meta` attachment list to `string[]`.
+ *
+ * `/api/chat` accepts any dictionary as message metadata, so a persisted
+ * `meta.files` / `meta.dirs` can be a string, or an array holding non-strings.
+ * A bare `as string[]` cast performed no runtime check, and replay then handed
+ * that value to buildFileLabels, where `p.split()` threw and the whole message
+ * failed to render.
+ *
+ * Invalid members are BLANKED IN PLACE (empty string), never dropped: marker
+ * number N indexes this list positionally, so filtering a bad entry out would
+ * shift every later path down one slot and `[attached_dir 2] /repo/my docs`
+ * would resolve against the wrong element — falling through to the
+ * whitespace-bounded scan that truncates at the space, the exact bug the
+ * ordered lists exist to prevent. A blank placeholder keeps later indices
+ * aligned and simply fails the `startsWith` check for its own marker, which
+ * degrades to the scan for that one entry alone. A wholly invalid value yields
+ * `[]`, which falls through to the content-scan fallback.
+ */
+function metaPathList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const out = value.map(p => (typeof p === 'string' ? p : ''))
+  // All-blank is indistinguishable from "no usable metadata" — let the caller's
+  // `.length` check fall through to the content scan rather than handing back a
+  // list of empty strings that can never match a marker.
+  return out.some(p => p.length > 0) ? out : []
+}
+
 /** Parse file paths from message meta or [attached_file N] patterns in content. */
 export function parseFiles(content: string, meta?: Record<string, unknown>): string[] {
-  const metaFiles = (meta?.files || []) as string[]
+  const metaFiles = metaPathList(meta?.files)
   return metaFiles.length
     ? metaFiles
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
@@ -19,12 +47,18 @@ export function parseFiles(content: string, meta?: Record<string, unknown>): str
 /** Per-path display label: basename, disambiguated to the last-2 path segments
  *  when two paths share a basename (e.g. two `report.docx` in different dirs). */
 export function buildFileLabels(paths: string[]): Map<string, string> {
-  const basenames = paths.map(p => p.split('/').pop() || p)
+  // Split on either separator: a native Windows path uses `\`, and splitting on
+  // `/` alone would leave the whole absolute path as the "basename", so every
+  // chip and card would display the full path and duplicate folder names would
+  // never disambiguate.
+  const seg = (p: string) => p.split(/[/\\]/)
+  const basenames = paths.map(p => seg(p).pop() || p)
   const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
   const map = new Map<string, string>()
   for (const p of paths) {
-    const name = p.split('/').pop() || p
-    map.set(p, dupes.has(name) ? p.split('/').slice(-2).join('/') : name)
+    const parts = seg(p)
+    const name = parts.pop() || p
+    map.set(p, dupes.has(name) ? [parts.pop() ?? '', name].filter(Boolean).join('/') : name)
   }
   return map
 }
@@ -34,8 +68,12 @@ export interface ResolvedFileSegment {
   display: string
   /** `@label` (without the leading @) -> full path, for files referenced inline IN THIS content. */
   mentionMap: Map<string, string>
+  /** `@label/` (without the leading @) -> full path, for FOLDERS referenced inline IN THIS content. Kept apart from `mentionMap` because a folder chip must not be clickable: there is nothing for the file viewer to open. */
+  dirMentionMap: Map<string, string>
   /** Standalone-upload paths whose token appears IN THIS content — render as cards. Does NOT include files that are absent from this content (the caller decides those at message level, to avoid per-segment duplication). */
   cardPaths: string[]
+  /** Standalone directory references whose `[attached_dir N]` token appears IN THIS content — render as folder cards. */
+  dirCardPaths: string[]
   /** Display label per path (basename, disambiguated). */
   labels: Map<string, string>
 }
@@ -75,20 +113,33 @@ export interface ResolvedFileSegment {
  * markdown, never as file cards); an image referenced by an embedded token is
  * likewise never added to mentionMap.
  */
-export function resolveFileSegment(content: string, orderedFiles: string[]): ResolvedFileSegment {
+export function resolveFileSegment(
+  content: string,
+  orderedFiles: string[],
+  orderedDirs: string[] = [],
+): ResolvedFileSegment {
   const labels = buildFileLabels(orderedFiles)
+  const dirLabels = buildFileLabels(orderedDirs)
   const mentionMap = new Map<string, string>()
+  const dirMentionMap = new Map<string, string>()
   const cardPaths: string[] = []
+  const dirCardPaths: string[] = []
   const seen = new Set<string>()
+  const seenDirs = new Set<string>()
 
-  const markerRe = /\[attached_file (\d+)\]([^\S\n]+)/g
+  // Both markers share one scan so their tokens interleave correctly in the
+  // output, but each numbers into its OWN ordered list: [attached_file 1] and
+  // [attached_dir 1] refer to different things.
+  const markerRe = /\[attached_(file|dir) (\d+)\]([^\S\n]+)/g
   let display = ''
   let lastIdx = 0
   let m: RegExpExecArray | null
   while ((m = markerRe.exec(content)) !== null) {
-    const n = parseInt(m[1], 10)
+    const isDirMarker = m[1] === 'dir'
+    const ordered = isDirMarker ? orderedDirs : orderedFiles
+    const n = parseInt(m[2], 10)
     const pathStart = m.index + m[0].length
-    const indexed = n >= 1 && n <= orderedFiles.length ? orderedFiles[n - 1] : undefined
+    const indexed = n >= 1 && n <= ordered.length ? ordered[n - 1] : undefined
     let path: string
     let pathEnd: number
     if (indexed && content.startsWith(indexed, pathStart)) {
@@ -110,15 +161,27 @@ export function resolveFileSegment(content: string, orderedFiles: string[]): Res
     const nlAfter = afterSlice.indexOf('\n')
     const lineAfter = nlAfter === -1 ? afterSlice : afterSlice.slice(0, nlAfter)
     const embedded = lineBefore.trim().length > 0 || lineAfter.trim().length > 0
-    const label = labels.get(path) || (path.split('/').pop() || path)
-    const isImage = IMG_EXT.test(path)
+    const label = isDirMarker
+      ? (dirLabels.get(path) || path.split('/').pop() || path)
+      : (labels.get(path) || path.split('/').pop() || path)
+    // A directory is never an image, so the image branch only applies to files.
+    const isImage = !isDirMarker && IMG_EXT.test(path)
 
     display += content.slice(lastIdx, m.index)
     if (embedded && !isImage) {
-      mentionMap.set(label, path)
-      display += `@${label}`
+      // Folder chips read with a trailing slash so they are visibly not files,
+      // and land in their own map: the caller renders them as non-clickable
+      // labels, since a directory has nothing to open in the file viewer.
+      if (isDirMarker) {
+        dirMentionMap.set(label + '/', path)
+        display += `@${label}/`
+      } else {
+        mentionMap.set(label, path)
+        display += `@${label}`
+      }
     } else if (!embedded && !isImage) {
-      cardPaths.push(path)
+      if (isDirMarker) dirCardPaths.push(path)
+      else cardPaths.push(path)
       // Drop a trailing newline the standalone token owns so it leaves no blank
       // line; if it had a leading newline instead, drop that from the output.
       if (afterSlice.startsWith('\n')) pathEnd += 1
@@ -128,18 +191,26 @@ export function resolveFileSegment(content: string, orderedFiles: string[]): Res
       if (afterSlice.startsWith('\n')) pathEnd += 1
       else if (content[m.index - 1] === '\n') display = display.slice(0, -1)
     }
-    seen.add(path)
+    if (isDirMarker) seenDirs.add(path)
+    else seen.add(path)
     lastIdx = pathEnd
     markerRe.lastIndex = pathEnd
   }
   display += content.slice(lastIdx)
 
   // Recover any `@relative` mentions already present (fresh optimistic bubble),
-  // for non-image files not already resolved from a token above.
-  const notSeen = orderedFiles.filter(p => !seen.has(p) && !IMG_EXT.test(p))
+  // for non-image files not already resolved from a token above. Blank entries
+  // are index-alignment placeholders for invalid metadata (see metaPathList) —
+  // they are not real paths, so they must never reach a chip or card.
+  const notSeen = orderedFiles.filter(p => p && !seen.has(p) && !IMG_EXT.test(p))
   buildRelMap(notSeen, display).forEach((fullPath, suffix) => mentionMap.set(suffix, fullPath))
+  // Same for folders: the optimistic bubble still carries `@src/pages/`.
+  const dirsNotSeen = orderedDirs.filter(p => p && !seenDirs.has(p))
+  buildDirRelMap(dirsNotSeen, display).forEach((fullPath, suffix) => {
+    dirMentionMap.set(suffix + '/', fullPath)
+  })
 
-  return { display, mentionMap, cardPaths, labels }
+  return { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels }
 }
 
 /**
@@ -162,34 +233,118 @@ export function findUnreferencedAttachments(text: string, orderedFiles: string[]
     if (text.includes(`[attached_file ${n}]`)) { referenced.add(p); return }
     if (buildRelMap([p], text).size) referenced.add(p)
   })
-  return orderedFiles.filter(p => !IMG_EXT.test(p) && !referenced.has(p))
+  return orderedFiles.filter(p => p && !IMG_EXT.test(p) && !referenced.has(p))
+}
+
+/**
+ * Directory counterpart to findUnreferencedAttachments. Token number N indexes
+ * `orderedDirs`, an index space entirely separate from the file markers', so a
+ * message carrying both `[attached_file 1]` and `[attached_dir 1]` resolves each
+ * against the right list.
+ */
+export function findUnreferencedDirs(text: string, orderedDirs: string[]): string[] {
+  const referenced = new Set<string>()
+  orderedDirs.forEach((p, i) => {
+    const n = i + 1
+    if (text.includes(`[attached_dir ${n}]`)) { referenced.add(p); return }
+    if (buildDirRelMap([p], text).size) referenced.add(p)
+  })
+  return orderedDirs.filter(p => p && !referenced.has(p))
+}
+
+/** Parse directory paths from message meta or [attached_dir N] patterns in content. */
+export function parseDirs(content: string, meta?: Record<string, unknown>): string[] {
+  const metaDirs = metaPathList(meta?.dirs)
+  return metaDirs.length
+    ? metaDirs
+    : (content.match(/\[attached_dir \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_dir \d+\] /, ''))
 }
 
 /** Walk path segments to find the shortest @suffix present in text. */
-export function buildRelMap(paths: string[], text: string): Map<string, string> {
+export function buildRelMap(
+  paths: string[], text: string,
+  /** Token matcher; folder mentions pass `dirTokenRegex`. */
+  matcher: (token: string, flags?: string) => RegExp = tokenRegex,
+): Map<string, string> {
   const map = new Map<string, string>()
   for (const p of paths) {
-    const segs = p.split('/')
-    for (let i = 1; i < segs.length; i++) {
-      const suffix = segs.slice(i).join('/')
-      if (tokenRegex(suffix).test(text) && !map.has(suffix)) { map.set(suffix, p); break }
+    for (const suffix of pathSuffixes(p.replace(/[/\\]+$/, ''))) {
+      if (matcher(suffix).test(text) && !map.has(suffix)) { map.set(suffix, p); break }
     }
   }
   return map
+}
+
+/**
+ * Directory variant of tokenRegex. The composer inserts folder mentions with a
+ * trailing slash (`@src/pages/ `), so the token must match with OR without it.
+ * The trailing separator may be either kind so a Windows path (`src\pages`) that
+ * the picker suffixed with `/` still matches.
+ */
+function dirTokenRegex(token: string, flags = ''): RegExp {
+  const escaped = token.replace(/[/\\]$/, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`@${escaped}[/\\\\]?(?=\\s|$)`, flags)
+}
+
+/**
+ * Path suffixes after each separator, longest first, with the ORIGINAL separator
+ * characters preserved.
+ *
+ * Splitting on `/` alone would collapse a native Windows path
+ * (`C:\repo\src\pages`) to a single segment, so no suffix would ever match the
+ * `@C:\repo\src\pages/` token the picker inserted, and the mention would be left
+ * as raw text while a duplicate `[attached_dir N]` marker was appended. Slicing
+ * rather than splitting-and-rejoining keeps the separators native, so the map key
+ * matches the text verbatim.
+ */
+function pathSuffixes(bare: string): string[] {
+  // The full path is a candidate too: when the root could not be stripped (e.g.
+  // an unrecognized root form), the picker inserts the absolute path, and a
+  // suffix-only walk would never match it, leaving the raw mention plus a
+  // duplicate marker. Suffixes are tried first so the short form still wins.
+  const out: string[] = []
+  const sepRe = /[/\\]/g
+  let m: RegExpExecArray | null
+  while ((m = sepRe.exec(bare)) !== null) {
+    const suffix = bare.slice(m.index + 1)
+    if (suffix) out.push(suffix)
+  }
+  out.push(bare)
+  return out
+}
+
+/**
+ * Directory variant of buildRelMap. Folder paths carry no trailing separator,
+ * but the inserted token does, so matching tolerates either form and either
+ * separator style.
+ */
+export function buildDirRelMap(paths: string[], text: string): Map<string, string> {
+  return buildRelMap(paths, text, dirTokenRegex)
 }
 
 /** Replace @rel tokens in text using a replacer function. */
 export function replaceTokens(
   text: string, paths: string[], relMap: Map<string, string>,
   replacer: (fullPath: string, idx: number) => string,
+  /** Token matcher. Folder mentions pass `dirTokenRegex`, which additionally
+   *  tolerates the trailing separator the composer inserts. */
+  matcher: (token: string, flags?: string) => RegExp = tokenRegex,
 ): string {
   let result = text
   paths.forEach((p, i) => {
     const rel = [...relMap.entries()].find(([, v]) => v === p)?.[0]
     if (!rel) return
-    result = result.replace(tokenRegex(rel, 'g'), () => replacer(p, i))
+    result = result.replace(matcher(rel, 'g'), () => replacer(p, i))
   })
   return result
+}
+
+/** Directory variant of replaceTokens, tolerant of the inserted trailing slash. */
+export function replaceDirTokens(
+  text: string, paths: string[], relMap: Map<string, string>,
+  replacer: (fullPath: string, idx: number) => string,
+): string {
+  return replaceTokens(text, paths, relMap, replacer, dirTokenRegex)
 }
 
 /** Build send payload from raw input text and pending files. */
@@ -198,9 +353,25 @@ export interface SendPayload {
   displayTxt: string // UI-facing content
   filePaths: string[]
   imgPaths: string[]
+  /** Directory references, in the order their `[attached_dir N]` tokens number. */
+  dirPaths: string[]
 }
 
-export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPayload {
+/**
+ * Serialize a directory reference. Folders get their OWN marker rather than
+ * reusing `[attached_file N]`, because the agent must not try to `read` a
+ * directory: the marker tells it this is a path to explore with its own
+ * glob/grep/read tools. Numbering is independent of the file marker's.
+ */
+function dirToken(n: number, path: string): string {
+  return `[attached_dir ${n}] ${path}`
+}
+
+export function prepareSendPayload(
+  raw: string,
+  pendingFiles: string[],
+  pendingDirs: string[] = [],
+): SendPayload {
   // All pending files (uploaded via button/drag-drop) are always included.
   // The @-token in text is used for display replacement, not as a gate.
   const files = [...new Set(pendingFiles)]
@@ -208,6 +379,20 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   const filePaths = files.filter(p => !IMG_EXT.test(p))
   const imgMd = imgPaths.map(p => `![image](${p})`).join('\n')
   const relMap = buildRelMap(files, raw)
+
+  // Directories are tracked and numbered separately from files so a folder
+  // reference never lands in filePaths/imgPaths (nothing downstream should try
+  // to read or thumbnail it).
+  // Normalize BEFORE dedup so "/repo/src" and "/repo/src/" collapse to one
+  // entry rather than producing two tokens for the same folder.
+  const dirs = [...new Set(pendingDirs.map(p => p.replace(/[/\\]+$/, '')))]
+  const dirRelMap = buildDirRelMap(dirs, raw)
+  const referencedDirs = new Set([...dirRelMap.values()])
+  const orderedDirs = [
+    ...dirs.filter(p => referencedDirs.has(p)),
+    ...dirs.filter(p => !referencedDirs.has(p)),
+  ]
+  const dirIdxMap = new Map(orderedDirs.map((p, i) => [p, i + 1]))
 
   // Assign sequential indices to all non-image files, ordered by upload order.
   // Referenced files get lower indices, unreferenced get higher — but indices
@@ -222,12 +407,21 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   ]
   const idxMap = new Map(indexedFilePaths.map((p, i) => [p, i + 1]))
 
+  // Replace inline folder mentions first: the dir regex tolerates the trailing
+  // slash the composer inserts, and dir paths are prefixes of the file paths
+  // beneath them, so running this before the file pass avoids a partial match.
+  const withDirs = replaceDirTokens(raw, orderedDirs, dirRelMap, p => dirToken(dirIdxMap.get(p) ?? 0, p))
+
   const llmRaw = replaceTokens(
-    replaceTokens(raw, imgPaths, relMap, () => ''),
+    replaceTokens(withDirs, imgPaths, relMap, () => ''),
     filePaths, relMap, (p) => `[attached_file ${idxMap.get(p) ?? 0}] ${p}`,
   )
   const unreferenced = filePaths.filter(p => !referencedPaths.has(p))
   const unreferencedTokens = unreferenced.map(p => `[attached_file ${idxMap.get(p) ?? 0}] ${p}`).join('\n')
+  const unreferencedDirTokens = orderedDirs
+    .filter(p => !referencedDirs.has(p))
+    .map(p => dirToken(dirIdxMap.get(p) ?? 0, p))
+    .join('\n')
   const displayRaw = replaceTokens(raw, imgPaths, relMap, () => '')
 
   // Separate the pasted-image markdown from the typed text with a blank line
@@ -243,11 +437,12 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   // It is newline-agnostic and pulls the image into its own content block, so
   // the surrounding whitespace never changes what the model receives. The
   // caption keeps a single '\n' to its appended [attached_file N] tokens.
-  const textBody = [llmRaw, unreferencedTokens].filter(Boolean).join('\n')
+  const textBody = [llmRaw, unreferencedTokens, unreferencedDirTokens].filter(Boolean).join('\n')
   return {
     txt: [imgMd, textBody].filter(Boolean).join('\n\n'),
     displayTxt: [imgMd, displayRaw].filter(Boolean).join('\n\n'),
     filePaths: indexedFilePaths,
     imgPaths,
+    dirPaths: orderedDirs,
   }
 }


### PR DESCRIPTION
## Problem

The `@`-mention picker matched files only. Pointing an agent at a directory meant typing the absolute path by hand, and pasting a folder path into the file-attachment flow made the agent try to `read` a directory, which fails.

## Why it matters

Directory-scoped work is common ("refactor everything under `src/pages/`", "what's in `docs/`?"), and it was the one attachment shape the composer could not express. The workaround — a hand-typed path — is error-prone and loses the affordances files get (a chip, a preview strip entry, per-slot draft persistence).

## Fix

A folder mention is a **path reference**, not an upload. The composer serializes it with a distinct `[attached_dir N] /full/path` marker that tells the agent to explore the path with its own glob/grep/read tools. No directory listing and no recursive content is inlined, so a large tree costs nothing in context.

**Backend.** `FileIndex` entries gained a `kind` field and the walk collects directories, so even an empty directory is searchable. `GET /api/file-search` returns `kind` on every result and accepts `kinds=all|files|dirs`. Files outrank directories on an equal fuzzy score, and the fallback walk gives each kind an independent scan budget and candidate cap — a shared counter let a file-heavy root spend the whole budget before any directory was examined, so directory search returned nothing.

**Security.** Both file and directory candidates are resolved with `realpath` before the `is_sensitive_path` check, matching the `api_browse_dirs` precedent. The two branches are deliberately symmetrical: a divergence would let a sensitive target be reachable as a file but not as a directory, or the reverse.

**Composer.** `pendingDirs` is tracked separately from `pendingFiles`, so a directory never reaches the upload, thumbnail, or `attached_file` paths. The two marker families number independently, and `resolveFileSegment` scans both in one pass with separate index spaces, preserving lossless index-based resolution for paths containing spaces. Folder chips are rendered from a separate `dirMentionMap` and are deliberately **not** clickable — a directory has nothing for the file viewer to open, and sharing the file `mentionMap` meant a click invoked the viewer with a directory.

**Persistence.** `send()` and `steer()` both write the ordered folder list to `meta.dirs`, the counterpart to `meta.files`. Without it a replayed message falls back to the whitespace-bounded content scan, which truncates any path containing a space. Staged folders are persisted per chat slot via `chatDirDrafts`; the slot-change effect restoring the incoming slot's list is what keeps slots isolated, and without it a folder picked in one chat rode along on the next send in another.

**Title generation.** Both marker families are stripped before the titling prompt is built, but stripping the marker *and* its path left messages with no nameable content: `tell me about @docs/ and @website/docs/` became `tell me about and`, which the titling model correctly answered `SKIP`. The scanner now substitutes the trailing path segment instead of deleting it, widened to two segments when basenames collide (three folders named `docs` read as "docs and docs and docs", which also draws a `SKIP`). Labels are bounded by a shared per-message budget so a pathological name cannot crowd out the user's caption. The truncated-fallback path still drops attachment names entirely, because an attachment-only message must stay unnameable so a later real title can win.

### Robustness fixes found in review

- **Send failure restores the pre-serialization state.** The catch path previously restored the serialized text with no backing pending lists, so a retry sent generated markers stripped of the ordered lists that resolve them. It now restores the raw typed text and re-stages both attachment families — including images, which are split out of the payload's file list and exist only in the staged list.
- **Windows separators.** `makeRelative` and the label basename split were `/`-only, so a native Windows root never stripped and a chip displayed the whole absolute path. Folder token matching, dedup normalization, and label derivation all accept either separator; the suffix walk also accepts the full path so an unstripped root resolves instead of appending a duplicate marker.
- **Untrusted metadata.** `meta.files` / `meta.dirs` pass through a runtime validator. The endpoint accepts any dictionary as metadata, so a persisted list could be a string or hold non-strings; the previous cast performed no check and replay threw while splitting a non-string, failing to render the whole message.
- **Preview-strip height.** The composer's manual-height compensation now keys off both staged families, so a folders-only strip no longer overlaps the textarea.

## Tests

150 targeted tests (46 backend, 104 frontend) across 11 test files, 8 of them new. What they lock in:

| Area | Locks in |
|---|---|
| `test_file_search_dirs.py` | Directory results, `kinds` filter, symlinked-file and symlinked-dir rejection, dirs cannot starve files under either the shared cap or the scan budget |
| `test_chat_title_dirs.py` | Both families stripped, label substitution and collision disambiguation, shared label budget, scan budget covers both families |
| `test_acp_send_prompt_dirs.py` | Directory markers pass through to the agent unmodified, including a directory named `screenshots.png` |
| `fileTokens.dirs.test.ts` | Marker serialization and independent numbering, `dirMentionMap` separation, Windows separators, malformed `meta` fallback |
| `renderUserContent.dirs.test.tsx` | Folder chips and cards, non-clickable folder chips, spaced-path replay in the true production shape (no `meta` rescue) |
| `ChatPageDrafts.test.tsx` | Per-slot draft isolation, `meta.dirs` persistence, send-failure restore including a staged image |
| `chatDirDrafts.test.ts` | Per-slot folder-draft store |
| `ChatInput.dirStripHeight.test.tsx` | Preview-strip height compensation for a folders-only strip |
| `FilePickerMenu.dirs.test.tsx` | Folder rows, selection payloads, separator-aware `makeRelative` |

Each regression guard was verified load-bearing by temporarily reverting its fix and confirming the test fails.

Full sweep: frontend 4586 passed / 3 skipped across 393 files; affected backend suites 113 passed; `tsc -b --force` clean; flake8 clean; working-tree scrub-lint clean (the git-history check fails on pre-existing commits, tracked separately).

## Manual verification

Recorded end-to-end below: picking folders in the composer, the serialized markers reaching the agent, and the rendered chips. Title generation was additionally verified against the live titling model — the same message that previously produced `SKIP` now titles correctly.

Two Windows CI failures are pre-existing on `main` and unrelated to this branch (`test_token_auth.py` POSIX file-mode assertions, and a `WinError 32` tempfile-lock flake in `test_mcp_gateway_bluegreen.py`); the same failures reproduce on `main`'s own runs.

## Screenshots

https://github.com/user-attachments/assets/5af133f8-9982-46b6-b58c-8792314f5b41

## Docs

`AGENTS.md` states a folder marker must not be passed to a file-read tool. Adds `docs/system-specs/modules/file-search.md` (indexed in `docs/system-specs/index.md`), covering the marker contract, rendering rules, composer state, and the security symmetry.
