### PR TITLE
fix(desktop): show spaced "Kiro Crew" in the macOS menu bar and Dock

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -403,6 +403,12 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       "-c.mac.icon=icon-nightly.png"
       "-c.linux.icon=icon-nightly.png"
       "-c.win.icon=icon-nightly.png"
+      # Menu-bar/Dock title (CFBundleName) mirrors the spaced display name. The
+      # static package.json extendInfo hard-codes "Kiro Crew"; nightly must
+      # re-override it or its menu bar would drop the "Nightly" suffix. The
+      # space-free .app FILENAME still comes from productName above, so CDN
+      # keys / DMG volume / notarization slugs are unaffected.
+      "-c.mac.extendInfo.CFBundleName=Kiro Crew Nightly"
       # Squirrel.Windows keys the INSTALL identity off squirrelWindows.name
       # (install dir %LocalAppData%\<name>, shortcuts, and the RELEASES/
       # .nupkg feed identity). On mac, a distinct productName alone gives

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -33,7 +33,10 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": false,
-      "x64ArchFiles": "{**/backend-dist/**,**/backend-dist/**/.*/**}"
+      "x64ArchFiles": "{**/backend-dist/**,**/backend-dist/**/.*/**}",
+      "extendInfo": {
+        "CFBundleName": "Kiro Crew"
+      }
     },
     "afterSign": "scripts/notarize.js",
     "linux": {


### PR DESCRIPTION
## Problem
On macOS the app menu (the bold item next to the Apple menu) and the Dock label read **"KiroCrew"** with no space, even though every user-facing spelling of the product elsewhere is **"Kiro Crew"** (see the screenshot).

## Why it matters
The menu bar and Dock are the most visible surfaces of the desktop app. Showing the run-together internal slug instead of the product name is an inconsistent, unpolished first impression on every macOS launch.

## Fix (symptom → root cause → change)
- **Symptom:** menu bar / Dock show "KiroCrew".
- **Root cause:** on a *packaged* macOS app, the OS renders the app menu's first item and the Dock label from the bundle's `CFBundleName`. electron-builder derives `CFBundleName` from `productName` (`"KiroCrew"`, deliberately space-free). The runtime `app.name = "Kiro Crew"` set in `main.js` **cannot** override the app menu on a packaged build — that's a documented macOS limitation — so the internal slug leaked through.
- **Change:** override just `CFBundleName` via `mac.extendInfo` in `website/electron/package.json`, leaving `productName` (and therefore the `.app` filename) space-free. The nightly build re-overrides `CFBundleName` to `"Kiro Crew Nightly"` in `packaging/build-desktop.sh`, because the static `extendInfo` value would otherwise drop the "Nightly" suffix.

Why `CFBundleName`-only and not renaming `productName`: the `.app` filename / `productName` is intentionally space-free because the notarization/CDN/DMG slugs derive from it. Both `packaging/signing/sign.sh` and `.github/workflows/sign-and-notarize.yml` compute their slug as `basename "$APP_PATH" .app` (the filename = `productName`), and **nothing reads `CFBundleName`** — so overriding only `CFBundleName` fixes the display name with zero impact on signing/notarization/CDN identity.

## Tests
No new automated test — this is packaging metadata (Info.plist key), not runtime code, and there is no existing harness that asserts on bundle-display strings. The existing Electron suite (`node --test`, 264 tests) passes unchanged, `package.json` remains valid JSON, and `bash -n packaging/build-desktop.sh` parses.

## Manual verification
- ✅ `python3 -c json.load` confirms `build.mac.extendInfo.CFBundleName == "Kiro Crew"` and `productName == "KiroCrew"`.
- ✅ 264/264 Electron `node --test` tests pass; `bash -n build-desktop.sh` clean.
- ⚠️ **Needs a real macOS build to confirm** (I developed this on Linux):
  1. Menu bar + Dock show **"Kiro Crew"** in a packaged `.app` (and **"Kiro Crew Nightly"** for a nightly build).
  2. **Cross-app takeover still works.** `instance-guard.js` quits the other family via AppleScript `quit app "<FAMILY_META.appName>"` (still `"KiroCrew"` / `"KiroCrew Nightly"`, i.e. the unchanged `.app` filename). This PR deliberately leaves that target unchanged. If AppleScript resolves a *running* app by `CFBundleName` rather than by the bundle filename, the takeover quit could miss after this change — in that case a follow-up should set `FAMILY_META.appName` to the spaced values (and update `instance-guard.test.js`). Please verify the takeover path on macOS before merge.

## Screenshots
Reported-issue screenshot (menu bar showing the run-together "KiroCrew"): the change makes this render as "Kiro Crew". A packaged-build screenshot requires a macOS signer and is part of the manual verification above.
