### PR TITLE
fix: trust any runnable Kiro CLI for setup and ACP launch

### DIFF
--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -270,21 +270,20 @@ package. The second step runs `kiro-cli login --use-device-flow`, displays the
 secure sign-in URL and code, and opens the Kiro Crew dashboard only after
 `kiro-cli whoami` succeeds.
 An installed candidate that cannot start is shown as needing repair rather than
-as merely signed out. A broken existing macOS app bundle or Linux user-local
+as merely signed out; one that runs is directly usable for sign-in regardless of
+install source (toolbox, Homebrew, winget, the official installer, or a
+self-updated bundle) — trust is "the CLI runs, and it has a valid login", not
+where it was installed. A broken existing macOS app bundle or Linux user-local
 binary is repaired through the official interactive guide when the upstream
 installer requires terminal confirmation before replacing it. Installation and
 sign-in never start silently in the background. Setup subprocesses receive a
 minimal allowlisted environment rather than the desktop shell's credentials;
-unverified version probes use the strict OS sandbox and hide every known Kiro
-identity store. The fixed `whoami` and device-login calls run only after
-Kiro Crew verifies immutable system/operator provenance or a SHA-256
-attestation recorded immediately after the pinned official installer. Those
-installer bytes may attest only the exact platform install target, and only
-when that target is new or changed; a higher-priority shadowing executable is
-reported for repair instead of receiving credential access. Those
-calls use a standard sandbox with a temporary home containing only Kiro
-identity token files; unrelated AWS, SSH, GitHub, Kubernetes, and Kiro Crew
-state remain unavailable. Timed-out commands signal a POSIX process group only
+version probes use the strict OS sandbox and hide every known Kiro identity
+store. `whoami` and device-login run for any runnable candidate; they use a
+standard sandbox with a temporary home containing only Kiro identity token
+files, so unrelated AWS, SSH, GitHub, Kubernetes, and Kiro Crew state remain
+unavailable, and POSIX auth still executes a private snapshot of the exact
+resolved bytes. Timed-out commands signal a POSIX process group only
 while its leader still anchors that identity; on Windows, exact retained process
 handles terminate observed descendants without trusting recycled PIDs. Cleanup
 finishes before the gateway permits a retry.

--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -1,8 +1,9 @@
 # ACP Client Module
 
-Last Updated: 2026-07-26 (cross-platform ACP executable provenance,
-direct-CLI process-start attestation, private launch snapshots, and off-loop
-cleanup)
+Last Updated: 2026-07-27 (ACP trust simplified to "the CLI runs" — install
+source/owner/path/codesign no longer gate launch, so toolbox/Homebrew/winget/
+self-updated installs work; resolve-to-exec integrity snapshots and off-loop
+cleanup retained)
 
 ## Overview
 
