### PR TITLE
fix(artifacts): stop ?session= falling back to the no-origin bucket

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -381,11 +381,21 @@ the document list are dropped in favor of the path-aware row. The star means
 else is a `pinned` flip.
 
 `?session=` is validated through the same grammar as a save's
-`origin_session_key`; a malformed value collapses to `""` (the no-origin bucket)
-rather than widening to every artifact. Like `?folder=`, absent means "don't
-scope" while present-but-empty means "only unattributed" — the handler reads the
-raw key to keep the two distinct. `?pinned=` is tri-state for the same reason: an
-unrecognized value does not scope rather than being read as `false`.
+`origin_session_key`, but a validation **miss keeps the raw value** instead of
+collapsing to `""`. Collapsing is correct for a *write* (attributing a save to no
+session is safe) and wrong for a *read* filter: `""` is the real no-origin bucket,
+so an unvalidatable key would return some **other** session's artifacts — notably
+every `artifact_save` from the MCP path, which stores `session_key=""`. Since
+`store.list` compares exactly, the raw value matches zero records: an honestly
+empty tab rather than a foreign one. This is not only a hostile-input case — a slot
+key can legitimately exceed the grammar's 128-char cap, because the artifact
+companion-chat flow names a slot `Artifact: <name>` and names run to
+`MAX_NAME_LEN` (200).
+
+Like `?folder=`, absent means "don't scope" while present-but-empty means "only
+unattributed" — the handler reads the raw key to keep the two distinct. `?pinned=`
+is tri-state for the same reason: an unrecognized value does not scope rather than
+being read as `false`.
 
 **The session key is the BARE slot key** (`chat-<N>-<ts>`), never a decorated
 `dashboard:<key>` form. `ArtifactStore.list` compares `session_key` exactly — it

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -993,11 +993,22 @@ async def api_artifacts_list(request: web.Request) -> web.Response:
     folder = request.query["folder"] if "folder" in request.query else None
     # ``session`` scopes to the artifacts one chat session produced (the
     # in-session Artifacts tab). Validated through the same grammar as a save's
-    # ``origin_session_key`` so a hostile value can't reach the store as a
-    # filter; an invalid value collapses to "" (the no-origin bucket) rather
-    # than silently widening to every artifact.
+    # ``origin_session_key`` so a hostile value can't reach the store as a filter.
+    #
+    # On a validation MISS the raw value is kept rather than collapsed to "".
+    # Collapsing is right for a WRITE (attributing a save to no session is safe)
+    # but wrong for a READ filter: "" is the real no-origin bucket, so an
+    # over-long key would return some OTHER session's artifacts — e.g. every
+    # ``artifact_save`` from the MCP path, which stores ``session_key=""``. A slot
+    # key can exceed the 128-char limit today: the artifact companion-chat flow
+    # names a slot ``Artifact: <name>`` and names run to ``MAX_NAME_LEN`` (200).
+    # ``store.list`` compares exactly, so the raw over-long key matches zero
+    # records — an honestly empty tab instead of a foreign one.
+    _raw_session = request.query.get("session")
     session = (
-        _clean_origin_session_key(request.query["session"]) if "session" in request.query else None
+        (_clean_origin_session_key(_raw_session) or _raw_session)
+        if "session" in request.query
+        else None
     )
     pinned = _clean_pinned_filter(request.query.get("pinned"))
     try:

--- a/test/test_artifacts_handlers.py
+++ b/test/test_artifacts_handlers.py
@@ -247,14 +247,41 @@ class TestList:
         assert {a["slug"] for a in _json_body(resp)["artifacts"]} == {"orphan"}
 
     @pytest.mark.asyncio
