### PR TITLE
docs: require feature-critical skills to live in builtin_skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,6 +588,35 @@ skills/                  ← on-demand skill definitions (edit without rebuildin
 - Saved to `~/.kiro/crew/project_dir` during `kirocrew setup` so it works from any directory
 - Falls back to bundled copies in the Python package if project dir not found
 
+#### Skill Bundling: `builtin_skills/` vs. top-level `skills/` (MUST read before adding a skill)
+
+There are **two** places a skill can live, and they ship very differently:
+
+- **`src/kiro_crew/builtin_skills/`** — **bundled** into the Python package. On
+  gateway start, `_ensure_builtin_skills()` copies these into the user's
+  `~/.kiro/crew/skills/`, so **every** `pip` / DMG install receives them
+  automatically. This is the ONLY path that reaches end users.
+- **top-level `skills/`** — a **repo-checkout-only** convenience dir loaded via
+  `KIROCREW_PROJECT_DIR` when running from a source tree. It is **NOT** packaged,
+  so `pip`/DMG users never get these skills.
+
+**Rule — decide by whether the skill is load-bearing for a shipped feature:**
+
+- If a skill is **fundamentally required** for a feature to work as designed
+  (the feature, MCP tool, or docs reference it, or it breaks/degrades without the
+  skill), it **MUST** live under `src/kiro_crew/builtin_skills/` so it is bundled
+  and reaches all users. Do NOT ship a required skill only in top-level `skills/`
+  — that leaves installed users without it (this has bitten us: `prepare-pr`,
+  `artifacts`, and `widgets` were code-referenced but lived only in `skills/`, so
+  DMG users silently ran without them until they were promoted to
+  `builtin_skills/`).
+- Only use top-level `skills/` for **reference-only or optional/suggestion**
+  skills — nice-to-have knowledge that no shipped feature depends on.
+
+When in doubt (a feature or docs mention the skill by name), treat it as required
+and bundle it. Nested layout is preserved on copy (e.g.
+`builtin_skills/kirocrew-dev/prepare-pr/`).
+
 #### Skill Loading
 
 1. **Always-on skills**: skills with `always: true` in YAML frontmatter have full content injected into every new session context


### PR DESCRIPTION
## Problem

Skills that a shipped feature depends on were being placed only in the
top-level `skills/` directory. That directory is a **repo-checkout-only**
convenience (loaded via `KIROCREW_PROJECT_DIR` from a source tree) and is
**not** packaged, so `pip`/DMG users never receive those skills. There was
no rule in `AGENTS.md` telling contributors where a required skill must live.

## Why it matters

Feature-critical skills silently missing from installed builds means the
feature degrades or breaks for real users while looking fine in a dev
checkout. This already happened: `prepare-pr`, `artifacts`, and `widgets`
were code-referenced but lived only in `skills/`, so DMG users ran without
them until they were promoted to `builtin_skills/`.

## Fix (symptoms → root cause → change)

- **Symptom:** required skills absent for installed users.
- **Root cause:** no documented rule distinguishing the packaged path
  (`src/kiro_crew/builtin_skills/`, copied into `~/.kiro/crew/skills/` by
  `_ensure_builtin_skills()` on gateway start) from the non-packaged
  top-level `skills/` dir — so contributors defaulted to `skills/`.
- **Change:** add a "Skill Bundling" subsection to `AGENTS.md` (under
  Project-Level Configuration) that states the decision rule: a skill
  **fundamentally required** for a shipped feature (referenced by feature
  code / an MCP tool / docs, or degrades without it) **MUST** live under
  `builtin_skills/`; top-level `skills/` is for reference/optional skills
  only; when in doubt, bundle. Cites the prepare-pr/artifacts/widgets
  regression as precedent.

## Tests

N/A — documentation-only change to `AGENTS.md`. No code, schema, or behavior
is modified, so no automated test locks in a doc rule.

## Manual verification

Verified the new subsection renders in `AGENTS.md` between
"Project-Level Configuration" and "Skill Loading", and that the described
mechanism matches the code (`_ensure_builtin_skills()` copies
`builtin_skills/` into the user skills dir; top-level `skills/` is resolved
only via `KIROCREW_PROJECT_DIR`).
