### PR TITLE
fix(setup): give the real-home whoami probe an ACP-style full environment

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -43,11 +43,16 @@ import aiohttp
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
+from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.kiro_cli import (
     find_kiro_cli_candidates,
     known_kiro_cli_dirs,
 )
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import (
+    resource_limit_preexec,
+    sandboxed_spawn_argv,
+    scrub_agent_denied_env,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -1993,6 +1998,29 @@ class KiroPrerequisiteService:
         )
         platform_compat.restrict_to_owner(str(self._binary_trust_path))
 
+    def _real_home_probe_env(self) -> dict[str, str]:
+        """Build the real-home readiness ``whoami`` env like an ACP session.
+
+        The readiness login check runs against the real home, so it must see the
+        same session environment a real ``kiro-cli acp`` session gets — the
+        D-Bus session bus / secret-service keyring, XDG runtime dir, Kerberos
+        ccache, proxy, SSH agent, locale, etc. A curated allowlist drops
+        whatever a given host's keyring backend needs (e.g. AL2023 validates the
+        login via the D-Bus secret service, which needs
+        ``DBUS_SESSION_BUS_ADDRESS``), so mirror ``acp/runtime.py`` exactly: the
+        full real environment minus gateway-owned channel credentials, with PATH
+        augmented and the Kerberos ccache repaired. The OS sandbox still scrubs
+        sensitive env and Kiro Crew's own home stays hidden.
+        """
+
+        env = {str(key): str(value) for key, value in self._environ.items()}
+        env = scrub_agent_denied_env(env)
+        env["PATH"] = augmented_path(env.get("PATH", ""))
+        resolve_krb5_ccname(env)
+        env["NO_COLOR"] = "1"
+        env["TERM"] = "dumb"
+        return env
+
     async def _run_auth_command(
         self,
         executable: str,
@@ -2061,7 +2089,7 @@ class KiroPrerequisiteService:
                 return await self._run(
                     fallback_executable,
                     args,
-                    env=base_env,
+                    env=self._real_home_probe_env(),
                     timeout_secs=timeout_secs,
                     on_output=on_output,
                     sandboxed=True,

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -1017,6 +1017,48 @@ class TestKiroPrerequisiteWorkflow:
         assert whoami_calls == [str(tmp_path)]
 
     @pytest.mark.asyncio
+    async def test_real_home_whoami_carries_full_session_env_like_acp(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # The real-home whoami mirrors an ACP session's environment, so session
+        # vars the CLI's keyring needs reach it — e.g. DBUS_SESSION_BUS_ADDRESS /
+        # XDG_RUNTIME_DIR for the secret-service keyring (AL2023). A curated
+        # allowlist would drop them and break login detection.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        seen_env: dict[str, str] = {}
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            seen_env.update(kwargs["env"])
+            return ProcessResult(ok=False)
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={
+                "HOME": str(tmp_path),
+                "PATH": "/usr/bin:/bin",
+                "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/4242/bus",
+                "XDG_RUNTIME_DIR": "/run/user/4242",
+            },
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        await service.snapshot(force=True)
+
+        # Session env reached the whoami (unlike the minimal probe allowlist).
+        assert seen_env.get("DBUS_SESSION_BUS_ADDRESS") == "unix:path=/run/user/4242/bus"
+        assert seen_env.get("XDG_RUNTIME_DIR") == "/run/user/4242"
+
+    @pytest.mark.asyncio
     async def test_self_updated_candidate_still_signs_in(
         self,
         tmp_path: Path,
@@ -1820,10 +1862,19 @@ class TestKiroPrerequisiteWorkflow:
         assert runtime.kwargs[login_index]["sandbox_mode"] == "standard"
         assert runtime.kwargs[login_index]["env"]["https_proxy"] == ("http://proxy.example:8443")
         assert runtime.kwargs[login_index]["env"]["HOME"] != str(tmp_path)
+        # The strict --version probe keeps the minimal env (no proxy / desktop
+        # IPC). The real-home whoami mirrors an ACP session and carries the full
+        # env, so proxy/session vars are present there by design.
         for index, call in enumerate(runtime.calls):
-            if call[1] in (["--version"], ["whoami"]):
+            if call[1] == ["--version"]:
                 assert "https_proxy" not in runtime.kwargs[index]["env"]
                 assert "DISPLAY" not in runtime.kwargs[index]["env"]
+        whoami_env = next(
+            runtime.kwargs[i]["env"]
+            for i, call in enumerate(runtime.calls)
+            if call[1] == ["whoami"]
+        )
+        assert whoami_env.get("https_proxy") == "http://proxy.example:8443"
 
     @pytest.mark.asyncio
     async def test_windows_clean_install_uses_powershell_script(


### PR DESCRIPTION
## Problem
On AL2023 hosts (shizuka, gian), the "Kiro Crew needs Kiro sign-in" banner persists even though `kiro-cli whoami` succeeds in a normal shell — while the same code fixed AL2 hosts (nobita, suneo) via #591.

## Why it matters
`ready=false` pauses all session creation, so the affected AL2023 dev desktops can't start sessions despite a working, authenticated CLI.

## Fix (symptom → root cause → change)
- **Symptom:** the readiness `whoami` reports signed-out on AL2023 (banner stays up), but works on AL2.
- **Root cause:** #591 made the `whoami` run against the real HOME (good) but still passed KiroCrew's **minimal probe env** (`_probe_environment` / `_PROBE_ENV_KEYS`), which deliberately omits `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR`. On AL2023 kiro-cli validates its login through the **D-Bus secret-service keyring**, so without the session-bus address it fails with `Failed to connect to bus: No medium found` → `whoami` non-zero → banner. AL2 doesn't need the bus for `whoami`, which is why #591 sufficed there. Reproduced on shizuka: the same sandboxed `whoami` fails with the minimal env and **succeeds** the moment `DBUS_SESSION_BUS_ADDRESS`/`XDG_RUNTIME_DIR` are restored.
- **Change:** give the real-home `whoami` the **same environment a real ACP session gets** instead of a curated allowlist. New `_real_home_probe_env()` mirrors `acp/runtime.py`: full `os.environ` → `scrub_agent_denied_env` (drop gateway channel creds) → `augmented_path` → `resolve_krb5_ccname`. This carries D-Bus, XDG runtime dir, Kerberos ccache, proxy, SSH agent, and locale — whatever a given host's keyring/auth backend needs — rather than whack-a-mole allowlisting. The strict `--version` probe keeps the minimal env; the device-login path is unchanged.

**Security:** unchanged posture from #591 — this is a read-only `whoami` and a strict subset of what a real ACP session already runs with the same binary (the OS sandbox still scrubs sensitive env and hides Kiro Crew's own home). `scrub_agent_denied_env` still removes the gateway's Slack/WeCom/Telegram channel credentials.

## Tests
- `test_real_home_whoami_carries_full_session_env_like_acp`: with `DBUS_SESSION_BUS_ADDRESS`/`XDG_RUNTIME_DIR` in the environment, the whoami subprocess receives them (the exact delta that flips shizuka fail→pass).
- Updated `test_linux_clean_install_then_device_login`: the minimal-env exclusion (no proxy/DISPLAY) now applies to `--version` only; the real-home `whoami` carries the full env (asserts `https_proxy` is present).
- Full suite: **98 passed / 1 skipped**; `test_spawn_audit.py` green; flake8 clean.

## Manual verification
On shizuka (AL2023), reproducing KiroCrew's exact real-home `whoami` path: it fails `Failed to connect to bus: No medium found` with the minimal env and returns "Logged in …" once the D-Bus/XDG session vars are present. The full-env change is a superset of that verified delta, so it resolves AL2023 (and the Kerberos-keyring case `resolve_krb5_ccname` documents for AL2023). Not unit-testable end-to-end (tests mock the CLI); the added test locks the env pass-through.
