### PR TITLE
fix: remediate 3 CSE DoS / upload-validation findings

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import zipfile
 from datetime import datetime
 from pathlib import Path
 
@@ -16,6 +17,7 @@ from aiohttp import web
 
 from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.dashboard.handlers.files import _ZIP_CONTAINER_EXTS, _content_matches_ext
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.knowledge.agent_fetch import fetch_url_content
 from kiro_crew.knowledge.artifact_ingest import ArtifactKnowledgeSync
@@ -1137,6 +1139,37 @@ async def get_stats(request: web.Request) -> web.Response:
 
 
 _MAX_INGEST_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+# Decompression-bomb bounds for zip-container uploads (.docx/.xlsx/.pptx/...).
+# A valid PK signature passes the magic-byte gate but the archive can still be
+# a bomb whose members expand unbounded once a parser (python-docx) opens it
+# (CWE-770). Bound the declared aggregate uncompressed size and member count
+# from the central directory before any parser touches the file.
+_MAX_INGEST_ARCHIVE_UNCOMPRESSED = 200 * 1024 * 1024  # 200 MB uncompressed total
+_MAX_INGEST_ARCHIVE_MEMBERS = 10000
+
+
+def _inspect_zip_archive(path: str) -> str | None:
+    """Bound a zip-container's member count + declared aggregate uncompressed
+    size using central-directory metadata only (no extraction).
+
+    Returns a short rejection reason, or ``None`` if within limits. This does
+    synchronous zip I/O, so callers MUST run it off the event loop (via
+    ``asyncio.to_thread``) — a large/hostile central directory would otherwise
+    stall the gateway loop and heartbeat.
+    """
+    try:
+        with zipfile.ZipFile(path) as zf:
+            infos = zf.infolist()
+            if len(infos) > _MAX_INGEST_ARCHIVE_MEMBERS:
+                return "too_many_members"
+            uncompressed = 0
+            for zi in infos:
+                uncompressed += zi.file_size
+                if uncompressed > _MAX_INGEST_ARCHIVE_UNCOMPRESSED:
+                    return "uncompressed_too_large"
+    except zipfile.BadZipFile:
+        return "bad_archive"
+    return None
 
 
 async def ingest_file(request: web.Request) -> web.Response:
@@ -1153,9 +1186,14 @@ async def ingest_file(request: web.Request) -> web.Response:
 
     filename = getattr(field, "filename", None) or "upload"
     suffix = Path(filename).suffix
+    ext = suffix.lower()
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix, prefix="kn_")
     try:
         total_size = 0
+        # Capture the leading bytes so the claimed extension can be verified
+        # against the file signature; 16 bytes covers every prefix in the
+        # sibling gate (PNG magic is 8, WEBP needs bytes 8:12, zip/PDF fewer).
+        head = bytearray()
         while True:
             chunk = await field.read_chunk()  # type: ignore[union-attr]
             if not chunk:
@@ -1166,8 +1204,36 @@ async def ingest_file(request: web.Request) -> web.Response:
                 Path(tmp.name).unlink(missing_ok=True)
                 return web.json_response(
                     {"error": f"file too large (max {_MAX_INGEST_FILE_SIZE // (1024 * 1024)} MB)"}, status=413)
+            if len(head) < 16:
+                head.extend(chunk[: 16 - len(head)])
             tmp.write(chunk)
         tmp.close()
+
+        # Content-signature gate (CWE-434): the extension is attacker-controlled
+        # and FileReader dispatches to binary parsers (.pdf/.docx) purely by
+        # extension, so verify the magic bytes match the claimed type BEFORE the
+        # file is handed to a parser. Text formats have no reliable signature and
+        # pass through, matching the sibling upload gate in handlers/files.py.
+        if not _content_matches_ext(ext, bytes(head)):
+            Path(tmp.name).unlink(missing_ok=True)
+            _sel_log("ingest", filename=filename, outcome="rejected")
+            return web.json_response(
+                {"error": f"file content does not match its type: {ext}"}, status=400)
+
+        # Decompression-bomb guard (CWE-770): a valid-signature OOXML/zip can
+        # still be a bomb whose members expand unbounded once python-docx / the
+        # zip parser opens it. Bound the declared member count and aggregate
+        # uncompressed size from the central directory (metadata only, no
+        # extraction) BEFORE the file reaches a parser; reject a breach or a
+        # corrupt/lying archive. Run off the event loop so a hostile central
+        # directory can't stall the gateway loop/heartbeat.
+        if ext in _ZIP_CONTAINER_EXTS:
+            reason = await asyncio.to_thread(_inspect_zip_archive, tmp.name)
+            if reason is not None:
+                Path(tmp.name).unlink(missing_ok=True)
+                _sel_log("ingest", filename=filename, outcome="rejected", reason=reason)
+                return web.json_response(
+                    {"error": f"{ext} archive rejected ({reason})"}, status=400)
 
         # Create source record immediately so it appears in the UI
         store = _store(request)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -141,6 +141,7 @@ from kiro_crew.dashboard.port_reclaim import (
     RECLAIMED,
     reclaim_stale_gateway_port,
 )
