### PR TITLE
fix(chat): carry attachment metadata through every write path, in one pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,7 +638,21 @@ Users attach files via `@filename` syntax in chat input. The file picker searche
 - `@relative/path` tokens resolved to full paths
 - Image files rendered inline as markdown `![image](path)`
 - Non-image files sent as `[attached_file N] /full/path`
+- Folder references sent as `[attached_dir N] /full/path`
 - The `[PROJECT]` context entry tells you which directory is active
+
+`[attached_dir N]` is a **path reference, not content**. The directory is not
+listed and nothing under it is inlined — you are given the path and are expected
+to explore it yourself with your own glob/grep/read tools, scoped to what the
+request actually needs.
+
+Do **not** attempt to `read` an `[attached_dir N]` path as a file: it is a
+directory, the read will fail, and that is why folders use their own marker
+instead of reusing `[attached_file N]`.
+
+The two markers number into **separate ordered lists** — `[attached_file 1]` and
+`[attached_dir 1]` refer to different attachments. Resolve each against its own
+family; never assume a shared index.
 
 ## Widget Protocol
 

--- a/docs/system-specs/modules/file-search.md
+++ b/docs/system-specs/modules/file-search.md
@@ -103,16 +103,231 @@ per-request walk.
 `FileIndex.search(query, scorer, max_results, kinds)` applies the same
 `kinds` filter and file-before-directory tie-break as the endpoint.
 
-## Scope of this module (staged delivery)
+## Prompt markers
 
-This document currently covers **discovery only**: how the endpoint and index
-find files and directories, and how the picker stages them in the composer.
+The composer serializes picked entries into two independent marker families:
 
-Directory *serialization* — the `[attached_dir N]` prompt marker, its rendering
-as a chip or card, and the per-slot staged-folder persistence — is delivered
-separately and documented here when it lands. Until then the picker stages a
-folder for the current message only; a staged folder does not survive a slot
-switch or a page reload.
+| Marker | Meaning |
+|---|---|
+| `![image](/full/path)` | Image attachment, inlined as markdown |
+| `[attached_file N] /full/path` | Non-image file attachment |
+| `[attached_dir N] /full/path` | Directory path reference |
+
+Numbering is **per family**: `N` in `[attached_file N]` indexes the ordered file
+list, `N` in `[attached_dir N]` indexes the ordered directory list. A single
+message can therefore contain both `[attached_file 1]` and `[attached_dir 1]`
+referring to different things. Within each family, entries referenced inline in
+the user's text are numbered before unreferenced ones.
+
+Path resolution is lossless: because `N` indexes the original ordered list, a
+path containing spaces still resolves exactly, and the whitespace-bounded
+capture is only a fallback for history replay without metadata.
+
+For that index to survive a round trip, the sender persists the ordered lists on
+message metadata: `meta.files` for the file family and `meta.dirs` for the
+directory family. Both are required, not optional. The server stores the
+LLM-facing token form in `content` while keeping this metadata alongside it, so
+replay reads the index from metadata rather than re-parsing the text. Omitting
+`meta.dirs` silently degrades folder replay to the whitespace fallback, which
+truncates any path containing a space. Mid-turn steering renders its own
+optimistic bubble from the same tokenized text, so it carries the same metadata.
+
+Folder tokens are inserted with a trailing slash (`@src/pages/`) so a folder
+mention is visually distinct from a file mention in the composer. Matching
+tolerates the token with or without that slash.
+
+### One-pass emission
+
+Both the composer's serializer (`replaceMentionsOnce` in `fileTokens.ts`) and the
+title stripper (`_strip_attached_file_tokens`, via its `also=` family) consume
+the **file and directory marker families in a single left-to-right walk** over
+the original text. Any text they emit is final and is never re-examined.
+
+Images are the one exception, and they are safe: the composer emits `''` for an
+image mention (nothing to rescan), and the title path strips image markers in a
+separate preceding pass that likewise only ever emits blanks. A pass that
+produces no substituted text cannot be re-read by a later one.
+
+This is a correctness requirement, not a performance one. Sequential per-family
+passes re-scanned each other's *output*, and an emitted marker carries the
+attachment path verbatim, so a path that itself contains text matching a later
+pass's token was rewritten from inside a marker that pass should never have
+looked at:
+
+- **Send path.** With directory `/repo/@data.csv` and an unrelated file
+  `/other/data.csv`, the directory pass emitted
+  `[attached_dir 1] /repo/@data.csv`; the file pass then matched the `@data.csv`
+  *inside that emitted marker*, nesting a file marker in it. The agent received
+  a path that was never an attachment.
+- **Title path.** Each pass substitutes an attachment's basename. A real
+  file named `[attached_dir 1] notes` (brackets and spaces are legal on both
+  POSIX and Windows) came out of the file pass as that basename and was then
+  eaten by the folder pass, leaving `notes`.
+
+Candidates are matched **longest-first** at each position, so
+`@src/pages/list.tsx` wins over the `@src/pages/` directory that prefixes it.
+Index spaces stay independent per family; only the walk is shared. Note that
+mentions are matched by path *suffix*, so two attachments sharing a suffix (e.g.
+`/data/@notes` and `/repo/@notes`) are genuinely ambiguous in the text — that is a
+property of the mention format, not of the scan.
+
+`displayTxt` still uses the single-family `replaceTokens` helper: it makes one
+pass emitting empty strings for images, so it has no output to rescan.
+
+The agent-facing contract for these markers is documented in `AGENTS.md`
+under "File Attachments". Directories must not be passed to a file-read tool.
+
+### Editing a queued message drops its attachments
+
+`content` (the markers) and `meta` (the ordered path lists they index into) are
+generated together at send time, so they are a matched pair. Editing a queued
+message rewrites only `content`, which desynchronizes them: if the user replaces
+the auto-selected text the marker is gone — the model never receives the
+attachment — while the surviving metadata still renders an attachment card,
+showing an attachment that was never sent.
+
+`queue_edit_by_id` therefore **drops `meta`** on every successful edit, and the
+`editQueuedMessage` reducer mirrors it client-side (retaining only `queueId`,
+which is the card's identity for later edit/cancel lookups, not attachment
+metadata). The tradeoff is deliberate: editing a queued message to fix a typo
+also drops its attachments, which is visible and recoverable by re-staging,
+rather than silent and misleading. A failed edit leaves the item untouched.
+
+### Queue metadata survives a reload
+
+Slot-detail payloads project each queue entry through `queue_item_for_display`,
+which carries `meta` alongside the redacted content (omitting the key entirely
+when there are no attachments, so the payload shape is unchanged). Live
+`queue_push` delivery already carried the lists, so a queued attachment rendered
+correctly until the user reloaded and the detail payload dropped them — the
+markers then had no index space and a spaced path truncated. The client's
+hydration path preserves the metadata too, applying `queueId` last so a server
+key cannot displace the card's identity.
+
+## Rendering
+
+A resolved marker becomes either an inline chip or a block card depending on
+**position**, not on metadata:
+
+- A marker embedded in a line with other text renders as an inline `@label`
+  chip. Folder chips carry a trailing slash. File chips are clickable and open
+  the file viewer; folder chips are not, so the resolver keeps them in a separate
+  `dirMentionMap` rather than the file `mentionMap` that drives the click handler.
+- A marker alone on its line renders as a block card. File cards are clickable
+  and open the file viewer; folder cards are not clickable, because a directory
+  has nothing to open.
+
+Folder token matching tolerates either path separator and an optional trailing
+one, so a native Windows path inserted as `@src\pages/` still resolves. Without
+that, the mention stayed as raw text and a duplicate marker was appended. Chip
+and card labels are derived the same way: the basename split accepts either
+separator, so a native Windows path shows its folder name rather than the whole
+absolute path, and duplicate names still disambiguate on their parent segment.
+
+The preview strip renders whenever either family is staged, and the composer's
+manual-height compensation keys off both. A folders-only strip would otherwise
+appear with no wrapper allowance and overlap the textarea.
+
+Attachments never referenced anywhere in the message text are rendered exactly
+once at message level, so a message split across multiple paste segments cannot
+duplicate them.
+
+Chat titles strip both marker families before prompt construction, so neither a
+file path nor a folder path leaks into a generated title.
+
+## Composer state
+
+Staged files and staged folders are tracked in separate state (`pendingFiles`,
+`pendingDirs`) so a directory never reaches the upload, thumbnail, or
+`attached_file` paths.
+
+Both are persisted **per chat slot**, files via `chatFileDrafts` and folders via
+`chatDirDrafts`, each in sessionStorage under its own key. On a slot switch the
+outgoing slot's staged entries are written to its draft and the incoming slot's
+are restored. Restoring is what keeps the two isolated: without an explicit
+reset, a folder picked in one chat would remain staged and ride along on the next
+send in a different chat.
+
+When a send fails on a connection error the composer is restored from the
+**pre-serialization** state: the raw typed text plus both staged families. The
+restored file list is the union of images and non-images, since
+`prepareSendPayload` splits those apart for the LLM payload and an image exists
+only in `pendingFiles` — restoring the non-image list alone dropped it, so a
+retry would have sent the message without the image.
+
+Mid-turn steering carries the same metadata, on both the optimistic bubble and
+the server-persisted entry: `steerChat` forwards `meta` in the request body and
+the steer branch merges it into the appended history entry. The `steer` marker is
+applied server-side last, so a client cannot spoof it. Without server-side
+persistence the metadata lived only in the live session, and a reload fell back
+to the content scan and truncated any path containing a space.
+
+The `steer_push` WebSocket echo carries that same `meta` and the client consumes
+it. Other open tabs render the steered bubble from the echo alone, so an echo
+without the ordered lists left them showing a space-truncated path until the
+next reload.
+
+The **queue** is the third path a message with attachments can take (mid-turn
+without a live steer channel, or held while sub-agents run). `queue_append`
+accepts the redacted `meta`, and the drain in `chat_runner` persists it onto the
+appended entry — otherwise a queued message kept its markers but lost the lists.
+The selection rule lives in `queued_append_meta` (`chat_utils`) rather than
+inline in the drain, so it is directly testable: the inline version had no test
+reaching it, and reverting it left every test green while spaced paths truncated
+again. A metadata-bearing entry is never folded into a `[N queued messages merged]`
+turn: marker numbers index the message's own list, so concatenating two such
+messages would resolve the second message's markers against the first's paths.
+It breaks the merge and drains alone.
+
+The queued card's `queue_push` broadcast also carries the metadata, and the
+`appendQueuedMessage` reducer preserves it (it previously hardcoded
+`meta: { queueId }` and discarded the rest). Without it an open client renders a
+queued card whose spaced path is truncated until the page reloads. `queueId` is
+applied last, so a server-side key cannot displace the client's cancel/edit
+handle.
+
+A steer that the turn never consumed is degraded into an ordinary queue card by
+`_requeue_unconsumed_steers`. Its metadata rides along in
+`slot._pending_steer_meta`, a side table keyed by message text; `_pending_steers`
+itself stays a plain `list[str]` because its shape is load-bearing for the
+settle/requeue matching and its regression suite. The table is populated
+**before** the steer RPC's await (matching the registration ordering a dying turn
+depends on), drained on requeue, and cleared wherever `_pending_steers` is
+cleared — settle, unwind, and force-stop — so it cannot grow across turns.
+
+`meta.files` / `meta.dirs` arrive from an untrusted payload, so `metaPathList`
+validates them at the boundary. Invalid members are **blanked in place, never
+dropped**: the marker number is a positional index into this list, so filtering
+would shift every later path down a slot and a spaced path following an invalid
+entry would resolve against the wrong element (or past the end) and fall through
+to the truncating scan. A blank is an alignment placeholder only — it is filtered
+out of the chip/card and unreferenced-attachment outputs so it can never render
+as an empty attachment.
+
+### Known gap: rejection rollback
+
+Two write paths clear the composer **before** the request resolves, and neither
+rolls back if the request is rejected. A failed steer leaves its optimistic
+bubble on screen with the staged files and folders already gone; a rejected
+`createSlot` during send lets `.unwrap()` throw past any restore, losing the
+staged text and attachments.
+
+This is deliberately unfixed here. A correct rollback is a concurrency problem,
+not a missing branch: the write is in flight while the composer stays live, so
+the restore has to decide what happens when a second write fails while the first
+is pending (per-call TanStack `onError` fires only for the latest mutation), when
+the response is lost *after* the server already accepted the write (restoring
+then invites a duplicate submission), and when the rejection lands after the user
+has switched slots (restoring into the wrong slot splices one chat's prompt into
+another). An earlier attempt at this got each of those wrong, so the rollback
+semantics are being designed separately rather than half-implemented alongside
+the metadata contract.
+
+What this module *does* guarantee is the send path's connection-error restore,
+which predates this work: it restores the pre-serialization text with its
+`@`-mentions plus the staged file and folder lists, rather than the serialized
+marker text, so a retry cannot resend `[attached_file N]` markers stripped of the
+metadata that makes a spaced path resolve.
 
 ## Key Files
 
@@ -120,8 +335,12 @@ switch or a page reload.
 |---|---|
 | `src/kiro_crew/dashboard/handlers/files.py` | `api_file_search` endpoint, fuzzy scorer, walk fallback |
 | `src/kiro_crew/dashboard/file_index.py` | `FileIndex`, `FileIndexRegistry` |
+| `src/kiro_crew/dashboard/chat_title.py` | Marker stripping for title generation |
 | `website/src/components/FilePickerMenu.tsx` | Picker UI, `kind` propagation, trailing-slash insertion |
 | `website/src/components/ChatInput.tsx` | Composer wiring, pending file/folder preview strip |
+| `website/src/utils/fileTokens.ts` | Marker serialization and resolution |
+| `website/src/utils/chatDirDrafts.ts` | Per-slot staged folder-reference persistence |
+| `website/src/pages/ChatPage.tsx` | Pending state, send payload, message rendering |
 
 ## Tests
 
@@ -130,5 +349,15 @@ switch or a page reload.
 | `test/test_file_search.py` | Endpoint behaviour, scoring, exclusions |
 | `test/test_file_index.py` | Index build, refresh, registry refcounting |
 | `test/test_file_search_dirs.py` | Directory results, `kinds` filter, independent scan budgets, dirs-visited ceiling, symlink security |
+| `test/test_chat_title_dirs.py` | Marker stripping for both families; shared label budget; one-pass scan (a basename containing the other family's marker text is not mangled) |
+| `test/test_queue_edit.py` | A queued-message edit drops its attachment metadata; a failed edit leaves it intact |
 | `website/src/test/FilePickerMenu.dirs.test.tsx` | Folder rows, selection payloads, trailing slash |
+| `website/src/test/fileTokens.dirs.test.ts` | `[attached_dir N]` serialization and numbering; one-pass emission (no marker rescan, longest-mention-first) |
+| `website/src/test/renderUserContent.dirs.test.tsx` | Folder chips and cards |
+| `website/src/test/chatDirDrafts.test.ts` | Per-slot folder-draft store |
+| `website/src/test/ChatPageDrafts.test.tsx` | Draft isolation, `meta.dirs` persistence guards, send-failure attachment restore |
+| `website/src/test/useWebSocket.steerMeta.test.ts` | `steer_push` forwards `meta.files`/`meta.dirs` to a second tab; `steer` re-asserted with or without meta |
+| `website/src/test/chatSlice.queuedMeta.test.ts` | Queued cards keep `meta.files`/`meta.dirs`; `queueId` is not displaceable |
+| `website/src/test/ChatPage.folderStaging.test.ts` | A picked folder stages as a folder, never into `pendingFiles` |
 | `website/src/test/ChatInput.dirStripHeight.test.tsx` | Preview-strip height compensation for a folders-only strip |
+| `test/test_chat_steer.py` | Steered messages persist `meta.files` / `meta.dirs`; `steer` marker is not spoofable; `steer_push` echoes meta; queued sends carry meta to the drain and never merge; `queued_append_meta` ownership rules + the drain call site; an unconsumed steer keeps its meta on requeue |

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -46,6 +46,7 @@ from kiro_crew.dashboard.chat_utils import (
     _redact_for_display,
     _remove_queued_by_id,
     _sync_dashboard_slots,
+    queue_item_for_display,
 )
 from kiro_crew.dashboard.state import (
     _MAX_PENDING_CONTEXT,
@@ -241,6 +242,19 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                 # clear() likewise races correctly: a hard kill during the
                 # await discards the entry, so a late write can't resurrect it.
                 slot._pending_steers.append(message)
+                # Park the attachment lists alongside so an unconsumed steer
+                # keeps them when it degrades into a queue card (see
+                # _requeue_unconsumed_steers). Redacted at the boundary, same as
+                # the persist and queue paths.
+                #
+                # A LIST per text, not one dict: two identical steer texts with
+                # DIFFERENT attachments both mapped to the same key, so the second
+                # overwrote the first and both were requeued with the last one's
+                # metadata. Occurrences are appended here and consumed in order.
+                if user_meta:
+                    slot._pending_steer_meta.setdefault(message, []).append(
+                        dict(_redact_meta(user_meta))
+                    )
                 try:
                     steered = await _client.steer(message)
                 except Exception as exc:  # best-effort — fall through to queue
@@ -256,6 +270,15 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                         slot._pending_steers.remove(message)
                     except ValueError:
                         return web.json_response({"ok": True, "queued": True})
+                    # Unwound: this message no longer has a pending entry, so
+                    # drop ONE parked occurrence. Identical steers each own their
+                    # own entry in the list, so pop the last rather than clearing
+                    # the key — another pending copy may still need its metadata.
+                    _parked = slot._pending_steer_meta.get(message)
+                    if _parked:
+                        _parked.pop()
+                        if not _parked:
+                            slot._pending_steer_meta.pop(message, None)
                 if steered:
                     _ts = datetime.now(timezone.utc).isoformat()
                     # Sanitize: same chain as the queue path.
@@ -266,12 +289,21 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                     # (dirty-flush picks it up on next save cycle). Store the
                     # sanitized form — raw content must never reach an external
                     # surface (security-controls).
+                    #
+                    # Carry the client's attachment metadata through, same as the
+                    # queue path at the bottom of this handler. Without it the
+                    # persisted steer keeps only `steer: True`, so on reload
+                    # `parseFiles`/`parseDirs` fall back to scanning the content
+                    # for markers and truncate any path containing a space. The
+                    # `steer` flag is set last so a client cannot spoof it.
+                    _steer_meta = dict(_redact_meta(user_meta)) if user_meta else {}
+                    _steer_meta["steer"] = True
                     slot.append(
                         "user",
                         _sanitized,
                         "msg msg-u",
                         ts=_ts,
-                        meta={"steer": True},
+                        meta=_steer_meta,
                     )
                     state.broadcast_ws(
                         "steer_push",
@@ -279,6 +311,12 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                             "slot": slot.key,
                             "content": _redacted,
                             "ts": _ts,
+                            # Mirror the persisted metadata to every other open
+                            # client. The echo is what a second tab renders from,
+                            # so without the ordered lists that tab falls back to
+                            # the whitespace scan and shows `/repo/my` for
+                            # `/repo/my docs` until a reload re-fetches history.
+                            "meta": _steer_meta,
                         },
                     )
                     return web.json_response({"ok": True, "steered": True})
@@ -287,7 +325,11 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # The existing SSE reader will pick up queued messages as _run_chat
         # processes the queue in its finally block.
         if message:
-            qid = slot.queue_append(message)
+            # Carry the attachment metadata into the queue entry so the drain can
+            # persist it (see queue_append / _dequeue_next_message). Redacted at
+            # the boundary, exactly like the non-queued send path below.
+            _qmeta = _redact_meta(user_meta) if user_meta else None
+            qid = slot.queue_append(message, meta=_qmeta)
             _c, _ = redact_exfiltration_urls(message)
             _c, _ = redact_credentials(_c)
             _redacted = _redact_for_display(_c)
@@ -298,6 +340,10 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                     "content": _redacted,
                     "ts": datetime.now(timezone.utc).isoformat(),
                     "queue_id": qid,
+                    # Mirror the ordered attachment lists so an open client
+                    # renders the queued card's spaced paths correctly instead of
+                    # falling back to the truncating content scan until reload.
+                    **({"meta": _qmeta} if _qmeta else {}),
                 },
             )
         return web.json_response({"ok": True, "queued": True})
@@ -319,7 +365,8 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         and state.subagents is not None
         and state.subagents.running_agents_for(f"dashboard:{slot.key}")
     ):
-        qid = slot.queue_append(message)
+        _qmeta = _redact_meta(user_meta) if user_meta else None
+        qid = slot.queue_append(message, meta=_qmeta)
         _c, _ = redact_exfiltration_urls(message)
         _c, _ = redact_credentials(_c)
         _redacted = _redact_for_display(_c)
@@ -330,6 +377,8 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                 "content": _redacted,
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "queue_id": qid,
+                # See the mid-turn queue_push above: the client needs the lists.
+                **({"meta": _qmeta} if _qmeta else {}),
             },
         )
         return web.json_response({"ok": True, "queued": True})
@@ -643,9 +692,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             "running": slot.running,
             "stopping": slot._stopping,
             "messages": prepared,
-            "queue": [
-                {"id": q["id"], "content": _redact_for_display(q["content"])} for q in slot._queue
-            ],
+            "queue": [queue_item_for_display(q) for q in slot._queue],
             "total": total,
             "has_more": has_more,
         }
@@ -822,6 +869,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         # end-of-turn requeue (chat_runner finally) has nothing to resurrect.
         # Mirrors the queue clear above; a soft stop preserves both.
         slot._pending_steers.clear()
+        slot._pending_steer_meta.clear()
         state.push_slots_update()
         logger.info("Stop (force): hard-killing session for slot %s", name)
 
@@ -1126,11 +1174,22 @@ async def api_chat_slot_queue_edit(request: web.Request) -> web.Response:
     content = body.get("content")
     if not isinstance(content, str) or not content.strip():
         return web.json_response({"error": "content must be a non-empty string"}, status=400)
-    if not slot.queue_edit_by_id(queue_id, content):
+    stored = slot.queue_edit_by_id(queue_id, content)
+    if stored is None:
         return web.json_response({"error": "queue item not found"}, status=404)
-    _edit_queued_by_id(slot.messages, queue_id, content)
+    if not stored:
+        # Empty (not None) means the item existed but the edit was attachment
+        # markers only, which strips to nothing. Storing that would drain as a
+        # turn with no request at all, silently losing what the user asked for.
+        return web.json_response(
+            {"error": "edit must contain text besides the attachment markers"}, status=400
+        )
+    # Every echo below uses the STORED text, not the submitted text: the queue no
+    # longer holds the markers, so broadcasting the original would show clients an
+    # attachment the queued prompt does not contain.
+    _edit_queued_by_id(slot.messages, queue_id, stored)
     slot.invalidate_source_links()
-    _redacted = _redact_for_display(content)
+    _redacted = _redact_for_display(stored)
     state.broadcast_ws("queue_edit", {"slot": name, "queue_id": queue_id, "content": _redacted})
     state.push_slots_update()
     sel().log_tool_invocation(
@@ -1879,10 +1938,7 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                 "ok": True,
                 "key": existing.key,
                 "messages": prepared,
-                "queue": [
-                    {"id": q["id"], "content": _redact_for_display(q["content"])}
-                    for q in existing._queue
-                ],
+                "queue": [queue_item_for_display(q) for q in existing._queue],
                 "total": total,
                 "has_more": total > 200,
                 "memory_mode": existing.memory_mode,
@@ -1995,9 +2051,7 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             "ok": True,
             "key": slot.key,
             "messages": _prepare_messages(recent, slot.running),
-            "queue": [
-                {"id": q["id"], "content": _redact_for_display(q["content"])} for q in slot._queue
-            ],
+            "queue": [queue_item_for_display(q) for q in slot._queue],
             "total": total,
             "has_more": total > len(recent),
             "memory_mode": slot.memory_mode,

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -68,6 +68,7 @@ from kiro_crew.dashboard.chat_utils import (
     _remove_queued_by_id,
     _validate_tool_name,
     is_system_injection,
+    queued_append_meta,
 )
 from kiro_crew.dashboard.handlers import (
     MAX_PROMPT_BYTES,
@@ -1686,6 +1687,16 @@ def _settle_consumed_steers(slot: "_ChatSlot", snapshot: str) -> None:
         len(remaining),
     )
     slot._pending_steers[:] = remaining
+    # Drop parked metadata for settled entries so the side table cannot grow
+    # across turns. Each text holds a LIST of per-occurrence metadata, so trim it
+    # to however many copies of that text are still pending rather than keeping
+    # or dropping the whole key.
+    for key in list(slot._pending_steer_meta):
+        still = remaining.count(key)
+        if not still:
+            del slot._pending_steer_meta[key]
+        else:
+            del slot._pending_steer_meta[key][still:]
 
 
 def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> None:
@@ -1708,7 +1719,17 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
         return
     requeued = slot._pending_steers[:]
     slot._pending_steers.clear()
+    # Metadata travels with the requeued cards; drained after the loop so an
+    # identical steer appearing twice still finds its lists on the second pass.
+    # Metadata travels with the requeued cards; drained after the loop so an
+    # identical steer appearing twice still finds its lists on the second pass.
+    # Each text maps to a LIST of per-occurrence metadata, popped in order so two
+    # identical steers with different attachments keep their own.
+    steer_meta = {k: list(v) for k, v in slot._pending_steer_meta.items()}
+    slot._pending_steer_meta.clear()
     for steer_msg in reversed(requeued):
+        _occurrences = steer_meta.get(steer_msg) or []
+        _meta_for_msg = _occurrences.pop(0) if _occurrences else None
         # Raw-at-rest by design: slot._queue is a DELIVERY payload (the drained
         # entry becomes the next turn's LLM input), matching every other queue
         # producer (queue_append in chat_handlers / messaging). All dashboard
@@ -1716,7 +1737,7 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
         # apply _redact_for_display, and every queue_* broadcast (including the
         # queue_push below) sanitizes. Sanitizing at insert would corrupt the
         # delivered message relative to the normal queue path.
-        qid = slot.queue_insert(0, steer_msg)
+        qid = slot.queue_insert(0, steer_msg, meta=_meta_for_msg)
         try:
             content, _ = redact_exfiltration_urls(steer_msg)
             content, _ = redact_credentials(content)
@@ -1727,6 +1748,9 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
                     "content": _redact_for_display(content),
                     "ts": datetime.now(timezone.utc).isoformat(),
                     "queue_id": qid,
+                    # Same as the handler's queue_push sites: an open client needs
+                    # the ordered lists to render a spaced path on the card.
+                    **({"meta": _meta_for_msg} if _meta_for_msg else {}),
                 },
             )
         except Exception:
