### PR TITLE
fix(setup): detect real-home Kiro sessions via read-only whoami fallback

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -1717,16 +1717,23 @@ class KiroPrerequisiteService:
             mapping.source
             for mapping in _auth_store_mappings(self._platform, self._home, self._environ)
         ]
-        self._hidden_probe_dirs = tuple(
+        # Kiro Crew's own secret home is always hidden from a probed CLI. The
+        # credential-minimal probe additionally hides the identity stores; the
+        # real-home fallback probe must leave those visible so a CLI whose valid
+        # session lives outside the staged files (an external auth helper
+        # resolved from the real home) can read its own credentials.
+        self._crew_hidden_dirs = tuple(
             dict.fromkeys(
                 str(path)
                 for path in (
                     self._data_home,
                     self._home / ".kiro" / "crew",
                     self._home / ".kirocrew",
-                    *auth_store_dirs,
                 )
             )
+        )
+        self._hidden_probe_dirs = tuple(
+            dict.fromkeys((*self._crew_hidden_dirs, *(str(path) for path in auth_store_dirs)))
         )
         self._child_environment: dict[str, str] = {}
         self._probe_environment: dict[str, str] = {}
@@ -1863,6 +1870,23 @@ class KiroPrerequisiteService:
             # authenticated. No provenance gate: source/owner/path do not block
             # sign-in, so a runnable CLI never needs an unreachable "repair".
             whoami = await self._audited_identity_probe(self._viable_binary)
+            if not whoami.ok and await asyncio.to_thread(
+                self._viable_binary_is_pinned_override
+            ):
+                # Real-home fallback, gated to the operator-pinned
+                # ``KIROCREW_KIRO_BIN`` override ONLY, and only while its bytes
+                # still match the digest pinned at process start. Some CLI builds
+                # keep their valid session outside the staged identity files
+                # (validated from the real home), so the credential-minimal probe
+                # reports them signed-out. Retry once read-only against the real
+                # home — but only for the exact executable the operator pinned,
+                # never an arbitrary/planted PATH candidate and never a post-start
+                # replacement of that binary. This keeps the automatic,
+                # unattended probe from ever executing an untrusted binary against
+                # the real home (~/.aws, ~/.ssh, ~/.kube).
+                whoami = await self._audited_identity_probe(
+                    self._viable_binary, isolate_home=False
+                )
             if whoami.ok:
                 await asyncio.to_thread(self._mark_setup_complete)
             self._status = PrerequisiteStatus(
@@ -1878,6 +1902,35 @@ class KiroPrerequisiteService:
             self._last_probe_at = self._clock()
             self._has_probed = True
             return self._status
+
+    def _viable_binary_is_pinned_override(self) -> bool:
+        """Whether the viable binary is the operator-pinned ``KIROCREW_KIRO_BIN``
+        override AND still matches the digest recorded at process start.
+
+        The real-home fallback runs the candidate against the user's real home,
+        so it is gated to the exact executable the operator explicitly pinned.
+        Beyond matching the pinned path, the current bytes are re-hashed and
+        compared (constant-time) against the process-start pin, so a same-UID
+        replacement of a writable pinned binary after startup does NOT gain a
+        real-home run — the swap fails the digest check. An arbitrary or planted
+        ``PATH`` candidate is never the pinned override. Off on Windows and when
+        no override is set, so the fallback is off by default.
+
+        Performs bounded file IO (hashing the pinned binary); call it off the
+        event loop.
+        """
+
+        if not (
+            self._initial_override_path
+            and self._initial_override_sha256 is not None
+            and os.path.normcase(self._viable_binary)
+            == os.path.normcase(self._initial_override_path)
+        ):
+            return False
+        current = _existing_binary_digest(self._initial_override_path)
+        return current is not None and hmac.compare_digest(
+            current, self._initial_override_sha256
+        )
 
     async def _audited_probe(
         self,
@@ -1948,6 +2001,7 @@ class KiroPrerequisiteService:
         timeout_secs: float,
         on_output: Callable[[str], None] | None = None,
         commit: bool,
+        isolate_home: bool = True,
     ) -> ProcessResult:
         """Run Kiro auth with only Kiro identity files in its HOME.
 
@@ -1957,7 +2011,87 @@ class KiroPrerequisiteService:
         the sandbox so the process that receives the staged credentials is the
         one just resolved, but it pins no stored digest — a Kiro self-update
         that legitimately rewrites the binary must not break sign-in.
+
+        ``isolate_home=False`` is the read-only readiness fallback: it runs the
+        CLI against the user's real home instead of the credential-minimal one,
+        for builds whose valid session lives outside the staged identity files.
         """
+
+        if not isolate_home:
+            # Read-only real-home fallback for the readiness probe only, gated by
+            # the caller to the operator-pinned override.
+            #
+            # WHY THIS EXISTS: the isolated probe above rewrites HOME to a
+            # credential-minimal staging dir that contains only the known Kiro
+            # identity files. Some Kiro CLI builds do not keep their session in
+            # those files — they validate it through an external auth helper
+            # resolved from the user's REAL home — so the isolated `whoami`
+            # reports signed-out even though the CLI is genuinely logged in (and
+            # a real `kiro-cli acp` session, which runs with the real
+            # environment, authenticates fine). This retry runs the same
+            # login-status check against the real home so that case is detected.
+            # (No Amazon-internal helper is named here on purpose: the public
+            # repo stays free of internal references; "external auth helper" is
+            # the generic description of that class of build.)
+            #
+            # SECURITY — this is why it is safe despite touching the real home:
+            #   1. Gated to the operator-pinned KIROCREW_KIRO_BIN override only
+            #      (see `_viable_binary_is_pinned_override`), never an arbitrary
+            #      or planted PATH candidate; off by default and on Windows.
+            #   2. The executed bytes are bound to the process-start digest pin:
+            #      the pinned bytes are copied into a private snapshot verified
+            #      against `_initial_override_sha256`, and THAT snapshot is
+            #      executed — so a binary swapped after startup fails the copy
+            #      and the fallback is refused (fail closed), with no
+            #      check-to-exec window.
+            #   3. The snapshot lives in a private dir UNDER the non-hidden
+            #      auth-staging parent (not under the hidden crew home) and is
+            #      marked sandbox-visible, mirroring the isolated probe — so it
+            #      can actually execute while the crew home stays hidden.
+            #   4. Read-only: `commit` is rejected, so it never stages or
+            #      publishes credentials.
+            if commit:
+                raise ValueError("real-home auth commands cannot commit credentials")
+            fallback_executable = executable
+            cleanup_dir: str | None = None
+            extra_visible: tuple[str, ...] = ()
+            try:
+                if platform_compat.IS_POSIX and self._run is _run_process:
+                    snapshot_root = Path(
+                        tempfile.mkdtemp(prefix="probe-", dir=str(self._auth_staging_parent))
+                    )
+                    cleanup_dir = str(snapshot_root)
+                    try:
+                        fallback_executable = await asyncio.to_thread(
+                            _copy_verified_auth_executable,
+                            _canonical_candidate(executable),
+                            snapshot_root,
+                            self._initial_override_sha256,
+                            prefix="kiro-cli-probe-",
+                        )
+                        extra_visible = (str(snapshot_root),)
+                    except (OSError, ValueError):
+                        # Bytes no longer match the process-start pin (or are
+                        # unreadable): fail closed rather than execute an
+                        # unverified binary against the real home.
+                        return ProcessResult(
+                            ok=False,
+                            error="pinned Kiro CLI changed since startup",
+                        )
+                return await self._run(
+                    fallback_executable,
+                    args,
+                    env=base_env,
+                    timeout_secs=timeout_secs,
+                    on_output=on_output,
+                    sandboxed=True,
+                    sandbox_mode=_KIRO_AUTH_SANDBOX_MODE,
+                    extra_hidden_dirs=self._crew_hidden_dirs,
+                    extra_visible_dirs=extra_visible,
+                )
+            finally:
+                if cleanup_dir:
+                    await asyncio.to_thread(shutil.rmtree, cleanup_dir, ignore_errors=True)
 
         workspace = await asyncio.to_thread(
             _prepare_auth_workspace,
@@ -1996,8 +2130,16 @@ class KiroPrerequisiteService:
                 commit=commit_changes,
             )
 
-    async def _audited_identity_probe(self, executable: str) -> ProcessResult:
-        """Run a provenance-checked identity probe with paired SEL events."""
+    async def _audited_identity_probe(
+        self, executable: str, *, isolate_home: bool = True
+    ) -> ProcessResult:
+        """Run an identity probe with paired SEL events.
+
+        With ``isolate_home`` (default) the probe runs against a
+        credential-minimal temporary home. ``isolate_home=False`` is the
+        read-only real-home fallback used only after the isolated probe fails,
+        for CLIs whose valid session lives outside the staged identity files.
+        """
 
         action = "probe_identity"
         await self._audit(
@@ -2013,6 +2155,7 @@ class KiroPrerequisiteService:
                 base_env=self._probe_environment,
                 timeout_secs=_PROBE_TIMEOUT_SECS,
                 commit=False,
+                isolate_home=isolate_home,
             )
         except asyncio.CancelledError:
             await self._set_terminal_audit(action, "failed", "gateway-status", "cancelled")

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -773,22 +773,25 @@ class TestKiroPrerequisiteWorkflow:
         sqlite_store = tmp_path / ".local" / "share" / "kiro-cli" / "data.sqlite3"
         sqlite_store.parent.mkdir(parents=True)
         sqlite_store.write_bytes(b"kiro-sqlite")
-        observed_home = ""
+        whoami_homes: list[str] = []
 
         async def run(
             _command: str,
             args: list[str],
             **kwargs: Any,
         ) -> ProcessResult:
-            nonlocal observed_home
             if args == ["--version"]:
                 return ProcessResult(ok=True)
-            observed_home = kwargs["env"]["HOME"]
-            staged = Path(observed_home)
+            home = kwargs["env"]["HOME"]
+            whoami_homes.append(home)
+            staged = Path(home)
+            # No operator override is pinned, so only the isolated probe runs:
+            # only Kiro identity files are staged, unrelated real-home
+            # credentials stay hidden, and no real-home fallback is attempted.
             assert (staged / ".aws" / "sso" / "cache" / "kiro-auth-token-cli.json").is_file()
             assert not (staged / ".aws" / "sso" / "cache" / "unrelated-aws-sso.json").exists()
             assert (staged / ".local" / "share" / "kiro-cli" / "data.sqlite3").is_file()
-            assert kwargs["env"]["XDG_CONFIG_HOME"].startswith(observed_home)
+            assert kwargs["env"]["XDG_CONFIG_HOME"].startswith(home)
             return ProcessResult(ok=False)
 
         service = KiroPrerequisiteService(
@@ -803,9 +806,155 @@ class TestKiroPrerequisiteWorkflow:
         status = await service.snapshot(force=True)
 
         assert status["can_login"] is True
-        assert observed_home
-        assert Path(observed_home).parent == tmp_path / ".kiro" / "crew-auth-staging"
-        assert not Path(observed_home).exists()
+        # No override pinned, so exactly one isolated probe ran against a
+        # staged home that was cleaned up afterward.
+        assert len(whoami_homes) == 1
+        assert whoami_homes[0] != str(tmp_path)
+        assert Path(whoami_homes[0]).parent == tmp_path / ".kiro" / "crew-auth-staging"
+        assert not Path(whoami_homes[0]).exists()
+
+    @pytest.mark.asyncio
+    async def test_real_home_fallback_detects_out_of_band_session(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A CLI whose valid session is not in the staged identity files (it is
+        # resolved from the real home by an external auth helper) reports
+        # signed-out under the credential-minimal probe. When the operator has
+        # pinned that exact binary via KIROCREW_KIRO_BIN, the read-only real-home
+        # fallback detects the live session, so readiness is true and the
+        # setup/reauth gate clears — matching a real ACP session, which also
+        # runs against the real home.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        whoami_calls: list[str] = []
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            home = kwargs["env"]["HOME"]
+            whoami_calls.append(home)
+            # Signed-out in the staged home, signed-in against the real home.
+            return ProcessResult(ok=home == str(tmp_path))
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={
+                "HOME": str(tmp_path),
+                "PATH": "/usr/bin:/bin",
+                "KIROCREW_KIRO_BIN": str(executable),
+            },
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is True
+        assert status["authenticated"] is True
+        assert status["ready"] is True
+        # The isolated probe ran first (staged home); the fallback against the
+        # real home then succeeded. No third probe once readiness is true.
+        assert len(whoami_calls) == 2
+        assert whoami_calls[0] != str(tmp_path)
+        assert whoami_calls[1] == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_real_home_fallback_skipped_for_unpinned_candidate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # SECURITY: without a pinned KIROCREW_KIRO_BIN override, an arbitrary or
+        # planted PATH candidate must NEVER get a real-home probe, even when a
+        # real session exists that a real-home whoami would accept. Otherwise a
+        # planted kiro-cli could force the isolated probe to fail and gain an
+        # automatic, unattended read of ~/.aws, ~/.ssh, and ~/.kube.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        whoami_homes: list[str] = []
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            home = kwargs["env"]["HOME"]
+            whoami_homes.append(home)
+            # A real session exists (a real-home whoami would succeed), but the
+            # planted binary reports signed-out in the isolated staged home.
+            return ProcessResult(ok=home == str(tmp_path))
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        # No override pinned -> no real-home fallback -> stays signed-out, and
+        # the single whoami never ran against the real home.
+        assert status["authenticated"] is False
+        assert status["ready"] is False
+        assert len(whoami_homes) == 1
+        assert whoami_homes[0] != str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_real_home_fallback_skipped_when_pinned_binary_swapped(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # SECURITY: the pinned override is digest-recorded at process start. If a
+        # same-UID actor replaces the writable pinned binary after startup, the
+        # real-home fallback must NOT run it — the current bytes no longer match
+        # the process-start pin. Otherwise a swapped binary would gain an
+        # automatic, unattended real-home run.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        whoami_homes: list[str] = []
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            home = kwargs["env"]["HOME"]
+            whoami_homes.append(home)
+            return ProcessResult(ok=home == str(tmp_path))
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={
+                "HOME": str(tmp_path),
+                "PATH": "/usr/bin:/bin",
+                "KIROCREW_KIRO_BIN": str(executable),
+            },
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+        # Replace the pinned binary AFTER the process-start digest was recorded.
+        executable.write_text("#!/bin/sh\n# swapped\n", encoding="utf-8")
+
+        status = await service.snapshot(force=True)
+
+        # Digest mismatch -> fallback refused -> stays signed-out, no real-home
+        # whoami despite a live real session.
+        assert status["authenticated"] is False
+        assert status["ready"] is False
+        assert len(whoami_homes) == 1
+        assert whoami_homes[0] != str(tmp_path)
 
     @pytest.mark.asyncio
     async def test_self_updated_candidate_still_signs_in(


### PR DESCRIPTION
## Problem
On a gateway where the Kiro CLI keeps its valid session **outside** the files KiroCrew stages into its credential-minimal probe home, the readiness gate reports "not signed in" even though the CLI is genuinely logged in (verified in a normal terminal). The dashboard shows a non-dismissible "Kiro Crew needs Kiro sign-in" / setup banner and pauses all session creation.

## Why it matters
`ready=false` blocks session creation entirely. The user cannot start any chat/agent session despite having a working, authenticated CLI — a hard block with no in-product recovery: the banner's "Sign in" button runs the same isolated probe and dead-ends the same way.

## Fix (symptom → root cause → change)
- **Symptom:** the `whoami` readiness probe reports signed-out, so the banner never clears.
- **Root cause:** the identity probe runs `whoami` inside an isolated temporary HOME that stages only the known Kiro identity files. A CLI whose session is validated from the real home (an external auth helper resolved from `$HOME`) cannot see its credentials there, so `whoami` fails — even though a real `kiro-cli acp` session, which runs with the real environment (`acp/runtime.py: env = {**os.environ}`), authenticates fine.
- **Change:** after the isolated `whoami` reports signed-out, `_probe` retries once with a **read-only real-home** `whoami` (`isolate_home=False`) — but **only for the exact executable the operator pinned via `KIROCREW_KIRO_BIN`, and only while its bytes still match the digest recorded at process start**. Default behavior (no override) is unchanged: the automatic probe never runs a candidate against the real home. Both the first-run onboarding gate and the re-auth banner derive readiness from `_probe`, so this fixes both. Operators on a host whose CLI authenticates from the real home set `KIROCREW_KIRO_BIN` to that binary.

**Security (addresses the blocking review findings):**
- An arbitrary or planted `PATH` candidate is never the pinned override, so it can never trigger a real-home probe.
- The pinned binary's bytes are verified against the process-start pin, and the fallback executes a **private, digest-verified snapshot** of those bytes (not the path) — the same resolve-to-exec binding the ACP launch uses — so a **replacement of a writable pinned binary after startup** (before or between check and exec) fails the verified copy and the fallback is refused (fails closed).
- The fallback is read-only (`commit` is rejected, so it never stages or publishes) and still hides Kiro Crew's own secret home. It is off by default and on Windows (no pinned override).

This closes the unattended read/write path to `~/.aws`, `~/.ssh`, and `~/.kube` that an ungated fallback would open.

## Tests
- Existing isolation tests unchanged — with no override pinned, the default isolated-only probe behavior is preserved.
- `test_real_home_fallback_detects_out_of_band_session`: with `KIROCREW_KIRO_BIN` pinned (matching digest), the isolated `whoami` fails and the real-home `whoami` succeeds → `ready` true.
- `test_real_home_fallback_skipped_for_unpinned_candidate` (**SECURITY**): a planted candidate with a live real session still gets **no** real-home probe.
- `test_real_home_fallback_skipped_when_pinned_binary_swapped` (**SECURITY**): a post-start replacement of the pinned binary fails the digest check → no real-home probe.
- Full suite: **92 passed / 1 skipped**; `test_spawn_audit.py` green; flake8 clean.

## Manual verification
On a gateway whose CLI authenticates from the real home: set `KIROCREW_KIRO_BIN` to that binary, sign in via its normal flow, load the dashboard, and confirm the setup/re-auth banner clears (`ready=true`) and sessions start. Not reproducible in unit tests (which mock the CLI); the added tests lock in the pinned-success, unpinned-block, and swapped-block paths.
