### PR TITLE
fix(approvals): stop background approvals hijacking unrelated conversations

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -884,20 +884,22 @@ class GatewayOrchestrator:
                 else ""
             )
 
-            # Heuristic fallback: pick the first running slot only when the caller
-            # supplied neither an authoritative parent nor an explicit resolver.
-            resolved_slot = parent_slot
-            if (
-                not resolved_slot
-                and slot_resolver is None
-                and self.dashboard_state
-                and self.dashboard_state._slots
-            ):
-                for k in self.dashboard_state._slots:
-                    if self.dashboard_state._slots[k].running:
-                        resolved_slot = k.removeprefix("dashboard:")
-                        break
-
+            # NO heuristic fallback. A background caller (cron / taskrunner /
+            # autonudge) that supplies neither an authoritative parent session
+            # nor a ``slot_resolver`` has no owning conversation, and there is
+            # no way to guess one. Borrowing "the first slot that is running"
+            # hijacked an unrelated chat and was wrong in three directions at
+            # once:
+            #   * the prompt surfaced in a conversation that never raised it,
+            #     with a truncated label and no provenance;
+            #   * the Trust control resolved against that innocent slot, so
+            #     trusting a cron's command granted blanket auto-approval to
+            #     the borrowed session (and did nothing for the cron);
+            #   * conversely, a borrowed slot that already had trust enabled
+            #     silently auto-approved the background command below —
+            #     privilege the cron was never granted.
+            # Unowned approvals now carry slot="" and are surfaced ONLY on the
+            # global approvals surface (notification feed / /api/approvals).
             if parent_slot:
                 approval_slot = parent_slot
             elif slot_resolver:
@@ -907,7 +909,7 @@ class GatewayOrchestrator:
                     logger.warning("slot_resolver failed for %s", request_id, exc_info=True)
                     approval_slot = ""
             else:
-                approval_slot = resolved_slot
+                approval_slot = ""
 
             # Per-source auto-approve (e.g. cron, taskrunner, subagent)
             if source in self._cfg.hooks.get("auto_approve_sources", []):
@@ -945,11 +947,11 @@ class GatewayOrchestrator:
 
             if self.dashboard_state:
                 # Check if the parent slot is trusted (not all slots).
-                # Use slot_resolver or resolved_slot to find the parent;
-                # only fall back to all-slots check when neither exists.
-                # When slot_resolver exists but returns falsy, we do NOT
-                # fall back to the heuristic -- if the explicit resolver
-                # can't find the parent, guessing would widen trust scope.
+                # The parent comes from the authoritative parent session key or
+                # an explicit slot_resolver -- never from a guess. When a
+                # slot_resolver exists but returns falsy we do NOT fall back to
+                # the all-slots rule: if the explicit resolver cannot find the
+                # parent, widening trust scope would be unsound.
 
                 def _sel_log(
                     *, caller: str, operation: str, outcome: str, resources: str = ""
@@ -992,24 +994,34 @@ class GatewayOrchestrator:
                             outcome="not_auto_approved",
                             resources=_safe_title,
                         )
