### PR TITLE
fix(dashboard): recognize PR URLs followed by CJK/fullwidth punctuation

### DIFF
--- a/website/src/test/pullRequestLinks.test.ts
+++ b/website/src/test/pullRequestLinks.test.ts
@@ -307,3 +307,59 @@ describe('first-mention attribution (Changes vs Resources)', () => {
     expect(result.map(l => l.url)).toEqual([agentPr])
   })
 })
+
+describe('CJK / fullwidth punctuation after a PR URL (issue #507)', () => {
+  const gh = 'https://github.com/kirodotdev/KiroCrew/pull/436'
+  const gl = 'https://gitlab.com/acme/platform/-/merge_requests/42'
+
+  // Fullwidth / CJK punctuation is kept as literals (the repo pre-commit hook
+  // blocks only CJK ideographs U+4E00-9FFF, not punctuation); the few ideographs
+  // needed to prove the scan stops on Han text are written as \u escapes, so the
+  // source stays free of literal Chinese words while the runtime strings are the
+  // genuine characters.
+  it.each([
+    ['a fullwidth open paren U+FF08', `PR up: ${gh}（one commit）`],
+    ['a fullwidth comma U+FF0C', `done ${gh}，then test`],
+    ['an ideographic full stop U+3002', `merged ${gh}。`],
+    ['adjacent Han text U+66F4 U+65B0', `see ${gh}\u66F4\u65B0 notes`],
+    ['an ideographic space U+3000', `see ${gh}\u3000thanks`],
+    ['fullwidth corner brackets U+300C U+300D', `ref 「${gh}」ok`],
+  ])('extracts the PR when the URL is followed by %s', (_label, content) => {
+    expect(extractPullRequestLinks(messages(content)).map(link => link.url)).toEqual([gh])
+  })
+
+  it('extracts a PR wrapped in a fullwidth-parenthesised clause', () => {
+    expect(extractPullRequestLinks(messages(`（see ${gh}，ok）`)).map(link => link.url)).toEqual([gh])
+  })
+
+  it('extracts a GitLab MR followed by fullwidth punctuation', () => {
+    expect(extractPullRequestLinks(messages(`MR up ${gl}，waiting review`)).map(link => link.url)).toEqual([gl])
+  })
+
+  it('still parses an ASCII query/fragment tail (no over-trim regression)', () => {
+    expect(extractPullRequestLinks(messages(
+      `see ${gh}?tab=checks and ${gh}#issuecomment-1`,
+    )).map(link => link.url)).toEqual([gh])
+  })
+
+  it('separates two PRs joined only by fullwidth punctuation', () => {
+    const a = 'https://github.com/acme/widgets/pull/436'
+    const b = 'https://github.com/acme/widgets/pull/9'
+    // No ASCII space anywhere: the old denylist scan swallowed both URLs into a
+    // single un-parseable candidate, so BOTH were lost. The allowlist stops at
+    // each fullwidth mark, recovering each URL independently.
+    expect(extractPullRequestLinks(messages(`${a}，${b}。`)).map(link => link.url)).toEqual([a, b])
+  })
+
+  it('extracts the PR from a realistic CJK assistant message', () => {
+    // Runtime string reads (translated): "PR opened: <url>(single commit,
+    // Fixes #435), CI all green, merge after approve." Han ideographs are \u
+    // escapes; fullwidth punctuation (（），。：) is literal.
+    const content =
+      `PR \u5DF2\u5F00：${gh}（\u5355 commit，Fixes #435），`
+      + `CI \u5168\u7EFF，approve \u540E merge。`
+    expect(extractPullRequestLinks(messages(content))).toEqual([
+      { url: gh, provider: 'github', number: 436, repo: 'KiroCrew' },
+    ])
+  })
+})

--- a/website/src/utils/pullRequestLinks.ts
+++ b/website/src/utils/pullRequestLinks.ts
@@ -47,11 +47,20 @@ const MAX_PERSISTED_SOURCE_URLS = 512
 const MAX_PERSISTED_SOURCE_URL_LENGTH = 2048
 const MAX_PERSISTED_SLOT_LENGTH = 512
 
