### PR TITLE
feat: narrate Dev Fleet restart and sync so they aren't fired twice

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -34,6 +34,7 @@ verification. Route names below are relative to that prefix.
 
 | Route | Description |
 |-------|-------------|
+| `/apps/dev-fleet/api/health` | Liveness + gateway **start identity**: `{status, start_id}`. `start_id` is the live unit's `ExecMainStartTimestampMonotonic` (or `null` when unavailable); the dashboard polls it to detect the NEW process after a restart (see Action narration). Served on the proxied `/api/` namespace because the gateway only forwards `/apps/dev-fleet/api/*` to the backend. (The bare `/health` carries the same body but is HMAC-exempt and reached only by the gateway's own internal liveness poll.) |
 | `/apps/dev-fleet/api/fleet` | Lightweight worktree + pod list (polled every 12s). `?fresh=1` forces cache bypass. |
 | `/apps/dev-fleet/api/worktree?name=` | Lazy per-branch detail: PR, commits, disk usage |
 | `/apps/dev-fleet/api/pod/logs?name=&n=` | Pod journal tail (recent N lines, default 120) |
@@ -46,7 +47,7 @@ verification. Route names below are relative to that prefix.
 
 | Route | Body | Description |
 |-------|------|-------------|
-| `/apps/dev-fleet/api/sync` | — | Pull main + rebuild (single-flight) |
+| `/apps/dev-fleet/api/sync` | — | Pull main + rebuild (single-flight; a concurrent call is refused **409**) |
 | `/apps/dev-fleet/api/worktree/remove` | `{name, force?}` | Remove a worktree (stops pod first) |
 | `/apps/dev-fleet/api/prune-run` | `{names[]}` | Batch-remove eligible worktrees |
 | `/apps/dev-fleet/api/pod/up` | `{name}` | Start isolated pod instance (re-verifies the unit is active) |