-                elif not slot_resolver and not resolved_slot:
-                    # No resolver available at all -- fall back to all-slots
-                    slots = self.dashboard_state._slots
-                    if slots and all(s._trust for s in slots.values()):
-                        _sel_log(
-                            caller=f"source:{source}",
-                            operation=f"{source}.all_slots_trust_auto_approve",
-                            outcome="ok",
-                            resources=_safe_title,
-                        )
-                        return True
-                    else:
-                        _sel_log(
-                            caller=f"source:{source}",
-                            operation=f"{source}.all_slots_trust_not_trusted",
-                            outcome="not_auto_approved",
-                            resources=_safe_title,
-                        )
+                elif not slot_resolver:
+                    # No owning slot and no resolver at all. There is NO
+                    # implicit trust path here: an unowned background command
+                    # always prompts.
+                    #
+                    # This used to consult an "all open conversations are
+                    # trusted" rule, which was narrower than the heuristic it
+                    # replaced but still reproduced the exact harm this change
+                    # exists to remove. For a single-user dashboard with one
+                    # trusted chat open -- the typical state -- `all()` is
+                    # trivially satisfied, so a cron's command was silently
+                    # auto-approved with no prompt: privilege the job was never
+                    # granted, justified by trust the user granted to a
+                    # conversation the job has nothing to do with.
+                    #
+                    # Session trust means "auto-approve tools for THIS chat
+                    # session". An unattended job is not this session, so no
+                    # amount of session trust should speak for it. Operators who
+                    # do want a source to run unprompted have the explicit
+                    # opt-in above (``hooks.auto_approve_sources``), which is
+                    # consent for that source rather than a side effect of
+                    # trusting a chat.
+                    _sel_log(
+                        caller=f"source:{source}",
+                        operation=f"{source}.unowned_no_implicit_trust",
+                        outcome="not_auto_approved",
+                        resources=_safe_title,
+                    )
                 else:
                     # Resolver existed but failed -- fall through to interactive approval
                     _sel_log(

--- a/test/test_background_approval_routing.py
+++ b/test/test_background_approval_routing.py
@@ -1,0 +1,231 @@
+"""Background tool approvals must never borrow an unrelated dashboard slot.
+
+``_interactive_approval`` used to fall back to "the first slot that is
+``running``" whenever a background caller (cron / taskrunner / autonudge)
+supplied neither an authoritative parent session key nor a ``slot_resolver``.
+That guess hijacked an unrelated conversation in three ways:
+
+* the prompt rendered in a chat that never raised it;
+* the slot-scoped Trust control resolved against that innocent slot;
+* a borrowed slot that already had trust enabled silently auto-approved the
+  background command -- privilege the job was never granted.
+
+These tests pin the replacement contract: an unowned approval carries
+``slot=""`` (global surface only), and slot trust is consulted ONLY for a slot
+the caller actually owns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.llm_helpers import LLMEvent
+
+
+def _make_gateway():
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gateway = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gateway.sessions = MagicMock()
+    gateway.sessions.get_pid = MagicMock(return_value=None)
+    gateway.sessions.get_channel = MagicMock(return_value=None)
+    gateway.sessions.get_thread = MagicMock(return_value=None)
+    # No Slack: the callback falls through to the dashboard-only path, which is
+    # where slot attribution is observable.
+    gateway.slack = None
+    gateway._owner_id = None
+    gateway.dashboard_state = MagicMock()
+    gateway.dashboard_state._slots = {}
+    gateway.dashboard_state.request_approval = AsyncMock(return_value=True)
+    gateway.dashboard_state.resolve_approval = MagicMock()
+    gateway._cfg = MagicMock()
+    gateway._cfg.hooks = MagicMock()
+    gateway._cfg.hooks.get = MagicMock(return_value=[])
+    gateway._approval_mode = None
+    return gateway
+
+
+def _slot(*, running: bool, trust: bool = False) -> MagicMock:
+    slot = MagicMock()
+    slot.running = running
+    slot._trust = trust
+    return slot
+
+
+def _event(request_id: str = "req-bg-1") -> LLMEvent:
+    return LLMEvent(
+        kind="permission_request",
+        request_id=request_id,
+        title="Running: cd /work/repo && git status",
+    )
+
+
+def _requested_slot(gateway) -> str:
+    """The ``slot=`` kwarg the callback handed to ``request_approval``."""
+    gateway.dashboard_state.request_approval.assert_awaited_once()
+    return gateway.dashboard_state.request_approval.await_args.kwargs["slot"]
+
+
+class TestUnownedBackgroundApprovalHasNoSlot:
+    """An approval with no owning conversation must not adopt one."""
+
+    @pytest.mark.asyncio
+    async def test_cron_with_running_slot_does_not_borrow_it(self) -> None:
+        """The regression: a running, untrusted slot must NOT be borrowed."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-unrelated": _slot(running=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("cron")
+            result = await approve_fn(_event(), "")
+
+        assert result is True  # request_approval stub approved it
+        assert _requested_slot(gateway) == "", "cron approval must not adopt an unrelated slot"
+
+    @pytest.mark.asyncio
+    async def test_borrowed_slot_trust_does_not_auto_approve(self) -> None:
+        """A trusted bystander slot must not silently auto-approve a cron command.
+
+        The two slots are chosen so the old and new policies disagree: the
+        *running* slot is trusted (the old heuristic would borrow it and
+        auto-approve without ever prompting) while another slot is not (so the
+        all-slots rule cannot fire). The prompt must actually be raised.
+        """
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {
+            "slot-trusted": _slot(running=True, trust=True),
+            "slot-idle": _slot(running=False, trust=False),
+        }
+        # Make the outcome distinguishable from a trust short-circuit.
+        gateway.dashboard_state.request_approval = AsyncMock(return_value=False)
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("cron")
+            result = await approve_fn(_event(), "")
+
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+        assert result is False, "trust on a bystander slot must not auto-approve a cron command"
+
+    @pytest.mark.asyncio
+    async def test_taskrunner_unowned_approval_has_no_slot(self) -> None:
+        """Every unattended source shares the contract, not just cron."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {
+            "slot-a": _slot(running=True),
+            "slot-b": _slot(running=True),
+        }
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("taskrunner")
+            await approve_fn(_event("req-bg-2"), "")
+
+        assert _requested_slot(gateway) == ""
+
+    @pytest.mark.asyncio
+    async def test_all_trusted_slots_do_not_auto_approve(self) -> None:
+        """No implicit trust path for an unowned job, however many slots trust.
+
+        This previously auto-approved via an "every conversation is trusted"
+        rule. For the typical single-open-chat dashboard that rule was
+        trivially satisfied, so it reproduced the exact harm this change
+        removes. Session trust speaks for a chat session, never for an
+        unattended job; ``hooks.auto_approve_sources`` is the explicit opt-in.
+        """
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {
+            "slot-a": _slot(running=True, trust=True),
+            "slot-b": _slot(running=False, trust=True),
+        }
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("cron")
+            await approve_fn(_event("req-bg-3"), "")
+
+        # The prompt is actually raised rather than short-circuited.
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+        assert _requested_slot(gateway) == ""
+
+    @pytest.mark.asyncio
+    async def test_single_trusted_slot_does_not_auto_approve(self) -> None:
+        """The common case the old rule made vacuous: one trusted chat open."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-only": _slot(running=True, trust=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("cron")
+            await approve_fn(_event("req-bg-3b"), "")
+
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_source_opt_in_still_auto_approves(self) -> None:
+        """Removing implicit trust must not break the explicit consent path."""
+        gateway = _make_gateway()
+        gateway._cfg.hooks.get = MagicMock(return_value=["cron"])
+        gateway.dashboard_state._slots = {"slot-a": _slot(running=True, trust=False)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("cron")
+            result = await approve_fn(_event("req-bg-3c"), "")
+
+        assert result is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+
+class TestOwnedApprovalStillRoutesToItsSlot:
+    """Removing the guess must not break legitimate attribution."""
+
+    @pytest.mark.asyncio
+    async def test_authoritative_parent_session_wins(self) -> None:
+        """An autonudge loop runs IN a dashboard slot and keeps its card."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-owner": _slot(running=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("autonudge")
+            await approve_fn(_event("req-owned-1"), "dashboard:slot-owner")
+
+        assert _requested_slot(gateway) == "slot-owner"
+
+    @pytest.mark.asyncio
+    async def test_owning_slot_trust_still_auto_approves(self) -> None:
+        """Trust on the slot that actually owns the turn is still honoured."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-owner": _slot(running=True, trust=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval("autonudge")
+            result = await approve_fn(_event("req-owned-2"), "dashboard:slot-owner")
+
+        assert result is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slot_resolver_result_is_used(self) -> None:
+        """Explicit resolvers (spawn approvals) keep their attribution."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-other": _slot(running=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval(
+                "subagent", slot_resolver=lambda _rid: "slot-spawner"
+            )
+            await approve_fn(_event("req-owned-3"), "")
+
+        assert _requested_slot(gateway) == "slot-spawner"
+
+    @pytest.mark.asyncio
+    async def test_failing_resolver_does_not_fall_back_to_a_guess(self) -> None:
+        """A resolver that finds nothing yields no slot -- never a bystander."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-other": _slot(running=True)}
+
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            approve_fn = gateway._interactive_approval(
+                "subagent", slot_resolver=lambda _rid: ""
+            )
+            await approve_fn(_event("req-owned-4"), "")
+
+        assert _requested_slot(gateway) == ""

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -531,8 +531,16 @@ class TestInteractiveApproval:
         )
 
     @pytest.mark.asyncio
-    async def test_all_slots_trusted_approves(self):
-        """All slots trusted, no resolver → auto-approve."""
+    async def test_all_slots_trusted_does_not_auto_approve(self):
+        """All slots trusted, no resolver → still PROMPTS (no implicit trust).
+
+        This previously asserted auto-approval. That rule is gone: session
+        trust speaks for a chat session, not for an unattended job, and with
+        one trusted chat open the `all()` test was trivially satisfied.
+        Asserting the return value alone would now pass vacuously, because the
+        mocked `request_approval` also returns True -- so assert the prompt was
+        actually raised.
+        """
         orch = _make_orchestrator(slack_enabled=False)
         ds = _mock_dashboard_state()
         ds._yolo = False
@@ -550,8 +558,8 @@ class TestInteractiveApproval:
         with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
             with patch("kiro_crew.sel.sel") as mock_sel:
                 mock_sel.return_value.log_api_access = MagicMock()
-                result = await callback(event, "")
-        assert result is True
+                await callback(event, "")
+        ds.request_approval.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_auto_approve_sources_config(self):

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -117,6 +117,13 @@ function toApiDecision(d: string): 'approve' | 'reject' {
   return (d === 'approved' || d === 'trust' || d === 'trust_reads') ? 'approve' : 'reject'
 }
 
+/** Approval sources that run unattended, with no human bound to the chat the
+ *  card renders in. Session-scoped Trust is meaningless for these (see
+ *  `approvalIsUnattended`), so the Trust controls are withheld and only
+ *  Allow once / Reject are offered. Kept in sync with the backend's
+ *  `_BACKGROUND_APPROVAL_SOURCES` minus `autonudge`, which does run in-session. */
+export const UNATTENDED_APPROVAL_SOURCES = new Set(['cron', 'heartbeat', 'taskrunner'])
+
 // Pending-approval selection is now slot-aware — see selectSlotPendingApproval
 // in chatSlice (Path B S3): each grid pane's approval bar reflects ITS slot.
 
@@ -455,6 +462,20 @@ function ChatInput({
   const approvalBaseCommand = (approvalMeta?.base_command as string) || ''
   const approvalToolTitle = (approvalMeta?.tool_title as string) || ''
   const approvalIsShell = approvalToolTitle.startsWith('Running: ')
+  /** Sources that run with no human attached to THIS conversation. Session
+   *  trust means "auto-approve tools for this chat session", which is
+   *  incoherent for an unattended job: the job is not this session, so the
+   *  grant would widen this slot's own auto-approval surface while doing
+   *  nothing for the job. `autonudge` is deliberately absent — a monitor loop
+   *  runs *in* this session, so trusting it is meaningful. */
+  const approvalSource = (approvalMeta?.source as string)
+    // Persisted permission rows are rehydrated from content alone (chatSlice's
+    // reconstruct path carries no `source`), so fall back to the `[source]`
+    // prefix the card was written with rather than silently treating a
+    // reloaded cron card as an ordinary in-session one.
+    || (pendingApproval?.content || '').match(/^(?:🔧\s*)?\[([a-z_]+)\]/)?.[1]
+    || ''
+  const approvalIsUnattended = UNATTENDED_APPROVAL_SOURCES.has(approvalSource)
   const simplified = useSimplifiedToolNames()
   const approvalLabelRaw = sanitizeLlmOutput(pendingApproval?.content || '').replace(/^🔧\s*/, '')
 
@@ -522,7 +543,15 @@ function ChatInput({
       // bug), so clear it and say why instead of only logging to the console.
       if (err instanceof ApiError && err.status === 404) {
         dispatch(resolveByApprovalId({ id: approvalId, decision: 'stale' }))
-        setApprovalNotice('That approval expired — the turn it belonged to is no longer waiting.')
+        // Say WHOSE turn expired. Unattended sources deny-fast on a short
+        // window (minutes), so by the time a human reads the card the job has
+        // usually already been denied and moved on — "expired" alone reads as
+        // a dashboard bug rather than the job's documented timeout.
+        setApprovalNotice(
+          approvalIsUnattended
+            ? `That ${approvalSource} request already timed out and was denied — the job is no longer waiting. Check the approvals feed for the record.`
+            : 'That approval expired — the turn it belonged to is no longer waiting.'
+        )
         return
       }
       // eslint-disable-next-line no-console -- surface real approval-resolution failures to the dev console
@@ -530,13 +559,22 @@ function ChatInput({
       setApprovalNotice('Could not submit that decision — see the console for details.')
     }
     if (['trust_command', 'trust_base', 'trust', 'trust_reads'].includes(decision) && activeSlot) {
+      // Defence in depth: the Trust controls are not rendered for unattended
+      // sources, but never let a trust grant be applied on their behalf. The
+      // grant would land on THIS slot (api.approveChatSlot is slot-scoped),
+      // widening its auto-approval surface for a job that is not this session.
+      // Downgrade to a one-shot allow instead of silently over-granting.
+      if (approvalIsUnattended) {
+        api.resolveApproval(approvalId, 'approve').then(finish).catch(fail)
+        return
+      }
       const extra: Record<string, string> = { request_id: approvalId }
       if (pattern) extra.pattern = pattern
       api.approveChatSlot(activeSlot, decision, extra).then(finish).catch(fail)
     } else {
       api.resolveApproval(approvalId, toApiDecision(decision)).then(finish).catch(fail)
     }
-  }, [approvalId, activeSlot, dispatch])
+  }, [approvalId, activeSlot, approvalIsUnattended, approvalSource, dispatch])
 
   // Pending sub-agent SPAWN approvals for this slot (blocked on user approval).
   // Surfaced as a top-level REMINDER only — the banner does not resolve
@@ -1811,15 +1849,17 @@ function ChatInput({
                   )}
                   <div className="flex gap-1.5 flex-wrap items-center">
                       <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('approved')}><CheckCircle size={12} className="shrink-0" />Allow once</button>
-                      {approvalIsReadOnly && <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('trust_reads')}><BookOpen size={12} className="shrink-0" />Trust reads</button>}
-                      <TrustDropdown
-                          fullCommand={approvalFullCommand || approvalLabelRaw}
-                          baseCommand={approvalBaseCommand || approvalLabelRaw.split(/\s+/)[0] || ''}
-                          isShell={approvalIsShell}
-                          disabled={approvalSubmitting}
-                          className={approvalBtnClass}
-                          onAction={(action, pattern) => { handleApprovalAction(action, pattern) }}
-                      />
+                      {approvalIsReadOnly && !approvalIsUnattended && <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('trust_reads')}><BookOpen size={12} className="shrink-0" />Trust reads</button>}
+                      {!approvalIsUnattended && (
+                        <TrustDropdown
+                            fullCommand={approvalFullCommand || approvalLabelRaw}
+                            baseCommand={approvalBaseCommand || approvalLabelRaw.split(/\s+/)[0] || ''}
+                            isShell={approvalIsShell}
+                            disabled={approvalSubmitting}
+                            className={approvalBtnClass}
+                            onAction={(action, pattern) => { handleApprovalAction(action, pattern) }}
+                        />
+                      )}
                       <button disabled={approvalSubmitting} className={`${approvalBtnClass} hover:!text-danger hover:!bg-[color-mix(in_srgb,var(--danger)_10%,transparent)]`} onClick={() => handleApprovalAction('rejected')}><Ban size={12} className="shrink-0" />Reject</button>
                   </div>
               </div>

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -324,8 +324,15 @@ export function useWebSocket() {
               ts: String(data.ts || Date.now() / 1000),
               approval_id: data.id,
             } as Notification))
