### PR TITLE
ci(review): make both Fable 5 reviewers terse and punchline-first

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -209,6 +209,11 @@ jobs:
             Do not report a finding you cannot ground in quoted diff lines. When
             unsure, lower the severity rather than guess. Only the base-branch
             AUTOSDE rules and the actual diff are authoritative — never invent rules.
+            These four elements are the INTERNAL bar for whether a finding is real
+            and correctly severed — you must be able to produce all four. In the
+            POSTED summary, state them COMPACTLY per SUMMARY FORMAT below (one line:
+            severity — location — consequence → fix), NOT as four labelled
+            paragraphs per finding.
 
             PROPORTIONALITY (anti-over-engineering) — a suggested Fix MUST be the
             smallest change that resolves the named problem. Prefer simplifying
@@ -318,11 +323,38 @@ jobs:
               Otherwise false. Per SEVERITY↔BLOCK COHERENCE, block_merge MUST be
               true whenever any finding is CRITICAL/HIGH; never label a
               non-blocking finding above MEDIUM.
-            - summary: your full markdown review (findings with the evidence
-              chain, or an explicit "no blocking findings"). CI posts this to the
-              PR on your behalf.
+            - summary: the human-facing review the CI posts. This is
+              PRESENTATION ONLY — your internal analysis stays exhaustive per
+              COVERAGE / THOROUGHNESS / EVIDENCE above; the summary is the
+              DISTILLED result, not a transcript of that work. Format it EXACTLY
+              per SUMMARY FORMAT below.
             You MAY still post inline comments during the review, but the
             structured result is the single source of truth for the merge gate.
+
+            SUMMARY FORMAT (authoritative for the `summary` field — terse,
+            precise, punchline-first; presentation only, never widens or narrows
+            the gate, which reads `block_merge`):
+            - NO preamble, NO restating the PR/diff, NO "Coverage"/methodology
+              narration (which files you inspected, which rules matched, YAML or
+              indent checks, "re-scanned N times") — that is internal work, never
+              output. NO praise, NO recap of what the change does.
+            - LINE 1 is ONE bold punchline: the verdict in one breath — either
+              "no blocking findings" (optionally noting how many advisory items
+              follow) or the single reason it blocks. If ANY finding is
+              CRITICAL/HIGH, this line MUST contain the literal [BLOCK-MERGE]
+              marker (per SEVERITY↔BLOCK COHERENCE).
+            - Then findings ONLY, most-severe-first, each as ONE compact line:
+              `SEVERITY — file:line — <consequence in one clause> → Fix: <minimal
+              change>`, quoting the offending token/line inline for grounding
+              (not a multi-line block quote). Merge findings sharing a root cause
+              into one line.
+            - Render a severity group only if it has content — never emit an
+              empty or "None" group, never pad. Drop pure LOW/nits entirely; keep
+              only substantive MEDIUMs (real correctness / robustness / clarity
+              help) in the same one-line shape.
+            - A clean review (no blocking, no substantive MEDIUM) is JUST the
+              punchline line — nothing else. Aim for the shortest text that still
+              conveys every real finding; a typical finding is one line.
 
       # Post the review summary for humans (best-effort, NON-gating). Reads the
       # summary from the action's structured output — not from a model-posted

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -133,7 +133,8 @@ jobs:
             accessibility, and rule violations — do NOT duplicate them. Do NOT
             report style, naming, formatting, import order, micro-optimizations,
             test-coverage nits, or line-level bugs. If your only findings are
-            line-level, return verdict PASS with "No design-level concerns."
+            line-level, return verdict PASS (the punchline states there are no
+            design-level concerns).
             Your lens is the senior-engineer question asked BEFORE any line
             review: "Should we build this, is it aimed at a real problem, and is
             this the right shape of solution?"
@@ -145,7 +146,12 @@ jobs:
             finding. When unsure, lower the concern (prefer CONCERNS over BLOCK),
             never invent one.
 
