### PR TITLE
feat: show queued sub-agents in the progress chip

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -2477,6 +2477,10 @@ class SubagentManager:
                 len(self._queue),
                 slot_free,
             )
+            # Advisory UI signal: tell the chip how many agents are now waiting
+            # to start for this parent so it can appear immediately and show a
+            # "waiting" count instead of only running/completed ones.
+            self._emit_queue_depth(parent_session_key, batch_id)
             # If a slot is free, no running agent will trigger the drain on
             # completion — schedule the staggered pump at the interval boundary
             # so the queued spawn still launches.
@@ -2694,6 +2698,13 @@ class SubagentManager:
         params = self._queue.pop(0)
         logger.info(
             "Draining queue: spawning '%s' (%d left)", str(params.get("task", ""))[:40], len(self._queue)
+        )
+        # The popped item's parent just lost one waiting agent — re-emit its
+        # queued depth (0 when this was its last) so the chip's "waiting" count
+        # tracks the drain. Done before spawn() so an immediate re-queue there
+        # (still too soon since last start) re-bumps it correctly afterwards.
+        self._emit_queue_depth(
+            str(params.get("parent_session_key", "")), str(params.get("batch_id", ""))
         )
         # spawn() re-checks the gate; since elapsed >= stagger and a slot is
         # free, it starts immediately and updates _last_spawn_ts. Forward the FULL
@@ -3329,6 +3340,40 @@ class SubagentManager:
                 await self._on_event(etype, info, extra or {})
             except Exception:
                 logger.warning("on_event failed for %s/%s", etype, info.id, exc_info=True)
+
+    def _queued_depth(self, parent_session_key: str) -> int:
+        """Number of spawns currently queued for *parent_session_key* (waiting
+        behind the concurrency cap / stagger gate, not yet started)."""
+        return sum(
+            1 for q in self._queue
+            if q.get("parent_session_key", "") == parent_session_key
+        )
+
+    def _emit_queue_depth(self, parent_session_key: str, batch_id: str = "") -> None:
+        """Emit the current queued depth for *parent_session_key* as a
+        ``subagent_queued`` lifecycle event.
+
+        The chip is otherwise driven only by agents that have actually started
+        (``subagent_spawn``), so agents sitting behind the concurrency cap /
+        stagger gate are invisible and the chip can appear late or flicker.
+        This advisory count lets the UI show "N waiting to start" the moment a
+        wave is accepted, and stay mounted across the staggered ramp.
+
+        Fire-and-forget: scheduled on the running loop; a no-op in sync/test
+        contexts without a loop (the count is advisory UI signal, not state).
+        """
+        depth = self._queued_depth(parent_session_key)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop (sync/test context) — advisory event skipped
+        info = SubagentInfo(
+            id="_queue",
+            task="",
+            parent_session_key=parent_session_key,
+            batch_id=batch_id,
+        )
+        loop.create_task(self._fire_event("subagent_queued", info, {"queued": depth}))
 
     @staticmethod
     def _write_tombstone(info: SubagentInfo, cause: str) -> None:

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -309,6 +309,133 @@ class TestDrainPump:
 # ---------------------------------------------------------------------------
 
 
