### PR TITLE
fix(crash-dump): clamp dump_age_seconds at 0 (Windows coarse-clock negative age)

### DIFF
--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -131,8 +131,15 @@ def newest_dump_with_stacks(dumps_dir: Path | None = None) -> Path | None:
 
 
 def dump_age_seconds(dump_path: Path) -> float:
-    """Return age of a dump file in seconds."""
-    return time.time() - dump_path.stat().st_mtime
+    """Return age of a dump file in seconds (never negative).
+
+    Clamped at 0: on Windows the coarse (~15ms) clock plus filesystem mtime
+    rounding can leave ``st_mtime`` a hair AHEAD of a subsequent ``time.time()``
+    for a just-created file, yielding a tiny negative delta. An "age" is never
+    negative, and callers (cli_doctor staleness formatting) assume ``>= 0``, so
+    floor it.
+    """
+    return max(0.0, time.time() - dump_path.stat().st_mtime)
 
 
 def dump_first_stack_lines(dump_path: Path, max_lines: int = 5) -> list[str]:

--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,17 @@ def test_dump_age_seconds(dumps_dir: Path) -> None:
     age = dump_age_seconds(p)
     # Should be very small since we just created it
     assert 0 <= age < 2.0
+
+
+def test_dump_age_seconds_never_negative_on_future_mtime(dumps_dir: Path) -> None:
+    """Regression: a file whose mtime is slightly AHEAD of the clock (Windows'
+    coarse clock + mtime rounding on a just-created file) must still report a
+    non-negative age, not a tiny negative delta. Clamped at 0 in production."""
+    p = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    # Force mtime a hair into the future relative to time.time().
+    future = time.time() + 0.5
+    os.utime(p, (future, future))
+    assert dump_age_seconds(p) == 0.0
 
 
 # ── Integration with LoopStallWatchdog dump_file param ──


### PR DESCRIPTION
## Problem
`test_crash_dump_store.py::test_dump_age_seconds` fails intermittently on the Windows Backend Tests shard: `assert 0 <= age` trips with a tiny negative value (e.g. `-2.38e-07`).

## Why it matters
`dump_age_seconds()` returned `time.time() - st_mtime`. On Windows the coarse (~15ms) clock plus filesystem mtime rounding can leave a just-created dump's `st_mtime` a hair AHEAD of a subsequent `time.time()`, producing a small negative delta. An "age" is never negative, and callers (`cli_doctor` staleness formatting) assume `>= 0` — a negative value is a latent real bug, not just a test artifact. (This is the same Windows coarse-clock class #450 addressed for history/auth, but a test #450 didn't touch.)

## Fix
Clamp: `max(0.0, time.time() - st_mtime)`. Production fix (not just loosening the test), so callers always get a non-negative age.

## Tests
- Existing `test_dump_age_seconds` passes.
- New `test_dump_age_seconds_never_negative_on_future_mtime` forces `st_mtime` 0.5s into the future via `os.utime` and asserts the age is `0.0` — would have returned negative before the clamp.
- flake8 + mypy clean.

## Manual verification
N/A — unit coverage sufficient (deterministic future-mtime test reproduces the Windows condition on any OS).