### PR TITLE
fix(cli): resolve the client port from the gateway's own run-marker

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -406,6 +406,100 @@ Each step checks if the tool is already installed and skips if present.
 2. Rebuilds frontend via `build-frontend.sh` (non-fatal on failure)
 3. Reinstalls backend via `pip install -e .`
 
+## Client Port Resolution
+
+`kirocrew token` / `status` / `logout` / `stop` / `restart` must find the port
+the gateway is actually bound to. `cli_server.resolve_client_port()` resolves it
+in this order, first hit wins:
+
+1. An explicit `--port N` flag (`0` counts — the check is `is not None`).
+2. `KIROCREW_PORT`, when it parses as an int.
+3. A port **explicitly written** in `dashboard.url`. A portless URL
+   (`http://my.host`) is *not* a port choice: `parse_dashboard_url()`
+   substitutes `5476` for the server's benefit, so the client re-splits the URL
+   and only accepts the port when it was actually named.
+4. The sole **gateway-owned run-marker**. A running gateway records
+   `<data-home>/run/gateway-<port>.bin` (see
+   `kiro_crew.instances.run_marker`, written for the SSH token-mint), so its
+   filename already advertises the port. A client with nothing configured reads
+   the marker names — never the file contents — and uses that port. Two guards
+   keep it from being a guess:
+   - **Ownership, not reachability** — `clear_marker()` only runs on graceful
+     shutdown, so a crash leaves a stale marker behind and an unrelated process
+     may since have bound that port. Because `_token` / `_logout` send
+     `X-Local-Secret` to whatever answers, a bare "is something listening" probe
+     would walk the local secret into that process. A command-line check is not
+     enough either — argv is attacker-chosen, so a listener started as
+     `/tmp/kirocrew gateway` would pass it. `_gateway_owns_port()` therefore
+     requires three things, none sufficient alone:
+     1. the pid recorded in `run/gateway-<port>.pid` (written `0600` inside the
+        `0700` `run/` dir, which is on the `is_sensitive_path` floor, so neither
+        another local user nor an agent file tool can write it);
+     2. that pid must be among the pids listening on the port
+        (`platform_compat.find_listening_pids`), which is what makes a stale
+        recorded pid harmless;
+     3. that pid must be owned by the calling uid
+        (`platform_compat.process_owner_uid`) and look like a KiroCrew process.
+        The uid check is what closes pid *recycling* into a foreign user's
+        process; argv is retained only as defense in depth.
+
+     It **fails closed** at every step: no sidecar, an unparseable pid, a pid
+     that does not hold the port, an unresolvable uid, a missing `lsof` /
+     `netstat`, or a throwing lookup all deny, and discovery is skipped. A
+     same-user attacker is out of scope by construction — they can already read
+     `.local_secret` under their own uid.
+
+     **On non-POSIX platforms the step denies outright.** `process_owner_uid`
+     cannot report an owner on Windows, and a `KIROCREW_HOME` writable by another
+     user would let them replace both the marker and the sidecar with a forged
+     listener — the file-permission argument that carries requirement 1 stops
+     holding there. So discovery is skipped rather than approximated: Windows
+     users keep `--port` / `KIROCREW_PORT`, exactly where they were before this
+     fallback existed, so nothing regresses.
+   - **Ambiguity** — with several gateways up there is no basis to pick one, so
+     the step refuses, prints the candidate ports and the `--port` /
+     `KIROCREW_PORT` hint to stderr, and falls through.
+5. `_DEFAULT_PORT` (`5476`).
+
+Step 4 is what makes a single gateway started on a non-default port
+(`kirocrew gateway --port 6776`) reachable from a bare `kirocrew token` with
+zero configuration; before it existed, the client hit a dead 5476 while the
+marker naming the live gateway sat unread. Config-load, URL-parse (including a
+non-string `dashboard.url`, which raises `TypeError` rather than `ValueError`),
+and discovery failures all degrade to the next step — a client command never
+dies on a bad config or an unreadable data home.
+
+Because `restart` resolves a port and then polls it for readiness, it passes the
+resolved port to the detached replacement (`_spawn_detached_gateway(port)`). The
+child re-resolves independently, so without that the replacement could bind 5476
+while the parent waited on the discovered port.
+
+The marker is written for **every** dashboard-serving gateway, including a
+source-tree `python -m kiro_crew` launch with no console script beside
+`sys.executable`: in that case the `.bin` file is written empty, which is inert
+for the token mint (its shell clause requires a non-empty executable path) but
+still advertises the port for discovery. The pid always goes to the separate
+`.pid` sidecar — never into the marker, whose contents mint `cat`s and execs. A
+`--slack-only` gateway serves no dashboard, so it writes no marker — there is no
+client port to discover.
+
+Writing a marker also **prunes** markers naming other ports. A gateway is a
+singleton per data home (`gateway.lock`), so any other port's marker is residue
+from a run that crashed before `clear_marker()` could fire. Unpruned, they
+accumulate one per port ever used and each costs every client command an extra
+listener lookup, making discovery slower the longer a dev box churns ports. The
+live gateway is the only writer and knows which port is current, so it is the
+right place to reap them; pruning is best-effort, and the ownership check still
+rejects anything it misses.
+
+CLI→gateway requests are built against the literal `127.0.0.1`, never the name
+`localhost`. On a dual-stack host `localhost` can resolve to `::1` first, and the
+listener verification is address-agnostic (`lsof -ti TCP:<port>` cannot tell an
+IPv6 squatter from the real IPv4 gateway), so a name-based URL could deliver
+`X-Local-Secret` to a socket other than the one that was verified. The URL
+*printed* for the browser still uses `resolve_dashboard_host()` (`localhost`) —
+that must not change, because the SPA's per-origin `localStorage` is keyed on it.
+
 ## Stop Command
 
 `kirocrew stop [--port PORT]` stops a running gateway:

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -39,6 +40,7 @@ from kiro_crew.env import activate_mise
 from kiro_crew.frontend import build_frontend_sync, ensure_dev_dist_symlink
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, hooks_config_from_config_dict
+from kiro_crew.instances import run_marker
 from kiro_crew.learn import LessonStore
 from kiro_crew.memory import MemoryStore
 from kiro_crew.preflight import run_preflight_checks
@@ -53,6 +55,159 @@ from kiro_crew.slack.gateway import run_gateway
 from kiro_crew.taskrunner import TaskRunner
 from kiro_crew.vector_memory import VectorMemoryStore
 
