### PR TITLE
feat(settings): grey policy-denied channel tabs ("Off by admin")

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -264,6 +264,37 @@ pinned" from "id is provided" by probing the posture with a sentinel value no
 real id can equal: if the leaf is an allow-mode allowlist the sentinel is denied
 (pinned → close), otherwise it permits (unpinned → the empty id is fine).
 
+### Channels governance-status surface (read-only) + Settings greying
+
+`GET /api/governance/channels` (`handlers_system.api_governance_channels`,
+registered in `dashboard/server.py`, behind the same dashboard token auth as the
+sibling `/api/*` GETs) returns the effective per-channel `channels` policy
+decision as a `{channel_type: bool}` map (`true` = permitted, `false` = denied by
+policy), e.g. `{"slack": true, "discord": false, "telegram": false, "webex":
+false, "wecom": false}`. It calls `governance_permits("channels", <member>,
+session_key=HOST_SESSION_KEY)` per member — the SAME decision source and
+`_host` surface as the messaging chokepoint (`_vet_channel_governance`) and the
+app-activation gate — reading `Decision.permitted`. The members are derived from
+each transport's `channel_type` class attribute
+(`handlers_system._channel_members()`: Slack / Discord / Telegram / Webex /
+WeCom), never a hardcoded divergent list. The per-member evaluation runs in a
+thread-pool executor (`run_in_executor`) because `governance_permits` can read
+profile files off disk — the aiohttp event loop is never blocked.
+
+Read-only and byte-identical by default: with NO policy governing `channels`
+(the standard OSS build) `governance_permits` returns `permitted=True` for every
+member, so the endpoint returns all-true and the Settings UI is unchanged (every
+channel tab fully enabled).
+
+The dashboard Settings UI consumes this map to make the channel tabs
+governance-aware: a policy-denied channel tab is **greyed + disabled with an
+"Off by admin" badge (NOT hidden)**, and its panel body renders a
+disabled-by-policy state (lock icon + explanation) instead of the editable
+bot-token form — so a user isn't confused by a toggle that silently does nothing,
+and cannot save config that would never take effect (the backend already gates
+the transport start at `_vet_channel_governance`). The tab stays clickable so the
+user can read the "why"; the greying is purely visual.
+
 ### Audit
 
 Every new chokepoint denial emits a `governance_decision` SEL record (file-

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -15,6 +15,7 @@ from typing import Any
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, config_path  # noqa: F401
 from kiro_crew.dashboard.handlers_system import (  # noqa: F401
     api_compliance_yolo_status,
+    api_governance_channels,
     api_sso_ttl,
     api_status,
     api_system,

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -561,3 +561,65 @@ async def api_compliance_yolo_status(request: web.Request) -> web.Response:
     """GET /api/admin/compliance/yolo-status — safety override governance status."""
     status = safety_override().status()
     return web.json_response(asdict(status))
+
+
+def _channel_members() -> tuple[str, ...]:
+    """Canonical ``channel_type`` ids for the messaging channels, derived from
+    each transport's ``channel_type`` class attribute — the single source of
+    truth — so this list can never drift from the transports themselves.
+    Imported here (off the event loop, inside the executor worker) so the
+    transport modules' own imports don't run on the aiohttp loop.
+    """
+    from kiro_crew.discord.transport import DiscordTransport
+    from kiro_crew.slack.transport import SlackTransport
+    from kiro_crew.telegram.transport import TelegramTransport
+    from kiro_crew.webex.transport import WebexTransport
+    from kiro_crew.wechat.transport import WeComTransport
+
+    return tuple(
+        t.channel_type
+        for t in (
+            SlackTransport,
+            DiscordTransport,
+            TelegramTransport,
+            WebexTransport,
+            WeComTransport,
+        )
+    )
+
+
+def _collect_channel_governance() -> dict[str, bool]:
+    """Resolve the effective ``channels`` policy decision for every transport.
+
+    Runs in a thread-pool executor (``governance_permits`` may read profile
+    files from disk via the ProfileStore). ``session_key=HOST_SESSION_KEY``
+    binds the host surface, matching the messaging chokepoint
+    (``mcp_core._vet_channel_governance``) and the app-activation gate.
+
+    Byte-identical default: with NO policy governing ``channels`` (the standard
+    OSS build), ``governance_permits`` returns ``permitted=True`` for every
+    member, so this returns all-true and the Settings UI is unchanged.
+    """
+    from kiro_crew.platform.governance_profiles import (
+        HOST_SESSION_KEY,
+        governance_permits,
+    )
+
+    result: dict[str, bool] = {}
+    for member in _channel_members():
+        decision = governance_permits("channels", member, session_key=HOST_SESSION_KEY)
+        result[member] = bool(getattr(decision, "permitted", True))
+    return result
+
+
+async def api_governance_channels(request: web.Request) -> web.Response:
+    """GET /api/governance/channels — effective per-channel policy decision.
+
+    Returns a ``{channel_type: bool}`` map (``true`` = permitted, ``false`` =
+    denied by the ``channels`` governance policy). The Settings UI greys out and
+    disables a policy-denied channel tab ("Off by admin") rather than hiding it.
+    Read-only; behind the same dashboard token auth as the sibling GETs.
+    """
+    loop = asyncio.get_running_loop()
+    data = await loop.run_in_executor(None, _collect_channel_governance)
+    return web.json_response(data)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1237,6 +1237,7 @@ async def start_dashboard(
     app.router.add_get("/api/ready", handlers.api_ready)
     app.router.add_get("/api/theme/boot", handlers.api_theme_boot)
     app.router.add_get("/api/admin/compliance/yolo-status", handlers.api_compliance_yolo_status)
+    app.router.add_get("/api/governance/channels", handlers.api_governance_channels)
 
     # Suggestions (pre-computed contextual prompts)
     app.router.add_get("/api/suggestions", api_suggestions)

--- a/test/test_governance_channels_endpoint.py
+++ b/test/test_governance_channels_endpoint.py
@@ -1,0 +1,121 @@
+"""Tests for the read-only ``GET /api/governance/channels`` surface.
+
+The endpoint returns the effective per-channel ``channels`` policy decision
+(``{channel_type: bool}``) that the Settings UI uses to grey out / disable a
+policy-denied channel tab ("Off by admin"). Byte-identical default: with NO
+policy governing ``channels`` (the standard OSS build) every member is
+``true`` and the UI is unchanged from today.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from kiro_crew.dashboard import handlers_system
+from kiro_crew.platform import context as ctx_mod
+from kiro_crew.platform import governance_profiles as gp
+from kiro_crew.platform.bootstrap import build_default_context
+from kiro_crew.platform.governance import parse_policy
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    d = tmp_path / "profiles"
+    d.mkdir()
+    monkeypatch.setattr(gp, "_PROFILES_DIR", d)
+    gp.reset_store()
+    yield
+    gp.reset_store()
+    ctx_mod.reset_context()
+
+
+def _install(policy_body):
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    base = build_default_context(KiroCrewConfig.load())
+    ceiling = parse_policy(policy_body) if policy_body is not None else None
+    ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+
+
+# The canonical members, derived from the transports' channel_type attrs.
+EXPECTED_MEMBERS = {"slack", "discord", "telegram", "webex", "wecom"}
+
+
+class TestChannelMembers:
+    def test_members_match_transport_channel_types(self):
+        # Derived from the transport class attrs — never a hardcoded divergent list.
+        assert set(handlers_system._channel_members()) == EXPECTED_MEMBERS
+
+
+class TestNoPolicyDefault:
+    def test_all_true_when_ungoverned(self):
+        # Byte-identical default: no policy → every channel permitted (all-true),
+        # so the UI is unchanged (every tab fully enabled).
+        _install(None)
+        result = handlers_system._collect_channel_governance()
+        assert result == {m: True for m in EXPECTED_MEMBERS}
+        assert all(result.values())
+
+    def test_all_true_when_policy_omits_channels(self):
+        # A policy that governs other scopes but NOT channels also leaves every
+        # channel permitted (no channels ScopedMap → ungoverned member).
+        _install(
+            {"version": 1, "boot": {"fail_closed": True}, "apps": {"mode": "allow", "allow": ["x"]}}
+        )
+        result = handlers_system._collect_channel_governance()
+        assert result == {m: True for m in EXPECTED_MEMBERS}
+
+
+class TestPolicyDenies:
+    def test_allow_only_slack_denies_others(self):
+        # allow=[slack] → slack true, every other channel denied (false).
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "allow", "allow": ["slack"]}},
+            }
+        )
+        result = handlers_system._collect_channel_governance()
+        assert result["slack"] is True
+        assert result["discord"] is False
+        assert result["telegram"] is False
+        assert result["webex"] is False
+        assert result["wecom"] is False
+
+    def test_deny_specific_channel(self):
+        # deny-mode: only the listed channel is denied; the rest stay permitted.
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "channels": {"members": {"mode": "deny", "deny": ["discord"]}},
+            }
+        )
+        result = handlers_system._collect_channel_governance()
+        assert result["discord"] is False
+        assert result["slack"] is True
+        assert result["telegram"] is True
+        assert result["webex"] is True
+        assert result["wecom"] is True
+
+
+class TestSessionKey:
+    def test_uses_host_session_key(self, monkeypatch):
+        # Every member must be evaluated with session_key=HOST_SESSION_KEY (the
+        # host surface, matching the messaging chokepoint + app-activation gate).
+        from kiro_crew.platform.governance import Decision
+
+        seen: list[str] = []
+
+        def _spy(scope, item, *, session_key="", **kw):
+            seen.append(session_key)
+            return Decision(True, "spy", rule="default")
+
+        monkeypatch.setattr("kiro_crew.platform.governance_profiles.governance_permits", _spy)
+        handlers_system._collect_channel_governance()
+        assert seen  # called at least once
+        assert all(sk == gp.HOST_SESSION_KEY for sk in seen)
+        assert len(seen) == len(EXPECTED_MEMBERS)

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1246,6 +1246,11 @@ export const api = {
   // Webex integration config
   getWebexConfig: () => get('/api/webex/config').then(j) as Promise<WebexConfigData>,
   saveWebexConfig: (body: Partial<WebexConfigSave>) => put('/api/webex/config', body).then(j) as Promise<{ ok: boolean; restart_required: boolean; verify_warning: string }>,
+  // Effective per-channel governance policy decision: { slack: true, discord: false, ... }
+  // (true = permitted, false = denied by the `channels` policy). All-true when
+  // no policy governs channels (standard build). Drives the Settings channel-tab
+  // "Off by admin" greying — the editable panel is replaced by a disabled state.
+  getGovernanceChannels: () => get('/api/governance/channels').then(j) as Promise<Record<string, boolean>>,
 
   // Auto-research
   researchValidate: (body: object) => post("/api/apps/auto-research/validate", body).then(j),

--- a/website/src/components/SidePanelLayout.tsx
+++ b/website/src/components/SidePanelLayout.tsx
@@ -9,6 +9,11 @@ export interface SidePanelTab {
   description?: string
   /** Presence dot after the label (e.g. About while an update is available). */
   dot?: boolean
+  /** Greyed / muted styling — the tab is disabled by policy (still clickable so
+   *  the user can read the disabled panel's "why", but visually de-emphasized). */
+  disabled?: boolean
+  /** Small pill after the label (e.g. "Off by admin" for a policy-denied tab). */
+  badge?: string
 }
 
 interface SidePanelLayoutProps {
@@ -48,7 +53,9 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
             {tabs.map(t => (
               <button
                 key={t.key}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium cursor-pointer border-none whitespace-nowrap transition-all ${
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium border-none whitespace-nowrap transition-all ${
+                  t.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                } ${
                   tab === t.key
                     ? 'bg-accent-subtle text-accent'
                     : 'bg-transparent text-muted hover:text-text hover:bg-bg-hover'
@@ -57,6 +64,11 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
               >
                 <span className="w-3.5 h-3.5 shrink-0 flex items-center justify-center">{t.icon}</span>
                 {t.label}
+                {t.badge && (
+                  <span className="ml-0.5 px-1.5 py-px rounded-full text-[9px] font-semibold uppercase tracking-wide bg-bg-hover text-muted border border-border shrink-0">
+                    {t.badge}
+                  </span>
+                )}
                 {t.dot && <span className="w-1.5 h-1.5 bg-accent rounded-full shrink-0" role="status" aria-label="update available" />}
               </button>
             ))}
@@ -69,7 +81,9 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
           {tabs.map(t => (
             <button
               key={t.key}
-              className={`flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-[13px] font-medium cursor-pointer border-none transition-all ${
+              className={`flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-[13px] font-medium border-none transition-all ${
+                t.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+              } ${
                 tab === t.key
                   ? 'bg-accent-subtle text-accent'
                   : 'bg-transparent text-muted hover:text-text hover:bg-bg-hover'
@@ -80,7 +94,12 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
                 {t.icon}
               </span>
               {t.label}
-              {t.dot && <span className="ml-auto w-2 h-2 bg-accent rounded-full shrink-0" role="status" aria-label="update available" />}
+              {t.badge && (
+                <span className="ml-auto px-1.5 py-px rounded-full text-[9px] font-semibold uppercase tracking-wide bg-bg-hover text-muted border border-border shrink-0">
+                  {t.badge}
+                </span>
+              )}
+              {t.dot && <span className={`${t.badge ? 'ml-1' : 'ml-auto'} w-2 h-2 bg-accent rounded-full shrink-0`} role="status" aria-label="update available" />}
             </button>
           ))}
           {footer && <div className="mt-auto pt-3 px-2.5">{footer}</div>}

--- a/website/src/pages/SettingsPage.tsx
+++ b/website/src/pages/SettingsPage.tsx
@@ -1,7 +1,10 @@
 import { Bell, Code, Globe, Info, Keyboard, MessageSquare, Mic, Palette, PanelsTopLeft, Server, ShieldCheck } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 import { SlackIcon } from '../components/SlackIcon'
 import { useAppSelector } from '../store'
-import SidePanelLayout from '../components/SidePanelLayout'
+import { api } from '../api/client'
+import SidePanelLayout, { type SidePanelTab } from '../components/SidePanelLayout'
+import { ChannelDisabledPanel } from './settings/ChannelDisabledPanel'
 import { useSettingHighlight } from '../hooks/useSettingHighlight'
 import { BrowserPanel } from './settings/BrowserPanel'
 import { InstancesPanel } from './settings/InstancesPanel'
@@ -25,7 +28,7 @@ import { NotificationsPanel } from './settings/NotificationsPanel'
 import { ShortcutsPanel } from './settings/ShortcutsPanel'
 import { AboutPanel } from './settings/AboutPanel'
 
-const TABS = [
+const TABS: SidePanelTab[] = [
   { key: 'overview', label: 'Overview', icon: <PanelsTopLeft size={16} />, description: 'System status, memory, agent config, and usage metrics' },
   { key: 'chat', label: 'Chat', icon: <MessageSquare size={16} />, description: 'Message behavior, history, timestamps, and context' },
   { key: 'voice', label: 'Voice', icon: <Mic size={16} />, description: 'Text-to-speech and speech-to-text (dictation) settings' },
@@ -44,6 +47,10 @@ const TABS = [
   { key: 'about', label: 'About', icon: <Info size={16} />, description: 'Version, update channel, check for updates, and license' },
 ]
 
+// Channel tabs whose visibility follows the `channels` governance policy. Keys
+// match the transports' canonical channel_type ids (the endpoint's map keys).
+const CHANNEL_TAB_KEYS = ['slack', 'discord', 'telegram', 'webex', 'wecom'] as const
+
 export default function SettingsPage() {
   const version = useAppSelector(s => s.dashboard.status?.version) || '—'
   useSettingHighlight()
@@ -53,8 +60,29 @@ export default function SettingsPage() {
   // Update nudge: dot on the About entry while a desktop update is available
   // (mirrored from Electron update-state by useUpdateSubscription).
   const updateAvailable = useAppSelector(s => s.dashboard.desktopUpdateAvailable)
+
+  // Effective per-channel `channels` policy: { slack: true, discord: false, ... }
+  // (true = permitted, false = denied by policy). All-true when no policy governs
+  // channels (standard build) → nothing greyed, UI unchanged from today. While
+  // loading, `data` is undefined so channelsPolicy?.[k] === false is never true —
+  // tabs stay enabled (no flash-disable).
+  const { data: channelsPolicy } = useQuery({
+    queryKey: ['governance-channels'],
+    queryFn: api.getGovernanceChannels,
+    staleTime: 60_000,
+  })
+  // A channel is disabled only when the policy explicitly returns false. Drive
+  // purely off the policy value — no per-channel special-casing (slack included).
+  const isChannelDenied = (key: string) =>
+    (CHANNEL_TAB_KEYS as readonly string[]).includes(key) && channelsPolicy?.[key] === false
+
   const baseTabs = embedded ? TABS.filter(t => t.key !== 'instances') : TABS
-  const tabs = updateAvailable ? baseTabs.map(t => (t.key === 'about' ? { ...t, dot: true } : t)) : baseTabs
+  const tabs = baseTabs.map(t => {
+    let next = t
+    if (updateAvailable && t.key === 'about') next = { ...next, dot: true }
+    if (isChannelDenied(t.key)) next = { ...next, disabled: true, badge: 'Off by admin' }
+    return next
+  })
 
   return (
     <SidePanelLayout
@@ -63,6 +91,13 @@ export default function SettingsPage() {
       footer={<span className="text-[12px] text-muted">KiroCrew v{version}</span>}
     >
       {tab => <>
+        {/* A denied channel renders the disabled-by-policy state instead of the
+            editable panel — so deep-linking ?tab=discord under a deny (or an
+            active tab that becomes denied) shows the lock state, never the form
+            (which could otherwise save config that never takes effect). */}
+        {isChannelDenied(tab)
+          ? <ChannelDisabledPanel label={TABS.find(t => t.key === tab)?.label || tab} />
+          : <>
         {tab === 'overview' && <OverviewPanel />}
         {tab === 'chat' && <ChatPanel />}
         {tab === 'voice' && <VoicePanel />}
@@ -84,6 +119,7 @@ export default function SettingsPage() {
             {TABS.find(t => t.key === tab)?.label} settings — coming soon
           </div>
         )}
+          </>}
       </>}
     </SidePanelLayout>
   )

--- a/website/src/pages/settings/ChannelDisabledPanel.tsx
+++ b/website/src/pages/settings/ChannelDisabledPanel.tsx
@@ -1,0 +1,26 @@
+import { Lock } from 'lucide-react'
+
+/**
+ * Shown in place of a channel's editable config panel when the `channels`
+ * governance policy DENIES that channel ("Off by admin"). The real panel (with
+ * the bot-token form) must NOT render for a denied channel — otherwise a user
+ * could type/save config that will never take effect (the backend gates the
+ * transport start, see the `channels` chokepoint). Parametrized by channel
+ * label so one component serves Discord / Telegram / Webex / WeCom.
+ */
+export function ChannelDisabledPanel({ label }: { label: string }) {
+  return (
+    <div className="py-10 flex flex-col items-center text-center max-w-md mx-auto">
+      <div className="w-12 h-12 rounded-full bg-bg-hover border border-border flex items-center justify-center mb-4">
+        <Lock size={20} className="lucide-inline text-muted" />
+      </div>
+      <div className="text-base font-semibold text-text-strong mb-1.5">
+        {label} is turned off by your administrator
+      </div>
+      <p className="text-sm text-muted leading-relaxed">
+        Your organization's security policy disables this channel. Its settings
+        are unavailable and any configuration here would not take effect.
+      </p>
+    </div>
+  )
+}

--- a/website/src/test/SettingsPage.channelGovernance.test.tsx
+++ b/website/src/test/SettingsPage.channelGovernance.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the governance-aware channel tabs on the Settings page.
+ *
+ * When the `channels` governance policy DENIES a channel (endpoint returns
+ * false), its Settings tab is greyed + disabled with an "Off by admin" badge
+ * (NOT hidden), and its panel body shows the disabled-by-policy state instead
+ * of the editable config form. With all-true (the standard build default),
+ * nothing is greyed and the editable panels render — UI unchanged from today.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mocks = vi.hoisted(() => ({ getGovernanceChannels: vi.fn() }))
+
+vi.mock('../api/client', () => ({ api: { getGovernanceChannels: mocks.getGovernanceChannels } }))
+
+// Stub the heavy panels — we test the tab greying + disabled-panel swap, not internals.
+vi.mock('../pages/settings/OverviewPanel', () => ({ OverviewPanel: () => <div data-testid="overview-panel" /> }))
+vi.mock('../pages/settings/ChatPanel', () => ({ ChatPanel: () => <div data-testid="chat-panel" /> }))
+vi.mock('../pages/settings/DisplayPanel', () => ({ DisplayPanel: () => <div data-testid="display-panel" /> }))
+vi.mock('../pages/settings/BrowserPanel', () => ({ BrowserPanel: () => <div data-testid="browser-panel" /> }))
+vi.mock('../pages/settings/InstancesPanel', () => ({ InstancesPanel: () => <div data-testid="instances-panel" /> }))
+vi.mock('../pages/settings/SecurityPanel', () => ({ SecurityPanel: () => <div data-testid="security-panel" /> }))
+vi.mock('../pages/settings/NotificationsPanel', () => ({ NotificationsPanel: () => <div data-testid="notifications-panel" /> }))
+vi.mock('../pages/settings/SlackPanel', () => ({ SlackPanel: () => <div data-testid="slack-panel" /> }))
+vi.mock('../pages/settings/DiscordPanel', () => ({ DiscordPanel: () => <div data-testid="discord-panel" /> }))
+vi.mock('../pages/settings/TelegramPanel', () => ({ TelegramPanel: () => <div data-testid="telegram-panel" /> }))
+vi.mock('../pages/settings/WebexPanel', () => ({ WebexPanel: () => <div data-testid="webex-panel" /> }))
+vi.mock('../pages/settings/WeComPanel', () => ({ WeComPanel: () => <div data-testid="wecom-panel" /> }))
+vi.mock('../pages/settings/GeneralPanel', () => ({ GeneralPanel: () => <div data-testid="general-panel" /> }))
+
+vi.mock('../store', () => ({ useAppSelector: () => undefined }))
+
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+import SettingsPage from '../pages/SettingsPage'
+
+function renderAt(route: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <QueryClientProvider client={queryClient}>
+        <SettingsPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('SettingsPage channel governance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('greys + badges a policy-denied channel tab and shows the disabled panel', async () => {
+    mocks.getGovernanceChannels.mockResolvedValue({
+      slack: true, discord: false, telegram: true, webex: true, wecom: true,
+    })
+    renderAt('/settings?tab=discord')
+
+    // Badge appears next to the denied tab's label.
+    await waitFor(() => expect(screen.getByText('Off by admin')).toBeInTheDocument())
+
+    // The Discord tab button is greyed (opacity-50 + cursor-not-allowed).
+    const discordBtn = screen.getByRole('button', { name: /Discord/ })
+    expect(discordBtn.className).toContain('opacity-50')
+    expect(discordBtn.className).toContain('cursor-not-allowed')
+
+    // The editable DiscordPanel must NOT render; the disabled state shows instead.
+    expect(screen.queryByTestId('discord-panel')).not.toBeInTheDocument()
+    expect(screen.getByText(/turned off by your administrator/)).toBeInTheDocument()
+  })
+
+  it('renders the editable panel and no greying when all channels are permitted', async () => {
+    mocks.getGovernanceChannels.mockResolvedValue({
+      slack: true, discord: true, telegram: true, webex: true, wecom: true,
+    })
+    renderAt('/settings?tab=discord')
+
+    // Editable panel renders; no badge, no disabled state.
+    await waitFor(() => expect(screen.getByTestId('discord-panel')).toBeInTheDocument())
+    expect(screen.queryByText('Off by admin')).not.toBeInTheDocument()
+    expect(screen.queryByText(/turned off by your administrator/)).not.toBeInTheDocument()
+
+    const discordBtn = screen.getByRole('button', { name: /Discord/ })
+    expect(discordBtn.className).not.toContain('opacity-50')
+  })
+})

--- a/website/src/test/SettingsPage.test.tsx
+++ b/website/src/test/SettingsPage.test.tsx
@@ -13,6 +13,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// SettingsPage fetches the channels governance policy via useQuery; mock it so
+// the tab-roster tests don't touch the network. Default all-true = nothing greyed.
+vi.mock('../api/client', () => ({
+  api: { getGovernanceChannels: vi.fn().mockResolvedValue({}) },
+}))
 
 // Stub the heavy panels — we are testing the tab roster, not panel internals.
 vi.mock('../pages/settings/OverviewPanel', () => ({ OverviewPanel: () => <div data-testid="overview-panel" /> }))
@@ -47,9 +54,12 @@ if (!window.matchMedia) {
 import SettingsPage from '../pages/SettingsPage'
 
 function renderAt(route: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <MemoryRouter initialEntries={[route]}>
-      <SettingsPage />
+      <QueryClientProvider client={queryClient}>
+        <SettingsPage />
+      </QueryClientProvider>
     </MemoryRouter>
   )
 }


### PR DESCRIPTION
> **⚠ Stacked on #482** — merge #482 (the transport-start gate) FIRST. The "Off by admin" disabled-panel copy is accurate only once that gate is live.

## Summary

Makes the Settings UI **governance-aware** for messaging channels. When the
`channels` governance policy denies a channel (discord / telegram / webex /
wecom), its Settings tab is now **greyed out and disabled** with an "Off by
admin" badge, and the panel body shows a clear disabled state — instead of a
live config form whose toggle silently does nothing.

This is the UX layer for the backend `channels` transport-start gate (#482):
that PR makes the backend refuse to start a policy-denied transport; this PR
stops the Settings UI from misleadingly offering an editable toggle for it.

## Why

Before this change the Settings tab list was static and channel panels were not
governance-aware, so under a policy that denies (say) Telegram, a user could
still open the Telegram tab, type a bot token, flip "enabled", and save — with
nothing ever connecting and no explanation. Enforcement was correct; the UX was
confusing.

## What changed

**Backend — new read-only surface**
- `GET /api/governance/channels` → `{"slack": true, "discord": false, ...}`
  (true = permitted, false = denied). Per member it calls
  `governance_permits("channels", member, session_key=HOST_SESSION_KEY)` (the
  same host-session evaluation the messaging + app-activation chokepoints use).
  Members are derived from each transport's `channel_type` attribute — no
  hardcoded divergent list. The per-member loop runs in `run_in_executor`
  (governance evaluation can read profile files) so it never blocks the loop.
- Registered next to the existing governance-status GET in `server.py`.

**Frontend — grey + badge + disabled panel**
- `SidePanelTab` gains optional `disabled` / `badge`; both the mobile pill strip
  and the desktop side-nav render a greyed tab (`opacity-50 cursor-not-allowed`)
  with a stylish "Off by admin" pill. The existing update `dot` still works.
- `SettingsPage` fetches the policy and, for a denied channel that is the active
  tab, renders a reusable `ChannelDisabledPanel` (a `lucide-react` lock-icon
  disabled state) instead of the editable panel — so a denied channel's config
  form never renders.
- All styling is theme-token driven (consistent light/dark); no emojis.

## Default behavior is byte-identical

With no policy governing `channels` (the standard build), the endpoint returns
all-true, `channelsPolicy[key] === false` is never true, and no tab is greyed —
the Settings UI is unchanged from today. The loading state is treated as enabled
(no flash-disable). Proven by backend tests (ungoverned + policy-omits-channels)
and a frontend all-true test.

## Verification

- Backend: `93 passed` (incl. the new `test_governance_channels_endpoint.py` —
  ungoverned all-true, per-member deny, `HOST_SESSION_KEY` asserted).
- Frontend: `npx tsc -b` clean; vitest `28 passed` (new channel-governance test +
  updated SettingsPage/SidePanel suites; the `dot` behavior test still passes).
- `flake8`, `isort --check-only`, `mypy src/kiro_crew` (`Success: no issues found
  in 473 source files`) all clean. Scrub-lint clean.
- `docs/system-specs/modules/governance.md` updated in the same commit (the new
  read-only surface + the Settings greying behavior).