### PR TITLE
ci(review): narrow Arbiter blocking bar and make suggested fixes proportionate and in-scope

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -158,6 +158,29 @@ jobs:
             unsure, lower the severity rather than guess. Only the base-branch
             AUTOSDE rules and the actual diff are authoritative — never invent rules.
 
+            PROPORTIONALITY (anti-over-engineering) — a suggested Fix MUST be the
+            smallest change that resolves the named problem. Prefer simplifying
+            or deleting code over adding new mechanisms, layers, abstractions,
+            config knobs, or defensive scaffolding. Do NOT suggest speculative
+            hardening or "future-proofing" the finding does not strictly require —
+            such additions become new surface a later review flags, creating a
+            churn spiral. The mere ABSENCE of an extra mechanism beyond what the
+            change needs is NOT a finding; a request to "add mechanism X" for a
+            hypothetical is LOW/advisory at most.
+
+            STAY WITHIN THE PR'S STATED PURPOSE — a suggested Fix MUST be
+            achievable inside the scope of THIS PR. If resolving a finding would
+            require work beyond the PR's goal (a new subsystem, refactoring
+            untouched code, or a cross-cutting change), do NOT demand it here:
+            downgrade to an advisory / "separate PR" follow-up. The review must
+            converge — a fix that spawns MORE reviewable surface than the
+            original problem is out of bounds and causes endless review.
+            This trims SPECULATIVE additions, not NECESSARY ones: still raise
+            what the change genuinely requires to be correct or safe, sized to
+            the PR's goal. Match the ambition of the fix to the ambition of the
+            change — a simple feature warrants a simple solution, not a new
+            subsystem.
+
             BLOCKING BAR (identical for the Codex reviewer) — a finding may block
             merge ONLY if it is CRITICAL or HIGH AND one of: a real, reachable
             security hole with a concrete trigger; a broken security keystone /

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -192,6 +192,28 @@ jobs:
           unsure, lower the severity rather than guess. Only the base-branch
           AUTOSDE rules and the actual diff are authoritative -- never invent rules.
 
+          PROPORTIONALITY (anti-over-engineering) -- a suggested Fix MUST be the
+          smallest change that resolves the named problem. Prefer simplifying or
+          deleting code over adding new mechanisms, layers, abstractions, config
+          knobs, or defensive scaffolding. Do NOT suggest speculative hardening
+          or "future-proofing" the finding does not strictly require -- such
+          additions become new surface a later review flags, creating a churn
+          spiral. The mere ABSENCE of an extra mechanism beyond what the change
+          needs is NOT a finding; a request to "add mechanism X" for a
+          hypothetical is LOW/advisory at most.
+
+          STAY WITHIN THE PR'S STATED PURPOSE -- a suggested Fix MUST be
+          achievable inside the scope of THIS PR. If resolving a finding would
+          require work beyond the PR's goal (a new subsystem, refactoring
+          untouched code, or a cross-cutting change), do NOT demand it here:
+          downgrade to an advisory / "separate PR" follow-up. The review must
+          converge -- a fix that spawns MORE reviewable surface than the
+          original problem is out of bounds and causes endless review.
+          This trims SPECULATIVE additions, not NECESSARY ones: still raise what
+          the change genuinely requires to be correct or safe, sized to the PR's
+          goal. Match the ambition of the fix to the ambition of the change -- a
+          simple feature warrants a simple solution, not a new subsystem.
+
           SELF-CRITIQUE (run BEFORE you emit anything):
           - Kill-filter: DROP pure style preferences, "consider"/"nice-to-have"
             nits, and anything that would not change the author's code or

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -232,8 +232,17 @@ jobs:
             <for each design finding: a short title tagged (design | fidelity |
             blast-radius | contract), then Evidence (quoted hunk/sentence),
             Consequence (cause → mechanism → consequence), and Suggestion (the
-            strongest alternative or missing consideration). If none: "No
-            design-level concerns.">
+            strongest alternative or missing consideration). Keep the Suggestion
+            PROPORTIONATE: prefer the simplest design that solves the stated
+            problem; do NOT recommend extra layers, abstractions, or
+            future-proofing the problem does not require — over-engineered
+            suggestions become new surface a later review flags. Stay within THIS
+            PR's stated purpose: if an alternative would require work beyond the
+            PR's goal, mark it as a separate follow-up, not a change to make here.
+            This trims SPECULATIVE additions, not NECESSARY ones: still surface
+            what the design genuinely requires to be correct or safe, sized to
+            the PR's goal — a simple goal warrants a simple design, not a new
+            subsystem. If none: "No design-level concerns.">
 
             End with this exact line as proof the review ran for this commit:
             [DESIGN-REVIEWED] ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -2,13 +2,18 @@ name: Arbiter
 
 # SECOND-ORDER GATE. The line-level reviewers (Claude / GPT 5.6) surface Medium
 # findings and the design reviewer surfaces CONCERNS — none of which block,