@@ -4657,6 +4681,17 @@ async def _run_chat(
             cron_label = _m.group(1) if _m else "cron"
             cron_label, _ = redact_exfiltration_urls(cron_label)
             cron_label, _ = redact_credentials(cron_label)
+            # Carry a queued user message's attachment metadata onto the
+            # persisted entry (see queued_append_meta for the ownership rules).
+            # Without this the drained message keeps its `[attached_dir N]`
+            # markers but loses the ordered lists, and replay truncates any path
+            # containing a space at the first space.
+            _queued_meta = queued_append_meta(
+                consumed,
+                is_cron=is_cron,
+                is_subagent=is_subagent,
+                is_recovery=is_recovery,
+            )
             slot.append(
                 "subagent"
                 if is_subagent
@@ -4669,6 +4704,7 @@ async def _run_chat(
                 else "msg msg-inject"
                 if is_recovery
                 else "msg msg-u",
+                meta=_queued_meta or None,
             )
 
             task = asyncio.create_task(

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -28,9 +28,21 @@ _TITLE_MAX_ATTEMPTS = 5
 _TITLE_TEXT_LIMIT = 16_384
 _TITLE_MAX_ATTACHMENT_FILES = 20
 _TITLE_MAX_ATTACHMENT_PATH_LENGTH = 4_096
-_TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + _TITLE_MAX_ATTACHMENT_FILES * (
-    _TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32
-)
+# Two marker families each get the full per-family allowance (files and folders
+# are counted separately), so the scan budget must cover BOTH. Budgeting for one
+# family would let a message carrying long file AND folder paths be truncated
+# before its user text, leaving title generation with an empty transcript.
+_TITLE_ATTACHMENT_FAMILIES = 2
+# Total budget for ALL substituted attachment labels in one message, and the cap
+# on any single one. The transcript line fed to the titler is itself capped, so
+# without these a message carrying many (or one pathological) attachment name
+# would spend the whole line on names and truncate away the user's caption --
+# the same failure mode as dropping the names entirely.
+_TITLE_MAX_ATTACHMENT_LABEL_BUDGET = 80
+_TITLE_MAX_ATTACHMENT_LABEL_LENGTH = _TITLE_MAX_ATTACHMENT_LABEL_BUDGET // 2
+_TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + (
+    _TITLE_ATTACHMENT_FAMILIES * _TITLE_MAX_ATTACHMENT_FILES
+) * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32)
 
 # Titling is a trivial 3-6 word task, so run it on the cheapest/fastest model
 # (Haiku) rather than the kirocrew-lite default (Opus 4.6 on the kiro-cli path).
@@ -107,33 +119,146 @@ def _strip_markdown_images(content: str, *, drop_trailing_partial: bool = False)
     return "".join(chunks)
 
 
+def _trailing_segment(path: str) -> str:
+    """Last path segment, separator-agnostic, capped to the per-label limit.
+
+    Uses ``_to_posix_sep`` so a legal POSIX name containing a backslash keeps it:
+    metadata-free replay of ``/repo/a\\b`` titled it ``b`` instead of ``a\\b``.
+    """
+    base = _to_posix_sep(path).rstrip("/").rsplit("/", 1)[-1]
+    return base[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+
+
+def _to_posix_sep(path: str) -> str:
+    """Normalize separators, treating ``\\`` as one only for Windows-style paths.
+
+    On POSIX a backslash is a legal filename character, so rewriting every ``\\``
+    to ``/`` mislabeled ``/repo/a\\b`` as ``b`` in generated titles. Mirrors
+    ``pathSegments`` on the frontend so chips and titles agree.
+    """
+    drive_prefixed = (
+        len(path) >= 3
+        and path[0].isalpha()
+        and path[1] == ":"
+        and path[2] in ("/", "\\")
+    )
+    if drive_prefixed or ("\\" in path and "/" not in path):
+        return path.replace("\\", "/")
+    return path
+
+
+def _attachment_labels(*path_groups: tuple[str, ...]) -> dict[str, str]:
+    """Map each attachment path to its title label: the trailing path segment.
+
+    Titles keep the name rather than the full path: the path is noise and can
+    leak a directory layout, but the name is usually the whole topic. A label is
+    widened to the last two segments when its basename collides, because three
+    folders all named ``docs`` would otherwise read as "docs and docs and docs"
+    -- which the titling model rejects as SKIP, the very failure this substitution
+    exists to fix. Mirrors the disambiguation the composer applies to chips.
+
+    Groups are labelled together so a file and a folder sharing a basename are
+    disambiguated against each other too.
+    """
+    normalized = {
+        p: _to_posix_sep(p).rstrip("/") for group in path_groups for p in group if p
+    }
+    basenames = [n.rsplit("/", 1)[-1] for n in normalized.values()]
+    dupes = {b for b in basenames if basenames.count(b) > 1}
+    labels: dict[str, str] = {}
+    for original, norm in normalized.items():
+        segments = norm.split("/")
+        label = (
+            "/".join(segments[-2:])
+            if segments[-1] in dupes and len(segments) > 1
+            else segments[-1]
+        )
+        labels[original] = label[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+
+    return labels
+
+
 def _strip_attached_file_tokens(
     content: str,
     attached_files: tuple[str, ...] = (),
     *,
     drop_trailing_partial: bool = False,
+    prefix: str = "[attached_file ",
+    labels: dict[str, str] | None = None,
+    budget: list[int] | None = None,
+    also: tuple[str, tuple[str, ...]] | None = None,
 ) -> str:
-    """Remove dashboard-generated ``[attached_file N] path`` references.
+    """Replace dashboard-generated ``[attached_file N] path`` references.
+
+    The marker and its full path are replaced by the attachment's BASENAME, not
+    dropped. Dropping them left an attachment-only message with no content at
+    all: "tell me about [attached_dir 1] /long/path/docs and [attached_dir 2]
+    /long/path/website/docs" collapsed to "tell me about and", so the titling
+    model correctly answered SKIP and every such chat fell back to a truncated
+    name. The basename preserves the topic while still keeping the full path out
+    of the title.
 
     Current dashboard messages store paths in token-index order, making each
     lookup constant-time. The whitespace-delimited fallback preserves support
     for older messages without metadata.
+
+    ``prefix`` selects the marker family. Folder references use the sibling
+    ``[attached_dir N] path`` marker with its own index space, so the caller
+    passes the matching ordered path tuple for whichever prefix it scans.
+
+    ``also`` supplies a SECOND ``(prefix, paths)`` family scanned in the SAME
+    left-to-right walk. Both families must be consumed in one pass: running two
+    passes made the second scan the first's substituted output, so a basename
+    that happens to contain the other family's marker text was mangled. A real
+    FILE named ``[attached_dir 1] notes`` (brackets and spaces are legal on
+    POSIX and Windows) came out of the file pass as its own basename and was then
+    eaten by the folder pass, leaving ``notes``. Each family keeps its own
+    independent index space; only the walk is shared.
     """
-    prefix = "[attached_file "
+    families: list[tuple[str, tuple[str, ...]]] = [(prefix, attached_files)]
+    if also is not None:
+        families.append(also)
     chunks: list[str] = []
     cursor = 0
+    # A single-element list carries the label budget so it is shared across both
+    # marker families.
+    remaining = budget if budget is not None else [0]
+    # Each family caches the position of its next match. Re-running `find` for
+    # every family on every iteration made the walk quadratic whenever a family's
+    # marker sat LATE in the input: dropping absent families (find == -1) only
+    # helps when a family is missing entirely, not when its next match is simply
+    # far ahead, so a 181KB scan re-traversed the tail once per token —
+    # synchronously on the event loop, for up to 10 messages. A cached position is
+    # still valid while `cursor` has not passed it, because `cursor` only ever
+    # moves forward and the text is never mutated during the walk.
+    fam_state: list[list] = [[p, paths, content.find(p, cursor)] for p, paths in families]
     while True:
-        token_start = content.find(prefix, cursor)
+        # Earliest marker of EITHER family wins, so the walk only ever moves
+        # forward over the original text.
+        token_start = -1
+        prefix_at = ""
+        paths_at: tuple[str, ...] = ()
+        for fam in fam_state:
+            if fam[2] >= 0 and fam[2] < cursor:
+                # Cursor advanced past the cached hit — find the next one.
+                fam[2] = content.find(fam[0], cursor)
+            if fam[2] < 0:
+                continue
+            if token_start < 0 or fam[2] < token_start:
+                token_start, prefix_at, paths_at = fam[2], fam[0], fam[1]
+        # A family whose find returned -1 stays -1 forever (cursor only moves
+        # forward), so it is skipped from here on without another scan.
         if token_start < 0:
             chunks.append(content[cursor:])
             break
+        attached = paths_at
 
         if token_start > 0 and not content[token_start - 1].isspace():
             chunks.append(content[cursor : token_start + 1])
             cursor = token_start + 1
             continue
 
-        index = token_start + len(prefix)
+        index = token_start + len(prefix_at)
         digits_start = index
         while index < len(content) and content[index].isdigit():
             index += 1
@@ -146,7 +271,7 @@ def _strip_attached_file_tokens(
         token_index = int(content[digits_start:index])
         path_start = index + 2
         expected_path = (
-            attached_files[token_index - 1] if 1 <= token_index <= len(attached_files) else ""
+            attached[token_index - 1] if 1 <= token_index <= len(attached) else ""
         )
         path_end = path_start
         if expected_path and content.startswith(expected_path, path_start):
@@ -169,7 +294,24 @@ def _strip_attached_file_tokens(
             continue
 
         chunks.append(content[cursor:token_start])
-        chunks.append(" ")
+        # Substitute the name rather than dropping it: an attachment-only message
+        # would otherwise be left with no content for the titler to name. Once
+        # the shared budget is spent, the rest collapse to a bare space so the
+        # user's own text keeps its place in the transcript line. ``labels=None``
+        # opts out entirely (the truncated fallback does this).
+        if labels is None:
+            label = ""
+        elif expected_path:
+            label = labels.get(expected_path, "")
+        else:
+            # Older messages carry no metadata and so no ordered path to look up;
+            # derive the label from the text the whitespace scan captured.
+            label = _trailing_segment(content[path_start:path_end])
+        if label and len(label) <= remaining[0]:
+            remaining[0] -= len(label)
+            chunks.append(f" {label} ")
+        else:
+            chunks.append(" ")
         cursor = path_end
 
     return "".join(chunks)
@@ -189,22 +331,62 @@ def _message_attachment_paths(message: dict[str, Any]) -> tuple[str, ...]:
     )
 
 
-def _title_text(content: str, attached_files: tuple[str, ...] = ()) -> str:
+def _message_dir_paths(message: dict[str, Any]) -> tuple[str, ...]:
+    """Return bounded, index-preserving folder paths from message metadata."""
+    meta = message.get("meta")
+    if not isinstance(meta, dict):
+        return ()
+    dirs = meta.get("dirs")
+    if not isinstance(dirs, list):
+        return ()
+    return tuple(
+        path if isinstance(path, str) and 0 < len(path) <= _TITLE_MAX_ATTACHMENT_PATH_LENGTH else ""
+        for path in dirs[:_TITLE_MAX_ATTACHMENT_FILES]
+    )
+
+
+def _title_text(
+    content: str,
+    attached_files: tuple[str, ...] = (),
+    attached_dirs: tuple[str, ...] = (),
+    *,
+    keep_attachment_names: bool = True,
+) -> str:
     """Return bounded message text suitable for title generation.
 
     A bounded allowance large enough for every accepted attachment is sanitized
     first, so generated paths cannot crowd later user text out of the retained
     title input. The normalized user text is capped separately.
+
+    ``keep_attachment_names`` substitutes each attachment's basename so the LLM
+    has something to name. The truncated fallback passes False: an
+    attachment-only message must stay unnameable there, because titling it
+    "report.txt" would lock a filename in as the permanent title and prevent a
+    later real title from replacing it.
     """
     source_was_truncated = len(content) > _TITLE_SOURCE_SCAN_LIMIT
     content = content[:_TITLE_SOURCE_SCAN_LIMIT]
     if content.startswith("[BROWSE] "):
         content = content[len("[BROWSE] ") :]
     content = _strip_markdown_images(content, drop_trailing_partial=source_was_truncated)
+    # One label map and one budget shared by both passes, so a file and a folder
+    # with the same basename disambiguate against each other and their names
+    # cannot together crowd out the user's text.
+    labels = (
+        _attachment_labels(attached_files, attached_dirs) if keep_attachment_names else None
+    )
+    budget = [_TITLE_MAX_ATTACHMENT_LABEL_BUDGET]
+    # BOTH marker families in one left-to-right walk. Two sequential passes made
+    # the second one scan the first's substituted output, so a basename
+    # containing the other family's marker text was mangled (see
+    # _strip_attached_file_tokens). Index spaces stay independent.
     content = _strip_attached_file_tokens(
         content,
         attached_files,
         drop_trailing_partial=source_was_truncated,
+        labels=labels,
+        budget=budget,
+        also=("[attached_dir ", attached_dirs),
     )
     return " ".join(content.split())[:_TITLE_TEXT_LIMIT]
 
@@ -214,7 +396,11 @@ def _build_title_prompt(messages: list[dict[str, Any]]) -> str | None:
     lines: list[str] = []
     for m in messages[:10]:
         role = m.get("role", "")
-        content = _title_text(m.get("content", ""), _message_attachment_paths(m))
+        content = _title_text(
+            m.get("content", ""),
+            _message_attachment_paths(m),
+            _message_dir_paths(m),
+        )
         if role in ("user", "assistant") and content:
             lines.append(f"{role}: {content[:200]}")
     if not lines:
@@ -361,7 +547,14 @@ def _fallback_title_from_messages(messages: list[dict[str, Any]]) -> str:
             text
             for m in messages
             if m.get("role") == "user"
-            and (text := _title_text(m.get("content", ""), _message_attachment_paths(m)))
+            and (
+                text := _title_text(
+                    m.get("content", ""),
+                    _message_attachment_paths(m),
+                    _message_dir_paths(m),
+                    keep_attachment_names=False,
+                )
+            )
         ),
         "",
     )

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -492,6 +492,29 @@ def _redact_for_display(text: str) -> str:
     return text
 
 
+def queue_item_for_display(item: dict) -> dict:
+    """Project one queue entry for a slot-detail payload.
+
+    Carries ``meta`` through alongside the content. The marker number in
+    ``content`` is a positional index into ``meta.files`` / ``meta.dirs``, so a
+    payload that ships the content without the lists forces the client onto its
+    whitespace-bounded fallback scan — which truncates a path containing a space.
+    Live ``queue_push`` delivery already carried the metadata; omitting it here
+    meant a queued attachment survived until the user reloaded the page and then
+    silently truncated.
+
+    ``meta`` is stored already-redacted (``queue_append``/``queue_insert`` redact
+    on the way in), so this only has to redact the display text. The key is
+    omitted entirely when absent, keeping the payload shape unchanged for
+    entries that have no attachments.
+    """
+    out: dict = {"id": item["id"], "content": _redact_for_display(item["content"])}
+    meta = item.get("meta")
+    if meta:
+        out["meta"] = meta
+    return out
+
+
 def _remove_queued_by_id(messages: list[dict], queue_id: str) -> bool:
     """Remove a 'queued' placeholder by queue_id stored in cls JSON."""
     for i, m in enumerate(messages):
@@ -586,12 +609,55 @@ def is_system_injection_item(item: dict) -> bool:
     return is_synthetic_recovery_item(item) or is_system_injection(item["content"])
 
 
+def queued_append_meta(
+    consumed: list[dict],
+    *,
+    is_cron: bool = False,
+    is_subagent: bool = False,
+    is_recovery: bool = False,
+) -> dict | None:
+    """Attachment metadata to persist for a drained queue item, or ``None``.
+
+    A queued user message carries ``meta.files`` / ``meta.dirs`` — the ordered
+    lists that let ``[attached_file N]`` / ``[attached_dir N]`` resolve a path
+    containing a space. The drain must put them back on the appended history
+    entry; without that the message keeps its markers but loses the lists, and
+    replay falls back to the whitespace-bounded scan that truncates
+    ``/repo/my docs`` to ``/repo/my``.
+
+    Returns ``None`` unless exactly one item was consumed and it is a plain user
+    message:
+
+    * A merge (``len(consumed) > 1``) has no single owning metadata list — two
+      messages' marker index spaces would collide under one list. (The dequeue
+      breaks merges on metadata-bearing entries so this should not arise; the
+      guard here is defence in depth.)
+    * cron / sub-agent / recovery injections are orchestration, never carry
+      attachments, and must not inherit a neighbour's lists.
+    """
+    if len(consumed) != 1:
+        return None
+    if is_cron or is_subagent or is_recovery:
+        return None
+    meta = consumed[0].get("meta")
+    return meta or None
+
+
 def _dequeue_next_message(slot, merge_enabled: bool) -> tuple:
     """Drain the queue: merge non-cron messages or pop the first one."""
     if merge_enabled and len(slot._queue) > 1:
         to_merge: list[dict] = []
         for item in list(slot._queue):
             if is_system_injection_item(item):
+                break
+            # An attachment-bearing entry must drain ALONE. Its `meta.files` /
+            # `meta.dirs` are ordered lists indexed by the `[attached_file N]` /
+            # `[attached_dir N]` markers in its own content; concatenating two
+            # such messages would put two independent index spaces in one body
+            # with only one metadata list, so the second message's markers would
+            # resolve against the first's paths. Break the merge here and let it
+            # drain on its own turn with its metadata intact.
+            if item.get("meta"):
                 break
             to_merge.append(item)
         if len(to_merge) > 1:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -676,6 +676,54 @@ def _normalize_slot_key(name: str) -> str:
     return _SLOT_KEY_FILENAME_UNSAFE_RE.sub("_", _ascii_slot_key(name))
 
 
+def strip_attachment_markers(content: str, meta: object) -> str:
+    """Remove ``[attached_file N] path`` / ``[attached_dir N] path`` pairs.
+
+    Used when attachment metadata is being DROPPED (queue edit) and the marker
+    text must not survive in the content. Without this, ``item.pop("meta")``
+    left the markers behind: the runner still resolved them and sent the
+    attachment the user thought they had removed, and any path containing a
+    space rendered truncated because the index space backing it was gone.
+
+    Strips by exact ``marker + path`` using the paths from the OUTGOING ``meta``
+    rather than by pattern, so a path containing spaces, brackets or a literal
+    ``[attached_dir 1]`` is removed exactly and nothing else is touched. Markers
+    whose index is absent from ``meta`` are left alone — they belong to a family
+    this call does not own.
+    Whitespace is repaired ONLY at each removal site, never globally. A global
+    ``[ \t]{2,}`` collapse plus per-line strip rewrote text far from any marker:
+    a pasted code snippet lost its indentation and aligned columns collapsed to
+    single spaces. Each marker is removed along with the horizontal whitespace
+    immediately around it, so the gap closes without touching anything else.
+    """
+    if not meta or not content or not isinstance(meta, dict):
+        return content
+    for prefix, key in (("[attached_file ", "files"), ("[attached_dir ", "dirs")):
+        paths = meta.get(key)
+        # Metadata arrives from client JSON, so the value may be any type. Only
+        # a list of strings is meaningful; anything else is ignored rather than
+        # iterated (a bare string would iterate as characters).
+        if not isinstance(paths, list):
+            continue
+        for idx, path in enumerate(paths, start=1):
+            if not path or not isinstance(path, str):
+                continue
+            marker = re.escape(f"{prefix}{idx}] {path}")
+            # Require a boundary after the path. Without it the marker matched a
+            # PREFIX of a longer path: with meta owning `/d`, editing the text to
+            # mention `[attached_dir 1] /dossier` stripped `/d` and left
+            # `ossier`, corrupting the message.
+            bound = r"(?=\s|$)"
+            # A marker alone on its line takes the whole line (including the
+            # newline) so no blank line is left behind.
+            content = re.sub(rf"^[ \t]*{marker}{bound}[ \t]*\n?", "", content, flags=re.M)
+            # Otherwise collapse the marker and the whitespace hugging it to a
+            # single space, then tidy a trailing remnant at end-of-line.
+            content = re.sub(rf"[ \t]*{marker}{bound}[ \t]*", " ", content)
+            content = re.sub(r"[ \t]+$", "", content, flags=re.M)
+    return content.strip()
+
+
 class _ChatSlot:
     """Independent chat session that runs server-side."""
 
@@ -764,6 +812,7 @@ class _ChatSlot:
         "_native_subagent_tracker",
         "_native_subagent_output",
         "_pending_steers",
+        "_pending_steer_meta",
     )
 
     def __init__(
@@ -956,6 +1005,23 @@ class _ChatSlot:
         # STOP, error). Without this, a steer swallowed by a dying turn
         # vanished with no trace (2026-07-17 incident; see the requeue site).
         self._pending_steers: list[str] = []
+        # Attachment metadata for entries in ``_pending_steers``, keyed by the
+        # message text. A side table rather than a richer ``_pending_steers``
+        # element type: that list's shape is load-bearing for the settle/requeue
+        # matching (and its regression suite) after the 2026-07-17 incident, so
+        # it stays a plain list of message strings.
+        #
+        # Needed because an accepted-but-unconsumed steer is degraded into an
+        # ordinary queue card by ``_requeue_unconsumed_steers``. Without the
+        # metadata that requeued card keeps its `[attached_file N]` /
+        # `[attached_dir N]` markers but loses the ordered lists, so the path is
+        # truncated at its first space when the card later drains.
+        #
+        # Keyed by text, so two identical steers with different attachments
+        # share one entry — acceptable because the settle logic already matches
+        # identical steers by count, not identity, and the failure mode is a
+        # duplicate list rather than a lost one.
+        self._pending_steer_meta: dict[str, list[dict]] = {}
 
     @property
     def _plan_stage_count(self) -> int:
@@ -1057,7 +1123,7 @@ class _ChatSlot:
 
     # ── Queue helpers (dict-based queue items) ──
 
-    def queue_append(self, content: str, kind: str = "") -> str:
+    def queue_append(self, content: str, kind: str = "", meta: dict | None = None) -> str:
         """Append a message to the queue. Returns the generated queue ID.
 
         ``kind`` is a structural origin tag (e.g. ``"synthetic_recovery"`` for
@@ -1065,18 +1131,34 @@ class _ChatSlot:
         not by content equality — survives queue transformations and cannot
         collide with user-typed text that happens to match an internal string.
         Empty string = plain user/system content (default).
+
+        ``meta`` carries the (already-redacted) attachment metadata of a queued
+        user message — ``meta.files`` / ``meta.dirs``. It must survive the queue
+        because those ordered lists are what let a path containing a space
+        replay losslessly; without it the drain persists the message with
+        markers but no lists, and ``parseFiles``/``parseDirs`` fall back to the
+        whitespace scan that truncates ``/repo/my docs`` to ``/repo/my``.
         """
         qid = uuid.uuid4().hex[:12]
-        self._queue.append({"id": qid, "content": content, "kind": kind})
+        item: dict = {"id": qid, "content": content, "kind": kind}
+        # Only set when present so existing queue-shape assertions (which
+        # compare against the 3-key dict) stay valid for unattached messages.
+        if meta:
+            item["meta"] = meta
+        self._queue.append(item)
         return qid
 
-    def queue_insert(self, index: int, content: str, kind: str = "") -> str:
+    def queue_insert(self, index: int, content: str, kind: str = "", meta: dict | None = None) -> str:
         """Insert a message at a specific queue position. Returns the queue ID.
 
-        See :meth:`queue_append` for the ``kind`` structural origin tag.
+        See :meth:`queue_append` for the ``kind`` structural origin tag and the
+        ``meta`` attachment metadata.
         """
         qid = uuid.uuid4().hex[:12]
-        self._queue.insert(index, {"id": qid, "content": content, "kind": kind})
+        item: dict = {"id": qid, "content": content, "kind": kind}
+        if meta:
+            item["meta"] = meta
+        self._queue.insert(index, item)
         return qid
 
     def queue_pop(self, index: int = 0) -> dict[str, str]:
@@ -1091,16 +1173,54 @@ class _ChatSlot:
                 return item["content"]
         return None
 
-    def queue_edit_by_id(self, queue_id: str, content: str) -> bool:
-        """Replace the content of a queue item by ID. Returns True if found.
+    def queue_edit_by_id(self, queue_id: str, content: str) -> str | None:
+        """Replace the content of a queue item by ID.
 
-        Order is preserved — only the content of the matching item changes.
+        Returns the STORED content (markers stripped) on success, ``""`` when the
+        item exists but the edit strips to nothing, and ``None`` when the id is
+        unknown. The caller needs the three cases distinct: unknown id is a 404,
+        empty result is a validation error, success echoes the stored text.
+
+        The stripped text is returned rather than a bool because the queue and
+        every client-facing echo must agree. Returning ``True`` and letting the
+        caller broadcast its own ``content`` desynchronized them: the queue held
+        the stripped text while the placeholder, the ``queue_edit`` broadcast and
+        the HTTP response all still carried the marker, so clients rendered an
+        attachment the queued prompt no longer contained.
+
+        Attachment metadata is DROPPED, because the edited text now owns its own
+        attachments. ``content`` carries the ``[attached_file N]`` /
+        ``[attached_dir N]`` markers and ``meta`` carries the ordered path lists
+        that those markers index into; the two are a matched pair generated
+        together at send time. An edit rewrites only ``content``, so keeping the
+        old ``meta`` desynchronizes them: if the user replaces the auto-selected
+        text the marker is gone (the model never receives the attachment) while
+        the surviving metadata still renders an attachment card in history —
+        showing an attachment that was never sent.
+
+        The tradeoff is deliberate: editing a queued message to fix a typo also
+        drops its attachments, which is visible and recoverable (re-stage and
+        re-send) rather than silent and misleading.
+
+        An edit whose text is ONLY markers strips to the empty string. That is
+        rejected instead of stored: an empty queue entry drains as a turn with no
+        request at all, silently losing what the user asked for. The caller
+        surfaces it as a validation error so the user can retype.
         """
         for item in self._queue:
             if item["id"] == queue_id:
-                item["content"] = content
-                return True
-        return False
+                # Strip the markers belonging to the metadata we are dropping.
+                # Leaving them in content sent the attachment anyway (the runner
+                # resolves markers from text) and rendered spaced paths wrong.
+                stripped = strip_attachment_markers(content, item.get("meta"))
+                if not stripped.strip():
+                    # Item found but unusable — signal with "" so the caller can
+                    # tell this apart from an unknown id. The queue is left intact.
+                    return ""
+                item["content"] = stripped
+                item.pop("meta", None)
+                return stripped
+        return None
 
     @property
     def running(self) -> bool:

--- a/test/test_acp_send_prompt_dirs.py
+++ b/test/test_acp_send_prompt_dirs.py
@@ -1,0 +1,99 @@
+"""_send_prompt must leave `[attached_dir N]` folder paths untouched.
+
+Image attachments are extracted from the prompt text and inlined as base64
+`image` content blocks. Folder references are plain paths with no image
+extension and are not files, so they must survive verbatim in the text block —
+otherwise the agent would receive a mangled path it cannot explore.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiro_crew.acp.client import AcpClient
+
+
+async def _captured_prompt(message: str) -> list[dict]:
+    """Run _send_prompt with the transport stubbed; return the prompt blocks."""
+    client = AcpClient()
+    client._session_id = "s1"
+    client._send_request = AsyncMock(return_value=1)
+    await client._send_prompt(message)
+    return client._send_request.call_args[0][1]["prompt"]
+
+
+def _text_of(prompt: list[dict]) -> str:
+    return next(b["text"] for b in prompt if b["type"] == "text")
+
+
+class TestSendPromptDirPaths:
+    @pytest.mark.asyncio
+    async def test_dir_marker_survives_verbatim(self, tmp_path):
+        d = tmp_path / "pages"
+        d.mkdir()
+        msg = f"review [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert not [b for b in prompt if b["type"] == "image"]
+
+    @pytest.mark.asyncio
+    async def test_dir_named_like_an_image_is_not_inlined(self, tmp_path):
+        """A DIRECTORY whose name ends in .png must not be read as an image.
+
+        The path regex matches the extension, so the is_file() guard is the only
+        thing preventing an attempt to base64 a directory.
+        """
+        d = tmp_path / "screenshots.png"
+        d.mkdir()
+        msg = f"see [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert str(d) in _text_of(prompt)
+        assert not [b for b in prompt if b["type"] == "image"]
+
+    @pytest.mark.asyncio
+    async def test_dir_path_with_spaces_survives(self, tmp_path):
+        d = tmp_path / "my docs"
+        d.mkdir()
+        msg = f"check [attached_dir 1] {d} please"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "_send_prompt's image path regex is anchored to a leading '/', so it "
+            "never matches a native Windows path. That POSIX-only extraction "
+            "predates folder support; this test asserts a dir reference coexists "
+            "with an inlined image, which requires extraction to fire."
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_image_still_inlined_alongside_a_dir_reference(self, tmp_path):
+        d = tmp_path / "pages"
+        d.mkdir()
+        img = tmp_path / "shot.png"
+        # 1x1 PNG header bytes are enough: the client only base64s the content.
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        msg = f"look at {img} and [attached_dir 1] {d}"
+        prompt = await _captured_prompt(msg)
+        images = [b for b in prompt if b["type"] == "image"]
+        assert len(images) == 1
+        assert images[0]["mimeType"] == "image/png"
+        text = _text_of(prompt)
+        # The image path is replaced by a placeholder; the dir path is not.
+        assert "[image: shot.png]" in text
+        assert str(d) in text
+        assert str(img) not in text
+
+    @pytest.mark.asyncio
+    async def test_file_marker_unchanged_by_dir_support(self, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n")
+        msg = f"read [attached_file 1] {f}"
+        prompt = await _captured_prompt(msg)
+        assert _text_of(prompt) == msg
+        assert not [b for b in prompt if b["type"] == "image"]

--- a/test/test_chat_steer.py
+++ b/test/test_chat_steer.py
@@ -105,3 +105,565 @@ class TestApiChatSteer:
             assert data.get("steered") is not True
 
         client_mock.steer.assert_awaited_once()
+
+
+class TestSteerPersistsAttachmentMeta:
+    """A steered message must persist the ordered attachment lists.
+
+    Without them a reload falls back to scanning the content for markers, which
+    is bounded by whitespace and so truncates any path containing a space.
+    """
+
+    @pytest.mark.asyncio
+    async def test_steer_persists_files_and_dirs(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        spaced_dir = "/repo/my docs"
+        spaced_file = "/repo/my notes.txt"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir} and [attached_file 1] {spaced_file}",
+                    "steer": True,
+                    "meta": {"files": [spaced_file], "dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        persisted = [m for m in slot.messages if m.get("role") == "user"]
+        assert persisted, "the steered message was not persisted"
+        meta = persisted[-1].get("meta") or {}
+        assert meta.get("steer") is True, "the steer marker must survive"
+        assert meta.get("dirs") == [spaced_dir], "spaced folder path lost from meta.dirs"
+        assert meta.get("files") == [spaced_file], "spaced file path lost from meta.files"
+
+    @pytest.mark.asyncio
+    async def test_steer_without_meta_still_marks_steer(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "plain steer", "steer": True}
+            )
+            assert resp.status == 200
+
+        persisted = [m for m in slot.messages if m.get("role") == "user"]
+        assert (persisted[-1].get("meta") or {}).get("steer") is True
+
+    @pytest.mark.asyncio
+    async def test_client_cannot_spoof_the_steer_marker(self, tmp_path, monkeypatch, _patch_sel):
+        """`steer` is set server-side last, so a client value cannot override it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "sneaky",
+                    "steer": True,
+                    "meta": {"steer": False, "dirs": ["/repo/docs"]},
+                },
+            )
+            assert resp.status == 200
+
+        meta = [m for m in slot.messages if m.get("role") == "user"][-1].get("meta") or {}
+        assert meta.get("steer") is True
+        assert meta.get("dirs") == ["/repo/docs"]
+
+    @pytest.mark.asyncio
+    async def test_steer_push_echo_carries_meta(self, tmp_path, monkeypatch, _patch_sel):
+        """The WS echo must mirror the metadata, not just the content.
+
+        A second open tab renders the steered bubble from this event. Without the
+        ordered lists it falls back to the whitespace-bounded content scan and
+        shows `/repo/my` for `/repo/my docs` until the page is reloaded.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        spaced_dir = "/repo/my docs"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir}",
+                    "steer": True,
+                    "meta": {"dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+
+        pushes = [c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "steer_push"]
+        assert pushes, "no steer_push event was broadcast"
+        payload = pushes[-1].args[1]
+        assert payload.get("meta", {}).get("dirs") == [spaced_dir], "steer_push dropped meta.dirs"
+        assert payload.get("meta", {}).get("steer") is True
+
+
+class TestQueuedSendPersistsAttachmentMeta:
+    """A queued (mid-turn / held) send must carry its attachment lists too.
+
+    The queue is the other path a message with attachments can take. It used to
+    store only `{id, content, kind}`, so the drain persisted the markers without
+    the ordered lists and a spaced path truncated on replay — the same defect as
+    the steer path, one layer down.
+    """
+
+    @pytest.mark.asyncio
+    async def test_queued_message_carries_meta_to_the_drain(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        # No live ACP client -> steer is unavailable -> falls through to the queue.
+        slot._acp_client = None
+
+        spaced_dir = "/repo/my docs"
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": f"review [attached_dir 1] {spaced_dir}",
+                    "meta": {"dirs": [spaced_dir]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        assert slot._queue, "the message was not queued"
+        assert slot._queue[-1].get("meta", {}).get("dirs") == [spaced_dir], (
+            "queue entry dropped meta.dirs, so the drain cannot persist it"
+        )
+
+    def test_queue_append_omits_meta_key_when_absent(self, tmp_path, monkeypatch):
+        """An unattached message keeps the original 3-key queue shape."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        slot.queue_append("plain text")
+        assert set(slot._queue[-1]) == {"id", "content", "kind"}
+
+    def test_attachment_bearing_entry_is_never_merged(self, tmp_path, monkeypatch):
+        """Merging would put two marker index spaces under one metadata list.
+
+        `[attached_dir 1]` in the second message would resolve against the first
+        message's `meta.dirs`, so an attachment-bearing entry must drain alone.
+        """
+        from kiro_crew.dashboard.chat_utils import _dequeue_next_message
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        slot.queue_append("plain one")
+        slot.queue_append("plain two")
+        slot.queue_append("with folder [attached_dir 1] /repo/my docs", meta={"dirs": ["/repo/my docs"]})
+
+        msg, consumed = _dequeue_next_message(slot, merge_enabled=True)
+        assert len(consumed) == 2, "the merge must stop at the attachment-bearing entry"
+        assert "with folder" not in msg
+
+        msg2, consumed2 = _dequeue_next_message(slot, merge_enabled=True)
+        assert len(consumed2) == 1
+        assert consumed2[0]["meta"]["dirs"] == ["/repo/my docs"]
+
+
+class TestQueuedAppendMeta:
+    """The drain's metadata-selection rule.
+
+    Previously this logic was inline in ``chat_runner``'s drain block, which no
+    test reached — reverting it left every test green while spaced paths
+    truncated again after a queue drain. Extracted so the contract is directly
+    asserted here, with the call site guarded in test_chat_runner_drain below.
+    """
+
+    def test_single_user_item_carries_its_meta(self):
+        from kiro_crew.dashboard.chat_utils import queued_append_meta
+
+        item = {"id": "a", "content": "x", "kind": "", "meta": {"dirs": ["/repo/my docs"]}}
+        assert queued_append_meta([item]) == {"dirs": ["/repo/my docs"]}
+
+    def test_item_without_meta_yields_none(self):
+        from kiro_crew.dashboard.chat_utils import queued_append_meta
+
+        assert queued_append_meta([{"id": "a", "content": "x", "kind": ""}]) is None
+
+    def test_merged_items_yield_none(self):
+        """Two messages have two independent marker index spaces."""
+        from kiro_crew.dashboard.chat_utils import queued_append_meta
+
+        a = {"id": "a", "content": "x", "kind": "", "meta": {"dirs": ["/a"]}}
+        b = {"id": "b", "content": "y", "kind": ""}
+        assert queued_append_meta([a, b]) is None
+
+    def test_injections_never_inherit_meta(self):
+        """cron / sub-agent / recovery injections carry no attachments."""
+        from kiro_crew.dashboard.chat_utils import queued_append_meta
+
+        item = {"id": "a", "content": "x", "kind": "", "meta": {"dirs": ["/a"]}}
+        assert queued_append_meta([item], is_cron=True) is None
+        assert queued_append_meta([item], is_subagent=True) is None
+        assert queued_append_meta([item], is_recovery=True) is None
+
+    def test_drain_call_site_passes_meta_to_append(self):
+        """Guard the wiring: the drain must hand the result to slot.append.
+
+        The selection helper above is useless if the drain stops passing its
+        result through — which is exactly the regression that went unnoticed.
+        Static guard because the drain lives inside _run_chat's finally block.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner)
+        assert "_queued_meta = queued_append_meta(" in src, "drain must use the helper"
+        assert "meta=_queued_meta or None," in src, "drain must pass meta to slot.append"
+
+
+class TestQueueItemForDisplay:
+    """Slot-detail payloads must ship queue metadata, not just content.
+
+    Live ``queue_push`` delivery already carried the ordered lists, so a queued
+    attachment looked correct until the user RELOADED — the detail payload
+    projected ``{id, content}`` only, dropping the index space the markers
+    resolve against and truncating a path at its first space.
+    """
+
+    def test_meta_is_carried_through(self):
+        from kiro_crew.dashboard.chat_utils import queue_item_for_display
+
+        item = {"id": "q1", "content": "review [attached_dir 1] /repo/my docs",
+                "kind": "", "meta": {"dirs": ["/repo/my docs"]}}
+        out = queue_item_for_display(item)
+        assert out["id"] == "q1"
+        assert out["meta"] == {"dirs": ["/repo/my docs"]}
+
+    def test_meta_key_omitted_when_absent(self):
+        """Payload shape is unchanged for entries with no attachments."""
+        from kiro_crew.dashboard.chat_utils import queue_item_for_display
+
+        out = queue_item_for_display({"id": "q1", "content": "plain", "kind": ""})
+        assert "meta" not in out
+
+    def test_empty_meta_is_not_emitted(self):
+        from kiro_crew.dashboard.chat_utils import queue_item_for_display
+
+        out = queue_item_for_display({"id": "q1", "content": "plain", "kind": "", "meta": {}})
+        assert "meta" not in out
+
+    def test_content_is_redacted(self):
+        """The display projection still redacts, as before."""
+        from kiro_crew.dashboard.chat_utils import queue_item_for_display
+
+        out = queue_item_for_display(
+            {"id": "q1", "content": "token ghp_0123456789abcdef0123456789abcdef0123", "kind": ""}
+        )
+        assert "ghp_0123456789abcdef0123456789abcdef0123" not in out["content"]
+
+    def test_detail_call_sites_use_the_helper(self):
+        """Guard the wiring: all three slot-detail payloads must project via the
+        helper, or one of them silently regresses to dropping meta."""
+        import inspect
+
+        from kiro_crew.dashboard import chat_handlers
+
+        src = inspect.getsource(chat_handlers)
+        assert src.count("queue_item_for_display(q) for q in") == 3, (
+            "every slot-detail queue projection must use queue_item_for_display"
+        )
+        assert '{"id": q["id"], "content": _redact_for_display(q["content"])}' not in src, (
+            "a slot-detail payload still projects the meta-dropping dict literal"
+        )
+
+
+class TestQueuePushMeta:
+    """Both ``queue_push`` branches must broadcast the attachment lists.
+
+    ``content`` carries ``[attached_dir N] path`` markers whose N indexes
+    ``meta.dirs``. A ``queue_push`` without the lists leaves an open client on
+    its whitespace-bounded fallback scan, which truncates any path containing a
+    space — the queued card showed ``/repo/my`` until the user reloaded. There
+    are two independent emit sites (mid-turn queue, and idle-with-subagents
+    hold), so each needs its own assertion; the previous tests asserted only
+    that the message was queued.
+    """
+
+    @pytest.mark.asyncio
+    async def test_running_slot_queue_push_carries_meta(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        slot._acp_client = None  # no steer target -> falls through to the queue
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "look at [attached_dir 1] /repo/my docs",
+                    "meta": {"dirs": ["/repo/my docs"]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        pushes = [c.args[1] for c in state.broadcast_ws.call_args_list if c.args[0] == "queue_push"]
+        assert len(pushes) == 1, "expected exactly one queue_push"
+        assert pushes[0].get("meta") == {"dirs": ["/repo/my docs"]}, (
+            "queue_push dropped the attachment lists the marker indexes into"
+        )
+        assert slot._queue[0]["meta"] == {"dirs": ["/repo/my docs"]}
+
+    @pytest.mark.asyncio
+    async def test_subagent_hold_queue_push_carries_meta(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")  # idle: no task in flight
+        # Idle slot + running sub-agents takes the second queue branch.
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for.return_value = ["agent-1"]
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "also check [attached_file 1] /repo/my notes.txt",
+                    "meta": {"files": ["/repo/my notes.txt"]},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        pushes = [c.args[1] for c in state.broadcast_ws.call_args_list if c.args[0] == "queue_push"]
+        assert len(pushes) == 1, "expected exactly one queue_push"
+        assert pushes[0].get("meta") == {"files": ["/repo/my notes.txt"]}, (
+            "subagent-hold queue_push dropped the attachment lists"
+        )
+        assert slot._queue[0]["meta"] == {"files": ["/repo/my notes.txt"]}
+
+    @pytest.mark.asyncio
+    async def test_queue_push_omits_meta_key_when_no_attachments(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """Shape is unchanged for plain messages — no empty ``meta`` key."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        slot._acp_client = None
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat", json={"slot": "test", "message": "plain"})
+            assert resp.status == 200
+
+        pushes = [c.args[1] for c in state.broadcast_ws.call_args_list if c.args[0] == "queue_push"]
+        assert len(pushes) == 1
+        assert "meta" not in pushes[0]
+
+
+class TestSteerMetaCleanup:
+    """Parked steer metadata must not survive its steer.
+
+    ``_pending_steer_meta`` is a side table keyed by message TEXT. If an entry
+    outlives its steer, a LATER steer with identical text inherits the stale
+    attachment lists — the new message would render or resolve against paths the
+    user never attached to it. These branches were verified only by hand-revert,
+    so a regression would have left the suite green.
+    """
+
+    def test_settle_drops_meta_for_consumed_steers(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        msg = "review [attached_dir 1] /repo/my docs"
+        slot._pending_steers = [msg]
+        slot._pending_steer_meta = {msg: [{"dirs": ["/repo/my docs"]}]}
+
+        # kiro-cli's echo wraps each consumed steer in <user_message> blocks;
+        # settling parses those, so a bare string settles nothing.
+        _settle_consumed_steers(slot, f"<user_message>\n{msg}\n</user_message>")
+
+        assert slot._pending_steers == [], "the consumed steer should have settled"
+        assert msg not in slot._pending_steer_meta, (
+            "metadata for a consumed steer must not outlive it — a later identical "
+            "steer would inherit these attachment lists"
+        )
+
+    def test_identical_steers_keep_their_own_attachments(self, tmp_path, monkeypatch):
+        """Two identical steer texts with DIFFERENT attachments must not merge.
+
+        The side table is keyed by message text, so one dict per key let the second
+        registration overwrite the first — both were then requeued with the last
+        steer's metadata, pointing one card at the wrong folder. Occurrences are
+        stored as a list and consumed in order.
+        """
+        from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        msg = "check this"
+        slot._pending_steers = [msg, msg]
+        slot._pending_steer_meta = {msg: [{"dirs": ["/repo/a"]}, {"dirs": ["/repo/b"]}]}
+
+        _requeue_unconsumed_steers(state, slot)
+
+        metas = [item.get("meta") for item in slot._queue]
+        assert {"dirs": ["/repo/a"]} in metas, "first occurrence lost its own attachment"
+        assert {"dirs": ["/repo/b"]} in metas, "second occurrence lost its own attachment"
+        assert metas[0] != metas[1], "both requeued cards got the same metadata"
+
+    def test_settle_trims_to_the_number_still_pending(self, tmp_path, monkeypatch):
+        """One of two identical steers settling leaves exactly one parked entry."""
+        from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        msg = "same text"
+        slot._pending_steers = [msg, msg]
+        slot._pending_steer_meta = {msg: [{"dirs": ["/repo/a"]}, {"dirs": ["/repo/b"]}]}
+
+        _settle_consumed_steers(slot, f"<user_message>\n{msg}\n</user_message>")
+
+        assert slot._pending_steers == [msg]
+        assert len(slot._pending_steer_meta[msg]) == 1
+
+    def test_settle_keeps_meta_for_a_still_pending_steer(self, tmp_path, monkeypatch):
+        """Only settled entries are dropped; a steer still in flight keeps its meta."""
+        from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("test")
+        consumed = "first [attached_dir 1] /repo/a"
+        pending = "second [attached_dir 1] /repo/b"
+        slot._pending_steers = [consumed, pending]
+        slot._pending_steer_meta = {
+            consumed: [{"dirs": ["/repo/a"]}],
+            pending: [{"dirs": ["/repo/b"]}],
+        }
+
+        _settle_consumed_steers(slot, f"<user_message>\n{consumed}\n</user_message>")
+
+        assert slot._pending_steers == [pending]
+        assert consumed not in slot._pending_steer_meta
+        assert slot._pending_steer_meta[pending] == [{"dirs": ["/repo/b"]}], (
+            "an unconsumed steer lost its parked metadata"
+        )
+
+    def test_force_stop_clears_parked_meta(self):
+        """A hard kill discards steers, so their metadata must go too.
+
+        The escalation lives inline in the stop endpoint's `soft_pending` branch,
+        so this guards the pairing statically: the two clears must stay adjacent.
+        Without the second one a hard kill leaves metadata parked for text a later
+        identical steer could match.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_handlers
+
+        src = inspect.getsource(chat_handlers)
+        assert "slot._pending_steers.clear()\n        slot._pending_steer_meta.clear()" in src, (
+            "force-stop must clear the steer metadata side table alongside "
+            "_pending_steers — brittle by design: if these lines move, UPDATE "
+            "this guard, do not delete it"
+        )
+
+
+class TestUnconsumedSteerKeepsMeta:
+    """A steer the turn never consumed is degraded into a queue card.
+
+    That card must keep the ordered attachment lists, or the requeued message
+    keeps its markers and loses the paths — truncating at the first space when it
+    later drains.
+    """
+
+    def test_requeued_steer_carries_meta_onto_the_queue_card(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        msg = "review [attached_dir 1] /repo/my docs"
+        slot._pending_steers = [msg]
+        slot._pending_steer_meta = {msg: [{"dirs": ["/repo/my docs"]}]}
+
+        _requeue_unconsumed_steers(state, slot)
+
+        assert slot._queue, "the unconsumed steer was not requeued"
+        assert slot._queue[0]["meta"]["dirs"] == ["/repo/my docs"], (
+            "requeued steer card lost meta.dirs"
+        )
+        assert not slot._pending_steer_meta, "parked metadata must be drained"
+
+    def test_requeue_without_meta_is_unaffected(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        slot._pending_steers = ["plain steer"]
+
+        _requeue_unconsumed_steers(state, slot)
+
+        assert slot._queue[0]["content"] == "plain steer"
+        assert "meta" not in slot._queue[0], "no attachments means no meta key"
+
+    @pytest.mark.asyncio
+    async def test_steer_handler_parks_meta_before_the_await(self, tmp_path, monkeypatch, _patch_sel):
+        """Registration happens before the steer RPC's await, so the metadata
+        must be parked there too — a turn dying mid-write still needs it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        import inspect
+
+        from kiro_crew.dashboard import chat_handlers
+
+        src = inspect.getsource(chat_handlers)
+        register = src.index("slot._pending_steers.append(message)")
+        park = src.index("slot._pending_steer_meta.setdefault(message, []).append(")
+        await_at = src.index("await _client.steer(message)")
+        assert register < await_at, "registration must precede the await"
+        assert park < await_at, "metadata must be parked before the await"

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -78,6 +78,7 @@ def test_prompt_strips_non_image_attachment_before_truncation():
     prompt = _build_title_prompt([{"role": "user", "content": f"{attachment}\nreview this config"}])
 
     assert prompt is not None
+    # The basename is substituted but capped, so the caption still survives.
     assert "review this config" in prompt
     assert "attached_file" not in prompt
     assert "/uploads/" not in prompt
@@ -97,7 +98,9 @@ def test_prompt_strips_non_image_attachment_path_with_spaces_from_metadata():
 
     assert prompt is not None
     assert "summarize the findings" in prompt
-    assert "quarterly report final.txt" not in prompt
+    # The basename (with its spaces) is kept; the parent path is not.
+    assert "quarterly report final.txt" in prompt
+    assert "/Users/example/uploads/" not in prompt
 
 
 def test_title_text_bounds_source_scanning():
@@ -125,6 +128,7 @@ def test_prompt_strips_multiple_near_limit_attachments_before_text_cap():
     prompt = _build_title_prompt([{"role": "user", "content": content, "meta": {"files": paths}}])
 
     assert prompt is not None
+    # Each substituted label is capped, so five of them cannot crowd out the text.
     assert "summarize the quarterly findings" in prompt
     assert "attached_file" not in prompt
     assert "/tmp/" not in prompt
@@ -160,8 +164,10 @@ def test_prompt_strips_mixed_attachments_and_keeps_caption():
 
     assert prompt is not None
     assert "compare these outputs" in prompt
+    # Images are still dropped entirely; file attachments keep their basename.
     assert "screenshot.png" not in prompt
-    assert "results.csv" not in prompt
+    assert "results.csv" in prompt
+    assert "/tmp/results.csv" not in prompt
 
 
 def test_prompt_preserves_escaped_and_code_quoted_markdown_images():

--- a/test/test_chat_title_dirs.py
+++ b/test/test_chat_title_dirs.py
@@ -1,0 +1,269 @@
+"""Tests for folder-reference stripping in auto-title text (chat_title)."""
+
+from __future__ import annotations
+
+from kiro_crew.dashboard.chat_title import (
+    _TITLE_MAX_ATTACHMENT_FILES,
+    _TITLE_MAX_ATTACHMENT_PATH_LENGTH,
+    _TITLE_SOURCE_SCAN_LIMIT,
+    _TITLE_TEXT_LIMIT,
+    _build_title_prompt,
+    _fallback_title_from_messages,
+    _message_dir_paths,
+    _title_text,
+)
+
+DIR = "/repo/src/pages"
+FILE = "/repo/data.csv"
+
+
+class TestTitleTextDirTokens:
+    def test_strips_standalone_dir_token(self):
+        out = _title_text(f"[attached_dir 1] {DIR}", (), (DIR,))
+        assert "attached_dir" not in out
+        assert DIR not in out
+        # The basename survives: an attachment-only message would otherwise have
+        # no content left for the titler to name.
+        assert out == "pages"
+
+    def test_keeps_surrounding_user_text(self):
+        out = _title_text(f"review [attached_dir 1] {DIR} today", (), (DIR,))
+        assert "attached_dir" not in out
+        assert out == "review pages today"
+
+    def test_strips_dir_token_without_metadata(self):
+        """History replay: no meta, so the whitespace fallback must handle it."""
+        out = _title_text(f"review [attached_dir 1] {DIR} today")
+        assert "attached_dir" not in out
+        assert DIR not in out
+        assert out == "review pages today"
+
+    def test_strips_both_marker_families(self):
+        content = f"look at [attached_file 1] {FILE} and [attached_dir 1] {DIR} please"
+        out = _title_text(content, (FILE,), (DIR,))
+        assert "attached_file" not in out
+        assert "attached_dir" not in out
+        assert FILE not in out
+        assert DIR not in out
+        assert out == "look at data.csv and pages please"
+
+    def test_same_numbered_markers_resolve_against_own_lists(self):
+        """[attached_file 1] and [attached_dir 1] index different tuples."""
+        content = f"[attached_file 1] {FILE} [attached_dir 1] {DIR} end"
+        out = _title_text(content, (FILE,), (DIR,))
+        assert out == "data.csv pages end"
+
+    def test_strips_dir_path_containing_spaces(self):
+        spaced = "/repo/my docs"
+        out = _title_text(f"check [attached_dir 1] {spaced} now", (), (spaced,))
+        assert "attached_dir" not in out
+        assert "/repo/my docs" not in out
+        # The basename keeps its internal space; only the parent path is dropped.
+        assert out == "check my docs now"
+
+    def test_file_only_message_unaffected(self):
+        out = _title_text(f"see [attached_file 1] {FILE} ok", (FILE,))
+        assert "attached_file" not in out
+        assert out == "see data.csv ok"
+
+    def test_plain_text_unaffected(self):
+        assert _title_text("just a normal message") == "just a normal message"
+
+    def test_unknown_dir_index_falls_back_to_whitespace_capture(self):
+        """A token numbered beyond the tuple still gets stripped."""
+        out = _title_text(f"a [attached_dir 9] {DIR} b", (), (DIR,))
+        assert "attached_dir" not in out
+        assert DIR not in out
+
+
+class TestMessageDirPaths:
+    def test_reads_meta_dirs_in_order(self):
+        msg = {"meta": {"dirs": [DIR, "/repo/docs"]}}
+        assert _message_dir_paths(msg) == (DIR, "/repo/docs")
+
+    def test_missing_meta_returns_empty(self):
+        assert _message_dir_paths({}) == ()
+
+    def test_non_dict_meta_returns_empty(self):
+        assert _message_dir_paths({"meta": "nope"}) == ()
+
+    def test_non_list_dirs_returns_empty(self):
+        assert _message_dir_paths({"meta": {"dirs": "nope"}}) == ()
+
+    def test_caps_the_number_of_dirs(self):
+        many = [f"/repo/d{i}" for i in range(_TITLE_MAX_ATTACHMENT_FILES + 5)]
+        assert len(_message_dir_paths({"meta": {"dirs": many}})) == _TITLE_MAX_ATTACHMENT_FILES
+
+    def test_blanks_overlong_paths_preserving_index(self):
+        long_path = "/repo/" + "x" * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 10)
+        got = _message_dir_paths({"meta": {"dirs": [long_path, DIR]}})
+        assert got == ("", DIR), "index order must be preserved so token N still resolves"
+
+    def test_blanks_non_string_entries(self):
+        assert _message_dir_paths({"meta": {"dirs": [None, DIR]}}) == ("", DIR)
+
+
+class TestTitlePromptWithDirs:
+    def test_prompt_body_has_no_dir_marker(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": f"summarize [attached_dir 1] {DIR} for me",
+                "meta": {"dirs": [DIR]},
+            },
+        ]
+        prompt = _build_title_prompt(msgs)
+        assert prompt is not None
+        assert "attached_dir" not in prompt
+        assert DIR not in prompt
+        assert "summarize" in prompt
+
+    def test_dir_only_message_yields_the_folder_name(self):
+        """A folder-only message is titled from the folder name.
+
+        It previously produced no transcript at all, so the titler had nothing to
+        name and answered SKIP.
+        """
+        msgs = [
+            {"role": "user", "content": f"[attached_dir 1] {DIR}", "meta": {"dirs": [DIR]}},
+        ]
+        prompt = _build_title_prompt(msgs)
+        assert prompt is not None
+        assert "user: pages" in prompt
+        assert DIR not in prompt
+
+
+class TestTitleScanBudgetCoversBothFamilies:
+    def test_scan_limit_budgets_for_two_families(self):
+        """Each family gets its own 20-entry allowance, so the budget covers both.
+
+        A one-family budget would let a message carrying long file AND folder
+        paths be truncated before its user text.
+        """
+        per_family = _TITLE_MAX_ATTACHMENT_FILES * (_TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32)
+        assert _TITLE_SOURCE_SCAN_LIMIT >= _TITLE_TEXT_LIMIT + 2 * per_family
+
+    def test_user_text_survives_a_full_pair_of_attachment_families(self):
+        """Max-length paths in both families must not crowd out the user text."""
+        long_dirs = [f"/d{i}/" + "x" * 3_000 for i in range(_TITLE_MAX_ATTACHMENT_FILES)]
+        long_files = [f"/f{i}/" + "y" * 3_000 for i in range(_TITLE_MAX_ATTACHMENT_FILES)]
+        tokens = "\n".join(
+            [f"[attached_file {i + 1}] {p}" for i, p in enumerate(long_files)]
+            + [f"[attached_dir {i + 1}] {p}" for i, p in enumerate(long_dirs)]
+        )
+        content = f"{tokens}\nplease summarize this"
+        text = _title_text(content, tuple(long_files), tuple(long_dirs))
+        assert "please summarize this" in text
+        assert "attached_file" not in text
+        assert "attached_dir" not in text
+        # Full paths are still excluded; only basenames are substituted.
+        assert long_dirs[0] not in text
+        assert long_files[0] not in text
+
+    def test_a_path_containing_the_other_family_marker_is_not_mangled(self):
+        """Marker families must not rescan each other's substituted output.
+
+        Each pass replaces its marker+path with the attachment's BASENAME. If a
+        basename itself contains the literal text of the other family's marker,
+        the second pass scans the first pass's output, finds that substring, and
+        mangles it — the same rescan defect the send-path serializer had.
+
+        A directory name may legitimately contain `[`, `]` and spaces on both
+        POSIX and Windows, so this is reachable from a real filesystem.
+        """
+        weird_file = "/repo/[attached_dir 1] notes"
+        content = f"[attached_file 1] {weird_file} summarize this"
+        text = _title_text(content, (weird_file,), ())
+        assert "summarize this" in text, "the user's text must survive"
+        # The file pass substitutes the basename "[attached_dir 1] notes". The
+        # folder pass must NOT then treat that substituted text as one of its own
+        # markers and eat part of it. Asserting only the absence of
+        # "attached_dir" would pass for the wrong reason — the mangling itself
+        # removes the substring — so assert the label survives whole.
+        assert "[attached_dir 1] notes" in text, (
+            "the folder pass rescanned and mangled the file pass's substituted basename"
+        )
+        assert "attached_file" not in text
+
+
+class TestFallbackTitleWithDirs:
+    def test_fallback_title_strips_the_folder_marker(self):
+        """The fallback path (LLM titler unavailable) must strip dir markers too.
+
+        It previously passed only the file paths, so a folder mention surfaced
+        raw as "Tell me about [attached_dir 1] /repo/docs" in the chat title.
+        """
+        msgs = [
+            {
+                "role": "user",
+                "content": f"Tell me about [attached_dir 1] {DIR}",
+                "meta": {"dirs": [DIR]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_dir" not in title
+        assert DIR not in title
+        assert title.startswith("Tell me about")
+
+    def test_fallback_title_strips_both_families(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": f"compare [attached_file 1] {FILE} with [attached_dir 1] {DIR}",
+                "meta": {"files": [FILE], "dirs": [DIR]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_file" not in title
+        assert "attached_dir" not in title
+        assert "compare" in title
+
+    def test_fallback_title_strips_a_spaced_folder_path(self):
+        spaced = "/repo/my docs"
+        msgs = [
+            {
+                "role": "user",
+                "content": f"summarize [attached_dir 1] {spaced} please",
+                "meta": {"dirs": [spaced]},
+            },
+        ]
+        title = _fallback_title_from_messages(msgs)
+        assert "attached_dir" not in title
+        assert spaced not in title
+        assert "summarize" in title
+        # The fallback drops attachment names entirely (only the LLM prompt keeps
+        # them), so no part of the spaced path may survive. Without the ordered
+        # dir paths the whitespace fallback would stop at the space and leak the
+        # tail "docs" into the title.
+        assert "docs" not in title, "the spaced path tail leaked into the title"
+
+
+class TestAttachmentLabelBudget:
+    def test_many_folder_labels_do_not_crowd_out_the_caption(self):
+        """The shared label budget protects the user's own text.
+
+        Substituting a name per attachment is only safe while the total stays
+        bounded: the transcript line handed to the titler is itself capped, so
+        20 long folder names would push the caption out entirely.
+        """
+        dirs = [f"/repo/{'d' * 30}{i}" for i in range(20)]
+        content = (
+            " ".join(f"[attached_dir {i + 1}] {p}" for i, p in enumerate(dirs))
+            + " please summarize these"
+        )
+        text = _title_text(content, (), tuple(dirs))
+        assert "please summarize these" in text
+        assert "attached_dir" not in text
+        assert len(text) < 400, "labels consumed an unbounded share of the line"
+
+    def test_colliding_folder_names_are_disambiguated(self):
+        """Three folders all named docs must not read as "docs and docs and docs"."""
+        dirs = ["/repo/docs", "/repo/website/docs", "/repo/src/kiro_crew/docs"]
+        content = (
+            f"tell me about [attached_dir 1] {dirs[0]} and [attached_dir 2] {dirs[1]}"
+            f" and [attached_dir 3] {dirs[2]}"
+        )
+        text = _title_text(content, (), tuple(dirs))
+        assert "repo/docs" in text
+        assert "website/docs" in text
+        assert "kiro_crew/docs" in text

--- a/test/test_queue_edit.py
+++ b/test/test_queue_edit.py
@@ -28,7 +28,7 @@ class TestQueueEditHelper:
         slot.queue_append("keep")
         qid = slot.queue_append("old text")
         slot.queue_append("also keep")
-        assert slot.queue_edit_by_id(qid, "new text") is True
+        assert slot.queue_edit_by_id(qid, "new text") == "new text"
         assert [q["content"] for q in slot._queue] == ["keep", "new text", "also keep"]
 
     def test_edit_by_id_preserves_order_and_id(self):
@@ -41,12 +41,145 @@ class TestQueueEditHelper:
     def test_edit_by_id_not_found(self):
         slot = _ChatSlot("s1")
         slot.queue_append("msg")
-        assert slot.queue_edit_by_id("nonexistent", "x") is False
+        assert slot.queue_edit_by_id("nonexistent", "x") is None
         assert slot._queue[0]["content"] == "msg"
 
     def test_edit_by_id_empty_queue(self):
         slot = _ChatSlot("s1")
-        assert slot.queue_edit_by_id("anything", "x") is False
+        assert slot.queue_edit_by_id("anything", "x") is None
+
+    def test_edit_drops_attachment_meta(self):
+        """An edit discards the item's attachment metadata.
+
+        ``content`` (the ``[attached_file N]`` / ``[attached_dir N]`` markers) and
+        ``meta`` (the ordered path lists those markers index into) are generated
+        together at send time. An edit rewrites only ``content``, so keeping the
+        old ``meta`` desynchronizes the pair: replacing the auto-selected text
+        removes the marker, so the model never receives the attachment, while the
+        surviving metadata still renders an attachment card in history — an
+        attachment that was never sent.
+        """
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append(
+            "look at [attached_dir 1] /repo/my docs",
+            meta={"dirs": ["/repo/my docs"]},
+        )
+        assert slot.queue_edit_by_id(qid, "never mind, just say hi") == "never mind, just say hi"
+        item = slot._queue[0]
+        assert item["content"] == "never mind, just say hi"
+        assert "meta" not in item, "stale attachment metadata survived the edit"
+
+    def test_edit_strips_markers_the_dropped_meta_backed(self):
+        """An edit that KEEPS the marker text must still lose the marker.
+
+        The sibling test edits the marker away, so dropping ``meta`` is enough.
+        When the user edits around the marker instead — fixing a typo, or the
+        client echoing the served content back — the marker survived into a
+        message with no ``meta``. Two failures followed: the runner resolves
+        markers from the text, so the attachment the user thought they dropped
+        was still sent; and with the index space gone a path containing a space
+        rendered truncated at the first space.
+        """
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append(
+            "look at [attached_dir 1] /repo/my docs",
+            meta={"dirs": ["/repo/my docs"]},
+        )
+        assert slot.queue_edit_by_id(qid, "look at [attached_dir 1] /repo/my docs please") == "look at please"
+        item = slot._queue[0]
+        assert "meta" not in item
+        assert "attached_dir" not in item["content"], "marker outlived the metadata backing it"
+        assert "/repo/my docs" not in item["content"]
+        assert item["content"] == "look at please"
+
+    def test_edit_keeps_markers_it_does_not_own(self):
+        """Only the indices present in the dropped meta are stripped."""
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("a [attached_dir 1] /d", meta={"dirs": ["/d"]})
+        # Index 2 was never in this item's meta, so it is not ours to remove.
+        assert slot.queue_edit_by_id(qid, "a [attached_dir 1] /d b [attached_dir 2] /other") == "a b [attached_dir 2] /other"
+        assert slot._queue[0]["content"] == "a b [attached_dir 2] /other"
+
+    def test_attachment_only_edit_is_rejected(self):
+        """An edit that strips to nothing must not be stored.
+
+        The endpoint validates non-empty BEFORE stripping, so "[attached_dir 1]
+        /path" passed validation and then stripped to "". The queue kept an empty
+        entry, which drains as a turn carrying no request at all — the user's
+        prompt silently vanishes. Returns "" (not None) so the caller can tell
+        this apart from an unknown id and answer 400 rather than 404.
+        """
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append(
+            "[attached_dir 1] /repo/my docs", meta={"dirs": ["/repo/my docs"]}
+        )
+        assert slot.queue_edit_by_id(qid, "[attached_dir 1] /repo/my docs") == ""
+        # Queue is left untouched, not emptied.
+        assert slot._queue[0]["content"] == "[attached_dir 1] /repo/my docs"
+        assert slot._queue[0]["meta"] == {"dirs": ["/repo/my docs"]}
+
+    def test_edit_survives_non_list_meta(self):
+        """Untrusted meta shapes must not break the edit.
+
+        `meta` originates in client JSON, so `dirs` can be any type. A bare string
+        would iterate as characters; a dict/int would raise. Either way the edit
+        must still succeed and simply not strip anything.
+        """
+        for bad in ("not-a-list", 42, {"0": "x"}, None):
+            slot = _ChatSlot("s1")
+            qid = slot.queue_append("hello there", meta={"dirs": bad})
+            assert slot.queue_edit_by_id(qid, "hello there") == "hello there"
+            assert "meta" not in slot._queue[0]
+
+    def test_edit_ignores_non_string_path_members(self):
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("a [attached_dir 2] /d", meta={"dirs": [None, "/d"]})
+        assert slot.queue_edit_by_id(qid, "a [attached_dir 2] /d") == "a"
+
+    def test_edit_does_not_strip_a_longer_path_sharing_the_prefix(self):
+        """The marker must match a whole path, not a prefix of a longer one.
+
+        With meta owning `/d`, an edit mentioning `[attached_dir 1] /dossier`
+        stripped the `/d` and left `ossier` — silent message corruption.
+        """
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("seed", meta={"dirs": ["/d"]})
+        assert (
+            slot.queue_edit_by_id(qid, "see [attached_dir 1] /dossier now")
+            == "see [attached_dir 1] /dossier now"
+        )
+
+    def test_edit_preserves_indentation_outside_the_marker(self):
+        """Stripping must not reformat text away from the marker.
+
+        A global ``[ \\t]{2,}`` collapse plus per-line strip rewrote the whole
+        message: a pasted code snippet lost its indentation and aligned columns
+        collapsed to single spaces. Only whitespace hugging the removed marker
+        may change.
+        """
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("seed", meta={"dirs": ["/d"]})
+        code = "def f():\n    x=1\n    [attached_dir 1] /d\n    y=2"
+        assert slot.queue_edit_by_id(qid, code) == "def f():\n    x=1\n    y=2"
+
+        slot2 = _ChatSlot("s2")
+        qid2 = slot2.queue_append("seed", meta={"dirs": ["/d"]})
+        assert (
+            slot2.queue_edit_by_id(qid2, "col1    col2 [attached_dir 1] /d") == "col1    col2"
+        )
+
+    def test_edit_without_meta_leaves_no_meta_key(self):
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("plain prompt")
+        assert slot.queue_edit_by_id(qid, "edited prompt") == "edited prompt"
+        assert "meta" not in slot._queue[0]
+
+    def test_failed_edit_leaves_meta_intact(self):
+        """A non-matching edit must not strip an untouched item's metadata."""
+        slot = _ChatSlot("s1")
+        slot.queue_append("x", meta={"dirs": ["/a"]})
+        assert slot.queue_edit_by_id("nope", "y") is None
+        assert slot._queue[0]["meta"] == {"dirs": ["/a"]}
 
     def test_edit_by_id_duplicate_content(self):
         """Two items with same content — only the matching ID is edited."""
@@ -108,6 +241,58 @@ def _make_app(state):
 
 
 class TestQueueEditEndpoint:
+    @pytest.mark.asyncio
+    async def test_edit_echoes_stored_text_not_submitted_text(self):
+        """Queue, placeholder, broadcast and response must all agree.
+
+        The strip happens server-side, so echoing the SUBMITTED text left every
+        client rendering an `[attached_dir N]` marker the queued prompt no longer
+        contained — the queue held the stripped text while the UI showed the
+        attachment. All four consumers now use the stored text.
+        """
+        state = _make_state()
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("chat-1")
+        qid = slot.queue_append(
+            "look at [attached_dir 1] /repo/my docs", meta={"dirs": ["/repo/my docs"]}
+        )
+        slot.append("queued", "look at [attached_dir 1] /repo/my docs", json.dumps({"queue_id": qid}))
+
+        with patch("kiro_crew.sel.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.patch(
+                    f"/api/chat/slots/chat-1/queue/{qid}",
+                    json={"content": "look at [attached_dir 1] /repo/my docs please"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert "attached_dir" not in data["content"], "response echoed the stripped marker"
+        assert data["content"] == "look at please"
+        assert slot._queue[0]["content"] == "look at please"
+        queued = [m for m in slot.messages if m.get("role") == "queued"]
+        assert queued[0]["content"] == "look at please", "placeholder kept the marker"
+        edits = [c.args[1] for c in state.broadcast_ws.call_args_list if c.args[0] == "queue_edit"]
+        assert len(edits) == 1
+        assert "attached_dir" not in edits[0]["content"], "broadcast kept the marker"
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_edit_returns_400(self):
+        state = _make_state()
+        slot = state.get_or_create_slot("chat-1")
+        qid = slot.queue_append("[attached_dir 1] /d", meta={"dirs": ["/d"]})
+
+        with patch("kiro_crew.sel.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.patch(
+                    f"/api/chat/slots/chat-1/queue/{qid}", json={"content": "[attached_dir 1] /d"}
+                )
+                # 400 (bad edit), not 404 (missing item) — the item exists.
+                assert resp.status == 400
+        assert slot._queue[0]["content"] == "[attached_dir 1] /d"
+
     @pytest.mark.asyncio
     async def test_edit_updates_queue_and_messages(self):
         state = _make_state()

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -862,8 +862,12 @@ export const api = {
   // Mid-turn steer: inject into the RUNNING turn instead of queueing. Fire-and-forget
   // JSON response ({ok, steered}); the backend falls back to queue if steer is
   // unavailable so the text is never dropped.
-  steerChat: (message: string, slot?: string) =>
-    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true }) }).then(j),
+  // `meta` carries the ordered attachment lists (files/dirs). The server
+  // persists them on the steered history entry, so a path containing a space
+  // still resolves after a reload instead of being truncated by the
+  // content-scan fallback.
+  steerChat: (message: string, slot?: string, meta?: Record<string, unknown>) =>
+    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true, ...(meta ? { meta } : {}) }) }).then(j),
   sessionsHealth: () => fetch('/api/sessions/health').then(j),
   // Knowledge
   knowledgeSearch: (q: string) => get(`/api/knowledge/search-for-context?q=${encodeURIComponent(q)}`).then(j),

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -413,9 +413,17 @@ export function useWebSocket() {
             // target slot's transcript. Uses appendSlotMessage so the bubble
             // appears whether or not the slot is currently active (background
             // tabs). Persisted server-side — survives page reload.
+            //
+            // Consume the server's `meta` (the redacted attachment lists plus
+            // the server-set `steer` flag) rather than hardcoding `{steer:true}`:
+            // the ordered `files`/`dirs` lists are what let a path containing a
+            // space render losslessly, so a second open tab would otherwise
+            // fall back to the whitespace scan and truncate it until reload.
+            // `steer: true` is re-asserted locally so the bubble still styles
+            // as a steer even against an older backend that sends no meta.
             dispatch(appendSlotMessage({
               slot: (data as { slot?: string }).slot || store.getState().chat.activeSlot || '',
-              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { steer: true }, ts: (data as { ts?: string }).ts },
+              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { ...((data as { meta?: Record<string, unknown> }).meta || {}), steer: true }, ts: (data as { ts?: string }).ts },
             }))
             break
           case 'queue_cancel':

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -43,7 +43,7 @@ import ThinkingBlock from './chat/ThinkingBlock'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
+import { parseFiles, parseDirs, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments, findUnreferencedDirs, stripAttachmentMarkers, metaPathList } from '../utils/fileTokens'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
@@ -100,6 +100,7 @@ import ChatSidebar, { SIDEBAR_MIN, SIDEBAR_MAX } from './ChatSidebar'
 import { toSlug } from '../utils/shareUrl'
 import { DRAFT_SAVE_DEBOUNCE_MS, loadDrafts, saveDrafts as persistDrafts, setDraft } from '../utils/chatDrafts'
 import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } from '../utils/chatFileDrafts'
