### PR TITLE
fix(dashboard): open signing key file in binary mode on Windows

### DIFF
--- a/src/kiro_crew/dashboard/token_secret.py
+++ b/src/kiro_crew/dashboard/token_secret.py
@@ -179,8 +179,18 @@ def _load_or_create_secret() -> bytes:
             #    winner's bytes. This is what eliminates the divergence: only
             #    one key is ever generated.
             try:
+                # os.O_BINARY is REQUIRED on Windows: os.open() there defaults
+                # to TEXT mode, so the os.write() below would translate any
+                # 0x0A ('\n') byte in the random key to 0x0D 0x0A ('\r\n'),
+                # persisting a longer, corrupted key that the creator's
+                # in-memory bytes (and every sibling read) no longer match ->
+                # silent auth divergence. getattr(..., 0) makes it a no-op on
+                # POSIX, where os.O_BINARY does not exist and there is no text
+                # mode. Evaluated at call time so tests can simulate the flag.
                 fd = os.open(
-                    str(key_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+                    str(key_path),
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+                    0o600,
                 )
             except FileExistsError:
                 # Someone else created it (possibly not yet written). Give the

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -1015,6 +1015,44 @@ def test_signing_secret_create_contention_retries_not_ephemeral(tmp_path, monkey
     assert secret == on_disk, "must return the persisted key, not an ephemeral one"
 
 
+def test_signing_secret_binary_write_survives_windows_text_mode(tmp_path, monkeypatch) -> None:
+    """Regression: the key must be written in BINARY mode.
+
+    On Windows ``os.open()`` defaults to TEXT mode, so the ``os.write()`` that
+    persists the random key translates every ``0x0A`` ('\\n') byte to
+    ``0x0D 0x0A`` ('\\r\\n'). The on-disk key then grows and no longer equals
+    the creator's in-memory bytes (nor a sibling's read) — silent auth
+    divergence, and the root cause of the flaky Windows failures in
+    ``test_signing_secret_{concurrent_first_init_converges,create_contention_retries_not_ephemeral,write_failure_cleans_up_incomplete_file}``.
+    The fix opens the file with ``os.O_BINARY``. Reproduced deterministically on
+    POSIX via the text-mode simulator plus a key that contains an ``0x0A`` byte.
+    """
+    from windows_sim import windows_text_mode_write
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+
+    # A deterministic 32-byte key that CONTAINS 0x0A (LF) at index 10, so a
+    # text-mode write would demonstrably corrupt it (a purely random key might
+    # by chance contain no 0x0A and hide the bug).
+    fixed_key = bytes(range(ts._MIN_KEY_BYTES))
+    assert b"\n" in fixed_key
+    monkeypatch.setattr(os, "urandom", lambda n: fixed_key[:n])
+
+    with windows_text_mode_write(match=ts._SECRET_KEY_FILE):
+        secret = ts._load_or_create_secret()
+
+    on_disk = key_file.read_bytes()
+    # With the O_BINARY fix, no translation occurs: the persisted key is the
+    # exact 32 bytes and equals what was returned. Without it, the simulator
+    # would have written 33 bytes ('\r\n' for the '\n') and these would differ.
+    assert len(on_disk) == ts._MIN_KEY_BYTES, "newline translation changed the key length"
+    assert on_disk == fixed_key, "persisted key was corrupted by text-mode newline translation"
+    assert secret == on_disk, "returned key diverged from the persisted key"
+
+
 def test_signing_secret_existing_file_never_overwritten(tmp_path, monkeypatch) -> None:
     """Regression (PR #338): warming must never overwrite or truncate an
     existing key file.

--- a/test/test_windows_sim.py
+++ b/test/test_windows_sim.py
@@ -15,6 +15,7 @@ from windows_sim import (
     open_sharing_violation,
     read_sharing_violation,
     replace_sharing_violation,
+    windows_text_mode_write,
 )
 
 
@@ -143,3 +144,53 @@ class TestOpenSharingViolation:
             fd = os.open(str(f), os.O_RDONLY)  # no O_CREAT — not faulted
             os.close(fd)
         assert f.read_bytes() == b"x"
+
+
+class TestWindowsTextModeWrite:
+    _PAYLOAD = bytes(range(32))  # contains 0x0A (LF) at index 10
+
+    def _write_via_os(self, path, flags):
+        fd = os.open(str(path), flags, 0o600)
+        try:
+            os.write(fd, self._PAYLOAD)
+        finally:
+            os.close(fd)
+
+    def test_text_mode_fd_translates_newline(self, tmp_path):
+        f = tmp_path / "cred"
+        with windows_text_mode_write(match="cred") as state:
+            # No os.O_BINARY -> simulated text mode -> 0x0A becomes 0x0D 0x0A.
+            self._write_via_os(f, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+        on_disk = f.read_bytes()
+        assert on_disk != self._PAYLOAD
+        assert len(on_disk) == len(self._PAYLOAD) + 1  # one '\n' -> '\r\n'
+        assert b"\r\n" in on_disk
+        assert state["translated"] == 1
+
+    def test_binary_fd_is_not_translated(self, tmp_path):
+        f = tmp_path / "cred"
+        with windows_text_mode_write(match="cred") as state:
+            # ORing the (simulated, non-zero) os.O_BINARY suppresses translation.
+            self._write_via_os(
+                f, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+            )
+        assert f.read_bytes() == self._PAYLOAD
+        assert state["translated"] == 0
+
+    def test_non_matching_path_unaffected(self, tmp_path):
+        f = tmp_path / "other"
+        with windows_text_mode_write(match="cred"):
+            self._write_via_os(f, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+        assert f.read_bytes() == self._PAYLOAD  # different name — never translated
+
+    def test_os_write_returns_input_byte_count(self, tmp_path):
+        # Windows reports the INPUT bytes consumed even though more land on disk;
+        # a short-write loop relies on this to terminate correctly.
+        f = tmp_path / "cred"
+        with windows_text_mode_write(match="cred"):
+            fd = os.open(str(f), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                n = os.write(fd, self._PAYLOAD)
+            finally:
+                os.close(fd)
+        assert n == len(self._PAYLOAD)

--- a/test/windows_sim.py
+++ b/test/windows_sim.py
@@ -51,6 +51,7 @@ __all__ = [
     "read_sharing_violation",
     "replace_sharing_violation",
     "open_sharing_violation",
+    "windows_text_mode_write",
 ]
 
 _DEFAULT_INSTANT = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.timezone.utc)
@@ -226,4 +227,95 @@ def open_sharing_violation(
         return real_open(path, flags, mode, *args, **kwargs)
 
     with mock.patch("os.open", _patched):
+        yield state
+
+
+# Real Windows uses 0x8000 for os.O_BINARY; reuse it so the simulated flag value
+# matches a real Windows host. It is high enough not to collide with the small
+# O_WRONLY/O_CREAT/O_EXCL flags the code under test ORs together.
+_SIM_O_BINARY = 0x8000
+
+
+@contextmanager
+def windows_text_mode_write(*, match: Optional[str] = None) -> Iterator[dict]:
+    """Mimic Windows ``os.open()`` defaulting to TEXT mode.
+
+    On Windows a descriptor from ``os.open()`` WITHOUT ``os.O_BINARY`` is in
+    text mode, so ``os.write()`` of bytes containing ``0x0A`` ('\\n') emits
+    ``0x0D 0x0A`` ('\\r\\n') to disk — silently corrupting binary payloads
+    (e.g. a random signing key). POSIX has no text mode and ``os.O_BINARY`` is
+    ``0``, so the corruption never reproduces locally: a binary writer that
+    forgets ``os.O_BINARY`` passes on Mac/Linux yet fails on Windows.
+
+    This installs a NON-ZERO synthetic ``os.O_BINARY`` and CRLF-translates
+    ``os.write`` for any fd opened WITHOUT that bit. To behave IDENTICALLY on
+    POSIX and on a real Windows host, every underlying fd is opened GENUINELY
+    BINARY: the real ``os.O_BINARY`` (captured before the patch below shadows
+    it) is always OR'd back into the real ``os.open`` flags, so the synthetic
+    translation here is the ONLY translation on any OS. Without this, on Windows
+    the CRT would translate too — double-translating the text case and breaking
+    the binary case — because the real flag and the synthetic sentinel share the
+    value ``0x8000``.
+
+    Code that ORs ``getattr(os, "O_BINARY", 0)`` into its open flags is
+    exercised as binary (no translation); code that omits it gets the Windows
+    corruption. ``os.write`` still returns the INPUT byte count (as Windows
+    does), so a caller's short-write loop stays correct.
+
+    *match* filters which paths are tracked (basename-equality or substring);
+    ``None`` tracks every ``os.open``. Reads are left untouched
+    (``Path.read_bytes`` is binary on Windows too). Yields
+    ``{"translated": extra_bytes_written}``.
+    """
+    real_open = os.open
+    real_write = os.write
+    real_close = os.close
+    # Capture the REAL os.O_BINARY BEFORE the mock.patch below shadows it with
+    # the synthetic sentinel. POSIX -> 0 (no-op); Windows -> 0x8000, which MUST
+    # be re-applied to every underlying fd so the CRT does not add its own
+    # translation on top of the synthetic one.
+    real_o_binary = getattr(os, "O_BINARY", 0)
+    opened_binary: dict[int, bool] = {}
+    state = {"translated": 0}
+
+    def _match(p: str) -> bool:
+        return match is None or os.path.basename(p) == match or match in p
+
+    def _open(path, flags, mode=0o777, *args, **kwargs):  # type: ignore[no-untyped-def]
+        want_binary = bool(flags & _SIM_O_BINARY)
+        # Strip the synthetic bit but FORCE the underlying fd genuinely binary
+        # (real_o_binary), so our synthetic translation is the only one on every
+        # OS — including Windows, where the sentinel value IS the real flag.
+        fd = real_open(
+            path, (flags & ~_SIM_O_BINARY) | real_o_binary, mode, *args, **kwargs
+        )
+        if _match(str(path)):
+            opened_binary[fd] = want_binary
+        return fd
+
+    def _write(fd, data):  # type: ignore[no-untyped-def]
+        # Only text-mode (non-binary) tracked fds translate; everything else is
+        # a straight passthrough.
+        if fd in opened_binary and not opened_binary[fd]:
+            raw = bytes(data)
+            translated = raw.replace(b"\n", b"\r\n")
+            # Write the whole translated buffer, tolerating short writes, then
+            # report the INPUT byte count consumed (as Windows text mode does).
+            mv = memoryview(translated)
+            while mv:
+                k = real_write(fd, mv)
+                if k <= 0:
+                    break
+                mv = mv[k:]
+            state["translated"] += len(translated) - len(raw)
+            return len(raw)
+        return real_write(fd, data)
+
+    def _close(fd):  # type: ignore[no-untyped-def]
+        opened_binary.pop(fd, None)
+        return real_close(fd)
+
+    with mock.patch("os.open", _open), mock.patch("os.write", _write), mock.patch(
+        "os.close", _close
+    ), mock.patch.object(os, "O_BINARY", _SIM_O_BINARY, create=True):
         yield state


### PR DESCRIPTION
## Problem
Three `test/test_token_auth.py` signing-secret tests fail on the `Backend Tests (Windows)` matrix (green on macOS/Linux):
- `test_signing_secret_concurrent_first_init_converges` — "concurrent inits diverged from the on-disk key"
- `test_signing_secret_create_contention_retries_not_ephemeral`
- `test_signing_secret_write_failure_cleans_up_incomplete_file`

The byte diffs show a stray `\r` inserted at the `\n` in the persisted key (the on-disk value is one byte longer than the returned value).

## Why it matters
The dashboard HMAC signing key signs every auth token and session cookie. If the bytes persisted to disk differ from the bytes held in memory, a restart or a sibling gateway sharing the same data home signs with a *different* key — silently invalidating outstanding Slack links and cookies (auth-key divergence). The Windows test matrix is also red, blocking merges.

## Fix (symptoms → root cause → change)
- **Symptom:** on Windows the on-disk signing key has a `\r` inserted before a `\n`, so it is longer than and unequal to the in-memory key the creator returns; racing/next inits read the corrupted bytes and diverge.
- **Root cause:** the key is created with `os.open()` + `os.write()`. On Windows `os.open()` opens in **text mode** unless `os.O_BINARY` is set, so `os.write()` translates each `0x0A` (`\n`) byte in the random 32-byte key to `0x0D 0x0A` (`\r\n`). The read path (`Path.read_bytes`) is binary, so it faithfully reads back the corrupted, longer key. POSIX has no text mode, so it never reproduces locally.
- **Change:** OR `getattr(os, "O_BINARY", 0)` into the exclusive-create `os.open()` flags in `src/kiro_crew/dashboard/token_secret.py`. `os.O_BINARY` disables newline translation on Windows; `getattr(..., 0)` makes it a no-op on POSIX (where the constant doesn't exist). Evaluated at call time so tests can drive the flag.

## Tests
- **New regression test** `test_signing_secret_binary_write_survives_windows_text_mode` — uses a deterministic 32-byte key containing a `0x0A` byte and the new simulator to assert the persisted key is exactly 32 bytes and equals both the on-disk and returned bytes. Fails without the fix (translated to 33 bytes), passes with it.
- **New simulator** `windows_text_mode_write` in `test/windows_sim.py` — installs a non-zero synthetic `os.O_BINARY` and CRLF-translates `os.write` for fds opened without it (returning the input byte count, as Windows does), so the Windows-only corruption reproduces on POSIX. Follows the existing simulator pattern from #453.
- **Simulator self-tests** (`test/test_windows_sim.py::TestWindowsTextModeWrite`) — text-mode fd translates `\n`→`\r\n`, `O_BINARY` fd does not, non-matching paths untouched, and `os.write` returns the input byte count.
- The three previously-failing signing-secret tests now pass under the simulator. Locally: **12 selected, 12 passed** (`test_windows_sim.py` + the signing-secret tests). Full suite green expected on the Windows matrix.

## Manual verification
Verified on macOS: the four `TestWindowsTextModeWrite` self-tests prove the simulator reproduces the corruption without `O_BINARY` and suppresses it with the flag; with the product fix in place the regression test and all three formerly-failing tests pass. The negative case (no `O_BINARY` → 33-byte corrupted key) is demonstrated directly by `test_text_mode_fd_translates_newline`.

Screenshots: N/A — backend-only change (no UI).
