### PR TITLE
fix(chat): stop tool pills re-flashing on remount

### DIFF
--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -14,6 +14,20 @@ import { isSafePath } from '../../utils/safePath'
 import { fileReadUrl } from '../../utils/fileReadUrl'
 import McpAppFrame from '../../components/McpAppFrame'
 
+// Tool-call ids that have already played their one-shot `.ft-block-reveal`
+// entrance fade. A CSS animation re-fires on every DOM *mount*, and a pill
+// remounts in several normal situations that are NOT a genuine first
+// appearance — singles→turn promotion (ChatPage flushTurn), the flat→segmented
+// restructure at turn completion (TurnBlock), expand/collapse via
+// AnimatePresence, and virtualizer window recycling on scroll. Without this
+// guard every one of those remounts replays the fade, so all previously-shown
+// tool results visibly flash whenever a new tool runs / the turn advances.
+// Keyed by the stable tool_call_id and held at module scope so it outlives any
+// unmount, this lets a pill fade in exactly once — the first time it appears.
+// (Same philosophy as the `.ft-word` streaming reveal: already-revealed nodes
+// don't re-fire.)
+const revealedToolIds = new Set<string>()
+
 /** Inline tool call pill. Click toggles an expanded panel below the pill that
  *  shows purpose / input / output (the same details that previously lived in
  *  the Activity sidebar's deprecated "Tools" tab). */
@@ -268,8 +282,21 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     return registerToolPill(toolCallId, el)
   }, [hasPendingPerm, toolCallId])
 
+  // Play the `.ft-block-reveal` entrance fade only on a pill's genuine first
+  // appearance, never on a remount (turn promotion, flat→segmented restructure,
+  // expand/collapse, virtualizer recycling). `revealId` prefers the message's
+  // own tool_call_id (available immediately) and falls back to the resolved
+  // toolLog id. The decision is read once in a useState initializer (pure — no
+  // side effect in render, so it's StrictMode-safe) and the id is marked
+  // revealed in an effect after commit; a later remount finds it already in the
+  // set and renders without the animation class, so it appears instantly. An
+  // id-less historical pill (no stable identity) falls back to animating.
+  const revealId = toolCallId ?? effectiveId ?? null
+  const [animateEntrance] = useState(() => !revealId || !revealedToolIds.has(revealId))
+  useEffect(() => { if (revealId) revealedToolIds.add(revealId) }, [revealId])
+
   return (
-    <div ref={containerRef} className="ft-block-reveal">
+    <div ref={containerRef} className={animateEntrance ? 'ft-block-reveal' : undefined}>
       <div className="inline-flex items-start gap-1 group/toolpill">
       <button
         ref={pillButtonRef}


### PR DESCRIPTION
## Problem
When the agent runs a tool, **all previously-shown tool-call pills in the current response bubble briefly flash** (fade from transparent back to opaque). It reads as the whole tool history "blinking" every time a new tool executes or the turn advances.

## Why it matters
The chat transcript is where the user follows what the agent is doing. A full-bubble flash on every tool step is visually jarring, draws the eye away from the actual new content, and makes a busy multi-tool turn feel unstable — a papercut on the most-watched surface in the app.

## Fix (symptoms → root cause → change)
- **Symptom:** every tool pill in the bubble re-fades whenever a new tool runs / the turn finishes / the group is expanded.
- **Root cause:** each `ToolCallLine` wraps its row in the `.ft-block-reveal` class, which is an unconditional `ft-fade` (opacity 0→1) CSS animation. A CSS animation re-fires on **every DOM mount**, and tool rows legitimately remount in several normal situations that are *not* a genuine first appearance:
  - singles→turn promotion (`ChatPage` `flushTurn` bundles loose rows into one `<TurnBlock>` once a turn has >2 steps),
  - the flat→segmented restructure at turn completion (`TurnBlock` wraps rows in `AnimatePresence`/`CollapsibleSection`),
  - expand/collapse of the tool group (mounts rows via `AnimatePresence`),
  - virtualizer window recycling on scroll.

  Each remount replayed the fade, so already-visible pills flashed. Pill React keys (`role-ts`) and the turn's `virtualKeyFor` are already stable — this was purely the entrance animation re-triggering on remount, not a key bug.
- **Change:** gate the entrance fade to a pill's genuine first appearance. A module-scoped `Set<string> revealedToolIds` records each pill's `tool_call_id` once it has appeared; `animateEntrance` is decided once in a `useState` initializer (a pure read of the set — StrictMode-safe), the id is marked in a post-commit `useEffect`, and the `.ft-block-reveal` class is applied only when `animateEntrance` is true. A later remount finds the id already present and renders with no animation class, so the pill appears instantly instead of re-fading. This mirrors the existing `.ft-word` streaming-reveal precedent (already-revealed nodes don't re-fire).

## Tests
No new automated test. The behavior is a CSS-animation re-trigger on DOM remount, which jsdom does not paint or run animations for — a DOM/count assertion cannot observe a flash or its absence (consistent with the project's "don't conclude from jsdom paint" guidance). The existing `ToolCallLine`, `TurnBlock`, and `ChatMessageList` suites (46 tests) pass unchanged, locking in that the gating logic doesn't alter render output, hook order, or keys.

## Manual verification
Verified locally: `tsc -b` clean, `eslint` clean on the changed file, and `vitest run` green for `ToolCallLine` + `TurnBlock` + `ChatMessageList` (46/46). Runtime check to do in a dev build: run a multi-tool turn and confirm earlier pills stay put (no fade) when a new tool starts, when the turn completes and collapses, and when the tool group is expanded again — while a genuinely new pill still fades in once.

## Screenshots
N/A — the change is the **absence** of a re-triggered animation, not a static visual difference. A still image can't distinguish "faded once" from "re-faded," so a screenshot adds nothing; the effect is only observable as motion in a live session (see Manual verification).
