### PR TITLE
ci(review): scope clause never lowers severity; tighten Arbiter harm bar

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -194,8 +194,12 @@ jobs:
             STAY WITHIN THE PR'S STATED PURPOSE — a suggested Fix MUST be
             achievable inside the scope of THIS PR. If resolving a finding would
             require work beyond the PR's goal (a new subsystem, refactoring
-            untouched code, or a cross-cutting change), do NOT demand it here:
-            downgrade to an advisory / "separate PR" follow-up. The review must
+            untouched code, or a cross-cutting change), do NOT demand that work
+            here: downgrade the DEMANDED FIX to a "separate PR" follow-up. This
+            NEVER lowers the severity of a finding that independently meets the
+            BLOCKING BAR — such a finding is always resolvable in-scope by
+            reverting the offending hunk, so it stays at its true severity and
+            still blocks. The review must
             converge — a fix that spawns MORE reviewable surface than the
             original problem is out of bounds and causes endless review.
             This trims SPECULATIVE additions, not NECESSARY ones: still raise

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -214,8 +214,12 @@ jobs:
           STAY WITHIN THE PR'S STATED PURPOSE -- a suggested Fix MUST be
           achievable inside the scope of THIS PR. If resolving a finding would
           require work beyond the PR's goal (a new subsystem, refactoring
-          untouched code, or a cross-cutting change), do NOT demand it here:
-          downgrade to an advisory / "separate PR" follow-up. The review must
+          untouched code, or a cross-cutting change), do NOT demand that work
+          here: downgrade the DEMANDED FIX to a "separate PR" follow-up. This
+          NEVER lowers the severity of a finding that independently meets the
+          BLOCKING BAR -- such a finding is always resolvable in-scope by
+          reverting the offending hunk, so it stays at its true severity and
+          still blocks. The review must
           converge -- a fix that spawns MORE reviewable surface than the
           original problem is out of bounds and causes endless review.
           This trims SPECULATIVE additions, not NECESSARY ones: still raise what

--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -6,7 +6,8 @@ name: Arbiter
 # findings and, with a DELIBERATELY NARROW rubric, blocks ONLY the few that are
 # genuinely hard to walk back once merged: a one-way door (an expensive-to-
 # reverse contract / API / schema / persisted-data decision) or concrete harm (a
-# latent security regression or data-correctness/loss bug this diff can trigger).
+# security regression, a data-correctness/loss bug, or an availability regression
+# — crash, hang, unbounded resource growth — this diff can trigger).
 # Everything else — architectural erosion, maintainability debt, missing
 # abstractions, "should eventually refactor" — is REVERSIBLE later, so it is
 # routed to non-blocking "Suggested follow-ups" rather than gating the PR. The
@@ -218,7 +219,7 @@ jobs:
               persisted-data / wire-format decision that merging as-is locks in,
               so fixing it later is materially harder or costlier (e.g. requires
               a data migration, a breaking API change, or coordinated rollout).
-            - CONCRETE HARM: a latent security regression, a data-correctness /
+            - CONCRETE HARM: a security regression, a data-correctness /
               data-loss bug, OR an availability / operational regression (a
               crash, hang / deadlock, or unbounded resource growth such as a
               memory / fd / thread leak or an unbounded retry loop) that this
@@ -291,17 +292,21 @@ jobs:
             If PASS, write this line:
             No sub-threshold finding meets the long-term-impact bar.
 
-            Then, under EITHER verdict, if the SCOPE TEST routed any
-            related-influence / sub-threshold items to be tracked without
-            blocking, append this section LAST. It is advisory and NEVER changes
-            the verdict (the machine-parsed verdict line is always the first line
-            above, regardless of what follows):
+            Then, under EITHER verdict, if you demoted ANY substantive
+            sub-threshold item to be tracked without blocking — whether routed
+            by the SCOPE TEST (related-influence / out-of-scope) OR demoted
+            because it is reversible-in-a-later-change (architectural erosion,
+            maintainability / tech-debt, missing abstraction) — append this
+            section LAST. It is advisory and NEVER changes the verdict (the
+            machine-parsed verdict line is always the first line above,
+            regardless of what follows):
 
             ### Suggested follow-ups (open as issues — non-blocking)
