### PR TITLE
ci(review): severity-tier the terse output for Claude + Codex reviewers

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -347,18 +347,26 @@ jobs:
               follow) or the single reason it blocks. If ANY finding is
               CRITICAL/HIGH, this line MUST contain the literal [BLOCK-MERGE]
               marker (per SEVERITY↔BLOCK COHERENCE).
-            - Then findings ONLY, most-severe-first, each as ONE compact line:
-              `SEVERITY — file:line — <consequence in one clause> → Fix: <minimal
-              change>`, quoting the offending token/line inline for grounding
-              (not a multi-line block quote). Merge findings sharing a root cause
-              into one line.
+            - Then findings ONLY, most-severe-first, TIERED by severity:
+                • CRITICAL/HIGH (blocking): a short STRUCTURED finding — a bold
+                  one-line title `SEVERITY — file:line`, then on their own lines
+                  the quoted offending line(s), a one-line consequence chain
+                  (inputs → call path → failure → blast radius), and
+                  `Fix: <minimal change>`. Keep it tight (~2–4 lines) — enough for
+                  the author to understand it, fix it, and trust it is real, but
+                  NEVER four padded paragraphs.
+                • MEDIUM / advisory: ONE compact line each — `MEDIUM — file:line —
+                  <consequence in one clause> → Fix: <minimal change>`, quoting the
+                  offending token inline.
+              Merge findings sharing a root cause into one finding.
             - Render a severity group only if it has content — never emit an
               empty or "None" group, never pad. Drop pure LOW/nits entirely; keep
               only substantive MEDIUMs (real correctness / robustness / clarity
-              help) in the same one-line shape.
+              help).
             - A clean review (no blocking, no substantive MEDIUM) is JUST the
               punchline line — nothing else. Aim for the shortest text that still
-              conveys every real finding; a typical finding is one line.
+              conveys every real finding; an advisory finding is one line, a
+              blocking finding is a tight few.
 
       # Post the review summary for humans (best-effort, NON-gating). Reads the
       # summary from the action's structured output — not from a model-posted

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -308,13 +308,22 @@ jobs:
           - NO preamble, NO restating the PR/diff, NO "Coverage"/methodology
             narration (which files you read, "I inspected...", "re-scanned"), NO
             praise, NO recap of what the change does -- that work is internal.
-          - Emit findings ONLY, most-severe-first, each as ONE compact line:
-              Severity: <LEVEL> -- <file>:<line> -- <consequence in one clause,
-              quoting the offending token> -> Fix: <minimal change>
-            Keep the leading "Severity: <LEVEL>" token verbatim at the start of
-            the line. Merge findings that share one root cause into ONE line.
+          - Emit findings ONLY, most-severe-first, TIERED by severity. EVERY
+            finding's line begins with the literal "Severity: <LEVEL>" token
+            (keep it verbatim at the start of the line):
+              • CRITICAL/HIGH (blocking): a short STRUCTURED finding -- first line
+                "Severity: <LEVEL> -- <file>:<line> -- <one-line title>", then on
+                their own lines the quoted offending line(s), a one-line
+                consequence chain (inputs -> call path -> observable failure ->
+                blast radius), and "Fix: <minimal change>". Keep it tight
+                (~2-4 lines) -- enough for the author to understand it, fix it, and
+                trust it is real, but NEVER four padded paragraphs.
+              • MEDIUM / advisory: ONE compact line -- "Severity: <LEVEL> --
+                <file>:<line> -- <consequence in one clause, quoting the offending
+                token> -> Fix: <minimal change>".
+            Merge findings that share one root cause into ONE finding.
           - Drop pure LOW/nits entirely; keep only substantive MEDIUMs (real
-            correctness / robustness / clarity help) in the same one-line shape.
+            correctness / robustness / clarity help).
           - Do NOT pad, do NOT add empty sections, do NOT add an end summary.
             Aim for the shortest output that still conveys every real finding; a
             typical finding is one line.


### PR DESCRIPTION
## Problem
PRs #496 and #501 made the Claude and Codex reviewers terse and punchline-first, but they compressed **every** finding — including CRITICAL/HIGH blockers — to a single line (`SEVERITY — file:line — consequence in one clause → Fix`). A blocking security / concurrency / data-loss finding is exactly where the author needs the quoted evidence and the inputs→path→failure→blast-radius chain, both to fix it and to trust it isn't a hallucination. One clause under-serves the most important findings and weakens the anti-hallucination auditability the EVIDENCE REQUIREMENT was built for.

Design review and the Arbiter do **not** have this problem — they are already severity-tiered (their `### Blockers` / escalated long-term items carry a full consequence chain + fix, while `### Watch` / `### Suggestions` / follow-ups stay one-liners), so they are unchanged.

## Why it matters
The terseness win should not cost depth on blockers. A HIGH finding rendered as a single clause is hard to act on and hard to audit, which either erodes trust in the gate or forces a round-trip. Keeping blockers structured (but tight) preserves the useful information while advisory noise stays compact.

## Fix (symptom → root cause → change)
- **Symptom:** blocking findings collapsed to one clause, losing evidence + reasoning depth.
- **Root cause:** the `SUMMARY FORMAT` (Claude) and `OUTPUT STYLE` (Codex) contracts applied "one compact line per finding" uniformly across all severities.
- **Change** (prompt-only, no gate/parsing/pass-loop change) — make the finding format **severity-tiered** in both reviewers:
  - **CRITICAL/HIGH (blocking):** a short *structured* finding — one-line title (`SEVERITY — file:line`), then the quoted offending line(s), a one-line consequence chain (inputs → call path → failure → blast radius), and `Fix: <minimal change>`. Kept tight (~2–4 lines) — never four padded paragraphs.
  - **MEDIUM / advisory:** unchanged — ONE compact line each.
  - Everything else is unchanged: punchline-first, no coverage/methodology narration, drop pure LOW/nits, clean review = just the punchline.

**Deliberately preserved in Codex:** the tiered CRITICAL/HIGH form still begins its first line with the literal `Severity: <LEVEL>` token, so the "Post/update review comment" step's fallback block-detection grep (`^\s*[-*]?\s*Severity:\s*(HIGH|CRITICAL)`) still matches. Claude's gate reads `block_merge` from structured output and Codex's reads the `[CODEX-REVIEWED]`/`[BLOCK-MERGE]` markers — both untouched, so formatting cannot alter gating.

## Tests
N/A — prompt/instruction text inside GitHub Actions workflows; no unit-testable code path. The gate contracts (`block_merge`; `[CODEX-REVIEWED]`/`[BLOCK-MERGE]`; the `Severity:`-prefixed fallback grep) are preserved unchanged.

## Manual verification
- Confirmed the Codex CRITICAL/HIGH form keeps `Severity: <LEVEL>` at line start, so the posting step's blocking-verdict fallback grep still fires on a HIGH/CRITICAL finding.
- Confirmed Claude's `block_merge` structured-output contract and Codex's `OUTPUT MARKERS` section are untouched.
- Both reviewers run on this PR, so they dogfood the tiered format on their own diff — the posted comments are the live verification.