@@ -55,8 +56,8 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/pod/token` | `{name}` | Mint a dashboard token for the pod |
 | `/apps/dev-fleet/api/pod/provision` | `{name}` | Start async venv+dist build (returns `{run_id}`) |
 | `/apps/dev-fleet/api/rebase` | `{name}` | Rebase worktree onto origin/main |
-| `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway in place (detached `systemd-run`) |
-| `/apps/dev-fleet/api/make-live` | `{path, dry_run?}` | Repoint the live gateway at another worktree (see Make Live) |
+| `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway in place (detached `systemd-run`); returns the pre-restart `start_id` for the restart handshake |
+| `/apps/dev-fleet/api/make-live` | `{path, dry_run?}` | Repoint the live gateway at another worktree (see Make Live); a real cutover returns `start_id` for the restart handshake |
 
 ## Authorization
 
@@ -258,6 +259,85 @@ Server-backed reattach (exposing active/failed provision run ids in `/fleet` so
 the page can reattach on mount, mirroring `sync_run_id`) is tracked as follow-up
 work ([issue #321](https://github.com/kirodotdev/KiroCrew/issues/321); see also
 [issue #231](https://github.com/kirodotdev/KiroCrew/issues/231), PR #320).
+
+## Action narration (restart + sync feedback)
+
+Dev Fleet's two slowest actions — **Restart Gateway** and **Sync (Pull+Build)** —
+narrate their progress so users don't read them as hung and fire them again. A
+duplicate Restart Gateway causes a second real ~10s gateway outage
+([issue #639](https://github.com/kirodotdev/KiroCrew/issues/639)).
+
+### Restart identity handshake
+
+`POST /apps/dev-fleet/api/restart-gateway` returns `{"ok": true, "start_id": …}`
+the instant `systemd-run --collect systemctl --user restart <unit>` has
+**scheduled** the restart — the bounce happens after the response and takes ~10s
+because graceful shutdown times out. "The request succeeded" therefore says
+nothing about whether the gateway is back.
+
+To close that gap the backend captures the unit's **start identity** BEFORE
+scheduling the restart and hands it to the frontend:
+
+- **Identity = `ExecMainStartTimestampMonotonic`** — the CLOCK_MONOTONIC
+  microsecond stamp of the unit's ExecStart *main* PID (`_gateway_start_id`).
+  Chosen because it is (a) monotonic, so it can only increase and never repeats
+  or goes backwards across a restart even if the wall clock is stepped by NTP,
+  and (b) tied to the actual main-process spawn, so it changes the instant the
+  NEW process starts (a unit can enter `active` before its replacement main PID
+  exists, so `ActiveEnterTimestampMonotonic` is a weaker signal).
+- The current identity is reported by extending the existing **`/health`**
+  surface (`{status, start_id}`). Because the gateway proxies only
+  `/apps/dev-fleet/api/*` to the backend, the same handler is registered at
+  **`/api/health`** and the dashboard polls **`/apps/dev-fleet/api/health`**
+  (the bare `/health` stays HMAC-exempt for the gateway's internal liveness
+  poll). The gateway is treated as recovered ONLY when the reported `start_id`
+  DIFFERS from the one captured before the restart. A 200 from the old process
+  still winding down returns the SAME identity and is correctly NOT counted as
+  recovered.
+- **None-safe degrade.** On a platform that cannot report identity (non-Linux,
+  no `systemctl`, or a `0`/absent stamp) `start_id` is `null`; the frontend then
+  degrades to the legacy "reload on the first reachable response" instead of
+  hanging forever in the restarting overlay.
+- **A reachable 404 counts as recovery.** Cutting over to a worktree whose
+  dev-fleet backend predates `/api/health` leaves that route answering 404
+  permanently, so its `start_id` can never appear and waiting for one would burn
+  the whole timeout. A 404 during the handshake still proves a gateway IS serving
+  us, so it is treated as recovered and the page reloads into it. (A backend that
+  is not up at all fails differently — the proxy answers 502, or the fetch
+  rejects — so this rule does not fire while the new process is still starting.)
+- **Make Live reuses the same handshake** — a cutover is a restart into
+  different code with the identical early-200 hazard, so a real
+  `POST …/make-live` cutover also returns the pre-restart `start_id` and the UI
+  recovers on an identity change.
+
+### Restarting UI state
+
+While the handshake runs, the frontend holds an explicit **"Restarting —
+reconnecting"** full-screen state and disables Restart / Pull+Build / Make Live
+so the slow window cannot be re-fired. The poll is bounded (`RESTART_TIMEOUT_MS`,
+60s); on timeout it surfaces an actionable error ("reload manually / check
+`kirocrew logs`") instead of spinning forever.
+
+**The lockout starts before the overlay does.** The restarting flag only goes
+true once `POST …/make-live` has *returned*, but that request is itself what
+writes the systemd drop-in and issues the daemon-reload — a Restart fired inside
+that window can tear the gateway down between the write and the reload, leaving
+persisted and loaded unit state inconsistent. Every global action predicate
+therefore also honours an in-flight cutover on ANY worktree row (the busy flag is
+per-worktree; the hazard is process-wide).
+
+### Sync single-flight + step narration
+
+`POST /apps/dev-fleet/api/sync` is single-flight: a second concurrent request is
+refused with **HTTP 409** (`{"ok": false, "error": "sync already running",
+"run_id": …}`) rather than launching a second ~90s fetch → merge → pip install →
+npm ci → npm build. The run script emits a `::step::<idx>::<label>` marker per
+step; the run worker records BOTH the authoritative step index and its **label**
+onto the run entry (`step` / `step_label`), so `/run` can name the CURRENT step
+even after the marker scrolls out of the 60-line output tail window. The
+frontend shows that label beside the "Syncing" progress bar. This reuses the
+existing `_RUNS` / `::step::` / `/run` run-tracking mechanism — the same channel
+the provision log panel uses (#320) — rather than adding a second one.
 
 ## Make Live
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -24,7 +24,8 @@ Routes (as seen by the backend after prefix stripping by gateway):
   POST /api/pod/provision {name}  -> start async build, returns {run_id}
   POST /api/rebase  {name}
   POST /api/make-live {path, dry_run?}  -> repoint the live gateway at a worktree
-  GET  /health                -> {"status": "ok"}
+  GET  /api/health            -> {"status": "ok", "start_id": ...}  (restart handshake; proxied)
+  GET  /health                -> same body, HMAC-exempt (gateway-internal liveness poll only)
 """
 
 from __future__ import annotations
@@ -681,6 +682,24 @@ _ACTIVE_RUNS: dict[str, tuple[asyncio.Task, Any]] = {}
 _RUNS_MAX_COMPLETED = 50
 
 
+def _parse_step_marker(text: str) -> tuple[int | None, str | None]:
+    """Parse a ``::step::<idx>::<label>`` progress marker into (index, label).
+
+    The sync/build script emits one marker per step (see _sync_start_locked).
+    The run worker records the parsed index AND label into the run entry so the
+    dashboard can name the CURRENT step ("npm ci") instead of showing a bare
+    percentage -- both survive the 60-line output tail window a chatty build
+    step would otherwise flush the marker out of. Either element is ``None``
+    when absent/malformed; a non-``::step::`` line yields ``(None, None)``.
+    """
+    if not text.startswith("::step::"):
+        return None, None
+    parts = text.split("::", 4)  # ['', 'step', '<idx>', '<label>', <rest>]
+    idx = int(parts[2]) if len(parts) >= 3 and parts[2].isdigit() else None
+    label = parts[3] if len(parts) >= 4 and parts[3] else None
+    return idx, label
+
+
 async def _start_run(
     label: str, cmd: list[str], *, cwd: str | None = None,
     env: dict | None = None, cleanup_paths: list[str] | None = None,
@@ -758,12 +777,14 @@ async def _start_run(
                     out = _RUNS[rid]["output"]
                     text = line.decode(errors="replace").rstrip("\n")
                     if text.startswith("::step::"):
-                        # Authoritative step index survives the output-window
-                        # cap (a chatty build step floods markers out of the
-                        # last-60-lines snapshot the API returns).
-                        parts = text.split("::", 4)
-                        if len(parts) >= 3 and parts[2].isdigit():
-                            _RUNS[rid]["step"] = int(parts[2])
+                        # Authoritative step index AND label survive the
+                        # output-window cap (a chatty build step floods markers
+                        # out of the last-60-lines snapshot the API returns).
+                        idx, label = _parse_step_marker(text)
+                        if idx is not None:
+                            _RUNS[rid]["step"] = idx
+                        if label is not None:
+                            _RUNS[rid]["step_label"] = label
                     out.append(text)
                     if len(out) > 500:
                         del out[: len(out) - 500]
@@ -2826,7 +2847,13 @@ async def hmac_proxy_middleware(request: web.Request, handler) -> web.Response:
 # =============================================================================
 
 async def api_health(request: web.Request) -> web.Response:
-    return web.json_response({"status": "ok"})
+    # Served at BOTH /health (HMAC-exempt, gateway-internal liveness poll) and
+    # /api/health (proxied, reached by the browser at /apps/dev-fleet/api/health).
+    # ``start_id`` lets the dashboard's restart handshake wait for the NEW
+    # gateway process rather than "a 200 came back" (see _gateway_start_id).
+    # None-safe: a platform that cannot report identity returns None here and
+    # the frontend degrades to reload-on-first-response instead of hanging.
+    return web.json_response({"status": "ok", "start_id": await _gateway_start_id()})
 
 
 # --- gateway service detection + restart ---
@@ -2900,11 +2927,53 @@ async def _gateway_service_active() -> bool:
     return _GATEWAY_SERVICE_ACTIVE
 
 
+async def _gateway_start_id() -> str | None:
+    """Monotonic start identity of the live gateway unit, or ``None``.
+
+    Reads ``ExecMainStartTimestampMonotonic`` -- the CLOCK_MONOTONIC microsecond
+    stamp of the unit's ExecStart *main* PID. Chosen over a wall-clock stamp or
+    ``ActiveEnterTimestampMonotonic`` because it is (a) monotonic, so it can
+    only increase and never repeats or goes backwards across a restart even if
+    the wall clock is stepped by NTP, and (b) tied to the actual main-process
+    spawn, so it changes the instant the NEW gateway process starts -- precisely
+    the "the new process is up" signal the restart handshake needs (a unit can
+    enter ``active`` before its replacement main PID exists).
+
+    Returns ``None`` on non-Linux / no ``systemctl`` / a failed probe / an unset
+    value (systemd prints ``0`` when no main-start stamp is recorded). Callers
+    MUST treat ``None`` as "identity unavailable" and degrade to the legacy
+    reload-on-first-response behaviour rather than waiting forever in
+    "restarting". Uses ``_gateway_unit_name()`` so it matches whichever unit
+    ``_restart_gateway`` / ``_make_live`` actually bounce (pod or live).
+    """
+    if sys.platform != "linux" or not shutil.which("systemctl"):
+        return None
+    rc, out, _err = await _run_cmd(
+        ["systemctl", "--user", "show", _gateway_unit_name(),
+         "--property=ExecMainStartTimestampMonotonic", "--value"],
+        timeout=5,
+    )
+    if rc != 0:
+        return None
+    val = out.strip()
+    # "0" == systemd has no recorded main-start stamp; empty == property absent.
+    # Both are indistinguishable from "unknown" for a handshake, so normalise to
+    # None (comparing against a stamp that can never change would hang the UI).
+    if not val or val == "0":
+        return None
+    return val
+
+
 async def _restart_gateway() -> dict:
     """Restart the gateway service via a detached systemd-run.
 
     The restart kills the current process, so we use systemd-run --collect
     to schedule a restart that survives our own death.
+
+    Returns the pre-restart ``start_id`` (the live unit's start identity
+    captured BEFORE scheduling) so the caller can poll until a DIFFERENT
+    identity appears -- a 200 from this same process still winding down must
+    not read as "recovered". ``start_id`` is None-safe (see _gateway_start_id).
     """
     if sys.platform != "linux" or not shutil.which("systemctl"):
         return {"ok": False, "error": "gateway is not running as a user service"}
@@ -2914,6 +2983,10 @@ async def _restart_gateway() -> dict:
     )
     if rc != 0:
         return {"ok": False, "error": "gateway is not running as a user service"}
+    # Capture identity BEFORE scheduling the restart: afterwards the systemd-run
+    # bounce can tear this process down at any moment, and the whole point is to
+    # hand the frontend the OLD identity to wait past.
+    start_id = await _gateway_start_id()
     rc, _, stderr = await _run_cmd(
         ["systemd-run", "--user", "--collect",
          "systemctl", "--user", "restart", _gateway_unit_name()],
@@ -2921,7 +2994,7 @@ async def _restart_gateway() -> dict:
     )
     if rc != 0:
         return {"ok": False, "error": _redact(stderr.strip()[:200]) or "systemd-run failed"}
-    return {"ok": True}
+    return {"ok": True, "start_id": start_id}
 
 
 @_audited("dev_fleet_restart_gateway")
@@ -3274,7 +3347,12 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
 
         # The restart tears down THIS backend with the gateway, so schedule it
         # via `systemd-run --collect` (same pattern as _restart_gateway) so the
-        # restart survives our own death.
+        # restart survives our own death. Capture the pre-restart identity FIRST
+        # so the dashboard reuses the same handshake it uses for restart-gateway
+        # (wait for a DIFFERENT start id, not "a 200 came back") -- a cutover is
+        # just a restart into different code, so it has the identical early-200
+        # hazard. None-safe (see _gateway_start_id).
+        start_id = await _gateway_start_id()
         rc, _out, stderr = await _run_cmd(
             ["systemd-run", "--user", "--collect",
              "systemctl", "--user", "restart", unit],
@@ -3301,7 +3379,8 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
         _LIVE_WORKTREE = None
         _LIVE_CHECK_AT = 0.0
 
-        return {"ok": True, "cutover": True, "target": str(real), "plan": plan}
+        return {"ok": True, "cutover": True, "target": str(real),
+                "plan": plan, "start_id": start_id}
 
 
 @_audited("dev_fleet_make_live")
@@ -3329,6 +3408,14 @@ def create_app() -> web.Application:
     """Build the aiohttp Application with all routes and lifecycle hooks."""
     app = web.Application(middlewares=[hmac_proxy_middleware])
     app.router.add_get("/health", api_health)
+    # The dashboard reaches this backend ONLY through the gateway proxy, which
+    # matches /apps/dev-fleet/api/{path} and forwards to /api/{path}
+    # (handle_app_api_proxy). The bare /health above is reachable only by the
+    # gateway's own in-process liveness poll (127.0.0.1:<port>/health, and it is
+    # the one path the HMAC middleware exempts). So the restart-identity
+    # handshake (issue #639) MUST poll a PROXIED path -- expose the same handler
+    # under /api/health, which the browser reaches at /apps/dev-fleet/api/health.
+    app.router.add_get("/api/health", api_health)
     app.router.add_get("/api/fleet", api_dev_fleet_fleet)
     app.router.add_get("/api/worktree", api_dev_fleet_worktree)
     app.router.add_get("/api/pod/logs", api_dev_fleet_pod_logs)

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -3756,3 +3756,218 @@ def test_own_checkout_path_resolves_this_worktree():
     assert own is not None
     from pathlib import Path
     assert (Path(own) / "src" / "kiro_crew").is_dir()
+
+
+# =============================================================================
+# Task: restart identity handshake + sync step labels (issue #639)
+# =============================================================================
+
+
+def test_parse_step_marker_index_and_label():
+    from kiro_crew.apps.builtins.dev_fleet.server import _parse_step_marker
+
+    assert _parse_step_marker("::step::0::Pull") == (0, "Pull")
+    assert _parse_step_marker("::step::3::pip install") == (3, "pip install")
+
+
+def test_parse_step_marker_non_marker_and_partial():
+    from kiro_crew.apps.builtins.dev_fleet.server import _parse_step_marker
+
+    assert _parse_step_marker("regular build output") == (None, None)
+    assert _parse_step_marker("::step::") == (None, None)  # no index or label
+    assert _parse_step_marker("::step::2::") == (2, None)  # empty label
+    assert _parse_step_marker("::step::x::npm ci") == (None, "npm ci")  # bad idx
+
+
+@pytest.mark.asyncio
+async def test_run_endpoint_exposes_step_label():
+    """/run returns the server-tracked step + step_label so the UI can name the
+    CURRENT sync step ("npm ci") instead of a bare spinner. The label survives
+    the 60-line output tail window because it is stored on the run entry."""
+    rid = "steplabel-rid"
+    async with mod._RUNS_LOCK:
+        mod._RUNS[rid] = {
+            "status": "running", "exit_code": None, "label": "sync",
+            "output": ["::step::3::npm ci"], "started": time.time(),
+            "step": 3, "step_label": "npm ci",
+        }
+    try:
+        req = MagicMock()
+        req.query = {"id": rid}
+        resp = await mod.api_dev_fleet_run(req)
+        payload = json.loads(resp.text)
+        assert payload["step"] == 3
+        assert payload["step_label"] == "npm ci"
+    finally:
+        async with mod._RUNS_LOCK:
+            del mod._RUNS[rid]
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_id_reads_monotonic():
+    """_gateway_start_id reads the unit's ExecMainStartTimestampMonotonic."""
+    async def fake_run_cmd(cmd, **kw):
+        assert "show" in cmd and "--value" in cmd
+        assert any("ExecMainStartTimestampMonotonic" in c for c in cmd)
+        return (0, "123456789\n", "")
+
+    with patch.object(mod, "_run_cmd", side_effect=fake_run_cmd), \
+         patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))):
+        assert await mod._gateway_start_id() == "123456789"
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_id_none_on_non_linux():
+    """Non-Linux / no systemctl degrades to None (no hang in 'restarting')."""
+    with patch.object(mod, "sys", MagicMock(platform="darwin")), \
+         patch.object(mod, "shutil", MagicMock(which=MagicMock(return_value=None))):
+        assert await mod._gateway_start_id() is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_id_none_on_zero_empty_or_error():
+    """A '0'/empty stamp or a failed probe all normalise to None."""
+    with patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))):
+        with patch.object(mod, "_run_cmd", new_callable=AsyncMock,
+                          return_value=(0, "0\n", "")):
+            assert await mod._gateway_start_id() is None
+        with patch.object(mod, "_run_cmd", new_callable=AsyncMock,
+                          return_value=(0, "\n", "")):
+            assert await mod._gateway_start_id() is None
+        with patch.object(mod, "_run_cmd", new_callable=AsyncMock,
+                          return_value=(1, "", "err")):
+            assert await mod._gateway_start_id() is None
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_returns_start_id_captured_before_restart():
+    """restart-gateway captures the unit's start identity BEFORE scheduling the
+    detached restart and returns it, so the frontend waits for a DIFFERENT one
+    rather than 'a 200 came back' (issue #639)."""
+    calls: list[list[str]] = []
+
+    async def mock_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        if "is-active" in cmd:
+            return (0, "active\n", "")
+        if "show" in cmd:  # _gateway_start_id identity probe
+            return (0, "555000\n", "")
+        return (0, "", "")  # systemd-run
+
+    with patch.object(mod, "_run_cmd", side_effect=mock_run_cmd), \
+         patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))):
+        result = await mod._restart_gateway()
+
+    assert result["ok"] is True
+    assert result["start_id"] == "555000"
+    # The identity probe MUST run before the detached restart is scheduled.
+    show_idx = next(i for i, c in enumerate(calls) if "show" in c)
+    run_idx = next(i for i, c in enumerate(calls) if "systemd-run" in c)
+    assert show_idx < run_idx
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_start_id_none_safe_when_probe_fails():
+    """A failed identity probe still restarts, with start_id=None — the frontend
+    then degrades to reload-on-first-response instead of hanging."""
+    async def mock_run_cmd(cmd, **kw):
+        if "is-active" in cmd:
+            return (0, "active\n", "")
+        if "show" in cmd:
+            return (1, "", "boom")  # probe fails
+        return (0, "", "")  # systemd-run
+
+    with patch.object(mod, "_run_cmd", side_effect=mock_run_cmd), \
+         patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))):
+        result = await mod._restart_gateway()
+
+    assert result["ok"] is True
+    assert result["start_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_api_health_includes_start_id():
+    """/health carries the current start identity for the restart handshake."""
+    with patch.object(mod, "_gateway_start_id", new_callable=AsyncMock,
+                      return_value="98765"):
+        resp = await mod.api_health(MagicMock())
+    payload = json.loads(resp.text)
+    assert resp.status == 200
+    assert payload["status"] == "ok"
+    assert payload["start_id"] == "98765"
+
+
+@pytest.mark.asyncio
+async def test_api_health_start_id_none_safe():
+    """/health stays 200/ok with start_id=None when identity is unavailable."""
+    with patch.object(mod, "_gateway_start_id", new_callable=AsyncMock,
+                      return_value=None):
+        resp = await mod.api_health(MagicMock())
+    payload = json.loads(resp.text)
+    assert resp.status == 200
+    assert payload["status"] == "ok"
+    assert payload["start_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_make_live_returns_start_id(monkeypatch, tmp_path):
+    """A real cutover captures + returns the pre-restart start identity so the
+    dashboard reuses the same restart handshake (issue #639)."""
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    dropin = tmp_path / "dropins" / "make-live.conf"
+    _stub_make_live(monkeypatch, wt)
+    monkeypatch.setattr(mod, "_dropin_path", lambda: dropin)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="linux"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/usr/bin/systemctl"))
+    )
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        if "show" in cmd and any("ExecMainStartTimestampMonotonic" in c for c in cmd):
+            return (0, "777111\n", "")
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is True and res.get("cutover") is True
+    assert res["start_id"] == "777111"
+    # The identity probe must precede the detached restart.
+    show_idx = next(
+        i for i, c in enumerate(calls)
+        if "show" in c and any("ExecMainStart" in x for x in c)
+    )
+    run_idx = next(
+        i for i, c in enumerate(calls)
+        if c[:2] == ["systemd-run", "--user"] and "restart" in c
+    )
+    assert show_idx < run_idx
+
+
+def test_health_registered_on_proxied_api_path():
+    """The restart handshake is only reachable if the identity handler is
+    registered on the PROXIED /api namespace.
+
+    The browser reaches this backend solely through the gateway proxy, which
+    matches /apps/dev-fleet/api/{path} and forwards to /api/{path}; a bare
+    /apps/dev-fleet/health is NOT proxied. So /api/health (not just the
+    HMAC-exempt internal /health) is what makes the handshake work on the live
+    gateway (issue #639). Guard both registrations against a silent regression.
+    """
+    app = mod.create_app()
+    paths = {
+        r.resource.canonical
+        for r in app.router.routes()
+        if r.method == "GET" and r.resource is not None
+    }
+    assert "/health" in paths        # gateway-internal liveness poll (exempt)
+    assert "/api/health" in paths    # proxied path the dashboard actually polls

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -68,6 +68,27 @@ function filterStepMarkers(lines: string[]): string[] {
   return lines.filter((l) => !STEP_MARKER_RE.test(l))
 }
 
+/* ─── Restart identity handshake (issue #639) ─── */
+// POST /restart-gateway and /make-live return the unit's start identity
+// captured BEFORE the bounce; GET /apps/dev-fleet/api/health reports the CURRENT
+// one. (It must be the /api/ path: the gateway only proxies /apps/dev-fleet/api/*
+// to the backend -- the bare /health is the gateway's own internal liveness
+// poll and never reaches the browser.) The UI holds "Restarting — reconnecting"
+// until it observes a DIFFERENT identity, so a 200 from the OLD process still
+// winding down never counts as recovered (the re-click trap issue #639 describes).
+const RESTART_TIMEOUT_MS = 60000
+
+// Recovered iff we captured an identity AND the gateway now reports a different
+// one. A null captured id (platform can't report identity) or a null/absent
+// current id is NOT recovery — the caller degrades or keeps waiting.
+export function gatewayRecovered(
+  capturedId: string | null | undefined,
+  currentId: string | null | undefined,
+): boolean {
+  if (capturedId == null || currentId == null) return false
+  return String(currentId) !== String(capturedId)
+}
+
 /* ─── Provision progress model (issue #231) ─── */
 // The last non-blank output line — the "current activity" shown inline.
 function lastLine(lines: string[] | undefined): string {
@@ -323,7 +344,7 @@ interface Worktree {
   path?: string
 }
 interface FleetData { worktrees: Worktree[]; error?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean }
-interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; phase: number; phaseAt?: number; lines: string[]; startedAt: number; exit?: number | null; last?: string }
+interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; phase: number; phaseAt?: number; lines: string[]; startedAt: number; exit?: number | null; last?: string; stepLabel?: string }
 // Provision run state (issue #231): the FULL output is kept (not just the last
 // line) so the expandable log panel can show everything, and a failed run
 // persists (failed=true) until the user dismisses it rather than vanishing.
