### PR TITLE
fix(onboarding): import skip continues into the feature tour

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -15,6 +15,7 @@ import { fetchNotifications, ackNotification } from './store/notificationsSlice'
 import { useWebSocket } from './hooks/useWebSocket'
 import { useDashboardHealthProbe } from './hooks/useDashboardHealthProbe'
 import { useTheme } from './hooks/useTheme'
+import { useOnboardingGate } from './hooks/useOnboardingGate'
 import { useBranding } from './hooks/useBranding'
 import { useRumPageView } from './hooks/useRumPageView'
 import { useIsMobile } from './hooks/useIsMobile'
@@ -752,41 +753,12 @@ export default function App() {
   const {
     colorTheme,
     theme: resolvedMode,
-    onboarded,
-    importOnboarded,
-    themeBootReady,
-    markOnboarded,
-    markImportOnboarded,
   } = useTheme()
-  // The E2E Playwright suite depends on this onboarding gate: playwright/auth.setup.ts
-  // seeds localStorage['mc-onboarded']='1' so the first-run "Choose your look" modal
-  // never overlays the shell and intercepts every spec's interactions. If this flag is
-  // renamed or the modal moves off localStorage, update auth.setup.ts to match.
-  const locallyImportOnboarded =
-    !!localStorage.getItem('mc-import-onboarded') || !!localStorage.getItem('mc-onboarded')
-  const [showAgentImport, setShowAgentImport] = useState(false)
-  const [showOnboarding, setShowOnboarding] = useState(
-    () => locallyImportOnboarded && !localStorage.getItem('mc-onboarded'),
-  )
-  const continueTourAfterImport = useRef(false)
-  // Dismiss onboarding when server reports user is already onboarded
-  // (handles the race: boot fetch completes after useState initializer ran).
-  useEffect(() => { if (onboarded) setShowOnboarding(false) }, [onboarded])
-  useEffect(() => {
-    if (!themeBootReady) return
-    setShowAgentImport(!importOnboarded)
-    setShowOnboarding(importOnboarded && !onboarded)
-  }, [importOnboarded, themeBootReady])
-  useEffect(() => {
-    const replay = (event: Event) => {
-      continueTourAfterImport.current =
-        !!(event as CustomEvent<{ continueOnboarding?: boolean }>).detail?.continueOnboarding
-      setShowOnboarding(false)
-      setShowAgentImport(true)
-    }
-    window.addEventListener('mc-start-import', replay)
-    return () => window.removeEventListener('mc-start-import', replay)
-  }, [])
+  // First-run onboarding gate: import flow → theme/feature tour. See
+  // useOnboardingGate for the visibility state, the boot seeding, and the
+  // Option-A hand-off (first-run import always continues into the tour).
+  const { showAgentImport, showOnboarding, onImportComplete, onOnboardingComplete } =
+    useOnboardingGate()
   // Capture Electron update lifecycle events app-wide so UpdateModal fires on
   // any page, not just after the user has opened Settings > About.
   useUpdateSubscription()
@@ -1670,14 +1642,7 @@ export default function App() {
           marker, while new users reach the feature tour only after this flow. */}
       <AgentImportFlow
         initialOpen={showAgentImport}
-        onComplete={() => {
-          markImportOnboarded()
-          setShowAgentImport(false)
-          if (!onboarded || continueTourAfterImport.current) {
-            setShowOnboarding(true)
-          }
-          continueTourAfterImport.current = false
-        }}
+        onComplete={onImportComplete}
       />
 
       {/* First-run onboarding: 4-step flow (theme → Schedule → Apps → Sessions).
@@ -1685,7 +1650,7 @@ export default function App() {
           it anytime; internal visibility is seeded by `initialOpen`. */}
       <OnboardingFlow
         initialOpen={showOnboarding}
-        onComplete={() => { markOnboarded(); setShowOnboarding(false) }}
+        onComplete={onOnboardingComplete}
       />
 
       {/* Mobile backdrop */}

--- a/website/src/hooks/useOnboardingGate.test.tsx
+++ b/website/src/hooks/useOnboardingGate.test.tsx
@@ -1,0 +1,131 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../api/client'
+import { useOnboardingGate } from './useOnboardingGate'
+import { renderWithProviders } from '../test/helpers'
+import AgentImportFlow from '../components/AgentImportFlow'
+import OnboardingFlow from '../components/OnboardingFlow'
+
+vi.mock('../api/client', () => ({
+  api: {
+    themes: vi.fn(),
+    themeDetail: vi.fn(),
+    themeBoot: vi.fn(),
+    updateThemeConfig: vi.fn(),
+    onboardingImportScan: vi.fn(),
+    onboardingImportApply: vi.fn(),
+    onboardingImportState: vi.fn(),
+    kirocrewConfig: vi.fn(),
+    patchConfig: vi.fn(),
+  },
+}))
+
+// Mirrors how App.tsx wires the gate to the two real first-run flows.
+function Harness() {
+  const { showAgentImport, showOnboarding, onImportComplete, onOnboardingComplete } =
+    useOnboardingGate()
+  return (
+    <>
+      <AgentImportFlow initialOpen={showAgentImport} onComplete={onImportComplete} />
+      <OnboardingFlow initialOpen={showOnboarding} onComplete={onOnboardingComplete} />
+    </>
+  )
+}
+
+const SCAN = {
+  sources: [
+    {
+      id: 'meshclaw',
+      name: 'MeshClaw',
+      detected: true,
+      detail: '~/.meshclaw',
+      categories: [{ id: 'skills', label: 'Skills', count: 5 }],
+    },
+  ],
+  skipped: [],
+  merge_only: true,
+}
+
+function seedApi(boot: { onboarded: boolean; import_onboarded: boolean }) {
+  vi.mocked(api.themes).mockResolvedValue({ themes: [] } as never)
+  vi.mocked(api.themeDetail).mockResolvedValue({} as never)
+  vi.mocked(api.updateThemeConfig).mockResolvedValue({ ok: true } as never)
+  vi.mocked(api.themeBoot).mockResolvedValue(boot as never)
+  vi.mocked(api.onboardingImportScan).mockResolvedValue(SCAN as never)
+  vi.mocked(api.onboardingImportState).mockResolvedValue({ ok: true } as never)
+  vi.mocked(api.kirocrewConfig).mockResolvedValue({ dashboard: {} } as never)
+  vi.mocked(api.patchConfig).mockResolvedValue({ ok: true } as never)
+}
+
+async function skipImport() {
+  await screen.findByRole('button', { name: 'Skip for now' })
+  await userEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
+}
+
+describe('useOnboardingGate — import-skip continues into onboarding (Option A)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('new user: skipping first-run import opens the theme tour', async () => {
+    seedApi({ onboarded: false, import_onboarded: false })
+    renderWithProviders(<Harness />)
+
+    await skipImport()
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Pick your look' })).toBeInTheDocument(),
+    )
+  })
+
+  it('onboarded=true but import not done: skipping first-run import still opens the tour', async () => {
+    // Regression: previously the boot seed effect re-fired on the import flag
+    // flip and, together with the `!onboarded` hand-off gate, suppressed the
+    // tour entirely — so "Skip for now" looked like it skipped every step.
+    seedApi({ onboarded: true, import_onboarded: false })
+    renderWithProviders(<Harness />)
+
+    await skipImport()
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Pick your look' })).toBeInTheDocument(),
+    )
+  })
+
+  it('Settings replay (plain event): skipping the re-run importer does NOT reopen the tour', async () => {
+    // Fully onboarded user re-importing from Settings must not be dragged back
+    // through the theme tour.
+    seedApi({ onboarded: true, import_onboarded: true })
+    renderWithProviders(<Harness />)
+
+    // First-run gate stays closed for an already-import-onboarded user.
+    await waitFor(() => expect(api.themeBoot).toHaveBeenCalled())
+    expect(screen.queryByRole('dialog', { name: 'Import agent setup' })).not.toBeInTheDocument()
+
+    // Settings dispatches a plain Event (no continueOnboarding).
+    window.dispatchEvent(new Event('mc-start-import'))
+    await skipImport()
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Import agent setup' })).not.toBeInTheDocument(),
+    )
+    expect(screen.queryByRole('heading', { name: 'Pick your look' })).not.toBeInTheDocument()
+  })
+
+  it('slash /onboarding replay (continueOnboarding): skipping the importer opens the tour', async () => {
+    seedApi({ onboarded: true, import_onboarded: true })
+    renderWithProviders(<Harness />)
+
+    await waitFor(() => expect(api.themeBoot).toHaveBeenCalled())
+    window.dispatchEvent(
+      new CustomEvent('mc-start-import', { detail: { continueOnboarding: true } }),
+    )
+    await skipImport()
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Pick your look' })).toBeInTheDocument(),
+    )
+  })
+})