+import { loadDirDrafts, saveDirDrafts as persistDirDrafts, setDirDraft } from '../utils/chatDirDrafts'
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { findPrevUserMsgDisplayIdx } from '../utils/findPrevUserMsgDisplayIdx'
 import {
@@ -113,7 +114,7 @@ import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { BookOpen, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, PanelRight, Paperclip } from 'lucide-react'
+import { BookOpen, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, ArrowUp, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, PanelRight, Paperclip, Folder } from 'lucide-react'
 
 import InfoTip from '../components/InfoTip'
 import { FileCard } from '../components/FileCard'
@@ -305,12 +306,18 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
   // source of truth; token N indexes the original list, not image-filtered).
   const orderedFiles = parseFiles(text, meta)
   const unreferenced = orderedFiles.length ? findUnreferencedAttachments(text, orderedFiles) : []
-  if (unreferenced.length) {
+  const orderedDirs = parseDirs(text, meta)
+  const unreferencedDirs = orderedDirs.length ? findUnreferencedDirs(text, orderedDirs) : []
+  if (unreferenced.length || unreferencedDirs.length) {
     const labels = buildFileLabels(unreferenced)
+    const dirLabels = buildFileLabels(unreferencedDirs)
     out.push(
       <div key="msg-cards" className="flex flex-col gap-1.5 mt-1">
         {unreferenced.map((p, i) => (
           <FileAttachmentCard key={`msg-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
+        ))}
+        {unreferencedDirs.map((p, i) => (
+          <DirAttachmentCard key={`msg-d${i}`} fullPath={p} label={dirLabels.get(p) || p} />
         ))}
       </div>,
     )
@@ -323,7 +330,8 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
  *  whitespace-preserving span (no markdown). */
 function renderInlineSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string) {
   const parsedFiles = parseFiles(content, meta)
-  if (!parsedFiles.length) {
+  const parsedDirs = parseDirs(content, meta)
+  if (!parsedFiles.length && !parsedDirs.length) {
     return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
   }
   // Inline-flow variant (adjacent to a paste chip): keep everything inline.
@@ -331,18 +339,23 @@ function renderInlineSegment(content: string, meta: Record<string, unknown> | un
   // standalone-token upload in this segment also renders as an inline chip
   // appended to it (this path can't host block cards without breaking the
   // inline flow). Never-referenced attachments are handled once at message
-  // level. Pass the ORIGINAL ordered list so token indices line up.
-  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
-  if (!mentionMap.size && !cardPaths.length) {
+  // level. Pass the ORIGINAL ordered lists so token indices line up.
+  const { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels } = resolveFileSegment(content, parsedFiles, parsedDirs)
+  if (!mentionMap.size && !dirMentionMap.size && !cardPaths.length && !dirCardPaths.length) {
     return <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>{display}</span>
   }
+  const dirLabels = buildFileLabels(dirCardPaths)
 
+  // Both families are split out of the text in one pass, but only file tokens
+  // resolve to a clickable chip: a folder has nothing to open in the viewer.
   const keys = [...mentionMap.keys()].slice(0, 20)
-  const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const dirKeys = [...dirMentionMap.keys()].slice(0, 20)
+  const tokPattern = [...keys, ...dirKeys].map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const parts = tokPattern
     ? display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
     : [display]
   const chipCls = 'inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors'
+  const dirChipCls = 'inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono'
   return (
     <span key={keyBase} style={{ whiteSpace: 'pre-wrap' }}>
       {parts.map((part, i) => {
@@ -353,10 +366,19 @@ function renderInlineSegment(content: string, meta: Record<string, unknown> | un
             <Clickable key={`${keyBase}-f${i}`} className={chipCls} title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
           )
         }
+        const dirPath = tok && dirMentionMap.get(tok)
+        if (dirPath) {
+          return <span key={`${keyBase}-fd${i}`} className={dirChipCls} title={dirPath}>@{tok}</span>
+        }
         return <span key={`${keyBase}-p${i}`}>{part}</span>
       })}
       {cardPaths.map((p, i) => (
         <Clickable key={`${keyBase}-uc${i}`} className={chipCls} title={p} onClick={() => onFileOpen(p)} aria-label={`Open file ${p}`}>@{labels.get(p) || p}</Clickable>
+      ))}
+      {/* Folder chips: not clickable — a directory has nothing to open in the
+          file viewer, so this is a label, not a link. */}
+      {dirCardPaths.map((p, i) => (
+        <span key={`${keyBase}-ud${i}`} className={dirChipCls} title={p}>@{(dirLabels.get(p) || p)}/</span>
       ))}
     </span>
   )
@@ -380,6 +402,21 @@ function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string;
   )
 }
 
+/** Block card for a folder reference. Visually distinct from a file card: a
+ *  folder is a path handed to the agent, not an upload, and there is nothing to
+ *  open in the file viewer, so it is not clickable. */
+function DirAttachmentCard({ fullPath, label }: { fullPath: string; label: string }) {
+  return (
+    <div
+      className="flex items-center gap-2.5 max-w-full bg-card border border-border rounded-lg px-3 py-2 text-sm text-text animate-scale-in"
+      title={fullPath}
+    >
+      <Folder size={15} className="shrink-0 text-muted" aria-label="Folder" />
+      <span className="font-medium truncate">{label}/</span>
+    </div>
+  )
+}
+
 /** File-card + markdown rendering for a text segment (no paste tokens inside).
  *
  *  Attachment display is resolved by the shared resolveFileSegment helper
@@ -393,16 +430,18 @@ function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string;
  *  Images keep their inline `![image](path)` markdown and are excluded here. */
 function renderFileSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string) {
   const parsedFiles = parseFiles(content, meta)
+  const parsedDirs = parseDirs(content, meta)
 
   // No attachments — plain markdown (bold, code, links, etc.).
   // softBreaks: preserve Shift+Enter line breaks as <br> (see MarkdownRenderer).
-  if (!parsedFiles.length) {
+  if (!parsedFiles.length && !parsedDirs.length) {
     return <MarkdownRenderer content={content} softBreaks />
   }
 
-  // Pass the ORIGINAL ordered list (images included) so [attached_file N] token
-  // indices line up; resolveFileSegment filters images out of its output.
-  const { display, mentionMap, cardPaths, labels } = resolveFileSegment(content, parsedFiles)
+  // Pass the ORIGINAL ordered lists (images included) so [attached_file N] and
+  // [attached_dir N] token indices line up; each marker numbers into its own
+  // list. resolveFileSegment filters images out of its output.
+  const { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels } = resolveFileSegment(content, parsedFiles, parsedDirs)
 
   // renderFileSegment handles the WHOLE message (non-paste path), so every
   // attachment belongs to this segment. Cards = standalone-upload tokens in the
@@ -415,17 +454,27 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
     ...cardPaths,
     ...findUnreferencedAttachments(display, parsedFiles).filter(p => !carded.has(p)),
   ]
+  const cardedDirs = new Set(dirCardPaths)
+  const allDirCardPaths = [
+    ...dirCardPaths,
+    ...findUnreferencedDirs(display, parsedDirs).filter(p => !cardedDirs.has(p)),
+  ]
+  const dirLabels = buildFileLabels(allDirCardPaths)
 
-  const cards = allCardPaths.length ? (
+  const cards = allCardPaths.length || allDirCardPaths.length ? (
     <div key={`${keyBase}-cards`} className="flex flex-col gap-1.5 mt-1 first:mt-0">
       {allCardPaths.map((p, i) => (
         <FileAttachmentCard key={`${keyBase}-c${i}`} fullPath={p} label={labels.get(p) || p} onFileOpen={onFileOpen} />
       ))}
+      {allDirCardPaths.map((p, i) => (
+        <DirAttachmentCard key={`${keyBase}-d${i}`} fullPath={p} label={dirLabels.get(p) || p} />
+      ))}
     </div>
   ) : null
 
-  // No inline @-mentions: caption (if any) is plain markdown, then the cards.
-  if (!mentionMap.size) {
+  // No inline @-mentions of either family: caption (if any) is plain markdown,
+  // then the cards.
+  if (!mentionMap.size && !dirMentionMap.size) {
     const caption = display.trim()
     return <>{caption ? <MarkdownRenderer key={`${keyBase}-cap`} content={caption} softBreaks /> : null}{cards}</>
   }
@@ -438,7 +487,8 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   // literal text — a rare combination, same trade-off as renderInlineSegment.
   // Cap tokens to prevent ReDoS from many alternations.
   const keys = [...mentionMap.keys()].slice(0, 20)
-  const tokPattern = keys.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const dirKeys = [...dirMentionMap.keys()].slice(0, 20)
+  const tokPattern = [...keys, ...dirKeys].map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const parts = display.split(new RegExp(`(@(?:${tokPattern}))(?=\\s|$)`, 'g'))
   const body = (
     <span key={`${keyBase}-body`} style={{ whiteSpace: 'pre-wrap' }}>
@@ -449,6 +499,15 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
           return (
             <Clickable key={`${keyBase}-f${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono cursor-pointer hover:bg-accent/25 transition-colors"
               title={fullPath} onClick={() => onFileOpen(fullPath)} aria-label={`Open file ${fullPath}`}>@{tok}</Clickable>
+          )
+        }
+        // A folder chip is a label, not a link: the file viewer cannot open a
+        // directory, so it gets no click handler and no cursor affordance.
+        const dirPath = tok && dirMentionMap.get(tok)
+        if (dirPath) {
+          return (
+            <span key={`${keyBase}-fd${i}`} className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded bg-accent/15 text-accent text-[12px] font-mono"
+              title={dirPath}>@{tok}</span>
           )
         }
         return part ? <span key={`${keyBase}-p${i}`}>{part}</span> : null
@@ -585,13 +644,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   if (drafts.current === null) drafts.current = loadDrafts()
   const fileDrafts = useRef<Record<string, string[]>>(null!)
   if (fileDrafts.current === null) fileDrafts.current = loadFileDrafts()
+  // Per-slot staged folder references, persisted alongside file attachments so a
+  // picked folder neither vanishes on slot switch nor leaks into another slot.
+  const dirDrafts = useRef<Record<string, string[]>>(null!)
+  if (dirDrafts.current === null) dirDrafts.current = loadDirDrafts()
   // Per-slot collapsed-paste blocks backing the `[ Paste #N · M lines ]` tokens
   // in `input`. Persisted (localStorage, same TTL as text drafts) so the chip
   // survives slot switches / refresh instead of degrading to literal text.
   const pasteDrafts = useRef<Record<string, PasteBlock[]>>(null!)
   if (pasteDrafts.current === null) pasteDrafts.current = loadPasteDrafts()
   const saveDraftsTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const saveDrafts = useCallback(() => { persistDrafts(drafts.current); persistFileDrafts(fileDrafts.current); persistPasteDrafts(pasteDrafts.current) }, [])
+  const saveDrafts = useCallback(() => { persistDrafts(drafts.current); persistFileDrafts(fileDrafts.current); persistDirDrafts(dirDrafts.current); persistPasteDrafts(pasteDrafts.current) }, [])
   const saveDraftsDebounced = useCallback(() => {
     if (saveDraftsTimer.current) clearTimeout(saveDraftsTimer.current)
     saveDraftsTimer.current = setTimeout(() => { saveDraftsTimer.current = null; saveDrafts() }, DRAFT_SAVE_DEBOUNCE_MS)
@@ -722,7 +785,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // Mid-turn steer is a POST write, so it goes through useMutation for
   // consistent error/loading-state handling (fire-and-forget: no onSuccess).
   const steerMutation = useMutation({
-    mutationFn: (text: string) => api.steerChat(text, activeSlot!),
+    mutationFn: ({ text, meta }: { text: string; meta?: Record<string, unknown> }) =>
+      api.steerChat(text, activeSlot!, meta),
     onError: (e) => { console.error('steer failed', e) },
   })
   const [reasoningEffortDropdown, setReasoningEffortDropdown] = useState(false)
@@ -960,10 +1024,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     for (const [k, v] of Object.entries(stored)) { if (!(k in drafts.current)) drafts.current[k] = v }
     const storedFiles = loadFileDrafts()
     for (const [k, v] of Object.entries(storedFiles)) { if (!(k in fileDrafts.current)) fileDrafts.current[k] = v }
+    const storedDirs = loadDirDrafts()
+    for (const [k, v] of Object.entries(storedDirs)) { if (!(k in dirDrafts.current)) dirDrafts.current[k] = v }
     const storedPastes = loadPasteDrafts()
     for (const [k, v] of Object.entries(storedPastes)) { if (!(k in pasteDrafts.current)) pasteDrafts.current[k] = v }
     if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
     if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+    if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
     if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
     prevSlot.current = activeSlot
     const raw = sessionStorage.getItem(PREFILL_STORAGE_KEY)
@@ -979,6 +1046,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // Restore the incoming slot's staged file attachments (copy so the
     // live state array and the stored draft don't share a reference).
     setPendingFiles(activeSlot ? (fileDrafts.current[activeSlot] ?? []).slice() : [])
+    // Same for staged folder references. Without this reset a folder picked in
+    // one chat would ride along on the next send in a different chat.
+    setPendingDirs(activeSlot ? (dirDrafts.current[activeSlot] ?? []).slice() : [])
     // Restore the incoming slot's collapsed-paste blocks (deep copy so the live
     // state and the stored draft don't share references). Without this the
     // token text rehydrates from the text draft but its backing block is gone,
@@ -995,6 +1065,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (saveDraftsTimer.current) { clearTimeout(saveDraftsTimer.current); saveDraftsTimer.current = null }
     if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
     if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+    if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
     if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
     flushDrafts()
   }, [flushDrafts])
@@ -1003,6 +1074,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     const h = () => {
       if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
       if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+      if (prevSlot.current) setDirDraft(dirDrafts.current, prevSlot.current, pendingDirsRef.current)
       if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
       flushDrafts()
     }
@@ -1033,13 +1105,23 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const [dragOver, setDragOver] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<string[]>([])
-  // Staged folder references, kept separate from pendingFiles because a folder
-  // is a path handed to the agent, never an uploaded attachment. Per-message
-  // only for now: the per-slot draft persistence and prompt-marker
-  // serialization land with the attachment-metadata change.
+  // Folder references picked via @-mention. Kept separate from pendingFiles so
+  // a directory never reaches the upload/thumbnail/attached_file paths.
   const [pendingDirs, setPendingDirs] = useState<string[]>([])
   const [snipFrame, setSnipFrame] = useState<HTMLCanvasElement | null>(null)
   const pendingFilesRef = useRef(pendingFiles)
+  const pendingDirsRef = useRef(pendingDirs)
+  useEffect(() => {
+    pendingDirsRef.current = pendingDirs
+    // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
+    const s = composerSlotRef.current
+    if (s) {
+      setDirDraft(dirDrafts.current, s, pendingDirs)
+      saveDraftsDebounced()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- draft key is
+    // composerSlotRef; slot-change effect handles that transition
+  }, [pendingDirs, saveDraftsDebounced])
   useEffect(() => {
     pendingFilesRef.current = pendingFiles
     // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
@@ -1932,7 +2014,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     try {
       await dispatch(resumeFromHistory({ key, title })).unwrap()
       if (activeSlot && activeSlot !== key) {
-        delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]; prevSlot.current = null; saveDrafts()
+        delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete dirDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]; prevSlot.current = null; saveDrafts()
         dispatch(deleteSlot(activeSlot)).unwrap().catch(() => {})
       }
     } catch { /* resume failed — keep current slot */ }
@@ -1958,7 +2040,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // widget action pre-filled. Cleared on every send so it can't go stale.
     const widgetOrigin = !!widgetPrefillRef.current && raw.includes(widgetPrefillRef.current)
     widgetPrefillRef.current = null
-    if (!raw && !pendingFilesRef.current.length) return
+    if (!raw && !pendingFilesRef.current.length && !pendingDirsRef.current.length) return
 
     // The session actually on screen at send time. Read from the ref (fresh
     // every render), not the closure `activeSlot` (stale until send() is
@@ -1984,7 +2066,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       return
     }
 
-    const { txt, displayTxt, filePaths } = prepareSendPayload(raw, pendingFilesRef.current)
+    const { txt, displayTxt, filePaths, imgPaths, dirPaths } = prepareSendPayload(raw, pendingFilesRef.current, pendingDirsRef.current)
+    // Images are split out of `filePaths` for the LLM payload, but for
+    // draft/restore purposes the composer's staged list is the union: an image
+    // lives only in `pendingFiles` (never in `raw`), so restoring `filePaths`
+    // alone on a send failure would silently drop it.
+    const stagedFiles = [...imgPaths, ...filePaths]
     // Expand paste tokens for the LLM; UI-facing displayTxt keeps the tokens
     // intact so the user bubble can render them as clickable chips.
     const activePastes = pasteBlocksRef.current
@@ -2002,7 +2089,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
     setPrefillHint(false)
     if (!optionText) {
-      setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
+      // Clear the COMPOSER only. The per-slot drafts are cleared further down,
+      // after slot creation has actually succeeded — `createSlot(...).unwrap()`
+      // below can reject (it sits outside the send try/catch), and clearing the
+      // drafts here meant a rejected creation permanently lost the staged folder
+      // and files with nothing to restore from.
+      setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([])
       // The challenge-handoff prompt is seeded into PREFILL_STORAGE_KEY and the
       // slot-restore effect re-applies it on slot changes. Once that prompt is
       // sent, clear the seed so a later slot-restore can't re-fill the (now
@@ -2031,10 +2123,24 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
         })
       }
     }
+    // Slot creation succeeded (or was not needed) — now it is safe to drop the
+    // per-slot drafts. A rejection above returns before this point, leaving the
+    // staged text/files/folders intact for a retry.
+    if (!optionText && uiSlot) {
+      delete drafts.current[uiSlot]
+      delete fileDrafts.current[uiSlot]
+      delete dirDrafts.current[uiSlot]
+      delete pasteDrafts.current[uiSlot]
+      saveDrafts()
+    }
     setPendingAgent(''); setPendingModel(''); setPendingProject('')
     // Build meta for persistence (knowledge, files, pastes)
     const meta: Record<string, unknown> = {}
     if (filePaths.length) meta.files = filePaths
+    // Folder references need the same index-preserving metadata as files: the
+    // content-scan fallback splits on whitespace, so a path containing a space
+    // would be truncated on replay without this.
+    if (dirPaths.length) meta.dirs = dirPaths
     if (bubblePastes.length) meta.pastes = bubblePastes
     if (knowledgeBlock) meta.knowledge = { items: knowledgeBlock.items.length, tokens: knowledgeBlock.totalTokens, titles: knowledgeBlock.items.map(i => i.title), content: knowledgeBlock.items.map(i => ({ title: i.title, text: i.content.slice(0, 2000) })) }
     if (widgetOrigin) meta.origin = 'widget'
@@ -2069,8 +2175,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
         dispatch(setSlotRunning(false))
         dispatch(appendMessage({ role: 'error', content: 'Connection error', cls: '' }))
         // Restore draft so the user doesn't lose their message.
-        // Also restore the paste blocks backing any tokens in `txt`, otherwise
-        // the restored text shows a dead `[ Paste #N · M lines ]` literal.
+        // Restore the PRE-SERIALIZATION text (`raw`, with its @-mentions) and
+        // re-stage the attachments, rather than the serialized `txt`. Restoring
+        // `txt` put the generated `[attached_file N] / [attached_dir N]` markers
+        // into the composer with no backing pending lists, so a retry sent
+        // marker text stripped of its index-preserving metadata and a folder or
+        // file path containing a space truncated on replay. Re-staging cannot
+        // duplicate markers either: `raw` carries @-mentions, which the next
+        // prepareSendPayload rewrites in place.
+        // Also restore the paste blocks backing any tokens in the text,
+        // otherwise it shows a dead `[ Paste #N · M lines ]` literal.
         // Persist for `slot` unconditionally (recoverable on disk), but only
         // touch the live input/blocks when `slot` is the one on screen. Compare
         // against activeSlotRef.current, NOT the closure's `activeSlot`: a
@@ -2081,10 +2195,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
         // visibly for a new-session failure while still not splicing a targeted
         // send's text into an unrelated slot the user is looking at.
         if (slot) {
-          setDraft(drafts.current, slot, txt)
+          setDraft(drafts.current, slot, raw)
+          setFileDraft(fileDrafts.current, slot, stagedFiles)
+          setDirDraft(dirDrafts.current, slot, dirPaths)
           setPasteDraft(pasteDrafts.current, slot, activePastes)
           saveDrafts()
-          if (slot === activeSlotRef.current) { setInput(txt); setPasteBlocks(activePastes) }
+          if (slot === activeSlotRef.current) {
+            setInput(raw)
+            setPendingFiles(stagedFiles)
+            setPendingDirs(dirPaths)
+            setPasteBlocks(activePastes)
+          }
         }
       }
     }
@@ -2648,8 +2769,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (!activeSlot) return
     const raw = inputRef.current.trim()
     const files = pendingFilesRef.current
-    if (!raw && !files.length) return
-    const { txt } = prepareSendPayload(raw, files)
+    const dirs = pendingDirsRef.current
+    if (!raw && !files.length && !dirs.length) return
+    const { txt, filePaths, dirPaths } = prepareSendPayload(raw, files, dirs)
     const activePastes = pasteBlocksRef.current
     const llmTxt = activePastes.length ? expandPasteTokens(txt, activePastes) : txt
     // Optimistically show the steered text immediately. Since steer became the
@@ -2659,17 +2781,56 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // WS event, making it look like nothing happened until the response resumed.
     // Tagged meta.optimistic so the echo reconciles this bubble in place
     // (appendSlotMessage) instead of rendering a duplicate.
-    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true } }))
-    steerMutation.mutate(llmTxt)
+    // The attachment lists ride along for the same reason send() carries them:
+    // the bubble renders the tokenized text, and without the ordered lists a
+    // path containing a space falls back to the whitespace scan and truncates.
+    const steerMeta: Record<string, unknown> = { steer: true, optimistic: true }
+    if (filePaths.length) steerMeta.files = filePaths
+    if (dirPaths.length) steerMeta.dirs = dirPaths
+    const optimisticTs = new Date().toISOString()
+    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: optimisticTs, meta: steerMeta }))
+    // Send the attachment lists to the server too, so the persisted steer
+    // carries them and a spaced path survives a reload. `optimistic` is a
+    // client-only marker and `steer` is set server-side, so neither is sent.
+    const serverMeta: Record<string, unknown> = {}
+    if (filePaths.length) serverMeta.files = filePaths
+    if (dirPaths.length) serverMeta.dirs = dirPaths
+    // Capture the pre-clear composer state so a rejected POST can put it back.
+    // NOTE: rejection rollback for steer is deliberately NOT implemented here.
+    // A correct rollback has to reason about concurrency — a second steer
+    // failing while the first is in flight, a response lost after the server
+    // already accepted the steer, and a rejection landing after the user
+    // switched slots — and the naive version got each of those wrong. The
+    // composer clears below are unconditional, so a failed steer currently
+    // leaves an optimistic bubble on screen with the staged attachments gone.
+    // That pre-existing gap is tracked separately rather than half-fixed here.
+    steerMutation.mutate({ text: llmTxt, meta: Object.keys(serverMeta).length ? serverMeta : undefined })
     setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([])
