### PR TITLE
fix(desktop): never evict a tunnelled gateway during boot takeover

### DIFF
--- a/website/electron/gateway-stop.js
+++ b/website/electron/gateway-stop.js
@@ -14,6 +14,13 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 
+// The single definition of "this LISTEN owner is one of ours". Shared by
+// forceStopPort (which may only ever SIGKILL our own processes) and
+// classifyPortOwner (which may only ever authorise an eviction of one).
+// Keep it in one place: a drift between the two would let one of them
+// mis-target a stranger's process.
+const KIROCREW_PROC_RE = /kiro_crew|kirocrew/i;
+
 /**
  * POST /api/shutdown with the local secret (mirrors the dashboard's
  * X-Local-Secret auth). Resolves true on HTTP 200, false on any failure
@@ -137,7 +144,7 @@ async function forceStopPort(
     getCommand,
     kill,
     sleep,
-    isKirocrew = /kiro_crew|kirocrew/i,
+    isKirocrew = KIROCREW_PROC_RE,
     verifyTimeoutMs = 4000,
     pollIntervalMs = 250,
     log = () => {},
@@ -203,4 +210,66 @@ async function forceStopPort(
   return { killed, freed, survivors, foreignHolder };
 }
 
-module.exports = { postShutdown, stopGatewayGracefully, forceStopPort };
+/**
+ * Classify who LOCALLY owns the LISTEN socket on `port`.
+ *
+ * This exists because an HTTP identity probe CANNOT distinguish a local rival
+ * gateway from a remote one reached through a port-forward: `ssh -L 5476:...`
+ * makes a gateway on another machine answer on `localhost:5476` with the same
+ * `/api/health` payload a local install would send. Deciding to evict on the
+ * payload alone therefore tears down the user's tunnel (and the AppleScript
+ * quit targets a local app that isn't even running). The listening socket's
+ * owner is the ground truth the payload lacks — on a tunnel it is `ssh`.
+ *
+ * Deliberately fail-safe: every outcome except a positively identified local
+ * KiroCrew process is a reason NOT to evict.
+ *   "kirocrew" — a local LISTEN owner matching KIROCREW_PROC_RE. Only this
+ *                value may authorise a takeover.
+ *   "foreign"  — a local LISTEN owner exists but is not ours (e.g. `ssh`).
+ *   "none"     — nothing is listening locally, yet something answered. A race,
+ *                or a socket we cannot see; treat as not ours.
+ *   "unknown"  — the probe itself could not run (no lsof / EACCES). Never
+ *                mistake "couldn't look" for "safe to kill".
+ *
+ * Side effects are injected so this is unit-testable without Electron or real
+ * OS processes (mirrors forceStopPort above).
+ *
+ * @param {number} port
+ * @param {object} deps
+ * @param {(port:number)=>Promise<number[]>} deps.getListenPids  lsof -t
+ * @param {(pid:number)=>Promise<string>}    deps.getCommand     ps -o command=
+ * @returns {Promise<"kirocrew"|"foreign"|"none"|"unknown">}
+ */
+async function classifyPortOwner(
+  port,
+  { getListenPids, getCommand, isKirocrew = KIROCREW_PROC_RE, log = () => {} }
+) {
+  let pids;
+  try {
+    pids = await getListenPids(port);
+  } catch (e) {
+    log(`port-owner: could not probe :${port} (${e && e.message}) — owner unknown, will not evict`);
+    return "unknown";
+  }
+  if (!pids.length) {
+    log(`port-owner: no local LISTEN owner on :${port}`);
+    return "none";
+  }
+  for (const pid of pids) {
+    const cmd = (await getCommand(pid)).trim();
+    if (isKirocrew.test(cmd)) {
+      log(`port-owner: :${port} held by local KiroCrew pid=${pid} (${cmd.slice(0, 80)})`);
+      return "kirocrew";
+    }
+    log(`port-owner: :${port} held by NON-KiroCrew pid=${pid} (${cmd.slice(0, 80)})`);
+  }
+  return "foreign";
+}
+
+module.exports = {
+  postShutdown,
+  stopGatewayGracefully,
+  forceStopPort,
+  classifyPortOwner,
+  KIROCREW_PROC_RE,
+};

