### PR TITLE
ci(review): flag simpler/more-elegant alternatives in design review + arbiter

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -161,10 +161,21 @@ jobs:
                central question — reason about the approach, not the syntax.
             3. ROOT CAUSE vs SYMPTOM: fixes the actual cause, or patches a symptom
                that resurfaces? A symptom-only fix is at best CONCERNS.
-            4. OPTIMAL / PROPORTIONATE: is there a simpler, more general, or
-               lower-risk alternative? Over- or under-engineered? Name the 1–2
-               strongest alternatives and why this wins. "No alternative
-               considered" on a non-trivial change is a finding.
+            4. OPTIMAL / PROPORTIONATE (weigh this heavily — AI-generated
+               changes skew toward OVER-ENGINEERING: extra layers, abstractions,
+               config knobs, defensive scaffolding, or a bespoke mechanism where
+               a few lines of existing/stdlib primitives would do). Ask: is there
+               a materially SIMPLER, MORE ELEGANT solution that solves THIS PR's
+               stated problem just as completely, with meaningfully less code /
+               fewer moving parts / less new surface? Also flag the rarer under-
+               engineered case. Name the 1–2 strongest alternatives and why this
+               wins — or, if a simpler one plainly wins, say so plainly. "No
+               alternative considered" on a non-trivial change is a finding. If a
+               simpler solution to the same problem exists, set the machine header
+               `Design-Simpler-Alternative: yes` and describe it in the dedicated
+               `### 💡 Simpler alternative` section so the author cannot miss it.
+               This is ADVISORY — a simpler-alternative finding NEVER raises the
+               verdict to BLOCK on its own; it informs, it does not gate.
             5. ARCHITECTURAL FIT: right layer/ownership boundary, or bolted on
                where convenient? A boundary violation is a design finding even if
                every line is correct.
@@ -206,10 +217,12 @@ jobs:
             - CONCERNS: acceptable to proceed, but a notable design risk humans
               should see.
             - BLOCK: the design itself is wrong — no real problem, the change does
-              not actually solve the stated problem, a clearly better alternative
-              was ignored, or an unsafe one-way door with no migration/compat
-              story. (Advisory: BLOCK does NOT block the merge; it flags for a
-              human.)
+              not actually solve the stated problem, or an unsafe one-way door
+              with no migration/compat story. (A simpler/more-elegant alternative
+              being available is NEVER a BLOCK — over-engineering when the
+              approach still works is owned entirely by the ADVISORY
+              `Design-Simpler-Alternative` signal.) (Advisory: BLOCK does NOT
+              block the merge; it flags for a human.)
             Tie-breaker: when torn between BLOCK and CONCERNS, choose CONCERNS.
             Only reach for BLOCK when the DESIGN is wrong — never merely because
             the change is large or far-reaching (that is the blast-radius call-out,
@@ -222,24 +235,42 @@ jobs:
             STYLE: terse, precise, punchline-first. NO preamble, NO restating the
             PR, NO echoing the design-gate questions, NO praise, NO summary of
             what the change does. The badge already shows the verdict and blast
-            radius — do NOT repeat them in prose. A clean PASS is TWO header lines
-            + a one-line punchline + the marker; nothing else. Aim for the
+            radius — do NOT repeat them in prose. A clean PASS is THREE header
+            lines + a one-line punchline + the marker; nothing else. Aim for the
             shortest output that conveys every real signal — usually well under
             ~150 words. Every sentence must be something the author would ACT on.
 
             Output EXACTLY this shape and nothing more:
 
-            The FIRST two lines are machine-parsed — emit them verbatim, each on
-            its own line, values only:
+            The FIRST three lines are machine-parsed — emit them verbatim, each
+            on its own line, values only:
             Design-Verdict: <PASS | CONCERNS | BLOCK>
             Design-Blast-Radius: <low | medium | high>
+            Design-Simpler-Alternative: <yes | no>
 
             Then a blank line and ONE bold punchline (≤25 words): the single most
             important takeaway — for PASS, why it's sound; for CONCERNS/BLOCK, the
-            core design problem in one breath.
+            core design problem in one breath. If a simpler alternative exists
+            (`Design-Simpler-Alternative: yes`) and no BLOCK/CONCERNS outranks it,
+            LEAD the punchline with it (e.g. "Works, but a simpler approach — X —
+            solves the same problem with far less machinery").
 
             Then include a section ONLY if it has real content (omit the heading
             entirely when empty — never write "None" sections, never pad):
+
+            ### 💡 Simpler alternative
+            <ONLY when `Design-Simpler-Alternative: yes`. Placed FIRST so the
+            author sees it. State, in 1–3 lines: the simpler/more-elegant approach
+            that solves THIS PR's SAME stated problem, WHY it is simpler (fewer
+            moving parts / less new surface / reuses an existing primitive), and
+            the rough shape of the trade-off. It must solve the problem as
+            COMPLETELY as the PR's approach — do NOT propose something that drops a
+            requirement or narrows scope. This is an OPTION for the author to
+            weigh, not a demand and not a blocker; phrase it as "consider X
+            instead" and keep it PROPORTIONATE (a simpler alternative is by
+            definition LESS machinery — never suggest adding layers here). Omit
+            the whole section when the PR's approach is already the simplest
+            reasonable one.>
 
             ### Blockers
             <ONLY when verdict is BLOCK. Each: one-line title, then a single