+class TestQueuedDepthEmission:
+    """_queued_depth / _emit_queue_depth: advisory 'waiting to start' count
+    surfaced to the UI as subagent_queued events so the chip can show queued
+    agents, not only running/completed ones."""
+
+    def test_queued_depth_counts_per_parent(self) -> None:
+        import time as _t
+
+        m = _mgr(running=0, max_concurrent=4, last_ts=_t.monotonic())
+        m._queue = [
+            {"task": "a", "parent_session_key": "dashboard:s1"},
+            {"task": "b", "parent_session_key": "dashboard:s1"},
+            {"task": "c", "parent_session_key": "dashboard:s2"},
+        ]
+        assert m._queued_depth("dashboard:s1") == 2
+        assert m._queued_depth("dashboard:s2") == 1
+        assert m._queued_depth("dashboard:absent") == 0
+
+    def test_emit_queue_depth_fires_event_with_count(self) -> None:
+        import asyncio
+        import time as _t
+
+        events: list = []
+
+        async def on_event(etype, info, extra):
+            events.append((etype, info.parent_session_key, dict(extra)))
+
+        async def run() -> None:
+            m = _mgr(running=0, max_concurrent=4, last_ts=_t.monotonic())
+            m._on_event = on_event
+            m._queue = [
+                {"task": "a", "parent_session_key": "dashboard:s1"},
+                {"task": "b", "parent_session_key": "dashboard:s1"},
+            ]
+            m._emit_queue_depth("dashboard:s1")
+            # scheduled via create_task — yield so it runs
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+        assert ("subagent_queued", "dashboard:s1", {"queued": 2}) in events
+
+    def test_emit_queue_depth_zero_when_parent_drained(self) -> None:
+        import asyncio
+        import time as _t
+
+        events: list = []
+
+        async def on_event(etype, info, extra):
+            events.append((etype, extra.get("queued")))
+
+        async def run() -> None:
+            m = _mgr(running=0, max_concurrent=4, last_ts=_t.monotonic())
+            m._on_event = on_event
+            # only a *different* parent has items queued — the drained parent
+            # reports 0 so the chip clears its "waiting" count.
+            m._queue = [{"task": "c", "parent_session_key": "dashboard:other"}]
+            m._emit_queue_depth("dashboard:s1")
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+        assert ("subagent_queued", 0) in events
+
+
+class TestQueuedDepthWiring:
+    """The two producer call-sites are wired: spawn()'s queue branch and
+    _drain_queue() each emit subagent_queued. Guards against silently
+    reverting the wiring (which would reintroduce the invisible-queue bug
+    while helper-only tests stayed green)."""
+
+    def test_spawn_queue_branch_emits_depth(self, monkeypatch) -> None:
+        import asyncio
+        import time as _t
+
+        import kiro_crew.subagent as sub
+
+        # Bypass governance so we deterministically reach the queue branch.
+        monkeypatch.setattr(sub, "_vet_spawn_governance", lambda *a, **k: None)
+
+        events: list = []
+
+        async def on_event(etype, info, extra):
+            if etype == "subagent_queued":
+                events.append((info.parent_session_key, extra.get("queued")))
+
+        async def run() -> None:
+            # At capacity → the spawn must be queued, not started.
+            m = _mgr(running=2, max_concurrent=2, last_ts=_t.monotonic())
+            m._on_event = on_event
+            info = m.spawn(task="x", parent_session_key="dashboard:s1")
+            assert info is not None and info.id.startswith("q")  # queued sentinel
+            assert len(m._queue) == 1  # actually appended
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+        assert ("dashboard:s1", 1) in events
+
+    def test_drain_emits_queued_depth_on_pop(self) -> None:
+        import asyncio
+        import time as _t
+        from unittest.mock import MagicMock
+
+        events: list = []
+
+        async def on_event(etype, info, extra):
+            if etype == "subagent_queued":
+                events.append((info.parent_session_key, extra.get("queued")))
+
+        async def run() -> None:
+            now = _t.monotonic()
+            m = _mgr(running=0, max_concurrent=16, last_ts=now - 5.0, stagger=2.0)
+            m._on_event = on_event
+            m.spawn = MagicMock()  # type: ignore[method-assign]
+            m._queue = [
+                {"task": "a", "parent_session_key": "dashboard:s1"},
+                {"task": "b", "parent_session_key": "dashboard:s1"},
+            ]
+            m._drain_queue()  # pops one → s1's remaining depth is 1
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+        assert ("dashboard:s1", 1) in events
+
+
 class TestCpuJiffiesParser:
     """_parse_cpu_jiffies: utime+stime from raw /proc/<pid>/stat bytes."""
 

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -6,7 +6,7 @@ import { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, setC
 import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, fetchNotifications } from '../store/notificationsSlice'
 import { MC_NOTIFICATION_EVENT, TURN_DONE_KIND, shouldChimeOnTurnDone, type McNotificationDetail } from './notificationEvent'
 import { emitThemeSound } from './themeSound'
