### PR TITLE
fix(chat): restore attachments losslessly on cancel and failed slot creation

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -43,7 +43,7 @@ import ThinkingBlock from './chat/ThinkingBlock'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
+import { parseFiles, parseFilesChecked, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments, stripAttachmentMarkers, mergeStagedFiles } from '../utils/fileTokens'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
@@ -615,6 +615,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // declared AFTER those effects so a batched keystroke+switch can't smear one
   // slot's draft onto another. See that advance effect for the full rationale.
   const composerSlotRef = useRef(activeSlot)
+  // Slot whose draft persistence is PAUSED because a send from it is in flight
+  // (two-phase commit). While set, the persist effects and the slot-switch /
+  // unmount / beforeunload flushes must not write this slot's draft: the
+  // composer has been cleared for UX, and persisting that empty state would
+  // destroy the draft copy that a failed slot creation relies on. The draft is
+  // deleted explicitly at commit (send succeeded) and left untouched on
+  // failure -- there is no "restore" step, because nothing was destroyed.
+  const pausedPersistSlotRef = useRef<string | null>(null)
+  // True for exactly the duration of the deferred `createSlot` await in send().
+  // Distinct from sendingRef (which also gates the welcome view and stays set
+  // through the HTTP POST): this one exists solely to serialize the create
+  // window, because the one-shot new-session intent is still armed while it is
+  // pending and a concurrent send would create a second, hidden slot.
+  const creatingSlotRef = useRef(false)
   const [input, setInput] = useState(() => activeSlot ? drafts.current[activeSlot] ?? '' : '')
 
   // History suggestions ("Continue a previous chat?") shown above the input on the welcome screen.
@@ -951,7 +965,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
   // Persist the composer text against the slot it BELONGS to (composerSlotRef),
   // not the live activeSlot (see the composerSlotRef note above).
