### PR TITLE
fix(diagnosability): surface the real reason a remote mint failed

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -67,6 +67,27 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew mcp-core` | MCP server for spawn, learn, task tools (spawned by kiro-cli) |
 | `kirocrew --version` | Print version |
 
+## Token Command Output Streams
+
+`kirocrew token` has a **machine-readable stdout contract**: stdout carries only
+the dashboard URL(s), and every failure reason (invalid TTL, gateway not running,
+gateway unreachable, empty token) goes to **stderr**.
+
+The contract exists because stdout is parsed, not just read by a human. The
+remote-mint path (`kiro_crew.instances.token_mint.mint_remote_token`) runs
+`kirocrew token` on a remote host over SSH and regex-extracts the JWT from its
+stdout. Error prose on stdout would both break the Unix convention and hide the
+reason from a caller that captures stderr.
+
+**Legacy remote handling.** Older remotes predate this split and still print
+their failure reasons to stdout, which made a stderr-only error message degrade
+to a bare `<no stderr>`. `mint_remote_token` therefore also carries a bounded,
+redacted **stdout tail** in `TokenMintError` — appended only when stdout was
+non-empty, so a current remote keeps the single-stream message shape. Because
+stdout is the one stream that legitimately carries a token, the tail is
+token-scrubbed (URL-borne and bare forms) before the generic credential and
+exfiltration redactors run.
+
 ## Setup Command
 
 `kirocrew setup` performs:

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -120,7 +120,16 @@ def _probe_dashboard_health(port: int) -> None:
 
 
 def _token(args: argparse.Namespace) -> None:
-    """Print a dashboard URL with a fresh auth token."""
+    """Print a dashboard URL with a fresh auth token.
+
+    Diagnostics discipline: **stdout carries only the URL(s)**; every failure
+    reason goes to **stderr**. stdout here is a parsed machine interface — the
+    remote-mint path (:func:`kiro_crew.instances.token_mint.mint_remote_token`)
+    runs this over SSH and regex-extracts the JWT from stdout, so mixing error
+    prose into stdout both violates the Unix convention and hides the reason
+    from any caller that only captures stderr (which is how a failed remote
+    mint used to surface as a useless ``<no stderr>``).
+    """
     # Seam-supplied pre-launch checks (CPP IdentityProvider seam) — e.g. a
     # companion SSO-session freshness prompt before minting a token. Public
     # default = no checks; see kiro_crew.preflight.
@@ -128,7 +137,7 @@ def _token(args: argparse.Namespace) -> None:
 
     ttl = parse_duration(args.ttl)
     if ttl is None:
-        print(f"❌ Invalid TTL: {args.ttl} (use e.g. 1h, 30m)")
+        print(f"❌ Invalid TTL: {args.ttl} (use e.g. 1h, 30m)", file=sys.stderr)
         sys.exit(1)
 
     port = resolve_client_port(args.port)
@@ -136,7 +145,7 @@ def _token(args: argparse.Namespace) -> None:
     try:
         secret = secret_path.read_text().strip()
     except FileNotFoundError:
-        print("❌ Gateway not running — start it with: kirocrew gateway")
+        print("❌ Gateway not running — start it with: kirocrew gateway", file=sys.stderr)
         sys.exit(1)
 
     url = f"http://localhost:{port}/api/token/local?ttl={args.ttl}"
@@ -149,11 +158,11 @@ def _token(args: argparse.Namespace) -> None:
             data = json.loads(resp.read())
             token = data.get("token", "")
     except Exception as exc:
-        print(f"❌ Could not reach gateway on port {port}: {exc}")
+        print(f"❌ Could not reach gateway on port {port}: {exc}", file=sys.stderr)
         sys.exit(1)
 
     if not token:
-        print("❌ Gateway returned empty token")
+        print("❌ Gateway returned empty token", file=sys.stderr)
         sys.exit(1)
     _probe_dashboard_health(port)
 

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -48,6 +48,49 @@ _TTL_RE = re.compile(r"^[1-9][0-9]{0,3}[hm]$")
 # (also matches https://.../?token=...&foo=bar).
 _TOKEN_RE = re.compile(r"[?&]token=([^\s&]+)")
 
+# Bare KiroCrew-token / JWT shape, used to scrub a token that reached stdout
+# outside a URL before a stdout tail is put into an exception message.
+#
+# The segment count is `{1,4}` REPEATED, not a fixed `head.payload.sig` triple:
+# `generate_token` (dashboard/token_auth.py) mints `payload.signature` — only
+# TWO segments — so a three-segment pattern would never match the shape this app
+# actually produces, leaving the scrub layer inert against its own tokens. The
+# upper bound covers a compact JWE (five segments) so a partial match cannot
+# leave a trailing `.ciphertext.tag` behind. Matching is greedy, so all segments
+# present are consumed.
+_JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{4,}(?:\.[A-Za-z0-9_-]+){1,4}")
+
+# How much of a failing remote's stdout to carry in the error (tail, not head —
+# the failure reason is the last thing printed).
+_OUTPUT_TAIL_CHARS = 300
+
+# How much stdout the scrubbers are allowed to SCAN. The remote's stdout is
+# unbounded (whatever the far side printed) and `re` does not release the GIL,
+# so scrubbing it whole blocks the gateway's event loop in proportion to its
+# size — measured ~1s per MB, i.e. ~13s on a 13MB payload. Bounding the scan
+# window keeps the cost flat (~10ms) regardless of what the remote emits. The
+# window is 8x the carried tail so a clipped left edge normally falls in noise
+# the tail would have dropped anyway. An executor hop is NOT a substitute: with
+# the GIL held by `re`, the same 13MB payload still stalled the loop for ~1.1s
+# in a thread.
+_OUTPUT_SCAN_CHARS = _OUTPUT_TAIL_CHARS * 8
+
+# Stand-in for the run touching the scan window's left edge: the slice may have
+# cut it out of the middle of a secret, leaving a suffix the token patterns can
+# no longer recognise.
+#
+# The floor is deliberately LOW rather than set to the window-minus-tail
+# "reachability" distance. A clipped fragment 2000+ chars from the end looks
+# unreachable only if the text keeps its length — but the scrubbers SHRINK it
+# (each matched blob collapses to `<redacted>`), so a stdout full of redactable
+# material pulls the leading fragment into the carried tail. Measured: with a
+# 2100-char floor, a stdout of dense JWT-shaped blobs surfaced a raw clipped
+# fragment in the error. Scrubbing the clipped run unconditionally costs nothing
+# the tail truncation would have kept anyway.
+_CLIPPED_RUN_MIN = 16
+_CLIPPED_RUN_RE = re.compile(r"^[A-Za-z0-9_\-.=+/%%:?&]{%d,}" % _CLIPPED_RUN_MIN)
+_CLIPPED_MARKER = "<clipped>"
+
 # How long to wait for the remote `kirocrew token` to return before giving up.
 _DEFAULT_MINT_TIMEOUT_SECS = 30.0
 
@@ -298,6 +341,54 @@ def _build_ssh_argv(ssh_host: str, remote_command: str) -> list[str]:
     ]
 
 
+def _redacted_output_tail(stdout: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
+    """Return a token-stripped, credential-redacted tail of *stdout*.
+
+    Why this exists: ``kirocrew token`` on a remote that predates the
+    stdout->stderr split prints its failure reasons (``❌ Could not reach gateway
+    on port 5476: ...``) to **stdout**, so an error built only from stderr came
+    back as ``<no stderr>`` and the operator had to SSH in to learn why. Carrying
+    a stdout tail makes the real reason travel with the exception.
+
+    Why stripping is mandatory: unlike stderr, stdout is the one stream that
+    *does* carry the minted JWT on success. This tail is only ever built on a
+    failure path, but a partially-successful remote (URL printed, then a
+    non-zero exit) could still put a live credential in it — so the token is
+    substituted out FIRST, before the generic credential/exfil redactors run,
+    and the result is truncated to the last *limit* chars (the tail, because the
+    reason is the last thing printed).
+
+    Why the scan is bounded: the scrubbers cost ~1s per MB of stdout and `re`
+    holds the GIL, so scanning an unbounded remote payload stalls the gateway's
+    event loop (13s measured on 13MB). Only the last ``_OUTPUT_SCAN_CHARS`` are
+    scanned. That slice can land mid-run, which would show the regexes a
+    *fragment* of a secret and let its suffix survive into the tail — so the run
+    touching the window's left edge is dropped when it is long enough to have
+    been clipped out of one. A reason printed inside such an over-long unbroken
+    run is sacrificed with it; a reason on its own line (what remotes actually
+    print) is unaffected.
+    """
+    if not stdout:
+        return ""
+    window = stdout
+    if len(window) > _OUTPUT_SCAN_CHARS:
+        window = _CLIPPED_RUN_RE.sub(_CLIPPED_MARKER, window[-_OUTPUT_SCAN_CHARS:], count=1)
+    stripped = _TOKEN_RE.sub(lambda m: m.group(0)[0] + "token=<redacted>", window)
+    stripped = _JWT_RE.sub("<redacted>", stripped)
+    safe = redact_exfiltration_urls(redact_credentials(stripped)[0])[0]
+    return safe.strip()[-limit:]
+
+
+def _with_stdout_tail(primary: str, safe_stdout: str) -> str:
+    """Append the redacted stdout tail to *primary* when there is one.
+
+    Keeps the original single-stream message shape for modern remotes (which
+    print their reasons to stderr) and only widens the message when stdout
+    actually carried something — i.e. on an older remote.
+    """
+    return f"{primary} | stdout tail: {safe_stdout}" if safe_stdout else primary
+
+
 async def mint_remote_token(
     ssh_host: str,
     *,
@@ -356,17 +447,23 @@ async def mint_remote_token(
     if proc.returncode != 0:
         # stderr may carry the "binary not found" diagnostic — safe to log; it
         # never contains the token (token only ever appears on stdout).
+        # Belt-and-suspenders for older remotes: pre-fix `kirocrew token` printed
+        # its failure reasons to STDOUT, so a stderr-only error message degraded
+        # to a useless "<no stderr>". The tail is built HERE, inside the failure
+        # branch, so the "only ever built on a failure path" invariant that
+        # _redacted_output_tail documents is enforced by control flow rather than
+        # merely asserted — the success path never touches stdout holding a token.
         raise TokenMintError(
             f"remote token mint on {ssh_host} exited {proc.returncode}: "
-            f"{safe_stderr or '<no stderr>'}"
+            f"{_with_stdout_tail(safe_stderr or '<no stderr>', _redacted_output_tail(stdout))}"
         )
 
     token = parse_token_from_stdout(stdout)
     if not token:
-        raise TokenMintError(
-            f"could not parse a token from {ssh_host} output "
-            f"(stderr: {safe_stderr or '<none>'})"
+        detail = _with_stdout_tail(
+            f"stderr: {safe_stderr or '<none>'}", _redacted_output_tail(stdout)
         )
+        raise TokenMintError(f"could not parse a token from {ssh_host} output ({detail})")
     return token
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3395,3 +3395,92 @@ class TestTokenCommand:
         assert custom_line in out
         # The two URLs must be separated by a blank line.
         assert f"{loopback_line}\n\n{custom_line}" in out
+
+    # ── stdout is a machine interface: failures go to stderr ─────────────────
+    #
+    # `_token`'s stdout is regex-parsed by the remote-mint path
+    # (kiro_crew.instances.token_mint.mint_remote_token) over SSH. Error prose on
+    # stdout both breaks the Unix convention and hides the reason from a caller
+    # that captures stderr — which is how a failed remote mint used to surface as
+    # a bare "<no stderr>".
+
+    def _stub_token_env(self, tmp_path, monkeypatch, *, secret: bool = True) -> None:
+        if secret:
+            (tmp_path / ".local_secret").write_text("test-secret")
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.KiroCrewConfig.load",
+            lambda: MagicMock(dashboard=MagicMock(url="")),
+        )
+        monkeypatch.setattr("kiro_crew.cli_server.dashboard_origin", lambda u: "")
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.resolve_dashboard_host",
+            lambda local_only=True: "canonical-host.invalid",
+        )
+
+    def test_invalid_ttl_error_goes_to_stderr(self, tmp_path, capsys, monkeypatch):
+        from kiro_crew.cli_server import _token
+
+        self._stub_token_env(tmp_path, monkeypatch)
+        with pytest.raises(SystemExit) as excinfo:
+            _token(argparse.Namespace(ttl="banana", port=7777))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Invalid TTL" in captured.err
+        assert captured.out == ""
+
+    def test_missing_secret_error_goes_to_stderr(self, tmp_path, capsys, monkeypatch):
+        from kiro_crew.cli_server import _token
+
+        self._stub_token_env(tmp_path, monkeypatch, secret=False)
+        with pytest.raises(SystemExit) as excinfo:
+            _token(argparse.Namespace(ttl="1h", port=7777))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Gateway not running" in captured.err
+        assert captured.out == ""
+
+    def test_unreachable_gateway_error_goes_to_stderr(self, tmp_path, capsys, monkeypatch):
+        from kiro_crew.cli_server import _token
+
+        self._stub_token_env(tmp_path, monkeypatch)
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            with pytest.raises(SystemExit) as excinfo:
+                _token(argparse.Namespace(ttl="1h", port=7777))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Could not reach gateway on port 7777" in captured.err
+        assert captured.out == ""
+
+    def test_empty_token_error_goes_to_stderr(self, tmp_path, capsys, monkeypatch):
+        from kiro_crew.cli_server import _token
+
+        self._stub_token_env(tmp_path, monkeypatch)
+        with patch("urllib.request.urlopen", return_value=self._mock_token_response("")):
+            with pytest.raises(SystemExit) as excinfo:
+                _token(argparse.Namespace(ttl="1h", port=7777))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "empty token" in captured.err
+        assert captured.out == ""
+
+    def test_success_stdout_carries_only_urls(self, tmp_path, capsys, monkeypatch):
+        """Every stdout line on the success path must be a parseable URL.
+
+        The docstring's "stdout carries only the URL(s)" is a contract the remote
+        mint depends on, and prose is not enforcement: any future preflight that
+        writes to stdout — a warning, or an `input()` prompt, whose prompt goes to
+        stdout — would silently corrupt the stream that mint_remote_token regexes
+        over SSH. This pins the contract to an assertion instead.
+        """
+        from kiro_crew.cli_server import _token
+
+        self._stub_token_env(tmp_path, monkeypatch)
+        with patch("urllib.request.urlopen", return_value=self._mock_token_response("eyJa.b")):
+            _token(argparse.Namespace(ttl="1h", port=7777))
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+        assert lines, "success path printed nothing to stdout"
+        for line in lines:
+            assert line.lstrip().startswith("http"), f"non-URL text on stdout: {line!r}"
+        assert "token=eyJa.b" in captured.out

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -332,6 +332,228 @@ class TestTokenMint:
         with pytest.raises(tm.TokenMintError):
             asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
 
+    # ── diagnosability: an older remote prints its reason to STDOUT ──────────
+
+    def _fake_proc(self, monkeypatch, rc: int, out: bytes, err: bytes) -> None:
+        class FakeProc:
+            returncode = rc
+
+            async def communicate(self):
+                return out, err
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    def test_nonzero_exit_surfaces_stdout_tail_when_stderr_empty(self, monkeypatch):
+        """The real reason travels with the error instead of '<no stderr>'.
+
+        Pre-fix ``kirocrew token`` printed its failure prose to stdout, so a
+        stderr-only message degraded to a useless ``<no stderr>`` and someone
+        had to SSH in to find out why.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        self._fake_proc(
+            monkeypatch,
+            1,
+            b"\xe2\x9d\x8c Could not reach gateway on port 5476: <urlopen error refused>\n",
+            b"",
+        )
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert "Could not reach gateway on port 5476" in msg
+        assert "stdout tail:" in msg
+        assert "<no stderr>" in msg  # stderr genuinely was empty — still reported
+
+    def test_unparseable_output_surfaces_stdout_tail(self, monkeypatch):
+        from kiro_crew.instances import token_mint as tm
+
+        self._fake_proc(monkeypatch, 0, b"Gateway returned empty token\n", b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert "could not parse a token" in msg
+        assert "Gateway returned empty token" in msg
+
+    def test_stdout_tail_never_leaks_a_token(self, monkeypatch):
+        """A URL-borne or bare token on stdout is scrubbed before it reaches the error.
+
+        The tail is only built on failure paths, but a partially-successful
+        remote (URL printed, then non-zero exit) can still put a live credential
+        on stdout — so the token substitution must happen unconditionally.
+
+        The bare-token case uses the shape this app ACTUALLY mints:
+        ``generate_token`` returns ``base64url(payload).base64url(signature)`` —
+        two segments, not the three of a classic JWT. A fabricated three-segment
+        token here would let a two-segment-blind pattern pass while leaving real
+        tokens unscrubbed, so the segment count is asserted explicitly and
+        ``test_bare_token_scrubbed_at_every_segment_count`` pins the full range.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        minted = "eyJzdWIiOiJvd25lciIsImV4cCI6MTIzfQ.c2lnbmF0dXJlLWJ5dGVz"
+        assert minted.count(".") == 1
+
+        self._fake_proc(
+            monkeypatch,
+            1,
+            f"http://localhost:5476?token={minted}\nbare {minted} too\nboom\n".encode(),
+            b"",
+        )
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert minted not in msg
+        # no fragment of the credential survives either — a pattern that matched
+        # only part of the token would leave the remaining segment(s) behind.
+        for segment in minted.split("."):
+            assert segment not in msg
+        assert "boom" in msg
+
+    @pytest.mark.parametrize("segments", [2, 3, 5])
+    def test_bare_token_scrubbed_at_every_segment_count(self, monkeypatch, segments):
+        """Two-segment (minted), three-segment (JWT) and five-segment (JWE) all scrub.
+
+        Five segments is the compact-JWE shape: a pattern capped lower would
+        match a prefix and leave ``.ciphertext.tag`` in the surfaced error.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        bare = "eyJhbGciOiJIUzI1NiJ9" + "".join(f".seg{i}" for i in range(segments - 1))
+        self._fake_proc(monkeypatch, 1, f"{bare}\nwhy it died\n".encode(), b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert bare not in msg
+        assert f"seg{segments - 2}" not in msg  # last segment gone, not just a prefix
+        assert "why it died" in msg
+
+    def test_stdout_tail_is_bounded_and_absent_when_stdout_empty(self, monkeypatch):
+        from kiro_crew.instances import token_mint as tm
+
+        # bounded: only the TAIL is carried (the reason is printed last). The
+        # reason sits on its own line, as a real remote prints it — the scan
+        # window's left edge falls inside the preceding noise run, which is
+        # dropped as potentially-clipped without touching the reason.
+        long_out = ("x" * 5000 + "\nREAL-REASON\n").encode()
+        self._fake_proc(monkeypatch, 1, long_out, b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert "REAL-REASON" in msg
+        assert len(msg) < 600
+
+        # modern remote (reason on stderr, nothing on stdout) keeps the original
+        # single-stream message shape — no empty "stdout tail:" noise.
+        self._fake_proc(monkeypatch, 127, b"", b"kirocrew binary not found")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert "stdout tail:" not in str(excinfo.value)
+        assert "kirocrew binary not found" in str(excinfo.value)
+
+    def test_success_path_never_builds_the_stdout_tail(self, monkeypatch):
+        """The tail is built inside the failure branches only.
+
+        On success, stdout holds a live token; running the scrub over it would be
+        pointless work on credential-bearing text and would contradict the
+        "only ever built on a failure path" invariant the helper documents. This
+        locks the invariant to control flow instead of a comment.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            tm, "_redacted_output_tail", lambda out, *a, **k: calls.append(out) or ""
+        )
+
+        self._fake_proc(monkeypatch, 0, b"http://localhost:5476?token=eyJa.b\n", b"")
+        assert asyncio.run(tm.mint_remote_token("cd-1", ttl="20h")) == "eyJa.b"
+        assert calls == []
+
+        # ...but a failing mint still builds it.
+        self._fake_proc(monkeypatch, 1, b"reason on stdout\n", b"")
+        with pytest.raises(tm.TokenMintError):
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert len(calls) == 1
+
+    def test_scrubbers_never_scan_more_than_the_bounded_window(self, monkeypatch):
+        """The scrub cost must not scale with the remote's stdout size.
+
+        `re` does not release the GIL, so scrubbing an unbounded payload blocks
+        the gateway's event loop in proportion to its length — measured ~1s per
+        MB (13s on 13MB), and an executor hop is no cure (~1.1s stall on the
+        same payload, GIL-bound). Asserting on the *input length* handed to the
+        redactors instead of on wall-clock keeps this deterministic.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        seen: list[int] = []
+        real = tm.redact_credentials
+        monkeypatch.setattr(
+            tm, "redact_credentials", lambda text, *a, **k: seen.append(len(text)) or real(text)
+        )
+
+        huge = ("x" * 60 + " could not reach gateway\n") * 20_000  # ~1.7 MB
+        self._fake_proc(monkeypatch, 1, huge.encode(), b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+
+        assert seen and max(seen) <= tm._OUTPUT_SCAN_CHARS
+        # The bound must not cost diagnosability: the reason still travels.
+        assert "could not reach gateway" in str(excinfo.value)
+
+    def test_secret_clipped_by_the_window_boundary_is_never_shown(self, monkeypatch):
+        """A token straddling the window start must not leak its suffix.
+
+        The window slice can land mid-run, which would show the token regexes a
+        fragment they cannot match while its suffix still lands inside the carried
+        300 chars. Truncated input therefore drops the leading run of URL /
+        base64url characters. The floor for that drop is low on purpose: a
+        fragment that looks too far from the end to matter is still pulled into
+        the tail when the scrubbers shrink the text around it, which the third
+        case below pins.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        secret = "eyJ" + "A" * 3000 + ".SIGNATURE-MUST-NOT-APPEAR"
+        for stdout in (f"noise\n{secret}\n", secret):  # with and without a trailing newline
+            self._fake_proc(monkeypatch, 1, stdout.encode(), b"")
+            with pytest.raises(tm.TokenMintError) as excinfo:
+                asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+            msg = str(excinfo.value)
+            assert "SIGNATURE-MUST-NOT-APPEAR" not in msg
+            assert "AAAA" not in msg
+            assert "<clipped>" in msg
+
+        # A clipped fragment far from the end is NOT unreachable: the scrubbers
+        # shrink the window (each blob collapses to `<redacted>`), pulling earlier
+        # text into the carried tail. This is why the clipped-run floor is low
+        # instead of the window-minus-tail distance — with a 2100-char floor this
+        # case surfaces the raw fragment.
+        blob = "eyJ" + "z" * 200 + "." + "y" * 200
+        redactable = f"{blob}\n" * 5
+        secret_run = "MUSTNOTAPPEAR" * 39  # one unbroken run, no whitespace
+        # Size the prefix so the window's left edge lands INSIDE secret_run.
+        prefix_len = tm._OUTPUT_SCAN_CHARS - len(redactable) - len(secret_run) // 2
+        shrinking = "p" * prefix_len + "\n" + secret_run + "\n" + redactable
+        assert len(shrinking) > tm._OUTPUT_SCAN_CHARS
+        self._fake_proc(monkeypatch, 1, shrinking.encode(), b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert "MUSTNOTAPPEAR" not in str(excinfo.value)
+
+        # A long stdout still carries its reason when nothing is clipped away.
+        padded = "x" * 4000 + "\n" + "short-run-word " * 20 + "\nWHY-IT-FAILED\n"
+        self._fake_proc(monkeypatch, 1, padded.encode(), b"")
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert "WHY-IT-FAILED" in msg
+        assert "short-run-word" in msg
+
 
 # ── gateway run-marker (mint prefers the running gateway's install) ───────────
 


### PR DESCRIPTION
## Problem

When a remote dashboard token mint fails, the operator gets no reason. The error reads:

```
remote token mint on <host> exited 1: <no stderr>
```

`kirocrew token` prints all four of its failure reasons — invalid TTL, missing `.local_secret`, unreachable gateway, empty token — to **stdout**. `mint_remote_token()` builds its `TokenMintError` from **stderr** only, so the actual reason (`❌ Could not reach gateway on port 5476: ...`) is discarded and the message degrades to `<no stderr>`.

## Why it matters

The reason exists, is already formatted for a human, and is thrown away at the one point where it is needed. Diagnosing a failed remote mint currently requires SSH-ing into the desktop and re-running `kirocrew token` by hand — for a class of failure (gateway down, wrong port, stale secret) that the message could have named outright.

## Fix (symptom → root cause → change)

Symptom: `<no stderr>`. Root cause: the reason is written to the wrong stream, and the consumer reads only the other stream. Both halves are cheap to fix, and fixing both means the message stays useful across a version skew where the remote is older than the gateway calling it.

**1. `cli_server.py::_token` — errors to stderr.** All four failure `print()`s gain `file=sys.stderr`. This is correct Unix behavior on its own merits: `_token`'s stdout is a parsed machine interface — `mint_remote_token` runs it over SSH and regex-extracts the JWT from stdout — so error prose never belonged there. A docstring records the invariant so it is not silently undone.

**2. `token_mint.py` — a redacted stdout tail in the error.** Belt-and-suspenders for remotes that predate change 1 and still print to stdout. `_redacted_output_tail()` scrubs the token first, then runs the existing `redact_credentials` / `redact_exfiltration_urls` helpers, then truncates to the last 300 chars (the tail, because the reason is printed last). `_with_stdout_tail()` appends it only when stdout was non-empty, so a modern remote keeps the existing single-stream message shape.

The token substitution is unconditional rather than conditional on the failure mode. stdout is the one stream that legitimately carries the JWT, and a partially-successful remote — URL printed, then a non-zero exit — would otherwise put a live credential into an exception that reaches logs and instance status. Both a URL-borne `?token=` and a bare `eyJ....` JWT are scrubbed.

## Tests

8 new tests, all revert-verified (each fails against unmodified source):

`test/test_cli.py::TestTokenCommand` — one per `_token` failure path (invalid TTL, missing secret, unreachable gateway, empty token). Each asserts the reason appears on **stderr** and that **stdout is empty**, which is the property the remote-mint parser depends on.

`test/test_instances.py::TestTokenMint`
- `test_nonzero_exit_surfaces_stdout_tail_when_stderr_empty` — reproduces the reported bug: reason on stdout, stderr empty, and asserts the reason now reaches the error message.
- `test_unparseable_output_surfaces_stdout_tail` — same for the "could not parse a token" path.
- `test_stdout_tail_never_leaks_a_token` — a URL-borne and a bare JWT on stdout are both replaced with `<redacted>` while the surrounding diagnostic survives.
- `test_stdout_tail_is_bounded_and_absent_when_stdout_empty` — 5 KB of stdout is truncated to the tail that contains the reason, and a stderr-only remote produces no empty `stdout tail:` noise.

## Manual verification

N/A — the failure paths are fully exercised by unit tests with a stubbed subprocess, and the change is confined to which stream a string is written to and which strings are concatenated into an exception message.

## Screenshots

N/A — no user-visible UI change; both files are CLI/backend.