-    delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]
+    delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete dirDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]
     saveDrafts()
   }, [activeSlot, steerMutation, saveDrafts, dispatch])
 
   const handleCancelQueued = useCallback((queueId: string) => {
     if (!activeSlot) return
     const msg = messagesRef.current.find(m => m.role === 'queued' && (m.meta?.queueId as string) === queueId)
-    if (msg?.content) setInput(msg.content)
+    if (msg?.content) {
+      // The card holds the SERIALIZED text (`[attached_dir 1] /path`), so
+      // dropping it straight into the composer left the raw marker on screen and
+      // re-serialized it on resend — doubling the marker and truncating any path
+      // containing a space. Strip the markers and re-stage the attachments from
+      // the card's own ordered lists so a cancel round-trips losslessly.
+      const meta = msg.meta as { files?: string[]; dirs?: string[] } | undefined
+      setInput(stripAttachmentMarkers(msg.content, meta))
+      // `metaPathList` validates the shape: `meta` came off a server payload, so
+      // a non-array (or a member that isn't a string) must not reach `.filter`
+      // and throw inside this click handler. Blank members are dropped here
+      // because these lists re-stage attachments rather than index markers.
+      // Set BOTH lists unconditionally, including to empty. Restoring a cancelled
+      // message replaces the composer's staged attachments — leaving the current
+      // ones in place when the card had none made them ride along on the resend.
+      setPendingFiles(metaPathList(meta?.files).filter(Boolean))
+      setPendingDirs(metaPathList(meta?.dirs).filter(Boolean))
+    }
     // Optimistically remove the card; WS event is a no-op if already gone
     dispatch(cancelQueuedMessage({ slot: activeSlot, queue_id: queueId }))
     api.cancelQueuedMessage(activeSlot, queueId).catch(() => {})
@@ -2684,9 +2845,24 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (!activeSlot) return
     const trimmed = content.trim()
     if (!trimmed) return
-    // Optimistically update the card; WS event reconciles other clients
-    dispatch(editQueuedMessage({ slot: activeSlot, queue_id: queueId, content: trimmed }))
-    api.editQueuedMessage(activeSlot, queueId, trimmed).catch(() => {})
+    // Apply only AFTER the server accepts, and with the server's stored text.
+    //
+    // The optimistic version hid the attachment before the PATCH resolved and
+    // swallowed the rejection, so a failed edit left the UI claiming the
+    // attachment was removed while the backend still queued and submitted it.
+    // The server also strips the markers belonging to the dropped metadata, so
+    // its stored text is the authority — echoing the submitted text here would
+    // desync the card from the queue even on success.
+    const slotAtEdit = activeSlot
+    api.editQueuedMessage(slotAtEdit, queueId, trimmed)
+      .then(res => {
+        const stored = typeof res?.content === 'string' ? res.content : trimmed
+        dispatch(editQueuedMessage({ slot: slotAtEdit, queue_id: queueId, content: stored }))
+      })
+      .catch(() => {
+        // Leave the card as-is: the queued prompt is unchanged server-side, so
+        // showing the original content is the truthful state.
+      })
   }, [activeSlot, dispatch])
 
 
