### PR TITLE
feat(channels): gate non-Slack transport start on the channels governance scope

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -146,20 +146,96 @@ canonical taxonomy parser — never re-implemented). Resolution is:
 
 **`host` surface (in-process host actions).** A governance check that is not
 driven by a user-facing surface — app activation
-(`apps.manager._app_activation_denied`) and Slack workspace admission
-(`slack.enterprise`) — runs under the `_host` sentinel session key, which
-classifies to surface `host`. Operators can bind a `surface:host` profile to
-narrow these on top of the policy ceiling (e.g. an `apps` allowlist that further
-restricts which apps may activate). NOTE: these callers used to pass an empty
-session key, which mis-classified to `slack` and accidentally picked up
-`surface:slack` profiles; they now use the honest `host` surface, so a
-`surface:slack` profile no longer governs host-side app activation. The Slack
-posture check itself stays policy-only (a profile cannot carry `posture`,
-Rule 6).
+(`apps.manager._app_activation_denied`), Slack workspace admission
+(`slack.enterprise`), and non-Slack transport startup
+(`slack.gateway._channel_transport_permitted`) — runs under the `_host` sentinel
+session key, which classifies to surface `host`. Operators can bind a
+`surface:host` profile to narrow these on top of the policy ceiling (e.g. an
+`apps` allowlist that further restricts which apps may activate, or a `channels`
+allowlist that narrows which transports may connect below what the ceiling
+permits). NOTE: these callers used to pass an empty session key, which
+mis-classified to `slack` and accidentally picked up `surface:slack` profiles;
+they now use the honest `host` surface, so a `surface:slack` profile no longer
+governs host-side app activation or transport startup. The two policy-scope
+chokepoints (app activation + transport start) audit their decisions via
+`sel().log_governance_decision` (`governance_permits` audits only its own
+degrade, never a normal permit/deny); Slack workspace admission audits via a
+different sink (`log_api_access`, see below). They also differ on the ERROR
+disposition:
+
+- **App activation (`apps.manager._app_activation_denied`)** audits a DENY and,
+  on an unexpected governance error, **fails open** (degrades to permit + an
+  `audit_governance_degraded` record) — the app's own enable guard still applies
+  and wedging host boot on a governance hiccup is worse.
+- **Non-Slack transport start (`slack.gateway._channel_transport_permitted`)**
+  audits BOTH the allowed and the denied decision and **fails closed**: it passes
+  `governance_permits(fail_closed=True)`, and its outer error branch also denies
+  (`return False` + `audit_governance_degraded(failed_closed=True)`), so a
+  transport connects ONLY on a positive permit. This deliberately DIVERGES from
+  app-activation and `mcp_core._vet_channel_governance` (both fail open) because a
+  transport is an externally-reachable network surface — deny-by-default on any
+  error is the safer posture there, and a transport that fails to start leaks
+  nothing. `fail_closed=True` is the same disposition the authorization/admission
+  chokepoints use (e.g. `capabilities.publish` in `handlers/artifacts.py`,
+  `capabilities.theme_install` in `handlers/themes.py`, `capabilities.theme_persona`
+  in `chat_runner.py`) where a wrong permit lets bytes leave the box or ingests
+  untrusted content. The ALLOW audit is disposition-split: a **governed** allow
+  (a policy/profile governs `channels`, so the Decision's `rule != "default"`) is
+  **audit-or-deny** — written `critical=True` (synchronous + raising) so a SEL
+  persistence failure propagates and DENIES the start (the default background
+  writer swallows disk failures, so `critical` is required for the guarantee to
+  be real); an **ungoverned** allow (no policy governs `channels` — the default
+  OSS build, `rule == "default"`) is **best-effort** so OSS transport
+  availability never depends on SEL disk health. The deny audit is best-effort
+  (the transport is not starting either way).
+- **Slack workspace admission (`slack.enterprise`)** audits via `log_api_access`
+  (not `log_governance_decision`) and its posture probe fails **closed** (returns
+  False + `audit_governance_degraded(failed_closed=True)`) on an error, because
+  admitting an unverified workspace is the higher-blast-radius mistake.
+
+The Slack posture check itself stays policy-only (a profile cannot carry
+`posture`, Rule 6).
 
 Profiles hot-reload via an mtime fingerprint (`ProfileStore`); a schema-invalid
 profile falls back to deny-all (Validation rule 5), **not** the ceiling.
 `extends` is monotonic narrowing (`compose_profiles`).
+
+**Present-but-unrecoverable profile — governed fleet fails closed, standalone is
+lenient.** The reload reads each file's bytes SEPARATELY from parsing and handles
+four on-disk states:
+
+- *Parse error with a salvageable bind* (present, readable, but invalid JSON /
+  schema, yet the parsed dict carries a valid `bind`): deny-all, binding
+  **salvaged from the parsed content** (`_salvage_bind`) so the bound surface
+  still resolves to deny-all, not policy-only.
+- *Present but unrecoverable* — an `OSError` on `read_text` (bad perms, IO error)
+  OR a `UnicodeError`/`UnicodeDecodeError` (invalid encoding) OR a parse error
+  with **no** salvageable bind. The intended `bind` cannot be recovered from the
+  file, so it **cannot** be honoured. We deliberately do **not** guess a bind from
+  the filename — the stem does not reliably encode the bind (an unreadable file
+  that binds `app:file-explorer` is not `surface:<stem>`, so a filename guess
+  would mis-bind and still fail open on the real lookup). Instead the disposition
+  splits on whether the fleet is governed:
+  - **Governed fleet** (a policy ceiling is present): boot **fails closed** —
+    `assert_profiles_within_ceiling` raises `PlatformCompositionError` and aborts
+    boot rather than run with a silently-dropped restrictive profile
+    (deny-by-default: refuse to run over run-ungoverned).
+  - **Standalone / ungoverned** (no ceiling): **lenient** — the file becomes an
+    unbound deny-all that drops out of the bind index, so the surface falls to
+    policy-only (matches pre-split standalone behavior; a profile blip never
+    crashes an ungoverned install). Catching `UnicodeError` alongside `OSError`
+    at the read is required: `UnicodeDecodeError` is not an `OSError`, so without
+    it a corrupt-encoding file would escape uncaught and crash boot inside
+    `assert_profiles_within_ceiling`.
+- *Absent* (missing file, or one that vanished between `iterdir()` and read):
+  **not** a policy — skipped, no manufactured deny. An attended/host surface with
+  no profile at all legitimately falls to the policy ceiling (policy-only), per
+  `resolve_active_scope`.
+
+A **transient** read error is not sticky: after a reload that hit an
+unrecoverable file the store does **not** commit the mtime/size fingerprint, so
+the next access re-reads and a since-recovered file takes effect (rather than the
+deny-all fallback staying cached until file metadata changes or restart).
 
 ## Enforcement planes
 
@@ -192,7 +268,14 @@ profile falls back to deny-all (Validation rule 5), **not** the ceiling.
   (at `cron_add`); the sandbox ordinal floor is clamped in `sandbox.wrap_argv`;
   spawn in `subagent._vet_spawn_governance`; outbound messaging in
   `mcp_core._vet_messaging_governance` plus the per-transport `channels` check
-  in `mcp_core._vet_channel_governance`; durable memory writes in
+  in `mcp_core._vet_channel_governance`; the per-transport **startup** gate in
+  `slack.gateway._channel_transport_permitted` (a `channels` deny for a member
+  keeps that non-Slack transport — `wecom`/`telegram`/`discord`/`webex` — from
+  connecting at boot; resolved under `session_key=HOST_SESSION_KEY` so a
+  `surface:host` profile can narrow it; the four decisions are computed in the
+  maintenance executor before any client starts, since the profile-file read is
+  blocking and this runs on the gateway loop; Slack itself is not gated here);
+  durable memory writes in
   `mcp_core._vet_memory_writes_governance` (at `learn_add`); script-hook
   execution in `hooks._script_hooks_capability_denied` (at `run_script_hook`);
   app activation in `apps.manager._app_activation_denied` (at `enable_app`). All
@@ -313,7 +396,8 @@ The **enforced** scopes in v1 are: `tools`, `mcp`, `commands` (host gate + cron
 command body + the enterprise force-pin for built-in denied-command rules, see
 below), `filesystem.read` / `filesystem.write` / `folders.*` and
 `network.egress` (host gate via tool kind + args), `channels` (per-transport at
-the messaging chokepoint), `apps` (app activation), `sandbox.min_level` (ordinal
+the messaging chokepoint AND at non-Slack transport startup), `apps` (app
+activation), `sandbox.min_level` (ordinal
 floor at `wrap_argv`), `approval_mode` (boot floor only), and every capability
 gate — `capabilities.spawn`, `capabilities.messaging`, `capabilities.cron`,
 `capabilities.memory_writes`, `capabilities.script_hooks`, and

--- a/src/kiro_crew/platform/governance_profiles.py
+++ b/src/kiro_crew/platform/governance_profiles.py
@@ -238,6 +238,15 @@ class ProfileStore:
         self._by_name: Dict[str, Profile] = {}
         # surface/app/task index → profile name, built from each profile's bind.
         self._by_bind: Dict[Tuple[str, str], str] = {}
+        # Set by a reload when a file was PRESENT but its bind could NOT be
+        # recovered (unreadable content / invalid encoding, data is None). Such a
+        # file cannot be honoured — it may carry a restrictive bind that is now
+        # silently dropped. For an ungoverned/standalone host we tolerate it
+        # (lenient, no crash — matches today's behavior); a GOVERNED fleet must
+        # fail closed to a boot-abort instead of running with a dropped profile,
+        # which ``assert_profiles_within_ceiling`` enforces by reading this flag.
+        # Records the offending file name(s) for the boot-abort message.
+        self._unrecoverable: Tuple[str, ...] = ()
 
     def _ensure_fresh(self) -> None:
         directory = _profiles_dir()
@@ -245,11 +254,20 @@ class ProfileStore:
         if fp == self._fingerprint:
             return
         self._reload(directory)
-        self._fingerprint = fp
+        # Only COMMIT the fingerprint cache when the reload fully succeeded. If a
+        # transient read error left an unrecoverable file (F2-3), leave the
+        # fingerprint stale so the NEXT access re-reads (the deny-all fallback
+        # otherwise stays cached until file metadata changes / restart even after
+        # the read recovers). A clean reload advances the cache as before.
+        if self._unrecoverable:
+            self._fingerprint = None
+        else:
+            self._fingerprint = fp
 
     def _reload(self, directory: Path) -> None:
         by_name: Dict[str, Profile] = {}
         by_bind: Dict[Tuple[str, str], str] = {}
+        unrecoverable: list[str] = []
         try:
             files = [p for p in sorted(directory.iterdir()) if p.suffix == ".json"]
         except OSError:
@@ -258,8 +276,47 @@ class ProfileStore:
         for path in files:
             stem = path.stem
             data: object = None
+            # Read the bytes FIRST, separately from parsing, so a present-but-
+            # UNREADABLE file is distinguished from a genuine parse error. The
+            # parse-error path below salvages the bind from the parsed content; an
+            # unreadable file has NO readable content, so its bind can't be
+            # salvaged — the fallback stays UNBOUND (deny_all_profile has
+            # bind=None). We do NOT guess a bind from the filename: the stem does
+            # not reliably encode the bind (an unreadable file that binds
+            # app:file-explorer is NOT surface:<stem>), so a filename guess would
+            # mis-bind and STILL fail open on the real lookup. Instead we record
+            # the file as unrecoverable; a GOVERNED fleet turns that into a
+            # boot-abort (assert_profiles_within_ceiling), while a standalone host
+            # tolerates it (lenient, no crash — matches pre-split behavior).
             try:
-                data = json.loads(path.read_text(encoding="utf-8"))
+                raw = path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                # Vanished between iterdir() and read (TOCTOU) — the file is now
+                # ABSENT, not a present policy. A missing file is not a deny, so
+                # skip it (don't manufacture a fail-closed for a surface that has
+                # no profile at all).
+                continue
+            except (OSError, UnicodeError):
+                # PRESENT but UNREADABLE: an IO/permission error (OSError) OR
+                # invalid encoding (UnicodeDecodeError, whose base is UnicodeError)
+                # — both mean the content, and thus the intended bind, cannot be
+                # read. Record it as unrecoverable and fall back to an UNBOUND
+                # deny-all (a lenient standalone tolerates it; a governed fleet
+                # boot-aborts via assert_profiles_within_ceiling). Catching
+                # UnicodeError here is required: it is NOT an OSError, so without
+                # it a corrupt-encoding profile would escape both handlers and
+                # crash boot inside assert_profiles_within_ceiling.
+                logger.warning(
+                    "profile %s is present but unreadable (bind unrecoverable); "
+                    "deny-all fallback (unbound). A governed fleet fails closed at boot.",
+                    path.name,
+                    exc_info=True,
+                )
+                by_name[stem] = deny_all_profile(stem)
+                unrecoverable.append(path.name)
+                continue
+            try:
+                data = json.loads(raw)
                 if not isinstance(data, dict):
                     raise PlatformCompositionError("profile is not a JSON object")
                 by_name[stem] = parse_profile(data)
@@ -273,11 +330,20 @@ class ProfileStore:
                 # to deny-all (not policy-only).  Without this, an invalid profile
                 # with a valid bind would be dropped from the bind index and its
                 # surface would fail OPEN to the policy ceiling — defeating
-                # Validation rule 5 on the binding path.
+                # Validation rule 5 on the binding path.  A parse error means the
+                # JSON parsed (or partially did), so ``_salvage_bind`` can often
+                # recover the real bind from the dict — unlike the unreadable case
+                # above where there is no content to salvage from.
                 fallback = deny_all_profile(stem)
                 salvaged = _salvage_bind(data)
                 if salvaged is not None:
                     fallback = replace(fallback, bind=salvaged)
+                else:
+                    # A parse error with NO salvageable bind (e.g. valid JSON but
+                    # missing/garbage bind) also leaves a restrictive profile
+                    # potentially dropped — same fail-closed treatment for a
+                    # governed fleet as the unreadable case.
+                    unrecoverable.append(path.name)
                 by_name[stem] = fallback
         # Pass 2: resolve ``extends`` (monotonic narrowing) now that all are parsed.
         # The "non-trivial chain" guard must read each parent's ORIGINAL ``extends``,
@@ -330,6 +396,19 @@ class ProfileStore:
                 by_bind[key] = name
         self._by_name = by_name
         self._by_bind = by_bind
+        self._unrecoverable = tuple(unrecoverable)
+
+    def unrecoverable_files(self) -> Tuple[str, ...]:
+        """File names that were PRESENT but whose bind could not be recovered.
+
+        Populated by the last reload (unreadable content / invalid encoding, or a
+        parse error with no salvageable bind). A governed fleet turns a non-empty
+        result into a boot-abort via :func:`assert_profiles_within_ceiling`; a
+        standalone host tolerates it (lenient). Reads through ``_ensure_fresh`` so
+        the value reflects the current on-disk state.
+        """
+        self._ensure_fresh()
+        return self._unrecoverable
 
     def get(self, name: str) -> Optional[Profile]:
         self._ensure_fresh()
@@ -395,6 +474,24 @@ def assert_profiles_within_ceiling(ceiling: "object") -> None:
 
     if not isinstance(ceiling, GovernanceCeiling):
         return
+    # Governed fleet + a PRESENT profile whose bind could not be recovered
+    # (unreadable content / invalid encoding / unsalvageable parse error) →
+    # fail closed to a boot-abort. Such a file may carry a restrictive bind that
+    # was silently dropped from the bind index; a governed fleet must refuse to
+    # run rather than run with the operator's narrowing missing. (No-op for a
+    # standalone host — ``ceiling is None`` returned above — so a profile blip on
+    # an ungoverned install never crashes boot.) Distinguished from a TRANSIENT
+    # blip by re-reading: ``unrecoverable_files`` runs through ``_ensure_fresh``,
+    # and the store deliberately does NOT cache the fingerprint after an
+    # unrecoverable reload, so a since-recovered file no longer reports here.
+    unrecoverable = _STORE.unrecoverable_files()
+    if unrecoverable:
+        raise PlatformCompositionError(
+            "governed fleet: profile file(s) present but unrecoverable "
+            f"(bind cannot be resolved): {', '.join(sorted(unrecoverable))}. "
+            "Refusing to boot with a silently-dropped restrictive profile "
+            "(fail-closed). Fix or remove the file(s)."
+        )
     for profile in _STORE.all_profiles():
         assert_governance_floor(ceiling, profile)  # raises PlatformCompositionError on weakening
 

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -607,6 +607,7 @@ class SecurityEventLog:
         rule: str = "",
         layer: str = "",
         reason: str = "",
+        critical: bool = False,
     ) -> None:
         """Convenience: log a governance (Level 1 ∩ Level 2) decision.
 
@@ -620,6 +621,14 @@ class SecurityEventLog:
         are redacted HERE (before ``log``) via ``redact_via_context`` — a command
         body or path that tripped governance must not leak a credential into the
         audit log.
+
+        Pass ``critical=True`` when the caller enforces "audit-or-deny" for a
+        GOVERNED decision (e.g. a governed transport-start allow): the event is
+        written SYNCHRONOUSLY and a persistence failure (unwritable SEL file,
+        full disk) is re-raised, so the caller can refuse the action rather than
+        proceed unaudited. Without it the write is enqueued to the background
+        writer, which swallows persistence failures — fine for best-effort audits
+        (e.g. an ungoverned allow) but NOT for audit-or-deny.
         """
         # Lazy import: sel.py is imported very early (security.py imports it), and
         # platform.context imports security indirectly — keep this off the
