### PR TITLE
feat(security): read-only governance policy viewer in Security settings

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -515,4 +515,5 @@ from kiro_crew.dashboard.handlers.security import (  # noqa: E402, F401
     api_denied_command_user_toggle,
     api_denied_commands_disable_all,
     api_denied_commands_list,
+    api_governance_policy,
 )

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -578,3 +578,183 @@ async def api_denied_command_user_delete(request: web.Request) -> web.Response:
         return err
     _audit(request, operation=op, outcome="ok", resources=rule_id)
     return await _snapshot_response()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Governance policy viewer — READ-ONLY effective ceiling across every scope
+# ──────────────────────────────────────────────────────────────────────────
+# The enterprise ceiling (Level 1 ``security_policy.json``) and per-surface
+# profiles (Level 2 ``profiles/*.json``) are file-authored and deliberately
+# un-editable via the UI (the agent cannot even read them — they sit on the
+# sensitive-path keystone). This surface lets an operator SEE the resolved
+# ceiling — for every governed scope, its effective state and where it comes
+# from — without exposing any write path. It mirrors the model's own
+# scope-name-agnostic style: a single per-archetype serializer, driven by
+# ``SCOPE_CATALOG``, so the view auto-covers any scope a future release (or the
+# companion) registers with zero handler edits.
+
+
+def _serialize_ruleset(value: object) -> dict:
+    """Serialize a ``RulesetLike`` (ScopedRuleset or composed ``_AndRuleset``).
+
+    A flat ``ScopedRuleset`` renders as ``{mode, allow, deny}``. A composed
+    ``_AndRuleset`` (an allow∩allow / allow∩deny intersection that cannot flatten
+    to one glob set) renders as ``{mode: "intersect", components: [...]}`` so the
+    viewer can show "narrowed by both levels" without the serializer having to
+    re-implement the intersection algebra.
+    """
+    from kiro_crew.platform.governance import ScopedRuleset, _AndRuleset
+
+    if isinstance(value, ScopedRuleset):
+        return {"mode": value.mode, "allow": list(value.allow), "deny": list(value.deny)}
+    if isinstance(value, _AndRuleset):
+        return {
+            "mode": "intersect",
+            "components": [
+                _serialize_ruleset(value.ceiling),
+                _serialize_ruleset(value.profile),
+            ],
+        }
+    return {}
+
+
+def _serialize_control(archetype: str, value: object) -> dict:
+    """Serialize one effective archetype value to a UI-friendly dict.
+
+    Dispatch is by ARCHETYPE (``spec.kind``), never by scope name — the same
+    decoupling the evaluator uses — so a newly registered scope serializes with
+    no edit here as long as it reuses one of the four archetypes.
+    """
+    from kiro_crew.platform.governance import (
+        CAPABILITY,
+        ORDINAL,
+        RULESET,
+        SCOPEDMAP,
+        CapabilityGate,
+        OrdinalControl,
+        ScopedMap,
+    )
+
+    if value is None:
+        return {}
+    if archetype == RULESET:
+        return _serialize_ruleset(value)
+    if archetype == ORDINAL and isinstance(value, OrdinalControl):
+        return {"scale": value.scale, "floor": value.value}
+    if archetype == CAPABILITY and isinstance(value, CapabilityGate):
+        return {
+            "enabled": value.enabled,
+            "inner": {name: _serialize_ruleset(rs) for name, rs in value.scopes.items()},
+        }
+    if archetype == SCOPEDMAP and isinstance(value, ScopedMap):
+        return {
+            "members": _serialize_ruleset(value.members),
+            "posture": {
+                member: {leaf: _serialize_ruleset(rs) for leaf, rs in leaves.items()}
+                for member, leaves in value.posture.items()
+            },
+        }
+    return {}
+
+
+def build_governance_policy_snapshot() -> dict:
+    """Compute the effective governance ceiling across ALL scopes (host surface).
+
+    Iterates ``SCOPE_CATALOG`` (so the list stays complete and auto-extends when
+    a scope is registered) and, for each scope, intersects the boot-frozen
+    POLICY control with the host-surface PROFILE control using the model's OWN
+    composition algebra (``_compose_controls`` — the same helper the evaluator's
+    ``compose_profiles`` path uses); it does not re-implement ``policy ∩
+    profile``. A scope governed by neither level is reported ``ungoverned`` (it
+    permits — the standalone default), so with NO policy and NO profile every
+    scope is ``ungoverned`` and the response is byte-identical to a standalone
+    host.
+
+    Synchronous — reading the ceiling is in-memory, but ``resolve_active_scope``
+    may read profile files, so async callers MUST offload it (see
+    :func:`build_governance_policy_snapshot_async`). Fail-SAFE for DISPLAY: any
+    unexpected governance error yields a well-formed ``unavailable`` response
+    rather than raising, so a resolution glitch never breaks the Security page
+    (this endpoint enforces nothing).
+    """
+    from kiro_crew.platform.context import current_context
+    from kiro_crew.platform.governance import (
+        _SCOPE_ALIASES,
+        SCOPE_CATALOG,
+        GovernanceCeiling,
+        _compose_controls,
+    )
+    from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY, resolve_active_scope
+
+    try:
+        ceiling = getattr(current_context(), "governance", None)
+        if ceiling is not None and not isinstance(ceiling, GovernanceCeiling):
+            ceiling = None
+        # Host-surface profile (bind: {type: surface, id: host}); usually None.
+        profile = resolve_active_scope(HOST_SESSION_KEY)
+
+        scopes: list[dict] = []
+        for scope, spec in SCOPE_CATALOG.items():
+            # Skip the folders.* aliases: they normalize to filesystem.* at parse
+            # time, so a control is never stored under the alias key — emitting it
+            # would be a permanently-ungoverned duplicate row.
+            if scope in _SCOPE_ALIASES:
+                continue
+            policy_control = ceiling.get(scope) if ceiling is not None else None
+            profile_control = profile.get(scope) if profile is not None else None
+
+            if policy_control is not None and profile_control is not None:
+                source = "policy+profile"
+                effective = _compose_controls(policy_control, profile_control)
+            elif policy_control is not None:
+                source = "policy"
+                effective = policy_control
+            elif profile_control is not None:
+                source = "profile"
+                effective = profile_control
+            else:
+                source = "ungoverned"
+                effective = None
+
+            scopes.append(
+                {
+                    "scope": scope,
+                    "archetype": spec.kind,
+                    "governed": effective is not None,
+                    "source": source,
+                    "detail": _serialize_control(spec.kind, effective),
+                }
+            )
+
+        return {
+            "version": ceiling.version if ceiling is not None else None,
+            "has_policy": ceiling is not None,
+            "profile": profile.name if profile is not None else None,
+            "unavailable": False,
+            "scopes": scopes,
+        }
+    except Exception:
+        # Display must never 500 the Security page on a governance glitch.
+        logger.warning("governance policy snapshot unavailable", exc_info=True)
+        return {
+            "version": None,
+            "has_policy": False,
+            "profile": None,
+            "unavailable": True,
+            "scopes": [],
+        }
+
+
+async def build_governance_policy_snapshot_async() -> dict:
+    """Build the governance-policy snapshot off the event loop.
+
+    ``build_governance_policy_snapshot`` may walk the profile store (filesystem)
+    via ``resolve_active_scope``, so it is offloaded to the default thread
+    executor rather than blocking aiohttp's sole event loop.
+    """
+    return await _run_off_loop(build_governance_policy_snapshot)
+
+
+async def api_governance_policy(request: web.Request) -> web.Response:
+    """GET /api/governance/policy — effective ceiling across all scopes (read)."""
+    return web.json_response(await build_governance_policy_snapshot_async())

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1695,6 +1695,9 @@ async def start_dashboard(
     app.router.add_delete(
         "/api/security/denied-commands/user/{id}", handlers.api_denied_command_user_delete
     )
+    # Read-only governance policy viewer — effective Level-1 ∩ Level-2 ceiling
+    # across every governed scope (no write path; the ceiling is file-authored).
+    app.router.add_get("/api/governance/policy", handlers.api_governance_policy)
     app.router.add_get("/api/approvals", handlers.api_approvals)
     app.router.add_post("/api/approvals/{id}/{action}", handlers.api_approval_resolve)
 

--- a/test/test_governance_policy_viewer.py
+++ b/test/test_governance_policy_viewer.py
@@ -1,0 +1,269 @@
+"""Read-only governance policy viewer — GET /api/governance/policy.
+
+Covers the effective-ceiling snapshot the Settings > Security viewer renders:
+
+* the byte-identical standalone default (no policy + no profile → every scope
+  ``ungoverned``, permits);
+* a policy that governs several scopes across all four archetypes → the right
+  ``source`` + ``detail`` per scope, the rest ungoverned;
+* ``HOST_SESSION_KEY`` is the surface used for profile resolution, and a
+  host-bound profile intersects the policy (``policy+profile``);
+* the endpoint is GET-only / fail-safe for display (a resolution error yields a
+  well-formed ``unavailable`` response, never a 500).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from kiro_crew.dashboard.handlers.security import (
+    api_governance_policy,
+    build_governance_policy_snapshot,
+)
+from kiro_crew.platform import context as ctx_mod
+from kiro_crew.platform import governance_profiles as gp
+from kiro_crew.platform.bootstrap import build_default_context
+from kiro_crew.platform.governance import _SCOPE_ALIASES, SCOPE_CATALOG, parse_policy
+
+
+@pytest.fixture
+def profiles_dir(tmp_path, monkeypatch):
+    d = tmp_path / "profiles"
+    d.mkdir()
+    monkeypatch.setattr(gp, "_PROFILES_DIR", d)
+    gp.reset_store()
+    yield d
+    gp.reset_store()
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx():
+    yield
+    ctx_mod.reset_context()
+
+
+def _install_ceiling(policy_body):
+    """Compose a context carrying the given policy and install it as active."""
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    base = build_default_context(KiroCrewConfig.load())
+    ceiling = parse_policy(policy_body) if policy_body is not None else None
+    ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+
+
+def _write(d, name, body):
+    (d / f"{name}.json").write_text(json.dumps(body))
+
+
+def _by_scope(snapshot):
+    return {row["scope"]: row for row in snapshot["scopes"]}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Byte-identical standalone default
+# ──────────────────────────────────────────────────────────────────────────
+class TestNoPolicyDefault:
+    def test_no_policy_no_profile_all_ungoverned(self, profiles_dir):
+        _install_ceiling(None)
+        snap = build_governance_policy_snapshot()
+
+        assert snap["has_policy"] is False
+        assert snap["version"] is None
+        assert snap["profile"] is None
+        assert snap["unavailable"] is False
+
+        # Every scope reports ungoverned + permits; none is governed.
+        assert snap["scopes"], "expected a row per catalog scope"
+        assert all(row["source"] == "ungoverned" for row in snap["scopes"])
+        assert all(row["governed"] is False for row in snap["scopes"])
+
+    def test_covers_every_catalog_scope_minus_aliases(self, profiles_dir):
+        # The viewer iterates SCOPE_CATALOG (never a hardcoded list) so it stays
+        # complete + auto-extends; the folders.* aliases are folded into
+        # filesystem.* and must not appear as their own rows.
+        _install_ceiling(None)
+        snap = build_governance_policy_snapshot()
+
+        expected = {s for s in SCOPE_CATALOG if s not in _SCOPE_ALIASES}
+        assert {row["scope"] for row in snap["scopes"]} == expected
+        assert not any(row["scope"].startswith("folders.") for row in snap["scopes"])
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# A governing policy — per-archetype source + detail
+# ──────────────────────────────────────────────────────────────────────────
+class TestGoverningPolicy:
+    @pytest.fixture
+    def snapshot(self, profiles_dir):
+        _install_ceiling(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "commands": {"mode": "deny", "deny": ["git push*", "*rm -rf /*"]},
+                "tools": {"mode": "allow", "allow": ["read", "grep"]},
+                "channels": {
+                    "members": {"mode": "allow", "allow": ["slack"]},
+                    "posture": {
+                        "slack": {"allowed_enterprise_ids": {"mode": "allow", "allow": ["E0123"]}}
+                    },
+                },
+                "sandbox": {"min_level": "cc"},
+                "capabilities": {
+                    "cron": {"enabled": False},
+                    "spawn": {
+                        "enabled": True,
+                        "scopes": {"agents": {"mode": "allow", "allow": ["researcher"]}},
+                    },
+                },
+            }
+        )
+        return build_governance_policy_snapshot()
+
+    def test_has_policy_and_version(self, snapshot):
+        assert snapshot["has_policy"] is True
+        assert snapshot["version"] == 1
+
+    def test_ruleset_allow_detail(self, snapshot):
+        row = _by_scope(snapshot)["tools"]
+        assert row["governed"] is True
+        assert row["source"] == "policy"
+        assert row["archetype"] == "ruleset"
+        assert row["detail"]["mode"] == "allow"
+        assert row["detail"]["allow"] == ["read", "grep"]
+
+    def test_ruleset_deny_detail(self, snapshot):
+        row = _by_scope(snapshot)["commands"]
+        assert row["source"] == "policy"
+        assert row["detail"]["mode"] == "deny"
+        assert row["detail"]["deny"] == ["git push*", "*rm -rf /*"]
+
+    def test_ordinal_detail_reports_floor(self, snapshot):
+        row = _by_scope(snapshot)["sandbox.min_level"]
+        assert row["archetype"] == "ordinal"
+        assert row["detail"] == {"scale": "sandbox", "floor": "cc"}
+
+    def test_capability_off_detail(self, snapshot):
+        row = _by_scope(snapshot)["capabilities.cron"]
+        assert row["archetype"] == "capability"
+        assert row["governed"] is True
+        assert row["detail"]["enabled"] is False
+
+    def test_capability_on_with_inner_allowlist(self, snapshot):
+        row = _by_scope(snapshot)["capabilities.spawn"]
+        assert row["detail"]["enabled"] is True
+        assert row["detail"]["inner"]["agents"]["allow"] == ["researcher"]
+
+    def test_scopedmap_members_and_posture(self, snapshot):
+        row = _by_scope(snapshot)["channels"]
+        assert row["archetype"] == "scopedmap"
+        assert row["detail"]["members"]["allow"] == ["slack"]
+        assert "slack" in row["detail"]["posture"]
+
+    def test_ungoverned_scopes_remain_ungoverned(self, snapshot):
+        # A scope the policy does not name (e.g. mcp / apps / messaging) stays
+        # ungoverned and permits — only the named scopes flip to governed.
+        by = _by_scope(snapshot)
+        for scope in ("mcp", "apps", "capabilities.messaging", "filesystem.read"):
+            assert by[scope]["governed"] is False
+            assert by[scope]["source"] == "ungoverned"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Host-surface profile resolution + intersection
+# ──────────────────────────────────────────────────────────────────────────
+class TestHostProfileIntersection:
+    def test_host_bound_profile_intersects_policy(self, profiles_dir):
+        _install_ceiling(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "tools": {"mode": "allow", "allow": ["read", "grep", "code"]},
+                "sandbox": {"min_level": "cc"},
+            }
+        )
+        # A profile bound to the HOST surface narrows tools + tightens sandbox.
+        _write(
+            profiles_dir,
+            "host-tight",
+            {
+                "name": "host-tight",
+                "bind": {"type": "surface", "id": "host"},
+                "tools": {"mode": "allow", "allow": ["read"]},
+                "sandbox": {"min_level": "strict"},
+            },
+        )
+        snap = build_governance_policy_snapshot()
+        by = _by_scope(snap)
+
+        # The host-surface profile was resolved (proves HOST_SESSION_KEY is used).
+        assert snap["profile"] == "host-tight"
+
+        tools = by["tools"]
+        assert tools["source"] == "policy+profile"
+        # An allow∩allow that cannot flatten renders as an intersection view.
+        assert tools["detail"]["mode"] == "intersect"
+        assert len(tools["detail"]["components"]) == 2
+
+        # Ordinal composes strictest-of → the profile's stricter "strict" wins.
+        assert by["sandbox.min_level"]["detail"]["floor"] == "strict"
+
+    def test_profile_only_scope_source_is_profile(self, profiles_dir):
+        # Policy present but does NOT govern apps; a host profile does → source
+        # is "profile" (profile-alone governs this scope).
+        _install_ceiling({"version": 1, "boot": {"fail_closed": True}})
+        _write(
+            profiles_dir,
+            "host-tight",
+            {
+                "name": "host-tight",
+                "bind": {"type": "surface", "id": "host"},
+                "apps": {"mode": "allow", "allow": ["auto-research"]},
+            },
+        )
+        snap = build_governance_policy_snapshot()
+        apps = _by_scope(snap)["apps"]
+        assert apps["source"] == "profile"
+        assert apps["governed"] is True
+        assert apps["detail"]["allow"] == ["auto-research"]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Endpoint behavior (GET-only, fail-safe for display)
+# ──────────────────────────────────────────────────────────────────────────
+class TestEndpoint:
+    async def _call(self):
+        # aiohttp request is unused by the handler (no body / match_info), so a
+        # bare sentinel suffices — the handler only offloads the snapshot build.
+        return await api_governance_policy(object())  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_get_returns_json_snapshot(self, profiles_dir):
+        _install_ceiling(None)
+        resp = await self._call()
+        assert resp.status == 200
+        payload = json.loads(resp.body)
+        assert payload["has_policy"] is False
+        assert payload["unavailable"] is False
+        assert all(row["source"] == "ungoverned" for row in payload["scopes"])
+
+    @pytest.mark.asyncio
+    async def test_display_fails_safe_on_resolution_error(self, profiles_dir, monkeypatch):
+        # A governance-resolution error must NOT 500 the Security page — the
+        # snapshot degrades to a well-formed "unavailable" response.
+        import kiro_crew.dashboard.handlers.security as sec
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("resolution glitch")
+
+        monkeypatch.setattr(sec, "resolve_active_scope", _boom, raising=False)
+        # Patch the symbol the function imports lazily inside its body.
+        monkeypatch.setattr("kiro_crew.platform.governance_profiles.resolve_active_scope", _boom)
+        resp = await self._call()
+        assert resp.status == 200
+        payload = json.loads(resp.body)
+        assert payload["unavailable"] is True
+        assert payload["scopes"] == []
+        assert payload["has_policy"] is False

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -227,6 +227,48 @@ export interface DeniedCommandsData {
   governance_locked: boolean
 }
 
+/** Serialized effective control for one governed scope (archetype-specific). */
+export interface GovernanceScopeDetail {
+  /** ruleset / scopedmap-members / capability-inner: the set mode + entries. */
+  mode?: string
+  allow?: string[]
+  deny?: string[]
+  /** ruleset intersection (allow∩ that can't flatten): the composed halves. */
+  components?: GovernanceScopeDetail[]
+  /** ordinal: the enforced floor value + its strictness scale. */
+  scale?: string
+  floor?: string
+  /** capability: on/off + inner allowlists (e.g. spawn→agents). */
+  enabled?: boolean
+  inner?: Record<string, GovernanceScopeDetail>
+  /** scopedmap (channels): allowed members + per-member posture. */
+  members?: GovernanceScopeDetail
+  posture?: Record<string, Record<string, GovernanceScopeDetail>>
+}
+
+/** One row of the effective governance ceiling for a single scope. */
+export interface GovernanceScope {
+  scope: string
+  archetype: 'ruleset' | 'ordinal' | 'capability' | 'scopedmap'
+  /** false = neither policy nor profile governs it → the scope permits. */
+  governed: boolean
+  source: 'policy' | 'profile' | 'policy+profile' | 'ungoverned'
+  detail: GovernanceScopeDetail
+}
+
+/** GET /api/governance/policy — the read-only effective ceiling across scopes. */
+export interface GovernancePolicyData {
+  /** Policy schema version, or null when no enterprise ceiling is present. */
+  version: number | null
+  /** Whether a Level-1 enterprise ceiling is in effect at all. */
+  has_policy: boolean
+  /** The bound host-surface profile name, or null. */
+  profile: string | null
+  /** True when governance resolution failed — the viewer shows a soft notice. */
+  unavailable: boolean
+  scopes: GovernanceScope[]
+}
+
 let _sessionExpiredShown = false
 
 /**
@@ -544,6 +586,9 @@ export const api = {
     patch('/api/security/denied-commands/user/' + encodeURIComponent(id), { enabled }).then(j) as Promise<DeniedCommandsData>,
   deleteUserDeniedCommand: (id: string) =>
     del('/api/security/denied-commands/user/' + encodeURIComponent(id)).then(j) as Promise<DeniedCommandsData>,
+  // Read-only governance policy viewer (Settings → Security). No write path —
+  // the enterprise ceiling is file-authored and un-editable via the UI.
+  governancePolicy: () => get('/api/governance/policy').then(j) as Promise<GovernancePolicyData>,
   suggestions: (force?: boolean) => fetch(`/api/suggestions${force ? '?force=1' : ''}`).then(j) as Promise<{ suggestions: string[]; generated_at: number; stale: boolean }>,
   branding: () => fetch('/api/dashboard/branding').then(j) as Promise<{ bot_name: string; avatar: string }>,
   // Instances (multi-instance management) — owner-only, gated by instances.enabled.

--- a/website/src/pages/settings/SecurityPanel.test.tsx
+++ b/website/src/pages/settings/SecurityPanel.test.tsx
@@ -23,10 +23,12 @@ vi.mock('../../api/client', () => ({
     addUserDeniedCommand: vi.fn(),
     toggleUserDeniedCommand: vi.fn(),
     deleteUserDeniedCommand: vi.fn(),
+    governancePolicy: vi.fn(),
   },
 }))
 
 import { api } from '../../api/client'
+import type { GovernancePolicyData } from '../../api/client'
 import { SecurityPanel } from './SecurityPanel'
 
 const PINNED_DESC = 'Blocks EC2 instance termination'
@@ -79,6 +81,42 @@ async function renderPanel(data: DeniedCommandsData = snapshot()) {
   return utils
 }
 
+/** No-policy (standalone) governance snapshot: every scope ungoverned. */
+function govNoPolicy(overrides: Partial<GovernancePolicyData> = {}): GovernancePolicyData {
+  return {
+    version: null,
+    has_policy: false,
+    profile: null,
+    unavailable: false,
+    scopes: [
+      { scope: 'tools', archetype: 'ruleset', governed: false, source: 'ungoverned', detail: {} },
+      { scope: 'commands', archetype: 'ruleset', governed: false, source: 'ungoverned', detail: {} },
+    ],
+    ...overrides,
+  }
+}
+
+/** A governed governance snapshot exercising every archetype + a profile. */
+function govGoverned(overrides: Partial<GovernancePolicyData> = {}): GovernancePolicyData {
+  return {
+    version: 1,
+    has_policy: true,
+    profile: 'host-tight',
+    unavailable: false,
+    scopes: [
+      { scope: 'tools', archetype: 'ruleset', governed: true, source: 'policy+profile', detail: { mode: 'intersect', components: [{ mode: 'allow', allow: ['read', 'grep', 'code'], deny: [] }, { mode: 'allow', allow: ['read'], deny: [] }] } },
+      { scope: 'commands', archetype: 'ruleset', governed: true, source: 'policy', detail: { mode: 'deny', allow: [], deny: ['git push*', '*rm -rf /*'] } },
+      { scope: 'mcp', archetype: 'ruleset', governed: false, source: 'ungoverned', detail: {} },
+      { scope: 'channels', archetype: 'scopedmap', governed: true, source: 'policy', detail: { members: { mode: 'allow', allow: ['slack'], deny: [] }, posture: { slack: { allowed_enterprise_ids: { mode: 'allow', allow: ['E0123'], deny: [] } } } } },
+      { scope: 'sandbox.min_level', archetype: 'ordinal', governed: true, source: 'policy', detail: { scale: 'sandbox', floor: 'cc' } },
+      { scope: 'capabilities.cron', archetype: 'capability', governed: true, source: 'policy', detail: { enabled: false, inner: {} } },
+      { scope: 'capabilities.spawn', archetype: 'capability', governed: true, source: 'policy', detail: { enabled: true, inner: { agents: { mode: 'allow', allow: ['researcher'], deny: [] } } } },
+      { scope: 'capabilities.messaging', archetype: 'capability', governed: false, source: 'ungoverned', detail: {} },
+    ],
+    ...overrides,
+  }
+}
+
 describe('SecurityPanel — denied commands', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -87,6 +125,7 @@ describe('SecurityPanel — denied commands', () => {
     ;(api.addUserDeniedCommand as ReturnType<typeof vi.fn>).mockResolvedValue(snapshot())
     ;(api.toggleUserDeniedCommand as ReturnType<typeof vi.fn>).mockResolvedValue(snapshot())
     ;(api.deleteUserDeniedCommand as ReturnType<typeof vi.fn>).mockResolvedValue(snapshot())
+    ;(api.governancePolicy as ReturnType<typeof vi.fn>).mockResolvedValue(govNoPolicy())
   })
 
   it('toggling a built-in OFF opens the confirm modal and only mutates after ack', async () => {
@@ -225,5 +264,53 @@ describe('SecurityPanel — denied commands', () => {
     const showButtons = screen.getAllByLabelText('Show pattern')
     fireEvent.click(showButtons[0])
     expect(screen.getByText('aws.*cloudformation.*delete-stack.*')).toBeInTheDocument()
+  })
+})
+
+describe('SecurityPanel — governance policy viewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(api.deniedCommands as ReturnType<typeof vi.fn>).mockResolvedValue(snapshot())
+  })
+
+  it('shows the standalone "no enterprise policy" state when has_policy is false', async () => {
+    ;(api.governancePolicy as ReturnType<typeof vi.fn>).mockResolvedValue(govNoPolicy())
+    renderWithProviders(<SecurityPanel />)
+
+    expect(await screen.findByText('No enterprise policy in effect')).toBeInTheDocument()
+    expect(screen.getByText(/All scopes are permitted \(standalone mode\)/)).toBeInTheDocument()
+    // No governed rows are rendered in standalone mode.
+    expect(screen.queryByText('policy ∩ profile')).not.toBeInTheDocument()
+  })
+
+  it('renders governed + ungoverned rows with effective state and source', async () => {
+    ;(api.governancePolicy as ReturnType<typeof vi.fn>).mockResolvedValue(govGoverned())
+    renderWithProviders(<SecurityPanel />)
+
+    // Policy + profile badges.
+    expect(await screen.findByText('Policy v1')).toBeInTheDocument()
+    expect(screen.getByText('Profile: host-tight')).toBeInTheDocument()
+
+    // Ruleset (deny) → "Blocks: …"; capability off → "Disabled by policy";
+    // ordinal → "Floor: cc"; capability on with inner allowlist.
+    expect(screen.getByText(/Blocks: git push\*/)).toBeInTheDocument()
+    expect(screen.getByText('Disabled by policy')).toBeInTheDocument()
+    expect(screen.getByText('Floor: cc')).toBeInTheDocument()
+    expect(screen.getByText(/Enabled · agents: researcher/)).toBeInTheDocument()
+
+    // policy+profile intersection badge is shown for the composed tools scope.
+    expect(screen.getAllByText('policy ∩ profile').length).toBeGreaterThan(0)
+
+    // An ungoverned scope (messaging) shows the muted "Not restricted".
+    expect(screen.getAllByText('Not restricted').length).toBeGreaterThan(0)
+  })
+
+  it('shows a soft notice when governance resolution is unavailable', async () => {
+    ;(api.governancePolicy as ReturnType<typeof vi.fn>).mockResolvedValue(
+      govNoPolicy({ unavailable: true }),
+    )
+    renderWithProviders(<SecurityPanel />)
+
+    expect(await screen.findByText(/Governance status is temporarily unavailable/)).toBeInTheDocument()
   })
 })

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ShieldCheck, ShieldAlert, Lock, Eye, EyeOff, FileWarning, Terminal, Globe, Fingerprint, KeyRound, ScanLine, Layers, AlertTriangle, CheckCircle2, ExternalLink, ChevronRight, ChevronDown, Plus, Trash2 } from 'lucide-react'
+import { ShieldCheck, ShieldAlert, Lock, Eye, EyeOff, FileWarning, Terminal, Globe, Fingerprint, KeyRound, ScanLine, Layers, AlertTriangle, CheckCircle2, ExternalLink, ChevronRight, ChevronDown, Plus, Trash2, Gavel, Building2, Gauge, ToggleRight, MessageSquare, ListChecks } from 'lucide-react'
 import { useAppSelector } from '../../store'
 import { Badge, Btn, Input, Toggle, Checkbox } from '../../components/ui'
 import { SettingsSection, SettingsCard } from '../../components/settings'
 import Modal from '../../components/Modal'
 import InfoTip from '../../components/InfoTip'
-import { api, type DeniedCommandsData, type DeniedCommandRule, type DeniedUserRule } from '../../api/client'
+import { api, type DeniedCommandsData, type DeniedCommandRule, type DeniedUserRule, type GovernancePolicyData, type GovernanceScope, type GovernanceScopeDetail } from '../../api/client'
 
 /* ── Security feature registry (static — derived from security-deep-dive.md) ── */
 
@@ -243,6 +243,200 @@ function AddDenyInput({ onAdd, busy }: { onAdd: (pattern: string) => void; busy:
   )
 }
 
+/* ── Governance Policy viewer (read-only effective ceiling) ── */
+
+/** Human-readable scope name, e.g. "capabilities.cron" → "Cron",
+ *  "filesystem.read" → "Filesystem read", "sandbox.min_level" → "Sandbox". */
+function scopeLabel(scope: string): string {
+  const SPECIAL: Record<string, string> = {
+    mcp: 'MCP servers',
+    'filesystem.read': 'Filesystem read',
+    'filesystem.write': 'Filesystem write',
+    'network.egress': 'Network egress',
+    'sandbox.min_level': 'Sandbox level',
+    approval_mode: 'Tool approval',
+    'capabilities.memory_writes': 'Memory writes',
+    'capabilities.script_hooks': 'Script hooks',
+    'capabilities.theme_persona': 'Theme persona',
+    'capabilities.theme_install': 'Theme install',
+  }
+  if (SPECIAL[scope]) return SPECIAL[scope]
+  const leaf = scope.includes('.') ? scope.slice(scope.indexOf('.') + 1) : scope
+  return leaf.charAt(0).toUpperCase() + leaf.slice(1)
+}
+
+/** Compact "a, b (+N)" summary of a list, capped so a long allow-list stays scannable. */
+function summarizeList(items: string[] | undefined, cap = 2): string {
+  const list = items ?? []
+  if (list.length === 0) return 'none'
+  const shown = list.slice(0, cap).join(', ')
+  return list.length > cap ? `${shown} (+${list.length - cap})` : shown
+}
+
+/** Short human label for one governed ruleset (or a composed intersection). */
+function rulesetLabel(d: GovernanceScopeDetail): string {
+  if (d.mode === 'intersect') {
+    return (d.components ?? []).map(rulesetLabel).join(' ∩ ')
+  }
+  if (d.mode === 'allow') {
+    return (d.allow?.length ?? 0) === 0 ? 'Nothing allowed' : `Allow: ${summarizeList(d.allow)}`
+  }
+  if (d.mode === 'deny') {
+    return (d.deny?.length ?? 0) === 0 ? 'All allowed' : `Blocks: ${summarizeList(d.deny)}`
+  }
+  return ''
+}
+
+/** Compact human label for a scope's EFFECTIVE state, by archetype. */
+function effectiveLabel(row: GovernanceScope): string {
+  if (!row.governed) return 'Not restricted'
+  const d = row.detail
+  switch (row.archetype) {
+    case 'ruleset':
+      return rulesetLabel(d)
+    case 'ordinal':
+      return `Floor: ${d.floor ?? '?'}`
+    case 'capability': {
+      if (!d.enabled) return 'Disabled by policy'
+      const inner = Object.entries(d.inner ?? {})
+      if (inner.length === 0) return 'Enabled'
+      return `Enabled · ${inner.map(([k, v]) => `${k}: ${summarizeList(v.allow)}`).join('; ')}`
+    }
+    case 'scopedmap': {
+      const members = d.members ? rulesetLabel(d.members) : ''
+      const postureN = Object.keys(d.posture ?? {}).length
+      return postureN > 0 ? `${members} · posture pinned` : members
+    }
+    default:
+      return ''
+  }
+}
+
+/** Plane grouping for the viewer — a clean split by governed surface. */
+interface GovPlane {
+  key: string
+  title: string
+  icon: React.ReactNode
+  scopes: string[]
+}
+const GOV_PLANES: GovPlane[] = [
+  { key: 'access', title: 'Tools & Commands', icon: <Terminal size={13} />, scopes: ['tools', 'mcp', 'apps', 'commands'] },
+  { key: 'io', title: 'Filesystem & Network', icon: <Globe size={13} />, scopes: ['filesystem.read', 'filesystem.write', 'network.egress'] },
+  { key: 'channels', title: 'Messaging Channels', icon: <MessageSquare size={13} />, scopes: ['channels'] },
+  { key: 'modes', title: 'Enforcement Modes', icon: <Gauge size={13} />, scopes: ['approval_mode', 'sandbox.min_level'] },
+  { key: 'capabilities', title: 'Capabilities', icon: <ToggleRight size={13} />, scopes: [] /* catch-all: every capabilities.* */ },
+]
+
+/** A single read-only governance scope row. */
+function GovernanceRow({ row }: { row: GovernanceScope }) {
+  const label = effectiveLabel(row)
+  return (
+    <div className="flex items-center justify-between py-2 gap-3">
+      <div className="flex items-center gap-2 min-w-0">
+        {row.governed
+          ? <Lock size={12} className="lucide-inline shrink-0 text-muted" />
+          : <span className="shrink-0 w-3" />}
+        <span className={`text-[13px] font-semibold truncate ${row.governed ? 'text-text' : 'text-muted'}`}>{scopeLabel(row.scope)}</span>
+        {row.source === 'policy+profile' && <Badge variant="muted">policy ∩ profile</Badge>}
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {row.governed ? (
+          <>
+            <span className="text-[12px] text-text-strong text-right max-w-[280px] truncate" title={label}>{label}</span>
+            <InfoTip text={PINNED_TOOLTIP} />
+          </>
+        ) : (
+          <span className="text-[12px] text-muted italic">Not restricted</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Read-only viewer: the effective governance ceiling across every scope. */
+function GovernancePolicyViewer() {
+  const { data, isLoading } = useQuery<GovernancePolicyData>({
+    queryKey: ['governance-policy'],
+    queryFn: api.governancePolicy,
+    staleTime: 60_000,
+  })
+
+  const byScope = useMemo(() => {
+    const m = new Map<string, GovernanceScope>()
+    for (const s of data?.scopes ?? []) m.set(s.scope, s)
+    return m
+  }, [data])
+
+  // Assign each scope to its plane; the Capabilities plane catches every
+  // capabilities.* scope so a future capability row shows with no code change.
+  const planeRows = useMemo(() => {
+    const explicit = new Set(GOV_PLANES.flatMap(p => p.scopes))
+    return GOV_PLANES.map(plane => {
+      const rows = plane.key === 'capabilities'
+        ? (data?.scopes ?? []).filter(s => s.scope.startsWith('capabilities.'))
+        : plane.scopes.map(sc => byScope.get(sc)).filter((s): s is GovernanceScope => !!s)
+      return { plane, rows, explicit }
+    })
+  }, [data, byScope])
+
+  return (
+    <SettingsSection title="Governance Policy">
+      <SettingsCard>
+        <div className="flex items-start gap-3 pb-1">
+          <div className="mt-0.5 shrink-0 w-7 h-7 rounded-md bg-accent-subtle flex items-center justify-center text-accent">
+            <Gavel size={14} className="lucide-inline" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-semibold text-text-strong">Effective security ceiling</div>
+            <div className="text-[12px] text-muted mt-0.5 leading-relaxed">
+              The strictest boundary in effect for each governed scope, resolved as your organization's policy intersected with the active profile. Read-only — the ceiling is authored in <code className="font-mono text-[11px]">security_policy.json</code> and cannot be changed here.
+            </div>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="text-[12px] text-muted py-2">Loading governance policy…</div>
+        ) : data?.unavailable ? (
+          <div className="flex items-start gap-2.5 py-2 mt-1">
+            <AlertTriangle size={14} className="lucide-inline text-warn shrink-0 mt-0.5" />
+            <span className="text-[12px] text-muted leading-relaxed">Governance status is temporarily unavailable. Enforcement is unaffected — this view could not resolve the ceiling for display.</span>
+          </div>
+        ) : !data?.has_policy && !data?.profile ? (
+          <div className="flex items-start gap-2.5 py-3 mt-1 rounded-md bg-bg-elevated border border-border px-3">
+            <ShieldCheck size={16} className="lucide-inline text-ok shrink-0 mt-0.5" />
+            <div>
+              <div className="text-[13px] font-semibold text-text">No enterprise policy in effect</div>
+              <div className="text-[12px] text-muted mt-0.5 leading-relaxed">All scopes are permitted (standalone mode). To enforce a ceiling, author <code className="font-mono text-[11px]">~/.kirocrew/security_policy.json</code> and per-surface <code className="font-mono text-[11px]">profiles/*.json</code>.</div>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 mt-1 mb-1 flex-wrap">
+              {data?.has_policy && (
+                <Badge variant="aim"><Building2 size={11} className="lucide-inline" /> Policy v{data.version ?? '?'}</Badge>
+              )}
+              {data?.profile && (
+                <Badge variant="muted"><ListChecks size={11} className="lucide-inline" /> Profile: {data.profile}</Badge>
+              )}
+            </div>
+            {planeRows.map(({ plane, rows }) => rows.length === 0 ? null : (
+              <div key={plane.key} className="border-t border-border first:border-t-0 pt-1.5 mt-1.5 first:mt-0 first:pt-0">
+                <div className="flex items-center gap-1.5 py-1">
+                  <span className="text-muted">{plane.icon}</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-[.04em] text-muted">{plane.title}</span>
+                </div>
+                <div className="divide-y divide-border">
+                  {rows.map(row => <GovernanceRow key={row.scope} row={row} />)}
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
 /* ── Confirm modal target ── */
 type ConfirmTarget =
   | { kind: 'builtin'; id: string; description: string }
@@ -373,6 +567,9 @@ export function SecurityPanel() {
           />
         </SettingsCard>
       </SettingsSection>
+
+      {/* ── Governance Policy (read-only effective ceiling) ── */}
+      <GovernancePolicyViewer />
 
       {/* ── Denied Commands ── */}
       <SettingsSection title="Denied Commands">


### PR DESCRIPTION
## Summary

Adds a **read-only governance policy viewer** to the Security settings page,
showing the effective governance ceiling across **every** governed scope. This
gives operators visibility into what an enterprise `security_policy.json` +
`profiles/*.json` actually enforce — the backend has governed ~19 scopes for a
while, but there was no UI to *see* the effective ceiling.

Read-only by design: the ceiling is file-authored and deliberately
un-editable via the dashboard (so it can't be weakened through the app). This
PR only surfaces it.

## Backend

`GET /api/governance/policy` returns the effective ceiling for the host surface:
- Iterates `SCOPE_CATALOG` (so the view auto-covers any future scope — no
  hardcoded list).
- For each scope, computes the effective state = **POLICY ∩ PROFILE**
  (tightest-wins), reusing the evaluator's composition, and reports `governed`,
  `source` (policy / profile / both / ungoverned), and per-archetype `detail`
  (ruleset allow/deny; scopedmap members; ordinal floor; capability enabled +
  inner allowlists).
- Host-surface profile resolved via `HOST_SESSION_KEY`. Profile read runs off
  the event loop.
- Fail-safe for *display*: a governance-resolution error returns a well-formed
  "governance unavailable" response rather than 500ing the Security page (this
  endpoint enforces nothing).

## Frontend

A "Governance Policy" section in `SecurityPanel` renders each scope's effective
state + source, grouped for readability, using the panel's existing
pinned-lock styling for governed rows and a muted "Not restricted" for
ungoverned ones. When no ceiling is present it shows a clear
"No enterprise policy in effect — standalone mode (all scopes permitted)"
state. No toggles/inputs — display only. No emojis (lucide icons).

## Byte-identical default

With no policy and no profile (the standard build), every scope reads
`ungoverned` and the viewer shows the standalone state — nothing changes from
today. Proven by tests.

## Verification

- Backend: `test/test_governance_policy_viewer.py` — 14 tests (no-policy
  all-ungoverned default; governed scopes with correct source+detail;
  `HOST_SESSION_KEY` used; GET-only). Full security/governance suite: 96 pass,
  no regressions.
- flake8 / mypy (changed modules) / inclusive-language / scrub: clean.
- Frontend `tsc`/vitest exercised by CI (SecurityPanel test updated with the
  mocked endpoint).
- `docs/system-specs/modules/governance.md` updated in the same commit.
