### PR TITLE
fix(nav): dismiss the Apps overflow hover label when the toggle is pressed

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -331,6 +331,16 @@ function useNavTip<T extends HTMLElement>(enabled: boolean) {
     setTipOn(false)
     hideTimer.current = setTimeout(() => setTip(null), 150) // keep mounted for fade-out
   }, [])
+  // Dismiss with NO fade-out, for rows whose label text changes on activation
+  // (the Apps overflow toggle flips "N more" <-> "Show less"). A fading label
+  // stays mounted through the re-render, so it would flash the OPPOSITE label
+  // as a ghost at the old coordinates before unmounting.
+  const dismissTip = useCallback(() => {
+    if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null }
+    if (rafId.current != null) { cancelAnimationFrame(rafId.current); rafId.current = null }
+    setTipOn(false)
+    setTip(null)
+  }, [])
   // While shown, follow the row on scroll/resize (capture:true catches the
   // nav's inner scroll container, which doesn't bubble scroll to window).
   // Depend on a stable boolean — not `tip` itself — so the listeners subscribe
@@ -361,7 +371,7 @@ function useNavTip<T extends HTMLElement>(enabled: boolean) {
     if (hideTimer.current) clearTimeout(hideTimer.current)
     if (rafId.current != null) cancelAnimationFrame(rafId.current)
   }, [])