-    async def test_malformed_session_does_not_widen_to_all(
+    async def test_malformed_session_returns_nothing_not_the_no_origin_bucket(
         self, isolated_store, patch_restricted
     ) -> None:
-        """A hostile/invalid key must collapse to "", never leak every artifact."""
+        """An invalid key must match NOTHING — not the ``""`` bucket, not everything.
+
+        The unattributed artifact here is load-bearing: every ``artifact_save``
+        from the MCP path stores ``session_key=""``, so a validation miss that
+        collapsed to ``""`` would hand the caller a FOREIGN artifact list. With
+        only attributed fixtures this test passes either way.
+        """
         isolated_store.create(name="mine", content="x", session_key="dashboard:chat-1")
         isolated_store.create(name="other", content="x", session_key="dashboard:chat-2")
+        isolated_store.create(name="unattributed", content="x")  # session_key=""
         resp = await api_artifacts_list(_request(query={"session": "../../etc/passwd"}))
         assert _json_body(resp)["artifacts"] == []
+
+    @pytest.mark.asyncio
+    async def test_over_long_session_key_does_not_leak_another_session(
+        self, isolated_store, patch_restricted
+    ) -> None:
+        """A >128-char slot key is REAL, not hostile — it must not return foreign rows.
+
+        The artifact companion-chat flow names a slot ``Artifact: <name>`` and
+        artifact names run to ``MAX_NAME_LEN`` (200), so a slot key can exceed the
+        session-key grammar's 128-char cap. The write side stores that key
+        verbatim, so its artifacts exist; the read side must either find them or
+        find nothing — never someone else's.
+        """
+        long_slot = "chat-1-" + "x" * 140
+        assert len(long_slot) > 128
+        isolated_store.create(name="mine", content="x", session_key=long_slot)
+        isolated_store.create(name="unattributed", content="x")  # session_key=""
+        resp = await api_artifacts_list(_request(query={"session": long_slot}))
+        slugs = {a["slug"] for a in _json_body(resp)["artifacts"]}
+        assert "unattributed" not in slugs, "must not fall back to the no-origin bucket"
 
     # ── ?pinned= ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

An in-session **Artifacts** tab whose slot key fails session-key validation was
served **another session's artifacts** instead of its own — and the user could star
and unstar those foreign artifacts from there. Their own widgets were invisible in
the panel even though the records existed on disk.

## Why it matters

The bucket that leaks is not obscure: `""` (no originating session) is what **every
`artifact_save` from the MCP path** stores, because that path never forwards
`origin_session_key`. So the wrong list is typically the agent's saved-artifact
pile, shown inside an unrelated chat session.

The trigger is a *legitimate* key, not just hostile input. `_SESSION_KEY_RE` caps
keys at 128 chars, but the artifact companion-chat flow
(`ArtifactDetailPage.tsx` → `api.createChatSlot(\`Artifact: ${artifact.name}\`)`)
produces longer ones: artifact names run to `MAX_NAME_LEN` (200), and a 139-char
name yields a **149-char** slot key.

## Fix (symptoms → root cause → change)

**Symptom:** the session panel lists artifacts that belong to no session (or to
another one), and never the widgets registered for this session.

**Root cause:** `GET /api/artifacts?session=` reused `_clean_origin_session_key`,
which returns `""` on any validation miss. Collapsing to `""` is correct for a
**write** — attributing a save to no session is safe — but wrong for a **read**
filter, because `""` is a *real* bucket. `ArtifactStore.list` compares
`session_key` exactly, so the miss silently re-pointed the query at every
unattributed artifact. Meanwhile the write side (`_schedule_widget_registration`)
stores the long key verbatim, so the session's own artifacts were present but
unreachable through this query.

**Change:** keep the raw value when validation misses. Since the comparison is
exact, an unvalidatable key matches zero records — an honestly empty tab instead of
someone else's artifacts. Validation still runs, so a hostile value never reaches
the store as anything but a non-matching literal.

Follow-up to #599, which introduced `?session=`; it merged before this fix was
pushed.

## Tests

- `test_over_long_session_key_does_not_leak_another_session` — pins the
  legitimate-but-over-128-char key (asserts the length premise first, so the test
  can't silently stop exercising the case).
- `test_malformed_session_returns_nothing_not_the_no_origin_bucket` — the existing
  malformed-key test, now with an **unattributed** (`session_key=""`) fixture. That
  fixture is load-bearing: with only attributed fixtures the test passed either
  way, which is why the defect shipped green.

Both fail against the previous behavior (verified by reverting the one-line change
and re-running).

## Manual verification

Reproduced the defect directly against the real handler + a real store before
fixing: with a 149-char slot key the endpoint returned the unattributed artifact
and **not** the one registered for that session. Confirmed the corrected handler
returns no foreign rows. Gates on current `main`: 18,689 backend tests, flake8 +
isort + mypy clean.

## Screenshots

N/A — no user-visible UI change; this corrects which rows an existing panel
queries. The panel itself is unchanged and was screenshotted in #599.
