### PR TITLE
fix: fall back to ctypes memfd_create on glibc < 2.27

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -28,7 +28,11 @@ wrapper chain and execute its `/proc/self/fd/<fd>` identity; the gateway closes
 its copy immediately after process creation, while the child retains the
 inherited descriptor. Kernels that predate `MFD_EXEC` reject the flag with
 `EINVAL`; creation retries once without that flag, while every other error
-remains fail-closed. There is no mutable pathname or verify-to-exec replacement
+remains fail-closed. Interpreters built against glibc < 2.27 (Amazon Linux 2)
+expose no `os.memfd_create` even though the kernel supports the syscall, so
+creation always goes through `platform_compat.create_memfd`, which falls back to
+a direct `syscall(2)` via `ctypes` and preserves `errno` so the `MFD_EXEC` retry
+still discriminates. There is no mutable pathname or verify-to-exec replacement
 window. macOS cannot reliably execute Mach-O through `/dev/fd`, so it first
 requires the current digest to match protected post-installer, process-start
 override, or immutable-system provenance and requires `/usr/bin/codesign` to

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -765,7 +765,10 @@ canonicalizes symlinks before its final no-follow open. Linux copies verified
 bytes into a kernel write-sealed `MFD_EXEC` memfd, passes its descriptor through
 every wrapper as `/proc/self/fd/<fd>`, and closes the gateway copy after process
 creation. Older kernels that reject `MFD_EXEC` with `EINVAL` retry creation
