### PR TITLE
ci: reuse coverage artifacts in Coverage Gate instead of re-running suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,106 @@ jobs:
           name: coverage-backend
           path: coverage.xml
 
+  # ── Coverage Gate ──────────────────────────────────────────────────────
+  # Enforces minimum line-coverage thresholds. Rather than re-running the
+  # entire backend + frontend suites (which duplicated ~30 min of work the
+  # test jobs already did on a single serial runner), this job CONSUMES the
+  # coverage artifacts those jobs already produced in this same run:
+  #   * backend-test (3.12 shards) -> coverage-combine -> coverage.xml
+  #     (artifact: coverage-backend)
+  #   * frontend-test -> build/coverage/cobertura-coverage.xml
+  #     (artifact: coverage-frontend)
+  # Result: download + parse + threshold-check only -- runs in seconds.
+  #
+  # Fail-closed: if an expected artifact/report is missing the job errors
+  # (download-artifact errors on a missing artifact; the report presence is
+  # asserted below), so a broken coverage pipeline can never silently pass.
+  # Lives here (not code-review.yml) so it can use `needs:` for a
+  # deterministic same-run handoff instead of a cross-workflow artifact race.
+  # The check name "Coverage Gate" is unchanged, so branch protection that
+  # requires it is still satisfied.
+  coverage-gate:
+    name: Coverage Gate
+    runs-on: ubuntu-latest
+    needs: [coverage-combine, frontend-test]
+    # Always run so the required check emits a real verdict. Without
+    # `if: always()`, a failing OR skipped dependency would SKIP this job, and
+    # GitHub treats a skipped required check as SATISFIED -- silently defeating
+    # the fail-closed guarantee (including the `if-no-files-found: error` upload
+    # guard this workflow relies on). The first step below converts any
+    # non-success upstream result into an explicit failure.
+    if: ${{ always() }}
+    steps:
+      - name: Require upstream coverage jobs to have succeeded
+        env:
+          CC: ${{ needs.coverage-combine.result }}
+          FE: ${{ needs.frontend-test.result }}
+        run: |
+          echo "coverage-combine=$CC  frontend-test=$FE"
+          if [ "$CC" != "success" ] || [ "$FE" != "success" ]; then
+            echo "::error::Upstream coverage jobs did not succeed (coverage-combine=$CC, frontend-test=$FE) -- failing closed."
+            exit 1
+          fi
+
+      - name: Download backend coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-backend
+          path: backend-cov
+
+      - name: Download frontend coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-frontend
+          path: frontend-cov
+
+      - name: Check backend coverage (min 50%)
+        run: |
+          F=backend-cov/coverage.xml
+          test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
+          # Compare the raw line-rate against the threshold; round only for
+          # display (a round-then-compare would let 49.95%..49.99% pass 50%).
+          python3 - "$F" 50 Backend <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+          rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
+          print(f"{label} coverage: {rate:.2f}%")
+          if rate < floor:
+              print(f"::error::{label} coverage {rate:.2f}% below {floor:.0f}% minimum")
+              sys.exit(1)
+          PY
+
+      - name: Check frontend coverage (min 40%)
+        run: |
+          F=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
+          test -n "$F" || { echo "::error::cobertura report missing from coverage-frontend artifact"; exit 1; }
+          python3 - "$F" 40 Frontend <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+          rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
+          print(f"{label} coverage: {rate:.2f}%")
+          if rate < floor:
+              print(f"::error::{label} coverage {rate:.2f}% below {floor:.0f}% minimum")
+              sys.exit(1)
+          PY
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Component | Coverage | Min |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|----------|-----|" >> "$GITHUB_STEP_SUMMARY"
+          BF=backend-cov/coverage.xml
+          if [ -f "$BF" ]; then
+            B=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$BF').getroot().attrib['line-rate'])*100:.2f}\")")
+            echo "| Backend | ${B}% | 50% |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          FF=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
+          if [ -n "$FF" ]; then
+            FR=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$FF').getroot().attrib['line-rate'])*100:.2f}\")")
+            echo "| Frontend | ${FR}% | 40% |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   frontend-lint:
     name: Frontend Lint & Type Check
     runs-on: ubuntu-latest