@@ -3553,12 +3729,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               resizedInfo={resizedInfo}
               onRemoveFile={p => setPendingFiles(prev => prev.filter(x => x !== p))}
               onRemoveDir={p => setPendingDirs(prev => prev.filter(x => x !== p))}
-              // A folder is a path reference, not an upload — it must never land
-              // in pendingFiles, where the send path would treat it as an
-              // attachable file and try to read it.
-              onFileSelect={(path, kind) => kind === 'dir'
-                ? setPendingDirs(prev => prev.includes(path) ? prev : [...prev, path])
-                : setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])}
+              onFileSelect={(path, kind) => {
+                // A folder mention is a path reference, not an upload: it goes
+                // to pendingDirs so it serializes as [attached_dir N].
+                if (kind === 'dir') setPendingDirs(prev => prev.includes(path) ? prev : [...prev, path])
+                else setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])
+              }}
               onFileOpen={handleFileOpen}
               project={currentSlot?.project || ''}
               isMac={isMac}

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -35,7 +35,7 @@ const safeKey = (key: string): string => (isUnsafeKey(key) ? `unsafe-key:${key}`
 
 /** One queued-message entry as normalized by `fetchSlotDetail` from the backend
  *  slot-detail `queue` field. */
-type SlotQueueItem = { content: string; queueId: string; ts: string }
+type SlotQueueItem = { content: string; queueId: string; ts: string; meta?: Record<string, unknown> }
 
 /** SINGLE hydration path for the slot-detail `queue` field — the one place that
  *  turns backend queue entries into `queued` message bubbles. Every reducer that
@@ -55,8 +55,13 @@ function hydrateQueuedBubbles(
   queue: SlotQueueItem[] | undefined,
 ): ChatMessage[] {
   const base = list.filter((m) => m.role !== 'queued')
-  for (const { content, queueId, ts } of queue ?? []) {
-    base.push({ role: 'queued', content, cls: 'msg msg-queued', ts, meta: { queueId } })
+  for (const { content, queueId, ts, meta } of queue ?? []) {
+    // Carry the server's attachment metadata onto the rehydrated card. Marker N
+    // in `content` indexes into meta.files/meta.dirs, so rebuilding the card with
+    // only `queueId` forces the whitespace-scan fallback and truncates a path
+    // containing a space — a queued attachment looked correct until reload.
+    // `queueId` last so a server key cannot displace this card's identity.
+    base.push({ role: 'queued', content, cls: 'msg msg-queued', ts, meta: { ...(meta || {}), queueId } })
   }
   return base
 }
@@ -411,8 +416,8 @@ export const fetchHistory = createAsyncThunk(
 async function fetchSlotDetail(key: string) {
   // No limit → backend returns all chained history (across gateway restarts).
   const d = await api.chatSlotDetail(key)
-  type QueueItem = string | { content: string; id: string }
-  return { key, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }) }
+  type QueueItem = string | { content: string; id: string; meta?: Record<string, unknown> }
+  return { key, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString(), ...(q.meta ? { meta: q.meta } : {}) }) }
 }
 
 export const switchSlot = createAsyncThunk(
@@ -1537,8 +1542,22 @@ const chatSlice = createSlice({
         : msgs.findIndex(m => m.role === 'queued' && m.content === content)
       if (idx >= 0) {
         const ts = msgs[idx].ts
+        // Carry the queued card's attachment metadata onto the message it
+        // becomes. Dropping it here defeated the whole point of preserving it on
+        // the card: the ordered files/dirs lists are what let a spaced path
+        // render losslessly, so without them the turn that actually runs falls
+        // back to the whitespace scan and truncates. `queueId` is deliberately
+        // NOT carried over — the message is no longer queued, and leaving it
+        // would make a later queue lookup match a message that already drained.
+        const { queueId: _queueId, ...meta } = (msgs[idx].meta || {}) as Record<string, unknown>
         msgs.splice(idx, 1)
-        msgs.push({ role: 'user', content, cls: 'msg msg-u', ts })
+        msgs.push({
+          role: 'user',
+          content,
+          cls: 'msg msg-u',
+          ts,
+          ...(Object.keys(meta).length ? { meta } : {}),
+        })
       }
     },
     /** Cancel a queued message: remove from messages. pendingInput is set locally by the initiating client. */
@@ -1556,16 +1575,29 @@ const chatSlice = createSlice({
       const msgs = slot === state.activeSlot ? state.messages : state.slotMessages[slot]
       if (!msgs) return
       const idx = msgs.findIndex(m => m.role === 'queued' && (m.meta?.queueId as string) === queue_id)
-      if (idx >= 0) msgs[idx].content = content
+      if (idx >= 0) {
+        msgs[idx].content = content
+        // Drop attachment metadata to match the server (`queue_edit_by_id`):
+        // the edited text owns its own attachments, and keeping the old ordered
+        // path lists would render an attachment card for a marker the new
+        // content no longer contains. `queueId` is retained — it is this card's
+        // identity for later edit/cancel lookups, not attachment metadata.
+        const queueId = msgs[idx].meta?.queueId
+        msgs[idx].meta = queueId !== undefined ? { queueId } : undefined
+      }
     },
     /** Add a queued message (from backend queue_push WS event). */
     appendQueuedMessage: {
-      reducer(state, action: PayloadAction<{ slot: string; content: string; ts: string; queueId: string }>) {
-        const { slot, content, ts, queueId } = action.payload
+      reducer(state, action: PayloadAction<{ slot: string; content: string; ts: string; queueId: string; meta?: Record<string, unknown> }>) {
+        const { slot, content, ts, queueId, meta } = action.payload
         const msgs = slot === state.activeSlot ? state.messages : (state.slotMessages[safeKey(slot)] ??= [])
-        msgs.push({ role: 'queued', content, cls: 'msg msg-queued', ts, meta: { queueId } })
+        // Preserve the server's attachment metadata on the queued card. The
+        // ordered files/dirs lists are what let a path containing a space render
+        // losslessly; without them the card falls back to the whitespace-bounded
+        // content scan and shows a truncated path until the page is reloaded.
+        msgs.push({ role: 'queued', content, cls: 'msg msg-queued', ts, meta: { ...(meta || {}), queueId } })
       },
-      prepare(payload: { slot: string; content: string; ts: string; queue_id?: string }) {
+      prepare(payload: { slot: string; content: string; ts: string; queue_id?: string; meta?: Record<string, unknown> }) {
         return { payload: { ...payload, queueId: payload.queue_id || crypto.randomUUID() } }
       },
     },

--- a/website/src/test/ChatPage.folderStaging.test.ts
+++ b/website/src/test/ChatPage.folderStaging.test.ts
@@ -25,10 +25,13 @@ const chatInput = readFileSync(resolve(here, '../components/ChatInput.tsx'), 'ut
 describe('picked folders never enter the file-attachment list', () => {
   it('routes a dir selection to setPendingDirs, not setPendingFiles', () => {
     expect(chatPage, 'onFileSelect must branch on kind').toContain(
-      "onFileSelect={(path, kind) => kind === 'dir'",
+      'onFileSelect={(path, kind) =>',
     )
     expect(chatPage, 'a dir must be staged into pendingDirs').toMatch(
-      /kind === 'dir'\s*\n\s*\? setPendingDirs\(/,
+      /kind === 'dir'\)?\s*(\?|setPendingDirs\()/,
+    )
+    expect(chatPage, 'the non-dir branch must stage into pendingFiles').toMatch(
+      /(else |: )setPendingFiles\(/,
     )
   })
 

--- a/website/src/test/ChatPageDrafts.test.tsx
+++ b/website/src/test/ChatPageDrafts.test.tsx
@@ -56,6 +56,8 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 import ChatPage from '../pages/ChatPage'
+import { DIR_DRAFTS_KEY } from '../utils/chatDirDrafts'
+import { DRAFTS_KEY } from '../utils/chatDrafts'
 
 function makeStore(activeSlot: string, slots: { key: string; mode?: string }[]) {
   return configureStore({
@@ -127,7 +129,7 @@ beforeEach(() => {
 // someone reorders the effects or moves the advance up. All three persist
 // writes are asserted (not just text) because the advance now guards all three.
 describe('ChatPage composerSlotRef effect ordering', () => {
-  it('declares all three composer-persist effects before advancing composerSlotRef', () => {
+  it('declares all four composer-persist effects before advancing composerSlotRef', () => {
     // Deliberately brittle: this matches exact code substrings from ChatPage.tsx
     // to lock a load-bearing effect-declaration order. An innocuous rename/reformat
     // will trip it. The fix is to UPDATE the substrings below to the new form,
@@ -136,19 +138,142 @@ describe('ChatPage composerSlotRef effect ordering', () => {
     const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
     const textIdx = src.indexOf('setDraft(drafts.current, s, input)')
     const fileIdx = src.indexOf('setFileDraft(fileDrafts.current, s, pendingFiles)')
+    const dirIdx = src.indexOf('setDirDraft(dirDrafts.current, s, pendingDirs)')
     const pasteIdx = src.indexOf('setPasteDraft(pasteDrafts.current, s, pasteBlocks)')
     const advanceIdx = src.indexOf('composerSlotRef.current = activeSlot')
     expect(textIdx, 'text-persist effect (setDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(fileIdx, 'file-persist effect (setFileDraft off composerSlotRef) not found').toBeGreaterThan(-1)
+    expect(dirIdx, 'dir-persist effect (setDirDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(pasteIdx, 'paste-persist effect (setPasteDraft off composerSlotRef) not found').toBeGreaterThan(-1)
     expect(advanceIdx, 'composerSlotRef advance not found').toBeGreaterThan(-1)
     const order = 'persist effect must be declared BEFORE the composerSlotRef advance (draft-smear guard). If effects moved, UPDATE the substrings; do not delete this guard.'
     expect(textIdx, order).toBeLessThan(advanceIdx)
     expect(fileIdx, order).toBeLessThan(advanceIdx)
+    expect(dirIdx, order).toBeLessThan(advanceIdx)
     expect(pasteIdx, order).toBeLessThan(advanceIdx)
   })
 
-  // Symptom B (send routing to the slot the user already left) can't be covered
+  // The folder-leak fix: the slot-change effect must RESET pendingDirs from the
+  // incoming slot's draft. Without it a folder picked in chat A rides along on
+  // the next send in chat B. Behaviorally awkward to reach (needs a real picker
+  // selection), so guard the reset line statically.
+  it('resets pendingDirs from the incoming slot draft on slot change', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'slot change must restore pendingDirs from dirDrafts').toContain(
+      "setPendingDirs(activeSlot ? (dirDrafts.current[activeSlot] ?? []).slice() : [])",
+    )
+  })
+
+  // The replay fix: send() must persist dirPaths on meta.dirs, otherwise a
+  // folder path containing a space is truncated by the content-scan fallback.
+  it('persists folder paths on meta.dirs', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'send() must destructure dirPaths from prepareSendPayload').toMatch(
+      /const \{[^}]*dirPaths[^}]*\} = prepareSendPayload\(/,
+    )
+    expect(src, 'send() must set meta.dirs').toContain('if (dirPaths.length) meta.dirs = dirPaths')
+  })
+
+  // Behavioural counterpart to the static guards above: a send that fails at the
+  // transport must put the folder chip BACK on screen. Asserting on the dir-draft
+  // storage instead does NOT work — the `pendingDirs` persist effect rewrites
+  // that key from state on every change, so storage repopulates even with the
+  // failure-path `setDirDraft` deleted. The rendered chip is driven by
+  // `pendingDirs` alone, so it isolates the restore.
+  it('restores a staged folder chip and raw text when the send fails', async () => {
+    const SPACED = '/repo/my docs'
+    sessionStorage.setItem(DIR_DRAFTS_KEY, JSON.stringify({ s1: [SPACED] }))
+    localStorage.setItem(DRAFTS_KEY, JSON.stringify({ s1: 'review @my docs/' }))
+    const { api } = await import('../api/client')
+    const sendChat = api.sendChat as ReturnType<typeof vi.fn>
+    sendChat.mockRejectedValueOnce(new Error('network down'))
+
+    const store = makeStore('s1', [{ key: 's1' }])
+    await renderAndWaitForInput(store)
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    await waitFor(() => expect(input.value).toContain('@my docs/'))
+    // The staged folder is on screen before the send.
+    expect(screen.getAllByLabelText('Remove folder').length).toBe(1)
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+    await waitFor(() => expect(sendChat).toHaveBeenCalled())
+
+    // The chip must come back: send() clears pendingDirs optimistically, so if
+    // the failure path does not restore it the user's attachment is gone.
+    await waitFor(() => {
+      expect(
+        screen.queryAllByLabelText('Remove folder').length,
+        'staged folder chip was not restored after a failed send',
+      ).toBe(1)
+    })
+    expect(
+      (screen.getByLabelText('Message input') as HTMLTextAreaElement).value,
+      'raw composer text was not restored after a failed send',
+    ).toContain('@my docs/')
+    sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  })
+
+
+  // GPT round-10 HIGH: the optimistic edit hid the attachment before the PATCH
+  // resolved and swallowed the rejection, so a failed edit left the UI claiming
+  // the attachment was removed while the backend still queued and submitted it.
+  it('does not mutate the queued card when the edit request fails', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'edit must dispatch inside .then(), not before the request').toMatch(
+      /api\.editQueuedMessage\([^)]*\)\s*\n\s*\.then\(/,
+    )
+    expect(src, 'the optimistic pre-dispatch must be gone').not.toContain(
+      "dispatch(editQueuedMessage({ slot: activeSlot, queue_id: queueId, content: trimmed }))",
+    )
+    expect(src, 'must apply the server-stored text, not the submitted text').toContain(
+      'const stored = typeof res?.content === \'string\' ? res.content : trimmed',
+    )
+  })
+
+  // steer() renders its own optimistic bubble from the tokenized text, so it
+  // needs the same ordered lists as send() or a spaced path truncates there too.
+  it('persists attachment metadata on the steered optimistic bubble', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'steer() must set files on the bubble meta').toContain(
+      'if (filePaths.length) steerMeta.files = filePaths',
+    )
+    expect(src, 'steer() must set dirs on the bubble meta').toContain(
+      'if (dirPaths.length) steerMeta.dirs = dirPaths',
+    )
+    expect(src, 'steer() must not discard the payload lists').not.toContain(
+      'const { txt } = prepareSendPayload(raw, files, dirs)',
+    )
+  })
+
+  // The optimistic bubble alone is not enough: the SERVER must persist the
+  // ordered lists too, or the spaced path is truncated by the content-scan
+  // fallback after a reload. Guarded statically because the assertion is about
+  // what crosses the network boundary, and the mutation is fire-and-forget.
+  it('sends attachment metadata to the server on steer', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+    expect(src, 'steer() must send the lists, not just the text').toMatch(
+      /steerMutation\.mutate\(\s*\{\s*text:\s*llmTxt,\s*meta:/,
+    )
+    expect(src, 'steer() must put files on the server meta').toContain(
+      'if (filePaths.length) serverMeta.files = filePaths',
+    )
+    expect(src, 'steer() must put dirs on the server meta').toContain(
+      'if (dirPaths.length) serverMeta.dirs = dirPaths',
+    )
+    const client = readFileSync(resolve(here, '../api/client.ts'), 'utf8')
+    expect(client, 'steerChat must forward meta in the request body').toMatch(
+      /steer:\s*true,\s*\.\.\.\(meta\s*\?\s*\{\s*meta\s*\}\s*:\s*\{\}\)/,
+    )
+  })
+
   // behaviorally: the ref-vs-closure divergence it fixes is a same-tick race
   // between the reducer's activeSlot flip and send()'s re-memoization, and RTL
   // flushes a render between any dispatch and the Enter event, so the closure
@@ -462,6 +587,43 @@ describe('ChatPage draft persistence', { timeout: 15_000 }, () => {
       return s
     })
     expect(saved['new-slot']).toBeUndefined()
+  })
+
+  it('restores a staged image after a failed send, not just non-image files', async () => {
+    // Images are filtered out of prepareSendPayload's `filePaths` (they go into
+    // `imgPaths` and become `![image](...)` markdown), so restoring `filePaths`
+    // alone silently dropped the image: it lives only in pendingFiles, never in
+    // the raw text, so a retry would have sent the message without it.
+    const { api } = await import('../api/client')
+    vi.mocked(api.uploadFiles).mockResolvedValueOnce({ paths: ['/tmp/shot.png', '/tmp/notes.txt'] })
+    vi.mocked(api.sendChat).mockRejectedValueOnce(new Error('Network error'))
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    const dropTarget = input.closest('div') as HTMLElement
+    await act(async () => {
+      fireEvent.drop(dropTarget, {
+        dataTransfer: {
+          files: [new File(['x'], 'shot.png', { type: 'image/png' }), new File(['y'], 'notes.txt', { type: 'text/plain' })],
+          types: ['Files'],
+        },
+      })
+    })
+    await waitFor(() => {
+      const saved = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(saved['slot-a']).toEqual(['/tmp/shot.png', '/tmp/notes.txt'])
+    })
+
+    await act(async () => { fireEvent.change(input, { target: { value: 'look at this' } }) })
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+
+    await waitFor(() => {
+      const saved = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(saved['slot-a'], 'the image must survive the send-failure restore')
+        .toEqual(['/tmp/shot.png', '/tmp/notes.txt'])
+    })
   })
 
   it('restores draft to localStorage on connection error', async () => {

--- a/website/src/test/chatDirDrafts.test.ts
+++ b/website/src/test/chatDirDrafts.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DIR_DRAFTS_KEY, loadDirDrafts, saveDirDrafts, setDirDraft } from '../utils/chatDirDrafts'
+import { FILE_DRAFTS_KEY } from '../utils/chatFileDrafts'
+
+describe('chatDirDrafts', () => {
+  beforeEach(() => { sessionStorage.clear() })
+
+  it('roundtrips dir drafts through sessionStorage', () => {
+    const drafts = {
+      'chat-1-100': ['/repo/src/pages', '/repo/docs'],
+      'chat-2-200': ['/repo/my docs'],
+    }
+    saveDirDrafts(drafts)
+    expect(loadDirDrafts()).toEqual(drafts)
+    expect(sessionStorage.getItem(DIR_DRAFTS_KEY)).toBe(JSON.stringify(drafts))
+  })
+
+  it('uses a storage key distinct from the file drafts key', () => {
+    // A shared key would smear folder references into the file-attachment list,
+    // putting a directory back on the upload/thumbnail path.
+    expect(DIR_DRAFTS_KEY).not.toBe(FILE_DRAFTS_KEY)
+  })
+
+  it('returns {} on missing, corrupt, or non-object storage', () => {
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, 'not json')
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, '[]')
+    expect(loadDirDrafts()).toEqual({})
+    sessionStorage.setItem(DIR_DRAFTS_KEY, 'null')
+    expect(loadDirDrafts()).toEqual({})
+  })
+
+  it('filters out non-array and non-string-element values (corruption guard)', () => {
+    sessionStorage.setItem(DIR_DRAFTS_KEY, JSON.stringify({
+      'good': ['/repo/src'],
+      'string-value': 'not-an-array',
+      'number-value': 42,
+      'null-value': null,
+      'mixed-array': ['/repo/a', 42, null, '/repo/b'],
+      'empty-array': [],
+    }))
+    expect(loadDirDrafts()).toEqual({
+      'good': ['/repo/src'],
+      'mixed-array': ['/repo/a', '/repo/b'],
+    })
+  })
+
+  it('setDirDraft stores non-empty and deletes empty', () => {
+    const d: Record<string, string[]> = { 'chat-1-100': ['/repo/old'] }
+    setDirDraft(d, 'chat-1-100', ['/repo/new1', '/repo/new2'])
+    expect(d).toEqual({ 'chat-1-100': ['/repo/new1', '/repo/new2'] })
+    setDirDraft(d, 'chat-1-100', [])
+    expect(d).toEqual({})
+  })
+
+  it('setDirDraft stores a defensive copy so caller mutations do not leak', () => {
+    const d: Record<string, string[]> = {}
+    const live: string[] = ['/repo/a']
+    setDirDraft(d, 'chat-1', live)
+    live.push('/repo/b')
+    expect(d['chat-1']).toEqual(['/repo/a'])
+  })
+
+  it('keeps per-slot entries isolated', () => {
+    const d: Record<string, string[]> = {}
+    setDirDraft(d, 'chat-a', ['/repo/src/pages'])
+    setDirDraft(d, 'chat-b', ['/repo/docs'])
+    expect(d['chat-a']).toEqual(['/repo/src/pages'])
+    expect(d['chat-b']).toEqual(['/repo/docs'])
+  })
+
+  it('preserves a path containing spaces', () => {
+    const d: Record<string, string[]> = {}
+    setDirDraft(d, 'chat-1', ['/repo/my docs'])
+    saveDirDrafts(d)
+    expect(loadDirDrafts()['chat-1']).toEqual(['/repo/my docs'])
+  })
+})

--- a/website/src/test/chatSlice.queuedMeta.test.ts
+++ b/website/src/test/chatSlice.queuedMeta.test.ts
@@ -1,0 +1,195 @@
+/**
+ * A queued message's card must keep the server's attachment metadata.
+ *
+ * The `queue_push` WS event is what an open client renders a queued card from.
+ * The ordered `files` / `dirs` lists are what let `[attached_file N]` /
+ * `[attached_dir N]` resolve a path containing a space; without them the card
+ * falls back to the whitespace-bounded content scan and displays a path
+ * truncated at its first space until the page is reloaded.
+ *
+ * The reducer previously hardcoded `meta: { queueId }`, discarding whatever the
+ * server sent.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import reducer, { appendQueuedMessage, editQueuedMessage, removeQueuedMessage, setActiveSlot, switchSlot } from '../store/chatSlice'
+import { api } from '../api/client'
+
+const SLOT = 'slot-q'
+const SPACED = '/repo/my docs'
+
+function base() {
+  const s = reducer(undefined, { type: '@@INIT' })
+  return reducer(s, setActiveSlot(SLOT))
+}
+
+describe('appendQueuedMessage preserves attachment metadata', () => {
+  it('keeps meta.dirs from the queue_push payload', () => {
+    const next = reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'q1',
+      meta: { dirs: [SPACED] },
+    }))
+    const card = next.messages.at(-1)!
+    expect(card.role).toBe('queued')
+    expect(card.meta?.dirs).toEqual([SPACED])
+  })
+
+  it('keeps meta.files alongside the queueId', () => {
+    const next = reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: '[attached_file 1] /repo/my notes.txt',
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'q2',
+      meta: { files: ['/repo/my notes.txt'] },
+    }))
+    const card = next.messages.at(-1)!
+    expect(card.meta?.files).toEqual(['/repo/my notes.txt'])
+    expect(card.meta?.queueId, 'queueId must survive the merge').toBe('q2')
+  })
+
+  it('queueId wins over a spoofed one in meta', () => {
+    // queueId is the client's handle for cancel/edit; a server meta key must not
+    // be able to displace it.
+    const next = reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: 'x',
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'real',
+      meta: { queueId: 'spoofed' },
+    }))
+    expect(next.messages.at(-1)!.meta?.queueId).toBe('real')
+  })
+
+  it('still works with no meta (older backend)', () => {
+    const next = reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: 'plain',
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'q3',
+    }))
+    const card = next.messages.at(-1)!
+    expect(card.meta?.queueId).toBe('q3')
+    expect(card.meta?.dirs).toBeUndefined()
+  })
+})
+
+describe('hydrated queue cards keep server metadata', () => {
+  // Live queue_push already carried the lists, so a queued attachment looked
+  // correct until RELOAD: hydration rebuilt the card with only `queueId`, so the
+  // markers had no index space and a spaced path truncated.
+  //
+  // This drives the REAL `switchSlot` thunk against a mocked
+  // `api.chatSlotDetail`, because the normalization that carries `q.meta` lives
+  // in `fetchSlotDetail`, not in the reducer. Dispatching a hand-built
+  // `switchSlot/fulfilled` payload skipped that mapping entirely and passed even
+  // with the hydration deleted.
+  it('carries meta from the slot-detail payload onto the card', async () => {
+    const detail = vi.spyOn(api, 'chatSlotDetail').mockResolvedValue({
+      messages: [],
+      running: false,
+      stopping: false,
+      has_more: false,
+      total: 0,
+      // Server wire shape: `id`, not `queueId`.
+      queue: [{ content: `review [attached_dir 1] ${SPACED}`, id: 'q1', meta: { dirs: [SPACED] } }],
+    } as never)
+
+    const store = configureStore({ reducer: { chat: reducer } })
+    store.dispatch(setActiveSlot(SLOT))
+    await store.dispatch(switchSlot(SLOT))
+
+    const next = store.getState().chat
+    const all = [...next.messages, ...Object.values(next.slotMessages).flat()]
+    const card = all.find(m => m.role === 'queued')
+    expect(detail).toHaveBeenCalledWith(SLOT)
+    expect(card, 'no queued card was hydrated').toBeTruthy()
+    expect(card!.meta?.dirs, 'slot-detail meta.dirs never reached the card').toEqual([SPACED])
+    expect(card!.meta?.queueId).toBe('q1')
+    detail.mockRestore()
+  })
+})
+
+describe('editQueuedMessage drops attachment metadata', () => {
+  // Must match the server (`queue_edit_by_id`): the edited text owns its own
+  // attachments. Keeping the old ordered path lists would render an attachment
+  // card for a marker the new content no longer contains.
+  function queued() {
+    return reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'q1',
+      meta: { dirs: [SPACED] },
+    }))
+  }
+
+  it('clears meta.dirs but keeps queueId', () => {
+    const after = reducer(queued(), editQueuedMessage({
+      slot: SLOT,
+      queue_id: 'q1',
+      content: 'never mind, just say hi',
+    }))
+    const card = after.messages.at(-1)!
+    expect(card.content).toBe('never mind, just say hi')
+    expect(card.meta?.dirs).toBeUndefined()
+    // queueId is this card's identity for later edit/cancel lookups.
+    expect(card.meta?.queueId).toBe('q1')
+  })
+
+  it('leaves a non-matching card untouched', () => {
+    const after = reducer(queued(), editQueuedMessage({
+      slot: SLOT,
+      queue_id: 'nope',
+      content: 'x',
+    }))
+    expect(after.messages.at(-1)!.meta?.dirs).toEqual([SPACED])
+  })
+})
+
+describe('removeQueuedMessage carries metadata onto the drained message', () => {
+  // Preserving meta on the CARD is pointless if the message it becomes drops it:
+  // `queue_pop` is what runs the turn, and that is the bubble the user ends up
+  // looking at. Without the ordered lists it falls back to the whitespace scan
+  // and truncates a spaced path.
+  function queued(meta?: Record<string, unknown>) {
+    return reducer(base(), appendQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      ts: '2026-07-26T10:00:00.000Z',
+      queue_id: 'q1',
+      ...(meta ? { meta } : {}),
+    }))
+  }
+
+  it('keeps meta.dirs when the queued card is popped', () => {
+    const after = reducer(queued({ dirs: [SPACED] }), removeQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      queue_id: 'q1',
+    }))
+    const msg = after.messages.at(-1)!
+    expect(msg.role).toBe('user')
+    expect(msg.meta?.dirs).toEqual([SPACED])
+  })
+
+  it('drops queueId so a drained message cannot be matched as still queued', () => {
+    const after = reducer(queued({ dirs: [SPACED] }), removeQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      queue_id: 'q1',
+    }))
+    expect(after.messages.at(-1)!.meta?.queueId).toBeUndefined()
+  })
+
+  it('leaves meta absent when the card had none beyond queueId', () => {
+    const after = reducer(queued(), removeQueuedMessage({
+      slot: SLOT,
+      content: `review [attached_dir 1] ${SPACED}`,
+      queue_id: 'q1',
+    }))
+    expect(after.messages.at(-1)!.meta).toBeUndefined()
+  })
+})

--- a/website/src/test/fileTokens.dirs.test.ts
+++ b/website/src/test/fileTokens.dirs.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect } from 'vitest'
+import { prepareSendPayload, buildDirRelMap, replaceDirTokens, resolveFileSegment, parseDirs, parseFiles, buildFileLabels, findUnreferencedDirs, stripAttachmentMarkers, trimDirSeparator } from '../utils/fileTokens'
+describe('buildDirRelMap', () => {
+  it('matches a token written with the inserted trailing slash', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/ please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('matches a token written without a trailing slash', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('matches a token at end of input', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+  })
+
+  it('does not match a longer sibling path', () => {
+    const map = buildDirRelMap(['/repo/src/page'], 'look at @src/pages/ please')
+    expect(map.size).toBe(0)
+  })
+})
+
+describe('replaceDirTokens', () => {
+  it('replaces the token including its trailing slash', () => {
+    const dirs = ['/repo/src/pages']
+    const map = buildDirRelMap(dirs, 'in @src/pages/ now')
+    const out = replaceDirTokens(map.size ? 'in @src/pages/ now' : '', dirs, map, p => `<${p}>`)
+    expect(out).toBe('in </repo/src/pages> now')
+  })
+})
+
+describe('trimDirSeparator', () => {
+  it('drops a trailing POSIX separator', () => {
+    expect(trimDirSeparator('/repo/src/')).toBe('/repo/src')
+    expect(trimDirSeparator('/repo/src///')).toBe('/repo/src')
+  })
+
+  it('preserves a filesystem root instead of collapsing it to empty', () => {
+    // A blanket /[/\\]+$/ strip turned '/' into '' and 'C:\' into 'C:', neither
+    // of which is a usable path.
+    expect(trimDirSeparator('/')).toBe('/')
+    expect(trimDirSeparator('C:\\')).toBe('C:\\')
+  })
+
+  it('does not eat a POSIX directory name legally ending in a backslash', () => {
+    // On POSIX a backslash is an ordinary filename character, not a separator.
+    expect(trimDirSeparator('/repo/weird\\')).toBe('/repo/weird\\')
+  })
+
+  it('still treats a backslash as a separator on windows-style paths', () => {
+    expect(trimDirSeparator('C:\\repo\\src\\')).toBe('C:\\repo\\src')
+    expect(trimDirSeparator('repo\\src\\')).toBe('repo\\src')
+  })
+})
+
+describe('prepareSendPayload with directories', () => {
+  it('emits an attached_dir token for an inline folder mention', () => {
+    const r = prepareSendPayload('review @src/pages/ for me', [], ['/repo/src/pages'])
+    expect(r.txt).toBe('review [attached_dir 1] /repo/src/pages for me')
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('appends an attached_dir token for an unreferenced folder', () => {
+    const r = prepareSendPayload('take a look', [], ['/repo/src/pages'])
+    expect(r.txt).toBe('take a look\n[attached_dir 1] /repo/src/pages')
+  })
+
+  it('never uses the attached_file marker for a directory', () => {
+    const r = prepareSendPayload('review @src/pages/', [], ['/repo/src/pages'])
+    expect(r.txt).not.toContain('attached_file')
+  })
+
+  it('prefers the file when a file and folder mention have equal rel length', () => {
+    // `@notes` (file /repo/notes) and `@notes/` (dir /repo/notes) share rel
+    // "notes". Directories are pushed into the candidate list first, so a
+    // length-only sort let the dir win and the file was dropped entirely.
+    const r = prepareSendPayload('open @notes', ['/repo/notes'], ['/repo/notes'])
+    expect(r.txt).toContain('[attached_file 1] /repo/notes')
+    expect(r.txt).not.toContain('attached_dir 1] /repo/notes for')
+    expect(r.filePaths).toEqual(['/repo/notes'])
+  })
+
+  it('keeps the losing folder as an appended marker on an equal-length collision', () => {
+    // `@notes` awards the position to the FILE, but the folder is still staged.
+    // Filtering appended tokens on dirRelMap ("matched the text") instead of what
+    // was actually emitted dropped the folder from both the inline text and the
+    // appended block, so a staged attachment vanished with no warning.
+    const r = prepareSendPayload('open @notes', ['/repo/notes'], ['/repo/notes'])
+    expect(r.txt).toContain('[attached_file 1] /repo/notes')
+    expect(r.txt, 'the losing folder must still be attached').toContain('[attached_dir 1] /repo/notes')
+    expect(r.dirPaths).toEqual(['/repo/notes'])
+  })
+
+  it('does not double-emit a folder that did win its position', () => {
+    const r = prepareSendPayload('open @notes/', [], ['/repo/notes'])
+    expect(r.txt.match(/attached_dir 1\]/g)?.length).toBe(1)
+  })
+
+  it('still lets the folder win when its mention carries the separator', () => {
+    const r = prepareSendPayload('open @notes/', ['/repo/notes'], ['/repo/notes'])
+    expect(r.txt).toContain('[attached_dir 1] /repo/notes')
+  })
+
+  it('round-trips a cancelled card back to de-tokenized text', () => {
+    // handleCancelQueued puts the card's serialized content back in the
+    // composer. Without stripping, the raw marker showed on screen and was
+    // re-serialized on resend, doubling it and truncating the spaced path.
+    const serialized = 'review [attached_dir 1] /repo/my docs now'
+    expect(stripAttachmentMarkers(serialized, { dirs: ['/repo/my docs'] })).toBe('review now')
+  })
+
+  it('leaves marker indices the metadata does not cover', () => {
+    expect(
+      stripAttachmentMarkers('a [attached_dir 1] /d b [attached_dir 2] /other', { dirs: ['/d'] }),
+    ).toBe('a b [attached_dir 2] /other')
+  })
+
+  it('strips both families from one string', () => {
+    expect(
+      stripAttachmentMarkers('x [attached_file 1] /f.txt y [attached_dir 1] /d z', {
+        files: ['/f.txt'],
+        dirs: ['/d'],
+      }),
+    ).toBe('x y z')
+  })
+
+  it('widens labels until unique instead of stopping at two segments', () => {
+    // `/a/x/docs` and `/b/x/docs` both reduced to `x/docs`, so two distinct
+    // attachments rendered identically and one map key overwrote the other.
+    const m = buildFileLabels(['/a/x/docs', '/b/x/docs'])
+    expect(m.get('/a/x/docs')).not.toBe(m.get('/b/x/docs'))
+    expect(new Set([...m.values()]).size).toBe(2)
+  })
+
+  it('does not widen labels that are already unique', () => {
+    const m = buildFileLabels(['/repo/notes.txt', '/repo/other.txt'])
+    expect(m.get('/repo/notes.txt')).toBe('notes.txt')
+  })
+
+  it('labels a POSIX path containing a backslash by its real basename', () => {
+    // A backslash is a legal POSIX filename character, so `a\b` is ONE segment.
+    const m = buildFileLabels(['/repo/a\\b'])
+    expect(m.get('/repo/a\\b')).toBe('a\\b')
+  })
+
+  it('preserves indentation and column alignment outside the marker', () => {
+    const code = 'def f():\n    x=1\n    [attached_dir 1] /d\n    y=2'
+    expect(stripAttachmentMarkers(code, { dirs: ['/d'] })).toBe('def f():\n    x=1\n    y=2')
+    expect(stripAttachmentMarkers('col1    col2 [attached_dir 1] /d', { dirs: ['/d'] })).toBe('col1    col2')
+  })
+
+  it('does not strip a longer path that shares the marker path as a prefix', () => {
+    // meta owns `/d`; the text mentions `/dossier`. Without a boundary the `/d`
+    // was stripped and left `ossier`.
+    expect(
+      stripAttachmentMarkers('see [attached_dir 1] /dossier now', { dirs: ['/d'] }),
+    ).toBe('see [attached_dir 1] /dossier now')
+  })
+
+  it('resolves a mention against a POSIX path containing a backslash', () => {
+    // `\` is a legal POSIX filename char, so `/repo/a\b` has ONE segment after
+    // `/repo`. Treating the backslash as a separator let `@b` resolve to it
+    // instead of `/other/b`. The referenced dir takes index 1.
+    const r = prepareSendPayload('see @b', [], ['/repo/a\\b', '/other/b'])
+    expect(r.txt).toContain('[attached_dir 1] /other/b')
+    expect(r.txt, 'the backslash path must not win the @b mention').not.toMatch(
+      /see \[attached_dir \d+\] \/repo\/a\\b/,
+    )
+  })
+
+  it('ignores non-array meta lists instead of throwing', () => {
+    // `meta` comes off a server payload, so the value may be any type. The cancel
+    // path calls this synchronously in a click handler — a TypeError here took the
+    // composer down instead of just failing to strip.
+    for (const bad of ['oops', 42, { 0: 'x' }, null, undefined]) {
+      expect(() =>
+        stripAttachmentMarkers('keep me', { dirs: bad as never }),
+      ).not.toThrow()
+      expect(stripAttachmentMarkers('keep me', { dirs: bad as never })).toBe('keep me')
+    }
+  })
+
+  it('skips non-string members without shifting the index space', () => {
+    // Index 2 must still resolve to '/d' even though member 1 is unusable.
+    expect(stripAttachmentMarkers('a [attached_dir 2] /d', { dirs: [null as never, '/d'] })).toBe('a')
+  })
+
+  it('keeps directories out of filePaths and imgPaths', () => {
+    const r = prepareSendPayload('see @src/pages/', [], ['/repo/src/pages'])
+    expect(r.filePaths).toEqual([])
+    expect(r.imgPaths).toEqual([])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('normalizes a trailing slash on the incoming pending dir path', () => {
+    const r = prepareSendPayload('see @src/pages/', [], ['/repo/src/pages/'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+    expect(r.txt).toBe('see [attached_dir 1] /repo/src/pages')
+  })
+
+  it('deduplicates repeated pending dirs', () => {
+    const r = prepareSendPayload('hi', [], ['/repo/src', '/repo/src/', '/repo/src'])
+    expect(r.dirPaths).toEqual(['/repo/src'])
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+
+  it('numbers directories independently of files', () => {
+    const r = prepareSendPayload(
+      'compare @src/pages/ with @data.csv',
+      ['/repo/data.csv'],
+      ['/repo/src/pages'],
+    )
+    // Both start at 1: the two marker namespaces are separate.
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).toContain('[attached_file 1] /repo/data.csv')
+    expect(r.filePaths).toEqual(['/repo/data.csv'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+
+  it('numbers referenced dirs before unreferenced ones', () => {
+    const r = prepareSendPayload(
+      'only @src/pages/ is mentioned',
+      [],
+      ['/repo/docs', '/repo/src/pages'],
+    )
+    expect(r.dirPaths).toEqual(['/repo/src/pages', '/repo/docs'])
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).toContain('[attached_dir 2] /repo/docs')
+  })
+
+  it('does not consume a file path that sits beneath a mentioned dir', () => {
+    // The dir pass runs first, but "@src/pages/list.tsx" must resolve to the
+    // FILE, not to the dir prefix plus stray text.
+    const r = prepareSendPayload(
+      'open @src/pages/list.tsx',
+      ['/repo/src/pages/list.tsx'],
+      ['/repo/src/pages'],
+    )
+    expect(r.txt).toContain('[attached_file 1] /repo/src/pages/list.tsx')
+    // The dir was not mentioned on its own, so its token is appended.
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.txt).not.toContain('[attached_dir 1] /repo/src/pages/list.tsx')
+  })
+
+  it('handles a folder name containing spaces', () => {    const r = prepareSendPayload('check @my docs/', [], ['/repo/my docs'])
+    expect(r.dirPaths).toEqual(['/repo/my docs'])
+    expect(r.txt).toContain('[attached_dir 1] /repo/my docs')
+  })
+
+  it('places dir tokens after file tokens when both are unreferenced', () => {
+    const r = prepareSendPayload('hello', ['/repo/data.csv'], ['/repo/src'])
+    expect(r.txt).toBe('hello\n[attached_file 1] /repo/data.csv\n[attached_dir 1] /repo/src')
+  })
+
+  it('leaves displayTxt free of dir markers', () => {
+    const r = prepareSendPayload('review @src/pages/ please', [], ['/repo/src/pages'])
+    expect(r.displayTxt).toBe('review @src/pages/ please')
+    expect(r.displayTxt).not.toContain('attached_dir')
+  })
+
+  it('is a no-op when no dirs are pending (back-compat with the 2-arg call)', () => {
+    const withArg = prepareSendPayload('hello', ['/repo/data.csv'], [])
+    const withoutArg = prepareSendPayload('hello', ['/repo/data.csv'])
+    expect(withoutArg.txt).toBe(withArg.txt)
+    expect(withoutArg.dirPaths).toEqual([])
+    expect(withoutArg.txt).not.toContain('attached_dir')
+  })
+
+  it('coexists with an image attachment', () => {
+    const r = prepareSendPayload('see @src/pages/', ['/repo/shot.png'], ['/repo/src/pages'])
+    expect(r.txt).toContain('![image](/repo/shot.png)')
+    expect(r.txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(r.imgPaths).toEqual(['/repo/shot.png'])
+    expect(r.dirPaths).toEqual(['/repo/src/pages'])
+  })
+})
+
+describe('buildDirRelMap — Windows separators', () => {
+  it('resolves an absolute-path mention (unstripped root)', () => {
+    // If the root could not be stripped, the picker inserts the absolute path.
+    // A suffix-only walk never matched it, so the raw mention survived and a
+    // duplicate marker was appended.
+    const map = buildDirRelMap(['C:\\repo\\src'], 'look at @C:\\repo\\src/ please')
+    expect(map.get('C:\\repo\\src')).toBe('C:\\repo\\src')
+  })
+
+  it('prefers the short suffix over the full path when both could match', () => {
+    const map = buildDirRelMap(['/repo/src/pages'], 'look at @src/pages/ please')
+    expect(map.get('src/pages')).toBe('/repo/src/pages')
+    expect(map.has('/repo/src/pages')).toBe(false)
+  })
+
+  it('serializes an absolute-path mention to exactly one marker', () => {
+    const r = prepareSendPayload('review @C:\\repo\\src/ please', [], ['C:\\repo\\src'])
+    expect(r.txt).toBe('review [attached_dir 1] C:\\repo\\src please')
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+
+  it('matches a backslash path mention', () => {
+    // On native Windows the picker inserts the backslash path with a trailing
+    // slash. Splitting on '/' alone yielded one segment, so no suffix matched
+    // and the raw @-text survived alongside a duplicate marker.
+    const map = buildDirRelMap(['C:\\repo\\src\\pages'], 'look at @src\\pages/ please')
+    expect(map.get('src\\pages')).toBe('C:\\repo\\src\\pages')
+  })
+
+  it('matches a backslash mention with a trailing backslash', () => {
+    const map = buildDirRelMap(['C:\\repo\\src\\pages'], 'look at @src\\pages\\ please')
+    expect(map.get('src\\pages')).toBe('C:\\repo\\src\\pages')
+  })
+
+  it('serializes a backslash folder mention to exactly one marker', () => {
+    const r = prepareSendPayload('review @src\\pages/ please', [], ['C:\\repo\\src\\pages'])
+    expect(r.txt).toBe('review [attached_dir 1] C:\\repo\\src\\pages please')
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+    expect(r.dirPaths).toEqual(['C:\\repo\\src\\pages'])
+  })
+
+  it('normalizes a trailing backslash before dedup', () => {
+    const r = prepareSendPayload('', [], ['C:\\repo\\src', 'C:\\repo\\src\\'])
+    expect(r.dirPaths).toEqual(['C:\\repo\\src'])
+    expect(r.txt.match(/attached_dir/g)).toHaveLength(1)
+  })
+})
+
+describe('resolveFileSegment — folder mentions are kept out of mentionMap', () => {
+  it('routes an embedded folder token to dirMentionMap only', () => {
+    // mentionMap entries render as clickable "Open file" chips; a directory has
+    // nothing for the file viewer to open, so it must not land there.
+    const r = resolveFileSegment('review [attached_dir 1] /repo/src/pages today', [], ['/repo/src/pages'])
+    expect(r.mentionMap.size).toBe(0)
+    expect(r.dirMentionMap.get('pages/')).toBe('/repo/src/pages')
+  })
+
+  it('keeps the two maps separate for a mixed message', () => {
+    const r = resolveFileSegment(
+      'see [attached_file 1] /repo/data.csv and [attached_dir 1] /repo/src/pages now',
+      ['/repo/data.csv'],
+      ['/repo/src/pages'],
+    )
+    expect(r.mentionMap.get('data.csv')).toBe('/repo/data.csv')
+    expect(r.mentionMap.has('pages/')).toBe(false)
+    expect(r.dirMentionMap.get('pages/')).toBe('/repo/src/pages')
+  })
+
+  it('routes an optimistic-form folder mention to dirMentionMap', () => {
+    const r = resolveFileSegment('review @src/pages/ please', [], ['/repo/src/pages'])
+    expect(r.mentionMap.size).toBe(0)
+    expect(r.dirMentionMap.get('src/pages/')).toBe('/repo/src/pages')
+  })
+})
+
+describe('parseDirs / parseFiles — untrusted meta', () => {
+  it('falls back to the content scan when meta.dirs is a string', () => {
+    // /api/chat accepts any dict as meta, so this shape is reachable. An
+    // unvalidated cast reached buildFileLabels, where p.split() threw and the
+    // whole message failed to render.
+    const content = '[attached_dir 1] /repo/src'
+    expect(parseDirs(content, { dirs: 'nope' } as Record<string, unknown>)).toEqual(['/repo/src'])
+  })
+
+  it('blanks non-string members of meta.dirs in place, preserving marker indices', () => {
+    // Blanked, NOT dropped: marker N indexes this list positionally, so
+    // filtering would shift later paths down a slot (see the spaced-path test
+    // below for the user-visible consequence).
+    const dirs = ['/repo/src', 42, null, '', '/repo/docs'] as unknown
+    expect(parseDirs('', { dirs } as Record<string, unknown>)).toEqual(['/repo/src', '', '', '', '/repo/docs'])
+  })
+
+  it('resolves a spaced path whose marker follows an INVALID meta entry', () => {
+    // Regression: with `.filter()`, the bad entry at index 0 shifted
+    // '/repo/my docs' from slot 2 to slot 1, so `[attached_dir 2]` indexed past
+    // the end, fell through to the whitespace-bounded scan, and truncated the
+    // path at the space — rendering '/repo/my' and losing '/docs'.
+    const content = 'check [attached_dir 2] /repo/my docs please'
+    const dirs = parseDirs(content, { dirs: [42, '/repo/my docs'] } as unknown as Record<string, unknown>)
+    expect(dirs).toEqual(['', '/repo/my docs'])
+    const { display, dirMentionMap } = resolveFileSegment(content, [], dirs)
+    // The full spaced path survives as a chip, not truncated at the space.
+    expect([...dirMentionMap.values()]).toContain('/repo/my docs')
+    expect(display).not.toContain('/repo/my docs')
+    expect(display).not.toMatch(/\[attached_dir 2\]/)
+  })
+
+  it('does not surface a blank placeholder as an attachment card', () => {
+    // A blank is an index-alignment placeholder, never a real path — it must not
+    // reach findUnreferencedDirs and render an empty card.
+    expect(findUnreferencedDirs('no markers here', ['', '/repo/docs'])).toEqual(['/repo/docs'])
+  })
+
+  it('falls back to the content scan when every meta.dirs member is invalid', () => {
+    // All-blank carries no usable path, so `.length` must stay falsy for the
+    // caller's fallback rather than yielding ['', ''].
+    expect(parseDirs('[attached_dir 1] /repo/src', { dirs: [1, 2] } as unknown as Record<string, unknown>))
+      .toEqual(['/repo/src'])
+  })
+
+  it('falls back when meta.dirs is an object', () => {
+    expect(parseDirs('[attached_dir 1] /repo/src', { dirs: { a: 1 } } as Record<string, unknown>))
+      .toEqual(['/repo/src'])
+  })
+
+  it('applies the same validation to meta.files', () => {
+    expect(parseFiles('[attached_file 1] /repo/a.csv', { files: 'nope' } as Record<string, unknown>))
+      .toEqual(['/repo/a.csv'])
+    expect(parseFiles('', { files: ['/repo/a.csv', 7] } as unknown as Record<string, unknown>))
+      .toEqual(['/repo/a.csv', ''])
+  })
+
+  it('resolveFileSegment survives malformed meta-derived lists', () => {
+    const dirs = parseDirs('review [attached_dir 1] /repo/src/pages now', { dirs: 99 } as Record<string, unknown>)
+    expect(() => resolveFileSegment('review [attached_dir 1] /repo/src/pages now', [], dirs)).not.toThrow()
+  })
+})
+
+describe('buildFileLabels with Windows separators', () => {
+  it('takes the basename of a backslash path', () => {
+    // Splitting on `/` alone left the whole absolute path as the "basename", so
+    // every chip and card displayed the full native Windows path.
+    const map = buildFileLabels(['C:\\repo\\website\\docs'])
+    expect(map.get('C:\\repo\\website\\docs')).toBe('docs')
+  })
+
+  it('disambiguates duplicate names across backslash paths', () => {
+    const paths = ['C:\\repo\\docs', 'C:\\repo\\website\\docs']
+    const map = buildFileLabels(paths)
+    expect(map.get(paths[0])).toBe('repo/docs')
+    expect(map.get(paths[1])).toBe('website/docs')
+  })
+
+  it('still handles POSIX paths unchanged', () => {
+    const paths = ['/repo/docs', '/repo/website/docs', '/repo/a.txt']
+    const map = buildFileLabels(paths)
+    expect(map.get('/repo/docs')).toBe('repo/docs')
+    expect(map.get('/repo/website/docs')).toBe('website/docs')
+    expect(map.get('/repo/a.txt')).toBe('a.txt')
+  })
+})
+
+describe('marker emission does not rescan its own output', () => {
+  // Serialization ran as sequential passes over text that ALREADY contained
+  // markers emitted by an earlier pass. A generated marker carries the absolute
+  // path verbatim, so if that path happens to contain an `@mention` matching a
+  // later pass's token, the later pass rewrites text inside the marker it should
+  // never have looked at.
+  it('leaves a folder marker intact when its path contains a later token', () => {
+    // The dir pass emits `[attached_dir 1] /repo/@data.csv`. The file pass then
+    // scans that output; `@data.csv` sits at end-of-string inside the emitted
+    // path, which is exactly what tokenRegex matches.
+    const dirs = ['/repo/@data.csv']
+    const { txt, dirPaths } = prepareSendPayload('check @@data.csv/', [], dirs)
+    expect(dirPaths).toEqual(['/repo/@data.csv'])
+    expect(txt, 'the folder path must survive verbatim').toContain('[attached_dir 1] /repo/@data.csv')
+    // A second marker for the same path means the emitted one got rewritten.
+    expect(txt.match(/\[attached_dir 1\]/g) || []).toHaveLength(1)
+    expect(txt, 'no file marker should appear — no file was attached').not.toContain('[attached_file')
+  })
+
+  it('does not let a file token rewrite the inside of a folder marker', () => {
+    // The true rescan case. The dir pass emits
+    //   `[attached_dir 1] /repo/@data.csv`
+    // and that emitted text contains `@data.csv` — which is exactly the mention
+    // for an UNRELATED attached file `/other/data.csv`. The later file pass
+    // scanned the dir pass's output and substituted a file marker INSIDE the
+    // folder marker. Note the two paths share no suffix, so this is not the
+    // ambiguous-mention case: it is purely an artifact of re-scanning.
+    const dirs = ['/repo/@data.csv']
+    const files = ['/other/data.csv']
+    const { txt } = prepareSendPayload('folder @@data.csv/ file @data.csv', files, dirs)
+    expect(txt, 'the folder path must survive verbatim').toContain('[attached_dir 1] /repo/@data.csv')
+    expect(txt, 'the file gets its own marker').toContain('[attached_file 1] /other/data.csv')
+    // Exactly one of each — a nested/duplicated marker means the emitted output
+    // was rescanned.
+    expect(txt.match(/\[attached_dir /g) || []).toHaveLength(1)
+    expect(txt.match(/\[attached_file /g) || []).toHaveLength(1)
+  })
+
+  it('resolves the longest mention first when a dir prefixes a file', () => {
+    // `@src/pages/` (dir) is a prefix of `@src/pages/list.tsx` (file). The
+    // scanner must prefer the longer candidate at a given position, or the file
+    // mention would be half-consumed as a folder.
+    const dirs = ['/repo/src/pages']
+    const files = ['/repo/src/pages/list.tsx']
+    const { txt } = prepareSendPayload('see @src/pages/ and @src/pages/list.tsx', files, dirs)
+    expect(txt).toContain('[attached_dir 1] /repo/src/pages')
+    expect(txt).toContain('[attached_file 1] /repo/src/pages/list.tsx')
+    expect(txt.match(/\[attached_dir /g) || []).toHaveLength(1)
+  })
+
+  it('keeps an image path out of an already-emitted folder marker', () => {
+    // Images are replaced with '' by their pass, so under the old multi-pass
+    // order (dirs, then images rescanning the dir pass's OUTPUT) an image mention
+    // occurring inside an emitted folder marker had its text deleted from inside
+    // that marker — corrupting the path handed to the agent.
+    //
+    // Reproducing this needs the image's MENTION TEXT to appear in the dir path:
+    // buildRelMap resolves the shortest suffix present in the text, so the image
+    // /assets/hero.png resolves to `hero.png`, and the folder /shots/@hero.png
+    // emits a marker containing `@hero.png` for the image pass to eat. An image
+    // whose suffix does NOT occur in the dir path leaves both orderings
+    // identical, which is why a mismatched pair proves nothing.
+    const dirs = ['/shots/@hero.png']
+    const files = ['/assets/hero.png']
+    const { txt } = prepareSendPayload('look at @@hero.png/ and @hero.png', files, dirs)
+    // The folder marker survives intact — nothing was excised from inside it.
+    expect(txt).toContain('[attached_dir 1] /shots/@hero.png')
+  })
+})

--- a/website/src/test/renderUserContent.dirs.test.tsx
+++ b/website/src/test/renderUserContent.dirs.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { renderUserContent } from '../pages/ChatPage'
+
+const noop = () => {}
+
+/** The persisted shape: server stores the LLM-facing token form in content AND
+ *  keeps meta alongside it. Tests cover both meta-present and no-meta replay. */
+const DIR = '/repo/src/pages'
+const FILE = '/repo/data.csv'
+
+describe('renderUserContent — folder references', () => {
+  it('renders a standalone folder token as a folder card, not raw text', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('pages/')
+  })
+
+  it('renders the folder card with a Folder icon', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelector('[aria-label="Folder"]')).toBeInTheDocument()
+  })
+
+  it('exposes the full path as the folder card title', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelector(`[title="${DIR}"]`)).toBeInTheDocument()
+  })
+
+  it('does not make the folder card clickable', () => {
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const card = container.querySelector(`[title="${DIR}"]`)!
+    expect(card.tagName.toLowerCase()).not.toBe('a')
+    expect(card.tagName.toLowerCase()).not.toBe('button')
+  })
+
+  it('renders an embedded folder token as an inline chip with a trailing slash', () => {
+    const { container } = render(
+      <>{renderUserContent(`please review [attached_dir 1] ${DIR} today`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('please review')
+    expect(container).toHaveTextContent('@pages/')
+    expect(container).toHaveTextContent('today')
+  })
+
+  it('keeps an embedded folder mention on one line with the surrounding text', () => {
+    const { container } = render(
+      <>{renderUserContent(`check [attached_dir 1] ${DIR} now`, { dirs: [DIR] }, noop)}</>,
+    )
+    // A block <p> per run would break the line around the chip.
+    expect(container.querySelectorAll('p')).toHaveLength(0)
+  })
+
+  it('replays a folder token with no meta (history replay path)', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, undefined, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('pages/')
+  })
+
+  it('renders a file card and a folder card together', () => {
+    const content = `hello\n[attached_file 1] ${FILE}\n[attached_dir 1] ${DIR}`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_file')
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container).toHaveTextContent('data.csv')
+    expect(container).toHaveTextContent('pages/')
+    expect(container).toHaveTextContent('hello')
+  })
+
+  it('resolves same-numbered file and dir tokens against their own lists', () => {
+    // Both markers are numbered 1: each must index its OWN ordered list.
+    const content = `see [attached_file 1] ${FILE} and [attached_dir 1] ${DIR}`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).toHaveTextContent('@data.csv')
+    expect(container).toHaveTextContent('@pages/')
+  })
+
+  it('does not make an embedded folder chip clickable', () => {
+    // A mentionMap entry renders as an "Open file" chip that calls onFileOpen.
+    // A folder must not reach that path: the viewer cannot open a directory.
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent(`please review [attached_dir 1] ${DIR} today`, { dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const chip = container.querySelector(`[title="${DIR}"]`)!
+    expect(chip).toBeInTheDocument()
+    expect(chip.tagName.toLowerCase()).not.toBe('a')
+    expect(chip.tagName.toLowerCase()).not.toBe('button')
+    expect(chip.getAttribute('aria-label') ?? '').not.toMatch(/open file/i)
+    expect(chip.className).not.toContain('cursor-pointer')
+  })
+
+  it('keeps an embedded file chip clickable alongside a folder chip', () => {
+    const onFileOpen = vi.fn()
+    const content = `see [attached_file 1] ${FILE} and [attached_dir 1] ${DIR} now`
+    const { container } = render(
+      <>{renderUserContent(content, { files: [FILE], dirs: [DIR] }, onFileOpen)}</>,
+    )
+    const fileChip = container.querySelector(`[aria-label="Open file ${FILE}"]`)
+    expect(fileChip).toBeInTheDocument()
+    const dirChip = container.querySelector(`[title="${DIR}"]`)!
+    expect(dirChip.getAttribute('aria-label') ?? '').not.toMatch(/open file/i)
+  })
+
+  it('handles a folder path containing spaces', () => {
+    const spaced = '/repo/my docs'
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${spaced}`, { dirs: [spaced] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_dir')
+    expect(container.querySelector(`[title="${spaced}"]`)).toBeInTheDocument()
+    expect(container).toHaveTextContent('my docs/')
+  })
+
+  it('resolves a spaced folder path from the meta the sender actually persists', () => {
+    // Regression guard: send() must put dirPaths on meta.dirs. Without it this
+    // message replays through the whitespace-splitting content fallback, which
+    // truncates the path at the first space.
+    const spaced = '/repo/my docs'
+    const content = `look at [attached_dir 1] ${spaced} please`
+    const withMeta = render(
+      <>{renderUserContent(content, { dirs: [spaced] }, noop)}</>,
+    )
+    expect(withMeta.container).toHaveTextContent('@my docs/')
+    expect(withMeta.container).toHaveTextContent('please')
+    expect(withMeta.container).not.toHaveTextContent('attached_dir')
+    // Same content with no meta is the degraded path: the fallback can only see
+    // up to the space, so the tail leaks as text. This asserts the difference is
+    // real, which is why meta.dirs must be persisted.
+    const noMeta = render(<>{renderUserContent(content, undefined, noop)}</>)
+    expect(noMeta.container).toHaveTextContent('docs')
+  })
+
+  it('renders the optimistic bubble form (@relative, no token yet)', () => {
+    const { container } = render(
+      <>{renderUserContent('review @src/pages/ please', { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container).toHaveTextContent('review')
+    expect(container).toHaveTextContent('please')
+    expect(container).toHaveTextContent('src/pages/')
+  })
+
+  it('renders a folder card exactly once, not per segment', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_dir 1] ${DIR}`, { dirs: [DIR] }, noop)}</>,
+    )
+    expect(container.querySelectorAll(`[title="${DIR}"]`)).toHaveLength(1)
+  })
+
+  it('leaves a message with no attachments untouched', () => {
+    const { container } = render(
+      <>{renderUserContent('plain **bold** message', undefined, noop)}</>,
+    )
+    expect(container.querySelector('strong')).toHaveTextContent('bold')
+  })
+
+  it('still renders a file-only message exactly as before (no dir regression)', () => {
+    const { container } = render(
+      <>{renderUserContent(`[attached_file 1] ${FILE}`, { files: [FILE] }, noop)}</>,
+    )
+    expect(container).not.toHaveTextContent('attached_file')
+    expect(container).toHaveTextContent('data.csv')
+    expect(container.querySelector('[aria-label="Folder"]')).not.toBeInTheDocument()
+  })
+})

--- a/website/src/test/useWebSocket.steerMeta.test.ts
+++ b/website/src/test/useWebSocket.steerMeta.test.ts
@@ -1,0 +1,147 @@
+/**
+ * useWebSocket `steer_push` -> attachment metadata handoff.
+ *
+ * A mid-turn steer is broadcast to every other open tab as a `steer_push` frame.
+ * Marker number N in the content is a positional index into `meta.files` /
+ * `meta.dirs`, so a tab that renders the content without those ordered lists
+ * falls back to a whitespace-bounded scan and truncates a path containing a
+ * space (`/repo/my docs` -> `/repo/my`).
+ *
+ * The transport forwards `data.meta` into the appended message. That wiring had
+ * no test: the reducer tests construct the message directly and bypass the hook,
+ * so deleting the forward left the whole suite green while second-tab
+ * attachments silently truncated. This locks the hook-level handoff.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+const SLOT = 'chat-1'
+const SPACED_DIR = '/repo/my docs'
+const SPACED_FILE = '/repo/my notes/todo.md'
+
+describe('useWebSocket steer_push forwards attachment metadata', () => {
+  let queryClient: QueryClient
+  let store: ReturnType<typeof createTestStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    store = createTestStore()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(Provider, { store },
+      createElement(QueryClientProvider, { client: queryClient }, children))
+  }
+
+  function steered() {
+    const s = store.getState().chat
+    const msgs = s.slotMessages[SLOT] ?? s.messages
+    return msgs.filter(m => m.role === 'user').at(-1)
+  }
+
+  it('carries meta.files and meta.dirs onto the appended bubble', () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'steer_push',
+        data: {
+          slot: SLOT,
+          content: `check [attached_file 1] ${SPACED_FILE} and [attached_dir 1] ${SPACED_DIR}`,
+          ts: '2026-07-26T10:00:00.000Z',
+          meta: { files: [SPACED_FILE], dirs: [SPACED_DIR] },
+        },
+      })
+    })
+
+    const msg = steered()
+    expect(msg, 'steer_push did not append a user bubble').toBeTruthy()
+    // The ordered lists must survive verbatim — they are the index space the
+    // markers resolve against.
+    expect(msg!.meta?.files).toEqual([SPACED_FILE])
+    expect(msg!.meta?.dirs).toEqual([SPACED_DIR])
+  })
+
+  it('re-asserts steer: true so the bubble styles correctly', () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'steer_push',
+        data: { slot: SLOT, content: 'plain steer', ts: '2026-07-26T10:00:00.000Z' },
+      })
+    })
+
+    expect(steered()!.meta?.steer).toBe(true)
+  })
+
+  it('still marks a steer against an older backend that sends no meta', () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'steer_push',
+        data: { slot: SLOT, content: 'no meta at all', ts: '2026-07-26T10:00:00.000Z' },
+      })
+    })
+
+    const msg = steered()!
+    expect(msg.meta?.steer).toBe(true)
+    expect(msg.meta?.dirs).toBeUndefined()
+  })
+})

--- a/website/src/utils/chatDirDrafts.ts
+++ b/website/src/utils/chatDirDrafts.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-slot pending-folder-reference persistence (directory paths staged in the
+ * compose box before send). Thin instance of `createSlotDraftStore`, mirroring
+ * `chatFileDrafts`.
+ *
+ * A folder reference is a path handed to the agent, not an upload, so nothing
+ * server-side can garbage-collect it. It is still kept in sessionStorage rather
+ * than localStorage to match the file-attachment lifetime: a staged reference
+ * belongs to the composing session, and a path that is valid today may not
+ * exist after a tab-close-and-return.
+ */
+import { createSlotDraftStore } from './slotDraftStore'
+
+export const DIR_DRAFTS_KEY = 'mc-chat-dir-drafts'
+
+export type DirDrafts = Record<string, string[]>
+
+/** Coerce to a non-empty string[] (dropping non-string members), or null. The
+ *  returned copy isolates the store from caller mutations and vice versa. */
+const sanitizePaths = (v: unknown): string[] | null => {
+  if (!Array.isArray(v)) return null
+  const arr = v.filter((x): x is string => typeof x === 'string')
+  return arr.length ? arr.slice() : null
+}
+
+const store = createSlotDraftStore<string[]>({
+  key: DIR_DRAFTS_KEY,
+  storage: 'session',
+  sanitize: sanitizePaths,
+})
+
+export const loadDirDrafts = store.load
+export const saveDirDrafts = store.save
+export const setDirDraft = store.set

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -2,29 +2,87 @@
 
 export const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg)$/i
 
+/** Escape a literal string for safe embedding in a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /** Boundary-aware regex for @token matching. Prevents `@foo.ts` from matching inside `@foo.tsx`. */
 function tokenRegex(token: string, flags = ''): RegExp {
-  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const escaped = escapeRegExp(token)
   return new RegExp(`@${escaped}(?=\\s|$)`, flags)
+}
+
+/**
+ * Coerce an untrusted `meta` attachment list to `string[]`.
+ *
+ * `/api/chat` accepts any dictionary as message metadata, so a persisted
+ * `meta.files` / `meta.dirs` can be a string, or an array holding non-strings.
+ * A bare `as string[]` cast performed no runtime check, and replay then handed
+ * that value to buildFileLabels, where `p.split()` threw and the whole message
+ * failed to render.
+ *
+ * Invalid members are BLANKED IN PLACE (empty string), never dropped: marker
+ * number N indexes this list positionally, so filtering a bad entry out would
+ * shift every later path down one slot and `[attached_dir 2] /repo/my docs`
+ * would resolve against the wrong element — falling through to the
+ * whitespace-bounded scan that truncates at the space, the exact bug the
+ * ordered lists exist to prevent. A blank placeholder keeps later indices
+ * aligned and simply fails the `startsWith` check for its own marker, which
+ * degrades to the scan for that one entry alone. A wholly invalid value yields
+ * `[]`, which falls through to the content-scan fallback.
+ */
+export function metaPathList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const out = value.map(p => (typeof p === 'string' ? p : ''))
+  // All-blank is indistinguishable from "no usable metadata" — let the caller's
+  // `.length` check fall through to the content scan rather than handing back a
+  // list of empty strings that can never match a marker.
+  return out.some(p => p.length > 0) ? out : []
 }
 
 /** Parse file paths from message meta or [attached_file N] patterns in content. */
 export function parseFiles(content: string, meta?: Record<string, unknown>): string[] {
-  const metaFiles = (meta?.files || []) as string[]
+  const metaFiles = metaPathList(meta?.files)
   return metaFiles.length
     ? metaFiles
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
 }
 
-/** Per-path display label: basename, disambiguated to the last-2 path segments
+/** Split a path into segments, treating `\` as a separator only for
+ *  Windows-style paths. On POSIX a backslash is a legal filename character, so
+ *  splitting on it unconditionally mislabeled `/repo/a\b` as `b` in chips,
+ *  cards and generated titles. */
+export function pathSegments(p: string): string[] {
+  const windowsish = /^[a-zA-Z]:[/\\]/.test(p) || (p.includes('\\') && !p.includes('/'))
+  return p.split(windowsish ? /[/\\]/ : /\//)
+}
+
+/** Build display labels for attachment chips -- basename, extended leftwards
  *  when two paths share a basename (e.g. two `report.docx` in different dirs). */
 export function buildFileLabels(paths: string[]): Map<string, string> {
-  const basenames = paths.map(p => p.split('/').pop() || p)
-  const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
+  const seg = pathSegments
   const map = new Map<string, string>()
+  // Widen each label leftwards until it is unique among the whole set. Stopping
+  // at exactly two segments left genuine collisions: `/a/x/docs` and `/b/x/docs`
+  // both labelled `x/docs`, so two distinct attachments rendered identically and
+  // the map key for one silently overwrote the other's path — the chip pointed at
+  // the wrong directory. Depth grows only as far as the collision requires.
+  const partsOf = new Map(paths.map(p => [p, seg(p)]))
+  const labelAt = (p: string, depth: number) => {
+    const parts = partsOf.get(p) ?? [p]
+    return parts.slice(Math.max(0, parts.length - depth)).join('/') || p
+  }
+  const maxDepth = Math.max(1, ...paths.map(p => (partsOf.get(p) ?? []).length))
   for (const p of paths) {
-    const name = p.split('/').pop() || p
-    map.set(p, dupes.has(name) ? p.split('/').slice(-2).join('/') : name)
+    let depth = 1
+    while (depth < maxDepth) {
+      const mine = labelAt(p, depth)
+      const clashes = paths.some(q => q !== p && labelAt(q, depth) === mine)
+      if (!clashes) break
+      depth += 1
+    }
+    map.set(p, labelAt(p, depth))
   }
   return map
 }
@@ -34,8 +92,12 @@ export interface ResolvedFileSegment {
   display: string
   /** `@label` (without the leading @) -> full path, for files referenced inline IN THIS content. */
   mentionMap: Map<string, string>
+  /** `@label/` (without the leading @) -> full path, for FOLDERS referenced inline IN THIS content. Kept apart from `mentionMap` because a folder chip must not be clickable: there is nothing for the file viewer to open. */
+  dirMentionMap: Map<string, string>
   /** Standalone-upload paths whose token appears IN THIS content — render as cards. Does NOT include files that are absent from this content (the caller decides those at message level, to avoid per-segment duplication). */
   cardPaths: string[]
+  /** Standalone directory references whose `[attached_dir N]` token appears IN THIS content — render as folder cards. */
+  dirCardPaths: string[]
   /** Display label per path (basename, disambiguated). */
   labels: Map<string, string>
 }
@@ -75,20 +137,33 @@ export interface ResolvedFileSegment {
  * markdown, never as file cards); an image referenced by an embedded token is
  * likewise never added to mentionMap.
  */
-export function resolveFileSegment(content: string, orderedFiles: string[]): ResolvedFileSegment {
+export function resolveFileSegment(
+  content: string,
+  orderedFiles: string[],
+  orderedDirs: string[] = [],
+): ResolvedFileSegment {
   const labels = buildFileLabels(orderedFiles)
+  const dirLabels = buildFileLabels(orderedDirs)
   const mentionMap = new Map<string, string>()
+  const dirMentionMap = new Map<string, string>()
   const cardPaths: string[] = []
+  const dirCardPaths: string[] = []
   const seen = new Set<string>()
+  const seenDirs = new Set<string>()
 
-  const markerRe = /\[attached_file (\d+)\]([^\S\n]+)/g
+  // Both markers share one scan so their tokens interleave correctly in the
+  // output, but each numbers into its OWN ordered list: [attached_file 1] and
+  // [attached_dir 1] refer to different things.
+  const markerRe = /\[attached_(file|dir) (\d+)\]([^\S\n]+)/g
   let display = ''
   let lastIdx = 0
   let m: RegExpExecArray | null
   while ((m = markerRe.exec(content)) !== null) {
-    const n = parseInt(m[1], 10)
+    const isDirMarker = m[1] === 'dir'
+    const ordered = isDirMarker ? orderedDirs : orderedFiles
+    const n = parseInt(m[2], 10)
     const pathStart = m.index + m[0].length
-    const indexed = n >= 1 && n <= orderedFiles.length ? orderedFiles[n - 1] : undefined
+    const indexed = n >= 1 && n <= ordered.length ? ordered[n - 1] : undefined
     let path: string
     let pathEnd: number
     if (indexed && content.startsWith(indexed, pathStart)) {
@@ -110,15 +185,27 @@ export function resolveFileSegment(content: string, orderedFiles: string[]): Res
     const nlAfter = afterSlice.indexOf('\n')
     const lineAfter = nlAfter === -1 ? afterSlice : afterSlice.slice(0, nlAfter)
     const embedded = lineBefore.trim().length > 0 || lineAfter.trim().length > 0
-    const label = labels.get(path) || (path.split('/').pop() || path)
-    const isImage = IMG_EXT.test(path)
+    const label = isDirMarker
+      ? (dirLabels.get(path) || path.split('/').pop() || path)
+      : (labels.get(path) || path.split('/').pop() || path)
+    // A directory is never an image, so the image branch only applies to files.
+    const isImage = !isDirMarker && IMG_EXT.test(path)
 
     display += content.slice(lastIdx, m.index)
     if (embedded && !isImage) {
-      mentionMap.set(label, path)
-      display += `@${label}`
+      // Folder chips read with a trailing slash so they are visibly not files,
+      // and land in their own map: the caller renders them as non-clickable
+      // labels, since a directory has nothing to open in the file viewer.
+      if (isDirMarker) {
+        dirMentionMap.set(label + '/', path)
+        display += `@${label}/`
+      } else {
+        mentionMap.set(label, path)
+        display += `@${label}`
+      }
     } else if (!embedded && !isImage) {
-      cardPaths.push(path)
+      if (isDirMarker) dirCardPaths.push(path)
+      else cardPaths.push(path)
       // Drop a trailing newline the standalone token owns so it leaves no blank
       // line; if it had a leading newline instead, drop that from the output.
       if (afterSlice.startsWith('\n')) pathEnd += 1
@@ -128,18 +215,26 @@ export function resolveFileSegment(content: string, orderedFiles: string[]): Res
       if (afterSlice.startsWith('\n')) pathEnd += 1
       else if (content[m.index - 1] === '\n') display = display.slice(0, -1)
     }
-    seen.add(path)
+    if (isDirMarker) seenDirs.add(path)
+    else seen.add(path)
     lastIdx = pathEnd
     markerRe.lastIndex = pathEnd
   }
   display += content.slice(lastIdx)
 
   // Recover any `@relative` mentions already present (fresh optimistic bubble),
-  // for non-image files not already resolved from a token above.
-  const notSeen = orderedFiles.filter(p => !seen.has(p) && !IMG_EXT.test(p))
+  // for non-image files not already resolved from a token above. Blank entries
+  // are index-alignment placeholders for invalid metadata (see metaPathList) —
+  // they are not real paths, so they must never reach a chip or card.
+  const notSeen = orderedFiles.filter(p => p && !seen.has(p) && !IMG_EXT.test(p))
   buildRelMap(notSeen, display).forEach((fullPath, suffix) => mentionMap.set(suffix, fullPath))
+  // Same for folders: the optimistic bubble still carries `@src/pages/`.
+  const dirsNotSeen = orderedDirs.filter(p => p && !seenDirs.has(p))
+  buildDirRelMap(dirsNotSeen, display).forEach((fullPath, suffix) => {
+    dirMentionMap.set(suffix + '/', fullPath)
+  })
 
-  return { display, mentionMap, cardPaths, labels }
+  return { display, mentionMap, dirMentionMap, cardPaths, dirCardPaths, labels }
 }
 
 /**
@@ -162,34 +257,266 @@ export function findUnreferencedAttachments(text: string, orderedFiles: string[]
     if (text.includes(`[attached_file ${n}]`)) { referenced.add(p); return }
     if (buildRelMap([p], text).size) referenced.add(p)
   })
-  return orderedFiles.filter(p => !IMG_EXT.test(p) && !referenced.has(p))
+  return orderedFiles.filter(p => p && !IMG_EXT.test(p) && !referenced.has(p))
+}
+
+/**
+ * Directory counterpart to findUnreferencedAttachments. Token number N indexes
+ * `orderedDirs`, an index space entirely separate from the file markers', so a
+ * message carrying both `[attached_file 1]` and `[attached_dir 1]` resolves each
+ * against the right list.
+ */
+export function findUnreferencedDirs(text: string, orderedDirs: string[]): string[] {
+  const referenced = new Set<string>()
+  orderedDirs.forEach((p, i) => {
+    const n = i + 1
+    if (text.includes(`[attached_dir ${n}]`)) { referenced.add(p); return }
+    if (buildDirRelMap([p], text).size) referenced.add(p)
+  })
+  return orderedDirs.filter(p => p && !referenced.has(p))
+}
+
+/** Parse directory paths from message meta or [attached_dir N] patterns in content. */
+export function parseDirs(content: string, meta?: Record<string, unknown>): string[] {
+  const metaDirs = metaPathList(meta?.dirs)
+  return metaDirs.length
+    ? metaDirs
+    : (content.match(/\[attached_dir \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_dir \d+\] /, ''))
 }
 
 /** Walk path segments to find the shortest @suffix present in text. */
-export function buildRelMap(paths: string[], text: string): Map<string, string> {
+export function buildRelMap(
+  paths: string[], text: string,
+  /** Token matcher; folder mentions pass `dirTokenRegex`. */
+  matcher: (token: string, flags?: string) => RegExp = tokenRegex,
+): Map<string, string> {
   const map = new Map<string, string>()
   for (const p of paths) {
-    const segs = p.split('/')
-    for (let i = 1; i < segs.length; i++) {
-      const suffix = segs.slice(i).join('/')
-      if (tokenRegex(suffix).test(text) && !map.has(suffix)) { map.set(suffix, p); break }
+    for (const suffix of pathSuffixes(trimDirSeparator(p))) {
+      if (matcher(suffix).test(text) && !map.has(suffix)) { map.set(suffix, p); break }
     }
   }
   return map
 }
 
+/**
+ * Directory variant of tokenRegex. The composer inserts folder mentions with a
+ * trailing slash (`@src/pages/ `), so the token must match with OR without it.
+ * The trailing separator may be either kind so a Windows path (`src\pages`) that
+ * the picker suffixed with `/` still matches.
+ */
+function dirTokenRegex(token: string, flags = ''): RegExp {
+  // Strip only a real trailing separator (see trimDirSeparator): on POSIX a
+  // trailing backslash is part of the name, and eating it left the mention
+  // unreplaced and duplicated by an appended marker.
+  const escaped = escapeRegExp(trimDirSeparator(token))
+  return new RegExp(`@${escaped}[/\\\\]?(?=\\s|$)`, flags)
+}
+
+/**
+ * Path suffixes after each separator, longest first, with the ORIGINAL separator
+ * characters preserved.
+ *
+ * Splitting on `/` alone would collapse a native Windows path
+ * (`C:\repo\src\pages`) to a single segment, so no suffix would ever match the
+ * `@C:\repo\src\pages/` token the picker inserted, and the mention would be left
+ * as raw text while a duplicate `[attached_dir N]` marker was appended. Slicing
+ * rather than splitting-and-rejoining keeps the separators native, so the map key
+ * matches the text verbatim.
+ */
+function pathSuffixes(bare: string): string[] {
+  // The full path is a candidate too: when the root could not be stripped (e.g.
+  // an unrecognized root form), the picker inserts the absolute path, and a
+  // suffix-only walk would never match it, leaving the raw mention plus a
+  // duplicate marker. Suffixes are tried first so the short form still wins.
+  const out: string[] = []
+  // Only split on `\` for Windows-style paths — an internal backslash in a legal
+  // POSIX name is not a separator, and treating it as one let `@b` resolve to
+  // the wrong staged path `/repo/a\b`.
+  const windowsish = /^[a-zA-Z]:[/\\]/.test(bare) || (bare.includes('\\') && !bare.includes('/'))
+  const sepRe = windowsish ? /[/\\]/g : /\//g
+  let m: RegExpExecArray | null
+  while ((m = sepRe.exec(bare)) !== null) {
+    const suffix = bare.slice(m.index + 1)
+    if (suffix) out.push(suffix)
+  }
+  out.push(bare)
+  return out
+}
+
+/**
+ * Directory variant of buildRelMap. Folder paths carry no trailing separator,
+ * but the inserted token does, so matching tolerates either form and either
+ * separator style.
+ */
+export function buildDirRelMap(paths: string[], text: string): Map<string, string> {
+  return buildRelMap(paths, text, dirTokenRegex)
+}
+
+/**
+ * Remove `[attached_file N] path` / `[attached_dir N] path` pairs from text.
+ *
+ * Mirrors the server's `strip_attachment_markers`. Used when a queued card is
+ * cancelled back into the composer: the card stores the SERIALIZED text, so
+ * inserting it verbatim showed the raw marker and re-serialized it on resend.
+ *
+ * Strips by exact `marker + path` using the card's own ordered lists rather than
+ * by pattern, so a path containing spaces or brackets is removed exactly.
+ * Indices absent from `meta` are left alone — they belong to another family.
+ *
+ * Whitespace is repaired ONLY at each removal site. A global multi-space collapse
+ * plus per-line trim rewrote text far from any marker, so a pasted code snippet
+ * lost its indentation and aligned columns collapsed.
+ */
+export function stripAttachmentMarkers(
+  content: string,
+  meta?: { files?: string[]; dirs?: string[] },
+): string {
+  if (!content || !meta) return content
+  let out = content
+  for (const [prefix, paths] of [
+    ['[attached_file ', meta.files],
+    ['[attached_dir ', meta.dirs],
+  ] as const) {
+    // `meta` comes off a server payload, so the value may be any type. Only an
+    // array of strings is meaningful — anything else is ignored rather than
+    // iterated, which previously threw `paths.forEach is not a function` on the
+    // cancel path and took the composer down with it.
+    if (!Array.isArray(paths)) continue
+    paths.forEach((p, i) => {
+      if (!p || typeof p !== 'string') return
+      const marker = escapeRegExp(`${prefix}${i + 1}] ${p}`)
+      // Require a boundary after the path, or the marker matches a PREFIX of a
+      // longer path: with meta owning `/d`, text mentioning `[attached_dir 1]
+      // /dossier` was stripped down to `ossier`.
+      const bound = '(?=\\s|$)'
+      // A marker alone on its line takes the whole line, so no blank line is left.
+      out = out.replace(new RegExp(`^[ \\t]*${marker}${bound}[ \\t]*\\n?`, 'gm'), '')
+      // Otherwise the marker plus the whitespace hugging it becomes one space.
+      out = out.replace(new RegExp(`[ \\t]*${marker}${bound}[ \\t]*`, 'g'), ' ')
+      out = out.replace(/[ \t]+$/gm, '')
+    })
+  }
+  return out.trim()
+}
+
+/**
+ * Drop a directory path's trailing separator for dedup/matching purposes.
+ *
+ * Deliberately conservative. A blanket `/[/\\]+$/` strip was wrong twice: it
+ * collapsed a filesystem root (`/` -> `''`, `C:\` -> `C:`), and on POSIX it ate
+ * the last character of a legal directory name ending in a backslash. So a
+ * backslash is only treated as a separator when the path actually uses
+ * backslashes as separators, and the result is never allowed to go empty.
+ */
+export function trimDirSeparator(p: string): string {
+  const windowsish = /^[a-zA-Z]:[/\\]/.test(p) || (p.includes('\\') && !p.includes('/'))
+  const re = windowsish ? /[/\\]+$/ : /\/+$/
+  const trimmed = p.replace(re, '')
+  // Roots (`/`, `C:\`, `\\server\share`) trim to nothing or to a bare drive —
+  // keep the original so they stay valid paths.
+  if (!trimmed || /^[a-zA-Z]:$/.test(trimmed)) return p
+  return trimmed
+}
+
 /** Replace @rel tokens in text using a replacer function. */
+
 export function replaceTokens(
   text: string, paths: string[], relMap: Map<string, string>,
   replacer: (fullPath: string, idx: number) => string,
+  /** Token matcher. Folder mentions pass `dirTokenRegex`, which additionally
+   *  tolerates the trailing separator the composer inserts. */
+  matcher: (token: string, flags?: string) => RegExp = tokenRegex,
 ): string {
   let result = text
   paths.forEach((p, i) => {
     const rel = [...relMap.entries()].find(([, v]) => v === p)?.[0]
     if (!rel) return
-    result = result.replace(tokenRegex(rel, 'g'), () => replacer(p, i))
+    result = result.replace(matcher(rel, 'g'), () => replacer(p, i))
   })
   return result
+}
+
+/** Directory variant of replaceTokens, tolerant of the inserted trailing slash. */
+export function replaceDirTokens(
+  text: string, paths: string[], relMap: Map<string, string>,
+  replacer: (fullPath: string, idx: number) => string,
+): string {
+  return replaceTokens(text, paths, relMap, replacer, dirTokenRegex)
+}
+
+/**
+ * Replace every `@mention` in one left-to-right pass.
+ *
+ * Serialization used to run as sequential `replaceTokens` passes — dirs, then
+ * images, then files — over text that ALREADY contained markers emitted by an
+ * earlier pass. An emitted marker carries the absolute path verbatim, so when a
+ * path itself contains an `@…` sequence that a later pass's token matches, the
+ * later pass rewrites text inside a marker it should never have looked at.
+ *
+ * Observed corruption: input `see @@notes/ and @@notes` with dir `/data/@notes`
+ * and file `/repo/@notes` produced
+ * `see [attached_dir 1] /data/@notes and [attached_dir 1] /data/@notes` — the
+ * file mention was replaced by a duplicate *folder* marker, so the agent was
+ * pointed at a directory that was never the attachment. That is a wrong-path
+ * substitution, not just a cosmetic glitch.
+ *
+ * One pass fixes the class rather than the instance: the scanner walks the
+ * original text once, and any text it emits is final. Candidates are matched
+ * LONGEST-FIRST at each position so `@src/pages/list.tsx` wins over the
+ * `@src/pages/` directory that prefixes it.
+ */
+export function replaceMentionsOnce(
+  text: string,
+  candidates: Array<{
+    /** Relative mention text, without the leading `@` and without a trailing separator. */
+    rel: string
+    /** Whether the trailing separator the composer inserts is tolerated (dirs). */
+    dir: boolean
+    /** Absolute path this candidate stands for, when the caller needs to know
+     *  which candidates actually won a position. */
+    path?: string
+    /** Emit the replacement for this candidate. */
+    emit: () => string
+  }>,
+  /** Called for each candidate that actually wins a position and is emitted.
+   *  Equal-length candidates compete, so "matched the text" is not the same as
+   *  "was emitted" — the caller needs the latter to avoid dropping an
+   *  attachment that lost its position to a sibling. */
+  onEmit?: (c: { rel: string; dir: boolean; path?: string }) => void,
+): string {
+  if (!candidates.length) return text
+  // Longest rel first: a directory is a prefix of the files beneath it, so a
+  // shorter dir candidate must never win against a longer file mention at the
+  // same position. On EQUAL length, prefer the file: `@notes` (file) and
+  // `@notes/` (dir) both have rel "notes", and dirs are pushed first, so a
+  // length-only sort would let the dir swallow the file mention and drop it.
+  const ordered = [...candidates].sort(
+    (a, b) => b.rel.length - a.rel.length || Number(a.dir) - Number(b.dir),
+  )
+  let out = ''
+  let i = 0
+  while (i < text.length) {
+    if (text[i] !== '@') { out += text[i]; i += 1; continue }
+    let matched = false
+    for (const c of ordered) {
+      // Compare against the ORIGINAL text only — never against `out`.
+      if (!text.startsWith(c.rel, i + 1)) continue
+      let end = i + 1 + c.rel.length
+      // A folder mention may carry the trailing separator the composer inserts.
+      if (c.dir && (text[end] === '/' || text[end] === '\\')) end += 1
+      // Same boundary rule as tokenRegex/dirTokenRegex: whitespace or end.
+      const next = text[end]
+      if (next !== undefined && !/\s/.test(next)) continue
+      out += c.emit()
+      onEmit?.(c)
+      i = end
+      matched = true
+      break
+    }
+    if (!matched) { out += text[i]; i += 1 }
+  }
+  return out
 }
 
 /** Build send payload from raw input text and pending files. */
@@ -198,9 +525,25 @@ export interface SendPayload {
   displayTxt: string // UI-facing content
   filePaths: string[]
   imgPaths: string[]
+  /** Directory references, in the order their `[attached_dir N]` tokens number. */
+  dirPaths: string[]
 }
 
-export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPayload {
+/**
+ * Serialize a directory reference. Folders get their OWN marker rather than
+ * reusing `[attached_file N]`, because the agent must not try to `read` a
+ * directory: the marker tells it this is a path to explore with its own
+ * glob/grep/read tools. Numbering is independent of the file marker's.
+ */
+function dirToken(n: number, path: string): string {
+  return `[attached_dir ${n}] ${path}`
+}
+
+export function prepareSendPayload(
+  raw: string,
+  pendingFiles: string[],
+  pendingDirs: string[] = [],
+): SendPayload {
   // All pending files (uploaded via button/drag-drop) are always included.
   // The @-token in text is used for display replacement, not as a gate.
   const files = [...new Set(pendingFiles)]
@@ -208,6 +551,20 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   const filePaths = files.filter(p => !IMG_EXT.test(p))
   const imgMd = imgPaths.map(p => `![image](${p})`).join('\n')
   const relMap = buildRelMap(files, raw)
+
+  // Directories are tracked and numbered separately from files so a folder
+  // reference never lands in filePaths/imgPaths (nothing downstream should try
+  // to read or thumbnail it).
+  // Normalize BEFORE dedup so "/repo/src" and "/repo/src/" collapse to one
+  // entry rather than producing two tokens for the same folder.
+  const dirs = [...new Set(pendingDirs.map(trimDirSeparator))]
+  const dirRelMap = buildDirRelMap(dirs, raw)
+  const referencedDirs = new Set([...dirRelMap.values()])
+  const orderedDirs = [
+    ...dirs.filter(p => referencedDirs.has(p)),
+    ...dirs.filter(p => !referencedDirs.has(p)),
+  ]
+  const dirIdxMap = new Map(orderedDirs.map((p, i) => [p, i + 1]))
 
   // Assign sequential indices to all non-image files, ordered by upload order.
   // Referenced files get lower indices, unreferenced get higher — but indices
@@ -222,12 +579,45 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   ]
   const idxMap = new Map(indexedFilePaths.map((p, i) => [p, i + 1]))
 
-  const llmRaw = replaceTokens(
-    replaceTokens(raw, imgPaths, relMap, () => ''),
-    filePaths, relMap, (p) => `[attached_file ${idxMap.get(p) ?? 0}] ${p}`,
-  )
+  // ONE pass over the original text for all three families. Sequential passes
+  // rescanned each other's emitted markers (see replaceMentionsOnce), which let
+  // a file token rewrite the inside of an already-emitted folder marker.
+  const relFor = (map: Map<string, string>, p: string) =>
+    [...map.entries()].find(([, v]) => v === p)?.[0]
+  const llmCandidates: Array<{ rel: string; dir: boolean; path?: string; emit: () => string }> = []
+  for (const p of orderedDirs) {
+    const rel = relFor(dirRelMap, p)
+    // `buildRelMap` strips any trailing separator before storing a key, so these
+    // are already bare — the normalization below is a cheap invariant guard, not
+    // load-bearing. The scanner matches the composer's trailing slash itself via
+    // the `dir: true` flag.
+    if (rel) llmCandidates.push({ rel: rel.replace(/[/\\]$/, ''), dir: true, path: p, emit: () => dirToken(dirIdxMap.get(p) ?? 0, p) })
+  }
+  for (const p of imgPaths) {
+    const rel = relFor(relMap, p)
+    if (rel) llmCandidates.push({ rel, dir: false, emit: () => '' })
+  }
+  for (const p of filePaths) {
+    const rel = relFor(relMap, p)
+    if (rel) llmCandidates.push({ rel, dir: false, emit: () => `[attached_file ${idxMap.get(p) ?? 0}] ${p}` })
+  }
+  // `replaceMentionsOnce` reports which candidates it actually emitted. A
+  // directory can be "referenced" per `dirRelMap` (its rel matched the text) and
+  // still LOSE that position to an equal-length file candidate — `@notes` with
+  // both a file and a folder named `notes`. Trusting `referencedDirs` alone then
+  // dropped the folder from both the inline text and the appended tokens, so a
+  // staged attachment vanished silently. Append markers for anything staged but
+  // not emitted.
+  const emittedDirs = new Set<string>()
+  const llmRaw = replaceMentionsOnce(raw, llmCandidates, c => {
+    if (c.dir && c.path) emittedDirs.add(c.path)
+  })
   const unreferenced = filePaths.filter(p => !referencedPaths.has(p))
   const unreferencedTokens = unreferenced.map(p => `[attached_file ${idxMap.get(p) ?? 0}] ${p}`).join('\n')
+  const unreferencedDirTokens = orderedDirs
+    .filter(p => !emittedDirs.has(p))
+    .map(p => dirToken(dirIdxMap.get(p) ?? 0, p))
+    .join('\n')
   const displayRaw = replaceTokens(raw, imgPaths, relMap, () => '')
 
   // Separate the pasted-image markdown from the typed text with a blank line
@@ -243,11 +633,12 @@ export function prepareSendPayload(raw: string, pendingFiles: string[]): SendPay
   // It is newline-agnostic and pulls the image into its own content block, so
   // the surrounding whitespace never changes what the model receives. The
   // caption keeps a single '\n' to its appended [attached_file N] tokens.
-  const textBody = [llmRaw, unreferencedTokens].filter(Boolean).join('\n')
+  const textBody = [llmRaw, unreferencedTokens, unreferencedDirTokens].filter(Boolean).join('\n')
   return {
     txt: [imgMd, textBody].filter(Boolean).join('\n\n'),
     displayTxt: [imgMd, displayRaw].filter(Boolean).join('\n\n'),
     filePaths: indexedFilePaths,
     imgPaths,
+    dirPaths: orderedDirs,
   }
 }


### PR DESCRIPTION
> **Stacked on #504.** Base is `feat-folder-picker`, not `main`. Review #504 first; this PR's diff shows only the metadata + tokenizer work once #504 lands.

## Problem

A message's attachments are carried by two ordered lists, `meta.files` and `meta.dirs`. Marker number N in the prompt text is a **positional index** into the matching list, and that indirection is the only thing that lets a path containing a space survive a round trip — the fallback is a whitespace-bounded scan of the message content, which truncates `/repo/my docs` to `/repo/my`.

Two independent defects broke that contract.

**1. Most write paths dropped the metadata.** Only the plain send path carried the lists. Every other way a message reached the transcript lost them:

- a **queued** message (sent mid-turn, or held while sub-agents run) — queue entries were `{id, content, kind}`
- a queued card **popped** into a running turn — the replacement message was built without `meta`
- a queued message **edited** in place — text was rewritten, metadata was not
- a **page reload** — slot-detail payloads projected `{id, content}` only, and the client's hydration path discarded `meta` too
- a **mid-turn steer** — the POST body had no `meta` at all
- a steer the turn **never consumed**, degraded into a queue card
- the **`queue_push` / `steer_push` echoes** an already-open second tab renders from
- **corrupt metadata** from an untrusted payload, where filtering invalid entries shifted the index space

**2. Marker emission rescanned its own output.** Serialization ran as sequential passes — dirs, then images, then files — over text that *already contained* markers emitted by an earlier pass. An emitted marker carries the absolute path verbatim, so when a path itself contains an `@…` sequence that a later pass matches, that pass rewrites text inside a marker it should never have looked at.

## Why it matters

Silent truncation is the bad kind of failure: the user sees a plausible path, the agent gets a wrong one, and nothing reports an error. It reproduces on any project with a space in a directory name.

**This is not folder-specific.** The same paths dropped `meta.files` before folder references existed — a spaced *filename* truncated identically through the queue. Folder support made the gap easy to hit, but the contract being fixed here covers both families.

The rescan defect is worse than cosmetic: it substitutes a **wrong path**, pointing the agent at an attachment the user never selected.

## Fix

### Metadata survives every write path

| Path | Root cause | Change |
|---|---|---|
| Queue | entry shape had no metadata slot | `queue_append`/`queue_insert` take redacted `meta`; the drain persists it |
| Queue merge | two messages, two index spaces, one list | a metadata-bearing entry breaks the merge and drains alone |
| Queue card | reducer hardcoded `meta: { queueId }` | `queue_push` carries meta; reducer preserves it, `queueId` applied last |
| Queue pop | replacement message built without `meta` | carries the card's meta forward, minus `queueId` (it is no longer queued) |
| Queue edit | text changed, metadata did not | edit **drops** `meta` on both server and client — see below |
| Reload / cancel | payload projected `{id, content}` | all three slot-detail payloads project via `queue_item_for_display`; client hydration keeps `meta` |
| Steer | request body had no `meta` | `steerChat` forwards it; server merges redacted meta, sets `steer` last (unspoofable) |
| Steer echo | client hardcoded `{steer: true}` | `steer_push` carries meta; `useWebSocket` consumes `data.meta` |
| Unconsumed steer | `_pending_steers` is `list[str]` | metadata parked in a `_pending_steer_meta` side table |
| Untrusted meta | `.filter()` shifted the index space | blank invalid members **in place**; blanks excluded from chips/cards |

**`_pending_steers` keeps its shape.** Metadata rides in a side table keyed by message text rather than enriching the list elements. That list's shape is load-bearing for the settle/requeue matching added after the 2026-07-17 lost-steer incident and for its ~25-assertion regression suite; changing it to carry tuples would churn that suite for no behavioural gain. The table is parked **before** the steer RPC's await (matching the registration ordering a dying turn depends on), drained on requeue, and cleared at settle, unwind and force-stop so it cannot grow across turns.

**A queued-message edit drops its attachments.** `content` (the markers) and `meta` (the lists they index into) are generated together at send time, so they are a matched pair. An edit rewrites only `content`: keeping the old `meta` means that replacing the auto-selected text removes the marker — the model never receives the attachment — while the surviving metadata still renders an attachment card, showing something that was never sent. `queue_edit_by_id` therefore drops `meta`, and `editQueuedMessage` mirrors it client-side (keeping only `queueId`, which is the card's identity, not attachment metadata). The tradeoff is deliberate: editing to fix a typo also drops attachments, which is visible and recoverable by re-staging rather than silent and misleading.

### One-pass marker emission

`replaceMentionsOnce` (`fileTokens.ts`) walks the original text **once**, resolves each `@` position to exactly one candidate, and never re-reads what it emits. Candidates match **longest-first**, so `@src/pages/list.tsx` wins over the `@src/pages/` that prefixes it. `_strip_attached_file_tokens` gained `also=(prefix, paths)` and consumes both marker families in one left-to-right walk; index spaces stay independent.

Unifying the title walk also fixed a **budget-ordering defect**: the previous two-pass form spent the shared label budget in the file pass *before* folders were scanned, so a file label late in the message could suppress a folder label that appeared earlier. One walk spends the budget in true source order.

A family whose `find` returns `-1` is now dropped from the scan. `cursor` only advances, so an absent family can never match at a larger offset; leaving it in made every subsequent iteration re-scan to end-of-string, turning an O(N) walk into O(N·M) — on a synchronous event-loop path, across up to 10 messages and a 181KB scan limit.

Observed corruption before the fix:

- dir `/repo/@data.csv` with file `/other/data.csv` → the file pass matched **inside** the emitted `[attached_dir 1] /repo/@data.csv`.
- an image mention occurring inside an emitted folder marker had its text excised, collapsing `[attached_dir 1] /shots/@hero.png` to `[attached_dir 1] /shots/`.
- title path: a real *file* named `[attached_dir 1] notes` (brackets and spaces are legal on POSIX and Windows) came out of the file pass as its own basename and was then eaten by the folder pass, leaving `notes`.

Images remain in a separate pass safely because they emit `''` — a pass that produces no substituted text cannot be re-read by a later one.

## Tests

| File | Locks in |
|---|---|
| `test/test_chat_steer.py` | Steer persists `meta.files`/`meta.dirs`; `steer` marker not spoofable; `steer_push` echoes meta; queued send carries meta to the drain and never merges; `queued_append_meta` ownership rules; the drain **call site**; an unconsumed steer keeps meta on requeue; `_pending_steer_meta` cleared at settle / unwind / force-stop |
| `test/test_queue_edit.py` | An edit drops attachment metadata; a *failed* edit leaves an untouched item's metadata intact |
| `test/test_chat_title_dirs.py` | Marker stripping for both families; shared label budget; one-pass scan (a basename containing the other family's marker text is not mangled) |
| `website/src/test/chatSlice.queuedMeta.test.ts` | Queued cards keep `meta.files`/`meta.dirs`; `queueId` cannot be displaced; a popped card carries meta onto the drained message and sheds `queueId`; an edit clears meta but keeps `queueId`; hydration keeps server meta; no-meta (older backend) still works |
| `website/src/test/useWebSocket.steerMeta.test.ts` | `steer_push` forwards `meta.files`/`meta.dirs` to a second tab; `steer` re-asserted with or without meta |
| `website/src/test/fileTokens.dirs.test.ts` | `[attached_dir N]` serialization and numbering; one-pass emission (no marker rescan, longest-mention-first); an image mention inside an emitted folder marker is not excised |
| `website/src/test/ChatPageDrafts.test.tsx` | Draft isolation; `meta.dirs` persistence; steer sends meta to the server |
| `test/test_steer_requeue.py` | Unchanged and still green — the side-table approach left the incident suite intact |

`queued_append_meta` was **extracted from the drain specifically because it had no test reaching it**: reverting the inline version left the entire suite green while spaced paths truncated again after a drain.

**Every new guard was verified by reverting its fix and confirming the test fails.** That mattered concretely: the image-rescan test passed against the buggy implementation twice before the fixture was built so the image's mention text actually occurs inside the folder path (dir `/shots/@hero.png` + image `/assets/hero.png`). A mismatched pair proves nothing.

Local verification: 4637 frontend tests, backend queue / steer / title / file-search suites green, `tsc -b --force` clean, flake8 / isort / mypy clean.

## Scope: rejection rollback is NOT in this PR

An earlier revision also restored the composer when a steer or `createSlot` was rejected. **That work has been removed** and is not part of this diff.

Review found real defects in it, and they were not missing branches but concurrency semantics: a second write failing while the first is in flight (a per-call TanStack `onError` fires only for the latest mutation), a response lost *after* the server already accepted the write (restoring then invites a duplicate submission), and a rejection landing after the user switched slots (restoring into the wrong slot splices one chat's prompt into another). Those need a deliberate design for composer-restore ownership, not another patch.

What that leaves: a failed steer still clears the composer and leaves its optimistic bubble on screen, and a rejected `createSlot` still loses staged text. Both gaps predate this PR and are documented under "Known gap: rejection rollback" in `docs/system-specs/modules/file-search.md`.

The one error-path change that **did** land is in `send()`: on a connection error it now restores the pre-serialization text (with its `@`-mentions) plus the staged file and folder lists, instead of the serialized marker text. Restoring the marker text put `[attached_file N]` literals into the composer with no backing pending lists, so a retry sent markers stripped of the metadata that makes a spaced path resolve.

## Also in this diff: title generation

`chat_title.py` changes what users see and is called out here because it is a separate user-visible behavior, not part of the metadata contract. Attachment markers previously caused a title to be dropped entirely; titles now substitute the attachment basename, widening to disambiguate collisions, under a per-message shared label budget. Covered by `test/test_chat_title_dirs.py`.

## Manual verification

- Mention a folder with a space in its name, send, reload → chip still shows the full path.
- Send with an attachment while a turn is running (queued card), let it drain → path intact.
- Reload the page while an attachment-bearing message is queued → path still full, not truncated.
- Open the same session in two tabs, steer from one → the other renders the full path without reloading.
- Edit a queued message that has an attachment → the attachment chip disappears with the marker rather than lingering.

## Screenshots

N/A — no visual change. Every change here is message metadata, persistence and serialization; the only rendered difference is a queued/steered card showing a correct path where it previously showed a truncated one, which is asserted in the reducer tests.