-# correctly, since most are not blockers. But some carry a real long-term cost
-# (architectural erosion, maintainability debt, latent security/data-correctness
-# risk, or an expensive-to-reverse contract) that an author can silently ignore.
-# This workflow reads the sub-threshold findings the three reviewers ALREADY
-# posted, judges — with a deliberately conservative rubric — which ones a human
-# must be forced to act on, posts an actionable checklist, and gates the PR via a
-# dedicated "Arbiter — judge from comments" check-run.
+# correctly, since most are not blockers. This workflow reads those sub-threshold
+# findings and, with a DELIBERATELY NARROW rubric, blocks ONLY the few that are
+# genuinely hard to walk back once merged: a one-way door (an expensive-to-
+# reverse contract / API / schema / persisted-data decision) or concrete harm (a
+# latent security regression or data-correctness/loss bug this diff can trigger).
+# Everything else — architectural erosion, maintainability debt, missing
+# abstractions, "should eventually refactor" — is REVERSIBLE later, so it is
+# routed to non-blocking "Suggested follow-ups" rather than gating the PR. The
+# author never needs a perfect/complete solution in one PR; a smaller in-scope
+# fix plus a tracked follow-up is the preferred outcome. It posts an actionable
+# checklist and gates the PR via a dedicated "Arbiter — judge from comments"
+# check-run.
 #
 # It is its OWN workflow (not a job inside design-review.yml) precisely so that
 # "Design Review" can be one of its workflow_run triggers — a job cannot be
@@ -205,37 +210,66 @@ jobs:
             /tmp/subthreshold.md. HIGH/CRITICAL items are already handled by the
             reviewers and block on their own — ignore them here.
 
-            ESCALATE a listed finding ONLY IF deferring it has a concrete, named
-            long-term cost in one of:
-            - architectural erosion / a wrong ownership boundary that will spread,
-            - maintainability / tech-debt that compounds (not a one-off nit),
-            - latent security or data-correctness risk,
-            - an expensive-to-reverse contract / API / schema / persisted-data
-              decision (a one-way door).
-            DO NOT escalate: style, naming, formatting, import order,
-            micro-optimizations, test-coverage nits, subjective preferences, or
-            "would be nice". When unsure, DO NOT escalate. Escalating everything
-            defeats the purpose — be sparing and specific. For each escalated
-            finding, name which reviewer raised it, quote the grounding line,
-            give a cause -> mechanism -> long-term-consequence chain, and a
-            concrete suggested fix.
+            THE BLOCKING BAR IS DELIBERATELY NARROW. Blocking a PR is reserved
+            for findings where merging as-is is genuinely hard to walk back or
+            can cause real harm. ESCALATE (BLOCK) a listed finding ONLY IF it
+            meets one of these two tests AND is caused or worsened BY THIS DIFF:
+            - ONE-WAY DOOR: an expensive-to-reverse contract / API / schema /
+              persisted-data / wire-format decision that merging as-is locks in,
+              so fixing it later is materially harder or costlier (e.g. requires
+              a data migration, a breaking API change, or coordinated rollout).
+            - CONCRETE HARM: a latent security regression, a data-correctness /
+              data-loss bug, OR an availability / operational regression (a
+              crash, hang / deadlock, or unbounded resource growth such as a
+              memory / fd / thread leak or an unbounded retry loop) that this
+              diff can actually trigger in production — name the concrete
+              trigger and outcome.
+
+            Two specific cases map INTO the two tests above (they are examples,
+            not a third category):
+            - A committed SECRET / CREDENTIAL (key, token, password) is BOTH
+              concrete harm and a one-way door — git history is permanent and it
+              forces rotation. This repo is public, so treat any real leaked
+              secret as blocking.
+            - A dependency with an INCOMPATIBLE LICENSE pulled into this public
+              repo is a one-way door (hard to unwind once released / consumed).
+
+            EVERYTHING ELSE IS A NON-BLOCKING FOLLOW-UP, not a block. In
+            particular, DO NOT block for: architectural erosion, ownership-
+            boundary drift, maintainability / tech-debt that compounds, missing
+            abstraction, duplication, or "this should eventually be refactored".
+            These are real and worth tracking, but they are reversible in a later
+            change, so route them to "Suggested follow-ups" instead of gating.
+            The author does NOT need a perfect or complete solution in THIS PR:
+            a smaller in-scope mitigation plus a tracked follow-up is an
+            acceptable, preferred outcome. Never demand a large, not-yet-designed
+            rework as a merge condition. Also DO NOT escalate: style, naming,
+            formatting, import order, micro-optimizations, test-coverage nits,
+            subjective preferences, or "would be nice".
+
+            When unsure whether something is a true one-way door or concrete
+            harm, it is NOT — route it to follow-ups. When the same item could
+            plausibly be blocked or followed-up, PREFER the follow-up. Escalating
+            everything defeats the purpose — be sparing and specific. For each
+            escalated finding, name which reviewer raised it, quote the grounding
+            line, give a cause -> mechanism -> long-term-consequence chain that
+            shows WHY it is a one-way door or concrete harm, and a concrete
+            suggested fix — the SMALLEST change that closes the door or removes
+            the harm, never a broad rework or speculative hardening. It must
+            still FULLY close the named door or harm — trim speculative extras,
+            not the necessary fix.
 
             SCOPE TEST (apply before escalating anything). Many findings flag
             SIDE EFFECTS on components this PR does not target. Weighing that
             blast radius is correct and valuable — but a related influence is
