### PR TITLE
fix(setup): forward D-Bus session-bus env to the Kiro CLI version probe

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -144,6 +144,7 @@ _SAFE_ENV_KEYS = frozenset(
         "XDG_CACHE_HOME",
         "XDG_CONFIG_HOME",
         "XDG_DATA_HOME",
+        "XDG_RUNTIME_DIR",
         "http_proxy",
         "https_proxy",
         "no_proxy",
@@ -152,6 +153,13 @@ _SAFE_ENV_KEYS = frozenset(
 _PROBE_ENV_KEYS = frozenset(
     {
         "APPDATA",
+        # Session bus + runtime dir: some Kiro CLI builds connect to the D-Bus
+        # secret-service keyring at startup — even for ``--version`` — so the
+        # probe must pass these through when the host sets them (e.g. AL2023,
+        # where without them the CLI exits "Failed to connect to bus"). They are
+        # only forwarded when present; hosts without a session bus (macOS, AL2,
+        # headless) simply don't set them, so this is a no-op there.
+        "DBUS_SESSION_BUS_ADDRESS",
         "HOME",
         "LANG",
         "LC_ALL",
@@ -172,6 +180,7 @@ _PROBE_ENV_KEYS = frozenset(
         "XDG_CACHE_HOME",
         "XDG_CONFIG_HOME",
         "XDG_DATA_HOME",
+        "XDG_RUNTIME_DIR",
     }
 )
 

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -1059,6 +1059,48 @@ class TestKiroPrerequisiteWorkflow:
         assert seen_env.get("XDG_RUNTIME_DIR") == "/run/user/4242"
 
     @pytest.mark.asyncio
+    async def test_version_probe_forwards_session_bus_vars(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Some Kiro CLI builds connect to the D-Bus secret-service keyring at
+        # startup even for `--version`, so the version probe must forward the
+        # session-bus vars when the host sets them (AL2023) — otherwise
+        # `--version` exits "Failed to connect to bus" and installed-detection
+        # fails before the whoami check is ever reached. No-op where unset.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        version_env: dict[str, str] = {}
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                version_env.update(kwargs["env"])
+            return ProcessResult(ok=True)
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={
+                "HOME": str(tmp_path),
+                "PATH": "/usr/bin:/bin",
+                "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/9/bus",
+                "XDG_RUNTIME_DIR": "/run/user/9",
+            },
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is True
+        assert version_env.get("DBUS_SESSION_BUS_ADDRESS") == "unix:path=/run/user/9/bus"
+        assert version_env.get("XDG_RUNTIME_DIR") == "/run/user/9"
+
+    @pytest.mark.asyncio
     async def test_self_updated_candidate_still_signs_in(
         self,
         tmp_path: Path,
@@ -1520,7 +1562,13 @@ class TestKiroPrerequisiteWorkflow:
                 )
                 assert "HTTPS_PROXY" not in runtime.kwargs[index]["env"]
                 assert "DISPLAY" not in runtime.kwargs[index]["env"]
-                assert "DBUS_SESSION_BUS_ADDRESS" not in runtime.kwargs[index]["env"]
+                # The session bus IS forwarded now — some CLI builds connect to
+                # the D-Bus secret-service keyring even at --version (AL2023).
+                # Other desktop IPC / proxy vars stay excluded.
+                assert (
+                    runtime.kwargs[index]["env"].get("DBUS_SESSION_BUS_ADDRESS")
+                    == "unix:path=/tmp/bus"
+                )
 
     @pytest.mark.asyncio
     async def test_probe_does_not_spawn_when_invoked_audit_fails(


### PR DESCRIPTION
## Problem
On AL2023 hosts (shizuka, gian) the setup/reauth banner persisted even after #591 and #596 — while nobita/suneo (AL2) were fixed. The Kiro CLI is signed in (`kiro-cli whoami` works in a shell), yet KiroCrew reports it as not ready.

## Why it matters
`ready=false` pauses all session creation, so the AL2023 dev desktops stay blocked despite a working, authenticated CLI.

## Fix (symptom → root cause → change)
- **Symptom:** banner persists on AL2023 after #596; the readiness probe reports the CLI as not usable.
- **Root cause:** this Kiro CLI build (2.12) connects to the **D-Bus secret-service keyring at startup — even for `--version`**. The `--version` version probe runs with the *minimal* env (`_PROBE_ENV_KEYS`), which omits `DBUS_SESSION_BUS_ADDRESS`/`XDG_RUNTIME_DIR`, so `--version` exits `Failed to connect to bus: No medium found` → `installed=False` → banner, and `_probe` never reaches the whoami check that #596 already fixed. Reproduced on shizuka: `--version` fails with the minimal env and returns `kiro-cli 2.12.0` the moment the session-bus vars are present; a full `snapshot()` with the two keys added returns `installed=True authenticated=True ready=True`.
- **Change:** add `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` to `_PROBE_ENV_KEYS` (the version-probe env), and `XDG_RUNTIME_DIR` to `_SAFE_ENV_KEYS` (device-login parity; `DBUS_SESSION_BUS_ADDRESS` was already there). The version probe stays otherwise minimal + strict-sandboxed (it runs an untrusted first candidate) — these are just the session-bus vars the CLI needs to not crash at startup.

**Generality / no regression:** this only *forwards* two well-known session vars **when the host sets them**. It hardcodes no path and forces no value, so it's a strict no-op on hosts that don't set them (macOS, AL2, headless/systemd) and cannot break them. It complements #596 (whoami got the full ACP env) by giving the version probe the minimum it needs.

## Tests
- `test_version_probe_forwards_session_bus_vars`: with `DBUS_SESSION_BUS_ADDRESS`/`XDG_RUNTIME_DIR` set, the `--version` probe env receives them and `installed=True`.
- Updated `test_probe_has_paired_audit_events_and_hides_crew_homes`: the version probe now forwards the session bus (asserts it is present) while still excluding other desktop IPC / proxy vars (`DISPLAY`, `HTTPS_PROXY`).
- Full suite: **99 passed / 1 skipped**; flake8 clean.

## Manual verification
On shizuka (AL2023): the `--version` probe fails `Failed to connect to bus` with the minimal env and succeeds (`kiro-cli 2.12.0`) with the session-bus vars; a full `snapshot()` with the two keys added returns `installed=True authenticated=True ready=True` — i.e. the banner clears. Deploying this + #596 resolves the AL2023 hosts. Not end-to-end unit-testable (tests mock the CLI); the added test locks the env pass-through.
