### PR TITLE
fix(ui): rename user-visible "App Store" strings to "Apps"

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/README.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/README.md
@@ -46,7 +46,7 @@ App-local runtime data lives under `~/.kirocrew/apps/code-review-sage/data/`
 ## Enable
 
 Code Review Sage is a built-in app (listed in `kiro_crew.apps.builtins`). Enable
-it from the dashboard App Store, or:
+it from the dashboard Apps page, or:
 
 ```bash
 kirocrew app enable code-review-sage

--- a/src/kiro_crew/data/tips_curated.json
+++ b/src/kiro_crew/data/tips_curated.json
@@ -100,13 +100,13 @@
     },
     {
       "id": "app-store",
-      "feature": "App Store",
-      "title": "Add capabilities from the App Store",
+      "feature": "Apps",
+      "title": "Add new capabilities with Apps",
       "body": "Open **Apps → Browse** and click **Enable** to add an app's agents, skills, and crons in one step.",
       "why": "",
       "doc": "",
       "cta_prompt": "",
-      "action": { "kind": "route", "label": "Open App Store", "route": "/apps" }
+      "action": { "kind": "route", "label": "Open Apps", "route": "/apps" }
     }
   ]
 }

--- a/src/kiro_crew/docs/dashboard.md
+++ b/src/kiro_crew/docs/dashboard.md
@@ -126,7 +126,7 @@ other pages.
 
 Display agent hooks configuration. View pre/post tool hooks and message hooks.
 
-### App Store
+### Apps
 
 Browse, install, and manage KiroCrew apps. SSE streaming install logs show
 real-time progress. Apps can be dashboard-hosted, gateway-side, or external.

--- a/website/src/components/AppHost.tsx
+++ b/website/src/components/AppHost.tsx
@@ -106,7 +106,7 @@ function AppCrashFallback({
           </p>
           <div className="flex gap-2 justify-center">
             <Btn onClick={onRetry}><RefreshCw size={14} /> Retry</Btn>
-            <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> App Store</Btn>
+            <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Apps</Btn>
           </div>
         </div>
       </div>
@@ -141,8 +141,8 @@ function AppNotFound({ name }: { name: string }) {
       <div className="flex-1 flex items-center justify-center p-8">
         <div className="text-center">
           <div className="text-[48px] mb-4 opacity-20"><Package size={48} /></div>
-          <p className="text-muted mb-4">Install it from the App Store or via CLI</p>
-          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> App Store</Btn>
+          <p className="text-muted mb-4">Install it from Apps or via CLI</p>
+          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Apps</Btn>
         </div>
       </div>
     </>
@@ -160,8 +160,8 @@ function AppDisabled({ app }: { app: AppHostProps['app'] }) {
       <div className="flex-1 flex items-center justify-center p-8">
         <div className="text-center max-w-md">
           <PowerOff size={48} className="text-muted mx-auto mb-4 opacity-30" />
-          <p className="text-sm text-muted mb-4">Enable this app from the App Store to use it.</p>
-          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> App Store</Btn>
+          <p className="text-sm text-muted mb-4">Enable this app from Apps to use it.</p>
+          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Apps</Btn>
         </div>
       </div>
     </>
@@ -184,7 +184,7 @@ function AppNoUI({ app }: { app: AppHostProps['app'] }) {
             This app provides agents and skills but no visual interface.
             Use its agents from chat.
           </p>
-          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> App Store</Btn>
+          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Apps</Btn>
         </div>
       </div>
     </>
@@ -236,7 +236,7 @@ function AppHostInner({ app }: AppHostProps) {
                 <AlertTriangle size={48} className="text-danger mx-auto mb-4" />
                 <h3 className="text-text font-medium mb-2">Failed to load {app.displayName || app.name}</h3>
                 <p className="text-sm text-muted mb-4">{err.message}</p>
-                <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> App Store</Btn>
+                <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Apps</Btn>
               </div>
             </div>
           ),

--- a/website/src/components/MigrationBanner.tsx
+++ b/website/src/components/MigrationBanner.tsx
@@ -26,7 +26,7 @@ export default function MigrationBanner({ appName, migratedTo }: MigrationBanner
           This feature is moving to a standalone app
         </div>
         <div className="text-[13px] text-muted mt-1">
-          Install "{appName}" from the App Store before the next KiroCrew update to keep using it.
+          Install "{appName}" from Apps before the next KiroCrew update to keep using it.
         </div>
       </div>
       <Btn
@@ -34,7 +34,7 @@ export default function MigrationBanner({ appName, migratedTo }: MigrationBanner
         onClick={() => navigate(`/apps/detail/${encodeURIComponent(targetName)}`)}
         className="shrink-0"
       >
-        Install from App Store <ArrowRight size={14} />
+        Install from Apps <ArrowRight size={14} />
       </Btn>
     </div>
   )

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -393,7 +393,7 @@ export default function AppDetailPage() {
   if (loading) {
     return (
       <>
-        <PageHeader title="App Store" subtitle="Loading…" />
+        <PageHeader title="Apps" subtitle="Loading…" />
         <div className="flex-1 flex items-center justify-center text-muted text-sm">
           <Loader2 size={16} className="animate-spin mr-2" /> Loading app details…
         </div>
@@ -406,7 +406,7 @@ export default function AppDetailPage() {
       <>
         <PageHeader title="App Not Found" subtitle={error || `"${name}" doesn't exist`} />
         <div className="flex-1 flex items-center justify-center p-8">
