### PR TITLE
fix(instances): probe new data-home for run-marker so remote token mint survives the home move

### DIFF
--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -24,6 +24,7 @@ import contextlib
 import logging
 import re
 
+from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -137,12 +138,13 @@ def build_candidate_command(
     a fixed literal or pre-validated string — never raw user input.
 
     When *marker_port* is given, the snippet first consults the run-marker the
-    *running* gateway wrote for that port
-    (``${KIROCREW_HOME:-$HOME/.kirocrew}/run/gateway-<port>.bin``) and execs the
-    launcher it names — so mint uses the same venv as the live gateway instead of
-    whatever ``~/.local/bin/kirocrew`` happens to point at. Falls through to the
-    candidate search when the marker is absent or doesn't name an executable
-    (older remotes, or gateway not running), so nothing regresses.
+    *running* gateway wrote for that port (``<data-home>/run/gateway-<port>.bin``,
+    probing ``$KIROCREW_HOME`` then ``$HOME/.kiro/crew`` then the legacy
+    ``$HOME/.kirocrew`` — see :func:`_run_marker_clause`) and execs the launcher
+    it names — so mint uses the same venv as the live gateway instead of whatever
+    ``~/.local/bin/kirocrew`` happens to point at. Falls through to the candidate
+    search when the marker is absent or doesn't name an executable (older
+    remotes, or gateway not running), so nothing regresses.
     See :mod:`kiro_crew.instances.run_marker`.
     """
     expanded = " ".join(f'"{p}"' for p in candidates)
@@ -163,31 +165,66 @@ def build_candidate_command(
 def _run_marker_clause(subcommand: str, port: int) -> str:
     """Shell prelude that execs the gateway's recorded launcher for *port*.
 
-    Reads ``${KIROCREW_HOME:-$HOME/.kirocrew}/run/gateway-<port>.bin`` (written by
-    :func:`kiro_crew.instances.run_marker.write_marker`). ``$HOME``/``$KIROCREW_HOME``
-    expand at remote-shell parse time; *port* is a bounded int (see
-    :func:`_validate_port`), so the path literal cannot inject shell syntax. Only
-    ``exec``s when the recorded path is an executable file.
+    Probes, in priority order, the run-marker
+    (``run/gateway-<port>.bin``, written by
+    :func:`kiro_crew.instances.run_marker.write_marker`) under each candidate
+    data home and ``exec``s the first launcher it names that is an executable
+    file:
 