-import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard, setFollowupCard } from '../store/chatSlice'
+import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard, setFollowupCard } from '../store/chatSlice'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import { applyStatusDelta, parseStatusDelta } from '../utils/pullRequestStatusDelta'
@@ -513,6 +513,9 @@ export function useWebSocket() {
             break
           case 'subagent_spawn':
             dispatch(sseSubagentSpawn(data as { slot: string; id: string; task: string; agent: string }))
+            break
+          case 'subagent_queued':
+            dispatch(sseSubagentQueued(data as { slot: string; queued: number }))
             break
           case 'subagent_chunk':
             dispatch(sseSubagentChunk(data as { slot: string; id: string; text: string }))

--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react'
-import { Bot, X, AlertTriangle, Loader2, CheckCircle, AlertCircle, Square, RotateCcw } from 'lucide-react'
+import { Bot, X, AlertTriangle, Loader2, CheckCircle, AlertCircle, Square, RotateCcw, Clock } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { openActivityToTab, selectSubagent, sseSubagentDone } from '../../store/chatSlice'
 import { api } from '../../api/client'
@@ -29,6 +29,9 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   // (dashboardSlice.subagentRunning only updates on subagent_status which fires at completion)
   const dispatch = useAppDispatch()
   const subagents = useAppSelector(s => slot === s.chat.activeSlot ? s.chat.subagents : s.chat.slotActivity[slot ?? '']?.subagents ?? EMPTY_SUBAGENTS)
+  // Aggregate "waiting to start" count for this slot — agents accepted but
+  // queued behind the concurrency cap / stagger gate (no individual card yet).
+  const queued = useAppSelector(s => s.chat.subagentQueued?.[slot ?? ''] ?? 0)
   const all = useMemo(() => Object.values(subagents), [subagents])
   // Exception-first ordering: retrying/stalled agents need eyes; the healthy
   // majority collapses behind the summary row at scale.
@@ -50,7 +53,12 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   const failedIds = useMemo(() => all.filter(a => a.status === 'error' && !a.id.startsWith('native:')).map(a => a.id), [all])
   const activeListRef = useRef(activeList)
   activeListRef.current = activeList
-  const hasActive = running > 0
+  // Mount when anything is in flight — running OR queued. Including queued is
+  // what makes the chip (1) appear the instant a wave is accepted, before the
+  // first agent's subagent_spawn arrives, and (2) stay mounted across the
+  // staggered ramp instead of flickering out whenever running momentarily hits
+  // zero between staggered starts.
+  const hasActive = running > 0 || queued > 0
   const visibleList = activeList.slice(0, CHIP_MAX_ROWS)
   const hiddenCount = activeList.length - visibleList.length
   // Only running/tool agents are cancellable via spawnDelete; pending agents
@@ -100,6 +108,7 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
           {/* Histogram header: whole-wave counts so mid-wave failures stay visible */}
           <span className="text-text-strong font-medium flex items-center gap-2 min-w-0" data-testid="subagent-histogram">
             <span className="inline-flex items-center gap-1" data-testid="subagent-running-count"><Loader2 size={12} className="animate-spin text-accent" /> {running}</span>
+            {queued > 0 && <span className="inline-flex items-center gap-1 text-muted" data-testid="subagent-queued-count" title="Waiting to start — queued behind the concurrency limit"><Clock size={12} /> {queued}</span>}
             {counts.done > 0 && <span className="inline-flex items-center gap-1 text-ok"><CheckCircle size={12} /> {counts.done}</span>}
             {counts.failed > 0 && <span className="inline-flex items-center gap-1 text-danger"><AlertCircle size={12} /> {counts.failed}</span>}
             {counts.stopped > 0 && <span className="inline-flex items-center gap-1 text-muted"><Square size={12} /> {counts.stopped}</span>}

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -180,6 +180,11 @@ interface ChatState {
   voicePlaying: boolean
   voiceAudio: string | null  // base64 stitched MP3 for replay
   subagents: Record<string, SubagentActivity>
+  /** Aggregate "waiting to start" count per slot — agents accepted but queued
+   *  behind the concurrency cap / stagger gate (no individual card yet). Keyed
+   *  by slot name so it survives active-slot switches without the subagents
+   *  map's active/non-active split. Populated by `subagent_queued` WS events. */
+  subagentQueued: Record<string, number>
   /** Agent id the user picked from the chip — the Activity Subagents tab
    *  scrolls to, expands, and auto-loads this card (1-click transcript). */
   selectedSubagentId: string | null
@@ -248,6 +253,7 @@ const initialState: ChatState = {
   voicePlaying: false,
   voiceAudio: null,
   subagents: {},
+  subagentQueued: {},
   selectedSubagentId: null,
   toolLog: [],
   workflowRuns: {},
@@ -1016,6 +1022,20 @@ const chatSlice = createSlice({
       }
       state.subagents = keepPending(state.subagents)
       for (const activity of Object.values(state.slotActivity)) activity.subagents = keepPending(activity.subagents)
+      // Queued counts are advisory and re-emitted on the next drain — reset to
+      // avoid showing a stale "waiting" count for a wave that finished during
+      // the disconnect (under-count self-heals on the next drain frame).
+      state.subagentQueued = {}
+    },
+    /** Aggregate "waiting to start" count for a slot. Agents queued behind the
+     *  concurrency cap / stagger gate have no individual card; this count lets
+     *  the chip appear immediately on spawn and show how many are pending
+     *  start (issues: late chip, flicker, invisible queue). */
+    sseSubagentQueued(state, action: PayloadAction<{ slot: string; queued: number }>) {
+      if (isUnsafeKey(action.payload.slot)) return
+      const n = Math.max(0, Math.floor(Number(action.payload.queued) || 0))
+      if (n === 0) delete state.subagentQueued[safeKey(action.payload.slot)]
+      else state.subagentQueued[safeKey(action.payload.slot)] = n
     },
     sseSubagentPending(state, action: PayloadAction<{ slot: string; id: string; task: string; approval_id: string }>) {
       if (isUnsafeKey(action.payload.slot) || isUnsafeKey(action.payload.id)) return
@@ -2002,7 +2022,7 @@ export const {
   setActiveSlot, clearSlotState, setPendingInput, setQuestionCard, clearQuestionCard, setFollowupCard, clearFollowupCard, dismissFollowupItem, appendMessage, appendSlotMessage, updateStreamingMessage, finalizeAssistant,
   removeThinking, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage,
   sseContextUsage, setVoicePlaying, setVoiceAudio,
-  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone,
+  toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentQueued,
   sseSubagentBatchUpdate, sseSubagentBatchChunks, selectSubagent, clearTerminalSubagents,
   sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent,
   sseWorkflowEvent, clearWorkflowRun,

--- a/website/src/test/SubagentProgressBar.test.tsx
+++ b/website/src/test/SubagentProgressBar.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
-import chatReducer, { setActiveSlot, sseSubagentSpawn, sseSubagentPending } from '../store/chatSlice'
+import chatReducer, { setActiveSlot, sseSubagentSpawn, sseSubagentPending, sseSubagentQueued, sseSubagentDone } from '../store/chatSlice'
 import dashboardReducer from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
 
@@ -72,5 +72,78 @@ describe('SubagentProgressBar — in-chat stop controls', () => {
     // The pending agent still shows in the header, but offers no stop affordance.
     expect(screen.queryByLabelText(/^Stop/)).toBeNull()
     expect(api.spawnDelete).not.toHaveBeenCalled()
+  })
+})
+
+describe('SubagentProgressBar — queued / waiting count', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('mounts on a queued-only wave (no running agents yet) and shows the waiting count', () => {
+    // Nothing has started (no subagent_spawn) — the wave is only queued.
+    // The chip must still appear so the user gets an immediate signal.
+    const store = makeStore([])
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 5 }))
+    renderBar(store)
+    const queued = screen.getByTestId('subagent-queued-count')
+    expect(queued).toBeInTheDocument()
+    expect(queued.textContent).toContain('5')
+    // running count is present and zero
+    expect(screen.getByTestId('subagent-running-count').textContent).toContain('0')
+  })
+
+  it('stays mounted across the staggered ramp when running momentarily hits zero but agents remain queued', () => {
+    const store = makeStore(['a1'])
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 3 }))
+    // The only running agent finishes, but 3 are still queued.
+    store.dispatch(sseSubagentDone({ slot: SLOT, id: 'a1', elapsed: 2, outcome: 'completed' }))
+    renderBar(store)
+    // Chip is still present (did not unmount) and shows the waiting count.
+    expect(screen.getByTestId('subagent-histogram')).toBeInTheDocument()
+    expect(screen.getByTestId('subagent-queued-count').textContent).toContain('3')
+  })
+
+  it('hides the waiting segment once the queue drains to zero', () => {
+    const store = makeStore(['a1'])
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 2 }))
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 0 }))
+    renderBar(store)
+    expect(screen.queryByTestId('subagent-queued-count')).toBeNull()
+  })
+
+  it('unmounts entirely when nothing is running and nothing is queued', () => {
+    const store = makeStore([])
+    const { container } = renderBar(store)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('sseSubagentQueued reducer', () => {
+  function freshStore() {
+    const store = configureStore({
+      reducer: { chat: chatReducer, dashboard: dashboardReducer, notifications: notificationsReducer },
+    })
+    store.dispatch(setActiveSlot(SLOT))
+    return store
+  }
+
+  it('stores the queued count keyed by slot', () => {
+    const store = freshStore()
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 4 }))
+    expect(store.getState().chat.subagentQueued[SLOT]).toBe(4)
+  })
+
+  it('deletes the entry when count reaches zero (keeps the map clean)', () => {
+    const store = freshStore()
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 4 }))
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 0 }))
+    expect(store.getState().chat.subagentQueued[SLOT]).toBeUndefined()
+  })
+
+  it('clamps negative / garbage payloads to a non-negative integer', () => {
+    const store = freshStore()
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: -3 as unknown as number }))
+    expect(store.getState().chat.subagentQueued[SLOT]).toBeUndefined()
+    store.dispatch(sseSubagentQueued({ slot: SLOT, queued: 2.9 }))
+    expect(store.getState().chat.subagentQueued[SLOT]).toBe(2)
   })
 })


