### PR TITLE
fix: preserve macOS Electron helper identity

### DIFF
--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -30,6 +30,9 @@ The electron-builder configuration lives in
 
 - **appId:** `dev.kirocrew.desktop`
 - **productName:** `KiroCrew`
+- macOS display name: `Kiro Crew` via `CFBundleDisplayName`; `CFBundleName`
+  remains aligned with `productName` because Electron uses it to locate the
+  `KiroCrew Helper` app bundles during startup
 - mac target: `dmg` (category `public.app-category.developer-tools`)
 - linux target: `AppImage` (category `Development`)
 

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -403,12 +403,12 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       "-c.mac.icon=icon-nightly.png"
       "-c.linux.icon=icon-nightly.png"
       "-c.win.icon=icon-nightly.png"
-      # Menu-bar/Dock title (CFBundleName) mirrors the spaced display name. The
-      # static package.json extendInfo hard-codes "Kiro Crew"; nightly must
-      # re-override it or its menu bar would drop the "Nightly" suffix. The
-      # space-free .app FILENAME still comes from productName above, so CDN
-      # keys / DMG volume / notarization slugs are unaffected.
-      "-c.mac.extendInfo.CFBundleName=Kiro Crew Nightly"
+      # Finder/Dock title (CFBundleDisplayName) mirrors the spaced display
+      # name. Never override CFBundleName: Electron derives its helper-app
+      # paths from that internal name, so changing it while productName stays
+      # space-free makes the packaged app abort with "Unable to find helper
+      # app". Nightly re-overrides the static display name to keep its suffix.
+      "-c.mac.extendInfo.CFBundleDisplayName=Kiro Crew Nightly"
       # Squirrel.Windows keys the INSTALL identity off squirrelWindows.name
       # (install dir %LocalAppData%\<name>, shortcuts, and the RELEASES/
       # .nupkg feed identity). On mac, a distinct productName alone gives

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -35,7 +35,7 @@
       "notarize": false,
       "x64ArchFiles": "{**/backend-dist/**,**/backend-dist/**/.*/**}",
       "extendInfo": {
-        "CFBundleName": "Kiro Crew"
+        "CFBundleDisplayName": "Kiro Crew"
       }
     },
     "afterSign": "scripts/notarize.js",

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -22,3 +22,31 @@ describe("electron-builder files list", () => {
     assert.deepStrictEqual(stale, [], `Stale entries in build.files: ${stale.join(", ")}`);
   });
 });
+
+
+describe("macOS bundle naming", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  const extendInfo = pkg.build.mac.extendInfo || {};
+  const buildScript = fs.readFileSync(
+    path.resolve(ROOT, "..", "..", "packaging", "build-desktop.sh"),
+    "utf8"
+  );
+
+  it("keeps CFBundleName aligned with productName for Electron helpers", () => {
+    assert.equal(pkg.build.productName, "KiroCrew");
+    assert.equal(
+      Object.hasOwn(extendInfo, "CFBundleName"),
+      false,
+      "CFBundleName overrides break Electron helper-app discovery"
+    );
+  });
+
+  it("uses CFBundleDisplayName for spaced stable and nightly names", () => {
+    assert.equal(extendInfo.CFBundleDisplayName, "Kiro Crew");
+    assert.match(
+      buildScript,
+      /-c\.mac\.extendInfo\.CFBundleDisplayName=Kiro Crew Nightly/
+    );
+    assert.doesNotMatch(buildScript, /-c\.mac\.extendInfo\.CFBundleName=/);
+  });
+});


### PR DESCRIPTION
## Summary

- use `CFBundleDisplayName` for the spaced macOS app label
- keep `CFBundleName` aligned with `productName` so Electron can locate `KiroCrew Helper.app`
- apply the same helper-safe naming to nightly packages
- add regression coverage and document the bundle naming contract

## Root cause

PR #578 overrode the main bundle's `CFBundleName` as `Kiro Crew`, while electron-builder continued emitting `KiroCrew Helper.app`. Electron derives its helper path from `CFBundleName` and aborted before JavaScript startup with:

```
FATAL:electron_main_delegate_mac.mm(65) Unable to find helper app
```

## Validation

- `npm test` (266 passed)
- `bash -n packaging/build-desktop.sh`
- `git diff --check`
- packaged a temporary arm64 app with electron-builder and verified:
  - `CFBundleName=KiroCrew`
  - `CFBundleDisplayName=Kiro Crew`
  - `KiroCrew Helper.app` exists
- smoke-launched the packaged app with isolated state and confirmed it remained alive