-          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Back to App Store</Btn>
+          <Btn onClick={() => navigate('/apps')}><ArrowLeft size={14} /> Back to Apps</Btn>
         </div>
       </>
     )
@@ -436,11 +436,11 @@ export default function AppDetailPage() {
 
   return (
     <>
-      <PageHeader title="App Store" subtitle={app.displayName} />
+      <PageHeader title="Apps" subtitle={app.displayName} />
       <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
         {/* Back link */}
         <button className="flex items-center gap-1.5 text-[13px] text-muted hover:text-text mb-5 bg-transparent border-none cursor-pointer p-0 font-body transition-colors" onClick={() => navigate('/apps')}>
-          <ArrowLeft size={14} /> Back to App Store
+          <ArrowLeft size={14} /> Back to Apps
         </button>
 
         {/* Error */}
@@ -648,7 +648,7 @@ export default function AppDetailPage() {
                   </p>
                 )}
                 <p className="text-[12px] text-muted mt-2">
-                  Once launched, the app will automatically connect to this KiroCrew instance and appear in the App Store.
+                  Once launched, the app will automatically connect to this KiroCrew instance and appear in Apps.
                 </p>
               </div>
             </div>

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -335,12 +335,12 @@ export default function AppsPage() {
                 )}
                 {uninstallTarget.origin === 'registry' && (
                   <div className="bg-bg-elevated border border-border rounded-md px-2.5 py-2 text-[12px] text-muted mb-2">
-                    Installed from App Store — KiroCrew metadata{uninstallTarget.resources === 'app' ? ', the app secret, and' : ' and'} the downloaded source code will be removed.{uninstallTarget.resources === 'app' && !uninstallTarget.manifest?.setup?.onUninstall ? ' The app itself is managed externally.' : ''}
+                    Installed from Apps — KiroCrew metadata{uninstallTarget.resources === 'app' ? ', the app secret, and' : ' and'} the downloaded source code will be removed.{uninstallTarget.resources === 'app' && !uninstallTarget.manifest?.setup?.onUninstall ? ' The app itself is managed externally.' : ''}
                   </div>
                 )}
                 {uninstallTarget.origin !== 'registry' && uninstallTarget.resources === 'app' && uninstallTarget.manifest?.setup?.onUninstall && (
                   <div className="bg-bg-elevated border border-border rounded-md px-2.5 py-2 text-[12px] text-muted mb-2">
-                    Not installed from App Store — your local source code will not be affected.
+                    Not installed from Apps — your local source code will not be affected.
                   </div>
                 )}
                 {(uninstallTarget.manifest?.agents?.length || 0) > 0 && (

--- a/website/src/pages/MigrationPage.tsx
+++ b/website/src/pages/MigrationPage.tsx
@@ -103,7 +103,7 @@ export default function MigrationPage() {
                 The old builtin entry has been removed. Your data has been preserved and is accessible to the standalone version.
               </div>
               <Btn primary onClick={() => navigate('/apps')}>
-                Back to App Store <ArrowRight size={14} />
+                Back to Apps <ArrowRight size={14} />
               </Btn>
             </div>
           </Card>
@@ -136,7 +136,7 @@ export default function MigrationPage() {
               {state === 'available' && (
                 <div className="flex items-center gap-3 mt-4">
                   <Btn primary onClick={() => navigate(`/apps/detail/${encodeURIComponent(targetName)}`)}>
-                    <Download size={14} /> Install from App Store
+                    <Download size={14} /> Install from Apps
                   </Btn>
                   <span className="text-[13px] text-muted">
                     Install the standalone version to continue using this feature.
@@ -147,7 +147,7 @@ export default function MigrationPage() {
               {state === 'not-in-registry' && (
                 <div className="bg-bg-elevated border border-border rounded-lg p-4 mt-4">
                   <div className="text-[13px] text-muted mb-3">
-                    Coming soon — this app is not yet available in the App Store. Check back after the next update.
+                    Coming soon — this app is not yet available in Apps. Check back after the next update.
                   </div>
                   <Btn onClick={() => refetch()}>
                     <RefreshCw size={14} /> Refresh


### PR DESCRIPTION
## Problem

The dashboard calls one surface by two different names. The sidebar entry and the route are **Apps**, but a lot of the copy around them says **App Store** — including the feature-discovery tip, which reads *"Add capabilities from the App Store"* and points at a name that appears nowhere in the navigation.

Every place this leaks today:

| Surface | Old string |
|---|---|
| Discovery tip | "Add capabilities from the App Store" / feature "App Store" / CTA "Open App Store" |
| App detail page | header "App Store", "Back to App Store" (×2), "…appear in the App Store." |
| App host (missing / disabled / crashed app) | "Install it from the App Store or via CLI", "Enable this app from the App Store to use it.", "App Store" back buttons (×3) |
| Uninstall dialog | "Installed from App Store — …", "Not installed from App Store — …" |
| Migration banner / page | "Install … from the App Store", "Install from App Store" (×2), "Back to App Store", "not yet available in the App Store" |
| In-dashboard docs | `### App Store` section heading |
| Code Review Sage README (rendered on the detail page) | "Enable it from the dashboard App Store" |

## Why it matters

Two names for one thing is a wayfinding bug, not just a wording nit: the tip's whole job is to teach a user where a feature lives, and it names a destination the user cannot find in the sidebar. The detail page then re-titles itself "App Store" after you navigate there from "Apps", so the breadcrumb trail contradicts itself.

## Fix (symptom → root cause → change)

**Symptom:** UI copy says "App Store"; nav says "Apps". **Root cause:** the surface was renamed to "Apps" in the nav/route, but the strings scattered across five components, the curated tip catalog, and two markdown files were never swept. **Change:** rename every user-visible occurrence to "Apps".

- `src/kiro_crew/data/tips_curated.json` — tip is now titled **"Add new capabilities with Apps"**, feature `Apps`, CTA `Open Apps`. The tip **`id` stays `app-store`** deliberately: it is the key used for per-tip feedback and opt-out state, so changing it would resurface the tip for users who already dismissed it.
- `website/src/components/AppHost.tsx` — 5 strings (missing / disabled / error states plus their back buttons).
- `website/src/pages/AppDetailPage.tsx` — page header (loading + loaded), both back links, and the external-app connect hint.
- `website/src/pages/AppsPage.tsx` — both uninstall-dialog origin notices.
- `website/src/components/MigrationBanner.tsx`, `website/src/pages/MigrationPage.tsx` — banner copy, install CTA (×2), back button, not-yet-in-registry notice.
- `src/kiro_crew/docs/dashboard.md` — the section heading rendered in the dashboard Docs page.
- `src/kiro_crew/apps/builtins/code_review_sage/README.md` — the enable instruction shown on the app detail page.

**Deliberately untouched:** source-code comments and developer docs (`docs/APP_STORE_GUIDELINES.md`, `docs/app-kit/**`, RFCs, spec files) — none render in the UI, and the published guidelines are a separate naming decision. Also untouched: `website/electron/scripts/notarize.js`, which refers to **Apple's** App Store Connect API and is unrelated to this surface.

No behavior, routing, or API change — the route stays `/apps`, the tip `id` stays `app-store`, and no props or types changed. Pure copy.

## Tests

No new tests. This is a string-only change with no branch or state logic, and the existing suites already pin the parts that could break:

- `test/test_tips.py` (117 tests) validates the curated tip catalog's schema and the stable id set — it locks in that the tip still parses and that `app-store` is still a known id after the rename.
- `test/test_doc_parser.py` + `test/test_builtin_discovery.py` + `test/test_builtin_app_optional_enable.py` (60 tests) cover the two markdown files' parse/serve paths.
- Frontend: `tsc` + the full vitest suite (4497 tests) — no snapshot or `getByText` assertion referenced any of the renamed strings, so none needed updating.

Verified locally: `tsc --noEmit` clean, `vitest run` 4497 passed, and the four backend suites above all green.

## Manual verification

Grepped the whole tree for `App Store` after the change and confirmed the only remaining hits are code comments, developer docs, and the Apple notarization script — no JSX text, no `PageHeader title=`, no button label, no served markdown.

## Screenshots

Not yet captured — no browser harness exists on this branch, and the change is text-only within existing layouts (no new/moved/resized elements, no theme-dependent styling). Happy to add before/after captures of the tip card, the Apps detail header, and the uninstall dialog if a reviewer wants them; say so and I'll push them under `temp-screenshots/apps-rename/`.