@@ -508,6 +529,15 @@ export default function DevFleetPage() {
   function toggleProvLog(name: string) { setProvLogOpen((o) => ({ ...o, [name]: !o[name] })) }
   const [confirmReq, setConfirmReq] = useState<{ title: string; desc: ReactNode; confirmLabel?: string; danger?: boolean; width?: number; resolve: (v: boolean) => void } | null>(null)
   const [restarting, setRestarting] = useState(false)
+  // A cutover is dangerous BEFORE `restarting` goes true: makeLive() awaits the
+  // /make-live POST, and that request writes the systemd drop-in and issues the
+  // daemon-reload. A Restart fired inside that window can tear the gateway down
+  // between the write and the reload, leaving persisted and loaded unit state
+  // inconsistent. `restarting` only covers the wait AFTER the POST returns, so
+  // every global action predicate must also honour an in-flight cutover on ANY
+  // row (the busy flag is per-worktree, the hazard is process-wide).
+  const makeLivePending = Object.entries(busy).some(([k, v]) => v && k.endsWith(':makelive'))
+  const gatewayMutating = restarting || makeLivePending
   const [pruneDialog, setPruneDialog] = useState<{ candidates: { name: string; code?: string }[]; kept: { name: string; code?: string }[]; scanned: number } | null>(null)
   const [pruneSelected, setPruneSelected] = useState<Set<string>>(new Set())
   const [pruneProgress, setPruneProgress] = useState<{ names: string[]; items: Record<string, { status: string; error?: string | null }>; done: number; total: number; running: boolean } | null>(null)
@@ -528,11 +558,11 @@ export default function DevFleetPage() {
     if (!fleet?.sync_run_id || syncAttachedRef.current) return
     syncAttachedRef.current = true
     const rid = fleet.sync_run_id
-    api.get<{ status?: string; output?: string[]; started?: number; step?: number }>('/run?id=' + rid)
+    api.get<{ status?: string; output?: string[]; started?: number; step?: number; step_label?: string }>('/run?id=' + rid)
       .then((run) => {
         if (run?.status === 'running') {
           const t0 = run.started ? run.started * 1000 : Date.now()
-          setSyncRun({ rid, status: 'running', phase: typeof run.step === 'number' ? run.step : syncPhaseFromLines(run.output || [], 0), lines: run.output || [], startedAt: t0 })
+          setSyncRun({ rid, status: 'running', phase: typeof run.step === 'number' ? run.step : syncPhaseFromLines(run.output || [], 0), lines: run.output || [], startedAt: t0, stepLabel: run.step_label })
           pollSyncRun(rid, t0)
         }
       })
@@ -555,7 +585,7 @@ export default function DevFleetPage() {
     for (let i = 0; i < 900; i++) {
       await sleep(2000)
       if (!pollAliveRef.current || cancelledRunsRef.current.has(rid)) return
-      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step?: number } | null = null
+      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step?: number; step_label?: string } | null = null
       let gone = false
       try { run = await api.get('/run?id=' + rid) } catch (e) {
         // 404 = the gateway restarted and dropped the run registry — the run
@@ -589,7 +619,7 @@ export default function DevFleetPage() {
         invalidateFleet()
         return
       }
-      setSyncRun({ rid, status: 'running', phase, phaseAt, lines: out, startedAt: t0, last })
+      setSyncRun({ rid, status: 'running', phase, phaseAt, lines: out, startedAt: t0, last, stepLabel: run.step_label })
     }
     setSyncRun((s) => (s && s.rid === rid ? { ...s, status: 'error', last: 'timed out after 30 min' } : s))
     setFlag('__syncmain', false)
@@ -828,27 +858,57 @@ export default function DevFleetPage() {
     }
   }
 
-  async function restartGateway() {
-    const ok = await askConfirm('Restart gateway?', 'Applies the last Pull+Build. The dashboard will briefly disconnect.', { confirmLabel: 'Restart' })
-    if (!ok) return
-    setRestarting(true)
-    try {
-      const r = await api.post<{ ok?: boolean; error?: string }>('/restart-gateway', {})
-      if (!r?.ok) { notify(r?.error || 'Restart failed', { type: 'error' }); setRestarting(false); return }
-      const ctrl = new AbortController()
-      const deadline = Date.now() + 60000
-      await sleep(3000)
-      while (Date.now() < deadline) {
-        try {
+  // Poll until the gateway reports a start identity DIFFERENT from the one
+  // captured before the restart, then hard-reload into the fresh process.
+  // `capturedId == null` means the platform can't report identity (non-Linux /
+  // no systemctl) — degrade to the legacy "reload on first response" so those
+  // hosts don't hang in the overlay forever. Returns only on the timeout path;
+  // the success path reloads the page, and the caller clears its own state.
+  async function awaitGatewayBack(capturedId: string | null): Promise<void> {
+    const deadline = Date.now() + RESTART_TIMEOUT_MS
+    await sleep(3000)  // let the detached systemd-run tear the old listener down
+    while (Date.now() < deadline) {
+      if (!pollAliveRef.current) return  // component unmounted — stop the loop
+      try {
+        if (capturedId == null) {
+          // Legacy degrade: no identity to compare, so any answer means "back".
           await fetch('/', { signal: AbortSignal.timeout(3000) })
           window.location.reload()
           return
-        } catch { /* still restarting */ }
-        await sleep(2000)
-      }
-      ctrl.abort()
-      setRestarting(false)
-      notify('Gateway still restarting after 60s \u2014 reload manually', { type: 'error' })
+        }
+        const res = await fetch('/apps/dev-fleet/api/health', { credentials: 'same-origin', signal: AbortSignal.timeout(3000) })
+        if (res.status === 404) {
+          // The route answered 404, which means a gateway IS serving us — just
+          // one whose dev-fleet backend predates /api/health. That is the normal
+          // outcome of a cutover to an older worktree, and its identity can never
+          // appear, so waiting for one would burn the full timeout. A reachable
+          // 404 during the handshake is therefore recovery: reload into it.
+          window.location.reload()
+          return
+        }
+        if (res.ok) {
+          const j = (await res.json().catch(() => null)) as { start_id?: string | null } | null
+          if (gatewayRecovered(capturedId, j?.start_id)) { window.location.reload(); return }
+          // A reachable health with the SAME id is the OLD process still winding
+          // down (or identity unavailable) — keep waiting, never reload here.
+        }
+      } catch { /* gateway is down mid-bounce — keep polling */ }
+      await sleep(2000)
+    }
+    setRestarting(false)
+    notify('Gateway did not come back within 60s \u2014 reload the page manually, or check `kirocrew logs`.', { type: 'error' })
+  }
+
+  async function restartGateway() {
+    const ok = await askConfirm('Restart gateway?', 'Applies the last Pull+Build. The dashboard will briefly disconnect and reconnect on its own.', { confirmLabel: 'Restart' })
+    if (!ok) return
+    setRestarting(true)
+    try {
+      const r = await api.post<{ ok?: boolean; error?: string; start_id?: string | null }>('/restart-gateway', {})
+      if (!r?.ok) { notify(r?.error || 'Restart failed', { type: 'error' }); setRestarting(false); return }
+      // Wait for the NEW process (a different start identity), not "a 200 came
+      // back" — see gatewayRecovered / issue #639.
+      await awaitGatewayBack(r.start_id ?? null)
     } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false) }
   }
 
@@ -863,19 +923,15 @@ export default function DevFleetPage() {
     if (!ok) return
     setFlag(w.name + ':makelive', true)
     try {
-      const r = await api.post<{ ok?: boolean; error?: string }>('/make-live', { path: w.path })
+      const r = await api.post<{ ok?: boolean; error?: string; start_id?: string | null }>('/make-live', { path: w.path })
       if (!r?.ok) { notify(r?.error || 'Make live failed', { type: 'error' }); setFlag(w.name + ':makelive', false); return }
-      // Gateway is restarting into the new worktree — reuse the restart overlay,
-      // poll until it answers again, then reload into the freshly-live code.
+      // Gateway is restarting into the new worktree — reuse the restart overlay
+      // and the SAME identity handshake (a cutover is a restart into different
+      // code, with the identical early-200 hazard). awaitGatewayBack reloads on
+      // a fresh identity; only its timeout path returns here.
       setRestarting(true)
-      await sleep(3000)
-      const deadline = Date.now() + 60000
-      while (Date.now() < deadline) {
-        try { await fetch('/', { signal: AbortSignal.timeout(3000) }); window.location.reload(); return } catch { /* still restarting */ }
-        await sleep(2000)
-      }
-      setRestarting(false); setFlag(w.name + ':makelive', false)
-      notify('Gateway still restarting after 60s \u2014 reload manually', { type: 'error' })
+      await awaitGatewayBack(r.start_id ?? null)
+      setFlag(w.name + ':makelive', false)
     } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false); setFlag(w.name + ':makelive', false) }
   }
 
