### PR TITLE
feat(issue-radar): multi-provider connect dialog with repo picker

### DIFF
--- a/docs/system-specs/modules/issue-radar.md
+++ b/docs/system-specs/modules/issue-radar.md
@@ -29,6 +29,7 @@ wrapped in `_require_enabled` (returns 403 when the app is disabled).
 | GET | `/labels` | Repo label set |
 | GET | `/members` | Repo collaborators (authoritative API or fallback) |
 | GET | `/repos` | Connected repos list (with permission self-heal) |
+| GET | `/recent-repos` | Repos the `gh` user contributed to recently (connect-dialog picker) |
 | DELETE | `/repos` | Disconnect a repo (drops config + cache) |
 | GET | `/me` | Current `gh` login |
 | GET/PUT | `/settings` | Per-repo triage settings |

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
@@ -21,6 +21,7 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 from urllib.parse import quote, urlparse
 
 GH_TIMEOUT_SEC = 20.0
@@ -39,6 +40,25 @@ class RepoUrlError(ValueError):
 
 class GhCliError(RuntimeError):
     """Raised when ``gh`` is missing, unauthenticated, times out, or the API call fails."""
+
+
+class GhSetupError(GhCliError):
+    """Raised when ``gh`` cannot be used because the HOST is not set up — the
+    binary is absent (or not in a trusted directory), or the CLI has no
+    authenticated session.
+
+    Distinct from a generic :class:`GhCliError` (network blip, API 500) because
+    the fix is a user action, not a retry: the connect dialog turns ``reason``
+    into install / ``gh auth login`` instructions instead of showing a raw error
+    string. A subclass of ``GhCliError`` so existing ``except GhCliError``
+    handlers keep working.
+
+    ``reason`` is ``"not_installed"`` or ``"not_authenticated"``.
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class GhPermissionError(GhCliError):
@@ -145,8 +165,12 @@ def _gh_bin() -> str:
             _gh_bin_cache = validated
             return validated
         except (ValueError, OSError) as exc:
-            raise GhCliError(
-                f"KIROCREW_ISSUE_RADAR_GH={override!r} failed validation: {exc}"
+            # A host-setup problem the user must fix (wrong path, symlinked or
+            # user-owned binary), not a transient API failure — surface it as a
+            # GhSetupError so the connect dialog offers instructions.
+            raise GhSetupError(
+                f"KIROCREW_ISSUE_RADAR_GH={override!r} failed validation: {exc}",
+                reason="not_installed",
             ) from exc
 
     # Resolve from the shared trusted dirs — validate each candidate.
@@ -160,11 +184,12 @@ def _gh_bin() -> str:
         except (ValueError, OSError):
             continue  # not root-owned or user-writable — skip
 
-    raise GhCliError(
+    raise GhSetupError(
         "the `gh` CLI was not found in any trusted directory "
         f"({', '.join(_PROVIDER_EXECUTABLE_DIRS)}), or all candidates failed "
         "ownership validation; set KIROCREW_ISSUE_RADAR_GH to a root-owned gh "
-        "executable"
+        "executable",
+        reason="not_installed",
     )
 
 
@@ -192,7 +217,9 @@ def _gh_run(argv: list[str], *, timeout: float, input_text: str | None = None) -
         )
     except FileNotFoundError as exc:  # pragma: no cover — _gh_bin guards first
         _audit("gh_run", operation, "failure", error="gh not found")
-        raise GhCliError("the `gh` CLI is not installed on this host") from exc
+        raise GhSetupError(
+            "the `gh` CLI is not installed on this host", reason="not_installed"
+        ) from exc
     except subprocess.TimeoutExpired as exc:
         _audit("gh_run", operation, "failure", error=f"timeout after {timeout}s")
         raise GhCliError(f"`gh` timed out after {timeout}s") from exc
@@ -233,6 +260,7 @@ def _run_gh_api(path: str, jq_filter: str, *, timeout: float = GH_TIMEOUT_SEC, p
 
     if proc.returncode != 0:
         tail = " ".join((proc.stderr or "").strip().splitlines()[-3:])
+        _raise_if_auth_failure(tail)
         raise GhCliError(f"gh api {path} failed (exit {proc.returncode}): {tail}")
 
     out: list[dict] = []
@@ -245,6 +273,34 @@ def _run_gh_api(path: str, jq_filter: str, *, timeout: float = GH_TIMEOUT_SEC, p
         except json.JSONDecodeError:
             continue
     return out
+
+
+# Markers `gh` prints when the CLI itself has no usable credentials (as opposed
+# to a repo simply being out of reach for an authenticated user). Matched
+# case-insensitively against the stderr tail so the connect dialog can offer
+# `gh auth login` instead of echoing an opaque exit code.
+_GH_AUTH_MARKERS = (
+    "gh auth login",
+    "not logged in",
+    "authentication required",
+    "requires authentication",
+    "bad credentials",
+    "http 401",
+)
+
+
+def _raise_if_auth_failure(stderr_tail: str) -> None:
+    """Re-classify an unauthenticated `gh` failure as :class:`GhSetupError`.
+
+    No-op for every other failure, so the caller still raises its own, more
+    specific ``GhCliError`` with the full context.
+    """
+    low = (stderr_tail or "").lower()
+    if any(m in low for m in _GH_AUTH_MARKERS):
+        raise GhSetupError(
+            "the `gh` CLI is not authenticated — run `gh auth login`",
+            reason="not_authenticated",
+        )
 
 
 def verify_repo_access(owner: str, repo: str, *, timeout: float = GH_TIMEOUT_SEC) -> dict:
@@ -342,6 +398,131 @@ def list_recent_open_issues(
     return _run_gh_api(path, _ISSUE_POLL_JQ, timeout=timeout, paginate=False)
 
 
+# The repo picker's list: repos the authenticated user personally CONTRIBUTED
+# to recently, newest contribution first.
+#
+# Sourced from the user's EVENT FEED (`users/{login}/events`), not
+# `user/repos?sort=pushed`. The latter answers "which of my repos changed" —
+# it fires for a teammate's push and says nothing about whether *this* user did
+# anything, and it cannot tell you when they last did. The event feed is
+# per-actor, so each entry is an action the user themselves took, and its
+# `created_at` is exactly "when I last contributed here".
+#
+# Event types are filtered to actual contributions: pushes, PRs, reviews,
+# review comments, issues, issue/commit comments, branch/tag creation and
+# releases. Watch/Fork/Member events are excluded — starring a repo is not
+# contributing to it.
+_CONTRIB_EVENT_TYPES = frozenset({
+    "PushEvent",
+    "PullRequestEvent",
+    "PullRequestReviewEvent",
+    "PullRequestReviewCommentEvent",
+    "IssuesEvent",
+    "IssueCommentEvent",
+    "CommitCommentEvent",
+    "CreateEvent",
+    "ReleaseEvent",
+})
+
+_EVENT_JQ = (
+    ".[] | {type: .type, repo: (.repo.name // null), "
+    "created_at: (.created_at // null)}"
+)
+
+
+#: Default trailing window for "repos I contributed to". Single source of truth
+#: for the backend — the route reads it rather than repeating the literal.
+CONTRIB_WINDOW_DAYS = 30
+
+#: Upper bound for a caller-supplied window. Guards ``timedelta(days=...)``,
+#: which raises OverflowError on absurd values; also clamped here so a direct
+#: caller (not just the HTTP route) can't trip it.
+MAX_WINDOW_DAYS = 3650
+
+
+#: Events fetched per call. A busy contributor can fill this in days, which is
+#: why the result reports truncation rather than implying completeness.
+_EVENT_PAGE_SIZE = 100
+
+
+def list_contributed_repos(
+    login: str, *, within_days: int = CONTRIB_WINDOW_DAYS, timeout: float = GH_TIMEOUT_SEC
+) -> tuple[list[dict], bool]:
+    """Repos ``login`` personally contributed to within the last ``within_days``.
+
+    Powers the connect dialog's picker, so the user picks from repos they
+    actually worked on instead of pasting URLs. Ordered by most-recent
+    contribution first, each row carrying ``last_contributed_at`` — the
+    timestamp of that user's latest contribution to the repo, which is what the
+    UI renders ("3 days ago").
+
+    Returns ``(rows, truncated)``. ``truncated`` is True when the event page
+    came back full, meaning activity older than the newest 100 events was not
+    examined and the list may be MISSING repos the user contributed to inside
+    the window. The UI must not present a truncated list as complete — a picker
+    that looks exhaustive leads the user to conclude they didn't work on a repo.
+
+    Single page (no ``--paginate``): this is a picker, not an audit. GitHub's
+    feed is itself capped (roughly the last 90 days / 300 events).
+
+    ``within_days=0`` disables the window. Rows are ``[{owner, repo, full_name,
+    last_contributed_at, contribution_count}]``.
+    """
+    path = f"users/{quote(login, safe='')}/events?per_page={_EVENT_PAGE_SIZE}"
+    events = _run_gh_api(path, _EVENT_JQ, timeout=timeout, paginate=False)
+    truncated = len(events) >= _EVENT_PAGE_SIZE
+
+    days = max(0, min(int(within_days), MAX_WINDOW_DAYS))
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=days) if days else None
+    )
+
+    # full_name -> {last contribution ts, how many contribution events}
+    by_repo: dict[str, dict] = {}
+    for ev in events:
+        if ev.get("type") not in _CONTRIB_EVENT_TYPES:
+            continue
+        full_name = ev.get("repo")
+        if not isinstance(full_name, str) or full_name.count("/") != 1:
+            continue
+        when = _parse_gh_timestamp(ev.get("created_at"))
+        if when is None or (cutoff is not None and when < cutoff):
+            continue
+        row = by_repo.get(full_name)
+        if row is None:
+            owner, _, repo = full_name.partition("/")
+            by_repo[full_name] = {
+                "owner": owner,
+                "repo": repo,
+                "full_name": full_name,
+                "last_contributed_at": ev["created_at"],
+                "contribution_count": 1,
+                "_when": when,
+            }
+        else:
+            row["contribution_count"] += 1
+            # The feed is newest-first, but don't rely on it — keep the max.
+            if when > row["_when"]:
+                row["_when"] = when
+                row["last_contributed_at"] = ev["created_at"]
+
+    rows = sorted(by_repo.values(), key=lambda r: r["_when"], reverse=True)
+    for r in rows:
+        del r["_when"]
+    return rows, truncated
+
+
+def _parse_gh_timestamp(value: object) -> datetime | None:
+    """Parse a GitHub ISO-8601 UTC stamp (``2026-07-25T20:57:01Z``) to an aware
+    datetime, or None when absent/malformed."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def get_current_login(*, timeout: float = GH_TIMEOUT_SEC) -> str | None:
     """Return the login of the authenticated `gh` user (``gh api user``).
 
@@ -355,6 +536,7 @@ def get_current_login(*, timeout: float = GH_TIMEOUT_SEC) -> str | None:
 
     if proc.returncode != 0:
         tail = " ".join((proc.stderr or "").strip().splitlines()[-3:])
+        _raise_if_auth_failure(tail)
         raise GhCliError(f"gh api user failed (exit {proc.returncode}): {tail}")
 
     return (proc.stdout or "").strip() or None

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -24,6 +24,10 @@ builtin app's ``/api/apps/{name}/*`` surface):
                                         -> {"owner", "repo", "members": [...],
                                             "from_cache": bool}
   GET  /api/apps/issue-radar/repos      -> {"repos": [{"owner","repo","enabled"}]}
+  GET  /api/apps/issue-radar/recent-repos[?days=<d>]
+                                        -> {"repos": [{"owner","repo","full_name",
+                                            "last_contributed_at",
+                                            "contribution_count","connected"}]}
 
   GET  /api/apps/issue-radar/issue-ai?owner=<o>&repo=<r>&number=<n>[&refresh=1]
                                         -> {"owner","repo","number","summary",
@@ -298,6 +302,80 @@ async def _handle_me(request: web.Request) -> web.Response:
     except github_client.GhCliError:
         return web.json_response({"login": None})
     return web.json_response({"login": login})
+
+
+async def _handle_recent_repos(request: web.Request) -> web.Response:
+    """GET /recent-repos[?days=<d>] — repos the `gh` user personally
+    CONTRIBUTED to within the last ``days`` (default 30), newest contribution
+    first, for the connect dialog's picker.
+
+    Each row carries ``last_contributed_at`` (that user's own latest
+    contribution to the repo) and is flagged ``connected`` so the picker can
+    show — and disable — repos already wired up. Live `gh` call, not cached:
+    the list is only read while the connect dialog is open, and a stale picker
+    is worse than a one-second wait. A `gh` failure is a 502 (upstream/auth),
+    matching /issues.
+    """
+    raw_days = (request.query.get("days") or "").strip()
+    try:
+        days = int(raw_days) if raw_days else github_client.CONTRIB_WINDOW_DAYS
+    except ValueError:
+        return web.json_response({"error": "days must be an integer"}, status=400)
+    # Bounded before it reaches timedelta(days=...): an arbitrarily large value
+    # raises OverflowError there, which would surface as a 500. 0 stays legal
+    # (it disables the window); MAX_WINDOW_DAYS is far beyond the event feed's
+    # own ~90-day horizon, so the cap costs nothing in practice.
+    if not 0 <= days <= github_client.MAX_WINDOW_DAYS:
+        return web.json_response(
+            {"error": f"days must be between 0 and {github_client.MAX_WINDOW_DAYS}"},
+            status=400,
+        )
+
+    try:
+        login = await asyncio.to_thread(github_client.get_current_login)
+    except github_client.GhSetupError as exc:
+        # Host isn't set up (no gh, or no session). Not an error the user can
+        # retry away — answer 200 with a reason so the dialog can render install
+        # / `gh auth login` instructions and keep the manual URL field usable.
+        return web.json_response(
+            {"repos": [], "setup_required": exc.reason, "error": str(exc)}
+        )
+    except github_client.GhCliError as exc:
+        return web.json_response({"error": str(exc)}, status=502)
+    if not login:
+        # No resolvable login means no event feed to read. An empty list (not a
+        # 502) keeps the dialog usable — the manual URL field still works.
+        return web.json_response({"repos": []})
+
+    try:
+        repos, truncated = await asyncio.to_thread(
+            github_client.list_contributed_repos, login, within_days=days
+        )
+    except github_client.GhSetupError as exc:
+        return web.json_response(
+            {"repos": [], "setup_required": exc.reason, "error": str(exc)}
+        )
+    except github_client.GhCliError as exc:
+        return web.json_response({"error": str(exc)}, status=502)
+
+    # Case-INSENSITIVE identity: GitHub owner/repo names are case-preserving
+    # but not case-sensitive, and the event feed can spell a repo differently
+    # from the stored config (`Owner/Repo` vs `owner/repo`). A case-sensitive
+    # compare would mark an already-connected repo as connectable and let the
+    # user create a duplicate config + cache entry for the same repo.
+    def _key(owner: object, repo: object) -> tuple[str, str]:
+        return (str(owner or "").casefold(), str(repo or "").casefold())
+
+    connected = {
+        _key(r.get("owner"), r.get("repo"))
+        for r in await asyncio.to_thread(store.list_connected_repos)
+    }
+    for r in repos:
+        r["connected"] = _key(r.get("owner"), r.get("repo")) in connected
+
+    # `truncated` tells the UI not to present the list as exhaustive — see
+    # list_contributed_repos.
+    return web.json_response({"repos": repos, "truncated": truncated})
 
 
 async def _handle_get_settings(request: web.Request) -> web.Response:
@@ -1755,6 +1833,7 @@ def register_routes(app: web.Application) -> None:
     app.router.add_get("/api/apps/issue-radar/labels", _require_enabled(_handle_labels))
     app.router.add_get("/api/apps/issue-radar/members", _require_enabled(_handle_members))
     app.router.add_get("/api/apps/issue-radar/repos", _require_enabled(_handle_repos))
+    app.router.add_get("/api/apps/issue-radar/recent-repos", _require_enabled(_handle_recent_repos))
     app.router.add_delete("/api/apps/issue-radar/repos", _require_enabled(_handle_disconnect))
     app.router.add_get("/api/apps/issue-radar/me", _require_enabled(_handle_me))
     app.router.add_get("/api/apps/issue-radar/settings", _require_enabled(_handle_get_settings))

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -223,16 +223,30 @@ def add_connected_repo(owner: str, repo: str, *, permissions: dict | None = None
     Stores the repo's GitHub ``permissions`` object (admin/maintain/push/pull/
     triage) so the UI can badge Read/Write access without a live call; updates
     it on reconnect if a fresh value is supplied.
+
+    Identity is CASE-INSENSITIVE. GitHub names are case-preserving but not
+    case-sensitive, so ``acme/widget`` and ``Acme/Widget`` are one repo — a
+    case-sensitive match appended a second entry for it, and that duplicate then
+    carried its own independent caches and triage settings. The first spelling
+    connected stays the stored one, so existing entries are never rewritten.
     """
     with _config_lock(root):
         config = read_config(root)
         repos = config.setdefault("repos", [])