-            <one line per related-influence / sub-threshold item worth tracking
-            but NOT worth blocking this PR (per the SCOPE TEST): what it is, why
-            it can safely wait, and where it should be fixed. Omit this heading
-            only if there are genuinely none.>
+            <one line per substantive sub-threshold item worth tracking but NOT
+            worth blocking this PR (whether out-of-scope per the SCOPE TEST or an
+            in-scope-but-reversible item you demoted): what it is, why it can
+            safely wait, and where it should be fixed. Omit this heading only if
+            there are genuinely none.>
 
             End with this exact line as proof the review ran for this commit:
             [ARBITER-REVIEWED] ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem

Follow-up to #495 (which narrowed the Arbiter blocking bar and added proportionality/scope discipline to the reviewers). The reviewers on #495 raised two legitimate MEDIUM findings against that same change, and #495 auto-merged before they could be folded in:

1. **The scope clause could demote a genuine blocking finding.** Both the Claude and GPT reviewers independently flagged that "if resolving a finding would require work beyond the PR's goal … downgrade to an advisory / separate-PR follow-up" reads as lowering the *finding's severity*, not just the suggested fix. A diff-introduced security/data-loss bug whose proper fix is cross-cutting could be waved below the blocking bar.
2. **The Arbiter's routing promise was unbacked.** The rubric tells the Arbiter to route demoted in-scope architectural/maintainability items to "Suggested follow-ups," but that output section was described as SCOPE-TEST-only (adjacent/out-of-scope), so an in-scope demoted item could silently vanish from the Arbiter's output.

Plus two accuracy nits in the Arbiter: the header parenthetical omitted the availability/operational leg of "concrete harm" (the PR body claimed the header was updated to match), and the word "latent" contradicted "can actually trigger."

## Why it matters

Finding (1) is the exact "too loose" failure mode — it could let a real security/correctness regression through the gate. Finding (2) risks silently dropping demoted-but-substantive feedback, undercutting the "track it as a follow-up" promise. The accuracy nits keep the rubric and its own header self-consistent.

## Fix (symptom → root cause → change)

- **Symptom:** scope guidance ambiguous about severity vs. remedy; Arbiter follow-up routing not represented in its output contract.
- **Root cause:** #495 worded the scope clause around "the suggested Fix" but used "downgrade to an advisory," and only wired the follow-ups section to the SCOPE TEST.
- **Change (prompt text only):**
  - `claude-review.yml` / `codex-review.yml`: scope discipline now downgrades **the demanded fix**, and explicitly **never lowers the severity** of a finding that meets the BLOCKING BAR — such a finding is always resolvable in-scope by reverting the offending hunk, so it stays at true severity and still blocks.
  - `longterm-arbiter.yml`: (a) "Suggested follow-ups" now covers **every substantive demoted item** — SCOPE-TEST-routed *or* in-scope-but-reversible (architectural erosion, maintainability, missing abstraction); (b) header parenthetical adds the **availability/operational** leg; (c) dropped the contradictory **"latent"** from the CONCRETE HARM security leg.

Deliberately NOT changed (would re-widen the bar or expand scope — the over-engineering this line of work is fighting): softening the security leg to "plausible path to exploitation" (advisory, declined), and the two Design CONCERNS (demote Arbiter to advisory / build a reviewer-eval harness — the design reviewer itself marked these as follow-ups, not this PR's job).

## Tests

N/A — reviewer/arbiter prompt text only, no unit-testable logic. All four workflows (three changed + design-review unchanged) were re-validated to parse (`YAML.load_file`).

## Manual verification

- Confirmed the three changed workflow files parse as valid YAML.
- Confirmed gating plumbing, verdict markers, triggers, and `defer-longterm` handling are untouched (edits confined to prompt prose + the Arbiter header comment).
- Behavioral effect is observable only on live PRs once merged; no local harness exists for model behavior.