-    Known limitation (non-interactive SSH env): the writer keys the marker off
-    the gateway process's ``config_dir()`` (its ``KIROCREW_HOME``), but this
-    prelude resolves ``${KIROCREW_HOME:-$HOME/.kirocrew}`` in the *remote* SSH
-    shell. If the remote gateway runs under a custom ``KIROCREW_HOME`` that the
-    non-interactive shell does not also export (a persistent one set in
-    ``~/.zshenv`` *is* inherited, so this is the uncommon case), the paths
-    diverge, the marker is missed, and mint falls through to the candidate search
-    — i.e. exactly today's behavior, no regression.
+    1. ``$KIROCREW_HOME`` — an explicit override, if exported into this shell.
+    2. ``$HOME/<CONFIG_DIR_NAME>`` — the current default data home.
+    3. ``$HOME/<LEGACY_CONFIG_DIR_NAME>`` — the pre-move legacy home (older remotes).
+
+    The default/legacy home segments are **interpolated from**
+    :data:`kiro_crew.config.paths.CONFIG_DIR_NAME` /
+    :data:`~kiro_crew.config.paths.LEGACY_CONFIG_DIR_NAME` — the same constants
+    ``config_dir()`` (the marker *writer*) derives its default from — so reader
+    and writer share one source of truth. A future data-home rename updates both
+    sides from that single edit instead of leaving these shell literals to drift
+    stale (which is precisely the read/write desync this whole mechanism guards).
+
+    ``$HOME``/``$KIROCREW_HOME`` expand at remote-shell parse time; *port* is a
+    bounded int (see :func:`_validate_port`) and the home segments are trusted
+    module constants, so the path literals cannot inject shell syntax.
+
+    Why the multi-home probe: the writer keys the marker off the gateway
+    process's ``config_dir()``, which now defaults to ``~/.kiro/crew`` after the
+    ``~/.kirocrew`` -> ``~/.kiro/crew`` data-home move. This prelude runs in the
+    *remote* non-interactive SSH shell, which usually does NOT export
+    ``KIROCREW_HOME`` — so a single ``${KIROCREW_HOME:-$HOME/.kirocrew}`` default
+    (the pre-move literal) would read the wrong, now-empty legacy path on every
+    migrated remote, miss the marker, and fall through to the blind candidate
+    search (which lands on whatever ``~/.local/bin/kirocrew`` points at, e.g. an
+    uninstalled worktree). Probing both the new default and the legacy home — and
+    still honoring an explicit ``KIROCREW_HOME`` above both — restores the marker
+    hit on migrated remotes while remaining a no-op on un-migrated ones. Falls
+    through to the candidate search when no marker names an executable, so
+    nothing regresses.
     """
-    marker = f'"${{KIROCREW_HOME:-$HOME/.kirocrew}}/run/gateway-{int(port)}.bin"'
+    fname = f"run/gateway-{int(port)}.bin"
+    # ``${KIROCREW_HOME:+...}`` expands to the value only when KIROCREW_HOME is
+    # set and non-empty (else an empty word, skipped below) — so an unset
+    # override never degrades to a bare ``/run/...`` absolute path. The default
+    # and legacy home segments come from the shared config.paths constants (not
+    # re-hardcoded here) so reader and writer never drift apart on a home move.
+    homes = " ".join(
+        [
+            f'"${{KIROCREW_HOME:+$KIROCREW_HOME/{fname}}}"',
+            f'"$HOME/{CONFIG_DIR_NAME}/{fname}"',
+            f'"$HOME/{LEGACY_CONFIG_DIR_NAME}/{fname}"',
+        ]
+    )
     return " ".join(
         [
-            f"__mk={marker};",
-            'if [ -f "$__mk" ]; then',
-            '  __kb="$(cat "$__mk" 2>/dev/null)";',
-            '  if [ -n "$__kb" ] && [ -x "$__kb" ]; then',
-            f'    exec "$__kb" {subcommand};',
+            f"for __mk in {homes}; do",
+            '  [ -n "$__mk" ] || continue;',
+            '  if [ -f "$__mk" ]; then',
+            '    __kb="$(cat "$__mk" 2>/dev/null)";',
+            '    if [ -n "$__kb" ] && [ -x "$__kb" ]; then',
+            f'      exec "$__kb" {subcommand};',
+            "    fi;",
             "  fi;",
-            "fi;",
+            "done;",
         ]
     )
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -236,31 +236,49 @@ class TestTokenMint:
             build_remote_token_command("", ttl="20h", port=99999)
 
     def test_token_command_prefers_run_marker_for_port(self):
+        from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
         from kiro_crew.instances.token_mint import (
             build_candidate_command,
             build_remote_token_command,
         )
 
         # empty remote_bin + port -> run-marker clause runs BEFORE the candidate
-        # ladder, keyed by the same port, and execs the recorded launcher.
+        # ladder, keyed by the same port, and execs the recorded launcher. The
+        # marker is probed under each candidate data home (KIROCREW_HOME override,
+        # the current default, then the legacy home) so a migrated remote whose
+        # non-interactive SSH shell doesn't export KIROCREW_HOME still hits the
+        # marker written under the new default home. The default/legacy home
+        # segments are asserted via the SHARED config.paths constants (not
+        # re-hardcoded literals) so that re-hardcoding — the read/write desync
+        # this fix closes — fails this test loudly at PR time.
+        default_marker = f'"$HOME/{CONFIG_DIR_NAME}/run/gateway-7879.bin"'
+        legacy_marker = f'"$HOME/{LEGACY_CONFIG_DIR_NAME}/run/gateway-7879.bin"'
         cmd = build_remote_token_command("", ttl="20h", port=7879)
-        assert '"${KIROCREW_HOME:-$HOME/.kirocrew}/run/gateway-7879.bin"' in cmd
+        assert '"${KIROCREW_HOME:+$KIROCREW_HOME/run/gateway-7879.bin}"' in cmd
+        assert default_marker in cmd
+        assert legacy_marker in cmd
+        # new default home is probed before the legacy home
+        assert cmd.index(default_marker) < cmd.index(legacy_marker)
         assert 'exec "$__kb" token --ttl 20h --port 7879;' in cmd
-        assert cmd.index("__mk=") < cmd.index("for b in ")  # marker tried first
+        assert cmd.index("for __mk in ") < cmd.index("for b in ")  # marker tried first
         # it still falls through to the candidate ladder (older remotes/no marker)
         assert 'exec "$b" token --ttl 20h --port 7879;' in cmd
 
         # no port -> no marker clause (can't key it); pure candidate ladder.
+        # NOTE: guard on the sentinels the generator actually emits — the marker
+        # prelude is a "for __mk in ...done" loop over "…/gateway-<port>.bin"
+        # paths — NOT the retired "__mk=" token (which would make these vacuous).
         no_port = build_remote_token_command("", ttl="20h")
-        assert "__mk=" not in no_port and "gateway-" not in no_port
+        assert "for __mk in" not in no_port and "gateway-" not in no_port
 
         # explicit custom remote_bin is never overridden by the marker.
         custom = build_remote_token_command("~/bin/kirocrew", ttl="20h", port=7879)
-        assert "__mk=" not in custom
+        assert "for __mk in" not in custom and "gateway-" not in custom
         assert '"$HOME/bin/kirocrew" token --ttl 20h --port 7879' in custom
 
         # generic candidate builder: marker only when a port is supplied.
-        assert "__mk=" not in build_candidate_command("restart")
+        assert "for __mk in" not in build_candidate_command("restart")
+        assert "gateway-" not in build_candidate_command("restart")
         assert "gateway-7880.bin" in build_candidate_command("token", marker_port=7880)
 
         # the sibling remote-exec path (restart, via run_remote_kirocrew) also
@@ -270,7 +288,8 @@ class TestTokenMint:
         restart = build_remote_command("", "restart", marker_port=7781)
         assert "gateway-7781.bin" in restart and 'exec "$__kb" restart;' in restart
         # ...unless an explicit custom remote_bin is set (never overridden).
-        assert "__mk=" not in build_remote_command("~/bin/kirocrew", "restart", marker_port=7781)
+        pinned_restart = build_remote_command("~/bin/kirocrew", "restart", marker_port=7781)
+        assert "for __mk in" not in pinned_restart and "gateway-" not in pinned_restart
 
     def test_ssh_argv_shape(self):
         from kiro_crew.instances.token_mint import _build_ssh_argv


### PR DESCRIPTION
## Problem
Connecting to a remote instance fails at token mint with:

```
token mint failed: remote token mint on <host> exited 1:
❌ KiroCrew venv not found at /workspace/kirocrew-wt-cse-g3/.venv
```

This is exactly the failure the run-marker was built to prevent — mint is
resolving to an *uninstalled git worktree* instead of the live gateway's venv.
Because the proactive/reactive token-refresh loop re-mints on every poll, the
pane also periodically disconnects and reconnects.

## Why it matters
Remote instances become unusable: the pane can't authenticate, and every
refresh cycle re-triggers the failure. The user's documented sync → rebuild →
restart of the gateway does not fix it, because mint never finds the marker the
running gateway wrote — the whole point of the run-marker mechanism is defeated.

## Fix (symptoms → root cause → change)
- **Symptom:** mint execs `~/.local/bin/kirocrew`, which symlinks into an
  uninstalled worktree with no `.venv`, instead of the running gateway's venv.
- **Root cause:** the run-marker has a *write* side and a *read* side that must
  agree on a path. `run_marker.write_marker()` writes under `config_dir()`,
  which after the `~/.kirocrew` → `~/.kiro/crew` **data-home migration** now
  defaults to `~/.kiro/crew`. But `_run_marker_clause` (the shell snippet mint
  runs over SSH) read a single default: `${KIROCREW_HOME:-$HOME/.kirocrew}`.
  Non-interactive SSH shells don't export `KIROCREW_HOME`, so the read resolved
  to the **stale legacy** `$HOME/.kirocrew/run/...`, missed the marker written
  at the new home, and fell through to the blind candidate ladder — landing on
  the worktree symlink. The old docstring flagged the custom-`KIROCREW_HOME`
  case as an "uncommon" limitation; the home migration silently promoted it to
  the **default** path, breaking every migrated remote.
- **Change:** `_run_marker_clause` now probes the marker under each candidate
  data home, in priority order, and execs the first launcher that is an
  executable file:
  1. `$KIROCREW_HOME` (only when exported — `${KIROCREW_HOME:+…}` so an unset
     override never degrades to a bare `/run/…` root path),
  2. `$HOME/<CONFIG_DIR_NAME>` (current default home),
  3. `$HOME/<LEGACY_CONFIG_DIR_NAME>` (legacy home, for un-migrated remotes).
  It still falls through to the candidate ladder when no marker names an
  executable, so nothing regresses on older remotes or when the gateway isn't
  running. `port` is a bounded int and the home segments are trusted module
  constants, so the path literals cannot inject shell syntax.
- **Closing the bug *class*, not just this instance (design-review concern):**
  the default/legacy home segments are **interpolated from**
  `kiro_crew.config.paths.CONFIG_DIR_NAME` / `LEGACY_CONFIG_DIR_NAME` — the same
  constants `config_dir()` (the marker *writer*) derives its default from —
  rather than re-hardcoded as fresh shell literals. This restores a single
  source of truth between reader and writer: a future data-home rename (e.g. the
  active `KIROCREW_EDITION_DIR` edition-seam work) updates both sides from one
  edit instead of leaving the shell clause to silently drift stale and recur the
  identical production failure. (`config.paths` is a stdlib-only leaf module, so
  the import adds no cycle.)

## Tests
`test/test_instances.py::test_token_command_prefers_run_marker_for_port`
updated to assert the new behavior:
- the marker is probed under all three homes (`${KIROCREW_HOME:+…}`,
  `$HOME/<CONFIG_DIR_NAME>`, `$HOME/<LEGACY_CONFIG_DIR_NAME>`),
- the new default home is probed **before** the legacy home,
- the marker loop still runs before the candidate ladder (`for __mk in` <
  `for b in`),
- **the expected home segments are derived from the shared `config.paths`
  constants**, so re-hardcoding a divergent literal (the desync this fix closes)
  fails the test loudly at PR time,
- explicit custom `remote_bin` is still never overridden by the marker,
- the sibling `restart` path (`run_remote_kirocrew`) is unchanged.
- **Restored negative guards (review follow-up):** the marker prelude was
  renamed from a `__mk=` assignment to a `for __mk in …` loop, which made four
  `"__mk=" not in …` assertions vacuous (the generator no longer emits that
  substring). They now guard the sentinels the generator actually emits
  (`for __mk in` and `gateway-`), so the precedence contract is really enforced:
  no marker prelude leaks into the no-port, explicit-`remote_bin`, or
  generic-`restart` paths of this security-sensitive remote-shell generator.

Full module passes (114) and `test_governance_self_protection.py` (43,
run-marker keystone paths) passes; flake8 + isort clean.

## Manual verification
Static generation + assertion covered by unit tests. Full end-to-end
(reconnect to a migrated remote) additionally requires the remote gateway to be
restarted so it writes the marker at the new `~/.kiro/crew` home and mints with
the corrected clause — noted for the maintainer; not reproducible from unit
tests alone.

## Follow-up (out of scope, noted)
`src/kiro_crew/mcp_gateway/stub_wrapper.sh:69` still carries the pre-move
`${KIROCREW_HOME:-$HOME/.kirocrew}/logs` literal (log dir, a different
subsystem). Same drift pattern but unrelated to token mint; flagged here so it
isn't lost, left out to keep this PR focused.
