### PR TITLE
style(theme): use neutral background for Kiro light mode

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -657,12 +657,12 @@
   color-scheme:dark;
 }
 [data-theme="kiro-light"]{
-  --bg:#f5f3f7;--bg-accent:#ece8f0;--bg-elevated:#ffffff;--bg-hover:#e4dfe9;
+  --bg:#fafafa;--bg-accent:#f5f5f5;--bg-elevated:#ffffff;--bg-hover:#f0f0f0;
   --card:#ffffff;--card-fg:#19161d;--card-hl:rgba(0,0,0,.03);
-  --panel:#f5f3f7;--panel-strong:#ece8f0;
-  --chrome:rgba(245,243,247,.95);
+  --panel:#fafafa;--panel-strong:#f5f5f5;
+  --chrome:rgba(250,250,250,.95);
   --text:#4a464f;--text-strong:#19161d;--muted:#5e5966;--muted-strong:#4a464f;
-  --border:#d8d2e0;--border-strong:#c4bcd0;--border-hover:#a99fc0;
+  --border:#e4e4e7;--border-strong:#d4d4d8;--border-hover:#a1a1aa;
   --accent:#8e48ff;--accent-fg:#ffffff;--accent-hover:#7a35e0;--accent-subtle:rgba(142,72,255,.12);
   --accent-glow:rgba(142,72,255,.15);--ring:#8e48ff;
   --ok:#008543;--ok-subtle:rgba(0,133,67,.12);


### PR DESCRIPTION
## Summary

The Kiro light theme (`[data-theme="kiro-light"]`) used a cool lavender-tinted background (`#f5f3f7`). Against the white cards it read as faintly purple rather than a clean light surface.

This switches the background family to the same neutral values the Amber and default light themes already use, so the surface reads clean and bright.

| CSS variable | Before | After |
|---|---|---|
| `--bg` | `#f5f3f7` | `#fafafa` |
| `--bg-accent` | `#ece8f0` | `#f5f5f5` |
| `--bg-hover` | `#e4dfe9` | `#f0f0f0` |
| `--panel` | `#f5f3f7` | `#fafafa` |
| `--panel-strong` | `#ece8f0` | `#f5f5f5` |
| `--chrome` | `rgba(245,243,247,.95)` | `rgba(250,250,250,.95)` |
| `--border` | `#d8d2e0` | `#e4e4e7` |
| `--border-strong` | `#c4bcd0` | `#d4d4d8` |
| `--border-hover` | `#a99fc0` | `#a1a1aa` |

## Scope

Backgrounds, panels, chrome and borders only.

- `--card` stays `#ffffff`
- The Kiro purple accent (`#8e48ff`) is unchanged
- All text colors are unchanged
- Dark mode (`kiro-dark`) is untouched
- No other theme is affected

The theme still reads as Kiro; only the surface tint changed.

## Testing

- Verified live in a local Vite dev server with the Kiro theme in light mode
- Ran the theme test suites: 58 tests pass across `themeCssCorpus`, `useTheme`, `DisplayPanel`, `themeScoper`, `StyledSelect`