### PR TITLE
fix(macos): stop repeated TCC folder-consent prompts on app open

### DIFF
--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -383,6 +383,44 @@ Requires a paid Apple Developer account ($99/yr) for the Developer ID cert and
 notary access. Without one, distribute via Homebrew cask or instruct users to
 clear the quarantine flag.
 
+## macOS folder-access (TCC) prompts
+
+macOS gates `~/Downloads`, `~/Documents`, `~/Desktop`, `~/Pictures`, `~/Movies`
+and `~/Music` behind **TCC** (Transparency, Consent and Control). The first time
+an app reads one of them, macOS shows a modal *"KiroCrew would like to access
+files in your Downloads folder"*, and consent is recorded **per (app, folder)
+pair** — so an operation that incidentally touches three of those folders
+produces **three separate prompts**, one after another.
+
+Nothing KiroCrew does at startup needs those folders. They were only ever
+reached *incidentally*, by the `@`-mention file picker's filesystem walk when it
+fell back to bare `$HOME` as a catch-all search root (no project selected). That
+single unscoped walk descended into `Downloads`/`Documents`/`Desktop` and
+tripped one prompt each.
+
+Those walks now prune the TCC-protected folders when — and only when — the walk
+root is `$HOME` itself
+(`platform_compat.tcc_protected_dirs_for_walk`, applied in
+`dashboard/file_index.py` and the `/api/file-search` fallback). Two consequences
+worth knowing:
+
+- **Explicit access is unaffected.** If you point KiroCrew at a project inside
+  `~/Documents`, browse to `~/Downloads` directly, or even name `$HOME` itself as
+  the project, the root is scoped by definition and is walked in full — only the
+  *unscoped* `$HOME` fallback prunes. macOS still shows its own one-time prompt
+  for that deliberate access — that is the expected OS contract, and granting it
+  once is enough.
+- **Pre-declaring usage strings would not have fixed this.** Adding
+  `NSDocumentsFolderUsageDescription` and friends to `Info.plist` only changes
+  the *wording* of each prompt; it does not reduce the count. Not reading the
+  folders is what removes the prompts.
+
+A signed, stable bundle identity matters here too: TCC keys consent off the
+app's code-signing identity, so an ad-hoc/unsigned local build can be treated as
+a *different* app after a rebuild and re-prompt for grants you already gave.
+Distributing the signed + notarized DMG (above) keeps grants sticky across
+updates.
+
 ## Remote tunnel mode
 
 The desktop app can also connect to a gateway running on a **remote** host (e.g.

--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 
+from kiro_crew import platform_compat
 from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
@@ -92,10 +93,15 @@ class FileIndex:
     def _walk(self) -> tuple[list[tuple[str, str, str, int, int]], bool]:
         entries: list[tuple[str, str, str, int, int]] = []
         truncated = False
+        # macOS: if this index is rooted at bare $HOME, prune the TCC-gated
+        # folders. This walk re-runs every _REFRESH_SECS, so without the prune
+        # a dismissed consent dialog would be re-triggered on every refresh.
+        tcc_skip = platform_compat.tcc_protected_dirs_for_walk(self.root)
         for dirpath, dirnames, filenames in os.walk(self.root):
             dirnames[:] = [
                 d for d in dirnames
                 if not d.startswith(".") and d not in _SKIP_DIRS
+                and not (dirpath == self.root and d in tcc_skip)
             ]
             for fname in filenames:
                 if len(entries) >= _MAX_ENTRIES:

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -22,6 +22,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 from aiohttp.multipart import BodyPartReader
 
+from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.platform import redact_via_context as redact
@@ -1933,10 +1934,21 @@ async def api_file_search(request: web.Request) -> web.Response:
         for root_dir in safe_roots:
             if walked >= max_scan or len(results) >= max_collect:
                 break
+            # macOS: when this root is the bare $HOME fallback, prune the
+            # TCC-gated folders. Reaching into them would pop one consent
+            # modal PER folder for a search the user scoped to nothing.
+            # ``scoped`` means the user NAMED this root (?project= / ?workspace=),
+            # so even ``project=$HOME`` is deliberate and is searched in full.
+            tcc_skip = (
+                frozenset() if scoped
+                else platform_compat.tcc_protected_dirs_for_walk(root_dir)
+            )
             for dirpath, dirnames, filenames in os.walk(root_dir):
                 dirnames[:] = [
                     d for d in dirnames
-                    if not d.startswith(".") and d not in skip_dirs
+                    if not d.startswith(".")
+                    and d not in skip_dirs
+                    and not (dirpath == root_dir and d in tcc_skip)
                 ]
                 for fname in filenames:
                     if walked >= max_scan or len(results) >= max_collect:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -69,6 +69,66 @@ _SUBPROCESS_NO_WINDOW: int = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 # child tree taskkill /T-reapable. Add DETACHED_PROCESS to the flags for a
 # fully detached, console-less child (e.g. the gateway respawn).
 
+# ── macOS TCC-protected home subdirectories ──
+# macOS gates these home subdirectories behind TCC (Transparency, Consent and
+# Control). The FIRST read of any one of them by a given app triggers a modal
+# "…would like to access files in your Downloads folder" prompt, and consent is
+# recorded PER (app, folder) pair — so incidentally touching three of them
+# during one operation produces THREE separate prompts, not one.
+#
+# Nothing KiroCrew does at startup needs these folders: they are only ever
+# reached INCIDENTALLY, by a breadth-first walk that was rooted at $HOME as a
+# catch-all fallback (the @-mention file picker's search root). Pruning them
+# from such unscoped walks removes the prompts entirely, which is strictly
+# better than pre-declaring NS*FolderUsageDescription strings — those change
+# the prompt's wording but still prompt, once per folder.
+#
+# This does NOT restrict a user's EXPLICIT navigation: an operation whose root
+# the user named (a project dir, or a browse request for ~/Downloads itself) is
+# scoped by definition and never consults this set. macOS still shows its own
+# one-time prompt for that deliberate access, which is the expected contract.
+#
+# Names only (no leading path): matched against a single path component so the
+# same set works for both os.walk dirname pruning and scandir entry filtering.
+TCC_PROTECTED_HOME_DIRS: frozenset[str] = frozenset({
+    "Downloads", "Documents", "Desktop", "Pictures", "Movies", "Music",
+})
+# Deliberately NOT included: ``Library``. It is not TCC-gated, so pruning it
+# removes zero prompts — while ``~/Library/CloudStorage/<Provider>/`` (modern
+# OneDrive / Google Drive / Dropbox mounts) and ``~/Library/Mobile Documents/``
+# (iCloud Drive) are common project homes, so hiding it costs real search hits.
+# Keep this set to exactly the folders macOS actually gates.
+
+
+def tcc_protected_dirs_for_walk(root: str | os.PathLike) -> frozenset[str]:
+    """Return the TCC-protected dir names to prune when walking *root*.
+
+    Empty off macOS (no TCC), and empty unless *root* is the user's home
+    directory itself: a walk the user explicitly scoped to ``~/Downloads`` (or
+    to a project that happens to live under it) must still see its own
+    contents. Only the incidental ``$HOME``-as-fallback walk is pruned.
+
+    Callers MUST pass the same ``str`` they hand to :func:`os.walk` — the
+    returned names are compared against ``os.walk``'s ``dirpath``, which is
+    byte-identical to the ``top`` argument it was given.
+
+    On any resolution failure this returns the empty set, i.e. it prunes
+    nothing. That degrades to today's behavior (a prompt may appear) rather
+    than silently hiding a directory the caller asked for.
+    """
+    if not IS_MACOS:
+        return frozenset()
+    try:
+        if os.path.realpath(root) != os.path.realpath(os.path.expanduser("~")):
+            return frozenset()
+    except (OSError, ValueError):
+        # OSError: EACCES / ELOOP / ENAMETOOLONG on an exotic path.
+        # ValueError: realpath() rejects a path containing a null byte — NOT an
+        # OSError subclass, so it would otherwise escape to the caller and 500
+        # the /api/file-search request (same class as agent.py's guard).
+        return frozenset()
+    return TCC_PROTECTED_HOME_DIRS
+
 
 def ensure_utf8_console() -> None:
     """Make stdout/stderr UTF-8 on Windows so KiroCrew's emoji output can't crash it.

--- a/test/test_tcc_protected_dirs.py
+++ b/test/test_tcc_protected_dirs.py
@@ -1,0 +1,218 @@
+"""Tests for macOS TCC-protected home-directory pruning.
+
+macOS gates ~/Downloads, ~/Documents, ~/Desktop (etc.) behind TCC, and records
+consent PER (app, folder) pair — so a single unscoped walk rooted at $HOME
+that reaches three of them produces THREE consent modals. The walks that only
+touched those folders incidentally (as a $HOME catch-all fallback) prune them.
+
+Walks the user explicitly scoped — a project dir, or ~/Downloads itself — are
+NOT pruned: that access is deliberate and macOS's own one-time prompt is the
+expected contract.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew import platform_compat
+from kiro_crew.dashboard.file_index import FileIndex
+from kiro_crew.dashboard.handlers import api_file_search
+
+# Folders that must never be walked incidentally from a bare $HOME root.
+_TCC_DIRS = ("Downloads", "Documents", "Desktop")
+
+
+def _home_env(tmp_path) -> dict[str, str]:
+    """Env overrides that repoint ``expanduser("~")`` at *tmp_path* on ANY OS.
+
+    ``$HOME`` alone is not enough: on Windows ``os.path`` is ``ntpath``, whose
+    ``expanduser`` consults ``%USERPROFILE%`` (then ``HOMEDRIVE``/``HOMEPATH``)
+    and ignores ``HOME`` entirely — so a HOME-only patch silently fails to pin
+    the fake home on the Windows CI shard and inverts every prune assertion.
+    """
+    return {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}
+
+
+def _make_home(tmp_path):
+    """Build a fake $HOME containing TCC folders plus a normal project dir."""
+    for name in _TCC_DIRS:
+        d = tmp_path / name
+        d.mkdir()
+        (d / "target.txt").write_text("x")
+    proj = tmp_path / "code"
+    proj.mkdir()
+    (proj / "target.txt").write_text("x")
+    return proj
+
+
+class TestTccHelper:
+    def test_empty_off_macos(self, tmp_path):
+        with patch.object(platform_compat, "IS_MACOS", False):
+            assert platform_compat.tcc_protected_dirs_for_walk(tmp_path) == frozenset()
+
+    def test_home_root_returns_protected_set(self, tmp_path):
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            got = platform_compat.tcc_protected_dirs_for_walk(tmp_path)
+        assert {"Downloads", "Documents", "Desktop"} <= got
+
+    def test_scoped_subdir_is_not_pruned(self, tmp_path):
+        """An explicitly-scoped root under home keeps full visibility."""
+        scoped = tmp_path / "Downloads"
+        scoped.mkdir()
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            assert platform_compat.tcc_protected_dirs_for_walk(scoped) == frozenset()
+
+    def test_unresolvable_root_prunes_nothing(self):
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.object(platform_compat.os.path, "realpath", side_effect=OSError),
+        ):
+            assert platform_compat.tcc_protected_dirs_for_walk("/nope") == frozenset()
+
+    def test_null_byte_path_does_not_raise(self):
+        """A NUL byte makes realpath raise ValueError — NOT an OSError subclass.
+
+        Left uncaught it escapes the walk and 500s /api/file-search, so the
+        helper must swallow it and simply prune nothing.
+        """
+        with patch.object(platform_compat, "IS_MACOS", True):
+            assert platform_compat.tcc_protected_dirs_for_walk("/tmp/a\x00b") == frozenset()
+
+    def test_library_is_not_pruned(self):
+        """``~/Library`` is not TCC-gated, and holds CloudStorage project mounts.
+
+        Pruning it would remove zero prompts while hiding OneDrive / Google
+        Drive / iCloud project trees from search.
+        """
+        assert "Library" not in platform_compat.TCC_PROTECTED_HOME_DIRS
+
+
+class TestFileIndexPruning:
+    @pytest.mark.asyncio
+    async def test_home_root_skips_tcc_dirs(self, tmp_path):
+        _make_home(tmp_path)
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            idx = FileIndex(str(tmp_path))
+            entries, _ = await __import__("asyncio").to_thread(idx._walk)
+        walked = {os.path.relpath(e[0], tmp_path).split(os.sep)[0] for e in entries}
+        for name in _TCC_DIRS:
+            assert name not in walked, f"{name} must not be walked from a $HOME root"
+        assert "code" in walked, "non-TCC project dirs must still be indexed"
+
+    @pytest.mark.asyncio
+    async def test_scoped_tcc_dir_is_still_indexed(self, tmp_path):
+        """Indexing ~/Downloads directly is deliberate — index it fully."""
+        _make_home(tmp_path)
+        scoped = tmp_path / "Downloads"
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            idx = FileIndex(str(scoped))
+            entries, _ = await __import__("asyncio").to_thread(idx._walk)
+        assert [e for e in entries if e[1] == "target.txt"]
+
+    @pytest.mark.asyncio
+    async def test_nested_dir_sharing_a_tcc_name_is_not_pruned(self, tmp_path):
+        """Only the TOP level of $HOME is pruned.
+
+        A project's own ``Documents/`` subdirectory is not TCC-gated (TCC covers
+        ``~/Documents`` specifically), so a name-only match deeper in the tree
+        must stay indexed — otherwise the prune silently hides real project files.
+        """
+        nested = tmp_path / "code" / "Documents"
+        nested.mkdir(parents=True)
+        (nested / "deep.txt").write_text("x")
+        (tmp_path / "Downloads").mkdir()
+        (tmp_path / "Downloads" / "top.txt").write_text("x")
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            idx = FileIndex(str(tmp_path))
+            entries, _ = await __import__("asyncio").to_thread(idx._walk)
+        rels = {os.path.relpath(e[0], tmp_path) for e in entries}
+        assert os.path.join("code", "Documents", "deep.txt") in rels
+        assert not any(r.startswith("Downloads") for r in rels)
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/file-search", api_file_search)
+    state = MagicMock()
+    state.file_indexes.get.return_value = None  # force the walk fallback
+    app["state"] = state
+    return app
+
+
+@pytest.fixture()
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+class TestFileSearchPruning:
+    @pytest.mark.asyncio
+    async def test_home_fallback_skips_tcc_dirs(self, tmp_path, mock_sel):
+        _make_home(tmp_path)
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(
+                os.environ, {**_home_env(tmp_path), "KIROCREW_PROJECT_DIR": ""}, clear=False
+            ),
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get("/api/file-search?q=target")
+                paths = [r["path"] for r in (await resp.json())["results"]]
+        for name in _TCC_DIRS:
+            assert not any(
+                f"{os.sep}{name}{os.sep}" in p for p in paths
+            ), f"{name} must not be searched from the bare $HOME fallback"
+        assert any(f"{os.sep}code{os.sep}" in p for p in paths)
+
+    @pytest.mark.asyncio
+    async def test_explicit_project_under_tcc_dir_still_searchable(self, tmp_path, mock_sel):
+        """A project the user pointed at is scoped — never pruned."""
+        _make_home(tmp_path)
+        scoped = tmp_path / "Downloads"
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/file-search?q=target&project={scoped}")
+                names = {r["name"] for r in (await resp.json())["results"]}
+        assert "target.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_explicit_home_as_project_is_not_pruned(self, tmp_path, mock_sel):
+        """Naming $HOME itself as the project is deliberate — search it in full.
+
+        Only the *unscoped* fallback prunes. Otherwise a user who explicitly
+        picked their home directory would silently lose Downloads/Documents
+        results, which is the opposite of the documented contract.
+        """
+        _make_home(tmp_path)
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/file-search?q=target&project={tmp_path}")
+                paths = [r["path"] for r in (await resp.json())["results"]]
+        assert any(f"{os.sep}Downloads{os.sep}" in p for p in paths)