-            // Also inject inline in active chat
-            const targetSlot = data.slot || store.getState().chat.activeSlot || ''
+            // Inject inline in the OWNING chat only. An approval with no
+            // explicit slot has no owning conversation (an unowned cron /
+            // taskrunner command): falling back to activeSlot planted the card
+            // in whatever chat the user happened to be viewing, where its
+            // Trust control resolved against that innocent slot and the card
+            // 404'd as soon as the short background window elapsed. Unowned
+            // approvals live on the global surface (notification feed) only —
+            // the addNotification above already delivered it there.
+            const targetSlot = data.slot || ''
             if (targetSlot) {
               dispatch(sseChatMessage({
                 slot: targetSlot,
@@ -356,7 +363,10 @@ export function useWebSocket() {
             const match = items.find((n: Notification) => n.approval_id === data.id)
             if (match) dispatch(removeNotificationByTs(match.ts))
             dispatch(resolveByApprovalId({ id: data.id, decision: data.approved ? 'approved' : 'rejected' }))
-            const targetSlot = data.slot || store.getState().chat.activeSlot || ''
+            // Resolve only in the slot that raised the card. Guessing
+            // activeSlot here mirrored the raise-path leak: it wrote
+            // subagent spawn/done entries into an unrelated conversation.
+            const targetSlot = data.slot || ''
             const resolvedType = typeof data.id === 'string' && data.id.startsWith('spawn:') ? 'spawn' : 'chat'
             if (targetSlot) {
               const chatState = store.getState().chat

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -398,3 +398,90 @@ describe('ChatInput sub-agent spawn-approval reminder', () => {
     expect(screen.queryByText(/awaiting your approval to run/)).not.toBeInTheDocument()
   })
 })
+
+/**
+ * Unattended sources (cron / heartbeat / taskrunner) run with no human bound to
+ * the conversation the card renders in. Session-scoped Trust is incoherent for
+ * them: `api.approveChatSlot` grants on THIS slot, widening its auto-approval
+ * surface for a job that is not this session — and doing nothing for the job.
+ * So the Trust controls are withheld, and the expiry copy names the source
+ * because these approvals deny-fast on a short window.
+ */
+describe('ChatInput unattended-source approvals', () => {
+  const withSource = (source: string, opts: { viaLabel?: boolean } = {}) => {
+    const state = stateWithApproval()
+    if (opts.viaLabel) {
+      // Rehydrated-from-content path: chatSlice's reconstruct carries no
+      // `source`, so the `[source]` label prefix is the only signal.
+      state.chat!.messages[1].content = `[${source}] Running: ls /tmp`
+    } else {
+      state.chat!.messages[1].meta!.source = source
+    }
+    return state
+  }
+
+  it.each(['cron', 'heartbeat', 'taskrunner'])('withholds Trust for %s', (source) => {
+    const store = createTestStore(withSource(source))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.queryByText('Trust')).not.toBeInTheDocument()
+    expect(screen.queryByText('Trust reads')).not.toBeInTheDocument()
+    // The actionable controls remain — the card is still answerable.
+    expect(screen.getByText('Allow once')).toBeInTheDocument()
+    expect(screen.getByText('Reject')).toBeInTheDocument()
+  })
+
+  it('keeps Trust for autonudge, which does run in this session', () => {
+    const store = createTestStore(withSource('autonudge'))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getByText('Trust')).toBeInTheDocument()
+  })
+
+  it('keeps Trust for an ordinary in-session approval', () => {
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getByText('Trust')).toBeInTheDocument()
+  })
+
+  it('withholds Trust when the source survives only in the card label', () => {
+    const store = createTestStore(withSource('cron', { viaLabel: true }))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.queryByText('Trust')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['Allow once', 'approve'],
+    ['Reject', 'reject'],
+  ])('answers an unattended card via %s without the slot-scoped grant', async (label, decision) => {
+    // No control on an unattended card may route through approveChatSlot,
+    // which grants on THIS slot. (handleApprovalAction also downgrades a trust
+    // decision to a one-shot allow as defence in depth, but the UI withholds
+    // those controls entirely, so that branch is not reachable from here.)
+    const store = createTestStore(withSource('cron'))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText(label))
+    await waitFor(() => {
+      expect(api.resolveApproval).toHaveBeenCalledWith('ap-123', decision)
+    })
+    expect(api.approveChatSlot).not.toHaveBeenCalled()
+  })
+
+  it('names the source when an unattended request already timed out', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValueOnce(new ApiError(404, 'gone'))
+    const store = createTestStore(withSource('cron'))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Allow once'))
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/cron request already timed out/i)
+    })
+  })
+
+  it('keeps the generic copy for an ordinary expired approval', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValueOnce(new ApiError(404, 'gone'))
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByText('Allow once'))
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/That approval expired/i)
+    })
+  })
+})

