### PR TITLE
ci: raise coverage floors and add regression-test review mandate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,13 +300,13 @@ jobs:
           name: coverage-frontend
           path: frontend-cov
 
-      - name: Check backend coverage (min 50%)
+      - name: Check backend coverage (min 70%)
         run: |
           F=backend-cov/coverage.xml
           test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
           # Compare the raw line-rate against the threshold; round only for
-          # display (a round-then-compare would let 49.95%..49.99% pass 50%).
-          python3 - "$F" 50 Backend <<'PY'
+          # display (a round-then-compare would let 69.95%..69.99% pass 70%).
+          python3 - "$F" 70 Backend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
           rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
@@ -316,11 +316,11 @@ jobs:
               sys.exit(1)
           PY
 
-      - name: Check frontend coverage (min 40%)
+      - name: Check frontend coverage (min 60%)
         run: |
           F=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
           test -n "$F" || { echo "::error::cobertura report missing from coverage-frontend artifact"; exit 1; }
-          python3 - "$F" 40 Frontend <<'PY'
+          python3 - "$F" 60 Frontend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
           rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
@@ -339,12 +339,12 @@ jobs:
           BF=backend-cov/coverage.xml
           if [ -f "$BF" ]; then
             B=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$BF').getroot().attrib['line-rate'])*100:.2f}\")")
-            echo "| Backend | ${B}% | 50% |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Backend | ${B}% | 70% |" >> "$GITHUB_STEP_SUMMARY"
           fi
           FF=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
           if [ -n "$FF" ]; then
             FR=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$FF').getroot().attrib['line-rate'])*100:.2f}\")")
-            echo "| Frontend | ${FR}% | 40% |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Frontend | ${FR}% | 60% |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   frontend-lint:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -162,11 +162,16 @@ jobs:
             merge ONLY if it is CRITICAL or HIGH AND one of: a real, reachable
             security hole with a concrete trigger; a broken security keystone /
             sensitive-path control; a crash / data-loss / corruption bug on a code
-            path the diff adds or changes; or a violation of a `blocking: true`
-            AUTOSDE.yaml rule whose file-patterns match a changed file. Style,
-            naming, speculative performance, hypothetical edge cases, and
-            test-coverage suggestions are NEVER blocking — label them MEDIUM/LOW
-            and keep them advisory.
+            path the diff adds or changes; a violation of a `blocking: true`
+            AUTOSDE.yaml rule whose file-patterns match a changed file; or a
+            missing regression test per the REGRESSION TESTS rule under SCOPE &
+            REGRESSION below (a bug fix or security/data-integrity/correctness
+            change that ships no test which would fail if it were reverted). Style,
+            naming, speculative performance, and hypothetical edge cases are
+            NEVER blocking — label them MEDIUM/LOW and keep them advisory.
+            Test-coverage gaps are ADVISORY (MEDIUM) by default, with ONE
+            exception that IS a blocking-bar item: the REGRESSION TESTS rule
+            under SCOPE & REGRESSION below.
 
             SEVERITY–BLOCK COHERENCE: reserve CRITICAL/HIGH for findings that meet
             the BLOCKING BAR above; anything that does not meet the bar MUST be
@@ -202,6 +207,26 @@ jobs:
               handling that a prior fix added, and the PR description does not say
               why, that is a blocking-bar finding (it re-exposes a bug on a changed
               path).
+            - Regression tests (mandatory check): for every PR that adds or
+              changes non-trivial LOGIC — a bug fix, a behavior change, a new
+              branch / edge-case handler, or a security/data-integrity control —
+              verify it ships unit tests that LOCK IN the new or fixed behavior:
+              a test that would FAIL if this change were reverted. This is the
+              guard against a future edit silently undoing valuable behavior.
+              Read the actual test files (Grep/Glob) to confirm a real assertion
+              on the changed behavior exists — do not accept an unrelated or
+              pre-existing test as coverage. Report the absence as:
+                * BLOCKING (HIGH) when the change FIXES A BUG or alters a
+                  security / data-integrity / correctness path AND ships no test
+                  that would catch its regression (nothing pins the behavior).
+                  Name the exact function/behavior and the specific test that is
+                  missing.
+                * ADVISORY (MEDIUM) for general new-feature logic whose behavior
+                  is untested but which is not a fix and not on a
+                  security/data/correctness path.
+              Trivial changes need NO new test — pure refactors already covered by
+              existing tests, comments, docs, formatting, config, and
+              vendored/generated files. Do NOT ask for tests there.
 
             FINAL OUTPUT (authoritative for the gate) — when you finish, return
             the structured result required by the --json-schema. The action
