### PR TITLE
fix: sign in with toolbox/multiplexer Kiro CLI and never 500 the gate

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -285,6 +285,11 @@ def _dispose_kiro_executable_snapshot(
     if snapshot_path is not None:
         with suppress(OSError):
             os.unlink(snapshot_path)
+        # The macOS snapshot keeps the source basename inside a unique holder
+        # subdir (so a multiplexer's argv[0] survives); remove that now-empty
+        # holder too rather than leaking one dir per spawn.
+        with suppress(OSError):
+            os.rmdir(os.path.dirname(snapshot_path))
 
 
 async def _cleanup_kiro_executable_snapshot(executable: str | None) -> None:

--- a/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
@@ -4,18 +4,41 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import asdict
+from typing import Any
 
 from aiohttp import web
 
 from kiro_crew.kiro_prerequisite import (
     OFFICIAL_INSTALL_DOCS_URL,
     KiroPrerequisiteService,
+    OperationStatus,
     PrerequisiteBusyError,
+    PrerequisiteStatus,
 )
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 _LOCAL_DASHBOARD_OWNER_SUBJECTS = frozenset({"local-app", "local-startup"})
+
+
+def _not_ready_snapshot() -> dict[str, Any]:
+    """A retryable not-ready snapshot for when a status probe cannot run.
+
+    Shaped exactly like ``KiroPrerequisiteService.snapshot()`` (built from the
+    same dataclasses so it cannot drift), it reports the CLI as installed but
+    not signed in so the dashboard shows a retry path rather than a 500 flash.
+    """
+
+    result: dict[str, Any] = asdict(PrerequisiteStatus(platform="gateway", installed=True))
+    result["operation"] = asdict(
+        OperationStatus(
+            status="failed",
+            message="Could not check Kiro CLI. Retry the gateway check.",
+            error="Kiro CLI status check could not run.",
+        )
+    )
+    return result
 
 
 def _service(request: web.Request) -> KiroPrerequisiteService:
@@ -79,7 +102,23 @@ async def api_kiro_prerequisite_status(request: web.Request) -> web.Response:
         assert denied is not None
         return denied
 
-    snapshot = await _service(request).snapshot()
+    # Resolve the service OUTSIDE the guard: a genuinely unwired service is a
+    # real misconfiguration that must stay a 503, not be masked as a 200
+    # not-ready. Only the probe itself is guarded.
+    service = _service(request)
+    try:
+        snapshot = await service.snapshot()
+    except asyncio.CancelledError:
+        raise
+    except web.HTTPException:
+        raise
+    except Exception:
+        # A transient probe failure must not surface as a 500 that flashes the
+        # full-screen "could not check Kiro CLI" gate. Report a retryable
+        # not-ready snapshot so the dashboard keeps polling. (The probe layer
+        # already degrades most failures; this is the last-resort backstop.)
+        logger.warning("Kiro prerequisite status probe failed", exc_info=True)
+        snapshot = _not_ready_snapshot()
     if _is_dashboard_owner(request):
         return web.json_response({**snapshot, "setup_allowed": True})
 

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -373,32 +373,46 @@ def _copy_verified_auth_executable(
     *,
     prefix: str = "kiro-cli-auth-",
 ) -> str:
-    """Snapshot a verified executable into the agent-protected runtime dir."""
+    """Snapshot a verified executable into the agent-protected runtime dir.
+
+    The snapshot keeps the SOURCE BASENAME (e.g. ``kiro-cli``) rather than a
+    random ``mkstemp`` name: a multiplexer launcher such as
+    ``~/.toolbox/bin/kiro-cli`` dispatches on its argv[0] basename, so a copy
+    named ``kiro-cli-auth-XXXX`` would run as the wrong tool and fail with
+    "Command doesn't appear to be associated with any tool". The copy lives in a
+    unique owner-only subdir (``mkdtemp``) so preserving the fixed basename still
+    can't collide across concurrent calls.
+    """
 
     destination_dir.mkdir(parents=True, exist_ok=True)
     if platform_compat.IS_POSIX:
         platform_compat.chmod_safe(str(destination_dir), 0o700)
     else:
         platform_compat.restrict_to_owner(str(destination_dir))
+    holder = tempfile.mkdtemp(prefix=prefix, dir=str(destination_dir))
+    if not platform_compat.IS_POSIX:
+        platform_compat.restrict_to_owner(holder)
+    # Preserve the basename the CALLER resolved (e.g. the ``kiro-cli`` symlink
+    # name), NOT the realpath — a multiplexer dispatches on argv[0], and its
+    # realpath (``toolbox-exec``) is exactly the name that fails to dispatch.
+    target = os.path.join(holder, os.path.basename(source) or "kiro-cli")
     destination_fd = -1
-    temporary = ""
     try:
-        destination_fd, temporary = tempfile.mkstemp(
-            prefix=prefix,
-            dir=str(destination_dir),
-        )
+        open_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+        destination_fd = os.open(target, open_flags, 0o700)
         _copy_verified_executable_to_fd(source, destination_fd, expected_sha256)
         os.close(destination_fd)
         destination_fd = -1
         if not platform_compat.IS_POSIX:
-            platform_compat.restrict_to_owner(temporary)
-        return temporary
+            platform_compat.restrict_to_owner(target)
+        return target
     except Exception:
         if destination_fd >= 0:
             os.close(destination_fd)
-        if temporary:
-            with contextlib.suppress(OSError):
-                os.unlink(temporary)
+        with contextlib.suppress(OSError):
+            os.unlink(target)
+        with contextlib.suppress(OSError):
+            os.rmdir(holder)
         raise
 
 
@@ -518,7 +532,13 @@ def snapshot_trusted_acp_executable(
                 expected_sha256=expected,
             )
         snapshot_path = _copy_verified_auth_executable(
-            canonical,
+            # Pass the UNRESOLVED path so the copy keeps the caller's basename
+            # (e.g. ``kiro-cli``): a multiplexer launcher dispatches on argv[0],
+            # and the copier re-canonicalizes internally to read+pin the exact
+            # resolved bytes, so byte integrity is unaffected. Passing
+            # ``canonical`` here would name the copy ``toolbox-exec`` and break
+            # ACP spawn for a toolbox CLI that just signed in.
+            executable,
             active_home / _ACP_EXECUTABLE_SNAPSHOT_RELATIVE,
             expected,
             prefix="kiro-cli-acp-",
@@ -542,7 +562,13 @@ def snapshot_trusted_acp_executable(
         # launched in place. The sealed in-memory fd is lost, but the resolved
         # bytes are still pinned, so a swap between resolve and exec is caught.
         snapshot_path = _copy_verified_auth_executable(
-            canonical,
+            # Pass the UNRESOLVED path so the copy keeps the caller's basename
+            # (e.g. ``kiro-cli``): a multiplexer launcher dispatches on argv[0],
+            # and the copier re-canonicalizes internally to read+pin the exact
+            # resolved bytes, so byte integrity is unaffected. Passing
+            # ``canonical`` here would name the copy ``toolbox-exec`` and break
+            # ACP spawn for a toolbox CLI that just signed in.
+            executable,
             active_home / _ACP_EXECUTABLE_SNAPSHOT_RELATIVE,
             expected,
             prefix="kiro-cli-acp-",
@@ -1843,7 +1869,14 @@ class KiroPrerequisiteService:
                     ["--version"],
                 )
                 if result.ok:
-                    self._viable_binary = _canonical_candidate(executable)
+                    # Keep the discovered path AS RESOLVED (not realpath'd): a
+                    # multiplexer launcher like ``~/.toolbox/bin/kiro-cli``
+                    # dispatches on its argv[0] basename, so resolving the
+                    # symlink to ``toolbox-exec`` would make whoami/login fail
+                    # with "Command doesn't appear to be associated with any
+                    # tool". This is the exact path ``--version`` just succeeded
+                    # with and the one ACP launches.
+                    self._viable_binary = executable
                     break
 
             repair_required = not self._viable_binary and repair_hint
@@ -1907,13 +1940,17 @@ class KiroPrerequisiteService:
             await self._set_terminal_audit(action, "failed", "gateway-status", "cancelled")
             raise
         except Exception:
+            # A probe that cannot even run means the candidate is not viable,
+            # not that the gateway is broken. Degrade to a not-ok result so the
+            # status endpoint stays a retryable "not ready" instead of a 500.
+            logger.warning("Kiro %s probe failed to run", action, exc_info=True)
             await self._set_terminal_audit(
                 action,
                 "failed",
                 "gateway-status",
                 "probe execution failed",
             )
-            raise
+            return ProcessResult(ok=False, error="Kiro CLI probe could not run")
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",
@@ -2018,13 +2055,18 @@ class KiroPrerequisiteService:
             await self._set_terminal_audit(action, "failed", "gateway-status", "cancelled")
             raise
         except Exception:
+            # A whoami that cannot even run means "not signed in", not a broken
+            # gateway. Degrade to a not-ok result so the status endpoint reports
+            # authenticated=False (retryable) instead of surfacing a 500 that
+            # flashes the full-screen "could not check Kiro CLI" error.
+            logger.warning("Kiro identity probe failed to run", exc_info=True)
             await self._set_terminal_audit(
                 action,
                 "failed",
                 "gateway-status",
                 "probe execution failed",
             )
-            raise
+            return ProcessResult(ok=False, error="Kiro identity probe could not run")
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -147,6 +147,31 @@ class TestKiroPrerequisiteHelpers:
         assert snapshot.read_bytes() == target.read_bytes()
         snapshot.unlink()
 
+    def test_verified_snapshot_keeps_source_basename_for_multiplexer(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A multiplexer launcher (e.g. ~/.toolbox/bin/kiro-cli -> toolbox-exec)
+        # dispatches on argv[0] basename. The snapshot must keep the caller's
+        # ``kiro-cli`` name — NOT the realpath'd ``toolbox-exec`` — or the copy
+        # runs as the wrong tool. Regression for the toolbox sign-in failure.
+        real = tmp_path / "toolbox-exec"
+        real.write_bytes(b"multiplexer bytes")
+        real.chmod(0o700)
+        symlink = tmp_path / "kiro-cli"
+        symlink.symlink_to(real)
+
+        snapshot = Path(
+            prerequisite_module._copy_verified_auth_executable(
+                str(symlink),
+                tmp_path / "protected-run",
+                None,
+            )
+        )
+
+        assert snapshot.name == "kiro-cli"
+        assert snapshot.read_bytes() == b"multiplexer bytes"
+
     def test_binary_digest_rejects_oversized_candidate(
         self,
         tmp_path: Path,
@@ -378,10 +403,65 @@ class TestKiroPrerequisiteHelpers:
         assert not snapshot.launch_path.startswith("/proc/self/fd/")
         assert snapshot.cleanup_path == snapshot.launch_path
         launch_path = Path(snapshot.launch_path)
-        # Copy lives in the agent-protected snapshot dir and pins the exact bytes.
-        assert launch_path.parent == data_home / "run" / "kiro-cli-snapshots"
+        snapshots_dir = data_home / "run" / "kiro-cli-snapshots"
+        # Copy lives under the agent-protected snapshot dir (inside a per-call
+        # holder subdir), keeps the source basename so a multiplexer's argv[0]
+        # survives, and pins the exact bytes.
+        assert launch_path.parent.parent == snapshots_dir
+        assert launch_path.name == "kiro-cli"
         assert launch_path.read_bytes() == executable.read_bytes()
         assert snapshot.expected_sha256 == digest
+
+    def test_acp_snapshot_keeps_symlink_basename_for_multiplexer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The ACP launch snapshot (macOS + Linux memfd-less fallback) must copy
+        # the resolved bytes under the SYMLINK basename (``kiro-cli``), not the
+        # realpath (``toolbox-exec``) — otherwise a toolbox CLI signs in but
+        # fails at agent spawn. Regression for the asymmetric multiplexer fix.
+        real = tmp_path / "toolbox-exec"
+        real.write_bytes(b"multiplexer bytes")
+        real.chmod(0o700)
+        symlink = tmp_path / "kiro-cli"
+        symlink.symlink_to(real)
+        digest = hashlib.sha256(real.read_bytes()).hexdigest()
+        environ = {"KIROCREW_KIRO_BIN": str(symlink)}
+        prerequisite_module._register_operator_override_attestation(str(symlink), digest)
+        monkeypatch.delattr(prerequisite_module.os, "memfd_create", raising=False)
+
+        snapshot = prerequisite_module.snapshot_trusted_acp_executable(
+            str(symlink),
+            data_home=tmp_path / "data",
+            platform_name="linux",
+            environ=environ,
+        )
+
+        # Named for dispatch, bytes pinned from the realpath.
+        assert Path(snapshot.launch_path).name == "kiro-cli"
+        assert Path(snapshot.launch_path).read_bytes() == b"multiplexer bytes"
+        assert snapshot.expected_sha256 == digest
+
+    def test_verified_snapshot_cleans_holder_on_verification_failure(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A copy that fails verification (wrong pinned digest) must not leak its
+        # per-call holder dir under the snapshot root.
+        source = tmp_path / "kiro-cli"
+        source.write_bytes(b"real bytes")
+        source.chmod(0o700)
+        dest = tmp_path / "protected-run"
+
+        with pytest.raises(ValueError):
+            prerequisite_module._copy_verified_auth_executable(
+                str(source),
+                dest,
+                "0" * 64,  # wrong digest → verification fails mid-copy
+            )
+
+        assert list(dest.iterdir()) == []
 
     @pytest.mark.skipif(sys.platform != "linux", reason="Linux memfd seals")
     def test_linux_memfd_seals_reject_later_writes(self) -> None:
@@ -752,6 +832,103 @@ class TestKiroPrerequisiteWorkflow:
         assert status["can_login"] is True
         assert status["authenticated"] is False
         assert calls == [["--version"], ["whoami"]]
+
+    @pytest.mark.asyncio
+    async def test_whoami_runs_against_unresolved_multiplexer_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A multiplexer launcher (toolbox) dispatches on argv[0] basename, so
+        # whoami/login must run against the resolved-but-symlink-named candidate
+        # (``kiro-cli``), NOT its realpath (``toolbox-exec``). Regression for the
+        # toolbox "Command doesn't appear to be associated with any tool" error.
+        real = tmp_path / "toolbox-exec"
+        _make_executable(real)
+        # A fixed home-relative dir the resolver checks first, so the real
+        # host's toolbox install cannot leak in as an earlier candidate.
+        symlink = tmp_path / ".local" / "bin" / "kiro-cli"
+        symlink.parent.mkdir(parents=True)
+        symlink.symlink_to(real)
+        commands: list[str] = []
+
+        async def run(command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            commands.append(command)
+            # Only the tmp symlink is viable, so the real host binary (if it
+            # leaks into discovery) is skipped and cannot shadow the assertion.
+            return ProcessResult(ok=command == str(symlink) and args == ["--version"])
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": ""},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        assert status["can_login"] is True
+        # whoami runs against the symlink name, never the realpath'd toolbox-exec.
+        assert str(symlink) in commands
+        assert str(real) not in commands
+
+    @pytest.mark.asyncio
+    async def test_status_probe_failure_degrades_to_not_ready(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A whoami that cannot even run (e.g. a wedged binary) must degrade to
+        # not-authenticated, never raise — otherwise the status endpoint 500s
+        # and the dashboard flashes the full-screen "could not check" gate.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+
+        async def run(_command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            raise OSError("whoami could not spawn")
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is True
+        assert status["can_login"] is True
+        assert status["authenticated"] is False
+        assert status["ready"] is False
+
+    @pytest.mark.asyncio
+    async def test_version_probe_failure_degrades_to_not_installed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A --version probe that cannot even spawn (e.g. sandbox failure) must
+        # degrade to not-installed, never raise — same 500-flash guard as the
+        # whoami branch, on the other probe.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+
+        async def run(_command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            raise OSError("--version could not spawn")
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is False
+        assert status["ready"] is False
 
     @pytest.mark.asyncio
     async def test_trusted_identity_probe_sees_only_staged_kiro_credentials(
@@ -2955,6 +3132,36 @@ class TestKiroPrerequisiteHandlers:
             assert (await client.post("/api/kiro-prerequisite/login")).status == 202
 
         assert calls == [("install", "test-user"), ("login", "test-user")]
+
+    @pytest.mark.asyncio
+    async def test_status_endpoint_returns_not_ready_instead_of_500_on_probe_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A transient probe failure must not surface as an HTTP 500 (which
+        # flashes the full-screen "could not check Kiro CLI" gate on reload).
+        # The handler returns a retryable not-ready snapshot instead.
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": ""},
+            home=tmp_path,
+            audit_writer=_no_audit,
+        )
+
+        async def boom() -> dict[str, Any]:
+            raise OSError("probe wedged")
+
+        monkeypatch.setattr(service, "snapshot", boom)
+
+        async with TestClient(TestServer(self._app(service, app_claim=""))) as client:
+            resp = await client.get("/api/kiro-prerequisite")
+            assert resp.status == 200
+            body = await resp.json()
+
+        assert body["ready"] is False
+        assert body["operation"]["status"] == "failed"
+        assert body["setup_allowed"] is True
 
     @pytest.mark.asyncio
     async def test_session_create_and_send_are_rejected_before_enqueue_when_not_ready(


### PR DESCRIPTION
## Problem

Two first-run / reauth bugs that surfaced once KiroCrew began accepting any
runnable Kiro CLI (regardless of install source):

1. **A toolbox / managed Kiro CLI can't sign in.** `~/.toolbox/bin/kiro-cli` is
   a symlink to a multiplexer (`toolbox-exec`) that dispatches on its argv[0]
   basename. Sign-in failed with `toolbox: Unable to run … Command "…" doesn't
   appear to be associated with any tool`, and the banner never cleared.
2. **A transient probe failure flashes a full-screen error.** On non-first load
   the dashboard blinks *"We could not check Kiro CLI — 500 Internal Server
   Error"* for a second.

## Why it matters

Anyone who installed Kiro CLI via toolbox (or another argv[0]-dispatching
launcher) is hard-blocked from starting any session — sign-in dead-ends with no
recovery. And a one-off probe hiccup shouldn't ever present as a scary
full-screen 500.

## Fix (symptom → root cause → change)

**Bug 1 — multiplexer dispatch.** *Symptom:* whoami/login error "Command
doesn't appear to be associated with any tool". *Root cause:* the probe
resolved the viable binary to its realpath (`toolbox-exec`) and the private
auth/ACP copy used a random `kiro-cli-auth-XXXX` / `kiro-cli-acp-XXXX` name —
both destroy the `kiro-cli` basename the multiplexer dispatches on. *Change:*
the probe keeps the resolved-but-symlink-named candidate for whoami/login, and
`_copy_verified_auth_executable` preserves the **source basename** inside a
unique owner-only holder dir (removed alongside the snapshot). The ACP-launch
snapshot (macOS + Linux memfd-less fallback) passes the **unresolved** path so
the copy is named `kiro-cli` too — otherwise a toolbox user would sign in but
fail at agent spawn. Bytes are still read from the realpath and
sha256-pinned, so exec-time integrity is unchanged.

**Bug 2 — 500 flash.** *Symptom:* full-screen "could not check Kiro CLI" on
reload. *Root cause:* a whoami/`--version` probe that couldn't spawn re-raised
out of the unguarded status endpoint as an HTTP 500. *Change:* a probe
execution failure degrades to not-ready (retryable; `authenticated=False`), and
the status handler has a last-resort backstop returning a not-ready snapshot
instead of a 500. The service is resolved outside the guard so a genuinely
unwired service still returns 503.

## Tests

- Multiplexer: the private copy (auth + ACP-snapshot callers) keeps the
  `kiro-cli` basename; whoami runs against the symlink path, never the
  realpath'd `toolbox-exec`. Verified end-to-end against the real toolbox
  binary (`kiro-cli 2.14.2` / `whoami` both dispatch).
- 500-flash: both probe branches (`whoami` + `--version`) degrade rather than
  raise; the status handler returns 200 not-ready (not 500) on a probe error.
- Holder cleanup on verification failure leaves no leaked dir.
- Full backend suite green (one unrelated pre-existing `test_stt_stream` xdist
  flake, passes in isolation); black/isort/flake8/mypy clean.

## Manual verification

N/A — unit + integration coverage is sufficient; the multiplexer dispatch is
verified against the real `~/.toolbox/bin/kiro-cli` in-repo. The 500-flash path
is fully mockable.

## Screenshots

No UI change — this is backend behavior (the existing gate/banner now clears
correctly and stops flashing the 500 error).

## Related

Overlaps **#576** (open), which fixes a *different* root cause of the same
symptom (a CLI whose valid session lives outside the staged credential files,
via a real-home whoami fallback). The two are complementary — #576's fallback
still runs through the same copier, so it does not fix the toolbox case until
this basename change lands. They touch the same functions, so whichever merges
second should rebase.