--- a/website/electron/instance-guard.js
+++ b/website/electron/instance-guard.js
@@ -13,15 +13,18 @@
  * module covers that cross-app seam.
  *
  * Decision inputs: our own stamped version (identity family derives from it,
- * mirroring auto-update.js channelForVersion) and the running gateway's
- * /api/health payload ({ok, app, version}). Legacy gateways (health without
- * identity fields) and source-run dev gateways keep today's reuse behavior —
- * the guard only interposes when BOTH sides are positively identified and
- * their families differ.
+ * mirroring auto-update.js channelForVersion), the running gateway's
+ * /api/health payload ({ok, app, version}), and who LOCALLY owns the port's
+ * LISTEN socket. Legacy gateways (health without identity fields) and
+ * source-run dev gateways keep today's reuse behavior — the guard only
+ * interposes when BOTH sides are positively identified, their families differ,
+ * AND the port is held by a local KiroCrew process. That last input is what
+ * separates a local rival from a REMOTE gateway forwarded in over `ssh -L`,
+ * which the health payload alone cannot distinguish.
  *
  * Pure logic only — the Electron shell (main.js) owns the dialog, the
  * quit-by-name AppleScript (bundle id is shared, so targeting must be by
- * app NAME), and the port-free wait.
+ * app NAME), the port-owner probe, and the port-free wait.
  */
 
 const { channelForVersion } = require("./auto-update");
@@ -60,10 +63,16 @@ function identityFamily(version) {
  * @param {string} ownVersion  app.getVersion() of this shell
  * @param {{ok?:boolean, app?:string, version?:string}|null} remoteHealth
  *        parsed /api/health JSON, or null when unreachable/unparseable
+ * @param {object} [opts]
+ * @param {"kirocrew"|"foreign"|"none"|"unknown"} [opts.localOwner="unknown"]
+ *        who LOCALLY owns the port's LISTEN socket (classifyPortOwner in
+ *        gateway-stop.js). Defaults to "unknown" so a caller that forgets to
+ *        pass it fails SAFE (reuse) rather than inheriting the old
+ *        evict-on-payload-alone behavior.
  * @returns {{action:"reuse", reason:string} |
  *           {action:"takeover-prompt", otherFamily:"prod"|"nightly", otherVersion:string}}
  */
-function decideGatewayAction(ownVersion, remoteHealth) {
+function decideGatewayAction(ownVersion, remoteHealth, { localOwner = "unknown" } = {}) {
   const own = identityFamily(ownVersion);
   // A shell we can't classify never evicts anyone.
   if (own === null) return { action: "reuse", reason: "unclassified-shell" };
@@ -76,6 +85,20 @@ function decideGatewayAction(ownVersion, remoteHealth) {
   const remote = identityFamily(remoteHealth.version);
   if (remote === null || remote === own) {
     return { action: "reuse", reason: remote === own ? "same-family" : "dev-gateway" };
+  }
+  // Cross-family: the payload says "a rival KiroCrew owns the port". That is
+  // necessary but NOT sufficient to evict, because the payload is identical
+  // whether the responder is a local install or a REMOTE gateway forwarded
+  // here by `ssh -L <port>:localhost:<port>`. Only a positively identified
+  // local KiroCrew LISTEN owner authorises the eviction; a tunnel ("foreign",
+  // owner is `ssh`), an unseen socket ("none"), or a failed probe ("unknown")
+  // all reuse instead. Evicting a tunnel is doubly wrong: the AppleScript quit
+  // targets a local app that is not running, and killing the port would tear
+  // down the user's forward. This mirrors chooseRecoveryStrategy in
+  // gateway-recovery.js, which already refuses to kill a gateway we did not
+  // spawn — the boot path simply never got the same rule.
+  if (localOwner !== "kirocrew") {
+    return { action: "reuse", reason: `non-local-holder:${localOwner}` };
   }
   return { action: "takeover-prompt", otherFamily: remote, otherVersion: remoteHealth.version };
 }

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -46,7 +46,7 @@ const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
 const { createDisplayMediaHandler } = require("./display-media");
 const { initAutoUpdate } = require("./auto-update");
-const { stopGatewayGracefully: _stopGatewayGracefully, forceStopPort } = require("./gateway-stop");
+const { stopGatewayGracefully: _stopGatewayGracefully, forceStopPort, classifyPortOwner } = require("./gateway-stop");
 const { waitForGateway, describeGatewayFailure, tailLines, isPortInUse } = require("./gateway-wait");
 const { sanitizeWindowState, captureWindowState } = require("./window-state");
 const { createLivenessMonitor } = require("./gateway-liveness");
@@ -257,13 +257,45 @@ function quitOtherApp(appName) {
   });
 }
 