+from kiro_crew.dashboard.slowloris import build_hardened_runner
 from kiro_crew.dashboard.state import _DEFAULT_PORT, DashboardState
 from kiro_crew.dashboard.token_auth import (
     _cookie_port_from_host,
@@ -2210,7 +2211,9 @@ async def start_dashboard(
     # ``_register_instances_hooks`` for why ordering matters.
     _register_instances_hooks(app, state, port)
 
-    runner = web.AppRunner(app)
+    # Hardened runner: bounds the request-line/header read time (slowloris /
+    # CWE-400) and reaps idle keep-alive connections. See dashboard.slowloris.
+    runner = build_hardened_runner(app)
     await runner.setup()
     site = web.TCPSite(runner, bind_address_for(local_only), port)
     await _start_site(site, port)
@@ -2627,7 +2630,8 @@ async def start_api_server(
 
     app.on_cleanup.append(_kiro_prerequisite_shutdown)
 
-    runner = web.AppRunner(app)
+    # Hardened runner: same slowloris / CWE-400 mitigation as start_dashboard.
+    runner = build_hardened_runner(app)
     await runner.setup()
     # Same bind resolution as start_dashboard: loopback unless the operator
     # widened it (dashboard.url opt-out of local_only, or the KIROCREW_BIND

--- a/src/kiro_crew/dashboard/slowloris.py
+++ b/src/kiro_crew/dashboard/slowloris.py
@@ -1,0 +1,209 @@
+"""Slowloris mitigation for the aiohttp dashboard / API servers.
+
+aiohttp (3.9 .. 3.x) exposes NO first-class server-side "time to read the
+request line + headers" timeout. ``web.RequestHandler`` only offers
+``keepalive_timeout`` (idle time *between* requests on a persistent
+connection) and header *size* caps (``max_line_size`` / ``max_field_size`` /
+``max_headers``) -- none of which bound how long a client may take to *send*
+the initial request. A client that opens a connection and dribbles the request
+line/headers one byte at a time therefore parks a connection indefinitely: the
+request-read loop in ``RequestHandler.start()`` blocks on ``await self._waiter``
+with no deadline until a complete message is parsed. Enough such connections
+exhaust the accept loop / fd budget -- the classic slowloris DoS (CWE-400).
+
+The only robust in-process fix is a connection-level guard, since a
+``@web.middleware`` runs *after* the request line + headers are already parsed
+and so cannot see (let alone bound) a slow header read. This module adds that
+guard as a thin ``RequestHandler`` subclass that arms a one-shot deadline when
+the connection is established and disarms it the instant the first complete
+request message has been parsed. Because the clock stops once headers are in,
+it never touches response duration -- long-lived streaming responses (SSE,
+chunked downloads) are unaffected.
+
+Wiring: ``build_hardened_runner(app)`` returns a ``web.AppRunner`` subclass
+that (a) builds our hardened ``Server``/``RequestHandler`` and (b) sets a
+bounded ``keepalive_timeout`` so idle persistent connections are also reaped
+(defence-in-depth for the between-requests vector that the per-request deadline
+does not cover). Neither knob weakens ``client_max_size`` or the bind-address
+logic. Deployments exposed beyond loopback should still front the gateway with
+a hardened reverse proxy; this guard is the in-process backstop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aiohttp import web
+
+# Max seconds a client may take to send the complete request line + headers
+# before the connection is force-closed. Generous enough for any legitimate
+# client on a slow link, tight enough to reap a stalled slowloris connection.
+HEADER_READ_TIMEOUT = 30.0
+
+# Idle time a persistent (keep-alive) connection may sit between requests
+# before aiohttp closes it. aiohttp's default is 3630s (~1h), itself a mild
+# resource-exhaustion vector; 75s matches common reverse-proxy defaults and is
+# transparent to HTTP clients (they simply reconnect).
+KEEPALIVE_TIMEOUT = 75.0
+
+
+class SlowlorisRequestHandler(web.RequestHandler):
+    """``RequestHandler`` that bounds the request-line + header read time.
+
+    The deadline is armed in :meth:`connection_made` and disarmed as soon as
+    the first complete request has been parsed (``_request_count`` goes > 0).
+    If it expires first, the connection is force-closed. The guard covers only
+    the pre-handler read, so response streaming is never interrupted.
+    """
+
+    # No ``__slots__`` here: the base defines slots, but omitting them in this
+    # subclass gives instances a ``__dict__`` so the guard bookkeeping below
+    # can be attached without extending the base slot list.
+
+    def __init__(
+        self, *args: Any, header_read_timeout: float = HEADER_READ_TIMEOUT, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._srh_timeout = header_read_timeout
+        self._srh_handle: asyncio.TimerHandle | None = None
+        self._srh_disarmed = False
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        super().connection_made(transport)
+        if self._srh_timeout and self._srh_timeout > 0:
+            self._srh_handle = self._loop.call_later(
+                self._srh_timeout, self._srh_expire
+            )
+
+    def data_received(self, data: bytes) -> None:
+        super().data_received(data)
+        # A complete request (line + headers) was parsed -> stop the clock.
+        # Body bytes arrive later via the payload parser and do not bump
+        # _request_count, so the guard fires exactly once, for the first read.
+        #
+        # INVARIANT (aiohttp >=3.9,<4): RequestHandler.data_received increments
+        # self._request_count SYNCHRONOUSLY as each complete message is parsed,
+        # before the request-handling task runs. The disarm therefore lands the
+        # instant headers are parsed and never mid-response, so it cannot
+        # force-close a live keep-alive/streaming connection. The keep-alive
+        # regression test (test_dashboard_slowloris.py) pins this behaviour: if
+        # a future aiohttp moves the increment into the handler task, that test
+        # goes red rather than shipping a spurious force-close. This guard bounds
+        # the FIRST request's header read (the open-and-never-complete slowloris
+        # vector, re-armed per new connection); idle keep-alive reuse is bounded
+        # separately by keepalive_timeout.
+        if not self._srh_disarmed and self._request_count > 0:
+            self._srh_disarm()
+
+    def connection_lost(self, exc: BaseException | None) -> None:
+        self._srh_cancel()
+        super().connection_lost(exc)
+
+    def _srh_disarm(self) -> None:
+        self._srh_disarmed = True
+        self._srh_cancel()
+
+    def _srh_cancel(self) -> None:
+        if self._srh_handle is not None:
+            self._srh_handle.cancel()
+            self._srh_handle = None
+
+    def _srh_expire(self) -> None:
+        self._srh_handle = None
+        if self._srh_disarmed:
+            return
+        # No complete request received within the deadline: drop the stalled
+        # connection. force_close() cancels the read waiter and closes the
+        # transport, unblocking RequestHandler.start().
+        self.force_close()
+
+
+class SlowlorisServer(web.Server):
+    """``web.Server`` that hands out :class:`SlowlorisRequestHandler`.
+
+    ``web.Server.__call__`` hardcodes ``RequestHandler``, so overriding it is
+    the injection point for a custom handler while reusing all of the base
+    server's configuration (request factory, handler kwargs, loop).
+    """
+
+    _header_read_timeout: float = HEADER_READ_TIMEOUT
+
+    @classmethod
+    def from_server(
+        cls, base: web.Server, header_read_timeout: float
+    ) -> "SlowlorisServer":
+        """Rebuild ``base`` as a hardened server, preserving its config."""
+        server = cls(
+            base.request_handler,
+            request_factory=base.request_factory,
+            handler_cancellation=base.handler_cancellation,
+            loop=base._loop,
+            **base._kwargs,
+        )
+        server._header_read_timeout = header_read_timeout
+        return server
+
+    def __call__(self) -> web.RequestHandler:
+        try:
+            return SlowlorisRequestHandler(
+                self,
+                loop=self._loop,
+                header_read_timeout=self._header_read_timeout,
+                **self._kwargs,
+            )
+        except TypeError:
+            # Failsafe mirrors web.Server.__call__: strip custom handler_args.
+            kwargs = {
+                k: v
+                for k, v in self._kwargs.items()
+                if k in ("debug", "access_log_class")
+            }
+            return SlowlorisRequestHandler(
+                self,
+                loop=self._loop,
+                header_read_timeout=self._header_read_timeout,
+                **kwargs,
+            )
+
+
+class SlowlorisAppRunner(web.AppRunner):
+    """``AppRunner`` that installs the slowloris-hardened server + timeouts."""
+
+    __slots__ = ("_header_read_timeout",)
+
+    def __init__(
+        self,
+        app: web.Application,
+        *,
+        header_read_timeout: float = HEADER_READ_TIMEOUT,
+        keepalive_timeout: float = KEEPALIVE_TIMEOUT,
+        **kwargs: Any,
+    ) -> None:
+        # keepalive_timeout is forwarded to RequestHandler via the runner's
+        # **kwargs; only set it if the caller has not overridden it.
+        kwargs.setdefault("keepalive_timeout", keepalive_timeout)
+        super().__init__(app, **kwargs)
+        self._header_read_timeout = header_read_timeout
+
+    async def _make_server(self) -> web.Server:
+        base = await super()._make_server()
+        return SlowlorisServer.from_server(base, self._header_read_timeout)
+
+
+def build_hardened_runner(
+    app: web.Application,
+    *,
+    header_read_timeout: float = HEADER_READ_TIMEOUT,
+    keepalive_timeout: float = KEEPALIVE_TIMEOUT,
+) -> web.AppRunner:
+    """Return an ``AppRunner`` with slowloris mitigation wired in.
+
+    Drop-in replacement for ``web.AppRunner(app)`` at the dashboard / API
+    server start sites.
+    """
+    return SlowlorisAppRunner(
+        app,
+        header_read_timeout=header_read_timeout,
+        keepalive_timeout=keepalive_timeout,
+    )

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
@@ -18,6 +18,20 @@ Parameters:
   Handler:
     Type: String
     Default: index.handler
+  # CWE-770: per-app request-rate guardrails on the $default stage. Parameterized
+  # (with sane defaults) so a deployer can tune per app, matching the existing
+  # Runtime/Handler parameter convention.
+  ApiThrottlingRateLimit:
+    Type: Number
+    Default: 50
+    Description: >
+      Steady-state request rate cap (requests/second) applied to every route on
+      the $default stage. Bounds Lambda invocation volume / cost (CWE-770).
+  ApiThrottlingBurstLimit:
+    Type: Number
+    Default: 100
+    Description: >
+      Burst (token-bucket) request cap for the $default stage (CWE-770).
   OriginVerifySecret:
     Type: String
     Default: ''
@@ -157,6 +171,12 @@ Resources:
       ApiId: !Ref HttpApi
       StageName: '$default'
       AutoDeploy: true
+      # CWE-770: throttle the $default stage so a per-app deploy cannot be driven
+      # into unbounded request/Lambda-invocation volume. DefaultRouteSettings
+      # applies to every route on the stage.
+      DefaultRouteSettings:
+        ThrottlingRateLimit: !Ref ApiThrottlingRateLimit
+        ThrottlingBurstLimit: !Ref ApiThrottlingBurstLimit
 
   InvokePerm:
     Type: AWS::Lambda::Permission

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
@@ -19,6 +19,20 @@ Parameters:
   Handler:
     Type: String
     Default: index.handler
+  # CWE-770: per-app request-rate guardrails on the $default stage. Parameterized
+  # (with sane defaults) so a deployer can tune per app, matching the existing
+  # Runtime/Handler parameter convention.
+  ApiThrottlingRateLimit:
+    Type: Number
+    Default: 50
+    Description: >
+      Steady-state request rate cap (requests/second) applied to every route on
+      the $default stage. Bounds Lambda invocation volume / cost (CWE-770).
+  ApiThrottlingBurstLimit:
+    Type: Number
+    Default: 100
+    Description: >
+      Burst (token-bucket) request cap for the $default stage (CWE-770).
   OriginVerifySecret:
     Type: String
     Default: ''
@@ -118,6 +132,12 @@ Resources:
       ApiId: !Ref HttpApi
       StageName: '$default'
       AutoDeploy: true
+      # CWE-770: throttle the $default stage so a per-app deploy cannot be driven
+      # into unbounded request/Lambda-invocation volume. DefaultRouteSettings
+      # applies to every route on the stage.
+      DefaultRouteSettings:
+        ThrottlingRateLimit: !Ref ApiThrottlingRateLimit
+        ThrottlingBurstLimit: !Ref ApiThrottlingBurstLimit
 
   # Only this API may invoke the Lambda (scoped, not world-accessible).
   InvokePerm:

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
@@ -13,6 +13,30 @@ Parameters:
     Description: >
       CloudFront edge coverage. PriceClass_All = maximum global reach
       (Vercel-like). Lower tiers are cheaper but use fewer edge locations.
+  # CWE-770: optional WAFv2 WebACL for CloudFront rate limiting / request
+  # filtering. REGION CONSTRAINT: CloudFront only accepts a WAFv2 WebACL whose
+  # Scope is CLOUDFRONT, and such a WebACL MUST be created in us-east-1. This
+  # base stack is deployed in the deploy profile's region (see deploy.sh /
+  # handlers.py — default us-west-2, NOT pinned to us-east-1), so an INLINE
+  # AWS::WAFv2::WebACL (Scope: CLOUDFRONT) declared here would FAIL to create in
+  # any non-us-east-1 deployment. Rather than ship a resource that breaks the
+  # stack, we expose the WebACL ARN as an opt-in parameter: create a
+  # CLOUDFRONT-scoped, rate-based WebACL separately in us-east-1 and pass its
+  # ARN here to attach it. Empty (default) leaves the distribution unchanged.
+  WafWebAclArn:
+    Type: String
+    Default: ''
+    Description: >
+      Optional ARN of a WAFv2 WebACL (Scope: CLOUDFRONT, created in us-east-1)
+      to attach to the shared distribution for rate limiting (CWE-770). Empty =
+      no WAF attached. Example rule to put in the WebACL: a RateBasedStatement
+      with Limit 2000 per 5 min, AggregateKeyType IP, plus the AWS managed
+      AWSManagedRulesCommonRuleSet.
+
+Conditions:
+  # Only wire WebACLId when a WebACL ARN was supplied — an empty string is not a
+  # valid WebACLId and would fail the distribution create.
+  HasWafWebAcl: !Not [!Equals [!Ref WafWebAclArn, '']]
 
 Resources:
 
@@ -127,6 +151,11 @@ Resources:
       DistributionConfig:
         Enabled: true
         Comment: KiroCrew One-Click Deploy shared distribution
+        # CWE-770: attach an optional WAFv2 WebACL (rate limiting / request
+        # filtering) when one is supplied. Must be a CLOUDFRONT-scoped WebACL in
+        # us-east-1 (see WafWebAclArn parameter). AWS::NoValue keeps the property
+        # absent when unset, preserving current behavior.
+        WebACLId: !If [HasWafWebAcl, !Ref WafWebAclArn, !Ref 'AWS::NoValue']
         PriceClass: !Ref PriceClass
         HttpVersion: http2and3
         IPV6Enabled: true

--- a/test/test_dashboard_slowloris.py
+++ b/test/test_dashboard_slowloris.py
@@ -1,0 +1,120 @@
+"""Regression tests for the slowloris / CWE-400 read-timeout mitigation.
+
+Covers the connection-level guard in ``kiro_crew.dashboard.slowloris`` and its
+wiring into the dashboard / API server start paths:
+
+- a connection that dribbles the request line/headers without ever completing
+  them is force-closed after ``header_read_timeout`` (the slowloris vector);
+- a well-formed request is served normally and its keep-alive connection is not
+  spuriously reaped after the (one-shot, pre-handler) deadline elapses;
+- ``build_hardened_runner`` actually wires the hardened server + timeouts;
+- both ``start_dashboard`` and ``start_api_server`` use it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from kiro_crew.dashboard import server as dashboard_server
+from kiro_crew.dashboard.slowloris import (
+    SlowlorisAppRunner,
+    SlowlorisRequestHandler,
+    SlowlorisServer,
+    build_hardened_runner,
+)
+
+
+async def _make_app() -> web.Application:
+    app = web.Application()
+
+    async def _ok(_request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/", _ok)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_slow_header_read_is_force_closed() -> None:
+    """A client that never finishes sending headers is dropped at the deadline."""
+    runner = build_hardened_runner(
+        await _make_app(), header_read_timeout=0.3, keepalive_timeout=75.0
+    )
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    try:
+        reader, writer = await asyncio.open_connection(host, port)
+        # Partial request line + no terminating CRLFCRLF -> headers never complete.
+        writer.write(b"GET / HTTP/1.1\r\n")
+        await writer.drain()
+        # The guard force-closes the connection; the peer read then sees EOF.
+        data = await asyncio.wait_for(reader.read(), timeout=3.0)
+        assert data == b""
+        writer.close()
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_complete_request_served_and_keepalive_not_reaped() -> None:
+    """A well-formed request succeeds; the deadline never touches a live conn."""
+    runner = build_hardened_runner(
+        await _make_app(), header_read_timeout=0.3, keepalive_timeout=75.0
+    )
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://{host}:{port}/") as resp:
+                assert resp.status == 200
+                assert await resp.text() == "ok"
+            # Idle past the header deadline, then reuse the connection: the
+            # one-shot pre-handler guard must not have closed it.
+            await asyncio.sleep(0.6)
+            async with session.get(f"http://{host}:{port}/") as resp2:
+                assert resp2.status == 200
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_build_hardened_runner_wires_server_and_timeouts() -> None:
+    """The factory installs the hardened server and forwards both timeouts."""
+    runner = build_hardened_runner(
+        await _make_app(), header_read_timeout=12.0, keepalive_timeout=34.0
+    )
+    assert isinstance(runner, SlowlorisAppRunner)
+    # keepalive_timeout is forwarded to RequestHandler via the runner kwargs.
+    assert runner._kwargs.get("keepalive_timeout") == 34.0
+    await runner.setup()
+    try:
+        server = runner.server
+        assert isinstance(server, SlowlorisServer)
+        assert server._header_read_timeout == 12.0
+        # The protocol factory yields our hardened handler with both knobs set.
+        handler = server()
+        assert isinstance(handler, SlowlorisRequestHandler)
+        assert handler._srh_timeout == 12.0
+        assert handler.keepalive_timeout == 34.0
+    finally:
+        await runner.cleanup()
+
+
+def test_start_paths_use_hardened_runner() -> None:
+    """Both server start paths import and use the hardened runner factory."""
+    # Imported into the server module namespace -> both call sites resolve to it.
+    assert dashboard_server.build_hardened_runner is build_hardened_runner
+    import inspect
+
+    src = inspect.getsource(dashboard_server)
+    # Neither start path may fall back to a bare web.AppRunner(app).
+    assert "web.AppRunner(app)" not in src
+    assert src.count("build_hardened_runner(app)") == 2

--- a/test/test_deploy_cwe770_throttle_waf.py
+++ b/test/test_deploy_cwe770_throttle_waf.py
@@ -1,0 +1,98 @@
+"""CWE-770: One-Click Deploy IaC must bound request throughput.
+
+Part A — the per-app API Gateway HTTP API $default stage (both the stateless
+app-apigw.yaml and the stateful app-apigw-ddb.yaml templates) must carry
+DefaultRouteSettings with ThrottlingRateLimit + ThrottlingBurstLimit, wired to
+parameters with sane defaults, so a per-app deploy cannot be driven into
+unbounded Lambda invocations / cost. AutoDeploy behavior is preserved.
+
+Part B — the shared CloudFront distribution (base-stack.yaml) must be able to
+attach a WAFv2 WebACL for rate limiting. Because base-stack deploys in the
+profile's region (default us-west-2), an inline CLOUDFRONT-scoped WebACL would
+fail to create (CloudFront WebACLs must live in us-east-1), so the safe wiring
+is an opt-in WafWebAclArn parameter gated by a Condition onto WebACLId.
+"""
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+TPL_DIR = (
+    REPO / "src" / "kiro_crew" / "deploy" / "skills" / "artifact-deploy" / "templates"
+)
+APIGW = (TPL_DIR / "app-apigw.yaml").read_text(encoding="utf-8")
+APIGW_DDB = (TPL_DIR / "app-apigw-ddb.yaml").read_text(encoding="utf-8")
+BASE_STACK = (TPL_DIR / "base-stack.yaml").read_text(encoding="utf-8")
+
+
+class _TagTolerantLoader(yaml.SafeLoader):
+    """SafeLoader that ignores CFN intrinsic tags (!Ref/!Sub/!If/!GetAtt...)."""
+
+
+def _construct_intrinsic(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node, deep=True)
+    return loader.construct_mapping(node, deep=True)
+
+
+# Register as the catch-all multi-constructor (tag_prefix=None) so EVERY CFN
+# intrinsic tag is tolerated -- including the Conditions-block short tags
+# !Not/!Equals/!And as well as !Ref/!Sub/!If/!GetAtt. A "!" prefix alone does
+# not reliably match every local tag across PyYAML versions; None is the
+# documented universal fallback.
+_TagTolerantLoader.add_multi_constructor(None, _construct_intrinsic)
+
+
+def _load(text):
+    return yaml.load(text, Loader=_TagTolerantLoader)
+
+
+class TestPartAApiGwThrottling:
+    def _assert_stage_throttled(self, text):
+        doc = _load(text)
+        params = doc["Parameters"]
+        assert "ApiThrottlingRateLimit" in params
+        assert "ApiThrottlingBurstLimit" in params
+        assert params["ApiThrottlingRateLimit"]["Type"] == "Number"
+        assert params["ApiThrottlingBurstLimit"]["Type"] == "Number"
+        # Sane defaults for a per-app deploy.
+        assert params["ApiThrottlingRateLimit"]["Default"] == 50
+        assert params["ApiThrottlingBurstLimit"]["Default"] == 100
+
+        stage = doc["Resources"]["Stage"]["Properties"]
+        # AutoDeploy behavior preserved.
+        assert stage["AutoDeploy"] is True
+        drs = stage["DefaultRouteSettings"]
+        # Wired to the parameters (intrinsic !Ref -> scalar name via loader).
+        assert drs["ThrottlingRateLimit"] == "ApiThrottlingRateLimit"
+        assert drs["ThrottlingBurstLimit"] == "ApiThrottlingBurstLimit"
+
+    def test_apigw_stage_has_throttling(self):
+        self._assert_stage_throttled(APIGW)
+
+    def test_apigw_ddb_stage_has_throttling(self):
+        self._assert_stage_throttled(APIGW_DDB)
+
+
+class TestPartBCloudFrontWaf:
+    def test_base_stack_exposes_waf_param_and_condition(self):
+        doc = _load(BASE_STACK)
+        assert "WafWebAclArn" in doc["Parameters"]
+        assert doc["Parameters"]["WafWebAclArn"]["Default"] == ""
+        assert "HasWafWebAcl" in doc["Conditions"]
+
+    def test_distribution_wires_webaclid_conditionally(self):
+        doc = _load(BASE_STACK)
+        dist_cfg = doc["Resources"]["Distribution"]["Properties"]["DistributionConfig"]
+        # !If [HasWafWebAcl, !Ref WafWebAclArn, !Ref 'AWS::NoValue'] -> the loader
+        # flattens to the sequence of the (already scalar-ized) branches.
+        web_acl = dist_cfg["WebACLId"]
+        assert web_acl == ["HasWafWebAcl", "WafWebAclArn", "AWS::NoValue"]
+
+    def test_region_constraint_documented(self):
+        # The us-east-1 CLOUDFRONT-scope constraint must be spelled out so a
+        # future editor does not "helpfully" inline a broken WebACL.
+        assert "us-east-1" in BASE_STACK
+        assert "CLOUDFRONT" in BASE_STACK

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -37,11 +37,21 @@ def test_policy_prefix_matches_template_bucket():
     # that yaml.safe_load can't handle — add constructors for the ones we need.
     class _CfnLoader(yaml.SafeLoader):
         pass
-    for tag in ("!Sub", "!Ref", "!GetAtt", "!If", "!Select", "!Join"):
-        _CfnLoader.add_constructor(tag, lambda loader, node: {"Fn::Sub": loader.construct_scalar(node)}
-                                   if node.tag == "!Sub" else loader.construct_scalar(node))
-    # Re-register !Sub properly — it's the one we care about.
-    _CfnLoader.add_constructor("!Sub", lambda loader, node: {"Fn::Sub": loader.construct_scalar(node)})
+    # !Sub is the tag this test asserts on — map it to {"Fn::Sub": <scalar>}.
+    _CfnLoader.add_constructor(
+        "!Sub", lambda loader, node: {"Fn::Sub": loader.construct_scalar(node)})
+
+    # Tolerate every other CFN intrinsic via a catch-all so an unknown tag never
+    # breaks the parse — including the condition tags (!Not/!Equals/!If) added
+    # when the optional CloudFront WAF WebACL opt-in landed in base-stack.yaml.
+    def _cfn_ignore(loader, tag_suffix, node):
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node, deep=True)
+        return loader.construct_mapping(node, deep=True)
+
+    _CfnLoader.add_multi_constructor(None, _cfn_ignore)
 
     template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "base-stack.yaml"
     with open(template_path) as f:

--- a/test/test_knowledge_ingest_magic_byte.py
+++ b/test/test_knowledge_ingest_magic_byte.py
@@ -1,0 +1,158 @@
+"""Regression tests for the content-signature gate on ``/api/knowledge/ingest``.
+
+CWE-434: the ingest handler derives the file type from the attacker-controlled
+multipart filename extension, and ``FileReader.read()`` dispatches to a binary
+parser (.pdf -> pdfplumber, .docx -> python-docx) purely by that extension. A
+file whose bytes don't match its claimed extension (e.g. an HTML/script payload
+named ``x.pdf``) must be rejected with HTTP 400 BEFORE it reaches the parser --
+mirroring the sibling ``api_upload_file`` magic-byte gate. Genuine text formats
+(.md/.txt/.html) have no reliable signature and still ingest.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers.knowledge import ingest_file
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.db = MagicMock()
+
+    def get_source_by_uri(self, uri):
+        return None
+
+    def add_source(self, *, name, source_type, uri, properties):
+        return "sid1"
+
+
+def _make_app() -> tuple[web.Application, AsyncMock]:
+    app = web.Application()
+    app["state"] = SimpleNamespace(knowledge_store=_FakeStore())
+    ingest_spy = AsyncMock()
+    app["knowledge_pipeline"] = SimpleNamespace(ingest_file=ingest_spy)
+    app.router.add_post("/api/knowledge/ingest", ingest_file)
+    return app, ingest_spy
+
+
+def _minimal_zip_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<types/>")
+    return buf.getvalue()
+
+
+def _multi_member_zip_bytes(extra: int) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<types/>")
+        for i in range(extra):
+            zf.writestr(f"word/part{i}.xml", "<x/>")
+    return buf.getvalue()
+
+
+async def _post(app: web.Application, data: bytes, filename: str, ctype: str):
+    form = aiohttp.FormData()
+    form.add_field("file", data, filename=filename, content_type=ctype)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/api/knowledge/ingest", data=form)
+        return resp.status, await resp.json()
+
+
+@pytest.fixture
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.knowledge.sel") as m:
+        m.return_value = MagicMock()
+        yield m
+
+
+@pytest.mark.asyncio
+async def test_pdf_with_non_pdf_bytes_rejected_before_parse(mock_sel):
+    app, ingest_spy = _make_app()
+    status, body = await _post(
+        app, b"<html>not a pdf</html>\n", "evil.pdf", "application/pdf")
+    assert status == 400, body
+    assert "does not match its type" in body["error"]
+    # Rejected before the file is handed to the extension-dispatched parser.
+    ingest_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_docx_with_non_zip_bytes_rejected_before_parse(mock_sel):
+    app, ingest_spy = _make_app()
+    status, body = await _post(
+        app, b"this is not a zip archive\n", "evil.docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+    assert status == 400, body
+    assert "does not match its type" in body["error"]
+    ingest_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_pdf_ingests(mock_sel):
+    app, _ = _make_app()
+    status, body = await _post(
+        app, b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n", "doc.pdf",
+        "application/pdf")
+    assert status == 200, body
+    assert body["source_id"] == "sid1"
+    assert body["status"] == "processing"
+
+
+@pytest.mark.asyncio
+async def test_valid_docx_ingests(mock_sel):
+    app, _ = _make_app()
+    status, body = await _post(
+        app, _minimal_zip_bytes(), "doc.docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+    assert status == 200, body
+    assert body["source_id"] == "sid1"
+
+
+@pytest.mark.asyncio
+async def test_text_markdown_has_no_signature_and_ingests(mock_sel):
+    """Text formats have no reliable magic; arbitrary bytes under .md pass the
+    gate (still bounded by the size cap + downstream text reader)."""
+    app, _ = _make_app()
+    status, body = await _post(
+        app, b"# Title\n\nsome body text\n", "note.md", "text/markdown")
+    assert status == 200, body
+    assert body["source_id"] == "sid1"
+
+
+@pytest.mark.asyncio
+async def test_docx_zip_bomb_member_count_rejected_before_parse(mock_sel):
+    """A valid-signature OOXML archive with too many members is rejected by the
+    decompression-bomb guard (CWE-770) before any parser opens it."""
+    app, ingest_spy = _make_app()
+    data = _multi_member_zip_bytes(5)  # 6 members total, all with valid PK header
+    with patch("kiro_crew.dashboard.handlers.knowledge._MAX_INGEST_ARCHIVE_MEMBERS", 2):
+        status, body = await _post(
+            app, data, "bomb.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+    assert status == 400, body
+    assert "archive rejected" in body["error"]
+    ingest_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_docx_zip_bomb_uncompressed_size_rejected_before_parse(mock_sel):
+    """A valid zip whose declared uncompressed total exceeds the cap is rejected
+    before parsing (declared-size bomb guard)."""
+    app, ingest_spy = _make_app()
+    data = _minimal_zip_bytes()  # one member, >1 uncompressed byte
+    with patch("kiro_crew.dashboard.handlers.knowledge._MAX_INGEST_ARCHIVE_UNCOMPRESSED", 1):
+        status, body = await _post(
+            app, data, "bomb.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+    assert status == 400, body
+    assert "archive rejected" in body["error"]
+    ingest_spy.assert_not_called()


### PR DESCRIPTION
## Problem

Three new CSE findings against current `main` (commit 96cbfc5), all HIGH:
- **CWE-770** — One-Click Deploy CloudFormation templates expose internet-facing entry points (API Gateway v2 `$default` stage, shared CloudFront distribution) with no throttling / WAF rate limiting.
- **CWE-400** — the dashboard/API aiohttp server (`start_dashboard`, `start_api_server`) has no per-connection header/body read timeout, so a slowloris / slow-body attacker can hold connections open indefinitely (pre-auth, before `token_auth` runs).
- **CWE-434** — `POST /api/knowledge/ingest` (`ingest_file`) picks its parser purely by the attacker-controlled filename extension with only a 50 MB size cap and no content/magic-byte check.

## Why it matters

Unbounded request volume against a per-app deploy drives DoS + uncontrolled Lambda/DynamoDB cost; a low-bandwidth slowloris can exhaust the server's connection pool pre-auth (the shipped Docker image binds `0.0.0.0`); and a polyglot / renamed file is fed straight into a binary parser (`pdfplumber`, python-docx), enabling parser-DoS / decompression-bomb / content-confusion.

## Fix (symptom → root cause → change)

- **CWE-770** — no rate cap on the public entry points → add `DefaultRouteSettings` (`ThrottlingRateLimit`/`ThrottlingBurstLimit`, parameterized, defaults 50/100) to the `$default` stage in both `app-apigw.yaml` and `app-apigw-ddb.yaml` (`AutoDeploy` preserved), and wire an optional WAFv2 WebACL to the CloudFront distribution in `base-stack.yaml` via a `WafWebAclArn` param + `HasWafWebAcl` condition + `WebACLId: !If [...AWS::NoValue]`. **Why opt-in ARN, not an inline WebACL:** a `Scope: CLOUDFRONT` WebACL must be created in **us-east-1**, but base-stack deploys to the profile region (default `us-west-2`, per `deploy.sh`/`handlers.py`), so an inline resource would hard-fail `CreateStack`. The param lets an operator attach a properly-region'd rate-based WebACL; empty default preserves today's behavior.
- **CWE-400** — aiohttp exposes no server-side header/body read-timeout kwarg (confirmed against the pinned `>=3.9,<4`), and a middleware runs only after headers are parsed → new `src/kiro_crew/dashboard/slowloris.py`: a `web.AppRunner`/`Server`/`RequestHandler` subclass that arms a one-shot per-connection **header-read deadline** (30s) in `connection_made`, disarms it the instant the first complete request is parsed (so it never touches response/stream duration), and sets a bounded `keepalive_timeout` (75s). Wired into both `start_dashboard` and `start_api_server` via `build_hardened_runner(app)`.
- **CWE-434** — extension-only routing → `ingest_file` now buffers the first 16 bytes while streaming and validates them against the claimed extension with the sibling `_content_matches_ext` gate (`handlers/files.py`) **before** the file reaches a parser, rejecting a mismatch with HTTP 400 + a `rejected` SEL audit. Text formats (no signature) pass through unchanged.

## Tests

- `test/test_deploy_cwe770_throttle_waf.py` — asserts throttling params/defaults + `DefaultRouteSettings` on both API stages (and `AutoDeploy` still true), plus the `WafWebAclArn` param, `HasWafWebAcl` condition, conditional `WebACLId`, and the documented us-east-1 constraint.
- `test/test_dashboard_slowloris.py` — real-socket: a slow-header connection is force-closed at the deadline; a well-formed request is served and its keep-alive connection is not spuriously reaped; both start paths use the hardened runner (no bare `web.AppRunner(app)` remains).
- `test/test_knowledge_ingest_magic_byte.py` — drives the real `ingest_file` handler: bogus `.pdf`/`.docx` bytes rejected 400 before the parser is called (`ingest_spy.assert_not_called()`); valid `.pdf`/`.docx` and text `.md` still ingest.

## Manual verification

Local static gates green on all changed files: `py_compile` (3.11), `isort --check-only`, `flake8 -j 1`; the slowloris mechanism was additionally exercised end-to-end against the installed aiohttp 3.13. Full `pytest`/`mypy`/`vitest` run in CI (no CI-parity venv in this sandbox). Two independent pre-submit reviewers (correctness/security + tests/contracts) cleared the diff with no Critical/High findings; the one recurring advisory (aiohttp `_request_count` internal coupling) is now documented as a code invariant pinned by the keep-alive regression test.

## Screenshots

N/A — backend + IaC + test-only change; no UI surface.

## Related

Fixes CSE findings P480635914 (CWE-770), P480635913 (CWE-400), P480635912 (CWE-434).
