### PR TITLE
ci(review): raise Opus review turn budget for large PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -139,7 +139,7 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-5
             --fallback-model us.anthropic.claude-opus-4-8
-            --max-turns 60
+            --max-turns 120
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*)"
             --json-schema '{"type":"object","additionalProperties":false,"required":["reviewed","block_merge","summary"],"properties":{"reviewed":{"type":"boolean","description":"true once you have completed the review of this commit"},"block_merge":{"type":"boolean","description":"true IFF at least one finding meets WHAT BLOCKS (a blocking:true AUTOSDE rule violation, or a reachable residual-class defect)"},"summary":{"type":"string","description":"markdown review summary CI will post to the PR"}}}'
           prompt: |


### PR DESCRIPTION
## Problem

`--max-turns 60` on the Opus 5 Review lane deterministically exhausts on wide diffs. Evidence: PR #422 (30-file diff) has died to `error_max_turns` on 5 consecutive attempts across 4 different heads — zero completions — and the gate correctly fails closed on a missing structured verdict, so no rerun can ever pass. The lane hard-blocks any sufficiently large PR.

## Fix

Raise the agentic turn budget to 120. The runaway bound is preserved unchanged: `timeout-minutes: 30` still cancels a wedged review and the gate still fails closed on no output. This only lets a legitimate wide review finish its single pass.

## Tested

Root-caused from the failing runs' logs (`"subtype": "error_max_turns"` followed by the fail-closed gate). One-line workflow change; no product code.