### PR TITLE
feat: touch-enable all remaining mouse-only resize handles

### DIFF
--- a/website/src/apps/file-explorer/FileExplorerPage.tsx
+++ b/website/src/apps/file-explorer/FileExplorerPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useQuery, useQueryClient, useMutation, useQueries } from '@tanstack/react-query'
+import { usePointerDrag } from '../../hooks/usePointerDrag'
 import { AlertTriangle, MessageSquare, Eye, CornerDownRight, Copy, ArrowUpFromLine } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../../store'
@@ -289,21 +290,17 @@ export default function FileExplorerPage() {
   }, [toggleSearch, newFolderTabAction, closeFolderTab, closeFileTab, activeFile, activeFolder])
 
   // ── Resizer ──
-  const dragRef = useRef({ active: false, startX: 0, startW: 0 })
-  const onResizeStart = (e: React.MouseEvent) => {
-    dragRef.current = { active: true, startX: e.clientX, startW: leftWidth }
-    document.body.style.cursor = 'col-resize'
-  }
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => {
-      if (!dragRef.current.active) return
-      setLeftWidth(Math.max(180, Math.min(640, dragRef.current.startW + (e.clientX - dragRef.current.startX))))
-    }
-    const onUp = () => { if (dragRef.current.active) { dragRef.current.active = false; document.body.style.cursor = '' } }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp) }
-  }, [])
+  const startWRef = useRef(0)
+  const leftDraggingRef = useRef(false)
+  const leftResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => { startWRef.current = leftWidth; leftDraggingRef.current = true; document.body.style.cursor = 'col-resize' },
+    onMove: ({ dx }) => { setLeftWidth(Math.max(180, Math.min(640, startWRef.current + dx))) },
+    onEnd: () => { leftDraggingRef.current = false; document.body.style.cursor = '' },
+  })
+  // Unmount guard: onEnd can't fire if the pane unmounts mid-drag, so clear the
+  // global resize cursor here to avoid leaving it stuck.
+  useEffect(() => () => { if (leftDraggingRef.current) document.body.style.cursor = '' }, [])
 
   // ── Derived state (must be above early returns for Rules of Hooks) ──
   const rootGitInfo = useMemo(() => {
@@ -399,7 +396,7 @@ export default function FileExplorerPage() {
         {/* Pane splitter: mouse-drag-only resize affordance; role=separator is
             correct for a window splitter but is non-interactive per jsx-a11y. */}
         {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-        <div className="mc-fe-resizer" aria-label="Resize panel" onMouseDown={onResizeStart} role="separator" tabIndex={-1} />
+        <div className="mc-fe-resizer" aria-label="Resize panel" aria-orientation="vertical" role="separator" tabIndex={-1} style={{ touchAction: 'none' }} {...leftResize} />
         <div className="mc-fe-right">
           {showSearch ? (
             <SearchPanel

--- a/website/src/apps/issue-radar/Workspace.tsx
+++ b/website/src/apps/issue-radar/Workspace.tsx
@@ -12,7 +12,7 @@
 // registry. 'settings' shows the Settings page in the same area. The rail stays
 // visible in every mode. All shared state comes from useIssueRadar(); this file
 // owns only presentational layout (column resize).
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { CircleDot, GitPullRequest } from 'lucide-react'
 import { useIssueRadar } from './context'
 import {
@@ -25,32 +25,43 @@ import PrList from './components/PrList'
 import PrDetail from './components/PrDetail'
 import SettingsView from './views/SettingsView'
 import { dashboardComponent } from './views/registry'
+import { usePointerDrag } from '../../hooks/usePointerDrag'
 
 export default function Workspace() {
   const { mainView, dashboardTab, activeIssue, activePull } = useIssueRadar()
   const [listWidth, setListWidth] = useState<number>(loadListWidth)
 
-  const startResize = (e: React.MouseEvent) => {
-    e.preventDefault()
-    const startX = e.clientX
-    const startW = listWidth
-    let latest = startW
-    const onMove = (ev: MouseEvent) => {
-      latest = Math.min(MAX_LIST_WIDTH, Math.max(MIN_LIST_WIDTH, startW + ev.clientX - startX))
-      setListWidth(latest)
-    }
-    const onUp = () => {
-      localStorage.setItem(LIST_WIDTH_KEY, String(latest))
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+  const startWRef = useRef(0)
+  const listDraggingRef = useRef(false)
+  const listResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => {
+      startWRef.current = listWidth
+      listDraggingRef.current = true
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    },
+    onMove: ({ dx }) => {
+      setListWidth(Math.min(MAX_LIST_WIDTH, Math.max(MIN_LIST_WIDTH, startWRef.current + dx)))
+    },
+    onEnd: ({ dx }) => {
+      listDraggingRef.current = false
+      const finalW = Math.min(MAX_LIST_WIDTH, Math.max(MIN_LIST_WIDTH, startWRef.current + dx))
+      localStorage.setItem(LIST_WIDTH_KEY, String(finalW))
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    },
+  })
+  // Unmount guard: onEnd can't fire if the component unmounts mid-drag
+  // (setPointerCapture dies with the element), so restore the global body styles
+  // here to avoid leaving the resize cursor / text-selection lock stuck.
+  useEffect(() => () => {
+    if (listDraggingRef.current) {
+      listDraggingRef.current = false
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-  }
+  }, [])
 
   const DashboardView = dashboardComponent(dashboardTab)
 
@@ -66,9 +77,13 @@ export default function Workspace() {
 
           {/* Drag handle — resize the issue-list column. */}
           <div
-            onMouseDown={startResize}
+            {...listResize}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize list"
             title="Drag to resize"
             className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-accent/30 transition-colors"
+            style={{ touchAction: 'none' }}
           />
 
           <main className="flex-1 min-w-0 min-h-0">
@@ -94,9 +109,13 @@ export default function Workspace() {
 
           {/* Drag handle — resize the PR-list column. */}
           <div
-            onMouseDown={startResize}
+            {...listResize}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize list"
             title="Drag to resize"
             className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-accent/30 transition-colors"
+            style={{ touchAction: 'none' }}
           />
 
           <main className="flex-1 min-w-0 min-h-0">

--- a/website/src/components/BottomTerminalPanel.tsx
+++ b/website/src/components/BottomTerminalPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence, Reorder } from 'framer-motion'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import { useLocation } from 'react-router-dom'
 import { TerminalSquare, Plus, X, ChevronDown, PanelRight } from 'lucide-react'
 import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from './CliPanel'
@@ -115,29 +116,26 @@ export default function BottomTerminalPanel() {
   }, [canTransferToChat, chatTabs, dispatch])
 
   /* ── Top grip resize (drag up → taller) ── */
-  const startRef = useRef<{ y: number; h: number } | null>(null)
-  const onGripDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    startRef.current = { y: e.clientY, h: height }
-    setDragging(true)
-    const onMove = (ev: MouseEvent) => {
-      if (!startRef.current) return
+  const startHRef = useRef(0)
+  const gripResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => {
+      startHRef.current = height
+      setDragging(true)
+      document.body.style.userSelect = 'none'
+      document.body.style.cursor = 'row-resize'
+    },
+    onMove: ({ dy }) => {
+      // Grip is at the panel TOP, so dragging UP (dy < 0) grows the panel.
       const maxH = Math.round(window.innerHeight * MAX_VH)
-      setBottomTerminalHeight(Math.min(maxH, startRef.current.h + (startRef.current.y - ev.clientY)))
-    }
-    const onUp = () => {
-      startRef.current = null
+      setBottomTerminalHeight(Math.min(maxH, startHRef.current - dy))
+    },
+    onEnd: () => {
       setDragging(false)
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
       document.body.style.userSelect = ''
       document.body.style.cursor = ''
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    document.body.style.userSelect = 'none'
-    document.body.style.cursor = 'row-resize'
-  }, [height])
+    },
+  })
 
   // Safety: restore body styles if unmounted mid-drag.
   useEffect(() => () => {
@@ -161,8 +159,9 @@ export default function BottomTerminalPanel() {
         >
           <div className="flex flex-col" style={{ height }}>
           <div
-            onMouseDown={onGripDown}
+            {...gripResize}
             className="relative shrink-0 h-[6px] cursor-row-resize group/drag"
+            style={{ touchAction: 'none' }}
             role="separator"
             aria-orientation="horizontal"
             aria-label="Resize terminal panel"

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
 import { ArrowUpFromLine, ArrowUp, Loader2, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
 import { Toggle } from './ui'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import VoiceStatusBar from './VoiceStatusBar'
 import { createPortal } from 'react-dom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -842,18 +843,34 @@ function ChatInput({
     return () => document.removeEventListener('keydown', onSlashFocus)
   }, [])
 
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => {
+  const inputResize = usePointerDrag({
+    threshold: 0,
+    onStart: (e) => {
+      if (!wrapperRef.current) return
+      const h = wrapperRef.current.offsetHeight
+      dragging.current = true
+      dragStartY.current = e.clientY
+      dragStartH.current = h
+      // Use current natural height as floor so drag never snaps up
+      dragMinHRef.current = Math.min(dragMinHRef.current, h)
+      // Lock in current height so auto-resize stops interfering
+      setManualHeight(h)
+      document.body.style.cursor = 'row-resize'
+      document.body.style.userSelect = 'none'
+      // Isolate reflow to this subtree during drag
+      wrapperRef.current.style.contain = 'strict'
+    },
+    onMove: ({ y }) => {
       if (!dragging.current || !wrapperRef.current) return
       // Account for CSS zoom/scale on #root
       const scale = parseInt(localStorage.getItem('mc-zoom') || '100', 10) / 100
       const maxH = effectiveVh() * INPUT_DRAG_MAX_RATIO
-      const delta = (dragStartY.current - e.clientY) / scale
+      const delta = (dragStartY.current - y) / scale
       const h = Math.min(maxH, Math.max(dragMinHRef.current, dragStartH.current + delta))
       // Direct DOM write on wrapper — no React state, no textarea auto-size
       wrapperRef.current.style.height = h + 'px'
-    }
-    const onUp = () => {
+    },
+    onEnd: () => {
       if (!dragging.current || !wrapperRef.current) return
       dragging.current = false
       document.body.style.cursor = ''
@@ -863,31 +880,20 @@ function ChatInput({
       const finalH = wrapperRef.current.offsetHeight
       setManualHeight(finalH)
       safeSetItem(INPUT_HEIGHT_LS_KEY, String(Math.round(finalH)))
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+    },
+  })
+  // Unmount guard: onEnd can't fire if the composer unmounts mid-drag
+  // (setPointerCapture dies with the element), so restore the global body styles
+  // here to avoid leaving the resize cursor / text-selection lock stuck.
+  useEffect(() => () => {
+    if (dragging.current) {
+      dragging.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
     }
   }, [])
 
-  const handleDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    if (!wrapperRef.current) return
-    const h = wrapperRef.current.offsetHeight
-    dragging.current = true
-    dragStartY.current = e.clientY
-    dragStartH.current = h
-    // Use current natural height as floor so drag never snaps up
-    dragMinHRef.current = Math.min(dragMinHRef.current, h)
-    // Lock in current height so auto-resize stops interfering
-    setManualHeight(h)
-    document.body.style.cursor = 'row-resize'
-    document.body.style.userSelect = 'none'
-    // Isolate reflow to this subtree during drag
-    wrapperRef.current.style.contain = 'strict'
-  }, [])
+
 
   const resetHeight = useCallback(() => {
     setManualHeight(null)
@@ -1690,7 +1696,8 @@ function ChatInput({
       {!showGhost && <div
         aria-hidden="true"
         className="flex items-center justify-center h-[6px] cursor-row-resize group/drag"
-        onMouseDown={handleDragStart}
+        style={{ touchAction: 'none' }}
+        {...inputResize}
         onDoubleClick={resetHeight}
         title="Drag to resize (double-click to reset)"
       >

--- a/website/src/components/SessionGridLayout.tsx
+++ b/website/src/components/SessionGridLayout.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useEffect, useRef, type ReactNode } from 'react'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import type { GridNode, GridLeaf, GridSplit } from '../hooks/useSessionGrid'
 
 const DIVIDER = 6 // px — draggable separator thickness between sibling panes
@@ -40,44 +41,41 @@ function SplitContainer({
   const ref = useRef<HTMLDivElement>(null)
   // Teardown for an in-progress divider drag, invoked on unmount so closing a
   // pane mid-drag still removes the overlay + window listeners (no leak).
-  const dragCleanupRef = useRef<(() => void) | null>(null)
-  useEffect(() => () => dragCleanupRef.current?.(), [])
+  useEffect(() => () => { document.body.style.cursor = '' }, [])
 
   const horizontal = node.dir === 'col' // children flow left→right
 
-  const startDrag = (index: number, e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    const el = ref.current
-    if (!el) return
-    const rect = el.getBoundingClientRect()
-    const extent = horizontal ? rect.width : rect.height
-    if (extent <= 0) return
-    let last = horizontal ? e.clientX : e.clientY
-    const cursor = horizontal ? 'col-resize' : 'row-resize'
-    const overlay = document.createElement('div')
-    overlay.style.cssText = `position:fixed;inset:0;z-index:9999;cursor:${cursor};`
-    document.body.appendChild(overlay)
-    const onMove = (ev: MouseEvent) => {
-      const pos = horizontal ? ev.clientX : ev.clientY
-      const d = (pos - last) / extent
-      if (d !== 0) {
-        onResize(node.id, index, d)
-        last = pos
-      }
-    }
-    const onUp = () => {
-      overlay.remove()
+  // Per-divider resize via Pointer Events (mouse + touch + pen). One hook
+  // instance serves every divider in this split: pointerdown records which
+  // divider (data-divider-index) plus the split's extent and start position;
+  // onMove applies the fractional delta to that divider. setPointerCapture keeps
+  // the drag glued to the handle even over iframe/canvas children, so the old
+  // full-screen overlay is no longer needed.
+  const dragState = useRef<{ index: number; extent: number; last: number } | null>(null)
+  const gridResize = usePointerDrag({
+    threshold: 0,
+    onStart: (e) => {
+      const el = ref.current
+      if (!el) { dragState.current = null; return }
+      const rect = el.getBoundingClientRect()
+      const extent = horizontal ? rect.width : rect.height
+      if (extent <= 0) { dragState.current = null; return }
+      const index = Number((e.currentTarget as HTMLElement).dataset.dividerIndex)
+      dragState.current = { index, extent, last: horizontal ? e.clientX : e.clientY }
+      document.body.style.cursor = horizontal ? 'col-resize' : 'row-resize'
+    },
+    onMove: ({ x, y }) => {
+      const st = dragState.current
+      if (!st) return
+      const pos = horizontal ? x : y
+      const d = (pos - st.last) / st.extent
+      if (d !== 0) { onResize(node.id, st.index, d); st.last = pos }
+    },
+    onEnd: () => {
+      dragState.current = null
       document.body.style.cursor = ''
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-      dragCleanupRef.current = null
-    }
-    document.body.style.cursor = cursor
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    dragCleanupRef.current = onUp
-  }
+    },
+  })
 
   return (
     <div
@@ -95,9 +93,11 @@ function SplitContainer({
           </div>
           {i < node.children.length - 1 && (
             <div
-              onMouseDown={(e) => startDrag(i, e)}
+              {...gridResize}
+              data-divider-index={i}
+              onPointerDown={(e) => { e.stopPropagation(); gridResize.onPointerDown(e) }}
               className={`shrink-0 flex items-center justify-center group/div ${horizontal ? 'cursor-col-resize' : 'cursor-row-resize'}`}
-              style={horizontal ? { width: DIVIDER } : { height: DIVIDER }}
+              style={{ ...(horizontal ? { width: DIVIDER } : { height: DIVIDER }), touchAction: 'none' }}
               role="separator"
               aria-orientation={horizontal ? 'vertical' : 'horizontal'}
             >

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -32,6 +32,7 @@ import { useSessionActions } from '../hooks/useSessionActions'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import { isTouchDevice } from '../utils/isTouchDevice'
 import { safeSetItem } from '../utils/safeStorage'
 import { resolveFolderAgent, resolveFolderProjectDir } from '../utils/folderAgent'
@@ -822,28 +823,38 @@ function ChatSidebar({
   })
   useEffect(() => { safeSetItem(HISTORY_HEIGHT_LS_KEY, String(historyHeight)) }, [historyHeight])
   const [historyDragging, setHistoryDragging] = useState(false)
-  const onHistoryDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    const startY = e.clientY
-    const startH = historyHeight
-    setHistoryDragging(true)
-    const onMove = (ev: MouseEvent) => {
-      // Drag handle is ABOVE the pane, so dragging UP grows the pane.
-      const next = Math.max(HISTORY_MIN_HEIGHT, Math.min(HISTORY_MAX_HEIGHT, startH - (ev.clientY - startY)))
-      setHistoryHeight(next)
-    }
-    const onUp = () => {
+  const historyStartHRef = useRef(0)
+  const historyDraggingRef = useRef(false)
+  const historyResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => {
+      historyStartHRef.current = historyHeight
+      historyDraggingRef.current = true
+      setHistoryDragging(true)
+      document.body.style.cursor = 'ns-resize'
+      document.body.style.userSelect = 'none'
+    },
+    onMove: ({ dy }) => {
+      // Drag handle is ABOVE the pane, so dragging UP (dy < 0) grows the pane.
+      setHistoryHeight(Math.max(HISTORY_MIN_HEIGHT, Math.min(HISTORY_MAX_HEIGHT, historyStartHRef.current - dy)))
+    },
+    onEnd: () => {
+      historyDraggingRef.current = false
       setHistoryDragging(false)
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    },
+  })
+  // Unmount guard: onEnd can't fire if the sidebar unmounts mid-drag
+  // (setPointerCapture dies with the element), so restore the global body styles
+  // here to avoid leaving the resize cursor / text-selection lock stuck.
+  useEffect(() => () => {
+    if (historyDraggingRef.current) {
+      historyDraggingRef.current = false
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    document.body.style.cursor = 'ns-resize'
-    document.body.style.userSelect = 'none'
-  }, [historyHeight])
+  }, [])
   const [cleanupOpen, setCleanupOpen] = useState(false)
   const [manageTagsOpen, setManageTagsOpen] = useState(false)  // header ⋮ → "Manage tags…" panel (list-view tag CRUD)
   const [filterSortOpen, setFilterSortOpen] = useState(false)
@@ -2911,16 +2922,16 @@ function ChatSidebar({
       {/* When expanded: doubles as the resize handle (accent on hover, drag to resize, dbl-click to collapse).
           When collapsed: just a static 1px divider between sessions and the Older Sessions footer. */}
       {historyOpen ? (
-        // Separator that doubles as a mouse-only resize handle (drag) / collapse
-        // (double-click); no keyboard analogue, so scope-disable the rule.
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+        // Separator that doubles as a Pointer-Events resize handle (drag,
+        // mouse/touch/pen) / collapse (double-click); no keyboard analogue.
         <div
           role="separator"
           aria-orientation="horizontal"
           aria-label="Resize history pane"
-          onMouseDown={onHistoryDragStart}
+          {...historyResize}
           onDoubleClick={() => setHistoryOpen(false)}
           className="relative h-[6px] cursor-ns-resize z-10 group/drag flex items-center justify-center select-none"
+          style={{ touchAction: 'none' }}
         >
           <div className={`w-full transition-all duration-200 ${historyDragging ? 'h-[2px] bg-accent-hover' : 'h-px bg-border group-hover/drag:h-[2px] group-hover/drag:bg-accent'}`} />
         </div>

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -1,5 +1,6 @@
 import { safeSetItem } from '../utils/safeStorage'
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { usePointerDrag } from '../hooks/usePointerDrag'
 import Clickable from '../components/Clickable'
 import { AnimatePresence, motion } from 'framer-motion'
 import { List, CalendarDays, CalendarClock, Plus, ClipboardList, ChevronRight, Globe, Check, History, Trash2 } from 'lucide-react'
@@ -493,23 +494,15 @@ function JobDetailPanel({ job, prefill, agents, defaultAgent, onClose, onSaved }
   useEffect(() => { setDetailTab('details') }, [job?.id])
   const panelRef = useRef<HTMLDivElement>(null)
   const submitRef = useRef<(() => void) | null>(null)
-  const moveRef = useRef<((ev: MouseEvent) => void) | null>(null)
-  const upRef = useRef<(() => void) | null>(null)
   const widthRef = useRef(width)
   widthRef.current = width
+  const startWRef = useRef(0)
 
-  useEffect(() => {
-    return () => {
-      if (moveRef.current) document.removeEventListener('mousemove', moveRef.current)
-      if (upRef.current) document.removeEventListener('mouseup', upRef.current)
-    }
-  }, [])
-
-  const onDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    setDragging(true)
-    const startX = e.clientX; const startW = widthRef.current
-    const onMove = (ev: MouseEvent) => {
+  const scheduleResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => { startWRef.current = widthRef.current; setDragging(true) },
+    onMove: ({ dx }) => {
+      // Left-edge handle, right edge pinned: dragging left (dx < 0) widens.
       // Cap to the panel's room in its flex row (row width minus the job-list
       // minimum), not a fraction of the whole window: the panel is `shrink-0`
       // in an `overflow-hidden` row, so a window-based cap lets it overflow the
@@ -517,29 +510,17 @@ function JobDetailPanel({ job, prefill, agents, defaultAgent, onClose, onSaved }
       // -> wrapping motion.div -> the flex row; if that nesting changes the
       // optional chain silently falls back to the viewport (restoring the old
       // over-cap), so keep the two levels in sync with the render tree below.
-      // Unlike DetailPanel this only re-caps during drag (width is ephemeral,
-      // not persisted, and there's no mount/resize re-clamp here) — a
-      // pre-existing gap left as-is to keep this fix scoped.
       const rowW = panelRef.current?.parentElement?.parentElement?.getBoundingClientRect().width ?? window.innerWidth
       const cap = Math.min(rowW - JOB_LIST_MIN, Math.round(window.innerWidth * 0.6))
-      setWidth(Math.max(300, Math.min(startW + (startX - ev.clientX), cap)))
-    }
-    const onUp = () => {
-      setDragging(false)
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      moveRef.current = null; upRef.current = null
-    }
-    moveRef.current = onMove; upRef.current = onUp
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-  }, [])
+      setWidth(Math.max(300, Math.min(startWRef.current - dx, cap)))
+    },
+    onEnd: () => { setDragging(false) },
+  })
 
   return (
     <div ref={panelRef} className="shrink-0 border-l border-border bg-bg flex flex-col h-full overflow-hidden relative" style={{ width, minWidth: 300 }}>
-      {/* Resize splitter: role=separator is the correct semantic, but jsx-a11y treats it as non-interactive; the mousedown drag is intrinsic to a resize handle. */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-[-2px] top-0 bottom-0 w-[5px] cursor-col-resize z-20 group/drag flex items-center justify-center" onMouseDown={onDragStart}>
+      {/* Resize splitter — Pointer Events (mouse + touch + pen) via usePointerDrag. */}
+      <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-[-2px] top-0 bottom-0 w-[5px] cursor-col-resize z-20 group/drag flex items-center justify-center" style={{ touchAction: 'none' }} {...scheduleResize}>
         <div className="w-[2px] h-full bg-transparent group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-colors duration-200" />
       </div>
       <div className="flex items-center justify-between px-5 py-4 border-b border-border">

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
+import { usePointerDrag } from '../../hooks/usePointerDrag'
 import { Reorder } from 'framer-motion'
 import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, PanelRightClose, Component, PanelBottom, Globe } from 'lucide-react'
 import ActivityViewer from './ActivityViewer'
@@ -229,21 +230,17 @@ export default function SidePanel({
   // the new spot each frame — so tabs visibly lag the resize and "catch up"
   // when it stops. During a resize we make the layout transition instant.
   const [resizing, setResizing] = useState(false)
-  const onDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    const startX = e.clientX; const startW = widthRef.current
-    const max = () => Math.min(Math.round(window.innerWidth * 0.7), window.innerWidth - measureSidePanelReservedW())
-    setResizing(true)
-    const onMove = (ev: MouseEvent) => setWidth(Math.max(MIN_W, Math.min(startW + (startX - ev.clientX), max())))
-    const onUp = () => {
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      setResizing(false)
-      safeSetItem(WIDTH_KEY, String(widthRef.current))
-    }
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-  }, [])
+  const startWRef = useRef(0)
+  const panelResize = usePointerDrag({
+    threshold: 0,
+    onStart: () => { startWRef.current = widthRef.current; setResizing(true) },
+    onMove: ({ dx }) => {
+      // Left-edge handle with the right edge pinned: dragging left (dx < 0) widens.
+      const max = Math.min(Math.round(window.innerWidth * 0.7), window.innerWidth - measureSidePanelReservedW())
+      setWidth(Math.max(MIN_W, Math.min(startWRef.current - dx, max)))
+    },
+    onEnd: () => { setResizing(false); safeSetItem(WIDTH_KEY, String(widthRef.current)) },
+  })
 
   useEffect(() => {
     if (!menuOpen) return
@@ -255,7 +252,7 @@ export default function SidePanel({
   return (
     <div className="shrink-0 min-h-0 my-2 flex flex-col bg-bg overflow-hidden relative border-l border-t border-b border-border rounded-l-xl" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
       {/* Left-edge resize handle */}
-      <div className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" onMouseDown={onDragStart}>
+      <div role="separator" aria-orientation="vertical" aria-label="Resize panel" className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" style={{ touchAction: 'none' }} {...panelResize}>
         <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
       </div>
       {/* Tab strip — drag chips horizontally to reorder (framer Reorder).

--- a/website/src/test/ChatInput.test.tsx
+++ b/website/src/test/ChatInput.test.tsx
@@ -362,14 +362,26 @@ describe('ChatInput', () => {
   })
 
   describe('drag-to-resize handle', () => {
-    it('initiates drag on mousedown on handle', () => {
+    it('initiates drag on pointerdown on handle', () => {
       renderWithProviders(<ChatInput {...defaultProps} value="test" />)
       const handle = screen.getByTitle(/Drag to resize/)
-      fireEvent.mouseDown(handle, { clientX: 100, clientY: 200 })
+      fireEvent.pointerDown(handle, { clientX: 100, clientY: 200 })
       expect(document.body.style.cursor).toBe('row-resize')
       expect(document.body.style.userSelect).toBe('none')
       // Clean up
-      fireEvent.mouseUp(window)
+      fireEvent.pointerUp(handle)
+    })
+
+    it('restores body styles if unmounted mid-drag', () => {
+      const { unmount } = renderWithProviders(<ChatInput {...defaultProps} value="test" />)
+      const handle = screen.getByTitle(/Drag to resize/)
+      fireEvent.pointerDown(handle, { clientX: 100, clientY: 200 })
+      expect(document.body.style.cursor).toBe('row-resize')
+      // Unmount mid-drag with no pointerup — the teardown guard must restore the
+      // global body styles (onEnd can't fire once the element is gone).
+      unmount()
+      expect(document.body.style.cursor).toBe('')
+      expect(document.body.style.userSelect).toBe('')
     })
 
     it('resets height on double-click', () => {

--- a/website/src/test/SessionGridLayout.resizeTouch.test.tsx
+++ b/website/src/test/SessionGridLayout.resizeTouch.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * SessionGridLayout divider resize via Pointer Events (mouse + touch + pen).
+ *
+ * The per-split dividers were mouse-only (window mousemove/mouseup + a full-
+ * screen overlay). They now use the shared usePointerDrag hook, keyed by
+ * data-divider-index, so a touch drag resizes a split exactly like a mouse drag.
+ *
+ * Locks:
+ *  (1) each divider is a role="separator" with the correct aria-orientation and
+ *      touch-action:none (so a touch drag resizes instead of scrolling);
+ *  (2) a pointer drag reports the fractional delta to onResize for the right
+ *      split id + divider index — a col split tracks clientX, a row split clientY.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import SessionGridLayout from '../components/SessionGridLayout'
+import type { GridSplit } from '../hooks/useSessionGrid'
+
+// jsdom has no layout: stub getBoundingClientRect so the split's measured extent
+// (width for a col split, height for a row split) is a deterministic 200px, and
+// the reported fraction is exact.
+let rectSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => {
+  rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    x: 0, y: 0, top: 0, left: 0, right: 200, bottom: 200, width: 200, height: 200, toJSON: () => ({}),
+  } as DOMRect)
+})
+afterEach(() => { rectSpy.mockRestore() })
+
+const leaf = (id: string) => ({ type: 'leaf' as const, id, kind: 'placeholder' as const })
+
+function renderSplit(dir: 'col' | 'row', onResize = vi.fn()) {
+  const node: GridSplit = { type: 'split', id: 'root', dir, children: [leaf('a'), leaf('b')], sizes: [1, 1] }
+  const utils = render(
+    <SessionGridLayout node={node} renderLeaf={(l) => <div data-leaf={l.id} />} onResize={onResize} />,
+  )
+  const divider = utils.container.querySelector('[data-divider-index="0"]') as HTMLElement
+  return { ...utils, divider, onResize }
+}
+
+describe('SessionGridLayout — pointer/touch divider resize', () => {
+  it('a col split divider is a vertical separator with touch-action:none', () => {
+    const { divider } = renderSplit('col')
+    expect(divider).toBeTruthy()
+    expect(divider.getAttribute('role')).toBe('separator')
+    expect(divider.getAttribute('aria-orientation')).toBe('vertical')
+    expect(divider.style.touchAction).toBe('none')
+  })
+
+  it('a pointer drag on a col divider reports the horizontal fractional delta to onResize', () => {
+    const { divider, onResize } = renderSplit('col')
+    fireEvent.pointerDown(divider, { clientX: 100, clientY: 50, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(divider, { clientX: 150, clientY: 50, pointerId: 1 }) })
+    act(() => { fireEvent.pointerUp(divider, { clientX: 150, clientY: 50, pointerId: 1 }) })
+    // extent = 200 (stubbed width); moved +50px → +0.25 fraction for split 'root', divider 0.
+    expect(onResize).toHaveBeenCalledWith('root', 0, 0.25)
+  })
+
+  it('a row split divider is a horizontal separator and tracks clientY', () => {
+    const { divider, onResize } = renderSplit('row')
+    expect(divider.getAttribute('aria-orientation')).toBe('horizontal')
+    fireEvent.pointerDown(divider, { clientX: 10, clientY: 100, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(divider, { clientX: 10, clientY: 130, pointerId: 1 }) })
+    act(() => { fireEvent.pointerUp(divider, { clientX: 10, clientY: 130, pointerId: 1 }) })
+    // extent = 200 (stubbed height); moved +30px → +0.15 fraction.
+    expect(onResize).toHaveBeenCalledWith('root', 0, 30 / 200)
+  })
+})


### PR DESCRIPTION
## Problem
Almost every draggable resize handle in the app was mouse-only. Each used `onMouseDown` + window/document `mousemove`/`mouseup` (reading `e.clientX/Y`), which never fire for a touch or pen drag. On a tablet or touchscreen the handles looked draggable but did nothing.

## Why it matters
Touch and pen users couldn't resize any of these panels/panes — the activity side panel, the schedule detail panel, split-view dividers, the file-explorer tree, issue-radar list columns, the bottom terminal, the composer, or the sidebar history pane. This is the same class of gap already fixed for the left ChatSidebar width handle (PR #585); this PR sweeps the rest.

## Fix (symptom → root cause → change)
- **Symptom:** dragging any of these handles on a touch device does nothing.
- **Root cause:** mouse-only event wiring (`onMouseDown` + window `mousemove`/`mouseup`); touch/pen emit pointer events, not mouse events, for a drag.
- **Change:** migrate each handle to the shared `usePointerDrag` hook (Pointer Events + `setPointerCapture`) — the same hook `DetailPanel` and the ChatSidebar width handle already use — so mouse, touch, and pen share one code path. Each handle also gains `role="separator"` (where missing), `aria-orientation`, and `touch-action: none` (so a touch drag resizes instead of scrolling the page). Handle geometry, min/max clamps, drag direction, and `localStorage` persistence are all preserved. `setPointerCapture` also lets the split-grid dividers drop their full-screen capture overlay.

Handles converted (8 files):
- `pages/chat/SidePanel.tsx` — activity panel width
- `pages/SchedulePage.tsx` — schedule detail panel width
- `components/SessionGridLayout.tsx` — split dividers (col **and** row), one hook keyed by `data-divider-index`
- `apps/file-explorer/FileExplorerPage.tsx` — tree pane width
- `apps/issue-radar/Workspace.tsx` — both list column handles
- `components/BottomTerminalPanel.tsx` — terminal height grip
- `components/ChatInput.tsx` — composer height (kept `aria-hidden` per its existing design)
- `pages/ChatSidebar.tsx` — history-pane height handle only

Excluded (already correct, verified): `DetailPanel` (already `usePointerDrag`), `BrowserLiveView` (already Pointer Events + `setPointerCapture`), `MarkdownPanel` (its `mousemove` is comment-hover hit-testing, not a resizer).

## Tests
- New `website/src/test/SessionGridLayout.resizeTouch.test.tsx` (3 tests) drives the dividers with `fireEvent.pointer*` and locks: col divider = vertical separator with `touch-action:none`; a pointer drag reports the correct fractional delta to `onResize` for the right split id + index (col tracks clientX, row tracks clientY).
- `website/src/test/ChatInput.test.tsx` resize test updated from `mouseDown` to `pointerDown` to match the migration.
- The shared `usePointerDrag` hook is already unit-tested via `DetailPanel.test.tsx`.

## Manual verification
The migrations are behavior-preserving (same math/clamps/persistence, only the input mechanism changed) and verified by `tsc -b`, the full vitest suite (4727 passing, 0 failing), and eslint (0 errors). The interactive touch-drag feel on each surface is best confirmed on a real touch device.

## Screenshots
N/A — no visual change. Every handle keeps its exact geometry and appearance; only the input modality changed (mouse-only → pointer/touch/pen).