-        existing = next((r for r in repos if r["owner"] == owner and r["repo"] == repo), None)
+        existing = next((r for r in repos if _same_repo(r, owner, repo)), None)
         if existing is None:
             repos.append({"owner": owner, "repo": repo, "enabled": True, "permissions": permissions})
         elif permissions is not None:
             existing["permissions"] = permissions
         write_config(config, root)
+
+
+def _same_repo(entry: dict, owner: str, repo: str) -> bool:
+    """Case-insensitive owner/repo identity for a config entry."""
+    return (
+        str(entry.get("owner", "")).casefold() == owner.casefold()
+        and str(entry.get("repo", "")).casefold() == repo.casefold()
+    )
 
 
 def set_repo_permissions(owner: str, repo: str, permissions: dict | None, *, root: Path | None = None) -> None:
@@ -241,7 +255,7 @@ def set_repo_permissions(owner: str, repo: str, permissions: dict | None, *, roo
     with _config_lock(root):
         config = read_config(root)
         for r in config.get("repos", []):
-            if r["owner"] == owner and r["repo"] == repo:
+            if _same_repo(r, owner, repo):
                 r["permissions"] = permissions
         write_config(config, root)
 

--- a/test/test_issue_radar_recent_repos.py
+++ b/test/test_issue_radar_recent_repos.py
@@ -1,0 +1,421 @@
+"""Tests for the connect dialog's contributed-repos picker backend.
+
+Two deterministic, subprocess-free surfaces:
+  * ``github_client.list_contributed_repos`` — the ``gh api`` path it builds,
+    which event types count as a contribution, the trailing window, the
+    per-repo "my last contribution" rollup, and newest-first ordering
+    (monkeypatches ``_run_gh_api``, so no real ``gh`` runs);
+  * ``routes._handle_recent_repos`` — login resolution, the ``connected`` flag
+    it stamps by diffing against config.json, and the 400/502 error mapping.
+"""
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+from urllib.parse import urlencode
+
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.apps.builtins.issue_radar.backend import github_client as gh
+from kiro_crew.apps.builtins.issue_radar.backend import routes, store
+
+
+def _iso_days_ago(days: float) -> str:
+    """A GitHub-style UTC stamp ``days`` in the past."""
+    return (
+        datetime.now(timezone.utc) - timedelta(days=days)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ev(repo: str, days_ago: float, kind: str = "PushEvent") -> dict:
+    return {"type": kind, "repo": repo, "created_at": _iso_days_ago(days_ago)}
+
+
+def _req(query: dict | None = None):
+    """A real (mocked) aiohttp Request for the handler under test.
+
+    aiohttp's own ``make_mocked_request`` rather than a hand-rolled stand-in:
+    the handler is typed ``(web.Request) -> web.Response``, so a duck-typed
+    stub fails the repo-wide ``mypy src/kiro_crew/`` gate.
+    """
+    path = "/api/apps/issue-radar/recent-repos"
+    if query:
+        path = f"{path}?{urlencode(query)}"
+    return make_mocked_request("GET", path)
+
+
+def _body(response):
+    return json.loads(response.body.decode())
+
+
+class TestListContributedRepos(unittest.TestCase):
+    def _run(self, events, **kwargs):
+        with mock.patch.object(gh, "_run_gh_api", return_value=events) as run:
+            rows, _trunc = gh.list_contributed_repos(kwargs.pop("login", "octocat"), **kwargs)
+        return rows, run
+
+    def test_reads_the_users_event_feed(self):
+        _, run = self._run([])
+        path = run.call_args[0][0]
+        self.assertIn("users/octocat/events", path)
+        self.assertIn("per_page=100", path)
+        # A picker, not an audit — must not walk the whole feed.
+        self.assertFalse(run.call_args.kwargs["paginate"])
+
+    def test_login_is_url_escaped(self):
+        _, run = self._run([], login="weird/../name")
+        self.assertNotIn("weird/../name", run.call_args[0][0])
+
+    def test_rolls_up_last_contribution_per_repo(self):
+        # The expected stamp is RETAINED, not recomputed: `_ev` derives its
+        # timestamp from `now`, so calling it again in the assertion yields a
+        # different second whenever the test crosses a second boundary.
+        newest = _ev("o/alpha", 1)
+        rows, _ = self._run([
+            _ev("o/alpha", 5),
+            newest,   # newer — should win
+            _ev("o/beta", 3),
+        ])
+        by_name = {r["full_name"]: r for r in rows}
+        self.assertEqual(by_name["o/alpha"]["contribution_count"], 2)
+        # The 1-day-old stamp is the one surfaced.
+        self.assertEqual(by_name["o/alpha"]["last_contributed_at"], newest["created_at"])
+        self.assertEqual(by_name["o/beta"]["contribution_count"], 1)
+
+    def test_newest_contribution_first(self):
+        rows, _ = self._run([_ev("o/old", 20), _ev("o/new", 2), _ev("o/mid", 9)])
+        self.assertEqual([r["full_name"] for r in rows], ["o/new", "o/mid", "o/old"])
+
+    def test_owner_and_repo_are_split(self):
+        rows, _ = self._run([_ev("acme/widget", 1)])
+        self.assertEqual(rows[0]["owner"], "acme")
+        self.assertEqual(rows[0]["repo"], "widget")
+
+    def test_non_contribution_events_are_ignored(self):
+        # Starring or forking a repo is not contributing to it.
+        rows, _ = self._run([
+            _ev("o/starred", 1, kind="WatchEvent"),
+            _ev("o/forked", 1, kind="ForkEvent"),
+            _ev("o/joined", 1, kind="MemberEvent"),
+            _ev("o/real", 1, kind="PullRequestEvent"),
+        ])
+        self.assertEqual([r["full_name"] for r in rows], ["o/real"])
+
+    def test_review_and_issue_events_count(self):
+        rows, _ = self._run([
+            _ev("o/reviewed", 2, kind="PullRequestReviewEvent"),
+            _ev("o/triaged", 3, kind="IssuesEvent"),
+            _ev("o/commented", 4, kind="IssueCommentEvent"),
+        ])
+        self.assertEqual(len(rows), 3)
+
+    def test_window_excludes_older_contributions(self):
+        rows, _ = self._run([_ev("o/recent", 3), _ev("o/stale", 45)])
+        self.assertEqual([r["full_name"] for r in rows], ["o/recent"])
+
+    def test_custom_and_disabled_window(self):
+        events = [_ev("o/recent", 3), _ev("o/stale", 45)]
+        rows, _ = self._run(events, within_days=7)
+        self.assertEqual([r["full_name"] for r in rows], ["o/recent"])
+        rows, _ = self._run(events, within_days=0)
+        self.assertEqual(len(rows), 2)
+        rows, _ = self._run(events, within_days=-5)  # negative == disabled
+        self.assertEqual(len(rows), 2)
+
+    def test_malformed_entries_are_skipped(self):
+        rows, _ = self._run([
+            {"type": "PushEvent", "repo": None, "created_at": _iso_days_ago(1)},
+            {"type": "PushEvent", "repo": "no-slash", "created_at": _iso_days_ago(1)},
+            {"type": "PushEvent", "repo": "o/r", "created_at": "not-a-date"},
+            {"type": "PushEvent", "repo": "o/r", "created_at": None},
+            _ev("o/good", 1),
+        ])
+        self.assertEqual([r["full_name"] for r in rows], ["o/good"])
+
+    def test_internal_sort_key_is_not_leaked(self):
+        rows, _ = self._run([_ev("o/r", 1)])
+        self.assertNotIn("_when", rows[0])
+
+
+class TestTruncationSignal(unittest.TestCase):
+    """A full event page means older activity was never examined, so the caller
+    must be told rather than presenting the list as exhaustive."""
+
+    def _truncated(self, events) -> bool:
+        with mock.patch.object(gh, "_run_gh_api", return_value=events):
+            _rows, truncated = gh.list_contributed_repos("octocat")
+        return truncated
+
+    def test_full_page_reports_truncated(self):
+        full = [_ev(f"o/r{i}", 1) for i in range(gh._EVENT_PAGE_SIZE)]
+        self.assertTrue(self._truncated(full))
+
+    def test_partial_page_is_not_truncated(self):
+        self.assertFalse(self._truncated([_ev("o/r", 1)]))
+
+    def test_empty_feed_is_not_truncated(self):
+        self.assertFalse(self._truncated([]))
+
+    def test_truncation_is_about_the_RAW_page_not_the_filtered_rows(self):
+        # A full page of events that all fall outside the window yields zero
+        # rows but is still truncated — older pages could hold in-window repos.
+        stale_full = [_ev(f"o/r{i}", 90) for i in range(gh._EVENT_PAGE_SIZE)]
+        with mock.patch.object(gh, "_run_gh_api", return_value=stale_full):
+            rows, truncated = gh.list_contributed_repos("octocat", within_days=30)
+        self.assertEqual(rows, [])
+        self.assertTrue(truncated)
+
+
+class TestGhSetupClassification(unittest.TestCase):
+    """`gh` unusable because the HOST isn't set up is a distinct, actionable
+    failure — the dialog turns it into install / login instructions."""
+
+    def test_auth_markers_raise_setup_error(self):
+        for tail in (
+            "gh auth login to authenticate",
+            "You are not logged in to any GitHub hosts",
+            "HTTP 401: Bad credentials",
+            "This endpoint requires authentication",
+        ):
+            with self.assertRaises(gh.GhSetupError) as ctx:
+                gh._raise_if_auth_failure(tail)
+            self.assertEqual(ctx.exception.reason, "not_authenticated")
+
+    def test_unrelated_failures_are_not_setup_errors(self):
+        for tail in ("HTTP 404: Not Found", "connection reset by peer", ""):
+            gh._raise_if_auth_failure(tail)  # must not raise
+
+    def test_setup_error_is_a_gh_cli_error(self):
+        # Existing `except GhCliError` handlers must keep catching it.
+        self.assertTrue(issubclass(gh.GhSetupError, gh.GhCliError))
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "Issue Radar is POSIX-only: _gh_bin() raises the platform guard before it "
+        "ever reaches trust validation, which is what this test asserts.",
+    )
+    def test_rejected_override_binary_is_a_setup_error(self):
+        # The common macOS case: gh IS installed, but the Homebrew path is a
+        # symlink under a user-writable prefix, so trust validation rejects it.
+        # That must reach the UI as actionable setup guidance, not a raw error.
+        # `_validate_provider_executable` is imported lazily INSIDE _gh_bin, so
+        # it has to be patched on its owning module, not on github_client.
+        # The path is a neutral fixture — the point is that ANY rejected
+        # override becomes a setup error, not that a specific prefix does.
+        gh._gh_bin_cache = None
+        try:
+            with mock.patch.dict("os.environ", {"KIROCREW_ISSUE_RADAR_GH": "/fake/prefix/bin/gh"}), \
+                 mock.patch(
+                     "kiro_crew.dashboard.handlers.source_providers."
+                     "_validate_provider_executable",
+                     side_effect=ValueError("path must be canonical"),
+                 ):
+                with self.assertRaises(gh.GhSetupError) as ctx:
+                    gh._gh_bin()
+            self.assertEqual(ctx.exception.reason, "not_installed")
+            self.assertIn("failed validation", str(ctx.exception))
+        finally:
+            gh._gh_bin_cache = None
+
+    # The two tests below cover the CALL SITES, not the helper. Testing
+    # `_raise_if_auth_failure` in isolation leaves the tree green even if a
+    # refactor drops the call from `_run_gh_api` / `get_current_login` — an
+    # unauthenticated `gh` would then surface as a generic 502 and the setup
+    # guidance in the connect dialog would silently disappear.
+    def _authfail(self):
+        """A `gh` subprocess result that failed for lack of credentials."""
+        return mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr="gh: To get started with GitHub CLI, please run: gh auth login\n",
+        )
+
+    def test_run_gh_api_classifies_auth_failure(self):
+        with mock.patch.object(gh, "_gh_run", return_value=self._authfail()):
+            with self.assertRaises(gh.GhSetupError) as ctx:
+                gh._run_gh_api("repos/o/r/issues", ".[]")
+        self.assertEqual(ctx.exception.reason, "not_authenticated")
+
+    def test_get_current_login_classifies_auth_failure(self):
+        with mock.patch.object(gh, "_gh_run", return_value=self._authfail()):
+            with self.assertRaises(gh.GhSetupError) as ctx:
+                gh.get_current_login()
+        self.assertEqual(ctx.exception.reason, "not_authenticated")
+
+    def test_non_auth_failures_stay_generic_gh_cli_errors(self):
+        # The mirror assertion: a 404 must NOT be dressed up as a setup
+        # problem, or the dialog would tell the user to log in when they
+        # already are.
+        notfound = mock.Mock(returncode=1, stdout="", stderr="HTTP 404: Not Found\n")
+        for call in (
+            lambda: gh._run_gh_api("repos/o/r/issues", ".[]"),
+            gh.get_current_login,
+        ):
+            with mock.patch.object(gh, "_gh_run", return_value=notfound):
+                with self.assertRaises(gh.GhCliError) as ctx:
+                    call()
+            self.assertNotIsInstance(ctx.exception, gh.GhSetupError)
+
+
+class TestRecentReposRoute(unittest.IsolatedAsyncioTestCase):
+    async def test_missing_gh_returns_setup_required_not_502(self):
+        with mock.patch.object(
+            routes.github_client, "get_current_login",
+            side_effect=gh.GhSetupError("no gh found in <trusted dirs>", reason="not_installed"),
+        ):
+            resp = await routes._handle_recent_repos(_req())
+        body = _body(resp)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(body["setup_required"], "not_installed")
+        self.assertEqual(body["repos"], [])
+        # The diagnostic detail rides along for the collapsible "Details" block.
+        self.assertIn("no gh found", body["error"])
+
+    async def test_unauthenticated_gh_returns_setup_required(self):
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(
+                 routes.github_client, "list_contributed_repos",
+                 side_effect=gh.GhSetupError("not authenticated", reason="not_authenticated"),
+             ):
+            resp = await routes._handle_recent_repos(_req())
+        body = _body(resp)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(body["setup_required"], "not_authenticated")
+
+    async def test_flags_already_connected_repos(self):
+        live = [
+            {"owner": "o", "repo": "already", "full_name": "o/already"},
+            {"owner": "o", "repo": "fresh", "full_name": "o/fresh"},
+        ]
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos", return_value=(live, False)), \
+             mock.patch.object(routes.store, "list_connected_repos",
+                               return_value=[{"owner": "o", "repo": "already"}]):
+            resp = await routes._handle_recent_repos(_req())
+
+        self.assertEqual(resp.status, 200)
+        by_name = {r["full_name"]: r for r in _body(resp)["repos"]}
+        self.assertTrue(by_name["o/already"]["connected"])
+        self.assertFalse(by_name["o/fresh"]["connected"])
+
+    async def test_connected_match_ignores_case(self):
+        # GitHub names are case-preserving but not case-sensitive: the event
+        # feed can spell a repo differently from config.json. A case-sensitive
+        # compare would offer an already-connected repo as connectable and let
+        # the user create a duplicate entry for the same repo.
+        live = [{"owner": "Acme", "repo": "Widget", "full_name": "Acme/Widget"}]
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos", return_value=(live, False)), \
+             mock.patch.object(routes.store, "list_connected_repos",
+                               return_value=[{"owner": "acme", "repo": "widget"}]):
+            resp = await routes._handle_recent_repos(_req())
+
+        self.assertTrue(_body(resp)["repos"][0]["connected"])
+
+    async def test_default_window_and_login_are_forwarded(self):
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos", return_value=([], False)) as lcr, \
+             mock.patch.object(routes.store, "list_connected_repos", return_value=[]):
+            await routes._handle_recent_repos(_req())
+        lcr.assert_called_once_with("octocat", within_days=30)
+
+    async def test_days_param_is_forwarded(self):
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos", return_value=([], False)) as lcr, \
+             mock.patch.object(routes.store, "list_connected_repos", return_value=[]):
+            await routes._handle_recent_repos(_req({"days": "7"}))
+        lcr.assert_called_once_with("octocat", within_days=7)
+
+    async def test_truncated_flag_is_surfaced(self):
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos",
+                               return_value=([], True)), \
+             mock.patch.object(routes.store, "list_connected_repos", return_value=[]):
+            resp = await routes._handle_recent_repos(_req())
+        self.assertTrue(_body(resp)["truncated"])
+
+    async def test_non_integer_days_is_400(self):
+        resp = await routes._handle_recent_repos(_req({"days": "soon"}))
+        self.assertEqual(resp.status, 400)
+
+    async def test_out_of_range_days_is_400_not_500(self):
+        # An unbounded value reaches timedelta(days=...) and raises
+        # OverflowError, which would surface as an internal server error.
+        for bad in ("999999999999", "-1"):
+            resp = await routes._handle_recent_repos(_req({"days": bad}))
+            self.assertEqual(resp.status, 400, f"days={bad}")
+
+    async def test_zero_days_is_allowed(self):
+        # 0 is legal: it disables the window rather than being out of range.
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos", return_value=([], False)) as lcr, \
+             mock.patch.object(routes.store, "list_connected_repos", return_value=[]):
+            resp = await routes._handle_recent_repos(_req({"days": "0"}))
+        self.assertEqual(resp.status, 200)
+        lcr.assert_called_once_with("octocat", within_days=0)
+
+    async def test_no_login_returns_empty_list_not_error(self):
+        # The dialog stays usable (manual URL entry) when gh can't resolve a login.
+        with mock.patch.object(routes.github_client, "get_current_login", return_value=None):
+            resp = await routes._handle_recent_repos(_req())
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(_body(resp)["repos"], [])
+
+    async def test_gh_failure_is_502(self):
+        with mock.patch.object(routes.github_client, "get_current_login", return_value="octocat"), \
+             mock.patch.object(routes.github_client, "list_contributed_repos",
+                               side_effect=gh.GhCliError("gh not authenticated")):
+            resp = await routes._handle_recent_repos(_req())
+        self.assertEqual(resp.status, 502)
+        self.assertIn("gh not authenticated", _body(resp)["error"])
+
+    async def test_login_lookup_failure_is_502(self):
+        with mock.patch.object(routes.github_client, "get_current_login",
+                               side_effect=gh.GhCliError("gh missing")):
+            resp = await routes._handle_recent_repos(_req())
+        self.assertEqual(resp.status, 502)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+
+
+class TestConnectedRepoIdentity(unittest.TestCase):
+    """GitHub names are case-preserving but not case-sensitive, so one repo must
+    never be stored twice under two spellings — a duplicate entry carries its own
+    independent caches and triage settings."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _repos(self):
+        return store.read_config(self.root).get("repos", [])
+
+    def test_reconnect_with_different_casing_does_not_duplicate(self):
+        store.add_connected_repo("Acme", "Widget", root=self.root)
+        store.add_connected_repo("acme", "widget", root=self.root)
+        self.assertEqual(len(self._repos()), 1)
+        # The FIRST spelling connected is the one kept — existing entries are
+        # never rewritten out from under their caches.
+        self.assertEqual((self._repos()[0]["owner"], self._repos()[0]["repo"]), ("Acme", "Widget"))
+
+    def test_permissions_update_reaches_the_differently_cased_entry(self):
+        store.add_connected_repo("Acme", "Widget", permissions={"push": False}, root=self.root)
+        store.add_connected_repo("acme", "widget", permissions={"push": True}, root=self.root)
+        self.assertEqual(len(self._repos()), 1)
+        self.assertEqual(self._repos()[0]["permissions"], {"push": True})
+
+    def test_set_repo_permissions_is_case_insensitive(self):
+        store.add_connected_repo("Acme", "Widget", root=self.root)
+        store.set_repo_permissions("ACME", "WIDGET", {"pull": True}, root=self.root)
+        self.assertEqual(self._repos()[0]["permissions"], {"pull": True})
+
+    def test_distinct_repos_are_still_distinct(self):
+        store.add_connected_repo("o", "alpha", root=self.root)
+        store.add_connected_repo("o", "beta", root=self.root)
+        self.assertEqual(len(self._repos()), 2)

--- a/website/src/apps/issue-radar/ConnectPanel.tsx
+++ b/website/src/apps/issue-radar/ConnectPanel.tsx
@@ -1,0 +1,669 @@
+// Shared "connect a source" panel — used by BOTH the first-run WelcomeCarousel
+// (as its last slide) and the ConnectRepoModal (the "connect another repo"
+// overlay), so the two flows can never drift apart.
+//
+// Layout, in two states:
+//
+//   1. Collapsed — a vertical stack of provider ROWS (horizontal bars), one per
+//      source. Replaced the single large GitHub square: a row list scales to N
+//      providers, a square does not.
+//
+//   2. Expanded (after picking GitHub) — the host card GROWS (see
+//      `EXPANDED_CARD` / how ConnectRepoModal and WelcomeCarousel apply it) and
+//      the body becomes two columns: the provider rows stay on the LEFT, and
+//      the RIGHT column holds everything GitHub-specific — the user's
+//      recently-pushed repos as a MULTI-select, plus the manual URL entry
+//      beneath them. The URL field sits on the right (not under the provider
+//      rows) because pasting a repo link is part of the GitHub flow, not a
+//      footer of the provider list. Pasting a URL and ticking repos are
+//      additive — the Connect action submits every selected target, so a user
+//      can add a repo that isn't in the recent list without losing their ticks.
+//
+// Only GitHub is wired to a backend today (Issue Radar reads issues through the
+// user's own `gh` CLI). GitLab/Jira/Linear render as rows with a "Soon" badge
+// and are non-selectable — visible roadmap, not a dead end that 404s.
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, Check, Orbit, RefreshCw, SquareKanban } from 'lucide-react'
+import { issueRadarApi, type GhSetupReason, type RecentRepo } from './api'
+import { relativeTimeOrDate } from './lib/format'
+import GithubLogo from '../../components/icons/GithubLogo'
+import GitlabLogo from '../../components/icons/GitlabLogo'
+
+export type ProviderId = 'github' | 'gitlab' | 'jira' | 'linear'
+
+/** Tailwind classes for the host card in each state — exported so the carousel
+ * and the modal stay dimensionally identical without duplicating the numbers.
+ * FIXED heights (h-, not min-h-): the expanded card must not grow or shrink
+ * when the async repo list resolves, so its box is reserved up front. The
+ * expanded height is sized to fit header + list + URL row + nav footer; the
+ * hosts additionally clip their body (min-h-0 + overflow-y-auto) so a content
+ * overrun can never push the Back/Connect row past the card edge.
+ *
+ * `max-w-full max-h-full` bounds both boxes to the overlay container (the
+ * Issue Radar app area, which is what the modal/carousel cover): the fixed
+ * 860x540 exceeds a narrow or short app viewport, and without the cap the
+ * dismiss and Connect controls get clipped off-screen with no way to reach
+ * them. Under the cap the body scrolls internally instead. */
+export const COLLAPSED_CARD = 'w-[480px] h-[420px] max-w-full max-h-full'
+export const EXPANDED_CARD = 'w-[860px] h-[540px] max-w-full max-h-full'
+
+/** Width of the provider list. Full-card-width rows read as oversized banners
+ * (a 480px-wide row for the word "GitHub"), so the column is capped and
+ * centred when collapsed.
+ *
+ * `w-full max-w-[300px]`, not a fixed `w-[300px]`: once the card is capped by
+ * `max-w-full` on a narrow viewport, a rigid 300px column plus a gap consumed
+ * the whole row and left the repo picker and URL field at zero width — i.e.
+ * unusable. Capped instead, the two columns share what's actually available. */
+const PROVIDER_COL = 'w-full max-w-[300px]'
+
+/** Below this card width the two-column expanded layout stops working — a
+ * 132px provider column plus a gap leaves the picker ~64px wide, i.e. unusable
+ * — so the columns STACK and the body scrolls instead. A container query on the
+ * card is not available here (the breakpoint must react to the card, not the
+ * window, since the modal is scoped to the app area), so the panel measures its
+ * own width. */
+const STACK_BELOW_PX = 640
+
+/** Only repos pushed to within this trailing window appear in the picker. The
+ * server applies the cutoff (GitHub's user/repos can sort but not filter by
+ * date), so this is passed through as the `days` query param. */
+export const RECENT_WINDOW_DAYS = 30
+
+/** Marks a ConnectTarget that came from the typed URL rather than a tick, so a
+ * successful connect can clear the input the same way it clears a tick. */
+const URL_TARGET_PREFIX = 'url:'
+
+/** Case-folded `owner/repo` identity for a GitHub repo URL, or null when the
+ * text isn't one. Used to dedupe a typed URL against the ticked repos.
+ *
+ * A literal string compare missed every spelling that resolves to the SAME
+ * repo — `WWW.`/`www.` host, a `.git` suffix, a trailing slash, or different
+ * casing (GitHub names are case-preserving but not case-sensitive). Each miss
+ * submitted a second connect for a repo already in the list, which the server
+ * then rejects as already connected — or, worse, stores under a second casing. */
+export function repoIdentity(text: string): string | null {
+  const parsed = parseRepoRef(text)
+  return parsed && `${parsed.owner}/${parsed.repo}`.toLowerCase()
+}
+
+/** The owner/repo of a GitHub repo reference, with its ORIGINAL casing intact,
+ * or null when the text isn't one.
+ *
+ * Case is preserved deliberately: the backend stores `owner`/`repo` verbatim,
+ * so submitting a folded `acme/widget` for an already-connected `Acme/Widget`
+ * appends a SECOND entry with its own caches and settings. Folding is for
+ * comparison only — see repoIdentity. */
+export function parseRepoRef(text: string): { owner: string; repo: string } | null {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+  // Tolerate a bare `owner/repo` and a scheme-less host, which is what people
+  // paste about as often as a full URL. A first segment with no dot cannot be a
+  // hostname, so it is treated as an owner on github.com.
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+  const looksHostless = !hasScheme && !trimmed.split('/')[0].includes('.')
+  const withScheme = hasScheme
+    ? trimmed
+    : looksHostless ? `https://github.com/${trimmed}` : `https://${trimmed}`
+  let host: string
+  let path: string
+  try {
+    const u = new URL(withScheme)
+    host = u.hostname.toLowerCase().replace(/^www\./, '')
+    path = u.pathname
+  } catch {
+    return null
+  }
+  if (host && host !== 'github.com') return null
+  // Trailing slashes come off FIRST: `.../repo.git/` would otherwise keep its
+  // `.git` (the anchor never matches) and count as a second, distinct repo.
+  const parts = path.replace(/\/+$/, '').replace(/\.git$/i, '').split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  return { owner: parts[0], repo: parts[1] }
+}
+
+interface Provider {
+  id: ProviderId
+  label: string
+  icon: React.ReactNode
+  /** false → rendered with a "Soon" badge and not selectable. */
+  available: boolean
+}
+
+// GitHub and GitLab reuse the repo's existing brand-mark components. Jira and
+// Linear use lucide glyphs instead: the `use-lucide-icons` rule forbids adding
+// hand-rolled SVG paths, and no brand marks for them exist in the repo yet.
+// They are placeholders next to a "Soon" badge, so a representative glyph
+// (board / orbit) reads acceptably until either provider is actually wired up.
+const PROVIDERS: Provider[] = [
+  { id: 'github', label: 'GitHub', icon: <GithubLogo size={18} />, available: true },
+  { id: 'gitlab', label: 'GitLab', icon: <GitlabLogo size={18} />, available: false },
+  { id: 'jira', label: 'Jira', icon: <SquareKanban size={18} />, available: false },
+  { id: 'linear', label: 'Linear', icon: <Orbit size={18} />, available: false },
+]
+
+/** One connect target: either a ticked recent repo or the manually typed URL. */
+export interface ConnectTarget {
+  key: string
+  /** What `POST /connect` receives — it parses owner/repo out of the URL. */
+  url: string
+  label: string
+}
+
+export interface ConnectFlow {
+  provider: ProviderId | null
+  selectProvider: (p: ProviderId) => void
+  /** Clear the provider (drives the carousel's two-level Back). */
+  clearProvider: () => void
+  url: string
+  setUrl: (u: string) => void
+  /** `owner/repo` keys ticked in the recent-repos column. */
+  picked: Set<string>
+  togglePicked: (fullName: string) => void
+  targets: ConnectTarget[]
+  submit: () => void
+  pending: boolean
+  /** Aggregate error text (per-target failures are joined), or null. */
+  error: string | null
+  /** "Connecting 2 of 3…" progress while a multi-connect runs. */
+  progress: { done: number; total: number } | null
+  /** Drop every queued target (ticks + typed URL). Used when the panel learns
+   * nothing is connectable, so Connect can't be armed for a certain failure. */
+  reset: () => void
+}
+
+/** Owns every piece of connect state the host card's action button needs.
+ * Lifted into a hook (not kept inside the panel) because both hosts render the
+ * Connect button OUTSIDE the panel body — the carousel in its nav row, the
+ * modal in its footer. */
+export function useConnectFlow(onConnected: (repo: { owner: string; repo: string }) => void): ConnectFlow {
+  const queryClient = useQueryClient()
+  const [provider, setProvider] = useState<ProviderId | null>(null)
+  const [url, setUrl] = useState('')
+  const [picked, setPicked] = useState<Set<string>>(() => new Set())
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
+
+  // The connect loop is sequential and long-lived, so it outlives its host: an
+  // SPA navigation (or any unmount the pending-dismissal guard can't intercept)
+  // leaves it connecting the remaining repos with no visible progress and
+  // nowhere to report a failure. This flag makes it stop at the next boundary.
+  const cancelledRef = useRef(false)
+  useEffect(() => {
+    // Reset on SETUP, not just on teardown: React StrictMode runs
+    // mount→cleanup→mount in development, so a teardown-only version left the
+    // flag latched true and every subsequent connect bailed before its first
+    // request.
+    cancelledRef.current = false
+    return () => { cancelledRef.current = true }
+  }, [])
+  /** Size of the batch handed to `submit`, so completion can be verified
+   * against what was actually dispatched rather than what's left selected. */
+  const targetCountRef = useRef(0)
+
+  const targets = useMemo<ConnectTarget[]>(() => {
+    const out: ConnectTarget[] = [...picked].map((fullName) => ({
+      key: fullName,
+      url: `https://github.com/${fullName}`,
+      label: fullName,
+    }))
+    const typed = url.trim()
+    // A typed URL that duplicates a tick is submitted once, not twice — matched
+    // on normalised owner/repo identity, not raw text (see repoIdentity).
+    if (typed) {
+      const typedId = repoIdentity(typed)
+      const already = typedId !== null && out.some((t) => repoIdentity(t.url) === typedId)
+      if (!already) {
+        // Submit the CANONICAL url when the text parses — `parseRepoRef` accepts
+        // shorthand the backend does not (a bare `owner/repo`, a scheme-less
+        // host), which would come back as a 400 from its URL parser. Case is
+        // taken from `parseRepoRef`, NOT the folded identity: the backend stores
+        // owner/repo verbatim, so a folded name would be persisted as a second,
+        // separate repo. Unparseable text is submitted as-is so the server's
+        // error stays the honest one.
+        const ref = parseRepoRef(typed)
+        const url = ref ? `https://github.com/${ref.owner}/${ref.repo}` : typed
+        out.push({ key: `${URL_TARGET_PREFIX}${typed}`, url, label: typed })
+      }
+    }
+    return out
+  }, [picked, url])
+
+  const connectMutation = useMutation({
+    mutationFn: async (list: ConnectTarget[]) => {
+      // Sequential, not Promise.all: each connect shells out to `gh`, and a
+      // burst of parallel calls just fights over the rate limit. Failures are
+      // collected rather than thrown so one bad URL can't discard the repos
+      // that DID connect.
+      const failures: string[] = []
+      const succeeded: string[] = []
+      let first: { owner: string; repo: string } | null = null
+      for (let i = 0; i < list.length; i++) {
+        // Checked BEFORE each request, so at most the in-flight one completes.
+        if (cancelledRef.current) break
+        setProgress({ done: i, total: list.length })
+        try {
+          const res = await issueRadarApi.connect(list[i].url)
+          succeeded.push(list[i].key)
+          if (!first) first = { owner: res.owner, repo: res.repo }
+        } catch (e) {
+          failures.push(`${list[i].label}: ${(e as Error).message}`)
+        }
+      }
+      setProgress(null)
+      // `cancelled` is distinct from `failures`: a batch cut short by unmount
+      // can have zero failures and still be incomplete, and reporting that as a
+      // full success would close the flow over silently skipped targets.
+      return { first, failures, succeeded, cancelled: cancelledRef.current }
+    },
+    onSuccess: ({ first, failures, succeeded, cancelled }) => {
+      setErrors(failures)
+      // Drop EVERY target that made it — ticked repos and the typed URL alike —
+      // so the leftover selection is exactly what still needs attention. The
+      // typed URL used to survive its own success and be resubmitted on the
+      // next click, failing the second time as "already connected".
+      if (succeeded.length) {
+        const succeededKeys = new Set(succeeded)
+        setPicked((prev) => {
+          const next = new Set(prev)
+          for (const key of succeededKeys) next.delete(key)
+          return next
+        })
+        if ([...succeededKeys].some((k) => k.startsWith(URL_TARGET_PREFIX))) setUrl('')
+        // This picker's "Connected" rows are now stale, so refresh them even on
+        // a partial failure — the dialog stays open and must not offer a repo it
+        // just connected.
+        queryClient.invalidateQueries({ queryKey: ['issue-radar', 'recent-repos'] })
+        // `repos`, by contrast, is deferred to the all-succeeded path below: on
+        // FIRST RUN it is what decides whether onboarding is still showing, so
+        // invalidating it mid-partial-failure unmounts the carousel and takes
+        // the unread error list with it.
+      }
+      // Only hand control back — which closes the dialog / leaves onboarding —
+      // when EVERY target succeeded. On a partial failure the dialog has to
+      // stay open, otherwise it unmounts with the error list still unread and
+      // a bulk connect looks like it fully succeeded.
+      const complete = !cancelled && failures.length === 0 && succeeded.length === targetCountRef.current
+      if (first && complete) {
+        queryClient.invalidateQueries({ queryKey: ['issue-radar', 'repos'] })
+        onConnected(first)
+      }
+    },
+    onError: (e) => {
+      setProgress(null)
+      setErrors([(e as Error).message])
+    },
+  })
+
+  return {
+    provider,
+    selectProvider: (p) => setProvider(p),
+    clearProvider: () => setProvider(null),
+    url,
+    setUrl,
+    picked,
+    togglePicked: (fullName) => setPicked((prev) => {
+      const next = new Set(prev)
+      if (next.has(fullName)) next.delete(fullName)
+      else next.add(fullName)
+      return next
+    }),
+    targets,
+    submit: () => {
+      if (!targets.length || connectMutation.isPending) return
+      setErrors([])
+      targetCountRef.current = targets.length
+      connectMutation.mutate(targets)
+    },
+    pending: connectMutation.isPending,
+    error: errors.length ? errors.join(' · ') : null,
+    progress,
+    reset: () => {
+      setPicked((prev) => (prev.size ? new Set() : prev))
+      setUrl((prev) => (prev ? '' : prev))
+    },
+  }
+}
+
+/** The panel body. Collapsed = provider rows only; expanded = rows on the left,
+ * repo multi-select (or setup notice) on the right.
+ *
+ * The recent-repos query lives HERE, not inside the picker, because its result
+ * gates more than the list: when `gh` isn't set up there is nothing the user
+ * can usefully connect, so the manual URL field is hidden too (pasting a URL
+ * would just fail the same way) and the whole right column becomes the setup
+ * notice. */
+export default function ConnectPanel({ flow }: { flow: ConnectFlow }) {
+  const expanded = flow.provider === 'github'
+
+  const query = useQuery({
+    queryKey: ['issue-radar', 'recent-repos', RECENT_WINDOW_DAYS],
+    queryFn: () => issueRadarApi.recentRepos(RECENT_WINDOW_DAYS),
+    // Only fetch once the GitHub panel is actually open, and don't re-shell out
+    // to `gh` on every window focus.
+    enabled: expanded,
+    refetchOnWindowFocus: false,
+  })
+  const setupRequired = query.data?.setup_required ?? null
+
+  // Nothing here is connectable without a working `gh`, so any target the user
+  // picked before the query resolved is now a guaranteed failure — and the URL
+  // field it may have come from is gone, leaving no way to clear it. Dropping
+  // them disables Connect instead of arming it for a certain 502.
+  useEffect(() => {
+    if (setupRequired) flow.reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setupRequired])
+
+  // Stack the columns on a narrow card — see STACK_BELOW_PX.
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const [stacked, setStacked] = useState(false)
+  useEffect(() => {
+    const el = bodyRef.current
+    if (!el || !expanded) return
+    const measure = () => setStacked(el.clientWidth > 0 && el.clientWidth < STACK_BELOW_PX)
+    measure()
+    // ResizeObserver, not a window listener: the card itself resizes when the
+    // provider expands, with no window event to hook.
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [expanded])
+
+  return (
+    <div className="flex flex-col gap-4 w-full flex-1 min-h-0 text-left">
+      <div className="text-center flex-shrink-0">
+        <div className="text-[20px] font-bold text-text tracking-[-0.2px]">Let's Connect a Provider</div>
+        <div className="text-[13.5px] text-muted leading-[1.7] mt-1.5">
+          Connect a provider. Nothing runs without your say.
+        </div>
+      </div>
+
+      {/* The columns row absorbs the card's remaining height (flex-1 min-h-0)
+       * and the repo list inside it flexes, so the URL row below can never be
+       * pushed out of the card — earlier this was a fixed 240px list plus a
+       * fixed URL block, whose combined height overran the card by a few px
+       * and got clipped. */}
+      <div
+        ref={bodyRef}
+        className={`flex-1 min-h-0 flex ${
+          expanded
+            ? stacked ? 'flex-col gap-4 overflow-y-auto' : 'gap-5'
+            : 'justify-center'
+        }`}
+      >
+        <div className={`${PROVIDER_COL} ${expanded && !stacked ? 'min-w-[180px]' : 'flex-shrink-0'} self-start flex flex-col gap-1.5`}>
+          {PROVIDERS.map((p) => (
+            <ProviderRow
+              key={p.id}
+              provider={p}
+              selected={flow.provider === p.id}
+              onSelect={() => flow.selectProvider(p.id)}
+            />
+          ))}
+        </div>
+
+        {/* Right column — everything GitHub-specific: the repo multi-select (or
+         * the setup notice) and, when usable, the manual URL entry. */}
+        {expanded && (
+          <div
+            className={`flex-1 min-w-0 flex flex-col gap-3 ${
+              stacked ? 'border-t border-border pt-4 min-h-[220px]' : 'min-h-0 border-l border-border pl-5'
+            }`}
+          >
+            <RecentRepoPicker
+              picked={flow.picked}
+              onToggle={flow.togglePicked}
+              // submit() snapshots the target list, so a tick added mid-flight
+              // is silently dropped when a full success closes the dialog.
+              // Freezing the controls makes the in-flight set the real one.
+              disabled={flow.pending}
+              repos={query.data?.repos ?? []}
+              truncated={query.data?.truncated ?? false}
+              setupRequired={setupRequired}
+              isLoading={query.isLoading}
+              error={query.isError ? (query.error as Error).message : null}
+              detail={query.data?.error ?? null}
+              onRetry={() => query.refetch()}
+            />
+
+            {!setupRequired && (
+              <div className="flex flex-col gap-2 border-t border-border pt-3 flex-shrink-0">
+                <span className="text-[11px] font-semibold text-muted uppercase tracking-[.08em] opacity-70">
+                  Or paste a URL
+                </span>
+                <input
+                  id="ir-repo-url"
+                  aria-label="Repository URL"
+                  value={flow.url}
+                  onChange={(e) => flow.setUrl(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') flow.submit() }}
+                  disabled={flow.pending}
+                  placeholder="https://github.com/<owner>/<repo>"
+                  className="w-full box-border text-[12.5px] px-3 py-2 rounded-md bg-bg text-text border border-border font-mono disabled:opacity-50"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {flow.error && (
+        <div className="flex items-start gap-1.5 text-danger text-xs flex-shrink-0">
+          <AlertCircle size={13} className="flex-shrink-0 mt-0.5" />
+          <span className="break-words">{flow.error}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProviderRow({ provider, selected, onSelect }: {
+  provider: Provider; selected: boolean; onSelect: () => void
+}) {
+  const disabled = !provider.available
+  return (
+    <button
+      onClick={disabled ? undefined : onSelect}
+      disabled={disabled}
+      aria-pressed={selected}
+      className={`w-full flex items-center gap-3 px-3 h-10 flex-shrink-0 rounded-md border text-left transition-colors ${
+        disabled
+          ? 'border-border bg-transparent opacity-45 cursor-default'
+          : selected
+            ? 'border-accent bg-accent-subtle cursor-pointer'
+            : 'border-border bg-transparent hover:bg-bg-hover cursor-pointer'
+      }`}
+    >
+      <span className={`flex-shrink-0 ${selected ? 'text-accent' : 'text-text'}`}>{provider.icon}</span>
+      <span className="flex-1 min-w-0 text-[13px] font-semibold text-text truncate">
+        {provider.label}
+      </span>
+      {disabled
+        ? <span className="flex-shrink-0 text-[10px] font-semibold text-muted uppercase tracking-[.08em] px-1.5 py-0.5 rounded border border-border">Soon</span>
+        : selected
+          ? <Check size={14} className="flex-shrink-0 text-accent" />
+          : null}
+    </button>
+  )
+}
+
+/** Right column: repos the user personally contributed to in the window,
+ * multi-select. Presentational — the query lives in ConnectPanel (see there).
+ *
+ * The scroll area is a FIXED height (not min/max): the card must not resize
+ * when the repo list arrives, so every state — loading, setup notice, error,
+ * empty, loaded — occupies exactly the same box. */
+function RecentRepoPicker({
+  picked, onToggle, repos, truncated, setupRequired, isLoading, error, detail, onRetry, disabled,
+}: {
+  picked: Set<string>
+  onToggle: (fullName: string) => void
+  repos: RecentRepo[]
+  truncated: boolean
+  setupRequired: GhSetupReason | null
+  isLoading: boolean
+  error: string | null
+  detail: string | null
+  onRetry: () => void
+  /** True while a connect is in flight — rows stop accepting changes. */
+  disabled: boolean
+}) {
+  const showList = !isLoading && !error && !setupRequired
+  // Never claim a count when the feed was truncated: repos contributed to
+  // earlier in the window may be missing, and a picker that looks exhaustive
+  // makes the user conclude they didn't work on a repo they did.
+  const countLabel = picked.size > 0
+    ? `${picked.size} selected`
+    : showList
+      ? (truncated ? 'most recent activity' : `${repos.length} found`)
+      : ''
+
+  return (
+    <div className="flex flex-col gap-2 flex-1 min-h-0">
+      {/* Header row is suppressed in the setup-error state: a "GITHUB CLI"
+       * column label above an error message is noise, and the row would only
+       * push the message further down. The h-4 spacer is kept so the right
+       * column still lines up with the provider list. */}
+      <div className="flex items-center justify-between gap-2 h-4 flex-shrink-0">
+        {!setupRequired && (
+          <>
+            <span className="text-[11px] font-semibold text-muted uppercase tracking-[.08em] opacity-70">
+              You contributed to
+            </span>
+            <span className="text-[11px] text-muted">{countLabel}</span>
+          </>
+        )}
+      </div>
+
+      {/* flex-1 min-h-0, not a fixed height: the card's height is what's fixed,
+       * so the list absorbs whatever is left after the header and the URL row.
+       * The card therefore still never resizes when the list resolves, and the
+       * URL row can never be pushed past the card edge. */}
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1 pr-0.5">
+        {isLoading && (
+          <div className="flex items-center gap-2 text-muted text-xs h-full justify-center">
+            <RefreshCw size={12} className="animate-spin" /> Loading your repos…
+          </div>
+        )}
+        {error && !setupRequired && (
+          <div className="text-xs text-danger h-full flex items-center justify-center text-center px-2">
+            {error}
+          </div>
+        )}
+        {setupRequired && <GhSetupNotice detail={detail} onRetry={onRetry} />}
+        {showList && repos.length === 0 && (
+          <div className="text-xs text-muted h-full flex items-center justify-center text-center px-3 leading-[1.6]">
+            {/* Never claim the month was empty when the feed was truncated: the
+              * user's contributions may simply lie beyond the fetched window,
+              * and telling them they did nothing is a plain falsehood. */}
+            {truncated
+              ? 'Couldn\u2019t read far enough back through your activity \u2014 paste a URL below instead.'
+              : 'No contributions in the last month \u2014 paste a URL below instead.'}
+          </div>
+        )}
+        {showList && repos.map((r) => (
+          <RepoRow
+            key={r.full_name}
+            repo={r}
+            checked={picked.has(r.full_name)}
+            onToggle={() => onToggle(r.full_name)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Shown instead of the repo list when the host has no usable `gh`. Issue Radar
+ * reads GitHub exclusively through the user's own CLI session, so there is no
+ * in-app fallback and nothing to connect — one plain "set it up" message, the
+ * same for every underlying cause (binary missing, rejected by trust
+ * validation, or not signed in). The server's specific diagnostic stays in the
+ * collapsible Details block for anyone who needs it.
+ *
+ * Left-aligned and top-anchored: centred text in a tall box reads as a stray
+ * fragment floating mid-column, and it broke alignment with the provider list
+ * across the divider. */
+function GhSetupNotice({ detail, onRetry }: { detail: string | null; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2 text-left pr-2">
+      <AlertCircle size={18} className="text-danger flex-shrink-0" />
+      <p className="text-[13px] font-semibold text-text">Please set up the GitHub CLI</p>
+      <p className="text-[11.5px] text-muted leading-[1.6]">
+        Issue Radar reads GitHub through your own <code>gh</code> session. Install and sign in to{' '}
+        <code>gh</code>, then{' '}
+        <button
+          onClick={onRetry}
+          className="underline text-accent bg-transparent border-0 p-0 cursor-pointer text-[11.5px]"
+        >
+          check again
+        </button>
+        .
+      </p>
+      {detail && (
+        <details className="text-[10.5px] text-muted opacity-60 max-w-full">
+          <summary className="cursor-pointer">Details</summary>
+          <p className="mt-1 leading-[1.5] break-words">{detail}</p>
+        </details>
+      )}
+    </div>
+  )
+}
+
+/** One picker row. Fixed height (h-9) so the list's scroll extent — and
+ * therefore the card — is identical whether rows carry long or short names. */
+function RepoRow({ repo, checked, onToggle, disabled }: {
+  repo: RecentRepo; checked: boolean; onToggle: () => void; disabled: boolean
+}) {
+  const inputId = useId()
+  const when = repo.last_contributed_at ? relativeTimeOrDate(repo.last_contributed_at) : ''
+
+  if (repo.connected) {
+    return (
+      <div className="flex items-center gap-2.5 px-2.5 h-9 flex-shrink-0 rounded-md opacity-45">
+        <Check size={13} className="flex-shrink-0 text-accent" />
+        <span className="flex-1 min-w-0 text-[12.5px] text-text truncate font-mono">{repo.full_name}</span>
+        <span className="flex-shrink-0 text-[10.5px] text-muted">Connected</span>
+      </div>
+    )
+  }
+
+  // `useId`, not a slug derived from the repo name: sanitising punctuation to
+  // `-` was NOT injective, so legitimately distinct names collided (`a.b` and
+  // `a-b` both became `a-b`) and clicking one row's label toggled the other
+  // row's checkbox. The input is also nested inside the label, which the
+  // `label-has-for` rule requires alongside the id.
+  return (
+    <label
+      htmlFor={inputId}
+      className={`flex items-center gap-2.5 px-2.5 h-9 flex-shrink-0 rounded-md border ${
+        disabled ? 'cursor-default opacity-50' : 'cursor-pointer'
+      } ${checked ? 'border-accent bg-accent-subtle' : 'border-transparent hover:bg-bg-hover'}`}
+    >
+      <input
+        id={inputId}
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        disabled={disabled}
+        aria-label={`Select ${repo.full_name}`}
+        className="flex-shrink-0 accent-[var(--accent)] cursor-pointer disabled:cursor-default"
+      />
+      <span className="flex-1 min-w-0 text-[12.5px] text-text truncate font-mono">
+        {repo.full_name}
+      </span>
+      <span
+        className="flex-shrink-0 text-[10.5px] text-muted"
+        title={repo.last_contributed_at
+          ? `Your last contribution: ${new Date(repo.last_contributed_at).toLocaleString()}`
+          : undefined}
+      >
+        {when}
+      </span>
+    </label>
+  )
+}

--- a/website/src/apps/issue-radar/ConnectRepoModal.tsx
+++ b/website/src/apps/issue-radar/ConnectRepoModal.tsx
@@ -1,0 +1,198 @@
+// Connect-a-repo modal — the LAST slide of the WelcomeCarousel (the connect
+// card) lifted out on its own and overlaid on top of the current Issue Radar
+// view (typically the Settings page), which shows through as a blurred
+// backdrop. Used for "connect ANOTHER repo" once at least one repo is already
+// connected; the full-screen WelcomeCarousel is reserved for the first-run
+// (no repos) onboarding.
+//
+// The card body is the SHARED <ConnectPanel> (provider rows + repo
+// multi-select), and the connect state lives in the shared `useConnectFlow`
+// hook — because the Connect button renders in this card's footer, OUTSIDE the
+// panel. Picking GitHub grows the card from COLLAPSED_CARD to EXPANDED_CARD so
+// the repo column has room.
+//
+// Scope note: this is `absolute inset-0`, not `fixed`, so the blur covers only
+// the Issue Radar app area (its `relative` wrapper in IssueRadarPage) rather
+// than the whole KiroCrew window — the settings page becomes the blurred
+// backdrop, per product intent.
+//
+// Motion is Framer Motion (not CSS keyframe animations) per the frontend rule:
+// only AnimatePresence can hold the dialog in the DOM long enough to play an
+// exit animation on unmount.
+import { useCallback, useEffect, useRef } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { RefreshCw, X } from 'lucide-react'
+import ConnectPanel, { COLLAPSED_CARD, EXPANDED_CARD, useConnectFlow } from './ConnectPanel'
+import { useIssueRadar } from './context'
+import Clickable from '../../components/Clickable'
+
+/** Focusable descendants of the dialog, in DOM order, skipping disabled ones. */
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), ' +
+  'textarea:not([disabled]), summary, [tabindex]:not([tabindex="-1"])'
+
+export default function ConnectRepoModal({
+  onConnected,
+  onClose,
+}: {
+  onConnected: (repo: { owner: string; repo: string }) => void
+  onClose: () => void
+}) {
+  // This modal only ever renders inside <IssueRadarProvider> (see
+  // IssueRadarPage), so the workspace's view state is live here. After a
+  // successful connect we switch to the issue list ourselves rather than
+  // relying on the persisted hint IssueRadarPage writes — the provider is
+  // already mounted, so it would overwrite that hint with its current view on
+  // the next render. Same for the OPEN filter: the auto-selected first issue
+  // should be an open one, not whatever a leftover "closed" filter surfaces.
+  const {
+    openIssues, setSelectedIssue, setStateFilter, setQuery, clearFilters,
+    setSelectedPull, setPrQuery, clearPrFilters,
+  } = useIssueRadar()
+  const flow = useConnectFlow((repo) => {
+    setSelectedIssue(null)
+    // The previous repo's search text and label/member filters would otherwise
+    // carry over and can exclude every issue in the new repo.
+    setQuery('')
+    clearFilters()
+    setStateFilter('open')
+    // Same reset on the PR side, mirroring `switchRepo` and the persisted path
+    // in IssueRadarPage. `selectedPull` matters most: it's a NUMBER, so a
+    // leftover #42 silently auto-opens the new repo's unrelated #42.
+    setSelectedPull(null)
+    setPrQuery('')
+    clearPrFilters()
+    openIssues()
+    onConnected(repo)
+  })
+  const expanded = flow.provider === 'github'
+  const count = flow.targets.length
+
+  const dialogRef = useRef<HTMLDivElement>(null)
+  // Whatever had focus before the dialog opened, restored on close so keyboard
+  // users don't get dumped at the top of the document.
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+
+  // Dismissal is BLOCKED while a connect is in flight: closing only unmounts
+  // the UI, it does not cancel the sequential fetch loop, so repos would keep
+  // connecting (and the success callback would still fire) after the user
+  // thought they'd cancelled.
+  const requestClose = useCallback(() => {
+    if (flow.pending) return
+    onClose()
+  }, [flow.pending, onClose])
+
+  // Move focus into the dialog on open, restore it on close.
+  useEffect(() => {
+    restoreFocusRef.current = document.activeElement as HTMLElement | null
+    const first = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE)
+    ;(first ?? dialogRef.current)?.focus()
+    return () => restoreFocusRef.current?.focus?.()
+  }, [])
+
+  // Escape to dismiss, and Tab/Shift+Tab cycle WITHIN the dialog — an
+  // aria-modal dialog that lets focus wander behind the overlay would let
+  // keyboard users activate obscured workspace controls.
+  //
+  // CAPTURE phase: the dialog stops keydown propagation so the workspace's own
+  // shortcuts (j/k navigation, `/` to search) don't fire while the user types a
+  // repo URL. A bubble-phase window listener would therefore never see Escape
+  // or Tab from inside the dialog, breaking both dismissal and the focus trap.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        requestClose()
+        return
+      }
+      if (e.key !== 'Tab' || !dialogRef.current) return
+      const items = Array.from(dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE))
+        .filter((el) => el.offsetParent !== null)
+      if (!items.length) return
+      const firstEl = items[0]
+      const lastEl = items[items.length - 1]
+      const active = document.activeElement
+      if (!e.shiftKey && active === lastEl) {
+        e.preventDefault()
+        firstEl.focus()
+      } else if (e.shiftKey && (active === firstEl || active === dialogRef.current)) {
+        e.preventDefault()
+        lastEl.focus()
+      } else if (!dialogRef.current.contains(active)) {
+        e.preventDefault()
+        firstEl.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [requestClose])
+
+  return (
+    <AnimatePresence>
+      {/* The backdrop and the dialog are SIBLINGS inside a non-interactive
+        * container. Wrapping the dialog in the <Clickable> backdrop gave every
+        * control inside it a `button` ancestor, which assistive technology can
+        * treat as one flattened widget and suppress the descendant semantics
+        * (the role="dialog", the checkboxes, the text input). */}
+      <div className="absolute inset-0 z-50 flex items-center justify-center p-3">
+        <Clickable
+          className="absolute inset-0 bg-bg/50 backdrop-blur-sm"
+          onClick={requestClose}
+          aria-label="Close connect dialog"
+        />
+        <motion.div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Connect a provider"
+          tabIndex={-1}
+          initial={{ opacity: 0, y: 8, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 8, scale: 0.98 }}
+          transition={{ duration: 0.18, ease: 'easeOut' }}
+          className={`relative border border-border rounded-[14px] bg-card flex flex-col items-center justify-between p-10 shadow-2xl outline-none transition-[width,height] duration-200 ease-out ${
+            expanded ? EXPANDED_CARD : COLLAPSED_CARD
+          }`}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <button
+            onClick={requestClose}
+            disabled={flow.pending}
+            aria-label="Close"
+            className="absolute top-3 right-3 p-1.5 rounded-md text-muted hover:text-text hover:bg-bg-hover cursor-pointer bg-transparent border-0 disabled:opacity-30 disabled:cursor-default"
+          >
+            <X size={16} />
+          </button>
+
+          {/* min-h-0 + overflow-y-auto: the footer row below is a sibling, so
+           * without constraining the body here a taller-than-expected body — or
+           * a card capped by max-h on a short viewport — would push
+           * Back/Connect past the card's height and out of reach. It scrolls
+           * rather than clips so capped content stays reachable.
+           * Top-anchored for the same reason as the carousel's connect slide —
+           * centring left a lopsided gap above the title. */}
+          <div className="flex-1 min-h-0 overflow-y-auto flex flex-col items-center justify-start gap-3.5 w-full">
+            <ConnectPanel flow={flow} />
+          </div>
+
+          {/* Footer action row — Connect sits bottom-right, mirroring the slot
+           * Next/Connect occupy in the carousel. Only shown once a provider is
+           * chosen; before that the provider rows are the only action. */}
+          <div className="flex items-center justify-end w-full pt-3 min-h-[34px] flex-shrink-0">
+            {flow.provider && (
+              <button
+                onClick={flow.submit}
+                disabled={count === 0 || flow.pending}
+                className="min-w-[84px] inline-flex items-center justify-center gap-1 px-4 py-1.5 rounded-md border border-accent text-accent bg-transparent text-xs font-semibold cursor-pointer hover:bg-accent-subtle disabled:opacity-30"
+              >
+                <RefreshCw size={12} className={flow.pending ? 'animate-spin' : ''} />
+                {flow.progress
+                  ? `Connecting ${flow.progress.done + 1} of ${flow.progress.total}…`
+                  : count > 1 ? `Connect ${count}` : 'Connect'}
+              </button>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </AnimatePresence>
+  )
+}

--- a/website/src/apps/issue-radar/IssueRadarPage.tsx
+++ b/website/src/apps/issue-radar/IssueRadarPage.tsx
@@ -7,11 +7,12 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { issueRadarApi } from './api'
-import { loadActiveRepo, saveActiveRepo } from './lib/format'
+import { loadActiveRepo, markAutoSelectFirstIssue, patchUiState, saveActiveRepo } from './lib/format'
 import type { ActiveRepo } from './lib/types'
 import { IssueRadarProvider } from './context'
 import Workspace from './Workspace'
 import WelcomeCarousel from './WelcomeCarousel'
+import ConnectRepoModal from './ConnectRepoModal'
 
 export default function IssueRadarPage() {
   const queryClient = useQueryClient()
@@ -29,6 +30,38 @@ export default function IssueRadarPage() {
     saveActiveRepo(repo)
     setActive(repo)
     setConnectingNew(false)
+    // Land on the issue list, not wherever the user happened to be (typically
+    // Settings, since that's where "Connect repo" lives), showing OPEN issues
+    // so the auto-selected first issue is an open one. On first run the
+    // provider isn't mounted yet, so the intent is persisted for it to restore;
+    // when it IS already mounted, ConnectRepoModal switches the view live
+    // through the context.
+    patchUiState({
+      mainView: 'issues',
+      stateFilter: 'open',
+      selectedIssue: null,
+      // Filters from a previous session would otherwise apply to the new repo
+      // and can hide every issue in it.
+      query: '',
+      selectedLabels: [],
+      requestedByMe: false,
+      assignedToMe: false,
+      createdByMember: false,
+      // The PR side needs the same reset, and for a sharper reason than the
+      // issue side: `selectedPull` is a NUMBER, so a leftover #42 silently
+      // auto-opens the new repo's unrelated #42. Mirrors `switchRepo`.
+      selectedPull: null,
+      prQuery: '',
+      prSelectedLabels: [],
+      prAuthoredByMe: false,
+      prAssignedToMe: false,
+      prReviewRequestedByMe: false,
+      prDraftOnly: false,
+      prCreatedByMember: false,
+    })
+    // Open the first issue once the list resolves (consumed by the provider,
+    // but only once THIS repo is the active one — see markAutoSelectFirstIssue).
+    markAutoSelectFirstIssue(repo)
     queryClient.invalidateQueries({ queryKey: ['issue-radar', 'repos'] })
   }
 
@@ -36,7 +69,11 @@ export default function IssueRadarPage() {
     return <div className="flex h-full items-center justify-center text-muted text-xs">Loading…</div>
   }
 
-  if (repos.length === 0 || connectingNew) {
+  // First run (no repos yet): the full-screen onboarding carousel. Adding
+  // ANOTHER repo when some already exist instead overlays a modal on the
+  // current view (see connectingNew below), so the workspace/settings page
+  // stays put behind a blurred backdrop.
+  if (repos.length === 0) {
     return <WelcomeCarousel onConnected={onConnected} />
   }
 
@@ -51,7 +88,12 @@ export default function IssueRadarPage() {
       onSwitch={(r) => { saveActiveRepo(r); setActive(r) }}
       onAddRepo={() => setConnectingNew(true)}
     >
-      <Workspace />
+      <div className="relative h-full">
+        <Workspace />
+        {connectingNew && (
+          <ConnectRepoModal onConnected={onConnected} onClose={() => setConnectingNew(false)} />
+        )}
+      </div>
     </IssueRadarProvider>
   )
 }

--- a/website/src/apps/issue-radar/WelcomeCarousel.tsx
+++ b/website/src/apps/issue-radar/WelcomeCarousel.tsx
@@ -4,26 +4,26 @@
 // rocky/gas giants, hover tooltips, Carl Sagan quote). Themed onto this
 // project's --accent/--bg/--text tokens.
 //
-// The GitHub connect step is a SLIDE OF THIS CAROUSEL, not a separate
-// component rendered after it — putting it outside the carousel meant Back
-// stopped working once you reached it (the parent swapped WelcomeCarousel
-// out entirely). Keeping it as the last slide means Back always has
-// somewhere to go, all the way back to slide 0.
+// The connect step is a SLIDE OF THIS CAROUSEL, not a separate component
+// rendered after it — putting it outside the carousel meant Back stopped
+// working once you reached it (the parent swapped WelcomeCarousel out
+// entirely). Keeping it as the last slide means Back always has somewhere to
+// go, all the way back to slide 0.
 //
-// Choosing GitHub and filling in the repo URL happen on the SAME slide (not
-// a slide transition): the button morphs in place into logo-left +
-// input-field-right, per product decision. That sub-state (showConnectForm)
-// is lifted to THIS component rather than kept private inside the slide
-// component, because the parent's Back button needs to know about it — Back
-// on this slide must first collapse the form back to the button before it
-// pops the page, otherwise a user who opened the form and changed their mind
-// gets yanked all the way to the previous content slide instead of a single
-// step back.
+// That last slide's BODY is the shared <ConnectPanel> (provider rows +
+// recent-repo multi-select), and its state lives in the shared
+// `useConnectFlow` hook — shared with ConnectRepoModal so the first-run flow
+// and the "connect another repo" overlay can never drift apart. The hook is
+// called HERE rather than inside the slide because this component renders the
+// Connect button in its nav row (the slot Next occupies on content slides) and
+// its Back button needs to see the provider selection: Back on the connect
+// slide first clears the chosen provider (collapsing the card back down)
+// before it pops the page, otherwise a user who opened GitHub and changed
+// their mind gets yanked all the way to the previous content slide instead of
+// a single step back.
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import { Radar, Search, GitPullRequest, BookOpen, RefreshCw, ArrowLeft, ArrowRight } from 'lucide-react'
-import { issueRadarApi } from './api'
-import GithubLogo from '../../components/icons/GithubLogo'
+import ConnectPanel, { COLLAPSED_CARD, EXPANDED_CARD, useConnectFlow } from './ConnectPanel'
 
 interface Slide {
   title: string
@@ -72,46 +72,54 @@ const SLIDES: Slide[] = [
   },
 ]
 
-// One extra "slide" beyond SLIDES: the GitHub connect slide (button ->
-// expands in place into the connect form, see GithubConnectSlide below).
+// One extra "slide" beyond SLIDES: the connect slide (provider rows ->
+// expands in place into the repo picker, see ConnectPanel).
 const CONNECT_PAGE = SLIDES.length
 
 export default function WelcomeCarousel({ onConnected }: { onConnected: (repo: { owner: string; repo: string }) => void }) {
   const [page, setPage] = useState(0)
-  // Lifted out of GithubConnectSlide (see file-header comment) so Back's
-  // two-level pop (form -> button, then button -> previous slide) can see it.
-  const [showConnectForm, setShowConnectForm] = useState(false)
-  // Also lifted (form field + mutation, not just the open/closed flag): the
-  // Connect action now renders in the NAV ROW's Next-button slot (per
-  // product decision — "same position Next used to occupy"), not inside the
-  // slide's own content area, so the button that triggers submission has to
-  // live where the parent renders it.
-  const [repoUrl, setRepoUrl] = useState('')
-  const connectMutation = useMutation({
-    mutationFn: (url: string) => issueRadarApi.connect(url),
-    onSuccess: (data) => onConnected({ owner: data.owner, repo: data.repo }),
-  })
-  const submitConnect = () => {
-    if (!repoUrl.trim() || connectMutation.isPending) return
-    connectMutation.mutate(repoUrl.trim())
-  }
+  const flow = useConnectFlow(onConnected)
 
   const isContentSlide = page < SLIDES.length
   const isConnectSlide = page === CONNECT_PAGE
+  const expanded = isConnectSlide && flow.provider === 'github'
+  const targetCount = flow.targets.length
 
   const handleBack = () => {
-    if (isConnectSlide && showConnectForm) {
-      setShowConnectForm(false)
+    // Blocked while a connect is in flight, for the same reason the modal
+    // blocks dismissal: navigating away only changes the UI, it does not
+    // cancel the sequential fetch loop, so repos would keep connecting behind
+    // a screen that looks like the user backed out.
+    if (flow.pending) return
+    // Two-level pop on the connect slide: first collapse the provider
+    // selection (shrinking the card), only then leave the slide.
+    if (isConnectSlide && flow.provider) {
+      flow.clearProvider()
       return
     }
     setPage((p) => p - 1)
   }
 
   return (
-    <div className="relative flex h-full items-center justify-center bg-bg overflow-hidden">
+    <div className="relative flex h-full items-center justify-center bg-bg overflow-hidden p-3">
       <SolarSystemBackground />
-      <div className="relative z-10 border border-border rounded-[14px] bg-card w-[480px] min-h-[420px] flex flex-col items-center justify-between p-10 text-center">
-        <div className="flex-1 flex flex-col items-center justify-center gap-3.5 w-full">
+      <div
+        className={`relative z-10 border border-border rounded-[14px] bg-card flex flex-col items-center justify-between p-10 text-center transition-[width,min-height] duration-200 ease-out ${
+          expanded ? EXPANDED_CARD : COLLAPSED_CARD
+        }`}
+      >
+        {/* min-h-0 + overflow-hidden: the nav row below is a sibling, so
+         * without clipping here a taller-than-expected slide would push
+         * Back/Next past the card's fixed height and out of the window.
+         * The connect slide is TOP-anchored (justify-start) — centring a
+         * two-column form in a 540px card left a large, lopsided gap above the
+         * title. The five content slides stay centred, which suits their
+         * single icon + headline. */}
+        <div
+          className={`flex-1 min-h-0 overflow-y-auto flex flex-col items-center gap-3.5 w-full ${
+            isConnectSlide ? 'justify-start' : 'justify-center'
+          }`}
+        >
           {isContentSlide && (
             <div key={page} className="animate-[wc-fade_.2s_ease] flex flex-col items-center gap-3.5">
               <div className={`flex items-center justify-center h-20 text-accent ${SLIDES[page].animClass}`}>
@@ -121,22 +129,13 @@ export default function WelcomeCarousel({ onConnected }: { onConnected: (repo: {
               <div className="text-[13.5px] text-muted leading-[1.7] max-w-[380px]">{SLIDES[page].subtitle}</div>
             </div>
           )}
-          {isConnectSlide && (
-            <GithubConnectSlide
-              showConnectForm={showConnectForm}
-              onOpenConnectForm={() => setShowConnectForm(true)}
-              url={repoUrl}
-              onUrlChange={setRepoUrl}
-              onSubmit={submitConnect}
-              submitError={connectMutation.isError ? (connectMutation.error as Error).message : null}
-            />
-          )}
+          {isConnectSlide && <ConnectPanel flow={flow} />}
         </div>
 
-        <div className="flex items-center justify-between w-full pt-3">
+        <div className="flex items-center justify-between w-full pt-3 flex-shrink-0">
           <button
             onClick={handleBack}
-            disabled={page === 0}
+            disabled={page === 0 || flow.pending}
             className="min-w-[84px] px-4 py-1.5 rounded-md border border-border bg-bg text-text text-xs cursor-pointer disabled:opacity-30 disabled:cursor-default hover:bg-bg-hover"
           >
             <ArrowLeft size={12} className="lucide-inline" /> Back
@@ -149,13 +148,11 @@ export default function WelcomeCarousel({ onConnected }: { onConnected: (repo: {
               />
             ))}
           </div>
-          {/* This slot is Next on content slides, Connect on the connect
-           * slide once the form is open (per product decision — "same
-           * position Next used to occupy"), and an empty spacer on the
-           * connect slide's collapsed (button-only) state, where the
-           * GitHub button itself is the only action and lives in the
-           * content area instead. The shared min-width keeps Back/dots
-           * aligned across all three variants. */}
+          {/* This slot is Next on content slides, Connect on the connect slide
+           * once a provider is chosen (per product decision — "same position
+           * Next used to occupy"), and an empty spacer on the connect slide's
+           * collapsed state, where the provider rows are the only action. The
+           * shared min-width keeps Back/dots aligned across all three. */}
           {isContentSlide && (
             <button
               onClick={() => setPage((p) => p + 1)}
@@ -164,17 +161,19 @@ export default function WelcomeCarousel({ onConnected }: { onConnected: (repo: {
               Next <ArrowRight size={12} className="lucide-inline" />
             </button>
           )}
-          {isConnectSlide && showConnectForm && (
+          {isConnectSlide && flow.provider && (
             <button
-              onClick={submitConnect}
-              disabled={!repoUrl.trim() || connectMutation.isPending}
+              onClick={flow.submit}
+              disabled={targetCount === 0 || flow.pending}
               className="min-w-[84px] inline-flex items-center justify-center gap-1 px-4 py-1.5 rounded-md border border-accent text-accent bg-transparent text-xs font-semibold cursor-pointer hover:bg-accent-subtle disabled:opacity-30"
             >
-              <RefreshCw size={12} className={connectMutation.isPending ? 'animate-spin' : ''} />
-              Connect
+              <RefreshCw size={12} className={flow.pending ? 'animate-spin' : ''} />
+              {flow.progress
+                ? `Connecting ${flow.progress.done + 1} of ${flow.progress.total}…`
+                : targetCount > 1 ? `Connect ${targetCount}` : 'Connect'}
             </button>
           )}
-          {isConnectSlide && !showConnectForm && <div className="min-w-[84px]" />}
+          {isConnectSlide && !flow.provider && <div className="min-w-[84px]" />}
         </div>
       </div>
 
@@ -315,83 +314,6 @@ function SolarSystemBackground() {
       <div className="wc-star" style={{ top: '38%', right: '3%' }} />
       <div className="wc-star" style={{ top: '88%', right: '30%' }} />
       <div className="wc-star" style={{ top: '60%', right: '25%' }} />
-    </div>
-  )
-}
-
-/** GitHub connect slide — a single slide with two visual states of the SAME
- * title/subtitle (their position never shifts between states — verified,
- * not assumed: they live in this component's own fixed header, above
- * whichever variant renders below):
- *
- * 1. Collapsed: a tall outlined (not filled — per product decision) button,
- *    logo above the "GitHub" label. No gh-CLI note here — that note only
- *    appears AFTER clicking GitHub (per product decision), so it reads as a
- *    confirmation of what just happened rather than a caveat shown before
- *    the user has committed to anything.
- * 2. Expanded (after clicking it): the button morphs in place into an
- *    UNBORDERED logo + input row — no wrapping box around them, per product
- *    decision. Connect itself is NOT rendered here — it moved to the parent
- *    (WelcomeCarousel)'s nav row, in the slot Next used to occupy, per
- *    product decision ("Connect goes bottom-right, where Next used to be").
- *    So this component is a pure display component now: form state (url,
- *    submit mutation) lives in the parent, which needs it to wire up that
- *    nav-row button; this component just renders the input and forwards
- *    onChange/onSubmit.
- */
-function GithubConnectSlide({
-  showConnectForm,
-  onOpenConnectForm,
-  url,
-  onUrlChange,
-  onSubmit,
-  submitError,
-}: {
-  showConnectForm: boolean
-  onOpenConnectForm: () => void
-  url: string
-  onUrlChange: (url: string) => void
-  onSubmit: () => void
-  submitError: string | null
-}) {
-  return (
-    <div className="flex flex-col items-center gap-4 w-full">
-      <div className="text-[20px] font-bold text-text tracking-[-0.2px]">Let's Connect a Repo</div>
-      <div className="text-[13.5px] text-muted leading-[1.7] max-w-[380px]">
-        Connect a repo. Nothing runs without your say.
-      </div>
-
-      {!showConnectForm && (
-        <button
-          onClick={onOpenConnectForm}
-          className="flex flex-col items-center justify-center gap-2.5 w-[120px] h-[140px] rounded-md border border-accent text-accent bg-transparent cursor-pointer hover:bg-accent-subtle"
-        >
-          <GithubLogo size={40} />
-          <span className="text-[13px] font-semibold">GitHub</span>
-        </button>
-      )}
-
-      {showConnectForm && (
-        <div className="flex items-center gap-3 w-full max-w-[380px]">
-          <GithubLogo size={20} className="flex-shrink-0 text-accent" />
-          <input
-            value={url}
-            onChange={(e) => onUrlChange(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') onSubmit() }}
-            autoFocus
-            aria-label="GitHub repository URL"
-            placeholder="https://github.com/<owner>/<repo>"
-            className="flex-1 box-border text-[13.5px] px-3 py-2 rounded-md bg-bg text-text border border-border font-mono"
-          />
-        </div>
-      )}
-
-      {submitError && <div className="text-danger text-xs">{submitError}</div>}
-      {showConnectForm && (
-        <p className="text-[12px] text-muted opacity-70 max-w-[380px]">
-          Read access via your existing <code>gh</code> CLI session — nothing is installed or granted beyond that.
-        </p>
-      )}
     </div>
   )
 }

--- a/website/src/apps/issue-radar/api.ts
+++ b/website/src/apps/issue-radar/api.ts
@@ -431,6 +431,38 @@ export interface ReposResponse {
   repos: ConnectedRepo[]
 }
 
+/** One row of the connect dialog's picker — a repo the `gh` user personally
+ * contributed to inside the requested window. `last_contributed_at` is that
+ * user's OWN latest contribution (push / PR / review / issue / comment), not
+ * the repo's last push, and is what the row renders. `connected` is
+ * server-computed against the config, so the picker can disable repos already
+ * wired up. */
+export interface RecentRepo {
+  owner: string
+  repo: string
+  full_name: string
+  /** ISO-8601 UTC timestamp of the user's most recent contribution. */
+  last_contributed_at: string
+  /** How many contribution events the user made in the window. */
+  contribution_count: number
+  connected: boolean
+}
+
+/** Why the host can't talk to GitHub yet, when it can't. The picker turns this
+ * into install / `gh auth login` instructions rather than an error string. */
+export type GhSetupReason = 'not_installed' | 'not_authenticated'
+
+export interface RecentReposResponse {
+  repos: RecentRepo[]
+  /** True when the event page came back full, so repos contributed to earlier
+   * in the window may be missing. The picker must not claim completeness. */
+  truncated?: boolean
+  /** Present only when `gh` is unusable; `repos` is then empty. */
+  setup_required?: GhSetupReason | null
+  /** The server's diagnostic detail (e.g. which dirs were searched). */
+  error?: string
+}
+
 export interface MeResponse {
   login: string | null
 }
@@ -634,6 +666,17 @@ export const issueRadarApi = {
 
   repos: async (): Promise<ReposResponse> => {
     const r = await fetch(`${API}/repos`, { credentials: 'same-origin' })
+    if (!r.ok) throw new Error(await parseErrorBody(r))
+    return r.json()
+  },
+
+  /** Repos the `gh` user personally contributed to within the last `days` —
+   * the connect dialog's multi-select picker. Live call (not cached).
+   * `days` is required: the window belongs to the caller (see
+   * RECENT_WINDOW_DAYS) so the value isn't defined in two places. */
+  recentRepos: async (days: number): Promise<RecentReposResponse> => {
+    const q = new URLSearchParams({ days: String(days) })
+    const r = await fetch(`${API}/recent-repos?${q.toString()}`, { credentials: 'same-origin' })
     if (!r.ok) throw new Error(await parseErrorBody(r))
     return r.json()
   },

--- a/website/src/apps/issue-radar/context.tsx
+++ b/website/src/apps/issue-radar/context.tsx
@@ -18,7 +18,7 @@ import {
 import type {
   ActiveRepo, DashboardTab, ExpandedSection, MainView, PrSortKey, PrStateFilter, SettingsTarget, SortDir, SortKey, StateFilter,
 } from './lib/types'
-import { asArray, loadUiState, saveUiState } from './lib/format'
+import { asArray, consumeAutoSelectFirstIssue, loadUiState, saveUiState } from './lib/format'
 
 /** GitHub author_association values that mark a repo member (maintainer). Kept
  * in sync with the backend's ``_MEMBER_ASSOC_RANK`` and the detail badge's
@@ -602,6 +602,27 @@ export function IssueRadarProvider({
     clearPrFilters()
     onSwitch(r)
   }
+
+  // A just-connected repo opens its first issue once the list resolves, so the
+  // user lands on real content instead of an empty detail pane. Driven by a
+  // one-shot flag (see markAutoSelectFirstIssue) because the connect happens
+  // before this query finishes — and, on first run, before this provider even
+  // mounts. Consumed exactly once, so a later reload doesn't re-select.
+  //
+  // Falls back to the UNFILTERED list: the connect flow clears filters, but if
+  // any survived (or a restored filter excludes everything in the new repo)
+  // sortedIssues can be empty while the repo does have issues — consuming the
+  // flag with nothing selected would strand the user on a blank pane.
+  //
+  // Gated on `active`: while the newly connected repo's issues are still
+  // refetching, this effect can run with the PREVIOUS repo's list, and an
+  // unscoped flag would select one of its issues.
+  useEffect(() => {
+    if (!issuesQuery.isSuccess) return
+    if (!consumeAutoSelectFirstIssue(active)) return
+    const first = sortedIssues[0] ?? issues[0]
+    if (first) setSelectedIssue(first.number)
+  }, [issuesQuery.isSuccess, sortedIssues, issues, active])
 
   const value: IssueRadarContextValue = {
     repos, active, switchRepo, onAddRepo,

--- a/website/src/apps/issue-radar/lib/format.ts
+++ b/website/src/apps/issue-radar/lib/format.ts
@@ -208,3 +208,51 @@ export function saveUiState(state: PersistedUiState) {
     /* quota exceeded / private mode — persistence is best-effort */
   }
 }
+
+/** Merge a single field into the persisted UI state, leaving the rest intact.
+ *
+ * Needed for the connect flow: after connecting a repo the user should land on
+ * the issue list, but on FIRST RUN the provider isn't mounted yet (the welcome
+ * carousel renders in its place), so there is no live `setMainView` to call —
+ * the provider will read this stored value when it mounts a moment later. The
+ * already-mounted case (the "connect another repo" modal) switches view through
+ * the context instead. */
+export function patchUiState(patch: Partial<PersistedUiState>) {
+  try {
+    localStorage.setItem(UI_STATE_KEY, JSON.stringify({ ...loadUiState(), ...patch }))
+  } catch {
+    /* best-effort, same as saveUiState */
+  }
+}
+
+/** Pending "open the first issue" intent, set at connect time.
+ *
+ * A MODULE-SCOPED variable, deliberately not localStorage/sessionStorage: the
+ * gap this must survive is only the one between `onConnected` and the provider
+ * mounting (which, on first run, happens moments later in the SAME JS session —
+ * no reload occurs). Persisting it would outlive that gap, so a user who closes
+ * the tab before the issues query resolves, or whose query errors, would have
+ * the flag fire on their next visit and yank selection to the first issue of
+ * whatever repo is active. Storage is also shared across tabs, where whichever
+ * tab resolved first would consume the other's intent. */
+let autoSelectFirstIssue: { owner: string; repo: string } | null = null
+
+/** GitHub names are case-preserving but not case-sensitive. */
+const repoKey = (r: { owner: string; repo: string }) => `${r.owner}/${r.repo}`.toLowerCase()
+
+/** Ask the workspace to open the first open issue once the list has loaded.
+ * SCOPED to the repo that was just connected: the provider may still be
+ * showing the previous repo while its issues refetch, and an unscoped flag
+ * would be consumed by that render and select an issue from the OLD repo. */
+export function markAutoSelectFirstIssue(repo: { owner: string; repo: string }) {
+  autoSelectFirstIssue = { owner: repo.owner, repo: repo.repo }
+}
+
+/** Read AND clear the flag, but only when `active` is the repo the intent was
+ * recorded for. Returns true only for that repo's first caller. */
+export function consumeAutoSelectFirstIssue(active: { owner: string; repo: string }): boolean {
+  if (!autoSelectFirstIssue) return false
+  if (repoKey(autoSelectFirstIssue) !== repoKey(active)) return false
+  autoSelectFirstIssue = null
+  return true
+}

--- a/website/src/apps/issue-radar/views/settings/RepoSettings.tsx
+++ b/website/src/apps/issue-radar/views/settings/RepoSettings.tsx
@@ -133,6 +133,10 @@ export default function RepoSettings({ owner, repo }: { owner: string; repo: str
     mutationFn: () => issueRadarApi.disconnect(owner, repo),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['issue-radar', 'repos'] })
+      // The connect dialog's picker caches a `connected` flag per repo, so
+      // without this the just-disconnected repo stays greyed out as "Connected"
+      // and un-tickable until that cache expires.
+      qc.invalidateQueries({ queryKey: ['issue-radar', 'recent-repos'] })
       openSettings({ kind: 'general', anchor: 'repos' })
     },
   })

--- a/website/src/test/IssueRadarConnectFlow.test.tsx
+++ b/website/src/test/IssueRadarConnectFlow.test.tsx
@@ -1,0 +1,337 @@
+// Regression coverage for the Issue Radar connect flow's non-obvious
+// behaviours — the ones whose failure modes are silent (a repo that keeps
+// connecting after the dialog "closed", a typed URL resubmitted after it
+// already succeeded, a checkbox label that toggles the wrong row).
+//
+// The panel and its state hook are exercised through a minimal host that
+// mirrors what the real hosts (WelcomeCarousel / ConnectRepoModal) do: render
+// <ConnectPanel> plus a Connect button wired to `flow.submit`.
+import { StrictMode } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockConnect = vi.fn()
+const mockRecentRepos = vi.fn()
+vi.mock('../apps/issue-radar/api', () => ({
+  issueRadarApi: {
+    connect: (...a: unknown[]) => mockConnect(...a),
+    recentRepos: (...a: unknown[]) => mockRecentRepos(...a),
+  },
+}))
+
+const { default: ConnectPanel, useConnectFlow, repoIdentity, parseRepoRef } = await import('../apps/issue-radar/ConnectPanel')
+const { markAutoSelectFirstIssue, consumeAutoSelectFirstIssue } = await import(
+  '../apps/issue-radar/lib/format'
+)
+
+function repo(fullName: string, connected = false) {
+  const [owner, name] = fullName.split('/')
+  return {
+    full_name: fullName,
+    owner,
+    repo: name,
+    connected,
+    contribution_count: 1,
+    last_contributed_at: new Date().toISOString(),
+  }
+}
+
+/** Minimal stand-in for a host card: panel body + the Connect button the real
+ * hosts render outside the panel. */
+function Host({ onConnected = vi.fn() }: { onConnected?: (r: { owner: string; repo: string }) => void }) {
+  const flow = useConnectFlow(onConnected)
+  return (
+    <div>
+      <ConnectPanel flow={flow} />
+      <button onClick={flow.submit} disabled={!flow.targets.length || flow.pending}>
+        Connect {flow.targets.length}
+      </button>
+    </div>
+  )
+}
+
+function renderHost(props: Parameters<typeof Host>[0] = {}) {
+  // A fresh client per test: these assertions depend on cache state.
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const invalidate = vi.spyOn(qc, 'invalidateQueries')
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <Host {...props} />
+    </QueryClientProvider>,
+  )
+  return { ...utils, invalidate }
+}
+
+/** Open the GitHub provider and wait for the repo picker to resolve. */
+async function openGithub(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /GitHub/ }))
+  await waitFor(() => expect(mockRecentRepos).toHaveBeenCalled())
+}
+
+beforeEach(() => {
+  mockConnect.mockReset()
+  mockRecentRepos.mockReset()
+  mockRecentRepos.mockResolvedValue({ repos: [repo('o/alpha'), repo('o/beta')], truncated: false })
+})
+
+describe('ConnectPanel provider rows', () => {
+  it('only GitHub is selectable; the rest are marked Soon', async () => {
+    const user = userEvent.setup()
+    renderHost()
+    for (const name of ['GitLab', 'Jira', 'Linear']) {
+      expect(screen.getByRole('button', { name: new RegExp(name) })).toBeDisabled()
+    }
+    // Nothing is fetched until GitHub is actually opened.
+    expect(mockRecentRepos).not.toHaveBeenCalled()
+    await openGithub(user)
+  })
+})
+
+describe('ConnectPanel repo picker', () => {
+  it('toggles exactly the clicked row when names differ only in punctuation', async () => {
+    // `a.b` and `a-b` both sanitise to the same string; a shared id/htmlFor
+    // made one row's label drive the other row's checkbox.
+    mockRecentRepos.mockResolvedValue({ repos: [repo('o/a.b'), repo('o/a-b')], truncated: false })
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    const first = await screen.findByRole('checkbox', { name: 'Select o/a.b' })
+    const second = screen.getByRole('checkbox', { name: 'Select o/a-b' })
+    await user.click(first)
+    expect(first).toBeChecked()
+    expect(second).not.toBeChecked()
+  })
+
+  it('counts every ticked repo as a connect target', async () => {
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select o/beta' }))
+    expect(screen.getByRole('button', { name: 'Connect 2' })).toBeEnabled()
+  })
+
+  it('submits a typed URL alongside ticks, and only once when it duplicates one', async () => {
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    // Different spelling, SAME repo: `www.`, mixed case and a `.git` suffix all
+    // normalise onto the ticked `o/alpha`, so this is NOT a second target.
+    await user.type(screen.getByLabelText('Repository URL'), 'https://www.github.com/O/Alpha.git')
+    expect(screen.getByRole('button', { name: 'Connect 1' })).toBeInTheDocument()
+  })
+})
+
+describe('bulk connect', () => {
+  it('hands control back only when every target succeeded', async () => {
+    mockConnect.mockImplementation(async (url: string) => {
+      if (String(url).includes('beta')) throw new Error('nope')
+      return { owner: 'o', repo: 'alpha' }
+    })
+    const onConnected = vi.fn()
+    const user = userEvent.setup()
+    const { invalidate } = renderHost({ onConnected })
+    await openGithub(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select o/beta' }))
+    await user.click(screen.getByRole('button', { name: 'Connect 2' }))
+
+    // Partial failure: the error is surfaced and the dialog must stay open, so
+    // the success callback (which unmounts it) never fires.
+    await waitFor(() => expect(screen.getByText(/nope/)).toBeInTheDocument())
+    expect(onConnected).not.toHaveBeenCalled()
+    // The repo that DID connect is dropped from the selection, leaving exactly
+    // what still needs a retry.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Connect 1' })).toBeInTheDocument())
+    // The picker's "Connected" rows are refreshed even on a partial failure —
+    // the dialog stays open and must not offer a repo it just connected.
+    const keys = invalidate.mock.calls.map((c) => JSON.stringify(c[0]))
+    expect(keys.some((k) => k.includes('recent-repos'))).toBe(true)
+    // `repos` is deliberately NOT invalidated here: on first run it is what
+    // decides whether onboarding is still mounted, so refreshing it mid-partial
+    // -failure would unmount the carousel and take the unread errors with it.
+    expect(keys.some((k) => k.includes('[\"issue-radar\",\"repos\"]'))).toBe(false)
+  })
+
+  it('clears a typed URL that connected, so it is not resubmitted', async () => {
+    mockConnect.mockImplementation(async (url: string) => {
+      if (String(url).includes('beta')) throw new Error('nope')
+      return { owner: 'o', repo: 'gamma' }
+    })
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/beta' }))
+    const input = screen.getByLabelText('Repository URL')
+    await user.type(input, 'https://github.com/o/gamma')
+    await user.click(screen.getByRole('button', { name: 'Connect 2' }))
+
+    await waitFor(() => expect(input).toHaveValue(''))
+    // Only the failed tick remains queued.
+    expect(screen.getByRole('button', { name: 'Connect 1' })).toBeInTheDocument()
+  })
+
+  it('calls onConnected and refreshes the repo list when all targets succeed', async () => {
+    mockConnect.mockResolvedValue({ owner: 'o', repo: 'alpha' })
+    const onConnected = vi.fn()
+    const user = userEvent.setup()
+    const { invalidate } = renderHost({ onConnected })
+    await openGithub(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('button', { name: 'Connect 1' }))
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith({ owner: 'o', repo: 'alpha' }))
+    // Deferred to here, not the partial-success path — see above.
+    const keys = invalidate.mock.calls.map((c) => JSON.stringify(c[0]))
+    expect(keys.some((k) => k.includes('[\"issue-radar\",\"repos\"]'))).toBe(true)
+  })
+})
+
+describe('gh setup notice', () => {
+  it('replaces the picker AND hides the URL field when gh is unusable', async () => {
+    mockRecentRepos.mockResolvedValue({
+      repos: [],
+      setup_required: 'not_authenticated',
+      error: 'gh: not logged in',
+    })
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    await waitFor(() =>
+      expect(screen.getByText(/set up the GitHub CLI/i)).toBeInTheDocument(),
+    )
+    // Pasting a URL would fail the same way, so there is nothing to offer.
+    expect(screen.queryByLabelText('Repository URL')).not.toBeInTheDocument()
+  })
+})
+
+describe('auto-select-first-issue intent', () => {
+  it('is consumed only by the repo it was recorded for', () => {
+    markAutoSelectFirstIssue({ owner: 'o', repo: 'new' })
+    // The previously active repo must not consume it — that would select an
+    // issue from the OLD repo while the new one is still refetching.
+    expect(consumeAutoSelectFirstIssue({ owner: 'o', repo: 'old' })).toBe(false)
+    expect(consumeAutoSelectFirstIssue({ owner: 'o', repo: 'new' })).toBe(true)
+    // One-shot: a later render (or a reload) must not re-select.
+    expect(consumeAutoSelectFirstIssue({ owner: 'o', repo: 'new' })).toBe(false)
+  })
+
+  it('matches case-insensitively, as GitHub names do', () => {
+    markAutoSelectFirstIssue({ owner: 'Acme', repo: 'Widget' })
+    expect(consumeAutoSelectFirstIssue({ owner: 'acme', repo: 'widget' })).toBe(true)
+  })
+})
+
+describe('repoIdentity (typed-URL dedupe key)', () => {
+  it('normalises every spelling that resolves to the same repo', () => {
+    for (const text of [
+      'https://github.com/o/alpha',
+      'https://github.com/o/alpha/',
+      'https://www.github.com/O/Alpha',
+      'https://github.com/o/alpha.git',
+      'https://github.com/o/alpha.git/',
+      'github.com/o/alpha',
+      'o/alpha',
+    ]) {
+      expect(repoIdentity(text)).toBe('o/alpha')
+    }
+  })
+
+  it('rejects non-GitHub and incomplete references', () => {
+    for (const text of ['', '   ', 'https://gitlab.com/o/alpha', 'https://github.com/o', 'not a url at all']) {
+      expect(repoIdentity(text)).toBeNull()
+    }
+  })
+})
+
+describe('in-flight connect', () => {
+  it('freezes the repo ticks and the URL field while connecting', async () => {
+    // submit() snapshots its target list, so a tick added mid-flight would be
+    // silently dropped when a full success closes the dialog.
+    let release: (v: unknown) => void = () => {}
+    mockConnect.mockImplementation(
+      () => new Promise((res) => { release = () => res({ owner: 'o', repo: 'alpha' }) }),
+    )
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    const alpha = await screen.findByRole('checkbox', { name: 'Select o/alpha' })
+    await user.click(alpha)
+    await user.click(screen.getByRole('button', { name: 'Connect 1' }))
+
+    await waitFor(() => expect(screen.getByLabelText('Repository URL')).toBeDisabled())
+    expect(screen.getByRole('checkbox', { name: 'Select o/beta' })).toBeDisabled()
+    release(null)
+  })
+})
+
+describe('canonical URL submitted for a typed reference', () => {
+  it('preserves the original casing', async () => {
+    // The backend stores owner/repo VERBATIM, so submitting a case-folded name
+    // for an already-connected `Acme/Widget` would append a second repo with
+    // its own caches and settings. Folding is for comparison only.
+    expect(parseRepoRef('Acme/Widget')).toEqual({ owner: 'Acme', repo: 'Widget' })
+    expect(repoIdentity('Acme/Widget')).toBe('acme/widget')
+
+    mockRecentRepos.mockResolvedValue({ repos: [], truncated: false })
+    mockConnect.mockResolvedValue({ owner: 'Acme', repo: 'Widget' })
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    // Shorthand the backend's URL parser would reject, so it must be expanded —
+    // but expanded with the case the user typed.
+    await user.type(screen.getByLabelText('Repository URL'), 'Acme/Widget')
+    await user.click(screen.getByRole('button', { name: 'Connect 1' }))
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledWith('https://github.com/Acme/Widget'))
+  })
+
+  it('submits unparseable text as typed, so the server error stays honest', async () => {
+    mockRecentRepos.mockResolvedValue({ repos: [], truncated: false })
+    mockConnect.mockRejectedValue(new Error('bad url'))
+    const user = userEvent.setup()
+    renderHost()
+    await openGithub(user)
+
+    await user.type(screen.getByLabelText('Repository URL'), 'https://gitlab.com/o/alpha')
+    await user.click(screen.getByRole('button', { name: 'Connect 1' }))
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledWith('https://gitlab.com/o/alpha'))
+  })
+})
+
+describe('StrictMode', () => {
+  it('still connects after the development mount/cleanup/mount cycle', async () => {
+    // StrictMode runs effects twice in development. A teardown-only cancel flag
+    // latched true on that first cleanup, so every connect bailed before its
+    // first request — the dialog looked alive but did nothing.
+    mockConnect.mockResolvedValue({ owner: 'o', repo: 'alpha' })
+    const onConnected = vi.fn()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const user = userEvent.setup()
+    render(
+      <StrictMode>
+        <QueryClientProvider client={qc}>
+          <Host onConnected={onConnected} />
+        </QueryClientProvider>
+      </StrictMode>,
+    )
+    await user.click(screen.getByRole('button', { name: /GitHub/ }))
+    await waitFor(() => expect(mockRecentRepos).toHaveBeenCalled())
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('button', { name: 'Connect 1' }))
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith({ owner: 'o', repo: 'alpha' }))
+  })
+})

--- a/website/src/test/IssueRadarConnectHosts.test.tsx
+++ b/website/src/test/IssueRadarConnectHosts.test.tsx
@@ -1,0 +1,383 @@
+// Regression coverage for the two Issue Radar connect behaviours that live in
+// the HOSTS rather than the shared panel, and whose failure modes are silent:
+//
+//   1. ConnectRepoModal refuses to dismiss while a connect is in flight.
+//      Closing only unmounts the UI — it does NOT cancel the sequential POST
+//      loop — so a dismissable modal keeps connecting repos (and still fires
+//      its success callback) after the user believes they cancelled.
+//   2. The provider selects the first issue of the JUST-CONNECTED repo once its
+//      list resolves. Without it a successful connect lands the user on a blank
+//      detail pane; with an unscoped intent it selects an issue from the repo
+//      that was active before.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+
+const mockApi = {
+  connect: vi.fn(),
+  recentRepos: vi.fn(),
+  issues: vi.fn(),
+  labels: vi.fn(),
+  members: vi.fn(),
+  getSettings: vi.fn(),
+  me: vi.fn(),
+  pulls: vi.fn(),
+  searchPulls: vi.fn(),
+  repos: vi.fn(),
+  issueDetail: vi.fn(),
+  getIssueAi: vi.fn(),
+  disconnect: vi.fn(),
+  getRecommendations: vi.fn(),
+}
+// Partial mock: the provider also imports real CONSTANTS from this module
+// (DEFAULT_REPO_SETTINGS et al), so only the client object is replaced.
+vi.mock('../apps/issue-radar/api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  issueRadarApi: mockApi,
+}))
+
+const { default: ConnectRepoModal } = await import('../apps/issue-radar/ConnectRepoModal')
+const { default: IssueRadarPage } = await import('../apps/issue-radar/IssueRadarPage')
+const { default: RepoSettings } = await import('../apps/issue-radar/views/settings/RepoSettings')
+const { default: WelcomeCarousel } = await import('../apps/issue-radar/WelcomeCarousel')
+const { IssueRadarProvider, useIssueRadar } = await import('../apps/issue-radar/context')
+const { markAutoSelectFirstIssue, UI_STATE_KEY } = await import('../apps/issue-radar/lib/format')
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+/** The full page mounts <Workspace>, whose Investigate button reaches for the
+ * app's Redux store and the router — so the page-level test needs both. */
+function wrapFullApp(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const store = configureStore({
+    reducer: { chat: chatReducer, dashboard: dashboardReducer, notifications: notificationsReducer },
+  })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  for (const fn of Object.values(mockApi)) fn.mockReset()
+  mockApi.recentRepos.mockResolvedValue({
+    repos: [
+      { full_name: 'o/alpha', owner: 'o', repo: 'alpha', connected: false, contribution_count: 1 },
+      { full_name: 'o/beta', owner: 'o', repo: 'beta', connected: false, contribution_count: 1 },
+    ],
+    truncated: false,
+  })
+  mockApi.me.mockResolvedValue({ login: 'octocat' })
+  mockApi.labels.mockResolvedValue({ labels: [] })
+  mockApi.members.mockResolvedValue({ members: [] })
+  mockApi.getSettings.mockResolvedValue({})
+  mockApi.pulls.mockResolvedValue({ pulls: [] })
+  mockApi.repos.mockResolvedValue({ repos: [] })
+  mockApi.issueDetail.mockResolvedValue({ issue: null, timeline: [] })
+  mockApi.getIssueAi.mockResolvedValue({ summary: null })
+})
+
+/** Renders the modal inside a provider (which it requires) and opens GitHub. */
+async function openModal(
+  user: ReturnType<typeof userEvent.setup>,
+  { onClose = vi.fn(), onConnected = vi.fn() } = {},
+) {
+  mockApi.issues.mockResolvedValue({ issues: [] })
+  wrap(
+    <IssueRadarProvider
+      repos={[{ owner: 'o', repo: 'existing' }] as never}
+      active={{ owner: 'o', repo: 'existing' }}
+      onSwitch={vi.fn()}
+      onAddRepo={vi.fn()}
+    >
+      <ConnectRepoModal onConnected={onConnected} onClose={onClose} />
+    </IssueRadarProvider>,
+  )
+  await user.click(screen.getByRole('button', { name: /GitHub/ }))
+  await waitFor(() => expect(mockApi.recentRepos).toHaveBeenCalled())
+  return { onClose, onConnected }
+}
+
+describe('ConnectRepoModal dismissal', () => {
+  it('closes on Escape and via the backdrop when idle', async () => {
+    const user = userEvent.setup()
+    const { onClose } = await openModal(user)
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+
+    await user.click(screen.getByRole('button', { name: 'Close connect dialog' }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(2))
+  })
+
+  it('refuses every dismissal path while a connect is in flight', async () => {
+    // A deferred connect holds the mutation open so the guard is observable.
+    let release: () => void = () => {}
+    mockApi.connect.mockImplementation(
+      () => new Promise((res) => { release = () => res({ owner: 'o', repo: 'alpha' }) }),
+    )
+    const user = userEvent.setup()
+    const { onClose, onConnected } = await openModal(user)
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('button', { name: /^Connect/ }))
+    await waitFor(() => expect(mockApi.connect).toHaveBeenCalled())
+
+    // Escape, the backdrop, and the X button must all be inert: the POST loop
+    // keeps running regardless of unmount, so closing here would connect repos
+    // behind a dismissed dialog.
+    await user.keyboard('{Escape}')
+    await user.click(screen.getByRole('button', { name: 'Close connect dialog' }))
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled()
+    expect(onClose).not.toHaveBeenCalled()
+
+    release()
+    // Once it finishes, the success path hands control back exactly once.
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith({ owner: 'o', repo: 'alpha' }))
+  })
+})
+
+describe('post-connect auto-selection', () => {
+  /** Surfaces the provider's selected issue so the effect can be asserted. */
+  function Probe() {
+    const { selectedIssue } = useIssueRadar()
+    return <div data-testid="selected">{selectedIssue ?? 'none'}</div>
+  }
+
+  function renderProvider(active: { owner: string; repo: string }) {
+    return wrap(
+      <IssueRadarProvider
+        repos={[active] as never}
+        active={active}
+        onSwitch={vi.fn()}
+        onAddRepo={vi.fn()}
+      >
+        <Probe />
+      </IssueRadarProvider>,
+    )
+  }
+
+  it('opens the first issue of the newly connected repo, per the active sort', async () => {
+    // The default sort is number-descending, so #8 is the list's first row —
+    // the effect must follow the SORTED order the user actually sees, not the
+    // server's response order.
+    mockApi.issues.mockResolvedValue({
+      issues: [
+        { number: 7, title: 'lower number', labels: [], state: 'open', updated_at: '2026-01-02T00:00:00Z', created_at: '2026-01-02T00:00:00Z', assignees: [] },
+        { number: 8, title: 'higher number', labels: [], state: 'open', updated_at: '2026-01-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z', assignees: [] },
+      ],
+    })
+    markAutoSelectFirstIssue({ owner: 'o', repo: 'fresh' })
+    renderProvider({ owner: 'o', repo: 'fresh' })
+
+    await waitFor(() => expect(screen.getByTestId('selected')).toHaveTextContent('8'))
+  })
+
+  it('leaves selection alone when the active repo is not the connected one', async () => {
+    mockApi.issues.mockResolvedValue({
+      issues: [
+        { number: 99, title: 'old repo issue', labels: [], state: 'open', updated_at: '2026-01-02T00:00:00Z', created_at: '2026-01-02T00:00:00Z', assignees: [] },
+      ],
+    })
+    // The intent belongs to `fresh`, but `stale` is still the active repo while
+    // its list refetches — selecting from it would open the wrong repo's issue.
+    markAutoSelectFirstIssue({ owner: 'o', repo: 'fresh' })
+    renderProvider({ owner: 'o', repo: 'stale' })
+
+    await waitFor(() => expect(mockApi.issues).toHaveBeenCalled())
+    expect(screen.getByTestId('selected')).toHaveTextContent('none')
+  })
+})
+
+describe('IssueRadarPage first connect', () => {
+  it('wires onConnected through to the issue view with the first issue open', async () => {
+    // End-to-end over the WIRING, not the helper: `onConnected` has to persist
+    // the view/filter reset AND record the auto-select intent, and a test that
+    // calls markAutoSelectFirstIssue directly stays green if that call is
+    // dropped.
+    mockApi.repos.mockResolvedValueOnce({ repos: [] })          // first run
+      .mockResolvedValue({ repos: [{ owner: 'o', repo: 'fresh' }] })
+    mockApi.connect.mockResolvedValue({ owner: 'o', repo: 'fresh' })
+    mockApi.issues.mockResolvedValue({
+      issues: [
+        { number: 5, title: 'only', labels: [], state: 'open', updated_at: '2026-01-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z', assignees: [] },
+      ],
+    })
+    const user = userEvent.setup()
+    wrapFullApp(<IssueRadarPage />)
+
+    // No repos yet → the onboarding carousel. Walk to its connect slide.
+    const next = await screen.findByRole('button', { name: /Next/ })
+    for (let i = 0; i < 10 && screen.queryByRole('button', { name: /Next/ }); i++) {
+      await user.click(screen.getByRole('button', { name: /Next/ }))
+    }
+    expect(next).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /GitHub/ }))
+    await user.type(screen.getByLabelText('Repository URL'), 'https://github.com/o/fresh')
+    await user.click(screen.getByRole('button', { name: /^Connect/ }))
+
+    // Lands on the issue LIST (not the dashboard) with the repo's only issue
+    // auto-opened — the title therefore appears twice, once per pane.
+    await waitFor(() => expect(screen.getAllByText('only').length).toBeGreaterThan(1))
+    expect(screen.getByText('1 issue')).toBeInTheDocument()
+    // The persisted reset put the workspace on the issues view showing OPEN.
+    const persisted = JSON.parse(localStorage.getItem(UI_STATE_KEY) ?? '{}')
+    expect(persisted.mainView).toBe('issues')
+    expect(persisted.stateFilter).toBe('open')
+    expect(persisted.selectedPull).toBeNull()
+  })
+})
+
+describe('disconnect', () => {
+  it('invalidates the connect picker cache as well as the repo list', async () => {
+    // The picker caches a `connected` flag per repo. Without this invalidation
+    // the just-disconnected repo stays greyed out as "Connected" and
+    // un-tickable in the connect dialog until that cache expires.
+    mockApi.disconnect.mockResolvedValue({ ok: true })
+    mockApi.getRecommendations.mockResolvedValue({ recommendations: null })
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+    mockApi.issues.mockResolvedValue({ issues: [] })
+    const user = userEvent.setup()
+    render(
+      <QueryClientProvider client={qc}>
+        <IssueRadarProvider
+          repos={[{ owner: 'o', repo: 'gone' }] as never}
+          active={{ owner: 'o', repo: 'gone' }}
+          onSwitch={vi.fn()}
+          onAddRepo={vi.fn()}
+        >
+          <RepoSettings owner="o" repo="gone" />
+        </IssueRadarProvider>
+      </QueryClientProvider>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /Disconnect/i }))
+    await user.click(await screen.findByRole('button', { name: /Confirm disconnect/i }))
+
+    await waitFor(() => expect(mockApi.disconnect).toHaveBeenCalledWith('o', 'gone'))
+    const keys = invalidate.mock.calls.map((c) => JSON.stringify(c[0]))
+    expect(keys.some((k) => k.includes('recent-repos'))).toBe(true)
+    expect(keys.some((k) => k.includes('[\"issue-radar\",\"repos\"]'))).toBe(true)
+  })
+})
+
+describe('unmount cancellation', () => {
+  it('stops the batch when the host unmounts mid-connect', async () => {
+    // The connect loop is sequential and outlives its host, so an SPA
+    // navigation must not leave it POSTing the remaining repos invisibly.
+    const releases: Array<() => void> = []
+    mockApi.connect.mockImplementation(
+      () => new Promise((res) => { releases.push(() => res({ owner: 'o', repo: 'alpha' })) }),
+    )
+    const onConnected = vi.fn()
+    const user = userEvent.setup()
+    const { onClose } = await openModal(user, { onConnected })
+    void onClose
+
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select o/beta' }))
+    await user.click(screen.getByRole('button', { name: /^Connect/ }))
+    await waitFor(() => expect(mockApi.connect).toHaveBeenCalledTimes(1))
+
+    // Unmount while the FIRST request is still open, then let it settle.
+    cleanup()
+    releases[0]()
+
+    // The second target is never dispatched, and completion is never reported.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mockApi.connect).toHaveBeenCalledTimes(1)
+    expect(onConnected).not.toHaveBeenCalled()
+  })
+})
+
+describe('WelcomeCarousel Back during a connect', () => {
+  it('stays disabled and does not leave the connect slide', async () => {
+    // Back only changes the UI — it does not cancel the loop — so allowing it
+    // would connect the remaining repos behind a screen the user backed out of.
+    let release: () => void = () => {}
+    mockApi.connect.mockImplementation(
+      () => new Promise((res) => { release = () => res({ owner: 'o', repo: 'alpha' }) }),
+    )
+    const user = userEvent.setup()
+    wrap(<WelcomeCarousel onConnected={vi.fn()} />)
+
+    while (screen.queryByRole('button', { name: /Next/ })) {
+      await user.click(screen.getByRole('button', { name: /Next/ }))
+    }
+    await user.click(screen.getByRole('button', { name: /GitHub/ }))
+    await waitFor(() => expect(mockApi.recentRepos).toHaveBeenCalled())
+    await user.click(await screen.findByRole('checkbox', { name: 'Select o/alpha' }))
+    await user.click(screen.getByRole('button', { name: /^Connect/ }))
+    await waitFor(() => expect(mockApi.connect).toHaveBeenCalled())
+
+    const back = screen.getByRole('button', { name: /Back/ })
+    expect(back).toBeDisabled()
+    await user.click(back)
+    // Still on the connect slide: the provider list and picker are present.
+    expect(screen.getByRole('button', { name: /GitHub/ })).toBeInTheDocument()
+    expect(screen.getByLabelText('Repository URL')).toBeInTheDocument()
+    release()
+  })
+})
+
+describe('modal live state reset', () => {
+  it('clears issue AND pr selection/filters in the mounted provider', async () => {
+    // A leftover `selectedPull` is the sharp edge: it's a NUMBER, so #42 from
+    // the old repo silently auto-opens the new repo's unrelated #42.
+    mockApi.connect.mockResolvedValue({ owner: 'o', repo: 'fresh' })
+    mockApi.issues.mockResolvedValue({ issues: [] })
+
+    let seed: (() => void) | null = null
+    let seen: { selectedIssue: number | null; selectedPull: number | null; query: string; prQuery: string } | null = null
+    function Probe() {
+      const c = useIssueRadar()
+      seed = () => { c.setSelectedIssue(11); c.setSelectedPull(42); c.setQuery('stale'); c.setPrQuery('stale-pr') }
+      seen = {
+        selectedIssue: c.selectedIssue, selectedPull: c.selectedPull,
+        query: c.query, prQuery: c.prQuery,
+      }
+      return null
+    }
+    const user = userEvent.setup()
+    wrap(
+      <IssueRadarProvider
+        repos={[{ owner: 'o', repo: 'existing' }] as never}
+        active={{ owner: 'o', repo: 'existing' }}
+        onSwitch={vi.fn()}
+        onAddRepo={vi.fn()}
+      >
+        <Probe />
+        <ConnectRepoModal onConnected={vi.fn()} onClose={vi.fn()} />
+      </IssueRadarProvider>,
+    )
+
+    await act(async () => { seed?.() })
+    expect(seen?.selectedPull).toBe(42)
+
+    await user.click(screen.getByRole('button', { name: /GitHub/ }))
+    await waitFor(() => expect(mockApi.recentRepos).toHaveBeenCalled())
+    await user.type(screen.getByLabelText('Repository URL'), 'https://github.com/o/fresh')
+    await user.click(screen.getByRole('button', { name: /^Connect/ }))
+
+    await waitFor(() => expect(seen?.selectedPull).toBeNull())
+    expect(seen?.selectedIssue).toBeNull()
+    expect(seen?.query).toBe('')
+    expect(seen?.prQuery).toBe('')
+  })
+})


### PR DESCRIPTION
## What changed

The connect step was a single large GitHub square. Invoked from Settings it
replaced the entire workspace with the first-run welcome carousel, and the only
way to add a repo was pasting a URL.

- **Modal, not a page swap.** "Connect repo" overlays the current view on a
  blurred backdrop; the full-screen carousel is now first-run only.
- **Provider rows.** GitHub, GitLab, Jira, Linear as a row list. Only GitHub has
  a backend, so the others carry a `Soon` badge and are non-selectable rather
  than failing on click.
- **Repo picker.** Picking GitHub grows the card into two columns: providers
  left; a multi-select of repos you contributed to right, with the manual URL
  field beneath. Ticks and a typed URL are additive and submit together
  (sequentially, collecting per-target failures so one bad URL cannot discard the
  repos that did connect).
- **New `GET /recent-repos`.** Backed by the user's event feed
  (`users/{login}/events`) rather than `user/repos?sort=pushed` — the latter
  fires on a teammate's push and cannot say when *you* last contributed. Rows
  roll up to your own latest contribution per repo, filtered to a trailing
  window (default 30 days, `?days=` to override). Watch/Fork events are
  excluded; starring is not contributing.
- **`gh` setup guidance.** A new `GhSetupError` carries a machine-readable
  `reason`, so when `gh` is missing / rejected by trust validation / not signed
  in, the panel shows one "please set up the GitHub CLI" notice instead of a raw
  error string, and hides the URL field (pasting would fail the same way).
- **Post-connect navigation.** Lands on the issue list and opens the new repo's
  first open issue once it loads, instead of leaving you on Settings.

The carousel's last slide and the modal share one `ConnectPanel` and one
`useConnectFlow` hook, so the two flows cannot drift apart.

## Testing

- 107 backend tests pass (18 new in `test_recent_repos.py`, covering event-type
  filtering, the window, the per-repo rollup, ordering, malformed entries,
  login escaping, and the setup-error classification).
- `flake8` / `isort` / `mypy` clean; `tsc --noEmit` clean; `eslint` 0 errors.
- `list_contributed_repos` verified against a live `gh` session: correct repo
  set, per-repo last-contribution timestamps, newest-first ordering. Confirmed
  private events are included, and that a repo whose only event is a
  `WatchEvent` is correctly excluded.
- The `GhSetupError` path verified live by pointing `KIROCREW_ISSUE_RADAR_GH` at
  a Homebrew `gh` (rejected by trust validation, giving
  `reason="not_installed"`).

## Not verified / known limits

- GitHub's event feed is capped (~90 days / 300 events), which covers the
  one-month window but means this is not an exhaustive contribution history.
- GitLab/Jira/Linear are UI-only placeholders; no client exists for them.
- The Jira and Linear marks are simplified monochrome glyphs, not official brand
  assets.

## Related

Independent of, but complementary to, #456: on a stock Homebrew macOS install
the `gh` binary fails this repo's trust validation, so the new picker will show
its "please set up the GitHub CLI" notice until #456 (or a root-owned copy in a
trusted dir) is in place. This PR does not depend on that change to build or
test.

## Screenshots

<img width="2560" height="1275" alt="Screenshot 2026-07-25 at 4 08 23 PM" src="https://github.com/user-attachments/assets/5e4370ff-0d43-43bb-8be2-80ef77e28664" />
<img width="2560" height="1282" alt="Screenshot 2026-07-25 at 4 06 03 PM" src="https://github.com/user-attachments/assets/7794a105-a210-4b66-ae4c-0de6b8cee256" />
<img width="2560" height="1276" alt="Screenshot 2026-07-25 at 4 09 30 PM" src="https://github.com/user-attachments/assets/0b071252-8628-40d1-88de-b7a960114ee6" />
