### PR TITLE
docs(apps): explain what each built-in app actually does

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/app.json
+++ b/src/kiro_crew/apps/builtins/auto_research/app.json
@@ -2,9 +2,18 @@
   "name": "auto-research",
   "version": "0.1.0",
   "displayName": "Research Lab",
-  "description": "Autonomous research campaigns powered by autonudge — pre-flight validation, live findings, stagnation detection, and lifecycle controls.",
+  "description": "Runs multi-cycle research campaigns that keep working after you walk away. Give it a question and it expands that into a tree of narrower sub-questions, sends agents to investigate each one, and streams findings to the page as they land. A campaign self-drives until the question is answered or it notices progress has stalled, and you can hand the finished report off to your knowledge library or a shareable artifact.",
   "author": "kirocrew",
   "tags": ["research", "autonomy", "autonudge"],
+  "highlights": [
+    "Expands one broad question into a scoped tree of sub-questions before spending agent time",
+    "Campaigns keep researching between your check-ins, with findings streamed live",
+    "Notices when a campaign stops making progress instead of looping forever",
+    "Attended mode pauses to ask you a question when it needs a decision; unattended runs straight through",
+    "Add follow-up questions mid-campaign without starting over",
+    "Start, pause, and resume any campaign from the dashboard",
+    "Export the finished report to your knowledge library or a shareable artifact"
+  ],
   "defaultEnabled": false,
   "permissions": {
     "api": ["/api/apps/auto-research"]

--- a/src/kiro_crew/apps/builtins/code_review_sage/app.json
+++ b/src/kiro_crew/apps/builtins/code_review_sage/app.json
@@ -2,13 +2,20 @@
   "name": "code-review-sage",
   "version": "0.9.3",
   "displayName": "Code Review Sage",
-  "description": "Self-evolving deep code reviewer for GitHub PRs with a prioritized focus report. Findings post as a PENDING (draft) review you submit.",
+  "description": "Deep-reviews GitHub pull requests and tells you which changes actually deserve your attention. Every changed file is reviewed in its own isolated agent session, weighted by how much blast radius it carries, and rolled up into a prioritized Focus Report. Findings are staged as a draft GitHub review that stays unpublished until you submit it, and the reviewer keeps learning your repository's real standards from shipped fixes and past review comments.",
   "author": "kirocrew",
   "tags": [
     "code-review",
     "learning",
     "developer-tools",
     "github"
+  ],
+  "highlights": [
+    "Focus Report ranks changes by blast radius so the risky files get read first",
+    "One isolated agent session per change, so findings never bleed between files",
+    "Posts as a PENDING (draft) GitHub review — you remain the one who submits it",
+    "Learns per-repository from shipped fixes, review comments, and design discussions",
+    "Reviews GitHub pull requests; needs an authenticated `gh` CLI on the gateway host"
   ],
   "defaultEnabled": false,
   "skills": [

--- a/src/kiro_crew/apps/builtins/dev_fleet/app.json
+++ b/src/kiro_crew/apps/builtins/dev_fleet/app.json
@@ -2,9 +2,17 @@
   "name": "dev-fleet",
   "version": "1.0.0",
   "displayName": "Dev Fleet",
-  "description": "Manage KiroCrew feature worktrees and their isolated pods.",
+  "description": "A control panel for working on KiroCrew itself. Lists every feature worktree alongside its pull request state, commit count, and disk usage, and can bring any of them up as a pod: a complete preview instance on its own port with its own data directory, so you can click through an unfinished change without disturbing your live gateway. It also handles the chores around that — pulling main and rebuilding, rebasing a branch, streaming pod logs, and pruning worktrees whose work has already merged.",
   "author": "kirocrew",
   "tags": ["dev", "pods", "worktrees"],
+  "highlights": [
+    "Bring up any worktree as an isolated pod on its own port and data directory, leaving your live gateway untouched",
+    "Fleet view with per-branch PR status, commit counts, and disk usage",
+    "Sync (pull main and rebuild) or rebase a branch without leaving the dashboard",
+    "'Prune merged' refuses to delete a worktree with uncommitted or untracked work rather than discarding it",
+    "Stream pod logs and mint pod access tokens from the UI",
+    "Built for people developing KiroCrew itself — not needed for everyday use"
+  ],
   "defaultEnabled": false,
   "permissions": {
     "api": ["/apps/dev-fleet/api", "/apps/dev-fleet/api/*"],

--- a/src/kiro_crew/apps/builtins/file_explorer/app.json
+++ b/src/kiro_crew/apps/builtins/file_explorer/app.json
@@ -2,7 +2,7 @@
   "name": "file-explorer",
   "version": "1.0.0",
   "displayName": "Files",
-  "description": "Multi-tab file explorer with tree navigation, syntax highlighting, markdown preview, search, and git status.",
+  "description": "Browse and read files on the machine running KiroCrew without leaving the dashboard. Keep several files open in tabs, walk the directory tree with each file's git status shown beside it, search a whole folder for a string, and read markdown rendered rather than raw. It is read-only by design: it opens and searches files but never edits, moves, or deletes them, and it can only reach your home directory plus /tmp and /opt.",
   "author": "kirocrew",
   "tags": [
     "files",
@@ -10,6 +10,14 @@
     "productivity",
     "code",
     "markdown"
+  ],
+  "highlights": [
+    "Read-only: opens and searches files, and never writes, moves, or deletes them",
+    "Multiple files open at once in tabs, with syntax highlighting",
+    "Markdown files render as formatted text instead of raw source",
+    "Directory tree shows each file's git status inline",
+    "Search across a directory with line-level matches and surrounding preview",
+    "Reachable paths are limited to your home directory, /tmp, and /opt — symlinks out are refused"
   ],
   "defaultEnabled": false,
   "permissions": {

--- a/src/kiro_crew/apps/builtins/issue_radar/app.json
+++ b/src/kiro_crew/apps/builtins/issue_radar/app.json
@@ -2,13 +2,21 @@
   "name": "issue-radar",
   "version": "0.1.0",
   "displayName": "Issue Radar",
-  "description": "An issue triage assistant that remembers. Browse, filter, and triage GitHub issues with AI-suggested labels and per-issue investigation notes \u2014 with findings kept in a local ledger so nothing gets re-investigated.",
+  "description": "An issue triage assistant that remembers what you already worked out. Connect a GitHub repository and work through its issues with AI-written summaries and suggested labels, each with the reasoning behind it, then apply the labels you agree with back to GitHub in a click. Your notes on an issue are kept in a local ledger keyed to that issue, so coming back weeks later you resume from what you found instead of re-reading the entire thread.",
   "author": "kirocrew",
   "tags": [
     "github",
     "issue-triage",
     "open-source",
     "developer-tools"
+  ],
+  "highlights": [
+    "AI summaries and suggested labels for issues and pull requests, each with its reasoning",
+    "Per-issue investigation notes kept in a local ledger so nothing gets re-investigated",
+    "Applying label changes is the only write it makes to GitHub — everything else is read-only",
+    "Surfaces repositories you have recently contributed to, so connecting one is a click",
+    "Caches issues, labels, and members locally, refreshed on demand",
+    "Works with GitHub; needs an authenticated `gh` CLI on the gateway host"
   ],
   "defaultEnabled": false,
   "permissions": {

--- a/src/kiro_crew/apps/builtins/workflows/app.json
+++ b/src/kiro_crew/apps/builtins/workflows/app.json
@@ -2,13 +2,20 @@
   "name": "workflows",
   "version": "1.0.0",
   "displayName": "Workflows",
-  "description": "Author, run, and watch dynamic workflows — agent-authored Python scripts that orchestrate KiroCrew agents with a live phase/progress view.",
+  "description": "Author, run, and watch dynamic workflows: Python scripts, usually written for you by an agent from a plain-English goal, that drive several KiroCrew agents through ordered phases. A script is checked against a sandboxed set of workflow commands before anything runs, so mistakes surface without executing, and the page then streams each phase and agent event as the run progresses. Runnable examples ship with the app to start from.",
   "author": "kirocrew",
   "tags": [
     "workflows",
     "orchestration",
     "automation",
     "agents"
+  ],
+  "highlights": [
+    "Validate a workflow before running it — errors surface without anything executing",
+    "Watch the run live, phase by phase, with per-agent progress events",
+    "Scripts are limited to a sandboxed workflow API rather than arbitrary Python",
+    "Usually authored for you from a plain-English goal, then editable by hand",
+    "Ships with runnable examples to start from"
   ],
   "defaultEnabled": false,
   "hidden": true,

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1174,9 +1174,22 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "name": "agent-worlds",
         "version": "1.0.0",
         "displayName": "Agent Worlds",
-        "description": "Visualize your agents in interactive pixel-art scenes",
+        "description": (
+            "Turns your running agents into characters in an animated pixel-art scene, so a "
+            "glance tells you how busy KiroCrew is. Each active agent appears as a sprite that "
+            "reacts as work starts and finishes, across themed scenes from a classic office to "
+            "a wizard tower or an underwater lab. Pop it out into its own window to keep it on "
+            "a second screen while you work."
+        ),
         "author": "kirocrew",
         "tags": ["visualization", "agents"],
+        "highlights": [
+            "Live view of which agents are running, as characters rather than a list",
+            "Themed scenes including Office, Panda Den, Neural Net, Wizard Tower, and Deep Lab",
+            "Pop out into a separate window for a second monitor; scene choice stays in sync",
+            "Remembers your chosen scene between visits",
+            "Purely a visualization — it never changes what your agents do",
+        ],
         "defaultEnabled": False,
         "iconUrl": "/app-assets/worlds/icon.svg",
         "heroImage": "/app-assets/worlds/hero-light.svg",
@@ -1191,9 +1204,23 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "name": "channels",
         "version": "1.0.0",
         "displayName": "Channels",
-        "description": "Multi-agent collaboration channels with persistent context",
+        "description": (
+            "A shared room where several agents work a problem together instead of one agent "
+            "working alone. You assign each agent a role, and they post progress into the "
+            "channel and answer each other's @mentions in the open — there is no private "
+            "agent-to-agent messaging, so the whole exchange stays readable, and you remain "
+            "the approver for anything that changes state. Agents stay alive in the channel "
+            "until dismissed or timed out."
+        ),
         "author": "kirocrew",
         "tags": ["collaboration", "agents"],
+        "highlights": [
+            "Several role-assigned agents collaborate in one shared, readable transcript",
+            "No private agent-to-agent messaging — every exchange happens in the channel",
+            "You stay the final approver for any operation that mutates state",
+            "Agents persist in the channel until dismissed or timed out",
+            "Hidden from the App Store grid; enable with `kirocrew app enable channels`",
+        ],
         "defaultEnabled": False,
         # Hidden from the App Store Browse grid (opt-in via `kirocrew app enable channels`).
         # Code and routes remain fully intact; this only gates store visibility.
@@ -1210,9 +1237,22 @@ _BUILTIN_APPS: list[dict[str, Any]] = [
         "name": "projects",
         "version": "1.0.0",
         "displayName": "Task Runner",
-        "description": "Autonomous multi-step task execution — compose ideas, generate plans, and run them to completion",
+        "description": (
+            "Hand over a multi-step job and let it run to completion unattended. Describe the "
+            "work in plain language, paste a written spec, or upload a YAML file, then either "
+            "generate a plan first to review the steps or start it straight away. Each run gets "
+            "its own page showing step-by-step progress, and you can pause, resume, retry, or "
+            "stop it at any point."
+        ),
         "author": "kirocrew",
         "tags": ["tasks", "autonomy", "execution"],
+        "highlights": [
+            "Three ways in: describe the work in plain language, paste a spec, or upload YAML",
+            "Generate a plan and review the steps before committing to a run",
+            "Runs execute unattended, with step-by-step progress on the run's own page",
+            "Pause, resume, retry, or stop a run at any point",
+            "Keeps a history of past runs and their outcomes",
+        ],
         "defaultEnabled": True,
         "iconUrl": "/app-assets/projects/icon.svg",
         "heroImage": "/app-assets/projects/hero-light.svg",


### PR DESCRIPTION
## Problem

Every built-in app shipped with a single-sentence description. Opening the App
Store told you an app's name and roughly its category, but not what it does,
whether it will modify anything, or whether it is even meant for you. Several
descriptions leaned on internal vocabulary — "autonudge", "stagnation
detection", "Focus Report" — that means nothing until after you have used the
app.

The worst case was Dev Fleet: *"Manage KiroCrew feature worktrees and their
isolated pods."* Files was a bare feature list that omitted the two facts a
user most needs.

## Change

Expanded the description for **all nine** built-in apps, and added a
`highlights` array to each.

`highlights` already flows from the manifest through `apps/discovery.py` to the
frontend, where `AppDetailPage.tsx` renders it in an existing **Features** card
(`app.highlights`). **No frontend change was required.** Descriptions stay
front-loaded because store cards clamp to two lines (`line-clamp-2`), while the
detail page renders the description unclamped.

Descriptions are grounded in the source, surfacing facts the old text omitted:

- **Files** is strictly read-only (`server.py` exposes only `do_GET`) and can
  only reach `$HOME`, `/tmp`, `/opt`.
- **Issue Radar**'s only write to GitHub is applying labels.
- **Code Review Sage** stages a PENDING review that nobody publishes but you.
- **Dev Fleet** is only useful to people building KiroCrew itself.
- **Research Lab**'s attended mode pauses to ask you a question.

Three of the nine (`agent-worlds`, `channels`, `projects`) are declared as
dicts in `apps/manager.py` rather than `app.json`, so they are updated there,
using implicit string concatenation to respect the 100-char line limit.

| App | Description | Features |
|---|---|---|
| agent-worlds | 356c | 5 |
| auto-research | 419c | 7 |
| channels | 420c | 5 |
| code-review-sage | 452c | 5 |
| dev-fleet | 498c | 6 |
| file-explorer | 424c | 6 |
| issue-radar | 442c | 6 |
| projects | 347c | 5 |
| workflows | 432c | 5 |

## Testing

- Full backend suite: **18,248 passed**. 9 pre-existing failures
  (process-reaping, platform-identity, module-reload, STT) reproduced on a
  clean `origin/main` checkout — none touch app manifests.
- `isort`, `flake8`, `mypy` (487 files), and `scrub-lint` all clean.
- Verified programmatically that all 9 manifests validate and `highlights`
  reaches the dict the frontend reads.
- Verified visually on a local dev instance: the Apps list renders the new
  text, clamping to two lines as designed.
- Frontend gates (tsc/eslint/vitest) not run locally — no `.ts`/`.tsx` file
  changed, no frontend test references these strings, and no snapshots exist.

## Notes

- `workflows` is `"hidden": true`, so its text only surfaces once the app is
  enabled.
- Text-only change: no code paths, routes, or permissions were touched.
