### PR TITLE
fix(pwa): let brand assets bypass the service worker so a restart can't strand the logo

### DIFF
--- a/website/public/sw.js
+++ b/website/public/sw.js
@@ -46,6 +46,13 @@ self.addEventListener('fetch', e => {
   if (url.pathname.startsWith('/vendor/')) return
   if (url.pathname.startsWith('/fonts/')) return
   if (url.pathname.startsWith('/sprites/')) return
+  // Backend-served brand assets: the sidebar logo + favicon (/logo.png) and the
+  // legacy /static/ tree. These are NOT in the shell cache, so the network-first
+  // fallback below would resolve them to Response.error() on any transient fetch
+  // failure (e.g. a gateway restart/redeploy while a tab is open) and strand them
+  // as a broken image until the tab reloads. Let the browser fetch them natively.
+  if (url.pathname === '/logo.png') return
+  if (url.pathname.startsWith('/static/')) return
 
   // ── Shell navigation: network-first, fall back to cached shell ──────
   e.respondWith(


### PR DESCRIPTION
## Problem

The top-left sidebar logo (and the browser favicon) render as the browser's **broken-image glyph** after a gateway restart/redeploy — including the recent data-home migration restart — and stay broken until the tab is reloaded.

## Why it matters

Every user with the dashboard open across a gateway restart/redeploy sees a broken brand mark until they manually reload. It looks like a shipping regression and undermines trust in the UI.

## Fix (symptom → root cause → change)

Both the sidebar logo and the favicon load from `/logo.png`, which the backend serves correctly (verified: the `logo` handler resolves to `static/kirocrew-logo.png` and returns 200). The failure is client-side, in the PWA service worker (`website/public/sw.js`):

- The `fetch` handler skips `/api`, `/apps/`, `/assets/`, `/vendor/`, `/fonts/`, `/sprites/` — but **not** `/logo.png`, so the SW intercepts it.
- Its strategy is network-first, and `/logo.png` is **never stored** in the shell cache (`SHELL = ['/', '/index.html']`).
- So when `fetch('/logo.png')` throws — e.g. the gateway restarting while a tab is open — the fallback hits `caches.match()`, finds nothing, and returns `Response.error()`. The browser renders that as a broken image, and it persists until the tab reloads.

Change: add `/logo.png` and the legacy `/static/` tree to the SW skip list, alongside `/assets`, `/fonts`, and `/sprites`, so brand assets always go straight to the network and a restart can never strand them.

```js
if (url.pathname === '/logo.png') return
if (url.pathname.startsWith('/static/')) return
```

Existing clients pick this up automatically: the build stamps a fresh `CACHE_VERSION`, so the new SW activates and claims clients on next load.

## Tests

No new automated test — the change is a two-line guard in a static service-worker asset with no existing SW test harness. Verified via the full frontend gate:

- `npx tsc -b` — clean
- `npm run build` — succeeds; skip rules present in built `dist/sw.js` and the SW build-hash placeholder is stamped
- `npx vitest run` — 388 files, 4497 passed / 3 skipped

## Manual verification

Backend behavior unchanged; the `/logo.png` unauth-allowlist assertion in the backend auth suite is unaffected (no Python touched). To reproduce/confirm the user-facing fix: open the dashboard, restart the gateway with the tab open — before this change the sidebar logo/favicon break until reload; after, they reload natively from the network.

## Screenshots

N/A — no visual/layout change to the UI itself; the fix restores the existing logo's reliability. The broken-state screenshot that motivated this is the browser's native broken-image glyph, not a component change.
