### PR TITLE
ci: give AI reviewers single-user tool-shape context

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -147,7 +147,12 @@ jobs:
             of ${{ github.repository }} (HEAD ${{ github.event.pull_request.head.sha }}).
 
             KiroCrew is an open-source AI agent platform (Python backend + React/TS
-            dashboard). CLAUDE.md and AGENTS.md (root and website/) are read
+            dashboard). It is a single-user tool: every component runs as one OS
+            user's own local processes sharing that user's resources — the trust
+            boundary is that OS user (a team deployment stays per-user, same-UID),
+            not a multi-tenant/shared service. Keep review proportional to that
+            shape.
+            CLAUDE.md and AGENTS.md (root and website/) are read
             automatically — follow the conventions there. This repo is a de-Amazoned
             public fork: do NOT flag the absence of Brazil/AUTOSDE tooling.
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -136,7 +136,11 @@ jobs:
           REPO CONTEXT:
           KiroCrew is an open-source AI agent platform (Python backend + React/TS
           dashboard). It is a de-Amazoned public fork: do NOT flag the absence of
-          Brazil/AUTOSDE build tooling or internal-only infrastructure. Follow the
+          Brazil/AUTOSDE build tooling or internal-only infrastructure. It is a
+          single-user tool: every component runs as one OS user's own local
+          processes sharing that user's resources — the trust boundary is that OS
+          user (a team deployment stays per-user, same-UID), not a multi-tenant/
+          shared service. Keep review proportional to that shape. Follow the
           conventions in CLAUDE.md and AGENTS.md (root and website/) when present.
 
           Start from the changes this branch introduces relative to the base:

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -126,6 +126,10 @@ jobs:
             REPO CONTEXT: KiroCrew is an open-source AI agent platform (Python
             backend + React/TS dashboard), a de-Amazoned public fork. Do NOT flag
             the absence of Brazil/AUTOSDE build tooling or internal-only infra.
+            It is a single-user tool: every component runs as one OS user's own
+            local processes sharing that user's resources — the trust boundary is
+            that OS user (a team deployment stays per-user, same-UID), not a
+            multi-tenant/shared service. Keep review proportional to that shape.
             CLAUDE.md and AGENTS.md (root and website/) hold the conventions.
 
             THIS IS A DESIGN REVIEW, NOT A LINE-LEVEL REVIEW. Two OTHER automated


### PR DESCRIPTION
## Problem
The AI code reviewers (Opus 5, GPT 5.6, Design) had no context about what *shape* of software KiroCrew is. Their `REPO CONTEXT` block described it only as "an open-source AI agent platform (Python + React/TS)." Lacking a trust-boundary/scale premise, they periodically proposed hardening and features scaled for a multi-tenant / shared service — disproportionate for a tool that runs entirely as one user's own local processes. A concrete recent example: a TOCTOU "copy the resolved binary into a private folder before exec" defense against a same-UID binary swap — added complexity with no real gain, since a same-UID actor is inside the trust boundary either way.

## Why it matters
Disproportionate review findings cost author time (investigating and rebutting), and when acted on they add real complexity and fragility to the codebase to defend against threats that don't exist at this tool's shape. Giving reviewers the shape up front makes their judgment proportional by default.

## Fix (symptom -> root cause -> change)
- **Symptom:** reviewers suggest multi-tenant / shared-instance solutions and same-UID hardening.
- **Root cause:** the reviewer prompts never stated the tool's shape or trust boundary.
- **Change:** add one general tool-shape sentence to the `REPO CONTEXT` block of all three reviewer prompts — KiroCrew is a single-user tool (every component runs as one OS user's own local processes sharing that user's resources; a team deployment stays per-user, same-UID), not a multi-tenant/shared service; keep review proportional to that shape. Stated as a **general premise, not an enumerated list of prohibitions**, so the reviewer derives proportionality itself rather than pattern-matching specific cases.

## Tests
N/A for new automated tests — the change is reviewer prompt prose inside YAML block scalars, with no executable surface. Verified the existing assertion suite still passes: `test/test_ai_review_workflows.py` — **37 passed**. No assertion targets the `REPO CONTEXT` prose, and the `FINDING BAR` / `WHAT BLOCKS` / division-of-labour logic is untouched.

## Manual verification
- Confirmed the added sentence sits inside each existing `REPO CONTEXT` block in claude-review.yml, codex-review.yml, and design-review.yml, adjacent to the existing "de-Amazoned public fork" context, and changes no control-flow/gating logic.
- Diff is +15/-2 across the 3 workflow files; no other files touched.
