### PR TITLE
fix(theme): stop self-repair resetting registered themes to default

### DIFF
--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -951,12 +951,17 @@ function useThemeState(): ThemeContextValue {
   // any theme-list refresh). Two dangling cases:
   //   1. An unknown *built-in* value (e.g. a theme removed in a newer build,
   //      like the retired 'lumon') — can never become valid, so repair at once.
+  //      A downstream-registered theme (registerTheme → REGISTERED_THEMES) is a
+  //      valid built-in picker entry too, so it must count as known here — else
+  //      selecting an edition theme (LCARS, Lumon, …) would bounce to the
+  //      default, since it isn't in the core THEMES array.
   //   2. A dangling custom-<slug> whose pack is uninstalled — repair once the
   //      theme list has loaded (gated so a valid install isn't reset early).
   useEffect(() => {
     if (
       !colorTheme.startsWith('custom-') &&
-      !THEMES.some(t => t.value === colorTheme)
+      !THEMES.some(t => t.value === colorTheme) &&
+      !REGISTERED_THEMES.some(t => t.value === colorTheme)
     ) {
       setColorTheme(DEFAULT_COLOR_THEME)
       return

--- a/website/src/test/ThemeSelfRepair.test.tsx
+++ b/website/src/test/ThemeSelfRepair.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../api/client', () => ({
   },
 }))
 
-import { useTheme, ThemeProvider } from '../hooks/useTheme'
+import { useTheme, ThemeProvider, registerTheme } from '../hooks/useTheme'
 
 const wrapper = ({ children }: { children: ReactNode }) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -67,5 +67,21 @@ describe('useTheme — self-repair (decision 6)', () => {
     localStorage.setItem('mc-color-theme', 'lumon')
     const { result } = renderHook(() => useTheme(), { wrapper })
     await waitFor(() => expect(result.current.colorTheme).toBe('kiro'))
+  })
+
+  it('keeps a downstream-registered (edition) theme selection', async () => {
+    // Regression: edition themes added via registerTheme() live in
+    // REGISTERED_THEMES, not the core THEMES array. Self-repair must treat them
+    // as valid built-ins — otherwise selecting LCARS/Lumon/Miami/etc bounced
+    // straight back to the default 'kiro'.
+    registerTheme([{ value: 'lcars', label: '🖖 LCARS' }])
+    themesFn.mockResolvedValue({ themes: [] })
+    localStorage.setItem('mc-color-theme', 'lcars')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    // Wait until the custom-theme load has run (which flips customThemesLoaded
+    // and re-fires the self-repair effect) — if the bug were present the value
+    // would have been reset by now.
+    await waitFor(() => expect(themesFn).toHaveBeenCalled())
+    expect(result.current.colorTheme).toBe('lcars')
   })
 })


### PR DESCRIPTION
## Summary
Downstream-registered themes (added via the `registerTheme()` extension seam) were reset to the default `kiro` theme the moment they were selected in the picker.

## Root cause
The self-repair effect in `useTheme.tsx` validated a persisted non-custom selection only against the core `THEMES` array:

```ts
if (!colorTheme.startsWith('custom-') && !THEMES.some(t => t.value === colorTheme)) {
  setColorTheme(DEFAULT_COLOR_THEME)
}
```

Themes contributed through `registerTheme()` land in `REGISTERED_THEMES` and show up in `allThemes` (the picker's option list), but this check never consulted `REGISTERED_THEMES` — so every edition-registered theme (LCARS, Lumon, Miami, …) looked like an unknown/retired built-in and was bounced back to the default on select. `custom-*` packs had their own valid branch, which is why only registered themes broke.

## Fix
Add `REGISTERED_THEMES` to the validity check so any theme that legitimately entered the picker via the seam is honored.

## Blast radius
No behavior change for the stock OSS build: `REGISTERED_THEMES` is empty there (the `virtual:kirocrew-edition` seam is inert), so the added clause is vacuously true and the check collapses to the original logic. A genuinely retired/unknown built-in still self-repairs to the default.

## Testing
- `vitest run src/test/ThemeSelfRepair.test.tsx` — 4 passed, including a new regression test asserting a `registerTheme()`'d value is **not** reset, and the existing "retired lumon → kiro" test (public-build semantics) still passes.
- `tsc --noEmit` clean; adjacent suites (`extensionSeams`, `DisplayPanel`, `ThemeExperienceLayer`) green (81 passed).