-            NOT automatically a blocker. Escalate an out-of-scope /
-            adjacent-component finding ONLY IF this PR itself CREATES or WORSENS
-            the long-term cost AND it is a one-way door — i.e. merging as-is
-            makes it materially harder or costlier to fix later (a persisted
-            schema/contract, a spreading ownership boundary, or a
-            security/data-correctness regression introduced BY this diff). If
-            the concern PRE-EXISTS this PR, is independently reversible in a
-            later change, or the PR merely touches nearby code without deepening
-            the problem, DO NOT block: route it to "Suggested follow-ups" so it
-            is tracked as a new issue instead of gating this PR. When the same
-            item could plausibly be either blocked or followed-up, PREFER the
-            follow-up. Opening a new issue for later is a legitimate outcome, not
-            a failure to act.
+            NOT a blocker unless it independently clears the narrow bar above
+            (one-way door OR concrete harm) AND this PR itself CREATES or WORSENS
+            it. If the concern PRE-EXISTS this PR, is independently reversible in
+            a later change, or the PR merely touches nearby code without
+            deepening the problem, DO NOT block: route it to "Suggested
+            follow-ups" so it is tracked as a new issue instead of gating this
+            PR. Opening a new issue for later is a legitimate outcome, not a
+            failure to act.
 
             FINAL OUTPUT (authoritative — your LAST message, captured verbatim
             from the transcript; do NOT call any tool to post it and write


### PR DESCRIPTION
## Problem

The automated review gates are too strict in two related ways:

1. **Arbiter over-blocks.** Its rubric escalated four categories — architectural erosion, compounding maintainability/tech-debt, latent security/data-correctness risk, and expensive-to-reverse contracts. The first two are reversible in a later change, so blocking on them holds otherwise-shippable PRs hostage.
2. **Reviewers drive an over-engineering / endless-review spiral.** The line and design reviewers suggest adding more mechanisms/abstractions/config. Those additions become new surface the next round flags, so a simple feature never converges — even when the required change is small.

## Why it matters

Contributors get stuck in review loops on simple changes: each suggested "improvement" expands scope and spawns fresh findings. Merge-blocking on non-one-way-door design concerns turns advisory judgment into a hard gate, slowing delivery without a proportionate risk reduction.

## Fix (symptom → root cause → change)

- **Symptom:** simple PRs block on long-term/architectural suggestions and never converge.
- **Root cause:** the Arbiter's blocking bar was broad, and the reviewers' suggested-fix guidance had no proportionality or scope constraint.
- **Change:**
  - **Arbiter (`longterm-arbiter.yml`)** — narrow the blocking bar to exactly two tests, both requiring the diff to *create or worsen* the cost:
    - **One-way door** — expensive-to-reverse contract / API / schema / persisted-data / wire-format decision.
    - **Concrete harm** — security regression, data-correctness/data-loss bug, **or availability/operational regression** (crash, hang/deadlock, unbounded resource growth). Committed secrets and incompatible-license deps are called out as examples that map into these two (not a third category).
    - Everything else (architectural erosion, maintainability/tech-debt, missing abstractions) is **demoted to non-blocking "Suggested follow-ups."** The header comment is updated to match.
  - **All reviewers (`claude-review.yml`, `codex-review.yml`, `design-review.yml`, Arbiter)** — add suggested-fix discipline:
    - **Proportionality** — smallest change that resolves the finding; prefer simplifying/deleting over adding mechanisms/layers/config; no speculative future-proofing; the mere *absence* of an extra mechanism is not a finding.
    - **Scope** — a fix must be achievable within the PR's stated purpose; work beyond the goal is downgraded to a "separate PR" follow-up.
    - **Balancing clause** — this trims *speculative* additions, not *necessary* ones: still raise what the change genuinely requires to be correct/safe, sized to the PR ("simple feature → simple solution, not a new subsystem"). The Arbiter's smallest fix must still *fully* close the named door/harm.

No gating plumbing, verdict parsing, `defer-longterm` override, or check-run behavior changed — this is a prompt/rubric change only.

## Tests

N/A — these workflows contain no unit-testable logic change; the edits are reviewer/arbiter prompt text. Each of the four YAML files was validated to parse (`YAML.load_file`) after every edit.

## Manual verification

- Confirmed all four workflow files parse as valid YAML locally.
- Confirmed the blocking/gating shell logic, verdict markers, and triggers are unchanged (edits are confined to prompt prose and the header comment).
- Full behavioral effect is observable only on live PRs once merged (the reviewers/Arbiter run against real diffs); no local harness exists for model behavior.
