### PR TITLE
fix(ci): stop late pull_request_target readiness runs from clobbering a decided verdict

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -221,11 +221,6 @@ jobs:
           passed=()
           pending=()
           failed=()
-          case "$TRIGGER_EVENT:$TRIGGER_ACTION" in
-            pull_request_target:opened|pull_request_target:synchronize|pull_request_target:reopened|pull_request_target:edited)
-              pending+=("validation runs are starting")
-              ;;
-          esac
 
           for spec in "${workflow_specs[@]}"; do
             file="${spec%%|*}"
@@ -276,6 +271,28 @@ jobs:
               fi
             fi
           done
+
+          # A pull_request_target open/synchronize/reopen/edit run is meant to
+          # surface a transient "checking" signal while validation spins up.
+          # But such a run can be runner-queue-delayed by many minutes and
+          # execute AFTER the workflow_run:completed runs have already published
+          # the terminal verdict for this same SHA. Seeding this sentinel
+          # unconditionally would then clobber that decided verdict back to
+          # "checking" with no further event left to recompute it on the
+          # unchanged commit -- freezing the status at pending indefinitely.
+          # Only add it when the live evaluation above still found at least one
+          # monitored workflow genuinely incomplete; in that case the verdict is
+          # already pending and the sentinel is merely a human-readable note.
+          # (A legitimate reviewer re-run arrives via workflow_run and shows up
+          # as an in_progress workflow above, so it keeps producing "checking"
+          # through this same real-pending path.)
+          case "$TRIGGER_EVENT:$TRIGGER_ACTION" in
+            pull_request_target:opened|pull_request_target:synchronize|pull_request_target:reopened|pull_request_target:edited)
+              if [ "${#pending[@]}" -gt 0 ]; then
+                pending+=("validation runs are starting")
+              fi
+              ;;
+          esac
 
           # Arbiter is an API-owned check rather than an ordinary pull_request
           # workflow run. Once the normal workflows finish, briefly wait for it


### PR DESCRIPTION
## Problem

On some PRs the `PR Readiness` commit status freezes at `pending` / `"1 readiness check(s) still pending"` even though **every** actual check (CI, Build, Code Review, CodeQL, Claude, GPT, Design Review, and the Arbiter) has already completed successfully. The PR shows the yellow `readiness: checking` label and a pending required status forever, with no event left to clear it.

Observed on #517: head SHA `7a667584` had all 38 check runs green, yet `PR Readiness` stayed `pending`. The readiness run that posted it was `event: pull_request_target`, `created_at 14:17:50` but `run_started_at 14:43:30` — it sat runner-queue-delayed ~26 minutes and executed *last*, after CI had finished at 14:27.

## Why it matters

`PR Readiness` is the branch-protection handle (a commit status), so a stuck `pending` keeps the PR `BLOCKED` / not auto-mergeable and requires a manual `workflow_dispatch` re-run to unfreeze — per PR, indefinitely. It erodes trust in the readiness signal and blocks otherwise-green PRs from landing.

## Fix (symptoms → root cause → change)

- **Symptom:** `PR Readiness` = `pending` while all monitored workflows for the SHA are `completed/success`.
- **Root cause:** the `Evaluate current revision` step seeded `pending` with a hardcoded `"validation runs are starting"` sentinel for `pull_request_target` `opened/synchronize/reopened/edited` **before** inspecting real workflow state. A PT run for that SHA can be runner-queue-delayed and execute *after* the `workflow_run: completed` runs have already published the terminal `success` verdict. Because the sentinel is unconditional and the SHA is unchanged, the late PT run re-posts `pending`, clobbering the decided verdict — and since the commit never changes again, no further event fires to recompute it. It stays `pending` permanently. (This is the ordering sibling of the earlier cancellation-race fix.)
- **Change:** move the sentinel from an unconditional pre-loop injection to a **post-loop** one gated on `${#pending[@]} > 0`. A PT run now emits the sentinel only when the live evaluation actually found a monitored workflow still incomplete (not-started / queued / in-progress). When everything is already terminal, it publishes the true verdict instead of a spurious `checking`.
- **Preserves intent:** a fresh push still shows `checking` (new runs are queued/not-started → real pending), and a legitimate reviewer re-run still drops the label back to `checking` (it arrives via `workflow_run` and appears as an `in_progress` workflow → real pending). Only the spurious "all done but re-marked pending" transition is removed.

## Tests

N/A — the change is inside a GitHub Actions workflow's embedded shell logic, which has no unit-test harness in this repo. Validated instead by: `yaml.safe_load` parse of the workflow, and `bash -n` on all four `run:` step bodies (with `${{ }}` expressions stubbed). Both pass.

## Manual verification

- Confirmed the pre-loop unconditional sentinel is removed and the gated post-loop sentinel only fires when `pending` already has real entries.
- Traced the three behavior paths by hand against the evaluation loop: (a) fresh push → monitored runs not-started/in-progress → `pending>0` → `checking`; (b) reviewer re-run via `workflow_run` → target workflow `in_progress` → `pending>0` → `checking`; (c) late PT run on an all-completed SHA → `pending==0` → publishes the terminal verdict (no clobber).
- Note: this does not retroactively recompute already-frozen commits (e.g. #517's `7a667584`); those still need a one-off `workflow_dispatch` re-run. It prevents the freeze going forward.
