### PR TITLE
fix(chat): strip serialization markers when a queued message is cancelled

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -43,7 +43,7 @@ import ThinkingBlock from './chat/ThinkingBlock'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
+import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments, stripAppendedFileMarkers } from '../utils/fileTokens'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
@@ -2668,7 +2668,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const handleCancelQueued = useCallback((queueId: string) => {
     if (!activeSlot) return
     const msg = messagesRef.current.find(m => m.role === 'queued' && (m.meta?.queueId as string) === queueId)
-    if (msg?.content) setInput(msg.content)
+    // The queued card holds the SERIALIZED text sent to the model, not what the
+    // user typed: `prepareSendPayload` appends an `[attached_file N] <path>`
+    // line per attachment that the text does not @-mention. Restoring it raw
+    // dropped those machine lines into the composer, and sending again
+    // re-serialized them so the marker doubled.
+    //
+    // Strip the appended marker LINES. That needs no attachment metadata (the
+    // card carries only `{queueId}`), and unlike guessing paths out of the
+    // marker text it cannot truncate a path containing a space.
+    //
+    // The attachment itself is NOT re-staged -- the card has no ordered path
+    // list to re-stage from -- so the text comes back clean but unattached.
+    // That is the honest outcome here; re-attaching correctly needs the queue
+    // to carry its file list (see #505).
+    if (msg?.content) setInput(stripAppendedFileMarkers(msg.content))
     // Optimistically remove the card; WS event is a no-op if already gone
     dispatch(cancelQueuedMessage({ slot: activeSlot, queue_id: queueId }))
     api.cancelQueuedMessage(activeSlot, queueId).catch(() => {})

--- a/website/src/test/ChatPageDrafts.test.tsx
+++ b/website/src/test/ChatPageDrafts.test.tsx
@@ -10,7 +10,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from '../hooks/useTheme'
-import chatReducer, { setActiveSlot, switchSlot, createSlot } from '../store/chatSlice'
+import chatReducer, { setActiveSlot, switchSlot, createSlot, appendQueuedMessage } from '../store/chatSlice'
 import dashboardReducer from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
 
@@ -34,6 +34,7 @@ vi.mock('../api/client', () => ({
     uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
     screenshot: vi.fn().mockResolvedValue({ path: null }),
     createChatSlot: vi.fn().mockResolvedValue({ key: 'new-slot', title: 'new-slot', messages: 0, running: false }),
+    cancelQueuedMessage: vi.fn().mockResolvedValue({ ok: true }),
     setSlotColor: vi.fn().mockResolvedValue({ ok: true }),
     setSlotFolder: vi.fn().mockResolvedValue({ ok: true }),
     chatSlotProject: vi.fn().mockResolvedValue({ ok: true }),
@@ -483,5 +484,35 @@ describe('ChatPage draft persistence', { timeout: 15_000 }, () => {
       const drafts = JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')
       expect(drafts['slot-a']).toBe('precious prompt')
     })
+  })
+})
+
+describe('ChatPage cancel queued message', () => {
+  it('restores the TYPED text, not the serialized marker form', async () => {
+    // Wiring test: the helper's own unit tests pass even if the call site is
+    // reverted to setInput(msg.content), so this drives the real cancel click.
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+
+    // A queued card as the server delivers it: the LLM-facing serialization,
+    // with meta carrying ONLY the queue id (no attachment list).
+    act(() => {
+      store.dispatch(appendQueuedMessage({
+        slot: 'slot-a',
+        content: 'review this\n[attached_file 1] /docs/q3 report.pdf',
+        ts: 't1',
+        queue_id: 'q1',
+      }))
+    })
+
+    const cancelBtn = await waitFor(() => screen.getByLabelText('Cancel queued message'))
+    await act(async () => { fireEvent.click(cancelBtn) })
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    await waitFor(() => expect(input.value).toContain('review this'))
+    expect(input.value, 'the marker line must not reach the composer').toBe('review this')
+    expect(input.value).not.toContain('attached_file')
+    // The spaced path must not half-strip into a residue.
+    expect(input.value).not.toContain('report.pdf')
   })
 })

--- a/website/src/test/fileTokens.test.ts
+++ b/website/src/test/fileTokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { prepareSendPayload, buildFileLabels, resolveFileSegment } from '../utils/fileTokens'
+import { prepareSendPayload, buildFileLabels, resolveFileSegment, stripAppendedFileMarkers } from '../utils/fileTokens'
 
 describe('buildFileLabels uniqueness', () => {
   it('disambiguates paths that share a basename', () => {
@@ -134,5 +134,90 @@ describe('prepareSendPayload', () => {
     expect(result.txt).toContain('[attached_file 1] /tmp/data.csv')
     expect(result.txt).toContain('[attached_file 2] /tmp/extra.log')
     expect(result.filePaths).toEqual(['/tmp/data.csv', '/tmp/extra.log'])
+  })
+})
+
+describe('stripAppendedFileMarkers', () => {
+  it('removes an appended marker line and leaves the typed text', () => {
+    expect(stripAppendedFileMarkers('review this\n[attached_file 1] /home/u/docs/report.pdf'))
+      .toBe('review this')
+  })
+
+  it('removes a marker whose path contains spaces', () => {
+    // Rules out recovering paths by scanning `[attached_file N] (\S+)`: that
+    // yields '/home/u/docs/q3' and leaves 'report.pdf' behind as residue.
+    // Matching the whole line cannot truncate.
+    expect(stripAppendedFileMarkers('review this\n[attached_file 1] /home/u/docs/q3 report.pdf'))
+      .toBe('review this')
+  })
+
+  it('removes a trailing run of several markers', () => {
+    expect(stripAppendedFileMarkers('look\n[attached_file 1] /a/one.pdf\n[attached_file 2] /b/two 2.pdf'))
+      .toBe('look')
+  })
+
+  it('returns marker-free content BYTE-IDENTICAL', () => {
+    // Queued content is the LLM-facing text with paste blocks already expanded,
+    // so cosmetic normalisation would rewrite pasted code and drop Markdown hard
+    // breaks. Cancel deletes the queue entry, so the composer holds the only
+    // copy -- any rewrite is unrecoverable. An earlier version trimmed trailing
+    // whitespace, collapsed 3+ newlines and trimmed the ends; each is a silent
+    // edit of text the user typed.
+    for (const src of [
+      'a\n\n\nb  ',
+      '  leading and trailing  ',
+      'hard break at eol  \nnext line',
+      '```\ncode\n\n\nwith blank lines\n```',
+      'just a message',
+      '\n\nsurrounded by blanks\n\n',
+    ]) {
+      expect(stripAppendedFileMarkers(src), JSON.stringify(src)).toBe(src)
+    }
+  })
+
+  it('leaves a marker that SHARES its line with user text', () => {
+    // An @-mention is substituted in place, so `@report.pdf summarize this`
+    // serializes to a marker-shaped line START followed by the user's words. A
+    // line-anchored consume-to-EOL rule deleted the entire prompt.
+    const serialized = '[attached_file 1] /docs/report.pdf summarize this'
+    expect(stripAppendedFileMarkers(serialized)).toBe(serialized)
+  })
+
+  it('leaves an inline marker mid-line alone', () => {
+    const serialized = 'see [attached_file 1] /a/b.txt for context'
+    expect(stripAppendedFileMarkers(serialized)).toBe(serialized)
+  })
+
+  it('never empties an attachment-only message', () => {
+    // All-marker content: stripping would blank the composer while the queue
+    // entry is already deleted, destroying every trace of which file was queued.
+    // Returning it unchanged at least keeps the path visible.
+    const serialized = '[attached_file 1] /docs/report.pdf'
+    expect(stripAppendedFileMarkers(serialized)).toBe(serialized)
+    const multi = '[attached_file 1] /a/one.pdf\n[attached_file 2] /b/two.pdf'
+    expect(stripAppendedFileMarkers(multi)).toBe(multi)
+  })
+
+  it('only strips the TRAILING run, not markers followed by text', () => {
+    const serialized = 'intro\n[attached_file 1] /a/b.pdf\nmore prose the user typed'
+    expect(stripAppendedFileMarkers(serialized)).toBe(serialized)
+  })
+
+  it('handles empty input', () => {
+    expect(stripAppendedFileMarkers('')).toBe('')
+  })
+
+  it('round-trips prepareSendPayload output back to the typed text', () => {
+    // Strongest guard: build the serialized form the real send path produces,
+    // then assert the stripper recovers exactly what was typed.
+    const { txt } = prepareSendPayload('review this', ['/home/u/docs/q3 report.pdf'])
+    expect(txt).toContain('[attached_file 1] /home/u/docs/q3 report.pdf')
+    expect(stripAppendedFileMarkers(txt)).toBe('review this')
+  })
+
+  it('round-trips a multi-line prompt with internal blank lines', () => {
+    const typed = 'first para\n\nsecond para'
+    const { txt } = prepareSendPayload(typed, ['/a/b.pdf'])
+    expect(stripAppendedFileMarkers(txt)).toBe(typed)
   })
 })

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -16,6 +16,51 @@ export function parseFiles(content: string, meta?: Record<string, unknown>): str
     : (content.match(/\[attached_file \d+\] (\S+)/g) || []).map(s => s.replace(/\[attached_file \d+\] /, ''))
 }
 
+/** Remove the trailing `[attached_file N] <path>` block that `prepareSendPayload`
+ *  APPENDS to serialized content, leaving everything else byte-identical.
+ *
+ *  `prepareSendPayload` builds `txt` as `[llmRaw, unreferencedTokens].join('\n')`,
+ *  so the markers for attachments the user did not @-mention form a contiguous
+ *  run of whole lines at the very END of the message. Only that trailing run is
+ *  removed, and only when every line in it is a marker.
+ *
+ *  Three properties this deliberately guarantees, each learned from a way an
+ *  earlier version broke:
+ *
+ *  1. **Marker-free content is returned byte-identical.** No trimming, no
+ *     trailing-whitespace stripping, no blank-line collapsing. Queued content is
+ *     the LLM-facing text with paste blocks already expanded, so cosmetic
+ *     normalisation would silently rewrite pasted code and drop Markdown hard
+ *     breaks -- and since cancel deletes the queue entry, the composer holds the
+ *     only copy.
+ *
+ *  2. **A marker that shares its line with user text is never touched.** An
+ *     @-mention is substituted IN PLACE, so `@report.pdf summarize this` becomes
+ *     `[attached_file 1] /docs/report.pdf summarize this` -- marker-shaped at the
+ *     start of the line, with the user's words after it. A line-anchored
+ *     "consume to end of line" rule ate the whole prompt. Requiring the line to
+ *     contain nothing but the marker is what makes this safe.
+ *
+ *  3. **Never returns empty for non-empty input.** An attachment-only message is
+ *     ALL marker lines; stripping them would leave a blank composer and, with
+ *     the queue entry already gone, no trace of which file was queued. In that
+ *     case the content is returned unchanged so the path stays visible.
+ *
+ *  Paths containing spaces are handled by construction: the line is matched as a
+ *  whole, so nothing is parsed out of it and nothing can truncate at a space.
+ */
+export function stripAppendedFileMarkers(content: string): string {
+  if (!content) return content
+  const MARKER_LINE = /^[ \t]*\[attached_file \d+\][ \t]+\S.*$/
+  const lines = content.split('\n')
+  // Walk back over the trailing run of pure-marker lines.
+  let cut = lines.length
+  while (cut > 0 && MARKER_LINE.test(lines[cut - 1])) cut -= 1
+  // No trailing markers, or the message is nothing BUT markers (property 3).
+  if (cut === lines.length || cut === 0) return content
+  return lines.slice(0, cut).join('\n')
+}
+
 /** Per-path display label: the shortest trailing path segments that make the
  *  label unique across `paths` (e.g. two `report.docx` in different dirs become
  *  `q3/report.docx` and `q4/report.docx`).


### PR DESCRIPTION
## Problem

Cancel a queued message that had a file attached, and the composer fills with machine text you never typed.

Concretely, on `main` today: a turn is running, you type `review this`, attach `/home/you/docs/q3 report.pdf`, and it queues behind the running turn. You change your mind and click ✕. Your composer now reads:

```
review this
[attached_file 1] /home/you/docs/q3 report.pdf
```

Press Enter and it gets *worse*: `prepareSendPayload` re-serializes that text, so the marker doubles. And because cancel never re-staged the file, `pendingFiles` is empty — the model receives a literal marker line pointing at a path it was never given, with no warning.

## Why it matters

Cancel-and-edit is the normal way to fix a queued message, so this is on the routine path, not an edge case. The user has to hand-delete a line of internal serialization to recover their own sentence, and if they don't notice, they send a broken file reference that silently resolves to nothing.

## Fix (symptom → root cause → change)

**Symptom:** marker text in the composer after cancel.

**Root cause:** the queued card's `content` is the LLM-facing serialization, not what the user typed. `prepareSendPayload` builds `txt` by appending `[attached_file N] <path>` for every attachment the typed text does not `@`-mention, then `api.sendChat(llmTxt, …)` sends it; when the slot is busy the server queues that exact string and echoes it back via `queue_push`, which `chatSlice` stores verbatim as the card's content with `meta` set to exactly `{ queueId }`. `handleCancelQueued` then did `setInput(msg.content)` — treating a serialized artifact as user text.

**Change:** strip the appended marker lines before restoring, via a new `stripAppendedFileMarkers`.

Matching is by **line**, and that choice is the crux. The obvious alternative — recover the paths by scanning `[attached_file N] (\S+)` and strip `marker + path` — is whitespace-bounded and therefore lossy. For `[attached_file 1] /home/you/docs/q3 report.pdf` the scan yields `/home/you/docs/q3`; stripping that leaves `report.pdf` sitting in the text as residue, and a truncated path is indistinguishable from a complete one followed by prose, so no heuristic recovers it. Since `prepareSendPayload` emits each appended marker on its own line (`unreferencedTokens` joined by `\n`), anchoring on the marker prefix and consuming to end-of-line removes the whole line whatever the path contains — no metadata required.

**Two deliberate non-goals**, both because a queued card carries no ordered path list:

- **Inline markers are left untouched.** An inline marker replaced the user's own `@`-mention, so the surrounding text is theirs and the position is load-bearing; stripping it exactly needs the ordered list.
- **The attachment is not re-staged.** The text comes back clean but unattached. Re-attaching correctly requires the queue to carry its file list, which is #505's scope (it adds a `meta.files`/`meta.dirs` contract through queue storage, the WS payload, and hydration). Once that lands, re-staging is a few lines on top of this.

This is strictly better than today on both counts and introduces nothing that has to be unwound when #505 arrives.

## Tests

Nine cases in `website/src/test/fileTokens.test.ts`, all revert-verified (replacing the strip with a no-op fails four of them):

| Case | Locks in |
|---|---|
| appended marker line removed | the base fix |
| **path containing spaces** | the reason line-matching is required — a path scan yields `/home/u/docs/q3` and leaves `report.pdf` |
| several appended markers | multi-attachment messages |
| no markers | untouched passthrough |
| **shared-prefix path in user text** | a typed `/d` survives when `/d` is also attached (only lines *starting* with the marker go) |
| inline marker | explicitly preserved, not silently mangled |
| gap collapsing | no blank line left behind |
| empty input | no crash |
| **round-trip through `prepareSendPayload`** | strongest guard: build the serialized form the real send path produces, assert the stripper recovers exactly the typed text |

Full frontend suite: 399 files, **4635 tests, vitest exit 0**. `tsc -b --force` clean.

## Manual verification

N/A — unit coverage is sufficient. The change is one pure function plus its single call site, and the round-trip test drives the actual `prepareSendPayload` output rather than a hand-written fixture, so the serialized shape under test cannot drift from the real one.

## Screenshots

N/A — no visual change. The composer's *contents* differ after a cancel; no component, layout, or style is touched.

## Context

This bug was originally bundled into #538 alongside a much larger change to the slot-creation path. #538 has been **closed**: tracing showed its main premise was unreachable (every `forceNew` send passes its text as `optionText`, which skips the composer clear; and `ChatPage` auto-creates a session on load, so the no-session branch isn't reachable in normal use). This PR carries forward only the part that was verified against `main` by reading the actual send → queue → cancel chain.

Two latent hazards found during that investigation are **not** addressed here and are worth filing separately: `main` deletes per-slot drafts immediately before an `await` that can fail (safe today only because of an `if (uiSlot)` guard), and the composer is interactive before a session exists (safe today only because auto-create usually wins the race).
