### PR TITLE
fix: clamp crash-dump age to non-negative (clock/float jitter)

### DIFF
--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -131,8 +131,16 @@ def newest_dump_with_stacks(dumps_dir: Path | None = None) -> Path | None:
 
 
 def dump_age_seconds(dump_path: Path) -> float:
-    """Return age of a dump file in seconds."""
-    return time.time() - dump_path.stat().st_mtime
+    """Return age of a dump file in seconds (never negative).
+
+    ``st_mtime`` and ``time.time()`` are both derived from the wall clock, but a
+    just-written file's mtime can round marginally AHEAD of an immediately
+    following ``time.time()`` (sub-microsecond float jitter, or higher-resolution
+    filesystem timestamps), yielding a tiny negative delta. An age is physically
+    never negative, so clamp to 0.0 — otherwise callers comparing/formatting the
+    age see a nonsensical negative right after a dump is created.
+    """
+    return max(0.0, time.time() - dump_path.stat().st_mtime)
 
 
 def dump_first_stack_lines(dump_path: Path, max_lines: int = 5) -> list[str]:

--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -193,6 +193,20 @@ def test_dump_age_seconds(dumps_dir: Path) -> None:
     assert 0 <= age < 2.0
 
 
+def test_dump_age_never_negative_with_future_mtime(dumps_dir: Path) -> None:
+    """A dump whose mtime rounds marginally AHEAD of ``time.time()`` (sub-microsecond
+    float jitter on a just-written file, or higher-resolution FS timestamps) must
+    report age 0.0 — never a negative. Regression for `assert 0 <= age` failing
+    with a tiny negative delta (~-2e-7)."""
+    import time
+
+    p = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    st = p.stat()
+    # Force mtime clearly into the future to reproduce the jitter deterministically.
+    os.utime(p, (st.st_atime, time.time() + 5.0))
+    assert dump_age_seconds(p) == 0.0
+
+
 # ── Integration with LoopStallWatchdog dump_file param ──
 
 


### PR DESCRIPTION
## Problem
`test_crash_dump_store.py::test_dump_age_seconds` intermittently fails with `assert 0 <= age` where `age` is a tiny negative (`-2.38e-7` ≈ `-2^-22`). `dump_age_seconds()` can return a negative for a just-created dump.

## Why it matters
An age is physically never negative. Any caller that formats or compares a dump's age (e.g. "is this dump older than N seconds") gets a nonsensical negative immediately after a dump is created, and the flaky assertion reddens CI.

## Fix (symptom → root cause → change)
- *Symptom:* `dump_age_seconds()` returns a sub-microsecond negative.
- *Root cause:* it computes `time.time() - dump_path.stat().st_mtime`. Both come from the wall clock, but a just-written file's `st_mtime` can round marginally **ahead** of the immediately-following `time.time()` (float rounding at ~`2^-22`, or higher-resolution filesystem timestamps), so the delta goes slightly negative.
- *Change:* clamp to `max(0.0, …)`. A dump can't be from the future; a marginally-ahead mtime reads as age 0.0.

## Tests
New `test_dump_age_never_negative_with_future_mtime` forces the file's mtime clearly into the future (`os.utime`) and asserts `dump_age_seconds() == 0.0`. It **fails without the clamp** (age `-5.0`) and passes after — deterministic on every OS.

## Manual verification
- `test/test_crash_dump_store.py`: **20 passed** with the clamp; the new test **fails on pre-fix code**.
- `flake8` + `isort` clean.