### PR DESCRIPTION
## Problem

Opening a build of KiroCrew from the source-package DMG on macOS pops **three separate** folder-access modals — *"KiroCrew would like to access files in your Downloads folder"*, then the same for **Documents**, then **Desktop** — before the dashboard is usable. A new app should ask at most once, and only for folders it actually needs.

## Why it matters

This is the very first thing a new macOS user sees. Three consecutive security modals on first launch read as "this app is rummaging through my home directory", which is the worst possible first impression for an agent that users are being asked to trust with local file access. It also recurs: the folder that triggers it is re-walked on a 30-second timer, so dismissing a dialog brings it back.

## Fix (symptoms → root cause → change)

**Symptom:** 3+ prompts, one per protected folder, at app open.

**Root cause:** macOS TCC records folder consent **per `(app, folder)` pair**, so a single operation that reads three protected folders produces three prompts — not one. Nothing KiroCrew does at startup *needs* those folders; they were only ever reached **incidentally**:

- `dashboard/handlers/files.py` — the `@`-mention file picker's `/api/file-search` falls back to bare `$HOME` as a catch-all search root when no project is selected, and `os.walk($HOME)` descends straight into `Downloads/`, `Documents/`, `Desktop/`.
- `dashboard/file_index.py` — the same walk shape, re-run every `_REFRESH_SECS` (30s), which is what makes a dismissed dialog reappear.

