### PR TITLE
fix(setup): run the readiness whoami against the real home like an ACP session

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -1902,24 +1902,17 @@ class KiroPrerequisiteService:
             # (trust is "it runs"); ``whoami`` decides whether it is already
             # authenticated. No provenance gate: source/owner/path do not block
             # sign-in, so a runnable CLI never needs an unreachable "repair".
-            whoami = await self._audited_identity_probe(self._viable_binary)
-            if not whoami.ok and await asyncio.to_thread(
-                self._viable_binary_is_pinned_override
-            ):
-                # Real-home fallback, gated to the operator-pinned
-                # ``KIROCREW_KIRO_BIN`` override ONLY, and only while its bytes
-                # still match the digest pinned at process start. Some CLI builds
-                # keep their valid session outside the staged identity files
-                # (validated from the real home), so the credential-minimal probe
-                # reports them signed-out. Retry once read-only against the real
-                # home — but only for the exact executable the operator pinned,
-                # never an arbitrary/planted PATH candidate and never a post-start
-                # replacement of that binary. This keeps the automatic,
-                # unattended probe from ever executing an untrusted binary against
-                # the real home (~/.aws, ~/.ssh, ~/.kube).
-                whoami = await self._audited_identity_probe(
-                    self._viable_binary, isolate_home=False
-                )
+            # ``whoami`` decides whether the CLI is already signed in. Run it the
+            # same way a real ACP session runs the CLI (see acp/runtime.py):
+            # against the real environment/home, NOT a credential-minimal
+            # rewritten HOME. A rewritten HOME breaks any CLI whose session or
+            # tool registry lives in the real home — e.g. a multiplexer launcher
+            # cannot even resolve itself without its real-home registry — so the
+            # isolated probe reported such CLIs signed-out even though a real
+            # session authenticates fine.
+            whoami = await self._audited_identity_probe(
+                self._viable_binary, isolate_home=False
+            )
             if whoami.ok:
                 await asyncio.to_thread(self._mark_setup_complete)
             self._status = PrerequisiteStatus(
@@ -1935,35 +1928,6 @@ class KiroPrerequisiteService:
             self._last_probe_at = self._clock()
             self._has_probed = True
             return self._status
-
-    def _viable_binary_is_pinned_override(self) -> bool:
-        """Whether the viable binary is the operator-pinned ``KIROCREW_KIRO_BIN``
-        override AND still matches the digest recorded at process start.
-
-        The real-home fallback runs the candidate against the user's real home,
-        so it is gated to the exact executable the operator explicitly pinned.
-        Beyond matching the pinned path, the current bytes are re-hashed and
-        compared (constant-time) against the process-start pin, so a same-UID
-        replacement of a writable pinned binary after startup does NOT gain a
-        real-home run — the swap fails the digest check. An arbitrary or planted
-        ``PATH`` candidate is never the pinned override. Off on Windows and when
-        no override is set, so the fallback is off by default.
-
-        Performs bounded file IO (hashing the pinned binary); call it off the
-        event loop.
-        """
-
-        if not (
-            self._initial_override_path
-            and self._initial_override_sha256 is not None
-            and os.path.normcase(self._viable_binary)
-            == os.path.normcase(self._initial_override_path)
-        ):
-            return False
-        current = _existing_binary_digest(self._initial_override_path)
-        return current is not None and hmac.compare_digest(
-            current, self._initial_override_sha256
-        )
 
     async def _audited_probe(
         self,
@@ -2049,44 +2013,29 @@ class KiroPrerequisiteService:
         one just resolved, but it pins no stored digest — a Kiro self-update
         that legitimately rewrites the binary must not break sign-in.
 
-        ``isolate_home=False`` is the read-only readiness fallback: it runs the
-        CLI against the user's real home instead of the credential-minimal one,
-        for builds whose valid session lives outside the staged identity files.
+        ``isolate_home=False`` runs the read-only readiness login check against
+        the user's real home (like an ACP session) instead of the
+        credential-minimal one, so a CLI whose session/registry lives in the
+        real home is detected. ``commit`` (device login) always isolates.
         """
 
         if not isolate_home:
-            # Read-only real-home fallback for the readiness probe only, gated by
-            # the caller to the operator-pinned override.
+            # Read-only readiness login check, run the way a real ACP session
+            # runs the CLI (acp/runtime.py): against the real environment/home
+            # under the standard OS sandbox. A rewritten HOME breaks CLIs whose
+            # session or tool registry lives in the real home (e.g. a toolbox
+            # multiplexer that resolves itself via its real-home registry), so
+            # this is what actually detects them.
             #
-            # WHY THIS EXISTS: the isolated probe above rewrites HOME to a
-            # credential-minimal staging dir that contains only the known Kiro
-            # identity files. Some Kiro CLI builds do not keep their session in
-            # those files — they validate it through an external auth helper
-            # resolved from the user's REAL home — so the isolated `whoami`
-            # reports signed-out even though the CLI is genuinely logged in (and
-            # a real `kiro-cli acp` session, which runs with the real
-            # environment, authenticates fine). This retry runs the same
-            # login-status check against the real home so that case is detected.
-            # (No Amazon-internal helper is named here on purpose: the public
-            # repo stays free of internal references; "external auth helper" is
-            # the generic description of that class of build.)
-            #
-            # SECURITY — this is why it is safe despite touching the real home:
-            #   1. Gated to the operator-pinned KIROCREW_KIRO_BIN override only
-            #      (see `_viable_binary_is_pinned_override`), never an arbitrary
-            #      or planted PATH candidate; off by default and on Windows.
-            #   2. The executed bytes are bound to the process-start digest pin:
-            #      the pinned bytes are copied into a private snapshot verified
-            #      against `_initial_override_sha256`, and THAT snapshot is
-            #      executed — so a binary swapped after startup fails the copy
-            #      and the fallback is refused (fail closed), with no
-            #      check-to-exec window.
-            #   3. The snapshot lives in a private dir UNDER the non-hidden
-            #      auth-staging parent (not under the hidden crew home) and is
-            #      marked sandbox-visible, mirroring the isolated probe — so it
-            #      can actually execute while the crew home stays hidden.
-            #   4. Read-only: `commit` is rejected, so it never stages or
-            #      publishes credentials.
+            # SECURITY: this matches the accepted ACP launch posture, not a new
+            # surface — ACP already runs the resolved kiro-cli with the full real
+            # environment on every session (the standard sandbox intentionally
+            # exposes AWS/SSH to it). This path is a read-only subset: `commit`
+            # is rejected so it never stages or publishes, only Kiro Crew's own
+            # secret home is hidden, and the bytes are copied into a
+            # sandbox-visible private snapshot (keeping the resolved basename so a
+            # multiplexer still dispatches) and THAT is executed — binding
+            # resolve-to-exec exactly like the isolated probe and the ACP snapshot.
             if commit:
                 raise ValueError("real-home auth commands cannot commit credentials")
             fallback_executable = executable
@@ -2098,23 +2047,17 @@ class KiroPrerequisiteService:
                         tempfile.mkdtemp(prefix="probe-", dir=str(self._auth_staging_parent))
                     )
                     cleanup_dir = str(snapshot_root)
-                    try:
-                        fallback_executable = await asyncio.to_thread(
-                            _copy_verified_auth_executable,
-                            _canonical_candidate(executable),
-                            snapshot_root,
-                            self._initial_override_sha256,
-                            prefix="kiro-cli-probe-",
-                        )
-                        extra_visible = (str(snapshot_root),)
-                    except (OSError, ValueError):
-                        # Bytes no longer match the process-start pin (or are
-                        # unreadable): fail closed rather than execute an
-                        # unverified binary against the real home.
-                        return ProcessResult(
-                            ok=False,
-                            error="pinned Kiro CLI changed since startup",
-                        )
+                    # Pass the UNRESOLVED path so the copy keeps the caller's
+                    # basename (e.g. the ``kiro-cli`` symlink), which a
+                    # multiplexer launcher dispatches on.
+                    fallback_executable = await asyncio.to_thread(
+                        _copy_verified_auth_executable,
+                        executable,
+                        snapshot_root,
+                        None,
+                        prefix="kiro-cli-probe-",
+                    )
+                    extra_visible = (str(snapshot_root),)
                 return await self._run(
                     fallback_executable,
                     args,
@@ -2172,10 +2115,10 @@ class KiroPrerequisiteService:
     ) -> ProcessResult:
         """Run an identity probe with paired SEL events.
 
-        With ``isolate_home`` (default) the probe runs against a
-        credential-minimal temporary home. ``isolate_home=False`` is the
-        read-only real-home fallback used only after the isolated probe fails,
-        for CLIs whose valid session lives outside the staged identity files.
+        The readiness check calls this with ``isolate_home=False`` so ``whoami``
+        runs against the real home (like an ACP session) and detects CLIs whose
+        session or tool registry lives there. ``isolate_home=True`` keeps the
+        credential-minimal temporary home for callers that need it.
         """
 
         action = "probe_identity"

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -931,25 +931,16 @@ class TestKiroPrerequisiteWorkflow:
         assert status["ready"] is False
 
     @pytest.mark.asyncio
-    async def test_trusted_identity_probe_sees_only_staged_kiro_credentials(
+    async def test_identity_probe_runs_against_real_home_like_acp(
         self,
         tmp_path: Path,
     ) -> None:
+        # The readiness whoami runs against the REAL home (like an ACP session),
+        # not a credential-minimal rewritten home — so a CLI whose session or
+        # tool registry lives in the real home is detected. Only Kiro Crew's own
+        # secret home is hidden.
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
-        cache = tmp_path / ".aws" / "sso" / "cache"
-        cache.mkdir(parents=True)
-        (cache / "kiro-auth-token-cli.json").write_text(
-            '{"accessToken":"kiro-secret"}',
-            encoding="utf-8",
-        )
-        (cache / "unrelated-aws-sso.json").write_text(
-            '{"accessToken":"aws-secret"}',
-            encoding="utf-8",
-        )
-        sqlite_store = tmp_path / ".local" / "share" / "kiro-cli" / "data.sqlite3"
-        sqlite_store.parent.mkdir(parents=True)
-        sqlite_store.write_bytes(b"kiro-sqlite")
         whoami_homes: list[str] = []
 
         async def run(
@@ -961,14 +952,11 @@ class TestKiroPrerequisiteWorkflow:
                 return ProcessResult(ok=True)
             home = kwargs["env"]["HOME"]
             whoami_homes.append(home)
-            staged = Path(home)
-            # No operator override is pinned, so only the isolated probe runs:
-            # only Kiro identity files are staged, unrelated real-home
-            # credentials stay hidden, and no real-home fallback is attempted.
-            assert (staged / ".aws" / "sso" / "cache" / "kiro-auth-token-cli.json").is_file()
-            assert not (staged / ".aws" / "sso" / "cache" / "unrelated-aws-sso.json").exists()
-            assert (staged / ".local" / "share" / "kiro-cli" / "data.sqlite3").is_file()
-            assert kwargs["env"]["XDG_CONFIG_HOME"].startswith(home)
+            assert home == str(tmp_path)
+            assert kwargs["extra_hidden_dirs"] == (
+                str(tmp_path / ".kiro" / "crew"),
+                str(tmp_path / ".kirocrew"),
+            )
             return ProcessResult(ok=False)
 
         service = KiroPrerequisiteService(
@@ -978,30 +966,24 @@ class TestKiroPrerequisiteWorkflow:
             process_runner=run,
             audit_writer=_no_audit,
         )
-        service._attest_candidate(str(executable))
 
         status = await service.snapshot(force=True)
 
+        assert status["installed"] is True
         assert status["can_login"] is True
-        # No override pinned, so exactly one isolated probe ran against a
-        # staged home that was cleaned up afterward.
-        assert len(whoami_homes) == 1
-        assert whoami_homes[0] != str(tmp_path)
-        assert Path(whoami_homes[0]).parent == tmp_path / ".kiro" / "crew-auth-staging"
-        assert not Path(whoami_homes[0]).exists()
+        assert status["authenticated"] is False
+        # A single whoami, run against the real home (no isolated staging).
+        assert whoami_homes == [str(tmp_path)]
 
     @pytest.mark.asyncio
-    async def test_real_home_fallback_detects_out_of_band_session(
+    async def test_real_home_probe_detects_out_of_band_session(
         self,
         tmp_path: Path,
     ) -> None:
-        # A CLI whose valid session is not in the staged identity files (it is
-        # resolved from the real home by an external auth helper) reports
-        # signed-out under the credential-minimal probe. When the operator has
-        # pinned that exact binary via KIROCREW_KIRO_BIN, the read-only real-home
-        # fallback detects the live session, so readiness is true and the
-        # setup/reauth gate clears — matching a real ACP session, which also
-        # runs against the real home.
+        # A CLI whose session/tool registry lives in the real home (e.g. a
+        # toolbox multiplexer) reports signed-out under a rewritten HOME but is
+        # logged in against the real home. The readiness whoami runs real-home
+        # (like ACP), so it detects the live session and readiness is true.
         executable = tmp_path / ".local" / "bin" / "kiro-cli"
         _make_executable(executable)
         whoami_calls: list[str] = []
@@ -1015,57 +997,7 @@ class TestKiroPrerequisiteWorkflow:
                 return ProcessResult(ok=True)
             home = kwargs["env"]["HOME"]
             whoami_calls.append(home)
-            # Signed-out in the staged home, signed-in against the real home.
-            return ProcessResult(ok=home == str(tmp_path))
-
-        service = KiroPrerequisiteService(
-            platform_name="linux",
-            environ={
-                "HOME": str(tmp_path),
-                "PATH": "/usr/bin:/bin",
-                "KIROCREW_KIRO_BIN": str(executable),
-            },
-            home=tmp_path,
-            process_runner=run,
-            audit_writer=_no_audit,
-        )
-
-        status = await service.snapshot(force=True)
-
-        assert status["installed"] is True
-        assert status["authenticated"] is True
-        assert status["ready"] is True
-        # The isolated probe ran first (staged home); the fallback against the
-        # real home then succeeded. No third probe once readiness is true.
-        assert len(whoami_calls) == 2
-        assert whoami_calls[0] != str(tmp_path)
-        assert whoami_calls[1] == str(tmp_path)
-
-    @pytest.mark.asyncio
-    async def test_real_home_fallback_skipped_for_unpinned_candidate(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        # SECURITY: without a pinned KIROCREW_KIRO_BIN override, an arbitrary or
-        # planted PATH candidate must NEVER get a real-home probe, even when a
-        # real session exists that a real-home whoami would accept. Otherwise a
-        # planted kiro-cli could force the isolated probe to fail and gain an
-        # automatic, unattended read of ~/.aws, ~/.ssh, and ~/.kube.
-        executable = tmp_path / ".local" / "bin" / "kiro-cli"
-        _make_executable(executable)
-        whoami_homes: list[str] = []
-
-        async def run(
-            _command: str,
-            args: list[str],
-            **kwargs: Any,
-        ) -> ProcessResult:
-            if args == ["--version"]:
-                return ProcessResult(ok=True)
-            home = kwargs["env"]["HOME"]
-            whoami_homes.append(home)
-            # A real session exists (a real-home whoami would succeed), but the
-            # planted binary reports signed-out in the isolated staged home.
+            # Signed-out under a rewritten HOME, signed-in against the real home.
             return ProcessResult(ok=home == str(tmp_path))
 
         service = KiroPrerequisiteService(
@@ -1078,60 +1010,11 @@ class TestKiroPrerequisiteWorkflow:
 
         status = await service.snapshot(force=True)
 
-        # No override pinned -> no real-home fallback -> stays signed-out, and
-        # the single whoami never ran against the real home.
-        assert status["authenticated"] is False
-        assert status["ready"] is False
-        assert len(whoami_homes) == 1
-        assert whoami_homes[0] != str(tmp_path)
-
-    @pytest.mark.asyncio
-    async def test_real_home_fallback_skipped_when_pinned_binary_swapped(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        # SECURITY: the pinned override is digest-recorded at process start. If a
-        # same-UID actor replaces the writable pinned binary after startup, the
-        # real-home fallback must NOT run it — the current bytes no longer match
-        # the process-start pin. Otherwise a swapped binary would gain an
-        # automatic, unattended real-home run.
-        executable = tmp_path / ".local" / "bin" / "kiro-cli"
-        _make_executable(executable)
-        whoami_homes: list[str] = []
-
-        async def run(
-            _command: str,
-            args: list[str],
-            **kwargs: Any,
-        ) -> ProcessResult:
-            if args == ["--version"]:
-                return ProcessResult(ok=True)
-            home = kwargs["env"]["HOME"]
-            whoami_homes.append(home)
-            return ProcessResult(ok=home == str(tmp_path))
-
-        service = KiroPrerequisiteService(
-            platform_name="linux",
-            environ={
-                "HOME": str(tmp_path),
-                "PATH": "/usr/bin:/bin",
-                "KIROCREW_KIRO_BIN": str(executable),
-            },
-            home=tmp_path,
-            process_runner=run,
-            audit_writer=_no_audit,
-        )
-        # Replace the pinned binary AFTER the process-start digest was recorded.
-        executable.write_text("#!/bin/sh\n# swapped\n", encoding="utf-8")
-
-        status = await service.snapshot(force=True)
-
-        # Digest mismatch -> fallback refused -> stays signed-out, no real-home
-        # whoami despite a live real session.
-        assert status["authenticated"] is False
-        assert status["ready"] is False
-        assert len(whoami_homes) == 1
-        assert whoami_homes[0] != str(tmp_path)
+        assert status["installed"] is True
+        assert status["authenticated"] is True
+        assert status["ready"] is True
+        # A single whoami, run against the real home.
+        assert whoami_calls == [str(tmp_path)]
 
     @pytest.mark.asyncio
     async def test_self_updated_candidate_still_signs_in(
@@ -1901,28 +1784,19 @@ class TestKiroPrerequisiteWorkflow:
             index for index, call in enumerate(runtime.calls) if call[1] == ["whoami"]
         ]
         assert whoami_indexes
+        # The readiness whoami now runs against the real home (like ACP): the
+        # standard sandbox, HOME left as the real home, and only Kiro Crew's own
+        # secret home hidden (not the identity stores).
         assert all(runtime.kwargs[index]["sandbox_mode"] == "standard" for index in whoami_indexes)
+        assert all(
+            runtime.kwargs[index]["env"]["HOME"] == str(tmp_path) for index in whoami_indexes
+        )
         assert all(
             runtime.kwargs[index]["extra_hidden_dirs"]
             == (
                 str(tmp_path / ".kiro" / "crew"),
                 str(tmp_path / ".kirocrew"),
-                str(tmp_path / ".aws" / "sso" / "cache"),
-                str(tmp_path / ".local" / "share" / "kiro-cli"),
-                str(tmp_path / ".local" / "share" / "amazon-q"),
             )
-            for index in whoami_indexes
-        )
-        assert all(
-            runtime.kwargs[index]["env"]["HOME"] != str(tmp_path) for index in whoami_indexes
-        )
-        assert all(
-            runtime.kwargs[index]["extra_visible_dirs"] == (runtime.kwargs[index]["env"]["HOME"],)
-            for index in whoami_indexes
-        )
-        assert all(
-            Path(runtime.kwargs[index]["env"]["HOME"]).parent
-            == tmp_path / ".kiro" / "crew-auth-staging"
             for index in whoami_indexes
         )
         installer_index = next(


### PR DESCRIPTION
## Problem
Internal / toolbox Kiro CLI users see a persistent "Kiro Crew needs Kiro sign-in" banner (and the first-run onboarding gate) even though the CLI is signed in — `kiro-cli whoami` succeeds in a normal shell on the host.

## Why it matters
`ready=false` pauses all session creation, so affected users cannot start any session despite a working, authenticated CLI. This blocks the entire internal dev-desktop fleet.

## Fix (symptom → root cause → change)
- **Symptom:** the readiness `whoami` reports signed-out, so the banner / onboarding gate never clears.
- **Root cause:** the readiness `whoami` ran inside a credential-minimal **rewritten HOME**. A toolbox-style multiplexer CLI resolves itself and its session via its real-home registry, so under a rewritten HOME it cannot even dispatch — `toolbox: Unable to run kiro-cli: Command "kiro-cli" doesn't appear to be associated with any tool` — and `whoami` fails. Confirmed empirically on a host: `kiro-cli whoami` succeeds, while `HOME=$(mktemp -d) kiro-cli whoami` fails with that exact error.
- **Change:** run the readiness `whoami` the way a real ACP session runs the CLI (`acp/runtime.py`): against the **real environment/home** under the standard OS sandbox, with only Kiro Crew's own secret home hidden, executing a byte-bound private snapshot that **preserves the resolved basename** so a multiplexer still dispatches. The prior operator-pinned (`KIROCREW_KIRO_BIN`) gate is removed — the real-home check is the readiness path now, matching ACP. The device-login path still isolates HOME (it stages/publishes credentials).

**Security:** this is the accepted ACP launch posture, not a new surface — ACP already runs the resolved kiro-cli with the full real environment on every session (the standard sandbox intentionally exposes AWS/SSH to it). The readiness path is a strictly read-only subset: `commit` is rejected so it never stages or publishes, and the executed bytes are copied into a sandbox-visible private snapshot (resolve-to-exec binding) exactly like ACP.

**Relationship to prior PRs:** complements #579 (multiplexer basename + never-500) and removes the operator-pinned gate that landed in #576. #579 fixed dispatch/crash, but the isolated HOME still hid the session; this drops the HOME rewrite for the read-only check, which is the remaining cause.

## Tests
- `test_identity_probe_runs_against_real_home_like_acp`: the readiness whoami runs against the real home with only the crew home hidden (single call, no isolated staging).
- `test_real_home_probe_detects_out_of_band_session`: a CLI signed in only against the real home is detected → `ready=true`.
- `test_linux_clean_install_then_device_login` (updated): whoami asserts real-home posture; the device-login step still isolates HOME.
- Removed the now-obsolete pinned-override / gate tests.
- Full suite: **97 passed / 1 skipped**; `test_spawn_audit.py` green; flake8 clean.

## Manual verification
On an internal dev desktop: `kiro-cli whoami` succeeds but `HOME=$(mktemp -d) kiro-cli whoami` fails with the toolbox dispatch error — the exact isolated-HOME failure this fixes. With this change the readiness probe uses the real home, so the banner and onboarding gate clear. Not end-to-end unit-testable (tests mock the CLI); the added tests lock the probe's home/basename behavior.