-without that flag; other creation errors fail closed. Snapshot registry
+without that flag; other creation errors fail closed. Creation is routed through
+`platform_compat.create_memfd` so hosts whose CPython was built against
+glibc < 2.27 (Amazon Linux 2) reach a `ctypes` `syscall(2)` fallback instead of
+failing closed on a missing `os.memfd_create` attribute. Snapshot registry
 ownership is removed synchronously, while descriptor close runs on the
 dedicated subprocess executor so cancellation and startup teardown cannot block
 the gateway event loop. Because Mach-O does not reliably launch through

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -633,20 +633,13 @@ def snapshot_trusted_acp_executable(
 
     snapshot_fd = -1
     try:
-        memfd_create = getattr(os, "memfd_create", None)
-        if not callable(memfd_create):
-            raise OSError("Linux memfd executable snapshots are unavailable")
-        memfd_flags = (
-            getattr(os, "MFD_CLOEXEC", 0x0001)
-            | getattr(os, "MFD_ALLOW_SEALING", 0x0002)
-            | _MFD_EXEC
-        )
+        memfd_flags = platform_compat.MFD_CLOEXEC | platform_compat.MFD_ALLOW_SEALING | _MFD_EXEC
         try:
-            snapshot_fd = memfd_create("kiro-cli-acp", memfd_flags)
+            snapshot_fd = platform_compat.create_memfd("kiro-cli-acp", memfd_flags)
         except OSError as exc:
             if exc.errno != errno.EINVAL:
                 raise
-            snapshot_fd = memfd_create("kiro-cli-acp", memfd_flags & ~_MFD_EXEC)
+            snapshot_fd = platform_compat.create_memfd("kiro-cli-acp", memfd_flags & ~_MFD_EXEC)
         _copy_verified_executable_to_fd(canonical, snapshot_fd, expected)
         platform_compat.seal_memfd(snapshot_fd)
         launch_path = f"/proc/self/fd/{snapshot_fd}"

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -221,6 +221,66 @@ def release_lock(fd: int) -> None:
         pass
 
 
+# Linux ``memfd_create(2)`` syscall numbers keyed by ``os.uname().machine``.
+# CPython exposes ``os.memfd_create`` ONLY when built against glibc >= 2.27,
+# which is when the libc wrapper appeared. Amazon Linux 2 ships glibc 2.26, so
+# interpreters built there lack the attribute even though the KERNEL supports
+# the syscall (Linux >= 3.17). Without a fallback, every ACP executable
+# snapshot fails closed on those hosts, which takes the agent offline.
+_MEMFD_CREATE_SYSCALLS: Mapping[str, int] = {
+    "x86_64": 319,
+    "aarch64": 279,
+}
+
+# memfd flags — absent from ``os`` on the same pre-2.27 builds as the function.
+MFD_CLOEXEC: int = getattr(os, "MFD_CLOEXEC", 0x0001)
+MFD_ALLOW_SEALING: int = getattr(os, "MFD_ALLOW_SEALING", 0x0002)
+
+
+def create_memfd(name: str, flags: int) -> int:
+    """
+    Create an anonymous Linux memfd and return its descriptor.
+    Prefers ``os.memfd_create``; falls back to a direct ``syscall(2)`` through
+    ``ctypes`` on interpreters that were built without the glibc wrapper. The
+    fallback raises ``OSError`` carrying ``errno`` so callers can keep
+    distinguishing failures (notably ``EINVAL`` for an unsupported flag such as
+    ``MFD_EXEC`` on kernels older than 6.3).
+
+    The native function is tried BEFORE the host-platform guard: callers are
+    parameterized by ``platform_name`` so they can exercise the Linux branch on
+    a non-Linux runner with ``os.memfd_create`` patched in. Only the raw syscall
+    fallback, which needs a real Linux kernel and ``os.uname``, is host-gated.
+    """
+
+    native = getattr(os, "memfd_create", None)
+    if callable(native):
+        return int(native(name, flags))
+    if not IS_LINUX:
+        raise OSError("memfd creation is only available on Linux")
+
+    machine = os.uname().machine
+    number = _MEMFD_CREATE_SYSCALLS.get(machine)
+    if number is None:
+        raise OSError(f"memfd_create syscall number is unknown for machine {machine!r}")
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        syscall = libc.syscall
+    except (AttributeError, OSError) as exc:
+        raise OSError(f"memfd_create syscall is unreachable: {exc}") from exc
+    syscall.restype = ctypes.c_long
+    fd = int(
+        syscall(
+            ctypes.c_long(number),
+            ctypes.c_char_p(name.encode("utf-8")),
+            ctypes.c_uint(flags),
+        )
+    )
+    if fd < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err), name)
+    return fd
+
+
 def seal_memfd(fd: int) -> None:
     """Make a populated Linux memfd permanently immutable.
 

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -446,10 +446,12 @@ class TestKiroPrerequisiteHelpers:
 
     @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd seals")
     def test_linux_memfd_seals_reject_later_writes(self) -> None:
-        memfd_create = getattr(os, "memfd_create")
-        fd = memfd_create(
+        # Goes through the platform_compat shim, not os.memfd_create directly:
+        # interpreters built against glibc < 2.27 (Amazon Linux 2) lack the
+        # attribute entirely even though the kernel supports the syscall.
+        fd = platform_compat.create_memfd(
             "kiro-cli-test",
-            getattr(os, "MFD_ALLOW_SEALING", 0x0002),
+            platform_compat.MFD_ALLOW_SEALING,
         )
         try:
             os.write(fd, b"immutable")

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -114,6 +114,76 @@ class TestProcessHelpers:
         assert pc.process_matches(2_000_000_000, ("kiro-cli", "claude")) is False
 
 
+class TestCreateMemfd:
+    """The ACP executable-snapshot path depends on this shim being total.
+
+    ``os.memfd_create`` only exists on CPython built against glibc >= 2.27, so
+    Amazon Linux 2 hosts (glibc 2.26) must reach the ctypes syscall fallback or
+    the agent cannot launch at all.
+    """
+
+    def test_rejects_non_linux_without_native(self, monkeypatch):
+        # The guard covers only the raw-syscall fallback, so the native
+        # function must be absent for it to be reachable. Callers pass an
+        # explicit platform_name and patch os.memfd_create to drive the Linux
+        # branch from a Windows runner; that path must stay open.
+        monkeypatch.delattr(os, "memfd_create", raising=False)
+        monkeypatch.setattr(pc, "IS_LINUX", False)
+        with pytest.raises(OSError, match="only available on Linux"):
+            pc.create_memfd("probe", pc.MFD_CLOEXEC)
+
+    def test_native_is_used_even_when_host_is_not_linux(self, monkeypatch):
+        # Regression: guarding the whole function on IS_LINUX broke the
+        # pre-existing simulated-Linux snapshot tests on Windows runners.
+        monkeypatch.setattr(pc, "IS_LINUX", False)
+        monkeypatch.setattr(os, "memfd_create", lambda _n, _f: 4242, raising=False)
+        assert pc.create_memfd("probe", pc.MFD_CLOEXEC) == 4242
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd")
+    def test_prefers_native_when_present(self, monkeypatch):
+        calls: list[tuple[str, int]] = []
+        monkeypatch.setattr(
+            os,
+            "memfd_create",
+            lambda name, flags: calls.append((name, flags)) or 4242,
+            raising=False,
+        )
+        assert pc.create_memfd("probe", pc.MFD_CLOEXEC) == 4242
+        assert calls == [("probe", pc.MFD_CLOEXEC)]
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd")
+    def test_ctypes_fallback_returns_usable_fd(self, monkeypatch):
+        # Force the fallback even on a glibc >= 2.27 host so both branches are
+        # covered everywhere, not just on old distros.
+        monkeypatch.delattr(os, "memfd_create", raising=False)
+        fd = pc.create_memfd("probe", pc.MFD_CLOEXEC | pc.MFD_ALLOW_SEALING)
+        try:
+            assert fd >= 0
+            assert os.path.exists(f"/proc/self/fd/{fd}")
+            os.write(fd, b"payload")
+            pc.seal_memfd(fd)
+            with pytest.raises(OSError):
+                os.write(fd, b"tamper")
+        finally:
+            os.close(fd)
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd")
+    def test_ctypes_fallback_surfaces_errno_for_bad_flags(self, monkeypatch):
+        # Callers distinguish EINVAL (unsupported flag, e.g. MFD_EXEC before
+        # kernel 6.3) from hard failures, so errno must survive the shim.
+        monkeypatch.delattr(os, "memfd_create", raising=False)
+        with pytest.raises(OSError) as excinfo:
+            pc.create_memfd("probe", 0xFFFF_FFFF)
+        assert excinfo.value.errno == errno.EINVAL
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd")
+    def test_ctypes_fallback_rejects_unknown_machine(self, monkeypatch):
+        monkeypatch.delattr(os, "memfd_create", raising=False)
+        monkeypatch.setattr(pc, "_MEMFD_CREATE_SYSCALLS", {})
+        with pytest.raises(OSError, match="syscall number is unknown"):
+            pc.create_memfd("probe", pc.MFD_CLOEXEC)
+
+
 class TestFindListeningPids:
     def test_returns_list_of_ints_for_unused_port(self):
         # A very-high port nothing is bound to → empty list, never raises, on any OS.
@@ -173,7 +243,7 @@ class TestStrftime:
         if pc.IS_WINDOWS:
             assert dt.fmt == "%#I:%M %p"
         else:
-            assert dt.fmt == "%-I:%M %p"   # untouched on POSIX
+            assert dt.fmt == "%-I:%M %p"  # untouched on POSIX
 
     def test_real_datetime_formats_without_error(self):
         # End-to-end against a real datetime: must not raise ValueError on
@@ -193,11 +263,11 @@ class TestIsExecutableFile:
         f.write_text("#!/bin/sh\nexit 0\n")
         os.chmod(f, 0o644)  # no x-bit
         if pc.IS_WINDOWS:
-            assert pc.is_executable_file(f) is True   # .sh extension → runnable
+            assert pc.is_executable_file(f) is True  # .sh extension → runnable
         else:
             assert pc.is_executable_file(f) is False  # no x-bit → not runnable
         os.chmod(f, 0o755)  # +x
-        assert pc.is_executable_file(f) is True       # runnable on both now
+        assert pc.is_executable_file(f) is True  # runnable on both now
 
     def test_missing_file_is_not_executable(self, tmp_path):
         assert pc.is_executable_file(tmp_path / "nope.sh") is False
@@ -254,9 +324,7 @@ class TestFindPythonInterpreter:
             return stub if name in ("python", "python3") else real
 
         monkeypatch.setattr("shutil.which", fake_which)
-        monkeypatch.setattr(
-            pc.subprocess, "check_output", lambda *a, **k: "3.12\n"
-        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: "3.12\n")
         got = pc.find_python_interpreter()
         assert got == real
         assert pc._is_windows_store_python_stub(got) is False
@@ -353,7 +421,7 @@ class TestChmodShims:
         f.write_text("x")
         fd = os.open(str(f), os.O_RDONLY)
         try:
-            pc.fchmod_safe(fd, 0o600)   # applies on POSIX, no-op on Windows
+            pc.fchmod_safe(fd, 0o600)  # applies on POSIX, no-op on Windows
         finally:
             os.close(fd)
 
@@ -766,13 +834,13 @@ class TestTaskkillErrorMapping:
         def _run(*_a, **_kw):
             r = types.SimpleNamespace(returncode=rc, stdout=b"", stderr=stderr)
             return r
+
         return _run
 
     def test_taskkill_rc128_maps_to_process_lookup(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(128, b"process not found"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(128, b"process not found"))
         with pytest.raises(ProcessLookupError):
             pc.kill_pid(99999, pc.SIGKILL)
         with pytest.raises(ProcessLookupError):
@@ -781,8 +849,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_rc5_maps_to_permission_error(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(5, b"access denied"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(5, b"access denied"))
         with pytest.raises(PermissionError):
             pc.kill_pid(99999, pc.SIGKILL)
         with pytest.raises(PermissionError):
@@ -791,8 +858,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_generic_rc_maps_to_oserror(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(42, b"weird error"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(42, b"weird error"))
         with pytest.raises(OSError) as ei:
             pc.kill_pid(99999, pc.SIGKILL)
         # not one of the more specific subclasses
@@ -811,6 +877,7 @@ class TestTaskkillErrorMapping:
 
         def _boom(*_a, **_kw):
             raise FileNotFoundError(2, "taskkill.exe not found")
+
         monkeypatch.setattr(pc.subprocess, "run", _boom)
         with pytest.raises(OSError):
             pc.kill_pid(99999, pc.SIGKILL)
@@ -835,8 +902,7 @@ class TestRestrictToOwnerArgvOnLinux:
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         # Reset the success-only SID memo so the monkeypatched stub wins
         monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid",
-                            lambda: "*S-1-5-21-1-2-3-1000")
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
         captured: dict = {}
 
         def fake_run(argv, **_kw):
@@ -864,11 +930,12 @@ class TestRestrictToOwnerArgvOnLinux:
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid",
-                            lambda: "*S-1-5-21-9-9-9-9")
-        monkeypatch.setattr(pc.subprocess, "run",
-                            lambda *a, **k: types.SimpleNamespace(
-                                returncode=1, stdout=b"", stderr=b"denied"))
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-9-9-9-9")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"denied"),
+        )
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         with pytest.raises(OSError):
@@ -917,10 +984,11 @@ class TestRestrictToOwnerArgvOnLinux:
             if len(attempts) == 1:
                 return types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
             return types.SimpleNamespace(
-                returncode=0, stdout=b'"ANT\\user","S-1-5-21-1-2-3-500"', stderr=b"")
+                returncode=0, stdout=b'"ANT\\user","S-1-5-21-1-2-3-500"', stderr=b""
+            )
 
         monkeypatch.setattr(pc.subprocess, "run", flaky_run)
-        assert pc._current_user_sid() is None          # first call fails...
+        assert pc._current_user_sid() is None  # first call fails...
         assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...retry succeeds
         assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...and is cached
         assert len(attempts) == 2, "success must be memoized (no third spawn)"
@@ -1029,7 +1097,8 @@ class TestRestrictToOwner:
         f.write_bytes(b"s" * 32)
         pc.restrict_to_owner(f)
         out = subprocess.check_output(
-            ["icacls", str(f)], stderr=subprocess.DEVNULL,
+            ["icacls", str(f)],
+            stderr=subprocess.DEVNULL,
         ).decode("utf-8", "replace")
         # Owner Rights SID rendered as "OWNER RIGHTS" in the DACL dump, with (F)
         # for full control; inheritance stripping means "(I)" (inherited) markers
@@ -1166,8 +1235,10 @@ class TestFindListeningPidsErrors:
 
     def _fake_netstat(self, blob: str):
         """Return a fake subprocess.check_output that returns *blob*."""
+
         def _run(*_a, **_kw):
             return blob
+
         return _run
 
     def test_windows_finds_ipv6_listener_via_netstat(self, monkeypatch):
@@ -1207,9 +1278,7 @@ class TestFindListeningPidsErrors:
         # future-proof against a hypothetical Windows build that switches to
         # "TCP6" (the netstat -p flag already accepts "tcpv6"). Guard the
         # defensive path so a future relabel doesn't silently re-break this.
-        blob = (
-            "  TCP6   [::1]:7777             [::]:0                 LISTENING       77\n"
-        )
+        blob = "  TCP6   [::1]:7777             [::]:0                 LISTENING       77\n"
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
@@ -1254,6 +1323,7 @@ class TestFindListeningPidsErrors:
         # canned-blob tests above by exercising the real netstat parse against
         # whatever this Windows build actually prints.
         import socket as _socket
+
         s = _socket.socket(_socket.AF_INET6, _socket.SOCK_STREAM)
         try:
             s.bind(("::1", 0))
@@ -1293,9 +1363,7 @@ class TestKillAsyncVariants:
         monkeypatch.setattr(pc, "kill_pid", fake_kill_pid)
         import asyncio as _asyncio
 
-        result = _asyncio.new_event_loop().run_until_complete(
-            pc.kill_pid_async(4242, pc.SIGKILL)
-        )
+        result = _asyncio.new_event_loop().run_until_complete(pc.kill_pid_async(4242, pc.SIGKILL))
         assert result is True
         assert seen == [(4242, pc.SIGKILL)]
 
@@ -1389,13 +1457,11 @@ class TestKillAsyncVariants:
 
         result = real_loop.run_until_complete(_driver())
         assert result is True
-        assert seen_executors == [sentinel], (
-            f"expected the subprocess_executor sentinel, got {seen_executors!r}"
-        )
+        assert seen_executors == [
+            sentinel
+        ], f"expected the subprocess_executor sentinel, got {seen_executors!r}"
 
-    def test_windows_kill_process_tree_async_offloads_via_subprocess_executor(
-        self, monkeypatch
-    ):
+    def test_windows_kill_process_tree_async_offloads_via_subprocess_executor(self, monkeypatch):
         """Same offload contract as kill_pid_async but for the /T variant."""
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
@@ -1406,9 +1472,7 @@ class TestKillAsyncVariants:
         monkeypatch.setattr(
             pc.subprocess,
             "run",
-            lambda *_a, **_kw: types.SimpleNamespace(
-                returncode=0, stdout=b"", stderr=b""
-            ),
+            lambda *_a, **_kw: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
         )
         monkeypatch.setattr(pc, "subprocess_executor", lambda: sentinel)
 


### PR DESCRIPTION
## Problem

The Linux ACP executable-snapshot path requires `os.memfd_create` and fails closed without it. On any host lacking it, every session spawn dies before the agent starts:

```
kiro_crew.acp.client._KiroExecutableTrustError: Linux memfd executable snapshots are unavailable
```

CPython only exposes `os.memfd_create` when built against **glibc >= 2.27**, which is when the libc wrapper appeared. **Amazon Linux 2 ships glibc 2.26**, so no interpreter built there ever has the attribute, regardless of Python version. Observed on an AL2 Cloud Desktop:

| Interpreter | `os.memfd_create` |
|---|---|
| `/usr/bin/python3` 3.7.16 | False |
| mise 3.9.25 | False |
| mise 3.10.20 | False |
| mise 3.12.13 | False |

The kernel is not the constraint. `memfd_create(2)` has existed since Linux 3.17, and the host in question runs 5.10.260. Only the libc convenience wrapper is missing, so the dependency on glibc was accidental rather than essential.

Upgrading is not an option: AL2 is pinned to glibc 2.26 for its whole supported life, its repos ship only patch revisions of 2.26, and installing a newer Python cannot help because any interpreter that runs on AL2 links against the system glibc. Since AL2 desktops are a standard internal dev environment, this makes KiroCrew unusable for that whole population.

The macOS branch already degrades gracefully to a private-file snapshot. The Linux branch had no equivalent.

## Change

Add `platform_compat.create_memfd`, which prefers `os.memfd_create` and otherwise issues `syscall(2)` directly through `ctypes`, plus the `MFD_CLOEXEC` / `MFD_ALLOW_SEALING` constants absent from the same builds. `kiro_prerequisite` now routes through the shim.

- The fallback raises `OSError` carrying `errno`, so the existing `MFD_EXEC` EINVAL retry still distinguishes an unsupported flag from a hard failure.
- Syscall numbers are keyed by `os.uname().machine` for `x86_64` and `aarch64`; an unknown machine raises rather than guessing.
- **Behavior is unchanged wherever `os.memfd_create` exists.** The native path is tried first, so modern hosts never reach the fallback.
- No change to the security properties: bytes are still verified, still sealed with `F_SEAL_WRITE|GROW|SHRINK|SEAL`, still launched via `/proc/self/fd/<fd>`. Calling the syscall directly is exactly what the glibc wrapper does.

## Testing

Verified on AL2 (glibc 2.26, kernel 5.10.260, CPython 3.10.20 without `os.memfd_create`), end to end through the real snapshot path:

- Fallback returns a usable fd; `/proc/self/fd/N` exists.
- `MFD_EXEC` correctly returns `EINVAL` on this kernel and the retry without the flag succeeds.
- Seal applied; write-after-seal rejected with `EPERM`.
- `snapshot_trusted_acp_executable` output exec'd with `pass_fds` returns `kiro-cli 2.14.2`.
- Gateway that previously failed every spawn now reports `ready: true` from `/api/kiro-prerequisite`.

5 new tests in `TestCreateMemfd` cover non-Linux rejection, native preference, fallback fd usability plus sealing, `errno` propagation on bad flags, and unknown-machine rejection. The fallback tests `monkeypatch.delattr(os, "memfd_create")` so both branches are exercised on modern hosts too, not only on old distros.

Also fixes `test_linux_memfd_seals_reject_later_writes`, which called `os.memfd_create` directly and therefore hard-failed on AL2 instead of skipping.

`black`, `isort`, `flake8`, `mypy` clean. `test_platform_compat.py`, `test_kiro_prerequisite.py`, `test_acp_client.py`: 619 passed, 5 skipped. Full suite deferred to CI.

## Note for reviewers

Separately, on Toolbox-managed installs the trust gate attests the **wrong bytes**: `~/.local/bin/kiro-cli` there is a bash shim that re-execs `aim sandbox --client kiro-cli`, so the digest covers a 17-line script while the real 101 MB binary and the `aim` re-exec go unattested. The kernel honors the shebang out of the memfd, so it appears to work while providing no integrity guarantee. Not addressed here; probably worth refusing script candidates with an actionable message.