### PR TITLE
fix(crash-guard): stop test runs writing to the live crash log

### DIFF
--- a/src/kiro_crew/crash_guard.py
+++ b/src/kiro_crew/crash_guard.py
@@ -140,5 +140,19 @@ def install(loop=None) -> None:
 
 
 def install_loop_handler(loop) -> None:
-    """Install the asyncio exception handler on the given loop."""
+    """Install the asyncio exception handler on the given loop.
+
+    Also pins ``_CRASH_LOG`` to the *current* config dir. asyncio reports
+    unretrieved task exceptions at GC time — potentially long after the owning
+    process/test has torn its environment down — so resolving the path lazily
+    inside ``_write_crash`` can send a record to whichever ``KIROCREW_HOME`` is
+    in effect at GC time rather than the one that was running. Pinning here
+    keeps every record with the instance that produced it.
+    """
+    global _CRASH_LOG
+
+    try:
+        _CRASH_LOG = _crash_log_path()
+    except Exception:  # pragma: no cover - path resolution is best-effort
+        logger.debug("crash log path resolution failed", exc_info=True)
     loop.set_exception_handler(_asyncio_exception_handler)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4242,9 +4242,16 @@ class GatewayOrchestrator:
         """
         from kiro_crew.memory import legacy_memory_present
 
-        store = self.vector_memory
+        # Every dereference lives inside the try so the "never raises" contract
+        # above holds even on a boot where ``_init_services`` never ran (or was
+        # stubbed): this is a fire-and-forget task, so an escaping exception is
+        # only surfaced later as an unretrieved-task error, far from its cause.
         loop = asyncio.get_running_loop()
         try:
+            store = getattr(self, "vector_memory", None)
+            if store is None:
+                logger.debug("auto-migrate skipped: vector memory not initialised")
+                return
             # ── Phase 1: migrate ──
             if not self._cfg.memory.migrated:
                 # Bind embed_fn so migration writes real vectors when the model

--- a/test/test_crash_guard.py
+++ b/test/test_crash_guard.py
@@ -1,0 +1,72 @@
+"""Tests: crash_guard crash-log path pinning.
+
+asyncio reports unretrieved task exceptions at GC time, which can be long after
+the owning process (or test) tore its environment down. If the crash-log path
+were resolved lazily at write time, such a record could land in whichever
+``KIROCREW_HOME`` happened to be in effect then — including a developer's live
+data home while the suite runs. ``install_loop_handler`` therefore pins the path
+to the config dir that was active when the handler was installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kiro_crew import crash_guard
+
+
+@pytest.fixture(autouse=True)
+def _restore_crash_log():
+    """Keep the module-level pinned path from leaking between tests."""
+    saved = crash_guard._CRASH_LOG
+    yield
+    crash_guard._CRASH_LOG = saved
+
+
+class TestInstallLoopHandler:
+    def test_pins_crash_log_to_current_config_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home_a"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+            assert loop.get_exception_handler() is crash_guard._asyncio_exception_handler
+        finally:
+            loop.close()
+
+        assert crash_guard._CRASH_LOG == tmp_path / "home_a" / "logs" / "crash.log"
+
+    def test_write_uses_pinned_path_after_home_changes(self, tmp_path, monkeypatch):
+        """A late (GC-time) write must not follow a since-changed home."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home_a"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        # Simulate the environment being restored (monkeypatch teardown, home
+        # switch) before the deferred write happens.
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home_b"))
+        crash_guard._write_crash("ASYNCIO UNHANDLED: late report")
+
+        pinned = tmp_path / "home_a" / "logs" / "crash.log"
+        assert "late report" in pinned.read_text()
+        assert not (tmp_path / "home_b" / "logs" / "crash.log").exists()
+
+    def test_path_resolution_failure_still_installs_handler(self, monkeypatch):
+        """Path resolution is best-effort — it must never block the handler."""
+        monkeypatch.setattr(
+            crash_guard, "_crash_log_path", lambda: (_ for _ in ()).throw(OSError("nope"))
+        )
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+            assert loop.get_exception_handler() is crash_guard._asyncio_exception_handler
+        finally:
+            loop.close()
+        assert crash_guard._CRASH_LOG is None

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -1867,6 +1867,10 @@ class TestRunMethod:
         # _init_services is mocked so vector_memory never gets created — mock
         # the default-on embeddings wiring too (it dereferences vector_memory).
         orch._start_embeddings = AsyncMock()
+        # run() spawns _auto_migrate_memory as a fire-and-forget task; with
+        # _init_services mocked it would raise AttributeError on
+        # vector_memory and surface as an unretrieved-task error at GC time.
+        orch._auto_migrate_memory = AsyncMock()
         orch._init_cron = AsyncMock()
         orch._init_heartbeat = AsyncMock()
         orch._init_mcp_discovery = MagicMock()
@@ -1908,6 +1912,10 @@ class TestRunMethod:
 
         orch._init_services = MagicMock()
         orch._start_embeddings = AsyncMock()
+        # run() spawns _auto_migrate_memory as a fire-and-forget task; with
+        # _init_services mocked it would raise AttributeError on
+        # vector_memory and surface as an unretrieved-task error at GC time.
+        orch._auto_migrate_memory = AsyncMock()
         orch._init_cron = AsyncMock()
         orch._init_heartbeat = AsyncMock()
         orch._init_mcp_discovery = MagicMock()
@@ -2876,6 +2884,22 @@ class TestAutoMigrateMemory:
         set_migrated.assert_not_awaited()
         assert orch._cfg.memory.migrated is False
 
+    @pytest.mark.asyncio
+    async def test_no_vector_store_returns_without_raising(self):
+        """A boot where ``_init_services`` never ran must not raise.
+
+        The task is fire-and-forget, so an escaping AttributeError would only
+        surface later as an unretrieved-task error, logged far from its cause.
+        """
+        orch = _make_orchestrator()
+        orch._cfg.memory.migrated = False
+        assert not hasattr(orch, "vector_memory")
+        set_migrated = AsyncMock()
+        with patch.object(orch, "_set_memory_migrated", set_migrated):
+            await orch._auto_migrate_memory()
+        set_migrated.assert_not_awaited()
+        assert orch._cfg.memory.migrated is False
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Tests: _auto_apply_update discards local edits before staging frontend
@@ -3643,6 +3667,10 @@ class TestRunSignalAndBgSession:
 
         orch._init_services = MagicMock()
         orch._start_embeddings = AsyncMock()
+        # run() spawns _auto_migrate_memory as a fire-and-forget task; with
+        # _init_services mocked it would raise AttributeError on
+        # vector_memory and surface as an unretrieved-task error at GC time.
+        orch._auto_migrate_memory = AsyncMock()
         orch._init_cron = AsyncMock()
         orch._init_heartbeat = AsyncMock()
         orch._init_mcp_discovery = MagicMock()
@@ -3693,6 +3721,10 @@ class TestBgSessionDashboardBranch:
 
         orch._init_services = MagicMock()
         orch._start_embeddings = AsyncMock()
+        # run() spawns _auto_migrate_memory as a fire-and-forget task; with
+        # _init_services mocked it would raise AttributeError on
+        # vector_memory and surface as an unretrieved-task error at GC time.
+        orch._auto_migrate_memory = AsyncMock()
         orch._init_cron = AsyncMock()
         orch._init_heartbeat = AsyncMock()
         orch._init_mcp_discovery = MagicMock()


### PR DESCRIPTION
## Problem

Four `ASYNCIO UNHANDLED` records showed up in a developer's **live** `~/.kiro/crew/logs/crash.log`, all identical:

```
AttributeError: 'GatewayOrchestrator' object has no attribute 'vector_memory'
  File ".../src/kiro_crew/slack/gateway.py", line 4245, in _auto_migrate_memory
    store = self.vector_memory
```

These were **not** gateway crashes. `run()` calls `_init_services()` (which assigns `vector_memory`) *before* spawning the auto-migrate task, and `_start_embeddings()` dereferences it in between — a real boot cannot reach the task with the attribute unset, and would have died earlier with a different record if it could.

The records came from the four tests that `await orch.run()` with `_init_services` and `_start_embeddings` mocked (the mock stack even carries a comment noting `vector_memory` never gets created). `_auto_migrate_memory` was *not* mocked, so `run()` spawned a real task that raised `AttributeError` with nobody retrieving it.

Why it escaped test isolation: asyncio reports unretrieved task exceptions at **GC time** — after the test ended and `conftest`'s per-test `KIROCREW_HOME` monkeypatch was reverted. The crash-guard loop handler installed by `run()` then resolved the log path lazily inside `_write_crash`, landing on the developer's real data home instead of the test's tmp home. Timestamps matched full-suite gate runs in three feature worktrees (two xdist workers one second apart).

## Changes

1. **`crash_guard.install_loop_handler`** pins `_CRASH_LOG` to the config dir active at install time. A deferred write can no longer follow a since-changed `KIROCREW_HOME` into another instance's data home. Resolution failure is best-effort and never blocks handler installation.
2. **`_auto_migrate_memory`** moves its `vector_memory` dereference inside the `try` and returns early when unset, so the docstring's "never raises" contract actually holds for this fire-and-forget task. Mirrors the existing `getattr(orch, "vector_memory", None)` pattern in `slack/events.py`.
3. **The four `run()` tests** now mock `_auto_migrate_memory`, so no orphan task is spawned in the first place.

Fix 1 is the one that matters for containment: it stops *any* future unretrieved-task report from a test run reaching a developer's live crash log, not just this one.

## Tests

- New `test/test_crash_guard.py`: path pinning, late-write isolation (write after home change lands on the pinned path, not the new one), resolution-failure fallback.
- New `TestAutoMigrateMemory::test_no_vector_store_returns_without_raising`.

## Verification

- `pytest`: 17,157 passed. The 3 failures in `test_dashboard_origin.py::TestParseDashboardUrlMalformed` reproduce on a clean `origin/main` checkout at the same commit (`9f0a3c0f`) — pre-existing, unrelated.
- `isort`, `flake8` clean; `mypy` 1.14.1 (CI-parity venv, no faiss) — no issues in 473 files.
- Confirmed empirically: after the fix, running the four `run()` tests left the live `crash.log` byte-identical (2527 bytes, 4 entries, mtime unchanged).
- No frontend changes.