-  return { tip, tipOn, rowRef, showTip, hideTip }
+  return { tip, tipOn, rowRef, showTip, hideTip, dismissTip }
 }
 
 function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride, onClick, navId }: {
@@ -448,7 +458,7 @@ function SortableAppNavRow({ id, children }: { id: string; children: React.React
 function NavToggle({ collapsed, expanded, hiddenCount, onClick }: {
   collapsed: boolean; expanded: boolean; hiddenCount: number; onClick: () => void
 }) {
-  const { tip, tipOn, rowRef, showTip, hideTip } = useNavTip<HTMLButtonElement>(collapsed)
+  const { tip, tipOn, rowRef, showTip, hideTip, dismissTip } = useNavTip<HTMLButtonElement>(collapsed)
   // `hiddenCount === 0 && !expanded` happens when the only overflow item is the
   // active app (kept visible) — nothing is actually hidden, so the toggle just
   // offers to re-collapse rather than reveal "0 more".
@@ -459,7 +469,16 @@ function NavToggle({ collapsed, expanded, hiddenCount, onClick }: {
   return (
     <button ref={rowRef}
       className="group/nav relative flex items-center rounded-md cursor-pointer text-sm font-medium whitespace-nowrap gap-2.5 py-2 pl-3 pr-3 transition-colors duration-200 text-muted hover:text-text hover:bg-bg-hover bg-transparent border-none w-full"
-      onClick={onClick}
+      // Dismiss the hover label on activation, without the fade-out. Unlike a
+      // NavItem (which stays put when clicked, so the pointer is still
+      // legitimately over it), activating this toggle re-flows the Apps list and
+      // moves the row out from under a stationary cursor — no mouseleave is
+      // dispatched, so the flyout used to hang at the old coordinates until the
+      // click's focus was lost. Fading it out is not enough either: the label
+      // text flips on activation, so a fading ghost flashes the OPPOSITE label.
+      // This runs after the focus a pointer press produces (focus precedes
+      // click), so it also clears a label that focus had just re-armed.
+      onClick={() => { dismissTip(); onClick() }}
       aria-expanded={expanded}
       aria-label={titleText}
       title={titleText}

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -409,6 +409,46 @@ describe('App routing', () => {
     fireEvent.keyDown(rows[0], { key: 'Enter' })
   })
 
+  it('dismisses the collapsed overflow-toggle hover label when the toggle is pressed', async () => {
+    // Regression: pressing the Apps overflow toggle in the collapsed rail left
+    // its portaled "N more" / "Show less" flyout on screen until the user
+    // clicked elsewhere. Two causes: expanding re-flows the list so the row
+    // moves out from under a stationary cursor (no mouseleave is dispatched),
+    // and the click's own focus re-armed the label. Activation must dismiss it.
+    const { fireEvent } = await import('@testing-library/react')
+    const { api } = await import('../api/client')
+    const manyApps = Array.from({ length: 10 }, (_, i) => ({
+      name: `tipapp${i}`,
+      displayName: `Tip App ${i}`,
+      enabled: true,
+      origin: 'installed',
+      manifest: { ui: { pages: [{ route: `/apps/tipapp${i}`, icon: 'Package', label: `Tip App ${i}` }] } },
+    }))
+    ;(api.listApps as ReturnType<typeof vi.fn>).mockResolvedValueOnce(manyApps)
+    localStorage.setItem('mc-nav', '1')          // collapsed (icon-only) rail
+    localStorage.setItem('mc-apps-expanded', '0')
+    renderWithProviders(<App />, { route: '/chat' })
+    const toggle = await screen.findByTitle(/more app/i)
+    // Hover -> the portaled label mounts (collapsed rows carry no inline text).
+    fireEvent.mouseEnter(toggle)
+    expect(await screen.findByText('4 more')).toBeInTheDocument()
+    // Press it the way a mouse does: pointerdown -> focus -> click. Neither the
+    // focus the press produces nor the surviving hover state may leave a label
+    // on screen — and the dismissal must be immediate, with no fade-out: the
+    // label text flips on activation, so a still-mounted fading label flashes
+    // the OPPOSITE label ("Show less") as a ghost at the old coordinates.
+    fireEvent.pointerDown(toggle)
+    fireEvent.focus(toggle)
+    act(() => { toggle.click() })
+    expect(screen.queryByText('4 more')).toBeNull()
+    expect(screen.queryByText('Show less')).toBeNull()
+    // ...and the press still did its job: dismissing the label must not swallow
+    // the toggle's own activation (the title flips once the list is expanded).
+    expect(screen.getByTitle(/show fewer apps/i)).toBeInTheDocument()
+    localStorage.removeItem('mc-nav')
+    localStorage.removeItem('mc-apps-expanded')
+  })
+
   it('renders Kiro Crew branding', () => {
     localStorage.removeItem('mc-nav') // expanded sidebar shows the brand text
     renderWithProviders(<App />, { route: '/chat' })


### PR DESCRIPTION
## Problem

In the collapsed (icon-only) left nav rail, the Apps overflow toggle's label — `N more` / `Show less` — is a portaled hover flyout rather than in-flow text. Pressing the toggle left that flyout on screen: it stayed until the user clicked somewhere else, hanging at the coordinates it was measured at, on top of a row that had just moved.

Reported symptom: *"pressing the show more button on the left most sidebar leaves the '2 more' and 'show less' hints visible until I click elsewhere."*

## Why it matters

The Apps overflow toggle is on the primary navigation rail, so anyone running the rail collapsed with more than `APPS_NAV_LIMIT` (6) apps hits this every time they expand or re-collapse the list. The stranded flyout overlaps the app row that took the toggle's place, so it does not just look wrong — it obscures a navigation target until dismissed by an unrelated click.

## Fix (symptoms → root cause → change)

Two distinct causes sat behind the one symptom, and the second only became visible once the first was fixed:

1. **The label was never dismissed on activation.** Unlike a `NavItem` — which stays put when clicked, so the pointer is still legitimately over it — activating this toggle re-flows the Apps list and moves the row out from under a stationary cursor. No `mouseleave` is dispatched in that case, and the click's own focus (`onFocus={showTip}`) keeps the label armed, so nothing hid it until blur, i.e. until the user clicked elsewhere.

2. **Fading it out is not enough.** `hideTip` deliberately keeps the flyout mounted for 150ms so the CSS opacity transition can run. Activation flips `labelText` in the same commit, so the still-mounted element re-rendered with the *opposite* label and faded out showing it — a brief `Show less` ghost after pressing `2 more`, and vice versa.

The change adds a `dismissTip` to `useNavTip` that unmounts with no fade — it clears the pending fade timer and the pending rAF and sets `tip` to `null` in the same update — and wires the toggle's `onClick` to it. Because a browser dispatches `focus` before `click`, running the dismissal from `onClick` also clears a label that the press's own focus had just re-armed, so no pointer/keyboard focus-source tracking is needed. `hideTip` keeps the fade for the ordinary hover-out path, and `NavItem` is untouched: its rows do not move on click, so its hover label is still correct while the pointer remains over it.

Known accepted tradeoff: keyboard `Tab` + `Enter` now also dismisses the flyout while focus stays on the button, so the label returns only on blur-and-refocus. `aria-expanded` and the updated `aria-label`/`title` still convey the new state, and re-arming after activation would resurrect the original bug — a mouse press focuses the button too, and separating the two cases needs the re-show deferred a frame to re-measure the re-flowed row.

## Tests

`website/src/test/App.test.tsx` — new case `dismisses the collapsed overflow-toggle hover label when the toggle is pressed`. With 10 enabled apps and the rail collapsed, it hovers the toggle to mount the `4 more` flyout, then drives the real press sequence (`pointerdown` → `focus` → `click`) and asserts, synchronously:

- neither `4 more` (the stale label) nor `Show less` (the flipped-label ghost) is on screen — the synchronous assertion is what rejects the weaker fade-out fix, since a fading label is still mounted at opacity 0 and still matched by `queryByText`;
- the toggle's title has flipped to `Show fewer apps`, pinning that dismissing the label did not swallow the toggle's own activation.

Verified non-vacuous: the case fails against `origin/main`'s `App.tsx` (on the `Show less` assertion — the pre-fix flyout stays mounted and re-renders with the flipped text) and passes with the change.

## Manual verification

Reproduced and confirmed fixed in a live dashboard running this build, at both steps: the flyout no longer persists after a press, and there is no opposite-label flash. Local gates: `npx tsc -b` clean, `npx eslint` 0 errors, `npx vitest run` 5203 passed / 3 skipped across 432 files.

## Screenshots

N/A — no static visual change to capture. The fix removes a transient, wrongly-positioned overlay; every steady state (collapsed rail, expanded rail, hover label while hovering) renders exactly as before, so a still frame of the corrected behavior is indistinguishable from the bug. The regression test asserts the transient state a screenshot cannot.