+// Who locally owns :PORT's LISTEN socket? Thin wiring over classifyPortOwner
+// (gateway-stop.js) using the same lsof/ps helpers forceStopGatewayPort uses.
+// Function declarations are hoisted, so the helpers defined further down this
+// file are available here.
+//
+// Platforms without lsof//bin/ps (Windows) resolve to "unknown", which reuses.
+// That is the safe direction: reuse can never produce two gateways on one data
+// home, so the cross-app mutex still holds — only the eviction prompt is lost,
+// and eviction was already darwin-only (canTakeover below).
+function probeGatewayPortOwner(port) {
+  return classifyPortOwner(port, {
+    getListenPids: _lsofListenPids,
+    getCommand: _psCommand,
+    log: glog,
+  });
+}
+
 // Budget: the other app's graceful gateway stop runs up to 15s
 // (POST /api/shutdown -> SIGTERM -> SIGKILL) after the quit event lands,
 // so the wait must comfortably exceed it.
+//
+// "Free" means the LISTEN socket is gone, NOT merely that /api/status stopped
+// answering. Those differ in exactly the cases that matter: a gateway wedged in
+// an uninterruptible kernel wait still holds the port while failing probes, and
+// a dropped SSH forward stops answering while `ssh` keeps the socket. Either
+// way the old HTTP heuristic reported "released" and we respawned straight into
+// EADDRINUSE. forceStopPort already learned this lesson; this is the same check.
 async function waitForPortFree(maxWaitMs = 30000) {
   const start = Date.now();
   for (;;) {
-    try { await checkBackend(); } catch { return true; } // probe fails => port free
+    const owner = await probeGatewayPortOwner(PORT);
+    if (owner === "none") return true;
+    if (owner === "unknown") {
+      // We cannot see the listener at all (no lsof). Fall back to the historical
+      // HTTP heuristic rather than blocking the takeover forever — but say so,
+      // because this is the weaker signal.
+      glog(`port-free: listener probe unavailable on :${PORT} — falling back to an HTTP probe`);
+      try { await checkBackend(); } catch { return true; }
+    }
     if (Date.now() - start > maxWaitMs) return false;
     await new Promise((r) => setTimeout(r, 500));
   }
@@ -271,7 +303,15 @@ async function waitForPortFree(maxWaitMs = 30000) {
 
 async function resolveGatewayConflict() {
   const health = await fetchHealthInfo();
-  const decision = decideGatewayAction(app.getVersion(), health);
+  // A remote host configured for THIS port means the user deliberately pointed
+  // this app at a gateway on another machine, so the local holder is a tunnel
+  // by construction and there is nothing here to evict.
+  const remoteHost = getRemoteHostConfig(store, PORT)?.host || "";
+  if (remoteHost) {
+    glog(`:${PORT} is a configured remote host (${remoteHost}) — holder treated as non-local`);
+  }
+  const localOwner = remoteHost ? "foreign" : await probeGatewayPortOwner(PORT);
+  const decision = decideGatewayAction(app.getVersion(), health, { localOwner });
   if (decision.action === "reuse") {
     glog(`reusing existing gateway on :${PORT} (${decision.reason}) — bundled backend NOT spawned`);
     weSpawnedGateway = false; // reuse path — recovery must not kill/respawn a gateway we don't own

--- a/website/electron/test/gateway-stop.test.js
+++ b/website/electron/test/gateway-stop.test.js
@@ -5,7 +5,7 @@ const os = require("os");
 const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
-const { postShutdown, stopGatewayGracefully, forceStopPort } = require("../gateway-stop");
+const { postShutdown, stopGatewayGracefully, forceStopPort, classifyPortOwner, KIROCREW_PROC_RE } = require("../gateway-stop");
 
 // Helper: temp KIROCREW_HOME containing a .local_secret file.
 function tmpHomeWithSecret(secret) {
@@ -217,4 +217,61 @@ test("forceStopPort: freed reflects real port state even after killing our targe
   assert.strictEqual(r.killed, 1);
   assert.deepStrictEqual(r.survivors, []); // OUR pid is gone
   assert.strictEqual(r.freed, false); // but the port is still held by 777
+});
+
+// ── classifyPortOwner ───────────────────────────────────────────────────────
+// Ground truth for "is the thing on our port local, or a tunnel?". Every
+// outcome except a positively identified local KiroCrew process must be
+// treated as "not ours" by callers.
+
+test("classifyPortOwner: local KiroCrew gateway is ours", async () => {
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => [4242],
+    getCommand: async () => "python -m kiro_crew gateway --port 5476",
+  });
+  assert.strictEqual(owner, "kirocrew");
+});
+
+test("classifyPortOwner: an ssh -L forward is foreign, not ours", async () => {
+  // The exact shape of the reported bug: the tunnel's local socket belongs to
+  // ssh, while the gateway answering /api/health lives on another machine.
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => [909],
+    getCommand: async () => "ssh -NL 5476:localhost:5476 dev-dsk-example.amazon.com",
+  });
+  assert.strictEqual(owner, "foreign");
+});
+
+test("classifyPortOwner: no listener is 'none'", async () => {
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => [],
+    getCommand: async () => "",
+  });
+  assert.strictEqual(owner, "none");
+});
+
+test("classifyPortOwner: an unrunnable probe is 'unknown', never 'none'", async () => {
+  // A swallowed ENOENT previously looked like "nothing is listening", which is
+  // the dangerous direction: it would authorise an eviction.
+  const enoent = Object.assign(new Error("spawn lsof ENOENT"), { code: "ENOENT" });
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => { throw enoent; },
+    getCommand: async () => "",
+  });
+  assert.strictEqual(owner, "unknown");
+});
+
+test("classifyPortOwner: ours wins when a mixed set holds the port", async () => {
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => [909, 4242],
+    getCommand: async (pid) => (pid === 4242 ? "kirocrew gateway" : "ssh -NL 5476:localhost:5476 host"),
+  });
+  assert.strictEqual(owner, "kirocrew");
+});
+
+test("classifyPortOwner and forceStopPort share one KiroCrew matcher", async () => {
+  // Drift between the two would let one mis-target a stranger's process.
+  assert.ok(KIROCREW_PROC_RE.test("python -m kiro_crew gateway"));
+  assert.ok(KIROCREW_PROC_RE.test("/Applications/KiroCrew.app/.../kirocrew"));
+  assert.ok(!KIROCREW_PROC_RE.test("ssh -NL 5476:localhost:5476 host"));
 });

