### PR TITLE
ci(review): switch code reviewer from Fable 5 to Opus 5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       # Load AUTOSDE rules from the BASE commit, not the PR HEAD, so a PR
-      # cannot weaken the rules that govern it. Fable 5 reads these snapshots
+      # cannot weaken the rules that govern it. Opus 5 reads these snapshots
       # (its restricted toolset can Read files but not run git).
       - name: Extract base-ref AUTOSDE rules
         env:
@@ -72,7 +72,7 @@ jobs:
       # secrets / OIDC, so the AWS role assumption below can never succeed —
       # it errors, the review step is skipped, and the gate fails closed on
       # every Dependabot PR. Skip the credential + review steps for Dependabot
-      # and let the gate pass (see "Gate on Fable 5 review"). Dependency bumps
+      # and let the gate pass (see "Gate on Opus 5 review"). Dependency bumps
       # are mechanical and remain covered by the non-AI gates (Semgrep,
       # Dependency Audit, CodeQL, build/tests).
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -81,7 +81,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Fable 5 review
+      - name: Opus 5 review
         id: review
         if: github.actor != 'dependabot[bot]'
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
@@ -102,7 +102,7 @@ jobs:
           # and any file it needs for context; the gh commands let it
           # post findings.
           claude_args: |
-            --model us.anthropic.claude-fable-5
+            --model us.anthropic.claude-opus-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
@@ -300,10 +300,10 @@ jobs:
       # comment — so it works even when the model doesn't call gh pr comment.
       # UPSERT a single marker-keyed comment per PR: re-scanning on every push
       # UPDATEs that one comment (PATCH) instead of stacking a new one —
-      # otherwise the PR fills with N near-duplicate Fable 5 summaries as the
+      # otherwise the PR fills with N near-duplicate Opus 5 summaries as the
       # branch evolves (PR #14 accumulated 3). Fully workflow-owned, so the
       # dedup does not depend on the model following posting instructions.