-  useEffect(() => { inputRef.current = input; const s = composerSlotRef.current; if (s) { setDraft(drafts.current, s, input); saveDraftsDebounced() } }, [input, saveDraftsDebounced]) // eslint-disable-line react-hooks/exhaustive-deps -- draft key is composerSlotRef; slot-change effect handles the transition
+  useEffect(() => { inputRef.current = input; const s = composerSlotRef.current; if (s && s !== pausedPersistSlotRef.current) { setDraft(drafts.current, s, input); saveDraftsDebounced() } }, [input, saveDraftsDebounced]) // eslint-disable-line react-hooks/exhaustive-deps -- draft key is composerSlotRef; slot-change effect handles the transition
   // Per-slot draft: save current → restore target (persisted to localStorage)
   useEffect(() => {
     // Re-hydrate from localStorage — only pull in keys we don't already have
@@ -962,9 +976,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     for (const [k, v] of Object.entries(storedFiles)) { if (!(k in fileDrafts.current)) fileDrafts.current[k] = v }
     const storedPastes = loadPasteDrafts()
     for (const [k, v] of Object.entries(storedPastes)) { if (!(k in pasteDrafts.current)) pasteDrafts.current[k] = v }
-    if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
-    if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
-    if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+    if (prevSlot.current && prevSlot.current !== pausedPersistSlotRef.current) {
+      setDraft(drafts.current, prevSlot.current, inputRef.current)
+      setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+      setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+    }
     prevSlot.current = activeSlot
     const raw = sessionStorage.getItem(PREFILL_STORAGE_KEY)
     const draftFallback = activeSlot ? drafts.current[activeSlot] ?? '' : ''
@@ -993,17 +1009,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // Persist drafts on unmount (navigating away from chat page)
   useEffect(() => () => {
     if (saveDraftsTimer.current) { clearTimeout(saveDraftsTimer.current); saveDraftsTimer.current = null }
-    if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
-    if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
-    if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+    if (prevSlot.current && prevSlot.current !== pausedPersistSlotRef.current) {
+      setDraft(drafts.current, prevSlot.current, inputRef.current)
+      setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+      setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+    }
     flushDrafts()
   }, [flushDrafts])
   // Flush pending draft save on tab close / refresh (debounce may not fire)
   useEffect(() => {
     const h = () => {
-      if (prevSlot.current) setDraft(drafts.current, prevSlot.current, inputRef.current)
-      if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
-      if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+      if (prevSlot.current && prevSlot.current !== pausedPersistSlotRef.current) {
+        setDraft(drafts.current, prevSlot.current, inputRef.current)
+        setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
+        setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
+      }
       flushDrafts()
     }
     window.addEventListener('beforeunload', h)
@@ -1039,7 +1059,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     pendingFilesRef.current = pendingFiles
     // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
     const s = composerSlotRef.current
-    if (s) {
+    if (s && s !== pausedPersistSlotRef.current) {
       setFileDraft(fileDrafts.current, s, pendingFiles)
       saveDraftsDebounced()
     }
@@ -1057,7 +1077,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // them alongside the text draft (mirrors the pendingFiles effect above).
     // Key off composerSlotRef, not activeSlot (see the composerSlotRef note).
     const s = composerSlotRef.current
-    if (s) {
+    if (s && s !== pausedPersistSlotRef.current) {
       setPasteDraft(pasteDrafts.current, s, pasteBlocks)
       saveDraftsDebounced()
     }
@@ -1947,12 +1967,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // message with no recovery path is the offline-UX regression we're
     // guarding against. Cheap belt-and-braces.
     if (!connected) return
+    // Re-entrancy guard for the deferred-create window. `forceNew` is read in
+    // Phase 1 and only consumed at COMMIT, so while a slow createSlot is
+    // awaiting, newSessionRef is still armed: a second send during that window
+    // took the create branch again and spawned a SECOND slot. Only the first
+    // one is activated, so the second prompt executed in a hidden, contextless
+    // session the user never sees. Serialize instead: creatingSlotRef covers
+    // exactly the create window and is cleared on both outcomes, so this
+    // rejects only an overlapping send, never an ordinary back-to-back one.
+    // Bail BEFORE the composer clear so the rejected attempt loses nothing --
+    // the text stays put and Enter works again once the slot exists.
+    if (creatingSlotRef.current) return
     const raw = (optionText || inputRef.current).trim()
- // Capture + clear the widget-origin tag: attribute this
+ // Capture the widget-origin tag: attribute this
     // turn to a widget only if the composer still carries the exact text a
-    // widget action pre-filled. Cleared on every send so it can't go stale.
+    // widget action pre-filled. CONSUMED AT COMMIT, not here -- a failed slot
+    // creation must leave the provenance armed so the retry still carries
+    // meta.origin='widget' (dropping it silently upgraded a widget-driven
+    // prompt to an unattended user prompt).
     const widgetOrigin = !!widgetPrefillRef.current && raw.includes(widgetPrefillRef.current)
-    widgetPrefillRef.current = null
     if (!raw && !pendingFilesRef.current.length) return
 
     // The session actually on screen at send time. Read from the ref (fresh
@@ -1968,6 +2001,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     const slashResult = await interceptSlashCommand(raw, uiSlot, dispatch)
     if (slashResult.intercepted) {
       if (!optionText) { setInput(''); setPasteBlocks([]) }
+      // An interception CONSUMES the composer without reaching commit, so the
+      // widget-origin seed must be released here too. Leaving it armed meant a
+      // later, unrelated prompt that happened to contain the widget's text was
+      // falsely attributed to a widget.
+      if (widgetOrigin) widgetPrefillRef.current = null
       return
     }
 
@@ -1976,6 +2014,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     if (kq && !optionText) {
       knowledgeFetchRef.current.searchKnowledge(kq)
       setInput('')
+      if (widgetOrigin) widgetPrefillRef.current = null
       return
     }
 
@@ -1991,13 +2030,38 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       knowledgeBlock = knowledgeFetchRef.current.pendingKnowledge
       llmTxt = expandKnowledgeBlock(knowledgeBlock) + '\n' + llmTxt
     }
-    knowledgeFetchRef.current.clearPending()
+    // NOTE: `clearPending()` is deliberately NOT called here. It used to run
+    // before the snapshot below, so a rejected slot creation restored the prompt
+    // WITHOUT its selected knowledge context -- the chip was already gone and the
+    // user had to re-pick it. It is cleared only once the send is committed.
     const bubblePastes = pruneBlocksUtil(displayTxt, activePastes)
     if (bubblePastes.length) saveStoredPaste(llmTxt, displayTxt, bubblePastes, filePaths)
 
     setPrefillHint(false)
+    // ── Two-phase commit ────────────────────────────────────────────────────
+    // Phase 1 (here, before any await): consume NOTHING destructive. The live
+    // composer is cleared for UX, but draft persistence for the origin slot is
+    // PAUSED first, so the clear cannot propagate into the draft store. The
+    // one-shot refs (newSessionRef, knowledge pending) are READ here but only
+    // consumed at commit. On failure there is nothing to restore -- the draft
+    // store and one-shot state were never touched.
+    //
+    // This replaces a snapshot-and-restore approach that went through five
+    // review rounds of races: every restore had to compare against LIVE state
+    // (activeSlotRef, drafts.current) which moves during the await -- slot
+    // switches, typing, persist effects, slot activation. Not destroying state
+    // removes the reconstruction problem instead of guarding it.
+    const pendingSend = {
+      originSlot: uiSlot,
+      raw,
+      files: pendingFilesRef.current.slice(),
+      pastes: activePastes.map(b => ({ ...b })),
+      // Read, not consumed: reset only at commit.
+      forceNew: !targetSlot && newSessionRef.current,
+    }
+    if (!optionText && uiSlot) pausedPersistSlotRef.current = uiSlot
     if (!optionText) {
-      setInput(''); setPendingFiles([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
+      setInput(''); setPendingFiles([]); setPasteBlocks([])
       // The challenge-handoff prompt is seeded into PREFILL_STORAGE_KEY and the
       // slot-restore effect re-applies it on slot changes. Once that prompt is
       // sent, clear the seed so a later slot-restore can't re-fill the (now
@@ -2008,23 +2072,86 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // not the stale closure `activeSlot`. See the uiSlot note above.
     let slot = targetSlot ?? uiSlot
     // Only a normal (non-targeted) send consumes the one-shot "new session"
-    // intent. A targeted send — e.g. submitting document comments to the
-    // document's origin slot — must leave it intact for the user's next send.
-    let forceNew = false
-    if (!targetSlot) {
-      forceNew = newSessionRef.current
-      newSessionRef.current = false
-    }
+    // intent -- and only at COMMIT (below), never here: a failed create must
+    // leave the intent armed, without any give-it-back logic that could re-arm
+    // it for the wrong slot.
+    const forceNew = pendingSend.forceNew
     if (!slot || forceNew) {
       sendingRef.current = true;
-      const result = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap();
+      creatingSlotRef.current = true;
+      let result: { key: string }
+      try {
+        result = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap();
+      } catch (e: unknown) {
+        // Slot creation failed. NOTHING was destroyed: the draft store still
+        // holds the origin slot's text/files/pastes (persistence was paused
+        // before the clear, so the empty composer never overwrote it), and the
+        // one-shot refs (newSessionRef, knowledge pending, widget prefill seed)
+        // were never consumed. Un-pause and re-fill the live composer as a
+        // courtesy when the user is still there and has not typed anything new;
+        // otherwise the ordinary draft-hydration on slot return recovers it.
+        sendingRef.current = false
+        creatingSlotRef.current = false
+        pausedPersistSlotRef.current = null
+        const stillThere = pendingSend.originSlot === activeSlotRef.current
+        // "Untouched" = the user typed nothing new since the send. Staged files
+        // do NOT count as touching: an option/auto send leaves pendingFiles
+        // uncleared (they were part of THIS send's payload), so checking them
+        // here wrongly suppressed the re-fill for exactly those sends. New text
+        // is the only thing the re-fill could clobber; files are re-staged from
+        // the pending send itself.
+        const untouched = !inputRef.current.trim()
+        if (stillThere && untouched) {
+          setInput(optionText || pendingSend.raw)
+          // MERGE, not replace: a slow create leaves the composer usable, so
+          // the user can stage another attachment while it is pending.
+          // Assigning the snapshot wholesale dropped that newer file. Snapshot
+          // order first (it is the payload's order), then anything staged since,
+          // de-duplicated by path.
+          setPendingFiles(mergeStagedFiles(pendingSend.files, pendingFilesRef.current))
+          setPasteBlocks(pendingSend.pastes)
+        }
+        // Do NOT re-throw. send() has FIVE call sites (onSend, follow-up send,
+        // quick-send, comment submit, auto-send effect) and most are
+        // fire-and-forget, so re-throwing produced unhandled promise rejections
+        // -- which is what broke CI on 42a22a0c. Nothing was lost, so there is
+        // nothing a caller could usefully do with the error.
+        // eslint-disable-next-line no-console -- surface the swallowed failure
+        console.error('slot creation failed; draft preserved', e)
+        return
+      }
       slot = result.key;
+      creatingSlotRef.current = false
       if (pendingProjectRef.current) {
         await api.chatSlotProject(result.key, pendingProjectRef.current).catch(e => {
           // eslint-disable-next-line no-console -- surface project-assign failures for debugging
           console.error('chatSlotProject failed', e)
         })
       }
+    }
+    // Phase 2 -- COMMIT. Slot creation succeeded (or was not needed): now, and
+    // only now, consume everything Phase 1 staged. All actions key off
+    // pendingSend.originSlot, never live state -- clearing the origin slot's
+    // draft and knowledge selection is correct whether or not the user has
+    // switched away, and keying off live state is what produced both wrong-slot
+    // bugs in review.
+    if (forceNew) newSessionRef.current = false
+    // Consume the widget-origin seed now that the send is committed (see the
+    // capture note at the top of send()).
+    widgetPrefillRef.current = null
+    // Consume the knowledge block only if it is still the SAME selection we
+    // serialized into this send (identity check). If the user picked fresh
+    // knowledge while the create was awaiting, that selection belongs to their
+    // NEXT send and must survive this commit.
+    if (knowledgeFetchRef.current.pendingKnowledge === knowledgeBlock) {
+      knowledgeFetchRef.current.clearPending()
+    }
+    if (!optionText && pendingSend.originSlot) {
+      pausedPersistSlotRef.current = null
+      delete drafts.current[pendingSend.originSlot]
+      delete fileDrafts.current[pendingSend.originSlot]
+      delete pasteDrafts.current[pendingSend.originSlot]
+      saveDrafts()
     }
     setPendingAgent(''); setPendingModel(''); setPendingProject('')
     // Build meta for persistence (knowledge, files, pastes)
@@ -2107,11 +2234,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const submitComments = useCallback((message: string) => {
     const target = tabsCtl.activeTab?.slot ?? null
     if (target && target !== activeSlot) dispatch(switchSlot(target))
-    send(message, target ?? undefined)
+    void send(message, target ?? undefined)
   }, [tabsCtl.activeTab, activeSlot, dispatch, send])
 
   // Auto-send when navigated with ?autoSend=1 or ?token= with prompt
-  useEffect(() => { if (connected && autoSendRef.current) { const txt = autoSendRef.current; autoSendRef.current = null; send(txt) } }, [send, connected, autoSendTick])  
+  useEffect(() => {
+    if (!connected || !autoSendRef.current) return
+    const txt = autoSendRef.current
+    autoSendRef.current = null
+    void send(txt)
+  }, [send, connected, autoSendTick])
 
   // Widget interactivity: when a mcwidget iframe fires an action, PRE-FILL the
  // composer instead of auto-submitting. Auto-send was a
@@ -2668,7 +2800,42 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const handleCancelQueued = useCallback((queueId: string) => {
     if (!activeSlot) return
     const msg = messagesRef.current.find(m => m.role === 'queued' && (m.meta?.queueId as string) === queueId)
-    if (msg?.content) setInput(msg.content)
+    if (msg?.content) {
+      // The card holds the SERIALIZED text (`[attached_file N] /path`), so
+      // dropping it straight into the composer shows the raw marker and
+      // re-serializes it on resend, doubling the marker.
+      //
+      // De-tokenizing needs the ORDERED attachment list, and a queued card does
+      // not have one: every producer sets `meta` to exactly `{ queueId }` (the
+      // backend `queue` payload carries only `{id, content}`). Recovering the
+      // paths by scanning the marker text is whitespace-bounded and therefore
+      // lossy -- a spaced path is truncated, the marker half-strips, and the
+      // truncated prefix would be staged as a phantom attachment.
+      //
+      // So: strip ONLY when the paths are exact (real `meta.files`). Otherwise
+      // leave the content verbatim -- a visible raw marker the user can edit is
+      // strictly better than mangled text plus an attachment pointing nowhere.
+      // The real fix is propagating `meta.files` through queue storage, the WS
+      // payload and hydration; that is a backend change and is #505's scope.
+      // This branch is already correct for the day that lands: it consumes
+      // whatever ordered list the card carries and gates on its exactness, so
+      // #505 widens the contract without touching this code.
+      const { files, exact } = parseFilesChecked(
+        msg.content,
+        msg.meta as Record<string, unknown> | undefined,
+      )
+      if (exact) {
+        setInput(stripAttachmentMarkers(msg.content, files))
+        // Replace rather than merge: restoring a cancelled message takes over the
+        // composer's attachments, so keeping the current ones made them ride
+        // along on the resend. Only reached when `files` is non-empty.
+        setPendingFiles(files.filter(Boolean))
+      } else {
+        // Never clear staged attachments here: the user may have staged unrelated
+        // files while the turn was running, and dropping them has no undo.
+        setInput(msg.content)
+      }
+    }
     // Optimistically remove the card; WS event is a no-op if already gone
     dispatch(cancelQueuedMessage({ slot: activeSlot, queue_id: queueId }))
     api.cancelQueuedMessage(activeSlot, queueId).catch(() => {})

--- a/website/src/test/ChatPage.widgetPrefill.test.tsx
+++ b/website/src/test/ChatPage.widgetPrefill.test.tsx
@@ -149,4 +149,39 @@ describe('ChatPage widget action pre-fill', { timeout: 15_000 }, () => {
     const metaArg = vi.mocked(api.sendChat).mock.calls[0][4]
     expect(metaArg === undefined || metaArg.origin !== 'widget').toBe(true)
   })
+
+  it('releases the widget seed when a knowledge interception consumes the composer', async () => {
+    // The provenance seed is consumed at COMMIT so a failed slot creation leaves
+    // a retry still attributable to the widget. But an INTERCEPTION (slash
+    // command, @knowledge prefix) consumes the composer and returns before
+    // commit — leaving the seed armed there meant a later, unrelated prompt
+    // that merely CONTAINED the widget's text was falsely tagged widget-origin.
+    const store = makeStore('slot-w', [{ key: 'slot-w' }])
+    await renderAndWaitForInput(store)
+
+    // Widget pre-fills, then the user replaces it with a knowledge query that
+    // still contains the seeded text. The interception eats this send.
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc-widget-send', { detail: { text: 'deploy' } }))
+    })
+    const ta = await waitFor(() => screen.getByLabelText('Message input') as HTMLTextAreaElement)
+    await waitFor(() => expect(ta.value).toContain('deploy'))
+    fireEvent.change(ta, { target: { value: '@knowledge deploy' } })
+    await act(async () => { fireEvent.keyDown(ta, { key: 'Enter' }) })
+    expect(api.sendChat, 'a knowledge query must not reach the server').not.toHaveBeenCalled()
+
+    // A genuinely user-authored follow-up that happens to contain 'deploy'.
+    fireEvent.change(
+      screen.getByLabelText('Message input'),
+      { target: { value: 'now deploy it for real' } },
+    )
+    await act(async () => { fireEvent.keyDown(screen.getByLabelText('Message input'), { key: 'Enter' }) })
+
+    await waitFor(() => expect(api.sendChat).toHaveBeenCalled())
+    const metaArg = vi.mocked(api.sendChat).mock.calls[0][4]
+    expect(
+      metaArg === undefined || metaArg.origin !== 'widget',
+      'a plain user turn after an interception must not inherit widget provenance',
+    ).toBe(true)
+  })
 })

--- a/website/src/test/ChatPageDrafts.test.tsx
+++ b/website/src/test/ChatPageDrafts.test.tsx
@@ -10,7 +10,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from '../hooks/useTheme'
-import chatReducer, { setActiveSlot, switchSlot, createSlot } from '../store/chatSlice'
+import chatReducer, { setActiveSlot, switchSlot, createSlot, appendQueuedMessage } from '../store/chatSlice'
 import dashboardReducer from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
 
@@ -37,6 +37,7 @@ vi.mock('../api/client', () => ({
     setSlotColor: vi.fn().mockResolvedValue({ ok: true }),
     setSlotFolder: vi.fn().mockResolvedValue({ ok: true }),
     chatSlotProject: vi.fn().mockResolvedValue({ ok: true }),
+    cancelQueuedMessage: vi.fn().mockResolvedValue({ ok: true }),
   },
   SEARCH_MIN_CHARS: 2,
 }))
@@ -421,6 +422,331 @@ describe('ChatPage draft persistence', { timeout: 15_000 }, () => {
       expect(pasteDrafts['slot-a']).toBeTruthy()
       expect(pasteDrafts['slot-a'][0].content).toBe(pasted)
     })
+  })
+
+  it('preserves the user content when slot creation is rejected mid-send', async () => {
+    // Two-phase commit contract: a send PAUSES draft persistence for the origin
+    // slot before clearing the live composer, and destroys nothing until the
+    // send commits. A rejected createSlot therefore needs no restore logic --
+    // the draft store was never touched -- and the live composer is re-filled
+    // as a courtesy when the user is still there.
+    //
+    // Driven through the chat-launch intent (useChatLauncher writes
+    // window.__mc_chat_launch; ChatPage consumes it on mount and sets
+    // newSessionRef), the app's own seam for "create a slot and send this".
+    const { api } = await import('../api/client')
+    const createMock = vi.mocked(api.createChatSlot)
+    createMock.mockRejectedValueOnce(new Error('slot creation failed'))
+
+    const launchWindow = window as Window & {
+      __mc_chat_launch?: { ts: number; message: string }
+    }
+    launchWindow.__mc_chat_launch = { ts: Date.now(), message: 'text I do not want to lose' }
+
+    // A file staged in the origin slot's draft BEFORE the send. An uncommitted
+    // send must leave it untouched (no clear runs for an optionText send, and
+    // commit never runs on rejection).
+    sessionStorage.setItem('mc-chat-file-drafts', JSON.stringify({ 'slot-a': ['/staged/keep.png'] }))
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    await waitFor(() => expect(createMock).toHaveBeenCalled())
+
+    // The rejection leaves the text visible in the live composer (the courtesy
+    // re-fill: same slot, nothing typed since).
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText('Message input') as HTMLTextAreaElement).value,
+        'a rejected slot creation must leave the text visible for retry',
+      ).toBe('text I do not want to lose')
+    })
+    // ...and the file draft was never destroyed: no commit ran, so the draft
+    // store was never touched. Under snapshot-and-restore this assertion was
+    // impossible to make meaningful -- restores raced the persist effects.
+    const fd = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+    expect(
+      fd['slot-a'],
+      'the staged file draft must survive an uncommitted send',
+    ).toEqual(['/staged/keep.png'])
+  })
+
+  it('a rejection landing after a slot switch leaves the origin draft intact', async () => {
+    // Send from slot-a, switch to slot-b while the create is pending, THEN the
+    // rejection lands. The courtesy re-fill is correctly suppressed (user is on
+    // slot-b), and slot-a's drafts must be byte-identical to pre-send.
+    //
+    // COVERAGE NOTE, stated honestly: this drives an optionText (auto-send)
+    // send, which never clears the composer, so the persistence PAUSE is a
+    // no-op on this path and deleting it does not fail this test. The pause
+    // protects normal composer sends, whose createSlot branch requires the New
+    // Chat intent -- not reachable from this harness. What this test DOES lock
+    // in: an uncommitted send destroys nothing, even when the rejection lands
+    // on a different slot than it started from.
+    const { api } = await import('../api/client')
+    let rejectCreate!: (e: Error) => void
+    const deferred = new Promise<{ key: string; title: string; messages: number; running: boolean }>(
+      (_r, rej) => { rejectCreate = rej },
+    )
+    vi.mocked(api.createChatSlot).mockReturnValueOnce(deferred as ReturnType<typeof api.createChatSlot>)
+
+    const launchWindow = window as Window & {
+      __mc_chat_launch?: { ts: number; message: string }
+    }
+    launchWindow.__mc_chat_launch = { ts: Date.now(), message: 'origin slot text' }
+    sessionStorage.setItem('mc-chat-file-drafts', JSON.stringify({ 'slot-a': ['/origin/file.png'] }))
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }, { key: 'slot-b' }])
+    await renderAndWaitForInput(store)
+    await waitFor(() => expect(api.createChatSlot).toHaveBeenCalled())
+
+    // User gives up and switches to slot-b while the create is still pending.
+    await act(async () => { await store.dispatch(switchSlot('slot-b')) })
+
+    // Now the rejection lands.
+    await act(async () => {
+      rejectCreate(new Error('slot creation failed'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // slot-a's text and file drafts must be exactly what they were pre-send.
+    await waitFor(() => {
+      const fd = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(
+        fd['slot-a'],
+        'the origin file draft must survive a rejection that lands after a switch',
+      ).toEqual(['/origin/file.png'])
+    })
+    const td = JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')
+    expect(
+      td['slot-a'] ?? 'origin slot text',
+      'the origin text draft must not have been overwritten with the empty clear',
+    ).toBe('origin slot text')
+  })
+
+  it('a rejected COMPOSER send preserves the persisted text, files and pastes', async () => {
+    // This is the path the persistence PAUSE actually protects, and the one the
+    // first two rejection tests could not reach: an ordinary composer send
+    // (no optionText) CLEARS the composer, so without the pause the persist
+    // effects — and the slot-switch flush — write that empty state straight
+    // into the draft store and the user's text/files/pastes are gone for good.
+    //
+    // Reaching it needs `newSessionRef` armed on a composer send. The seam is
+    // the app's own behavior: a REJECTED new-session send leaves the one-shot
+    // intent armed on purpose (that is the two-phase-commit contract), so the
+    // user's next keystroke-driven send still takes the createSlot branch.
+    // First rejection arms it; the second (deferred) rejection is under test.
+    //
+    // The user then switches AWAY before the rejection lands, which suppresses
+    // the courtesy live re-fill. That matters for falsifiability: with the
+    // re-fill in play the restored text is re-persisted, masking the loss. With
+    // the user on another slot, only the pause stands between the composer
+    // clear and the draft store.
+    //
+    // Revert-verified: removing the pause guard from the slot-switch /
+    // unmount / beforeunload flushes fails this test, as does removing all six
+    // guards. Removing ONLY the live text-persist-effect guard still passes —
+    // on this path the outgoing-slot flush is the write that destroys the
+    // draft. The live-effect guards are defence for other orderings and are
+    // not claimed as covered here.
+    const { api } = await import('../api/client')
+    const createMock = vi.mocked(api.createChatSlot)
+    // Call counts are cumulative across this file (no global clearMocks), so
+    // assert on the delta from where this test starts.
+    const baseCalls = createMock.mock.calls.length
+    createMock.mockRejectedValueOnce(new Error('slot creation failed'))
+    let rejectSecond!: (e: Error) => void
+    const deferred = new Promise<{ key: string; title: string; messages: number; running: boolean }>(
+      (_r, rej) => { rejectSecond = rej },
+    )
+    createMock.mockReturnValueOnce(deferred as ReturnType<typeof api.createChatSlot>)
+
+    const launchWindow = window as Window & {
+      __mc_chat_launch?: { ts: number; message: string }
+    }
+    launchWindow.__mc_chat_launch = { ts: Date.now(), message: 'arming send' }
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }, { key: 'slot-b' }])
+    await renderAndWaitForInput(store)
+    await waitFor(() => expect(createMock.mock.calls.length).toBe(baseCalls + 1))
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    // Clear the courtesy re-fill from the arming send, then compose fresh:
+    // typed text plus a pasted block.
+    fireEvent.change(input, { target: { value: '' } })
+    await act(async () => {
+      fireEvent.paste(input, {
+        clipboardData: { items: [], getData: (t: string) => (t === 'text' ? 'p1\np2\np3\np4' : '') },
+      })
+    })
+    await waitFor(() => expect(input.value).toMatch(/\[ Paste #1 · 4 lines \]/))
+    fireEvent.change(input, { target: { value: `keep this text ${input.value}` } })
+    // Let the debounced persist land the composed draft before the send.
+    await waitFor(() => {
+      const td = JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')
+      expect(td['slot-a'] ?? '').toContain('keep this text')
+    }, { timeout: 3000 })
+
+    // Second send: keystroke-driven, so the composer clear runs.
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+    await waitFor(() => expect(createMock.mock.calls.length).toBe(baseCalls + 2))
+    expect(
+      (screen.getByLabelText('Message input') as HTMLTextAreaElement).value,
+      'a composer send must clear the live composer (this is the destructive path)',
+    ).toBe('')
+
+    // User switches away while the create is still pending, then it rejects.
+    await act(async () => { await store.dispatch(switchSlot('slot-b')) })
+    await act(async () => {
+      rejectSecond(new Error('slot creation failed again'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // slot-a's persisted text and paste drafts must be exactly what they were
+    // before the send: the clear was never allowed to reach the draft store.
+    const td = JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')
+    expect(
+      td['slot-a'] ?? '',
+      'the pause must stop the composer clear from erasing the persisted text draft',
+    ).toContain('keep this text')
+    const pd = JSON.parse(localStorage.getItem('mc-chat-paste-drafts') || '{}')
+    expect(
+      pd['slot-a']?.[0]?.content,
+      'the pasted block backing the preserved token must survive',
+    ).toBe('p1\np2\np3\np4')
+  })
+
+  it('a rejection keeps a file staged DURING the slow create', async () => {
+    // The composer stays usable while a create is pending, so the user can
+    // attach another file. Re-filling with the payload snapshot wholesale
+    // replaced the live list and that newer attachment vanished — silently, with
+    // no undo. The re-fill must MERGE: snapshot order first, then anything
+    // staged since.
+    const { api } = await import('../api/client')
+    const createMock = vi.mocked(api.createChatSlot)
+    const baseCalls = createMock.mock.calls.length
+    let rejectCreate!: (e: Error) => void
+    const deferred = new Promise<{ key: string; title: string; messages: number; running: boolean }>(
+      (_r, rej) => { rejectCreate = rej },
+    )
+    createMock.mockReturnValueOnce(deferred as ReturnType<typeof api.createChatSlot>)
+    vi.mocked(api.uploadFiles).mockResolvedValueOnce({ paths: ['/uploaded/during.png'] } as Awaited<ReturnType<typeof api.uploadFiles>>)
+
+    const launchWindow = window as Window & {
+      __mc_chat_launch?: { ts: number; message: string }
+    }
+    launchWindow.__mc_chat_launch = { ts: Date.now(), message: 'send with attachment' }
+    // A file staged before the send — part of this send's payload.
+    sessionStorage.setItem('mc-chat-file-drafts', JSON.stringify({ 'slot-a': ['/staged/before.png'] }))
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    await waitFor(() => expect(createMock.mock.calls.length).toBe(baseCalls + 1))
+
+    // While the create hangs, the user attaches another file.
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(fileInput, 'the attach control must exist to stage a file mid-create').toBeTruthy()
+    await act(async () => {
+      fireEvent.change(fileInput, {
+        target: { files: [new File(['x'], 'during.png', { type: 'image/png' })] },
+      })
+    })
+    await waitFor(() => {
+      const fd = JSON.parse(sessionStorage.getItem('mc-chat-file-drafts') || '{}')
+      expect(fd['slot-a']).toContain('/uploaded/during.png')
+    }, { timeout: 3000 })
+
+    // Now the create rejects.
+    await act(async () => {
+      rejectCreate(new Error('slot creation failed'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Live composer chips are the falsifiable assertion: the re-fill writes
+    // pendingFiles directly, and the draft store would keep the mid-create file
+    // either way (nothing destroys it). Both chips must be present, snapshot
+    // first.
+    await waitFor(() => {
+      const alts = Array.from(document.querySelectorAll('img[data-lightbox-image]'))
+        .map(el => el.getAttribute('alt'))
+      expect(
+        alts,
+        'the mid-create attachment must not be replaced by the older snapshot',
+      ).toEqual(['/staged/before.png', '/uploaded/during.png'])
+    }, { timeout: 3000 })
+  })
+
+  it('a second send during a slow create does not spawn a hidden second slot', async () => {
+    // The new-session intent is only consumed at COMMIT, so while a slow create
+    // awaits it is still armed: a second send took the create branch again and
+    // made a SECOND slot. Only the first is activated, so the second prompt ran
+    // in a session the user never sees. The send is rejected instead — and,
+    // because it bails before the composer clear, it loses nothing.
+    const { api } = await import('../api/client')
+    const createMock = vi.mocked(api.createChatSlot)
+    const baseCalls = createMock.mock.calls.length
+    let resolveCreate!: (v: { key: string; title: string; messages: number; running: boolean }) => void
+    const deferred = new Promise<{ key: string; title: string; messages: number; running: boolean }>(
+      r => { resolveCreate = r },
+    )
+    createMock.mockReturnValueOnce(deferred as ReturnType<typeof api.createChatSlot>)
+
+    const launchWindow = window as Window & {
+      __mc_chat_launch?: { ts: number; message: string }
+    }
+    launchWindow.__mc_chat_launch = { ts: Date.now(), message: 'first send' }
+
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    await waitFor(() => expect(createMock.mock.calls.length).toBe(baseCalls + 1))
+
+    // Second send while the first create is still pending.
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'second send' } })
+    await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+
+    expect(
+      createMock.mock.calls.length,
+      'the overlapping send must not start a second slot creation',
+    ).toBe(baseCalls + 1)
+    expect(
+      (screen.getByLabelText('Message input') as HTMLTextAreaElement).value,
+      'the rejected send must leave the typed text in place',
+    ).toBe('second send')
+
+    // Let the first create finish so the component settles.
+    await act(async () => {
+      resolveCreate({ key: 'new-slot', title: 'new-slot', messages: 0, running: false })
+      await Promise.resolve()
+    })
+  })
+
+  it('cancelling a card WITHOUT ordered files leaves the content verbatim', async () => {
+    // An edited card intentionally has no ordered list (the retyped text's
+    // markers no longer line up with the old paths). Falling back to a
+    // whitespace-bounded scan would mangle the text and stage a phantom
+    // attachment, so the raw marker is left visible for the user to fix by hand.
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+
+    const content = 'review [attached_file 1] /docs/quarterly report.pdf please'
+    act(() => {
+      store.dispatch(appendQueuedMessage({
+        slot: 'slot-a', content, ts: 't1', queue_id: 'q1',
+      }))
+    })
+
+    const cancelBtn = await waitFor(() => screen.getByLabelText('Cancel queued message'))
+    await act(async () => { fireEvent.click(cancelBtn) })
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    await waitFor(() => expect(input.value).toContain('review'))
+    expect(
+      input.value,
+      'without a trustworthy ordered list the content is restored verbatim',
+    ).toBe(content)
   })
 
   it('slow New Chat that resolves after a slot switch does not steal the typed text', async () => {

--- a/website/src/test/fileTokens.test.ts
+++ b/website/src/test/fileTokens.test.ts
@@ -1,5 +1,52 @@
 import { describe, it, expect } from 'vitest'
-import { prepareSendPayload, buildFileLabels, resolveFileSegment } from '../utils/fileTokens'
+import { prepareSendPayload, buildFileLabels, resolveFileSegment, stripAttachmentMarkers, metaFileList, parseFilesChecked, mergeStagedFiles } from '../utils/fileTokens'
+
+describe('stripAttachmentMarkers', () => {
+  it('removes a marker and its path, closing the gap', () => {
+    expect(
+      stripAttachmentMarkers('look at [attached_file 1] /repo/my notes.txt please', ['/repo/my notes.txt']),
+    ).toBe('look at please')
+  })
+
+  it('handles a path containing spaces', () => {
+    // The whole point of the ordered list: a whitespace-bounded scan would stop
+    // at the first space and leave `notes.txt` behind.
+    expect(
+      stripAttachmentMarkers('[attached_file 1] /a/quarterly report.pdf', ['/a/quarterly report.pdf']),
+    ).toBe('')
+  })
+
+  it('does not strip a longer path that shares the marker path as a prefix', () => {
+    // Without an end boundary, `/d` matched inside `/dossier` and left `ossier`.
+    expect(
+      stripAttachmentMarkers('see [attached_file 1] /dossier now', ['/d']),
+    ).toBe('see [attached_file 1] /dossier now')
+  })
+
+  it('preserves indentation and column alignment away from the marker', () => {
+    const code = 'def f():\n    x=1\n    [attached_file 1] /d\n    y=2'
+    expect(stripAttachmentMarkers(code, ['/d'])).toBe('def f():\n    x=1\n    y=2')
+    expect(stripAttachmentMarkers('col1    col2 [attached_file 1] /d', ['/d'])).toBe('col1    col2')
+  })
+
+  it('leaves marker indices the list does not cover', () => {
+    expect(
+      stripAttachmentMarkers('a [attached_file 1] /d b [attached_file 2] /other', ['/d']),
+    ).toBe('a b [attached_file 2] /other')
+  })
+
+  it('ignores a non-array files value instead of throwing', () => {
+    for (const bad of ['oops', 42, { 0: 'x' }, null, undefined]) {
+      expect(() => stripAttachmentMarkers('keep me', bad)).not.toThrow()
+      expect(stripAttachmentMarkers('keep me', bad)).toBe('keep me')
+    }
+  })
+
+  it('keeps the index space when a member is not a string', () => {
+    expect(metaFileList([null, '/d'])).toEqual(['', '/d'])
+    expect(stripAttachmentMarkers('a [attached_file 2] /d', [null, '/d'])).toBe('a')
+  })
+})
 
 describe('buildFileLabels uniqueness', () => {
   it('disambiguates paths that share a basename', () => {
@@ -136,3 +183,64 @@ describe('prepareSendPayload', () => {
     expect(result.filePaths).toEqual(['/tmp/data.csv', '/tmp/extra.log'])
   })
 })
+
+describe('parseFilesChecked', () => {
+  it('trusts real meta.files', () => {
+    const r = parseFilesChecked('see [attached_file 1] /a/q report.pdf', {
+      files: ['/a/q report.pdf'],
+    })
+    expect(r).toEqual({ files: ['/a/q report.pdf'], exact: true })
+  })
+
+  it('refuses the content fallback, which cannot recover spaced paths', () => {
+    // The `\S+` scan truncates at the first space. Feeding that to
+    // stripAttachmentMarkers half-strips the marker (leaving `report.pdf`) AND
+    // stages a phantom `/a/quarterly` attachment, so callers must not mutate.
+    const r = parseFilesChecked('see [attached_file 1] /a/quarterly report.pdf ok')
+    expect(r.exact, 'the content fallback is never trustworthy').toBe(false)
+    expect(r.files).toEqual(['/a/quarterly'])
+  })
+
+  it('refuses an all-invalid meta array instead of trusting it', () => {
+    // `metaFileList` blanks invalid members in place to keep the index space
+    // aligned, so `[null]` still has length 1. Trusting that let the cancel path
+    // clear unrelated staged files while stripping nothing.
+    for (const bad of [[null], [null, null], ['', '']]) {
+      const r = parseFilesChecked('see [attached_file 1] /a/b.txt', { files: bad })
+      expect(r.exact, `all-invalid meta ${JSON.stringify(bad)} must not be exact`).toBe(false)
+    }
+    // One valid member is enough to trust the ordered list.
+    expect(parseFilesChecked('see [attached_file 1] /a/b.txt', { files: [null, '/a/b.txt'] }).exact).toBe(true)
+  })
+
+  it('refuses the fallback even when no path contains a space', () => {
+    // A truncated path is indistinguishable from a complete one followed by
+    // prose, so there is no safe heuristic -- the fallback is always inexact.
+    expect(parseFilesChecked('see [attached_file 1] /a/b.txt').exact).toBe(false)
+  })
+})
+
+describe('mergeStagedFiles', () => {
+  it('keeps the first list order and appends the newer additions', () => {
+    // Used when re-filling the composer after an uncommitted send: the payload
+    // snapshot comes first (it is the order the user assembled), then anything
+    // staged while the send was in flight.
+    expect(mergeStagedFiles(['/a.png', '/b.png'], ['/a.png', '/c.png']))
+      .toEqual(['/a.png', '/b.png', '/c.png'])
+  })
+
+  it('de-duplicates rather than double-staging a path present in both', () => {
+    expect(mergeStagedFiles(['/a.png'], ['/a.png'])).toEqual(['/a.png'])
+  })
+
+  it('drops falsy members', () => {
+    expect(mergeStagedFiles(['', '/a.png'], ['/b.png', ''])).toEqual(['/a.png', '/b.png'])
+  })
+
+  it('handles either side being empty', () => {
+    expect(mergeStagedFiles([], ['/a.png'])).toEqual(['/a.png'])
+    expect(mergeStagedFiles(['/a.png'], [])).toEqual(['/a.png'])
+    expect(mergeStagedFiles([], [])).toEqual([])
+  })
+})
+

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -16,6 +16,40 @@ export function parseFiles(content: string, meta?: Record<string, unknown>): str
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
 }
 
+/**
+ * Attachment paths for a message plus whether they are TRUSTWORTHY.
+ *
+ * `parseFiles` silently falls back to scanning `[attached_file N] (\S+)` out of
+ * the content when metadata is absent. That fallback is whitespace-bounded, so a
+ * path containing a space is truncated at the first space -- and feeding a
+ * truncated path to `stripAttachmentMarkers` is actively harmful: the marker's
+ * exact-match boundary is satisfied by that same space, so the marker is
+ * half-stripped (leaving `report.pdf` behind) and the truncated prefix is staged
+ * as an attachment pointing at a file that does not exist.
+ *
+ * A truncated path is NOT distinguishable from a complete one: `[attached_file 1]
+ * /a/b.txt ok` and `[attached_file 1] /a/quarterly report.pdf` have the same
+ * shape, so any "does the remainder look like a path" heuristic misfires on
+ * ordinary prose. Rather than guess, the content fallback is reported as
+ * `exact: false` unconditionally -- only real `meta.files` is trustworthy.
+ *
+ * Callers that MUTATE state from these paths must do nothing when `exact` is
+ * false: a raw marker the user can fix by hand beats mangled text plus a phantom
+ * attachment.
+ */
+export function parseFilesChecked(
+  content: string,
+  meta?: Record<string, unknown>,
+): { files: string[]; exact: boolean } {
+  const metaFiles = metaFileList(meta?.files)
+  // `metaFileList` blanks invalid members in place to keep the index space
+  // aligned, so an all-invalid array (`[null]`, `['', '']`) still has length.
+  // Treating that as exact let the cancel path clear unrelated staged files
+  // while stripping nothing -- worse than falling back.
+  if (metaFiles.some(Boolean)) return { files: metaFiles, exact: true }
+  return { files: parseFiles(content, undefined), exact: false }
+}
+
 /** Per-path display label: the shortest trailing path segments that make the
  *  label unique across `paths` (e.g. two `report.docx` in different dirs become
  *  `q3/report.docx` and `q4/report.docx`).
@@ -190,6 +224,67 @@ export function buildRelMap(paths: string[], text: string): Map<string, string> 
     }
   }
   return map
+}
+
+/** Replace @rel tokens in text using a replacer function. */
+/** Escape a literal string for safe embedding in a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Validate an untrusted `meta.files` value into a list of strings.
+ *
+ * `meta` arrives from a server payload, so the value may be any type. A blank
+ * placeholder is kept for a non-string member so later indices still line up
+ * with their `[attached_file N]` markers.
+ */
+export function metaFileList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map(p => (typeof p === 'string' ? p : ''))
+}
+
+/**
+ * Remove `[attached_file N] path` pairs from text.
+ *
+ * Used when a queued card is cancelled back into the composer: the card stores
+ * the SERIALIZED text, so inserting it verbatim showed the raw marker and
+ * re-serialized it on the next send.
+ *
+ * Strips by exact `marker + path` using the card's own ordered list rather than
+ * by pattern, so a path containing spaces or brackets is removed exactly.
+ * A trailing boundary is required or the marker would match a PREFIX of a
+ * longer path (`/d` inside `/dossier`). Whitespace is repaired only at each
+ * removal site, so indentation and column alignment elsewhere survive.
+ */
+export function stripAttachmentMarkers(content: string, files?: unknown): string {
+  const paths = metaFileList(files)
+  if (!content || !paths.length) return content
+  let out = content
+  paths.forEach((p, i) => {
+    if (!p) return
+    const marker = escapeRegExp(`[attached_file ${i + 1}] ${p}`)
+    const bound = '(?=\\s|$)'
+    // A marker alone on its line takes the whole line, so no blank line is left.
+    out = out.replace(new RegExp(`^[ \\t]*${marker}${bound}[ \\t]*\\n?`, 'gm'), '')
+    // Otherwise the marker plus the whitespace hugging it becomes one space.
+    out = out.replace(new RegExp(`[ \\t]*${marker}${bound}[ \\t]*`, 'g'), ' ')
+    out = out.replace(/[ \t]+$/gm, '')
+  })
+  return out.trim()
+}
+
+/**
+ * Union of two staged-attachment lists, `first` order preserved, de-duplicated.
+ *
+ * Used when re-filling the composer after an uncommitted send: the payload's
+ * snapshot comes first (it is the order the user assembled), then anything
+ * staged while the send was in flight. Assigning the snapshot wholesale
+ * silently discarded a file the user attached during a slow slot creation.
+ * Falsy members are dropped -- an empty path is not a stageable attachment.
+ */
+export function mergeStagedFiles(first: string[], second: string[]): string[] {
+  return [...new Set([...first, ...second])].filter(Boolean)
 }
 
 /** Replace @rel tokens in text using a replacer function. */


### PR DESCRIPTION
## Problem

Five defects on the file-attachment send/cancel paths, all live on `main`. One is the cancel path; the other four live in the `createSlot` await window inside `send()`.

1. **Cancelling a queued message inserts raw marker text.** The card holds the *serialized* form, so the composer shows a literal `[attached_file 1] /path`. Resending doubles the marker, and the attachment is never re-staged.
2. **A failed slot creation destroys the staged message.** The composer and drafts are cleared *before* the fallible `await`, which sits outside the try/catch — so a rejection leaves nothing to restore.
3. **A file staged *during* a slow create is discarded.** The rejection path assigned the pre-send snapshot wholesale, silently replacing a newer attachment.
4. **A concurrent send spawns a hidden second session.** The new-session intent stays armed through the await, so a second send creates a second slot. Only the first is activated; the second prompt runs in a session the user never sees.
5. **Widget provenance leaks past an interception.** A slash-command or `@knowledge` interception consumes the composer and returns before commit, leaving the widget seed armed — so a later unrelated prompt containing that text is falsely tagged `origin='widget'`.

## Why it matters

All five hit the user when they can least recover. Cancel-and-edit is the normal way to fix a queued message; instead of their text they get machine markers. A transient slot-creation failure silently eats staged input, because the state was discarded before the call that failed. Under a *slow* create — the case most likely in practice, since that is when a user keeps working — the same window also loses a freshly attached file and can strand a whole prompt invisibly. And a mis-attributed `origin='widget'` corrupts the one field that distinguishes a widget-driven turn from a human-authored one.

## Fix (symptom → root cause → change)

**Two-phase commit (defect 2).** Root cause: cleanup ordered before the fallible await. Reordering the draft `delete` is not enough — the persist effects key off `input`/`pendingFiles`/`pasteBlocks`, so clearing the composer writes empties into the drafts regardless. Snapshot-and-restore was tried and abandoned after four review rounds of races: every restore had to compare against *live* state, which moves during the await.

Change: Phase 1 (pre-await) captures a `pendingSend`, **pauses draft persistence for the origin slot** (`pausedPersistSlotRef`, honoured by all six persist sites — three live effects plus the slot-switch / unmount / beforeunload flushes), then clears only the live composer. One-shot state is *read* but left armed. Phase 2 (post-success) consumes everything keyed by `pendingSend.originSlot`, never live state, with an identity check on the knowledge block so a mid-await selection survives for the next send. On rejection there is **no restore logic** — nothing was destroyed; the pause lifts and the composer is re-filled as a courtesy when the user is still there and has typed nothing new. The `catch` deliberately does not re-throw: four of `send()`'s five call sites are fire-and-forget, so re-throwing produced unhandled rejections that failed CI with every test passing.

**Mid-create attachment (3).** New `mergeStagedFiles(snapshot, live)` unions the two lists — snapshot order first, then anything staged since, de-duplicated — instead of assigning the snapshot.

**Concurrent send (4).** A dedicated `creatingSlotRef` covers exactly the create window and clears on both outcomes, so an overlapping send is rejected but ordinary back-to-back sends are not. It bails *before* the composer clear, so the rejected attempt loses nothing. Deliberately not `sendingRef`, which also gates the welcome view and stays set through the HTTP POST.

**Widget provenance (5).** Both interception branches release the seed when they consume the composer.

**Cancel path (1).** Root cause: the card is a serialized artifact and the handler treated it as user text. De-tokenizing needs the ordered attachment list, which queued cards don't carry (`meta` is exactly `{queueId}`). Scanning the marker text is whitespace-bounded and lossy: `[attached_file 1] /a/quarterly report.pdf` yields `/a/quarterly`, half-strips the marker leaving `report.pdf`, and would stage a phantom path — and a truncated path is indistinguishable from a complete one followed by prose, so no heuristic recovers it.

Change: `parseFilesChecked` reports whether the paths are trustworthy; the handler strips **only** for real `meta.files`, else inserts content verbatim and leaves `pendingFiles` alone. The strip needs an end boundary or a marker matches a *prefix* of a longer path (`/d` inside `/dossier`), and repairs whitespace only at the removal site.

**Scope:** since queued cards carry no metadata on `main`, the strip never fires there — this ships the mechanism and the refusal, not a working queue-cancel de-tokenization. Propagating the ordered list through queue storage/payload/hydration belongs to **#505**, which already implements it with a wider contract (`meta.files` *and* `meta.dirs`, a `queue_item_for_display` projection, plus its spec section). This branch consumes whatever list the card carries and gates on exactness, so #505 widens the contract without touching this code.

## Tests

`ChatPageDrafts.test.tsx` — six behavioural tests, each revert-verified:

| Test | Locks in | Mutation that fails it |
|---|---|---|
| `preserves the user content when slot creation is rejected mid-send` | text visible for retry, pre-staged draft untouched | delete the courtesy re-fill |
| `a rejection landing after a slot switch leaves the origin draft intact` | an uncommitted send destroys nothing, across a switch | — (invariant test) |
| `a rejected COMPOSER send preserves the persisted text, files and pastes` | the destructive path: a keystroke send *does* clear the composer | remove the flush pause guards |
| `a rejection keeps a file staged DURING the slow create` | both chips present, snapshot first | restore the wholesale assignment |
| `a second send during a slow create does not spawn a hidden second slot` | no second `createChatSlot`, text survives | remove `creatingSlotRef` |
| `cancelling a card WITHOUT ordered files leaves the content verbatim` | the refusal, not the (unreachable) strip | — |

`ChatPage.widgetPrefill.test.tsx` — `releases the widget seed when a knowledge interception consumes the composer`: a genuinely user-authored follow-up containing the widget text must not carry `origin: 'widget'`.

Unit coverage: `parseFilesChecked` (3 cases), `stripAttachmentMarkers` (7), `mergeStagedFiles` (4).

**Coverage boundary, stated rather than overclaimed.** The composer-send test falsifies the persistence pause, but only via the slot-switch/unmount/beforeunload flush guards; removing *only* the live text-persist-effect guard still passes, because on that path the outgoing-slot flush is the write that destroys the draft. The three live-effect guards are defence for other orderings and are **not** claimed as covered — the in-file comment says so.

Full frontend suite: 395 files, **4594 tests, vitest exit 0** (the exit code matters — an unhandled rejection fails the run while every test reports passing). `tsc -b --force` clean.

## Manual verification

Verified end-to-end against a live gateway built from this branch (isolated `KIROCREW_HOME`, browser-driven): a forced slot-creation failure left composer text and staged files intact with no unhandled rejection in the console, and the retry succeeded.

## Screenshots

N/A — no visual change in the working case; the difference is confined to the failure paths.

## Context

Extracted from #505, where these were found while building folder references. All affect **file** attachments on `main` independently of that work. One of three independent carve-outs, all against `main`: #534 (chip label uniqueness, **merged**), #537 (titles keep the attachment name), and this PR. No ordering constraint between them; each is separately revertible.

Frontend-only diff (`ChatPage.tsx`, `fileTokens.ts`, three test files) — no backend change, so no module spec update applies.
