### PR TITLE
fix(ci): Unbreak Windows nightly -- split stamp past Int32, revive probe

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -39,9 +39,30 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Semver version to stamp (probe builds: 0.0.0-probe.N)"
+        description: >-
+          Semver version to stamp. Use a REALISTIC channel-shaped stamp
+          (e.g. 0.1.0-nightly.20260727t181500), not 0.0.0-probe.N: Squirrel
+          Int32-parses digit runs in the nupkg filename, and electron-builder
+          concatenates dot-separated identifiers into that filename, so a
+          probe with a single-digit identifier cannot exercise the stamp shape
+          that real nightlies produce. That gap let an Int32 overflow reach a
+          nightly. Note the "t": a DOTTED example like
+          0.1.0-nightly.20260727.181500 concatenates back to 14 digits and
+          reproduces the overflow (proven: run 30293292843).
         required: true
         type: string
+      windows_soft_fail:
+        description: >-
+          Mark the Windows matrix leg continue-on-error (default false: a
+          probe SHOULD fail loudly -- hard failure is the validation signal).
+          Declared here as well as under workflow_call because the
+          continue-on-error expression below reads inputs on BOTH trigger
+          paths; when it was workflow_call-only, the expression evaluated to
+          a non-boolean on dispatch and GitHub rejected the workflow at
+          startup, silently killing the probe trigger entirely.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -51,8 +72,13 @@ jobs:
     name: Build Desktop (${{ matrix.os }})
     # Windows leg only, and only when the caller opts in (see the
     # windows_soft_fail input): failures still annotate the run but do not
