### PR TITLE
fix(stt): emit stt_stream_end before awaiting the peer WS close

### DIFF
--- a/docs/system-specs/features/stt-streaming.md
+++ b/docs/system-specs/features/stt-streaming.md
@@ -1,6 +1,8 @@
 # Streaming STT — Design Document
 
-Last Updated: 2026-04-18
+Last Updated: 2026-07-28 (SEL audit ordering: `stt_stream_end` is emitted
+BEFORE the WebSocket close on every exit path, so the balanced audit trail no
+longer depends on a well-behaved peer)
 
 ## Overview
 
@@ -74,6 +76,26 @@ absent in the browser.
   `onFinal(combined)`, stops mic tracks, closes `AudioContext`.
 - Component unmount: same cleanup; guarantees no leaked Transcribe
   session (billable).
+
+### SEL audit pairing — emit before closing
+
+Every accepted connection logs `stt_stream_start`, and **every** exit path must
+log a matching `stt_stream_end` (`error`, `timeout`, or `ok`) or the audit trail
+shows an unmatched start.
+
+`stt_stream_end` is emitted **before** `await ws.close()`, never after — on the
+four early-return paths (via `_close_and_end_audit`) and on the normal cleanup
+path. `WebSocketResponse.close()` awaits the *peer's* close acknowledgement under
+its own timeout (10s by default), so a client that has already gone away (abrupt
+disconnect, closed tab) parks the handler inside `close()`; with the audit after
+the close, the end event is withheld for up to that timeout. Emitting first makes
+the pairing independent of the peer. The close still runs and is still awaited
+immediately after, and still tolerates a broken transport (logged, not raised).
+
+Tests asserting on the audit pair must **wait** for the end event
+(`_wait_for_operation`): neither receiving the error frame nor exiting the
+`TestClient` context orders the assertion after the server handler's remaining
+steps, so asserting straight after either is a race.
 
 ## Frozen-prefix Behaviour
 

--- a/src/kiro_crew/dashboard/stt_stream.py
+++ b/src/kiro_crew/dashboard/stt_stream.py
@@ -71,6 +71,32 @@ def _emit_end_audit(caller: str, *, outcome: str) -> None:
         logger.exception("Failed to emit stt_stream_end SEL audit")
 
 