--- a/website/src/test/useWebSocket.approvalRouting.test.ts
+++ b/website/src/test/useWebSocket.approvalRouting.test.ts
@@ -1,0 +1,155 @@
+/**
+ * An approval frame with no `slot` has no owning conversation.
+ *
+ * The transport used to fall back to `chat.activeSlot`, so an unowned cron /
+ * taskrunner command planted a permission card in whatever chat the user
+ * happened to be viewing. There the card carried a slot-scoped Trust control
+ * that resolved against that innocent slot, and it 404'd as soon as the short
+ * background window elapsed ("That approval expired"). Unowned approvals must
+ * reach the global surface (the notification feed) ONLY.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store as globalStore } from '../store'
+import { setActiveSlot } from '../store/chatSlice'
+import type { RootState } from '../store'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+/** A store whose viewed slot already holds a turn — the slot the old fallback
+ *  would have hijacked. */
+function storeViewingSlot1() {
+  return createTestStore({
+    chat: {
+      activeSlot: 'slot-1',
+      messages: [{ role: 'user', content: 'unrelated work' }],
+      toolLog: [],
+      subagents: {},
+      slotActivity: {},
+      slotStatusDetail: {},
+    } as unknown as RootState['chat'],
+  })
+}
+
+describe('useWebSocket unowned approval routing', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // useWebSocket reads `chat.activeSlot` off the SINGLETON store (not the
+    // Provider store), so the removed fallback is only reachable when the
+    // singleton has a slot selected. Priming it is what makes these tests
+    // discriminate the fix from the bug rather than passing either way.
+    globalStore.dispatch(setActiveSlot('slot-1'))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(setActiveSlot(null))
+  })
+
+  function mount(store: ReturnType<typeof storeViewingSlot1>) {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  const cronApproval = (extra: Record<string, unknown> = {}) => ({
+    type: 'approval',
+    data: {
+      id: 'ap-cron-1',
+      source: 'cron',
+      tool: 'Running: cd /work/repo && git status',
+      tool_input: '{"command":"git status"}',
+      ts: 1.0,
+      ...extra,
+    },
+  })
+
+  it('does not plant an unowned approval in the viewed conversation', () => {
+    const store = storeViewingSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(cronApproval()) })
+
+    const msgs = store.getState().chat.messages
+    expect(msgs.some(m => m.role === 'permission')).toBe(false)
+    // ...and nothing was written to the slot's activity log either.
+    expect(store.getState().chat.toolLog.some(e => e.approval_id === 'ap-cron-1')).toBe(false)
+  })
+
+  it('still delivers the unowned approval to the global notification feed', () => {
+    const store = storeViewingSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(cronApproval()) })
+
+    const notifs = store.getState().notifications.items
+    const match = notifs.find(n => n.approval_id === 'ap-cron-1')
+    expect(match).toBeDefined()
+    expect(match!.kind).toBe('approval')
+    // Provenance survives: the feed says which job asked.
+    expect(match!.body).toContain('cron')
+  })
+
+  it('still renders inline when the frame names its owning slot', () => {
+    const store = storeViewingSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(cronApproval({ slot: 'slot-1', id: 'ap-owned-1' })) })
+
+    const msgs = store.getState().chat.messages
+    const card = msgs.find(m => m.role === 'permission')
+    expect(card).toBeDefined()
+    expect(card!.meta?.approval_id).toBe('ap-owned-1')
+    expect(card!.meta?.source).toBe('cron')
+  })
+})