### PR DESCRIPTION
## Problem
The sub-agent progress chip only rendered agents that had **actually started** (the `subagent_spawn` event). Agents that were accepted but held behind the concurrency cap / stagger gate were invisible. This produced three symptoms users hit:

1. **Late / missing signal** — after a wave is spawned, the chip didn't appear until the first agent actually started, so there was no immediate indication that sub-agents were running.
2. **Card flickers away** — whenever the running count momentarily hit zero during the staggered ramp (one agent finishes before the next starts), the whole chip unmounted and then re-appeared, reading as "the card disappeared when new sub-agents got spawned."
3. **Queue is invisible** — agents waiting behind the concurrency limit were never shown; only running and completed counts were.

## Why it matters
At 60–100 concurrent sub-agents (the scale this chip was built for), most of a wave is queued at any instant. With the queue invisible and the chip flickering, the user has no reliable "work is happening / N still waiting" signal — exactly when they most need it.

## Fix (symptom → root cause → change)
Root cause: the chip's lifecycle was driven solely by *actually-running* agents, with no representation of the *accepted-but-not-started* population, and it hard-unmounted the instant `running === 0`.

- **Backend** (`src/kiro_crew/subagent.py`): `SubagentManager` now emits an advisory `subagent_queued` lifecycle event carrying the **per-parent queued depth** at both queue mutation sites — when a spawn is queued (`spawn()`) and after each pop (`_drain_queue()`). `_emit_queue_depth` reads the depth synchronously and schedules the emit only when a running loop exists (`get_running_loop()` guard → no-op in sync/test contexts). No gateway change is needed: `subagent_queued` is not coalescable, so the existing `_subagent_event` else-branch passes it straight through, and — correctly — it does **not** flip `subagents_running` (queued agents aren't running).
- **Frontend**: a per-slot aggregate `subagentQueued` count in `chatSlice` (keyed by slot, so it survives active-slot switches; payloads clamped to a non-negative int; deleted at 0), routed from the new WS event in `useWebSocket`. The chip (`SubagentProgressBar.tsx`) now mounts when `running > 0 || queued > 0` and renders a "waiting to start" segment (⏱ + count) in the histogram header.

This makes the chip appear the instant a wave is accepted (#1), stay mounted across the staggered ramp (#2), and show the waiting backlog (#3).

## Tests
- **Backend** (`test/test_subagent_sizing.py`): `TestQueuedDepthEmission` (per-parent depth counting, event emission with count, drain-to-zero) and `TestQueuedDepthWiring` (asserts the real `spawn()` queue branch and `_drain_queue()` each fire `subagent_queued` — locks in the two producer call-sites so the wiring can't be silently reverted).
- **Frontend** (`website/src/test/SubagentProgressBar.test.tsx`): reducer tests (store-by-slot, delete-at-zero, clamp garbage) and component tests (queued-only mount, no-flicker across the ramp when running hits zero with agents still queued, waiting-segment hides at zero, full unmount when nothing running/queued).

## Manual verification
Automated coverage exercises the reducer, component render states, and both backend call-sites. Local gates all green: pytest (`test_subagent_sizing` 53 + related subagent/gateway/queue suites 298), isort, flake8, mypy (479 files); tsc; vitest 18/18.

## Screenshots
Not captured in this change: a faithful shot needs a **live, model-backed queued wave** (a batch large enough to exceed the concurrency cap so agents sit in the "waiting" state), which the sandbox this was built in cannot run, and interactive browsing (Playwright MCP) was not enabled in the session. The visual delta is small and additive: a new muted `⏱ N` segment in the existing histogram header row (rendered only when `queued > 0`), sitting between the running-count spinner and the ✓ done count, matching the sibling `size={12}` icons. Happy to attach a captured shot from an isolated pod before merge if desired.
