### PR TITLE
fix(build): stop build/install tooling writing to legacy ~/.kirocrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ frontend:
 	# recipe line, so the target fails before npm is ever reached. An absent
 	# marker must degrade to "use whatever node is on PATH", not stop the build.
 	cd website && \
-	  NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null || true)"; \
+	  NBD="$$(cat "$${KIROCREW_HOME:-$$HOME/.kiro/crew}/node-bin-dir" 2>/dev/null || true)"; \
 	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; }; \
 	  if ! command -v npm >/dev/null 2>&1; then \
 	    echo "ERROR: npm not found. Install Node >= 18 (see ensure-node.sh) and re-run." >&2; \
@@ -43,7 +43,7 @@ backend:
 	bash ensure-python.sh || true
 	# Same `|| true` reasoning as the frontend target: an absent marker file must
 	# fall back to $(PY), not abort the recipe.
-	PY="$$(cat $$HOME/.kirocrew/python-bin 2>/dev/null || true)"; [ -n "$$PY" ] || PY="$(PY)"; \
+	PY="$$(cat "$${KIROCREW_HOME:-$$HOME/.kiro/crew}/python-bin" 2>/dev/null || true)"; [ -n "$$PY" ] || PY="$(PY)"; \
 	  if [ -x $(VENV)/bin/python ] && ! $(VENV)/bin/python -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then \
 	    echo "  → recreating $(VENV) (existing interpreter < 3.10)"; rm -rf $(VENV); fi; \
 	  if ! "$$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then \
@@ -100,7 +100,7 @@ backend-bin: frontend
 # script's npm step instead of installing it like every other target does.
 desktop:
 	bash ensure-node.sh || true
-	NBD="$$(cat $$HOME/.kirocrew/node-bin-dir 2>/dev/null || true)"; \
+	NBD="$$(cat "$${KIROCREW_HOME:-$$HOME/.kiro/crew}/node-bin-dir" 2>/dev/null || true)"; \
 	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; }; \
 	  bash packaging/build-desktop.sh
 

--- a/cli.sh
+++ b/cli.sh
@@ -54,7 +54,8 @@ KiroCrew CLI installer (channel / wheel based).
 Installs the prebuilt `kirocrew` wheel for a release channel: resolves the
 channel feed, downloads the wheel over HTTPS, verifies its SHA-256 against
 the published manifest, then installs it (pipx if available, else a managed
-venv at ~/.kirocrew/venv). Records the channel to ~/.kirocrew/channel.
+venv under the data home — $KIROCREW_HOME or ~/.kiro/crew). Records the
+channel there too.
 
 Options / env:
   --channel <nightly|insider|stable>   (default: stable; env KIROCREW_CHANNEL)
@@ -149,7 +150,7 @@ if command -v pipx >/dev/null 2>&1; then
   pipx install --force --python "$PY" "$WHL" >/dev/null
   BIN="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
 else
-  VENV="$HOME/.kirocrew/venv"
+  VENV="${KIROCREW_HOME:-$HOME/.kiro/crew}/venv"
   echo "Installing into managed venv at $VENV ..."
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true
@@ -159,8 +160,9 @@ else
   BIN="$HOME/.local/bin"
 fi
 
-mkdir -p "$HOME/.kirocrew"
-printf '%s\n' "$CHANNEL" > "$HOME/.kirocrew/channel"
+_DATA_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+mkdir -p "$_DATA_HOME"
+printf '%s\n' "$CHANNEL" > "$_DATA_HOME/channel"
 
 echo ""
 echo "Installed kirocrew $VER (channel: $CHANNEL)."

--- a/ensure-node.sh
+++ b/ensure-node.sh
@@ -4,8 +4,11 @@
 # Platforms: macOS, Amazon Linux 2 (glibc 2.26), Amazon Linux 2023, Linux
 #
 # On success this records the resolved node bin directory in
-# "$HOME/.kirocrew/node-bin-dir" so non-interactive callers (e.g. make) can put
-# the right node on PATH without re-running a version manager.
+# "<data-home>/node-bin-dir" so non-interactive callers (e.g. make) can put
+# the right node on PATH without re-running a version manager. The data home is
+# "$KIROCREW_HOME" when set, else "$HOME/.kiro/crew" (the current default) —
+# NOT the pre-move "$HOME/.kirocrew", which the one-time data-home migration
+# deletes, so writing there would resurrect the legacy dir on every build.
 
 MIN_VERSION=18
 TARGET_VERSION=20
