### PR TITLE
feat(issue-radar): resizable, collapsible left rail

### DIFF
--- a/website/src/apps/issue-radar/Workspace.tsx
+++ b/website/src/apps/issue-radar/Workspace.tsx
@@ -12,79 +12,51 @@
 // registry. 'settings' shows the Settings page in the same area. The rail stays
 // visible in every mode. All shared state comes from useIssueRadar(); this file
 // owns only presentational layout (column resize).
-import { useState, useRef, useEffect } from 'react'
 import { CircleDot, GitPullRequest } from 'lucide-react'
 import { useIssueRadar } from './context'
 import {
   loadListWidth, LIST_WIDTH_KEY, MIN_LIST_WIDTH, MAX_LIST_WIDTH,
+  loadRailWidth, loadRailCollapsed, RAIL_WIDTH_KEY, RAIL_COLLAPSED_KEY,
+  MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, COLLAPSED_RAIL_WIDTH,
 } from './lib/format'
+import { useColumnResize, type CollapseConfig } from './lib/useColumnResize'
 import LeftRail from './components/LeftRail'
+import ResizeHandle from './components/ResizeHandle'
 import IssueList from './components/IssueList'
 import IssueDetail from './components/IssueDetail'
 import PrList from './components/PrList'
 import PrDetail from './components/PrDetail'
 import SettingsView from './views/SettingsView'
 import { dashboardComponent } from './views/registry'