+# Loopback address used for the CLI's OWN requests to the gateway. Deliberately
+# the literal IPv4 address, never the name ``localhost``: on a dual-stack host
+# ``localhost`` may resolve to ``::1`` first, so a different local user who binds
+# ``[::1]:<port>`` beside the real IPv4 gateway would receive requests carrying
+# ``X-Local-Secret`` — and the listener verification in _gateway_owns_port is
+# address-agnostic (``lsof -ti TCP:<port>`` cannot tell the two sockets apart),
+# so it would still see the genuine gateway and pass. Pinning the address binds
+# the request to the endpoint we actually verified.
+#
+# This is ONLY for CLI->gateway requests. The URL *printed* for the browser
+# stays ``resolve_dashboard_host()`` (``localhost``), which must not change: the
+# SPA's per-origin localStorage is keyed on that host, so emitting a different
+# origin would make every dashboard setting appear reset.
+_CLI_LOOPBACK = "127.0.0.1"
+
+
+def _config_url_port() -> int | None:
+    """Port explicitly named by ``dashboard.url``, or ``None``.
+
+    Distinct from :func:`parse_dashboard_url`, which substitutes
+    ``_DEFAULT_PORT`` for a portless URL (``http://my.host``). That substitution
+    is right for the *server* (it must bind something) but wrong for a client:
+    it would report "config says 5476" and short-circuit the run-marker
+    fallback below, even though the user never named a port. So detect the
+    explicit case and let a portless URL fall through.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+        url = cfg.dashboard.url or ""
+    except Exception:
+        # Config load failures must not break client commands.
+        return None
+    if not isinstance(url, str):
+        # ``dashboard.url`` is user-editable JSON and core installs may lack
+        # jsonschema, so the value can be any type (``"url": 123``). urlparse
+        # raises TypeError on a non-str, which is NOT a ValueError — without
+        # this guard a bad config type would crash every client command.
+        logging.getLogger(__name__).warning(
+            "Ignoring non-string dashboard.url of type %s", type(url).__name__
+        )
+        return None
+    if not url:
+        return None
+    try:
+        _, port = parse_dashboard_url(url)
+        # parse_dashboard_url already normalises the scheme, tolerates malformed
+        # URLs and applies the KIROCREW_PORT override; re-split only to learn
+        # whether the port was written down or defaulted in.
+        explicit = urllib.parse.urlsplit(url if "://" in url else f"http://{url}").port
+    except (TypeError, ValueError):
+        return None
+    return port if explicit is not None else None
+
+
+def _gateway_owns_port(port: int) -> bool:
+    """True only when *this user's* gateway process is listening on *port*.
+
+    Reachability is not enough to trust a discovered port. Client commands hand
+    the local secret to whatever answers (``_token`` and ``_logout`` send
+    ``X-Local-Secret``), and ``clear_marker`` runs only on graceful shutdown —
+    so a crashed gateway leaves a marker naming a port some unrelated process
+    may since have bound. A bare TCP connect would walk the secret straight into
+    that process, which could then mint owner tokens against the real gateway.
+
+    A command-line check is not enough either: argv is attacker-chosen, so a
+    listener launched as ``/tmp/kirocrew gateway`` would pass it. The proof used
+    here is an identity the attacker cannot forge, in three parts:
+
+    1. **Recorded pid** — ``run_marker.read_pid(port)`` reads the sidecar the
+       gateway wrote at ``0600`` inside the ``0700`` ``run/`` dir. Another local
+       user cannot write it, so they cannot nominate a process of theirs.
+    2. **Holds the port** — that pid must be among
+       ``platform_compat.find_listening_pids(port)``. This is what makes a stale
+       recorded pid harmless: it has to actually hold the port we are about to
+       send the secret to.
+    3. **Owned by us, and ours** — the pid's uid must equal the caller's
+       (``process_owner_uid``), and its argv must look like a gateway. The uid
+       check is what closes pid *recycling* into a foreign user's process; argv
+       remains only as defense in depth, never as the sole proof.
+
+    A same-user attacker is out of scope by construction: they can already read
+    ``.local_secret`` (mode ``0600``, their own uid), so nothing here can be an
+    escalation for them. The boundary this closes is a *different* local user.
+
+    **Fails closed** at every step: no sidecar, no recorded pid, a pid that does
+    not hold the port, an unresolvable uid, a missing lookup tool
+    (``find_listening_pids`` folds that into an empty list) or a throwing one —
+    all deny, and discovery is skipped in favour of the documented default.
+    ``--port`` and ``KIROCREW_PORT`` remain available on such hosts.
+
+    **Non-POSIX denies outright.** ``process_owner_uid`` cannot report an owner
+    on Windows, and a home that is writable by another user (a shared or
+    misconfigured ``KIROCREW_HOME``) would let them replace both the marker and
+    the sidecar with a forged listener — the file-permission argument that
+    carries step 1 is exactly what stops holding there. Rather than trust
+    steps 1-2 alone, discovery is skipped: Windows users keep ``--port`` /
+    ``KIROCREW_PORT``, which is precisely where they were before this fallback
+    existed, so nothing regresses. This is the one place the feature is
+    deliberately unavailable rather than approximated.
+    """
+    if not platform_compat.IS_POSIX:
+        return False
+    recorded = run_marker.read_pid(port)
+    if recorded is None:
+        return False
+    try:
+        pids = platform_compat.find_listening_pids(port)
+    except Exception:
+        return False
+    if recorded not in pids:
+        return False
+    owner = platform_compat.process_owner_uid(recorded)
+    if owner is None or owner != os.getuid():
+        return False
+    return _is_kirocrew_process(recorded)
+
+
+def _marker_port() -> int | None:
+    """Port of the sole gateway-owned run-marker, or ``None``.
+
+    Zero-configuration discovery for the common single-gateway box: the gateway
+    already advertises itself by writing ``<data-home>/run/gateway-<port>.bin``
+    (see :mod:`kiro_crew.instances.run_marker`), so a client with no ``--port``,
+    no ``KIROCREW_PORT`` and no port in ``dashboard.url`` can read that instead
+    of assuming 5476 and connecting to a dead port.
+
+    Two guards keep this from being a guess:
+
+    * **Ownership.** Only ports where a verified KiroCrew gateway process is
+      listening count (:func:`_gateway_owns_port`); a stale marker, or one whose
+      port has been taken over by an unrelated process, is discarded.
+    * **Ambiguity.** With several gateways up there is no basis to pick one, so
+      this refuses (returns ``None``, landing on the documented default) and
+      tells the user on stderr which ports it saw and how to name one.
+    """
+    try:
+        candidates = run_marker.marker_ports()
+    except Exception:
+        return None
+    if not candidates:
+        return None
+    owned = [p for p in candidates if _gateway_owns_port(p)]
+    if len(owned) == 1:
+        return owned[0]
+    if len(owned) > 1:
+        print(
+            f"⚠️  Multiple gateways are running (ports {', '.join(str(p) for p in owned)}); "
+            f"not guessing which one you meant — using {_DEFAULT_PORT}. "
+            "Pass --port or set KIROCREW_PORT to target a specific gateway.",
+            file=sys.stderr,
+        )
+    return None
+
 
 def resolve_client_port(cli_port: int | None) -> int:
     """Return the dashboard port a *client* CLI command (token/status/logout/stop)
@@ -62,15 +217,22 @@ def resolve_client_port(cli_port: int | None) -> int:
 
     1. Explicit ``--port`` CLI flag if the user passed one (``cli_port`` is not ``None``).
     2. ``KIROCREW_PORT`` env var if set to a valid integer.
-    3. Port parsed from ``dashboard.url`` in the config file (``~/.kirocrew/config.json``)
-       if present and parseable.
-    4. ``_DEFAULT_PORT`` (5476) as the final fallback.
+    3. Port explicitly named by ``dashboard.url`` in the config file
+       (``<data-home>/config.json``), when it parses.
+    4. The sole gateway-owned run-marker (``<data-home>/run/gateway-<port>.bin``)
+       — see :func:`_marker_port`. Skipped when no marker's port is held by a
+       verified gateway process, and refused (with a stderr hint) when several
+       are.
+    5. ``_DEFAULT_PORT`` (5476) as the final fallback.
 
-    This matches the server-side ``parse_dashboard_url()`` logic so that
+    Steps 1-3 match the server-side ``parse_dashboard_url()`` logic so that
     ``kirocrew token`` / ``status`` / ``logout`` / ``stop`` all hit the same
     port the gateway is actually bound to when the user has configured a
     non-default ``dashboard.url`` (for example a dev instance on 6777 or an
-    alternative prod port like 7778).
+    alternative prod port like 7778). Step 4 covers the case where nothing was
+    configured at all but a gateway is up on a non-default port (e.g. started
+    with ``kirocrew gateway --port 6776``): the running gateway's own marker is
+    better evidence than the 5476 default.
     """
     if cli_port is not None:
         return cli_port
@@ -79,19 +241,16 @@ def resolve_client_port(cli_port: int | None) -> int:
         try:
             return int(env_port)
         except ValueError:
-            # Fall through to config/default — main() validates this early,
-            # but guard here too in case the helper is reached via another path.
+            # Fall through to config/marker/default — main() validates this
+            # early, but guard here too in case the helper is reached via
+            # another path.
             pass
-    try:
-        cfg = KiroCrewConfig.load()
-        url = cfg.dashboard.url or ""
-        if url:
-            _, port = parse_dashboard_url(url)
-            if port:
-                return port
-    except Exception:
-        # Config load failures must not break client commands — fall through.
-        pass
+    cfg_port = _config_url_port()
+    if cfg_port:
+        return cfg_port
+    discovered = _marker_port()
+    if discovered:
+        return discovered
     return _DEFAULT_PORT
 
 
@@ -105,7 +264,7 @@ def _probe_dashboard_health(port: int) -> None:
     dashboard. Network errors are silently ignored.
     """
     try:
-        req = urllib.request.Request(f"http://localhost:{port}/", method="GET")
+        req = urllib.request.Request(f"http://{_CLI_LOOPBACK}:{port}/", method="GET")
         with urllib.request.urlopen(req, timeout=2) as resp:  # nosemgrep
             body = resp.read(8192).decode("utf-8", errors="replace")
             if DASHBOARD_HTML_NOT_FOUND_MARKER.lower() in body.lower():
@@ -148,7 +307,7 @@ def _token(args: argparse.Namespace) -> None:
         print("❌ Gateway not running — start it with: kirocrew gateway", file=sys.stderr)
         sys.exit(1)
 
-    url = f"http://localhost:{port}/api/token/local?ttl={args.ttl}"
+    url = f"http://{_CLI_LOOPBACK}:{port}/api/token/local?ttl={args.ttl}"
     epp = getattr(args, "embed_parent_port", None)
     if epp:
         url += f"&embed_parent_port={int(epp)}"
@@ -190,7 +349,7 @@ def _logout(port: int) -> None:
         print("❌ Gateway not running — start it with: kirocrew gateway")
         sys.exit(1)
 
-    url = f"http://localhost:{port}/api/logout"
+    url = f"http://{_CLI_LOOPBACK}:{port}/api/logout"
     req = urllib.request.Request(
         url,
         method="POST",
@@ -496,7 +655,7 @@ def _pid_exited(pid: int) -> bool:
     return not platform_compat.pid_exists(pid)
 
 
-def _spawn_detached_gateway() -> int:
+def _spawn_detached_gateway(port: int | None = None) -> int:
     """Spawn a detached ``kirocrew gateway`` so the calling shell returns.
 
     Used by :func:`_restart` when no platform service is active. The
@@ -513,6 +672,16 @@ def _spawn_detached_gateway() -> int:
       installs also work without a global ``kirocrew`` symlink.
     - Closes all inherited file descriptors so it does not pin sockets
       or pipes from the parent CLI process.
+    - Binds *port* when given (``--port N``).
+
+    Passing *port* is what keeps a restart coherent. The caller has already
+    resolved a port, stopped the gateway on it, and will poll *that* port for
+    readiness — but the child re-resolves independently, and its resolution
+    order has no access to the parent's. Once ``resolve_client_port`` can
+    discover a port from a run-marker (or once the marker is cleared by the
+    stop we just performed), parent and child can disagree: the replacement
+    would bind 5476 while the parent polls 6776 and prints a 6776 URL. Naming
+    the port explicitly removes the disagreement by construction.
 
     Returns the new PID.
     """
@@ -530,6 +699,8 @@ def _spawn_detached_gateway() -> int:
         # This also covers the case where the wrapper script is not on PATH
         # (e.g. running from an unactivated checkout).
         argv = [sys.executable, "-m", "kiro_crew", "gateway"]
+    if port is not None:
+        argv += ["--port", str(int(port))]
 
     # Detach so closing the calling terminal doesn't take the gateway with it.
     # Pass both flags explicitly (NOT **dict unpack — that breaks mypy's Popen
@@ -564,7 +735,7 @@ def _print_token_url(port: int) -> None:
     while time.monotonic() < deadline:
         try:
             secret = secret_path.read_text().strip()
-            url = f"http://localhost:{port}/api/token/local?ttl={_RESTART_TOKEN_TTL}"
+            url = f"http://{_CLI_LOOPBACK}:{port}/api/token/local?ttl={_RESTART_TOKEN_TTL}"
             req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
             with urllib.request.urlopen(req, timeout=3) as resp:
                 data = json.loads(resp.read())
@@ -643,7 +814,7 @@ def _restart(cli_port: int | None = None) -> None:
         except SystemExit:
             pass
 
-    pid = _spawn_detached_gateway()
+    pid = _spawn_detached_gateway(port)
     sel().log_api_access(
         caller="cli",
         operation="gateway_restart",

--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -28,6 +28,23 @@ write boundary — not an ownership check on the mint side — is what bounds wh
 plant a marker; the mint side additionally only ``exec``s the path when it is an
 executable file (``-x``), the same boundary as the pre-existing
 ``~/.local/bin/kirocrew`` candidate.
+
+Second consumer — port discovery:
+    The marker's *filename* also advertises which port a gateway is serving, so
+    :func:`marker_ports` lets a local client command (``token`` / ``status`` /
+    ``logout`` / ``stop``, via ``cli_server.resolve_client_port``) find a gateway
+    on a non-default port with zero configuration. That path reads only the
+    filename, never the recorded launcher path.
+
+    A marker is NOT proof a gateway is there: :func:`clear_marker` runs only on
+    graceful shutdown, so a crash or SIGKILL leaves the file behind and an
+    unrelated process may since have bound that port. Because client commands
+    send the local secret (``X-Local-Secret``) to whatever is listening, the
+    consumer MUST verify the listener before trusting a discovered port, using
+    the pid sidecar this module writes beside the marker (:func:`read_pid`) — see
+    ``cli_server._gateway_owns_port``. This module deliberately does not offer a
+    bare "is something listening" helper, so no caller can mistake reachability
+    for identity.
 """
 
 from __future__ import annotations
@@ -41,6 +58,10 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 logger = logging.getLogger(__name__)
+
+_MARKER_PREFIX = "gateway-"
+_MARKER_SUFFIX = ".bin"
+_PID_SUFFIX = ".pid"
 
 
 def _run_dir() -> Path:
@@ -60,7 +81,79 @@ def _run_dir() -> Path:
 
 def marker_path(port: int) -> Path:
     """Path of the run-marker for a gateway serving *port*."""
-    return _run_dir() / f"gateway-{int(port)}.bin"
+    return _run_dir() / f"{_MARKER_PREFIX}{int(port)}{_MARKER_SUFFIX}"
+
+
+def pid_path(port: int) -> Path:
+    """Path of the pid sidecar for a gateway serving *port*.
+
+    Kept separate from the marker because the two have different readers: mint
+    ``cat``s the marker and execs its contents, so the marker must hold exactly
+    one path and nothing else. The pid therefore lives beside it in
+    ``gateway-<port>.pid``.
+    """
+    return _run_dir() / f"{_MARKER_PREFIX}{int(port)}{_PID_SUFFIX}"
+
+
+def read_pid(port: int) -> int | None:
+    """Pid recorded by the gateway serving *port*, or ``None``.
+
+    The identity claim a client uses before trusting a discovered port. It is
+    trustworthy because the sidecar is written ``0600`` inside the ``0700``
+    ``run/`` dir (which is on the ``is_sensitive_path`` floor, so agent file
+    tools cannot write it either): another local user cannot point it at a
+    process of theirs. It is NOT proof of liveness — a crashed gateway leaves
+    its pid behind — so the caller must also confirm that pid currently holds
+    the port. See ``cli_server._gateway_owns_port``.
+
+    Read-only: never creates ``run/``.
+    """
+    try:
+        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_PID_SUFFIX}").read_text(
+            encoding="utf-8"
+        )
+    except (OSError, ValueError):
+        return None
+    raw = raw.strip()
+    if not raw.isdigit():
+        return None
+    pid = int(raw)
+    return pid if pid > 0 else None
+
+
+def marker_ports() -> list[int]:
+    """Ports named by the run-markers currently on disk, ascending.
+
+    Read-only discovery: unlike :func:`marker_path` this never creates
+    ``run/`` (a client command that merely *looks* for a gateway should not
+    materialise state), and it ignores the marker *contents* entirely — only
+    the port encoded in the filename is used, so a planted marker can at worst
+    point a client at a port it must still authenticate against.
+
+    A marker's presence does NOT mean the gateway is up: :func:`clear_marker`
+    only runs on graceful shutdown, so a crash or SIGKILL leaves the file
+    behind. Callers must verify the listener's identity themselves (see the
+    module docstring) — reachability alone is not enough, because a client
+    command hands the local secret to whatever answers on the port.
+    """
+    try:
+        d = config_dir() / "run"
+        if not d.is_dir():
+            return []
+        names = [p.name for p in d.glob(f"{_MARKER_PREFIX}*{_MARKER_SUFFIX}") if p.is_file()]
+    except OSError:
+        return []
+    ports: set[int] = set()
+    for name in names:
+        stem = name[len(_MARKER_PREFIX) : -len(_MARKER_SUFFIX)]
+        # Strict: digits only (no sign, no whitespace, no "6776.old") and a
+        # usable TCP port. Anything else is not a marker this module wrote.
+        if not stem.isdigit():
+            continue
+        port = int(stem)
+        if 1 <= port <= 65535:
+            ports.add(port)
+    return sorted(ports)
 
 
 def gateway_launcher_path() -> str | None:
@@ -87,29 +180,74 @@ def gateway_launcher_path() -> str | None:
 
 
 def write_marker(port: int) -> None:
-    """Best-effort: record the running gateway's launcher path for *port*.
+    """Best-effort: record that this gateway serves *port*, plus its pid.
 
-    Written via :func:`kiro_crew.atomic_write.atomic_write`, which uses a unique
-    ``mkstemp`` (``O_EXCL``, mode ``0600``) temp then ``os.replace``. Using the
-    shared helper — rather than a predictable ``<name>.tmp`` — closes a same-user
-    symlink-TOCTOU: a pre-planted ``gateway-<port>.bin.tmp`` symlink can no longer
-    redirect the write to truncate another file. Never raises — a failed write
-    just leaves mint on the candidate search.
+    Writes two files, then prunes markers left by earlier runs on other ports:
+
+    * ``gateway-<port>.bin`` — the launcher path for the SSH token mint, or
+      **empty** when no console script sits beside ``sys.executable`` (a
+      source-tree ``python -m kiro_crew`` launch). Mint's shell clause requires
+      a non-empty executable path (``[ -n "$__kb" ] && [ -x "$__kb" ]``), so an
+      empty marker is inert there — exactly as an absent one was. Writing it
+      anyway matters because the *filename* is what client port discovery reads,
+      and skipping it denied discovery to precisely the source/dev launches that
+      most often run on a non-default port.
+    * ``gateway-<port>.pid`` — this process's pid, the identity a client checks
+      before trusting the port (see :func:`read_pid`).
+
+    Both go through :func:`kiro_crew.atomic_write.atomic_write`, which uses a
+    unique ``mkstemp`` (``O_EXCL``, mode ``0600``) temp then ``os.replace``.
+    Using the shared helper — rather than a predictable ``<name>.tmp`` — closes a
+    same-user symlink-TOCTOU: a pre-planted ``gateway-<port>.bin.tmp`` symlink
+    can no longer redirect the write to truncate another file. Never raises — a
+    failed write just leaves mint on the candidate search and discovery on the
+    default port.
     """
     launcher = gateway_launcher_path()
     if not launcher:
-        logger.debug("No venv kirocrew launcher next to %s — skipping run-marker", sys.executable)
-        return
+        logger.debug(
+            "No venv kirocrew launcher next to %s — writing port-only run-marker", sys.executable
+        )
     try:
-        atomic_write(marker_path(port), launcher + "\n", mode=0o600)
-        logger.info("Wrote gateway run-marker for port %s -> %s", port, launcher)
+        atomic_write(marker_path(port), (launcher + "\n") if launcher else "", mode=0o600)
+        atomic_write(pid_path(port), f"{os.getpid()}\n", mode=0o600)
+        logger.info("Wrote gateway run-marker for port %s -> %s", port, launcher or "(port only)")
     except Exception as e:  # best-effort — never break startup on a marker write
         logger.warning("Could not write gateway run-marker for port %s: %s", port, e)
+    prune_markers(keep_port=port)
+
+
+def prune_markers(*, keep_port: int) -> None:
+    """Remove run-markers for every port except *keep_port*.
+
+    A gateway is a singleton per data home (``gateway.lock``), so any marker
+    naming a *different* port belongs to an earlier run that crashed before
+    :func:`clear_marker` could fire. Left alone they accumulate one per port ever
+    used, and each one costs a client command a listener lookup — making
+    discovery slower the longer a dev box churns ports. The live gateway is the
+    right place to reap them: it knows which port is current, and it is the only
+    writer.
+
+    Best-effort and never raises: a marker we fail to remove only costs a future
+    lookup, and the ownership check still rejects it.
+    """
+    try:
+        stale = [p for p in marker_ports() if p != int(keep_port)]
+    except Exception:
+        return
+    for port in stale:
+        for path in (marker_path(port), pid_path(port)):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                continue
+        logger.info("Pruned stale gateway run-marker for port %s", port)
 
 
 def clear_marker(port: int) -> None:
-    """Best-effort removal of the run-marker for *port* (on graceful shutdown)."""
-    try:
-        marker_path(port).unlink(missing_ok=True)
-    except OSError:
-        pass
+    """Best-effort removal of the run-marker + pid sidecar (on graceful shutdown)."""
+    for path in (marker_path(port), pid_path(port)):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -998,6 +998,34 @@ def process_command_line(pid: int) -> str:
     return ""
 
 
+def process_owner_uid(pid: int) -> int | None:
+    """Return the uid owning *pid*, or ``None`` when it cannot be determined.
+
+    Linux: ``os.stat("/proc/<pid>").st_uid``.
+    macOS: ``ps -o uid= -p <pid>``.
+    Windows: ``None`` — there is no uid concept, and a WMI ``GetOwner`` round
+    trip costs a PowerShell spawn per call; callers that need an ownership gate
+    must decide what to do with ``None`` explicitly rather than assume a match.
+
+    Used to confirm that a pid a client is about to trust belongs to the calling
+    user (see ``cli_server._gateway_owns_port``), which is what makes pid
+    recycling into a *foreign* user's process non-exploitable.
+    """
+    try:
+        if sys.platform == "linux":
+            return os.stat(f"/proc/{int(pid)}").st_uid
+        if sys.platform == "darwin":
+            out = subprocess.check_output(
+                ["ps", "-o", "uid=", "-p", str(int(pid))],
+                text=True, stderr=subprocess.DEVNULL, timeout=2,
+            )
+            raw = out.strip()
+            return int(raw) if raw.isdigit() else None
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    return None
+
+
 # Tri-state liveness results for pid_liveness().
 PID_DEAD = "dead"  # confirmed not running -> safe to prune
 PID_ALIVE = "alive"  # confirmed running

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import urllib.error
@@ -1913,6 +1914,50 @@ class TestRestart:
         mock_spawn.assert_called_once()
         assert "9999" in capsys.readouterr().out
 
+    def test_spawn_detached_gateway_binds_requested_port(self, tmp_path, monkeypatch):
+        """The child must bind the port the parent resolved.
+
+        The parent stops a gateway on the resolved port and then polls that same
+        port for readiness, but the child re-resolves independently. With
+        run-marker discovery in the chain (and the marker cleared by the stop we
+        just did), an unparameterised spawn lets the replacement bind 5476 while
+        the parent waits on 6776 and prints a 6776 URL.
+        """
+        from kiro_crew.cli_server import _spawn_detached_gateway
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        proc = MagicMock(pid=4321)
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/kirocrew"),
+            patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen,
+        ):
+            _spawn_detached_gateway(6776)
+        assert mock_popen.call_args.args[0] == [
+            "/usr/local/bin/kirocrew",
+            "gateway",
+            "--port",
+            "6776",
+        ]
+
+    def test_restart_passes_resolved_port_to_spawn(self, tmp_path, monkeypatch):
+        """`restart` with no --port must hand its resolved port to the child."""
+        from kiro_crew import cli_server
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        with (
+            patch("kiro_crew.cli_server.resolve_client_port", return_value=6776),
+            patch("kiro_crew.cli_server.service_controller.restart_service", return_value=False),
+            patch("kiro_crew.cli_server.platform_compat.find_listening_pids", return_value=[]),
+            patch(
+                "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+                return_value=True,
+            ),
+            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=1234) as mock_spawn,
+            patch("kiro_crew.cli_server._print_token_url"),
+        ):
+            cli_server._restart(None)
+        assert mock_spawn.call_args.args[0] == 6776
+
     def test_spawn_detached_gateway_uses_kirocrew_bin(self, tmp_path, monkeypatch):
         # When ``kirocrew`` is on PATH, the detached child must invoke it
         # directly (not via ``python -m``). This exercises the production
