### PR TITLE
feat: enable touch/pen sidebar resize on tablets (>=768px)

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -32,6 +32,7 @@ import { useSessionActions } from '../hooks/useSessionActions'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import { isTouchDevice } from '../utils/isTouchDevice'
 import { safeSetItem } from '../utils/safeStorage'
 import { resolveFolderAgent, resolveFolderProjectDir } from '../utils/folderAgent'
@@ -993,10 +994,13 @@ function ChatSidebar({
     if (!renamingSlot && !editingId && !creatingIn) suppressMenuRestoreRef.current = false
   }, [renamingSlot, editingId, creatingIn])
 
-  // Resize logic
-  const sidebarDragging = useRef(false)
-  const sidebarStartX = useRef(0)
+  // Resize logic — Pointer Events (mouse + touch + pen) via usePointerDrag, so
+  // the handle works on touch devices too, e.g. a tablet at desktop width where
+  // the sidebar is a side-by-side panel (the mouse-only handler ignored touch).
+  // setPointerCapture keeps move/up firing when the pointer leaves the thin
+  // handle, replacing the old window-level mousemove/mouseup listeners.
   const sidebarStartW = useRef(0)
+  const sidebarDraggingRef = useRef(false)
   const sidebarWidthRef = useRef(sidebarWidth)
   sidebarWidthRef.current = sidebarWidth
   const onWidthChangeRef = useRef(onWidthChange)
@@ -1005,34 +1009,44 @@ function ChatSidebar({
   onDragChangeRef.current = onDragChange
   useEffect(() => { onWidthChangeRef.current?.(sidebarWidth) }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => {
-      if (!sidebarDragging.current) return
-      const newW = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarStartW.current + e.clientX - sidebarStartX.current))
+  // threshold 0: a dedicated edge affordance resizes immediately on press (no
+  // 10px hysteresis), matching the original mouse resizer's feel.
+  const sidebarResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => {
+      sidebarStartW.current = sidebarWidthRef.current
+      sidebarDraggingRef.current = true
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+      onDragChangeRef.current?.(true)
+    },
+    onMove: ({ dx }) => {
+      const newW = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarStartW.current + dx))
       setSidebarWidth(newW)
       onWidthChangeRef.current?.(newW)
-    }
-    const onUp = () => {
-      if (!sidebarDragging.current) return
-      sidebarDragging.current = false
+    },
+    onEnd: () => {
+      sidebarDraggingRef.current = false
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
       onDragChangeRef.current?.(false)
       const w = sidebarWidthRef.current
       safeSetItem(SIDEBAR_LS_KEY, String(w))
       onWidthChangeRef.current?.(w)
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-      if (sidebarDragging.current) {
-        sidebarDragging.current = false
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        onDragChangeRef.current?.(false)
-      }
+    },
+  })
+
+  // Unmount guard: if the sidebar unmounts mid-drag (collapse / route change),
+  // onEnd never fires — setPointerCapture dies with the element — so the global
+  // body styles and the parent's dragging state would stay stuck. Restore them
+  // on teardown. The old mouse-only handler did this in its listener cleanup;
+  // the pointer migration must preserve it.
+  useEffect(() => () => {
+    if (sidebarDraggingRef.current) {
+      sidebarDraggingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      onDragChangeRef.current?.(false)
     }
   }, [])
 
