### PR TITLE
ci: raise Codex review to high reasoning effort and actively pull related code

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -77,9 +77,16 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: |
           mkdir -p "$HOME/.codex"
+          # model_reasoning_effort defaults to "medium" when unset. Pin it to
+          # "high": the review is a lean read-only single-shot per pass (fast even
+          # at high effort), so we spend the available time budget on DEEPER
+          # reasoning — better recall on subtle logic/security bugs — rather than
+          # finishing early. Latency/cost rise modestly; acceptable for a merge
+          # gate.
           cat > "$HOME/.codex/config.toml" <<'EOF'
           model_provider = "amazon-bedrock"
           model = "openai.gpt-5.6-sol"
+          model_reasoning_effort = "high"
           EOF
 
       - name: Write review prompt
@@ -102,12 +109,17 @@ jobs:
           You are reviewing a pull request. Start from the changes this branch
           introduces relative to the base commit:
               git diff ${{ github.event.pull_request.base.sha }}...HEAD
-          FOCUS on the changed files. You MAY open the full changed files and any
-          surrounding or referenced files (the sandbox is read-only) for CONTEXT
-          -- to understand a changed line -- but do NOT review or report on code
-          outside the diff, and do not go on a whole-repo audit. Report findings
-          ONLY on lines this PR adds or changes; use context reads to judge those
-          lines, never to expand scope into unrelated code.
+          FOCUS on the changed files. The sandbox is READ-ONLY but you have full
+          repo access — USE IT. Actively pull the RELATED code needed to judge a
+          change instead of assuming: open the full changed files, and read the
+          definition AND call sites of a changed symbol, the other side of a
+          changed contract/interface, the validation or guard a changed line
+          relies on, and the tests that exercise it. Prefer reading the real code
+          over guessing about it. This context-gathering is EXPECTED (you have the
+          time budget). But do NOT review or report on code outside the diff, and
+          do not go on a whole-repo audit: report findings ONLY on lines this PR
+          adds or changes; the related-code reads exist to judge those lines
+          correctly, never to expand scope into unrelated code.
 
           Review the diff for:
           1. Security vulnerabilities (injection, path traversal, credential exposure)


### PR DESCRIPTION
## Problem
The GPT 5.6 (Codex) reviewer finishes very fast. Two reasons: (a) its `~/.codex/config.toml` sets only `model` + `model_provider`, so `model_reasoning_effort` falls back to the CLI default **medium**; (b) its prompt only *permits* ("You MAY") reading related files, so it tends to review straight from the diff rather than pulling surrounding context.

## Why it matters
This is a required merge gate. We have plenty of time budget (the review is a lean read-only single-shot per pass, fast even at higher effort), so we should spend it on **deeper reasoning and more context** — better recall on subtle logic/security bugs — rather than finishing early.

## Fix (symptom → root cause → change)
- *Reasoning depth:* `model_reasoning_effort` was unset → medium. **Pin it to `high`** in `config.toml`. GPT-5 family honors the effort knob; latency/cost rise modestly, acceptable for a gate.
- *Context pulling:* the prompt's passive "You MAY open … surrounding files" is now an **active mandate** — the sandbox is read-only but has full repo access, so the reviewer is told to pull the definition + call sites of changed symbols, the other side of changed contracts, the guards a changed line relies on, and the exercising tests, preferring real code over assumptions. The scope guard is retained verbatim: **report findings ONLY on lines this PR adds/changes**; related-code reads are for judging those lines, never to expand scope.

No change to the model, provider, 3-pass loop, markers, gate, or sandbox (still `--sandbox read-only`, network-unshared).

## Tests
N/A — GitHub Actions workflow change. Validated the YAML parses. Behavioural effect is observable on this PR's own GPT 5.6 Review run (deeper reasoning + more context reads; it must still emit `[CODEX-REVIEWED] <sha>` and gate correctly).

## Manual verification
- `ruby -ryaml` load of the workflow: OK.
- `config.toml` now emits `model_reasoning_effort = "high"`; prompt scope guard ("report ONLY on changed lines") unchanged.