+async def _close_and_end_audit(ws: web.WebSocketResponse, caller: str, *, outcome: str) -> None:
+    """Emit ``stt_stream_end``, then close *ws*, on an early-return path.
+
+    Order matters, and it is audit-first on purpose.
+    ``WebSocketResponse.close()`` awaits the peer's close acknowledgement under
+    its own timeout (10s by default), so a client that has already gone away —
+    an abrupt disconnect, a closed tab, or a test client that read the error
+    frame and left — parks the handler inside ``close()``. With the audit after
+    the close, ``stt_stream_end`` is withheld for as long as that takes, leaving
+    a start with no end in the trail for up to the full timeout. Emitting first
+    makes the audit independent of the peer, which is the property the balanced
+    trail actually needs; the close still runs (and is still awaited) right
+    after, so nothing leaks.
+
+    ``_emit_end_audit`` never raises, so the close is always reached.
+    """
+
+    _emit_end_audit(caller, outcome=outcome)
+    try:
+        await ws.close()
+    except Exception:
+        # A broken transport must not turn an already-audited early return into
+        # a 500 — the balanced trail is the invariant, the close is best-effort.
+        logger.exception("Failed to close STT WebSocket on early return")
+
+
 def _emit_guard_audit(caller: str, *, outcome: str) -> None:
     """Log ``stt_stream_rejected`` defensively on guard-path rejections.
 
@@ -165,8 +191,7 @@ async def api_ws_stt(request: web.Request) -> web.WebSocketResponse:
                 await ws.send_json({"type": "error", "message": "audit subsystem unavailable"})
             except Exception:
                 pass
-            await ws.close()
-            _emit_end_audit(caller, outcome="error")
+            await _close_and_end_audit(ws, caller, outcome="error")
             return ws
 
         if TranscribeStreamingClient is None:
@@ -174,8 +199,7 @@ async def api_ws_stt(request: web.Request) -> web.WebSocketResponse:
             # import fell back to None so the gateway could boot; surface a
             # friendly error here and keep the audit trail balanced.
             await ws.send_json({"type": "error", "message": "amazon-transcribe not installed"})
-            await ws.close()
-            _emit_end_audit(caller, outcome="error")
+            await _close_and_end_audit(ws, caller, outcome="error")
             return ws
 
         try:
@@ -192,8 +216,7 @@ async def api_ws_stt(request: web.Request) -> web.WebSocketResponse:
             # unmatched stt_stream_start. Mirrors the start_stream path.
             logger.exception("Failed to create Transcribe client")
             await ws.send_json({"type": "error", "message": "failed to create transcription client"})
-            await ws.close()
-            _emit_end_audit(caller, outcome="error")
+            await _close_and_end_audit(ws, caller, outcome="error")
             return ws
 
         stream = None
@@ -213,8 +236,7 @@ async def api_ws_stt(request: web.Request) -> web.WebSocketResponse:
         except Exception:
             logger.exception("Failed to start Transcribe stream")
             await ws.send_json({"type": "error", "message": "failed to start transcription"})
-            await ws.close()
-            _emit_end_audit(caller, outcome="error")
+            await _close_and_end_audit(ws, caller, outcome="error")
             return ws
 
         # Enforce the bill-cap with a dedicated task, not an in-loop check.
@@ -313,17 +335,17 @@ async def api_ws_stt(request: web.Request) -> web.WebSocketResponse:
                     # expiry) so operators can see why transcription stopped instead of
                     # silently cancelling the task.
                     logger.exception("Transcribe handler task failed")
+            # Audit BEFORE the close, for the reason documented on
+            # _close_and_end_audit: ws.close() awaits the peer's close ack under
+            # its own timeout, so a client that already went away would otherwise
+            # hold stt_stream_end back for up to that long. The close is still
+            # awaited right after, and still tolerates a broken transport.
+            _emit_end_audit(caller, outcome="timeout" if timed_out else "ok")
             if not ws.closed:
-                # ws.close() can raise on a broken transport. If it did,
-                # the uncaught exception would skip _emit_end_audit below,
-                # leaving an unmatched stt_stream_start — exactly what the
-                # surrounding cleanup is designed to prevent. Matches the
-                # defensive pattern in _enforce_deadline.
                 try:
                     await ws.close()
                 except Exception:
-                    pass
-            _emit_end_audit(caller, outcome="timeout" if timed_out else "ok")
+                    logger.exception("Failed to close STT WebSocket during cleanup")
 
         return ws
     finally:

--- a/test/test_stt_stream.py
+++ b/test/test_stt_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock
 
@@ -10,6 +11,45 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.config.loader import KiroCrewConfig, SttConfig
+
+# Upper bound for _wait_for_operation. Generous because it only ever elapses on
+# a genuine regression (the audit never fires); the happy path returns as soon
+# as the handler's next step runs, so a large bound costs nothing in wall clock.
+_AUDIT_WAIT_TIMEOUT_SECS = 5.0
+
+
+async def _wait_for_operation(calls: list[dict], operation: str) -> None:
+    """Await *operation* appearing in *calls*, or fail with what did arrive.
+
+    The WS error-frame handshake does NOT order the client's assertion after the
+    server's audit. Every early-return path in ``api_ws_stt`` runs
+    ``send_json(error)`` -> ``ws.close()`` -> ``_emit_end_audit(...)``, so
+    ``receive_json()`` returns on the error frame while the handler still has two
+    steps to go. Exiting the ``TestClient`` context is not a barrier either: it
+    closes the client side and does not await the server handler's coroutine to
+    completion. Asserting on ``calls`` right after either point is therefore a
+    race that fails whenever the event loop happens not to resume the handler
+    first — reproduced at roughly 1-in-8 locally and seen intermittently on CI.
+
+    Polling the real condition removes the guesswork: it returns the instant the
+    audit lands and fails with a useful message if it never does.
+    """
+
+    async def _poll() -> None:
+        while operation not in [c["operation"] for c in calls]:
+            # sleep(0) yields to the loop so the pending handler continues; the
+            # loop is single-threaded, so a busy-wait without it would hang.
+            await asyncio.sleep(0)
+
+    # asyncio.wait_for, not asyncio.timeout: the latter is 3.11+ and this project
+    # supports 3.10 (CI runs a 3.10 shard).
+    try:
+        await asyncio.wait_for(_poll(), timeout=_AUDIT_WAIT_TIMEOUT_SECS)
+    except asyncio.TimeoutError:
+        raise AssertionError(
+            f"{operation!r} audit never emitted within {_AUDIT_WAIT_TIMEOUT_SECS}s; "
+            f"got {[c['operation'] for c in calls]}"
+        ) from None
 
 
 def _make_app() -> web.Application:
@@ -225,6 +265,9 @@ class TestStreamLifecycle:
             ws = await client.ws_connect("/api/ws/stt")
             await ws.receive_json()
             await ws.close()
+        # Wait for the end audit instead of assuming the handler already ran:
+        # the error frame / client close is not a barrier for it.
+        await _wait_for_operation(calls, "stt_stream_end")
         ops = [c["operation"] for c in calls]
         assert "stt_stream_start" in ops and "stt_stream_end" in ops
         end = next(c for c in calls if c["operation"] == "stt_stream_end")
@@ -254,6 +297,9 @@ class TestStreamLifecycle:
             msg = await ws.receive_json()
             assert msg == {"type": "error", "message": "amazon-transcribe not installed"}
             await ws.close()
+        # Wait for the end audit instead of assuming the handler already ran:
+        # the error frame / client close is not a barrier for it.
+        await _wait_for_operation(calls, "stt_stream_end")
         ops = [c["operation"] for c in calls]
         assert "stt_stream_start" in ops and "stt_stream_end" in ops
         end = next(c for c in calls if c["operation"] == "stt_stream_end")
@@ -566,6 +612,9 @@ class TestDefensiveGuards:
             msg = await ws.receive_json()
             assert msg == {"type": "error", "message": "failed to create transcription client"}
             await ws.close()
+        # Wait for the end audit instead of assuming the handler already ran:
+        # the error frame / client close is not a barrier for it.
+        await _wait_for_operation(calls, "stt_stream_end")
         ops = [c["operation"] for c in calls]
         assert "stt_stream_start" in ops and "stt_stream_end" in ops, (
             f"both start and end audit events required; got {ops}"
@@ -603,8 +652,9 @@ class TestDefensiveGuards:
             msg = await ws.receive_json()
             assert msg == {"type": "error", "message": "audit subsystem unavailable"}
             await ws.close()
-        # Assertions on `calls` must run after the TestClient context exits so
-        # the server-side handler's `_emit_end_audit` has definitively run.
+        # Wait for the end audit instead of assuming the handler already ran:
+        # the error frame / client close is not a barrier for it.
+        await _wait_for_operation(calls, "stt_stream_end")
         ops = [c["operation"] for c in calls]
         assert "stt_stream_start" in ops and "stt_stream_end" in ops, (
             f"both start and end audit events required; got {ops}"
@@ -670,6 +720,9 @@ class TestDefensiveGuards:
             assert (await ws.receive_json()) == {"type": "ready"}
             await ws.send_str('{"type":"stop"}')
             await ws.close()
+        # Wait for the end audit instead of assuming the handler already ran:
+        # the error frame / client close is not a barrier for it.
+        await _wait_for_operation(calls, "stt_stream_end")
         ops = [c["operation"] for c in calls]
         assert "stt_stream_start" in ops and "stt_stream_end" in ops, (
             f"both start and end audit events required; got {ops}"


### PR DESCRIPTION
## Problem

Two related defects with one root cause.

**1. The streaming-STT audit trail can show an unmatched `stt_stream_start`.** Every accepted connection logs a start event and is supposed to log a matching `stt_stream_end`. When the browser goes away abruptly — closed tab, dropped network, killed renderer — the end event is withheld for up to 10 seconds, so anything reading the trail in that window sees an unbalanced pair. The concurrency slot (`_active_sessions`, cap 3) is held for that whole time too.

**2. `test_stt_stream.py` flakes intermittently on CI and locally.** Three tests, all in the same family:

- `TestStreamLifecycle::test_start_failure_emits_sel_end_audit`
- `TestDefensiveGuards::test_client_construction_failure_closes_ws_and_emits_end_audit`
- `TestDefensiveGuards::test_start_audit_sel_failure_closes_ws_and_emits_end_audit`

Each fails as `AssertionError: both start and end audit events required; got ['stt_stream_start']`. They pass in isolation every time, which is what made this look like unfixable test noise.

## Why it matters

The balanced audit pair is a security-log invariant — the surrounding code has three separate defensive guards written specifically to preserve it, and it was still breakable by an ordinary client disconnect. Separately, an intermittent failure in a shared test file erodes trust in CI for everyone: this one was already dismissed as a flake once (by me, in #609's review), which is exactly how a real ordering bug survives.

## Fix (symptom → root cause → change)

**Symptom.** Only `stt_stream_start` is ever recorded; the end event does not arrive, even given seconds of extra waiting.

**Root cause.** Every early-return path ran:

```python
await ws.send_json({"type": "error", ...})
await ws.close()                      # ← awaits the PEER's close ack
_emit_end_audit(caller, outcome="error")
```

`WebSocketResponse.close()` awaits the peer's close acknowledgement under its own timeout (10s by default, confirmed in aiohttp 3.14.3: `async with async_timeout.timeout(self._timeout)`). A client that has already gone away never sends that ack, so the handler parks *inside* `close()` and the audit on the next line is withheld until the timeout expires. The invariant depended on the peer being well-behaved.

This also explains the test flake exactly: `receive_json()` returns on the error frame while the handler still has two steps to go, and exiting the `TestClient` context is not a barrier either — it closes the client side without awaiting the server handler to completion. One test even carried a comment asserting that false guarantee ("Assertions on `calls` must run after the TestClient context exits so ... `_emit_end_audit` has definitively run").

**Change.**

- **Production:** emit the audit *before* the close, on all four early-return paths (new `_close_and_end_audit` helper) and on the normal cleanup path. The audit no longer depends on the peer; the close still runs and is still awaited immediately after, and still tolerates a broken transport (now logged rather than silently swallowed).
- **Tests:** wait for the end audit via a new `_wait_for_operation` poller instead of assuming the handler already ran, and drop the comment claiming the false guarantee. Uses `asyncio.wait_for`, not `asyncio.timeout` (3.11+), since CI runs a 3.10 shard.

## Tests

Since this is an intermittent failure, I measured it rather than eyeballing one green run — **matched 60-run arms, same command, same machine**:

| Arm | Result |
|---|---|
| Test wait only, production reordering reverted | **3/60 failed** |
| Test wait + production reordering (this PR) | **0/60 failed** |

That control matters: it shows the test-side wait alone is *not* sufficient, and the production reordering is what actually fixes it. An earlier 20-run control came back 0/20 and would have let me draw the wrong conclusion — at a ~5% base rate, 20 runs isn't enough to distinguish.

Baseline for reference: 3 failures in 40 runs before any change, and 1-in-8 in an earlier sample.

Full suite: **18902 passed** / 82 skipped / 5 xfailed. mypy clean on 496 files; flake8 and isort clean.

## Manual verification

Traced `WebSocketResponse.close()` in the installed aiohttp to confirm it awaits the peer under a timeout, which is the mechanism the whole fix rests on. Also disproved two earlier hypotheses before landing on the real one — a leaked `_active_sessions` counter (probed directly: no leak, counter returns to 0) and a plain assertion-ordering race (disproved by the audit still not arriving after 5s of yielding).

**Unrelated local-only failure, not introduced here:** `test_mcp_apps_call_endpoint.py` (3 tests) fails on my machine with `OSError: AF_UNIX path too long` — macOS's 104-char socket-path limit blown by pytest's long tmpdir. Reproduced on clean `main` with my changes stashed, so it is pre-existing and environmental; CI's shorter paths don't hit it. Flagging rather than silently ignoring.