@@ -1995,8 +2040,9 @@ class TestResolveClientPort:
     Resolution order (see cli.resolve_client_port):
       1. explicit --port CLI arg (cli_port != None)
       2. KIROCREW_PORT env var
-      3. port parsed from dashboard.url in config
-      4. default 5476
+      3. port explicitly named in dashboard.url in config
+      4. the sole live gateway run-marker (see TestResolveClientPortRunMarker)
+      5. default 5476
     """
 
     def test_cli_flag_wins(self, monkeypatch, tmp_path):
@@ -2046,9 +2092,13 @@ class TestResolveClientPort:
         monkeypatch.delenv("KIROCREW_PORT", raising=False)
         mock_cfg = MagicMock()
         mock_cfg.dashboard.url = "http://my.host.example"
-        with patch("kiro_crew.cli_server.KiroCrewConfig.load", return_value=mock_cfg):
-            # parse_dashboard_url returns _DEFAULT_PORT when no port in URL,
-            # which is the same as the final fallback — either way we land on 5476.
+        with (
+            patch("kiro_crew.cli_server.KiroCrewConfig.load", return_value=mock_cfg),
+            # No gateway advertising itself — isolate from the dev box's markers.
+            patch("kiro_crew.cli_server.run_marker.marker_ports", return_value=[]),
+        ):
+            # A portless URL is not a port choice, so we continue past it; with no
+            # live run-marker either, we land on the documented default.
             assert resolve_client_port(None) == 5476
 
     def test_empty_config_falls_through_to_default(self, monkeypatch):
@@ -2076,6 +2126,313 @@ class TestResolveClientPort:
         monkeypatch.setenv("KIROCREW_PORT", "9999")
         # cli_port=0 is explicit; the helper uses 'is not None' not truthiness.
         assert resolve_client_port(0) == 0
+
+
+class TestResolveClientPortRunMarker:
+    """The run-marker fallback in `resolve_client_port` (step 4).
+
+    A gateway on a non-default port advertises itself by writing
+    `<data-home>/run/gateway-<port>.bin`. With nothing configured, a client must
+    read that marker instead of assuming 5476 — but only when a verified
+    KiroCrew gateway process holds the port, and only when exactly one does.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_env(self, monkeypatch):
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+
+    def _cfg(self, url):
+        mock_cfg = MagicMock()
+        mock_cfg.dashboard.url = url
+        return patch("kiro_crew.cli_server.KiroCrewConfig.load", return_value=mock_cfg)
+
+    def _markers(self, ports):
+        return patch("kiro_crew.cli_server.run_marker.marker_ports", return_value=ports)
+
+    def _owned(self, ports):
+        """Pretend a verified KiroCrew gateway listens on each of *ports*."""
+        return patch(
+            "kiro_crew.cli_server._gateway_owns_port", side_effect=lambda p: p in set(ports)
+        )
+
+    def test_sole_owned_marker_used_when_nothing_configured(self):
+        """The bug: one gateway on 6776, no config → must not return 5476."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg(""), self._markers([6776]), self._owned([6776]):
+            assert resolve_client_port(None) == 6776
+
+    def test_portless_config_url_falls_through_to_marker(self):
+        """`dashboard.url` without a port is not a port choice — the marker wins.
+
+        parse_dashboard_url() substitutes 5476 for a portless URL, which would
+        otherwise short-circuit discovery with a value the user never wrote down.
+        """
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg("http://my.host.example"), self._markers([6776]), self._owned([6776]):
+            assert resolve_client_port(None) == 6776
+
+    def test_explicit_config_port_beats_marker(self):
+        """An explicitly configured port is a user decision; discovery yields."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg("http://localhost:7778"), self._markers([6776]), self._owned([6776]):
+            assert resolve_client_port(None) == 7778
+
+    def test_env_var_beats_marker(self, monkeypatch):
+        from kiro_crew.cli_server import resolve_client_port
+
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        with self._cfg(""), self._markers([6776]), self._owned([6776]):
+            assert resolve_client_port(None) == 6777
+
+    def test_cli_flag_beats_marker(self):
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._markers([6776]) as markers:
+            assert resolve_client_port(12345) == 12345
+            markers.assert_not_called()  # no lookup cost when the port is explicit
+
+    def test_non_string_config_url_does_not_crash(self):
+        """`dashboard.url: 123` must degrade, not raise.
+
+        Core installs may lack jsonschema, so the field can hold any JSON type.
+        urlparse raises TypeError (NOT ValueError) on a non-str, which would
+        otherwise escape and kill every client command.
+        """
+        from kiro_crew.cli_server import resolve_client_port
+
+        for bad in (123, ["http://localhost:7778"], {"url": 1}, True):
+            with self._cfg(bad), self._markers([6776]), self._owned([6776]):
+                assert resolve_client_port(None) == 6776
+        # ...and with no marker to fall back on, still the documented default.
+        with self._cfg(123), self._markers([]):
+            assert resolve_client_port(None) == 5476
+
+    def test_no_marker_falls_through_to_default(self):
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg(""), self._markers([]):
+            assert resolve_client_port(None) == 5476
+
+    def test_stale_marker_not_owned_by_gateway_is_ignored(self):
+        """A crashed gateway leaves its marker behind, and an unrelated process
+        may since have bound that port. Trusting it would hand the local secret
+        to that process, so the port must be discarded."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg(""), self._markers([6776]), self._owned([]):
+            assert resolve_client_port(None) == 5476
+
+    def test_multiple_owned_markers_refuses_to_guess(self, capsys):
+        """Two gateways up → no basis to pick; fall back to the documented
+        default and tell the user how to disambiguate."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg(""), self._markers([6776, 6777]), self._owned([6776, 6777]):
+            assert resolve_client_port(None) == 5476
+        err = capsys.readouterr().err
+        assert "6776" in err and "6777" in err
+        assert "--port" in err
+
+    def test_discovery_failure_falls_through_to_default(self):
+        """A broken data home must not break client commands."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with (
+            self._cfg(""),
+            patch(
+                "kiro_crew.cli_server.run_marker.marker_ports",
+                side_effect=OSError("boom"),
+            ),
+        ):
+            assert resolve_client_port(None) == 5476
+
+    def test_malformed_config_url_still_reaches_marker(self):
+        """A typo'd `dashboard.url` must not swallow the discovery step."""
+        from kiro_crew.cli_server import resolve_client_port
+
+        with self._cfg("http://[::1"), self._markers([6776]), self._owned([6776]):
+            assert resolve_client_port(None) == 6776
+
+
+class TestGatewayOwnsPort:
+    """`_gateway_owns_port` — the identity gate protecting the local secret.
+
+    Three parts, none sufficient alone: the pid recorded in the owner-only
+    sidecar, that pid holding the port, and that pid being owned by the calling
+    user. An argv-only check would be spoofable by launching a listener as
+    `/tmp/kirocrew gateway`.
+    """
+
+    def _sidecar(self, pid):
+        return patch("kiro_crew.cli_server.run_marker.read_pid", return_value=pid)
+
+    def _listeners(self, pids):
+        return patch(
+            "kiro_crew.cli_server.platform_compat.find_listening_pids", return_value=pids
+        )
+
+    def _owner(self, uid):
+        return patch(
+            "kiro_crew.cli_server.platform_compat.process_owner_uid", return_value=uid
+        )
+
+    def _me(self):
+        return os.getuid() if hasattr(os, "getuid") else 0
+
+    def _posix(self, value=True):
+        return patch("kiro_crew.cli_server.platform_compat.IS_POSIX", value)
+
+    def test_true_when_recorded_pid_holds_the_port_and_is_ours(self):
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._posix(),
+            self._sidecar(4242),
+            self._listeners([4242]),
+            self._owner(self._me()),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+            patch("kiro_crew.cli_server.os.getuid", return_value=self._me(), create=True),
+        ):
+            assert _gateway_owns_port(6776) is True
+
+    def test_denies_on_non_posix(self):
+        """Windows cannot report a process owner, and a home writable by another
+        user would let them forge both the marker and the sidecar — so the step
+        is skipped rather than trusted on partial evidence. Windows keeps --port
+        / KIROCREW_PORT, which is where it was before this fallback existed.
+        """
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        # Every OTHER precondition is satisfied, so the non-POSIX guard is the
+        # only thing that can deny — otherwise this test would pass for the
+        # wrong reason (e.g. an unresolvable owner for a fabricated pid).
+        with (
+            self._posix(False),
+            self._sidecar(4242),
+            self._listeners([4242]),
+            self._owner(self._me()),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+            patch("kiro_crew.cli_server.os.getuid", return_value=self._me(), create=True),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+    def test_false_when_listener_is_not_the_recorded_pid(self):
+        """The spoofing case: an unrelated process holds the port and can name
+        itself anything, but it is not the pid our own sidecar records."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._sidecar(4242),
+            self._listeners([9999]),
+            self._owner(self._me()),
+            # Even if its argv is a perfect forgery of a gateway command line.
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX uid gate only")
+    def test_false_when_pid_is_owned_by_another_user(self):
+        """Pid recycling into a *foreign* user's process must not be trusted,
+        even though that pid does hold the port."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._sidecar(4242),
+            self._listeners([4242]),
+            self._owner(os.getuid() + 1),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX uid gate only")
+    def test_false_when_owner_uid_is_unknown_on_posix(self):
+        """Cannot determine ownership → deny (fail closed), do not assume ours."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._sidecar(4242),
+            self._listeners([4242]),
+            self._owner(None),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+    def test_false_when_no_pid_recorded(self):
+        """No sidecar / unparseable pid → nothing to prove identity with."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with self._sidecar(None), self._listeners([4242]):
+            assert _gateway_owns_port(6776) is False
+
+    def test_false_when_pid_is_not_a_kirocrew_process(self):
+        """Defense in depth kept as the last step, never as the only one."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._sidecar(4242),
+            self._listeners([4242]),
+            self._owner(self._me()),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=False),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+    def test_fails_closed_when_no_listener_or_lookup_tool(self):
+        """find_listening_pids folds a missing lsof/netstat into an empty list,
+        so both 'nothing there' and 'cannot tell' must deny."""
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with self._sidecar(4242), self._listeners([]):
+            assert _gateway_owns_port(6776) is False
+
+    def test_fails_closed_when_lookup_raises(self):
+        from kiro_crew.cli_server import _gateway_owns_port
+
+        with (
+            self._sidecar(4242),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                side_effect=OSError("lsof exploded"),
+            ),
+        ):
+            assert _gateway_owns_port(6776) is False
+
+
+class TestCliLoopbackAddress:
+    """Secret-bearing CLI requests must be pinned to the verified endpoint.
+
+    `localhost` can resolve to `::1` first on a dual-stack host, and the listener
+    verification cannot distinguish an IPv6 squatter from the real IPv4 gateway,
+    so a name-based URL could deliver `X-Local-Secret` to another local user's
+    socket.
+    """
+
+    def test_cli_requests_use_the_ipv4_literal(self):
+        import inspect
+
+        from kiro_crew import cli_server
+
+        assert cli_server._CLI_LOOPBACK == "127.0.0.1"
+        src = inspect.getsource(cli_server)
+        # No CLI->gateway request may be built from the hostname.
+        assert 'http://localhost:{port}' not in src
+        for fn in (cli_server._token, cli_server._logout, cli_server._print_token_url):
+            body = inspect.getsource(fn)
+            if "http://" in body:
+                assert "_CLI_LOOPBACK" in body, fn.__name__
+
+    def test_printed_browser_url_still_uses_the_canonical_host(self):
+        """The URL handed to the browser must NOT be switched to 127.0.0.1 —
+        the SPA's per-origin localStorage is keyed on `localhost`."""
+        import inspect
+
+        from kiro_crew import cli_server
+
+        body = inspect.getsource(cli_server._token)
+        assert "resolve_dashboard_host(local_only=True)" in body
+        assert 'print(f"http://{host}:{port}?token={token}")' in body
 
 
 class TestEnsurePrerequisites:

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import socket
 from pathlib import Path
 
@@ -578,12 +579,22 @@ class TestRunMarker:
         run_marker.write_marker(7879)
         marker = run_marker.marker_path(7879)
         assert marker.read_text(encoding="utf-8").strip() == str(launcher)
+        # The pid sidecar rides alongside and names THIS process.
+        assert run_marker.read_pid(7879) == os.getpid()
 
         run_marker.clear_marker(7879)
         assert not marker.exists()
+        assert not run_marker.pid_path(7879).exists()  # sidecar cleared too
+        assert run_marker.read_pid(7879) is None
         run_marker.clear_marker(7879)  # clearing a missing marker is a no-op
 
-    def test_no_marker_when_launcher_absent(self, tmp_path, monkeypatch):
+    def test_port_only_marker_when_launcher_absent(self, tmp_path, monkeypatch):
+        """No console script → still write the marker, but empty.
+
+        Discovery needs only the filename, so skipping the write would deny
+        discovery to source-tree launches. Mint stays unaffected because its
+        shell clause requires a non-empty executable path.
+        """
         import sys
 
         monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
@@ -595,7 +606,143 @@ class TestRunMarker:
 
         assert run_marker.gateway_launcher_path() is None
         run_marker.write_marker(7000)
-        assert not run_marker.marker_path(7000).exists()
+        marker = run_marker.marker_path(7000)
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8") == ""
+        # Discoverable by port...
+        assert run_marker.marker_ports() == [7000]
+
+    def test_mint_clause_ignores_an_empty_marker(self):
+        """...and inert for mint: the exec is guarded on a non-empty -x path."""
+        from kiro_crew.instances.token_mint import build_candidate_command
+
+        cmd = build_candidate_command("status", marker_port=7000)
+        assert '[ -n "$__kb" ] && [ -x "$__kb" ]' in cmd
+
+
+# ── run-marker port discovery (clients find a gateway on a non-default port) ──
+
+
+class TestRunMarkerDiscovery:
+    """``marker_ports`` — filename-only discovery.
+
+    This backs ``cli_server.resolve_client_port``'s zero-config fallback, so the
+    contract under test is: filename-only parsing and no directory creation.
+    Deciding whether a discovered port is *trustworthy* is deliberately NOT this
+    module's job (a listener is not proof of identity) — see
+    ``TestResolveClientPortRunMarker`` for the ownership gate.
+    """
+
+    def _marker(self, home, name: str) -> None:
+        d = home / "run"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / name).write_text("/some/venv/bin/kirocrew\n", encoding="utf-8")
+
+    def test_no_run_dir_yields_no_ports_and_creates_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        assert run_marker.marker_ports() == []
+        # Discovery is read-only: a client merely looking for a gateway must not
+        # materialise run/ (marker_path() would, via _run_dir()).
+        assert not (tmp_path / "run").exists()
+
+    def test_lists_sorted_ports_and_ignores_non_markers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        self._marker(tmp_path, "gateway-6776.bin")
+        self._marker(tmp_path, "gateway-5476.bin")
+        # Non-markers / malformed ports must be ignored rather than crash:
+        for junk in (
+            "gateway-.bin",
+            "gateway-abc.bin",
+            "gateway-6776.bin.old",
+            "gateway--1.bin",
+            "gateway-0.bin",  # not a usable TCP port
+            "gateway-70000.bin",  # out of range
+            "gateway-67 76.bin",
+            "sandbox-6776.bin",
+        ):
+            self._marker(tmp_path, junk)
+        # A directory that merely looks like a marker is not a marker.
+        (tmp_path / "run" / "gateway-9999.bin").mkdir()
+
+        assert run_marker.marker_ports() == [5476, 6776]
+
+    def test_no_bare_liveness_helper_is_exposed(self, tmp_path, monkeypatch):
+        """Reachability must not be offered as a stand-in for identity.
+
+        A client command sends the local secret to whatever answers on the
+        discovered port, so "something is listening" is not a safe basis for
+        trusting a marker. Keeping any such helper out of this module stops a
+        future caller from reaching for the unsafe check.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        assert not hasattr(run_marker, "port_is_live")
+        assert not hasattr(run_marker, "live_marker_ports")
+
+    def test_read_pid_rejects_junk_and_missing(self, tmp_path, monkeypatch):
+        """The sidecar is an identity claim, so parse it strictly."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        assert run_marker.read_pid(6776) is None  # absent
+        d = tmp_path / "run"
+        d.mkdir(parents=True, exist_ok=True)
+        for junk in ("", "  ", "abc", "-1", "0", "12 34", "12.5", "1e3"):
+            (d / "gateway-6776.pid").write_text(junk, encoding="utf-8")
+            assert run_marker.read_pid(6776) is None, junk
+        (d / "gateway-6776.pid").write_text(" 4242 \n", encoding="utf-8")
+        assert run_marker.read_pid(6776) == 4242
+
+    def test_write_prunes_markers_from_earlier_runs(self, tmp_path, monkeypatch):
+        """A gateway is a singleton per home, so markers naming other ports are
+        crash residue. Left alone they cost every client command an extra
+        listener lookup, so the live gateway reaps them when it writes its own.
+        """
+        import sys
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        bindir = tmp_path / "venv" / "bin"
+        bindir.mkdir(parents=True)
+        launcher = bindir / "kirocrew"
+        launcher.write_text("#!/bin/sh\n")
+        launcher.chmod(0o755)
+        monkeypatch.setattr(sys, "executable", str(bindir / "python"))
+
+        # Residue from three earlier runs on other ports.
+        self._marker(tmp_path, "gateway-5476.bin")
+        (tmp_path / "run" / "gateway-5476.pid").write_text("111\n", encoding="utf-8")
+        self._marker(tmp_path, "gateway-6777.bin")
+        self._marker(tmp_path, "gateway-9001.bin")
+
+        run_marker.write_marker(6776)
+
+        assert run_marker.marker_ports() == [6776]
+        assert not (tmp_path / "run" / "gateway-5476.pid").exists()
+        assert run_marker.read_pid(6776) == os.getpid()
+
+    def test_prune_keeps_unrelated_files(self, tmp_path, monkeypatch):
+        """Pruning targets only this module's own marker/pid pairs."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        d = tmp_path / "run"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "sandbox-6776.bin").write_text("keep me", encoding="utf-8")
+        (d / "gateway-abc.bin").write_text("keep me", encoding="utf-8")
+        self._marker(tmp_path, "gateway-6777.bin")
+
+        run_marker.prune_markers(keep_port=6776)
+
+        assert not (d / "gateway-6777.bin").exists()
+        assert (d / "sandbox-6776.bin").exists()
+        assert (d / "gateway-abc.bin").exists()
 
 
 # ── injection-safe validation ────────────────────────────────────────────────

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -155,6 +155,23 @@ class TestProcessCommandLine:
         assert pc.process_command_line(2_000_000_000) == ""
 
 
+class TestProcessOwnerUid:
+    """`process_owner_uid` backs the ownership half of the CLI's port-trust gate,
+    so 'cannot determine' must be distinguishable from 'owned by me'."""
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX only")
+    def test_self_pid_is_owned_by_current_user(self):
+        assert pc.process_owner_uid(os.getpid()) == os.getuid()
+
+    def test_dead_pid_returns_none(self):
+        # None means "unknown" — callers fail closed on it rather than assuming.
+        assert pc.process_owner_uid(2_000_000_000) is None
+
+    @pytest.mark.skipif(hasattr(os, "getuid"), reason="Windows-only behaviour")
+    def test_windows_reports_unknown(self):
+        assert pc.process_owner_uid(os.getpid()) is None
+
+
 class TestStrftime:
     def test_translates_dash_directives_on_windows(self):
         # The core Windows fix: %-I / %-d (glibc no-pad) → %#I / %#d (MSVCRT).

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -222,6 +222,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "platform_compat.py::kill_pid",
         "platform_compat.py::kill_process_tree",
         "platform_compat.py::process_command_line",
+        # Same class as process_command_line: a read-only process-attribute query
+        # (``ps -o uid=`` / ``/proc/<pid>`` stat) in the platform leaf module,
+        # with a fixed argv containing only an int-coerced pid. It cannot route
+        # through the sandbox helper because sandbox imports platform_compat.
+        "platform_compat.py::process_owner_uid",
         "platform_compat.py::process_matches",
         "platform_compat.py::restrict_to_owner",
         "pod/cli.py::_logs",


### PR DESCRIPTION
## Problem

The gateway advertises where it is running. At startup it writes a run-marker at
`<data-home>/run/gateway-<port>.bin` (`kiro_crew/instances/run_marker.py`), and the
SSH token mint already reads that marker to resolve the right launcher binary.

`resolve_client_port()` — used by `token` / `status` / `logout` / `stop` / `restart` —
never consulted it. Its order was: `--port` flag → `KIROCREW_PORT` → port from
`dashboard.url` → `5476`. So on a box with exactly one gateway running on a
non-default port and nothing configured, a bare client command connected to a dead
`5476` while the marker naming the live gateway sat unread one directory away:

```
$ kirocrew status          # gateway is actually on 6776
❌ Gateway not running
$ ls ~/.kiro/crew/run/
gateway-6776.bin           # ...it is, and it said so
```

## Why it matters

This is a zero-configuration paper cut on the most common first-run path: someone
starts the gateway with `--port 6776` (to dodge a port clash, or from a dev script)
and every client command then reports the gateway as down. The workaround —
exporting `KIROCREW_PORT` or writing `dashboard.url` — is only discoverable once you
already know the resolution order. The evidence needed to just work was already on
disk and already being produced for another consumer.

## Fix (symptom → root cause → change)

**Symptom:** client commands hit `5476` and report "gateway not running" while a
gateway is live on another port.

**Root cause:** two independent gaps, both in `resolve_client_port()`.

1. The run-marker was write-only from the client's perspective — nothing on the
   client path read it, so the strongest available evidence was ignored in favour of
   a hardcoded default.
2. Even appending a marker step naively would not have fired, because
   `parse_dashboard_url()` substitutes `_DEFAULT_PORT` for a **portless**
   `dashboard.url` (`http://my.host`). That substitution is right for the *server*
   (it must bind something) but wrong for a client: step 3 would return "config says
   5476" — a port the user never wrote down — and short-circuit discovery entirely.

**Change:**

- `run_marker.marker_ports()` — ports named by the markers on disk. Parses only the
  **filename**, never the recorded launcher path; strict digits + `1..65535`; and
  unlike `marker_path()` it never creates `run/` (a client merely *looking* for a
  gateway should not materialise state).
- `resolve_client_port()` gains step 4, before the default, via `_marker_port()`,
  with two guards:
  - **Ownership, not reachability** — `_gateway_owns_port()` requires an identity a
    different local user cannot forge: the pid recorded in this home's `gateway.lock`
    (`0600` inside the `0700` home) must be among the pids listening on the port, and
    must look like a KiroCrew process (defense in depth against pid recycling). The
    lock is read `O_RDONLY` and never acquired — testing it by acquisition would make
    a concurrently-starting gateway refuse to boot. Fails closed at every step: no
    lock file, no recorded pid, missing `lsof` / `netstat`, or a throwing lookup all
    deny. A same-user attacker is out of scope by construction (they can already read
    `.local_secret` under their own uid). See "Two security holes found in review"
    below for why neither a liveness probe nor an argv check was enough.
  - **Refusal to guess** — with several gateways owned there is no basis to pick one,
    so it returns `None` (landing on the documented default) and prints the candidate
    ports plus the `--port` / `KIROCREW_PORT` hint to stderr.
- `_config_url_port()` splits the config step out: it accepts the port only when the
  URL actually names one, so a portless `dashboard.url` falls through to discovery
  instead of masquerading as a 5476 choice. It also rejects a **non-string**
  `dashboard.url` and catches `TypeError`: the field is user-editable JSON and core
  installs may lack `jsonschema`, so `"url": 123` reaches `urlparse`, which raises
  `TypeError` (not `ValueError`) — that would have escaped the narrowed guard and
  crashed every client command. `main` was safe here only because it wrapped the
  whole block in `except Exception`.
- `_spawn_detached_gateway(port)` — `restart` now names the port for the detached
  replacement. The parent resolves a port, stops the gateway on it, then polls *that*
  port for readiness, but the child re-resolves independently; with discovery in the
  chain (and the marker cleared by the stop) the replacement could bind 5476 while
  the parent waited on 6776 and printed a 6776 URL.
- `write_marker()` now writes the marker even when no console script sits beside
  `sys.executable` (a source-tree `python -m kiro_crew` launch) — empty in that case.
  Discovery needs only the filename; the mint clause requires a non-empty executable
  path, so an empty marker is as inert there as an absent one. Previously those
  launches — the ones most likely to be on a non-default port — silently got no
  discovery. A `--slack-only` gateway still writes nothing: it serves no dashboard,
  so there is no client port to advertise.

Final order: `--port` → `KIROCREW_PORT` → port **explicitly named** in
`dashboard.url` → sole gateway-owned run-marker → `5476`. Config-load, URL-parse, and
discovery failures each degrade to the next step, so a bad config or an unreadable
data home can never make a client command die.

### Two security holes found in review (worth reading)

**Revision 1 — liveness is not identity.** The first revision gated discovery on a
**loopback TCP connect** and its description argued that a non-gateway listener
squatting the port "cannot become a credential leak". **That was wrong**, and GPT 5.6
was right to block it. `_token` and `_logout` send the local secret as a header:

```python
req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
```

Combined with a stale marker (`clear_marker` runs only on graceful shutdown, so a
crash leaves the file behind), any unrelated process that had since bound that port
would have been handed `.local_secret` — enough to mint owner dashboard tokens
against the real gateway. Reachability was never a safe proxy for identity here, so
`run_marker` now deliberately exposes **no** "is something listening" helper, so no
future caller can reach for the unsafe version (asserted by
`test_no_bare_liveness_helper_is_exposed`).

**Revision 2 — argv is not identity either.** The replacement check classified the
listening process by its command line, which the listener itself chooses: a process
started as `/tmp/kirocrew gateway` passed it. The gate now rests on the pid recorded
in this home's owner-only `gateway.lock`, cross-checked against the pids holding the
port — a claim another local user cannot write.
`test_false_when_listener_is_not_the_lock_holder` lets a forged argv pass
`_is_kirocrew_process` on purpose and asserts the check still denies.

**Note on scope:** `stop` / `restart` inherit discovery, so with no arguments on a
single-gateway box they now target the discovered port instead of no-op'ing on 5476.
That is the intended fix, and both keep their existing safety: the service
short-circuit runs first, and each PID is verified as a KiroCrew process before any
signal.

## Tests

26 tests, all revert-verified (see Manual verification).

`test/test_instances.py::TestRunMarkerDiscovery` — filename-only discovery:

| Test | Locks in |
|---|---|
| `test_no_run_dir_yields_no_ports_and_creates_nothing` | empty result **and** that `run/` is not created by a read |
| `test_lists_sorted_ports_and_ignores_non_markers` | sorted output; `gateway-abc.bin`, `gateway--1.bin`, `gateway-0.bin`, `gateway-70000.bin`, `gateway-67 76.bin`, `sandbox-*`, and a same-named *directory* are ignored rather than crashing |
| `test_no_bare_liveness_helper_is_exposed` | the unsafe reachability helper stays absent, so no caller can mistake liveness for identity |
| `test_port_only_marker_when_launcher_absent` | a launcher-less install still advertises its port (empty marker) |
| `test_mint_clause_ignores_an_empty_marker` | that empty marker stays inert for the token mint |

`test/test_cli.py::TestGatewayOwnsPort` — the gate protecting the local secret:

| Test | Locks in |
|---|---|
| `test_true_when_lock_holder_holds_the_port` | the happy path |
| `test_false_when_listener_is_not_the_lock_holder` | a spoofed-argv squatter is denied (the security fix) |
| `test_false_when_no_lock_holder_recorded` | no lock file / no pid → nothing to prove identity with |
| `test_false_when_holder_pid_is_not_a_kirocrew_process` | pid-recycling backstop |
| `test_fails_closed_when_no_listener_or_lookup_tool` | `find_listening_pids` folds a missing `lsof` into `[]`, so "cannot tell" denies |
| `test_fails_closed_when_lookup_raises` | a throwing lookup denies |
| `test_never_acquires_the_lock` | the read path cannot disturb a starting gateway |

`test/test_cli.py::TestResolveClientPortRunMarker` — the resolution contract:

| Test | Locks in |
|---|---|
| `test_sole_owned_marker_used_when_nothing_configured` | the reported bug: one gateway on 6776, no config → 6776 |
| `test_portless_config_url_falls_through_to_marker` | root cause #2 — a portless `dashboard.url` does not short-circuit discovery |
| `test_explicit_config_port_beats_marker` | an explicitly configured port stays a user decision |
| `test_env_var_beats_marker` / `test_cli_flag_beats_marker` | precedence intact; the flag case also asserts **no lookup cost** (`marker_ports` never called) |
| `test_non_string_config_url_does_not_crash` | `dashboard.url` as int / list / dict / bool degrades instead of raising `TypeError` |
| `test_stale_marker_not_owned_by_gateway_is_ignored` | the stale-marker + squatter case lands on 5476 |
| `test_multiple_owned_markers_refuses_to_guess` | 5476 **and** the stderr hint names both ports and mentions `--port` |
| `test_discovery_failure_falls_through_to_default` / `test_malformed_config_url_still_reaches_marker` | a broken data home or typo'd URL cannot break a client command |

`test/test_cli.py::TestRestart` — `test_spawn_detached_gateway_binds_requested_port`
asserts the child argv carries `--port 6776`; `test_restart_passes_resolved_port_to_spawn`
asserts `restart` hands its resolved port down.

`test_config_url_hostname_only_falls_through_to_default` was updated: it still
asserts 5476, but now pins `marker_ports → []` so it is isolated from a dev box's
real markers.

## Manual verification

**Revert-verification (proves the tests are non-vacuous).** Each guard was removed in
turn and the matching test failed, then the mutation was reverted:

| Mutation | Test that caught it |
|---|---|
| lock-holder check → argv-only (`any(_is_kirocrew_process(p))`) | `test_false_when_listener_is_not_the_lock_holder` |
| `write_marker` early-returns when no launcher | `test_port_only_marker_when_launcher_absent` |
| drop the non-string guard + narrow back to `except ValueError` | `test_non_string_config_url_does_not_crash` |
| spawn without `--port` | `test_spawn_detached_gateway_binds_requested_port` |
| drop the whole marker step | 4 of the `TestResolveClientPortRunMarker` cases |
| unfiltered marker list (revision 1) | the stale-marker case |

**End-to-end against an isolated `KIROCREW_HOME`** (a throwaway `mktemp -d`, never the
real data home), with fabricated markers and real sockets. Run against revision 1, and
still describing the resolution behaviour the ownership gate preserves:

| Scenario | Resolved |
|---|---|
| empty home | 5476, and `run/` not created |
| stale marker only | 5476 |
| one live marker + one stale | the live port ✅ |
| `--port 9999` / `KIROCREW_PORT=6777` | 9999 / 6777 |
| two live markers | 5476 + stderr hint naming both |

One honest note on that harness: the first run of the two-gateway case returned a live
port instead of 5476, which was a harness artifact — the fake listeners used
`listen(1)` and never accepted, so repeated probes filled the accept queue and later
connects timed out. Re-run with listeners that accept, it refused correctly. That
class of artifact is gone now that discovery no longer connects at all.

Local gates green: 17370 pytest passed, isort / flake8 clean, mypy clean (1.14.1,
CI-parity venv, no faiss). Frontend untouched.

## Screenshots

N/A — no user-visible UI change. The only new user-facing output is a stderr line on
the ambiguous multi-gateway path, asserted in
`test_multiple_owned_markers_refuses_to_guess`:

```
⚠️  Multiple gateways are running (ports 6776, 6777); not guessing which one you
meant — using 5476. Pass --port or set KIROCREW_PORT to target a specific gateway.
```

## Spec

`docs/system-specs/modules/cli.md` gains a **Client Port Resolution** section
documenting all five steps, the ownership-not-reachability and non-forgeable-identity
rationale, the no-acquire constraint on the lock read, the fail-closed behaviour, the
restart port pinning, and the write-always / slack-only marker distinction.
