### PR TITLE
ci: keep PR Readiness from showing as cancelled

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -57,17 +57,33 @@ permissions:
   statuses: write
 
 concurrency:
+  # pull_request_target runs are the only readiness runs that surface as a
+  # CheckRun in the PR's status rollup. If they share a cancelling group -- with
+  # the workflow_run burst OR with each other -- a superseded PT run is marked
+  # "cancelled" by GitHub, and that cancelled check then shows on the PR even
+  # though the authoritative "PR Readiness" commit status is fine (this is the
+  # "canceled at the end of CI" symptom: a workflow_run:completed fires as CI
+  # finishes and collapses an in-flight PT run). GitHub always marks a
+  # superseded run cancelled -- cancel-in-progress:true kills the in-flight one,
+  # and false still cancels the pending one -- so the only way a PT run never
+  # shows cancelled is to keep it out of any group that can cancel it. Each PT
+  # run therefore gets its own isolated group and always resolves to a real
+  # conclusion (success / failure / skipped), never cancelled. The evaluate and
+  # publish steps are idempotent and stale-SHA guarded, so un-collapsed PT runs
+  # on superseded revisions simply no-op green. workflow_run / workflow_dispatch
+  # runs do NOT appear in the rollup, so they keep the cheap per-(pr, sha)
+  # burst collapse via cancel-in-progress.
   group: >-
-    pr-readiness-${{
-      inputs.pr
-      || github.event.pull_request.number
-      || github.event.workflow_run.pull_requests[0].number
-      || github.run_id
-    }}-${{
-      inputs.sha
-      || github.event.pull_request.head.sha
-      || github.event.workflow_run.head_sha
-      || github.run_id
+    ${{
+      github.event_name == 'pull_request_target'
+      && format('pr-readiness-pt-{0}', github.run_id)
+      || format('pr-readiness-wr-{0}-{1}',
+           inputs.pr
+             || github.event.workflow_run.pull_requests[0].number
+             || github.run_id,
+           inputs.sha
+             || github.event.workflow_run.head_sha
+             || github.run_id)
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
## Problem
The **PR Readiness** check regularly shows as **cancelled** on a PR around the end of CI, instead of a clean pass or fail. A cancelled check is ambiguous — it reads as neither green nor red — and undermines the at-a-glance readiness signal it exists to provide.

## Why it matters
PR Readiness is the aggregated, single-glance verdict for the wide PR workflow fan-out (the label on PR lists + the commit status branch protection keys off). When it renders as "cancelled," reviewers and the author can't tell whether the revision actually passed, and the signal loses its purpose.

## Fix (symptom → root cause → change)
- **Symptom:** every cancelled `PR Readiness` entry in a PR's status rollup is a `pull_request_target` (PT) run that died **3–11s after starting**.
- **Root cause:** the workflow ran *all* triggers under one `concurrency` group keyed by `(pr, sha)` with `cancel-in-progress: true`. PT runs are the **only** readiness runs that surface as a CheckRun in the PR rollup (workflow_run runs post only the commit status, which is never cancelled). When a `workflow_run: completed` fired as CI finished — or a second PT event arrived — it collapsed the in-flight PT run, and GitHub marks a superseded run **cancelled**. A shared cancelling group can never avoid this: `cancel-in-progress: true` kills the in-flight run, and `false` still cancels the pending one.
- **Change:** split the concurrency group by event family. Each `pull_request_target` run gets its **own isolated group** (`pr-readiness-pt-<run_id>`), so it always resolves to `success`/`failure`/`skipped` and is never cancelled. `workflow_run` / `workflow_dispatch` runs — which don't appear in the rollup — keep the cheap per-`(pr, sha)` burst collapse via `cancel-in-progress`. The evaluate/publish steps are already idempotent and stale-SHA guarded, so un-collapsed PT runs on superseded revisions simply no-op green rather than post a stale verdict.

## Tests
N/A — this is a GitHub Actions `concurrency` change with no product code path; it can only be exercised by Actions itself. YAML validity and the group-expression ternary were verified locally (PT → `pr-readiness-pt-<run_id>`, workflow_run/dispatch → `pr-readiness-wr-<pr>-<sha>`).

## Manual verification
This PR dogfoods the change: its own `pull_request_target` readiness runs should now complete as success/failure and never show cancelled, even as its CI workflows finish. Confirm on the PR's checks that no `Publish readiness signal` entry is cancelled.
