### PR TITLE
docs(ci): refresh CI & prepare-pr doc for PR #549 review de-noise

### DIFF
--- a/docs/ci/ci-and-prepare-pr.md
+++ b/docs/ci/ci-and-prepare-pr.md
@@ -1,6 +1,6 @@
 # KiroCrew CI & Prepare-PR — How It Works
 
-_Source of truth: `.github/workflows/*` on `main` (@ `e7e9256c`) and the `prepare-pr` skill._
+_Source of truth: `.github/workflows/*` on `main` (@ `9dd99f97`, incl. PR #549's AI-review de-noise) and the `prepare-pr` skill._
 
 This doc explains (1) the overall shape of KiroCrew's CI, (2) the purpose and design of each workflow — with emphasis on the four AI reviewers and the Arbiter — and (3) how the `prepare-pr` skill drives a change to review-ready by working *with* CI, including how the whole system resists over-engineering.
 
@@ -89,10 +89,12 @@ Primary correctness gate. Blocking jobs:
 - **`scrub-lint`** — fails on any Amazon-internal marker in the public tree (this is a public repo).
 - **`backend-lint`** — `isort`/`flake8`/`mypy` on Python 3.10 + 3.12 (`black --check` currently disabled).
 - **`backend-test`** — 3.10×3.12 × 4 shards (8 jobs), pytest-split duration-balanced via `.test_durations`, coverage collected only on 3.12. Plus **`backend-test-windows`** (windows-latest, 4 shards, `--no-cov`).
+- **`backend-test-sandbox`** (added in **PR #549**) — runs the two suites the sharded matrix *deselects* because they need unprivileged user namespaces (`unshare` `NEWNS`): `test_script_hooks.py` + `test_cron_script.py`. It enables `kernel.apparmor_restrict_unprivileged_userns=0`, then **fails loudly** (`unshare --mount --map-root-user true`) if the runner ever stops allowing the namespace — rather than letting the suite silently skip and the gate go green having asserted nothing. This is what gives the `hooks.py` sensitive-path keystone real CI coverage. (`test_run_aim_path` stays deselected everywhere — it needs the Amazon-internal `aim` CLI absent from this fork.)
 - **`coverage-combine` → `coverage-gate`** — combines shard coverage, then enforces **backend ≥ 70%, frontend ≥ 60%** on raw line-rate. Runs `if: always()` and fails unless both upstreams succeeded, so a skipped required check can't count as satisfied (fail-closed).
 - **`frontend-lint`** — `tsc -b`, `eslint --max-warnings 1116` (a ratchet baseline — do not raise), `jscpd`.
 - **`frontend-test`** — `vitest run --coverage`.
 - **`e2e`** — offline Playwright run against a stubbed ACP backend (`KIROCREW_E2E_REQUIRE=1`), no model cost.
+- **`cfn-lint`** ("CloudFormation Lint") — lints the artifact-deploy templates; #549 SHA-pinned its actions and pinned `cfn-lint==1.22.3` so an unpinned lint tool can't silently shift the gate's behaviour on each upstream release.
 
 _CodeQL is not a checked-in workflow — it runs via GitHub default-setup and is referenced only by pr-readiness._
 
@@ -106,16 +108,18 @@ Four reviewers, each with a distinct question and a distinct trust posture. The 
 
 | Reviewer | Model / harness | Reads | Question it answers | Can block? | Fail posture |
 |---|---|---|---|---|---|
-| **Claude AI Review** (`claude-review`) | Opus 5, agentic (`claude-code-action`), 1 pass (2nd only for security/large diffs) | **CODE ONLY** — `Read/Grep/Glob/gh pr diff`; **no `gh pr view`/`gh api`** | Line-level correctness/security/AUTOSDE | Yes | **Fail-closed** |
-| **GPT 5.6 Review** (`codex-review`) | GPT 5.6, non-agentic single-shot, real **3-pass** (discover→discover→reconcile) | Code + **PR title/description + prior-round context as nonce-wrapped UNTRUSTED data** | Line-level (2nd perspective) **+ description↔diff consistency** | Yes | **Fail-closed** |
+| **Claude AI Review** (`claude-review`) | Opus 5, agentic (`claude-code-action`), 1 pass (2nd only for security/data-integrity paths); `--max-turns 60`, 30-min timeout | **CODE ONLY** — `Read/Grep/Glob/gh pr diff`; **no `gh pr view`/`gh api`**, and (since #549) **no `gh pr comment`** | Line-level correctness/security/AUTOSDE | Yes | **Fail-closed** |
+| **GPT 5.6 Review** (`codex-review`) | GPT 5.6, non-agentic single-shot, **2-pass** (discovery → authoritative **falsification**); `reasoning_effort: medium` | Code + **PR title/description as nonce-wrapped UNTRUSTED context** (no prior-round context — removed in #549) | Line-level (2nd perspective) **+ description↔diff consistency** (advisory) | Yes | **Fail-closed** |
 | **Design Review** (`design-review`) | Fable 5, agentic | Code + `gh pr view` (must judge intent) | **Should we build this? Is it the right *shape*?** | No (advisory) | **Fail-open/neutral**, red only on genuine BLOCK |
 | **Arbiter** (`longterm-arbiter`) | Fable 5, `Read` only (2 pre-fetched files) | The **other three reviewers' posted comments** + capped diff | Which sub-threshold findings have real long-term impact | Yes (narrow bar) | Fail-closed until all 3 present; neutral on model error |
 
 Cross-cutting design details:
 
 - **Why Claude is code-only:** it's the *write-capable agentic* reviewer, so pulling attacker-controllable PR title/description/comments into its context is a prompt-injection surface. That responsibility (PR-intent + description-vs-diff mismatch) is deliberately handed to the **read-only, non-agentic** Codex reviewer, which treats that prose as **UNTRUSTED evidence, never authority to waive a code finding.**
-- **Asymmetric multi-pass is intentional, not inconsistent:** the agentic Claude harness already loops internally (1 careful pass suffices), while the lean single-shot Codex CLI benefits from real separate invocations (3 passes; pass 3 is the authoritative reconciliation and the only gated verdict).
-- **Verdicts are structured markers, not free prose:** Claude uses a `--json-schema` `{reviewed, block_merge, summary}` read from `structured_output` (not a scraped comment). Codex emits `[CODEX-REVIEWED] <sha>` always and `[BLOCK-MERGE] <sha>` only when a blocking CRITICAL/HIGH exists, with a coherence backstop (a `Severity: HIGH` line without `[BLOCK-MERGE]` fails closed as self-contradictory). Design emits `Design-Verdict: PASS|CONCERNS|BLOCK`. Arbiter emits `Arbiter-Verdict: BLOCK|PASS`.
+- **One shared binary contract (reworked in #549):** both line reviewers now run the *same* review contract — **DIVISION OF LABOUR → FINDING BAR → WHAT BLOCKS → FIX BAR → BUDGET → CALIBRATION** — and severity encodes exactly one thing: *does this block the merge*, **never confidence**. There is **no "possible issue" tier** — a finding must state (a) a concrete input/condition that occurs in practice, (b) the call path to the changed line, (c) an observable wrong outcome; anything "could / might / if a caller were to" is **NOT A FINDING** (silence is the correct output). Only two labels exist: **BLOCKING** (on the closed **WHAT BLOCKS** list — a `blocking:true` AUTOSDE violation on a changed file, or a reachable+concrete residual-class defect) and **FINDING** (advisory, never blocks). The **FIX BAR** kills over-engineering demands at the source (see §4), and a **BUDGET** caps each review at ≤2 BLOCKING findings; "No findings." is the expected output for a typical PR.
+- **De-noise (#549):** Claude no longer posts inline line comments — the agent lost `gh pr comment`, and a *CI step* upserts a **single** marker-keyed summary (`<!-- claude-ai-review -->`) read from the action's `structured_output.summary`. The gate blocks solely on the `block_merge` boolean, with **no text backstop**. This trades scattered inline chatter for one terse, punchline-first summary plus a binary gate.
+- **Asymmetric multi-pass is intentional, not inconsistent:** the agentic Claude harness already loops internally (1 careful pass suffices; a 2nd only on security/data-integrity paths). The lean single-shot Codex CLI runs **two** real invocations — a **discovery** pass that generates candidates, then an **authoritative falsification** pass whose primary job is to *kill* those candidates (a candidate survives only if pass 2 re-derives input + call path + observable outcome from code it opened itself). #549 replaced the old third "find what pass 1 missed" pass — a recall ratchet that only ever *added* candidates — with this falsification pass; pass 2 is the only gated verdict.
+- **Verdicts are structured markers, not free prose:** Claude uses a `--json-schema` `{reviewed, block_merge, summary}` read from `structured_output`. Codex emits `[CODEX-REVIEWED] <sha>` always and `[BLOCK-MERGE] <sha>` only when a blocking finding exists — **the markers are the only gate**; #549 downgraded the old "`Severity: HIGH` without `[BLOCK-MERGE]`" coherence check from fail-closed to a non-gating **advisory warning** (it mis-fired whenever the model quoted prior text). Design emits `Design-Verdict: PASS|CONCERNS|BLOCK`. Arbiter emits `Arbiter-Verdict: BLOCK|PASS`.
 - **Security guards:** explicit fork guards (`head.repo.full_name == github.repository`), `persist-credentials:false`, least-privilege Bedrock roles assumed *late* (after npm install so it never sees creds), read-only network-unshared sandboxes, and post-run redaction of AWS key/ARN/account shapes before any public comment.
 - **Human override** (`ai-review-human-override.yml`): a repo writer can post `/ai-review override <fable|gpt|arbiter|all> <head-sha>: <reason>`. It runs from the trusted default branch, validates target + 7-40-hex sha + writer permission + **commit freshness** (sha must be current head), then records a bot-authored marker the reviewers trust. Scope is **this commit only** — a new push needs a new judgment.
 
@@ -168,26 +172,27 @@ Executes no tests. It resolves the PR's current head SHA, **drops stale events**
 - **Non-fork also required:** CodeQL, Claude, GPT 5.6, Arbiter.
 - **Design Review is completion-required but advisory** — its verdict/infra failures score as `"(advisory)"` and never independently block (its job is to feed the Arbiter).
 - **Forks skip** CodeQL + all four bots.
+- **Refreshes on re-run (#549):** it now triggers on `workflow_run` `requested` / `in_progress` / `completed` (was `completed` only). When a monitored workflow flips *back* to running — most commonly a reviewer re-run after a human override — the job re-evaluates *while* that workflow runs: the live-queried workflow buckets into `pending`, so the label honestly drops from a stale `action required` (red) back to `checking` (yellow) instead of freezing on the previous commit's verdict. It stays cheap: the `in_progress` path has `pending>0` so it skips the ~5-min Arbiter settle loop (only the all-clear path waits), and the `pr+sha` concurrency group (`cancel-in-progress`) collapses the burst of near-simultaneous fires into one live evaluation.
 
 ---
 
 ## 3. Prepare-PR — and how it rides CI
 
-The `prepare-pr` skill drives whatever is in the working tree to **review-ready** (one clean commit, PR open, all required checks green, no open legitimate High/Medium findings). It **never merges** — it only *arms* GitHub auto-merge so the PR lands after a human approves and checks are green.
+The `prepare-pr` skill drives whatever is in the working tree to **review-ready** (one clean commit, PR open, all required checks green, no open legitimate Critical/High findings). It **never merges** — it only *arms* GitHub auto-merge so the PR lands after a human approves and checks are green.
 
 ### 3a. Phase flow
 
-- **Phase 0 — Preflight** (`preflight.sh`): repo/branch/base/auth/dirty/divergence/existing-PR. `0` proceed · `30` blocker (usually: on protected branch → `git switch -c <type>/<slug>`) · `2` env.
+- **Phase 0 — Preflight** (`preflight.py`): repo/branch/base/auth/dirty/divergence/existing-PR. `0` proceed · `30` blocker (usually: on protected branch → `git switch -c <type>/<slug>`) · `2` env.
 - **Phase 1 — Prepare:** commit (specific files, Conventional-Commits subject) → `git rebase origin/<base>` → **squash to one commit** (`git reset --soft origin/<base> && git commit`) → **mandatory pre-submit review** (fan the diff to two independent read-only subagents, fix verified Critical/High locally, one focused verifier) → push (`-u` first, `--force-with-lease` after own squash) → **reconcile the description with the diff (mandatory)** → create/update PR → arm auto-merge.
-- **Phase 2 — Poll** (full loop only, max 10 rounds ~5 min): loop on `pr_status.sh`.
-- **Phase 3 — Triage & fix** (on exit 20): `pr_findings.sh`, then fix in order — conflicts → CI/build/test root cause → review findings — re-push (still one commit), and **record GPT dispositions before the next push** (§3d).
-- **Phase 4 — Converge or escalate:** on `pr_status.sh`=0 report URL/sha/auto-merge state and stop; escalate early if convergence stalls.
+- **Phase 2 — Poll** (full loop only, max 10 rounds ~5 min): loop on `pr_status.py`.
+- **Phase 3 — Triage & fix** (on exit 20): `pr_findings.py`, then fix in order — conflicts → CI/build/test root cause → review findings — re-push (still one commit), and **record GPT dispositions before the next push** (§3d).
+- **Phase 4 — Converge or escalate:** on `pr_status.py`=0 report URL/sha/auto-merge state and stop; escalate early if convergence stalls.
 
-> **Which skill version:** the authoritative `prepare-pr` skill lives in-repo at `skills/kirocrew-dev/prepare-pr/` with **Python** scripts (`preflight.py`, `pr_status.py`, …). The pre-submit-review and disposition steps below were added in **PR #528**. An older Bash (`.sh`) copy may still be installed under `~/.kiro/crew/skills/prepare-pr/` — treat the in-repo Python skill as source of truth.
+> **Which skill version:** the authoritative `prepare-pr` skill lives in-repo at `skills/kirocrew-dev/prepare-pr/` with **Python** scripts (`preflight.py`, `pr_status.py`, …). The pre-submit-review and disposition steps below were added in **PR #528**; **#549 later removed the reviewer-side consumption of the disposition record** (see §3d — the comment is now a human-only audit trail). An older Bash (`.sh`) copy may still be installed under `~/.kiro/crew/skills/prepare-pr/` — treat the in-repo Python skill as source of truth.
 
 ### 3b. How it integrates with CI — the exit-code contract
 
-The skill's design principle is **script-first / deterministic exit codes** — *"decisions come from script exit codes, not eyeballing."* The AI only engages on a red signal; yes/no gates ("round complete? clean? blocked?") are decided by scripts, not model judgment. `pr_status.sh` is the loop driver:
+The skill's design principle is **script-first / deterministic exit codes** — *"decisions come from script exit codes, not eyeballing."* The AI only engages on a red signal; yes/no gates ("round complete? clean? blocked?") are decided by scripts, not model judgment. `pr_status.py` is the loop driver:
 
 ```
 0  → FINISHED and CLEAN  (all checks green, no unresolved threads)   → Phase 4 converge
@@ -196,15 +201,15 @@ The skill's design principle is **script-first / deterministic exit codes** — 
 2  → env error           (gh missing / not authed / no PR)           → fix env or escalate
 ```
 
-`pr_status.sh` makes one `gh pr view … --json statusCheckRollup,reviewDecision,…` call and normalizes the mixed CheckRun/StatusContext rollup via `jq` into `running` / `failing` counts, plus a GraphQL `reviewThreads` query counting `isResolved==false`. Its ordered logic — *any running → 10; else any failing → 20; else any unresolved thread → 20; else 0* — is exactly what maps CI's fan-out (§1) back to a single agent action. This is the client-side mirror of what `pr-readiness.yml` does server-side.
+`pr_status.py` makes one `gh pr view … --json statusCheckRollup,reviewDecision,…` call and normalizes the mixed CheckRun/StatusContext rollup **in Python** (`json.loads`, no `jq`) into `running` / `failing` counts, plus a `gh api graphql` `reviewThreads` query counting `isResolved==false`. Its ordered logic — *any running → 10; else any failing → 20; else any unresolved thread → 20; else 0* — is exactly what maps CI's fan-out (§1) back to a single agent action. This is the client-side mirror of what `pr-readiness.yml` does server-side.
 
 ```mermaid
 flowchart TB
-    P0["🩺 Phase 0 · preflight.sh"] --> P1["🛠️ Phase 1 · prepare<br/><small>commit → rebase → squash → push →<br/>reconcile body → arm auto-merge</small>"]
-    P1 --> S(["🔁 pr_status.sh"])
+    P0["🩺 Phase 0 · preflight.py"] --> P1["🛠️ Phase 1 · prepare<br/><small>commit → rebase → squash → push →<br/>reconcile body → arm auto-merge</small>"]
+    P1 --> S(["🔁 pr_status.py"])
     S --> E{"exit code"}
     E -- "🟡 10 running" --> WAIT["⏳ wait(300) · Round N/10"] --> S
-    E -- "🔴 20 fail / findings" --> F["🔧 Phase 3 · pr_findings.sh<br/><small>conflicts → CI root cause →<br/>validate finding: fix or rebut</small>"]
+    E -- "🔴 20 fail / findings" --> F["🔧 Phase 3 · pr_findings.py<br/><small>conflicts → CI root cause →<br/>validate finding: fix or rebut</small>"]
     F --> RP["⬆️ re-push --force-with-lease<br/><small>still one commit</small>"] --> S
     E -- "🟢 0 clean" --> DONE["✅ Phase 4 · converge<br/><small>report URL/sha/auto-merge · STOP</small>"]
     E -- "⚠️ 2 env" --> ENV["🩹 fix env / escalate"]
@@ -227,15 +232,15 @@ flowchart TB
     class ENV,ESC warn;
 ```
 
-A **round is only complete when every required check has finished AND every bot has posted** — acting on a half-finished round means fixing a moving target. On exit 20, `pr_findings.sh` pulls failing-log tails (`gh run view <run-id> --log-failed`) and unresolved threads as `path:line [author] body`.
+A **round is only complete when every required check has finished AND every bot has posted** — acting on a half-finished round means fixing a moving target. On exit 20, `pr_findings.py` pulls failing-log tails (`gh run view <run-id> --log-failed`) and unresolved threads as `path:line [author] body`.
 
-**Auto-merge** (`enable_automerge.sh`, default `--squash`, matching the single-commit invariant) is idempotent and does *not* merge now — GitHub completes the merge only after required checks are green **and** `reviewDecision=APPROVED`, so the human gate is preserved. Exit `20` (auto-merge disabled / no branch-protection rule / no permission) is a non-blocking note.
+**Auto-merge** (`enable_automerge.py`, default `--squash`, matching the single-commit invariant) is idempotent and does *not* merge now — GitHub completes the merge only after required checks are green **and** `reviewDecision=APPROVED`, so the human gate is preserved. Exit `20` (auto-merge disabled / no branch-protection rule / no permission) is a non-blocking note.
 
-**Round cap = 10** (unconditional backstop), but **escalate early** the moment convergence stalls: ~3 rounds with no drop in failing-check / open-High-Medium count, a finding needing a human/product/design decision, or a hard external blocker (infra/permissions, a check that never runs).
+**Round cap = 10** (unconditional backstop), but **escalate early** the moment convergence stalls: ~3 rounds with no drop in failing-check / open-Critical-High count, a finding needing a human/product/design decision, or a hard external blocker (infra/permissions, a check that never runs).
 
 ### 3c. The PR description contract
 
-Reconciled against the diff before **every** publish (Phase 1.5), driven by `diff_signals.sh` (flags deps/lockfiles/migrations/CI/deletions/config as `⚠`). Five sections — body must be **complete** (covers every `⚠`) and **accurate** (no claim the diff doesn't support):
+Reconciled against the diff before **every** publish (Phase 1.5), driven by `diff_signals.py` (flags deps/lockfiles/migrations/CI/deletions/config as `⚠`). Five sections — body must be **complete** (covers every `⚠`) and **accurate** (no claim the diff doesn't support):
 
 1. **Problem** — the concrete symptom.
 2. **Why it matters** — impact if unfixed.
@@ -245,19 +250,17 @@ Reconciled against the diff before **every** publish (Phase 1.5), driven by `dif
 
 This contract is not busywork: it's the exact input the **Codex reviewer** and **Design Review** read to judge description↔diff fidelity and scope. A body that overclaims triggers a real finding.
 
-### 3d. Cross-round convergence — how repeat findings are avoided (PR #528)
+### 3d. Reducing repeat findings — shift-left review (PR #528, simplified in #549)
 
-The most expensive failure mode is not a *wrong* review — it's a review that keeps **re-litigating settled points** round after round. #528 attacks this with three interlocking mechanisms. Model the cost of the review loop as `rounds × (CI latency + model latency + human attention)`; each mechanism cuts a different term.
+The most expensive failure mode is not a *wrong* review — it's a review that keeps **re-litigating settled points** round after round. #528 first attacked this with a three-mechanism *cross-round convergence* design; **#549 then removed the two Codex-side mechanisms**, leaving the cheaper and more robust half. Model the cost of the review loop as `rounds × (CI latency + model latency + human attention)`.
 
-**1. Pre-submit dual-subagent review (shift-left) — cuts the round *count*.** Before the *first* push, `prepare-pr` fans the finished diff out to **two independent read-only subagents** that review under the *same* severity/blocking contract as the GitHub reviewers; verified Critical/High are fixed locally, then **one focused verifier** confirms. A GitHub round costs CI spin-up + model latency + a re-push (~5+ min); every blocker caught locally is a round never paid for. Two independent passes raise recall at zero cloud cost, so round 1 on GitHub starts from an already-cleaned diff — collapsing `push → wait → findings → fix → push → wait` into `local-review → fix → push → (likely green)`. Medium/Low advice is deliberately *not* acted on here, so pre-review can't become scope growth.
+**The surviving lever — pre-submit dual-subagent review (shift-left), which cuts the round *count*.** Before the *first* push, `prepare-pr` fans the finished diff out to **two independent read-only subagents** that review under the *same* severity/blocking contract as the GitHub reviewers; verified Critical/High are fixed locally, then **one focused verifier** confirms. A GitHub round costs CI spin-up + model latency + a re-push (~5+ min); every blocker caught locally is a round never paid for, so round 1 on GitHub starts from an already-cleaned diff — collapsing `push → wait → findings → fix → push → wait` into `local-review → fix → push → (likely green)`. Medium/Low advice is deliberately *not* acted on here, so pre-review can't become scope growth. This mechanism lives entirely in the skill and is unaffected by #549.
 
-**2. Disposition recording — gives the cloud reviewer memory.** When a round fixes or rebuts a GPT finding, `prepare-pr` posts one concise comment beginning `<!-- ai-review-disposition target=gpt -->` **before** the next push. It names the prior reviewed SHA and marks each finding `fixed` / `rebutted` / `accepted` with the smallest evidence-based reason. This is **untrusted continuity evidence** — it does *not* authorize or suppress a finding, and the formal `/ai-review override` stays current-SHA-scoped.
+**What #549 removed — Codex's cross-round memory.** #528 had also added two Codex-side pieces: (2) `prepare-pr` posted a `<!-- ai-review-disposition target=gpt -->` comment recording each finding as `fixed`/`rebutted`/`accepted`, and (3) a **third Codex pass** ingested a ~24KB bounded bundle of prior-round review + writer dispositions and reconciled it under a "a new SHA is not a delta" rule. #549 **deleted both the 24KB prior-context injection and the third pass** (Codex is now the stateless 2-pass discovery→falsification reviewer of §2d). The rationale: carrying prior-round prose back into the reviewer was a standing prompt-injection surface for little gain, and the new **falsification pass** raises precision *within a single run* rather than needing round-to-round state. Codex is now stateless like Claude — every review judges only the current SHA's code.
 
-**3. Codex pass-3 convergence — consumes that memory monotonically.** GPT 5.6 runs exactly three calls: passes 1–2 discover candidates; **pass 3** rechecks the full diff, ingests a *bounded* prior-review bundle (previous GPT review + bot-recorded overrides + writer dispositions, nonce-delimited, treated as untrusted), reconciles it, and alone publishes/gates the verdict. The rule that makes it converge: **a concrete code/evidence delta is required to re-raise or reverse settled guidance — "a new commit SHA by itself is not a delta."** So a point you already rebutted stays quiet unless the *code* changed in a way that genuinely reopens it.
+> **Skill/workflow drift to watch:** the in-repo `prepare-pr` skill still emits the `ai-review-disposition` comment (Phase 3). With #549, **no reviewer consumes it anymore** — it survives only as a human-readable audit trail of how each finding was handled, not as machine-read continuity evidence. Treat that skill step accordingly until it's reconciled.
 
-**Producer / consumer interlock.** `prepare-pr` is the **producer** (writes durable dispositions, never silently appeases, and bails out via escalate-on-stall) and the **circuit-breaker**; Codex pass-3 is the **consumer** (reconciles the record against changed code instead of re-arguing from scratch). Neither works alone: without the disposition record Codex has nothing to converge against; without Codex's delta rule the record wouldn't suppress repeats.
-
-**Why it's better *and* cheaper.** Better = more eyes (two local subagents + the GitHub reviewers) and self-consistent guidance that can't contradict itself across rounds. Cheaper = fewer rounds to begin with (shift-left), each round makes forward progress (memory), and progress is monotonic (no backsliding). The older design optimized *per-round* review quality; #528 optimizes the *number and progress* of rounds — which is where the wall-clock actually went. The single **`PR Readiness`** status (§2f) closes it off with one trustworthy "is this SHA done?" answer, so nobody eyeballs 35 checks to decide when to stop.
+**Why the simplified design still converges.** The heavy lifting was always the shift-left pre-submit review (fewer rounds to begin with) plus `prepare-pr`'s own severity gate — validate each finding, fix true Critical/High, rebut false positives with evidence, never silently appease — and its **escalate-on-stall** circuit-breaker (~3 rounds without progress → hand off). Stateless per-SHA reviewers can't contradict themselves across rounds *because they hold no cross-round state to contradict*; a rebutted-but-correct point simply won't recur unless the *code* changes to reopen it. The single **`PR Readiness`** status (§2f) closes the loop with one trustworthy "is this SHA done?" answer — now also honestly reverting to `checking` on a reviewer re-run — so nobody eyeballs 35 checks to decide when to stop.
 
 ---
 
@@ -265,10 +268,10 @@ The most expensive failure mode is not a *wrong* review — it's a review that k
 
 AI-native coding skews toward over-engineering — extra layers, abstractions, config knobs, defensive scaffolding — and naïve AI reviewers *compound* it by demanding still more mechanisms, creating infinite review loops. KiroCrew counters this at every layer:
 
-- **Line reviewers (Claude + Codex) share an identical PROPORTIONALITY block:** *"a suggested Fix MUST be the smallest change… The mere ABSENCE of an extra mechanism is NOT a finding; a request to 'add mechanism X' for a hypothetical is LOW/advisory at most."* Plus a scope cap — **Claude** stays within "the evident scope of *this diff*", **Codex** within "the PR's stated purpose" (it reads the description, Claude doesn't). PREMISE/DESIGN concerns are **advisory (MEDIUM), never BLOCK unless a one-way door.**
-- **A strict BLOCKING BAR:** a finding blocks *only* if CRITICAL/HIGH **and** one of {reachable security hole with a concrete trigger, broken security keystone, crash/data-loss on a changed path, a `blocking:true` AUTOSDE violation, a missing regression test}. Style / naming / speculative-perf / hypotheticals never block.
+- **Line reviewers (Claude + Codex) share an identical FIX BAR:** *"every finding must carry a fix expressible as an edit to lines THIS PR changed. If the fix would need a new function, module, abstraction, config knob, dependency, or an edit to untouched code, it is out of scope for this bot: DROP THE FINDING. The absence of a mechanism is never a finding. Prefer deleting or simplifying code over adding anything."* This makes "add mechanism X" structurally un-reportable — the demand fails the FIX BAR before it can become a finding. A scope cap complements it — **Claude** stays within "the evident scope of *this diff*" (code-only), **Codex** within "the PR's stated purpose" (it reads the description and flags a description↔diff mismatch as an **advisory FINDING**, never a block).
+- **A strict, closed WHAT BLOCKS list:** *"exhaustive — never extend it, never reason by analogy, there is no 'and other serious issues' clause."* A finding blocks *only* if it is (1) a `blocking:true` AUTOSDE-rule violation on a changed file (or this PR weakening/removing such a rule), or (2) a **reachable and concrete** residual-class defect — a security hole with a named trigger, a crash/data-loss/corruption on a path this diff changes, or a removed guard with no compensating replacement. There is **no "possible issue" tier**: severity answers only *does this block the merge* and never encodes confidence, so anything "could / might / if a caller were to" is **NOT A FINDING**. A per-review **BUDGET of ≤2 BLOCKING findings** and a **CALIBRATION** note ("No findings." is the expected output for a typical PR) further resist manufactured escalation. Style / naming / speculative-perf / hypotheticals never block.
 - **Design Review's Suggestions must be proportionate:** *"NEVER recommend extra layers, abstractions, or future-proofing the problem does not require (over-engineered suggestions become new surface a later review flags)."* It also carries the **Design-Simpler-Alternative** ethos — actively flag when a materially simpler solution exists — but always **advisory**, never raising the verdict to BLOCK. Its tie-breaker: *"when torn between BLOCK and CONCERNS, choose CONCERNS… Only reach for BLOCK when the DESIGN is wrong — never merely because the change is large."*
 - **The Arbiter enforces it by omission:** everything reversible (architectural erosion, maintainability, "should eventually be refactored") is routed to non-blocking follow-ups; only one-way doors and concrete harm caused by *this* diff can block. *"The author does NOT need a perfect or complete solution in THIS PR."*
-- **prepare-pr's severity gate closes the loop:** it validates each finding's legitimacy first — fix true High/Medium, **rebut false positives with evidence rather than appeasing them by changing correct code**, defer Low/nits. Combined with single-commit + description reconciliation, this keeps a PR converging on its stated purpose instead of accreting scope round over round.
+- **prepare-pr's severity gate closes the loop:** it validates each finding's legitimacy first — fix true Critical/High, **rebut false positives with evidence rather than appeasing them by changing correct code**, defer Low/nits. Combined with single-commit + description reconciliation, this keeps a PR converging on its stated purpose instead of accreting scope round over round.
 
 Net: expensive/irreversible risk blocks; everything else is advice a human can take or defer — the design deliberately refuses to let "more mechanism" be a blocking demand.


### PR DESCRIPTION
## Problem
`docs/ci/ci-and-prepare-pr.md` (merged in #547) describes the CI and `prepare-pr`
system as it stood at commit `e7e9256c`. PR #549 ("de-noise AI review gates and
refresh readiness on re-run") then reworked the two AI review gates and the
readiness aggregator, and the in-repo `prepare-pr` skill scripts are Python
(`.py`), not the bash (`.sh`) names the doc still used. The doc is now stale.

## Why it matters
This doc is the reference contributors read to understand how a PR gets to
review-ready and why the reviewers block (or don't). A stale doc misleads them
about the reviewers' behaviour (e.g. describing a 3-pass Codex and a cross-round
convergence mechanism that no longer exist), which erodes trust in the whole
review ladder and wastes time chasing behaviour the workflows no longer have.

## Fix (symptom → root cause → change)
Symptom: doc claims (3-pass Codex, prior-round context injection, Claude posting
inline comments, `.sh` scripts, `jq` parsing) contradict current `main`.
Root cause: #549 landed after the doc (#547) and the skill was ported to Python;
no reconciliation pass ran. Change — reconcile the doc against `main` @ `9dd99f97`:

- **§2b** — document the new `backend-test-sandbox` job (unshare-NEWNS keystone
  coverage for `hooks.py`) and the pinned `cfn-lint` job.
- **§2d** — Claude: `gh pr comment` revoked (CI upserts one structured-output
  summary; gate is `block_merge`-only), `--max-turns 60` / 30-min timeout.
  Codex: 3-pass → 2-pass (discovery → authoritative falsification),
  `reasoning_effort: medium`, prior-round context removed, severity coherence
  check downgraded to advisory. Added the shared FINDING BAR → WHAT BLOCKS →
  FIX BAR binary-contract bullet.
- **§2f** — pr-readiness now triggers on `requested/in_progress/completed`
  (label reverts to `checking` on a reviewer re-run).
- **§3a/§3b/§3c + diagram** — all `.sh` script names → `.py`; `jq` → Python
  `json.loads`.
- **§3d** — rewritten: #549 removed Codex's cross-round convergence; the
  shift-left pre-submit review survives as the primary lever, and the
  disposition comment is now a human-only audit trail (flagged as skill drift).
- **§4** — replaced the stale PROPORTIONALITY/BLOCKING-BAR quotes with the
  current FIX BAR / WHAT BLOCKS language.
- Header source-of-truth SHA `e7e9256c` → `9dd99f97`.

## Tests
N/A — documentation only; no code paths change. Every claim was verified against
the current workflow files and `skills/kirocrew-dev/prepare-pr/` on `main`.

## Manual verification
- Cross-checked each edit against `.github/workflows/{ci,claude-review,codex-review,pr-readiness}.yml`
  and the #549 diff (`b62f79b2`).
- `grep` swept the doc for residual `.sh`, "3-pass", "pass 3", `jq`, and the old
  source SHA — none remain except the intentional note about the legacy bash copy.
- Mermaid diagrams only had node labels updated (`.sh` → `.py`); structure intact.
