### PR TITLE
fix(chat): show the activity panel toggle on mobile

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2481,6 +2481,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     window.addEventListener('resize', check)
     return () => window.removeEventListener('resize', check)
   }, [])
+  // On mobile the panel is full-width (SidePanel: effectiveWidth = '100%') and
+  // is rendered inline rather than in the actbar grid column, so "does it fit
+  // beside the chat" is the wrong question — the toggle stays enabled.
+  const actEnabled = isMobile || actSpace
   // Bridge explicit view requests (e.g. the /side slash command dispatches
   // openActivityToTab('side')) into the tab model.
   const activityTab = useAppSelector(s => s.chat.activityTab)
@@ -3241,14 +3245,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               {/* Activity panel open toggle — relocated here from the top bar
                   (item 2.4) so opening the panel no longer narrows the now
                   full-width header. Shown only while the panel is closed; the
-                  panel's own header carries the close button. Disabled when the
-                  window is too narrow (the panel would be force-collapsed). */}
-              {!embedMode && !isMobile && !popout && !activityOpen && (
+                  panel's own header carries the close button. On desktop it is
+                  disabled when the window is too narrow (the panel would be
+                  force-collapsed); on mobile the panel takes the full width
+                  instead of sitting beside the chat, so the fits-beside test
+                  (actSpace) does not apply and the button is always live. */}
+              {!embedMode && !popout && !activityOpen && (
                 <Clickable
-                  className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto ${actSpace ? 'text-muted hover:text-text hover:bg-bg-hover cursor-pointer' : 'text-muted opacity-40 !cursor-not-allowed'}`}
-                  onClick={() => { if (actSpace) toggleAct() }}
-                  title={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
-                  aria-label={actSpace ? 'Open activity panel' : 'Window too narrow for the activity panel'}
+                  className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto ${actEnabled ? 'text-muted hover:text-text hover:bg-bg-hover cursor-pointer' : 'text-muted opacity-40 !cursor-not-allowed'}`}
+                  onClick={() => { if (actEnabled) toggleAct() }}
+                  title={actEnabled ? 'Open activity panel' : 'Window too narrow for the activity panel'}
+                  aria-label={actEnabled ? 'Open activity panel' : 'Window too narrow for the activity panel'}
                 >
                   <PanelRight size={15} />
                 </Clickable>

--- a/website/src/test/ChatPage.responsivePanel.test.tsx
+++ b/website/src/test/ChatPage.responsivePanel.test.tsx
@@ -51,6 +51,11 @@ vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', 
 vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
 vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
 vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+// useIsMobile reads window.matchMedia at MODULE load, so per-test matchMedia
+// stubs can't move it. Mock the hook with a mutable flag instead: desktop
+// (false) by default, flipped by the mobile describe below.
+let mockIsMobile = false
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mockIsMobile }))
 
 // --- Stub API ---
 vi.mock('../api/client', () => ({
@@ -279,5 +284,46 @@ describe('ChatPage — session-header activity toggle (relocated from the top ba
     await screen.findByLabelText('Open activity panel')
     resizeTo(800) // below the 880 space threshold (320 + 560)
     expect(await screen.findByLabelText('Window too narrow for the activity panel')).toBeInTheDocument()
+  })
+})
+
+/**
+ * Mobile regression: the toggle used to be gated on `!isMobile`, so a phone had
+ * NO way to open the activity panel even though SidePanel already renders
+ * full-width there and ChatPage keeps an inline (non-portal) render path
+ * specifically for mobile. The `actSpace` "does it fit beside the chat" test is
+ * also meaningless at full width, so it must not disable the button on mobile.
+ */
+describe('ChatPage — activity toggle on mobile', () => {
+  beforeEach(() => { mockIsMobile = true; setWindowWidth(390); localStorage.clear() })
+  afterEach(() => { mockIsMobile = false })
+
+  function renderWithSlot() {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch(switchSlot.pending('req-mob', 'slot-mob'))
+      store.dispatch(switchSlot.fulfilled({
+        key: 'slot-mob',
+        messages: [{ role: 'assistant', content: 'hi', cls: '' }],
+        running: false, hasMore: false, total: 1, queue: [],
+      }, 'req-mob', 'slot-mob'))
+    })
+    return renderChat(store)
+  }
+
+  it('renders the toggle at a phone viewport and opens the panel', async () => {
+    const { store } = renderWithSlot()
+    const btn = await screen.findByLabelText('Open activity panel')
+    fireEvent.click(btn)
+    expect(store.getState().chat.activityOpen).toBe(true)
+    // Mobile has no actbar grid column, so the panel renders inline.
+    expect(await screen.findByTestId('side-panel')).toBeInTheDocument()
+  })
+
+  it('does not disable the toggle at widths below the desktop space threshold', async () => {
+    renderWithSlot()
+    // 390px is far below 880, which would disable it on desktop.
+    expect(await screen.findByLabelText('Open activity panel')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Window too narrow for the activity panel')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem

On a phone there is no way to open the activity (right side) panel. The session
header shows the pop-out arrow and the split-view button, but the panel toggle
is absent entirely, so the panel can never be summoned.

## Why it matters

The activity panel is where Files, Changes, Subagents, Workflows, Logs and the
terminal live — on mobile all of it is unreachable. Worse, the panel *can*
still appear on mobile as a side effect (`handleFileOpen` and the source/nav
handlers dispatch `openActivityPanel()`), so a user who taps a file chip lands
in the panel with no button to bring it back once closed.

## Fix (symptom → root cause → change)

**Symptom:** no `PanelRight` button in the session header at phone widths.

**Root cause:** the toggle is gated on `!isMobile`
(`useIsMobile` = `max-width: 767px`). Git history shows this is a regression,
not a product decision:

- Before the Electron shell redesign (`3b76f971`), the toggle was the
  `<SessionStatus />` chip, gated only on `embedMode !== 'chat' && !activityOpen`
  — **no `isMobile` check**, so mobile could open the panel.
- `3b76f971` ("feat(shell): Electron shell redesign — tabbed side panel,
  unified top bar") replaced it with a top-bar button carrying
  `!isMobile` + an `actSpace` disabled state. The same commit added the
  genuinely-correct mobile guards for the *grid column*
  (`!isMobile && <div id="activity-bar-slot">` in `App.tsx`, and
  `if (isMobile || embedMode) { setActivitySlot(null); return }`), and the
  button guard appears to have been swept along with them.
- `d47a7fd0` (#145, "consolidate top header and restructure left nav") moved
  the button into the session header **verbatim** — identical className/title/
  aria strings — carrying `!isMobile` forward.

The panel itself is already mobile-ready, which is what makes the gate a dead
end rather than a deliberate exclusion:

- `SidePanel` renders `effectiveWidth = isMobile ? '100%' : …`
- `ChatPage` keeps an inline (non-portal) render branch explicitly commented
  *"Inline side panel — mobile / embed frames where there's no actbar grid
  column"*

**Change** (`website/src/pages/ChatPage.tsx`):

1. Drop `!isMobile` from the toggle's render condition.
2. Introduce `actEnabled = isMobile || actSpace` for the disabled state.
   `actSpace` asks *"does the panel fit beside the chat"*
   (`innerWidth >= SIDE_PANEL_MIN_W + measureSidePanelReservedW()`, ~880px) —
   a desktop-layout question. On mobile the panel is full-width and inline, so
   the test does not apply; without this the button would render but sit
   permanently disabled ("Window too narrow…") at every phone width.

Desktop behavior is unchanged: `actEnabled === actSpace` when `isMobile` is
false, so the narrow-window disabled state and the auto-collapse/hysteresis
logic are untouched.

## Tests

Two regression tests in `website/src/test/ChatPage.responsivePanel.test.tsx`,
both confirmed to **fail on unfixed code** and pass with the change:

| Test | Locks in |
|---|---|
| `renders the toggle at a phone viewport and opens the panel` | The button exists at 390px, clicking it sets `activityOpen`, and the panel mounts via the inline (non-portal) path |
| `does not disable the toggle at widths below the desktop space threshold` | 390px (far below 880) does **not** produce the "Window too narrow" disabled state |

Test-infra note: `useIsMobile` reads `window.matchMedia` at **module load**, so
per-test `matchMedia` stubs cannot move it. The suite now mocks the hook behind
a mutable `mockIsMobile` flag (desktop `false` by default, flipped by the new
mobile `describe`), which leaves the nine existing desktop tests unchanged.

Full frontend suite: **391 files / 4525 passed, 3 skipped**. `npx tsc -b --force` clean.