@@ -309,6 +340,7 @@ jobs:
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^Design-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
           blast="$(printf '%s\n' "$summary" | grep -iE '^Design-Blast-Radius:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:upper:]' '[:lower:]')"
+          simpler="$(printf '%s\n' "$summary" | grep -iE '^Design-Simpler-Alternative:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:upper:]' '[:lower:]')"
           [ -z "$verdict" ] && verdict="UNKNOWN"
           [ -z "$blast" ] && blast="unknown"
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
@@ -319,11 +351,18 @@ jobs:
             BLOCK) badge="🔴 BLOCK (advisory)" ;;
             *) badge="" ;;
           esac
+          # A prominent, non-blocking flag so the author immediately notices the
+          # design reviewer found a simpler/more-elegant way to solve the SAME
+          # problem. Advisory only — it never changes the verdict or the check.
+          simpler_badge=""
+          case "$simpler" in
+            yes*) simpler_badge=" · 💡 simpler alternative available" ;;
+          esac
           if [ -n "$badge" ]; then
             # Valid verdict → post the review body (redacted below).
             {
               echo "$MARKER"
-              echo "## Design Review (Fable 5) — $badge · blast radius: $blast"
+              echo "## Design Review (Fable 5) — $badge · blast radius: $blast$simpler_badge"
               echo
               echo "_Advisory design-level review of \`$HEAD\` — updated in place on each push; does **not** block merge._"
               echo

--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -264,6 +264,18 @@ jobs:
             particular, DO NOT block for: architectural erosion, ownership-
             boundary drift, maintainability / tech-debt that compounds, missing
             abstraction, duplication, or "this should eventually be refactored".
+            ALSO NON-BLOCKING: OVER-ENGINEERING / a SIMPLER-ALTERNATIVE signal
+            from the design reviewer (its `### 💡 Simpler alternative` section or
+            a `Design-Simpler-Alternative: yes` header). "A simpler design exists"
+            is a design OPTION, not a one-way door or concrete harm — the current
+            approach still works, and simplifying later is reversible. NEVER block
+            on it. (Scope: only the SIMPLICITY / over-engineering aspect is
+            non-blocking — if the SAME finding also names a concrete harm or a
+            one-way door, that aspect is still judged against the normal bar
+            above.) But it is HIGH-VALUE for the author, so do the opposite of
+            burying it: surface it PROMINENTLY and near the TOP of "Suggested
+            follow-ups", quoting the design reviewer's alternative, so the author
+            clearly notices the simpler option they can choose to take.
             These are real and worth tracking, but they are reversible in a later
             change, so route them to "Suggested follow-ups" instead of gating.
             The author does NOT need a perfect or complete solution in THIS PR:
@@ -321,8 +333,9 @@ jobs:
             sub-threshold item to be tracked without blocking — whether routed
             by the SCOPE TEST (related-influence / out-of-scope) OR demoted
             because it is reversible-in-a-later-change (architectural erosion,
-            maintainability / tech-debt, missing abstraction) — append this
-            section LAST. It is advisory and NEVER changes the verdict (the
+            maintainability / tech-debt, missing abstraction) — OR the design
+            reviewer flagged a SIMPLER ALTERNATIVE / over-engineering — append
+            this section LAST. It is advisory and NEVER changes the verdict (the
             machine-parsed verdict line is always the first line above,
             regardless of what follows):
 
@@ -330,8 +343,11 @@ jobs:
             <one line per substantive sub-threshold item worth tracking but NOT
             worth blocking this PR (whether out-of-scope per the SCOPE TEST or an
             in-scope-but-reversible item you demoted): what it is, why it can
-            safely wait, and where it should be fixed. Omit this heading only if
-            there are genuinely none.>
+            safely wait, and where it should be fixed. If the design reviewer
+            flagged a SIMPLER ALTERNATIVE, list it FIRST and prefix it with
+            "💡 Simpler alternative:" — restate the simpler approach concisely so
+            the author can weigh adopting it now; make clear it is optional and
+            non-blocking. Omit this heading only if there are genuinely none.>
 
             End with this exact line as proof the review ran for this commit:
             [ARBITER-REVIEWED] ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
@@ -424,6 +440,13 @@ jobs:
               if [ "$CONCLUSION" = "failure" ]; then
                 printf '%s\n' "$DETAILS"
               else
+                # Even when details collapse on a PASS, keep the design reviewer's
+                # SIMPLER-ALTERNATIVE pointer ABOVE the fold so the author still
+                # notices the leaner option (advisory, never blocking).
+                simpler_line="$(printf '%s\n' "$DETAILS" | grep -m1 -F '💡 Simpler alternative:' || true)"
+                if [ -n "$simpler_line" ]; then
+                  printf '%s\n\n' "$simpler_line"
+                fi
                 echo "<details>"
                 echo "<summary>Review details</summary>"
                 echo

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -93,3 +93,44 @@ class TestArbiterPresentation:
         assert 'TITLE="✅ human override accepted"' in workflow
         assert "/ai-review override arbiter $SHA:" in workflow
         assert "defer-longterm" in workflow
+
+
+class TestSimplerAlternativeSignal:
+    """The advisory 'a simpler solution exists' signal: surfaced prominently by
+    the design reviewer, emphasized by the Arbiter, and NEVER a blocker."""
+
+    def test_design_review_emits_and_renders_the_signal(self) -> None:
+        workflow = _workflow("design-review.yml")
+
+        # Machine header contract + dedicated, prominently-rendered section.
+        assert "Design-Simpler-Alternative: <yes | no>" in workflow
+        assert "### 💡 Simpler alternative" in workflow
+        # The post step parses the header, matches decorated values (yes*), and
+        # composes the badge INTO the posted comment header (assert the wiring,
+        # not just that the strings exist somewhere).
+        assert "^Design-Simpler-Alternative:" in workflow
+        assert "yes*) simpler_badge=" in workflow
+        assert "blast radius: $blast$simpler_badge" in workflow
+
+    def test_design_review_never_blocks_on_mere_over_engineering(self) -> None:
+        workflow = _workflow("design-review.yml")
+
+        # Gate #4 says the finding is advisory ...
+        assert "a simpler-alternative finding NEVER raises the" in workflow
+        # ... and the BLOCK verdict no longer lists "a better alternative was
+        # ignored" as a ground — over-engineering is owned by the advisory signal.
+        assert "owned entirely by the ADVISORY" in workflow
+        assert "a clearly better alternative\n              was ignored" not in workflow
+
+    def test_arbiter_emphasizes_but_never_blocks_on_the_signal(self) -> None:
+        workflow = _workflow("longterm-arbiter.yml")
+
+        assert "ALSO NON-BLOCKING: OVER-ENGINEERING / a SIMPLER-ALTERNATIVE signal" in workflow
+        # A co-stated concrete harm is still judged against the normal bar.
+        assert "only the SIMPLICITY / over-engineering aspect is" in workflow
+        # Emphasized at the top of the non-blocking follow-ups, and kept above
+        # the collapsed fold on a PASS so the author still notices it (assert the
+        # extraction is wired in, not merely that the prose exists).
+        assert '"💡 Simpler alternative:"' in workflow
+        assert "notices the leaner option (advisory, never blocking)" in workflow
+        assert "grep -m1 -F '💡 Simpler alternative:'" in workflow


### PR DESCRIPTION
## Problem
AI-native coding skews toward **over-engineering** — extra layers, abstractions, config knobs, defensive scaffolding, or a bespoke mechanism where a few lines of an existing/stdlib primitive would do. The CI reviewers had **no first-class signal** for "a materially simpler, more elegant solution to the SAME problem exists." Any such observation was buried inside the generic `Suggestions` list (design review) or the undifferentiated follow-up bucket (Arbiter), so authors easily missed the simpler option.

## Why it matters
Unnoticed over-engineering ships as permanent complexity: more surface for later reviews to flag, more code to maintain, more moving parts to break. Making "you could solve this more simply" a prominent, explicit — but **non-blocking** — signal lets the author choose the leaner design while it's still cheap, without gating the PR on a subjective preference.

## Fix (symptoms → root cause → change)
- **Symptom:** simpler-alternative observations were invisible/low-salience and inconsistently surfaced.
- **Root cause:** neither reviewer had a dedicated, machine-detectable channel for this signal; design-gate #4 mentioned "simpler alternative" only in passing, and the Arbiter lumped it into generic follow-ups.
- **Change:**
  - `design-review.yml`: strengthened design-gate #4 (OPTIMAL/PROPORTIONATE) to weigh over-engineering heavily and ask whether a simpler/more-elegant approach solves the **same stated problem as completely**. Added a third machine-parsed header `Design-Simpler-Alternative: <yes|no>`; a dedicated `### 💡 Simpler alternative` section rendered **first**; a punchline lead-in when set; and a `💡 simpler alternative available` badge in the posted comment header. Explicitly **advisory** — the BLOCK verdict is qualified so mere over-engineering (approach still works) is the advisory signal, **never** a BLOCK.
  - `longterm-arbiter.yml`: classified the simpler-alternative / over-engineering signal as explicitly **non-blocking** (a design *option*, not a one-way door or concrete harm; only the *simplicity* aspect is non-blocking — a co-stated harm is still judged on the normal bar). The Arbiter floats it to the **top** of its non-blocking "Suggested follow-ups" (prefixed `💡 Simpler alternative:`) and keeps that pointer **above the fold** even when the details collapse on a PASS.

This stays aligned with the repo's proportionality principle: a simpler alternative is by definition **less** machinery, never more, and by construction cannot trip the Arbiter's narrow one-way-door / concrete-harm blocking bar.

## Tests
`test/test_ai_review_workflows.py::TestSimplerAlternativeSignal` (3 cases) locks in the contract: (1) the design reviewer emits the `Design-Simpler-Alternative` header, the `### 💡 Simpler alternative` section, and the header badge; (2) mere over-engineering never trips a BLOCK (advisory-only wording + qualified BLOCK ground); (3) the Arbiter emphasizes the signal at the top of non-blocking follow-ups, scopes non-blocking to the simplicity aspect, and keeps it above the collapsed fold. All string-presence assertions verified against both workflow files.

## Manual verification
- YAML load of both workflow files: OK (`ruby -ryaml`).
- **Dogfooded on this PR:** the Design Review posted `Design-Simpler-Alternative: no` (correct — this change is itself the minimal mechanism) and PASSed; the Arbiter PASSed and routed every finding into non-blocking "Suggested follow-ups" — never a BLOCK. Round-2 bot MEDIUMs (heading-string mismatch, BLOCK-criterion conflict, PASS-fold prominence, non-blocking scope, missing test) were all legitimate and fixed in this revision.
