### PR TITLE
fix(dashboard): stop per-port auth cookies overflowing the shared 127.0.0.1 jar

### DIFF
--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -25,6 +25,8 @@ from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
     REFRESH_COOKIE_PATH,
     _get_state,
+    cookie_jar_needs_pruning,
+    foreign_port_cookies,
     generate_refresh_token,
     refresh_cookie_name,
     validate_refresh_token,
@@ -274,6 +276,30 @@ def _clear_refresh_cookie(
     resp.set_cookie(cookie_name, "", max_age=0, path=REFRESH_COOKIE_PATH)
 
 
+def _expire_foreign_port_cookies(
+    resp: web.Response,
+    request: web.Request,
+) -> None:
+    """Expire per-port auth cookies left behind by gateways on OTHER ports.
+
+    Keeps the shared 127.0.0.1 cookie jar from growing past aiohttp's header
+    limit (see ``refresh_tokens.foreign_port_cookies``). Runs on the refresh
+    happy path, which — unlike the initial page mint — sees BOTH cookie types
+    because ``/api/auth/refresh`` matches the access (``/``) and refresh
+    (``/api/auth``) cookie paths, so one refresh cycle trims the whole jar.
+
+    No-op unless the jar is actually approaching the limit
+    (``cookie_jar_needs_pruning``) so co-existing live gateways in one browser
+    keep their sessions until accumulation genuinely threatens overflow.
+    """
+    if not cookie_jar_needs_pruning(request.cookies):
+        return
+    port = request.app.get("port", 7777)
+    current = _cookie_port_from_host(request, port)
+    for name, path in foreign_port_cookies(request.cookies, current):
+        resp.set_cookie(name, "", max_age=0, path=path)
+
+
 def _audit(
     user_id: str,
     operation: str,
@@ -417,6 +443,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
                 _set_refresh_cookie(
                     resp, request, payload["_refresh_token"], payload["refresh_exp"]
                 )
+                _expire_foreign_port_cookies(resp, request)
                 _audit(user_id, "refresh_token_use", "grace_replay")
                 return resp
         # Genuine reuse → revoke the chain.
@@ -476,6 +503,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     resp = web.json_response(public_payload)
     _set_access_cookie(resp, request, new_access_token, new_session_exp)
     _set_refresh_cookie(resp, request, new_refresh_token, new_refresh_exp)
+    _expire_foreign_port_cookies(resp, request)
     _audit(user_id, "refresh_token_use", "ok")
     return resp
 

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -29,7 +29,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, Mapping
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir
@@ -60,6 +60,28 @@ MAX_REFRESH_TTL_SECS = 30 * 86400  # 30 days
 # must add its own scrubbing — but that's a deliberate choice we'd
 # rather make than have logout silently no-op.
 REFRESH_COOKIE_PATH = "/api/auth"
+
+# Per-port cookie name prefixes. Browser cookies are NOT isolated by port
+# (RFC 6265 §8.5), so on 127.0.0.1 every gateway instance ever run on a
+# different port leaves its own ``mc_token_<port>`` / ``mc_refresh_<port>``
+# pair in the single shared cookie jar. Nothing pruned them, so the Cookie
+# header grew without bound until it crossed aiohttp's ``max_field_size``
+# and every request 400'd (``LineTooLong``) inside the C parser, before any
+# handler could run. Callers expire the OTHER-port pairs on a successful
+# auth so the jar self-trims — see ``foreign_port_cookies``.
+ACCESS_COOKIE_PREFIX = "mc_token_"
+REFRESH_COOKIE_PREFIX = "mc_refresh_"
+ACCESS_COOKIE_PATH = "/"
+
+# Only trim the jar once it is actually approaching the header limit. Below
+# this, per-port cookies coexist untouched — so a developer legitimately
+# running two LIVE gateways in one browser (e.g. the main instance plus an
+# isolated test pod) does not have one session's refresh expire the other's
+# cookie. Pruning kicks in only when accumulation (mostly dead ports whose
+# gateways no longer exist) genuinely threatens overflow. 6 KiB leaves ample
+# headroom under the raised 32 KiB parser limit AND under the stock 8190-byte
+# default any fronting proxy might still enforce.
+COOKIE_JAR_PRUNE_THRESHOLD_BYTES = 6 * 1024
 
 # Multi-tab grace window: a jti consumed within this many seconds is
 # still accepted from the same chain + same source IP. The handler
@@ -459,4 +481,51 @@ def validate_refresh_token(token: str) -> tuple[bool, str, str, str, str, float]
 
 def refresh_cookie_name(port: str | int) -> str:
     """Mirror the existing per-port pattern used for the access cookie."""
-    return f"mc_refresh_{port}"
+    return f"{REFRESH_COOKIE_PREFIX}{port}"
+
+
+def foreign_port_cookies(
+    cookie_names: Iterable[str], current_port: str | int
+) -> list[tuple[str, str]]:
+    """Return ``(name, path)`` pairs for per-port auth cookies of OTHER ports.
+
+    ``cookie_names`` is what the browser sent (e.g. ``request.cookies``);
+    ``current_port`` is the port THIS gateway resolved for the request
+    (``_cookie_port_from_host``), whose own pair is always preserved.
+
+    The returned ``path`` matches how each cookie was originally set
+    (access = ``/``, refresh = ``/api/auth``) because cookie deletion is
+    path-sensitive: a ``Set-Cookie`` with ``max_age=0`` only removes a
+    cookie when its ``path`` matches the one used to set it. Suffixes must
+    be digit-only, so non-port names — including the legacy ``mc_token``
+    (no suffix) — are never touched.
+
+    Callers expire the returned cookies on successful auth so the shared
+    127.0.0.1 jar self-trims and can never grow past aiohttp's header limit.
+    """
+    current = str(current_port)
+    stale: list[tuple[str, str]] = []
+    for name in cookie_names:
+        for prefix, path in (
+            (ACCESS_COOKIE_PREFIX, ACCESS_COOKIE_PATH),
+            (REFRESH_COOKIE_PREFIX, REFRESH_COOKIE_PATH),
+        ):
+            if not name.startswith(prefix):
+                continue
+            suffix = name[len(prefix) :]
+            if suffix.isdigit() and suffix != current:
+                stale.append((name, path))
+            break
+    return stale
+
+
+def cookie_jar_needs_pruning(cookies: Mapping[str, str]) -> bool:
+    """True when the incoming cookie jar is large enough to warrant trimming.
+
+    Approximates the wire size of the ``Cookie`` request header (``name=value``
+    pairs joined by ``"; "``). Kept as a cheap gate so pruning only fires once
+    accumulation approaches the limit — see ``COOKIE_JAR_PRUNE_THRESHOLD_BYTES``
+    for why small jars are deliberately left alone.
+    """
+    total = sum(len(name) + len(value) + 2 for name, value in cookies.items())
+    return total > COOKIE_JAR_PRUNE_THRESHOLD_BYTES

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -383,6 +383,19 @@ _PERMISSIONS_POLICY = "clipboard-write=(self), clipboard-read=(self)"
 _IMMUTABLE_PATH_PREFIXES = ("/assets/",)
 _IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
+# Max size of a single incoming HTTP header field, raised from aiohttp's
+# 8190-byte default. Browser cookies are not port-isolated (RFC 6265), so on
+# 127.0.0.1 the per-port mc_token_<port>/mc_refresh_<port> cookies of every
+# gateway instance pile up in one shared Cookie header. At the 8190 default
+# that header crosses the limit after ~16 ports and aiohttp's C parser rejects
+# the request with 400 LineTooLong BEFORE any handler runs — so the request
+# that would prune the jar can never execute. This headroom lets an oversized
+# request reach the handler, which then expires the other-port cookies (see
+# refresh_tokens.foreign_port_cookies) so the jar self-trims. 32 KiB stays well
+# under a DoS-relevant size while covering ~60 accumulated ports plus other
+# request headers.
+_MAX_HEADER_FIELD_SIZE = 32 * 1024
+
 
 def _extra_frame_ancestors(
     request: "web.Request | None", app: "web.Application | None" = None
@@ -2220,7 +2233,10 @@ async def start_dashboard(
 
     # Hardened runner: bounds the request-line/header read time (slowloris /
     # CWE-400) and reaps idle keep-alive connections. See dashboard.slowloris.
-    runner = build_hardened_runner(app)
+    # max_field_size is raised from aiohttp's 8190 default so the accumulated
+    # shared per-port cookie jar can't 400 at the parser before a handler
+    # prunes it (see refresh_tokens.foreign_port_cookies).
+    runner = build_hardened_runner(app, max_field_size=_MAX_HEADER_FIELD_SIZE)
     await runner.setup()
     site = web.TCPSite(runner, bind_address_for(local_only), port)
     await _start_site(site, port)
@@ -2637,8 +2653,10 @@ async def start_api_server(
 
     app.on_cleanup.append(_kiro_prerequisite_shutdown)
 
-    # Hardened runner: same slowloris / CWE-400 mitigation as start_dashboard.
-    runner = build_hardened_runner(app)
+    # Hardened runner: same slowloris / CWE-400 mitigation as start_dashboard,
+    # plus the raised max_field_size (see start_dashboard for the cookie-jar
+    # rationale).
+    runner = build_hardened_runner(app, max_field_size=_MAX_HEADER_FIELD_SIZE)
     await runner.setup()
     # Same bind resolution as start_dashboard: loopback unless the operator
     # widened it (dashboard.url opt-out of local_only, or the KIROCREW_BIND

--- a/src/kiro_crew/dashboard/slowloris.py
+++ b/src/kiro_crew/dashboard/slowloris.py
@@ -196,14 +196,17 @@ def build_hardened_runner(
     *,
     header_read_timeout: float = HEADER_READ_TIMEOUT,
     keepalive_timeout: float = KEEPALIVE_TIMEOUT,
+    **kwargs: Any,
 ) -> web.AppRunner:
     """Return an ``AppRunner`` with slowloris mitigation wired in.
 
     Drop-in replacement for ``web.AppRunner(app)`` at the dashboard / API
-    server start sites.
+    server start sites. Extra ``**kwargs`` (e.g. ``max_field_size``) are
+    forwarded through to the underlying aiohttp request handler.
     """
     return SlowlorisAppRunner(
         app,
         header_read_timeout=header_read_timeout,
         keepalive_timeout=keepalive_timeout,
+        **kwargs,
     )

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -28,6 +28,8 @@ from kiro_crew.dashboard.origin import is_https_request, is_loopback
 from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
     REFRESH_COOKIE_PATH,
+    cookie_jar_needs_pruning,
+    foreign_port_cookies,
     generate_refresh_token,
     refresh_cookie_name,
 )
@@ -1583,6 +1585,19 @@ def token_auth_middleware(
             )
             # Clean up legacy cookie from pre-port-specific era
             resp.set_cookie("mc_token", "", max_age=0, path="/")
+
+            # Trim other-port auth cookies from the shared 127.0.0.1 jar so it
+            # can't grow past aiohttp's header limit (see
+            # refresh_tokens.foreign_port_cookies). Gated on jar size so live
+            # co-existing gateways keep their sessions until accumulation
+            # genuinely threatens overflow. This page request only carries
+            # other-port ACCESS cookies (path "/"); other-port refresh cookies
+            # (path "/api/auth") are trimmed on the next refresh call.
+            if cookie_jar_needs_pruning(request.cookies):
+                for _stale_name, _stale_path in foreign_port_cookies(
+                    request.cookies, _cookie_port_from_host(request, port)
+                ):
+                    resp.set_cookie(_stale_name, "", max_age=0, path=_stale_path)
 
             # Initial mint via token URL: also attach a refresh cookie so
             # the user does not have to re-mint via URL every ~20h. Inlined

--- a/test/test_dashboard_slowloris.py
+++ b/test/test_dashboard_slowloris.py
@@ -117,4 +117,7 @@ def test_start_paths_use_hardened_runner() -> None:
     src = inspect.getsource(dashboard_server)
     # Neither start path may fall back to a bare web.AppRunner(app).
     assert "web.AppRunner(app)" not in src
-    assert src.count("build_hardened_runner(app)") == 2
+    # Both start paths call the hardened runner. Match the call prefix (not a
+    # fixed closing paren) so passing extra kwargs — e.g.
+    # max_field_size=_MAX_HEADER_FIELD_SIZE — still satisfies the invariant.
+    assert src.count("build_hardened_runner(app") == 2

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -22,6 +22,8 @@ from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
     REFRESH_GRACE_SECS,
     RefreshStateManager,
+    cookie_jar_needs_pruning,
+    foreign_port_cookies,
     generate_refresh_token,
     refresh_cookie_name,
     validate_refresh_token,
@@ -744,6 +746,66 @@ def test_refresh_cookie_name_per_port():
     assert refresh_cookie_name("5555") == "mc_refresh_5555"
 
 
+# -- Foreign-port cookie pruning (cookie-jar overflow, issue #610) ------------
+
+
+def test_foreign_port_cookies_selects_other_ports_with_matching_paths():
+    """Other-port access/refresh cookies are returned with the path each was
+    set with (access="/", refresh="/api/auth") so a max_age=0 Set-Cookie
+    actually deletes them (cookie deletion is path-sensitive)."""
+    jar = [
+        "mc_token_7777",
+        "mc_refresh_7777",
+        "mc_token_5599",
+        "mc_refresh_5599",
+        "mc_token_6821",
+    ]
+    stale = foreign_port_cookies(jar, 7777)
+    assert set(stale) == {
+        ("mc_token_5599", "/"),
+        ("mc_refresh_5599", "/api/auth"),
+        ("mc_token_6821", "/"),
+    }
+
+
+def test_foreign_port_cookies_preserves_current_port():
+    """The current port's own pair must never be expired."""
+    stale = foreign_port_cookies(["mc_token_7777", "mc_refresh_7777"], 7777)
+    assert stale == []
+    # Current port passed as int or str resolves identically.
+    assert foreign_port_cookies(["mc_token_7777"], "7777") == []
+
+
+def test_foreign_port_cookies_ignores_non_port_names():
+    """Legacy 'mc_token' (no suffix), non-digit suffixes, and unrelated
+    cookies must be left untouched — only digit-suffixed per-port names
+    are pruned."""
+    jar = [
+        "mc_token",  # legacy, pre-per-port
+        "mc_token_abc",  # non-digit suffix
+        "session",  # unrelated
+        "mc_refresh_",  # empty suffix
+        "mc_token_5599",  # genuine other port -> only this one
+    ]
+    stale = foreign_port_cookies(jar, 7777)
+    assert stale == [("mc_token_5599", "/")]
+
+
+def test_cookie_jar_needs_pruning_threshold():
+    """The size gate is False for a small jar (live gateways coexist) and True
+    once the approximate Cookie header size crosses the threshold."""
+    from kiro_crew.dashboard.refresh_tokens import COOKIE_JAR_PRUNE_THRESHOLD_BYTES
+
+    small = {"mc_token_7777": "abc", "mc_refresh_7777": "def"}
+    assert cookie_jar_needs_pruning(small) is False
+
+    # One oversized value pushes the jar past the threshold.
+    big = {"mc_token_7777": "x" * (COOKIE_JAR_PRUNE_THRESHOLD_BYTES + 1)}
+    assert cookie_jar_needs_pruning(big) is True
+
+    assert cookie_jar_needs_pruning({}) is False
+
+
 # -- Atomic write under crash (TR-U-19) — best-effort smoke test --------------
 
 
@@ -1048,3 +1110,100 @@ def test_tr_u_27_logout_revokes_access_cookie(tmp_path, monkeypatch):
     ok, _uid, reason = validate_token(access_token, use_session_exp=True)
     assert ok is False
     assert reason == "session revoked"
+
+
+# -- Refresh endpoint trims the shared cookie jar (issue #610) ----------------
+
+
+def test_refresh_expires_foreign_port_cookies_keeps_current(
+    isolated_state: RefreshStateManager,
+):
+    """POST /api/auth/refresh must expire other-port mc_token_*/mc_refresh_*
+    cookies (max_age=0 with the matching path) so the shared 127.0.0.1 jar
+    self-trims, while re-setting the CURRENT port's pair with a live TTL.
+    Without this the per-port cookies accumulate until the Cookie header
+    exceeds aiohttp's max_field_size and every request 400s (LineTooLong).
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from aiohttp import web
+
+    from kiro_crew.dashboard.handlers import auth_refresh as ar
+
+    token, _chain_id, _jti, _exp = generate_refresh_token("alice")
+
+    request = MagicMock(spec=web.Request)
+    request.app = {"port": 7777, "allowed_origins": set()}
+    request.cookies = {
+        refresh_cookie_name(7777): token,
+        # Stale pairs left by gateways on other ports, sized so the whole jar
+        # exceeds COOKIE_JAR_PRUNE_THRESHOLD_BYTES and the size gate fires.
+        "mc_token_5599": "x" * 2500,
+        "mc_refresh_5599": "y" * 2500,
+        "mc_token_6821": "z" * 2500,
+    }
+    request.headers = {"Origin": "http://localhost:7777", "Host": "localhost:7777"}
+    request.scheme = "http"
+    request.host = "localhost:7777"
+    request.remote = "127.0.0.1"
+
+    with patch(
+        "kiro_crew.dashboard.handlers.auth_refresh.check_origin", return_value=True
+    ), patch(
+        "kiro_crew.dashboard.handlers.auth_refresh._rate_limited", return_value=False
+    ):
+        resp = asyncio.run(ar.api_auth_refresh(request))
+
+    assert resp.status == 200
+    # Current port's pair re-issued with a live TTL (not expired).
+    assert int(resp.cookies["mc_token_7777"]["max-age"]) > 0
+    assert int(resp.cookies["mc_refresh_7777"]["max-age"]) > 0
+    # Foreign-port cookies expired with the path each was set with.
+    assert int(resp.cookies["mc_token_5599"]["max-age"]) == 0
+    assert resp.cookies["mc_token_5599"]["path"] == "/"
+    assert int(resp.cookies["mc_refresh_5599"]["max-age"]) == 0
+    assert resp.cookies["mc_refresh_5599"]["path"] == "/api/auth"
+    assert int(resp.cookies["mc_token_6821"]["max-age"]) == 0
+    assert resp.cookies["mc_token_6821"]["path"] == "/"
+
+
+def test_refresh_leaves_small_jar_untouched(
+    isolated_state: RefreshStateManager,
+):
+    """With a small cookie jar (e.g. two live gateways sharing a browser), the
+    refresh endpoint must NOT expire the other port's cookies — pruning only
+    fires once the jar approaches the header limit."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from aiohttp import web
+
+    from kiro_crew.dashboard.handlers import auth_refresh as ar
+
+    token, _chain_id, _jti, _exp = generate_refresh_token("alice")
+
+    request = MagicMock(spec=web.Request)
+    request.app = {"port": 7777, "allowed_origins": set()}
+    request.cookies = {
+        refresh_cookie_name(7777): token,
+        # A second LIVE gateway's cookies — small jar, must be preserved.
+        "mc_token_6821": "small",
+        "mc_refresh_6821": "small",
+    }
+    request.headers = {"Origin": "http://localhost:7777", "Host": "localhost:7777"}
+    request.scheme = "http"
+    request.host = "localhost:7777"
+    request.remote = "127.0.0.1"
+
+    with patch(
+        "kiro_crew.dashboard.handlers.auth_refresh.check_origin", return_value=True
+    ), patch(
+        "kiro_crew.dashboard.handlers.auth_refresh._rate_limited", return_value=False
+    ):
+        resp = asyncio.run(ar.api_auth_refresh(request))
+
+    assert resp.status == 200
+    # The other live gateway's cookies were not touched (no expiry Set-Cookie).
+    assert "mc_token_6821" not in resp.cookies
+    assert "mc_refresh_6821" not in resp.cookies


### PR DESCRIPTION
## Problem

On `127.0.0.1` the dashboard's auth cookies are named per-port —
`mc_token_<port>` (~243 B) and `mc_refresh_<port>` (~266 B). Browser cookies
are **not** isolated by port (RFC 6265 §8.5), so every gateway/dev-pod/test
instance ever run on a different port leaves its pair in the single shared
`127.0.0.1` cookie jar, and nothing prunes them. Once the accumulated `Cookie`
header exceeds aiohttp's `max_field_size` (8190 B default), aiohttp's C HTTP
parser rejects the request with `400 LineTooLong` **before any handler runs**:

```
aiohttp.http_exceptions.LineTooLong: 400, message:
  Got more than 8190 bytes when reading: b'mc_refresh_5599=eyJ...'
```

Fixes #610.

## Why it matters

The failure is silent first, then total:

- The refresh cookie is path-scoped to `/api/auth`, so `POST /api/auth/refresh`
  starts 400ing at ~16 accumulated ports while the SPA still looks fine. Silent
  token rotation fails, so sessions quietly expire every ~20h instead of the
  intended ~30-day cadence.
- At ~34 ports **every** request 400s and the dashboard is unreachable until
  cookies are cleared.
- Anyone who runs isolated pods / test gateways on rotating ports (a normal
  KiroCrew dev workflow) hits this quickly.

## Fix (symptom → root cause → change)

Symptom: `400 LineTooLong` / silent session loss. Root cause: unbounded
per-port cookie accumulation in the shared jar, and the rejection happens in
the C parser before any handler can prune. Both must be addressed:

1. **Raise the header-field limit.** `web.AppRunner(..., max_field_size=32 KiB)`
   on both entry points (`start_dashboard` and `start_api_server`). This is the
   only thing that lets an already-oversized request *reach* a handler — at the
   8190 default the request that would prune the jar can never execute.
2. **Self-trim on successful auth.** On the refresh happy/grace paths and the
   initial token-URL mint, expire other-port `mc_token_*` / `mc_refresh_*`
   cookies (`Set-Cookie` `max_age=0`) so the jar can never grow unbounded. New
   pure classifier `refresh_tokens.foreign_port_cookies()` returns `(name, path)`
   pairs, using each cookie's original path (`/` for access, `/api/auth` for
   refresh) because cookie deletion is path-sensitive. The **current** port's
   pair is always preserved, and only digit-suffixed per-port names are touched
   (legacy `mc_token` and unrelated cookies are left alone).

Pruning is **size-gated** (`cookie_jar_needs_pruning`, 6 KiB threshold): a small
jar is left untouched, so a developer legitimately running two *live* gateways
in one browser keeps both sessions. Trimming only fires once accumulation
(mostly dead ports whose gateways no longer exist) actually approaches the
limit.

## Tests

`test/test_refresh_tokens.py`:
- `test_foreign_port_cookies_*` — selection returns the right `(name, path)`
  pairs, preserves the current port, and ignores non-port names (legacy
  `mc_token`, non-digit suffixes, unrelated cookies).
- `test_cookie_jar_needs_pruning_threshold` — gate is False below the threshold,
  True above, False on an empty jar.
- `test_refresh_expires_foreign_port_cookies_keeps_current` — a bloated jar
  through `POST /api/auth/refresh` expires each foreign cookie with the correct
  path while re-issuing the current pair with a live TTL.
- `test_refresh_leaves_small_jar_untouched` — a small jar (two live gateways in
  one browser) is NOT pruned.

## Manual verification

N/A for automated coverage of the logic. The `max_field_size` kwarg is
exercised indirectly: `test_api_server.py` boots both server entry points with
the new argument. End-to-end reproduction (accumulate >34 ports' cookies in a
real browser, confirm the dashboard recovers) requires many live gateways and
was not run; the unit + handler tests lock in the pruning and gating behavior.

## Screenshots

N/A — backend-only change, no user-visible UI.