@@ -211,7 +236,10 @@ jobs:
             - block_merge: true IF AND ONLY IF at least one finding meets the
               BLOCKING BAR above (a real reachable security hole, a broken
               keystone/sensitive-path control, a crash/data-loss on a changed
-              path, or a violation of a `blocking: true` AUTOSDE.yaml rule).
+              path, a violation of a `blocking: true` AUTOSDE.yaml rule, or a
+              missing regression test per the REGRESSION TESTS rule — a bug fix
+              or security/data-integrity/correctness change shipping no test that
+              would fail if reverted).
               Otherwise false. Per SEVERITY↔BLOCK COHERENCE, block_merge MUST be
               true whenever any finding is CRITICAL/HIGH; never label a
               non-blocking finding above MEDIUM.

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -128,8 +128,11 @@ jobs:
           4. API design issues (breaking changes, missing error handling)
           5. Scope coherence (changes unrelated to the PR's stated purpose)
           6. Regression (removal of a guard/validation/error-handling a prior fix added)
-          Performance, test-coverage, and style-adjacent observations are ADVISORY
-          only (see the blocking contract below) -- report them as MEDIUM/LOW.
+          7. Regression tests: non-trivial new/changed logic must ship unit tests
+             that lock in the behavior (see SCOPE & REGRESSION below)
+          Performance and style-adjacent observations are ADVISORY only -- report
+          them as MEDIUM/LOW. Test-coverage gaps are ADVISORY by default too,
+          EXCEPT the regression-test case in SCOPE & REGRESSION below.
 
           COVERAGE (mandatory): enumerate EVERY file in the diff and inspect each
           one -- do not sample or stop early. Your review MUST account for all
@@ -162,10 +165,16 @@ jobs:
             - a crash, data-loss, or corruption bug on a code path the diff adds
               or changes;
             - a violation of a `blocking: true` AUTOSDE.yaml rule whose
-              file-patterns match a changed file.
+              file-patterns match a changed file;
+            - a missing regression test per the REGRESSION TESTS rule under
+              SCOPE & REGRESSION below: a bug fix or a
+              security/data-integrity/correctness change that ships no test
+              which would fail if the change were reverted.
           Style, naming, formatting, "consider"/"might want to", speculative
-          performance, hypothetical edge cases, and test-coverage suggestions
-          are NEVER blocking -- label them MEDIUM/LOW and keep them advisory.
+          performance, and hypothetical edge cases are NEVER blocking -- label
+          them MEDIUM/LOW and keep them advisory. Test-coverage gaps are ADVISORY
+          (MEDIUM) by default, with ONE blocking exception: the regression-test
+          rule in SCOPE & REGRESSION below.
 
           SEVERITY-BLOCK COHERENCE: reserve CRITICAL/HIGH for findings that meet
           the BLOCKING BAR above; anything that does not meet the bar MUST be
@@ -217,6 +226,25 @@ jobs:
             handling that a prior fix added, and the PR description does not say
             why, that is a blocking-bar finding (it re-exposes a bug on a changed
             path).
+          - Regression tests (mandatory check): for every PR that adds or changes
+            non-trivial LOGIC -- a bug fix, a behavior change, a new branch /
+            edge-case handler, or a security/data-integrity control -- verify it
+            ships unit tests that LOCK IN the new or fixed behavior: a test that
+            would FAIL if this change were reverted. This is the guard against a
+            future edit silently undoing valuable behavior. Read the actual test
+            files to confirm a real assertion on the changed behavior exists -- do
+            not accept an unrelated or pre-existing test as coverage. Report the
+            absence as:
+              * Severity: HIGH (blocking) when the change FIXES A BUG or alters a
+                security / data-integrity / correctness path AND ships no test
+                that would catch its regression (nothing pins the behavior). Name
+                the exact function/behavior and the specific test that is missing.
+              * Severity: MEDIUM (advisory) for general new-feature logic whose
+                behavior is untested but which is not a fix and not on a
+                security/data/correctness path.
+            Trivial changes need NO new test -- pure refactors already covered by
+            existing tests, comments, docs, formatting, config, and
+            vendored/generated files. Do NOT ask for tests there.
 
           OUTPUT MARKERS (how CI gates the merge -- emit verbatim, each on its
           own line, with the SHA exactly as written):


### PR DESCRIPTION
## Problem
The Coverage Gate floors (backend **50%**, frontend **40%**) sat far below actual coverage on `main` (backend **71.98%**, frontend **64.73%**). They would only fire after a catastrophic drop, so a PR could add hundreds of untested lines and still pass. Separately, there was **no regression guard via tests**: the AI reviewers treated *all* test-coverage gaps as never-blocking, so a change could silently revert valuable behavior that no test pinned.

## Why it matters
Loose floors give a false sense of safety and let the aggregate coverage erode PR-by-PR. And the exact failure the user called out — "a new change reverted something valuable, but it wasn't guarded by tests" — was undetectable: a bug fix could land, no test locked it in, and a later edit could undo it with every check green.

## Fix (symptom → root cause → change)
Symptom: gate rubber-stamps real coverage; regressions of unpinned behavior slip through. Root cause: (1) thresholds were placeholder-low; (2) reviewer contracts explicitly declared test-coverage "NEVER blocking". Changes:
- **`ci.yml` Coverage Gate** — raise line-rate floors to **backend 70% / frontend 60%** (step names, the Python threshold args, and the summary table).
- **`claude-review.yml` + `codex-review.yml`** — add a **Regression tests** rule under SCOPE & REGRESSION: non-trivial new/changed logic (bug fix, behavior change, new branch/edge-case handler, security/data-integrity control) must ship a unit test that would **FAIL if the change were reverted**, and the reviewer reads the actual test file to confirm a real assertion exists. One blocking exception is carved out of the "test-coverage is never blocking" rule: **BLOCKING (HIGH)** only when the change fixes a bug or alters a security/data/correctness path **and** ships no regression test. General new-feature coverage gaps stay **advisory MEDIUM**; trivial changes (pure refactors already covered, docs, config, vendored/generated) require no new test. Mirrored into both reviewers using each one's severity/label convention.
- **Authoritative blocking-bar enumerations updated (coherence)** — the exception is also added as a **fifth item** to every restated "block ONLY if … one of:" list: Claude's BLOCKING BAR, Claude's `block_merge: true IF AND ONLY IF …` parenthetical, and Codex's SEVERITY+BLOCKING CONTRACT list. Without this, a reviewer faithfully following the IFF would label the finding HIGH yet set `block_merge=false` (the block silently never fires on Claude), or trip Codex's fail-closed severity↔block coherence backstop on a legitimate finding. This keeps the new mandate's blocking behavior real and self-consistent across both gates.

## Tests
N/A — workflow-only config/prompt change. All three YAML files parse via `yaml.safe_load`.

## Manual verification
- Confirmed current `main` coverage (backend 71.98%, frontend 64.73%, from the latest green CI Coverage Gate) clears the new floors — this PR does not self-trip the gate.
- Isolated the edits from the unrelated open PR #454 branch and applied them cleanly onto `origin/main`.
- Verified the regression-test exception is now present in all four places (SCOPE & REGRESSION rule + three blocking-bar enumerations) so the mandate actually blocks.
- Note: backend headroom is thin (~2 pts). The new regression-test mandate is expected to raise per-PR coverage over time and grow that margin.
