### PR TITLE
fix(prompt): write OPTIONS labels in the user's voice

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -628,6 +628,13 @@ _CRITICAL_RULES = (
     "(links, CR/ticket IDs, status, a gloss on any unclear option label, and any "
     "clarifying questions) in the body BEFORE the [OPTIONS:] line -- the UI "
     "collapses earlier steps, so the final message is all that remains.\n"
+    "Write every option label in the USER's voice, not yours. Clicking a label "
+    "inserts it verbatim into the user's input box and sends it as their next "
+    "message to you, so each label must read as a short instruction or answer "
+    "FROM the user (\"Merge it now\", \"Show me the diff\", \"Skip the rebase\", "
+    "\"Yes, delete it\"). Never phrase a label in your own voice or as your own "
+    "next action (\"I'll merge it\", \"Let me show the diff\", \"I can rebase "
+    "first\"), and never phrase it as a question back to the user.\n"
     "[END CRITICAL RULES]\n\n"
 )
 
@@ -1814,7 +1821,9 @@ class ContextBuilder:
             parts.append(
                 "\n\n(If presenting choices, end with [OPTIONS: choice1 | choice2 | choice3] "
                 "as the very last line — exactly once, nothing after it. "
-                "Users can select multiple options before submitting.)"
+                "Users can select multiple options before submitting. Label each choice "
+                "in the user's voice as an instruction to you — \"Merge it now\", not "
+                "\"I'll merge it\".)"
             )
             # Dashboard-only, situational nudge for the suggest_followup tool.
             # Gated to dashboard sessions because the tool rejects Slack/cron/

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -89,6 +89,10 @@ class TestContextBuilder:
         # ...and the standalone-final-message rule (decision context must not
         # live only in a now-collapsed step)
         assert "collapses earlier steps" in ctx
+        # ...and the option-label voice rule. Labels are sent verbatim as the
+        # user's next message, so agent-voice labels ("I'll merge it") read
+        # backwards once clicked.
+        assert "in the USER's voice" in ctx
 
     def test_cc_provider_has_full_parity_with_kiro(self, tmp_path):
         """Full parity: anything injected for kiro ACP must also be injected for


### PR DESCRIPTION
## Problem

`[OPTIONS:]` labels are inserted **verbatim into the user's input box** and sent as
their next message (`ChatPage.tsx` → `onFollowUpSelect` → `setInput(prev => ... + o)`
→ `send()`). But `_CRITICAL_RULES` only specified the *format* of the tag — last line,
exactly once, self-contained body — and never said whose voice the labels should be in.

With no rule, the model infers voice from the surrounding sentence, so it drifts:

- Ends on a question ("shall I continue?") → labels come out in the user's voice, correct.
- Ends on a proposal ("I can do X, Y, Z") → labels continue the agent's action list
  (`I'll open the PR`), which reads backwards the moment it's clicked and becomes the
  user's message.

The drift is per-session sticky: the model sees its own earlier `[OPTIONS:]` lines in
history, so whichever voice it picked first tends to persist for the rest of the session.
That's why the bug looks intermittent rather than random.

The only real user-voice exemplar in the repo is in `skills/grill/SKILL.md`, which is
only in context when that skill is loaded. The placeholders in the prompt itself
(`Choice A | Choice B | Choice C`) carry no voice signal at all.

## Change

State the contract explicitly, in both places the option instruction appears:

- `_CRITICAL_RULES` — the label is the user's next message; write it as a short
  instruction or answer *from* the user, with concrete good/bad examples
  ("Merge it now" vs "I'll merge it"), and never as a question back to the user.
- The per-turn `interactive` reminder — a one-line version of the same rule. This
  matters for providers (incl. Claude Code) where that reminder is the nearest
  instruction to the response being generated.

Prompt-only change; no behavioural code touched.

## Tests

- `test_context.py::test_empty_context_has_critical_rules` asserts the voice rule is
  present in the built context, alongside the existing `[OPTIONS:` and
  "collapses earlier steps" assertions.
- `test/test_context.py` + `test/test_memory_smoke.py`: 106 passed.

## Caveat

This is a prompt-level constraint, not a hard guarantee — a deterministic backstop
would have to live in the `parseOptions` boundary (detect/rewrite agent-voice labels).
Deliberately out of scope here; shipping the prompt fix first to see how much of the
drift it removes.