--- a/website/electron/test/instance-guard.test.js
+++ b/website/electron/test/instance-guard.test.js
@@ -28,15 +28,19 @@ test("same family reuses: nightly shell, nightly gateway (relaunch)", () => {
   assert.equal(d.action, "reuse");
 });
 
+// A local KiroCrew LISTEN owner is what makes an eviction legitimate. Passing
+// it explicitly in the cross-family cases keeps those tests about FAMILY logic.
+const LOCAL = { localOwner: "kirocrew" };
+
 test("cross family prompts: nightly shell over prod gateway", () => {
-  const d = decideGatewayAction("0.2.0-nightly.20260722120000", { ok: true, app: "kirocrew", version: "0.1.0" });
+  const d = decideGatewayAction("0.2.0-nightly.20260722120000", { ok: true, app: "kirocrew", version: "0.1.0" }, LOCAL);
   assert.equal(d.action, "takeover-prompt");
   assert.equal(d.otherFamily, "prod");
   assert.equal(d.otherVersion, "0.1.0");
 });
 
 test("cross family prompts: prod shell over nightly gateway", () => {
-  const d = decideGatewayAction("0.1.0", { ok: true, app: "kirocrew", version: "0.1.0-nightly.20260722120000" });
+  const d = decideGatewayAction("0.1.0", { ok: true, app: "kirocrew", version: "0.1.0-nightly.20260722120000" }, LOCAL);
   assert.equal(d.action, "takeover-prompt");
   assert.equal(d.otherFamily, "nightly");
 });
