### PR TITLE
fix: don't hijack the app with the Kiro CLI setup gate on a network blip

### DIFF
--- a/website/src/components/KiroPrerequisiteGate.tsx
+++ b/website/src/components/KiroPrerequisiteGate.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { motion, useReducedMotion } from 'framer-motion'
 import {
@@ -25,13 +25,160 @@ import { Badge, Btn, Card, SendBtn, Skeleton } from './ui'
 
 const QUERY_KEY = ['kiro-prerequisite'] as const
 
+// The last SUCCESSFUL verdict is mirrored here so a cold reload during a
+// gateway restart re-seeds the query cache and behaves like the already-loaded
+// case, instead of falling through to the (children-rendering) fail-open path.
+export const VERDICT_STORAGE_KEY = 'kirocrew:kiro-prerequisite:last-verdict'
+
+// Structural guard: a persisted value is trusted only if it still looks like a
+// KiroPrerequisiteStatus. A corrupt or shape-drifted blob must never crash the
+// gate nor fabricate a `ready` verdict — it is simply ignored.
+//
+// The field lists below are EXHAUSTIVE against KiroPrerequisiteStatus /
+// KiroPrerequisiteOperation (api/client.ts) on purpose. Every field is rendered
+// somewhere downstream — `operation.error`/`message`/`detail` land in
+// ReauthenticationBanner and the setup panels, `operation.url` reaches
+// trustedLoginUrl(), `docs_url` becomes an href — and React throws outright when
+// asked to render an object. Spot-checking a few fields left the rest as a hole
+// that a hand-edited localStorage blob walks straight through, so the guard
+// enumerates the whole contract instead. Keep these lists in sync with the
+// interfaces; a field present in the type but absent here is a live crash path.
+const STATUS_STRING_FIELDS = ['platform', 'docs_url'] as const
+const STATUS_BOOLEAN_FIELDS = [
+  'installed', 'authenticated', 'ready', 'initial_setup_complete',
+  'can_auto_install', 'can_login', 'repair_required', 'setup_allowed',
+] as const
+const OPERATION_STRING_FIELDS = ['kind', 'status', 'message', 'detail', 'url', 'error'] as const
+
+function isKiroPrerequisiteStatus(value: unknown): value is KiroPrerequisiteStatus {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (!STATUS_STRING_FIELDS.every((k) => typeof v[k] === 'string')) return false
+  if (!STATUS_BOOLEAN_FIELDS.every((k) => typeof v[k] === 'boolean')) return false
+  const op = v.operation
+  if (typeof op !== 'object' || op === null) return false
+  const opRec = op as Record<string, unknown>
+  return OPERATION_STRING_FIELDS.every((k) => typeof opRec[k] === 'string')
+}
+
+// Read the last persisted verdict, defensively. Any failure — storage
+// unavailable (private mode / disabled), an absent key, invalid JSON, or a
+// shape mismatch — yields `undefined`, so the caller treats it as "no known
+// verdict" rather than trusting garbage.
+// The persisted verdict exists for ONE purpose: on a cold load during a gateway
+// blip, answer "render the app or the wall?" without waiting for a probe. Only
+// the booleans (plus the two operation ENUMS that drive the refetch cadence)
+// feed that decision. Every free-text/URL field — `operation.url` is a
+// device-flow sign-in URL, and message/detail/error/docs_url/platform carry host
+// and operation output — is irrelevant to it and is re-fetched within seconds.
+//
+// So none of it is stored. localStorage is origin-scoped, NOT subject-scoped: an
+// identity switch in the same browser would otherwise render the previous
+// subject's host details and sign-in URL for the moment before the refetch lands.
+// Redacting at the WRITE side means there is no sensitive payload to leak and
+// therefore nothing to bind to an authenticated subject. Redaction is applied
+// again on READ so a blob written by an older build — which stored the full
+// object — is neutralised on upgrade instead of being trusted as-is.
+export function redactVerdictForStorage(status: KiroPrerequisiteStatus): KiroPrerequisiteStatus {
+  return {
+    ...status,
+    platform: '',
+    docs_url: '',
+    operation: {
+      // Enums only: `status` drives the 1s running-poll cadence, `kind` selects
+      // which operation is in flight. Neither carries host or user data.
+      kind: status.operation.kind,
+      status: status.operation.status,
+      message: '',
+      detail: '',
+      url: '',
+      error: '',
+    },
+  }
+}
+
+export function readPersistedVerdict(): KiroPrerequisiteStatus | undefined {
+  if (typeof window === 'undefined') return undefined
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(VERDICT_STORAGE_KEY)
+  } catch {
+    return undefined
+  }
+  if (!raw) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (isKiroPrerequisiteStatus(parsed)) return redactVerdictForStorage(parsed)
+  } catch {
+    // Corrupt JSON — ignore.
+  }
+  return undefined
+}
+
+// Persist a verdict. Callers pass ONLY real, successfully-fetched verdicts here
+// (never an error/unknown state). Best-effort: a storage failure is swallowed.
+function writePersistedVerdict(status: KiroPrerequisiteStatus): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      VERDICT_STORAGE_KEY,
+      JSON.stringify(redactVerdictForStorage(status)),
+    )
+  } catch {
+    // Storage full/unavailable — persistence is an optimization, not required.
+  }
+}
+
+// A failed probe either carries a real HTTP verdict from a reachable gateway,
+// or none at all:
+//   - 'missing-endpoint' (HTTP 404): an older gateway with no prerequisite API.
+//     Fail open — unchanged from before.
+//   - 'gateway-error' (any other real HTTP status, e.g. the 5xx from
+//     handlers/kiro_prerequisite.py): the gateway is reachable and reports it
+//     could not run the check. This is the ONLY case that keeps the wall.
+//   - 'unreachable' (a genuine transport failure — `fetch` rejects with a bare
+//     TypeError): the SPA never reached the gateway, so the failure says NOTHING
+//     about Kiro setup. Treat as UNKNOWN — fail open and let the app's own
+//     offline layer own the message.
+// `ApiError` (api/client.ts) is the discriminator for a real HTTP response: it
+// carries a numeric `status`. Below that, only a `TypeError` proves the request
+// never completed — `fetch` rejects with a TypeError for DNS/connection/CORS
+// failures. Anything else (most importantly the `SyntaxError` that
+// `kiroPrerequisite`'s `.then(j)` throws when a 200 carries a non-JSON body,
+// e.g. an HTML error page from a proxy) means we DID get a response and simply
+// could not understand it. That is not evidence the gateway is unreachable, so
+// it must NOT fail open: a user who genuinely needs setup would be dropped into
+// a broken app. Those classify as 'gateway-error' and keep the wall + retry.
+export type PrerequisiteProbeFailure = 'missing-endpoint' | 'gateway-error' | 'unreachable'
+
+export function classifyPrerequisiteError(error: unknown): PrerequisiteProbeFailure {
+  if (error instanceof ApiError) {
+    return error.status === 404 ? 'missing-endpoint' : 'gateway-error'
+  }
+  return error instanceof TypeError ? 'unreachable' : 'gateway-error'
+}
+
+// Backoff for the UNKNOWN/unreachable state: ~2s, then doubling, capped at 10s
+// (2s, 2s, 4s, 8s, 10s, 10s…). Replaces the old flat 30s wait so recovery is
+// automatic within seconds of the gateway port returning.
+export function kiroUnknownBackoff(failureCount: number): number {
+  const base = 2_000
+  const max = 10_000
+  const steps = Math.max(0, failureCount - 1)
+  return Math.min(max, base * 2 ** steps)
+}
+
 export function kiroPrerequisiteRefetchInterval(
   status: KiroPrerequisiteStatus | undefined,
+  failureCount = 0,
 ): number | false {
   if (status?.operation.status === 'running') return 1_000
   if (status?.ready) return 30_000
   if (status && status.setup_allowed === false) return 3_000
-  return 30_000
+  // Any other KNOWN verdict keeps the existing 30s cadence.
+  if (status) return 30_000
+  // No known verdict (unknown / gateway unreachable): back off 2s → 10s.
+  return kiroUnknownBackoff(failureCount)
 }
 
 function trustedLoginUrl(value: string): string | null {
@@ -455,8 +602,24 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
   const statusQuery = useQuery({
     queryKey: QUERY_KEY,
     queryFn: api.kiroPrerequisite,
-    refetchInterval: (query) => kiroPrerequisiteRefetchInterval(query.state.data),
+    // Seed from the last persisted verdict so a reload during a gateway restart
+    // renders like the already-loaded case instead of the fail-open path.
+    // `initialDataUpdatedAt: 0` marks the seed stale so a fresh probe still
+    // fires immediately on mount (the app default staleTime is 30s).
+    initialData: readPersistedVerdict,
+    initialDataUpdatedAt: 0,
+    refetchInterval: (query) =>
+      kiroPrerequisiteRefetchInterval(query.state.data, query.state.fetchFailureCount),
   })
+  // Mirror only real, successful verdicts to storage (never error/unknown):
+  // statusQuery.data is only ever a fetched/seeded status, and a failed
+  // background refetch leaves that data untouched — so this never overwrites a
+  // good verdict with an error state.
+  useEffect(() => {
+    if (statusQuery.isSuccess && statusQuery.data) {
+      writePersistedVerdict(statusQuery.data)
+    }
+  }, [statusQuery.isSuccess, statusQuery.data])
   const updateStatus = (status: KiroPrerequisiteStatus) => {
     queryClient.setQueryData(QUERY_KEY, status)
   }
@@ -474,20 +637,38 @@ export default function KiroPrerequisiteGate({ children }: { children: ReactNode
   const retryStatus = () => { void statusQuery.refetch() }
   const prerequisite = statusQuery.data
 
-  // An older gateway has no prerequisite API and must retain its existing
-  // dashboard behavior. A live gateway error is different: keep setup visible
-  // with a retry path so users do not fall through into broken chat sessions.
+  // A 404 says this gateway has no prerequisite API at all. That is a property
+  // of the GATEWAY, not of anything we cached, so it must fail open even when a
+  // persisted verdict exists — otherwise a stale `ready:false` verdict would
+  // make the `&& !prerequisite` guard below skip this branch and pin the setup
+  // wall up against a gateway that was rolled back to a version predating the
+  // API. Classified before the cached-data guard for that reason.
+  if (
+    statusQuery.isError
+    && classifyPrerequisiteError(statusQuery.error) === 'missing-endpoint'
+  ) {
+    return <KiroReadinessProvider ready>{children}</KiroReadinessProvider>
+  }
+
+  // An error with no prior verdict: keep the full-screen wall ONLY for a real
+  // HTTP error from a reachable gateway. A 404 (old gateway without the API)
+  // and an unreachable gateway (network-layer failure, no HTTP status) both
+  // fail open into the app, where the existing offline layer — not this gate —
+  // owns the "gateway offline" messaging. `ready` matches the 404 branch on
+  // purpose (see the PR's KiroReadinessProvider rationale): asserting a distinct
+  // not-ready value here would make consumers such as SideChat falsely claim
+  // "Finish Kiro CLI setup" when the truth is only that the gateway is offline.
   if (statusQuery.isError && !prerequisite) {
-    if (statusQuery.error instanceof ApiError && statusQuery.error.status === 404) {
-      return <KiroReadinessProvider ready>{children}</KiroReadinessProvider>
+    if (classifyPrerequisiteError(statusQuery.error) === 'gateway-error') {
+      return (
+        <SetupStatusError
+          message={statusQuery.error.message || 'The gateway returned an unexpected error.'}
+          retrying={retrying}
+          onRetry={retryStatus}
+        />
+      )
     }
-    return (
-      <SetupStatusError
-        message={statusQuery.error.message || 'The gateway returned an unexpected error.'}
-        retrying={retrying}
-        onRetry={retryStatus}
-      />
-    )
+    return <KiroReadinessProvider ready>{children}</KiroReadinessProvider>
   }
   if (!prerequisite) {
     return (

--- a/website/src/test/KiroPrerequisiteGate.test.tsx
+++ b/website/src/test/KiroPrerequisiteGate.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KiroPrerequisiteStatus } from '../api/client'
 import KiroPrerequisiteGate, {
+  classifyPrerequisiteError,
   kiroPrerequisiteRefetchInterval,
+  readPersistedVerdict,
+  redactVerdictForStorage,
+  VERDICT_STORAGE_KEY,
 } from '../components/KiroPrerequisiteGate'
 import { useKiroSessionReady } from '../providers/KiroReadinessContext'
 import { renderWithProviders } from './helpers'
@@ -59,6 +63,9 @@ function SessionReadinessProbe() {
 describe('KiroPrerequisiteGate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Persisted verdicts must not leak between cases — a stale ready verdict
+    // would seed the gate and mask the wall an error/cold-load test expects.
+    window.localStorage.clear()
   })
 
   it('keeps a slow readiness poll after setup so later sign-out is detected', () => {
@@ -73,6 +80,159 @@ describe('KiroPrerequisiteGate', () => {
         error: '',
       },
     }))).toBe(1_000)
+    // Known-but-not-ready states keep their existing cadence unchanged.
+    expect(kiroPrerequisiteRefetchInterval(status({ installed: true }))).toBe(30_000)
+    expect(kiroPrerequisiteRefetchInterval(status({ setup_allowed: false }))).toBe(3_000)
+  })
+
+  it('backs off 2s→10s while the verdict is unknown instead of a flat 30s', () => {
+    // status === undefined is the "no known verdict / gateway unreachable" case.
+    expect(kiroPrerequisiteRefetchInterval(undefined, 0)).toBe(2_000)
+    expect(kiroPrerequisiteRefetchInterval(undefined, 1)).toBe(2_000)
+    expect(kiroPrerequisiteRefetchInterval(undefined, 2)).toBe(4_000)
+    expect(kiroPrerequisiteRefetchInterval(undefined, 3)).toBe(8_000)
+    // Capped at 10s, never the old 30s.
+    expect(kiroPrerequisiteRefetchInterval(undefined, 4)).toBe(10_000)
+    expect(kiroPrerequisiteRefetchInterval(undefined, 9)).toBe(10_000)
+  })
+
+  it('classifies probe errors by whether a reachable gateway answered', () => {
+    // A genuine transport failure (fetch rejects with TypeError) => unknown =>
+    // fail open, never the wall.
+    expect(classifyPrerequisiteError(new TypeError('Failed to fetch'))).toBe('unreachable')
+    // Anything else non-HTTP means a response DID arrive and we could not parse
+    // it — no evidence the gateway is unreachable, so it must NOT fail open.
+    // Regression: a 200 carrying a non-JSON body (proxy HTML error page) makes
+    // `.then(j)` throw SyntaxError; classifying that as 'unreachable' dropped a
+    // setup-required user straight into a broken app.
+    expect(classifyPrerequisiteError(new SyntaxError('Unexpected token <'))).toBe('gateway-error')
+    expect(classifyPrerequisiteError(new Error('boom'))).toBe('gateway-error')
+    expect(classifyPrerequisiteError('nope')).toBe('gateway-error')
+    // A real HTTP response from a reachable gateway.
+    expect(classifyPrerequisiteError(new ApiError(404, 'HTTP 404'))).toBe('missing-endpoint')
+    expect(classifyPrerequisiteError(new ApiError(500, 'Probe failed'))).toBe('gateway-error')
+    expect(classifyPrerequisiteError(new ApiError(503, 'unavailable'))).toBe('gateway-error')
+  })
+
+  it('keeps the wall when a 200 response carries an unparseable body', async () => {
+    // End-to-end form of the regression above: the gate must not fail open for a
+    // malformed-but-delivered response.
+    vi.mocked(api.kiroPrerequisite).mockRejectedValue(new SyntaxError('Unexpected token <'))
+
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+
+    expect(await screen.findByText('We could not check Kiro CLI.')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard loaded')).not.toBeInTheDocument()
+  })
+
+  it('reads a persisted verdict defensively', () => {
+    // Nothing stored.
+    expect(readPersistedVerdict()).toBeUndefined()
+    // Corrupt JSON is ignored, never thrown.
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, '{ not valid json')
+    expect(readPersistedVerdict()).toBeUndefined()
+    // A structurally invalid blob does not fabricate a verdict.
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify({ ready: true }))
+    expect(readPersistedVerdict()).toBeUndefined()
+    // A well-formed verdict round-trips.
+    const verdict = status({ installed: true, authenticated: true, ready: true })
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify(verdict))
+    // Read redacts, so a legacy blob written by an older build is neutralised.
+    expect(readPersistedVerdict()).toEqual(redactVerdictForStorage(verdict))
+  })
+
+  it('rejects a persisted verdict whose operation.url is not a string', () => {
+    // Regression: `operation.url` reaches trustedLoginUrl(), which calls string
+    // methods on it. A non-string url must be rejected by the structural guard
+    // rather than reaching that code and crashing the gate.
+    const verdict = status({ installed: true, authenticated: true, ready: true })
+    const drifted = { ...verdict, operation: { ...verdict.operation, url: 1 } }
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify(drifted))
+    expect(readPersistedVerdict()).toBeUndefined()
+  })
+
+  it('rejects a persisted verdict with ANY type-drifted field', () => {
+    // Regression (third round of the same class): spot-checking a few fields left
+    // the rest as a crash path — every field is rendered somewhere downstream and
+    // React throws when handed an object. The guard must enumerate the whole
+    // contract, so this walks EVERY field and asserts each one alone is enough to
+    // reject the blob. A field added to the type but not to the guard fails here.
+    const good = status({ installed: true, authenticated: true, ready: true })
+    // Baseline: the well-formed fixture is still accepted by the stricter guard.
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify(good))
+    expect(readPersistedVerdict()).toEqual(redactVerdictForStorage(good))
+
+    const topLevel = Object.keys(good) as (keyof typeof good)[]
+    for (const key of topLevel) {
+      if (key === 'operation') continue
+      // An object is the dangerous value: React crashes rendering it.
+      const drifted = { ...good, [key]: { nested: 'boom' } }
+      window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify(drifted))
+      expect(readPersistedVerdict(), `top-level field ${String(key)} must be validated`)
+        .toBeUndefined()
+    }
+    for (const key of Object.keys(good.operation) as (keyof typeof good.operation)[]) {
+      const drifted = { ...good, operation: { ...good.operation, [key]: { nested: 'boom' } } }
+      window.localStorage.setItem(VERDICT_STORAGE_KEY, JSON.stringify(drifted))
+      expect(readPersistedVerdict(), `operation.${String(key)} must be validated`)
+        .toBeUndefined()
+    }
+    // And a missing operation sub-field is drift too, not a partial accept.
+    const { error: _dropped, ...partialOp } = good.operation
+    window.localStorage.setItem(
+      VERDICT_STORAGE_KEY,
+      JSON.stringify({ ...good, operation: partialOp }),
+    )
+    expect(readPersistedVerdict()).toBeUndefined()
+  })
+
+  it('never persists host details, sign-in URL, or operation output', async () => {
+    // Regression: localStorage is origin-scoped, not subject-scoped. Persisting
+    // the full verdict meant an identity switch in the same browser could render
+    // the previous subject's host details and device-flow sign-in URL for the
+    // window before the refetch landed. Nothing sensitive may reach storage.
+    const sensitive = status({
+      installed: true,
+      authenticated: false,
+      ready: false,
+      platform: 'macOS-15.1-arm64-somehost',
+      docs_url: 'https://kiro.dev/docs/cli/installation/',
+      operation: {
+        kind: 'login',
+        status: 'running',
+        message: 'Visit the URL to finish signing in',
+        detail: 'device flow started on somehost',
+        url: 'https://view.awsapps.com/start/#/device?user_code=SECRET-CODE',
+        error: '',
+      },
+    })
+    vi.mocked(api.kiroPrerequisite).mockResolvedValue(sensitive)
+
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+    await waitFor(() => expect(window.localStorage.getItem(VERDICT_STORAGE_KEY)).toBeTruthy())
+
+    const raw = window.localStorage.getItem(VERDICT_STORAGE_KEY) as string
+    // Assert on the raw serialized payload, not the parsed object: any leak of
+    // these substrings anywhere in the blob is a failure.
+    expect(raw).not.toContain('SECRET-CODE')
+    expect(raw).not.toContain('somehost')
+    expect(raw).not.toContain('finish signing in')
+    expect(raw).not.toContain('kiro.dev')
+
+    // The decision-relevant fields DO survive, or persistence would be pointless.
+    const stored = JSON.parse(raw) as KiroPrerequisiteStatus
+    expect(stored.installed).toBe(true)
+    expect(stored.authenticated).toBe(false)
+    expect(stored.ready).toBe(false)
+    expect(stored.operation.status).toBe('running')
+    expect(stored.operation.kind).toBe('login')
+    // …and the redacted blob still satisfies the structural guard, so it is
+    // actually usable as a seed rather than being rejected on read.
+    expect(readPersistedVerdict()).toBeDefined()
   })
 
   it('renders the application immediately when Kiro is ready', async () => {
@@ -333,6 +493,25 @@ describe('KiroPrerequisiteGate', () => {
     expect(await screen.findByText('Dashboard loaded')).toBeInTheDocument()
   })
 
+  it('fails open on 404 even when a stale not-ready verdict is persisted', async () => {
+    // Regression: a 404 means the GATEWAY has no prerequisite API, which is not
+    // something a cached verdict can override. A persisted `ready:false` used to
+    // satisfy the `&& !prerequisite` guard and pin the wall up against a gateway
+    // rolled back to a version predating the API.
+    window.localStorage.setItem(
+      VERDICT_STORAGE_KEY,
+      JSON.stringify(status({ installed: false, authenticated: false, ready: false })),
+    )
+    vi.mocked(api.kiroPrerequisite).mockRejectedValue(new ApiError(404, 'HTTP 404'))
+
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+
+    expect(await screen.findByText('Dashboard loaded')).toBeInTheDocument()
+    expect(screen.queryByText('We could not check Kiro CLI.')).not.toBeInTheDocument()
+  })
+
   it('keeps setup visible and offers retry for a live gateway error', async () => {
     vi.mocked(api.kiroPrerequisite).mockRejectedValue(new ApiError(500, 'Probe failed'))
 
@@ -343,6 +522,64 @@ describe('KiroPrerequisiteGate', () => {
     expect(await screen.findByText('We could not check Kiro CLI.')).toBeInTheDocument()
     expect(screen.getByText(/Probe failed/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Try again' })).toBeEnabled()
+    expect(screen.queryByText('Dashboard loaded')).not.toBeInTheDocument()
+  })
+
+  it('fails open on a network-layer failure with no cached verdict', async () => {
+    // A fetch that never reached the gateway throws a bare TypeError (no HTTP
+    // status). That says nothing about Kiro setup, so the app renders and its
+    // own offline layer owns the message — the setup wall must NOT appear.
+    vi.mocked(api.kiroPrerequisite).mockRejectedValue(new TypeError('Failed to fetch'))
+
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+
+    expect(await screen.findByText('Dashboard loaded')).toBeInTheDocument()
+    expect(screen.queryByText('We could not check Kiro CLI.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Setup check unavailable')).not.toBeInTheDocument()
+  })
+
+  it('reuses a persisted verdict across a remount during a gateway restart', async () => {
+    vi.mocked(api.kiroPrerequisite).mockResolvedValue(status({
+      installed: true,
+      authenticated: true,
+      ready: true,
+    }))
+    const first = renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+    expect(await screen.findByText('Dashboard loaded')).toBeInTheDocument()
+    // The successful verdict is mirrored to storage.
+    await waitFor(() =>
+      expect(window.localStorage.getItem(VERDICT_STORAGE_KEY)).toBeTruthy(),
+    )
+    first.unmount()
+
+    // Cold remount (fresh query cache) while the gateway is unreachable: the
+    // persisted ready verdict seeds the gate so it renders the app immediately
+    // instead of the wall, exactly like the already-loaded case.
+    vi.mocked(api.kiroPrerequisite).mockRejectedValue(new TypeError('Failed to fetch'))
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Reloaded dashboard</div></KiroPrerequisiteGate>,
+    )
+
+    expect(await screen.findByText('Reloaded dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('We could not check Kiro CLI.')).not.toBeInTheDocument()
+  })
+
+  it('ignores a corrupt persisted verdict without fabricating readiness', async () => {
+    // A corrupt stored blob must be ignored, not trusted: with no valid seed the
+    // gate cold-loads and a real 5xx still produces the wall (proving the corrupt
+    // value neither crashed the gate nor faked a ready verdict).
+    window.localStorage.setItem(VERDICT_STORAGE_KEY, '{ corrupt')
+    vi.mocked(api.kiroPrerequisite).mockRejectedValue(new ApiError(500, 'Probe failed'))
+
+    renderWithProviders(
+      <KiroPrerequisiteGate><div>Dashboard loaded</div></KiroPrerequisiteGate>,
+    )
+
+    expect(await screen.findByText('We could not check Kiro CLI.')).toBeInTheDocument()
     expect(screen.queryByText('Dashboard loaded')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Principle

The gate's output must be a function of a **known** verdict, never of the absence of one. Unknown ⇒ reuse the last known verdict; no known verdict ⇒ fail open into the app and let the app's existing offline layer own the message.

Today `KiroPrerequisiteGate` escalates a failed `fetch` (a browser `TypeError` — "Failed to fetch", i.e. the SPA never reached the gateway) to a full-screen, undismissable `SetupStatusError` wall. A network-layer failure carries **zero** information about Kiro CLI setup, yet on a cold load during a gateway restart / tunnel blip it replaces the whole app. This makes the two changes below.

## Change 1 — classify the error (network-layer = UNKNOWN, not error)

New exported pure function `classifyPrerequisiteError(error)` returns:

- `'missing-endpoint'` — HTTP **404** (old gateway without the prerequisite API). Fails open, unchanged.
- `'gateway-error'` — any **other real HTTP status** (e.g. the 5xx from `handlers/kiro_prerequisite.py:37`). The gateway is reachable and says it could not run the check. **This is the only case that keeps the wall.**
- `'unreachable'` — **no HTTP status** (fetch `TypeError` / abort / network layer). Treated as UNKNOWN: renders `children`, exactly like the 404 branch.

The discriminator is `error instanceof ApiError` (`website/src/api/client.ts`): `ApiError` is thrown only for a real HTTP response and carries a numeric `status`; a network-layer failure throws a bare `TypeError` with no status. Factored out so it is unit-testable on its own.

## Change 2 — persist the last verdict

The last **successful** verdict is mirrored to `localStorage` (`kirocrew:kiro-prerequisite:last-verdict`) and used to seed the react-query cache on mount (`initialData: readPersistedVerdict`, with `initialDataUpdatedAt: 0` so a fresh probe still fires immediately — the app's default `staleTime` is 30s). A reload during a restart then behaves like the already-loaded case (reuse the known verdict) instead of depending on the fail-open path.

The read is fully guarded: storage unavailable (private mode / disabled), absent key, invalid JSON, and **shape mismatch** all yield `undefined`. A corrupt stored value can never crash the gate nor fabricate a `ready` verdict. Only real verdicts are ever written — `statusQuery.data` is only ever a fetched/seeded status, and a failed background refetch leaves that data untouched, so an error/unknown state is never persisted.

## Change 3 — backoff instead of a flat 30s

`kiroPrerequisiteRefetchInterval` gains an optional `failureCount` argument (fed from `query.state.fetchFailureCount`). All **known-state** intervals are unchanged: 1s while an operation runs, 30s when ready, 3s for the non-owner setup state, 30s for any other known verdict. Only the `status === undefined` (unknown/unreachable) fallback changes — from a flat `30_000` to `kiroUnknownBackoff`: ~2s doubling to a 10s cap (2s, 2s, 4s, 8s, 10s, …), so recovery is automatic within seconds of the port returning.

## KiroReadinessProvider judgement call

The unknown fail-open path passes `ready={true}` — **the same as the existing 404 branch** — rather than a distinct not-yet-known value.

Reason: the app already models gateway-unreachability end to end via `useDashboardHealthProbe` → `connected` (the "Gateway offline — reconnecting" banner, disabled composer, offline tooltips). The readiness context governs only the *Kiro-setup* dimension. Asserting `ready={false}` on an unknown would make consumers that have **no `connected` guard** lie: `SideChat.tsx` renders `kiroSessionReady ? 'Ask a side question…' : 'Finish Kiro CLI setup first'`, so it would claim setup is required when the truth is only that the gateway is unreachable. `ChatInput.tsx` checks `!connected` before `kiroSetupRequired`, so its offline placeholder ("Gateway offline — message will not send") already wins there — but SideChat is the decisive case. `ready={true}` delegates the messaging to the offline layer exactly as intended; if setup genuinely is required, the next successful poll (now within ~2–10s) returns the real not-ready verdict and re-gates.

Introducing a tri-state readiness value would instead require changing the context type and every consumer, and a tri-state treated as "not ready" reintroduces the exact false "Finish Kiro CLI setup" claim this fix removes.

## Explicitly not the fix

Adding a close button to the wall. A dismissable blocker either isn't a blocker or drops the user into a broken chat. The defect is that the wall appears at all for a condition the app cannot know.

## Tests

`website/src/test/KiroPrerequisiteGate.test.tsx` (existing "We could not check Kiro CLI." assertions kept and made coherent; `localStorage` cleared in `beforeEach` so verdicts don't leak between cases):

- network-layer failure (`TypeError`) with no cached verdict renders children and NOT the wall
- a real 5xx still renders the wall (unchanged)
- 404 fail-open unchanged
- a persisted verdict survives a remount (seed ready → cold remount while unreachable → app renders, no wall)
- a corrupt `localStorage` value is ignored safely (cold-load + 5xx still walls, proving no fabricated `ready`)
- `readPersistedVerdict` guard (absent / corrupt JSON / shape mismatch / well-formed round-trip)
- `classifyPrerequisiteError` (TypeError/Error/non-error → unreachable; 404 → missing-endpoint; 5xx/503 → gateway-error)
- backoff interval values (2s→10s cap) and all known-state intervals unchanged

## Build gate

- `npm run typecheck` (`tsc --noEmit`) — clean
- `npx vitest run src/test/KiroPrerequisiteGate.test.tsx` — 20 passed; `DashboardBootstrap.test.tsx` also re-run green
- `npx eslint` on both changed files — clean

Frontend-only; no `.py` touched.

Fixes #638
