### PR TITLE
fix(acp): fall back to verified copy when Linux lacks os.memfd_create

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -480,9 +480,11 @@ def snapshot_trusted_acp_executable(
     launch, so a toolbox / Homebrew / self-updated Kiro CLI launches like any
     other. The snapshot still pins the
     resolved bytes so a swap between resolve and exec is caught: Linux executes
-    a write-sealed ``memfd`` of the exact bytes; because Mach-O cannot launch
-    reliably through ``/dev/fd``, macOS executes a verified private copy; Windows
-    launches the resolved path in place.
+    a write-sealed ``memfd`` of the exact bytes, falling back to a verified
+    private copy when the interpreter lacks ``os.memfd_create`` (glibc < 2.27
+    portable builds); because Mach-O cannot launch reliably through ``/dev/fd``,
+    macOS executes a verified private copy; Windows launches the resolved path
+    in place.
     """
 
     platform_name = platform_name or sys.platform
@@ -529,11 +531,30 @@ def snapshot_trusted_acp_executable(
     if not platform_name.startswith("linux"):
         raise ValueError("ACP executable snapshots are unsupported on this POSIX platform")
 
+    memfd_create = getattr(os, "memfd_create", None)
+    if not callable(memfd_create):
+        # Some Linux CPython builds — notably the portable python-build-standalone
+        # interpreters shipped by mise/pyenv, compiled against a glibc that predates
+        # the memfd_create(3) wrapper (glibc < 2.27) — omit os.memfd_create even
+        # though the running kernel supports the syscall. Rather than fail every
+        # ACP spawn, degrade to the same swap-safe mechanism macOS uses: a
+        # sha256-verified private copy in the agent-protected 0700 snapshot dir,
+        # launched in place. The sealed in-memory fd is lost, but the resolved
+        # bytes are still pinned, so a swap between resolve and exec is caught.
+        snapshot_path = _copy_verified_auth_executable(
+            canonical,
+            active_home / _ACP_EXECUTABLE_SNAPSHOT_RELATIVE,
+            expected,
+            prefix="kiro-cli-acp-",
+        )
+        return TrustedAcpExecutableSnapshot(
+            launch_path=snapshot_path,
+            expected_sha256=expected,
+            cleanup_path=snapshot_path,
+        )
+
     snapshot_fd = -1
     try:
-        memfd_create = getattr(os, "memfd_create", None)
-        if not callable(memfd_create):
-            raise OSError("Linux memfd executable snapshots are unavailable")
         memfd_flags = (
             getattr(os, "MFD_CLOEXEC", 0x0001)
             | getattr(os, "MFD_ALLOW_SEALING", 0x0002)

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -349,6 +349,40 @@ class TestKiroPrerequisiteHelpers:
         finally:
             os.close(snapshot_fd)
 
+    def test_linux_snapshot_falls_back_to_verified_copy_without_memfd(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Portable python-build-standalone interpreters (glibc < 2.27) omit
+        # os.memfd_create even on kernels that support the syscall. The Linux
+        # snapshot must degrade to the macOS-style verified private copy instead
+        # of failing every ACP spawn.
+        executable = tmp_path / "kiro-cli"
+        executable.write_bytes(b"trusted executable bytes")
+        executable.chmod(0o700)
+        digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+        environ = {"KIROCREW_KIRO_BIN": str(executable)}
+        prerequisite_module._register_operator_override_attestation(str(executable), digest)
+        monkeypatch.delattr(prerequisite_module.os, "memfd_create", raising=False)
+        data_home = tmp_path / "data"
+
+        snapshot = prerequisite_module.snapshot_trusted_acp_executable(
+            str(executable),
+            data_home=data_home,
+            platform_name="linux",
+            environ=environ,
+        )
+
+        assert snapshot.fd is None
+        assert not snapshot.launch_path.startswith("/proc/self/fd/")
+        assert snapshot.cleanup_path == snapshot.launch_path
+        launch_path = Path(snapshot.launch_path)
+        # Copy lives in the agent-protected snapshot dir and pins the exact bytes.
+        assert launch_path.parent == data_home / "run" / "kiro-cli-snapshots"
+        assert launch_path.read_bytes() == executable.read_bytes()
+        assert snapshot.expected_sha256 == digest
+
     @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd seals")
     def test_linux_memfd_seals_reject_later_writes(self) -> None:
         memfd_create = getattr(os, "memfd_create")


### PR DESCRIPTION
## Problem
On a remote instance whose gateway runs under a portable
`python-build-standalone` interpreter (e.g. one installed by mise/pyenv),
every background ACP session fails to start. The gateway log shows:

```
WARNING kiro_crew.session: Failed to create background session
...
OSError: Linux memfd executable snapshots are unavailable
  (src/kiro_crew/kiro_prerequisite.py:536, snapshot_trusted_acp_executable)
-> kiro_crew.acp.client._KiroExecutableTrustError
-> kiro_crew.acp.session_handle.AcpRuntimeError: Linux memfd executable snapshots are unavailable
```

## Why it matters
It is not intermittent — it fails 100% of the time on that interpreter, so the
gateway starts but can never spawn a Kiro runtime. No chat/background session
works on affected remotes until the process is moved to a different Python.

## Fix (symptoms → root cause → change)
- **Symptom:** `_ensure_background` → `runtime.spawn()` dies in
  `snapshot_trusted_acp_executable` at the Linux memfd guard.
- **Root cause:** that guard does `getattr(os, "memfd_create", None)` and raises
  when it is not callable. Portable standalone CPython builds are compiled
  against a glibc that predates the `memfd_create(3)` wrapper (glibc < 2.27), so
  `os.memfd_create` is simply absent from the interpreter — even though the
  running kernel supports the syscall. The Linux path treated the sealed memfd
  as mandatory and hard-failed instead of degrading.
- **Change:** when `os.memfd_create` is unavailable, fall back to the exact
  swap-safe mechanism macOS already uses in this same function — a
  `sha256`-verified private copy written into the 0700 agent-protected
  `run/kiro-cli-snapshots` dir (`_copy_verified_auth_executable`), launched in
  place with `cleanup_path` set. The in-memory write-sealed fd is given up, but
  the resolved bytes remain pinned by digest, so a swap between resolve and exec
  is still caught. The memfd path is unchanged when the binding exists.

## Tests
- `test_linux_snapshot_falls_back_to_verified_copy_without_memfd` (new): deletes
  `os.memfd_create`, snapshots with `platform_name="linux"`, and asserts the
  result is a private copy (no `fd`, launch path not `/proc/self/fd/...`,
  `cleanup_path == launch_path`, the copy lives under
  `<data_home>/run/kiro-cli-snapshots`, its bytes match the source, and
  `expected_sha256` equals the source digest).
- Existing `test_linux_snapshot_populates_and_seals_memfd` and
  `test_linux_snapshot_retries_without_mfd_exec_on_einval` continue to pass,
  confirming the sealed-memfd path is untouched when the binding is present.

## Manual verification
On the affected remote: `python3 -c "import os; print(hasattr(os,'memfd_create'))"`
returns `False`; after this change, restarting the gateway spawns background
sessions cleanly instead of raising `AcpRuntimeError`. Local `pytest` run of the
Linux/macOS/Windows snapshot suite: 8 passed, 1 skipped (Linux-only seal test
skips on the macOS dev host).
