### PR TITLE
test(session-sharing): deflake spawn-completion waits with a bounded poll

### DIFF
--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -22,6 +22,27 @@ from kiro_crew.subagent import SubagentManager
 # ``_isolate_subagents_dir`` fixture in ``conftest.py`` — no per-file fixture needed.
 
 
+async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
+    """Wait for a spawned subagent to finish, deterministically.
+
+    ``manager.spawn`` runs the subagent as a background asyncio task that flips
+    ``info.done`` once ``_run`` completes. Sleeping a fixed amount races that
+    task under load — the source of the intermittent
+    ``test_shared_session_cleanup_destroys_handle`` failure (``info.done`` still
+    ``False`` when the assertion ran). Polling ``info.done`` against a deadline
+    is race-free: it returns as soon as the task settles and only fails if the
+    task genuinely never completes.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while not info.done:
+        if loop.time() >= deadline:
+            raise AssertionError(
+                f"subagent {info.id} did not complete within {timeout}s"
+            )
+        await asyncio.sleep(0.01)
+
+
 def _mock_sessions(*, sharing_eligible: bool = True) -> MagicMock:
     """Create a mock SessionManager with session-sharing support."""
     sessions = MagicMock()
@@ -205,7 +226,7 @@ class TestSessionSharingSpawn:
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
             assert info is not None
             # Wait for the subagent to complete
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         # Verify runtime.create_session was called (not get_or_create)
         sessions.get_subagent_runtime.assert_awaited_once_with("dashboard:slot1")
@@ -228,7 +249,7 @@ class TestSessionSharingSpawn:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         assert info._session_sharing is True
         assert info._shared_provider is not None
@@ -248,7 +269,7 @@ class TestSessionSharingSpawn:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         assert info.done  # completed
         # reset should NOT have been called (shared path skips it)
@@ -274,7 +295,7 @@ class TestSessionSharingSpawn:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         # Legacy path: get_or_create called, runtime NOT called
         sessions.get_or_create.assert_awaited()
@@ -304,7 +325,7 @@ class TestSessionSharingFallback:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         # Should have fallen back to get_or_create
         sessions.get_or_create.assert_awaited()
@@ -335,7 +356,7 @@ class TestSessionSharingFallback:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         # Should have fallen back to get_or_create
         sessions.get_or_create.assert_awaited()
@@ -479,7 +500,7 @@ class TestSessionSharingMultiAgent:
              patch("kiro_crew.subagent.Stats"), \
              patch("kiro_crew.subagent.sel"):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(0.5)
+            await _wait_until_done(info)
 
         # The provider wraps the handle which has the session_id
         assert info._shared_provider is not None


### PR DESCRIPTION
## Problem
`test/test_session_sharing.py::TestSessionSharingSpawn::test_shared_session_cleanup_destroys_handle`
fails intermittently in CI:

```
AssertionError: assert False
 +  where False = SubagentInfo(id='...', task='test task', ..., done=False, ...).done
```

It passes in isolation and on re-run, so it has been a recurring, non-deterministic
red on otherwise-clean PRs.

## Why it matters
A flaky required check erodes trust in CI, forces manual shard re-runs, and can
mask or delay real failures. Six other tests in the same file share the identical
racy pattern and could flake the same way.

## Fix (symptoms → root cause → change)
- **Symptom:** the assertion sees `info.done == False`.
- **Root cause:** every spawn test does `info = manager.spawn(...)` then
  `await asyncio.sleep(0.5)` before asserting completion state. `spawn` runs the
  subagent as a background `asyncio` task (`self._tasks[id] = create_task(self._run(info))`)
  that flips `info.done` only when `_run` finishes. Under a loaded full parallel
  run, 0.5s is not always enough, so the assertions race the still-running task.
- **Change:** add `_wait_until_done(info, timeout=5.0)` — a bounded poll on
  `info.done` — and replace all seven fixed 0.5s sleeps with it. It returns as
  soon as the task settles (race-free and typically ~ms instead of always 0.5s)
  and raises a clear timeout only if the task genuinely never completes. No
  production code changes: the bug was in the test's synchronization, not the
  teardown path.

## Tests
No new tests — this hardens existing ones. `test_session_sharing.py` runs green
(22 passed locally). The previously-flaky assertion now waits deterministically
for the background subagent to finish.

## Manual verification
Ran `pytest test/test_session_sharing.py` locally (22 passed in ~2.7s) and the
previously-flaky test 3× in isolation (passes each). N/A beyond that — pure test
synchronization change.