### PR DESCRIPTION
## Problem

A cron's shell-command approval was surfacing in whatever interactive chat happened to be open — with a truncated label, no provenance, and buttons that 404'd moments later ("That approval expired — the turn it belonged to is no longer waiting").

Two **independent** fallbacks caused this, and one of them was a privilege leak.

### 1. Backend: the first-running-slot heuristic

`_interactive_approval` fell back to "the first slot that is `running`" whenever a background caller supplied neither an authoritative parent session key nor a `slot_resolver`. Every call site that reaches that path is unattended (`cron` ×2, `autonudge`, `taskrunner`), so the guess could only ever misattribute. It was wrong in three directions at once:

- the prompt rendered in a conversation that never raised it;
- the slot-scoped Trust control resolved against that innocent slot, so trusting a cron's command granted blanket auto-approval to the **borrowed** session — and did nothing for the cron;
- conversely, a borrowed slot that already had trust enabled **silently auto-approved the background command with no prompt at all** — privilege the job was never granted.

That third point is the most serious finding here, and it is verified rather than inferred: `test_borrowed_slot_trust_does_not_auto_approve` fails against the old code. My first draft of that test used `dashboard:`-prefixed slot keys and masked the bug; production `_slots` keys are unprefixed (the prefix only forms session keys), and with realistic keys the auto-approve reproduces.