@@ -646,7 +655,8 @@ class SecurityEventLog:
                     "layer": layer,
                     "reason": safe_reason[:_MAX_ARG_LEN],
                 },
-            )
+            ),
+            critical=critical,
         )
 
     def log_governance_degraded(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -88,6 +88,7 @@ from kiro_crew.dashboard.origin import (
 from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
+from kiro_crew.discord.gateway import maybe_start_discord
 from kiro_crew.embeddings import (
     get_shared_embedder,
     make_sync_embed_fn,
@@ -128,6 +129,12 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.memory import MemoryStore
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
+from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.governance_profiles import (
+    HOST_SESSION_KEY,
+    audit_governance_degraded,
+    governance_permits,
+)
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import safety_override
 from kiro_crew.sandbox import prewarm_backend
@@ -158,6 +165,9 @@ from kiro_crew.subagent import (
     resolve_max_subagents,
 )
 from kiro_crew.taskrunner import TaskRunner
+from kiro_crew.telegram.gateway import maybe_start_telegram
+from kiro_crew.webex.gateway import maybe_start_webex
+from kiro_crew.wechat.gateway import maybe_start_wecom
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import _ChatSlot
@@ -511,6 +521,175 @@ def _result_hash(text: str) -> str:
     text = _VOLATILE_RE.sub("", text)
     text = _EPOCH_RE.sub(_strip_epoch, text)
     return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def _channel_transport_permitted(member: str) -> bool:
+    """Return True only if the ``channels`` scope POSITIVELY permits *member*.
+
+    Gates each non-Slack transport's STARTUP on the same ``channels`` ScopedMap
+    the two OUTBOUND chokepoints consult: outbound-send
+    (``mcp_core._vet_channel_governance``) and outbound cross-surface mirroring
+    (``dashboard.chat_runner._resolve_mirror_target``).  So one ``channels``
+    policy governs a transport consistently at connect and on every outbound
+    path — this gate is the connect-time member.  (It does NOT enforce inbound
+    receive; inbound handling is the transport's own concern.)  *member* is the
+    transport's ``channel_type`` (``wecom`` / ``telegram`` / ``discord`` /
+    ``webex``) — the IDENTICAL member id the outbound chokepoints use, so one
+    allowlist covers them all.
+
+    HOST-side resolution mirrors the canonical
+    ``apps.manager._app_activation_denied`` template:
+
+    * ``session_key=HOST_SESSION_KEY`` — starting a transport is an operator/host
+      action, so it is governed by the policy ceiling AND any ``bind: {type:
+      surface, id: host}`` profile.  An empty key would classify to surface
+      ``unknown`` and silently ignore a host profile (and historically
+      mis-classified to ``slack``); the same fix ``apps/manager`` and
+      ``slack/enterprise.py`` apply.
+    * Both the DENY and the ALLOW decision are audited here via
+      ``sel().log_governance_decision`` — ``governance_permits`` audits only its
+      own degrade, not a normal permit/deny, so the caller owns both.
+
+    Default-build invariant: with no policy governing ``channels`` (the standard
+    open-source case) ``governance_permits`` returns a permitting Decision, so
+    every ENABLED transport starts exactly as before — byte-identical behavior.
+
+    Audit + error posture (exact):
+
+    * GOVERNED allow (a policy/profile governs ``channels`` → ``rule !=
+      "default"``): **audit-or-deny**. The allow SEL is written with
+      ``critical=True`` (synchronous + raising), so a persistence failure
+      (unwritable SEL / full disk) propagates to the outer ``except`` and DENIES
+      the start — a policy-governed transport never connects unaudited. This is
+      why ``critical`` is required: the default background writer SWALLOWS disk
+      failures, so a best-effort allow-audit would let the transport connect even
+      when its audit record never landed.
+    * UNGOVERNED allow (no policy governs ``channels`` — the default OSS build →
+      ``rule == "default"`` / ``_PERMIT_NOT_GOVERNED``): **best-effort**
+      (``critical=False``). OSS transport availability must never depend on SEL
+      disk health when the operator configured no governance at all.
+    * DENY: best-effort audit (the transport is not starting either way).
+    * ERROR: **fail-closed**. A transport is an externally-reachable network
+      surface, so it starts ONLY on a positive permit. We pass
+      ``governance_permits(fail_closed=True)`` so an internal
+      governance-evaluation error yields a DENYING Decision, and the outer
+      ``except Exception`` ALSO denies (``return False`` + a ``failed_closed=True``
+      degrade audit) — deny-by-default on any error, never an unaudited connect.
+      This deliberately DIVERGES from ``apps.manager`` /
+      ``mcp_core._vet_channel_governance`` (which fail open) because they gate
+      in-process actions, not a network-reachable listener.  A
+      ``PlatformCompositionError`` still propagates (a broken CPP composition must
+      abort, not silently deny).
+    """
+    try:
+        # A bare member id queries the ``channels`` ScopedMap ``members`` ruleset.
+        # session_key=HOST_SESSION_KEY: honour a surface:host profile (empty key
+        # → "unknown" would silently ignore it), matching apps/manager.
+        # fail_closed=True: an internal governance error DENIES (network surface).
+        decision = governance_permits(
+            "channels", member, session_key=HOST_SESSION_KEY, fail_closed=True
+        )
+        if not getattr(decision, "permitted", False):
+            logger.warning(
+                "%s transport not started: denied by the channels governance policy (%s).",
+                member,
+                getattr(decision, "reason", "") or "denied",
+            )
+            # governance_permits does NOT audit a normal deny — the caller must.
+            try:
+                sel().log_governance_decision(
+                    session_key=HOST_SESSION_KEY,
+                    tool_name=f"start_transport:{member}",
+                    scope="channels",
+                    item=member,
+                    outcome="denied",
+                    rule=getattr(decision, "rule", ""),
+                    layer=getattr(decision, "layer", ""),
+                    reason=getattr(decision, "reason", ""),
+                )
+            except Exception:
+                logger.debug("transport-start deny audit failed", exc_info=True)
+            return False
+        # Audit the ALLOWED decision too (a connect to an externally-reachable
+        # surface is worth a positive audit trail). The disposition splits on
+        # whether the ``channels`` scope was actually GOVERNED for this member:
+        #   * GOVERNED allow (a policy AND/OR profile governs ``channels``):
+        #     audit-or-deny. Pass critical=True so the SEL write is
+        #     synchronous+raising; a persistence failure (unwritable SEL, full
+        #     disk) propagates to the outer except and DENIES the start — never
+        #     connect a policy-governed transport unaudited. (A background enqueue
+        #     would swallow the disk failure, so critical is required to make
+        #     audit-or-deny real, not just cover a synchronous raise.)
+        #   * UNGOVERNED allow (no policy/profile governs ``channels``):
+        #     best-effort (critical=False). OSS transport availability must NOT
+        #     depend on SEL disk health when the operator has configured no
+        #     governance for this scope.
+        # Detect "governed" via the Decision's LAYER, not its rule. ``resolve()``
+        # returns rule="rule2-intersect" for EVERY permit — including the case
+        # where a policy exists but does not govern ``channels`` — so a rule-based
+        # check would mis-treat that ungoverned case as governed. ``layer`` names
+        # WHICH level actually carried the decision:
+        #   * no policy at all   → governance_permits early-returns layer="" ;
+        #   * policy, but channels ungoverned → resolve() sets layer="default" ;
+        #   * channels governed  → layer is "policy" / "profile" / "both".
+        # So "governed" is exactly layer ∈ {policy, profile, both}.
+        governed = getattr(decision, "layer", "") in ("policy", "profile", "both")
+        try:
+            sel().log_governance_decision(
+                session_key=HOST_SESSION_KEY,
+                tool_name=f"start_transport:{member}",
+                scope="channels",
+                item=member,
+                outcome="allowed",
+                rule=getattr(decision, "rule", ""),
+                layer=getattr(decision, "layer", ""),
+                reason=getattr(decision, "reason", ""),
+                critical=governed,
+            )
+        except PlatformCompositionError:
+            raise
+        except Exception:
+            if governed:
+                # audit-or-deny: a GOVERNED transport must never connect
+                # unaudited. Re-raise so the outer fail-closed branch denies the
+                # start (critical=True already forced a synchronous+raising write,
+                # so this is a real persistence failure, not a swallowed enqueue).
+                raise
+            # UNGOVERNED allow: best-effort. An SEL ill-health (e.g. corrupt HMAC
+            # key during sel() init/redaction) must NOT deny an ungoverned
+            # transport — OSS availability does not depend on SEL disk health when
+            # the operator configured no governance for this scope. Log and start.
+            logger.warning(
+                "%s transport: ungoverned allow could not be audited (best-effort); "
+                "starting anyway",
+                member,
+                exc_info=True,
+            )
+        return True
+    except PlatformCompositionError:
+        raise
+    except Exception:
+        # Fail CLOSED (deliberate divergence from apps/manager + mcp_core, which
+        # fail open): a transport is an externally-reachable network surface, so
+        # an unexpected governance error must DENY the connect, not permit it.
+        # Record the failed-closed degrade; wrap it so a late-import failure
+        # cannot raise out of this branch and mask the deny.
+        try:
+            audit_governance_degraded(
+                "start_transport",
+                session_key=HOST_SESSION_KEY,
+                scope="channels",
+                failed_closed=True,
+            )
+        except Exception:
+            logger.debug("transport-start governance degrade audit unavailable", exc_info=True)
+        logger.warning(
+            "%s transport not started: channels governance check errored; "
+            "failing closed (deny-by-default for a network-exposed surface).",
+            member,
+            exc_info=True,
+        )
+        return False
 
 
 class GatewayOrchestrator:
@@ -4963,22 +5142,7 @@ class GatewayOrchestrator:
         init_interactions(self)
         init_socket_mode(self, seen)
 
-        # WeChat (WeCom AI-bot) channel — guarded no-op unless enabled + credentialed.
-        from kiro_crew.wechat.gateway import maybe_start_wecom
-
-        self._wecom_client = await maybe_start_wecom(self)
-        # Telegram channel — guarded no-op unless enabled + token present.
-        from kiro_crew.telegram.gateway import maybe_start_telegram
-
-        self._telegram_client = await maybe_start_telegram(self)
-        # Discord channel — guarded no-op unless enabled + token present.
-        from kiro_crew.discord.gateway import maybe_start_discord
-
-        self._discord_client = await maybe_start_discord(self)
-        # Webex channel — guarded no-op unless enabled + token present.
-        from kiro_crew.webex.gateway import maybe_start_webex
-
-        self._webex_client = await maybe_start_webex(self)
+        await self._start_channel_transports()
 
         # Check for updates before printing URLs
         print("👻 Checking for updates…")
@@ -5148,6 +5312,65 @@ class GatewayOrchestrator:
         # Kill any kiro-cli processes that survived graceful shutdown
         cleanup_orphaned_sessions()
         os._exit(0)
+
+    async def _start_channel_transports(self) -> None:
+        """Start each non-Slack transport, gated on the ``channels`` scope.
+
+        Every transport is a guarded no-op unless enabled + credentialed (its
+        own ``maybe_start_*``), and is ADDITIONALLY gated on the ``channels``
+        governance scope: a policy that denies the transport member keeps it from
+        connecting at all, and its client stays ``None``. The scope + member ids
+        (``wecom``/``telegram``/``discord``/``webex``) are IDENTICAL to the
+        outbound chokepoints — outbound-send (``mcp_core``) and outbound
+        cross-surface mirroring (``chat_runner``) — so one ``channels`` allowlist
+        governs a transport at connect time and on every outbound path (this gate
+        is the connect-time member; it does not enforce inbound receive).
+
+        Default-build invariant: with no policy governing ``channels`` (the
+        standard OSS build) the gate permits, so every transport starts exactly
+        as before — byte-identical behavior. Slack itself is NOT gated here: it
+        is the primary channel and its enterprise gate is separate.
+
+        Loop hygiene: ``_channel_transport_permitted`` reaches
+        ``ProfileStore._ensure_fresh``, which stats/reads the profile files off
+        disk — blocking I/O. This method runs on the gateway event loop (inside
+        ``run()``), so the governance decisions are computed together in the
+        maintenance executor BEFORE any transport is started; only the actual
+        ``await maybe_start_*`` stays on the loop.
+
+        Enabled-only eval: the gate is queried ONLY for a transport whose
+        ``_<member>_enabled`` is set (config-enabled + credentialed). A transport
+        that is off never starts regardless of policy, so evaluating it would only
+        emit a spurious deny-SEL for a channel that was never going to connect.
+        A member not evaluated defaults to not-permitted (it is off anyway), so
+        the no-policy default is unchanged: every ENABLED transport still resolves
+        to permit and starts exactly as before.
+        """
+        # Evaluate each channel-start decision OFF the loop (each does blocking
+        # profile-file I/O), but ONLY for config-enabled transports — a disabled
+        # transport never starts, so skip it to avoid a deny-SEL for a channel
+        # that would no-op anyway. Members not evaluated stay not-permitted.
+        members = ("wecom", "telegram", "discord", "webex")
+        enabled = {m: bool(getattr(self, f"_{m}_enabled", False)) for m in members}
+        loop = asyncio.get_running_loop()
+        permitted = await loop.run_in_executor(
+            maintenance_executor(),
+            lambda: {
+                m: (_channel_transport_permitted(m) if enabled[m] else False) for m in members
+            },
+        )
+        # WeChat (WeCom AI-bot) channel — guarded no-op unless enabled + credentialed.
+        if permitted["wecom"]:
+            self._wecom_client = await maybe_start_wecom(self)
+        # Telegram channel — guarded no-op unless enabled + token present.
+        if permitted["telegram"]:
+            self._telegram_client = await maybe_start_telegram(self)
+        # Discord channel — guarded no-op unless enabled + token present.
+        if permitted["discord"]:
+            self._discord_client = await maybe_start_discord(self)
+        # Webex channel — guarded no-op unless enabled + token present.
+        if permitted["webex"]:
+            self._webex_client = await maybe_start_webex(self)
 
 
 async def run_gateway(

--- a/test/test_governance_chokepoints.py
+++ b/test/test_governance_chokepoints.py
@@ -493,6 +493,415 @@ class TestChannelsGate:
         assert mcp_core._vet_channel_governance("cli_chat", "slack") is None
 
 
+# ── channels per-transport STARTUP gate (slack/gateway) ──
+class TestChannelTransportStartGate:
+    """The transport-start gate shares the ``channels`` scope + member ids with
+    the send/receive chokepoints, so one policy governs a transport everywhere.
+    """
+
+    def test_denied_member_not_permitted_to_start(self):
+        # Only discord is permitted; the others are denied → skip their start.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["discord"]}},
+            }
+        )
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        assert _channel_transport_permitted("telegram") is False
+        assert _channel_transport_permitted("webex") is False
+        assert _channel_transport_permitted("wecom") is False
+        # The single allowed member still starts.
+        assert _channel_transport_permitted("discord") is True
+
+    def test_allowed_member_permitted_to_start(self):
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram", "discord"]}},
+            }
+        )
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        assert _channel_transport_permitted("telegram") is True
+        assert _channel_transport_permitted("discord") is True
+
+    def test_deny_mode_blocks_named_member_only(self):
+        # deny-mode: everything permitted EXCEPT the named member.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "deny", "deny": ["telegram"]}},
+            }
+        )
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        assert _channel_transport_permitted("telegram") is False
+        assert _channel_transport_permitted("discord") is True
+        assert _channel_transport_permitted("wecom") is True
+
+    def test_ungoverned_starts_as_today(self):
+        # Default OSS build: no policy governing channels → byte-identical start.
+        _install(None)
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        for member in ("wecom", "telegram", "discord", "webex"):
+            assert _channel_transport_permitted(member) is True
+
+    def test_policy_without_channels_scope_starts_all(self):
+        # A policy present but not governing ``channels`` → every transport starts.
+        _install({"version": 1, "boot": {"fail_closed": True}})
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        for member in ("wecom", "telegram", "discord", "webex"):
+            assert _channel_transport_permitted(member) is True
+
+    def test_platform_composition_error_propagates(self, monkeypatch):
+        # Fail-closed: a broken CPP composition must NOT degrade to permit here.
+        # gateway imports governance_permits at module top (hoisted; no cycle),
+        # so patch the name bound IN the gateway module, not its source.
+        from kiro_crew.platform import context as _ctx
+        from kiro_crew.slack import gateway as gw
+
+        def _boom(*_a, **_k):
+            raise _ctx.PlatformCompositionError("composition broken")
+
+        monkeypatch.setattr(gw, "governance_permits", _boom)
+        with pytest.raises(_ctx.PlatformCompositionError):
+            gw._channel_transport_permitted("telegram")
+
+    def test_unexpected_error_fails_closed(self, monkeypatch):
+        # FAIL-CLOSED (deliberate divergence from apps/manager + mcp_core, which
+        # fail open): a transport is an externally-reachable network surface, so a
+        # non-composition governance error must DENY the connect (return False),
+        # not permit it. The degrade is audited failed_closed (see
+        # test_unexpected_error_emits_failed_closed_degrade_audit).
+        from kiro_crew.slack import gateway as gw
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("unexpected governance failure")
+
+        monkeypatch.setattr(gw, "governance_permits", _boom)
+        assert gw._channel_transport_permitted("telegram") is False
+
+    def test_host_session_key_and_fail_closed_are_passed(self, monkeypatch):
+        # HIGH: the host chokepoint MUST resolve with session_key=HOST_SESSION_KEY
+        # (so a surface:host profile is honoured) AND fail_closed=True (network
+        # surface → deny-by-default on an internal governance error).
+        from kiro_crew.platform.governance import Decision
+        from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+        from kiro_crew.slack import gateway as gw
+
+        seen = {}
+
+        def _capture(scope, member, **kwargs):
+            seen["scope"] = scope
+            seen["member"] = member
+            seen["session_key"] = kwargs.get("session_key")
+            seen["fail_closed"] = kwargs.get("fail_closed")
+            return Decision(True, "ok", rule="default")
+
+        monkeypatch.setattr(gw, "governance_permits", _capture)
+        assert gw._channel_transport_permitted("telegram") is True
+        assert seen["scope"] == "channels"
+        assert seen["member"] == "telegram"
+        assert seen["session_key"] == HOST_SESSION_KEY
+        assert seen["fail_closed"] is True
+
+    def test_host_profile_deny_skips_transport(self):
+        # Regression: policy ALLOWS telegram, but a surface:host profile denies
+        # it → the host chokepoint must skip telegram (profile ∩ policy, tightest
+        # wins). Proves session_key=HOST_SESSION_KEY actually binds the profile
+        # (an empty key would classify to "unknown" and never match this profile).
+        import json
+
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram", "discord"]}},
+            }
+        )
+        from kiro_crew.slack.gateway import _channel_transport_permitted
+
+        # Write into the store's dir (the autouse _isolate fixture points
+        # gp._PROFILES_DIR at a tmp dir) and reset so the store re-reads it.
+        (gp._PROFILES_DIR / "host.json").write_text(
+            json.dumps(
+                {
+                    "name": "host",
+                    "bind": {"type": "surface", "id": "host"},
+                    "channels": {"members": {"mode": "allow", "allow": ["discord"]}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        gp.reset_store()
+        # Policy allows telegram, but the host profile narrows to discord only.
+        assert _channel_transport_permitted("telegram") is False
+        assert _channel_transport_permitted("discord") is True
+
+    def test_denial_emits_governance_decision_sel(self, monkeypatch):
+        # HIGH: a policy deny must be audited by the CALLER via
+        # log_governance_decision (governance_permits audits only its own degrade,
+        # never a normal deny).
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["discord"]}},
+            }
+        )
+        from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+        from kiro_crew.slack import gateway as gw
+
+        calls = []
+
+        class _FakeSel:
+            def log_governance_decision(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(gw, "sel", lambda: _FakeSel())
+        assert gw._channel_transport_permitted("telegram") is False
+        assert len(calls) == 1
+        rec = calls[0]
+        assert rec["session_key"] == HOST_SESSION_KEY
+        assert rec["tool_name"] == "start_transport:telegram"
+        assert rec["scope"] == "channels"
+        assert rec["item"] == "telegram"
+        assert rec["outcome"] == "denied"
+
+    def test_unexpected_error_emits_failed_closed_degrade_audit(self, monkeypatch):
+        # HIGH: the fail-closed branch must record a governance-degraded SEL with
+        # failed_closed=True so the deny-on-error is auditable.
+        from kiro_crew.slack import gateway as gw
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("unexpected governance failure")
+
+        degrades = []
+
+        def _capture_degrade(chokepoint, **kwargs):
+            degrades.append((chokepoint, kwargs))
+
+        monkeypatch.setattr(gw, "governance_permits", _boom)
+        monkeypatch.setattr(gw, "audit_governance_degraded", _capture_degrade)
+        assert gw._channel_transport_permitted("telegram") is False
+        assert len(degrades) == 1
+        chokepoint, kwargs = degrades[0]
+        assert chokepoint == "start_transport"
+        assert kwargs.get("scope") == "channels"
+        assert kwargs.get("failed_closed") is True
+
+    def test_governed_allow_audited_critical(self, monkeypatch):
+        # FIX B: a GOVERNED positive permit is audited (outcome="allowed") AND is
+        # audit-or-deny → written critical=True (synchronous + raising) so a
+        # persistence failure would deny the start.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram"]}},
+            }
+        )
+        from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+        from kiro_crew.slack import gateway as gw
+
+        calls = []
+
+        class _FakeSel:
+            def log_governance_decision(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(gw, "sel", lambda: _FakeSel())
+        assert gw._channel_transport_permitted("telegram") is True
+        assert len(calls) == 1
+        rec = calls[0]
+        assert rec["session_key"] == HOST_SESSION_KEY
+        assert rec["tool_name"] == "start_transport:telegram"
+        assert rec["scope"] == "channels"
+        assert rec["item"] == "telegram"
+        assert rec["outcome"] == "allowed"
+        # Governed allow → critical=True (audit-or-deny).
+        assert rec["critical"] is True
+
+    def test_ungoverned_allow_audited_best_effort(self, monkeypatch):
+        # FIX B/F1-2 split: an UNGOVERNED allow (no ceiling at all — the
+        # governance_permits early-return carries layer="") is audited best-effort
+        # (critical=False) so OSS transport availability never depends on SEL disk
+        # health. "governed" is decided by Decision.layer ∈ {policy,profile,both},
+        # not rule.
+        _install(None)  # no ceiling at all
+        from kiro_crew.slack import gateway as gw
+
+        calls = []
+
+        class _FakeSel:
+            def log_governance_decision(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(gw, "sel", lambda: _FakeSel())
+        assert gw._channel_transport_permitted("telegram") is True
+        assert len(calls) == 1
+        assert calls[0]["outcome"] == "allowed"
+        # Ungoverned allow → best-effort (NOT critical).
+        assert calls[0]["critical"] is False
+
+    def test_policy_present_but_channels_ungoverned_is_best_effort(self, monkeypatch):
+        # F1-2 (the regression): a policy EXISTS but does NOT govern channels.
+        # resolve() returns rule="rule2-intersect" (which the old rule-based check
+        # mis-read as governed) but layer="default" — so this is UNGOVERNED and
+        # must be audited best-effort (critical=False), NOT critical. Otherwise an
+        # SEL failure would wrongly DENY an ungoverned transport.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                # governs tools, NOT channels
+                "tools": {"mode": "deny", "deny": []},
+            }
+        )
+        from kiro_crew.slack import gateway as gw
+
+        calls = []
+
+        class _FakeSel:
+            def log_governance_decision(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(gw, "sel", lambda: _FakeSel())
+        assert gw._channel_transport_permitted("telegram") is True
+        assert len(calls) == 1
+        rec = calls[0]
+        assert rec["outcome"] == "allowed"
+        assert rec["rule"] == "rule2-intersect"  # resolve() always uses this for a permit
+        assert rec["layer"] == "default"  # but layer says channels is NOT governed
+        assert rec["critical"] is False  # → best-effort, the F1-2 fix
+
+    def test_governed_allow_persistence_failure_denies_start(self, monkeypatch):
+        # Arbiter item 1: a GOVERNED allow whose CRITICAL SEL write fails at
+        # PERSISTENCE time (not a synchronous fake-raise — a real disk failure that
+        # only surfaces because critical=True makes the write synchronous+raising)
+        # → transport NOT started (return False), failed-closed degrade audited.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram"]}},
+            }
+        )
+        from kiro_crew.slack import gateway as gw
+
+        # Simulate the SEL layer: a persistence failure surfaces ONLY on the
+        # critical (synchronous+raising) path; the best-effort path swallows it
+        # (mirrors the real background writer with raise_on_error=False).
+        class _PersistSel:
+            def log_governance_decision(self, *, critical=False, **kwargs):
+                if critical:
+                    raise OSError("SEL file unwritable (disk full)")
+                # best-effort: swallow, as the background writer does
+
+        degrades = []
+        monkeypatch.setattr(gw, "sel", lambda: _PersistSel())
+        monkeypatch.setattr(
+            gw, "audit_governance_degraded", lambda *a, **k: degrades.append((a, k))
+        )
+        # Governed → critical write → persistence OSError → outer except → deny.
+        assert gw._channel_transport_permitted("telegram") is False
+        assert degrades and degrades[0][1].get("failed_closed") is True
+
+    def test_ungoverned_allow_audit_error_still_starts(self, monkeypatch):
+        # F3-1: even if the ungoverned best-effort audit itself RAISES (e.g. a
+        # corrupt HMAC key during sel() init/redaction, not just a swallowed
+        # enqueue), the transport must STILL start — OSS availability must not
+        # depend on SEL ill-health. The caller wraps the ungoverned allow-audit and
+        # returns True on error; only a GOVERNED (critical) audit failure denies.
+        _install(None)  # ungoverned → layer "" → not critical
+        from kiro_crew.slack import gateway as gw
+
+        class _BoomSel:
+            def log_governance_decision(self, **kwargs):
+                raise RuntimeError("SEL init/HMAC failure")
+
+        monkeypatch.setattr(gw, "sel", lambda: _BoomSel())
+        # Ungoverned allow + audit raises → best-effort → transport STILL starts.
+        assert gw._channel_transport_permitted("telegram") is True
+
+    def test_ungoverned_allow_composition_error_still_propagates(self, monkeypatch):
+        # F3-1 guard: even for an ungoverned allow, a PlatformCompositionError from
+        # the audit path must still propagate (never swallowed into a best-effort
+        # start) — a broken CPP composition is not an SEL-health issue.
+        from kiro_crew.platform.context import PlatformCompositionError
+        from kiro_crew.slack import gateway as gw
+
+        _install(None)
+
+        class _CompErrSel:
+            def log_governance_decision(self, **kwargs):
+                raise PlatformCompositionError("composition broken")
+
+        monkeypatch.setattr(gw, "sel", lambda: _CompErrSel())
+        with pytest.raises(PlatformCompositionError):
+            gw._channel_transport_permitted("telegram")
+
+    def test_governed_allow_real_sel_persistence_failure_denies(self, tmp_path, monkeypatch):
+        # F2-2 (end-to-end, REAL SecurityEventLog): prove the critical→log→
+        # synchronous-raise chain end to end. A GOVERNED transport start whose
+        # audit file CANNOT be written is DENIED. Uses a REAL SecurityEventLog in
+        # sync mode whose file append is forced to fail (monkeypatch os.open in the
+        # sel module to raise OSError). This proves production
+        # log_governance_decision forwards critical= to log(critical=True) →
+        # _flush_batch(raise_on_error=True) → raise; reverting that forwarding
+        # would make the write a swallowed enqueue and the transport would WRONGLY
+        # start, failing this test.
+        import dataclasses
+
+        from kiro_crew import sel as sel_mod
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.platform import context as ctx_mod
+        from kiro_crew.platform.bootstrap import build_default_context
+        from kiro_crew.platform.governance import parse_policy
+        from kiro_crew.slack import gateway as gw
+
+        # Fresh REAL sync SEL in a valid tmp dir (reset the singleton first).
+        sel_mod.SecurityEventLog._instance = None
+        sel_mod.SecurityEventLog._initialized = False
+        real_sel = sel_mod.SecurityEventLog(base_dir=tmp_path, sync=True)
+        sel_mod.SecurityEventLog._instance = None
+        sel_mod.SecurityEventLog._initialized = False
+
+        # Force the audit FILE APPEND to fail (a genuine persistence failure that
+        # only surfaces because critical=True makes _flush_batch raise).
+        def _boom_open(*_a, **_k):
+            raise OSError("SEL append failed (disk full)")
+
+        monkeypatch.setattr(sel_mod.os, "open", _boom_open)
+        monkeypatch.setattr(gw, "sel", lambda: real_sel)
+
+        # Governed ceiling that permits telegram → the gate audits critical=True.
+        base = build_default_context(KiroCrewConfig.load())
+        ceiling = parse_policy(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram"]}},
+            }
+        )
+        ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+        try:
+            # Governed allow → critical audit → real sync write RAISES → outer
+            # except → transport DENIED.
+            assert gw._channel_transport_permitted("telegram") is False
+        finally:
+            ctx_mod.set_context(None)
+            sel_mod.SecurityEventLog._instance = None
+            sel_mod.SecurityEventLog._initialized = False
+
+
 # ── apps activation allowlist ──
 class TestAppsGate:
     def test_app_not_in_allowlist_blocked(self):