@@ -69,11 +72,14 @@ _source_nvm() {
     fi
 }
 
-# Record where node ended up so make / other callers can find it.
+# Record where node ended up so make / other callers can find it. Writes into
+# the data home ($KIROCREW_HOME, else ~/.kiro/crew) — never the legacy
+# ~/.kirocrew (see header).
 _record_node_bin() {
     if command -v node >/dev/null 2>&1; then
-        mkdir -p "$HOME/.kirocrew"
-        dirname "$(command -v node)" > "$HOME/.kirocrew/node-bin-dir" 2>/dev/null || true
+        local home="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+        mkdir -p "$home"
+        dirname "$(command -v node)" > "$home/node-bin-dir" 2>/dev/null || true
     fi
 }
 

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -12,8 +12,11 @@
 # import (AL2023/3.9). Prefer any already-usable system Python >= 3.10;
 # otherwise install one via mise, whose python-build-standalone binaries run on
 # AL2's glibc 2.26. On success the chosen interpreter path is recorded in
-# "$HOME/.kirocrew/python-bin" so non-interactive callers (make) can use it
-# without re-running a version manager.
+# "<data-home>/python-bin" so non-interactive callers (make) can use it without
+# re-running a version manager. The data home is "$KIROCREW_HOME" when set, else
+# "$HOME/.kiro/crew" (the current default) — NOT the pre-move "$HOME/.kirocrew",
+# which the one-time data-home migration deletes, so writing there would
+# resurrect the legacy dir on every build.
 
 MIN_MAJOR=3
 MIN_MINOR=10
@@ -51,8 +54,9 @@ _mise_bin() {
 }
 
 _record() {
-    mkdir -p "$HOME/.kirocrew"
-    printf '%s\n' "$1" > "$HOME/.kirocrew/python-bin" 2>/dev/null || true
+    home="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+    mkdir -p "$home"
+    printf '%s\n' "$1" > "$home/python-bin" 2>/dev/null || true
 }
 
 # 1. Existing usable system python.

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,9 @@ done
 # ── Constants ──
 # Repo root = directory containing this script (run from a local clone).
 KIROCREW_APP_DIR="$(cd "$(dirname "$0")" && pwd)"
-KIROCREW_DATA_DIR="$HOME/.kirocrew"
+# Data home: honor KIROCREW_HOME, else the current default ~/.kiro/crew (NOT the
+# pre-move ~/.kirocrew, which the one-time data-home migration deletes).
+KIROCREW_DATA_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}"
 NODE_VERSION="20"
 PYTHON_VERSION="3.12"
 KIROCREW_PORT="${KIROCREW_PORT:-5476}"

--- a/scripts/sync-to-remote.sh
+++ b/scripts/sync-to-remote.sh
@@ -91,9 +91,9 @@ echo "=== Syncing KiroCrew to $HOST (port=$PORT) $(${DRY_RUN} && echo '[DRY RUN]
 
 # --- Create remote dirs ---
 if ! $DRY_RUN; then
-  ssh "$HOST" "mkdir -p ~/.kirocrew/{workspace/memory,workspace/knowledge,workspace/kb-strategy,workspace/kb-docs,workspace/kiro-agents,workspace/scripts,tasks,skills,hooks,sessions}"
+  ssh "$HOST" "mkdir -p ~/.kiro/crew/{workspace/memory,workspace/knowledge,workspace/kb-strategy,workspace/kb-docs,workspace/kiro-agents,workspace/scripts,tasks,skills,hooks,sessions}"
 else
-  echo "  [dry-run] ssh $HOST mkdir -p ~/.kirocrew/{workspace/...,tasks,skills,hooks,sessions}"
+  echo "  [dry-run] ssh $HOST mkdir -p ~/.kiro/crew/{workspace/...,tasks,skills,hooks,sessions}"
 fi
 
 # --- [1] Memory databases (atomic snapshot via .backup) ---
@@ -102,30 +102,30 @@ if ! $DRY_RUN; then
   if command -v sqlite3 &>/dev/null; then
     TMP_DB=$(mktemp -t mc-memory-XXXXXX.db)
     trap "rm -f $TMP_DB $TMP_DB-wal $TMP_DB-shm" EXIT