-import { usePointerDrag } from '../../hooks/usePointerDrag'
+
+// Module-level so the hook's memoised resolver isn't invalidated every render.
+const RAIL_COLLAPSE: CollapseConfig = { width: COLLAPSED_RAIL_WIDTH, storageKey: RAIL_COLLAPSED_KEY }
 
 export default function Workspace() {
   const { mainView, dashboardTab, activeIssue, activePull } = useIssueRadar()
-  const [listWidth, setListWidth] = useState<number>(loadListWidth)
-
-  const startWRef = useRef(0)
-  const listDraggingRef = useRef(false)
-  const listResize = usePointerDrag({
-    threshold: 0,
-    onStart: () => {
-      startWRef.current = listWidth
-      listDraggingRef.current = true
-      document.body.style.cursor = 'col-resize'
-      document.body.style.userSelect = 'none'
-    },
-    onMove: ({ dx }) => {
-      setListWidth(Math.min(MAX_LIST_WIDTH, Math.max(MIN_LIST_WIDTH, startWRef.current + dx)))
-    },
-    onEnd: ({ dx }) => {
-      listDraggingRef.current = false
-      const finalW = Math.min(MAX_LIST_WIDTH, Math.max(MIN_LIST_WIDTH, startWRef.current + dx))
-      localStorage.setItem(LIST_WIDTH_KEY, String(finalW))
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    },
-  })
-  // Unmount guard: onEnd can't fire if the component unmounts mid-drag
-  // (setPointerCapture dies with the element), so restore the global body styles
-  // here to avoid leaving the resize cursor / text-selection lock stuck.
-  useEffect(() => () => {
-    if (listDraggingRef.current) {
-      listDraggingRef.current = false
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-  }, [])
+  const rail = useColumnResize(
+    RAIL_WIDTH_KEY, loadRailWidth, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, RAIL_COLLAPSE, loadRailCollapsed,
+  )
+  const list = useColumnResize(LIST_WIDTH_KEY, loadListWidth, MIN_LIST_WIDTH, MAX_LIST_WIDTH)
 
   const DashboardView = dashboardComponent(dashboardTab)
 
   return (
     <div className="flex h-full bg-bg text-text">
-      <LeftRail />
+      <LeftRail width={rail.width} collapsed={rail.collapsed} onExpand={rail.expand} />
+
+      {/* Drag handle — resize the left rail. Present in every main view, since
+          the rail itself is. Dragging well past the minimum collapses it. */}
+      <ResizeHandle handleProps={rail.handleProps} label="Resize sidebar" />
 
       {mainView === 'issues' ? (
         <>
-          <section style={{ width: listWidth }} className="flex-shrink-0 min-h-0">
-            <IssueList />
+          <section style={{ width: list.width }} className="flex-shrink-0 min-h-0">
+            <IssueList resizing={list.dragging} />
           </section>
 
           {/* Drag handle — resize the issue-list column. */}
-          <div
-            {...listResize}
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize list"
-            title="Drag to resize"
-            className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-accent/30 transition-colors"
-            style={{ touchAction: 'none' }}
-          />
+          <ResizeHandle handleProps={list.handleProps} label="Resize list" />
 
           <main className="flex-1 min-w-0 min-h-0">
             {activeIssue
@@ -103,20 +75,12 @@ export default function Workspace() {
         </main>
       ) : mainView === 'pulls' ? (
         <>
-          <section style={{ width: listWidth }} className="flex-shrink-0 min-h-0">
-            <PrList />
+          <section style={{ width: list.width }} className="flex-shrink-0 min-h-0">
+            <PrList resizing={list.dragging} />
           </section>
 
           {/* Drag handle — resize the PR-list column. */}
-          <div
-            {...listResize}
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize list"
-            title="Drag to resize"
-            className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-accent/30 transition-colors"
-            style={{ touchAction: 'none' }}
-          />
+          <ResizeHandle handleProps={list.handleProps} label="Resize list" />
 
           <main className="flex-1 min-w-0 min-h-0">
             {activePull

--- a/website/src/apps/issue-radar/components/IssueList.tsx
+++ b/website/src/apps/issue-radar/components/IssueList.tsx
@@ -16,8 +16,13 @@ const ANIM_CAP = 200
 
 /** Middle column: a search box, the filtered + sorted issue list (cards
  * animate as the search narrows them), and a footer carrying the count, the
- * time since the last refresh, and the refresh button. */
-export default function IssueList() {
+ * time since the last refresh, and the refresh button.
+ *
+ * `resizing` is true while the user drags the column's width handle: card layout
+ * animation is switched off for the duration, since animating a size change
+ * scale-transforms the card and visibly stretches its text on every pointer
+ * move. Dropped from the drag, the cards simply re-wrap. */
+export default function IssueList({ resizing = false }: { resizing?: boolean }) {
   const {
     filteredIssues, sortedIssues, issuesLoading, issuesError,
     stateFilter, issues, colorByName,
@@ -104,7 +109,10 @@ export default function IssueList() {
               {sortedIssues.map((iss) => (
                 <motion.button
                   key={iss.number}
-                  layout
+                  // 'position' (not the default size+position): a size-animating
+                  // layout pass distorts the card's text with a scale transform
+                  // whenever the column rewraps. Off entirely mid-resize.
+                  layout={resizing ? false : 'position'}
                   initial={{ opacity: 0, y: 6 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.97 }}

--- a/website/src/apps/issue-radar/components/LeftRail.tsx
+++ b/website/src/apps/issue-radar/components/LeftRail.tsx
@@ -1,23 +1,49 @@
 import { LayoutDashboard, CircleDot, Settings, Radar, GitPullRequest } from 'lucide-react'
+import GithubLogo from '../../../components/icons/GithubLogo'
 import { useIssueRadar } from '../context'
-import { APP_VERSION } from '../lib/format'
+import { APP_VERSION, DEFAULT_RAIL_WIDTH } from '../lib/format'
 import AccordionSection from './Accordion'
 import DashboardsSection from './DashboardsSection'
 import FiltersSection from './FiltersSection'
 import PrFiltersSection from './PrFiltersSection'
 import SettingsSection from './SettingsSection'
+import ReadOnlyTag, { isReadOnly } from './ReadOnlyTag'
 import RepoSwitcher from './RepoSwitcher'
 
 /** The left rail: a prominent repo switcher pinned at the top, then a
  * four-section accordion (Dashboards / Issues / Pull requests / Settings) that
  * follows the main view (see context follow-mode), with the app identity at the
  * very bottom. Clicking a section header navigates to that section's default
- * page (not just expand it), so you never stay on the previous view. */
-export default function LeftRail() {
-  const { expanded, dashboardTab, openDashboard, openIssues, openPulls, openSettings } = useIssueRadar()
+ * page (not just expand it), so you never stay on the previous view. The rail's
+ * width is owned by Workspace, which renders the drag handle on its right edge;
+ * the default matches the former fixed `w-72`. Dragging the handle far enough
+ * past the minimum collapses the rail to `CollapsedRail`. */
+export default function LeftRail({
+  width = DEFAULT_RAIL_WIDTH, collapsed = false, onExpand,
+}: {
+  width?: number
+  collapsed?: boolean
+  onExpand?: () => void
+}) {
+  const {
+    expanded, dashboardTab, active, repos, openDashboard, openIssues, openPulls, openSettings,
+  } = useIssueRadar()
+
+  if (collapsed) {
+    const activeEntry = repos.find((r) => r.owner === active.owner && r.repo === active.repo)
+    return (
+      <CollapsedRail
+        width={width}
+        owner={active.owner}
+        repo={active.repo}
+        readOnly={isReadOnly(activeEntry?.permissions)}
+        onExpand={onExpand}
+      />
+    )
+  }
 
   return (
-    <aside className="w-72 flex-shrink-0 flex flex-col min-h-0 py-2 gap-2">
+    <aside style={{ width }} className="flex-shrink-0 flex flex-col min-h-0 py-2 gap-2">
       {/* Repo switcher — top of the rail, opens downward. */}
       <div className="px-2">
         <RepoSwitcher />
@@ -67,6 +93,65 @@ export default function LeftRail() {
         <Radar size={16} className="text-accent flex-shrink-0" />
         <span className="text-[14px] font-medium text-text">Issue Radar</span>
         <span className="ml-auto text-[12px] text-muted opacity-70">v{APP_VERSION}</span>
+      </div>
+    </aside>
+  )
+}
+
+/** The rail dragged shut: one vertical rounded-rect card carrying the provider
+ * logo and the full `owner/repo`, with the app mark below — the same
+ * elevated-pill treatment the repo switcher gets when the rail is open, so you
+ * still know which repo the workspace points at while the list and detail
+ * columns take the window. The repo label rotates clockwise (top-to-bottom
+ * reading) so it starts next to the logo. Clicking the repo half reopens the
+ * rail at its previous width (dragging the handle back out works too). */
+function CollapsedRail({
+  width, owner, repo, readOnly, onExpand,
+}: {
+  width: number
+  owner: string
+  repo: string
+  readOnly: boolean
+  onExpand?: () => void
+}) {
+  const full = `${owner}/${repo}`
+  return (
+    <aside style={{ width }} className="flex-shrink-0 flex flex-col min-h-0 py-2 px-1">
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden rounded-xl border border-border-strong bg-bg-elevated shadow-sm">
+        <button
+          type="button"
+          onClick={onExpand}
+          title={`${full} — click to expand the sidebar`}
+          aria-label="Expand sidebar"
+          className="flex-1 min-h-0 w-full flex flex-col items-center gap-3 pt-3.5 pb-2 cursor-pointer outline-none text-muted hover:text-text hover:bg-bg-hover transition-colors"
+        >
+          <GithubLogo size={18} className="flex-shrink-0 text-text" />
+          <div className="min-h-0 flex flex-col items-center gap-2">
+            {/* Rotated CLOCKWISE (writing-mode alone, no counter-rotation) so the
+                string reads top-to-bottom, starting right under the logo — the
+                same icon-then-label order as the open rail, just turned. It
+                truncates at the strip's height instead of pushing the read-only
+                flag out of view. */}
+            <span
+              className="min-h-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium tracking-[.02em]"
+              style={{ writingMode: 'vertical-rl' }}
+            >
+              {full}
+            </span>
+            {/* Write access constrains what the workspace can do, so the flag
+                survives the collapse — trailing the repo name exactly as it does
+                in the open rail's switcher, just turned with it. */}
+            {readOnly && <ReadOnlyTag vertical />}
+          </div>
+        </button>
+        {/* App mark only — the name doesn't earn its space at 48px, so it and
+            the version live in the title. */}
+        <div
+          className="flex-shrink-0 flex justify-center pb-3.5"
+          title={`Issue Radar v${APP_VERSION}`}
+        >
+          <Radar size={16} className="text-accent" />
+        </div>
       </div>
     </aside>
   )

--- a/website/src/apps/issue-radar/components/PrList.tsx
+++ b/website/src/apps/issue-radar/components/PrList.tsx
@@ -112,8 +112,10 @@ function ChecksDot({ state }: { state: PullRequest['checks_state'] }) {
 /** Middle column for the pull-request view: a search box, the filtered + sorted
  * PR list (cards animate as the search narrows them), and a footer carrying the
  * count, the time since the last refresh, and the refresh button. The PR
- * analogue of IssueList. */
-export default function PrList() {
+ * analogue of IssueList. `resizing` (true while the width handle is dragged)
+ * switches off the card layout animation, which would otherwise scale-distort
+ * the card text on every pointer move — see IssueList. */
+export default function PrList({ resizing = false }: { resizing?: boolean }) {
   const {
     filteredPulls, sortedPulls, pullsLoading, pullsError,
     prStateFilter, colorByName,
@@ -230,7 +232,10 @@ export default function PrList() {
               {sortedPulls.map((pr) => (
                 <motion.button
                   key={pr.number}
-                  layout
+                  // 'position' (not the default size+position): a size-animating
+                  // layout pass distorts the card's text with a scale transform
+                  // whenever the column rewraps. Off entirely mid-resize.
+                  layout={resizing ? false : 'position'}
                   initial={{ opacity: 0, y: 6 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.97 }}

--- a/website/src/apps/issue-radar/components/ReadOnlyTag.tsx
+++ b/website/src/apps/issue-radar/components/ReadOnlyTag.tsx
@@ -9,8 +9,22 @@ export function isReadOnly(perms?: RepoPermissions | null): boolean {
 
 /** Outlined (no-fill) "Read Only" tag shown next to a repo lacking write
  * access. Kept short with zero vertical padding and a capped line-height so it
- * fits inside a single text row and never changes the row's height. */
-export default function ReadOnlyTag() {
+ * fits inside a single text row and never changes the row's height.
+ *
+ * `vertical` turns the pill on its side for the collapsed rail strip, where the
+ * padding axes swap: the text runs down the block axis, so the length padding
+ * becomes vertical and the pill's thickness comes from the line-height. */
+export default function ReadOnlyTag({ vertical = false }: { vertical?: boolean }) {
+  if (vertical) {
+    return (
+      <span
+        className="inline-flex items-center flex-shrink-0 rounded-full border border-border py-1.5 text-[10px] leading-[14px] text-muted whitespace-nowrap"
+        style={{ writingMode: 'vertical-rl' }}
+      >
+        Read Only
+      </span>
+    )
+  }
   return (
     <span className="inline-flex items-center flex-shrink-0 rounded-full border border-border px-1.5 py-0 text-[10px] leading-[14px] text-muted whitespace-nowrap">
       Read Only

--- a/website/src/apps/issue-radar/components/ResizeHandle.tsx
+++ b/website/src/apps/issue-radar/components/ResizeHandle.tsx
@@ -1,0 +1,23 @@
+import type { usePointerDrag } from '../../../hooks/usePointerDrag'
+
+/** The 6px vertical drag strip on a workspace column's right edge. Shared by
+ * the left rail and the issue / PR list so every column edge looks and behaves
+ * identically. */
+export default function ResizeHandle({
+  handleProps, label,
+}: {
+  handleProps: ReturnType<typeof usePointerDrag>
+  label: string
+}) {
+  return (
+    <div
+      {...handleProps}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      title="Drag to resize"
+      className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-accent/30 transition-colors"
+      style={{ touchAction: 'none' }}
+    />
+  )
+}

--- a/website/src/apps/issue-radar/lib/format.ts
+++ b/website/src/apps/issue-radar/lib/format.ts
@@ -10,6 +10,17 @@ export const DEFAULT_LIST_WIDTH = 320
 export const MIN_LIST_WIDTH = 240
 export const MAX_LIST_WIDTH = 600
 
+export const RAIL_WIDTH_KEY = 'kc:issue-radar:rail-width'
+export const RAIL_COLLAPSED_KEY = 'kc:issue-radar:rail-collapsed'
+/** Matches the rail's original fixed `w-72`, so an existing user sees no jump. */
+export const DEFAULT_RAIL_WIDTH = 288
+export const MIN_RAIL_WIDTH = 220
+export const MAX_RAIL_WIDTH = 460
+/** Width of the collapsed rail: a vertical rounded-rect strip showing only the
+ * repo logo and the full owner/repo turned on its side. Dragging the rail well
+ * past its minimum snaps to this instead of stopping at a stubborn wall. */
+export const COLLAPSED_RAIL_WIDTH = 48
+
 export const APP_VERSION = '0.1.0'
 
 /** Coerce an API/cache value to an array. A non-array — an unexpected response
@@ -109,10 +120,27 @@ export function relativeDate(iso: string): string {
   return `${y} year${y > 1 ? 's' : ''} ago`
 }
 
+/** Read a persisted column width, falling back to `fallback` when the stored
+ * value is missing, unparseable, or outside the allowed range (a stale value
+ * from an older min/max, or a hand-edited key). */
+function loadWidth(key: string, min: number, max: number, fallback: number): number {
+  const raw = Number(localStorage.getItem(key))
+  if (raw >= min && raw <= max) return raw
+  return fallback
+}
+
 export function loadListWidth(): number {
-  const raw = Number(localStorage.getItem(LIST_WIDTH_KEY))
-  if (raw >= MIN_LIST_WIDTH && raw <= MAX_LIST_WIDTH) return raw
-  return DEFAULT_LIST_WIDTH
+  return loadWidth(LIST_WIDTH_KEY, MIN_LIST_WIDTH, MAX_LIST_WIDTH, DEFAULT_LIST_WIDTH)
+}
+
+export function loadRailWidth(): number {
+  return loadWidth(RAIL_WIDTH_KEY, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, DEFAULT_RAIL_WIDTH)
+}
+
+/** Collapsed state is stored apart from the width so collapsing and re-expanding
+ * the rail returns it to the width the user had chosen, not the default. */
+export function loadRailCollapsed(): boolean {
+  return localStorage.getItem(RAIL_COLLAPSED_KEY) === '1'
 }
 
 export function loadActiveRepo(): ActiveRepo | null {

--- a/website/src/apps/issue-radar/lib/useColumnResize.ts
+++ b/website/src/apps/issue-radar/lib/useColumnResize.ts
@@ -1,0 +1,148 @@
+// Drag-to-resize behaviour shared by Issue Radar's fixed-width columns (the
+// left rail and the issue / PR list). Every column behaves the same way — the
+// handle sits on its right edge, dragging right widens it, the width is clamped
+// while dragging and persisted to localStorage on release — so the logic lives
+// here once instead of being duplicated per column.
+//
+// A column may also opt into COLLAPSING (the left rail does): drag far enough
+// past the minimum and the column snaps to a narrow icon strip instead of
+// stopping dead at the minimum. Expanding again requires dragging a comparable
+// distance back out, so the snap has hysteresis and doesn't flicker around the
+// boundary.
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePointerDrag } from '../../../hooks/usePointerDrag'
+
+export interface CollapseConfig {
+  /** Width of the collapsed strip, in px. */
+  width: number
+  /** Where the collapsed flag is persisted. */
+  storageKey: string
+  /** Overshoot past `min` (to collapse) / past `width` (to expand) required
+   *  before the snap fires. */
+  slop?: number
+}
+
+const DEFAULT_SLOP = 48
+
+export interface ColumnResize {
+  /** Current width in px: inside [min, max], or the collapsed width. */
+  width: number
+  /** True while the column is showing its collapsed strip. */
+  collapsed: boolean
+  /** True only while a resize drag is in flight. Consumers use it to switch off
+   *  layout animations that would otherwise scale-distort their content while
+   *  the column width changes on every pointer move. */
+  dragging: boolean
+  /** Re-open a collapsed column at the width the user last dragged it to. */
+  expand: () => void
+  /** Spread onto the drag handle element (see components/ResizeHandle). */
+  handleProps: ReturnType<typeof usePointerDrag>
+}
+
+export function useColumnResize(
+  storageKey: string,
+  load: () => number,
+  min: number,
+  max: number,
+  collapse?: CollapseConfig,
+  loadCollapsed?: () => boolean,
+): ColumnResize {
+  // The stored width is always an EXPANDED width, so collapsing and reopening
+  // restores the user's chosen size rather than the default.
+  const [openWidth, setOpenWidth] = useState<number>(load)
+  const [collapsed, setCollapsed] = useState<boolean>(() => !!collapse && !!loadCollapsed?.())
+  const [dragging, setDragging] = useState(false)
+  const width = collapse && collapsed ? collapse.width : openWidth
+
+  const startWRef = useRef(0)
+  const startCollapsedRef = useRef(false)
+  const startOpenRef = useRef(0)
+  const draggingRef = useRef(false)
+  // usePointerDrag reads its options through a ref, but the resolver needs the
+  // live values at pointer-down; keep them in refs so onStart never captures a
+  // stale render.
+  const liveRef = useRef({ width, collapsed, openWidth })
+  liveRef.current = { width, collapsed, openWidth }
+
+  /** Where the column lands for a drag delta of `dx`, as the OPEN width plus the
+   *  collapsed flag. Pure in (dx, drag start), so onMove and onEnd can never
+   *  disagree about the result. */
+  const resolve = useCallback((dx: number): { openWidth: number, collapsed: boolean } => {
+    const raw = startWRef.current + dx
+    const clamp = (v: number) => Math.min(max, Math.max(min, v))
+    if (!collapse) return { openWidth: clamp(raw), collapsed: false }
+    const slop = collapse.slop ?? DEFAULT_SLOP
+    if (startCollapsedRef.current) {
+      // Collapsed: stay collapsed until the pointer has pulled clearly outwards,
+      // then reopen AT the remembered width and grow from there. Resolving to
+      // the raw pointer position instead would reopen at the clamped minimum and
+      // bank it, losing the width the user had before collapsing.
+      const overshoot = raw - (collapse.width + slop)
+      return overshoot < 0
+        ? { openWidth: startOpenRef.current, collapsed: true }
+        : { openWidth: clamp(startOpenRef.current + overshoot), collapsed: false }
+    }
+    // A drag that ends collapsed must not bank the widths it swept through on
+    // the way in: dragging a 400px rail slowly through the 220px minimum would
+    // otherwise leave 220 as the remembered width, so reopening lost the 400.
+    return raw <= min - slop
+      ? { openWidth: startOpenRef.current, collapsed: true }
+      : { openWidth: clamp(raw), collapsed: false }
+  }, [min, max, collapse])
+
+  const apply = useCallback((dx: number) => {
+    const next = resolve(dx)
+    setCollapsed(next.collapsed)
+    setOpenWidth(next.openWidth)
+    return next
+  }, [resolve])
+
+  const persist = useCallback((next: { openWidth: number, collapsed: boolean }) => {
+    try {
+      // Always the OPEN width — the collapsed strip width is never a column width.
+      localStorage.setItem(storageKey, String(next.openWidth))
+      if (collapse) localStorage.setItem(collapse.storageKey, next.collapsed ? '1' : '0')
+    } catch {
+      /* storage blocked or full — the layout still applies for this session */
+    }
+  }, [storageKey, collapse])
+
+  const handleProps = usePointerDrag({
+    threshold: 0,
+    onStart: () => {
+      startWRef.current = liveRef.current.width
+      startCollapsedRef.current = liveRef.current.collapsed
+      startOpenRef.current = liveRef.current.openWidth
+      draggingRef.current = true
+      setDragging(true)
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    },
+    onMove: ({ dx }) => { apply(dx) },
+    onEnd: ({ dx }) => {
+      draggingRef.current = false
+      setDragging(false)
+      persist(apply(dx))
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    },
+  })
+
+  // Unmount guard: onEnd can't fire if the component unmounts mid-drag
+  // (setPointerCapture dies with the element), so restore the global body
+  // styles here to avoid leaving the resize cursor / text-selection lock stuck.
+  useEffect(() => () => {
+    if (draggingRef.current) {
+      draggingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [])
+
+  const expand = useCallback(() => {
+    setCollapsed(false)
+    persist({ openWidth: liveRef.current.openWidth, collapsed: false })
+  }, [persist])
+
+  return { width, collapsed: !!collapse && collapsed, dragging, expand, handleProps }
+}

--- a/website/src/test/IssueRadarColumnResize.test.tsx
+++ b/website/src/test/IssueRadarColumnResize.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import {
+  loadRailWidth, loadRailCollapsed, RAIL_WIDTH_KEY, RAIL_COLLAPSED_KEY,
+  DEFAULT_RAIL_WIDTH, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, COLLAPSED_RAIL_WIDTH,
+} from '../apps/issue-radar/lib/format'
+import { useColumnResize, type CollapseConfig } from '../apps/issue-radar/lib/useColumnResize'
+import ResizeHandle from '../apps/issue-radar/components/ResizeHandle'
+
+const COLLAPSE: CollapseConfig = { width: COLLAPSED_RAIL_WIDTH, storageKey: RAIL_COLLAPSED_KEY }
+// The default overshoot the hook requires before snapping (see DEFAULT_SLOP).
+const SLOP = 48
+
+function Harness({ collapse }: { collapse?: CollapseConfig }) {
+  const col = useColumnResize(
+    RAIL_WIDTH_KEY, loadRailWidth, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, collapse, loadRailCollapsed,
+  )
+  return (
+    <div>
+      <aside data-testid="col" style={{ width: col.width }} />
+      <button data-testid="expand" onClick={col.expand}>{col.collapsed ? 'collapsed' : 'open'}</button>
+      <span data-testid="dragging">{col.dragging ? 'dragging' : 'idle'}</span>
+      <ResizeHandle handleProps={col.handleProps} label="Resize sidebar" />
+    </div>
+  )
+}
+
+function renderHarness(collapse?: CollapseConfig) {
+  const utils = render(<Harness collapse={collapse} />)
+  return {
+    ...utils,
+    col: utils.getByTestId('col'),
+    state: utils.getByTestId('expand'),
+    dragging: utils.getByTestId('dragging'),
+    handle: utils.getByRole('separator', { name: 'Resize sidebar' }),
+  }
+}
+
+/** One complete pointer drag of `dx` px starting from clientX 0. */
+function drag(handle: HTMLElement, dx: number, id = 1) {
+  fireEvent.pointerDown(handle, { clientX: 0, pointerId: id })
+  fireEvent.pointerMove(handle, { clientX: dx, pointerId: id })
+  fireEvent.pointerUp(handle, { clientX: dx, pointerId: id })
+}
+
+beforeEach(() => localStorage.clear())
+
+describe('loadRailWidth / loadRailCollapsed', () => {
+  it('falls back to the default when nothing is stored', () => {
+    expect(loadRailWidth()).toBe(DEFAULT_RAIL_WIDTH)
+    expect(loadRailCollapsed()).toBe(false)
+  })
+
+  it('honours a stored width inside the allowed range', () => {
+    localStorage.setItem(RAIL_WIDTH_KEY, String(MIN_RAIL_WIDTH + 40))
+    expect(loadRailWidth()).toBe(MIN_RAIL_WIDTH + 40)
+  })
+
+  it('ignores an out-of-range or unparseable stored width', () => {
+    // A value persisted under an older min/max — or hand-edited — must not
+    // resurrect a rail that is 4px or half the screen wide.
+    localStorage.setItem(RAIL_WIDTH_KEY, String(MAX_RAIL_WIDTH + 500))
+    expect(loadRailWidth()).toBe(DEFAULT_RAIL_WIDTH)
+    localStorage.setItem(RAIL_WIDTH_KEY, 'wide')
+    expect(loadRailWidth()).toBe(DEFAULT_RAIL_WIDTH)
+  })
+
+  it('reads the collapsed flag independently of the width', () => {
+    localStorage.setItem(RAIL_COLLAPSED_KEY, '1')
+    expect(loadRailCollapsed()).toBe(true)
+    // The width the user had before collapsing survives the collapse.
+    localStorage.setItem(RAIL_WIDTH_KEY, '400')
+    expect(loadRailWidth()).toBe(400)
+  })
+})
+
+describe('useColumnResize', () => {
+  it('exposes the handle as an accessible vertical separator', () => {
+    const { handle } = renderHarness()
+    expect(handle.getAttribute('aria-orientation')).toBe('vertical')
+    // touch-action:none lets a touch drag resize instead of scrolling the page.
+    expect(handle.style.touchAction).toBe('none')
+  })
+
+  it('a pointer drag widens the column by the pointer delta and persists it', () => {
+    const { col, handle } = renderHarness()
+    drag(handle, 60)
+    expect(col.style.width).toBe(`${DEFAULT_RAIL_WIDTH + 60}px`)
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).toBe(String(DEFAULT_RAIL_WIDTH + 60))
+  })
+
+  it('clamps to the min and max bounds', () => {
+    const { col, handle } = renderHarness()
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: -5000, pointerId: 1 })
+    expect(col.style.width).toBe(`${MIN_RAIL_WIDTH}px`)
+    fireEvent.pointerMove(handle, { clientX: 5000, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: 5000, pointerId: 1 })
+    expect(col.style.width).toBe(`${MAX_RAIL_WIDTH}px`)
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).toBe(String(MAX_RAIL_WIDTH))
+  })
+
+  it('resumes a second drag from the new width, not the initial one', () => {
+    const { col, handle } = renderHarness()
+    drag(handle, 40, 1)
+    drag(handle, 30, 2)
+    expect(col.style.width).toBe(`${DEFAULT_RAIL_WIDTH + 70}px`)
+  })
+
+  it('restores the body cursor and text selection after the drag', () => {
+    const { handle } = renderHarness()
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+    fireEvent.pointerUp(handle, { clientX: 0, pointerId: 1 })
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('restores the body styles when unmounted mid-drag', () => {
+    const { handle, unmount } = renderHarness()
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    unmount()
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('reports dragging only for the duration of the gesture', () => {
+    // Consumers switch off layout animation while this is true — a card layout
+    // animation scale-distorts its text on every width change.
+    const { handle, dragging } = renderHarness()
+    expect(dragging.textContent).toBe('idle')
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    expect(dragging.textContent).toBe('dragging')
+    fireEvent.pointerMove(handle, { clientX: 30, pointerId: 1 })
+    expect(dragging.textContent).toBe('dragging')
+    fireEvent.pointerUp(handle, { clientX: 30, pointerId: 1 })
+    expect(dragging.textContent).toBe('idle')
+  })
+})
+
+describe('useColumnResize — collapsing', () => {
+  const toMin = MIN_RAIL_WIDTH - DEFAULT_RAIL_WIDTH // dx that lands exactly on min
+
+  it('holds at the minimum until the pointer overshoots it', () => {
+    const { col, state, handle } = renderHarness(COLLAPSE)
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: toMin - (SLOP - 1), pointerId: 1 })
+    expect(col.style.width).toBe(`${MIN_RAIL_WIDTH}px`)
+    expect(state.textContent).toBe('open')
+  })
+
+  it('snaps to the collapsed strip when dragged past the minimum', () => {
+    const { col, state, handle } = renderHarness(COLLAPSE)
+    drag(handle, toMin - SLOP)
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    expect(state.textContent).toBe('collapsed')
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe('1')
+    // The collapsed strip width must never be persisted as a real column width.
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).not.toBe(String(COLLAPSED_RAIL_WIDTH))
+  })
+
+  it('does not re-expand on a small outward nudge (hysteresis)', () => {
+    localStorage.setItem(RAIL_COLLAPSED_KEY, '1')
+    const { col, handle } = renderHarness(COLLAPSE)
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    drag(handle, SLOP - 1)
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe('1')
+  })
+
+  it('re-expands to the remembered width once pulled clear of the strip', () => {
+    localStorage.setItem(RAIL_COLLAPSED_KEY, '1')
+    const { col, handle } = renderHarness(COLLAPSE)
+    drag(handle, SLOP)
+    expect(col.style.width).toBe(`${DEFAULT_RAIL_WIDTH}px`)
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe('0')
+  })
+
+  it('a drag-expand restores the saved width and grows from there', () => {
+    // Regression (mirror of the slow-collapse case): resolving to the raw pointer
+    // position reopened at the clamped minimum and banked it, so a 400px rail
+    // came back as 220px. The reopen must land ON the saved width.
+    localStorage.setItem(RAIL_WIDTH_KEY, '400')
+    localStorage.setItem(RAIL_COLLAPSED_KEY, '1')
+    const { col, handle } = renderHarness(COLLAPSE)
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: SLOP, pointerId: 1 })
+    expect(col.style.width).toBe('400px')
+    fireEvent.pointerMove(handle, { clientX: SLOP + 30, pointerId: 1 })
+    fireEvent.pointerUp(handle, { clientX: SLOP + 30, pointerId: 1 })
+    expect(col.style.width).toBe('430px')
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).toBe('430')
+  })
+
+  it('a slow collapse still reopens at the pre-drag width', () => {
+    // Regression: onMove used to bank every intermediate width, so dragging a
+    // 400px rail slowly THROUGH the minimum left 220 remembered and reopening
+    // lost the 400. A drag that ends collapsed must not bank what it swept past.
+    localStorage.setItem(RAIL_WIDTH_KEY, '400')
+    const { col, state, handle } = renderHarness(COLLAPSE)
+    expect(col.style.width).toBe('400px')
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: MIN_RAIL_WIDTH - 400, pointerId: 1 }) // rest on the min
+    fireEvent.pointerMove(handle, { clientX: MIN_RAIL_WIDTH - 400 - SLOP, pointerId: 1 }) // then past it
+    fireEvent.pointerUp(handle, { clientX: MIN_RAIL_WIDTH - 400 - SLOP, pointerId: 1 })
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).toBe('400')
+    fireEvent.click(state)
+    expect(col.style.width).toBe('400px')
+  })
+
+  it('expand() reopens at the width the user had chosen, not the default', () => {
+    localStorage.setItem(RAIL_WIDTH_KEY, '400')
+    localStorage.setItem(RAIL_COLLAPSED_KEY, '1')
+    const { col, state } = renderHarness(COLLAPSE)
+    expect(col.style.width).toBe(`${COLLAPSED_RAIL_WIDTH}px`)
+    fireEvent.click(state)
+    expect(col.style.width).toBe('400px')
+    expect(localStorage.getItem(RAIL_WIDTH_KEY)).toBe('400')
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe('0')
+  })
+
+  it('never collapses a column that did not opt in', () => {
+    const { col, handle } = renderHarness()
+    drag(handle, -5000)
+    expect(col.style.width).toBe(`${MIN_RAIL_WIDTH}px`)
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBeNull()
+  })
+})

--- a/website/src/test/IssueRadarLeftRail.test.tsx
+++ b/website/src/test/IssueRadarLeftRail.test.tsx
@@ -25,6 +25,7 @@ beforeEach(() => {
   ctx.value = {
     expanded: 'filters',
     dashboardTab: 'tagging',
+    repos: [],
     openDashboard,
     openIssues: vi.fn(),
     openPulls: vi.fn(),
@@ -48,5 +49,73 @@ describe('LeftRail', () => {
     render(<LeftRail />)
     await userEvent.click(screen.getByText('Dashboards'))
     expect(openDashboard).toHaveBeenCalledWith('overview')
+  })
+
+  it('applies the width it is given, defaulting to the former fixed width', () => {
+    const { container, unmount } = render(<LeftRail />)
+    expect((container.querySelector('aside') as HTMLElement).style.width).toBe('288px')
+    unmount()
+    const second = render(<LeftRail width={340} />)
+    expect((second.container.querySelector('aside') as HTMLElement).style.width).toBe('340px')
+  })
+})
+
+describe('LeftRail — collapsed strip', () => {
+  const ACTIVE = { owner: 'kirodotdev', repo: 'KiroCrew' }
+  const entry = (push: boolean) => ({ ...ACTIVE, permissions: { push, triage: false } })
+
+  beforeEach(() => {
+    ctx.value = { ...ctx.value, active: ACTIVE, repos: [entry(true)] }
+  })
+
+  it('shows the full owner/repo turned on its side and drops the accordion', () => {
+    const { container } = render(<LeftRail width={48} collapsed />)
+    // The org matters: two repos can share a name across owners.
+    const name = screen.getByText('kirodotdev/KiroCrew')
+    expect(name.style.writingMode).toBe('vertical-rl')
+    // The nav sections have no room in a 48px strip.
+    expect(screen.queryByText('Dashboards')).toBeNull()
+    expect(container.querySelector('[data-testid="repo-switcher"]')).toBeNull()
+    expect((container.querySelector('aside') as HTMLElement).style.width).toBe('48px')
+    // The strip reads as one rounded card, matching the open rail's switcher pill.
+    expect(container.querySelector('aside > div')!.className).toContain('rounded-xl')
+  })
+
+  it('repeats the owner/repo in the tooltip for a name too long to fit', async () => {
+    render(<LeftRail width={48} collapsed />)
+    const btn = screen.getByRole('button', { name: 'Expand sidebar' })
+    expect(btn.getAttribute('title')).toContain('kirodotdev/KiroCrew')
+  })
+
+  it('keeps the app mark but not its name — no room at 48px', () => {
+    const { container } = render(<LeftRail width={48} collapsed />)
+    expect(screen.queryByText('Issue Radar')).toBeNull()
+    // Name and version stay reachable through the mark's tooltip.
+    expect(container.querySelector('[title="Issue Radar v0.1.0"]')).toBeTruthy()
+  })
+
+  it('carries the read-only flag through the collapse, trailing the repo name', () => {
+    // Losing the flag would hide a real constraint on what the workspace can do,
+    // and it belongs with the repo it describes — not parked at the card's foot.
+    ctx.value = { ...ctx.value, repos: [entry(false)] }
+    render(<LeftRail width={48} collapsed />)
+    const tag = screen.getByText('Read Only')
+    const name = screen.getByText('kirodotdev/KiroCrew')
+    expect(tag.style.writingMode).toBe('vertical-rl')
+    expect(name.parentElement).toBe(tag.parentElement)
+    // DOCUMENT_POSITION_FOLLOWING — the tag comes after the name.
+    expect(name.compareDocumentPosition(tag) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('does not flag a writable repo', () => {
+    render(<LeftRail width={48} collapsed />)
+    expect(screen.queryByText('Read Only')).toBeNull()
+  })
+
+  it('clicking the strip asks to expand', async () => {
+    const onExpand = vi.fn()
+    render(<LeftRail width={48} collapsed onExpand={onExpand} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Expand sidebar' }))
+    expect(onExpand).toHaveBeenCalledTimes(1)
   })
 })

--- a/website/src/test/IssueRadarListResize.test.tsx
+++ b/website/src/test/IssueRadarListResize.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Surface Framer's `layout` prop as an attribute so the test can assert which
+// layout mode each card is mounted with.
+vi.mock('framer-motion', () => ({
+  useReducedMotion: () => false,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    button: ({
+      children, layout, initial, animate, exit, transition, ...rest
+    }: Record<string, unknown> & { children?: React.ReactNode }) => {
+      void initial; void animate; void exit; void transition
+      return <button data-layout={String(layout)} {...rest}>{children}</button>
+    },
+  },
+}))
+
+const ctx = { value: {} as Record<string, unknown> }
+vi.mock('../apps/issue-radar/context', () => ({ useIssueRadar: () => ctx.value }))
+
+const IssueList = (await import('../apps/issue-radar/components/IssueList')).default
+
+const ISSUE = {
+  number: 7,
+  title: 'A title long enough to rewrap when the column narrows',
+  author: 'octocat',
+  updated_at: new Date().toISOString(),
+  labels: [] as string[],
+}
+
+beforeEach(() => {
+  ctx.value = {
+    filteredIssues: [ISSUE], sortedIssues: [ISSUE], issues: [ISSUE],
+    issuesLoading: false, issuesError: null, stateFilter: 'open',
+    colorByName: new Map<string, string>(),
+    selectedIssue: null, setSelectedIssue: vi.fn(),
+    refresh: vi.fn(), refreshing: false,
+    query: '', setQuery: vi.fn(), issuesUpdatedAt: Date.now(),
+  }
+})
+
+describe('IssueList — layout animation during a column resize', () => {
+  it('animates position only when idle', () => {
+    // The default `layout` (size + position) animates a width change with a
+    // scale transform, which visibly stretches the card text every time the
+    // column rewraps. Position-only keeps reorder animation without the stretch.
+    const { container } = render(<IssueList />)
+    expect(container.querySelector('[data-layout]')!.getAttribute('data-layout')).toBe('position')
+  })
+
+  it('drops layout animation entirely while the handle is being dragged', () => {
+    const { container } = render(<IssueList resizing />)
+    expect(container.querySelector('[data-layout]')!.getAttribute('data-layout')).toBe('false')
+  })
+})


### PR DESCRIPTION
## Problem

Issue Radar's left rail was a fixed `w-72` (288px) sitting next to a drag-resizable list column. Two things followed from that:

- Long `owner/repo` names and label chips truncated in the rail with no way to give it more room.
- The rail's 288px could not be reclaimed. On a narrow window it competed with the list and detail columns for space even when the user only needed to know *which* repo they were on.

Separately, dragging the **list** column's handle visibly **stretched and squashed the text** inside every card while dragging.

## Why it matters

The rail is the app's only navigation surface, so a truncated repo name or label is a daily papercut for anyone with long org/repo names or a deep label taxonomy. And the text-stretching made a core interaction (resizing the list) feel broken — the kind of visual glitch that reads as "this app is janky" even though the layout settled correctly on release.

## Fix (symptoms → root cause → change)

**1. Rail not resizable.** The rail had no handle at all — the width was a Tailwind class, not state. Added a drag handle on the rail's right edge, identical in look and behaviour to the list handle (same 6px strip, hover accent, `role="separator"`, pointer-events drag, `localStorage` persistence), clamped to 220–460px. The handle renders outside the main-view conditional, so the rail is resizable in Issues, Pull requests, Dashboards, and Settings alike.

**2. Rail could not be dismissed.** Dragging left just stopped dead at the minimum. Overshooting the minimum by 48px now snaps the rail shut to a 48px vertical rounded-rect strip carrying the provider logo, the full `owner/repo` turned on its side, the `Read Only` flag when the repo lacks write access, and the app mark. Re-expanding takes the same 48px of travel back out (hysteresis, so the snap can't flicker at the boundary) or one click on the strip.

The collapsed flag lives in its **own** `localStorage` key (`kc:issue-radar:rail-collapsed`) rather than encoding "collapsed" as a width, so reopening restores the width the user had chosen instead of the default. A drag that *ends* collapsed also does not bank the widths it swept through on the way in — otherwise dragging a 400px rail slowly through the 220px minimum would leave 220 remembered and lose the 400.

**3. Text stretching on list resize.** Root cause: the list cards animate with Framer Motion's default `layout`, which animates **size as well as position**. A size-animating layout pass applies a scale transform to the card, and nothing inverse-scales the text inside it, so every width change during the drag distorted the glyphs. Cards now use `layout="position"` — reorder animation when filtering/sorting survives, distortion cannot happen — and drop layout animation entirely while a handle is held, so a resize does nothing but re-wrap. Same fix in `PrList`.

**4. Duplication removed.** `Workspace.tsx` had the drag handle markup and its drag/persist logic inlined twice (issue list + PR list). Extracted into `useColumnResize` (built on the existing shared `usePointerDrag` hook) and a `ResizeHandle` component, now used for all three column edges. `ReadOnlyTag` gained a `vertical` variant for the strip; note the padding axes swap under `writing-mode: vertical-rl`, so the pill's end caps come from `py-*` and its thickness from the capped `leading`.

Frontend-only change; no backend, API, dependency, migration, or CI surface touched.

## Tests

`website/src/test/IssueRadarColumnResize.test.tsx` (new, 18 tests) — locks in the hook contract:
- drag widens by the pointer delta and persists; clamping at both bounds; a second drag resumes from the new width
- `loadRailWidth` / `loadRailCollapsed`: default, valid stored value, and rejection of an out-of-range or unparseable value (so a width persisted under an older min/max can't resurrect a 4px rail)
- collapse: holds at the minimum until the overshoot, snaps at it, and never writes the strip width into the width key
- hysteresis both ways: a small outward nudge does not re-expand; clearing the strip does
- **regression**: a *slow* collapse (rest on the minimum, then push past it) still reopens at the pre-drag width — mutation-verified, this test fails without the fix
- `dragging` is true only for the duration of the gesture
- body cursor / `user-select` are restored on release *and* on unmount mid-drag
- a column that did not opt into collapsing never collapses

`website/src/test/IssueRadarListResize.test.tsx` (new) — asserts the cards' `layout` prop is `"position"` when idle and `false` while resizing (framer-motion mocked to surface it), so the stretch fix can't silently regress.

`website/src/test/IssueRadarLeftRail.test.tsx` (extended) — width prop applied and defaulted; collapsed strip renders the full `owner/repo` with `writing-mode: vertical-rl`, drops the accordion, and reads as one rounded card; read-only flag appears for a read-only repo and sits with the repo name (same parent, after it in document order); absent for a writable repo; click asks to expand.

Gates: `tsc -b` clean, eslint clean on all touched files, full frontend suite **5229 passed / 3 skipped**.

## Manual verification

Ran the dev backend against a local build and drove the real UI: dragged the rail across its full range in each of the four main views, collapsed and re-expanded it by drag and by click, reloaded to confirm both the width and the collapsed state persist, and dragged the list column to confirm the card text re-wraps without stretching. Screenshots below are from that session (the `kirodotdev/Kiro` repo is read-only for this account, which is why the flag shows).

## Screenshots

> The two screenshots below were captured from a local dev-backend session. They are **not committed to the branch** — per Arbiter's escalation, `temp-screenshots/` PNGs would be baked into `main`'s history permanently on squash-merge, so they are attached to this description via GitHub upload instead.

**1. Rail dragged wider than the old fixed 288px**, with the list column beside it — the drag handle on the rail's right edge is visually identical to the list/detail divider.

<img width="2560" height="1279" alt="Screenshot 2026-07-28 at 12 32 34 AM" src="https://github.com/user-attachments/assets/f282739e-be7a-4d8d-a493-541e6113e189" />

**2. Rail collapsed to the 48px strip** — provider logo, `kirodotdev/Kiro` turned on its side (`writing-mode: vertical-rl`), and the vertical `Read Only` badge trailing the repo name (that account has no write access to `kirodotdev/Kiro`).

<img width="2560" height="1274" alt="Screenshot 2026-07-28 at 12 32 46 AM" src="https://github.com/user-attachments/assets/7535b92c-70d8-4ab5-a4c5-1ce2ba25ca0a" />

