### PR TITLE
fix(chat): keep the attachment name in generated titles instead of dropping it

### DIFF
--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -28,6 +28,11 @@ _TITLE_MAX_ATTEMPTS = 5
 _TITLE_TEXT_LIMIT = 16_384
 _TITLE_MAX_ATTACHMENT_FILES = 20
 _TITLE_MAX_ATTACHMENT_PATH_LENGTH = 4_096
+# Total budget for ALL substituted attachment labels in one message, and the cap
+# for any single label. Bounded so a message carrying 20 deep paths cannot push
+# the real user text out of the prompt window.
+_TITLE_MAX_ATTACHMENT_LABEL_BUDGET = 80
+_TITLE_MAX_ATTACHMENT_LABEL_LENGTH = _TITLE_MAX_ATTACHMENT_LABEL_BUDGET // 2
 _TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + _TITLE_MAX_ATTACHMENT_FILES * (
     _TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32
 )
@@ -107,18 +112,66 @@ def _strip_markdown_images(content: str, *, drop_trailing_partial: bool = False)
     return "".join(chunks)
 
 
+def _attachment_labels(paths: tuple[str, ...]) -> dict[str, str]:
+    """Map each attachment path to its title label: the trailing path segment.
+
+    Titles keep the name rather than the full path: the path is noise and can
+    leak a directory layout, but the name is usually the whole topic. A label is
+    widened leftwards while it collides, because three files all named
+    ``report.pdf`` would otherwise read as "report.pdf and report.pdf and
+    report.pdf". Mirrors the disambiguation the composer applies to chips.
+    """
+    normalized = {p: p.replace("\\", "/").rstrip("/") for p in paths if p}
+    labels: dict[str, str] = {}
+    for original, norm in normalized.items():
+        segments = [s for s in norm.split("/") if s]
+        if not segments:
+            labels[original] = ""
+            continue
+        depth = 1
+        while depth < len(segments):
+            mine = "/".join(segments[-depth:])
+            clash = any(
+                other != norm
+                and "/".join([s for s in other.split("/") if s][-depth:]) == mine
+                for other in normalized.values()
+            )
+            if not clash:
+                break
+            depth += 1
+        labels[original] = "/".join(segments[-depth:])[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+    return labels
+
+
 def _strip_attached_file_tokens(
     content: str,
     attached_files: tuple[str, ...] = (),
     *,
     drop_trailing_partial: bool = False,
+    labels: dict[str, str] | None = None,
+    budget: list[int] | None = None,
 ) -> str:
-    """Remove dashboard-generated ``[attached_file N] path`` references.
+    """Replace dashboard-generated ``[attached_file N] path`` references.
+
+    The marker and its full path are replaced by the attachment's disambiguated
+    NAME, not dropped. Dropping them left an attachment-only message with no
+    content at all: "compare [attached_file 1] /a/x.txt and [attached_file 2]
+    /b/y.txt" collapsed to "compare   and", and an attachment-only message
+    collapsed to a single space. The titling model correctly answered SKIP for
+    those, so every such chat fell back to a truncated default name. The name
+    preserves the topic while still keeping the full path out of the title.
+
+    ``labels`` maps path -> replacement name (see ``_attachment_labels``); pass
+    ``None`` to keep the historical drop-to-space behaviour. ``budget`` is a
+    single-element list carrying the remaining label allowance, so a message with
+    many attachments substitutes the first few and collapses the rest rather than
+    crowding out the user's own words.
 
     Current dashboard messages store paths in token-index order, making each
     lookup constant-time. The whitespace-delimited fallback preserves support
     for older messages without metadata.
     """
+    remaining = budget if budget is not None else [_TITLE_MAX_ATTACHMENT_LABEL_BUDGET]
     prefix = "[attached_file "
     chunks: list[str] = []
     cursor = 0
@@ -169,7 +222,25 @@ def _strip_attached_file_tokens(
             continue
 
         chunks.append(content[cursor:token_start])
-        chunks.append(" ")
+        # Substitute the attachment's name, not a bare space. `labels=None`
+        # preserves the historical drop for callers that only want the text.
+        if labels is None:
+            label = ""
+        else:
+            label = labels.get(expected_path, "")
+            if not label:
+                # Older message with no metadata: derive the label from whatever
+                # the whitespace scan captured.
+                scanned = content[path_start:path_end].strip()
+                label = scanned.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+                label = label[:_TITLE_MAX_ATTACHMENT_LABEL_LENGTH]
+            if len(label) > remaining[0]:
+                # Budget spent — collapse the rest so the user's own text keeps
+                # its place in the transcript line.
+                label = ""
+            else:
+                remaining[0] -= len(label)
+        chunks.append(f" {label} " if label else " ")
         cursor = path_end
 
     return "".join(chunks)
@@ -189,12 +260,24 @@ def _message_attachment_paths(message: dict[str, Any]) -> tuple[str, ...]:
     )
 
 
-def _title_text(content: str, attached_files: tuple[str, ...] = ()) -> str:
+def _title_text(
+    content: str,
+    attached_files: tuple[str, ...] = (),
+    *,
+    substitute_labels: bool = False,
+) -> str:
     """Return bounded message text suitable for title generation.
 
     A bounded allowance large enough for every accepted attachment is sanitized
     first, so generated paths cannot crowd later user text out of the retained
     title input. The normalized user text is capped separately.
+
+    ``substitute_labels`` replaces each attachment marker with the attachment's
+    disambiguated NAME instead of dropping it. Only the LLM prompt path sets it:
+    the model needs a topic to title, and dropping the markers left it with
+    "compare   and". The FALLBACK title path deliberately leaves it off -- that
+    path is a raw slice of user text with no model to interpret it, so a bare
+    filename reads worse than the "New session" label it already falls back to.
     """
     source_was_truncated = len(content) > _TITLE_SOURCE_SCAN_LIMIT
     content = content[:_TITLE_SOURCE_SCAN_LIMIT]
@@ -205,6 +288,8 @@ def _title_text(content: str, attached_files: tuple[str, ...] = ()) -> str:
         content,
         attached_files,
         drop_trailing_partial=source_was_truncated,
+        labels=_attachment_labels(attached_files) if substitute_labels else None,
+        budget=[_TITLE_MAX_ATTACHMENT_LABEL_BUDGET],
     )
     return " ".join(content.split())[:_TITLE_TEXT_LIMIT]
 
@@ -214,7 +299,9 @@ def _build_title_prompt(messages: list[dict[str, Any]]) -> str | None:
     lines: list[str] = []
     for m in messages[:10]:
         role = m.get("role", "")
-        content = _title_text(m.get("content", ""), _message_attachment_paths(m))
+        content = _title_text(
+            m.get("content", ""), _message_attachment_paths(m), substitute_labels=True
+        )
         if role in ("user", "assistant") and content:
             lines.append(f"{role}: {content[:200]}")
     if not lines:

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -83,6 +83,87 @@ def test_prompt_strips_non_image_attachment_before_truncation():
     assert "/uploads/" not in prompt
 
 
+def test_prompt_substitutes_attachment_name_from_metadata():
+    """The NAME survives; the directory path does not.
+
+    Previously the marker and path were replaced by a bare space, so an
+    attachment-only or attachment-dominated message lost its topic entirely and
+    the titling model answered SKIP. The basename is the topic, so it is kept --
+    the full path is still stripped.
+    """
+    path = "/Users/example/uploads/quarterly report final.txt"
+    prompt = _build_title_prompt(
+        [
+            {
+                "role": "user",
+                "content": f"[attached_file 1] {path}\nsummarize the findings",
+                "meta": {"files": [path]},
+            }
+        ]
+    )
+
+    assert prompt is not None
+    assert "summarize the findings" in prompt
+    assert "quarterly report final.txt" in prompt, "the attachment name is the topic"
+    assert "/Users/example/uploads" not in prompt, "the directory path must not leak"
+    assert "attached_file" not in prompt
+
+
+def test_multi_attachment_message_keeps_a_titleable_sentence():
+    """`compare A and B` must not collapse to `compare and`."""
+    prompt = _build_title_prompt(
+        [
+            {
+                "role": "user",
+                "content": "compare [attached_file 1] /a/x.txt and [attached_file 2] /b/y.txt",
+                "meta": {"files": ["/a/x.txt", "/b/y.txt"]},
+            }
+        ]
+    )
+
+    assert prompt is not None
+    assert "x.txt" in prompt and "y.txt" in prompt
+    assert "compare" in prompt
+
+
+def test_colliding_attachment_names_are_disambiguated():
+    """Three `report.pdf` would read as `report.pdf and report.pdf`."""
+    files = ["/q3/report.pdf", "/q4/report.pdf"]
+    prompt = _build_title_prompt(
+        [
+            {
+                "role": "user",
+                "content": "diff [attached_file 1] /q3/report.pdf vs [attached_file 2] /q4/report.pdf",
+                "meta": {"files": files},
+            }
+        ]
+    )
+
+    assert prompt is not None
+    assert "q3/report.pdf" in prompt
+    assert "q4/report.pdf" in prompt
+
+
+def test_attachment_label_budget_is_bounded():
+    """Many deep attachments must not crowd out the user's own words."""
+    files = [f"/very/deep/directory/tree/file-number-{i:02d}.txt" for i in range(20)]
+    markers = " ".join(f"[attached_file {i + 1}] {p}" for i, p in enumerate(files))
+    prompt = _build_title_prompt(
+        [
+            {
+                "role": "user",
+                "content": f"{markers} please summarize everything",
+                "meta": {"files": files},
+            }
+        ]
+    )
+
+    assert prompt is not None
+    assert "please summarize everything" in prompt, "user text must survive the labels"
+    # Budget is 80 chars total; 20 labels of ~22 chars each would be ~440.
+    assert prompt.count("file-number-") <= 4
+
+
 def test_prompt_strips_non_image_attachment_path_with_spaces_from_metadata():
     path = "/Users/example/uploads/quarterly report final.txt"
     prompt = _build_title_prompt(
@@ -97,7 +178,7 @@ def test_prompt_strips_non_image_attachment_path_with_spaces_from_metadata():
 
     assert prompt is not None
     assert "summarize the findings" in prompt
-    assert "quarterly report final.txt" not in prompt
+    assert "/Users/example/uploads" not in prompt
 
 
 def test_title_text_bounds_source_scanning():
@@ -161,7 +242,11 @@ def test_prompt_strips_mixed_attachments_and_keeps_caption():
     assert prompt is not None
     assert "compare these outputs" in prompt
     assert "screenshot.png" not in prompt
-    assert "results.csv" not in prompt
+    # No `meta` on this message, so the label comes from the whitespace-scan
+    # fallback. The name is kept (it is the topic); images stay dropped because
+    # they carry no textual topic.
+    assert "results.csv" in prompt
+    assert "/tmp/results.csv" not in prompt
 
 
 def test_prompt_preserves_escaped_and_code_quoted_markdown_images():


### PR DESCRIPTION
## Problem

A message dominated by file attachments loses its topic before the titling model ever sees it. `_strip_attached_file_tokens` replaced each `[attached_file N] /path` marker with a bare space:

| input | what the model received |
|---|---|
| `compare [attached_file 1] /a/x.txt and [attached_file 2] /b/y.txt` | `compare   and` |
| `[attached_file 1] /a/notes.txt` | `" "` |
| `tell me about [attached_file 1] /repo/docs/quarterly report.pdf` | `tell me about` |

(Verified by running `main`'s own `_strip_attached_file_tokens` against these inputs.)

The model correctly answers SKIP for text like that — there is nothing to title. So the chat falls back to a truncated default name.

## Why it matters

Attaching a file and saying little else is a normal way to start a chat: drop in a log, a CSV, a report, and ask "what's wrong here". Those are exactly the sessions that end up unnamed in the sidebar, which is where the user most needs a name to find them again. The attachment's filename is usually the entire topic, and it was the one thing being thrown away.

## Fix (symptom → root cause → change)

Symptom: attachment-dominated chats get default/truncated titles.

Root cause: the strip step is shared between "remove the path so it can't leak into a title" and "remove the marker so the text reads naturally". Those want different things. Collapsing both to a space satisfied the first and destroyed the second.

Change: substitute the attachment's **name** rather than dropping it. The directory path is still stripped (it is noise and can leak a tree layout); only the trailing segment survives. Names are widened leftwards while they collide, so two `report.pdf` become `q3/report.pdf` and `q4/report.pdf` rather than reading as "report.pdf and report.pdf". A shared 80-character budget caps total substituted label text per message so 20 deep paths cannot crowd out the user's own words — labels past the budget collapse to a space, as before.

Deliberately scoped to the **LLM prompt path** via a `substitute_labels` flag. The **fallback** title path keeps the old drop behaviour: it is a raw slice of user text with no model to interpret it, so a bare filename there reads worse than the `New session` label it already falls back to. The two fallback-path tests are untouched, which is the evidence that path kept its semantics.

## Tests

Four new cases in `test/test_chat_title.py`:

- metadata-backed substitution keeps the name, still drops the directory
- `compare A and B` stays a titleable sentence
- colliding names disambiguate to distinct labels
- the label budget bounds total label text while preserving the user's words

All four fail with `substitute_labels=False` (revert-verified).

Three existing tests asserted the old drop-to-space behaviour and were updated to the new contract — including one that explicitly asserted the basename must *not* appear. Those assertions encoded the bug.

215 backend tests pass across `test_chat_title.py`, `test_pending_title.py`, `test_chat_steer.py`, and `test_history.py`. flake8, mypy, and isort clean.

## Manual verification

N/A — unit coverage is sufficient. This is pure text transformation with no I/O; the titling model call itself is unchanged.

## Screenshots

N/A — no UI change. The visible difference is the generated session title text, covered by the tests above.

## Context

Extracted from #505, where this was found and fixed while building folder references (folders made the bug more visible, but it affects file attachments on `main` today). It stands alone, fixes a live defect, and is small enough to review on its own.

One of three independent fixes carved out of #505, all against `main`:

- #534 — attachment chip label uniqueness (**merged**)
- **#537 — this PR:** generated titles keep the attachment name
- #538 — cancel / failed-slot-creation attachment restore

The three are independent: no ordering constraint, no shared files except `fileTokens.ts` between #534 and #538 (different functions), and each is separately revertible.