@@ -324,7 +424,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-frontend
-          path: website/coverage/
+          # vitest's reportsDirectory is website/build/coverage (see
+          # vite.config.ts) -- NOT website/coverage. Uploading the wrong dir
+          # produced an empty artifact, which is why the Coverage Gate used to
+          # re-run vitest instead of consuming this. Fail loudly if the
+          # cobertura report is ever missing again.
+          path: website/build/coverage/
+          if-no-files-found: error
 
   e2e:
     name: E2E (stub ACP backend, offline)

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -250,94 +250,11 @@ jobs:
           npm audit --audit-level=high
 
   # ── Coverage Gate ────────────────────────────────────────────────────
-  # Prevents coverage regression below minimum thresholds.
-  # Downloads artifacts from the CI workflow's test jobs.
-  coverage-gate:
-    name: Coverage Gate
-    runs-on: ubuntu-latest
-    # This job needs the test artifacts from ci.yml. We use workflow_run
-    # instead of needs: since these are separate workflow files. However,
-    # since ci.yml and code-review.yml both trigger on pull_request, the
-    # artifacts may not be ready yet. Use a polling approach or rely on
-    # the branch protection rule requiring CI to pass first.
-    #
-    # Simpler approach: just re-run the coverage commands here (fast, <60s).
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: website/package-lock.json
-
-      - name: Install and run backend tests with coverage
-        run: |
-          pip install -e ".[voice,desktop,dev]" --quiet
-          pytest -q -n auto --timeout=120 --cov=kiro_crew --cov-report=xml \
-            --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=test/test_run_aim_path.py \
-            --no-header 2>/dev/null || true
-
-      - name: Check backend coverage (min 50%)
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "::warning::No backend coverage report — skipping"
-            exit 0
-          fi
-          LINE_RATE=$(python3 -c "
-          import xml.etree.ElementTree as ET
-          tree = ET.parse('coverage.xml')
-          print(f\"{float(tree.getroot().attrib['line-rate']) * 100:.1f}\")
-          ")
-          echo "Backend coverage: ${LINE_RATE}%"
-          python3 -c "import sys; sys.exit(0 if float('${LINE_RATE}') >= 50 else 1)" \
-            || { echo "::error::Backend coverage ${LINE_RATE}% below 50% minimum"; exit 1; }
-
-      - name: Install and run frontend tests with coverage
-        working-directory: website
-        run: |
-          npm ci --no-audit --no-fund
-          npx vitest run --coverage --reporter=dot 2>/dev/null || true
-
-      - name: Check frontend coverage (min 40%)
-        run: |
-          # Vitest outputs cobertura XML (not json-summary). Search likely paths.
-          COV_FILE=$(find website/build/coverage website/coverage -name "cobertura*.xml" 2>/dev/null | head -1)
-          if [ -z "$COV_FILE" ]; then
-            echo "::warning::No frontend coverage report found — skipping"
-            exit 0
-          fi
-          LINE_PCT=$(python3 -c "
-          import xml.etree.ElementTree as ET
-          tree = ET.parse('$COV_FILE')
-          print(f\"{float(tree.getroot().attrib['line-rate']) * 100:.1f}\")
-          ")
-          echo "Frontend coverage: ${LINE_PCT}%"
-          python3 -c "import sys; sys.exit(0 if float('${LINE_PCT}') >= 40 else 1)" \
-            || { echo "::error::Frontend coverage ${LINE_PCT}% below 40% minimum"; exit 1; }
-
-      - name: Coverage summary
-        if: always()
-        run: |
-          echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Component | Coverage | Min |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----------|----------|-----|" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f coverage.xml ]; then
-            B=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('coverage.xml').getroot().attrib['line-rate'])*100:.1f}\")")
-            echo "| Backend | ${B}% | 50% |" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          COV_F=$(find website/build/coverage website/coverage -name "cobertura*.xml" 2>/dev/null | head -1)
-          if [ -n "$COV_F" ]; then
-            F=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$COV_F').getroot().attrib['line-rate'])*100:.1f}\")")
-            echo "| Frontend | ${F}% | 40% |" >> "$GITHUB_STEP_SUMMARY"
-          fi
+  # MOVED to ci.yml. It now consumes the coverage-backend / coverage-frontend
+  # artifacts that ci.yml's test jobs already produce in the same run (via
+  # `needs:`), instead of re-installing everything and re-running the full
+  # backend + frontend suites here (~30 min of duplicated work). The check
+  # name "Coverage Gate" is unchanged, so branch protection is unaffected.
 
   # ── SAST (Semgrep) ───────────────────────────────────────────────────
   # Static Application Security Testing. Catches vulnerability patterns


### PR DESCRIPTION
## Problem

The `Coverage Gate` CI check took ~30 minutes per PR. Despite an inline comment claiming it was "fast, <60s", the job re-installed the backend and re-ran the **entire** backend and frontend test suites from a cold start — unsharded, on a single runner, with coverage instrumentation — purely to recompute a line-rate that the CI test jobs had *already* computed in the same PR run.

## Why it matters

It was the redundant long pole on every PR: it duplicated work `ci.yml` already does (backend across 4 parallel shards, frontend once), collapsing that parallelism back onto one serial runner. It also masked a latent bug (below) that meant frontend coverage was never actually enforced from the intended artifact.

## Fix (symptom → root cause → change)

- **Symptom:** Coverage Gate ~30 min; frontend coverage effectively re-derived every run.
- **Root cause:** The gate re-ran `pytest --cov` and `vitest run --coverage` inline instead of consuming the `coverage-backend` / `coverage-frontend` artifacts the test jobs already produce. Separately, `frontend-test` uploaded `website/coverage/`, but vitest's `reportsDirectory` is `website/build/coverage/` (see `vite.config.ts`), so the `coverage-frontend` artifact was **empty** — which is exactly why the gate fell back to re-running vitest.
- **Change:**
  - Moved `Coverage Gate` into `ci.yml` as a downstream job with `needs: [coverage-combine, frontend-test]`, so it consumes the already-produced artifacts via a deterministic same-run handoff (no cross-workflow `workflow_run` artifact race — the reason the original author gave up and re-ran everything). It now only downloads, parses `line-rate`, and threshold-checks (backend ≥ 50%, frontend ≥ 40%). Runs in seconds.
  - Fixed the `frontend-test` upload path to `website/build/coverage/` and added `if-no-files-found: error` so an empty coverage artifact fails loudly instead of silently.
  - Made the gate **fail-closed** on missing data: a missing artifact or cobertura report errors the job, replacing the old `|| true` + warn-and-skip that could silently pass.
  - Made the gate **fail-closed on skipped upstream**: added `if: ${{ always() }}` plus a guard step that fails when `coverage-combine` or `frontend-test` did not succeed. Without this, a failing/skipped dependency would *skip* `coverage-gate`, and GitHub treats a skipped required check as satisfied — which would have defeated the fail-closed guarantee (caught by the Arbiter/GPT/Design review).
  - Threshold now compares the **raw** `line-rate` against 50%/40% (rounding only for display), so a value like 49.97% can no longer round up to pass.
  - Removed the old re-running job from `code-review.yml`, leaving a pointer comment.

The check name `Coverage Gate` is unchanged, so branch protection that requires it stays satisfied. Backend coverage is now computed from the combined all-shard data (`coverage-combine`), which is at least as complete as the old single serial run.

## Tests

N/A — this is CI workflow configuration (`.github/workflows/*.yml`); there is no unit-test harness for GitHub Actions YAML in this repo. Validated structurally by confirming the new job matches sibling job indentation/shape and reuses the same pinned `download-artifact`/`upload-artifact` action SHAs already in `ci.yml`.

## Manual verification

Static verification done locally:
- Confirmed `vite.config.ts` `reportsDirectory: './build/coverage'` + `cobertura` reporter → `website/build/coverage/cobertura-coverage.xml`, matching the corrected upload path and the gate's `find … -name 'cobertura*.xml'`.
- Confirmed `coverage-combine` runs `coverage xml -o coverage.xml` and uploads `coverage-backend`, matching the gate's `backend-cov/coverage.xml` read.

End-to-end behavior (artifact download + thresholds) can only run on GitHub Actions; will confirm on the PR's own CI run that `Coverage Gate` goes green in seconds with the expected line-rates.