**Change:** prune the TCC-gated folder names from those two walks **when, and only when, the walk root is `$HOME` itself** — via a new `platform_compat.tcc_protected_dirs_for_walk()` (empty off macOS, so Linux/Windows behavior is byte-identical).

Three deliberate scoping decisions:

- **Explicit intent is never pruned.** A root the user *named* — `?project=` / `?workspace=`, including `$HOME` itself, or `~/Downloads` browsed directly — is scoped by definition and walked in full. macOS's own one-time prompt stays the contract for real user intent. (`/api/file-search` threads its existing `scoped` flag through for exactly this.)
- **Depth-0 only.** A project's own nested `Documents/` subdirectory is not TCC-gated, so a name-only match deeper in the tree stays indexed. Pruning by name at every level would silently hide real project files.
- **`~/Library` is deliberately excluded** from the set: it is *not* TCC-gated (pruning it removes zero prompts) while it holds `CloudStorage/<Provider>/` (OneDrive/Google Drive/Dropbox) and `Mobile Documents/` (iCloud) — common project homes. Including it would have been a pure correctness cost.

**Rejected alternative:** pre-declaring `NSDownloadsFolderUsageDescription` & friends in `Info.plist`. Those only change the *wording* of each prompt; the count stays at one-per-folder. Not reading the folders is what removes the prompts.

