### PR TITLE
fix: require writer permission for AI review overrides

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -1,8 +1,7 @@
 name: AI Review Human Override
 
-# Human judgment is authoritative over the three AI review gates. A PR author
-# or repository writer can record a SHA-scoped false-positive / not-applicable
-# decision with:
+# Human judgment is authoritative over the three AI review gates. A repository
+# writer can record a SHA-scoped false-positive / not-applicable decision with:
 #
 #   /ai-review override <fable|gpt|arbiter|all> <current-sha>: <reason>
 #
@@ -76,24 +75,19 @@ jobs:
 
           pr_json="$(gh api "repos/$REPO/pulls/$PR")"
           head="$(printf '%s' "$pr_json" | jq -r '.head.sha')"
-          author="$(printf '%s' "$pr_json" | jq -r '.user.login')"
           if [[ "$head" != "$requested_sha"* ]]; then
             post_notice "AI-review override not recorded: \`$requested_sha\` is not the current PR head. Re-run the command with \`$head\`."
             exit 1
           fi
 
           allowed=false
-          if [ "$ACTOR" = "$author" ]; then
-            allowed=true
-          else
-            permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
-              --jq '.permission' 2>/dev/null || true)"
-            case "$permission" in
-              admin|maintain|write) allowed=true ;;
-            esac
-          fi
+          permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
+            --jq '.permission' 2>/dev/null || true)"
+          case "$permission" in
+            admin|maintain|write) allowed=true ;;
+          esac
           if [ "$allowed" != "true" ]; then
-            post_notice "AI-review override not recorded: only the PR author or a repository writer may override an AI finding."
+            post_notice "AI-review override not recorded: only a repository writer may override an AI finding."
             exit 1
           fi
 

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -140,8 +140,8 @@ under `(allow default)`, never an edition-resolved or user-writable executable.
 ### GitHub AI Review Human Overrides (`.github/workflows/`)
 
 Human judgment is the final authority over the Fable 5, GPT 5.6, and Arbiter
-AI-review results. A PR author or repository member with `write`, `maintain`, or
-`admin` permission can record a false-positive, not-applicable, or accepted-risk
+AI-review results. A repository member with `write`, `maintain`, or `admin`
+permission can record a false-positive, not-applicable, or accepted-risk
 decision with:
 
 ```text
@@ -159,7 +159,8 @@ or executes PR-controlled code. Before changing a result it requires:
 
 1. The exact command shape above and a non-empty, at-most-500-character reason.
 2. A current-head SHA match.
-3. The commenter to be the PR author or have repository write-level permission.
+3. The commenter to have `write`, `maintain`, or `admin` collaborator
+   permission. PR authors receive no exemption.
 
 After validation it posts a `github-actions[bot]` comment whose hidden marker
 binds `{target, full head SHA, actor, source comment id}`. Reviewer workflows

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -21,15 +21,16 @@ class TestHumanOverrideHandler:
         assert "actions/checkout@" not in workflow
         assert "/ai-review override <fable|gpt|arbiter|all> <current-sha>: <reason>" in workflow
 
-    def test_handler_requires_authority_fresh_sha_and_reason(self) -> None:
+    def test_handler_requires_write_permission_fresh_sha_and_reason(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")
 
-        assert 'if [ "$ACTOR" = "$author" ]; then' in workflow
+        assert 'if [ "$ACTOR" = "$author" ]; then' not in workflow
+        assert "collaborators/$ACTOR/permission" in workflow
         assert "admin|maintain|write) allowed=true" in workflow
         assert 'if [[ "$head" != "$requested_sha"* ]]; then' in workflow
         assert 'if [ -z "$reason" ]; then' in workflow
         assert 'if [ "${#reason}" -gt 500 ]; then' in workflow
-        assert "only the PR author or a repository writer" in workflow
+        assert "only a repository writer" in workflow
 
     def test_handler_records_a_bot_marker_before_changing_checks(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")


### PR DESCRIPTION
## Problem

The AI-review override workflow added in #488 lets any pull request author bypass Fable 5, GPT 5.6, or Arbiter findings, even when that author has no repository write permission.

## Why it matters

An external contributor could mark required AI review gates green on their own pull request. Human judgment remains authoritative, but override authority must be limited to trusted repository collaborators.

## Fix

Remove the pull request author shortcut and authorize every override through the GitHub collaborator-permission endpoint. Only `write`, `maintain`, or `admin` permissions are accepted. Update the security specification and regression coverage to make the no-author-exemption boundary explicit.

## Tests

- `python -m pytest test/test_ai_review_workflows.py test/test_workflow_permissions.py --override-ini="addopts=-v --ignore=build/private --durations=5 --color=yes" -q` (13 passed)
- `flake8 src/kiro_crew test`
- `mypy src/kiro_crew`
- YAML parse, Black check, isort check, and `git diff --check`
- Full no-coverage run: 17,236 passed, 86 skipped, 5 xfailed; one pre-existing current-main failure remains in `test_numeric_string_still_coerces` because schema validation rejects numeric strings before loader coercion.

## Manual verification

N/A - workflow regression coverage locks the authorization branch and accepted permission levels.

## Screenshots

N/A - no UI change.

Follow-up to #488.