@@ -15,46 +16,41 @@ The ACP layer spans **five** modules: the legacy per-session client (`acp/client
 - `""` (default): `kiro-cli acp --agent <name>` (resolved by `_resolve_kiro_bin`). Per-session kiro settings are layered in via the workspace overlay `<work_dir>/.kiro/settings/cli.json` (written by `AcpProvider`, not the client): reasoning **effort** (`chat.modelDefaults`) and **MCP Tool Search** (`toolSearch.enabled` + zeroed thresholds, gated by `agent.tool_search`, default on) — see providers.md.
 - `"claude"` (`ACP_BACKEND_CLAUDE`): `claude-agent-acp` (resolved by `_resolve_claude_acp_bin` → `list[str] | None`). Resolution order: `CLAUDE_AGENT_ACP_BIN` env var, then the **vendored copy** (`_resolve_vendored_claude_acp` — `<node_modules>/@agentclientprotocol/claude-agent-acp/dist/index.js` found under the package's `_vendor/node_modules` from the distribution bundle, the sibling `KiroCrewWebsite/node_modules` in a source checkout, or `KIROCREW_PROJECT_DIR`; needs no global npm install or network — matters on hosts that have no package-registry token at gateway runtime), then `mise which claude-agent-acp` (respects MISE_DATA_DIR and all mise config), then `~/.local/share/mise/installs/node/*/bin/claude-agent-acp` (direct glob fallback), then augmented PATH (`env.augmented_path` — mise shims, `~/.npm-packages/bin`, `~/.volta/bin`, `/opt/homebrew/bin`, plus globbed nvm/fnm node bins via `_node_version_manager_bins`, so a non-login launchd/systemd gateway also finds globally-installed binaries). The adapter is vendored into the distribution bundle and the pip build by `setup.py` (`_vendor_acp_into_pkg` → `kiro_crew/_vendor/node_modules`), so every install method ships it without asking the user to `npm i -g`. Vendoring copies the adapter **plus its full transitive dependency closure** (`_acp_dependency_closure` walks `dependencies`/`optionalDependencies` from the resolved website `node_modules`, ~96 flat top-level packages) — npm hoists deps like `@agentclientprotocol/sdk` flat, so copying only the adapter package crashes the ESM loader with `ERR_MODULE_NOT_FOUND`. `_resolve_vendored_claude_acp` accepts a root only when the hoisted dependency marker `@agentclientprotocol/sdk` is present alongside the entry, so an incomplete vendored copy is skipped in favour of a complete one instead of being spawned and crashed. For scripts under mise installs, returns `[node_binary, script_path]` to bypass `#!/usr/bin/env node` shebang resolution which fails in non-interactive daemon contexts. For standalone binaries, returns `[binary_path]`. Pre-spawn the client writes `<work_dir>/.claude/settings.local.json` with `defaultMode: default` so the adapter routes every tool decision back to KiroCrew via `session/request_permission`. This makes claude-agent-acp participate in the same approve / trust_reads / trust / yolo protocol as kiro-cli — dashboard, subagents, channel agents, cron, and heartbeat all share the path. KiroCrew still enforces per-tool security via `HooksConfig.auto_deny_tools` (evaluated by `HookManager.on_tool_call` in `hooks.py`) on every `session/request_permission` event. The subprocess env also carries `CLAUDE_CONFIG_DIR=<config_dir>/cc-config` (isolated config root, distinct from the project-scope `<work_dir>/.claude/settings.local.json` which stays) so the adapter's `SettingsManager` and the SDK read KiroCrew's seeded settings (creds/models kept, plugins stripped) instead of the user's global `~/.claude` — see claude-code-provider.md "Config Isolation" (the "Standalone provider — removed" record). Disable via `KIROCREW_CC_ISOLATE=0`. The env also carries `CLAUDE_CODE_EXECUTABLE` (claude backend only, set in `_spawn` when unset): the adapter delegates the model turn to `@anthropic-ai/claude-agent-sdk`, which needs a per-platform native Claude binary (~250 MB each) shipped as npm `optionalDependencies` that the website install omits — so the vendored closure does **not** include it and the SDK fails `session/new` with `Claude native binary not found for <platform>`. The SDK does **not** search PATH for `claude` itself (so the host merely having the external agent CLI installed is not enough), and bundling a quarter-GB binary per platform is not viable; instead `_resolve_claude_code_executable` finds an existing `claude` (`CLAUDE_CODE_EXECUTABLE` override → `mise which claude` → augmented PATH incl. `~/.toolbox/bin`, where a managed distribution may ship the external agent CLI) and the adapter forwards it to the SDK as `pathToClaudeCodeExecutable` (no version check). If none is found the var is left unset (with a warning) so the adapter's native-binary error surfaces rather than a guessed bad path; an explicit operator-set value always wins.
 
-**Kiro executable provenance at spawn.** Current bytes must match the protected
-official-installer trust record, an immutable root-owned system candidate, or
-the explicit override digest pinned when the owning process started. The
-gateway pins through the prerequisite service; direct agent-bearing CLI
-commands pin before the jail gate or provider factory runs.
-Symlink candidates are canonicalized before the final no-follow open. On Linux,
-the verified bytes are copied into a `MFD_ALLOW_SEALING | MFD_EXEC` memfd and
-`F_SEAL_WRITE|GROW|SHRINK|SEAL` is applied through `platform_compat`; both
-`AcpClient` and `AcpRuntime` pass that descriptor through the sandbox/cgroup
-wrapper chain and execute its `/proc/self/fd/<fd>` identity; the gateway closes
-its copy immediately after process creation, while the child retains the
-inherited descriptor. Kernels that predate `MFD_EXEC` reject the flag with
-`EINVAL`; creation retries once without that flag, while every other error
-remains fail-closed. There is no mutable pathname or verify-to-exec replacement
-window. macOS cannot reliably execute Mach-O through `/dev/fd`, so it first
-requires the current digest to match protected post-installer, process-start
-override, or immutable-system provenance and requires `/usr/bin/codesign` to
-verify the pinned Kiro Developer ID designated requirement, identifier/team,
-and hardened-runtime flag. It then copies those exact digest-checked bytes into
-the agent-protected `<data-home>/run/kiro-cli-snapshots` directory and launches
-that private path, closing the user-owned `/Applications` replacement window.
-The spawn passes an explicit `is_kiro_cli` classification to `wrap_argv`, so
-macOS internal-sandbox delegation does not depend on the private launch-path
-basename. Windows canonicalizes the resolved candidate and rejects it before
-spawn unless it remains under the fixed Program Files `Kiro-Cli` tree; an
-override, inherited `PATH`, or interpreter `Scripts` candidate cannot bypass
-that boundary. Digest, signature, and snapshot preparation runs off the event
-loop; oversized candidates are rejected before hashing. If a caller is
-cancelled while a worker is still preparing a snapshot, startup waits for that
-worker and reclaims any late descriptor or private path. Snapshot ownership is
-removed from the registry synchronously. Descriptor close runs immediately
-after spawn; a macOS private path remains until the ACP handshake proves the
-sandbox wrapper executed it. Close and unlink use the dedicated
-`subprocess_executor` so teardown cannot block the gateway event loop. The ACP
-clients and dashboard usage/model-list one-shot callers all pass inherited
-Linux descriptors when spawning and release their
-registered snapshot in every success, error, and early-return path. The offline
-E2E harness can launch only the exact packaged fake ACP backend under its
-explicit test marker; arbitrary macOS overrides still require the production
-provenance and Developer ID checks.
+**Kiro executable integrity at spawn.** Trust is "the CLI runs": any resolvable
+executable Kiro CLI launches for ACP, regardless of install source, owner, or
+fixed path — KiroCrew is not the authority on where Kiro CLI is installed, and
+Kiro CLI's own self-updater legitimately rewrites its bytes as the user, so an
+install-source/owner/path/codesign gate would strand real installs (toolbox,
+Homebrew, winget, a self-updated `/Applications` bundle) with no recovery path.
+`snapshot_trusted_acp_executable` refuses only a non-runnable candidate.
+The snapshot still pins the resolved bytes so a swap **between resolve and exec**
+cannot reach the running process. Symlink candidates are canonicalized before
+the final no-follow open. On Linux, the resolved bytes are copied into a
+`MFD_ALLOW_SEALING | MFD_EXEC` memfd and `F_SEAL_WRITE|GROW|SHRINK|SEAL` is
+applied through `platform_compat`; both `AcpClient` and `AcpRuntime` pass that
+descriptor through the sandbox/cgroup wrapper chain and execute its
+`/proc/self/fd/<fd>` identity; the gateway closes its copy immediately after
+process creation, while the child retains the inherited descriptor. Kernels that
+predate `MFD_EXEC` reject the flag with `EINVAL`; creation retries once without
+that flag, while every other error remains fail-closed. There is no mutable
+pathname or verify-to-exec replacement window. macOS cannot reliably execute
+Mach-O through `/dev/fd`, so it copies the resolved bytes into the
+agent-protected `<data-home>/run/kiro-cli-snapshots` directory and launches that
+private path, closing the resolve-to-exec replacement window. The spawn passes
+an explicit `is_kiro_cli` classification to `wrap_argv`, so macOS
+internal-sandbox delegation does not depend on the private launch-path basename.
+Windows launches the resolved candidate in place. Digest and snapshot
+preparation runs off the event loop; oversized candidates are rejected before
+hashing. If a caller is cancelled while a worker is still preparing a snapshot,
+startup waits for that worker and reclaims any late descriptor or private path.
+Snapshot ownership is removed from the registry synchronously. Descriptor close
+runs immediately after spawn; a macOS private path remains until the ACP
+handshake proves the sandbox wrapper executed it. Close and unlink use the
+dedicated `subprocess_executor` so teardown cannot block the gateway event loop.
+The ACP clients and dashboard usage/model-list one-shot callers all pass
+inherited Linux descriptors when spawning and release their registered snapshot
+in every success, error, and early-return path. The offline E2E harness launches
+the exact packaged fake ACP backend in place under its explicit test marker.
 
 ## Tool Permission Protocol
 

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1,7 +1,8 @@
 # CLI Module
 
-Last Updated: 2026-07-26 (first-run setup, direct-CLI ACP provenance, and
-fail-closed process tracking)
+Last Updated: 2026-07-27 (Kiro CLI trust simplified to "runs + valid login" —
+install source/owner/path no longer gate setup or ACP launch; resolve-to-exec
+integrity snapshots retained)
 
 ## Overview
 
@@ -131,9 +132,9 @@ from a different later installation.
   POSIX installer would require an interactive `/dev/tty` replacement prompt
   (an existing macOS app bundle or Linux `~/.local/bin/kiro-cli`), automatic
   repair is disabled and the user is directed to the official guide.
-  A usable but unattested candidate outside those interactive replacement
-  locations can run the validated reinstall path and is attested only after the
-  installer completes.
+  A candidate that already runs is directly usable for sign-in regardless of
+  install source; the post-installer attestation file is now write-only
+  bookkeeping and does not gate credential access.
 - Installed but signed out: the setup page starts
   `kiro-cli login --use-device-flow`, relays its sign-in URL/code, and requires
   a successful `kiro-cli whoami` before continuing. Only the official
@@ -164,17 +165,14 @@ or subprocess implementation. Filesystem discovery runs off the event loop.
 Version probes use a minimal noninteractive environment with no proxy
 credentials or desktop-session IPC. They use the strict OS sandbox and
 additionally hide the configured data home, `~/.kiro/crew`, `~/.kirocrew`, and
-every known Kiro identity store. A candidate is eligible for `whoami` and
-device login only when it has immutable system/operator provenance or matches
-the path and SHA-256 attestation recorded immediately after Kiro Crew runs the
-release-pinned official installer. That attestation is on the
-agent-inaccessible sensitive-path floor. POSIX auth calls execute an owner-only
-snapshot under the protected runtime directory, binding the bytes that passed
-verification to the executable that receives staged credentials.
-When `KIROCREW_KIRO_BIN` is set on POSIX, the gateway prerequisite service and
-every direct agent-bearing CLI command (`chat`, `tui`, `run`, `consolidate`,
-and `eval`) register the override's canonical path and first-observed digest
-before a jail re-exec or provider can start.
+every known Kiro identity store. Any candidate that runs `--version` is eligible
+for `whoami` and device login — trust is "it runs, and it has a valid login",
+not install source, owner, or fixed path (KiroCrew is not the authority on where
+Kiro CLI is installed, and its self-updater rewrites its own bytes as the user).
+POSIX auth calls still execute an owner-only snapshot of the exact resolved
+bytes under the protected runtime directory, binding the process that receives
+staged credentials to the bytes just resolved (no stored digest pin, so a
+legitimate self-update does not break sign-in).
 Authentication commands run in the standard sandbox against a temporary home
 populated only with Kiro identity JSON and SQLite files. The temporary state is
 published only after a successful command; failure, timeout, or cancellation
@@ -224,15 +222,16 @@ POSIX setup operation fails cleanly before spawning a command.
 Sandbox launcher/profile preparation and cleanup are worker-thread operations
 and do not stall the asyncio gateway loop.
 
-Setup and ACP launch share the side-effect-free `kiro_cli` resolver. Status
-requests never publish a discovered path by mutating `KIROCREW_KIRO_BIN`.
-Because Windows has no equivalent OS sandbox for passive probes, setup readiness
-executes only candidates under the fixed Program Files `Kiro-Cli` tree.
-The shared resolver still enumerates inherited `PATH`, the interpreter Scripts
-directory, and an operator override for compatibility, but Windows ACP launch
-rejects any resolved candidate outside that same Program Files tree before
-spawn. A higher-priority untrusted candidate therefore blocks readiness and
-launch rather than silently falling through to a later executable.
+Setup and ACP launch share the side-effect-free `kiro_cli` resolver on every OS.
+Status requests never publish a discovered path by mutating `KIROCREW_KIRO_BIN`.
+Both setup discovery and ACP launch enumerate the same candidates — inherited
+`PATH`, the interpreter Scripts directory, package-manager dirs (incl. the
+Windows Program Files `Kiro-Cli` tree and winget/scoop/user installs on `PATH`),
+and an operator override — and accept a runnable candidate wherever it lives,
+since trust is "the CLI runs". ACP launch runs the resolved candidate in place
+(macOS/Linux snapshot the resolved bytes for resolve-to-exec integrity; Windows
+launches in place). Setup discovery and ACP resolution therefore agree on
+Windows, so a winget/scoop install is never sent to a redundant reinstall.
 
 When a previously completed setup is no longer ready, the dashboard remains
 navigable but session creation and turn submission are paused. The shared

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -493,13 +493,13 @@ still refresh while the dashboard body is blocked. On a new gateway it:
 4. polls setup operations every second, surfaces the HTTPS login URL and code
    as React text, and records first-run completion when `ready=true`.
 
-On Linux, an existing unverified default target (`~/.local/bin/kiro-cli`) cannot
-be overwritten automatically because the official installer would require an
-interactive terminal prompt, and reinstalling outside Kiro Crew would not create
-the binary attestation required before credential access. The setup and
-reauthentication surfaces therefore direct the owner to remove that exact target,
-choose **Check again**, and then use the newly enabled dashboard installer. This
-validated dashboard install is what writes the attestation before sign-in.
+Any Kiro CLI that runs is directly usable for sign-in regardless of how it was
+installed (toolbox, Homebrew, winget, the official installer, or a self-updated
+bundle). Trust is "the CLI runs, and it has a valid login" — install source,
+owner, and path do not gate setup or ACP launch — so an installed-but-signed-out
+CLI always offers an enabled **Sign in to Kiro** rather than a button-less
+"repair" dead end. The `.kiro_cli_binary_trust.json` the dashboard installer
+still writes is bookkeeping only and does not gate credential access.
 
 Ready dashboards continue prerequisite polling every 30 seconds so later
 sign-out or CLI damage is detected without a reload. Paused session-start

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1,7 +1,12 @@
 # Security Module
 
-Latest amendment: 2026-07-26 (pre-request installer redirect validation,
-direct-CLI ACP attestation, and fail-closed Windows process enumeration).
+Latest amendment: 2026-07-27 (Kiro CLI prerequisite trust simplified to "the CLI
+runs, and it has a valid login" — install source/owner/path/Developer-ID no
+longer gate setup or ACP launch, removing the first-run/reauth dead end for
+toolbox/Homebrew/winget/self-updated installs; the resolve-to-exec integrity
+snapshot, HOME isolation, output redaction, publish lock, and SEL audit are
+retained). Prior: pre-request installer redirect validation, direct-CLI ACP
+attestation, and fail-closed Windows process enumeration.
 
 Last Updated: 2026-07-24 (`file_send` Slack audience is now decided by a strict three-state caller-identity classification (`_classify_slack_identity` → `thread`/`non_slack`/`unresolved`) resolved via `_resolve_session_key_strict()` only; an `unresolved` caller's Slack upload is REFUSED (SEL `slack_identity_unresolved_upload_refused`, dashboard delivery still succeeds) rather than broadcast at the channel root — see "Slack Delivery Audience" under Binary File Handling. Prior — Data home moved from top-level `~/.kirocrew` to `~/.kiro/crew` (nested under kiro-cli's `~/.kiro/` base). The sensitive-path floor now expands each KiroCrew secret/trust-root leaf under EVERY known crew-home prefix — `_CREW_HOME_PREFIXES = (".kiro/crew", ".kirocrew.archived", ".kirocrew")` — so `.env`/`sel_hmac.key`/`security_events.jsonl`/`app_admission.json`/`security_policy.json`/`profiles`/`admission_policy.json`/`denied_commands.json`/`token_signing.key`/`refresh_chains.json`/`.local_secret`/`run` are read+write-blocked in the current home, the archived rollback copy `~/.kirocrew.archived` (which still holds real secret bytes after the one-time migration), AND a not-yet-migrated pre-move `~/.kirocrew`. `_WRITE_PROTECTED_HOME_PATHS` (`config.json`/`config.local.json`) is expanded the same way; multi-segment leaves are re-joined with the OS separator so a `.kiro/crew/...` target still matches on Windows. The file-explorer crew-home deny-by-default matcher (`_crew_home_index`) now casefolds so an uppercase `~/.KIRO/crew/...` path can't slip past it on case-insensitive filesystems. Prior — 2026-07-24 remote-instance run-marker exec dir on the sensitive floor — the gateway records its own venv `kirocrew` launcher at `<home>/run/gateway-<port>.bin` (`instances/run_marker.py`, written via `atomic_write`) and the SSH token-mint + `restart_remote` `exec` it first, keyed by the remote port (marker-first resolution, falling back to the PATH candidate ladder); `run` was added to the crew-home secret leaves (full read+write block under every prefix) because its contents are exec'd unsandboxed over SSH, so an agent that could write a marker or a sandbox launcher there could escalate to unsandboxed execution — the gateway's own writers open these paths directly and do NOT route through `is_sensitive_path`. Prior: federated registry URL support: `POST /api/apps/registries` now admits a vetted full git URL as `repo` (not just a bare name) via `_is_safe_repo_identifier`, requires `https://` for HTTP-style remotes (plaintext `http://` rejected — CWE-319 MITM), derives a collision-safe default `name` from URL host+path (`_derive_registry_name`), and defaults `branch` to `main` (was `mainline`); all cache-path derivations (`_safe_cache_stem`/`_external_registry_cache_path`/`_blob_cache_key`) keep pure-safe names byte-identical but slug+sha256 disambiguate URL-derived names so a traversal/collision entry can neither escape `_manifest_cache_dir()` nor clobber another's cache; new `POST /api/apps/registries/refresh` fetch-then-swap re-warm returns `{ok, refreshed, failed, results, apps, lastSyncedAt}` and only overwrites a cache on a successful fetch (stale > missing); an untrusted registry index is treated as untrusted input on two trust boundaries — `is_clone_host_trusted` (fail-closed SSRF/rebinding gate at the three clone chokepoints `_fetch_git_blob`/`_fetch_app_manifest`/`_git_clone_or_pull`, host-level not IP) refuses cloning any host outside the public-forge ∪ configured-registry set, and a `KEBAB_RE` entry-name filter drops non-kebab index entries before they reach a filesystem op (path-traversal defense, warning-logged only); admitting a new registry host emits a distinct per-host `registries.host_trust_granted` SEL event and returns `newlyTrustedHosts` so the one-way trust grant is auditable. Prior: user-configurable denied commands — opt-out state on the KEYSTONE floor. The opt-out state (`{disable_all, disabled_ids, user_added}`) lives in `~/.kirocrew/denied_commands.json`, added to `_SENSITIVE_HOME_DIRS` (full read+write block) + the governance boot-integrity `required` tuple — NOT in the agent-readable `config.json`. So the agent can neither read nor write its own deny ceiling via ANY shell form, inheriting the mature `is_sensitive_path` gate (variable-indirection, symlinks, KIROCREW_HOME, interpreters, casefold, realpath) at the same protection level as `security_policy.json`. This REPLACED an earlier config.json + bespoke bash write-matcher approach (removed) that a series of shell-obfuscation vectors kept bypassing. Boot merges the keystone state over config.json's flat `hooks` keys (`hooks_config_from_config_dict`); the 6 dashboard mutations + `_write_denied_state` target the keystone file (0600); `_reload_live_hooks` splices the new opt-out fields onto the live `HookManager` preserving flat keys. Other invariants retained from the feature build: `HooksConfig.from_dict` is fully defensive against malformed hand-edited values (type-checks every field; `_coerce_bool` for booleans so `"false"` is not truthy); `_DenyMatcher` runs the fast fragment-split path ONLY for the RE2-authored, parity-tested built-ins; EVERY user custom regex uses the exact bounded whole-regex engine (backtracking preserved, ReDoS-safe via `is_safe_user_regex`), so a user pattern like `(ab|a).*b` or a greedy `rm .+.*x` cannot under-match the forward-only fragment matcher and let a denied command through — the bound is the first `_DENY_FALLBACK_SCAN_MAX_CHARS` (2000) chars, a DOCUMENTED trade-off (Python `re` can't give exact-semantics + full-input + ReDoS-safety at once, and true full-input would need an RE2 dependency the project avoids); the residual is user-custom-regex-only (the 137 built-in security rules are full-input via the fragment matcher) and the only bypass is a single >2000-char shell segment defeating the user's OWN custom rule; the Settings > Security disable-all toggle stays functional when governance-locked (backend keeps pinned rules enforced under `disable_all`); `pinned_builtin_command_ids()` is ceiling-only for ENFORCEMENT while `pinned_builtin_command_ids_for_snapshot()` unions all profiles for DISPLAY; heartbeat hooks rebuild per run. Prior: macOS sandbox mutual exclusion: kiro-cli >= 2.13 ships an internal agent sandbox toggled by `"sandbox"` in `~/.kiro/settings/amazon-internal.json`; it cannot nest inside KiroCrew's seatbelt (kernel EPERM), so `wrap_argv()` delegates isolation to it for kiro-cli spawns on macOS when enabled (`kiro_internal_sandbox_enabled()`/`_delegate_to_kiro_internal_sandbox()`), audit-or-deny SEL + shared env scrub + fail-toward-KiroCrew's-sandbox; macOS-only. Also Stop hooks now receive the full final assistant segment on stdin as `assistant_text` (env `KIROCREW_HOOK_CONTEXT` capped at 500 for ARG_MAX). Prior: independent source-tabs hardening: authenticated GitHub/GitLab provider spawns now fail closed unless the CLI path is canonical, root-owned end to end, non-writable by the gateway user, and contains no symlinks, which makes path validation stable through exec against a same-UID agent; ordinary user-owned Homebrew/Linuxbrew binaries are deliberately rejected. Provider commands use 1 MiB metadata/check, 2 MiB discussion, and 4 MiB diff stdout ceilings; unique direct full/check tasks hold conservative 64/8 MiB reservations under a 128 MiB aggregate ceiling until task completion, with same-URL coalescing before admission and detached stale work retaining its lease. Frontend source indexing admits only durable messages, and backend/frontend/panel source retention stops at 64 first-seen links per slot. Prior: authenticated GitHub/GitLab source-provider CLI spawns use validated absolute executables, `sandboxed_spawn_argv(..., mode="standard")`, fixed provider environments and public hosts, bounded outputs/payloads, and global process/admission caps; review-thread resolution remains exact-owner-only with coarse redacted SEL audit and pre-dispatch cache-generation invalidation. Prior: edition-neutral agent executable resolver seam: the public core no longer contains edition-specific launcher detection; `PlatformContext.agent_executable` resolves argv[0] before the unchanged outer sandbox, with identity standalone behavior and fail-closed composition semantics. Prior: Sandbox probe cache policy — transient probe failures never cached, prewarm_backend() boot hook + never-block-on-loop invariant; see "Probe failure classification + cache policy". Prior: macOS 26 sandbox restored: removed the wrong hard-coded `major >= 26 -> return False` gate in `_probe_sandbox_exec()` — Seatbelt/`sandbox-exec` still work on macOS 26 (Tahoe), so the empirical probe now decides on all versions. macOS 26 users get full Seatbelt isolation (credential-path + hardlink denies) instead of the fail-closed no-isolation path; verified the real profile compiles, runs kiro-cli, and enforces `~/.aws` denies on 26.5. Commit 92e24570: added the `sandboxed_spawn_argv` chokepoint — `wrap_argv` OS isolation + `scrub_env` credential-env scrub in one call — and routed the three agent-influenced subprocess spawns through it (`mcp_discovery.probe_server`, `task_executor.run_tests`, `git_coord._git`/`_is_git_repo`), which previously ran with the full inherited environment and no wrapper; added `test/test_spawn_audit.py`, an AST tripwire asserting every spawn in `src/kiro_crew` is either chokepoint-routed or in an explicit benign allowlist. Prior: Gateway boot resilience: `apps/backend.py:start_enabled_app_backends()` now wraps each `start_app_backend()` in try/except so a per-app spawn failure — notably `wrap_argv()` fail-closing when no sandbox backend exists, e.g. macOS 26 where `sandbox-exec` is gone — is logged + `error`-audited + skipped instead of crashing the whole gateway. Prior: documented the advisory-only App Kit manifest permission model — `apps/permissions.py:validate_permissions`/`format_permissions_summary` are unwired dead code (only exercised by tests), `check_tool_permission` empty-list fail-open, distinct from the enforced HTTP app-token scope; in-process enforcement deferred to app-sandbox-roadmap.md. Also: contained App Kit admission gate (`apps/admission.py`, banned/approved/optional-HMAC-signature, fail-closed on unreadable policy) on install/update/enable/register/registry, and canonical path-containment on `backend.entryPoint` + absolute-path rejection in `AppManifest.validate` with a runtime backstop in `apps/backend.py`; hard off-switch `agent.apps_allow_third_party` refuses in-process AND out-of-process third-party app Python (per input-validation guidance); reverse-proxy HMAC now binds `sha256(body)`; `~/.kirocrew/app_admission.json` added to the sensitive-path floor. Prior commit 78224f3f: exfil-URL scan now covers the full path (not just query-after-`?`) via `_HARD_CREDENTIAL_RE` and `_URL_RE` matches raw IPv4 / bracketed IPv6 literal hosts, closing the path-embedded-secret and raw-IP-destination bypasses; commit 5682f92b: data-egress/reverse-shell command shapes (`_BASH_EXFIL_PATTERNS` / `audit_bash_exfiltration()`) are now DENIED at the tool-invocation gate (`hooks.on_tool_call` + `mcp_cron`), previously only advisory-audited. Prior: Consolidated redaction/SSRF/XPIA follow-ups: PEM round-3 (05687e60) — truncated-key run crosses a single blank line via `(?=\r?\n[A-Za-z0-9+/=])` so RFC 1421 ENCRYPTED bodies past the `DEK-Info:` blank line are redacted, TWO+ blanks still terminate; JWT/JWE union (cc1d6bdd/a8e5fe6a) — `_CREDENTIAL_PATTERNS` `eyJ` quantifier widened to `(?:\.[A-Za-z0-9_-]*){2,4}` (JWS + 5-seg JWE incl. dir/ECDH-ES empty segment) and Bearer alternative made JSON-aware + case-insensitive (`(?i:Authorization)["']?[:=]["']?(?i:Bearer)`); `StreamRedactor` split-Bearer + ceiling — `_BEARER_ANCHOR_PARTIAL_RE` holds a split `Authorization: Bearer <token>` across chunks, `_PARTIAL_JWT_TAIL_RE` (`{0,4}`) + `_STREAM_HOLDBACK_JWT_MAX=4096` un-bisect a terminal JWT/JWE/opaque-Bearer, and a credential-anchored tail past the ceiling FAILS CLOSED via `_REDACTED_CREDENTIAL_TAG` (plain runs still committed); entropy glued-secret (bf7b1baf) — pass 3 gates each `{40,}` run through `_contains_bare_secret()` sliding a 40-char window so a secret glued to an adjacent base64 char is caught; XPIA round-2 (1fde6107) — case-insensitive/whitespace-tolerant thread-parent fence neutralization (`_neutralize_fence_markers`) + explicit WITHHELD branch for an injection-tripped parent, and `scan_memory()` degrades on ANY import failure (was `ImportError`-only); SSRF trailing-dot (76640a75) — `_resolve_blocked_addr` rstrips a trailing dot before parsing so `169.254.169.254.`/`127.0.0.1.` classify as blocked. Also folds the empty-user DB-URI fix (`://[^\s:/@]*:`). Prior: shared redacting `_dm_owner` owner-DM exit point for the Slack expiry notification; Spec drift sync: documented protected-branch git-push gate (`_PROTECTED_BRANCHES` + ambiguous refs + `_PUSH_ALL_BRANCHES_FLAGS` deny, pure `_is_git_publish` detector, centralized allow/deny + `push_allowed`/deny SEL in `is_denied`, per-segment `_is_push_to_protected_branch`); Host-header DNS-rebinding validation (`check_host`/`build_allowed_hosts`/`host_validation_middleware`); conditional PYTHONPATH/PYTHONHOME strip on the kiro-cli spawn path (`_PYTHON_ENV_PREFIXES`); denied-command count 113→116 + bundled-defaults path fix to `src/kiro_crew/config/defaults.json`. Prior: widget-postMessage forged-turn: backend deny-by-default guard in `api_chat` refuses orchestrator `go`/`go all` auto-run escalation for `meta.origin='widget'` turns — SEL `auto_run_denied` — completing item 5 backend half; frontend human-gesture pre-fill + `origin` tag already shipped. Prior: Pentest round 2 + auth hardening: `StreamRedactor` cross-chunk credential holdback (`_STREAM_HOLDBACK_MAX=512`) + ~12 third-party provider token families (GitHub/GitLab/Stripe/SendGrid/OpenAI/Anthropic/npm/PyPI/DigitalOcean/Google OAuth) + DB connection URIs added to `redact_credentials`; `is_sensitive_path()` symlink resolution (realpath/`Path.resolve` + casefold home-realpath anchor, CWE-59) + `ln`/`cp` symlink-staging block; per-session logout `RevokedNonceStore` denylist + `revoke_access_cookie()` deny-by-default (CWE-613), link-click mints a separate session cookie (`register_nonce=False`) and denylists the link nonce; app-token `_enforce_app_scope` least-privilege confinement (CWE-269); `mc_token_<port>` `Secure` via `origin.is_https_request()`. Prior: challenge-and-redirect for Slack REMOVED — messages processed inline; SEC-009 loud no-isolation fallback + `agent.sandbox_allow_no_isolation`; time-limited safety override replacing permanent YOLO, per-segment deny pattern evaluation, 3-tier interactive trust escalation, SSH tunnel -N flag fix)
 
@@ -698,30 +703,30 @@ preventing a planted `kiro-cli` basename from selecting the provider's trusted
 internal macOS delegation path. The strict wrapper additionally hides the
 configured data home, `~/.kiro/crew`, `~/.kirocrew`, and all known Kiro
 identity stores, so setup probes cannot read Kiro Crew state or bearer tokens.
-Passing `--version` never promotes a user-writable candidate into credential
-access. `whoami` and device login require either an immutable system/operator
-candidate or an exact path + SHA-256 attestation written after the validated
-official installer completes. The attestation file is included in
-`_CREW_SECRET_LEAVES`, making the trust decision unreadable and unwritable to
-agent tools. Installation can attest only the exact official platform target,
-and only when the installer created it or changed its digest; an unchanged or
-shadowed pre-existing candidate fails closed. A POSIX operator override is
-pinned to its canonical path and SHA-256 on the owning process's first
-registration. The gateway registers through its prerequisite service; direct
-agent-bearing CLI commands register before their jail gate or provider factory.
-Mutation before credential access fails closed, and the digest is required
-again while copying the private auth executable. It is rechecked before staging
-credentials; POSIX auth commands then execute a private verified-byte snapshot
-inside the per-call auth workspace rather than the mutable discovery pathname.
-ACP launches use the same byte-binding rule: Linux executes a sealed memfd,
-while macOS verifies the official Developer ID source and copies its exact
-digest-checked bytes below the agent-protected `<data-home>/run` directory
-before spawn. Registered snapshot descriptors and private files are released
+Trust is "the CLI runs, and it has a valid login": a Kiro CLI that answers
+`--version` is eligible for `whoami` and device login, regardless of install
+source, owner, or fixed path. KiroCrew is not the authority on where Kiro CLI
+is installed, and Kiro CLI's own self-updater legitimately rewrites its bytes as
+the user — so an install-source/owner/path/Developer-ID gate would strand real
+installs (toolbox, Homebrew, winget, a self-updated `/Applications` bundle) with
+no in-product recovery path, which is the concrete first-run/reauth dead end
+this model removes. `whoami` reporting a valid session is what makes readiness
+true; a runnable CLI never surfaces an unreachable "repair" state. POSIX auth
+commands still execute a private snapshot of the exact resolved bytes inside the
+per-call auth workspace rather than the mutable discovery pathname, binding the
+process that receives the staged credentials to the bytes just resolved (no
+stored digest pin — a legitimate self-update must not break sign-in). ACP
+launches use the same resolve-to-exec byte-binding: Linux executes a sealed
+memfd of the resolved bytes, while macOS copies them below the agent-protected
+`<data-home>/run` directory before spawn (Mach-O cannot launch through
+`/dev/fd`). Installation still refuses a no-op (unchanged-digest) or shadowed
+install so the Install button cannot silently succeed without producing a
+working target. Registered snapshot descriptors and private files are released
 after every ACP, usage, and model-list spawn path.
 Auth commands use `mode="standard"` only with HOME/XDG/AppData redirected below
 the fixed `~/.kiro/crew-auth-staging` parent. That parent is on the shared
 sensitive-path floor and hidden by every agent sandbox. The separately
-constructed sandbox for the provenance-verified Kiro auth process exposes that
+constructed sandbox for the Kiro auth process exposes that
 fixed staging root, with HOME directed at its random per-call workspace, while
 the complete Kiro Crew data home remains hidden. The staging root contains only
 per-call workspaces and a dedicated publication lock; each workspace contains
@@ -742,46 +747,35 @@ fails both initial staging and the locked generation scan; it is never omitted
 as though absent, so staged login state cannot replace it. The
 temporary home is then removed;
 unrelated AWS SSO/MCP cache files, SSH, GitHub, Kubernetes, and Kiro Crew state
-remain hidden. Windows discovery does not trust user-writable `PATH`
-entries or an explicit override because no equivalent OS sandbox protects a
-passive probe: it executes only candidates under the fixed Program Files
-`Kiro-Cli` tree. If an executable untrusted explicit override would shadow the fixed
-candidate in ACP resolution, readiness fails without executing either binary
-until the override is removed or moved under that trusted tree; a nonexistent
-override is ignored just as it is by the shared resolver. The shared ACP
-resolver retains inherited Windows `PATH`, the interpreter Scripts directory,
-and the explicit operator override, while setup asks that resolver for fixed
-passive-probe locations only. Status requests never mutate
-`KIROCREW_KIRO_BIN`. Electron delegates entirely to this gateway service and
-does not execute a second candidate or installer path. For each local-token
-request Electron re-resolves the authoritative migrated or pinned data home,
-reads exactly that home's one bootstrap secret, and sends it only to the
-literal `127.0.0.1` gateway bind address; it never probes canonical and legacy
-secrets across multiple loopback addresses. ACP launch independently
-re-enforces executable provenance. The shared client/runtime resolver requires
-the official-installer trust digest, immutable system provenance, or the
-operator override digest captured by the process-start registration, and
-canonicalizes symlinks before its final no-follow open. Linux copies verified
-bytes into a kernel write-sealed `MFD_EXEC` memfd, passes its descriptor through
-every wrapper as `/proc/self/fd/<fd>`, and closes the gateway copy after process
-creation. Older kernels that reject `MFD_EXEC` with `EINVAL` retry creation
-without that flag; other creation errors fail closed. Snapshot registry
-ownership is removed synchronously, while descriptor close runs on the
-dedicated subprocess executor so cancellation and startup teardown cannot block
-the gateway event loop. Because Mach-O does not reliably launch through
-`/dev/fd` and a normal drag-installed app bundle is user-owned, macOS executes
-only the canonical
-official app target after approved protected-installer, process-start override,
-or immutable-system provenance and pinned Developer
-ID/identifier/team/hardened-runtime checks succeed; explicit Kiro
-classification preserves internal-sandbox delegation without relying on the
-executable basename. Arbitrary unsandboxed same-user native code is outside the
-enforceable in-process boundary on macOS; excluding it would require a
-privileged helper or a platform installer ownership change. Windows relies on
-its fixed protected Program Files tree: the ACP resolver canonicalizes and
-rejects override, inherited-`PATH`, or interpreter-Scripts candidates outside
-that tree before spawn. This is an operator-triggered system prerequisite,
-accepts no LLM input, and is absent from the headless MCP server route set.
+remain hidden. Candidate discovery spans the inherited `PATH`, interpreter
+Scripts directory, and explicit operator override on every OS — a runnable
+candidate from any of these is eligible, since trust is "it runs". Status
+requests never mutate `KIROCREW_KIRO_BIN`. Electron delegates entirely to this
+gateway service and does not execute a second candidate or installer path. For
+each local-token request Electron re-resolves the authoritative migrated or
+pinned data home, reads exactly that home's one bootstrap secret, and sends it
+only to the literal `127.0.0.1` gateway bind address; it never probes canonical
+and legacy secrets across multiple loopback addresses. ACP launch does not
+re-impose a provenance gate: the shared client/runtime resolver accepts any
+runnable candidate and canonicalizes symlinks before its final no-follow open.
+Linux copies the resolved bytes into a kernel write-sealed `MFD_EXEC` memfd,
+passes its descriptor through every wrapper as `/proc/self/fd/<fd>`, and closes
+the gateway copy after process creation. Older kernels that reject `MFD_EXEC`
+with `EINVAL` retry creation without that flag; other creation errors fail
+closed. Snapshot registry ownership is removed synchronously, while descriptor
+close runs on the dedicated subprocess executor so cancellation and startup
+teardown cannot block the gateway event loop. Because Mach-O does not reliably
+launch through `/dev/fd`, macOS copies the resolved bytes below the
+agent-protected `<data-home>/run` directory and launches that private path;
+explicit Kiro classification preserves internal-sandbox delegation without
+relying on the executable basename. Windows launches the resolved candidate in
+place. The resolve-to-exec byte-binding is the retained integrity property — it
+prevents a swap between resolve and exec — but it is deliberately NOT an
+install-source/owner gate: arbitrary unsandboxed same-user native code is
+outside the enforceable in-process boundary regardless, and gating on origin
+only strands legitimate self-updating installs. This is an operator-triggered
+system prerequisite, accepts no LLM input, and is absent from the headless MCP
+server route set.
 
 **App manifest permission model — advisory (`apps/permissions.py`)**: distinct from the HTTP app-token scope above, the App Kit manifest `permissions` block (`mcpTools`, `network`, `memory`) is currently **advisory, not enforced in-process**. `validate_permissions()` and `format_permissions_summary()` exist but are **not wired into the install or runtime path** — they have no callers outside `test/`, so the manifest `permissions` block is neither enforced nor even surfaced today. `check_tool_permission()` **fails open on an empty `mcpTools` allowlist** (returns `True`) and is not called at the tool-dispatch boundary, so `mcpTools` is a review/display signal rather than a runtime capability gate. (Install-time path-traversal blocking is a separate mechanism: `_check_path_safety(name)` + `manifest.validate()` in `_validate_source_path`, not the permission validator.) Real in-process enforcement (and per-resource `owner_app` ownership) is tracked in `docs/app-kit/app-sandbox-roadmap.md`; today an installed app runs with the user's full trust, confined only by the HTTP app-token scope, the OS sandbox, the `agent.apps_allow_third_party` off-switch, and destructive-command deny patterns (TRACKING).
 

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -92,17 +92,7 @@ _AUTH_STAGING_RELATIVE = Path(".kiro") / "crew-auth-staging"
 _AUTH_PUBLISH_LOCK_FILENAME = ".publish.lock"
 _ACP_EXECUTABLE_SNAPSHOT_RELATIVE = Path("run") / "kiro-cli-snapshots"
 _BINARY_TRUST_VERSION = 1
-_MACOS_OFFICIAL_KIRO_CLI = "/Applications/Kiro CLI.app/Contents/MacOS/kiro-cli"
-_MACOS_KIRO_IDENTIFIER = "kiro-cli"
-_MACOS_KIRO_TEAM_ID = "94KV3E626L"
-_MACOS_CODESIGN = "/usr/bin/codesign"
-_MACOS_CODESIGN_TIMEOUT_SECS = 5
-_MACOS_HARDENED_RUNTIME_FLAG = 0x10000
 _MFD_EXEC = 0x0010
-_MACOS_KIRO_DESIGNATED_REQUIREMENT = (
-    '=identifier "kiro-cli" and anchor apple generic '
-    'and certificate leaf[subject.OU] = "94KV3E626L"'
-)
 FAKE_ACP_TEST_MODE_ENV = "KIROCREW_FAKE_ACP_TEST_MODE"
 _PACKAGED_FAKE_ACP_BACKEND = str(Path(__file__).with_name("testing") / "fake_acp_backend.py")
 _MAX_AUTH_EXECUTABLE_BYTES = 512 * 1024 * 1024
@@ -287,6 +277,20 @@ def _canonical_candidate(path: str) -> str:
         return path
 
 
+def _is_runnable_executable(path: str, platform_name: str | None = None) -> bool:
+    """True if *path* resolves to an executable regular file on this platform.
+
+    The single trust primitive for the "runs + valid login" model: a Kiro CLI
+    that can be executed is eligible for sign-in and ACP launch, regardless of
+    install source, owner, or fixed path.
+    """
+
+    return platform_compat.is_executable_file(
+        _canonical_candidate(path),
+        platform_name=platform_name,
+    )
+
+
 def _bounded_file_sha256(path: Path) -> str | None:
     """Return a digest for one bounded regular file, or ``None`` when absent."""
 
@@ -398,38 +402,6 @@ def _copy_verified_auth_executable(
         raise
 
 
-def _root_owned_immutable_candidate(path: str) -> bool:
-    """Recognize a POSIX binary whose resolved chain is root-owned and fixed."""
-
-    if not platform_compat.IS_POSIX:
-        return False
-    canonical = Path(_canonical_candidate(path))
-    trusted_roots = tuple(
-        Path(_canonical_candidate(str(root)))
-        for root in (
-            Path("/Applications/Kiro CLI.app/Contents/MacOS"),
-            Path("/usr/bin"),
-            Path("/usr/local/bin"),
-            Path("/opt/homebrew/bin"),
-        )
-    )
-    if not any(canonical.parent == root for root in trusted_roots):
-        return False
-    try:
-        for index, component in enumerate((canonical, *canonical.parents)):
-            metadata = component.stat()
-            expected_type = stat.S_ISREG if index == 0 else stat.S_ISDIR
-            if (
-                not expected_type(metadata.st_mode)
-                or metadata.st_uid != 0
-                or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-            ):
-                return False
-        return True
-    except OSError:
-        return False
-
-
 def _register_operator_override_attestation(path: str, digest: str | None) -> None:
     """Remember the first gateway-start digest for one explicit override."""
 
@@ -441,6 +413,32 @@ def _register_operator_override_attestation(path: str, digest: str | None) -> No
     _OPERATOR_OVERRIDE_ATTESTATIONS.setdefault(key, digest)
 
 
+def _recorded_trust_digest(trust_path: Path, canonical: str) -> str | None:
+    """Return the pinned sha256 recorded for *canonical*, or ``None``.
+
+    Single reader for the ``.kiro_cli_binary_trust.json`` attestation: parse the
+    file, require the current schema version and an exact path match, and return
+    the recorded 64-char digest. Callers that must prove the on-disk bytes still
+    match re-hash the candidate and ``hmac.compare_digest`` against this value;
+    callers that only need the recorded pin use it directly.
+    """
+
+    try:
+        payload = json.loads(trust_path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    expected = str(payload.get("sha256", ""))
+    if (
+        payload.get("version") != _BINARY_TRUST_VERSION
+        or os.path.normcase(str(payload.get("path", ""))) != os.path.normcase(canonical)
+        or len(expected) != 64
+    ):
+        return None
+    return expected
+
+
 def _trusted_acp_binary_digest(
     executable: str,
     *,
@@ -448,106 +446,25 @@ def _trusted_acp_binary_digest(
     platform_name: str,
     environ: MutableMapping[str, str],
 ) -> str | None:
-    """Return the digest ACP may execute, or ``None`` for untrusted bytes."""
+    """Return the digest ACP may execute for a runnable Kiro CLI, else ``None``.
 
+    Trust is "it runs" — install source, owner, and fixed path do not gate ACP
+    launch, so a toolbox / Homebrew / self-updated CLI is accepted like any
+    other (KiroCrew is not the authority on where Kiro CLI is installed). The
+    returned digest
+    still pins the exact bytes for the exec-time integrity snapshot (sealed
+    memfd on Linux, verified copy on macOS), so a swap between resolve and exec
+    is still caught; ``None`` means the file is not a runnable executable.
+    """
+
+    del data_home, environ  # provenance no longer gates ACP launch
     canonical = _canonical_candidate(executable)
+    if not _is_runnable_executable(canonical, platform_name):
+        return None
     try:
-        current = _binary_sha256(canonical)
+        return _binary_sha256(canonical)
     except (OSError, ValueError):
         return None
-
-    override = environ.get("KIROCREW_KIRO_BIN", "")
-    if override and os.path.normcase(_canonical_candidate(override)) == os.path.normcase(canonical):
-        expected = _OPERATOR_OVERRIDE_ATTESTATIONS.get(os.path.normcase(canonical))
-        if expected and hmac.compare_digest(expected, current):
-            return expected
-        return None
-
-    if platform_name != "win32" and _root_owned_immutable_candidate(canonical):
-        return current
-
-    trust_path = data_home / _BINARY_TRUST_FILENAME
-    try:
-        payload = json.loads(trust_path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict):
-            return None
-        expected = str(payload.get("sha256", ""))
-        if (
-            payload.get("version") != _BINARY_TRUST_VERSION
-            or os.path.normcase(str(payload.get("path", ""))) != os.path.normcase(canonical)
-            or len(expected) != 64
-            or not hmac.compare_digest(expected, current)
-        ):
-            return None
-        return expected
-    except (OSError, TypeError, json.JSONDecodeError):
-        return None
-
-
-def _protected_binary_trust_digest(data_home: Path, canonical: str) -> str | None:
-    """Read the exact installer attestation for *canonical* without fallback."""
-
-    try:
-        payload = json.loads((data_home / _BINARY_TRUST_FILENAME).read_text(encoding="utf-8"))
-        if not isinstance(payload, dict):
-            return None
-        expected = str(payload.get("sha256", ""))
-        if (
-            payload.get("version") != _BINARY_TRUST_VERSION
-            or os.path.normcase(str(payload.get("path", ""))) != os.path.normcase(canonical)
-            or len(expected) != 64
-        ):
-            return None
-        return expected
-    except (OSError, TypeError, json.JSONDecodeError):
-        return None
-
-
-def _macos_codesign_allows_official_kiro(canonical: str) -> bool:
-    """Require Kiro's pinned Developer ID identity and hardened runtime."""
-
-    if os.path.normcase(canonical) != os.path.normcase(_MACOS_OFFICIAL_KIRO_CLI):
-        return False
-    clean_env = {
-        "LANG": "C",
-        "LC_ALL": "C",
-        "PATH": "/usr/bin:/bin",
-    }
-    try:
-        verification = subprocess.run(
-            [
-                _MACOS_CODESIGN,
-                "--verify",
-                "--strict",
-                "--test-requirement",
-                _MACOS_KIRO_DESIGNATED_REQUIREMENT,
-                canonical,
-            ],
-            capture_output=True,
-            env=clean_env,
-            timeout=_MACOS_CODESIGN_TIMEOUT_SECS,
-            check=False,
-        )
-        if verification.returncode != 0:
-            return False
-        details = subprocess.run(
-            [_MACOS_CODESIGN, "-dvvv", canonical],
-            capture_output=True,
-            env=clean_env,
-            timeout=_MACOS_CODESIGN_TIMEOUT_SECS,
-            check=False,
-        )
-        metadata = details.stderr[: 64 * 1024].decode("utf-8", errors="replace")
-        flags_match = re.search(r"(?m)^CodeDirectory .* flags=0x([0-9a-fA-F]+)", metadata)
-        return bool(
-            details.returncode == 0
-            and f"Identifier={_MACOS_KIRO_IDENTIFIER}\n" in metadata
-            and f"TeamIdentifier={_MACOS_KIRO_TEAM_ID}\n" in metadata
-            and flags_match
-            and int(flags_match.group(1), 16) & _MACOS_HARDENED_RUNTIME_FLAG
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
 
 
 def snapshot_trusted_acp_executable(
@@ -557,22 +474,20 @@ def snapshot_trusted_acp_executable(
     platform_name: str | None = None,
     environ: MutableMapping[str, str] | None = None,
 ) -> TrustedAcpExecutableSnapshot:
-    """Return an attestation-checked, OS-bound executable snapshot for ACP.
+    """Return an integrity-checked, OS-bound executable snapshot for ACP.
 
-    Windows candidates live in the protected Program Files tree and retain
-    their original path. Linux executes a write-sealed memfd. Because Mach-O
-    cannot launch reliably through ``/dev/fd``, macOS executes only the
-    canonical official target after verifying approved provenance, its pinned
-    Developer ID identity, and its hardened-runtime signature.
+    Trust is "the CLI runs" — install source, owner, and fixed path do not gate
+    launch, so a toolbox / Homebrew / self-updated Kiro CLI launches like any
+    other. The snapshot still pins the
+    resolved bytes so a swap between resolve and exec is caught: Linux executes
+    a write-sealed ``memfd`` of the exact bytes; because Mach-O cannot launch
+    reliably through ``/dev/fd``, macOS executes a verified private copy; Windows
+    launches the resolved path in place.
     """
 
     platform_name = platform_name or sys.platform
     active_environ = environ if environ is not None else os.environ
     if platform_name == "win32":
-        if not _trusted_windows_candidate(executable, active_environ):
-            raise ValueError(
-                "Windows Kiro CLI must be inside the trusted Program Files Kiro-Cli tree"
-            )
         return TrustedAcpExecutableSnapshot(launch_path=_canonical_candidate(executable))
     active_home = data_home if data_home is not None else config_dir()
     expected = _trusted_acp_binary_digest(
@@ -582,40 +497,23 @@ def snapshot_trusted_acp_executable(
         environ=active_environ,
     )
     if not expected:
-        raise ValueError("Kiro CLI provenance is not trusted for ACP execution")
+        raise ValueError("Kiro CLI is not a runnable executable for ACP execution")
 
     canonical = _canonical_candidate(executable)
     if platform_name == "darwin":
-        protected_digest = _protected_binary_trust_digest(active_home, canonical)
         override = active_environ.get("KIROCREW_KIRO_BIN", "")
-        override_digest = None
-        if override and os.path.normcase(_canonical_candidate(override)) == os.path.normcase(
-            canonical
-        ):
-            override_digest = _OPERATOR_OVERRIDE_ATTESTATIONS.get(os.path.normcase(canonical))
-        provenance_matches = bool(
-            (protected_digest and hmac.compare_digest(protected_digest, expected))
-            or (override_digest and hmac.compare_digest(override_digest, expected))
-            or _root_owned_immutable_candidate(canonical)
-        )
         packaged_fake_test_mode = bool(
             active_environ.get(FAKE_ACP_TEST_MODE_ENV) == "1"
             and override
             and os.path.normcase(canonical)
             == os.path.normcase(_canonical_candidate(_PACKAGED_FAKE_ACP_BACKEND))
         )
-        if provenance_matches and packaged_fake_test_mode:
-            # The offline E2E harness opts into one exact, packaged executable.
-            # It cannot use the production Developer ID requirement because the
-            # deterministic fake is a source-tree Python entry point.
+        if packaged_fake_test_mode:
+            # The offline E2E harness opts into one exact, packaged executable
+            # (a source-tree Python entry point) and launches it in place.
             return TrustedAcpExecutableSnapshot(
                 launch_path=canonical,
                 expected_sha256=expected,
-            )
-        if not provenance_matches or not _macos_codesign_allows_official_kiro(canonical):
-            raise ValueError(
-                "macOS Kiro CLI must match approved provenance and the pinned "
-                "Developer ID signature"
             )
         snapshot_path = _copy_verified_auth_executable(
             canonical,
@@ -1050,25 +948,6 @@ def register_process_start_override_attestation(
 def _powershell_path(environ: MutableMapping[str, str]) -> str:
     system_root = environ.get("SystemRoot") or environ.get("WINDIR") or r"C:\Windows"
     return str(Path(system_root) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe")
-
-
-def _trusted_windows_candidate(
-    candidate: str,
-    environ: MutableMapping[str, str],
-) -> bool:
-    """Restrict unsandboxed Windows probes to the official Program Files tree."""
-
-    program_files = (
-        environ.get("ProgramFiles") or environ.get("PROGRAMFILES") or r"C:\Program Files"
-    )
-    trusted_root = os.path.realpath(str(Path(program_files) / "Kiro-Cli"))
-    resolved = os.path.realpath(candidate)
-    try:
-        return os.path.normcase(os.path.commonpath((trusted_root, resolved))) == os.path.normcase(
-            trusted_root
-        )
-    except ValueError:
-        return False
 
 
 def official_installer_command(
@@ -1726,13 +1605,18 @@ def _probe_filesystem_state(
     """Collect path/candidate state on a worker thread."""
 
     separator = ";" if platform_name == "win32" else os.pathsep
-    include_inherited_path = platform_name != "win32"
+    # Setup discovery matches ACP resolution on every OS: a runnable Kiro CLI is
+    # recognized wherever it lives (PATH, Scripts, override, package-manager
+    # dir), since trust is "the CLI runs". Windows is no longer restricted to
+    # the Program Files tree — a winget/scoop/user install that ACP would launch
+    # must also be recognized by setup, or the two disagree and the user is sent
+    # to a redundant reinstall.
     search_path = separator.join(
         known_kiro_cli_dirs(
             platform_name,
             home,
             environ,
-            include_inherited_path=include_inherited_path,
+            include_inherited_path=True,
         )
     )
     child_environment = _child_env(environ, search_path)
@@ -1741,31 +1625,8 @@ def _probe_filesystem_state(
         platform_name,
         home,
         environ,
-        include_inherited_path=include_inherited_path,
+        include_inherited_path=True,
     )
-    if platform_name == "win32":
-        override = environ.get("KIROCREW_KIRO_BIN", "")
-        if (
-            override
-            and platform_compat.is_executable_file(override, platform_name=platform_name)
-            and not _trusted_windows_candidate(override, environ)
-        ):
-            # ACP resolution gives the explicit override priority. Windows has
-            # no equivalent of the POSIX probe sandbox, so do not execute an
-            # arbitrary override and do not approve a later Program Files
-            # candidate that ACP would never launch.
-            candidates = []
-            installer_plan = official_installer_command(platform_name, environ)
-            return (
-                child_environment,
-                probe_environment,
-                candidates,
-                installer_plan,
-                True,
-            )
-        candidates = [
-            candidate for candidate in candidates if _trusted_windows_candidate(candidate, environ)
-        ]
     installer_plan = official_installer_command(platform_name, environ)
     repair_hint = _interactive_repair_required(platform_name, candidates, home)
     return child_environment, probe_environment, candidates, installer_plan, repair_hint
@@ -1976,18 +1837,11 @@ class KiroPrerequisiteService:
                 self._has_probed = True
                 return self._status
 
-            can_login = await asyncio.to_thread(
-                self._candidate_trusted_for_auth,
-                self._viable_binary,
-            )
-            whoami = (
-                await self._audited_identity_probe(self._viable_binary)
-                if can_login
-                else ProcessResult(
-                    ok=False,
-                    error="Kiro CLI provenance is not trusted for credential access",
-                )
-            )
+            # A viable binary answered ``--version``, so it can be signed into
+            # (trust is "it runs"); ``whoami`` decides whether it is already
+            # authenticated. No provenance gate: source/owner/path do not block
+            # sign-in, so a runnable CLI never needs an unreachable "repair".
+            whoami = await self._audited_identity_probe(self._viable_binary)
             if whoami.ok:
                 await asyncio.to_thread(self._mark_setup_complete)
             self._status = PrerequisiteStatus(
@@ -1995,10 +1849,9 @@ class KiroPrerequisiteService:
                 installed=True,
                 authenticated=whoami.ok,
                 ready=whoami.ok,
-                can_auto_install=self._installer_plan is not None
-                and not (not can_login and repair_hint),
-                can_login=can_login,
-                repair_required=not can_login,
+                can_auto_install=self._installer_plan is not None,
+                can_login=True,
+                repair_required=False,
                 initial_setup_complete=self._initial_setup_complete,
             )
             self._last_probe_at = self._clock()
@@ -2048,77 +1901,6 @@ class KiroPrerequisiteService:
         )
         return result
 
-    def _candidate_trusted_for_auth(self, executable: str) -> bool:
-        """Require launch-equivalent platform provenance before Kiro auth."""
-
-        canonical = _canonical_candidate(executable)
-        if self._platform == "darwin" and not _macos_codesign_allows_official_kiro(canonical):
-            return False
-        override = self._environ.get("KIROCREW_KIRO_BIN", "")
-        if override and os.path.normcase(_canonical_candidate(override)) == os.path.normcase(
-            canonical
-        ):
-            if self._platform == "win32":
-                return _trusted_windows_candidate(canonical, self._environ)
-            try:
-                return bool(
-                    self._initial_override_sha256
-                    and os.path.normcase(self._initial_override_path) == os.path.normcase(canonical)
-                    and hmac.compare_digest(
-                        self._initial_override_sha256,
-                        _binary_sha256(canonical),
-                    )
-                )
-            except (OSError, ValueError):
-                return False
-        if self._platform == "win32":
-            return _trusted_windows_candidate(canonical, self._environ)
-        if _root_owned_immutable_candidate(canonical):
-            return True
-        try:
-            payload = json.loads(self._binary_trust_path.read_text(encoding="utf-8"))
-            if (
-                not isinstance(payload, dict)
-                or payload.get("version") != _BINARY_TRUST_VERSION
-                or os.path.normcase(str(payload.get("path", ""))) != os.path.normcase(canonical)
-            ):
-                return False
-            expected = str(payload.get("sha256", ""))
-            return len(expected) == 64 and hmac.compare_digest(
-                expected,
-                _binary_sha256(canonical),
-            )
-        except (OSError, ValueError, TypeError, json.JSONDecodeError):
-            return False
-
-    def _attested_sha256(self, executable: str) -> str | None:
-        """Return the protected pinned digest for *executable*, when present."""
-
-        canonical = _canonical_candidate(executable)
-        override = self._environ.get("KIROCREW_KIRO_BIN", "")
-        if (
-            self._platform != "win32"
-            and self._initial_override_sha256
-            and override
-            and os.path.normcase(_canonical_candidate(override)) == os.path.normcase(canonical)
-            and os.path.normcase(self._initial_override_path) == os.path.normcase(canonical)
-        ):
-            return self._initial_override_sha256
-        try:
-            payload = json.loads(self._binary_trust_path.read_text(encoding="utf-8"))
-            if not isinstance(payload, dict):
-                return None
-            expected = str(payload.get("sha256", ""))
-            if (
-                payload.get("version") == _BINARY_TRUST_VERSION
-                and os.path.normcase(str(payload.get("path", ""))) == os.path.normcase(canonical)
-                and len(expected) == 64
-            ):
-                return expected
-        except (OSError, TypeError, json.JSONDecodeError):
-            pass
-        return None
-
     def _attest_candidate(self, executable: str) -> None:
         """Pin the exact binary produced by the validated official installer."""
 
@@ -2146,13 +1928,16 @@ class KiroPrerequisiteService:
         on_output: Callable[[str], None] | None = None,
         commit: bool,
     ) -> ProcessResult:
-        """Run trusted Kiro auth with only Kiro identity files in its HOME."""
+        """Run Kiro auth with only Kiro identity files in its HOME.
 
-        if not await asyncio.to_thread(self._candidate_trusted_for_auth, executable):
-            return ProcessResult(
-                ok=False,
-                error="Kiro CLI provenance changed before credential access",
-            )
+        The CLI is trusted because it runs (its install source, owner, and path
+        do not gate sign-in); KiroCrew is not the authority on where Kiro CLI is
+        installed. The POSIX copy still snapshots the exact resolved bytes into
+        the sandbox so the process that receives the staged credentials is the
+        one just resolved, but it pins no stored digest — a Kiro self-update
+        that legitimately rewrites the binary must not break sign-in.
+        """
+
         workspace = await asyncio.to_thread(
             _prepare_auth_workspace,
             self._platform,
@@ -2163,19 +1948,12 @@ class KiroPrerequisiteService:
         auth_executable = executable
         commit_changes = False
         try:
-            # Revalidate after copying credentials and immediately before spawn.
-            # A changed user-local binary never receives the staged bearer token.
-            if not await asyncio.to_thread(self._candidate_trusted_for_auth, executable):
-                return ProcessResult(
-                    ok=False,
-                    error="Kiro CLI provenance changed before credential access",
-                )
             if platform_compat.IS_POSIX and self._run is _run_process:
                 auth_executable = await asyncio.to_thread(
                     _copy_verified_auth_executable,
                     executable,
                     workspace.root / ".bin",
-                    self._attested_sha256(executable),
+                    None,
                 )
             result = await self._run(
                 auth_executable,
@@ -2435,19 +2213,6 @@ class KiroPrerequisiteService:
                     kind="login",
                     status="failed",
                     message="Kiro sign-in cannot start.",
-                    error=error,
-                )
-                await self._set_terminal_audit("login", "denied", caller, error)
-                return
-            if not current.can_login:
-                error = (
-                    "Reinstall Kiro CLI from the official guide before signing in. "
-                    "Kiro Crew will not expose credentials to an unverified executable."
-                )
-                self._operation = OperationStatus(
-                    kind="login",
-                    status="failed",
-                    message="Kiro sign-in cannot start safely.",
                     error=error,
                 )
                 await self._set_terminal_audit("login", "denied", caller, error)

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -447,22 +447,6 @@ def _windows_process_parent_map() -> dict[int, int]:
         raise OSError("Windows process enumeration failed") from exc
 
 
-def descendant_pids(pid: int) -> list[int]:
-    """Return a retained Windows process-tree snapshot for timeout cleanup.
-
-    Windows loses parent-child linkage after a launcher exits, so callers that
-    need reliable cleanup should sample this while the root is alive and retain
-    the returned PIDs. POSIX callers use process groups and receive an empty
-    list.
-    """
-
-    if type(pid) is not int or pid <= 1:
-        raise ValueError(f"descendant_pids: refusing non-int/reserved pid {pid!r}")
-    if not IS_WINDOWS:
-        return []
-    return _descendants_from_parent_map(pid, _windows_process_parent_map())
-
-
 def _open_process_termination_handle(pid: int) -> int | None:
     """Open an identity-stable Windows handle suitable for later termination."""
 

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6953,12 +6953,14 @@ class TestResolveKiroBinEnvOverride:
         assert not snapshot.exists()
         assert str(snapshot) not in client_module._KIRO_EXECUTABLE_SNAPSHOT_PATHS
 
-    def test_windows_resolver_rejects_candidate_outside_program_files(self, tmp_path):
+    def test_windows_resolver_accepts_runnable_candidate_anywhere(self, tmp_path):
         from kiro_crew.acp import client as client_module
 
-        untrusted = tmp_path / "venv" / "Scripts" / "kiro-cli.exe"
-        untrusted.parent.mkdir(parents=True)
-        untrusted.write_bytes(b"untrusted")
+        # Trust is "it runs": a Windows CLI outside Program Files (winget/scoop,
+        # a venv Scripts dir) resolves for ACP launch rather than being rejected.
+        candidate = tmp_path / "venv" / "Scripts" / "kiro-cli.exe"
+        candidate.parent.mkdir(parents=True)
+        candidate.write_bytes(b"runnable")
         program_files = tmp_path / "Program Files"
 
         with (
@@ -6966,27 +6968,23 @@ class TestResolveKiroBinEnvOverride:
             patch.object(
                 client_module,
                 "resolve_kiro_cli",
-                return_value=str(untrusted),
+                return_value=str(candidate),
             ),
             patch.dict(
                 "os.environ",
                 {"ProgramFiles": str(program_files)},
                 clear=True,
             ),
-            pytest.raises(
-                client_module._KiroExecutableTrustError,
-                match="trusted Program Files",
-            ),
         ):
-            client_module._resolve_kiro_bin()
+            assert client_module._resolve_kiro_bin() == os.path.realpath(str(candidate))
 
     @pytest.mark.asyncio
-    async def test_spawn_rejects_override_replaced_after_readiness(self, tmp_path):
+    async def test_spawn_launches_self_updated_override(self, tmp_path):
         from kiro_crew.acp import client as client_module
         from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
         fake = tmp_path / "kiro-cli"
-        fake.write_bytes(b"#!/bin/sh\n# trusted\n")
+        fake.write_bytes(b"#!/bin/sh\n# original\n")
         fake.chmod(0o755)
         mock_exec = AsyncMock()
         with (
@@ -7001,16 +6999,16 @@ class TestResolveKiroBinEnvOverride:
                 mock_exec,
             ),
         ):
-            # Service construction is the gateway-start trust boundary. A
-            # replacement after that readiness pin must never reach ACP spawn.
+            # A Kiro self-update legitimately rewrites the binary after gateway
+            # start. Trust is "it runs", so the updated bytes still launch — the
+            # snapshot just pins whatever bytes are resolved at spawn time.
             KiroPrerequisiteService(home=tmp_path, data_home=tmp_path / "data")
-            fake.write_bytes(b"#!/bin/sh\n# replacement\n")
+            fake.write_bytes(b"#!/bin/sh\n# self-updated\n")
             fake.chmod(0o755)
 
             client = AcpClient(work_dir=tmp_path / "workspace")
-            with pytest.raises(AcpError, match="provenance is not trusted"):
-                await client._spawn()
-            mock_exec.assert_not_awaited()
+            await client._spawn()
+            mock_exec.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_spawn_passes_fd_snapshot_through_exact_wrappers(self, tmp_path):

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -5,10 +5,8 @@ import contextlib
 import copy
 import errno
 import hashlib
-import json
 import os
 import sqlite3
-import stat
 import sys
 import threading
 from pathlib import Path
@@ -198,79 +196,48 @@ class TestKiroPrerequisiteHelpers:
             == hashlib.sha256(content).hexdigest()
         )
 
-    def test_windows_snapshot_rejects_candidate_outside_program_files(
+    def test_windows_snapshot_accepts_any_runnable_candidate(
         self,
         tmp_path: Path,
     ) -> None:
-        program_files = tmp_path / "Program Files"
-        untrusted = tmp_path / "venv" / "Scripts" / "kiro-cli.exe"
-        _make_executable(untrusted)
+        # Trust is "it runs": a Windows CLI outside Program Files (winget/scoop,
+        # a venv Scripts dir, a user install) launches in place, not rejected.
+        candidate = tmp_path / "venv" / "Scripts" / "kiro-cli.exe"
+        _make_executable(candidate)
 
-        with pytest.raises(ValueError, match="trusted Program Files"):
-            prerequisite_module.snapshot_trusted_acp_executable(
-                str(untrusted),
-                platform_name="win32",
-                environ={"ProgramFiles": str(program_files)},
-            )
+        snapshot = prerequisite_module.snapshot_trusted_acp_executable(
+            str(candidate),
+            platform_name="win32",
+            environ={"ProgramFiles": str(tmp_path / "Program Files")},
+        )
 
-    def test_macos_snapshot_requires_official_attestation_and_codesign(
+        assert snapshot.launch_path == os.path.realpath(str(candidate))
+
+    def test_macos_snapshot_accepts_user_owned_cli_and_pins_bytes(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # A user-owned macOS CLI resolved via a symlink (the toolbox / self-
+        # updated bundle case) is accepted without codesign/official-path gating.
+        # The snapshot is a private verified copy pinned to the resolved bytes,
+        # so a swap after resolution cannot reach the running process.
         executable = tmp_path / "kiro-cli-real"
         executable.write_bytes(b"trusted executable bytes")
         executable.chmod(0o700)
         symlink = tmp_path / "kiro-cli"
         symlink.symlink_to(executable)
-        digest = hashlib.sha256(executable.read_bytes()).hexdigest()
-        environ = {"KIROCREW_KIRO_BIN": str(symlink)}
         data_home = tmp_path / "data"
         data_home.mkdir()
-        (data_home / prerequisite_module._BINARY_TRUST_FILENAME).write_text(
-            json.dumps(
-                {
-                    "version": prerequisite_module._BINARY_TRUST_VERSION,
-                    "path": str(executable),
-                    "sha256": digest,
-                }
-            )
-        )
-        prerequisite_module._register_operator_override_attestation(str(symlink), digest)
-        monkeypatch.setattr(
-            prerequisite_module,
-            "_MACOS_OFFICIAL_KIRO_CLI",
-            str(executable),
-        )
 
-        monkeypatch.setattr(
-            prerequisite_module,
-            "_macos_codesign_allows_official_kiro",
-            lambda _path: False,
-        )
-        with pytest.raises(ValueError, match="pinned Developer ID"):
-            prerequisite_module.snapshot_trusted_acp_executable(
-                str(symlink),
-                data_home=data_home,
-                platform_name="darwin",
-                environ=environ,
-            )
-
-        monkeypatch.setattr(
-            prerequisite_module,
-            "_macos_codesign_allows_official_kiro",
-            lambda path: path == str(executable),
-        )
         snapshot = prerequisite_module.snapshot_trusted_acp_executable(
             str(symlink),
             data_home=data_home,
             platform_name="darwin",
-            environ=environ,
+            environ={},
         )
         snapshot_path = Path(snapshot.launch_path)
         try:
             executable.write_bytes(b"replacement after validation")
-
             assert snapshot_path != executable
             assert snapshot_path.read_bytes() == b"trusted executable bytes"
             assert snapshot.cleanup_path == str(snapshot_path)
@@ -278,13 +245,12 @@ class TestKiroPrerequisiteHelpers:
         finally:
             snapshot_path.unlink(missing_ok=True)
 
-    def test_macos_snapshot_allows_only_packaged_fake_in_explicit_test_mode(
+    def test_macos_snapshot_launches_packaged_fake_in_explicit_test_mode(
         self,
         tmp_path: Path,
     ) -> None:
         fake = Path(prerequisite_module._PACKAGED_FAKE_ACP_BACKEND)
         digest = hashlib.sha256(fake.read_bytes()).hexdigest()
-        prerequisite_module._register_operator_override_attestation(str(fake), digest)
         environ = {
             "KIROCREW_KIRO_BIN": str(fake),
             prerequisite_module.FAKE_ACP_TEST_MODE_ENV: "1",
@@ -297,71 +263,10 @@ class TestKiroPrerequisiteHelpers:
             environ=environ,
         )
 
+        # The packaged fake launches in place (source-tree Python entry point).
         assert snapshot.launch_path == str(fake.resolve())
         assert snapshot.expected_sha256 == digest
         assert snapshot.fd is None
-
-        other = tmp_path / "fake_acp_backend.py"
-        other.write_bytes(fake.read_bytes())
-        other.chmod(0o700)
-        other_digest = hashlib.sha256(other.read_bytes()).hexdigest()
-        prerequisite_module._register_operator_override_attestation(
-            str(other),
-            other_digest,
-        )
-        with pytest.raises(ValueError, match="pinned Developer ID"):
-            prerequisite_module.snapshot_trusted_acp_executable(
-                str(other),
-                data_home=tmp_path,
-                platform_name="darwin",
-                environ={
-                    "KIROCREW_KIRO_BIN": str(other),
-                    prerequisite_module.FAKE_ACP_TEST_MODE_ENV: "1",
-                },
-            )
-
-    def test_macos_codesign_requires_pinned_identity_and_hardened_runtime(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        calls: list[tuple[list[str], dict[str, Any]]] = []
-        metadata = (
-            "Executable=/Applications/Kiro CLI.app/Contents/MacOS/kiro-cli\n"
-            "Identifier=kiro-cli\n"
-            "CodeDirectory v=20500 flags=0x10000(runtime) hashes=1+2\n"
-            "TeamIdentifier=94KV3E626L\n"
-        ).encode()
-
-        def run(argv: list[str], **kwargs: Any) -> SimpleNamespace:
-            calls.append((argv, kwargs))
-            stderr = b"" if "--verify" in argv else metadata
-            return SimpleNamespace(returncode=0, stderr=stderr, stdout=b"")
-
-        monkeypatch.setattr(prerequisite_module.subprocess, "run", run)
-        assert prerequisite_module._macos_codesign_allows_official_kiro(
-            prerequisite_module._MACOS_OFFICIAL_KIRO_CLI
-        )
-        assert calls[0][0] == [
-            "/usr/bin/codesign",
-            "--verify",
-            "--strict",
-            "--test-requirement",
-            prerequisite_module._MACOS_KIRO_DESIGNATED_REQUIREMENT,
-            prerequisite_module._MACOS_OFFICIAL_KIRO_CLI,
-        ]
-        for _argv, kwargs in calls:
-            assert kwargs["env"] == {
-                "LANG": "C",
-                "LC_ALL": "C",
-                "PATH": "/usr/bin:/bin",
-            }
-            assert kwargs["timeout"] == 5
-            assert kwargs["capture_output"] is True
-
-        metadata = metadata.replace(b"flags=0x10000(runtime)", b"flags=0x0(none)")
-        assert not prerequisite_module._macos_codesign_allows_official_kiro(
-            prerequisite_module._MACOS_OFFICIAL_KIRO_CLI
-        )
 
     def test_linux_snapshot_populates_and_seals_memfd(
         self,
@@ -492,33 +397,6 @@ class TestKiroPrerequisiteHelpers:
         assert write_calls > 1
         assert snapshot.read_bytes() == content
         snapshot.unlink()
-
-    def test_system_candidate_requires_immutable_parent_chain(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(prerequisite_module.platform_compat, "IS_POSIX", True)
-        monkeypatch.setattr(
-            prerequisite_module,
-            "_canonical_candidate",
-            lambda path: path,
-        )
-
-        def immutable_stat(path: Path) -> SimpleNamespace:
-            mode = stat.S_IFREG | 0o755 if path.name == "kiro-cli" else stat.S_IFDIR | 0o755
-            return SimpleNamespace(st_mode=mode, st_uid=0)
-
-        monkeypatch.setattr(Path, "stat", immutable_stat)
-        assert prerequisite_module._root_owned_immutable_candidate("/usr/local/bin/kiro-cli")
-
-        def writable_parent_stat(path: Path) -> SimpleNamespace:
-            metadata = immutable_stat(path)
-            if path == Path("/usr/local"):
-                metadata.st_mode |= stat.S_IWGRP
-            return metadata
-
-        monkeypatch.setattr(Path, "stat", writable_parent_stat)
-        assert not prerequisite_module._root_owned_immutable_candidate("/usr/local/bin/kiro-cli")
 
     def test_extract_secure_login_url_rejects_non_https(self) -> None:
         assert (
@@ -689,40 +567,31 @@ class TestKiroPrerequisiteHelpers:
 
         assert str(executable) in candidates
 
-    def test_windows_launch_candidates_include_inherited_path_but_passive_probe_does_not(
+    def test_windows_candidates_include_inherited_path(
         self,
         tmp_path: Path,
     ) -> None:
-        planted = tmp_path / "agent-writable" / "kiro-cli.exe"
+        # A winget/scoop/user Windows install on PATH (outside Program Files) is
+        # a valid candidate for both ACP launch and setup discovery — trust is
+        # "it runs". The shared resolver picks it up on win32 like every OS.
+        planted = tmp_path / "user-install" / "kiro-cli.exe"
         _make_executable(planted)
+        environ = {
+            "ProgramFiles": str(tmp_path / "Program Files"),
+            "PATH": str(planted.parent),
+        }
 
         launch_candidates = find_kiro_cli_candidates(
             "win32",
             tmp_path / "Users" / "new-user",
-            {
-                "ProgramFiles": str(tmp_path / "Program Files"),
-                "PATH": str(planted.parent),
-            },
-        )
-        passive_candidates = find_kiro_cli_candidates(
-            "win32",
-            tmp_path / "Users" / "new-user",
-            {
-                "ProgramFiles": str(tmp_path / "Program Files"),
-                "PATH": str(planted.parent),
-            },
-            include_inherited_path=False,
+            environ,
         )
 
         assert str(planted) in launch_candidates
-        assert str(planted) not in passive_candidates
         assert resolve_kiro_cli(
             platform_name="win32",
             home=tmp_path / "Users" / "new-user",
-            environ={
-                "ProgramFiles": str(tmp_path / "Program Files"),
-                "PATH": str(planted.parent),
-            },
+            environ=environ,
         ) == str(planted)
 
     def test_process_group_membership_ignores_zombies(self) -> None:
@@ -813,10 +682,13 @@ class TestKiroPrerequisiteWorkflow:
         assert status["initial_setup_complete"] is True
 
     @pytest.mark.asyncio
-    async def test_untrusted_candidate_never_receives_auth_store(
+    async def test_user_owned_path_candidate_probes_version_then_whoami(
         self,
         tmp_path: Path,
     ) -> None:
+        # A user-owned ``~/.local/bin`` CLI (the common non-root install) runs,
+        # so it is eligible for sign-in: the probe first checks ``--version``
+        # then ``whoami``. Trust is "runs + valid login", not root ownership.
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
         token = tmp_path / ".aws" / "sso" / "cache" / "kiro-auth-token-cli.json"
@@ -830,7 +702,7 @@ class TestKiroPrerequisiteWorkflow:
             **_kwargs: Any,
         ) -> ProcessResult:
             calls.append(args)
-            return ProcessResult(ok=True)
+            return ProcessResult(ok=args == ["--version"])
 
         service = KiroPrerequisiteService(
             platform_name="linux",
@@ -843,9 +715,9 @@ class TestKiroPrerequisiteWorkflow:
         status = await service.snapshot(force=True)
 
         assert status["installed"] is True
-        assert status["can_login"] is False
+        assert status["can_login"] is True
         assert status["authenticated"] is False
-        assert calls == [["--version"]]
+        assert calls == [["--version"], ["whoami"]]
 
     @pytest.mark.asyncio
     async def test_trusted_identity_probe_sees_only_staged_kiro_credentials(
@@ -902,77 +774,43 @@ class TestKiroPrerequisiteWorkflow:
         assert not Path(observed_home).exists()
 
     @pytest.mark.asyncio
-    async def test_changed_attested_candidate_is_not_given_credentials(
+    async def test_self_updated_candidate_still_signs_in(
         self,
         tmp_path: Path,
     ) -> None:
+        # A Kiro CLI whose bytes changed after startup (its own self-updater ran
+        # as the user) must still sign in — trust is "it runs + valid login",
+        # not a pinned digest that a legitimate update invalidates.
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
-        calls: list[list[str]] = []
-
-        async def run(
-            _command: str,
-            args: list[str],
-            **_kwargs: Any,
-        ) -> ProcessResult:
-            calls.append(args)
-            return ProcessResult(ok=True)
+        runtime = _FakeRuntime(executable)
+        runtime.installed = True
+        runtime.authenticated = True
 
         service = KiroPrerequisiteService(
             platform_name="linux",
             environ={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
             home=tmp_path,
-            process_runner=run,
+            process_runner=runtime.run,
             audit_writer=_no_audit,
         )
         service._attest_candidate(str(executable))
-        executable.write_text("#!/bin/sh\n# replaced\n", encoding="utf-8")
+        executable.write_text("#!/bin/sh\n# self-updated\n", encoding="utf-8")
         executable.chmod(0o700)
 
         status = await service.snapshot(force=True)
 
-        assert status["can_login"] is False
-        assert calls == [["--version"]]
-
-    @pytest.mark.asyncio
-    async def test_changed_posix_override_is_not_given_credentials(self, tmp_path: Path) -> None:
-        executable = tmp_path / "operator" / "kiro-cli"
-        _make_executable(executable)
-        calls: list[list[str]] = []
-
-        async def run(
-            _command: str,
-            args: list[str],
-            **_kwargs: Any,
-        ) -> ProcessResult:
-            calls.append(args)
-            return ProcessResult(ok=True)
-
-        service = KiroPrerequisiteService(
-            platform_name="linux",
-            environ={
-                "HOME": str(tmp_path),
-                "PATH": "",
-                "KIROCREW_KIRO_BIN": str(executable),
-            },
-            home=tmp_path,
-            process_runner=run,
-            audit_writer=_no_audit,
-        )
-        executable.write_text("#!/bin/sh\n# replaced after startup\n", encoding="utf-8")
-        executable.chmod(0o700)
-
-        status = await service.snapshot(force=True)
-
-        assert status["can_login"] is False
-        assert calls == [["--version"]]
+        assert status["can_login"] is True
+        assert status["ready"] is True
 
     @pytest.mark.parametrize("payload", ("[]", "null"))
-    def test_non_object_binary_trust_payload_fails_closed(
+    def test_non_object_binary_trust_payload_is_ignored(
         self,
         tmp_path: Path,
         payload: str,
     ) -> None:
+        # A malformed trust file must never crash the recorded-digest reader;
+        # it simply yields no pinned digest (trust no longer depends on it).
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
         service = KiroPrerequisiteService(
@@ -984,8 +822,86 @@ class TestKiroPrerequisiteWorkflow:
         service._binary_trust_path.parent.mkdir(parents=True, exist_ok=True)
         service._binary_trust_path.write_text(payload, encoding="utf-8")
 
-        assert service._candidate_trusted_for_auth(str(executable)) is False
-        assert service._attested_sha256(str(executable)) is None
+        assert (
+            prerequisite_module._recorded_trust_digest(
+                service._binary_trust_path,
+                str(executable),
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_runnable_path_cli_can_login_without_attestation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Trust model: a Kiro CLI that RUNS is eligible for sign-in, regardless
+        # of install source (PATH / toolbox / Homebrew), owner, or attestation.
+        # This mirrors a real toolbox/self-updated bundle: user-owned, no
+        # trust-file, not on any official fixed path.
+        executable = tmp_path / "toolbox" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        runtime = _FakeRuntime(executable)
+        runtime.installed = True
+        runtime.authenticated = True
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": str(executable.parent)},
+            home=tmp_path,
+            process_runner=runtime.run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+        assert status["installed"] is True
+        assert status["can_login"] is True
+        assert status["ready"] is True
+        assert status["repair_required"] is False
+
+    @pytest.mark.asyncio
+    async def test_runnable_path_cli_not_signed_in_still_offers_login(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Zezhen's exact stuck state: installed + runnable but no valid login.
+        # Must offer sign-in (can_login=True), NOT a button-less dead end.
+        executable = tmp_path / "toolbox" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        runtime = _FakeRuntime(executable)
+        runtime.installed = True
+        runtime.authenticated = False
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": str(executable.parent)},
+            home=tmp_path,
+            process_runner=runtime.run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+        assert status["installed"] is True
+        assert status["can_login"] is True
+        assert status["ready"] is False
+        assert status["repair_required"] is False
+
+    def test_acp_snapshot_accepts_runnable_cli_without_provenance(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # The ACP launch gate must not refuse a runnable CLI for lack of
+        # provenance, or sessions 503 even after a successful sign-in.
+        if not sys.platform.startswith(("linux", "darwin")):
+            pytest.skip("POSIX snapshot path")
+        real = Path(sys.executable)  # a genuinely executable, user-owned file
+        snapshot = prerequisite_module.snapshot_trusted_acp_executable(
+            str(real),
+            data_home=tmp_path,
+            platform_name="linux" if sys.platform.startswith("linux") else "darwin",
+            environ={},
+        )
+        assert snapshot.launch_path
 
     @pytest.mark.asyncio
     async def test_failed_auth_does_not_publish_staged_credentials(self, tmp_path: Path) -> None:
@@ -1295,11 +1211,16 @@ class TestKiroPrerequisiteWorkflow:
 
         status = await service.snapshot(force=True)
 
+        # A runnable CLI is eligible for sign-in, so the probe pairs a version
+        # check with an identity (whoami) check; here whoami reports not-signed.
         assert [(item["action"], item["outcome"]) for item in events] == [
             ("probe_version", "invoked"),
             ("probe_version", "completed"),
+            ("probe_identity", "invoked"),
+            ("probe_identity", "failed"),
         ]
-        assert status["can_login"] is False
+        assert status["can_login"] is True
+        assert status["ready"] is False
         assert events[0]["critical"] is True
         assert all("secret" not in repr(item) for item in events)
         for index, call in enumerate(runtime.calls):
@@ -1383,7 +1304,6 @@ class TestKiroPrerequisiteWorkflow:
         )
 
         assert await service.session_ready() is False
-        service._attest_candidate(str(executable))
         runtime.authenticated = True
         now[0] += prerequisite_module._SESSION_GUARD_REPROBE_SECS + 0.1
 
@@ -1394,8 +1314,10 @@ class TestKiroPrerequisiteWorkflow:
         await service._session_probe_task
 
         assert await service.session_ready() is True
+        # A runnable CLI is probed for identity every time (trust is "runs +
+        # valid login"), so both probes run version then whoami.
         assert runtime.calls.count((str(executable), ["--version"])) == 2
-        assert runtime.calls.count((str(executable), ["whoami"])) == 1
+        assert runtime.calls.count((str(executable), ["whoami"])) == 2
 
     @pytest.mark.asyncio
     async def test_close_cancels_background_session_probe(
@@ -1727,16 +1649,19 @@ class TestKiroPrerequisiteWorkflow:
         )
 
     @pytest.mark.asyncio
-    async def test_unattested_cargo_install_can_be_reinstalled_and_attested(
+    async def test_cargo_install_is_usable_without_reattestation(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # A ``~/.cargo/bin`` install that runs is directly usable — no
+        # "repair", no forced reinstall. Clicking Install reports it is already
+        # installed rather than reinstalling to earn a provenance pin.
         cargo_executable = tmp_path / ".cargo" / "bin" / "kiro-cli"
         _make_executable(cargo_executable)
-        installed_executable = tmp_path / ".local" / "bin" / "kiro-cli"
-        runtime = _FakeRuntime(installed_executable)
+        runtime = _FakeRuntime(cargo_executable)
         runtime.installed = True
+        runtime.authenticated = True
         installer = b"#!/bin/bash\n# Kiro CLI Installation Script\n"
         monkeypatch.setitem(
             prerequisite_module._INSTALLER_SHA256,
@@ -1759,8 +1684,8 @@ class TestKiroPrerequisiteWorkflow:
         )
         before = await service.snapshot(force=True)
         assert before["installed"] is True
-        assert before["repair_required"] is True
-        assert before["can_auto_install"] is True
+        assert before["can_login"] is True
+        assert before["repair_required"] is False
 
         service.start_install("test-user")
         await _wait_for_operation(service)
@@ -1768,12 +1693,7 @@ class TestKiroPrerequisiteWorkflow:
 
         assert after["can_login"] is True
         assert after["operation"]["status"] == "succeeded"
-        trust = json.loads(
-            (service._data_home / prerequisite_module._BINARY_TRUST_FILENAME).read_text(
-                encoding="utf-8"
-            )
-        )
-        assert trust["path"] == str(installed_executable)
+        assert "already installed" in after["operation"]["message"]
 
     @pytest.mark.asyncio
     async def test_installer_refuses_shadowing_candidate_instead_of_attesting_it(
@@ -1781,8 +1701,11 @@ class TestKiroPrerequisiteWorkflow:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        cargo_executable = tmp_path / ".cargo" / "bin" / "kiro-cli"
-        _make_executable(cargo_executable)
+        # linux keeps candidate discovery to home-relative dirs (no real system
+        # install can leak in). The installer's official target lands in a dir
+        # that is not searched, while ``.local/bin`` shadows it as the first
+        # resolved candidate — the install-quality guard must refuse rather than
+        # bless the shadow, even though the shadow itself runs.
         installer = b"#!/bin/bash\n# Kiro CLI Installation Script\n"
         monkeypatch.setitem(
             prerequisite_module._INSTALLER_SHA256,
@@ -1804,16 +1727,22 @@ class TestKiroPrerequisiteWorkflow:
             "official_installer_command",
             lambda _platform, _environ: ("bash", ["-s"]),
         )
+        shadow_executable = tmp_path / ".local" / "bin" / "kiro-cli"
         official_executable = tmp_path / "official" / "kiro-cli"
+        installed = {"done": False}
 
         async def run(command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
             if args == ["--version"]:
-                return ProcessResult(ok=Path(command).exists())
+                # Only the tmp-path shadow is viable, and only after install —
+                # so no real system CLI on the host can leak into discovery.
+                return ProcessResult(ok=installed["done"] and command == str(shadow_executable))
+            installed["done"] = True
+            _make_executable(shadow_executable)
             _make_executable(official_executable)
             return ProcessResult(ok=True)
 
         service = KiroPrerequisiteService(
-            platform_name="darwin",
+            platform_name="linux",
             environ={"HOME": str(tmp_path), "PATH": ""},
             home=tmp_path,
             process_runner=run,
@@ -1836,7 +1765,11 @@ class TestKiroPrerequisiteWorkflow:
     ) -> None:
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
+        # The target exists but is not runnable yet (so Install is entered, not
+        # short-circuited). The installer "runs" but leaves the exact same bytes
+        # in place; the guard must refuse a no-op install rather than pin it.
         runtime = _FakeRuntime(executable)
+        runtime.installed = False
         installer = b"#!/bin/bash\n# Kiro CLI Installation Script\n"
         monkeypatch.setitem(
             prerequisite_module._INSTALLER_SHA256,
@@ -1895,16 +1828,19 @@ class TestKiroPrerequisiteWorkflow:
         assert status["ready"] is False
 
     @pytest.mark.asyncio
-    async def test_windows_status_never_executes_arbitrary_override(
+    async def test_windows_override_that_runs_is_used_for_setup(
         self,
         tmp_path: Path,
     ) -> None:
-        planted = tmp_path / "user-writable" / "kiro-cli.exe"
+        # Trust is "it runs": a Windows override outside Program Files (a winget/
+        # user install) that answers --version is probed and usable — no
+        # Program-Files restriction. (ACP launches the same override in place.)
+        planted = tmp_path / "user-install" / "kiro-cli.exe"
         _make_executable(planted)
-        calls: list[str] = []
+        calls: list[tuple[str, list[str]]] = []
 
-        async def run(command: str, _args: list[str], **_kwargs: Any) -> ProcessResult:
-            calls.append(command)
+        async def run(command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            calls.append((command, args))
             return ProcessResult(ok=True)
 
         service = KiroPrerequisiteService(
@@ -1922,22 +1858,30 @@ class TestKiroPrerequisiteWorkflow:
 
         status = await service.snapshot(force=True)
 
-        assert calls == []
-        assert status["installed"] is False
+        assert status["installed"] is True
+        assert status["can_login"] is True
+        assert status["ready"] is True
+        assert calls == [
+            (str(planted), ["--version"]),
+            (str(planted), ["whoami"]),
+        ]
 
     @pytest.mark.asyncio
-    async def test_windows_override_cannot_be_shadowed_by_ready_program_files_candidate(
+    async def test_windows_override_takes_priority_over_program_files_candidate(
         self,
         tmp_path: Path,
     ) -> None:
-        planted = tmp_path / "user-writable" / "kiro-cli.exe"
+        # The explicit override wins over a Program Files install (ACP resolves
+        # the override first), and being outside Program Files no longer blocks
+        # it — it is probed and usable because it runs.
+        planted = tmp_path / "user-install" / "kiro-cli.exe"
         official = tmp_path / "Program Files" / "Kiro-Cli" / "kiro-cli.exe"
         _make_executable(planted)
         _make_executable(official)
-        calls: list[str] = []
+        calls: list[tuple[str, list[str]]] = []
 
-        async def run(command: str, _args: list[str], **_kwargs: Any) -> ProcessResult:
-            calls.append(command)
+        async def run(command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            calls.append((command, args))
             return ProcessResult(ok=True)
 
         service = KiroPrerequisiteService(
@@ -1955,10 +1899,11 @@ class TestKiroPrerequisiteWorkflow:
 
         status = await service.snapshot(force=True)
 
-        assert calls == []
-        assert status["ready"] is False
-        assert status["repair_required"] is True
-        assert status["can_auto_install"] is False
+        assert status["ready"] is True
+        assert calls == [
+            (str(planted), ["--version"]),
+            (str(planted), ["whoami"]),
+        ]
 
     @pytest.mark.asyncio
     async def test_missing_windows_override_does_not_shadow_program_files_candidate(

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -207,10 +207,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "instances/ssh_tunnel_manager.py::start",
         "instances/token_mint.py::mint_remote_token",
         "instances/token_mint.py::run_remote_kirocrew",
-        # macOS Kiro signature verification uses fixed /usr/bin/codesign
-        # argv/requirements against the canonical official app target. No
-        # command, argument, cwd, or environment value is agent-controlled.
-        "kiro_prerequisite.py::_macos_codesign_allows_official_kiro",
         "mcp_caller.py::_parent_pid",
         "mcp_core.py::_get_ppid",
         "mcp_discovery.py::sync_to_agent_config",

--- a/website/src/components/KiroPrerequisiteGate.tsx
+++ b/website/src/components/KiroPrerequisiteGate.tsx
@@ -136,6 +136,47 @@ function SetupStage() {
   )
 }
 
+// Shared full-screen chrome for every gate state: the ambient-blur backdrop,
+// the centered card, and the branded SetupStage panel. Only the right-hand
+// content differs between states. `scroll` switches the tall two-step setup to
+// vertical overflow (and adds a second blur); `cardLabel` sets the card's
+// aria-label for the loading state.
+function SetupShell({
+  children,
+  scroll = false,
+  cardLabel,
+}: {
+  children: ReactNode
+  scroll?: boolean
+  cardLabel?: string
+}) {
+  return (
+    <main
+      className={`relative flex min-h-screen items-center justify-center ${
+        scroll ? 'overflow-y-auto' : 'overflow-hidden'
+      } bg-bg px-4 py-8 sm:px-8`}
+    >
+      <div
+        aria-hidden="true"
+        className="absolute left-[-12rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-accent/10 blur-[100px]"
+      />
+      {scroll && (
+        <div
+          aria-hidden="true"
+          className="absolute bottom-[-15rem] right-[-10rem] h-[34rem] w-[34rem] rounded-full bg-accent/5 blur-[120px]"
+        />
+      )}
+      <div
+        className="relative grid w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-card shadow-[0_30px_90px_rgba(0,0,0,.2)] lg:grid-cols-[.82fr_1.18fr]"
+        aria-label={cardLabel}
+      >
+        <SetupStage />
+        {children}
+      </div>
+    </main>
+  )
+}
+
 function StepStatus({
   complete,
   current,
@@ -189,29 +230,6 @@ function OperationProgress({ status }: { status: KiroPrerequisiteStatus }) {
   )
 }
 
-function needsLinuxDashboardRepair(status: KiroPrerequisiteStatus): boolean {
-  return status.platform.toLowerCase() === 'linux'
-    && status.repair_required
-    && !status.can_auto_install
-}
-
-function LinuxDashboardRepairInstructions() {
-  return (
-    <div className="mt-3 rounded-lg border border-warn/20 bg-warn/10 p-3 text-[13px] leading-relaxed text-muted">
-      <p>
-        Remove the existing unverified Kiro CLI from the Linux gateway host:
-      </p>
-      <code className="mt-2 block overflow-x-auto rounded-md bg-bg px-3 py-2 font-mono text-[12px] text-text">
-        rm -- ~/.local/bin/kiro-cli
-      </code>
-      <p className="mt-2">
-        Then choose Check again. When Install Kiro CLI becomes available, use it here so
-        Kiro Crew can verify the new executable before sign-in.
-      </p>
-    </div>
-  )
-}
-
 function ReauthenticationBanner({
   status,
   busy,
@@ -232,7 +250,6 @@ function ReauthenticationBanner({
   const owner = status.setup_allowed !== false
   const loginUrl = trustedLoginUrl(status.operation.url)
   const needsInstall = !status.installed
-  const needsLinuxRepair = needsLinuxDashboardRepair(status)
   return (
     <aside
       className="pointer-events-none fixed inset-x-3 top-3 z-[100] mx-auto max-w-4xl rounded-xl border border-warn/30 bg-card/95 p-4 shadow-[0_18px_55px_rgba(0,0,0,.24)] backdrop-blur-md"
@@ -275,7 +292,6 @@ function ReauthenticationBanner({
                 {status.operation.detail}
               </pre>
             )}
-            {owner && needsLinuxRepair && <LinuxDashboardRepairInstructions />}
             {mutationError && <p className="mt-2 text-[13px] text-danger">{mutationError.message}</p>}
           </div>
         </div>
@@ -288,7 +304,7 @@ function ReauthenticationBanner({
               Install Kiro CLI
             </SendBtn>
           )}
-          {owner && status.installed && status.can_login && (
+          {owner && status.installed && (
             <SendBtn type="button" disabled={busy} onClick={onLogin}>
               {busy
                 ? <Loader2 className="lucide-inline animate-spin" />
@@ -310,16 +326,6 @@ function ReauthenticationBanner({
               Installation guide <ExternalLink className="lucide-inline" />
             </a>
           )}
-          {owner && status.installed && !status.can_login && !needsLinuxRepair && (
-            <a
-              className="text-[13px] font-medium text-accent hover:underline focus-ring"
-              href={status.docs_url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Reinstall from the official guide <ExternalLink className="lucide-inline" />
-            </a>
-          )}
         </div>
       </div>
     </aside>
@@ -334,57 +340,43 @@ function OwnerSetupRequired({
   onRetry: () => void
 }) {
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-bg px-4 py-8 sm:px-8">
-      <div
-        aria-hidden="true"
-        className="absolute left-[-12rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-accent/10 blur-[100px]"
-      />
-      <div className="relative grid w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-card shadow-[0_30px_90px_rgba(0,0,0,.2)] lg:grid-cols-[.82fr_1.18fr]">
-        <SetupStage />
-        <section className="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-accent-subtle text-accent">
-            <ShieldCheck className="lucide-inline" />
-          </div>
-          <p className="mt-6 text-[12px] font-bold uppercase tracking-[0.16em] text-accent">
-            Gateway setup required
-          </p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-text-strong">
-            The gateway owner needs to finish setup.
-          </h1>
-          <p className="mt-3 max-w-lg text-sm leading-relaxed text-muted">
-            Ask the Kiro Crew owner to install Kiro CLI and sign in on this gateway. This dashboard
-            will open for you as soon as the gateway is ready.
-          </p>
-          <div className="mt-6">
-            <Btn type="button" disabled={retrying} onClick={onRetry}>
-              <RefreshCw className={`lucide-inline ${retrying ? 'animate-spin' : ''}`} />
-              Check again
-            </Btn>
-          </div>
-        </section>
-      </div>
-    </main>
+    <SetupShell>
+      <section className="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-accent-subtle text-accent">
+          <ShieldCheck className="lucide-inline" />
+        </div>
+        <p className="mt-6 text-[12px] font-bold uppercase tracking-[0.16em] text-accent">
+          Gateway setup required
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-text-strong">
+          The gateway owner needs to finish setup.
+        </h1>
+        <p className="mt-3 max-w-lg text-sm leading-relaxed text-muted">
+          Ask the Kiro Crew owner to install Kiro CLI and sign in on this gateway. This dashboard
+          will open for you as soon as the gateway is ready.
+        </p>
+        <div className="mt-6">
+          <Btn type="button" disabled={retrying} onClick={onRetry}>
+            <RefreshCw className={`lucide-inline ${retrying ? 'animate-spin' : ''}`} />
+            Check again
+          </Btn>
+        </div>
+      </section>
+    </SetupShell>
   )
 }
 
 function LoadingGate() {
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-bg px-4 py-8 sm:px-8">
-      <div
-        aria-hidden="true"
-        className="absolute left-[-12rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-accent/10 blur-[100px]"
-      />
-      <div className="relative grid w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-card shadow-[0_30px_90px_rgba(0,0,0,.2)] lg:grid-cols-[.82fr_1.18fr]" aria-label="Checking Kiro CLI">
-        <SetupStage />
-        <div className="space-y-4 p-7 sm:p-10 lg:p-12">
-          <Skeleton className="h-4 w-28" />
-          <Skeleton className="h-10 w-64 max-w-full" />
-          <Skeleton className="h-5 w-full max-w-lg" />
-          <Skeleton className="mt-8 h-44 w-full" />
-          <Skeleton className="h-44 w-full" />
-        </div>
+    <SetupShell cardLabel="Checking Kiro CLI">
+      <div className="space-y-4 p-7 sm:p-10 lg:p-12">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-10 w-64 max-w-full" />
+        <Skeleton className="h-5 w-full max-w-lg" />
+        <Skeleton className="mt-8 h-44 w-full" />
+        <Skeleton className="h-44 w-full" />
       </div>
-    </main>
+    </SetupShell>
   )
 }
 
@@ -398,35 +390,28 @@ function SetupStatusError({
   onRetry: () => void
 }) {
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-bg px-4 py-8 sm:px-8">
-      <div
-        aria-hidden="true"
-        className="absolute left-[-12rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-accent/10 blur-[100px]"
-      />
-      <div className="relative grid w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-card shadow-[0_30px_90px_rgba(0,0,0,.2)] lg:grid-cols-[.82fr_1.18fr]">
-        <SetupStage />
-        <section className="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-danger/10 text-danger">
-            <AlertTriangle className="lucide-inline" />
-          </div>
-          <p className="mt-6 text-[12px] font-bold uppercase tracking-[0.16em] text-danger">
-            Setup check unavailable
-          </p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-text-strong">
-            We could not check Kiro CLI.
-          </h1>
-          <p className="mt-3 max-w-lg text-sm leading-relaxed text-muted">
-            {message} Retry the gateway check before starting a session.
-          </p>
-          <div className="mt-6">
-            <SendBtn type="button" disabled={retrying} onClick={onRetry}>
-              <RefreshCw className={`lucide-inline ${retrying ? 'animate-spin' : ''}`} />
-              Try again
-            </SendBtn>
-          </div>
-        </section>
-      </div>
-    </main>
+    <SetupShell>
+      <section className="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-danger/10 text-danger">
+          <AlertTriangle className="lucide-inline" />
+        </div>
+        <p className="mt-6 text-[12px] font-bold uppercase tracking-[0.16em] text-danger">
+          Setup check unavailable
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-text-strong">
+          We could not check Kiro CLI.
+        </h1>
+        <p className="mt-3 max-w-lg text-sm leading-relaxed text-muted">
+          {message} Retry the gateway check before starting a session.
+        </p>
+        <div className="mt-6">
+          <SendBtn type="button" disabled={retrying} onClick={onRetry}>
+            <RefreshCw className={`lucide-inline ${retrying ? 'animate-spin' : ''}`} />
+            Try again
+          </SendBtn>
+        </div>
+      </section>
+    </SetupShell>
   )
 }
 
@@ -487,7 +472,6 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
     || loginMutation.isPending
   const mutationError = installMutation.error || loginMutation.error
   const platform = status.platform || 'local'
-  const needsLinuxRepair = needsLinuxDashboardRepair(status)
   if (status.initial_setup_complete) {
     return (
       <>
@@ -509,17 +493,7 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
   }
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-y-auto bg-bg px-4 py-8 sm:px-8">
-      <div
-        aria-hidden="true"
-        className="absolute left-[-12rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-accent/10 blur-[100px]"
-      />
-      <div
-        aria-hidden="true"
-        className="absolute bottom-[-15rem] right-[-10rem] h-[34rem] w-[34rem] rounded-full bg-accent/5 blur-[120px]"
-      />
-      <div className="relative grid w-full max-w-5xl overflow-hidden rounded-2xl border border-border bg-card shadow-[0_30px_90px_rgba(0,0,0,.2)] lg:grid-cols-[.82fr_1.18fr]">
-        <SetupStage />
+    <SetupShell scroll>
         <section className="p-7 sm:p-10 lg:p-12">
           <div className="mb-7">
             <div className="mb-3 flex items-center gap-2 text-[12px] font-semibold tracking-[0.14em] text-accent">
@@ -554,16 +528,14 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <SendBtn
                 type="button"
-                disabled={busy || (status.installed && !status.repair_required) || !status.can_auto_install}
+                disabled={busy || status.installed || !status.can_auto_install}
                 onClick={() => installMutation.mutate()}
               >
                 {busy && status.operation.kind === 'install'
                   ? <><Loader2 className="lucide-inline animate-spin" /> Installing…</>
-                  : status.installed && !status.repair_required
+                  : status.installed
                     ? <><CheckCircle2 className="lucide-inline" /> Installed</>
-                    : status.repair_required
-                      ? <><Package className="lucide-inline" /> Reinstall Kiro CLI</>
-                      : <><Package className="lucide-inline" /> Install Kiro CLI</>}
+                    : <><Package className="lucide-inline" /> Install Kiro CLI</>}
               </SendBtn>
               <a
                 className="inline-flex items-center gap-1.5 text-[13px] font-medium text-accent hover:underline focus-ring"
@@ -574,12 +546,9 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
                 Installation guide <ExternalLink className="lucide-inline" />
               </a>
             </div>
-            {needsLinuxRepair && <LinuxDashboardRepairInstructions />}
-            {!needsLinuxRepair
-              && !status.can_auto_install
-              && (!status.installed || status.repair_required) && (
+            {!status.installed && !status.can_auto_install && (
               <p className="mt-3 text-[13px] leading-relaxed text-muted">
-                Automatic installation cannot safely repair this installation. Follow the official
+                Automatic installation is unavailable here. Install Kiro CLI from the official
                 guide on the gateway host, then choose Check again.
               </p>
             )}
@@ -611,7 +580,6 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
                 disabled={
                   busy
                   || !status.installed
-                  || !status.can_login
                   || status.authenticated
                 }
                 onClick={() => loginMutation.mutate()}
@@ -623,12 +591,6 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
                     : <><LogIn className="lucide-inline" /> Sign in to Kiro</>}
               </SendBtn>
             </div>
-            {status.installed && !status.can_login && !needsLinuxRepair && (
-              <p className="mt-3 text-[13px] leading-relaxed text-muted">
-                Kiro Crew will not give credentials to an unverified executable. Reinstall Kiro
-                CLI from the official guide, then choose Check again.
-              </p>
-            )}
             {status.operation.kind === 'login' && <OperationProgress status={status} />}
           </Card>
 
@@ -658,7 +620,6 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
             </Btn>
           </div>
         </section>
-      </div>
-    </main>
+    </SetupShell>
   )
 }

--- a/website/src/test/KiroPrerequisiteGate.test.tsx
+++ b/website/src/test/KiroPrerequisiteGate.test.tsx
@@ -120,49 +120,31 @@ describe('KiroPrerequisiteGate', () => {
     expect(await screen.findByRole('button', { name: 'Sign in to Kiro' })).toBeEnabled()
   })
 
-  it('recovers an unverified Linux install through the dashboard installer', async () => {
-    vi.mocked(api.kiroPrerequisite)
-      .mockResolvedValueOnce(status({
-        installed: true,
-        can_auto_install: false,
-        can_login: false,
-        repair_required: true,
-      }))
-      .mockResolvedValueOnce(status({
-        installed: false,
-        can_auto_install: true,
-        can_login: true,
-        repair_required: false,
-      }))
-    vi.mocked(api.installKiroPrerequisite).mockResolvedValue(status({
+  it('offers sign-in for an already-installed CLI regardless of install source', async () => {
+    // A user-owned / self-updated / toolbox Kiro CLI that runs is installed and
+    // sign-in ready — no "unverified executable" dead end, no repair prompt.
+    // The mock reproduces the exact OLD rejected-provenance status
+    // (can_login:false + repair_required:true): under the pre-change gate this
+    // rendered a button-less "Reinstall" dead end; the new "runs" contract must
+    // ignore both fields and still offer an enabled Sign-in — so this fails on
+    // revert of the can_login/repair_required gate removals.
+    vi.mocked(api.kiroPrerequisite).mockResolvedValue(status({
       installed: true,
-      can_auto_install: true,
-      can_login: true,
-      operation: {
-        kind: 'install',
-        status: 'succeeded',
-        message: 'Kiro CLI is installed.',
-        detail: '',
-        url: '',
-        error: '',
-      },
+      authenticated: false,
+      can_auto_install: false,
+      can_login: false,
+      repair_required: true,
     }))
 
     renderWithProviders(
       <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
     )
 
-    expect(await screen.findByText('rm -- ~/.local/bin/kiro-cli')).toBeInTheDocument()
-    expect(screen.getByText(/When Install Kiro CLI becomes available/)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Reinstall Kiro CLI' })).toBeDisabled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Check again' }))
-    const installButton = await screen.findByRole('button', { name: 'Install Kiro CLI' })
-    expect(installButton).toBeEnabled()
-    fireEvent.click(installButton)
-
-    await waitFor(() => expect(api.installKiroPrerequisite).toHaveBeenCalledOnce())
+    const loginButton = await screen.findByRole('button', { name: 'Sign in to Kiro' })
+    expect(loginButton).toBeEnabled()
+    expect(screen.queryByText(/unverified executable/)).not.toBeInTheDocument()
     expect(screen.queryByText('rm -- ~/.local/bin/kiro-cli')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Installed' })).toBeDisabled()
   })
 
   it('shows the secure device URL and advances when login becomes ready', async () => {


### PR DESCRIPTION
## Problem

A brand-new user whose Kiro CLI was installed **outside** KiroCrew's own
installer — a toolbox / Homebrew / winget install, or an `/Applications` bundle
that Kiro's self-updater rewrote — opened the dashboard to a
**"Kiro Crew needs Kiro sign-in"** banner with **no working Sign-in button**,
only "Reinstall from the official guide." Sessions also 503'd. (Reported by a
real user stuck in exactly this state.)

## Why it matters

Kiro CLI is legitimately installed from many sources on every OS, and its own
self-updater rewrites its bytes as the user. PR #475 gated sign-in **and** every
ACP session launch behind a binary-provenance model — macOS codesign at the
exact `/Applications` path, a root-owned immutable chain, or a KiroCrew-installer
SHA-256 attestation file. A user-owned install matching none of those anchors was
permanently rejected, with no in-product recovery path. Any user who installed
Kiro CLI independently and let it self-update would eventually land here.

## Fix (symptom → root cause → change)

- **Symptom:** `installed=true` but `can_login=false` → banner renders the
  reauth copy while the Sign-in button (`owner && installed && can_login`) is
  hidden; ACP spawn raises `ValueError("provenance is not trusted")` → 503.
- **Root cause:** `_candidate_trusted_for_auth` (auth) and
  `_trusted_acp_binary_digest` (launch) both required install-source provenance,
  which a legitimate user-owned / self-updated binary can't satisfy.
- **Change:** trust is now **"the CLI runs, and it has a valid login."** Any
  resolvable executable candidate is eligible for `whoami`/device-login and ACP
  launch, on every OS, regardless of install source, owner, or path — KiroCrew
  is not the authority on where Kiro CLI is installed. `whoami` reporting a valid
  session is what makes readiness true; a runnable CLI never surfaces an
  unreachable "repair" state. Windows setup discovery now matches ACP resolution
  (a winget/scoop install on `PATH` is recognized, not forced to Program Files).

**Retained (NOT a security regression):** the exec-time integrity snapshot —
Linux executes a write-sealed `memfd` of the resolved bytes, macOS a verified
private copy — so a swap **between resolve and exec** is still caught; it just no
longer pins a stored digest a legitimate self-update would invalidate. HOME
isolation for the auth process, output credential/exfil redaction, the
cross-process publish lock, deny-by-default owner-gating, and SEL audit are all
unchanged.

**Removed** the now-dead provenance machinery (`_candidate_trusted_for_auth`,
`_attested_sha256`, `_macos_codesign_allows_official_kiro`,
`_root_owned_immutable_candidate`, `_protected_binary_trust_digest`,
`platform_compat.descendant_pids`, the Windows Program-Files probe filter) and
the frontend repair/reinstall dead ends (`LinuxDashboardRepairInstructions`,
the `!can_login` "unverified executable" fallbacks). Net −381 lines.

## Tests

- New backend regression tests (fail on revert): a user-owned `~/.toolbox/bin`
  CLI signs in (`can_login=true`, `ready=true`); a self-updated binary still
  signs in; the ACP snapshot accepts a runnable CLI without provenance; a
  runnable Windows override outside Program Files is probed and used.
- Rewrote the tests that encoded the removed provenance gate (macOS
  codesign/official-path, Linux root-owned, Windows Program-Files restriction,
  install-refusal) to the new model; kept the install-quality guards
  (shadowing / no-op-install) which still fire when no runnable CLI pre-exists.
- Frontend: the reauth banner offers an enabled Sign-in for an already-installed
  CLI even when the backend reports the old rejected-provenance status
  (`can_login:false, repair_required:true`) — pins the dead-end fix on revert.
- Full backend suite green; full website vitest green; black/isort/flake8/mypy
  and tsc/eslint clean.

## Manual verification

N/A — unit + integration coverage is sufficient. The observable behavior (an
installed-but-signed-out CLI shows an enabled "Sign in to Kiro" instead of a
button-less dead end) is asserted at both the backend readiness layer and the
frontend gate.

## Screenshots

No UI screenshots — this change adds no new surface and alters no layout; it
makes the **existing** "Sign in to Kiro" button reachable in a state where it was
previously hidden, and removes a dead-end message. The gate's visuals are
unchanged.

## Specs

Updated in the same commit (per AGENTS.md): `security.md`, `cli.md`,
`acp-client.md`, `learn-cron-dashboard.md`, `docs/DESKTOP_APP.md` — all now
describe the "runs + valid login" model and the retained integrity snapshot.