### 2. Frontend: the activeSlot fallback

`useWebSocket` separately fell back to `chat.activeSlot` when an approval frame carried no slot. Fixing only the backend would have left the leak **fully intact**.

## Changes

- Unowned approvals now carry `slot=""` and reach the global surface (notification feed / `/api/approvals`) only. No guessing.
- **There is no implicit trust path left.** An unowned background command always prompts. An earlier revision of this PR kept an "every open conversation is trusted" rule and defended it as strictly narrower than the heuristic it replaced. That was true and beside the point: with one trusted chat open — the typical single-user state — `all()` is trivially satisfied, so the exact harm above still reproduced. The branch is deleted. Operators who want a source to run unprompted use the explicit `hooks.auto_approve_sources` opt-in, which already sits upstream of the trust check and is untouched — consent for that source, rather than a side effect of trusting an unrelated conversation.
- Both the raise and the resolve paths in the transport now require an explicit slot.
- Trust controls are withheld for `cron` / `heartbeat` / `taskrunner`, because session trust means "auto-approve tools for this chat session" and an unattended job is not this session. `autonudge` keeps them — a monitor loop genuinely does run in-session. `handleApprovalAction` also degrades a trust decision to a one-shot allow as defence in depth.
- Expired-card copy names the source and says the job already timed out, rather than reading like a dashboard bug. Background approvals deny-fast on a 180s window (`_BACKGROUND_APPROVAL_TIMEOUT_SECS`), so a human who looks after a few minutes is normally too late by design.

