### PR TITLE
fix(chat): make attachment chip labels unique past two path segments

### DIFF
--- a/website/src/test/fileTokens.test.ts
+++ b/website/src/test/fileTokens.test.ts
@@ -1,5 +1,37 @@
 import { describe, it, expect } from 'vitest'
-import { prepareSendPayload } from '../utils/fileTokens'
+import { prepareSendPayload, buildFileLabels, resolveFileSegment } from '../utils/fileTokens'
+
+describe('buildFileLabels uniqueness', () => {
+  it('disambiguates paths that share a basename', () => {
+    const m = buildFileLabels(['/q3/report.docx', '/q4/report.docx'])
+    expect(m.get('/q3/report.docx')).toBe('q3/report.docx')
+    expect(m.get('/q4/report.docx')).toBe('q4/report.docx')
+  })
+
+  it('widens past two segments when the last two also collide', () => {
+    // Regression: both collapsed to `x/report.docx`, so two distinct
+    // attachments got the same chip label and the same mentionMap key.
+    const m = buildFileLabels(['/a/x/report.docx', '/b/x/report.docx'])
+    expect(new Set([...m.values()]).size, 'labels must be distinct').toBe(2)
+    expect(m.get('/a/x/report.docx')).not.toBe(m.get('/b/x/report.docx'))
+  })
+
+  it('leaves an already-unique basename alone', () => {
+    const m = buildFileLabels(['/repo/notes.txt', '/repo/other.txt'])
+    expect(m.get('/repo/notes.txt')).toBe('notes.txt')
+    expect(m.get('/repo/other.txt')).toBe('other.txt')
+  })
+
+  it('keeps a colliding mention resolvable to its own path', () => {
+    // The label is also the mentionMap key, so a collision made one path
+    // unreachable from its own chip.
+    const content = '[attached_file 1] /a/x/report.docx\n[attached_file 2] /b/x/report.docx'
+    const r = resolveFileSegment(content, ['/a/x/report.docx', '/b/x/report.docx'])
+    const targets = new Set([...r.mentionMap.values(), ...r.cardPaths])
+    expect(targets.has('/a/x/report.docx')).toBe(true)
+    expect(targets.has('/b/x/report.docx')).toBe(true)
+  })
+})
 
 describe('prepareSendPayload', () => {
   it('includes non-image files without @-mention', () => {

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -16,15 +16,29 @@ export function parseFiles(content: string, meta?: Record<string, unknown>): str
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
 }
 
-/** Per-path display label: basename, disambiguated to the last-2 path segments
- *  when two paths share a basename (e.g. two `report.docx` in different dirs). */
+/** Per-path display label: the shortest trailing path segments that make the
+ *  label unique across `paths` (e.g. two `report.docx` in different dirs become
+ *  `q3/report.docx` and `q4/report.docx`).
+ *
+ *  Widens until unique rather than stopping at two segments. Two paths that
+ *  share their last TWO segments -- `/a/x/report.docx` and `/b/x/report.docx` --
+ *  both collapsed to `x/report.docx`, so two distinct attachments rendered with
+ *  the same chip label AND the same `mentionMap` key: the second overwrote the
+ *  first, and clicking either chip opened whichever path won. */
 export function buildFileLabels(paths: string[]): Map<string, string> {
-  const basenames = paths.map(p => p.split('/').pop() || p)
-  const dupes = new Set(basenames.filter((n, i) => basenames.indexOf(n) !== i))
   const map = new Map<string, string>()
+  const partsOf = new Map(paths.map(p => [p, p.split('/')]))
+  const labelAt = (p: string, depth: number) => {
+    const parts = partsOf.get(p) ?? [p]
+    return parts.slice(Math.max(0, parts.length - depth)).join('/') || p
+  }
+  const maxDepth = Math.max(1, ...paths.map(p => (partsOf.get(p) ?? []).length))
   for (const p of paths) {
-    const name = p.split('/').pop() || p
-    map.set(p, dupes.has(name) ? p.split('/').slice(-2).join('/') : name)
+    let depth = 1
+    while (depth < maxDepth && paths.some(q => q !== p && labelAt(q, depth) === labelAt(p, depth))) {
+      depth += 1
+    }
+    map.set(p, labelAt(p, depth))
   }
   return map
 }


### PR DESCRIPTION
## Problem

Two file attachments whose paths share their last **two** segments render with the same chip label. `/a/x/report.docx` and `/b/x/report.docx` both display as `x/report.docx`.

That label is also the key of the `mentionMap` that `resolveFileSegment` returns, so the collision is not merely cosmetic: the second path overwrites the first in the map. One attachment becomes unreachable from its own chip, and clicking either chip opens whichever path won.

## Why it matters

This is live in the shipped file-attachment feature, not a new code path. Attaching two same-named files from parallel directory trees is ordinary — `q3/x/report.docx` and `q4/x/report.docx`, or the same filename under two package directories — and the user gets two identical-looking chips, one of which silently points at the wrong file.

## Fix (symptom → root cause → change)

Symptom: two chips, same label, one path unreachable.

Root cause: `buildFileLabels` widened a colliding basename to exactly the last two segments and stopped. It never checked whether the *widened* label was itself unique, so any pair agreeing on their last two segments stayed collided.

Change: widen leftwards until the label is unique across the whole input set. Depth grows only as far as the collision requires, so an already-unique basename stays a bare basename and existing labels are unchanged. Splitting remains `/`-only, exactly as before — this PR does not touch separator semantics.

## Tests

Four cases in `website/src/test/fileTokens.test.ts`:

- basename collision still disambiguates to one parent segment (`q3/report.docx` vs `q4/report.docx`)
- **the regression**: paths sharing their last two segments now produce distinct labels — fails against the previous implementation with `expected 1 to be 2`
- an already-unique basename is *not* widened (guards against over-correcting)
- `resolveFileSegment` keeps both colliding paths individually addressable, which is the part that made the bug more than cosmetic

Full frontend suite green: 395 files, 4572 tests. `tsc -b` clean. `buildFileLabels` is shared with the existing attachment rendering path, so the whole suite passing is the relevant signal that no consumer relied on the old labels.

## Manual verification

N/A — unit coverage is sufficient. `buildFileLabels` is a pure function over path strings with no I/O, network, or UI state.

## Screenshots

N/A — no visual change on any path a user can currently reach without the bug. The rendered chip differs only in the collision case, where the previous output was wrong (two identical labels).

## Context

Extracted from #505, where this was found by review while that PR was expanding `fileTokens.ts`. It stands alone against `main`, fixes a defect that exists independently of the folder-reference work, and is small enough to review on its own.
