### PR TITLE
feat(sidebar): flat view respects collapsed folders

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1234,6 +1234,65 @@ function ChatSidebar({
     [enrichedSlots, slotFilter, slotSearchKeys, pinned, sortKey, activeFilters]
   )
 
+  // Folder IDs whose sessions are hidden in flat view because the folder — or
+  // any ancestor — is collapsed. Flat view has no folder headers, so without
+  // this a collapsed folder's sessions would leak into the flat lane; this
+  // makes "flat view" mean "flatten the folders I currently have expanded".
+  const collapsedHiddenFolders = useMemo(() => {
+    const byId = new Map(folders.map(f => [f.id, f]))
+    const hidden = new Set<string>()
+    for (const f of folders) {
+      let cur: ChatFolder | undefined = f
+      const visited = new Set<string>()
+      while (cur && !visited.has(cur.id)) {
+        visited.add(cur.id)
+        if (cur.collapsed) { hidden.add(f.id); break }
+        cur = cur.parent_id ? byId.get(cur.parent_id) : undefined
+      }
+    }
+    return hidden
+  }, [folders])
+
+  // Flat-view slot list: filteredSlots minus sessions in collapsed folders —
+  // EXCEPT while searching, where every match must stay reachable so a
+  // collapsed folder never becomes a search dead-end.
+  const flatSlots = useMemo(() => {
+    if (slotFilter.trim() !== '' || collapsedHiddenFolders.size === 0) return filteredSlots
+    return filteredSlots.filter(s => {
+      const fid = slotFolders[s.key]
+      return !(fid && collapsedHiddenFolders.has(fid))
+    })
+  }, [filteredSlots, slotFilter, collapsedHiddenFolders, slotFolders])
+
+  // Topmost collapsed folders that actually hide ≥1 flat-view session — the
+  // pills in the flat-lane reveal strip. Only the highest collapsed folder in
+  // each chain is listed (expanding it reveals its sessions; a nested collapsed
+  // child re-appears here once its parent is expanded). Empty while searching.
+  const collapsedFolderPills = useMemo(() => {
+    if (slotFilter.trim() !== '' || collapsedHiddenFolders.size === 0) return [] as ChatFolder[]
+    const byId = new Map(folders.map(f => [f.id, f]))
+    const topCollapsedOf = (fid: string): ChatFolder | undefined => {
+      let cur: ChatFolder | undefined = byId.get(fid)
+      let top: ChatFolder | undefined
+      const visited = new Set<string>()
+      while (cur && !visited.has(cur.id)) {
+        visited.add(cur.id)
+        if (cur.collapsed) top = cur
+        cur = cur.parent_id ? byId.get(cur.parent_id) : undefined
+      }
+      return top
+    }
+    const seen = new Map<string, ChatFolder>()
+    for (const s of filteredSlots) {
+      const fid = slotFolders[s.key]
+      if (fid && collapsedHiddenFolders.has(fid)) {
+        const top = topCollapsedOf(fid)
+        if (top && !seen.has(top.id)) seen.set(top.id, top)
+      }
+    }
+    return [...seen.values()].sort((a, b) => a.order - b.order)
+  }, [folders, filteredSlots, slotFolders, collapsedHiddenFolders, slotFilter])
+
   // Flat-view projection: every visible session (foldered + unfoldered) in one
   // list. Removes ONLY the folder rendering hierarchy — the user's sort
   // (incl. pin priority) and active filters/search apply exactly as in the
@@ -2603,6 +2662,25 @@ function ChatSidebar({
           // Inactive without folders (the toggle is hidden then too), so a
           // persisted flat preference can never strand the user.
           <motion.div layoutScroll className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col" data-testid="flat-view-lane">
+            {collapsedFolderPills.length > 0 && (
+              <div className="px-1 pb-2 flex items-center gap-1.5 flex-wrap" data-testid="flat-collapsed-strip">
+                <span className="text-[11px] text-muted select-none">Show collapsed folders:</span>
+                {collapsedFolderPills.map(f => (
+                  <button
+                    key={f.id}
+                    type="button"
+                    className="inline-flex items-center gap-1 pl-1.5 pr-2 py-0.5 rounded-full text-[11px] cursor-pointer transition-colors border-none"
+                    style={{ background: 'color-mix(in srgb, var(--muted) 12%, transparent)', color: 'var(--muted)', borderWidth: 1, borderColor: 'color-mix(in srgb, var(--muted) 30%, transparent)' }}
+                    onClick={() => toggleCollapse(f.id)}
+                    title={`Show sessions in ${f.name}`}
+                    aria-label={`Show sessions in folder ${f.name}`}
+                  >
+                    <FolderGlyph icon={f.icon} size={11} className="shrink-0" />
+                    <span className="truncate max-w-[110px]">{f.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
             {(() => {
               // Date segments (Today / Yesterday / Last 7 Days / …) between
               // rows — resurrects the 9bb0f71 active-list pattern: only for
@@ -2612,11 +2690,11 @@ function ChatSidebar({
               const isDateSort = sortKey === 'date-desc' || sortKey === 'date-asc'
               const segOf = (s: Slot) => isDateSort && !pinned.has(s.key) ? dateSegment(s.last_ts || s.created) : ''
               let prevSeg = ''
-              return filteredSlots.map((s, i) => {
+              return flatSlots.map((s, i) => {
                 const seg = segOf(s)
                 const showHeader = seg !== '' && seg !== prevSeg
                 if (seg) prevSeg = seg
-                const next = i < filteredSlots.length - 1 ? filteredSlots[i + 1] : null
+                const next = i < flatSlots.length - 1 ? flatSlots[i + 1] : null
                 const nextIsActive = next != null && activeSlot === next.key
                 const isActive = activeSlot === s.key
                 // No divider before a segment header — the header separates.
@@ -2632,7 +2710,7 @@ function ChatSidebar({
                 )
               })
             })()}
-            {filteredSlots.length === 0 && (
+            {flatSlots.length === 0 && (
               <div className="px-3 py-4 text-[12px] text-muted">No sessions match</div>
             )}
             {!historyOpen && (

--- a/website/src/test/ChatSidebar.flatCollapse.test.tsx
+++ b/website/src/test/ChatSidebar.flatCollapse.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Chat sidebar flat view respects collapsed folders.
+ * In flat view ("explode chats out of folders"), a session is dropped when its
+ * folder — or any ancestor folder — is collapsed, so "flat view" means
+ * "flatten the folders I currently have expanded". Each topmost collapsed
+ * folder that still hides a session surfaces as a pill in the reveal strip
+ * ("Show collapsed folders: <folder>") whose click expands it. Tree view is
+ * unaffected; searching bypasses the collapse-hiding (not exercised here).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, { get: () => vi.fn().mockResolvedValue([]) }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+function renderSidebar(slots: any[], folders: any[]) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {}, workflowRuns: {} } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], folders)
+  return render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+// Flat view on from the first render.
+beforeEach(() => { localStorage.clear(); localStorage.setItem('mc-sidebar-flat-view', '1') })
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — flat view respects collapsed folders', () => {
+  const cronInFolder = { key: 'cron-abc123', title: 'nightly report', running: false, messages: 2, folder_id: 'cronsF' }
+  const looseChat = { key: 'chat-1-100', title: 'loose chat', running: false, messages: 2 }
+
+  it('hides a collapsed folder\'s session in flat view and shows a reveal pill', () => {
+    const folders = [{ id: 'cronsF', name: 'crons', collapsed: true, order: 0 }]
+    const { getByText, queryByText, getByTestId } = renderSidebar([cronInFolder, looseChat], folders)
+    expect(queryByText('nightly report')).toBeNull() // in collapsed folder → hidden
+    expect(getByText('loose chat')).toBeTruthy()       // un-foldered → shown
+    // Reveal strip present, listing the collapsed folder.
+    expect(getByTestId('flat-collapsed-strip')).toBeTruthy()
+    expect(getByText('Show collapsed folders:')).toBeTruthy()
+    expect(getByText('crons')).toBeTruthy()
+  })
+
+  it('shows the session and no reveal strip when the folder is expanded', () => {
+    const folders = [{ id: 'cronsF', name: 'crons', collapsed: false, order: 0 }]
+    const { getByText, queryByTestId } = renderSidebar([cronInFolder, looseChat], folders)
+    expect(getByText('nightly report')).toBeTruthy() // expanded folder → shown
+    expect(getByText('loose chat')).toBeTruthy()
+    expect(queryByTestId('flat-collapsed-strip')).toBeNull() // nothing hidden → no strip
+  })
+
+  it('lists the TOPMOST collapsed ancestor (parent), not an expanded child', () => {
+    // Parent 'p' collapsed, child 'c' expanded, session filed in the child:
+    // the session is hidden (ancestor collapsed) and the pill names the parent,
+    // since expanding the parent is what reveals it.
+    const folders = [
+      { id: 'p', name: 'parent-fold', collapsed: true, order: 0 },
+      { id: 'c', name: 'child-fold', collapsed: false, order: 1, parent_id: 'p' },
+    ]
+    const nested = { key: 'chat-9-900', title: 'nested chat', running: false, messages: 2, folder_id: 'c' }
+    const { queryByText, getByText } = renderSidebar([nested, looseChat], folders)
+    expect(queryByText('nested chat')).toBeNull()   // ancestor collapsed → hidden
+    expect(getByText('parent-fold')).toBeTruthy()   // pill names the topmost collapsed folder
+    expect(queryByText('child-fold')).toBeNull()    // not the expanded child
+  })
+
+  it('does not hang on cyclic folder ancestry (visited-set guard)', () => {
+    // A hand-edited folders.json can contain a parent_id cycle. The ancestry
+    // walks must terminate (visited-set guard) rather than freeze the tab.
+    const folders = [
+      { id: 'a', name: 'Aye', collapsed: true, order: 0, parent_id: 'b' },
+      { id: 'b', name: 'Bee', collapsed: false, order: 1, parent_id: 'a' },
+    ]
+    const inCycle = { key: 'chat-7-700', title: 'cycle chat', running: false, messages: 2, folder_id: 'a' }
+    const { queryByText, getByText } = renderSidebar([inCycle, looseChat], folders)
+    // Render completed (no infinite loop): the collapsed cycle member hides its
+    // session and the reveal pill names that collapsed folder.
+    expect(queryByText('cycle chat')).toBeNull()
+    expect(getByText('loose chat')).toBeTruthy()
+    expect(getByText('Aye')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Makes the sidebar's **flat view** ("explode chats out of folders") respect folder collapse state. **Frontend-only** — no backend change; keys off `slot.folder_id` and the existing folder `collapsed` state.

In flat view, a session is dropped when its folder — or **any ancestor** — is collapsed, so flat view flattens only the folders you currently have expanded. This lets you keep, say, a `crons` folder collapsed and have its sessions stay out of the flat lane.

- **Search bypasses** the collapse-hiding, so a session in a collapsed folder is never a search dead-end.
- Since flat view has no folder headers, collapsed folders that still hide sessions surface as pills in a **"Show collapsed folders: &lt;folder&gt;"** reveal strip at the top of the lane; clicking a pill expands that folder. Only the **topmost** collapsed folder per chain is listed (expanding it is what reveals sessions; a nested collapsed child re-appears once its parent is expanded).

Tree view is unaffected.

## Testing
- `ChatSidebar.flatCollapse.test.tsx` (3): collapsed folder hides its session + shows the reveal pill; expanded folder shows it + no strip; nested — the pill names the topmost collapsed ancestor, not an expanded child.
- `tsc -b` clean; `eslint` 0 errors on changed files.

Rebased onto latest `main`.
