### PR TITLE
ci: add fork guard to Claude AI Review + document fork CI behavior

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,6 +32,16 @@ jobs:
     # branch-protection change.
     name: Claude AI Review
     runs-on: ubuntu-latest
+    # Same-repo PRs only (not forks). Fork PRs get NO OIDC/secrets access from
+    # GitHub, so the Bedrock role assumption below can never succeed — without
+    # this guard the review step is skipped and the fail-closed gate turns the
+    # required check RED on every external contribution. Skipping the whole job
+    # instead reports the required "Claude AI Review" check as "skipped", which
+    # branch protection treats as satisfied. Mirrors the fork guard in
+    # codex-review.yml and design-review.yml. Dependabot PRs are same-repo
+    # (branch lives in this repo) so they still enter the job and are handled by
+    # the step-level dependabot skip + gate pass below.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Hard runtime ceiling: if the agentic review ever runs away, the job is
     # cancelled at 30 min and the gate fails closed (a no-output review can't
     # look clean). Lowered from 40 alongside --max-turns: the review is now a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,38 @@ npm run test:playwright      # E2E (requires a running backend)
 6. A maintainer will review. Address feedback by pushing additional commits to
    your branch.
 
+### CI checks on your PR (forks vs. direct branches)
+
+GitHub deliberately withholds repository secrets and OIDC credentials from
+workflows triggered by **pull requests opened from a fork**. Three of our
+checks need those credentials to reach Amazon Bedrock, so their behaviour
+depends on *where your branch lives*:
+
+| Check | Fork PR | Branch pushed to `kirodotdev/KiroCrew` |
+| --- | --- | --- |
+| **Claude AI Review** | Skipped (neutral — not a failure) | Runs |
+| **GPT 5.6 Review** | Skipped | Runs |
+| **Design Review** | Skipped | Runs |
+| Tests, lint, typecheck, CodeQL, coverage, build | Run normally | Run normally |
+
+- **Opening from a fork (the default for most contributors):** the three AI
+  reviews are **skipped, not failed** — and this is identical for *everyone*,
+  regardless of permission level. A maintainer who opens a PR from their own
+  personal fork gets exactly the same skip; write access does not change it.
+  A skipped review does **not** block your PR and there is nothing for you to
+  fix: just make sure the credential-free checks (tests, lint, typecheck,
+  CodeQL, coverage, build) are green. A maintainer runs the AI review on their
+  side (or re-pushes your branch to the upstream repo) and reviews manually.
+- **Getting the AI reviews to run** depends only on *where the branch lives*,
+  never on who you are: the branch has to be on `kirodotdev/KiroCrew` itself,
+  not on a fork. Pushing a branch directly to the upstream repo requires write
+  access — so if you have it, push there and open the PR from that branch to
+  get the full suite. Without write access, the fork path above is the correct
+  and only route, by design.
+
+If your only red checks are the AI reviews on a fork PR, there is nothing for
+you to fix — flag it to a maintainer.
+
 ## Commit Messages
 
 [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## Problem

The **Claude AI Review** required check fails RED on every PR opened from a
fork (e.g. #564). GitHub withholds OIDC/secrets from fork-triggered workflows,
so `aws-actions/configure-aws-credentials` exhausts all 12 retries
(`Could not load credentials from any providers`), the Opus 5 review step is
skipped, and the fail-closed gate exits 1
(`Opus 5 review step did not succeed (outcome=skipped) … Failing closed`).

## Why it matters

Every external contribution shows a scary red required check that the
contributor can neither diagnose nor fix — they have no way to supply the
secrets. It obscures whether the *real* checks passed and adds maintainer
triage overhead on each fork PR. The sibling reviewers already handle this
correctly, so Claude was the lone inconsistent gate.

## Fix (symptom → root cause → change)

- **Symptom:** Claude AI Review red on fork PRs; GPT 5.6 Review and Design
  Review show a clean `skipping`.
- **Root cause:** `codex-review.yml` and `design-review.yml` carry a job-level
  fork guard (`if: github.event.pull_request.head.repo.full_name == github.repository`);
  `claude-review.yml` never had it, so the job ran, hit the credential wall,
  and failed closed.
- **Change:** add the identical job-level guard to `claude-review.yml`. Fork
  PRs now skip the whole job → the required "Claude AI Review" check reports
  **skipped**, which branch protection treats as satisfied (not red).
  Dependabot is unaffected: its branch is same-repo, so it still enters the
  job and is handled by the existing step-level dependabot skip + gate pass.
- Also document the fork-vs-direct CI behavior in `CONTRIBUTING.md` so
  contributors know skipped AI reviews on fork PRs are expected (not a
  failure), and that write-access contributors should push branches directly
  to `kirodotdev/KiroCrew` to run the full AI-review suite.

## Tests

N/A — no runnable unit coverage for GitHub Actions job-level `if:` gating.
The guard is byte-identical (same 4-space indent, same expression) to the two
already-passing reviewer workflows; correctness is validated by this PR's own
same-repo run of Claude AI Review going green, and will be validated on the
skip path by the next fork PR.

## Manual verification

- Confirmed the failure on #564: OIDC step failed 12/12, `REVIEW_OUTCOME=skipped`,
  empty structured output, gate exited 1.
- Confirmed `codex-review.yml` and `design-review.yml` `skipping` on the same
  fork PR via the identical guard.
- Verified the new `if:` sits at the job level (col 4) alongside `runs-on:` /
  `timeout-minutes:`, matching the two sibling workflows.