@@ -939,13 +995,13 @@ export default function DevFleetPage() {
   function rowButtons(w: Worktree): ReactNode[] {
     if (w.is_main) {
       const out: ReactNode[] = [
-        <ConfirmBtn key="sync" title="Pull + Build main" desc="Pulls main and rebuilds (~6 min). Does NOT restart." confirmLabel="Start" onConfirm={() => syncMain()} btn={{ disabled: !!busy['__syncmain'] || syncRun?.status === 'running' }}>
+        <ConfirmBtn key="sync" title="Pull + Build main" desc="Pulls main and rebuilds (~6 min). Does NOT restart." confirmLabel="Start" onConfirm={() => syncMain()} btn={{ disabled: !!busy['__syncmain'] || syncRun?.status === 'running' || gatewayMutating }}>
           {iconLabel(<RefreshCw size={13} className="lucide-inline" />, busy['__syncmain'] || syncRun?.status === 'running' ? 'Building\u2026' : 'Pull+Build')}
         </ConfirmBtn>,
       ]
       if (fleet?.gateway_service_active) {
         out.push(
-          <Btn key="restart" onClick={() => restartGateway()} aria-label="Restart gateway">
+          <Btn key="restart" onClick={() => restartGateway()} disabled={gatewayMutating} aria-label="Restart gateway">
             {iconLabel(<RotateCw size={13} className="lucide-inline" />, 'Restart')}
           </Btn>
         )
@@ -954,7 +1010,7 @@ export default function DevFleetPage() {
         // Consistent with makeLive()'s guard: shown iff the row is NOT live.
         if (!w.is_live) {
           out.push(
-            <Btn key="makelive" onClick={() => makeLive(w)} disabled={!!busy[w.name + ':makelive']} title="Repoint the live gateway back at main (restarts the gateway)">
+            <Btn key="makelive" onClick={() => makeLive(w)} disabled={gatewayMutating} title="Repoint the live gateway back at main (restarts the gateway)">
               {iconLabel(<Rocket size={13} className="lucide-inline" />, 'Make live')}
             </Btn>
           )
@@ -982,7 +1038,7 @@ export default function DevFleetPage() {
       w.has_dist && !w.running ? { label: 'Spin up pod', icon: <Play size={13} className="lucide-inline" />, onClick: () => act(w.name, 'up') } : null,
       w.running ? { label: 'Restart pod', icon: <RefreshCw size={13} className="lucide-inline" />, onClick: () => act(w.name, 'restart') } : null,
       { label: 'Rebase onto main', icon: <RefreshCw size={13} className="lucide-inline" />, onClick: () => rebaseWorktree(w.name), disabled: !!busy[w.name + ':rebase'] },
-      !w.is_live ? { label: 'Make live', icon: <Rocket size={13} className="lucide-inline" />, onClick: () => makeLive(w), disabled: !!busy[w.name + ':makelive'], title: 'Repoint the live gateway at this worktree (restarts the gateway)' } : null,
+      !w.is_live ? { label: 'Make live', icon: <Rocket size={13} className="lucide-inline" />, onClick: () => makeLive(w), disabled: gatewayMutating, title: 'Repoint the live gateway at this worktree (restarts the gateway)' } : null,
       { label: 'QA + video', icon: <Video size={13} className="lucide-inline" />, onClick: () => launchQa(w.name) },
       w.running ? { label: 'Stop pod', icon: <Square size={13} className="lucide-inline" />, onClick: () => act(w.name, 'down'), danger: true } : null,
     ]} />)
@@ -1001,6 +1057,7 @@ export default function DevFleetPage() {
         <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 } as CSSProperties}>
           <LoaderCircle size={12} className="lucide-inline" style={{ color: 'var(--accent)', flexShrink: 0 } as CSSProperties} />
           <span style={{ fontSize: 11, fontWeight: 600, flexShrink: 0 }}>Syncing</span>
+          {syncRun.stepLabel ? <span style={{ ...mono, flexShrink: 0 } as CSSProperties} title="current step">{syncRun.stepLabel}</span> : null}
           <span role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100} aria-label="Sync progress" style={{ flex: 1, height: 4, borderRadius: 2, background: 'var(--border)', overflow: 'hidden', minWidth: 60 } as CSSProperties}>
             <span style={{ display: 'block', height: '100%', width: pct + '%', background: 'var(--accent)', borderRadius: 2, transition: 'width 0.6s ease' } as CSSProperties} />
           </span>
@@ -1234,10 +1291,10 @@ export default function DevFleetPage() {
       {pruneReviewDialog}
       {pruneProgressModal}
       {restarting && (
-        <div style={{ position: 'fixed', inset: 0, zIndex: 9999, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', background: 'var(--bg)', color: 'var(--text)' }}>
+        <div role="alert" aria-busy="true" style={{ position: 'fixed', inset: 0, zIndex: 9999, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', background: 'var(--bg)', color: 'var(--text)' }}>
           <LoaderCircle size={32} className="lucide-inline" style={{ animation: 'spin 1s linear infinite' }} />
-          <p style={{ marginTop: 16, fontSize: 16, fontWeight: 600 }}>Restarting gateway...</p>
-          <p style={{ fontSize: 12, color: 'var(--muted)' }}>The page will reload automatically when the gateway is back.</p>
+          <p style={{ marginTop: 16, fontSize: 16, fontWeight: 600 }}>{'Restarting \u2014 reconnecting\u2026'}</p>
+          <p style={{ fontSize: 12, color: 'var(--muted)' }}>Waiting for the new gateway process. The page reloads automatically once it is up.</p>
         </div>
       )}
       <div className="flex flex-1 min-h-0 overflow-hidden">

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -3,10 +3,10 @@
  * verifies loading state, fleet table, and empty state.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 
-import DevFleetPage, { mergeLogWindow, LOG_GAP_MARKER, pruneVerdictLabel } from '../pages/DevFleetPage'
+import DevFleetPage, { mergeLogWindow, LOG_GAP_MARKER, pruneVerdictLabel, gatewayRecovered } from '../pages/DevFleetPage'
 
 function renderPage() {
   return renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
@@ -785,4 +785,178 @@ describe('pruneVerdictLabel', () => {
     expect(pruneVerdictLabel(undefined)).toBe('')
     expect(pruneVerdictLabel('')).toBe('')
   })
+})
+
+
+// Restart identity handshake (issue #639): "recovered" means a DIFFERENT start
+// identity appeared, never "a 200 came back".
+describe('gatewayRecovered', () => {
+  it('is true only when a captured id and a different current id are both present', () => {
+    expect(gatewayRecovered('100', '200')).toBe(true)
+  })
+  it('is false when the current id equals the captured id (old process still winding down)', () => {
+    expect(gatewayRecovered('100', '100')).toBe(false)
+  })
+  it('is false when identity is unavailable on either side (degrade, never falsely recover)', () => {
+    expect(gatewayRecovered(null, '200')).toBe(false)
+    expect(gatewayRecovered('100', null)).toBe(false)
+    expect(gatewayRecovered('100', undefined)).toBe(false)
+    expect(gatewayRecovered(undefined, undefined)).toBe(false)
+  })
+})
+
+describe('DevFleetPage restart handshake', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('enters the "Restarting — reconnecting" state and disables the action buttons on restart', async () => {
+    const FLEET_LIVE = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/main' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      if (u.includes('/restart-gateway')) return Promise.resolve(new Response(JSON.stringify({ ok: true, start_id: 'BEFORE' }), { status: 200 }))
+      // Health keeps returning the SAME identity, so the handshake never fires a
+      // reload during the test — we can observe the held "restarting" state.
+      if (u.includes('/apps/dev-fleet/api/health')) return Promise.resolve(new Response(JSON.stringify({ status: 'ok', start_id: 'BEFORE' }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+    await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+
+    const syncBtn = () => screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    expect(syncBtn()).not.toBeDisabled()
+
+    // Click the row Restart button, then confirm in the dialog.
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+
+    // The explicit overlay shows and the action buttons are disabled while held.
+    await waitFor(() => expect(screen.getByText(/Restarting/)).toBeInTheDocument())
+    expect(syncBtn()).toBeDisabled()
+    expect(screen.getByLabelText('Restart gateway')).toBeDisabled()
+  })
+
+  it('reloads once the polled start identity DIFFERS from the captured one', async () => {
+    const FLEET_LIVE = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/main' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      if (u.includes('/restart-gateway')) return Promise.resolve(new Response(JSON.stringify({ ok: true, start_id: 'BEFORE' }), { status: 200 }))
+      // The NEW process reports a DIFFERENT identity -> handshake must reload.
+      if (u.includes('/apps/dev-fleet/api/health')) return Promise.resolve(new Response(JSON.stringify({ status: 'ok', start_id: 'AFTER' }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    // Stub the navigation side effect so the identity-change branch is observable.
+    const origReload = window.location.reload
+    const reloadSpy = vi.fn()
+    Object.defineProperty(window.location, 'reload', { configurable: true, value: reloadSpy })
+    try {
+      renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+      await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+
+      fireEvent.click(screen.getByLabelText('Restart gateway'))
+      const dialog = await screen.findByRole('dialog')
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+
+      // awaitGatewayBack sleeps ~3s before its first poll, then reloads on the
+      // differing identity; allow generous headroom over real timers.
+      await waitFor(() => expect(reloadSpy).toHaveBeenCalled(), { timeout: 8000 })
+    } finally {
+      Object.defineProperty(window.location, 'reload', { configurable: true, value: origReload })
+    }
+  }, 12000)
+
+  it('disables Restart and Pull+Build while a Make Live request is still in flight', async () => {
+    // Regression: `restarting` only goes true AFTER the /make-live POST resolves,
+    // but that POST is what writes the systemd drop-in and issues the
+    // daemon-reload. A Restart fired inside that window can tear the gateway down
+    // mid-write, leaving persisted and loaded unit state inconsistent. The global
+    // action predicates must therefore also honour an in-flight cutover.
+    const FLEET = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: false, path: '/wt/main' },
+      ],
+    }
+    // Hold /make-live open so the test observes the pre-`restarting` window.
+    let releaseMakeLive: (() => void) | null = null
+    const makeLiveHeld = new Promise<void>((res) => { releaseMakeLive = res })
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      if (u.includes('/make-live')) {
+        return makeLiveHeld.then(
+          () => new Response(JSON.stringify({ ok: true, cutover: true, start_id: 'BEFORE' }), { status: 200 }),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    try {
+      renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+      await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+
+      expect(screen.getByLabelText('Restart gateway')).not.toBeDisabled()
+
+      fireEvent.click(screen.getByText('Make live').closest('button') as HTMLButtonElement)
+      const dialog = await screen.findByRole('dialog')
+      fireEvent.click(within(dialog).getByRole('button', { name: /Make live/i }))
+
+      // POST is still pending: `restarting` is false, yet both global actions
+      // must already be locked out.
+      await waitFor(() => expect(screen.getByLabelText('Restart gateway')).toBeDisabled())
+      expect(screen.getByText('Pull+Build').closest('button')).toBeDisabled()
+    } finally {
+      releaseMakeLive?.()
+    }
+  }, 15000)
+
+  it('treats a reachable 404 on the health route as recovery instead of waiting out the timeout', async () => {
+    // Regression: making live a worktree that predates /api/health means the new
+    // gateway answers 404 forever, so its identity can never appear and the
+    // handshake would burn the whole 60s window. A reachable 404 during the
+    // handshake proves a gateway IS serving us — reload into it.
+    const FLEET_LIVE = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/main' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      if (u.includes('/restart-gateway')) return Promise.resolve(new Response(JSON.stringify({ ok: true, start_id: 'BEFORE' }), { status: 200 }))
+      // Post-cutover backend has no /api/health at all.
+      if (u.includes('/apps/dev-fleet/api/health')) return Promise.resolve(new Response('not found', { status: 404 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    const origReload = window.location.reload
+    const reloadSpy = vi.fn()
+    Object.defineProperty(window.location, 'reload', { configurable: true, value: reloadSpy })
+    try {
+      renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+      await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+
+      fireEvent.click(screen.getByLabelText('Restart gateway'))
+      const dialog = await screen.findByRole('dialog')
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+
+      await waitFor(() => expect(reloadSpy).toHaveBeenCalled(), { timeout: 8000 })
+    } finally {
+      Object.defineProperty(window.location, 'reload', { configurable: true, value: origReload })
+    }
+  }, 12000)
 })


### PR DESCRIPTION
## Problem

Dev Fleet's two slowest actions — **Restart Gateway** and **Sync (Pull+Build)** — give the user nothing to look at while they run, so they read as hung and get clicked again. The second click causes a second real outage.

Observed on a live gateway (all timestamps UTC, one session — from issue #639):

```
07:55:05  Sync #1   git fetch → merge --ff-only → pip install -e . → npm ci → npm run build
07:56:45  Sync #1 build finishes (88 s)
07:56:46  Sync #2   ← a second full run, one second later
07:58:16  Restart Gateway #1
07:58:26  Graceful shutdown timed out — force exiting   (~10 s with no listener)
07:59:21  Restart Gateway #2   ← 65 s later
```

`NRestarts=0` and an untouched make-live drop-in confirm both restarts were explicit `POST /api/restart-gateway` calls — not crash-restarts, not Make Live. Root cause: `_restart_gateway` returns `{"ok": true}` the instant `systemd-run --collect systemctl --user restart <unit>` has *scheduled* the restart; the bounce happens after the HTTP response and takes ~10s because graceful shutdown times out. "The request succeeded" therefore says nothing about whether the gateway is back, and the buttons stay live.

## Changes

### 1. Restart identity handshake (backend)

`POST /api/restart-gateway` now captures the live unit's **start identity BEFORE** scheduling the restart and returns it as `start_id`. `GET /api/health` reports the CURRENT identity. The frontend treats the gateway as recovered ONLY when the reported identity DIFFERS from the captured one, so a 200 from the OLD process still winding down never counts as recovered.

**Identity = `ExecMainStartTimestampMonotonic`** (`_gateway_start_id`). Chosen over a wall-clock stamp or `ActiveEnterTimestampMonotonic` because it is (a) monotonic — it can only increase and never repeats or goes backwards across a restart even if NTP steps the wall clock, and (b) tied to the actual main-process spawn, so it changes the instant the NEW gateway process starts (a unit can enter `active` before its replacement main PID exists, so `ActiveEnterTimestampMonotonic` is a weaker signal).

**None-safe:** on non-Linux / no `systemctl` / a `0`/absent stamp, `start_id` is `None`; the frontend then degrades to the legacy "reload on first reachable response" instead of hanging forever in the overlay — same platform handling `_restart_gateway` already used.

**Make Live reuses the same handshake** — a cutover is a restart into different code with the identical early-200 hazard, so a real `POST /api/make-live` cutover also returns the pre-restart `start_id`.

### 2. Restarting UI state (frontend)

On restart (and Make Live) the UI enters an explicit **"Restarting — reconnecting"** full-screen state and disables **Restart / Pull+Build / Make live** while it holds, so the slow window cannot be re-fired. It clears (hard reload into the fresh process) only when the polled identity differs, and is bounded (`RESTART_TIMEOUT_MS`, 60s) — on timeout it surfaces an actionable error ("reload manually / check the gateway logs") instead of spinning forever.

### 3. Sync single-flight + step narration

The sync single-flight guard (a concurrent `POST /api/sync` is refused **409** `sync already running`) and the `::step::<idx>::<label>` marker emission **already existed on `main`** (from the provision-log work, #320). This PR **reuses that existing `_RUNS` / `::step::` / `/run` run-tracking mechanism rather than inventing a second one**: the run worker now records the step **label** (e.g. `npm ci`) alongside the authoritative index, and the frontend shows that label beside the "Syncing" progress bar instead of a bare percentage. The label survives the 60-line output-tail window because it is stored on the run entry.

## Routing fix a reviewer should scrutinise

The identity handler must be reachable **through the gateway app-proxy**, which matches only `/apps/dev-fleet/api/{path}` and forwards to the backend's `/api/{path}` (`apps/routes.py:handle_app_api_proxy`). The backend's bare `/health` route is HMAC-exempt and reached only by the gateway's own in-process liveness poll (`127.0.0.1:<port>/health`) — a browser `fetch('/apps/dev-fleet/health')` is **not** proxied and would fall through to the SPA (200 + HTML), so the handshake would never see an identity and would always hit the 60s timeout — worse than the code it replaces.

Fix: register the same `api_health` handler at **`/api/health`** too, and have the frontend poll **`/apps/dev-fleet/api/health`**. A new backend test (`test_health_registered_on_proxied_api_path`) asserts both `/health` and `/api/health` are registered so this can't silently regress, and a new frontend test (`reloads once the polled start identity DIFFERS`) exercises the real recovery→reload path (the prior test only observed the held overlay with an unchanging identity).

Other things worth a look:
- Identity captured strictly before the detached `systemd-run` is scheduled (verified by ordering assertions in the backend tests) — after scheduling, this process can be torn down at any moment.
- `gatewayRecovered(captured, current)` returns `false` when either side is null, so an unavailable identity degrades rather than false-positives.
- Scope: the graceful-shutdown drain gap ("Graceful shutdown timed out — force exiting") is deliberately untouched — tracked separately on `fix/makelive-drain`.

## Spec

`docs/system-specs/modules/dev-fleet.md` updated: the `/api/health` identity route, the 409 single-flight semantics, and a new "Action narration" section documenting the handshake, the identity property choice, the None-safe degrade, and the sync step-label reuse.

## Tests / build gate

- `pytest test/test_dev_fleet_app.py` → **194 passed**, 1 pre-existing environment failure unrelated to this PR (`test_trusted_bin_pins_the_resolved_target_not_the_symlink`, a `gh`-symlink test from #630 that depends on host PATH; fails identically on the base commit, passes in CI).
- `isort --check-only` and `flake8 -j 1` on the touched `.py` files → clean.
- `tsc --noEmit` (website) → clean.
- `vitest run src/test/DevFleetPage.test.tsx` → **46 passed** (incl. the held-state and the new identity-change→reload tests).

Fixes #639