-// Cheap URL candidate scan; each candidate is then parsed with the URL API
-// and validated with linear string ops (no lazy-quantifier regex: the prior
-// pattern had the same polynomial-backtracking shape CodeQL flagged on the
-// backend parser).
-const URL_CANDIDATE_RE = /https:\/\/[^\s<>()[\]{}"']+/g
+// Cheap URL candidate scan; each candidate is then parsed with the URL API and
+// validated with linear string ops. This is an ALLOWLIST of URL-safe ASCII
+// characters (RFC 3986 unreserved + gen-/sub-delims + '%'), minus the bracket
+// and quote characters we deliberately treat as delimiters -- ()[]{}"' -- so a
+// PR wrapped in parens or a markdown link still parses. Because it is an
+// allowlist, the scan stops at the first byte that cannot appear in a URL,
+// including every CJK ideograph and fullwidth punctuation mark. A URL packed
+// against CJK text with no ASCII space -- routine in Chinese/Japanese/Korean
+// messages, e.g. a fullwidth "(" placed right after the PR number -- therefore
+// no longer swallows the trailing text and fails the numeric-tail check.
+// extractChatLinks.ts uses the same allowlist approach for its bare-URL scan.
+// Still a single greedy character class (no lazy quantifier), preserving the
+// linear, no-backtracking shape CodeQL flagged on the old backend parser.
+const URL_CANDIDATE_RE = /https:\/\/[A-Za-z0-9!#$%&*+,.\/:;=?@_~-]+/g
 
 function parseCandidate(raw: string): PullRequestLink | null {
   // Trim trailing punctuation and markdown emphasis (**bold**, *italic*,


### PR DESCRIPTION
## Summary

Fixes #507. The dashboard PR **Changes** tab silently fell back to the Files view whenever an agent message wrote a PR URL immediately followed by CJK / fullwidth punctuation — routine in Chinese / Japanese / Korean conversation. The PR still appeared under **Resources** (that scan is unaffected), so the panel looked "half-loaded" while the Changes source list was empty and the diff/summary never rendered.

## Root cause

`website/src/utils/pullRequestLinks.ts`:

- `URL_CANDIDATE_RE` was a **denylist** — `/https:\/\/[^\s<>()[\]{}"']+/g` — that only excludes ASCII whitespace, brackets and quotes. CJK ideographs and fullwidth punctuation are not excluded, so the candidate swallowed the trailing CJK text.
- `parseCandidate()` trims only ASCII trailing punctuation (`replace(/[.,!?;:*_~` + "`" + `]+$/, '')`), so the fullwidth tail survived and the last path component failed the `/^\d+$/` numeric-tail check → `parseCandidate` returns `null` → zero Change sources.
- In `ActivityViewer`, `effectiveTab = requestedTab === 'changes' && !hasSources ? 'files' : requestedTab`, so clicking **Changes** silently rendered **Files**.

### Concrete before / after candidate

For the message `PR up: https://github.com/kirodotdev/KiroCrew/pull/436（single commit`:

|  | candidate captured | `parseCandidate` |
|---|---|---|
| **before** | `https://github.com/kirodotdev/KiroCrew/pull/436（single` — the scan only stops at the ASCII space, so the last path part is `436（single` | `null` |
| **after** | `https://github.com/kirodotdev/KiroCrew/pull/436` — the scan stops at the fullwidth `（` | `{ number: 436, repo: "KiroCrew" }` |

## Fix

Flip the candidate scan from a denylist to an **allowlist** of URL-safe ASCII characters:

```diff
-const URL_CANDIDATE_RE = /https:\/\/[^\s<>()[\]{}"']+/g
+const URL_CANDIDATE_RE = /https:\/\/[A-Za-z0-9!#$%&*+,.\/:;=?@_~-]+/g
```

The allowlist is the RFC 3986 URL character set (unreserved + gen-/sub-delims + `%`) **minus** `()[]{}"'`, which the scanner already treated as delimiters — so a PR wrapped in ASCII parens or a markdown `[text](url)` link still parses exactly as before. Because it is an allowlist, the scan now stops at the first byte that cannot appear in a URL: every CJK ideograph, fullwidth punctuation mark, ideographic space, emoji, etc.

### Design choices

- **Allowlist over a wider denylist / a bigger trailing trim.** Enumerating CJK/fullwidth Unicode ranges in the denylist (or the trailing trim) is fragile — the CJK ideograph block, Kana, Hangul, fullwidth forms, CJK punctuation and general punctuation are many ranges and easy to under-cover. An allowlist of the finite URL character set is exhaustive by construction, and mirrors what `extractChatLinks.ts` (`BARE_URL_RE`) already does.
- **The trailing trim in `parseCandidate()` is left unchanged.** Trailing ASCII sentence/markdown punctuation (`.`, `**`, `` ` ``, …) is still a valid URL character, so it stays in the candidate and the existing trim removes it. CJK now never reaches the trim because the scan stops earlier.
- **No backtracking.** It remains a single greedy character class `[...]+` (no lazy quantifier / alternation), preserving the linear, no-backtracking shape the file comment notes CodeQL flagged on the old backend parser.
- **First-mention attribution unchanged** — user-first PRs still land in Resources, not Changes.

### Why `extractChatLinks.ts` (Resources) was unaffected

Its `BARE_URL_RE` already uses an allowlist char class (`[\w/._?&#=-]`) that stops at fullwidth characters, so Resources kept working — which is exactly why the bug presented as "Changes empty, but the PR still shows in Resources".

## Tests

Added a `CJK / fullwidth punctuation after a PR URL (issue #507)` block in `website/src/test/pullRequestLinks.test.ts`:

- URL followed by `（`, `，`, `。`, adjacent Han text with no punctuation, an ideographic space, and fullwidth corner brackets `「」`
- URL inside a fullwidth-parenthesised clause
- a GitLab MR followed by fullwidth punctuation
- **regression**: an ASCII query/fragment tail (`?tab=checks`, `#issuecomment-1`) still parses (the trim was not widened, so it is not over-trimming URL-valid ASCII)
- two PRs joined only by fullwidth punctuation are each recovered (the old denylist merged them into one un-parseable candidate and lost both)
- a realistic mixed-CJK assistant message

The repo pre-commit hook forbids literal CJK ideographs (U+4E00–U+9FFF) in source, so Han ideographs in fixtures are written as `\u` escapes (identical runtime strings); fullwidth punctuation, which the hook permits, is kept as readable literals.

## Verification (from the worktree)

```
cd website
npx tsc -b                                                                    # exit 0
npx eslint src/utils/pullRequestLinks.ts src/test/pullRequestLinks.test.ts    # exit 0
npx vitest run src/test/pullRequestLinks.test.ts                              # 35 passed
npx vitest run                                                                # 391 files, 4534 passed, 3 skipped, 0 failed
```

Frontend-only change; no Python touched.