--- a/website/src/hooks/useOnboardingGate.ts
+++ b/website/src/hooks/useOnboardingGate.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTheme } from './useTheme'
+
+/**
+ * First-run onboarding gate: sequences the agent-import flow and the theme /
+ * feature tour, and decides which is visible.
+ *
+ * The two flows have independent completion flags on the server
+ * (`dashboard.import_onboarded` and `dashboard.onboarded`), but they are shown
+ * as one first-run experience: import first, then the tour. This hook owns the
+ * visibility state and the hand-off between them.
+ *
+ * Option A hand-off rule: dismissing the FIRST-RUN import (via "Skip for now",
+ * the header Skip, or finishing an import) always flows into the remaining
+ * onboarding — regardless of the `onboarded` flag. This prevents "Skip for now"
+ * from looking like it skipped every step when the user is in an
+ * `onboarded=true` / `import_onboarded=false` state (e.g. re-testing just the
+ * importer). A Settings/slash replay is NOT a first run: it only continues into
+ * the tour when the replay explicitly asked to (`continueOnboarding`), so
+ * re-importing from Settings never re-opens the theme tour.
+ *
+ * The E2E Playwright suite depends on this gate: playwright/auth.setup.ts seeds
+ * localStorage['mc-onboarded']='1' so the first-run "Choose your look" modal
+ * never overlays the shell and intercepts every spec's interactions. If this
+ * flag is renamed or the modal moves off localStorage, update auth.setup.ts.
+ */
+export function useOnboardingGate() {
+  const {
+    onboarded,
+    importOnboarded,
+    themeBootReady,
+    markOnboarded,
+    markImportOnboarded,
+  } = useTheme()
+
+  const locallyImportOnboarded =
+    !!localStorage.getItem('mc-import-onboarded') || !!localStorage.getItem('mc-onboarded')
+  const [showAgentImport, setShowAgentImport] = useState(false)
+  const [showOnboarding, setShowOnboarding] = useState(
+    () => locallyImportOnboarded && !localStorage.getItem('mc-onboarded'),
+  )
+
+  // Whether the currently-open import gate was opened as the first run (from
+  // boot) rather than a Settings/slash replay. First-run import always chains
+  // into the tour on completion; a replay only chains when it asked to.
+  const importFirstRun = useRef(false)
+  const continueTourAfterImport = useRef(false)
+  // Seed visibility from server boot state exactly once. Kept to a single run
+  // so a later `importOnboarded` flip (from finishing/skipping the importer)
+  // can't re-run this effect and stomp the tour the completion handler opened.
+  const bootSeeded = useRef(false)
+
+  // Dismiss onboarding when the server reports the user is already onboarded
+  // (handles the race: boot fetch completes after the useState initializer ran).
+  useEffect(() => {
+    if (onboarded) setShowOnboarding(false)
+  }, [onboarded])
+
+  useEffect(() => {
+    if (!themeBootReady || bootSeeded.current) return
+    bootSeeded.current = true
+    const firstRunImport = !importOnboarded
+    importFirstRun.current = firstRunImport
+    setShowAgentImport(firstRunImport)
+    setShowOnboarding(importOnboarded && !onboarded)
+  }, [themeBootReady, importOnboarded, onboarded])
+
+  // Settings / slash-command replay of the importer.
+  useEffect(() => {
+    const replay = (event: Event) => {
+      continueTourAfterImport.current =
+        !!(event as CustomEvent<{ continueOnboarding?: boolean }>).detail?.continueOnboarding
+      // A replay is never the first-run chain: only continue into the tour
+      // when the replay explicitly requested it.
+      importFirstRun.current = false
+      setShowOnboarding(false)
+      setShowAgentImport(true)
+    }
+    window.addEventListener('mc-start-import', replay)
+    return () => window.removeEventListener('mc-start-import', replay)
+  }, [])
+
+  const onImportComplete = useCallback(() => {
+    markImportOnboarded()
+    setShowAgentImport(false)
+    if (importFirstRun.current || continueTourAfterImport.current) {
+      setShowOnboarding(true)
+    }
+    continueTourAfterImport.current = false
+    importFirstRun.current = false
+  }, [markImportOnboarded])
+
+  const onOnboardingComplete = useCallback(() => {
+    markOnboarded()
+    setShowOnboarding(false)
+  }, [markOnboarded])
+
+  return { showAgentImport, showOnboarding, onImportComplete, onOnboardingComplete }
+}