-      - name: Post Fable 5 review summary
+      - name: Post Opus 5 review summary
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -319,7 +319,7 @@ jobs:
           MARKER="<!-- claude-ai-review -->"
           {
             echo "$MARKER"
-            echo "## Fable 5 Review — $verdict"
+            echo "## Opus 5 Review — $verdict"
             echo
             echo "_Reviewed \`$HEAD\` — this comment is updated in place on each push._"
             echo
@@ -345,10 +345,10 @@ jobs:
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               --field body="$(cat /tmp/claude-summary.md)" >/dev/null || true
-            echo "Updated existing Fable 5 summary comment #$existing"
+            echo "Updated existing Opus 5 summary comment #$existing"
           else
             gh pr comment "$PR" --body-file /tmp/claude-summary.md || true
-            echo "Created new Fable 5 summary comment"
+            echo "Created new Opus 5 summary comment"
           fi
 
       # Fail-CLOSED gate. Gates on the action's OWN structured output
@@ -364,7 +364,7 @@ jobs:
       # Fail closed unless the step succeeded AND emitted structured output with
       # reviewed==true, so a review that errored / ran out of turns / produced no
       # verdict can never look clean.
-      - name: Gate on Fable 5 review
+      - name: Gate on Opus 5 review
         if: always()
         env:
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -376,31 +376,31 @@ jobs:
           # Pass the gate green rather than fail closed — dependency bumps are
           # covered by Semgrep, Dependency Audit, CodeQL and the build/tests.
           if [ "$ACTOR" = "dependabot[bot]" ]; then
-            echo "Dependabot PR ($ACTOR): Fable 5 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
+            echo "Dependabot PR ($ACTOR): Opus 5 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
             exit 0
           fi
           if [ "$REVIEW_OUTCOME" != "success" ]; then
-            echo "::error::Fable 5 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
+            echo "::error::Opus 5 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
             exit 1
           fi
           if [ -z "$SO" ]; then
-            echo "::error::Fable 5 review produced no structured output for $HEAD (review did not complete / ran out of turns). Failing closed — re-run or inspect the Fable 5 review step logs."
+            echo "::error::Opus 5 review produced no structured output for $HEAD (review did not complete / ran out of turns). Failing closed — re-run or inspect the Opus 5 review step logs."
             exit 1
           fi
           reviewed=$(printf '%s' "$SO" | jq -r '.reviewed // false')
           block=$(printf '%s' "$SO" | jq -r 'if has("block_merge") then (.block_merge|tostring) else "MISSING" end')
           if [ "$reviewed" != "true" ]; then
-            echo "::error::Fable 5 review did not confirm completion (reviewed != true) for $HEAD. Failing closed."
+            echo "::error::Opus 5 review did not confirm completion (reviewed != true) for $HEAD. Failing closed."
             printf 'structured_output: %s\n' "$SO"
             exit 1
           fi
           if [ "$block" = "MISSING" ]; then
-            echo "::error::Fable 5 structured output is missing block_merge for $HEAD. Failing closed."
+            echo "::error::Opus 5 structured output is missing block_merge for $HEAD. Failing closed."
             printf 'structured_output: %s\n' "$SO"
             exit 1
           fi
           if [ "$block" = "true" ]; then
-            echo "::error::Fable 5 review flagged a blocking (CRITICAL/HIGH) issue on $HEAD — see the posted review summary."
+            echo "::error::Opus 5 review flagged a blocking (CRITICAL/HIGH) issue on $HEAD — see the posted review summary."
             exit 1
           fi
-          echo "Fable 5 review completed for $HEAD with no blocking findings."
+          echo "Opus 5 review completed for $HEAD with no blocking findings."


### PR DESCRIPTION
## Problem
The Claude AI code reviewer (`.github/workflows/claude-review.yml`) runs on `us.anthropic.claude-fable-5`. Fable via the Claude Code (agentic) harness is slow on this workflow, which grinds through up to `--max-turns 100` tool calls per review — the review step is a long pole on every PR.

## Why it matters
Fable is overkill for line-level diff review and its latency delays convergence on every PR. Opus 5 gives us a top-tier reviewer at better throughput for this many-turn, concrete review task. (Design Review and the Long-Term Arbiter stay on Fable on purpose — those are high-level, vaguer-guidance judgments where Fable is the right fit; only the deep line-level reviewer moves.)

## Fix (symptom → root cause → change)
- Symptom: slow Claude review step, long PR turnaround.
- Root cause: the reviewer model is `us.anthropic.claude-fable-5`, heavier than needed for a 100-turn line-level pass.
- Change: swap the reviewer model to `us.anthropic.claude-opus-5` (kept on the `us.` regional inference profile, matching the account's `provider_data_share` retention requirement documented in `design-review.yml`; `--fallback-model us.anthropic.claude-opus-4-8` unchanged). All cosmetic "Fable 5" strings in the file (step names, log lines, posted-summary heading) are renamed to "Opus 5" for consistency.

No cross-workflow references change:
- The workflow name (`Claude AI Review`) and job/check name (`Claude AI Review`) are model-agnostic and unchanged — branch protection and the Arbiter's `workflow_run` trigger (`workflows: ["Claude AI Review", ...]`) still match.
- The Arbiter picks the review comment by the `<!-- claude-ai-review -->` marker, which is unchanged (only the human-readable `## … Review` heading changed).
- The fail-closed gate reads the review step via its step **id** (`steps.review.*`), not its name, so renaming the step is safe.

## Tests
N/A — CI workflow config change with no unit-testable logic. Validated by the workflow running on this very PR (the Opus 5 review executes here, providing live verification).

## Manual verification
- Audited every consumer of the reviewer: workflow name, job/check name, `<!-- claude-ai-review -->` marker, and `steps.review.*` id reference — none changed.
- Confirmed `grep -n Fable .github/workflows/claude-review.yml` returns nothing after the rename.
- Pending: confirm `us.anthropic.claude-opus-5` is a granted regional inference profile in us-west-2 (`aws bedrock list-inference-profiles`); the Opus 5 review step on this PR is the live check — if the model ID is invalid the review step errors and the fail-closed gate goes red.
