### PR TITLE
fix(instances): surface remote mint stdout so connect failures aren't blind

### DIFF
--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -298,6 +298,51 @@ def _build_ssh_argv(ssh_host: str, remote_command: str) -> list[str]:
     ]
 
 
+# Cap the length of a remote-output tail surfaced in an exception, so a chatty
+# remote (banner + traceback) can't bloat the error / logs. Diagnostics from
+# `kirocrew token` are short single lines, so the tail is what matters.
+_MAX_DIAG_CHARS = 500
+
+
+def _redact_output(text: str) -> str:
+    """Redact secrets from a remote command's output before it enters an error.
+
+    Applied to BOTH the stdout and stderr tails surfaced in a
+    :class:`TokenMintError`. ``kirocrew token`` writes its *failure* diagnostics
+    (e.g. "Gateway not running", "could not reach gateway on port N") to
+    **stdout**, so surfacing a stdout tail is what makes a remote-mint failure
+    diagnosable instead of an opaque ``<no stderr>``. But stdout is also where a
+    *successful* mint prints the ``?token=<jwt>`` URL, so any ``token=`` value is
+    scrubbed first (defensively — a non-zero exit should not carry one) before
+    the standard credential / exfiltration-URL redaction runs. The result is
+    stripped and tail-truncated to :data:`_MAX_DIAG_CHARS`.
+    """
+    if not text:
+        return ""
+    scrubbed = re.sub(r"([?&]token=)[^\s&]+", r"\1<redacted>", text)
+    scrubbed = redact_exfiltration_urls(redact_credentials(scrubbed)[0])[0].strip()
+    if len(scrubbed) > _MAX_DIAG_CHARS:
+        scrubbed = "…" + scrubbed[-_MAX_DIAG_CHARS:]
+    return scrubbed
+
+
+def _format_remote_diag(safe_stdout: str, safe_stderr: str) -> str:
+    """Combine redacted stdout/stderr tails into one diagnostic string.
+
+    Both are included (labelled) when present because they carry different
+    signals: ``kirocrew token`` prints its reason to stdout, while the candidate
+    search's "binary not found" note and any SSH/WSSH banner land on stderr.
+    Preferring only one would let a benign stderr banner mask the real stdout
+    reason (or vice-versa).
+    """
+    parts = []
+    if safe_stdout:
+        parts.append(f"stdout: {safe_stdout}")
+    if safe_stderr:
+        parts.append(f"stderr: {safe_stderr}")
+    return " | ".join(parts) if parts else "<no output>"
+
+
 async def mint_remote_token(
     ssh_host: str,
     *,
@@ -348,24 +393,29 @@ async def mint_remote_token(
 
     stdout = stdout_b.decode("utf-8", "replace")
     stderr = stderr_b.decode("utf-8", "replace").strip()
-    # stderr is proxy-controlled (WSSH banner etc.); redact credentials/exfil URLs
-    # before surfacing it in an exception that may reach logs/status. The token
-    # only ever appears on stdout, never stderr.
-    safe_stderr = redact_exfiltration_urls(redact_credentials(stderr)[0])[0] if stderr else ""
+    # Both streams are surfaced (redacted) in failure exceptions. `kirocrew token`
+    # writes its failure reason ("Gateway not running", "could not reach gateway
+    # on port N") to STDOUT and exits non-zero; the candidate-search "binary not
+    # found" note and any proxy (WSSH) banner land on STDERR. Redaction scrubs any
+    # token value first — the token only ever appears on stdout, on the success
+    # path — so neither tail can leak the credential.
+    safe_stdout = _redact_output(stdout)
+    safe_stderr = _redact_output(stderr)
 
     if proc.returncode != 0:
-        # stderr may carry the "binary not found" diagnostic — safe to log; it
-        # never contains the token (token only ever appears on stdout).
+        # Include the stdout tail: for a `kirocrew token` failure (exit 1) the
+        # actionable reason is ONLY on stdout, so without it this error was an
+        # opaque "exited 1: <no stderr>".
         raise TokenMintError(
             f"remote token mint on {ssh_host} exited {proc.returncode}: "
-            f"{safe_stderr or '<no stderr>'}"
+            f"{_format_remote_diag(safe_stdout, safe_stderr)}"
         )
 
     token = parse_token_from_stdout(stdout)
     if not token:
         raise TokenMintError(
             f"could not parse a token from {ssh_host} output "
-            f"(stderr: {safe_stderr or '<none>'})"
+            f"({_format_remote_diag(safe_stdout, safe_stderr)})"
         )
     return token
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -332,8 +332,72 @@ class TestTokenMint:
         with pytest.raises(tm.TokenMintError):
             asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
 
+    def test_mint_nonzero_exit_surfaces_stdout_reason(self, monkeypatch):
+        """A `kirocrew token` failure prints its reason to stdout (exit 1).
 
-# ── gateway run-marker (mint prefers the running gateway's install) ───────────
+        The error message must carry that reason, not the old opaque
+        "<no stderr>" — stderr is empty in this case.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        class FakeProc:
+            returncode = 1
+
+            async def communicate(self):
+                return (
+                    b"\xe2\x9d\x8c Could not reach gateway on port 5477: "
+                    b"Connection refused\n",
+                    b"",
+                )
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        with pytest.raises(tm.TokenMintError) as exc:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(exc.value)
+        assert "Could not reach gateway on port 5477" in msg
+        assert "Connection refused" in msg
+        assert "<no stderr>" not in msg
+
+    def test_mint_nonzero_exit_scrubs_token_from_stdout(self, monkeypatch):
+        """Defensive: even if a token URL rides along on a non-zero exit, the
+        raw JWT is never surfaced in the exception (only a scrubbed marker)."""
+        from kiro_crew.instances import token_mint as tm
+
+        class FakeProc:
+            returncode = 1
+
+            async def communicate(self):
+                return b"http://localhost:5477?token=SECRETJWT\n", b""
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        with pytest.raises(tm.TokenMintError) as exc:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert "SECRETJWT" not in str(exc.value)
+
+    def test_mint_parse_failure_surfaces_stdout(self, monkeypatch):
+        """Exit 0 but no parseable token → the diagnostic includes the stdout
+        tail so the operator can see what the remote actually printed."""
+        from kiro_crew.instances import token_mint as tm
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"unexpected banner, no url here\n", b""
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        with pytest.raises(tm.TokenMintError) as exc:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert "unexpected banner" in str(exc.value)
 
 
 class TestRunMarker:


### PR DESCRIPTION
## Problem

Connecting to a managed cloud-desktop instance can fail with a completely
opaque error:

```
Connect to baymax failed: token mint failed: remote token mint on baymax exited 1: <no stderr>
```

`<no stderr>` gives the user nothing to act on, even though the remote side
knew exactly what went wrong.

## Why it matters

Instance connect is the primary entry point to a managed desktop. When it
fails blind, the user has no path forward without reading source or manually
SSHing in to reproduce — every remote-mint failure (gateway down, wrong port,
stale session) collapses into the same dead-end message.

## Fix (symptom → root cause → change)

- **Symptom:** `exited 1: <no stderr>`.
- **Root cause:** the remote mint runs `kirocrew token --port <n>`, and that
  CLI prints *all* of its failure diagnostics (`Gateway not running`,
  `Could not reach gateway on port N`, invalid TTL, empty token) to **stdout**
  before `sys.exit(1)`. `mint_remote_token` only surfaced **stderr** in its
  `TokenMintError`, so the actionable message was discarded. Exit 1 (vs. 127)
  confirms a binary *was* found and `kirocrew token` itself failed — its reason
  was on stdout the whole time.
- **Change:** in `src/kiro_crew/instances/token_mint.py`, surface a redacted
  stdout tail (labelled `stdout:`/`stderr:` via a small `_format_remote_diag`
  helper) on both the non-zero-exit and unparseable-token paths. A new
  `_redact_output` helper scrubs any `token=<jwt>` value **first** (defensively —
  a non-zero exit shouldn't carry one, but stdout is where the success URL with
  the JWT appears), then runs the existing credential / exfiltration-URL
  redaction, and truncates to a bounded tail so a chatty remote can't bloat the
  error/log.

The same failure now reads:

```
remote token mint on baymax exited 1: stdout: ❌ Could not reach gateway on port 5477: Connection refused
```

Both streams are included when present because they carry different signals:
`kirocrew token` writes its reason to stdout, while the candidate-search
"binary not found" note (exit 127) and any SSH/WSSH banner land on stderr —
preferring only one would let a benign banner mask the real reason.

## Tests

Added to `test/test_instances.py` (`TestTokenMint`):
- `test_mint_nonzero_exit_surfaces_stdout_reason` — exit 1 with the reason on
  stdout and empty stderr → the error carries the reason and no longer says
  `<no stderr>`.
- `test_mint_nonzero_exit_scrubs_token_from_stdout` — a `token=` URL riding a
  non-zero exit is never surfaced raw in the exception.
- `test_mint_parse_failure_surfaces_stdout` — exit 0 but unparseable output →
  the diagnostic includes the stdout tail.

The existing `test_mint_success_and_no_token_in_logs` (token never logged) and
`test_mint_nonzero_exit_raises` (exit 127 / stderr path) still pass unchanged.

## Manual verification

N/A — unit coverage is sufficient; this is a pure error-message/redaction
change with no runtime behavior change on the success path (the token is still
parsed from stdout and returned exactly as before).

## Screenshots

N/A — no user-visible UI change (backend error string only).