-            THE DESIGN GATE — answer each, grounded in the diff + description:
+            THE DESIGN GATE (INTERNAL REASONING — think through each silently;
+            do NOT echo these questions or their answers in your output. They
+            EXIST ONLY to surface findings. If a question raises no finding, it
+            produces NO output. NEVER restate the PR's problem/description back to
+            the author — they wrote it; only mention the problem if it is itself
+            broken, e.g. no real harm exists or the code doesn't solve it):
             1. PROBLEM: state the problem this PR solves in ONE sentence, from the
                user's/system's view. If you cannot name a real harm or affected
                user, that itself is a finding.
@@ -211,38 +217,52 @@ jobs:
 
             FINAL OUTPUT (authoritative — this is your LAST message; the workflow
             captures it verbatim from the run transcript, so do NOT call any tool
-            to post it, and write nothing after the marker line). Output EXACTLY
-            this shape:
+            to post it, and write nothing after the marker line).
+
+            STYLE: terse, precise, punchline-first. NO preamble, NO restating the
+            PR, NO echoing the design-gate questions, NO praise, NO summary of
+            what the change does. The badge already shows the verdict and blast
+            radius — do NOT repeat them in prose. A clean PASS is TWO header lines
+            + a one-line punchline + the marker; nothing else. Aim for the
+            shortest output that conveys every real signal — usually well under
+            ~150 words. Every sentence must be something the author would ACT on.
+
+            Output EXACTLY this shape and nothing more:
 
             The FIRST two lines are machine-parsed — emit them verbatim, each on
             its own line, values only:
             Design-Verdict: <PASS | CONCERNS | BLOCK>
             Design-Blast-Radius: <low | medium | high>
 
-            Then the human-readable review:
+            Then a blank line and ONE bold punchline (≤25 words): the single most
+            important takeaway — for PASS, why it's sound; for CONCERNS/BLOCK, the
+            core design problem in one breath.
 
-            - **Problem:** <one sentence, or "not clearly stated in the PR">
-            - **Why it matters:** <who is hurt / what user-visible symptom>
-            - **Design risk:** <low | medium | high>
-            - **Blast radius:** <low | medium | high> — <what it reaches & why>
-            - **Solves the stated problem:** <yes | partially | no> — <one-line
-              consequence chain>
+            Then include a section ONLY if it has real content (omit the heading
+            entirely when empty — never write "None" sections, never pad):
 
-            ### Findings
-            <for each design finding: a short title tagged (design | fidelity |
-            blast-radius | contract), then Evidence (quoted hunk/sentence),
-            Consequence (cause → mechanism → consequence), and Suggestion (the
-            strongest alternative or missing consideration). Keep the Suggestion
-            PROPORTIONATE: prefer the simplest design that solves the stated
-            problem; do NOT recommend extra layers, abstractions, or
-            future-proofing the problem does not require — over-engineered
-            suggestions become new surface a later review flags. Stay within THIS
-            PR's stated purpose: if an alternative would require work beyond the
-            PR's goal, mark it as a separate follow-up, not a change to make here.
-            This trims SPECULATIVE additions, not NECESSARY ones: still surface
-            what the design genuinely requires to be correct or safe, sized to
-            the PR's goal — a simple goal warrants a simple design, not a new
-            subsystem. If none: "No design-level concerns.">
+            ### Blockers
+            <ONLY when verdict is BLOCK. Each: one-line title, then a single
+            consequence chain (cause → mechanism → consequence) quoting the diff/
+            description, then a one-line fix. These are the things that must be
+            resolved or human-overridden.>
+
+            ### Watch
+            <ONLY for a genuine CONCERNS-level design risk a human should see
+            before merging. One or two lines each. Skip if none.>
+
+            ### Suggestions
+            <0–3 genuinely valuable design optimizations or simplifications
+            (a simpler/more general/lower-risk approach). One line each. Omit nits
+            and "consider"s entirely — if it wouldn't change what the author
+            builds, drop it. Keep every suggestion PROPORTIONATE: prefer the
+            simplest design that solves the stated problem; NEVER recommend extra
+            layers, abstractions, or future-proofing the problem does not require
+            (over-engineered suggestions become new surface a later review flags).
+            Stay within THIS PR's purpose — if an alternative needs work beyond
+            the PR's goal, it is a separate follow-up, not a change to make here.
+            This trims SPECULATIVE additions, not NECESSARY ones. Skip the whole
+            section if none.>
 
             End with this exact line as proof the review ran for this commit:
             [DESIGN-REVIEWED] ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem
