### PR TITLE
fix(desktop): defeat .DS_Store race in build-output pre-clean removals

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -101,6 +101,39 @@ esac
 
 log() { printf '\n\033[1;36m▶ %s\033[0m\n' "$*"; }
 
+# Recursively remove a directory tree, defeating the macOS .DS_Store/ENOTEMPTY
+# race. macOS Desktop Services (Finder/Spotlight) can drop a fresh .DS_Store
+# into a subdirectory *between* rm's child-sweep and its final rmdir, so a plain
+# `rm -rf` aborts with ENOTEMPTY (the -f flag suppresses ENOENT, not ENOTEMPTY;
+# electron-userland/electron-builder#6890). Every destructive rm of a build
+# output dir in this script is exposed to that race, so route them all through
+# here: sweep any .DS_Store, rm, and if the tree survives (the race re-created a
+# file) sweep + retry a bounded number of times. Success is detected by the
+# directory being gone — NOT by grepping stderr — so it is locale-independent
+# (a non-English macOS emits a translated "Directory not empty" that a string
+# match would silently miss). No-op when the path is already absent.
+rm_rf_resilient() {
+  local target="$1" attempt=1 max_attempts=5
+  # A dangling symlink is "not -e" but must still be removed (leaving it makes
+  # the following build step operate on a broken link), so treat -e OR -L as
+  # present; only a truly absent path is the no-op.
+  { [ -e "$target" ] || [ -L "$target" ]; } || return 0
+  while : ; do
+    find "$target" -name .DS_Store -delete 2>/dev/null || true
+    rm -rf "$target" 2>/dev/null || true
+    { [ -e "$target" ] || [ -L "$target" ]; } || return 0
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "  ⚠ '$target' survived $max_attempts rm attempts (macOS .DS_Store race?); one final attempt with errors surfaced…" >&2
+      # Let a genuine, non-transient failure abort the build under `set -e`
+      # instead of looping forever or masking a real permissions problem.
+      rm -rf "$target"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+}
+
 # --- 1. Frontend ------------------------------------------------------------
 if [ "${SKIP_FRONTEND:-0}" != "1" ]; then
   log "Building dashboard (npm)…"
@@ -305,7 +338,7 @@ resolver_gate() {
 }
 
 # --- 3. Build the backend tree(s) --------------------------------------------
-rm -rf "$ELECTRON_DIR/backend-dist"
+rm_rf_resilient "$ELECTRON_DIR/backend-dist"
 mkdir -p "$ELECTRON_DIR/backend-dist"
 
 if [ "$UNIVERSAL" = "1" ]; then
@@ -394,7 +427,10 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
   # Start from a pristine output dir. A prior interrupted universal build can
   # leave dist/mac-universal-<arch>-temp dirs behind (with a .DS_Store inside);
   # those linger and re-trip the ENOTEMPTY cleanup below on every later run.
-  rm -rf dist
+  # This pre-clean is itself exposed to the .DS_Store race (Finder re-drops one
+  # mid-removal), so it MUST go through the resilient helper — a plain rm here
+  # aborts the build before the retry loop below is ever reached.
+  rm_rf_resilient dist
 
   # macOS universal .DS_Store/ENOTEMPTY race:
   # electron-builder's universal step stages each arch into

