### PR TITLE
test(nav): fix KiroGhostMark mask assertions under jsdom (unblocks Frontend Tests)

### DIFF
--- a/website/src/test/KiroGhostMark.test.tsx
+++ b/website/src/test/KiroGhostMark.test.tsx
@@ -11,24 +11,33 @@
  */
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactElement } from 'react'
 import { KiroGhostMark } from '../components/KiroGhostMark'
 import '../surfaces/builtins'
 import { getBuiltinSurface } from '../surfaces/registry'
 
 describe('KiroGhostMark', () => {
-  // jsdom's cssstyle does not implement `mask-*`, so `style.getPropertyValue`
-  // returns '' for them and `-webkit-` prefixed props are dropped entirely.
-  // Assert against the serialized style attribute, which does carry them.
-  const styleOf = (el: HTMLElement) => el.getAttribute('style') ?? ''
+  // The mask contract must be asserted against React's OWN style serialization,
+  // not the test DOM: jsdom's `cssstyle` does not implement the `mask-*`
+  // longhands, so React's CSSOM assignment is silently dropped and neither
+  // `el.style` nor the serialized `style` attribute carries them under jsdom.
+  // `renderToStaticMarkup` emits every style key verbatim (React escapes the
+  // inline `"` as `&quot;`), independent of the DOM's CSS-property allowlist.
+  // DOM-observable props (background-color, size, aria-hidden) are still checked
+  // via jsdom, which handles them.
+  const maskStyle = () => {
+    const html = renderToStaticMarkup(<KiroGhostMark />)
+    return /style="([^"]*)"/.exec(html)?.[1] ?? ''
+  }
 
   it('paints the ghost asset as a mask over currentColor', () => {
     const { getByTestId } = render(<KiroGhostMark />)
-    const el = getByTestId('kiro-ghost-mark')
     // currentColor is what makes the glyph inherit the nav row's text colour.
-    expect(el.style.backgroundColor).toBe('currentcolor')
-    expect(styleOf(el)).toContain('kiro-ghost-mark')
-    expect(styleOf(el)).toContain('mask-size: contain')
+    expect(getByTestId('kiro-ghost-mark').style.backgroundColor).toBe('currentcolor')
+    const style = maskStyle()
+    expect(style).toContain('kiro-ghost-mark') // the ghost asset is the mask source
+    expect(style).toContain('mask-size:contain')
   })
 
   it('quotes the mask URL', () => {
@@ -36,9 +45,8 @@ describe('KiroGhostMark', () => {
     // whose attributes are single-quoted. An UNQUOTED css `url(…)` token cannot
     // contain quotes, so the browser drops the declaration and the glyph paints
     // as a solid `currentColor` square (this shipped once and was caught only
-    // in a real-browser screenshot).
-    const { getByTestId } = render(<KiroGhostMark />)
-    expect(styleOf(getByTestId('kiro-ghost-mark'))).toMatch(/mask-image: url\("/)
+    // in a real-browser screenshot). React serializes the quotes as `&quot;`.
+    expect(maskStyle()).toMatch(/mask-image:url\(&quot;/)
   })
 
   it('is decorative (hidden from the accessibility tree)', () => {


### PR DESCRIPTION
## Problem

`Frontend Tests` fails on `main` (and therefore on every open PR's merge ref) with two assertion failures in `website/src/test/KiroGhostMark.test.tsx`:

```
AssertionError: expected 'width: 16px; height: 16px; background…' to contain 'kiro-ghost-mark'
AssertionError: expected 'width: 16px; height: 16px; background…' to match /mask-image: url\("/
```

## Why it matters

This is a **required** check, so it currently blocks merging **every** PR, not just the one that introduced it. The test was added in #446 ("use the Kiro ghost mark for Agent Capabilities"), whose own `Frontend Tests` run shows as `cancelled` (concurrency) — so it merged without that check ever completing green on the final commit, and the breakage has been latent on `main` since.

## Fix (symptom → root cause → change)

- **Symptom**: the two mask assertions see only `width/height/background-color` in the rendered node's serialized `style` — the `mask-*` longhands are absent.
- **Root cause**: `KiroGhostMark` → `BrandGlyph` paints the SVG as a CSS mask by assigning `maskImage`/`maskSize`/`-webkit-mask-*` inline. React applies inline styles through the **CSSOM** (`node.style.maskImage = …`). jsdom's pinned `cssstyle` **does not implement the `mask-*` properties**, so those assignments are silently dropped and never reach `el.style` *or* the serialized `style` attribute the test reads. The assertions can't observe what jsdom discarded. (The test's comment claimed the serialized attribute "does carry them" — that only holds on a `cssstyle` build that implements `mask-*`.)
- **Change**: assert the mask contract against **React's own server-side style serialization** — `renderToStaticMarkup(<KiroGhostMark />)` emits every style key verbatim (escaping the inline `"` as `&quot;`), independent of the DOM's CSS-property allowlist. DOM-observable props (`background-color`, `width`/`height`, `aria-hidden`) still use jsdom, which handles them. The regression intent is fully preserved: the ghost asset is the mask source (`kiro-ghost-mark`), `mask-size:contain` is set, and the `url()` is quoted (`url(&quot;…`). **No production code changes** — the component was always correct; only the test's observation method was DOM-dependent.

## Tests

- `website/src/test/KiroGhostMark.test.tsx` — the 2 previously-failing mask assertions now read React's server-rendered style; all 5 tests pass. `tsc -b` clean.

## Manual verification

Reproduced the failure under the repo's pinned deps (fresh `npm ci`, node 22): 2 failed / 3 passed before, 5 passed after. No source/component change, so no runtime behavior is affected.

## Screenshots

N/A — test-only change; no user-visible UI surface is modified.