Both Fable 5 review bots post walls of text on every PR. Two *different* workflows run the Fable 5 model, and both were verbose:
- **`design-review.yml`** (design-level, "Design Review (Fable 5)") forced a five-field bullet block (Problem / Why it matters / Design risk / Blast radius / Solves the stated problem) + an always-present `### Findings` section — restating the PR's own problem back to the author.
- **`claude-review.yml`** (line-level, "Fable 5 Review") told the model to post its "full markdown review with the evidence chain", so a clean PASS still rendered a `## Coverage` section (files inspected, rules matched, YAML/indent checks) plus 4-part Location/Evidence/Reasoning/Fix paragraphs per finding.

The signal — what actually blocks, and what's genuinely worth optimizing — was buried under boilerplate.

## Why it matters
Reviewers skim these comments; long, self-repeating output trains them to ignore the bots, defeating the advisory/gate purpose. Punchline-first output makes "does this block us? is there a better approach?" immediately visible.

## Fix (symptom → root cause → change)
- **Symptom:** verbose comments that echo the PR and always render every field/section.
- **Root cause:** the prompts' output contracts mandated fixed multi-field blocks and narrated the internal analysis (design gate questions; coverage/methodology) as output.
- **Change** (prompt-only, no logic/parsing/gating change):
  - **`design-review.yml`**: the seven design-gate questions are now explicit **internal reasoning** (think silently, emit nothing unless a question raises a finding, never restate the PR's problem back). `FINAL OUTPUT` replaced with a punchline-first contract — two unchanged machine-parsed header lines (`Design-Verdict:` / `Design-Blast-Radius:`), one bold ≤25-word punchline, then `### Blockers` (BLOCK only), `### Watch` (real CONCERNS), `### Suggestions` (0–3 real optimizations) rendered **only when non-empty**. PR #495's proportionality guidance is preserved inside `### Suggestions`. Also fixed a retained "No design-level concerns." literal that contradicted the new no-padding format.
  - **`claude-review.yml`**: added a `SUMMARY FORMAT` contract governing the `summary` field only (presentation) — punchline-first line (carrying `[BLOCK-MERGE]` when blocking), then one compact line per finding (`SEVERITY — file:line — consequence → Fix: …`), no `## Coverage`/methodology narration, LOW/nits dropped, clean reviews are just the punchline. The exhaustive COVERAGE / THOROUGHNESS / EVIDENCE internal analysis is unchanged — the 4-element evidence chain is now the *internal bar* for reporting, stated compactly in the posted line rather than as four paragraphs.

Parsing/posting/gating logic is untouched in both files: `design-review.yml` still greps `Design-Verdict:` / `Design-Blast-Radius:` and gates only on `BLOCK`; `claude-review.yml` still gates on the structured-output `block_merge` (the `summary` is presentation only and cannot widen/narrow the gate).

## Tests
N/A — prompt/instruction text inside GitHub Actions workflows; no unit-testable code path. The machine-parse contracts both posting/gating steps depend on (`Design-Verdict:`/`Design-Blast-Radius:` header lines; the `[DESIGN-REVIEWED]` trailer; the `block_merge` structured output) are preserved unchanged.

## Manual verification
- Confirmed the design reviewer's two header lines + `[DESIGN-REVIEWED] <sha>` trailer are intact, so `Post design review summary` and the BLOCK gate parse correctly.
- Confirmed `claude-review.yml` still returns `reviewed`/`block_merge`/`summary` per the `--json-schema`; the gate reads `block_merge`, so the terser `summary` does not affect it.
- Both reviewers run on this PR, so they **dogfood the new formats** on their own diff — the posted comments are the live verification of the terser output.