--- a/test/test_build_desktop_rm_resilient.py
+++ b/test/test_build_desktop_rm_resilient.py
@@ -1,0 +1,150 @@
+"""Regression guard for the macOS ``.DS_Store``/``ENOTEMPTY`` retry helper in
+``packaging/build-desktop.sh``.
+
+Background
+----------
+``make desktop`` clears its build-output dirs with ``rm -rf`` before (re)staging
+them.  On macOS, Desktop Services can drop a fresh ``.DS_Store`` into a subdir
+*between* ``rm``'s child-sweep and its final ``rmdir``, so a plain ``rm -rf``
+aborts with ``ENOTEMPTY`` (``-f`` suppresses ``ENOENT``, not ``ENOTEMPTY``;
+electron-builder#6890) and the whole build fails.  ``rm_rf_resilient`` defeats
+that race by sweeping ``.DS_Store`` and retrying until the tree is actually gone.
+
+Why this test exists
+--------------------
+The *race* is timing-dependent and can't be reproduced deterministically, but
+the *retry mechanism* can: we shadow ``rm`` so the first removal is a no-op
+(the tree survives, exactly as the race leaves it) and assert the helper loops
+and succeeds on a later attempt.  If the retry loop is ever reverted to a single
+``rm``, ``test_retries_after_transient_failure`` goes red instead of the desktop
+build silently breaking while CI stays green.
+
+The helper body is extracted from the shipped script (not copied) so the test
+tracks the real source of truth.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="rm_rf_resilient is a POSIX bash helper (find/rm)"
+)
+
+SCRIPT = Path(__file__).parent.parent / "packaging" / "build-desktop.sh"
+
+
+def _extract_helper() -> str:
+    """Pull the ``rm_rf_resilient`` function body out of the shipped script.
+
+    Extraction (rather than a hard-coded copy) means a revert or edit of the
+    real helper is what this test runs against.
+    """
+    text = SCRIPT.read_text()
+    m = re.search(r"^rm_rf_resilient\(\) \{.*?^\}", text, re.DOTALL | re.MULTILINE)
+    assert m, "rm_rf_resilient() not found in packaging/build-desktop.sh"
+    return m.group(0)
+
+
+def _run(harness: str) -> subprocess.CompletedProcess:
+    """Run a bash snippet that has the extracted helper sourced above it."""
+    script = "set -euo pipefail\n" + _extract_helper() + "\n" + harness
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_preclean_sites_route_through_helper():
+    """Wiring guard: the two build-output pre-cleans MUST call ``rm_rf_resilient``.
+
+    ``test_retries_after_transient_failure`` proves the helper *works*, but the
+    whole point of this fix is that the pre-clean removals — which previously used
+    a bare ``rm -rf`` — now go through it. Without this assertion, reverting either
+    call site back to ``rm -rf`` would leave every behavioral test green while the
+    ``.DS_Store`` race again aborts desktop builds *before* electron-builder runs.
+    So assert the wiring directly, at both sites.
+    """
+    text = SCRIPT.read_text()
+    assert "rm_rf_resilient() {" in text, "helper definition missing"
+
+    # Section 3 backend-dist pre-clean.
+    assert re.search(r'(?m)^\s*rm_rf_resilient\s+"\$ELECTRON_DIR/backend-dist"\s*$', text), (
+        "backend-dist pre-clean must call rm_rf_resilient (not bare rm -rf)"
+    )
+    # Section 4 electron dist pre-clean, just before the electron-builder retry loop.
+    assert re.search(r"(?m)^\s*rm_rf_resilient\s+dist\s*$", text), (
+        "electron dist pre-clean must call rm_rf_resilient (not bare rm -rf)"
+    )
+    # And the reverted forms must NOT be present at those pre-clean sites. (A bare
+    # `rm -rf dist` still legitimately exists for the deep site-packages staging
+    # and `rm -rf dist/*-temp` inside the retry loop, so we forbid only the exact
+    # backend-dist revert, which is unambiguous.)
+    assert not re.search(r'(?m)^\s*rm -rf\s+"\$ELECTRON_DIR/backend-dist"\s*$', text), (
+        "backend-dist pre-clean reverted to bare rm -rf"
+    )
+
+
+def test_retries_after_transient_failure(tmp_path):
+    """The core race guard: a first removal that leaves the tree in place (as the
+    ``.DS_Store`` race does) must be retried until the tree is actually gone."""
+    target = tmp_path / "dist"
+    (target / "mac-universal").mkdir(parents=True)
+    (target / "mac-universal" / ".DS_Store").write_text("x")
+    counter = tmp_path / "rm_calls"
+    counter.write_text("")
+
+    # Shadow `rm` in the helper's shell: the FIRST call is a no-op (the tree
+    # survives -> simulates the race re-creating a file mid-removal); every
+    # later call delegates to the real /bin/rm. A functioning retry loop makes
+    # a second call and wins.
+    harness = f"""
+rm() {{
+  printf 'x' >> "{counter}"
+  if [ "$(wc -c < "{counter}" | tr -d ' ')" = "1" ]; then
+    return 0            # first attempt: pretend success but remove nothing
+  fi
+  command /bin/rm "$@"  # subsequent attempts: real removal
+}}
+rm_rf_resilient "{target}"
+echo "EXIT=$?"
+"""
+    proc = _run(harness)
+    assert proc.returncode == 0, proc.stderr
+    assert "EXIT=0" in proc.stdout, proc.stdout
+    assert not target.exists(), "tree should be removed after retry"
+    assert len(counter.read_text()) >= 2, "helper must have retried (>=2 rm calls)"
+
+
+def test_noop_on_absent_path(tmp_path):
+    """An already-absent path is a clean no-op (no error under set -e)."""
+    proc = _run(f'rm_rf_resilient "{tmp_path / "does-not-exist"}"; echo "EXIT=$?"')
+    assert proc.returncode == 0, proc.stderr
+    assert "EXIT=0" in proc.stdout
+
+
+def test_removes_tree_with_ds_store(tmp_path):
+    """A tree containing .DS_Store is removed."""
+    target = tmp_path / "backend-dist"
+    (target / "sub").mkdir(parents=True)
+    (target / "sub" / ".DS_Store").write_text("x")
+    (target / "file").write_text("y")
+    proc = _run(f'rm_rf_resilient "{target}"')
+    assert proc.returncode == 0, proc.stderr
+    assert not target.exists()
+
+
+def test_removes_dangling_symlink(tmp_path):
+    """A dangling symlink is "not -e" but MUST still be removed (the -L guard);
+    leaving it would make the following build step operate on a broken link."""
+    link = tmp_path / "dist"
+    link.symlink_to(tmp_path / "nonexistent-target")
+    assert link.is_symlink() and not link.exists()  # dangling
+    proc = _run(f'rm_rf_resilient "{link}"')
+    assert proc.returncode == 0, proc.stderr
+    assert not os.path.lexists(link), "dangling symlink should be removed"


### PR DESCRIPTION
## Problem
Running `make desktop` on macOS can still abort during cleanup with:

```
rm: dist/mac-universal: Directory not empty
rm: dist: Directory not empty
make: *** [desktop] Error 1
```

This happens even though #205 shipped the `.DS_Store`/`ENOTEMPTY` race fix — because #205 only hardened the `electron-builder` invocation, not the pre-clean `rm` steps that run before it.

## Why it matters
It breaks `make desktop` for any macOS user whose Finder/Spotlight touches the output dir, and the failure requires a manual `find dist -name .DS_Store -delete && rm -rf dist` before the build can proceed. A build command that ships in the repo should work with no manual steps for everyone.

## Fix (symptom → root cause → change)
- Symptom: the `rm` failures name `dist/mac-universal` and `dist`, i.e. the shell `rm -rf dist` **pre-clean**, not electron-builder's internal `fs.rm`.
- Root cause: macOS Desktop Services drops a fresh `.DS_Store` into a subdir *between* `rm`'s child-sweep and its final `rmdir`, so `rm -rf` aborts with `ENOTEMPTY` (`-f` suppresses `ENOENT`, not `ENOTEMPTY`; electron-builder#6890). #205's bounded retry only wraps the `electron-builder` call, so the two unprotected pre-clean removals — `rm -rf "$ELECTRON_DIR/backend-dist"` (section 3) and `rm -rf dist` (right before the retry loop) — hit the identical race *before* the retry loop is ever reached.
- Change: factor the sweep-and-retry into an `rm_rf_resilient` helper and route both pre-clean removals through it. Success is detected by the **directory being gone**, not by grepping stderr, so it is locale-independent (a non-English macOS emits a translated "Directory not empty" that a string match would silently miss). The helper sweeps `.DS_Store`, `rm -rf`s, and retries up to 5× with a 1s backoff; on exhaustion it does one final un-suppressed `rm -rf` so a genuine non-transient failure still aborts under `set -e`. The present-check treats a **dangling symlink** (`-L`, which `-e` reports false) as present, so such a link is removed rather than skipped and left to break the next build step. The existing `electron-builder` retry loop is intentionally left as-is — its `grep -q "ENOTEMPTY"` matches Node's errno *symbol* (not localized), so it is already correct.

## Tests
`test/test_build_desktop_rm_resilient.py` (5 cases, POSIX-only via skipif). It extracts the real `rm_rf_resilient` body from the shipped script (not a copy, so a revert is what runs) and drives it under bash:
- `test_retries_after_transient_failure` — the core race guard: shadows `rm` so the **first** removal is a no-op (the tree survives, exactly as the race leaves it) and asserts the helper loops and succeeds on a later attempt (≥2 `rm` calls).
- `test_preclean_sites_route_through_helper` — the **wiring** guard: asserts both pre-clean sites (`backend-dist` and the electron `dist`) call `rm_rf_resilient` and that the backend-dist site is not a bare `rm -rf`. Behavioral tests prove the helper works; this proves it is actually *used*, so reverting either call site to `rm -rf` goes red instead of silently reintroducing the race with CI green. (Verified: reverting either site fails this test.)
- `test_removes_dangling_symlink` — locks in the `-L` guard.
- `test_noop_on_absent_path`, `test_removes_tree_with_ds_store` — no-op/basic cases.

## Manual verification
- `bash -n packaging/build-desktop.sh` → clean.
- `pytest test/test_build_desktop_rm_resilient.py` → 5 passed locally (macOS); confirmed each pre-clean-site revert makes the wiring test fail.
- Reproduced the original failure's leftover (`dist/mac-universal/.DS_Store`) and confirmed the swept removal clears it.
