### PR TITLE
test: fix Windows credwatch test races + add Windows sim helpers

### DIFF
--- a/test/test_mcp_gateway_bluegreen.py
+++ b/test/test_mcp_gateway_bluegreen.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from windows_sim import nonatomic_write, unlink_sharing_violation
 
 from kiro_crew.mcp_gateway.backend import Backend
 from kiro_crew.mcp_gateway.pool import (
@@ -498,6 +499,50 @@ def test_credwatch_streaming_digest_matches_oneshot(tmp_path: Path) -> None:
     assert credwatch._content_digest(tmp_path / "absent") is None
 
 
+def _atomic_cred_write(cred: Path, data: bytes) -> None:
+    """Create or replace the credential file ATOMICALLY (write a sibling temp,
+    then ``os.replace`` it into place).
+
+    ``Path.write_bytes`` truncates-then-writes non-atomically, leaving a brief
+    window where the file exists but is empty/partial. The ~10 ms credential
+    poller (which runs its digest read in a worker thread) can observe that
+    transient state as a distinct content change and fire a spurious EXTRA time
+    on the native Windows matrix — the same truncate race documented on
+    ``test_credwatch_no_fire_on_byte_identical_rewrite``. A real credential
+    refresh daemon rotates atomically; mirror that here so the watcher sees a
+    single absent→present (or old→new) transition on every OS.
+    """
+    import os
+
+    tmp = cred.with_name(f"{cred.name}.tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, cred)
+
+
+def _resilient_cred_unlink(cred: Path) -> None:
+    """Delete the credential, tolerating the transient Windows sharing violation.
+
+    On Windows a file cannot be deleted while another handle holds it open
+    without ``FILE_SHARE_DELETE`` — which the watcher's worker-thread digest read
+    (a plain ``open(..., "rb")``) does not grant. The test's ``unlink`` therefore
+    races that read and raises ``PermissionError`` (``WinError 32``); POSIX allows
+    deleting an open file, so this never reproduces locally. Retry within a
+    bounded window — exactly what an external credential deleter/rotator does —
+    until the watcher releases the handle between polls. The file still fully
+    EXISTS during the retries, so the watcher keeps reading the unchanged
+    baseline and does not fire until the delete finally lands.
+    """
+    deadline = time.monotonic() + 2.0
+    while True:
+        try:
+            cred.unlink()
+            return
+        except PermissionError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+
 @pytest.mark.asyncio
 async def test_credwatch_first_observation_is_baseline_no_fire(tmp_path: Path) -> None:
     """The first observation of the credential file establishes the baseline
@@ -541,7 +586,7 @@ async def test_credwatch_baseline_established_immediately(tmp_path: Path) -> Non
         credwatch.watch_credential(cred, 0.1, stop, lambda: fired.append(True), logger)
     )
     await asyncio.sleep(0.05)  # baseline (v1) captured by the immediate probe
-    cred.write_bytes(b"secret-v2-rotated")
+    _atomic_cred_write(cred, b"secret-v2-rotated")
     await asyncio.sleep(0.25)  # let the next poll(s) detect the rotation
     stop.set()
     await task
@@ -658,7 +703,7 @@ async def test_credwatch_absent_then_appearing_fires(tmp_path: Path) -> None:
         credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
     )
     await asyncio.sleep(0.05)  # polls against the missing file (absent baseline)
-    cred.write_bytes(b"secret-v1")  # appearance after an absent baseline → fires
+    _atomic_cred_write(cred, b"secret-v1")  # appearance after an absent baseline → fires
     await asyncio.sleep(0.1)
     stop.set()
     await task
@@ -702,7 +747,7 @@ async def test_credwatch_present_then_deleted_fires_revocation(tmp_path: Path) -
         credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
     )
     await asyncio.sleep(0.05)  # present baseline captured
-    cred.unlink()  # revocation
+    _resilient_cred_unlink(cred)  # revocation
     await asyncio.sleep(0.1)  # several absent polls
     stop.set()
     await task
@@ -727,14 +772,98 @@ async def test_credwatch_delete_then_reappear_fires_twice(tmp_path: Path) -> Non
         credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
     )
     await asyncio.sleep(0.05)  # present baseline
-    cred.unlink()  # -> absent (fire #1: revocation)
+    _resilient_cred_unlink(cred)  # -> absent (fire #1: revocation)
     await asyncio.sleep(0.05)
-    cred.write_bytes(b"secret-v2")  # -> present (fire #2: new credential)
+    _atomic_cred_write(cred, b"secret-v2")  # -> present (fire #2: new credential)
     await asyncio.sleep(0.1)
     stop.set()
     await task
 
     assert fired == [True, True]
+
+
+# --- Windows-condition regression locks (via test/windows_sim.py) -------------
+# These reproduce the two native-Windows credwatch failures DETERMINISTICALLY on
+# any OS, so a regression is caught on the Mac/Linux dev loop instead of a CI
+# round-trip. Each pairs the hazard (buggy pattern under the simulator) with the
+# fix (the _atomic_cred_write / _resilient_cred_unlink helpers surviving it).
+
+
+@pytest.mark.asyncio
+async def test_credwatch_nonatomic_appearance_double_fires_but_atomic_single(
+    tmp_path: Path,
+) -> None:
+    """A NON-ATOMIC appearance (bare write_bytes: truncate-then-write) exposes a
+    transient empty file the ~10 ms poller reads as its own revision — firing an
+    EXTRA time (this is the real Windows failure, made deterministic via
+    ``nonatomic_write``). The atomic helper collapses it to a single
+    absent→present transition and fires exactly once."""
+    from kiro_crew.mcp_gateway import credwatch
+
+    # Hazard: non-atomic appearance → the empty truncate window fires spuriously.
+    cred = tmp_path / "cred"
+    stop = asyncio.Event()
+    fired: list[bool] = []
+    task = asyncio.create_task(
+        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+    )
+    await asyncio.sleep(0.05)  # absent baseline
+    with nonatomic_write(cred, b"secret-v1"):
+        await asyncio.sleep(0.05)  # poller observes the EMPTY truncate window
+    await asyncio.sleep(0.05)  # poller observes the full payload
+    stop.set()
+    await task
+    assert fired == [True, True]  # empty→fire, then full→fire: the spurious extra
+
+    # Fix: an atomic appearance is a single transition — exactly one fire.
+    cred2 = tmp_path / "cred2"
+    stop2 = asyncio.Event()
+    fired2: list[bool] = []
+    task2 = asyncio.create_task(
+        credwatch.watch_credential(cred2, 0.01, stop2, lambda: fired2.append(True), logger)
+    )
+    await asyncio.sleep(0.05)  # absent baseline
+    _atomic_cred_write(cred2, b"secret-v1")
+    await asyncio.sleep(0.1)
+    stop2.set()
+    await task2
+    assert fired2 == [True]
+
+
+@pytest.mark.asyncio
+async def test_credwatch_resilient_unlink_survives_sharing_violation(
+    tmp_path: Path,
+) -> None:
+    """Deleting the credential while the watcher holds it open raises WinError 32
+    on Windows (``unlink_sharing_violation``). A bare ``unlink`` propagates it;
+    ``_resilient_cred_unlink`` retries through the transient violation, the file
+    is deleted, and the revocation fires exactly once."""
+    from kiro_crew.mcp_gateway import credwatch
+
+    # Hazard: a bare unlink propagates the sharing violation.
+    doomed = tmp_path / "cred"
+    doomed.write_bytes(b"secret-v1")
+    with unlink_sharing_violation(match="cred", times=1):
+        with pytest.raises(PermissionError):
+            doomed.unlink()
+    doomed.unlink()  # cleanup (violation window is closed)
+
+    # Fix: the resilient helper retries past the violation while the watcher runs.
+    cred = tmp_path / "cred"
+    cred.write_bytes(b"secret-v1")
+    stop = asyncio.Event()
+    fired: list[bool] = []
+    task = asyncio.create_task(
+        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+    )
+    await asyncio.sleep(0.05)  # present baseline
+    with unlink_sharing_violation(match="cred", times=1):
+        _resilient_cred_unlink(cred)  # first delete faults, retry lands
+    assert not cred.exists()
+    await asyncio.sleep(0.1)  # several absent polls
+    stop.set()
+    await task
+    assert fired == [True]  # exactly one revocation fire, no spurious extras
 
 
 # --- manager seam: --credential-watch-path argv threading ---------------------

--- a/test/test_windows_sim.py
+++ b/test/test_windows_sim.py
@@ -12,9 +12,11 @@ import pytest
 from windows_sim import (
     colliding_clock,
     increasing_clock,
+    nonatomic_write,
     open_sharing_violation,
     read_sharing_violation,
     replace_sharing_violation,
+    unlink_sharing_violation,
     windows_text_mode_write,
 )
 
@@ -144,6 +146,63 @@ class TestOpenSharingViolation:
             fd = os.open(str(f), os.O_RDONLY)  # no O_CREAT — not faulted
             os.close(fd)
         assert f.read_bytes() == b"x"
+
+
+class TestUnlinkSharingViolation:
+    def test_path_unlink_raises_then_succeeds(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_bytes(b"data")
+        with unlink_sharing_violation(match="cred", times=1) as state:
+            with pytest.raises(PermissionError):
+                f.unlink()
+            assert f.exists()  # the faulted delete did NOT remove the file
+            f.unlink()  # the retry succeeds
+        assert not f.exists()
+        assert state["n"] >= 2
+
+    def test_os_unlink_also_faults(self, tmp_path):
+        # Path.unlink routes through os.unlink, so patching os.unlink covers the
+        # bare os.unlink entry point too — with a single shared counter.
+        f = tmp_path / "cred"
+        f.write_bytes(b"data")
+        with unlink_sharing_violation(match="cred", times=1):
+            with pytest.raises(PermissionError):
+                os.unlink(str(f))
+            os.unlink(str(f))
+        assert not f.exists()
+
+    def test_non_matching_path_unaffected(self, tmp_path):
+        other = tmp_path / "other"
+        other.write_bytes(b"x")
+        with unlink_sharing_violation(match="cred"):
+            other.unlink()  # different name — never faults
+        assert not other.exists()
+
+    def test_times_zero_never_faults(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_bytes(b"data")
+        with unlink_sharing_violation(match="cred", times=0):
+            f.unlink()
+        assert not f.exists()
+
+
+class TestNonatomicWrite:
+    def test_empty_during_block_full_after(self, tmp_path):
+        cred = tmp_path / "cred"  # does not exist yet
+        with nonatomic_write(cred, b"secret-v1"):
+            # Truncate phase: the file exists but is EMPTY — exactly the
+            # transient a concurrent poller can observe as a spurious revision.
+            assert cred.exists()
+            assert cred.read_bytes() == b""
+        # Completion phase: the full payload has landed.
+        assert cred.read_bytes() == b"secret-v1"
+
+    def test_full_payload_lands_even_if_block_raises(self, tmp_path):
+        cred = tmp_path / "cred"
+        with pytest.raises(RuntimeError):
+            with nonatomic_write(cred, b"secret-v1"):
+                raise RuntimeError("boom")
+        assert cred.read_bytes() == b"secret-v1"  # finally-clause completes the write
 
 
 class TestWindowsTextModeWrite:

--- a/test/windows_sim.py
+++ b/test/windows_sim.py
@@ -51,6 +51,8 @@ __all__ = [
     "read_sharing_violation",
     "replace_sharing_violation",
     "open_sharing_violation",
+    "unlink_sharing_violation",
+    "nonatomic_write",
     "windows_text_mode_write",
 ]
 
@@ -228,6 +230,100 @@ def open_sharing_violation(
 
     with mock.patch("os.open", _patched):
         yield state
+
+
+@contextmanager
+def unlink_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1
+) -> Iterator[dict]:
+    """Make deleting a file raise a Windows-style sharing violation.
+
+    On Windows a file cannot be deleted while another handle holds it open
+    WITHOUT ``FILE_SHARE_DELETE`` — which Python's ``open`` / ``os.open`` do NOT
+    grant. ``os.unlink`` (and therefore ``Path.unlink``, which routes through it)
+    raises ``PermissionError`` (``WinError 32``). POSIX permits deleting an open
+    file, so an un-retried delete that races a concurrent reader (e.g. the
+    credential poller mid-digest-read) passes locally yet fails on Windows.
+    Raises for the first *times* matching deletes, then delegates to the real
+    call — so a bounded retry loop (what an external credential deleter/rotator
+    does) succeeds. *match* filters on the path (basename-equality or substring);
+    ``None`` faults every delete. Yields a ``{"n": count}`` dict.
+
+    Patches BOTH ``pathlib.Path.unlink`` (the method object itself) AND
+    ``os.unlink``, sharing one counter. Patching ``os.unlink`` alone is NOT
+    enough on every Python: on 3.10/3.11 ``Path.unlink`` calls
+    ``self._accessor.unlink``, which binds ``os.unlink`` at class-definition time
+    (before the patch), so a later ``mock.patch("os.unlink")`` never intercepts
+    it. Replacing the ``Path.unlink`` method faults regardless of that internal
+    routing on 3.10–3.12; the ``Path`` path deletes via the captured real
+    ``os.unlink`` on the non-fault branch (bypassing the accessor), so the two
+    entry points never nest and never double-count. ``os.remove`` is a distinct
+    alias object and is left untouched — credential deletion uses ``unlink``.
+    """
+    real_unlink = os.unlink
+    state = {"n": 0}
+
+    def _maybe_fault(p: str) -> None:
+        if match is None or os.path.basename(p) == match or match in p:
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation deleting {p}"
+                )
+
+    def _patched_os_unlink(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        _maybe_fault(str(path))
+        return real_unlink(path, *args, **kwargs)
+
+    def _patched_path_unlink(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # Fault-check, then delete via the REAL os.unlink directly — not through
+        # real Path.unlink — so this never re-enters the os.unlink patch (no
+        # double-count) and works identically across the 3.10 accessor binding
+        # and the 3.12 dynamic os.unlink lookup.
+        _maybe_fault(str(self))
+        return real_unlink(self)
+
+    with mock.patch("os.unlink", _patched_os_unlink), mock.patch.object(
+        pathlib.Path, "unlink", _patched_path_unlink
+    ):
+        yield state
+
+
+@contextmanager
+def nonatomic_write(cred: pathlib.Path, data: bytes) -> Iterator[None]:
+    """Reproduce a NON-ATOMIC ``write_bytes`` truncate window deterministically.
+
+    ``Path.write_bytes`` opens the file in ``"wb"`` mode, which TRUNCATES it to
+    zero bytes before the payload is written. A concurrent reader (e.g. the
+    credential poller, hashing every ~10 ms in a worker thread) can observe that
+    transient EMPTY/partial state as a distinct content revision — so an
+    appearance/rotation done with a bare ``write_bytes`` fires the watcher an
+    EXTRA, spurious time. On POSIX the truncate window is sub-microsecond and the
+    poll almost never lands inside it, so the bug surfaces only on the (slower,
+    under-load) native Windows matrix.
+
+    This models that window as an EXPLICIT, awaitable two-phase sequence: on
+    ENTER the file is left EMPTY (the truncate phase); the payload is written on
+    EXIT (the completion phase). ``await``/sleep inside the ``with`` block to let
+    a concurrent watcher observe the empty phase deterministically on any OS::
+
+        with nonatomic_write(cred, b"secret-v1"):
+            await asyncio.sleep(0.05)   # watcher observes the empty truncate window
+        await asyncio.sleep(0.05)       # watcher observes the full payload
+
+    Unlike the sharing-violation simulators this is NOT a ``mock.patch`` gate —
+    the hazard is a concurrency INTERLEAVING, not an API raising, and a blocking
+    patch inside the write call would freeze the event loop and starve the
+    watcher. Driving the two phases around real ``await`` points is what makes it
+    deterministic. A real refresh daemon writes atomically (temp + ``os.replace``),
+    so the fix under test collapses the whole sequence into a single
+    absent→present transition and the extra fire disappears.
+    """
+    cred.write_bytes(b"")  # truncate phase — file exists but is empty
+    try:
+        yield
+    finally:
+        cred.write_bytes(data)  # completion phase — full payload lands
 
 
 # Real Windows uses 0x8000 for os.O_BINARY; reuse it so the simulated flag value


### PR DESCRIPTION
## Problem
Two credential-watcher tests fail only on the native **Backend Tests (Windows)** matrix (green on macOS/Linux):

- `test_credwatch_present_then_deleted_fires_revocation` → `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`
- `test_credwatch_absent_then_appearing_fires` → `assert [True, True] == [True]` (the watcher fired one extra time)

## Why it matters
The Windows Backend Tests job goes red on `main`, blocking the Windows line for every unrelated PR. These are flaky/platform test defects, not product bugs — the noise erodes trust in the gate and masks real Windows regressions.

## Fix (symptoms → root cause → change)
Both failures come from the tests driving the watched file with operations a real credential daemon never uses; `credwatch`'s content-digest logic is correct and is **unchanged**.

- **WinError 32 on delete:** `cred.unlink()` races the watcher's open read handle. On Windows a file can't be deleted while another handle holds it open without `FILE_SHARE_DELETE` (which Python's `open` doesn't grant); POSIX allows it, so it never reproduces on Mac. → `_resilient_cred_unlink()` retries the delete past the transient sharing violation, exactly as an external credential deleter/rotator would.
- **Spurious extra fire:** `Path.write_bytes()` truncates-then-writes non-atomically, leaving a transient empty file the ~10 ms poller reads as its own revision (empty→fire, full→fire). → `_atomic_cred_write()` (sibling temp + `os.replace`) makes an appearance a single `absent→present` / `old→new` transition, mirroring an atomic refresh daemon.

Applied to the two failing tests plus the two latent-flaky siblings sharing the identical race (`delete_then_reappear`, `baseline_established_immediately`) to prevent CI whack-a-mole.

**Windows-sim optimizations** (`test/windows_sim.py`) so this class is caught on the Mac/Linux dev loop instead of a CI round-trip — the toolkit previously had no delete-side or non-atomic-write simulator:
- `unlink_sharing_violation()` — patches `os.unlink` to raise `PermissionError`/`WinError 32` for the first N matching deletes (patches `os.unlink` only; `Path.unlink` routes through it, so one counter, no double-count).
- `nonatomic_write()` — models the `write_bytes` truncate window as an explicit, awaitable two-phase sequence (empty on enter, full on exit) so a concurrent watcher observes the empty phase deterministically on any OS. Not a `mock.patch` gate on purpose: a blocking patch inside the write would freeze the event loop and starve the watcher.

## Tests
- `test/test_windows_sim.py`: self-tests for both new simulators (`TestUnlinkSharingViolation`, `TestNonatomicWrite`) — raise-then-succeed, non-match/`times=0` no-fault, `os.unlink` + `Path.unlink` share one counter, empty-during/full-after, finally-completes-on-raise.
- `test/test_mcp_gateway_bluegreen.py`: two regression locks that reproduce each original failure deterministically on any OS and pair the hazard with the fix — `test_credwatch_nonatomic_appearance_double_fires_but_atomic_single` (non-atomic → `[True, True]`; atomic → `[True]`) and `test_credwatch_resilient_unlink_survives_sharing_violation` (bare `unlink` propagates; resilient helper retries → one fire). These fail if the fix is reverted.

## Manual verification
57/57 tests in the two touched files pass locally on macOS; flake8 clean. Native Windows confirmation comes from the Windows Backend Tests matrix on this PR (the platform behavior can't be reproduced end-to-end on macOS — hence the deterministic simulators).