## Scope

This is the harm-stopping half of the fix. A follow-up will add the approvals **inbox** — provenance, a countdown, and expiry becoming a durable record instead of a vanishing card — plus prevention at `cron_add` time. Those share a new backend store and the same files, so they are deliberately not stacked here.

## Tests

22 new tests; every regression guard revert-verified against the original code.

| Suite | Count | Revert-verified guards |
|---|---|---|
| `test/test_background_approval_routing.py` | 10 | 6 |
| `website/src/test/useWebSocket.approvalRouting.test.ts` | 3 | 1 |
| `website/src/test/ChatInput.approval.test.tsx` (appended) | 9 | 5 |

One **pre-existing** test also had to be rewritten rather than deleted: `test_slack_gateway.py::test_all_slots_trusted_approves` asserted `result is True`, which kept passing after the implicit-trust removal **for the wrong reason** — the mocked `request_approval` also returns `True`. It is now `test_all_slots_trusted_does_not_auto_approve` and asserts the prompt was actually raised.

Two notes on test honesty:

- One candidate test was **dropped rather than shipped**: revert-verification showed it passed against the buggy code too, so it guarded nothing.
- The transport tests must prime the **singleton** store's `activeSlot`, because `useWebSocket` reads it there rather than from the Provider store. Without that priming the tests pass either way — the harness detail is what makes them discriminate.

## Verification

- `pytest`: 18702 passed, 78 skipped, 5 xfailed
- `vitest`: 5161 passed, 3 skipped (427 files)
- `isort`, `flake8`, `tsc -b` clean
- `mypy` 1.14.1 (matching the `pyproject.toml` pin, no `faiss` installed): clean, 490 files

One unrelated flake surfaced in the first full frontend run (`ChatPage.responsivePanel` activity-slot self-healing); it passes in isolation and on a second full run, and this diff touches no ChatPage code.

No UI screenshots: the visible change is the *absence* of a card in an unrelated conversation plus two withheld buttons, neither of which photographs meaningfully.

