### PR TITLE
fix: retry signing-key exclusive-create on Windows sharing violation + add Windows-condition test simulators

### DIFF
--- a/src/kiro_crew/dashboard/token_secret.py
+++ b/src/kiro_crew/dashboard/token_secret.py
@@ -187,6 +187,22 @@ def _load_or_create_secret() -> bytes:
                 # writer a beat, then loop back to read their bytes.
                 time.sleep(_CREATE_BACKOFF_SECONDS)
                 continue
+            except OSError:
+                # On Windows the winner may hold the freshly-created file open
+                # while it writes; a racer's exclusive-create can then hit a
+                # sharing violation (PermissionError / WinError 32) INSTEAD of
+                # FileExistsError. Treat it as contention — back off and retry
+                # within the bounded loop rather than propagating to the outer
+                # ephemeral fallback, which would make this racer diverge from
+                # the winner's persisted key (silent auth corruption). POSIX does
+                # not raise here; a genuinely unwritable dir still degrades to an
+                # ephemeral secret once the retry budget is exhausted.
+                logger.debug(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
+                    "token signing key exclusive-create contended at %s; retrying",
+                    key_path,
+                )
+                time.sleep(_CREATE_BACKOFF_SECONDS)
+                continue
 
             # We hold the exclusive create. Capture the created file's identity
             # (device + inode) NOW, while we still hold the fd, so that if we

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -986,6 +986,35 @@ def test_signing_secret_read_contention_retries_not_ephemeral(tmp_path, monkeypa
     assert got == persisted, "must return the persisted key, not an ephemeral one"
 
 
+def test_signing_secret_create_contention_retries_not_ephemeral(tmp_path, monkeypatch) -> None:
+    """A TRANSIENT sharing violation on the EXCLUSIVE-CREATE of the key file must
+    be retried, not degraded to an ephemeral secret.
+
+    On Windows a racer's ``os.open(..., O_CREAT|O_EXCL)`` can hit a sharing
+    violation (``PermissionError`` / WinError 32) while the winner holds the
+    freshly-created file open — landing on ``os.open``, not the read. The
+    create-side companion to ``test_signing_secret_read_contention_retries_not_ephemeral``;
+    reproduced deterministically with the ``os.open`` simulator so it is caught
+    on the POSIX dev loop.
+    """
+    from windows_sim import open_sharing_violation
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+
+    # Fault the FIRST exclusive-create of the key file; the retry must succeed.
+    with open_sharing_violation(match=ts._SECRET_KEY_FILE, times=1) as state:
+        secret = ts._load_or_create_secret()
+
+    assert state["n"] >= 2, "the contended exclusive-create was not retried"
+    assert key_file.exists(), "key must be persisted after retrying the create"
+    on_disk = key_file.read_bytes()
+    assert len(on_disk) >= ts._MIN_KEY_BYTES, "retry wrote a short/incomplete key"
+    assert secret == on_disk, "must return the persisted key, not an ephemeral one"
+
+
 def test_signing_secret_existing_file_never_overwritten(tmp_path, monkeypatch) -> None:
     """Regression (PR #338): warming must never overwrite or truncate an
     existing key file.

--- a/test/test_windows_sim.py
+++ b/test/test_windows_sim.py
@@ -1,0 +1,145 @@
+"""Self-tests for the Windows-condition simulators in ``windows_sim``.
+
+These also serve as worked usage examples: each simulator is exercised both in
+isolation and against the real code path it is meant to guard.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from windows_sim import (
+    colliding_clock,
+    increasing_clock,
+    open_sharing_violation,
+    read_sharing_violation,
+    replace_sharing_violation,
+)
+
+
+class TestCollidingClock:
+    def test_now_is_frozen(self):
+        import kiro_crew.history as h
+
+        with colliding_clock("kiro_crew.history") as at:
+            a = h.datetime.now()
+            b = h.datetime.now()
+        assert a == b == at
+        assert a.isoformat() == b.isoformat()
+
+    def test_inherited_classmethods_still_work(self):
+        # The stub subclasses real datetime, so fromisoformat/strptime keep
+        # working for code under test that uses them next to now().
+        import kiro_crew.history as h
+
+        with colliding_clock("kiro_crew.history"):
+            parsed = h.datetime.fromisoformat("2020-05-01T12:00:00+00:00")
+        assert (parsed.year, parsed.month) == (2020, 5)
+
+    def test_tz_aware_now_respects_tz(self):
+        import datetime as dt
+
+        import kiro_crew.history as h
+
+        with colliding_clock("kiro_crew.history"):
+            aware = h.datetime.now(dt.timezone.utc)
+        assert aware.tzinfo is not None
+
+    def test_real_appends_collide(self, tmp_path):
+        from kiro_crew.history import ConversationLog
+
+        log = ConversationLog(base_dir=tmp_path)
+        with colliding_clock("kiro_crew.history"):
+            log.append("t", "user", "a")
+            log.append("t", "user", "b")
+            log.append("t", "user", "c")
+        ts = [m["ts"] for m in log.read_messages("t")]
+        assert len(set(ts)) == 1  # the exact coarse-clock collision Windows hits
+
+
+class TestIncreasingClock:
+    def test_now_strictly_increases(self):
+        import kiro_crew.history as h
+
+        with increasing_clock("kiro_crew.history"):
+            first = h.datetime.now()
+            second = h.datetime.now()
+        assert second > first
+
+    def test_real_appends_are_distinct_and_ordered(self, tmp_path):
+        from kiro_crew.history import ConversationLog
+
+        log = ConversationLog(base_dir=tmp_path)
+        with increasing_clock("kiro_crew.history"):
+            log.append("t", "user", "a")
+            log.append("t", "user", "b")
+        ts = [m["ts"] for m in log.read_messages("t")]
+        assert len(set(ts)) == len(ts)  # distinct
+        assert ts == sorted(ts)  # chronological
+
+
+class TestReadSharingViolation:
+    def test_first_read_raises_then_succeeds(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_bytes(b"data")
+        with read_sharing_violation(match="cred", times=1) as state:
+            with pytest.raises(PermissionError):
+                f.read_bytes()
+            assert f.read_bytes() == b"data"  # the retry sees the real bytes
+        assert state["n"] >= 2
+
+    def test_non_matching_path_unaffected(self, tmp_path):
+        other = tmp_path / "other"
+        other.write_bytes(b"x")
+        with read_sharing_violation(match="cred"):
+            assert other.read_bytes() == b"x"  # different name — never faults
+
+    def test_times_zero_never_faults(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_bytes(b"data")
+        with read_sharing_violation(match="cred", times=0):
+            assert f.read_bytes() == b"data"
+
+
+class TestReplaceSharingViolation:
+    def test_first_replace_raises_then_succeeds(self, tmp_path):
+        src = tmp_path / "src"
+        src.write_bytes(b"v2")
+        dst = tmp_path / "dst"
+        dst.write_bytes(b"v1")
+        with replace_sharing_violation(match="dst", times=1):
+            with pytest.raises(PermissionError):
+                os.replace(src, dst)
+            os.replace(src, dst)  # retry succeeds
+        assert dst.read_bytes() == b"v2"
+        assert not src.exists()
+
+    def test_non_matching_dest_unaffected(self, tmp_path):
+        src = tmp_path / "src"
+        src.write_bytes(b"v2")
+        dst = tmp_path / "keep"
+        dst.write_bytes(b"v1")
+        with replace_sharing_violation(match="dst"):
+            os.replace(src, dst)  # dest name != "dst" — not faulted
+        assert dst.read_bytes() == b"v2"
+
+
+class TestOpenSharingViolation:
+    def test_first_create_raises_then_succeeds(self, tmp_path):
+        target = tmp_path / "cred"
+        with open_sharing_violation(match="cred", times=1) as state:
+            with pytest.raises(PermissionError):
+                os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            os.close(fd)  # the retry succeeds
+        assert target.exists()
+        assert state["n"] >= 2
+
+    def test_reads_not_faulted_when_create_only(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_bytes(b"x")
+        with open_sharing_violation(match="cred", create_only=True):
+            fd = os.open(str(f), os.O_RDONLY)  # no O_CREAT — not faulted
+            os.close(fd)
+        assert f.read_bytes() == b"x"

--- a/test/windows_sim.py
+++ b/test/windows_sim.py
@@ -1,0 +1,229 @@
+"""Windows-condition simulators for POSIX dev machines.
+
+KiroCrew is developed on macOS/Linux but must pass the ``Backend Tests
+(Windows)`` matrix. Several classes of Windows-only behaviour never occur on
+POSIX, so the buggy code path is never exercised by a local ``pytest`` run and
+the failure only shows up in CI:
+
+* **Coarse system clock (~15 ms tick).** ``datetime.now()`` on Windows advances
+  in ~15.6 ms steps, so a burst of rapid appends gets an *identical* ``ts``.
+  POSIX gives microsecond resolution, so the collision (and the bugs it exposes
+  — history-dedup duplication, ambiguous cross-session sort) never reproduces
+  locally.
+* **File-sharing semantics.** Reading a file another process holds open for
+  write raises a sharing violation (``PermissionError`` / ``WinError 32``), and
+  ``os.replace()`` over an open handle fails likewise. POSIX permits both.
+
+These context managers reproduce those conditions **deterministically on any
+OS**, so the *logic* of Windows-relevant code can be unit-tested locally. They
+do NOT reproduce the raw OS behaviour end-to-end (that still needs a real
+Windows host) — they let a POSIX test drive the exact code path a Windows
+machine would take.
+
+Guidance:
+    Any code that touches timestamps, cross-file/-process ordering, file locking
+    or atomic replacement should get a test that wraps it in the matching
+    simulator below, so a regression is caught on the Mac/Linux dev loop instead
+    of a CI round-trip.
+
+    from windows_sim import colliding_clock, read_sharing_violation
+
+    def test_no_dupe_under_colliding_ts(tmp_path):
+        with colliding_clock("kiro_crew.history"):
+            ...  # every datetime.now() in kiro_crew.history returns ONE instant
+
+Extending: keep each simulator small, name the real Windows behaviour it mimics
+in its docstring, and add a self-test in ``test_windows_sim.py``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import Iterator, Optional
+from unittest import mock
+
+__all__ = [
+    "colliding_clock",
+    "increasing_clock",
+    "read_sharing_violation",
+    "replace_sharing_violation",
+    "open_sharing_violation",
+]
+
+_DEFAULT_INSTANT = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+def _fixed_datetime_class(value: _dt.datetime) -> type:
+    """A ``datetime`` subclass whose ``now()`` always returns *value*.
+
+    Subclassing the real ``datetime`` (rather than a bare stub) keeps every other
+    classmethod — ``fromisoformat``, ``strptime``, ``fromtimestamp``, … — working
+    for code under test that uses them alongside ``now()``.
+    """
+
+    class _FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return value.astimezone(tz) if tz is not None else value
+
+    return _FixedDatetime
+
+
+def _increasing_datetime_class(start: _dt.datetime, step_seconds: float) -> type:
+    """A ``datetime`` subclass whose ``now()`` advances by *step_seconds* on every
+    call (strictly increasing, deterministic ordering)."""
+    state = {"n": 0}
+
+    class _IncreasingDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            state["n"] += 1
+            value = start + _dt.timedelta(seconds=step_seconds * state["n"])
+            return value.astimezone(tz) if tz is not None else value
+
+    return _IncreasingDatetime
+
+
+@contextmanager
+def colliding_clock(
+    module_path: str, *, at: Optional[_dt.datetime] = None
+) -> Iterator[_dt.datetime]:
+    """Freeze ``<module_path>.datetime.now()`` to a single instant.
+
+    Mimics a burst of operations completing within one coarse Windows clock tick,
+    so every ``datetime.now().isoformat()`` stamp COLLIDES — the condition behind
+    the history colliding-timestamp bugs. *module_path* is the dotted module that
+    does ``from datetime import datetime`` (e.g. ``"kiro_crew.history"``).
+
+    Yields the fixed instant.
+    """
+    value = at if at is not None else _DEFAULT_INSTANT
+    with mock.patch(f"{module_path}.datetime", _fixed_datetime_class(value)):
+        yield value
+
+
+@contextmanager
+def increasing_clock(
+    module_path: str,
+    *,
+    start: Optional[_dt.datetime] = None,
+    step_seconds: float = 1.0,
+) -> Iterator[None]:
+    """Make ``<module_path>.datetime.now()`` strictly increasing.
+
+    The opposite extreme of :func:`colliding_clock`: guarantees distinct, ordered
+    timestamps regardless of how fast the calls happen, so a test that asserts a
+    time-ordered result is deterministic on every OS (a coarse Windows clock would
+    otherwise collide the stamps and leak the underlying merge order).
+    """
+    start = start if start is not None else _DEFAULT_INSTANT
+    with mock.patch(
+        f"{module_path}.datetime", _increasing_datetime_class(start, step_seconds)
+    ):
+        yield
+
+
+@contextmanager
+def read_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1
+) -> Iterator[dict]:
+    """Make ``Path.read_bytes()`` raise a Windows-style sharing violation.
+
+    On Windows, reading a file another process holds open for write raises
+    ``PermissionError`` (``WinError 32``). POSIX permits the read, so code that
+    only guards ``FileNotFoundError`` (and treats every other ``OSError`` as
+    fatal) misbehaves only on Windows. This raises ``PermissionError`` for the
+    first *times* matching reads, then delegates to the real call.
+
+    *match*: if given, only paths whose name equals it OR whose string contains it
+    fault; otherwise every ``read_bytes`` faults. Yields a ``{"n": count}`` dict
+    of how many reads were intercepted (faulted or passed the match), useful for
+    asserting a retry happened.
+    """
+    real_read_bytes = pathlib.Path.read_bytes
+    state = {"n": 0}
+
+    def _patched(self: pathlib.Path):  # type: ignore[no-untyped-def]
+        if match is None or self.name == match or match in str(self):
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation reading {self}"
+                )
+        return real_read_bytes(self)
+
+    with mock.patch.object(pathlib.Path, "read_bytes", _patched):
+        yield state
+
+
+@contextmanager
+def replace_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1
+) -> Iterator[dict]:
+    """Make ``os.replace()`` raise a Windows-style sharing violation.
+
+    On Windows an atomic ``os.replace(src, dst)`` fails with ``PermissionError``
+    (``WinError 32``) if *dst* is currently open by another handle — POSIX allows
+    replacing an open file. Raises for the first *times* matching calls, then
+    delegates. *match* filters on either path (name-equality or substring).
+    Yields a ``{"n": count}`` dict.
+    """
+    real_replace = os.replace
+    state = {"n": 0}
+
+    def _patched(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if (
+            match is None
+            or os.path.basename(str(dst)) == match
+            or match in str(dst)
+            or match in str(src)
+        ):
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation replacing {dst}"
+                )
+        return real_replace(src, dst, *args, **kwargs)
+
+    with mock.patch("os.replace", _patched):
+        yield state
+
+
+@contextmanager
+def open_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1, create_only: bool = True
+) -> Iterator[dict]:
+    """Make ``os.open()`` raise a Windows-style sharing violation.
+
+    On Windows, opening a file another process holds open can raise
+    ``PermissionError`` (``WinError 32``) — notably an exclusive create
+    (``O_CREAT | O_EXCL``) racing a writer that still holds the just-created
+    file open. Raises for the first *times* matching ``os.open`` calls, then
+    delegates.
+
+    *match* filters on the path (basename-equality or substring); ``None`` faults
+    every ``os.open``. *create_only* (default ``True``) restricts faults to opens
+    that include ``os.O_CREAT`` — so plain reads (``pathlib`` read paths call
+    ``os.open`` with ``O_RDONLY``) are left untouched and only the exclusive
+    create is exercised. Yields a ``{"n": count}`` dict.
+    """
+    real_open = os.open
+    state = {"n": 0}
+
+    def _patched(path, flags, mode=0o777, *args, **kwargs):  # type: ignore[no-untyped-def]
+        p = str(path)
+        name_ok = match is None or os.path.basename(p) == match or match in p
+        create_ok = (not create_only) or bool(flags & os.O_CREAT)
+        if name_ok and create_ok:
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation opening {p}"
+                )
+        return real_open(path, flags, mode, *args, **kwargs)
+
+    with mock.patch("os.open", _patched):
+        yield state


### PR DESCRIPTION
## Problem
Two related things:
1. **A real Windows bug:** `test_signing_secret_concurrent_first_init_converges` still fails intermittently on the Windows matrix (`concurrent inits diverged from the on-disk key`), even after #450's read-side retry.
2. **A testing gap:** Windows-only behaviours (coarse ~15 ms clock that collides `datetime.now()`; file-sharing violations on reading/replacing/creating an open handle) never occur on the macOS/Linux dev loop, so bugs like the above escape local `pytest` and only surface in CI, round after round.

## Why it matters
The divergence silently corrupts token/cookie signatures when two gateway first-inits race on Windows. And without shared tooling, every Windows-relevant change goes unguarded locally, so the fix-then-CI-then-new-failure loop repeats (as it did across #450).

## Fix (symptom → root cause → change)
**1. Signing-key create-side retry (product — `token_secret.py`).**
- *Symptom:* concurrent first-inits diverge — a racer signs with an ephemeral key instead of the persisted one.
- *Root cause:* #450 made the fast-path **read** retry on a Windows sharing violation, but the exclusive **create** `os.open(O_CREAT|O_EXCL)` still caught only `FileExistsError`. On Windows a racer's create can raise a sharing violation (`PermissionError` / WinError 32) while the winner holds the freshly-created file open; that propagated to the outer `except OSError` → ephemeral secret → divergence.
- *Change:* retry a transient `OSError` on the exclusive-create within the bounded loop (mirroring the read-side fix). POSIX never raises here; a genuinely unwritable dir still degrades to ephemeral once the retry budget is exhausted.

**2. Windows-condition simulators (test infra — `test/windows_sim.py`).**
Context managers that reproduce the Windows condition **deterministically on any OS** so the *logic* can be unit-tested locally (they don't reproduce raw OS behaviour end-to-end — that still needs a Windows host):
`colliding_clock` / `increasing_clock` (freeze / strictly-increase `datetime.now()`), and `read_sharing_violation` / `replace_sharing_violation` / `open_sharing_violation` (raise `PermissionError` on the first N matching `Path.read_bytes` / `os.replace` / `os.open` calls). The module docstring explains each and how to extend it.

## Tests
- `test/test_windows_sim.py` (13 tests) exercises every simulator in isolation **and** against real code paths (e.g. `colliding_clock` around `ConversationLog.append` yields identical `ts`).
- New `test_signing_secret_create_contention_retries_not_ephemeral` uses `open_sharing_violation` to fault the first exclusive-create; it **fails without the fix** (returns ephemeral, nothing persisted) and passes after — the create-side companion to #450's read-contention test.

## Manual verification
- `test/test_windows_sim.py`: **13 passed**; `test_token_auth.py -k signing_secret`: **7 passed** on macOS.
- The create-side regression test confirmed to **fail on pre-fix code** and pass after (also reproduced directly: a single injected `PermissionError` on `os.open` made the old code return an ephemeral key with nothing persisted; the fix converges).
- `flake8` + `isort` clean on all changed files.
