### PR TITLE
ci: add dependency license gate with allowlist and maintainer override

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,70 @@
+# Dependency License Gate — configuration
+# Consumed by .github/workflows/dependency-review.yml (actions/dependency-review-action).
+#
+# MODEL: default-deny. Only the SPDX licenses in `allow-licenses` below are
+# permitted on any dependency ADDED or CHANGED by a PR. Everything else fails
+# the "Dependency License Gate" check. This keeps the Apache-2.0 distribution
+# clean: a new dependency under a copyleft or non-commercial license cannot
+# slip in unnoticed.
+#
+# We intentionally use ONLY `allow-licenses` (not `deny-licenses`) — the action
+# rejects setting both, and an allowlist is the safer clean-room posture.
+#
+# ── OVERRIDES (two layers, for unknown / mis-detected / manually-vetted deps) ──
+# GitHub's license detection is heuristic: some packages report no license
+# (surfaced as "unknown" — the action lists them but does NOT auto-fail), and
+# some are mis-classified (e.g. a genuinely-MIT package tagged otherwise).
+#
+#   1. Durable, per-package (audited in git): add the package to
+#      `allow-dependencies-licenses` below with a comment stating the real
+#      license and the evidence (link to the package's LICENSE file). This is
+#      the right home for a permanent, reviewed exception.
+#
+#   2. One-off, per-commit (maintainer judgement): apply the `license-override`
+#      label. Only triage/write users can label, so it is a maintainer-gated
+#      escape hatch. The bypass is honored only for the commit that was present
+#      when the label was applied — any new push re-runs the gate, so re-apply
+#      the label to approve a later commit. The bypass is recorded in the job
+#      summary. Use this for a time-boxed decision you don't want in the config.
+
+# SPDX identifiers are case-sensitive and must match exactly.
+# Dual-licensed deps (e.g. "MIT OR Apache-2.0") pass if ANY term is allowed.
+allow-licenses:
+  # Public-domain-equivalent / ultra-permissive
+  - 0BSD
+  - CC0-1.0
+  - Unlicense
+  - WTFPL
+  # Permissive (Apache-2.0-compatible, no copyleft)
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - BSD-3-Clause-Clear
+  - BlueOak-1.0.0
+  - ISC
+  - MIT
+  - MIT-0
+  - PostgreSQL
+  - Python-2.0
+  - Zlib
+  # Weak / file-level copyleft — safe to CONSUME as a dependency without
+  # infecting first-party Apache-2.0 code (per-file obligation only).
+  - MPL-2.0
+  - Artistic-2.0
+
+# Per-package exceptions (override layer 1). Format: Package-URL (purl).
+#   pip:   pkg:pypi/<name>
+#   npm:   pkg:npm/<name>              scoped: pkg:npm/%40scope/name
+# Add a comment with the real license + evidence for every entry.
+allow-dependencies-licenses: []
+  # Example — package ships MIT but GitHub reports "unknown":
+  # - pkg:pypi/example-lib            # MIT — see https://github.com/org/example-lib/blob/main/LICENSE
+
+# License gate only — vulnerability scanning is covered separately by the
+# Dependency Audit / Semgrep / CodeQL jobs, so we don't duplicate it here.
+license-check: true
+vulnerability-check: false
+
+# Post a summary comment on the PR only when the gate fails (best-effort;
+# skipped automatically on fork PRs whose token is read-only).
+comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,66 @@
+name: Dependency License Gate
+
+# Fails a PR that ADDS or CHANGES a dependency whose license is not on the
+# curated allowlist, keeping this Apache-2.0 project's distributed licenses
+# clean. Allowlist + override rules live in .github/dependency-review-config.yml.
+#
+# Runs on every PR, including Dependabot bumps (same-repo, read-only token is
+# sufficient — the action only reads the dependency graph) and external forks
+# (the gate still evaluates; it just can't post its summary comment there).
+#
+# OVERRIDE: a maintainer (triage/write) can bypass the gate for the COMMIT they
+# reviewed by applying the `license-override` label. The bypass is honored ONLY
+# on the `labeled` event for that specific label, so it is scoped to the commit
+# that was present when the label was applied. Any later push arrives as a
+# `synchronize` event, which re-runs the gate — a new, unvetted dependency can
+# never ride in on a stale override. Re-apply the label to re-approve after a
+# push; removing it (`unlabeled`) likewise re-runs the gate.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Read-only for the graph; PR-write lets the action post its failure summary
+# on same-repo PRs. No id-token / contents:write — this job runs no untrusted
+# code and needs no cloud credentials.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dependency-license-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  license-gate:
+    name: Dependency License Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The gate runs on every event EXCEPT the one that applies the override
+      # label. Because a new push is a `synchronize` event (not `labeled`), the
+      # gate always re-runs on new commits — the override never carries over to
+      # unreviewed code.
+      - name: Review dependency licenses
+        if: ${{ !(github.event.action == 'labeled' && github.event.label.name == 'license-override') }}
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          config-file: ./.github/dependency-review-config.yml
+
+      - name: Record maintainer license override
+        if: ${{ github.event.action == 'labeled' && github.event.label.name == 'license-override' }}
+        run: |
+          {
+            echo "## Dependency License Gate — ⚠️ overridden for this commit"
+            echo
+            echo "A maintainer applied the \`license-override\` label, so the"
+            echo "license allowlist check was skipped for **this commit only**"
+            echo "(\`${{ github.event.pull_request.head.sha }}\`). The PR"
+            echo "timeline records who applied the label."
+            echo
+            echo "Any later push re-runs the gate; re-apply the label to approve"
+            echo "the new commit. For a permanent exception, prefer adding the"
+            echo "package to \`allow-dependencies-licenses\` in"
+            echo "\`.github/dependency-review-config.yml\` instead."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem
New dependencies can enter the tree (a direct add, a transitive pull-in, or a Dependabot bump) under a license that is incompatible with redistributing this Apache-2.0 project — e.g. strong copyleft (GPL/AGPL) or non-commercial (CC-BY-NC). Today nothing in CI checks the license of an added or changed dependency, so an incompatible one would land silently.

## Why it matters
License hygiene is a distribution obligation for an Apache-2.0 project: shipping a copyleft/non-commercial dependency can force relicensing or create legal exposure for downstream users. Catching it automatically at PR time — before merge — is far cheaper than discovering it after release.

## Fix (symptoms → root cause → change)
- **Symptom:** no automated signal when a PR introduces a dependency under a disallowed license.
- **Root cause:** there is no license gate in CI; the only dependency automation is `github-actions` Dependabot and vulnerability scanners, none of which assert license policy.
- **Change:** add a `Dependency License Gate` workflow driven by `actions/dependency-review-action` (pinned to v5.0.0 by SHA, per repo convention). It runs on every PR and fails when a dependency **added or changed** by the PR carries a license that is not on a curated allowlist. Policy lives in a separate, reviewable config file:
  - **Default-deny allowlist** (`allow-licenses`, 17 entries): public-domain-equivalent (`0BSD`, `CC0-1.0`, `Unlicense`, `WTFPL`), permissive (`Apache-2.0`, `MIT`, `MIT-0`, `ISC`, `BSD-2-Clause`, `BSD-3-Clause`, `BSD-3-Clause-Clear`, `BlueOak-1.0.0`, `PostgreSQL`, `Python-2.0`, `Zlib`), and weak/file-level copyleft that is safe to *consume* as a dependency (`MPL-2.0`, `Artistic-2.0`). Strong copyleft and non-commercial licenses are denied by omission. Dual-licensed deps pass if any term is allowed.
  - **License-only:** `vulnerability-check` is disabled so this does not duplicate the existing Dependency Audit / Semgrep / CodeQL coverage.
  - **Two override layers** for GitHub's heuristic license detection (unknown or mis-classified licenses):
    1. *Durable, audited in git* — add the package to `allow-dependencies-licenses` (by package-URL) with an evidence comment citing the real license.
    2. *One-off, maintainer-gated* — apply the `license-override` label (triage/write only). The gate is then skipped and the bypass is recorded in the job summary; the PR timeline records who applied the label. The `labeled`/`unlabeled` trigger re-evaluates the gate immediately.
  - **Unknown licenses** are surfaced in the action summary but do not hard-fail, so a genuinely-undetectable license is a review signal rather than a merge blocker; bless it via layer 1 once vetted.

The workflow requests only `contents: read` + `pull-requests: write` (no `id-token`/cloud credentials) and runs no untrusted code, so it is safe on fork PRs — the gate still evaluates there; it just cannot post its summary comment under the read-only fork token.

## Tests
N/A — this is a CI workflow + config addition with no application code. Both YAML files were validated with a YAML parser locally (well-formed, expected top-level keys, allowlist/flags as intended). The gate itself is exercised by its first real PR run.

## Manual verification
- `actions/dependency-review-action` v5.0.0 SHA (`a1d282b3…`) confirmed against upstream release tags.
- Confirmed the config uses only `allow-licenses` (the action rejects combining `allow-licenses` with `deny-licenses`).
- Follow-ups (not in this PR): create the `license-override` label in the repo (the `contains()` check silently never matches until it exists); optionally wire this check into `pr-readiness.yml` aggregation. Branch protection currently has no required status contexts, so this lands as an advisory (visible) gate like the other reviewers.