### PR DESCRIPTION
## Problem

Skipping (or finishing) the first-run **agent-import** gate could strand the user with no further onboarding — the theme picker, About-you, and feature tour never appeared. To the user, "Skip for now" looked like it **skipped every step**.

## Root cause

The import → tour hand-off in `App.tsx` was gated on the `onboarded` flag:

```tsx
if (!onboarded || continueTourAfterImport.current) setShowOnboarding(true)
```

and the boot seed effect (`deps: [importOnboarded, themeBootReady]`) **re-fired** when `markImportOnboarded()` flipped `import_onboarded`, re-computing `showOnboarding = importOnboarded && !onboarded` — forcing it back to `false` whenever `onboarded` was already `true`.

- A genuinely new user (`onboarded=false`) was fine.
- The desynced **`onboarded=true` / `import_onboarded=false`** state was not — which is exactly what you land in when re-testing *just* the importer (flip `import_onboarded` back to false).

Reproduced with the real components: new user → tour shows ✅; `onboarded=true`+`import_onboarded=false` → nothing ❌.

## Fix (Option A — import is the front of one onboarding sequence)

Extract the gate into `hooks/useOnboardingGate.ts` and:

- **Seed visibility from server boot state exactly once** (`bootSeeded` ref) so a later `import_onboarded` flip can't re-run the seed effect and stomp the tour the completion handler just opened.
- **Track whether the import gate was opened as first-run** (`importFirstRun` ref): first-run import **always** continues into the remaining onboarding, regardless of `onboarded`. A Settings/slash replay is not a first run and only continues when it asked to (`continueOnboarding`) — so re-importing from **Settings still never reopens the theme tour**.

No visual change; behavior-only.

## Testing

- New `hooks/useOnboardingGate.test.tsx` drives the two **real** flows through the hook:
  - new user → skip import → theme tour opens
  - `onboarded=true` + `import_onboarded=false` (the regression) → skip import → tour opens
  - Settings plain-event replay → skip → tour does **not** reopen
  - `/onboarding` `continueOnboarding` replay → skip → tour opens
- `tsc -b` clean, eslint clean on changed files.
- Existing `AgentImportFlow` / `OnboardingFlow` / `SideSlashCommand` / `ImportPanel` suites green (29 tests).
