### PR TITLE
docs(rules): document the brand-mark exception to use-lucide-icons

### DIFF
--- a/website/AUTOSDE.yaml
+++ b/website/AUTOSDE.yaml
@@ -189,6 +189,45 @@ custom-rules:
 
       Existing inline SVGs are grandfathered but all new icons must use lucide-react.
 
+      BRAND-MARK EXCEPTION (narrow; documents existing practice, adds no new latitude):
+      lucide-react deliberately ships no brand, product, or mascot marks, so a logo /
+      wordmark / mascot has no Lucide equivalent to use. Such a mark is exempt from the
+      "use lucide-react" requirement ONLY when ALL of the following hold:
+
+        1. Asset, not code — the art lives in its own image file (`.svg`, or `.png` when
+           no vector original exists), either under `src/assets/` or co-located beside
+           its component (e.g. `components/icons/`), and is consumed through a plain URL
+           import. No `<svg>` element and no path data appear in any `.tsx` file (the
+           regex gate above still blocks that unconditionally, in every file, with no
+           exception).
+        2. Render matches the mark — a MONOCHROME mark that sits inline among lucide
+           glyphs is painted as a CSS `mask` over `currentColor` so it inherits their
+           size and colour states; reuse the `BrandGlyph` helper in
+           `components/BrandIcon.tsx` (export it if needed) rather than re-implementing
+           the mask, which has a non-obvious data-URI quoting requirement. A FULL-COLOUR
+           mark whose identity depends on its own colours (the channel logos) is rendered
+           as a plain `<img>` — do not flatten it to `currentColor`.
+        3. Brand identity, not affordance — it depicts an identity (a product, a
+           company, the Kiro ghost). Anything lucide-react can express — actions,
+           objects, status, navigation verbs — MUST use lucide-react. "No exact Lucide
+           match for the concept I want" is NOT a brand mark and does NOT qualify.
+
+      In-tree precedent this codifies — monochrome, CSS-mask over `currentColor`:
+      `components/BrandIcon.tsx` (GitHub, Discord marks — "lucide-react ships no brand
+      icons"), `components/icons/GithubLogo.tsx`, `components/icons/GitlabLogo.tsx`.
+      Full-colour, plain `<img>`: `components/SlackIcon.tsx`,
+      `components/TelegramLogo.tsx`, `components/WebexIcon.tsx`,
+      `components/WeComLogo.tsx` (all used as Settings tab glyphs at `size={16}`), and
+      `assets/onboarding/GhostIcons.tsx` (onboarding mascot).
+
+      Why write it down: the exception was already being applied per-PR from those
+      precedents, which made every branded-mark change an argument about intent rather
+      than a check against a rule. Stating the three conditions makes it verifiable in
+      review, and stating condition 3 keeps the escape hatch from widening into
+      "hand-roll any icon Lucide lacks", which is the abuse the rule exists to prevent.
+      This exception removes nothing: the rule stays `blocking: true`, the regex gate is
+      untouched, and ordinary icons remain lucide-only.
+
   - id: accessible-interactive-elements
     blocking: true
     file-patterns:


### PR DESCRIPTION
## Problem

`website/AUTOSDE.yaml`'s `use-lucide-icons` rule (blocking) says only:

> Existing inline SVGs are grandfathered but all new icons must use lucide-react.

But `lucide-react` deliberately ships no brand, product, or mascot marks, so a logo or mascot has **no Lucide equivalent to substitute**. The codebase has therefore been applying an unwritten exception for a while:

| Precedent | What it renders | How |
| --- | --- | --- |
| `website/src/components/BrandIcon.tsx` | GitHub, Discord marks | `.svg` asset via CSS mask over `currentColor` — its own comment says *"lucide-react ships no brand icons"* |
| `website/src/components/icons/GithubLogo.tsx`, `GitlabLogo.tsx` | source-provider logos | same mask technique |
| `website/src/assets/onboarding/GhostIcons.tsx` | onboarding Kiro-ghost mascot | `.svg` asset via `<img>`; its header comment states it *"doesn't fall under the `use-lucide-icons` rule"* |

## Why it matters

Because the carve-out lives only in code comments, every branded-mark change turns into an argument about the rule's *intent* rather than a check against the rule's *text* — and the reviewers disagree with each other about it.

Concretely, on #446 (Kiro ghost as the Agent Capabilities nav icon) the GPT 5.6 reviewer has blocked three times citing this rule, while the Claude reviewer and Design Review both passed the same commit citing these same precedents, and the Arbiter ruled the finding outside its remit. GPT's own suggested remedy was to *"amend the base rule separately before introducing a branded-icon exception"* — which is this PR. Reviewers load the rule snapshot from the **base** commit (`.github/workflows/codex-review.yml` L42-51, `claude-review.yml` L37-46), by design, so a PR cannot amend the rule that governs it; the amendment has to land on `main` first.

## Fix

Symptom: a blocking rule is being enforced inconsistently across reviewers on brand marks.
Root cause: the exception exists in practice and in per-file comments, but not in the rule text — so there is nothing objective to check against.
Change: write the exception into the rule with three conditions that are all mechanically checkable in review.

1. **Asset, not code** — art lives in its own image file (`.svg`, or `.png` where no vector original exists), under `src/assets/` **or** co-located beside its component (e.g. `components/icons/`), consumed by URL import. No `<svg>` element and no path data in any `.tsx`, with no exception.
2. **Render matches the mark** — a *monochrome* mark sitting inline among lucide glyphs is painted as a CSS `mask` over `currentColor` (reuse `BrandGlyph` in `BrandIcon.tsx`, which already carries the non-obvious data-URI quoting fix) so it follows their size/colour states. A *full-colour* mark whose identity depends on its own colours (the channel logos) uses a plain `<img>` and is explicitly not flattened to `currentColor`.
3. **Brand identity, not affordance** — it depicts a product/company/mascot identity. Anything lucide-react can express (actions, objects, status, navigation verbs) must use lucide-react. *"No exact Lucide match for the concept I want"* explicitly does **not** qualify.

Condition 3 is the load-bearing one: it is what keeps the exception from widening into "hand-roll any icon Lucide lacks", which is the abuse the rule exists to prevent.

### This does not weaken the rule

The reviewer prompts flag any weakening of a blocking rule as HIGH, so stating the delta explicitly:

- `blocking: true` — **unchanged**
- `regex.pattern: "<svg[^>]*viewBox"`, `check-added: true`, `check-removed: false` — **unchanged**; inline SVG in TSX is still gated in every file
- `file-patterns: src/**/*.tsx` — **unchanged**
- "all new icons must use lucide-react" — **unchanged** for ordinary icons
- Net diff: **+39 lines, 0 deletions**, all inside the `rule:` prose block

The exception narrows and documents what was already being permitted; it grants no latitude that was not already in use in `main` today.

## Tests

N/A — documentation-only change to a rule's prose. Verified `website/AUTOSDE.yaml` still parses as YAML and that the parsed `use-lucide-icons` entry retains `blocking: true` and its original `regex` block byte-for-byte.

## Manual verification

- `python3 -c "yaml.safe_load(...)"` on `website/AUTOSDE.yaml` — parses; `blocking=True`, `regex={'pattern': '<svg[^>]*viewBox', 'check-added': True, 'check-removed': False}`.
- `git diff --stat` — 1 file changed, 39 insertions, 0 deletions.
- Each condition was checked against actual in-tree usage after the Opus 5 review flagged that conditions 1 and 2 were stricter than the precedents: `icons/GithubLogo.tsx` / `GitlabLogo.tsx` import co-located `.svg`s, `WeComLogo.tsx` imports a `.png`, and `SlackIcon` / `TelegramLogo` / `WebexIcon` / `WeComLogo` are full-colour `<img>` marks used as Settings tab glyphs at `size={16}`. Both conditions were rewritten to match.
- Grepped the added prose against the inclusive-language ruleset's common triggers — no matches.
- Each precedent cited above was read in-tree on `main` (not inferred) before being listed.

## Screenshots

N/A — no user-visible UI change; this PR touches only a lint-rule description.

## Follow-up

Once this lands, #446 rebases onto it so the reviewers' base-commit snapshot contains the exception, which should resolve the GPT block on its own terms rather than by override.