## Tests

New `test/test_tcc_protected_dirs.py` (12 tests). Verified red→green: **6 fail without the fix, all pass with it.**

| Test | Locks in |
|---|---|
| `test_empty_off_macos` | zero behavior change on Linux/Windows |
| `test_home_root_returns_protected_set` | the `$HOME` root does prune |
| `test_scoped_subdir_is_not_pruned` | `~/Downloads` as root keeps full visibility |
| `test_unresolvable_root_prunes_nothing` | resolution failure degrades to "prune nothing" |
| `test_null_byte_path_does_not_raise` | a NUL-byte path can't 500 `/api/file-search` (`ValueError` is **not** an `OSError` subclass) |
| `test_library_is_not_pruned` | `~/Library`/CloudStorage projects stay searchable |
| `test_home_root_skips_tcc_dirs` | FileIndex prunes at `$HOME`, still indexes `code/` |
| `test_scoped_tcc_dir_is_still_indexed` | indexing `~/Downloads` directly works |
| `test_nested_dir_sharing_a_tcc_name_is_not_pruned` | the depth-0 guard (**mutation-verified**: deleting the guard fails only this test) |
| `test_home_fallback_skips_tcc_dirs` | the actual bug, end-to-end through the API |
| `test_explicit_project_under_tcc_dir_still_searchable` | scoped project under a TCC dir |
| `test_explicit_home_as_project_is_not_pruned` | naming `$HOME` as the project isn't pruned |

