### PR TITLE
test(setup): skip the exec-bit rejection test on Windows hosts

### DIFF
--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -362,6 +362,19 @@ class TestKiroPrerequisiteHelpers:
                 environ={},
             )
 
+    @pytest.mark.skipif(
+        not platform_compat.IS_POSIX,
+        reason=(
+            "execute-bit semantics are POSIX-only, so this rejection is "
+            "unobservable on a Windows HOST: chmod(0o600) cannot clear a POSIX "
+            "exec bit there, and is_executable_file() deliberately accepts any "
+            "existing regular file for an explicit POSIX target (a Windows host "
+            "cannot represent POSIX exec bits). The candidate is therefore always "
+            "'runnable' and no ValueError is raised. The size-based rejection in "
+            "test_rejects_zero_byte_candidate is platform-independent and keeps "
+            "the not-runnable gate covered on Windows."
+        ),
+    )
     @pytest.mark.parametrize("platform_name", ["darwin", "linux"])
     def test_rejects_non_runnable_candidate(
         self,


### PR DESCRIPTION
## Problem

`Backend Tests (Windows)` fails deterministically on `main` after #609:

```
FAILED test/test_kiro_prerequisite.py::TestKiroPrerequisiteHelpers::test_rejects_non_runnable_candidate[linux] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED test/test_kiro_prerequisite.py::TestKiroPrerequisiteHelpers::test_rejects_non_runnable_candidate[darwin] - Failed: DID NOT RAISE <class 'ValueError'>
```

## Why it matters

Every Windows CI run on `main` is red until this is fixed, so the Windows shard stops being a usable signal for everyone else's PRs. It is a broken test premise, not a product defect — the shipped behavior is correct on all three platforms.

## Fix (symptom → root cause → change)

**Symptom.** Both params of `test_rejects_non_runnable_candidate` fail with `DID NOT RAISE ValueError`, on Windows only.

**Root cause.** The test's premise cannot hold on a Windows *host*. It writes 4 bytes and calls `chmod(0o600)` expecting a non-executable candidate, but:

1. `chmod` cannot clear a POSIX execute bit on Windows — every file reports the same mode, so the call is a no-op.
2. `platform_compat.is_executable_file()` **deliberately** accepts any existing regular file for an explicit POSIX target (`return not IS_POSIX or os.access(path, os.X_OK)`, `platform_compat.py:1421`) precisely because a Windows host cannot represent POSIX exec bits.

So the candidate is always "runnable", `snapshot_trusted_acp_executable` never raises, and `pytest.raises` fails. Verified by simulating a Windows host (`IS_POSIX=False`, `IS_WINDOWS=True`): `is_executable_file` returns `True` for both the `linux` and `darwin` targets regardless of the `chmod`.

This is a test-only defect introduced by #609, which replaced the retired snapshot path's implicit `fstat` size/mode guard with an explicit runnable check. It didn't surface on that PR's final run because deleting ~370 test lines re-sharded xdist and moved the test into a shard that hadn't reported yet at merge time.

**Change.** `@pytest.mark.skipif(not platform_compat.IS_POSIX, ...)` with the reasoning recorded in the skip reason. The not-runnable gate stays covered on Windows by `test_rejects_zero_byte_candidate`, whose size-based rejection is platform-independent — so this narrows the test to the platform where its premise is meaningful rather than deleting coverage.

## Tests

No new tests: this *is* a test fix. `test_kiro_prerequisite.py` — 105 passed locally (POSIX, so the test still runs and still asserts the rejection here). Full suite **18755 passed / 82 skipped / 5 xfailed**; mypy clean on 491 files; flake8 and isort clean.

One unrelated failure appeared in the full parallel run — `test_stt_stream.py::TestStreamLifecycle::test_start_failure_emits_sel_end_audit`. It passes in isolation (36 passed) and this branch touches only `test/test_kiro_prerequisite.py`. It is the same pre-existing parallel-load race in that class as `test_client_construction_failure_closes_ws_and_emits_end_audit`: the client asserts the error frame and closes, while the server appends `stt_stream_end` asynchronously, so under load the assertion can run first. Worth a separate fix; out of scope here.

## Manual verification

Simulated a Windows host in-process to confirm the premise fails there (both targets return `is_executable_file == True` despite `chmod(0o600)`), and confirmed on POSIX that the test still runs and still asserts the `ValueError`. N/A beyond that — the change is a platform skip guard.