-    sqlite3 ~/.kirocrew/memory.db ".backup '$TMP_DB'" || {
+    sqlite3 ~/.kiro/crew/memory.db ".backup '$TMP_DB'" || {
       echo "  Warning: sqlite3 .backup failed; falling back to raw copy (may be inconsistent if DB is active)" >&2
-      cp ~/.kirocrew/memory.db "$TMP_DB"
+      cp ~/.kiro/crew/memory.db "$TMP_DB"
     }
-    rsync -az "$TMP_DB" "$HOST":~/.kirocrew/memory.db
+    rsync -az "$TMP_DB" "$HOST":~/.kiro/crew/memory.db
     # Remove stale WAL/SHM from previous syncs — they'd corrupt the fresh backup
-    ssh "$HOST" "rm -f ~/.kirocrew/memory.db-wal ~/.kirocrew/memory.db-shm"
+    ssh "$HOST" "rm -f ~/.kiro/crew/memory.db-wal ~/.kiro/crew/memory.db-shm"
   else
     # Fallback: direct rsync of all DB files (less atomic but works without sqlite3)
-    rsync -az ~/.kirocrew/memory.db "$HOST":~/.kirocrew/
-    if [ -f ~/.kirocrew/memory.db-wal ]; then
-      rsync -az ~/.kirocrew/memory.db-wal "$HOST":~/.kirocrew/
+    rsync -az ~/.kiro/crew/memory.db "$HOST":~/.kiro/crew/
+    if [ -f ~/.kiro/crew/memory.db-wal ]; then
+      rsync -az ~/.kiro/crew/memory.db-wal "$HOST":~/.kiro/crew/
     else
-      ssh "$HOST" "rm -f ~/.kirocrew/memory.db-wal"
+      ssh "$HOST" "rm -f ~/.kiro/crew/memory.db-wal"
     fi
-    if [ -f ~/.kirocrew/memory.db-shm ]; then
-      rsync -az ~/.kirocrew/memory.db-shm "$HOST":~/.kirocrew/
+    if [ -f ~/.kiro/crew/memory.db-shm ]; then
+      rsync -az ~/.kiro/crew/memory.db-shm "$HOST":~/.kiro/crew/
     else
-      ssh "$HOST" "rm -f ~/.kirocrew/memory.db-shm"
+      ssh "$HOST" "rm -f ~/.kiro/crew/memory.db-shm"
     fi
   fi
   # memory_index.db is small and not in WAL mode — safe as direct rsync
-  if [ -f ~/.kirocrew/memory_index.db ]; then
-    rsync -az ~/.kirocrew/memory_index.db "$HOST":~/.kirocrew/
+  if [ -f ~/.kiro/crew/memory_index.db ]; then
+    rsync -az ~/.kiro/crew/memory_index.db "$HOST":~/.kiro/crew/
   fi
 else
   echo "  [dry-run] sqlite3 .backup → rsync atomic snapshot to $HOST"
@@ -134,36 +134,36 @@ fi
 
 # --- [2] Workspace ---
 echo "  [2/7] Workspace..."
-if [ -d ~/.kirocrew/workspace/memory/ ]; then
-  rsync_dry ~/.kirocrew/workspace/memory/ "$HOST":~/.kirocrew/workspace/memory/
+if [ -d ~/.kiro/crew/workspace/memory/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/memory/ "$HOST":~/.kiro/crew/workspace/memory/
 fi
-if [ -d ~/.kirocrew/workspace/knowledge/ ]; then
-  rsync_dry ~/.kirocrew/workspace/knowledge/ "$HOST":~/.kirocrew/workspace/knowledge/
+if [ -d ~/.kiro/crew/workspace/knowledge/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/knowledge/ "$HOST":~/.kiro/crew/workspace/knowledge/
 fi
-if [ -d ~/.kirocrew/workspace/kb-strategy/ ]; then
-  rsync_dry ~/.kirocrew/workspace/kb-strategy/ "$HOST":~/.kirocrew/workspace/kb-strategy/
+if [ -d ~/.kiro/crew/workspace/kb-strategy/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/kb-strategy/ "$HOST":~/.kiro/crew/workspace/kb-strategy/
 fi
-if [ -d ~/.kirocrew/workspace/kb-docs/ ]; then
-  rsync_dry ~/.kirocrew/workspace/kb-docs/ "$HOST":~/.kirocrew/workspace/kb-docs/
+if [ -d ~/.kiro/crew/workspace/kb-docs/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/kb-docs/ "$HOST":~/.kiro/crew/workspace/kb-docs/
 fi
-if [ -d ~/.kirocrew/workspace/kiro-agents/ ]; then
-  rsync_dry ~/.kirocrew/workspace/kiro-agents/ "$HOST":~/.kirocrew/workspace/kiro-agents/
+if [ -d ~/.kiro/crew/workspace/kiro-agents/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/kiro-agents/ "$HOST":~/.kiro/crew/workspace/kiro-agents/
 fi
-if [ -d ~/.kirocrew/workspace/scripts/ ]; then
-  rsync_dry ~/.kirocrew/workspace/scripts/ "$HOST":~/.kirocrew/workspace/scripts/
+if [ -d ~/.kiro/crew/workspace/scripts/ ]; then
+  rsync_dry ~/.kiro/crew/workspace/scripts/ "$HOST":~/.kiro/crew/workspace/scripts/
 fi
-rsync_dry ~/.kirocrew/workspace/*.md "$HOST":~/.kirocrew/workspace/ 2>/dev/null || true
-rsync_dry ~/.kirocrew/workspace/*.yaml "$HOST":~/.kirocrew/workspace/ 2>/dev/null || true
-rsync_dry ~/.kirocrew/workspace/*.json "$HOST":~/.kirocrew/workspace/ 2>/dev/null || true
+rsync_dry ~/.kiro/crew/workspace/*.md "$HOST":~/.kiro/crew/workspace/ 2>/dev/null || true
+rsync_dry ~/.kiro/crew/workspace/*.yaml "$HOST":~/.kiro/crew/workspace/ 2>/dev/null || true
+rsync_dry ~/.kiro/crew/workspace/*.json "$HOST":~/.kiro/crew/workspace/ 2>/dev/null || true
 
 # --- [3] Config (copy + patch port) ---
 echo "  [3/7] Config (port=$PORT, auto_open_browser=false)..."
 if ! $DRY_RUN; then
-  scp -q ~/.kirocrew/config.json "$HOST":~/.kirocrew/config.json
+  scp -q ~/.kiro/crew/config.json "$HOST":~/.kiro/crew/config.json
   ssh "$HOST" python3 - "$PORT" <<'PY'
 import json, os, sys
 port = sys.argv[1]
-p = os.path.expanduser('~/.kirocrew/config.json')
+p = os.path.expanduser('~/.kiro/crew/config.json')
 with open(p) as f: cfg = json.load(f)
 cfg['dashboard']['url'] = f'http://localhost:{port}'
 cfg['dashboard']['auto_open_browser'] = False
@@ -175,14 +175,14 @@ fi
 
 # --- [4] Skills, hooks & tasks ---
 echo "  [4/7] Skills, hooks & tasks..."
-if [ -d ~/.kirocrew/skills/ ]; then
-  rsync_dry ~/.kirocrew/skills/ "$HOST":~/.kirocrew/skills/
+if [ -d ~/.kiro/crew/skills/ ]; then
+  rsync_dry ~/.kiro/crew/skills/ "$HOST":~/.kiro/crew/skills/
 fi
-if [ -d ~/.kirocrew/hooks/ ]; then
-  rsync_dry ~/.kirocrew/hooks/ "$HOST":~/.kirocrew/hooks/
+if [ -d ~/.kiro/crew/hooks/ ]; then
+  rsync_dry ~/.kiro/crew/hooks/ "$HOST":~/.kiro/crew/hooks/
 fi
-if [ -d ~/.kirocrew/tasks/ ]; then
-  rsync_dry ~/.kirocrew/tasks/ "$HOST":~/.kirocrew/tasks/
+if [ -d ~/.kiro/crew/tasks/ ]; then
+  rsync_dry ~/.kiro/crew/tasks/ "$HOST":~/.kiro/crew/tasks/
 fi
 
 # --- [5] Crons & dashboard metadata ---
@@ -193,8 +193,8 @@ fi
 # autonudge.json — autonudge loop state.
 echo "  [5/7] Crons & dashboard metadata..."
 for f in crons.json hooks.json folders.json tags.json tag_boards.json autonudge.json; do
-  if [ -f ~/.kirocrew/"$f" ]; then
-    run scp -q ~/.kirocrew/"$f" "$HOST":~/.kirocrew/
+  if [ -f ~/.kiro/crew/"$f" ]; then
+    run scp -q ~/.kiro/crew/"$f" "$HOST":~/.kiro/crew/
   fi
 done
 
@@ -205,8 +205,8 @@ echo "  [6/7] Dotfiles (skipped by default)..."
 
 # --- [7] Sessions ---
 echo "  [7/7] Sessions..."
-if [ -d ~/.kirocrew/sessions/ ]; then
-  rsync_dry ~/.kirocrew/sessions/ "$HOST":~/.kirocrew/sessions/
+if [ -d ~/.kiro/crew/sessions/ ]; then
+  rsync_dry ~/.kiro/crew/sessions/ "$HOST":~/.kiro/crew/sessions/
 fi
 
 echo ""


### PR DESCRIPTION
## Problem

On a machine that had already completed the `~/.kirocrew` → `~/.kiro/crew` data-home migration, `~/.kirocrew` **kept coming back** — reappearing with a lone `node-bin-dir` (or `python-bin`) file after every `make build`. Because the migration's short-circuit is "trust the new home only if the legacy dir is absent," a resurrected `~/.kirocrew` re-triggers the whole migration on the next gateway start and muddies which home is authoritative.

## Why it matters

The build/install tooling was silently working against the data-home migration: it wrote build markers into a directory the migration is designed to delete. That produces a confusing, self-perpetuating loop (migrate → delete legacy → next build recreates legacy → migrate again), and in one case a real hazard — `cli.sh` put the managed **venv** under `~/.kirocrew/venv`, so a later migration would delete the installed venv out from under the `~/.local/bin/kirocrew` symlink. It's the same hardcoded-`.kirocrew` bug class as the original data-home report, just in build/install scripts the earlier de-Amazon audit's grep scope didn't cover.

## Fix (symptom → root cause → change)

- **Symptom:** `~/.kirocrew` recreated on every build; only a `node-bin-dir`/`python-bin` marker inside.
- **Root cause:** build/install shell tooling hardcoded `$HOME/.kirocrew` as the data home instead of resolving `${KIROCREW_HOME:-$HOME/.kiro/crew}` the way the app itself does. The migration deletes `~/.kirocrew`; these scripts recreate it.
- **Change:** route every functional path through `${KIROCREW_HOME:-$HOME/.kiro/crew}`:
  - `ensure-node.sh` / `ensure-python.sh` — write `node-bin-dir` / `python-bin` into the resolved data home.
  - `Makefile` (frontend/backend/desktop) — read those markers from the same resolved path.
  - `cli.sh` — the managed venv and channel file move to the data home (fixes the delete-venv-out-from-under-symlink hazard).
  - `install.sh` — `KIROCREW_DATA_DIR` (writes `project_dir`) resolves to the data home.
  - `scripts/sync-to-remote.sh` — local + remote paths use `~/.kiro/crew`.

Honoring `KIROCREW_HOME` (not a blind `.kirocrew → .kiro/crew` swap) keeps dev/worktree isolation working.

## Scope note — runtime `src/` is already clean

I ran a package-wide `.kirocrew` audit. Runtime source (`src/`) has **no** hardcoded `~/.kirocrew` path construction — every remaining `.kirocrew` literal there is deliberate: the legacy sensitive-path floors (`security.py`, `cloud/source.py`, `file_explorer`), skip-lists, dev-home examples (`~/.kirocrew-dev`), and product identifiers (`.kirocrew-managed`, `dev.kirocrew.gateway`). The residue was purely in top-level `Makefile` + `*.sh` build/install tooling, which this PR fixes. (Docstrings/spec text still say `~/.kirocrew` in places; those are doc-only and out of scope — the code resolves via `config_dir()`.)

## Tests

No unit tests — these are build/install shell scripts. Verified by:
- `bash -n` syntax check on all five edited scripts (pass).
- `make -n frontend backend desktop` parses (pass).
- Functional isolation test of the `_record_node_bin` logic: with a fresh `$HOME` it writes to `~/.kiro/crew/node-bin-dir` and creates **no** `~/.kirocrew`; with `KIROCREW_HOME` set it writes there instead (dev isolation preserved).
- Post-edit grep confirms **zero** functional `~/.kirocrew` writers remain across `*.sh` + `Makefile` (the only remaining mentions are explanatory comments describing what not to write to).

## Manual verification

N/A beyond the above — the failure only manifests as a filesystem side effect of running the build tooling, which the isolation test reproduces directly. Reproduced the original symptom on a real machine (a migrated home kept regenerating `~/.kirocrew/node-bin-dir` after each `make build`); with this change the build writes to `~/.kiro/crew` and the legacy dir stays gone.