@@ -56,6 +60,55 @@ test("non-kirocrew responder on the port reuses (never evict a stranger)", () =>
 
 test("unclassifiable own version never evicts", () => {
   assert.equal(decideGatewayAction("", { ok: true, app: "kirocrew", version: "0.1.0" }).action, "reuse");
+});
+
+// ── Locality: a cross-family payload alone must never authorise an eviction ──
+// An `ssh -L 5476:localhost:5476 host` forward makes a REMOTE gateway answer
+// /api/health on localhost with a payload identical to a local install's. Every
+// case below is cross-family (the family logic says "evict") and must still
+// reuse, because the port is not held by a local KiroCrew process.
+const CROSS_FAMILY_HEALTH = { ok: true, app: "kirocrew", version: "0.1.0" };
+const NIGHTLY_SHELL = "0.2.0-nightly.20260722120000";
+
+test("tunnelled remote gateway is reused, never evicted (ssh owns the socket)", () => {
+  const d = decideGatewayAction(NIGHTLY_SHELL, CROSS_FAMILY_HEALTH, { localOwner: "foreign" });
+  assert.equal(d.action, "reuse");
+  assert.match(d.reason, /non-local-holder:foreign/);
+});
+
+test("no visible local listener is reused, never evicted", () => {
+  const d = decideGatewayAction(NIGHTLY_SHELL, CROSS_FAMILY_HEALTH, { localOwner: "none" });
+  assert.equal(d.action, "reuse");
+  assert.match(d.reason, /non-local-holder:none/);
+});
+
+test("a failed owner probe fails SAFE: unknown never evicts", () => {
+  // "couldn't look" must never be mistaken for "safe to kill".
+  const d = decideGatewayAction(NIGHTLY_SHELL, CROSS_FAMILY_HEALTH, { localOwner: "unknown" });
+  assert.equal(d.action, "reuse");
+  assert.match(d.reason, /non-local-holder:unknown/);
+});
+
+test("omitting the locality input defaults to no eviction", () => {
+  // A caller that forgets the third argument must not inherit the old
+  // evict-on-payload-alone behavior.
+  assert.equal(decideGatewayAction(NIGHTLY_SHELL, CROSS_FAMILY_HEALTH).action, "reuse");
+});
+
+test("a genuine local rival install still prompts (cross-app mutex preserved)", () => {
+  // Regression pin for the case the takeover was built for (#193): two installs
+  // on ONE machine sharing ~/.kiro/crew and :5476. The guard must keep working.
+  const d = decideGatewayAction(NIGHTLY_SHELL, CROSS_FAMILY_HEALTH, { localOwner: "kirocrew" });
+  assert.equal(d.action, "takeover-prompt");
+  assert.equal(d.otherFamily, "prod");
+});
+
+test("locality is checked only after family — same-family still short-circuits", () => {
+  // A same-family gateway reuses for the family reason regardless of owner, so
+  // the reason string stays useful for diagnosing reuse causes.
+  const d = decideGatewayAction("0.1.0", { ok: true, app: "kirocrew", version: "0.1.0-insider.3" }, { localOwner: "foreign" });
+  assert.equal(d.action, "reuse");
+  assert.equal(d.reason, "same-family");
 });
 
 test("FAMILY_META separates display names from quit-by-name targets", () => {


### PR DESCRIPTION
## Problem

The boot-time ownership guard decided whether to evict the holder of `:5476` from the `/api/health` payload alone (`{app, version}`). That payload is **identical** whether the responder is a local rival install or a REMOTE gateway forwarded in by `ssh -L 5476:localhost:5476 host`.

Observed on a real machine tunnelling a dev-desktop gateway to a Mac:

```
[18:50:15.905Z] gateway on :5476 is owned by KiroCrew (0.1.0) — prompting for takeover
[18:50:43.489Z] takeover: KiroCrew released :5476 — proceeding to spawn
[18:50:43.493Z] no gateway on :5476 — spawning bundled backend
```

The gateway on `:5476` was on another host. The user got a takeover prompt naming an app that was not installed locally, and the app then spawned its own backend onto the port they were forwarding.

Two compounding defects:

1. **`decideGatewayAction` had no locality input**, so cross-family identity was treated as sufficient grounds to evict.
2. **`waitForPortFree` returned `true` on the FIRST failed HTTP probe** — `try { await checkBackend(); } catch { return true; }`. A single 2s `/api/status` timeout over the tunnel read as "the port was released", after which the spawn raced an `ssh` process still holding the socket.

## Fix

Require a positively identified **local** KiroCrew LISTEN owner before a takeover, and make "port free" mean the listener is gone.

- **`gateway-stop.js`** — new `classifyPortOwner`, a pure injectable probe returning `kirocrew | foreign | none | unknown`. Also hoists the KiroCrew process matcher to one shared exported regex so it cannot drift from the set of processes `forceStopPort` is allowed to signal.
- **`instance-guard.js`** — `decideGatewayAction` takes `{ localOwner }` and only prompts when it is `"kirocrew"`. **Defaults to `"unknown"`** so a caller that omits it fails safe (reuse) rather than inheriting the old evict-on-payload-alone behavior.
- **`main.js`** — probe the owner before deciding; short-circuit to reuse when a remote host is already configured for this port (`getRemoteHostConfig` was previously consulted only in token flows); rebuild `waitForPortFree` on the listener check, keeping the HTTP heuristic only as a fallback when the probe cannot run.

This extends the rule `chooseRecoveryStrategy` already applies on the post-handoff liveness path — never tear down a gateway we did not spawn — to the boot path, which never got it. `gateway-recovery.js` already documents this exact tunnel scenario; the guard was simply missing one layer down.

## Testing

- `npm run test:electron` — **278/278 pass** (12 new cases)
- `npx tsc -b` — clean
- `npx jscpd .` — 0 clones
- `node --check` on all three modified modules

New coverage in `test/instance-guard.test.js`: tunnelled/`none`/`unknown` holders all reuse; omitting the locality argument fails safe; same-family short-circuit preserved; **and a regression pin that a genuine local rival still prompts**, so the cross-app mutex from #193 keeps working.

New coverage in `test/gateway-stop.test.js` for `classifyPortOwner`, including the literal `ssh -NL 5476:localhost:5476 host` command string and an ENOENT probe failure resolving to `unknown` rather than `none` (the dangerous direction, since `none` would authorise an eviction).

## Reviewer notes

**Behavior change on platforms without `lsof` / `/bin/ps` (Windows):** an unprobeable port resolves to `unknown` and therefore reuses, so the informational "quit the other app" dialog is lost there. I chose that direction deliberately — reuse can never produce two gateways on one data home, so the mutex still holds, and eviction was already darwin-only (`canTakeover`). Happy to change it if reviewers prefer keeping the dialog.

**Not fixed here:** with the app now reusing a tunnelled gateway instead of evicting it, users land on `token-prompt.html`, which tells them to run `kirocrew token` — an instruction that cannot succeed against a foreign gateway, because `.local_secret` is per-data-home and regenerated at each startup. That is a separate defect and a separate PR.

**Pre-existing gap:** `website/electron/test/*.test.js` is not run by any workflow in `.github/workflows/` — no `test:electron` or `node --test`. These tests pass locally but CI will not see them. Left alone to keep this PR scoped.