Tests pin the fake home via **both** `HOME` and `USERPROFILE`: on Windows `os.path` is `ntpath`, whose `expanduser` reads `%USERPROFILE%` and ignores `$HOME` — a HOME-only patch silently inverts every prune assertion on the Windows CI shard. Verified by simulating `ntpath` resolution locally.

**Gates:** isort · flake8 · mypy (496 files) · scrub-lint · `tsc -b` · vitest (5148) all green. Backend suite **18,934 passed**; the 3 remaining failures (`test_cli` pidfd, `test_mcp_apps_call_endpoint` ×2) reproduce identically on clean `origin/main` and pass serially — pre-existing parallel-isolation flakes, not from this change.

## Manual verification

N/A on this host — the trigger is macOS-only TCC and this was developed on Linux, where the helper returns an empty set by construction. The behavior is covered by the API-level tests above plus a simulated-`ntpath` run for the Windows shard; the macOS-only branch is exercised by patching `IS_MACOS`.

## Screenshots

N/A — no user-visible UI change. The only user-facing difference is the *absence* of OS-level modals at launch.

## Docs

`docs/DESKTOP_APP.md` gains a **"macOS folder-access (TCC) prompts"** section: why consent is per-`(app, folder)`, what is and isn't pruned, why usage-description strings wouldn't have fixed it, and a note that a stable signed identity keeps grants sticky across updates (an ad-hoc local build can re-prompt after a rebuild because TCC keys off the code-signing identity).