--- a/test/test_governance_profiles.py
+++ b/test/test_governance_profiles.py
@@ -125,6 +125,183 @@ def test_invalid_profile_with_valid_bind_still_denies_its_surface(profiles_dir):
     assert not resolve(None, prof, "capabilities.spawn", "researcher").permitted
 
 
+def _make_read_text_raise(monkeypatch, target: "object", exc: Exception):
+    """Monkeypatch ``Path.read_text`` to raise ``exc`` for ``target`` only.
+
+    Portable simulation of a present-but-unreadable file (chmod 000 is a no-op on
+    Windows). ``target`` is compared by resolved path so it matches regardless of
+    how the store constructs the Path.
+    """
+    from pathlib import Path
+
+    real_read_text = Path.read_text
+    target_str = str(target)
+
+    def _patched(self, *args, **kwargs):
+        if str(self) == target_str:
+            raise exc
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _patched)
+
+
+def _write_host_profile(path):
+    path.write_text(
+        json.dumps(
+            {
+                "name": "host",
+                "bind": {"type": "surface", "id": "host"},
+                "channels": {"members": {"mode": "allow", "allow": ["slack"]}},
+            }
+        )
+    )
+
+
+def _make_ceiling():
+    from kiro_crew.platform.governance import parse_policy
+
+    return parse_policy({"version": 1, "boot": {"fail_closed": True}})
+
+
+def test_unreadable_profile_governed_fleet_boot_aborts(profiles_dir, monkeypatch):
+    # F1-1 (corrected): a PRESENT-but-UNREADABLE profile whose bind cannot be
+    # recovered must NOT be guessed by filename (the stem does not reliably encode
+    # the bind). For a GOVERNED fleet (ceiling present) it fails CLOSED to a
+    # boot-abort: assert_profiles_within_ceiling raises PlatformCompositionError
+    # rather than run with a silently-dropped restrictive profile.
+    from kiro_crew.platform.context import PlatformCompositionError
+    from kiro_crew.platform.governance_profiles import assert_profiles_within_ceiling
+
+    path = profiles_dir / "host.json"
+    _write_host_profile(path)
+    _make_read_text_raise(monkeypatch, path, OSError("permission denied"))
+    gp.reset_store()
+
+    with pytest.raises(PlatformCompositionError):
+        assert_profiles_within_ceiling(_make_ceiling())
+
+
+def test_unreadable_profile_standalone_is_lenient(profiles_dir, monkeypatch):
+    # F1-1 (corrected): a standalone/ungoverned host (no ceiling) must NOT crash
+    # on an unreadable profile blip. assert_profiles_within_ceiling(None) is a
+    # no-op, and the unbound deny-all fallback simply drops out — the surface
+    # falls to policy-only (matches pre-split standalone behavior, no regression).
+    from kiro_crew.platform.governance_profiles import (
+        HOST_SESSION_KEY,
+        assert_profiles_within_ceiling,
+    )
+
+    path = profiles_dir / "host.json"
+    _write_host_profile(path)
+    _make_read_text_raise(monkeypatch, path, OSError("permission denied"))
+    gp.reset_store()
+
+    assert_profiles_within_ceiling(None)  # no ceiling → no crash
+    # Unbound deny-all drops from the bind index → host surface is policy-only.
+    assert gp.resolve_active_scope(HOST_SESSION_KEY) is None
+
+
+def test_invalid_utf8_profile_governed_fleet_boot_aborts(profiles_dir, monkeypatch):
+    # F2-1 (UTF-8): an invalid-encoding file raises UnicodeDecodeError (base
+    # UnicodeError), which is NOT an OSError. The read guard must catch
+    # (OSError, UnicodeError) so it does not escape both handlers and crash boot
+    # uncaught. Treated as present-but-unreadable → governed fleet boot-aborts.
+    from kiro_crew.platform.context import PlatformCompositionError
+    from kiro_crew.platform.governance_profiles import assert_profiles_within_ceiling
+
+    path = profiles_dir / "host.json"
+    # Write raw invalid UTF-8 bytes (0xff is never valid UTF-8).
+    path.write_bytes(b'{"name": "host", "bind": {"type": "surface", "id": "\xff\xfe"}}')
+    gp.reset_store()
+
+    # Must not escape uncaught; a governed fleet boot-aborts fail-closed.
+    with pytest.raises(PlatformCompositionError):
+        assert_profiles_within_ceiling(_make_ceiling())
+
+
+def test_invalid_utf8_profile_standalone_does_not_crash(profiles_dir):
+    # F2-1: the SAME invalid-encoding file on a standalone host (no ceiling) must
+    # be tolerated — resolve must not raise UnicodeDecodeError.
+    from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+
+    path = profiles_dir / "host.json"
+    path.write_bytes(b'{"name": "host", "bind": {"type": "surface", "id": "\xff\xfe"}}')
+    gp.reset_store()
+    # No crash; unbound deny-all → policy-only.
+    assert gp.resolve_active_scope(HOST_SESSION_KEY) is None
+
+
+def test_transient_read_error_not_cached(profiles_dir, monkeypatch):
+    # F2-3: a transient read error must NOT be cached — once the read recovers,
+    # the next access re-reads and the real (readable) profile takes effect,
+    # instead of the deny-all fallback staying cached until metadata changes.
+    from pathlib import Path
+
+    path = profiles_dir / "cron.json"
+    path.write_text(
+        json.dumps(
+            {
+                "name": "cron",
+                "bind": {"type": "surface", "id": "cron"},
+                "tools": {"mode": "allow", "allow": ["read"]},
+            }
+        )
+    )
+    real_read_text = Path.read_text
+    state = {"fail": True}
+    target = str(path)
+
+    def _patched(self, *args, **kwargs):
+        if str(self) == target and state["fail"]:
+            raise OSError("transient NFS blip")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _patched)
+    gp.reset_store()
+    # First access hits the transient error → unbound deny-all → cron surface
+    # policy-only (the fallback dropped out); fingerprint NOT cached.
+    assert gp.resolve_active_scope("cron:job-1:run-1") is None
+    # Read recovers WITHOUT any file-metadata change.
+    state["fail"] = False
+    # Next access must re-read (fingerprint was not committed) and pick up the
+    # real profile — proving the transient error was not cached.
+    prof = gp.resolve_active_scope("cron:job-1:run-1")
+    assert prof is not None and prof.name == "cron"
+
+
+def test_absent_profile_still_yields_policy_only(profiles_dir):
+    # GUARDRAIL: the fix must NOT manufacture a deny for a surface that has NO
+    # profile at all. An absent host profile → resolve_active_scope returns None
+    # (attended/host surface, policy ceiling alone governs), NOT a false deny.
+    from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+
+    # profiles_dir is empty (no host.json).
+    assert gp.resolve_active_scope(HOST_SESSION_KEY) is None
+
+
+def test_vanished_profile_mid_reload_is_absent_not_deny(profiles_dir, monkeypatch):
+    # A file present at iterdir() but gone at read (TOCTOU) is treated as ABSENT
+    # (skipped), not as a present-but-unreadable deny — a missing file is not a
+    # policy. FileNotFoundError is a subclass of OSError, so the reload must
+    # distinguish it from the genuine-unreadable case.
+    from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+
+    path = profiles_dir / "host.json"
+    path.write_text(
+        json.dumps(
+            {
+                "name": "host",
+                "bind": {"type": "surface", "id": "host"},
+                "channels": {"members": {"mode": "allow", "allow": ["slack"]}},
+            }
+        )
+    )
+    _make_read_text_raise(monkeypatch, path, FileNotFoundError("vanished"))
+    gp.reset_store()
+    # Vanished → absent → policy-only (None), no false deny.
+    assert gp.resolve_active_scope(HOST_SESSION_KEY) is None
+
+
 def test_extends_narrows(profiles_dir):
     _write(
         profiles_dir,

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4336,3 +4336,196 @@ class TestCountInFlightWork:
         undone.done.return_value = False
         orch._session_tasks = {"x": undone}
         assert orch._count_in_flight_work() == 2
+
+
+class TestChannelTransportStartGate:
+    """`_start_channel_transports` gates each non-Slack transport start on the
+    ``channels`` governance scope, using the same member ids as the send/receive
+    chokepoints. Clients are mocked — no real network connections are opened.
+    """
+
+    def _install_policy(self, policy_body):
+        import dataclasses
+
+        from kiro_crew.platform import context as ctx_mod
+        from kiro_crew.platform.bootstrap import build_default_context
+        from kiro_crew.platform.governance import parse_policy
+
+        base = build_default_context(KiroCrewConfig.load())
+        ceiling = parse_policy(policy_body) if policy_body is not None else None
+        ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+
+    @staticmethod
+    def _enable_all_transports(orch):
+        # The start gate now evaluates governance ONLY for config-enabled
+        # transports (enabled-only eval), so a test that expects a transport to
+        # reach maybe_start_* must mark it enabled — a transport is credential-
+        # gated in real use anyway. Set the four flags the orchestrator would set
+        # from config so the governance decision (not an off switch) is what
+        # decides whether each transport starts.
+        for _m in ("wecom", "telegram", "discord", "webex"):
+            setattr(orch, f"_{_m}_enabled", True)
+
+    def _patch_starts(self, stack, *, discord_ret=None):
+        import contextlib as _cl  # local import; keeps module import block untouched
+
+        assert isinstance(stack, _cl.ExitStack)  # documents the contract
+        # slack.gateway imports the four maybe_start_* at module top (hoisted; no
+        # cycle), so patch the names bound IN the gateway module, not their source
+        # modules — patching the source would not affect the already-bound refs.
+        mocks = {}
+        mocks["wecom"] = stack.enter_context(
+            patch("kiro_crew.slack.gateway.maybe_start_wecom", new=AsyncMock())
+        )
+        mocks["telegram"] = stack.enter_context(
+            patch("kiro_crew.slack.gateway.maybe_start_telegram", new=AsyncMock())
+        )
+        mocks["discord"] = stack.enter_context(
+            patch(
+                "kiro_crew.slack.gateway.maybe_start_discord",
+                new=AsyncMock(return_value=discord_ret),
+            )
+        )
+        mocks["webex"] = stack.enter_context(
+            patch("kiro_crew.slack.gateway.maybe_start_webex", new=AsyncMock())
+        )
+        return mocks
+
+    def teardown_method(self):
+        from kiro_crew.platform import context as ctx_mod
+        from kiro_crew.platform import governance_profiles as gp
+
+        ctx_mod.reset_context()
+        gp.reset_store()
+
+    @pytest.mark.asyncio
+    async def test_denied_transport_is_skipped_and_client_stays_none(self):
+        import contextlib
+
+        # Policy allows only discord → telegram/wecom/webex must NOT start.
+        self._install_policy(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["discord"]}},
+            }
+        )
+        orch = _make_orchestrator()
+        self._enable_all_transports(orch)
+        discord_client = MagicMock(name="discord_client")
+        with contextlib.ExitStack() as stack:
+            mocks = self._patch_starts(stack, discord_ret=discord_client)
+            await orch._start_channel_transports()
+
+        # Denied members: maybe_start_* never invoked, clients stay None.
+        mocks["wecom"].assert_not_awaited()
+        mocks["telegram"].assert_not_awaited()
+        mocks["webex"].assert_not_awaited()
+        assert orch._wecom_client is None
+        assert orch._telegram_client is None
+        assert orch._webex_client is None
+        # Allowed member: started, client wired.
+        mocks["discord"].assert_awaited_once()
+        assert orch._discord_client is discord_client
+
+    @pytest.mark.asyncio
+    async def test_no_policy_starts_every_transport_as_today(self):
+        import contextlib
+
+        # Default OSS build: no policy governing channels → all maybe_start_*
+        # invoked exactly as before (byte-identical default behavior).
+        self._install_policy(None)
+        orch = _make_orchestrator()
+        self._enable_all_transports(orch)
+        with contextlib.ExitStack() as stack:
+            mocks = self._patch_starts(stack)
+            await orch._start_channel_transports()
+
+        mocks["wecom"].assert_awaited_once()
+        mocks["telegram"].assert_awaited_once()
+        mocks["discord"].assert_awaited_once()
+        mocks["webex"].assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_host_profile_deny_skips_transport(self, tmp_path, monkeypatch):
+        import contextlib
+        import json
+
+        from kiro_crew.platform import governance_profiles as gp
+
+        # Policy ALLOWS telegram + discord, but a surface:host profile narrows to
+        # discord only → telegram must NOT start. This exercises the full
+        # _start_channel_transports path (through the executor) and proves the
+        # gate binds the host profile (session_key=HOST_SESSION_KEY); an empty key
+        # would classify to "unknown" and silently ignore this profile.
+        self._install_policy(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["telegram", "discord"]}},
+            }
+        )
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        (profiles_dir / "host.json").write_text(
+            json.dumps(
+                {
+                    "name": "host",
+                    "bind": {"type": "surface", "id": "host"},
+                    "channels": {"members": {"mode": "allow", "allow": ["discord"]}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gp, "_PROFILES_DIR", profiles_dir)
+        gp.reset_store()
+
+        orch = _make_orchestrator()
+        self._enable_all_transports(orch)
+        discord_client = MagicMock(name="discord_client")
+        with contextlib.ExitStack() as stack:
+            mocks = self._patch_starts(stack, discord_ret=discord_client)
+            await orch._start_channel_transports()
+
+        # Host profile narrows telegram out even though the policy allowed it.
+        mocks["telegram"].assert_not_awaited()
+        assert orch._telegram_client is None
+        # discord is in BOTH policy and profile → starts.
+        mocks["discord"].assert_awaited_once()
+        assert orch._discord_client is discord_client
+
+    @pytest.mark.asyncio
+    async def test_disabled_transport_not_evaluated_for_governance(self, monkeypatch):
+        import contextlib
+
+        from kiro_crew.slack import gateway as gw
+
+        # Enabled-only eval: a config-disabled transport is NEVER passed to the
+        # governance gate (avoids a spurious deny-SEL for a channel that would
+        # never connect anyway). Permissive policy, but only telegram enabled →
+        # the gate is queried for telegram alone; the other three never start.
+        self._install_policy(None)
+        orch = _make_orchestrator()
+        orch._telegram_enabled = True  # only telegram enabled
+        orch._wecom_enabled = False
+        orch._discord_enabled = False
+        orch._webex_enabled = False
+
+        queried = []
+        real_gate = gw._channel_transport_permitted
+
+        def _spy(member):
+            queried.append(member)
+            return real_gate(member)
+
+        monkeypatch.setattr(gw, "_channel_transport_permitted", _spy)
+        with contextlib.ExitStack() as stack:
+            mocks = self._patch_starts(stack)
+            await orch._start_channel_transports()
+
+        # Only the enabled transport was evaluated + started.
+        assert queried == ["telegram"]
+        mocks["telegram"].assert_awaited_once()
+        mocks["wecom"].assert_not_awaited()
+        mocks["discord"].assert_not_awaited()
+        mocks["webex"].assert_not_awaited()


### PR DESCRIPTION
## Summary

Gate each **non-Slack messaging transport's startup** on the existing `channels`
governance scope, so a `channels`-scope policy deny actually prevents that
transport from connecting. Today the transports (Telegram / Discord / WeCom /
Webex) start purely on `cfg.<channel>.enabled` + a token, with no governance
check at start — even though the `channels` scope is already enforced at the
outbound-send (`mcp_core`) and inbound-routing (`chat_runner`) chokepoints. This
closes that gap so one `channels` allowlist governs a transport consistently at
**connect, send, and receive**.

## What changed

- **`src/kiro_crew/slack/gateway.py`** — new module-level helper
  `_channel_transport_permitted(member)` + a new
  `GatewayOrchestrator._start_channel_transports()` that routes the four
  `maybe_start_*` calls through the gate. If `channels` denies a member, that
  transport is skipped (logged) and its client stays `None`.
- **`docs/system-specs/modules/governance.md`** — added transport-start to the
  chokepoint list and noted `channels` now enforces at startup too.
- **`test/test_governance_chokepoints.py`** + **`test/test_slack_gateway.py`** —
  9 new tests.

## Design

- The gate lives at the **call site** in `slack/gateway.py`, not inside each
  per-transport module — so `telegram` / `discord` / `wechat` / `webex` stay pure
  transport code with no governance dependency, mirroring the existing chokepoint
  pattern, and the extracted `_start_channel_transports` gives the integration
  tests a clean seam.
- **Member strings** (`wecom` / `telegram` / `discord` / `webex`) are each
  transport's own `channel_type`, identical to what the inbound
  (`chat_runner`, via `link.channel_type`) and outbound (`mcp_core`) chokepoints
  use — so a single `channels` allowlist governs all three planes coherently.
- **Slack is not gated here** (it is the primary channel; its enterprise gate is
  separate). Only the four non-Slack transports.

## Default behavior is byte-identical

When no policy governs `channels` (the standard build), `governance_permits`
returns a permitting `Decision` and every transport starts exactly as today —
proven by `test_ungoverned_starts_as_today`,
`test_policy_without_channels_scope_starts_all`, and
`test_no_policy_starts_every_transport_as_today`. Fail-closed discipline matches
the sibling chokepoints: a `PlatformCompositionError` propagates; any other
unexpected error degrades to permit (the transport's own enabled/token guard
still applies).

## Verification

- `419 passed` across the governance / gateway / mcp_core / enterprise / discord
  / webex / wechat suites (9 new tests included).
- `flake8 src/kiro_crew test`, `isort --check-only`, `mypy src/kiro_crew`
  (`Success: no issues found in 473 source files`) — all clean.
- Clients fully mocked in tests — no network.