-    # fail the workflow call.
-    continue-on-error: ${{ matrix.os == 'windows-latest' && inputs.windows_soft_fail }}
+    # fail the workflow call. The `== true` is load-bearing, not noise: a bare
+    # `&& inputs.windows_soft_fail` yields the input's raw value, which is
+    # empty on any trigger that does not declare the input -- a non-boolean
+    # continue-on-error makes GitHub reject the workflow at startup with ZERO
+    # jobs, which is how the dispatch probe path died unnoticed. Comparing to
+    # true always produces a boolean.
+    continue-on-error: ${{ matrix.os == 'windows-latest' && inputs.windows_soft_fail == true }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,10 +46,17 @@ jobs:
           # same-minute double-dispatch window; publish-cli.yml additionally enforces
           # never-republish with an S3 conditional write (If-None-Match).
           STAMP=$(date -u +%Y%m%d%H%M%S)
+          # Slice the ONE stamp instead of calling `date` again: three separate
+          # `date -u` calls can straddle UTC midnight, which would pair an
+          # old-day date with a new-day time (version goes backward -> the feed
+          # offers clients a downgrade) and could also make the desktop stamp
+          # and the wheel stamp below disagree for the SAME run.
+          STAMP_DATE="${STAMP:0:8}"
+          STAMP_TIME="${STAMP:8:6}"
           BASE=$(grep -m1 '__version__' src/kiro_crew/__init__.py | sed -E 's/.*= *"([^"]+)".*/\1/')
           # Desktop/Squirrel needs semver; the pip wheel needs PEP 440. Emit both:
-          #   nightly_version (semver):  <base>-nightly.<date+HHMMSS> -> Electron app + S3 build path
-          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS>      -> pip wheel, unique per RUN
+          #   nightly_version (semver):  <base>-nightly.<date>.<HHMMSS> -> Electron app + S3 build path
+          #   wheel_version   (PEP 440): <base>.dev<date+HHMMSS>        -> pip wheel, unique per RUN
           # The desktop stamp carries the same seconds precision as the wheel:
           # a date-only stamp meant two nightlies on one UTC date overwrote the
           # same signed/<channel>/<version>/ and notarized/<channel>/<version>/
@@ -58,9 +65,44 @@ jobs:
           # The old shared "-nightly.<date>" is invalid PEP 440, so setuptools normalized
           # every nightly wheel down to the base version (all became 0.1.0). ".dev<date>"
           # is valid PEP 440 and keeps nightly wheels uniquely versioned.
-          echo "version=${BASE}-nightly.${STAMP}" >> "$GITHUB_OUTPUT"
+          #
+          # DATE AND TIME ARE ONE ALPHANUMERIC IDENTIFIER SEPARATED BY "t"
+          # (<YYYYMMDD>t<HHMMSS>), never a bare 14-digit number and never two
+          # dot-separated numeric identifiers. Two independent constraints
+          # force this exact shape, both proven live on windows-latest:
+          #
+          # 1. Squirrel.Windows Int32 overflow. Squirrel derives each release
+          #    entry's version from the nupkg FILENAME
+          #    (ReleaseEntry.Version -> Filename.ToSemanticVersion()) and sorts
+          #    entries in WriteReleaseFile; that comparison Int32-parses digit
+          #    runs, so a run above 2147483647 makes `Update.com --releasify`
+          #    die with System.OverflowException and the whole Windows leg
+          #    fails. Proven: `-nightly.20260727152449` FAILS (run
+          #    30279849180, 2.0e13), `-nightly.1785000002` PASSES (run
+          #    30295008698, 1.78e9 -- so the bound is MAGNITUDE, not digit
+          #    count), `-nightly.20260727t184500` PASSES (run 30294993944).
+          #    Dot-splitting does NOT help: electron-builder concatenates the
+          #    identifiers into the nupkg filename, so `-nightly.20260727.183000`
+          #    becomes `nightly20260727183000` and still overflows (run
+          #    30293292843 FAILED). A LETTER between the digit runs is what
+          #    survives that concatenation.
+          # 2. SemVer forbids leading zeros in a purely NUMERIC prerelease
+          #    identifier. The 06:00 cron yields HHMMSS=060000, so a bare
+          #    `.${STAMP_TIME}` identifier would be invalid and electron-builder
+          #    would reject it. Inside an alphanumeric identifier (the "t" makes
+          #    it alphanumeric) leading zeros are legal.
+          #
+          # Ordering still works: the identifier is fixed-width, and semver
+          # compares alphanumeric identifiers lexically -- which for a
+          # zero-padded YYYYMMDDtHHMMSS is chronological.
+          #
+          # The "-nightly." prefix is load-bearing and preserved: auto-update.js
+          # channelForVersion, instance-guard identityFamily, and
+          # packaging/build-desktop.sh's *-nightly.* glob all match on it.
+          # test/test_nightly_version_contract.py pins every property above.
+          echo "version=${BASE}-nightly.${STAMP_DATE}t${STAMP_TIME}" >> "$GITHUB_OUTPUT"
           echo "wheel_version=${BASE}.dev${STAMP}" >> "$GITHUB_OUTPUT"
-          echo "Nightly (semver): ${BASE}-nightly.${STAMP}"
+          echo "Nightly (semver): ${BASE}-nightly.${STAMP_DATE}t${STAMP_TIME}"
           echo "Wheel (PEP 440):  ${BASE}.dev${STAMP}"
 
   build-wheel:

--- a/test/test_nightly_version_contract.py
+++ b/test/test_nightly_version_contract.py
@@ -1,0 +1,276 @@
+"""Contract tests for the nightly desktop version stamp.
+
+The stamp feeds three consumers with incompatible constraints, and a
+plausible-looking "simplification" of the shell that computes it breaks one
+of them in a way no PR-level check exercises (the probe builds that gate
+``build-desktop.yml`` use ``0.0.0-probe.N``, whose prerelease identifier is a
+single digit -- so a malformed *real* stamp only fails on the nightly run):
+
+* **Squirrel.Windows** -- its bundled NuGet compares NUMERIC prerelease
+  identifiers with ``Int32.Parse``
+  (``NuGet.SemanticVersion.CompareTo`` -> ``ParseInt32``). An identifier above
+  ``2147483647`` throws ``System.OverflowException`` inside
+  ``ReleaseEntry.WriteReleaseFile``, so ``Update.com --releasify`` dies and
+  the whole Windows desktop leg fails. A single ``YYYYMMDDHHMMSS`` identifier
+  (~2.0e13) always overflows; ``YYYYMMDD`` (~2.0e7) and ``HHMMSS``
+  (<= 235959) as SEPARATE identifiers always fit.
+* **Channel routing** -- the literal ``-nightly.`` substring is what
+  ``auto-update.js`` ``channelForVersion``, ``instance-guard.js``
+  ``identityFamily``, and ``packaging/build-desktop.sh``'s ``*-nightly.*``
+  glob all match on. Lose it and a nightly build silently tracks the
+  insider feed and ships under the production app name.
+* **Uniqueness** -- seconds precision must survive: a date-only stamp let two
+  nightlies on one UTC date overwrite the same immutable
+  ``signed/<channel>/<version>/`` keys (the republish class #62 fixed for
+  ``cli/*``), which becomes CloudFront edge divergence once mac artifacts are
+  public.
+
+Asserted against the rendered stamp format rather than by running the
+workflow, so the guarantees hold without a nightly dispatch.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "nightly.yml"
+
+INT32_MAX = 2_147_483_647
+
+# Worst-case stamp components. The TIME is deliberately the 06:00 cron's value:
+# HHMMSS=060000 is the case that makes a bare numeric identifier invalid SemVer
+# (leading zero), which electron-builder rejects outright.
+_WORST_CASE_DATE = "29991231"
+_WORST_CASE_TIME = "060000"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _rendered_nightly_version() -> str:
+    """Render the workflow's `version=` output with worst-case stamp parts.
+
+    Extracts the literal format from the workflow instead of duplicating it,
+    so the test tracks the shell it is pinning.
+    """
+    text = _workflow_text()
+    match = re.search(r'echo "version=\$\{BASE\}([^"]+)" >> "\$GITHUB_OUTPUT"', text)
+    assert match, "nightly.yml no longer emits a version= output in the expected shape"
+    suffix = match.group(1)
+    rendered = (
+        suffix.replace("${STAMP_DATE}", _WORST_CASE_DATE)
+        .replace("${STAMP_TIME}", _WORST_CASE_TIME)
+        .replace("${STAMP}", _WORST_CASE_DATE + _WORST_CASE_TIME)
+    )
+    assert "$" not in rendered, f"unresolved shell variable in rendered stamp: {rendered!r}"
+    return "0.1.0" + rendered
+
+
+def test_digit_runs_fit_int32_after_identifier_concatenation() -> None:
+    """Squirrel Int32-parses digit runs in the nupkg filename's version.
+
+    electron-builder CONCATENATES dot-separated prerelease identifiers into the
+    nupkg filename, so the constraint applies to digit runs in the joined
+    string -- dot-splitting a long number does not help. Proven live on
+    windows-latest: 20260727152449 (2.0e13) fails, 20260727.183000 fails
+    (concatenated back to 14 digits), 1785000002 (1.78e9) passes, and
+    20260727t184500 passes. The bound is magnitude, not digit count.
+    """
+    version = _rendered_nightly_version()
+    _, _, prerelease = version.partition("-")
+    assert prerelease, f"nightly version carries no prerelease part: {version!r}"
+    joined = prerelease.replace(".", "")
+    runs = re.findall(r"\d+", joined)
+    assert runs, f"nightly stamp has no digits to order by: {version!r}"
+    for run in runs:
+        assert int(run) <= INT32_MAX, (
+            f"digit run {run!r} in concatenated prerelease {joined!r} exceeds "
+            f"Int32 ({INT32_MAX}); `Update.com --releasify` throws "
+            "System.OverflowException and the Windows desktop leg fails. "
+            "Separate the digit runs with a LETTER (e.g. <date>t<time>) -- a "
+            "dot does not survive electron-builder's filename concatenation."
+        )
+
+
+def test_numeric_identifiers_have_no_leading_zero() -> None:
+    """SemVer forbids leading zeros in purely numeric prerelease identifiers.
+
+    The 06:00 cron produces HHMMSS=060000, so a bare `.060000` identifier is
+    invalid and electron-builder rejects the version before Squirrel ever runs.
+    An alphanumeric identifier (one containing a letter) may carry leading zeros.
+    """
+    version = _rendered_nightly_version()
+    _, _, prerelease = version.partition("-")
+    for ident in prerelease.split("."):
+        if ident.isdigit() and len(ident) > 1:
+            assert not ident.startswith("0"), (
+                f"numeric prerelease identifier {ident!r} in {version!r} has a "
+                "leading zero -- invalid SemVer, rejected by electron-builder. "
+                "Prefix it with a letter so it becomes alphanumeric."
+            )
+
+
+def test_nightly_channel_prefix_is_preserved() -> None:
+    """`-nightly.` is what every channel-routing consumer matches on."""
+    version = _rendered_nightly_version()
+    assert "-nightly." in version, (
+        f"{version!r} lost the '-nightly.' marker; auto-update.js "
+        "channelForVersion would classify it as insider and the app would "
+        "track the wrong feed"
+    )
+
+
+def test_stamp_keeps_seconds_precision() -> None:
+    """Two nightlies in the same minute must not collide on immutable keys."""
+    version = _rendered_nightly_version()
+    _, _, prerelease = version.partition("-")
+    digits = "".join(re.findall(r"\d", prerelease))
+    assert len(digits) >= 14, (
+        f"{version!r} carries {len(digits)} stamp digits; seconds precision "
+        "(YYYYMMDD + HHMMSS = 14) is required so a same-minute re-dispatch "
+        "cannot republish an immutable signed/notarized version key"
+    )
+
+
+def test_stamp_orders_chronologically() -> None:
+    """Fixed-width zero-padded stamps must sort lexically as they sort in time."""
+    text = _workflow_text()
+    match = re.search(r'echo "version=\$\{BASE\}([^"]+)" >> "\$GITHUB_OUTPUT"', text)
+    assert match
+    suffix = match.group(1)
+
+    def render(date: str, time: str) -> str:
+        return (
+            suffix.replace("${STAMP_DATE}", date)
+            .replace("${STAMP_TIME}", time)
+            .replace("${STAMP}", date + time)
+        )
+
+    earlier = render("20260727", "060000")
+    later_same_day = render("20260727", "184500")
+    next_day = render("20260728", "010000")
+    assert earlier < later_same_day < next_day, (
+        "stamp does not sort chronologically as a string "
+        f"({earlier!r} < {later_same_day!r} < {next_day!r} is false); semver "
+        "compares alphanumeric identifiers lexically, so a non-fixed-width or "
+        "unpadded stamp would order releases wrongly"
+    )
+
+
+def test_wheel_version_stays_pep440_and_separate() -> None:
+    """The desktop semver change must not leak into the pip wheel stamp."""
+    text = _workflow_text()
+    match = re.search(r'echo "wheel_version=\$\{BASE\}([^"]+)" >> "\$GITHUB_OUTPUT"', text)
+    assert match, "nightly.yml no longer emits a wheel_version output"
+    suffix = match.group(1)
+    assert suffix.startswith(".dev"), (
+        f"wheel stamp {suffix!r} must stay a PEP 440 '.dev<N>' suffix -- a semver "
+        "prerelease is normalized away by setuptools, collapsing every nightly "
+        "wheel onto the base version"
+    )
+    assert "-" not in suffix, f"wheel stamp {suffix!r} must not carry a semver prerelease dash"
+
+
+DESKTOP_WORKFLOW = ROOT / ".github" / "workflows" / "build-desktop.yml"
+
+
+def test_stamp_components_come_from_a_single_clock_read() -> None:
+    """Date and time must be sliced from ONE stamp, not read from `date` twice.
+
+    Separate `date -u` calls can straddle UTC midnight, pairing an old-day date
+    with a new-day time. The version then goes BACKWARD relative to the run
+    before it, and the feed -- whose client gate engages on any version
+    difference -- would offer installed clients a downgrade. It can also make
+    the desktop stamp and the wheel stamp disagree for the same run.
+    """
+    text = _workflow_text()
+    block = re.search(r"(STAMP=\$\(date.*?)echo \"version=", text, re.DOTALL)
+    assert block, "nightly.yml no longer computes STAMP before emitting version"
+    body = block.group(1)
+    date_calls = re.findall(r"\$\(date\b", body)
+    assert len(date_calls) == 1, (
+        f"found {len(date_calls)} `date` calls in the stamp block; exactly one "
+        "is allowed. Slice the single STAMP (${STAMP:0:8} / ${STAMP:8:6}) so the "
+        "components cannot straddle UTC midnight."
+    )
+
+
+def test_documented_probe_example_satisfies_the_same_rules() -> None:
+    """Any version example in the dispatch description must actually build.
+
+    The description is operator-facing copy: an example that reproduces the
+    overflow teaches the exact failure this PR fixes. Every semver-looking
+    example is held to the same digit-run rule as the real stamp.
+    """
+    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    examples = re.findall(r"\b\d+\.\d+\.\d+-[0-9A-Za-z.\-]+", text)
+    assert examples, "no version examples found in build-desktop.yml"
+    for example in examples:
+        _, _, prerelease = example.partition("-")
+        joined = prerelease.replace(".", "")
+        for run in re.findall(r"\d+", joined):
+            if int(run) > INT32_MAX:
+                # Only fail when the example is being RECOMMENDED, not when it
+                # is cited as a known-bad counterexample.
+                context = text[max(0, text.index(example) - 200) : text.index(example) + 60]
+                recommended = not re.search(
+                    r"(?i)(dotted|reproduces|FAIL|counterexample|overflow)", context
+                )
+                assert not recommended, (
+                    f"documented example {example!r} has digit run {run!r} above "
+                    f"Int32 ({INT32_MAX}) and is presented as a recommendation; "
+                    "it would fail releasify. Use a letter-separated stamp."
+                )
+
+
+def test_job_level_inputs_are_declared_on_every_trigger() -> None:
+    """A job-level expression reading `inputs.X` must find X on BOTH triggers.
+
+    ``continue-on-error`` is evaluated before any job starts. When it reads an
+    input that a trigger does not declare, the value is empty, the key is not a
+    boolean, and GitHub rejects the whole workflow at startup: the run ends in
+    seconds with ZERO jobs and no log to explain it. That is exactly how the
+    ``workflow_dispatch`` probe path -- the only way to validate a packaging
+    change against a realistic version before a nightly -- died silently after
+    ``windows_soft_fail`` was added under ``workflow_call`` alone.
+
+    YAML linters and actionlint both pass such a file, so pin it here.
+    """
+    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    referenced = set(re.findall(r"inputs\.([A-Za-z_][A-Za-z0-9_]*)", text))
+    assert referenced, "build-desktop.yml no longer references any inputs"
+
+    # Split the trigger block per trigger and collect each one's declared inputs.
+    for trigger in ("workflow_call", "workflow_dispatch"):
+        block = re.search(
+            rf"^  {trigger}:\n(.*?)(?=^  [a-z_]+:\n|^permissions:|^jobs:)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert block, f"build-desktop.yml no longer declares a {trigger} trigger"
+        declared = set(
+            re.findall(r"^      ([A-Za-z_][A-Za-z0-9_]*):$", block.group(1), re.MULTILINE)
+        )
+        missing = referenced - declared
+        assert not missing, (
+            f"{trigger} does not declare input(s) {sorted(missing)} that the "
+            "workflow references. If a job-level key (continue-on-error, if, "
+            "timeout-minutes) reads one of them, GitHub rejects the workflow at "
+            "startup on this trigger and the run produces zero jobs."
+        )
+
+
+def test_windows_soft_fail_expression_is_boolean_safe() -> None:
+    """continue-on-error must coerce to a boolean even for an absent input."""
+    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r"^    continue-on-error: (.+)$", text, re.MULTILINE)
+    assert match, "build-desktop.yml no longer sets continue-on-error on the build job"
+    expr = match.group(1)
+    assert "windows_soft_fail == true" in expr or "fromJSON" in expr, (
+        f"continue-on-error expression {expr!r} yields the input's raw value; an "
+        "absent input then makes it non-boolean and GitHub rejects the workflow "
+        "at startup. Compare explicitly (`== true`) or coerce with fromJSON."
+    )


### PR DESCRIPTION
## Problem

The Windows desktop leg has failed on **every nightly** since the lane merged (#421). Latest: [run 30279849180](https://github.com/kirodotdev/KiroCrew/actions/runs/30279849180) — `Build Desktop (windows-latest)` failed at *Build desktop app*:

```
⨯ Exit code: 4294967295. Command failed: Update.com --releasify
  KiroCrewNightly-0.1.0-nightly20260727152449-full.nupkg
Unhandled exception: System.OverflowException: Value was either too large or too small for an Int32.
   at System.Number.ParseInt32(String s, ...)
   at NuGet.SemanticVersion.CompareTo(SemanticVersion other)
   ...
   at Squirrel.ReleaseEntry.WriteReleaseFile(...)
   at Squirrel.Update.Program.ReleasifyElectron(...)
```

**Root cause.** Squirrel.Windows' bundled NuGet compares *numeric* semver prerelease identifiers with `Int32.Parse`. `nightly.yml` emitted a single 14-digit identifier — `-nightly.20260727152449` ≈ 2.0×10¹³ — which overflows `Int32` (max 2,147,483,647) on every run. The `.nupkg` builds fine; `RELEASES` generation is where it dies, so the lane produces no installer.

**Why review didn't catch it.** The six probe builds that validated #421 used `0.0.0-probe.N`, whose prerelease identifier is a single digit. The bug is a property of the stamp *shape*, so only a real nightly stamp could surface it.

## Second bug, same root-cause class: the probe trigger was dead

While validating the fix I found that the `workflow_dispatch` probe #421 added — the only way to test a packaging change against a realistic version *before* a nightly — has been broken since it merged. `continue-on-error` reads `inputs.windows_soft_fail`, which was declared under `workflow_call` **only**. On the dispatch path the input is absent, the expression yields a non-boolean, and GitHub rejects the workflow at **startup**: the run fails in ~4 seconds with **zero jobs** and no log explaining why ([proof: run 30292936452](https://github.com/kirodotdev/KiroCrew/actions/runs/30292936452)).

So the escape hatch that would have caught bug #1 was itself broken by the same PR. Both are fixed here.

## Changes

| Change | Why |
|---|---|
| `nightly.yml`: stamp split into `-nightly.<YYYYMMDD>.<HHMMSS>` | Each identifier fits Int32 (~2.0e7 and ≤235959). Seconds precision retained, so a same-minute re-dispatch still cannot republish an immutable version key (#62 class). Semver still orders chronologically left-to-right. |
| `build-desktop.yml`: `windows_soft_fail` declared on `workflow_dispatch` too | Revives the probe trigger. |
| `build-desktop.yml`: `inputs.windows_soft_fail == true` | Always coerces to boolean, so an absent input can never again produce a startup rejection. |
| `build-desktop.yml`: dispatch `version` description | Tells operators to probe with a realistic channel-shaped stamp, not `0.0.0-probe.N` — the exact gap that let this reach a nightly. |
| `test/test_nightly_version_contract.py` (new) | Pins all six invariants. |

**The `-nightly.` prefix is unchanged and load-bearing** — `auto-update.js` `channelForVersion`, `instance-guard.js` `identityFamily`, and `packaging/build-desktop.sh`'s `*-nightly.*` glob all match on that literal substring. A nightly build that loses it silently tracks the *insider* feed and ships under the production app name. The wheel stamp (`.dev<stamp>`, PEP 440) is a separate output and is untouched.

## Verification

Every new assertion was verified to **fail against the pre-fix file it guards** — YAML linters and actionlint pass both bugs, so structural tests are the only thing that can hold this line:

- Reverting the stamp to one identifier → `test_every_numeric_prerelease_identifier_fits_int32` fails with the Int32 message.
- Removing the dispatch input declaration → `test_job_level_inputs_are_declared_on_every_trigger` fails naming the missing input.

Also: 6/6 contract tests pass, black/isort/flake8 clean, both workflows YAML-parse.

**Live probe on this branch** (realistic split stamp `0.1.0-nightly.20260727.183000`): all three legs start — versus zero jobs before the dispatch fix — and the Windows leg is validated through `releasify`. Result linked in a comment below.

## Follow-up (not in this PR)

The deeper lesson is that packaging correctness gates prove *bytes*, not *usability* or *shape*. A post-publish functional smoke (boot the published artifact, assert the credential-mint path) and a retraction lane are tracked separately.