@@ -2161,11 +2175,18 @@ function ChatSidebar({
   return (
     // stable theming hook 'sidebar' — see website/docs/theming-contract.md
     <div className="sidebar sidebar-inner bg-bg-elevated border border-border rounded-xl shadow-sm flex flex-col shrink-0 relative h-full" style={{ width: sidebarWidth }}>
-      {/* Drag handle — mouse-only column resize gesture; no keyboard analogue. */}
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      {/* Drag handle — Pointer-Events column resize (mouse + touch + pen).
+          role="separator" gives it correct ARIA; touch-action:none so a touch
+          drag resizes the panel instead of scrolling the page. Pointer capture
+          (in usePointerDrag) continues the drag off the thin handle. No
+          keyboard analogue for a drag splitter. */}
       <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize sidebar"
         className="sidebar-resize-handle absolute top-0 -right-[2px] w-[5px] h-full cursor-col-resize z-10 group/drag flex items-center justify-center"
-        onMouseDown={e => { e.preventDefault(); sidebarDragging.current = true; sidebarStartX.current = e.clientX; sidebarStartW.current = sidebarWidth; document.body.style.cursor = 'col-resize'; document.body.style.userSelect = 'none'; onDragChange?.(true) }}
+        style={{ touchAction: 'none' }}
+        {...sidebarResize}
       >
         <div className="w-[2px] h-full bg-transparent group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-colors duration-200" />
       </div>

--- a/website/src/test/ChatSidebar.resizeTouch.test.tsx
+++ b/website/src/test/ChatSidebar.resizeTouch.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Sidebar column resize via Pointer Events (mouse + touch + pen).
+ *
+ * The handle used to be `onMouseDown` + window mousemove/mouseup, which never
+ * fired for a touch drag — so a tablet at desktop width (where the sidebar is a
+ * side-by-side panel with a visible handle) could not resize it. It now uses
+ * usePointerDrag, so the same gesture works for any pointer type.
+ *
+ * Locks the contract:
+ *  (1) A pointer drag on the handle changes the panel width by the pointer delta.
+ *  (2) Width is clamped to [SIDEBAR_MIN, SIDEBAR_MAX].
+ *  (3) The final width persists to localStorage on pointer-up.
+ *  (4) onDragChange brackets the gesture (true on down, false on up).
+ *
+ * fireEvent.pointer* is the input path a touch drag takes in the browser; the
+ * handler is pointer-type-agnostic, so exercising it proves touch works too.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: () => vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+// Desktop viewport: not mobile, so the sidebar renders as a side-by-side panel
+// with the resize handle visible (the mobile overlay CSS-hides the handle).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar, { SIDEBAR_MIN, SIDEBAR_MAX } from '../pages/ChatSidebar'
+
+const SLOTS = [
+  { key: 'k1', title: 'One', messages: 1, running: false, modified: 1000 },
+]
+
+function renderSidebar() {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots: SLOTS, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {} } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  const onWidthChange = vi.fn()
+  const onDragChange = vi.fn()
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={SLOTS} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+              onWidthChange={onWidthChange} onDragChange={onDragChange}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  const handle = utils.container.querySelector('.sidebar-resize-handle') as HTMLElement
+  const panel = utils.container.querySelector('.sidebar-inner') as HTMLElement
+  return { ...utils, handle, panel, onWidthChange, onDragChange }
+}
+
+// Default width when localStorage is empty (see ChatSidebar useState init).
+const DEFAULT_W = 260
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — pointer/touch resize', () => {
+  it('exposes the handle as an accessible vertical separator', () => {
+    const { getByRole } = renderSidebar()
+    const sep = getByRole('separator', { name: 'Resize sidebar' })
+    expect(sep).toBeTruthy()
+    expect(sep.getAttribute('aria-orientation')).toBe('vertical')
+    // touch-action:none lets a touch drag resize instead of scrolling the page.
+    expect(sep.style.touchAction).toBe('none')
+  })
+
+  it('a pointer drag widens the panel by the pointer delta and persists it', () => {
+    const { handle, panel, onWidthChange, onDragChange } = renderSidebar()
+    fireEvent.pointerDown(handle, { clientX: DEFAULT_W, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: DEFAULT_W + 100, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: DEFAULT_W + 100, pointerId: 1 })
+
+    expect(panel.style.width).toBe(`${DEFAULT_W + 100}px`)
+    expect(onWidthChange).toHaveBeenCalledWith(DEFAULT_W + 100)
+    expect(localStorage.getItem('mc-sidebar-width')).toBe(String(DEFAULT_W + 100))
+    // Drag state brackets the gesture.
+    expect(onDragChange).toHaveBeenCalledWith(true)
+    expect(onDragChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('clamps width to SIDEBAR_MIN when dragged far left', () => {
+    const { handle, panel } = renderSidebar()
+    fireEvent.pointerDown(handle, { clientX: DEFAULT_W, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: DEFAULT_W - 5000, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: DEFAULT_W - 5000, pointerId: 1 })
+    expect(panel.style.width).toBe(`${SIDEBAR_MIN}px`)
+    expect(localStorage.getItem('mc-sidebar-width')).toBe(String(SIDEBAR_MIN))
+  })
+
+  it('clamps width to SIDEBAR_MAX when dragged far right', () => {
+    const { handle, panel } = renderSidebar()
+    fireEvent.pointerDown(handle, { clientX: DEFAULT_W, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: DEFAULT_W + 100000, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: DEFAULT_W + 100000, pointerId: 1 })
+    expect(panel.style.width).toBe(`${SIDEBAR_MAX}px`)
+  })
+
+  it('restores body styles and clears drag state if unmounted mid-drag', () => {
+    const { handle, onDragChange, unmount } = renderSidebar()
+    fireEvent.pointerDown(handle, { clientX: DEFAULT_W, pointerId: 1 })
+    // Drag started: body is locked and the parent is told dragging=true.
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(onDragChange).toHaveBeenCalledWith(true)
+    // Unmount mid-drag (collapse / route change) with no pointerup — the
+    // teardown guard must restore the global body styles and clear drag state
+    // so nothing is left stuck (onEnd can't fire once the element is gone).
+    unmount()
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+    expect(onDragChange).toHaveBeenLastCalledWith(false)
+  })
+})


### PR DESCRIPTION
## Problem
The sidebar column-resize handle can't be dragged on touch devices. On a touch device at desktop width (≥768px) — a tablet, or a phone in landscape — the sidebar renders as a side-by-side panel with a visible resize handle, but dragging it does nothing.

## Why it matters
Tablet and landscape-phone users are stuck with the default sidebar width and no way to adjust it, even though the handle is right there and looks draggable. (Portrait phones <768px are **not** affected: there the sidebar is a full-width overlay drawer and the handle is CSS-hidden by design — that path is intentionally out of scope.)

## Fix (symptom → root cause → change)
- **Symptom:** dragging the visible handle on a tablet does nothing.
- **Root cause:** the handle used `onMouseDown` + window `mousemove`/`mouseup` listeners (`e.clientX`). Touch drags don't emit those mouse events, so the whole gesture was mouse-only.
- **Change:** swap the ad-hoc mouse handler for the existing `usePointerDrag` hook (Pointer Events + `setPointerCapture`) — the same hook `DetailPanel` already uses for its splitter — so mouse, touch, and pen share one code path. Added `role="separator"` + `aria-orientation` + `aria-label` for correct ARIA, and `touch-action: none` so a touch drag resizes the panel instead of scrolling the page. Handle geometry, appearance, min/max clamping, and the `mc-sidebar-width` localStorage persistence are all unchanged.

## Tests
New `website/src/test/ChatSidebar.resizeTouch.test.tsx` (4 tests) drives the handle with `fireEvent.pointer*` (the path a touch drag takes) and locks:
- a pointer drag widens the panel by the pointer delta, fires `onWidthChange`, persists to `mc-sidebar-width`, and brackets the gesture with `onDragChange(true→false)`;
- width clamps to `SIDEBAR_MIN` / `SIDEBAR_MAX` at the extremes;
- the handle exposes `role="separator"`, `aria-orientation="vertical"`, and `touch-action: none`.

All 60 `ChatSidebar.*` tests pass; `tsc -b` clean; `eslint src/` within the warning budget (0 errors).

## Manual verification
Verified live on a tablet at ≥768px via the dev gateway (tunnel): dragging the sidebar's right edge now resizes it and the width persists across reload. Desktop mouse-drag behavior is unchanged.

## Screenshots
N/A — no visual change. The handle is pixel-identical to before (same 5px hit strip, same 2px accent line); only the input modality changed (mouse-only → pointer/touch/pen). A screenshot would be indistinguishable from `main`.
