### PR TITLE
fix: bound pod-e2e teardown so --video can't eat the verdict

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -423,7 +423,14 @@ All user-visible output passes through `redact_credentials()` and
 
 The app bundles two skills declared in `app.json`:
 
-- `skills/pod-e2e` — end-to-end test harness for isolated pod instances
+- `skills/pod-e2e` — end-to-end test harness for isolated pod instances.
+  Every phase is time-bounded: the Playwright phase runs under `timeout`
+  (`POD_E2E_PW_TIMEOUT`, default 600s) and each browser-teardown step under
+  `POD_E2E_TEARDOWN_TIMEOUT` (default 30s), because video finalization
+  (`context.close()`) can block indefinitely. On expiry the runner keeps the
+  artifacts, kills the browser descendants, and reports a timeout as a distinct
+  outcome. Per-phase results are appended to `verdict.jsonl` as they are decided
+  so a killed run still yields a verdict.
 - `skills/feature-demo-recording` — headless Playwright video recording
 
 `kirocrew-worktree-dev` is deliberately NOT bundled: the canonical copy is

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -75,7 +75,7 @@ green). Flags:
 | `--keep` / `--no-stop` | leave the pod running after tests (debug) |
 | `--api-only` | skip the Playwright phase |
 | `--fe-only` | skip the API-test phase |
-| `--video` | record the session at 1080p → `.webm` + `.mp4` |
+| `--video` | record the session at 1080p → `.webm` + `.mp4` (finalization is time-capped) |
 
 ## What each phase does
 
@@ -97,8 +97,25 @@ green). Flags:
      gracefully** (no failure, just a warning).
    - `--video` requires `ffmpeg` for mp4 transcoding; if absent, the `.webm` is
      kept but no `.mp4` is produced.
+   - **Bounded, always.** The whole phase runs under `timeout`
+     (`POD_E2E_PW_TIMEOUT`, default 600s) and each browser-teardown step under
+     its own cap (`POD_E2E_TEARDOWN_TIMEOUT`, default 30s). Video finalization
+     (`context.close()`) has been observed to block forever *after* a spec
+     passed; on expiry the driver keeps every artifact, kills the browser tree,
+     and exits, and the summary reports `playwright — TIMED OUT` as a distinct
+     outcome. A recording that grew past 200MB is reported and left
+     un-transcoded — for a short spec that size is itself a defect signal.
+     The per-step cap uses `SIGALRM`, so on a platform without it the teardown
+     degrades to unbounded and says so in the log (the harness is POSIX-only
+     anyway); the phase-level `timeout` still applies.
 6. **collect** — all logs + screenshots land in
-   `~/.kirocrew-pods/.e2e-artifacts/<wt>/`.
+   `~/.kirocrew-pods/.e2e-artifacts/<wt>/`. Per-phase results are appended to
+   `verdict.jsonl` **as they are decided** (and `playwright.log` is unbuffered),
+   so a stalled or killed run still leaves a readable verdict. The file is
+   truncated at the start of **every** run — including runs that skip the FE
+   phase — so it can never show a previous run's rows. The rest of the artifact
+   dir DOES persist across runs, so check timestamps before trusting an old
+   screenshot.
 7. **stop** — `kirocrew pod down <wt>` (zero residue). Skipped if `--keep` or if
    the pod was already up.
 
@@ -127,8 +144,11 @@ you would be willing to build and test locally.
 A spec is plain Python exec'd with these names in scope (no imports needed):
 `page` (already on the authed app), `context`, `base_url`, `token`,
 `artifact_dir`, `expect` (Playwright's **native web-first assertion** —
-`expect(locator).to_be_visible()`, auto-retries), and `expect_true(cond, msg)`
-(boolean fallback, raises `AssertionError`). Assert UI, take screenshots into
+`expect(locator).to_be_visible()`, auto-retries), `expect_true(cond, msg)`
+(boolean fallback, raises `AssertionError`), and `record(name, ok, detail="")`
+(append a per-assertion row to `verdict.jsonl` immediately, so a later stall
+still leaves your decided results on disk — an `ok=False` row **fails the run**,
+it is not a silent note). Assert UI, take screenshots into
 `artifact_dir`. Run with `--video` to also record a `.webm` (+ a shareable
 `.mp4`) at 1080p, paced.
 
@@ -167,8 +187,9 @@ Rules:
 - Do NOT `cat` any .local_secret yourself (credential-read blocked). The script
   mints the token internally via the CLI — just run the one command above.
 - After it finishes, READ the artifacts in the printed ARTIFACT_DIR:
-  api-tests.log, playwright.log, fe-*.png screenshots (use the Read tool on the
-  .png to actually look at the UI), and boot-fail.log if present.
+  verdict.jsonl (per-phase results, written as decided — trust this even if the
+  run was killed), api-tests.log, playwright.log, fe-*.png screenshots (use the
+  Read tool on the .png to actually look at the UI), and boot-fail.log if present.
 
 Then return a QA VERDICT, not a raw dump:
   1. Overall: PASS / FAIL / BLOCKED (couldn't even boot the pod).
@@ -207,8 +228,10 @@ no dist → build-or-`--provision`.
 
 - Playwright venv: controlled by env `KIROCREW_PW_PY`.
   The FE phase skips gracefully if this interpreter is not executable.
-- `--video` needs `ffmpeg` on PATH (or pointed to by `POD_FFMPEG` env).
-  If absent, `.webm` is kept but no `.mp4` transcoding occurs.
+- `--video` needs `ffmpeg` on PATH (or pointed to by `POD_E2E_FFMPEG` env).
+  If absent, `.webm` is kept but no `.mp4` transcoding occurs. Recording
+  finalization is time-capped (see `POD_E2E_TEARDOWN_TIMEOUT`), so `--video`
+  can cost you the `.mp4` — never the verdict.
 
 ## Hands off the live plane
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -12,6 +12,10 @@
 #
 # Exit code = number of failed phases (0 = all green). Structured summary + an
 # artifact dir path are printed at the end so a subagent can parse them.
+#
+# Env knobs:
+#   POD_E2E_PW_TIMEOUT        hard cap (s) on the whole Playwright phase (default 600)
+#   POD_E2E_TEARDOWN_TIMEOUT  hard cap (s) per browser-teardown step (default 30)
 set -uo pipefail
 
 # ---------------------------------------------------------------- args ----
@@ -111,9 +115,17 @@ case "$(readlink -f -- "$ARTIFACT_DIR" 2>/dev/null || echo "$ARTIFACT_DIR")" in
 esac
 mkdir -p "$ARTIFACT_DIR"
 
+# Truncate the verdict on EVERY invocation, not just when the driver is
+# launched. The artifact dir is keyed per worktree and persists, so a run
+# that skips the FE phase (--api-only, unhealthy pod, no KIROCREW_PW_PY) or
+# a driver that dies before it can reset the file itself would otherwise
+# leave a PREVIOUS run's rows to be read as this run's verdict.
+: > "$ARTIFACT_DIR/verdict.jsonl"
+
 # ---------------------------------------------------------------- state ---
 ALREADY_UP=0   # if pod was already running, don't stop it
 FAILURES=0
+WARNINGS=0
 declare -a RESULTS=()
 
 # Initialize MANIFEST early (before both API and FE phases reference it).
@@ -134,6 +146,9 @@ trap '_pod_down_best_effort' EXIT
 log() { printf '\033[36m[pod-e2e]\033[0m %s\n' "$*"; }
 pass() { RESULTS+=("  ✅ $1"); }
 fail() { RESULTS+=("  ❌ $1"); FAILURES=$((FAILURES + 1)); }
+# A warning is neither a pass nor a fail — it is counted separately so it
+# never inflates the passed count in the summary.
+warn() { RESULTS+=("  ⚠️  $1"); WARNINGS=$((WARNINGS + 1)); }
 
 # ---------------------------------------------------------------- up ------
 log "starting pod '$NAME' ..."
@@ -234,15 +249,16 @@ fi
 if [ "$RUN_FE" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then
   if [ -z "$PW_PY" ] || [ ! -x "$PW_PY" ]; then
     log "SKIP: Playwright python not found (set KIROCREW_PW_PY)"
-    RESULTS+=("  ⚠️  playwright — skipped (no KIROCREW_PW_PY)")
+    warn "playwright — skipped (no KIROCREW_PW_PY)"
   elif [ ! -f "$PW_RUNNER" ]; then
     log "SKIP: pod-playwright.py not found at $PW_RUNNER"
-    RESULTS+=("  ⚠️  playwright — skipped (script missing)")
+    warn "playwright — skipped (script missing)"
   else
     log "running Playwright FE check ..."
     # Token goes via env, not argv — process arguments are world-readable
     # on Linux (/proc/<pid>/cmdline) while environment is uid-restricted.
     PW_ARGS=("$PW_RUNNER" --base-url "$BASE_URL" --artifact-dir "$ARTIFACT_DIR" --checkout "$CHECKOUT")
+    PW_ARGS+=(--teardown-timeout "${POD_E2E_TEARDOWN_TIMEOUT:-30}")
     [ "$VIDEO" -eq 1 ] && PW_ARGS+=(--video)
     # Declarative manifest parse: extract ONLY the PLAYWRIGHT_SPEC value.
     # The manifest is branch-controlled — never source/eval it on the host.
@@ -259,10 +275,31 @@ if [ "$RUN_FE" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then
       esac
       PW_ARGS+=(--spec "$PLAYWRIGHT_SPEC")
     fi
-    if KIROCREW_POD_TOKEN="$TOKEN" "$PW_PY" "${PW_ARGS[@]}" > "$ARTIFACT_DIR/playwright.log" 2>&1; then
-      pass "playwright — headless chromium loaded dashboard, SPA rendered"
+    # Every other phase here is bounded (health polling caps at 45s); this one
+    # used to be unbounded and could stall forever in browser teardown, burning
+    # a whole agent budget after the verdict was already decided. `python -u`
+    # keeps playwright.log flushed so a stall is still diagnosable.
+    PW_TIMEOUT="${POD_E2E_PW_TIMEOUT:-600}"
+    PW_CMD=("$PW_PY" -u "${PW_ARGS[@]}")
+    if command -v timeout >/dev/null 2>&1; then
+      PW_CMD=(timeout --kill-after=30s "${PW_TIMEOUT}s" "${PW_CMD[@]}")
     else
-      fail "playwright — exit $? (see playwright.log + screenshots)"
+      log "WARN: coreutils 'timeout' not found — Playwright phase runs unbounded"
+    fi
+    KIROCREW_POD_TOKEN="$TOKEN" "${PW_CMD[@]}" > "$ARTIFACT_DIR/playwright.log" 2>&1
+    PW_RC=$?
+    if [ "$PW_RC" -eq 0 ]; then
+      pass "playwright — headless chromium loaded dashboard, SPA rendered"
+    elif [ "$PW_RC" -eq 124 ] || [ "$PW_RC" -eq 137 ]; then
+      # 124 = timeout expired, 137 = SIGKILL from --kill-after.
+      fail "playwright — TIMED OUT after ${PW_TIMEOUT}s (partial artifacts kept: see playwright.log, verdict.jsonl, screenshots)"
+    else
+      fail "playwright — exit $PW_RC (see playwright.log + screenshots)"
+    fi
+    # A bounded-teardown bail keeps the verdict (so the phase can still pass),
+    # but the operator should know the recording may be truncated.
+    if grep -q '"phase": "teardown".*"status": "fail"' "$ARTIFACT_DIR/verdict.jsonl" 2>/dev/null; then
+      warn "playwright teardown — abandoned on timeout; recording may be truncated (assertions above still valid)"
     fi
   fi
 fi
@@ -280,7 +317,9 @@ trap - EXIT
 echo ""
 echo "=== POD-E2E SUMMARY ==="
 printf '%s\n' "${RESULTS[@]}"
-PASSED=$(( ${#RESULTS[@]} - FAILURES ))
-echo "result:       $PASSED passed, $FAILURES failed"
+PASSED=$(( ${#RESULTS[@]} - FAILURES - WARNINGS ))
+SUMMARY="result:       $PASSED passed, $FAILURES failed"
+[ "$WARNINGS" -gt 0 ] && SUMMARY="$SUMMARY, $WARNINGS warning(s)"
+echo "$SUMMARY"
 echo "ARTIFACT_DIR=$ARTIFACT_DIR"
 exit "$FAILURES"

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-playwright.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-playwright.py
@@ -27,12 +27,23 @@ Names in scope for a spec (no imports needed):
 1080p with paced (slow-mo) actions for clarity and also writes a shareable .mp4
 beside the .webm. Exit 0 = all phases passed.
 Never touches the live gateway — only the URL passed in --base-url.
+
+Teardown is BOUNDED: `context.close()` is what finalizes a recording and has
+been observed to block forever (unbounded .webm growth) after a spec has already
+passed. Every teardown step therefore runs under a hard wall-clock cap
+(--teardown-timeout); on expiry the already-determined verdict is kept, browser
+descendants are killed, and the process exits instead of hanging. The verdict is
+also written incrementally to <artifact-dir>/verdict.jsonl as each phase is
+decided, so even a wedged run leaves a readable result.
 """
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import signal
 import sys
+import time
 import traceback
 from pathlib import Path
 
@@ -49,18 +60,202 @@ _FIRST_RUN_LS = {
     "kc-onboarded": "1",   # theme onboarding
 }
 
+# Defaults for the guards added for the "--video wedges the run" defect:
+# a spec that passes in 16s must never be lost to an unbounded teardown.
+_DEFAULT_TEARDOWN_TIMEOUT = 30.0   # seconds per teardown step
+_DEFAULT_MAX_VIDEO_MB = 200        # a sane .webm for a short spec is single-digit MB
+# A process exit status is truncated to its low 8 bits, so a raw failure count
+# of 256 would be reported as 0 — a silent pass. Clamp every exit through
+# _exit_code() and leave headroom below 255 for shell-reserved codes.
+_MAX_EXIT_CODE = 250
 
-def _transcode_videos(art_dir):
+
+def _exit_code(failures: int) -> int:
+    """Map a failure count to a safe process exit status (0 stays 0)."""
+    return min(failures, _MAX_EXIT_CODE)
+
+
+def _log(msg: str) -> None:
+    """Print immediately — a wedged run must still leave a diagnosable log."""
+    print(msg, flush=True)
+
+
+class _Verdict:
+    """Append-only per-phase result log.
+
+    Written as each phase is decided (and flushed), so a hang during teardown
+    still leaves a usable verdict on disk instead of an empty log file.
+    """
+
+    def __init__(self, art_dir: Path):
+        self.path = art_dir / "verdict.jsonl"
+        try:
+            self.path.write_text("")   # fresh per run
+        except OSError:
+            pass
+
+    def record(self, phase: str, ok: bool, detail: str = "") -> None:
+        _log(f"{'PASS' if ok else 'FAIL'} {phase}: {detail}" if detail
+             else f"{'PASS' if ok else 'FAIL'} {phase}")
+        row = {
+            "ts": time.time(),
+            "phase": phase,
+            "status": "pass" if ok else "fail",
+            "detail": detail,
+        }
+        try:
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(row) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+        except OSError:
+            pass
+
+
+class _Deadline(Exception):
+    """Raised inside a bounded block when its wall-clock budget expires."""
+
+
+def _bounded(label: str, seconds: float, fn) -> bool:
+    """Run fn() under a hard wall-clock cap. True = completed, False = gave up.
+
+    SIGALRM is the mechanism because the sync Playwright API is greenlet-based
+    and must be driven from the thread that created it — a worker thread cannot
+    be used to bound a blocking call like context.close().
+    """
+    if not hasattr(signal, "setitimer") or seconds <= 0:
+        if seconds > 0:                          # pragma: no cover - env guard
+            _log(f"[teardown] {label}: UNBOUNDED on this platform "
+                 "(no SIGALRM) — a wedged close cannot be interrupted here")
+        try:
+            fn()
+            return True
+        except Exception as exc:                     # pragma: no cover - env guard
+            _log(f"[teardown] {label} raised {type(exc).__name__}: {exc}")
+            return False
+
+    def _fire(_signum, _frame):
+        raise _Deadline(label)
+
+    prev = signal.signal(signal.SIGALRM, _fire)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        fn()
+        return True
+    except _Deadline:
+        _log(f"[teardown] TIMEOUT: {label} exceeded {seconds:g}s — abandoning graceful close")
+        return False
+    except Exception as exc:
+        _log(f"[teardown] {label} raised {type(exc).__name__}: {exc}")
+        return False
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, prev)
+
+
+def _descendant_pids(root: int) -> list[int]:
+    """Best-effort descendant walk via /proc (Linux). [] where /proc is absent."""
+    children: dict[int, list[int]] = {}
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return []
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text()
+            # comm can contain ')' — ppid is the field right after the last ')'
+            ppid = int(stat[stat.rindex(")") + 1:].split()[1])
+        except (OSError, ValueError, IndexError):
+            continue
+        children.setdefault(ppid, []).append(int(entry.name))
+    out: list[int] = []
+    stack = list(children.get(root, []))
+    while stack:
+        pid = stack.pop()
+        out.append(pid)
+        stack.extend(children.get(pid, []))
+    return out
+
+
+def _kill_browser_tree() -> None:
+    """Kill the playwright driver + chromium descendants of THIS process.
+
+    A wedged teardown previously left orphaned drivers and ~19 chromium
+    processes behind that had to be killed by hand.
+    """
+    pids = _descendant_pids(os.getpid())
+    if not pids:
+        return
+    _log(f"[teardown] force-killing {len(pids)} browser descendant process(es)")
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        for pid in pids:
+            try:
+                os.kill(pid, sig)
+            except OSError:
+                pass
+        if sig is signal.SIGTERM:
+            time.sleep(1.0)
+
+
+def _bail_teardown(verdict: "_Verdict", failures: int, detail: str) -> None:
+    """Record the abandoned teardown, kill the browser, and exit immediately.
+
+    Deliberately skips sync_playwright().__exit__, which would block on the same
+    wedged connection. Closing our pipes makes the driver process exit too.
+    """
+    verdict.record("teardown", False, detail)
+    _kill_browser_tree()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(_exit_code(failures))
+
+
+def _install_termination_cleanup() -> None:
+    """On SIGTERM/SIGINT (e.g. pod-e2e.sh's `timeout`), take the browser with us.
+
+    Without this, killing a stalled driver leaves the playwright driver and its
+    chromium processes running until someone notices them.
+    """
+    def _bail(signum, _frame):
+        _log(f"[teardown] received signal {signum} — killing browser tree and exiting")
+        _kill_browser_tree()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(128 + signum)
+
+    for sig in (getattr(signal, "SIGTERM", None), getattr(signal, "SIGINT", None)):
+        if sig is not None:
+            try:
+                signal.signal(sig, _bail)
+            except (OSError, ValueError):       # pragma: no cover - env guard
+                pass
+
+
+def _transcode_videos(art_dir, max_mb: int = _DEFAULT_MAX_VIDEO_MB):
     """Best-effort .webm -> .mp4 transcode for shareability (per SKILL.md:
-    requires ffmpeg; when absent the .webm is kept and no .mp4 is produced)."""
+    requires ffmpeg; when absent the .webm is kept and no .mp4 is produced).
+
+    Recordings larger than max_mb are reported and skipped: a short spec that
+    produced hundreds of MB is a defect signal, and transcoding it would burn
+    minutes for an unusable artifact.
+    """
     import shutil as _shutil
     import subprocess as _sp
     from pathlib import Path as _P
     ffmpeg = os.environ.get("POD_E2E_FFMPEG") or _shutil.which("ffmpeg")
     if not ffmpeg:
-        print("[video] ffmpeg not found - keeping .webm only")
+        _log("[video] ffmpeg not found - keeping .webm only")
         return
     for webm in sorted(_P(art_dir).glob("*.webm")):
+        try:
+            size_mb = webm.stat().st_size / (1024 * 1024)
+        except OSError:
+            size_mb = 0.0
+        if max_mb > 0 and size_mb > max_mb:
+            _log(f"[video] {webm.name} is {size_mb:.0f}MB (> {max_mb}MB cap) - "
+                 "recording ran away, skipping transcode")
+            continue
         mp4 = webm.with_suffix(".mp4")
         try:
             # ffmpeg path comes from POD_E2E_FFMPEG (operator env) or
@@ -70,20 +265,24 @@ def _transcode_videos(art_dir):
                     "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(mp4)]
             r = _sp.run(argv, capture_output=True, timeout=600)  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
             if r.returncode == 0:
-                print(f"[video] wrote {mp4.name}")
+                _log(f"[video] wrote {mp4.name}")
             else:
-                print(f"[video] ffmpeg failed for {webm.name} - keeping .webm")
+                _log(f"[video] ffmpeg failed for {webm.name} - keeping .webm")
         except (OSError, _sp.TimeoutExpired):
-            print(f"[video] transcode error for {webm.name} - keeping .webm")
+            _log(f"[video] transcode error for {webm.name} - keeping .webm")
 
 
 def run(base_url: str, token: str, artifact_dir: str, spec: str | None,
         video: bool, default_timeout_ms: int, suppress_first_run: bool = True,
-        slow_mo_ms: int = 0, checkout: str | None = None) -> int:
+        slow_mo_ms: int = 0, checkout: str | None = None,
+        teardown_timeout: float = _DEFAULT_TEARDOWN_TIMEOUT,
+        max_video_mb: int = _DEFAULT_MAX_VIDEO_MB) -> int:
     art = Path(artifact_dir)
     art.mkdir(parents=True, exist_ok=True)
     authed = f"{base_url}/?token={token}"
     failures = 0
+    verdict = _Verdict(art)
+    started = time.monotonic()
 
     pw_expect.set_options(timeout=default_timeout_ms)
 
@@ -121,12 +320,13 @@ def run(base_url: str, token: str, artifact_dir: str, spec: str | None,
             # Assert SPA shell rendered (not a blank/error page)
             body_text = page.text_content("body") or ""
             if "Cannot GET" in body_text or len(body_text.strip()) < 20:
-                print(f"FAIL smoke: body too short or error page: {body_text[:100]}")
+                verdict.record("smoke", False,
+                               f"body too short or error page: {body_text[:100]}")
                 failures += 1
             else:
-                print("PASS smoke: SPA shell rendered")
+                verdict.record("smoke", True, "SPA shell rendered")
         except Exception as exc:
-            print(f"FAIL smoke: {exc}")
+            verdict.record("smoke", False, str(exc))
             traceback.print_exc()
             page.screenshot(path=str(art / "fe-smoke-FAIL.png"))
             failures += 1
@@ -150,18 +350,30 @@ def run(base_url: str, token: str, artifact_dir: str, spec: str | None,
                 allowed = f"skill specs/ ({_skill_dir})"
                 if checkout:
                     allowed += f" or checkout .pod-e2e/ ({Path(checkout).resolve() / '.pod-e2e'})"
-                print(
-                    f"FAIL spec: path {spec_path} is outside allowed directories: "
-                    f"{allowed} — refusing to execute"
+                verdict.record(
+                    "spec", False,
+                    f"path {spec_path} is outside allowed directories: "
+                    f"{allowed} — refusing to execute",
                 )
                 failures += 1
             elif not spec_path.exists():
-                print(f"FAIL spec: file not found: {spec}")
+                verdict.record("spec", False, f"file not found: {spec}")
                 failures += 1
             else:
                 def expect_true(condition: bool, msg: str = "assertion failed"):
                     if not condition:
                         raise AssertionError(msg)
+
+                def record_result(name: str, ok: bool, detail: str = "") -> None:
+                    """Spec-facing record: an ok=False row FAILS the run.
+
+                    Without this, a spec could report a failed assertion and
+                    still exit 0 — a silent pass on a real defect.
+                    """
+                    nonlocal failures
+                    verdict.record(name, ok, detail)
+                    if not ok:
+                        failures += 1
 
                 scope = {
                     "page": page,
@@ -171,6 +383,10 @@ def run(base_url: str, token: str, artifact_dir: str, spec: str | None,
                     "artifact_dir": str(art),
                     "expect": pw_expect,
                     "expect_true": expect_true,
+                    # Specs may append their own per-assertion rows so a later
+                    # stall still leaves the decided results on disk. A False
+                    # row counts as a failure, so it cannot pass silently.
+                    "record": record_result,
                 }
                 try:
                     # Dev-only E2E harness: spec files are local, developer-authored
@@ -178,23 +394,69 @@ def run(base_url: str, token: str, artifact_dir: str, spec: str | None,
                     # the worktree under test — not external/user input. Path is
                     # containment-checked above against skill specs/ dir and
                     # KiroCrew worktree roots.
-                    exec(spec_path.read_text(), scope)  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
-                    print(f"PASS spec: {spec}")
+                    exec(spec_path.read_text(encoding="utf-8"), scope)  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+                    verdict.record("spec", True, spec)
                 except Exception as exc:
-                    print(f"FAIL spec: {exc}")
+                    verdict.record("spec", False, f"{spec}: {exc}")
                     traceback.print_exc()
                     page.screenshot(path=str(art / "fe-spec-FAIL.png"))
                     failures += 1
 
-        context.close()
+        # --- Teardown (bounded) ---------------------------------------------
+        # The verdict above is already decided and on disk. context.close() is
+        # what finalizes a video recording and has been observed to block
+        # forever, so every step below runs under a hard cap and a stall can
+        # only cost the .mp4 — never the result.
+        _log(f"[teardown] closing browser (cap {teardown_timeout:g}s per step) ...")
+        elapsed = time.monotonic() - started
         if video:
-            _transcode_videos(art)
-        browser.close()
+            _log(f"[video] session length {elapsed:.0f}s — finalizing recording")
+
+        # Give the recording a defined end: stop route handlers and page
+        # activity BEFORE asking the context to finalize.
+        unroute_all = getattr(page, "unroute_all", None)   # playwright >= 1.41
+        if unroute_all is not None:
+            _bounded("page.unroute_all", min(5.0, teardown_timeout), unroute_all)
+        _bounded("page.close", min(10.0, teardown_timeout), page.close)
+
+        ctx_closed = _bounded("context.close", teardown_timeout, context.close)
+        if not ctx_closed:
+            # The recording never reached a defined end, so the .webm is
+            # incomplete: transcoding it would spend up to ffmpeg's 600s
+            # timeout to produce a truncated .mp4. Keep the partial file and
+            # get out instead of doing more bounded work on a wedged browser.
+            if video:
+                _log("[video] recording never finalized — keeping the partial "
+                     ".webm, skipping transcode")
+            _bail_teardown(verdict, failures,
+                           "context.close timed out — recording not finalized; "
+                           "artifacts kept, browser killed, exiting hard")
+
+        if video:
+            _transcode_videos(art, max_video_mb)
+
+        if not _bounded("browser.close", teardown_timeout, browser.close):
+            _bail_teardown(verdict, failures,
+                           "browser.close timed out — artifacts kept, "
+                           "browser killed, exiting hard")
 
     return failures
 
 
 def main():
+    # A wedged run must still be diagnosable: pod-e2e.sh redirects our stdout to
+    # a file, which would otherwise stay block-buffered and empty mid-hang.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:                # pragma: no cover - env guard
+            continue
+        try:
+            reconfigure(line_buffering=True)
+        except (OSError, ValueError):          # pragma: no cover - env guard
+            pass
+
+    _install_termination_cleanup()
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--base-url", required=True)
     ap.add_argument("--token", default=None,
@@ -205,6 +467,10 @@ def main():
                     help="Worktree checkout path; specs under <checkout>/.pod-e2e/ are trusted")
     ap.add_argument("--video", action="store_true")
     ap.add_argument("--timeout", type=int, default=10000)
+    ap.add_argument("--teardown-timeout", type=float, default=_DEFAULT_TEARDOWN_TIMEOUT,
+                    help="Hard cap (seconds) per browser-teardown step; 0 disables the cap")
+    ap.add_argument("--max-video-mb", type=int, default=_DEFAULT_MAX_VIDEO_MB,
+                    help="Skip transcoding recordings larger than this (runaway guard); 0 disables")
     ap.add_argument("--no-suppress-first-run", action="store_true")
     ap.add_argument("--slow-mo", type=int, default=0)
     args = ap.parse_args()
@@ -223,8 +489,10 @@ def main():
         suppress_first_run=not args.no_suppress_first_run,
         slow_mo_ms=args.slow_mo,
         checkout=args.checkout,
+        teardown_timeout=args.teardown_timeout,
+        max_video_mb=args.max_video_mb,
     )
-    sys.exit(rc)
+    sys.exit(_exit_code(rc))
 
 
 if __name__ == "__main__":

--- a/test/test_pod_e2e_video_guard.py
+++ b/test/test_pod_e2e_video_guard.py
@@ -1,0 +1,563 @@
+"""Guards for the pod-e2e ``--video`` hang (issue #645).
+
+A spec that passed in 16s must never be lost to an unbounded browser teardown,
+so these tests pin the three mechanisms that make that impossible:
+
+* ``_bounded`` returns instead of blocking forever;
+* the verdict is on disk the moment a phase is decided;
+* a runaway recording is reported and skipped, not transcoded for minutes.
+
+The driver is a bundled *skill script* (``pod-playwright.py``, a dash in the
+name and not importable as a module), so it is loaded by path.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+_SKILL = (
+    Path(__file__).resolve().parent.parent
+    / "src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e"
+)
+_DRIVER = _SKILL / "scripts/pod-playwright.py"
+_RUNNER = _SKILL / "scripts/pod-e2e.sh"
+
+
+_DRIVER_MOD = None
+
+
+def _runner_text() -> str:
+    """Read the runner as UTF-8 — the default locale codec is cp1252 on
+    Windows and the script contains em dashes and ⚠️."""
+    return _RUNNER.read_text(encoding="utf-8")
+
+
+def _load_driver():
+    """Load the skill script, stubbing playwright if it isn't installed here.
+
+    The driver only needs ``playwright.sync_api`` at import time; every helper
+    under test is pure Python, so CI does not need a browser stack to pin them.
+    The stub is removed from ``sys.modules`` afterwards so nothing else in the
+    worker sees a fake playwright.
+    """
+    global _DRIVER_MOD
+    if _DRIVER_MOD is not None:
+        return _DRIVER_MOD
+
+    saved: dict[str, object] = {}
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        pw = types.ModuleType("playwright")
+        sync_api = types.ModuleType("playwright.sync_api")
+        # Give both stubs a real __spec__: importlib.util.find_spec() raises
+        # ValueError on a sys.modules entry whose __spec__ is None.
+        pw.__spec__ = importlib.machinery.ModuleSpec("playwright", loader=None)
+        sync_api.__spec__ = importlib.machinery.ModuleSpec(
+            "playwright.sync_api", loader=None
+        )
+        sync_api.expect = types.SimpleNamespace(set_options=lambda **k: None)
+        sync_api.sync_playwright = lambda: None
+        pw.sync_api = sync_api
+        for name, stub in (("playwright", pw), ("playwright.sync_api", sync_api)):
+            saved[name] = sys.modules.get(name)
+            sys.modules[name] = stub
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "pod_playwright_under_test", _DRIVER
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+
+    _DRIVER_MOD = mod
+    return mod
+
+
+@pytest.fixture(scope="module")
+def driver():
+    return _load_driver()
+
+
+# --- bounded teardown -------------------------------------------------------
+
+
+def test_bounded_returns_true_when_call_completes(driver):
+    calls = []
+    assert driver._bounded("noop", 5, lambda: calls.append(1)) is True
+    assert calls == [1]
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "setitimer"), reason="SIGALRM-based bound is POSIX-only"
+)
+def test_bounded_gives_up_on_a_blocking_call(driver, capsys):
+    """The defect: context.close() blocks forever. It must now be abandoned."""
+    started = time.monotonic()
+
+    def _wedged():
+        time.sleep(30)          # stands in for the never-finalizing recording
+
+    assert driver._bounded("context.close", 0.5, _wedged) is False
+    assert time.monotonic() - started < 10, "bounded call did not return early"
+    assert "TIMEOUT" in capsys.readouterr().out
+
+
+def test_bounded_reports_but_swallows_exceptions(driver, capsys):
+    def _boom():
+        raise RuntimeError("browser already gone")
+
+    assert driver._bounded("browser.close", 5, _boom) is False
+    assert "browser.close raised RuntimeError" in capsys.readouterr().out
+
+
+# --- incremental verdict ----------------------------------------------------
+
+
+def test_verdict_rows_land_on_disk_immediately(driver, tmp_path):
+    verdict = driver._Verdict(tmp_path)
+    verdict.record("smoke", True, "SPA shell rendered")
+    verdict.record("spec", False, "boom")
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "verdict.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [(r["phase"], r["status"]) for r in rows] == [
+        ("smoke", "pass"),
+        ("spec", "fail"),
+    ]
+    assert rows[1]["detail"] == "boom"
+
+
+def test_verdict_is_reset_per_run(driver, tmp_path):
+    (tmp_path / "verdict.jsonl").write_text('{"phase": "stale"}\n')
+    driver._Verdict(tmp_path).record("smoke", True)
+    assert "stale" not in (tmp_path / "verdict.jsonl").read_text(encoding="utf-8")
+
+
+# --- runaway recording ------------------------------------------------------
+
+
+def test_oversized_recording_is_skipped_not_transcoded(driver, tmp_path, monkeypatch, capsys):
+    """386MB for a 16s spec is a defect signal — don't burn minutes on ffmpeg."""
+    monkeypatch.setenv("POD_E2E_FFMPEG", "/bin/false")
+    (tmp_path / "page@runaway.webm").write_bytes(b"\0" * (2 * 1024 * 1024))
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: ran.append(list(argv)))
+
+    driver._transcode_videos(tmp_path, max_mb=1)
+
+    assert ran == [], "ffmpeg invoked for an oversized recording"
+    assert "skipping transcode" in capsys.readouterr().out
+
+
+def test_normal_recording_is_transcoded(driver, tmp_path, monkeypatch):
+    monkeypatch.setenv("POD_E2E_FFMPEG", "/bin/true")
+    (tmp_path / "page@small.webm").write_bytes(b"\0" * 16)
+
+    argvs: list[list[str]] = []
+
+    def _fake_run(argv, **kwargs):
+        argvs.append(list(argv))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    driver._transcode_videos(tmp_path, max_mb=200)
+
+    assert len(argvs) == 1
+    assert argvs[0][0] == "/bin/true"
+    assert argvs[0][-1].endswith("page@small.mp4")
+
+
+# --- orphan cleanup ---------------------------------------------------------
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="/proc walk is Linux-only")
+def test_descendant_pids_finds_a_grandchild(driver):
+    """A wedged run used to leave the driver + ~19 chromium processes behind."""
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import subprocess,sys,time;"
+         "subprocess.Popen([sys.executable,'-c','import time;time.sleep(20)']);"
+         "time.sleep(20)"]
+    )
+    try:
+        deadline = time.monotonic() + 5
+        pids: list[int] = []
+        while time.monotonic() < deadline:
+            pids = driver._descendant_pids(os.getpid())
+            if len(pids) >= 2:
+                break
+            time.sleep(0.1)
+        assert child.pid in pids
+        assert len(pids) >= 2, "grandchild (chromium stand-in) not walked"
+    finally:
+        child.kill()
+        child.wait(timeout=10)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGTERM"), reason="POSIX only")
+def test_termination_cleanup_is_installed(driver):
+    """`timeout` SIGTERMs us — we must take chromium with us, not orphan it."""
+    prev = signal.getsignal(signal.SIGTERM)
+    try:
+        driver._install_termination_cleanup()
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler) and handler is not prev
+    finally:
+        signal.signal(signal.SIGTERM, prev)
+
+
+# --- the orchestrator bounds the phase --------------------------------------
+
+
+# --- spec-facing record() affects the exit code ------------------------------
+
+
+class _FakeKeyboard:
+    def press(self, _key):
+        pass
+
+
+class _FakeLocator:
+    first = None
+
+    def __init__(self):
+        self.first = self
+
+    def is_visible(self):
+        return False
+
+
+class _FakePage:
+    def __init__(self):
+        self.keyboard = _FakeKeyboard()
+        self.closed = False
+        self.unrouted = False
+
+    def goto(self, *_a, **_k):
+        pass
+
+    def locator(self, _sel):
+        return _FakeLocator()
+
+    def screenshot(self, path=None):
+        Path(path).write_bytes(b"")
+
+    def text_content(self, _sel):
+        return "KiroCrew dashboard shell rendered fine"
+
+    def unroute_all(self):
+        self.unrouted = True
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeContext:
+    def __init__(self, hang_close: bool = False):
+        self.page = _FakePage()
+        self.closed = False
+        self.hang_close = hang_close
+
+    def add_init_script(self, _script):
+        pass
+
+    def new_page(self):
+        return self.page
+
+    def close(self):
+        if self.hang_close:
+            time.sleep(30)                      # the defect: never finalizes
+        self.closed = True
+
+
+class _FakeBrowser:
+    def __init__(self, hang_close: bool = False):
+        self.context = _FakeContext(hang_close=hang_close)
+        self.closed = False
+
+    def new_context(self, **_k):
+        return self.context
+
+    def close(self):
+        self.closed = True
+
+
+class _FakePlaywright:
+    def __init__(self, hang_close: bool = False):
+        self.browser = _FakeBrowser(hang_close=hang_close)
+        self.chromium = types.SimpleNamespace(launch=lambda **_k: self.browser)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _run_spec(driver, tmp_path, spec_body: str):
+    """Drive run() end-to-end against a fake browser, with a trusted spec."""
+    spec_dir = tmp_path / ".pod-e2e"
+    spec_dir.mkdir()
+    spec = spec_dir / "feature.spec.py"
+    spec.write_text(spec_body, encoding="utf-8")
+
+    fake = _FakePlaywright()
+    original = driver.sync_playwright
+    driver.sync_playwright = lambda: fake
+    try:
+        rc = driver.run(
+            base_url="http://127.0.0.1:1",
+            token="t",
+            artifact_dir=str(tmp_path / "art"),
+            spec=str(spec),
+            video=False,
+            default_timeout_ms=1000,
+            checkout=str(tmp_path),
+        )
+    finally:
+        driver.sync_playwright = original
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "art" / "verdict.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if line.strip()
+    ]
+    return rc, rows, fake
+
+
+def test_spec_recorded_failure_fails_the_run(driver, tmp_path):
+    """A recorded ok=False row must not exit 0 (GPT 5.6 finding on aedafbff)."""
+    rc, rows, _ = _run_spec(driver, tmp_path, 'record("widget", False, "boom")\n')
+
+    assert rc >= 1, "recorded failure produced a passing verdict"
+    assert ("widget", "fail") in [(r["phase"], r["status"]) for r in rows]
+
+
+def test_spec_recorded_pass_keeps_the_run_green(driver, tmp_path):
+    rc, rows, fake = _run_spec(driver, tmp_path, 'record("widget", True, "ok")\n')
+
+    assert rc == 0
+    assert ("widget", "pass") in [(r["phase"], r["status"]) for r in rows]
+    # teardown ran in order: routes off, page closed, context + browser closed
+    assert fake.browser.context.page.unrouted is True
+    assert fake.browser.context.page.closed is True
+    assert fake.browser.context.closed is True
+    assert fake.browser.closed is True
+
+
+def _usable_bash() -> str | None:
+    """Return a bash that can actually execute a script, else None.
+
+    `shutil.which("bash")` is not enough: on GitHub's Windows runners it finds
+    the WSL launcher stub, which exits 1 with a UTF-16 "no installed
+    distributions" message instead of running anything. Probe it.
+    """
+    candidates = ["bash", r"C:\Program Files\Git\bin\bash.exe"]
+    for cand in candidates:
+        exe = shutil.which(cand)
+        if exe is None and Path(cand).exists():
+            exe = cand
+        if exe is None:
+            continue
+        try:
+            probe = subprocess.run(
+                [exe, "-c", "echo ok"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+            )
+        except OSError:                         # pragma: no cover - env guard
+            continue
+        if probe.returncode == 0 and "ok" in (probe.stdout or ""):
+            return exe
+    return None
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "setitimer"),
+    reason="the teardown bound needs SIGALRM; it degrades to unbounded here "
+           "(the harness itself is POSIX-only)",
+)
+def test_unfinalized_recording_is_not_transcoded(driver, tmp_path, monkeypatch):
+    """A wedged context.close() must not hand an incomplete .webm to ffmpeg.
+
+    (GPT 5.6 finding on b29f392a: that costs ffmpeg's 600s timeout and yields a
+    truncated .mp4.) The run must bail immediately instead.
+    """
+    class _Bail(Exception):
+        pass
+
+    transcodes: list[tuple] = []
+    monkeypatch.setattr(
+        driver, "_transcode_videos", lambda *a, **k: transcodes.append(a)
+    )
+    monkeypatch.setattr(driver, "_kill_browser_tree", lambda: None)
+
+    def _fake_exit(code):
+        raise _Bail(code)
+
+    monkeypatch.setattr(driver.os, "_exit", _fake_exit)
+
+    fake = _FakePlaywright(hang_close=True)
+    monkeypatch.setattr(driver, "sync_playwright", lambda: fake)
+
+    art = tmp_path / "art"
+    with pytest.raises(_Bail):
+        driver.run(
+            base_url="http://127.0.0.1:1",
+            token="t",
+            artifact_dir=str(art),
+            spec=None,
+            video=True,
+            default_timeout_ms=1000,
+            teardown_timeout=0.2,
+        )
+
+    assert transcodes == [], "ffmpeg invoked on an unfinalized recording"
+    rows = [
+        json.loads(line)
+        for line in (art / "verdict.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    teardown = [r for r in rows if r["phase"] == "teardown"]
+    assert teardown and teardown[-1]["status"] == "fail"
+    assert "not finalized" in teardown[-1]["detail"]
+    assert fake.browser.closed is False, "browser.close attempted after the bail"
+
+
+def test_exit_code_cannot_wrap_to_zero(driver):
+    """A raw count of 256 would be reported as exit 0 (GPT on 62d4fd38)."""
+    assert driver._exit_code(0) == 0
+    assert driver._exit_code(3) == 3
+    assert driver._exit_code(256) == driver._MAX_EXIT_CODE
+    assert 0 < driver._exit_code(100000) < 255
+
+
+def test_both_exit_sites_are_clamped(driver, monkeypatch, tmp_path):
+    """The bail path and main() must route through _exit_code, not the raw count."""
+    source = _DRIVER.read_text(encoding="utf-8")
+    assert "os._exit(failures)" not in source
+    assert "sys.exit(rc)" not in source
+
+    codes: list[int] = []
+    monkeypatch.setattr(driver, "_kill_browser_tree", lambda: None)
+    monkeypatch.setattr(driver.os, "_exit", lambda code: codes.append(code))
+    driver._bail_teardown(driver._Verdict(tmp_path), 300, "wedged")
+    assert codes == [driver._MAX_EXIT_CODE]
+
+
+def test_verdict_is_truncated_on_every_invocation():
+    """A stale verdict must never be presented as this run's.
+
+    GPT on `e4618909` caught the driver-dies-early case; the Arbiter on
+    `0a853308` caught that truncating inside the Playwright branch still leaves
+    stale rows for every skip path (--api-only, unhealthy pod, no
+    KIROCREW_PW_PY). So it must run unconditionally, right after mkdir.
+    """
+    lines = _runner_text().splitlines()
+
+    def _index(needle: str):
+        return next((i for i, ln in enumerate(lines) if needle in ln), None)
+
+    mkdir = _index('mkdir -p "$ARTIFACT_DIR"')
+    truncate = _index(': > "$ARTIFACT_DIR/verdict.jsonl"')
+    fe_branch = _index('if [ "$RUN_FE" -eq 1 ]')
+    launch = _index('KIROCREW_POD_TOKEN="$TOKEN" "${PW_CMD[@]}"')
+
+    assert truncate is not None, "verdict.jsonl is never truncated"
+    assert mkdir is not None and fe_branch is not None and launch is not None
+    assert mkdir < truncate, "truncated before its directory exists"
+    assert truncate < fe_branch, (
+        "truncation is inside the FE phase — skip paths would serve a stale verdict"
+    )
+    assert truncate < launch
+
+
+def test_warnings_do_not_inflate_the_passed_count():
+    """A ⚠️ line is neither a pass nor a fail (GPT 5.6 finding on 82ff4f3a).
+
+    Runs the runner's OWN helper definitions and summary arithmetic under bash,
+    so this fails if either side drifts.
+    """
+    bash = _usable_bash()
+    if bash is None:                            # pragma: no cover - Windows
+        pytest.skip("no working bash on this host")
+
+    lines = _runner_text().splitlines()
+    helpers = [ln for ln in lines if ln.startswith(("pass()", "fail()", "warn()"))]
+    assert len(helpers) == 3, "pass/fail/warn helpers not found"
+
+    start = next(i for i, ln in enumerate(lines) if ln.startswith("PASSED="))
+    end = next(i for i, ln in enumerate(lines) if ln.startswith('echo "$SUMMARY"'))
+    summary = lines[start:end + 1]
+
+    script = "\n".join(
+        [
+            "set -uo pipefail",
+            "declare -a RESULTS=(); FAILURES=0; WARNINGS=0",
+            *helpers,
+            'pass "phase-a"; fail "phase-b"; warn "phase-c"',
+            *summary,
+        ]
+    )
+    out = subprocess.run(
+        [bash, "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert out.returncode == 0, f"{out.stdout}\n{out.stderr}"
+    assert "result:       1 passed, 1 failed, 1 warning(s)" in out.stdout, out.stdout
+
+
+def test_pod_e2e_sh_bounds_the_playwright_phase():
+    body = _runner_text()
+    assert "POD_E2E_PW_TIMEOUT" in body
+    assert "timeout --kill-after" in body
+    # unbuffered driver output, so playwright.log is diagnosable mid-hang
+    assert '"$PW_PY" -u' in body
+    # a timeout is a distinct reportable outcome, not a silent stall
+    assert "TIMED OUT" in body
+    assert "-eq 124" in body
+
+
+def test_teardown_bail_row_matches_the_summary_grep(driver, tmp_path):
+    """The summary warning greps verdict.jsonl — keep the two in lockstep."""
+    import re
+
+    driver._Verdict(tmp_path).record("teardown", False, "graceful close timed out")
+    line = (tmp_path / "verdict.jsonl").read_text(encoding="utf-8").strip()
+
+    pattern = re.search(
+        r"grep -q '([^']+)' \"\$ARTIFACT_DIR/verdict\.jsonl\"", _runner_text()
+    )
+    assert pattern, "summary no longer greps verdict.jsonl"
+    assert re.search(pattern.group(1), line), (
+        f"grep pattern {pattern.group(1)!r} no longer matches a teardown row"
+    )


### PR DESCRIPTION
Fixes #645.

## Problem

`pod-e2e.sh --video` could hang **indefinitely after the spec had already passed**. `context.close()` — the call that finalizes a Playwright recording — blocked forever, the `.webm` grew past 380MB for a 16-second spec, `playwright.log` stayed 0 bytes, and orphaned drivers plus ~19 chromium processes had to be killed by hand. A QA subagent burned its whole wall-clock budget and reported nothing, even though the verdict was decided seconds in.

## Fix

Nothing here tries to explain Playwright's internal stall. The engineering defect is that the only path producing the artifact was an unbounded blocking teardown on an unbounded phase, so both are now bounded and the verdict is durable before teardown starts.

**`pod-playwright.py`**
- Every teardown step (`page.unroute_all` → `page.close` → `context.close` → `browser.close`) runs under a hard wall-clock cap, `--teardown-timeout` (default 30s). SIGALRM is the mechanism because the sync API is greenlet-based and cannot be bounded from a worker thread.
- On expiry: log it, keep every artifact, kill the browser descendants, and `os._exit(failures)` — deliberately skipping `sync_playwright().__exit__`, which would block on the same wedged connection. **A stall can now cost the `.mp4`, never the result.**
- The recording gets a defined end: route handlers are removed and the page closed *before* the context is asked to finalize.
- Runaway guard: a `.webm` over `--max-video-mb` (default 200) is reported and left un-transcoded — 386MB for a 16s spec is a defect signal, and ffmpeg on it wastes minutes for an unusable file.
- The verdict is appended to `<artifact-dir>/verdict.jsonl` **as each phase is decided** (fsync'd), and `record(name, ok, detail)` is exposed to specs for per-assertion rows. Output is line-buffered, so `playwright.log` is diagnosable mid-hang instead of empty.
- SIGTERM/SIGINT kill the browser tree before exiting, so the phase timeout no longer leaves orphans.

**`pod-e2e.sh`**
- The driver runs under `timeout --kill-after=30s` (`POD_E2E_PW_TIMEOUT`, default 600s) and with `python -u`. Every other phase was already bounded (health polling caps at 45s); this one wasn't.
- Expiry (124/137) is reported as a distinct `playwright — TIMED OUT after Ns` outcome pointing at the surviving artifacts, instead of a silent stall.

**Docs** — `SKILL.md` and `docs/system-specs/modules/dev-fleet.md` state the bounds and the `verdict.jsonl` contract, and the QA-agent prompt now tells the agent to read it. Also fixes a stale env name: the docs said `POD_FFMPEG`, the code reads `POD_E2E_FFMPEG`.

## Tests

New `test/test_pod_e2e_video_guard.py` (10 tests, all passing) pins the mechanisms rather than the symptom:

- `_bounded` returns early on a call that blocks for 30s (the defect's shape), reports the timeout, and swallows/reports exceptions.
- `verdict.jsonl` rows land on disk the moment a phase is decided, and are reset per run.
- An oversized recording is skipped (ffmpeg never invoked); a normal one still transcodes.
- `_descendant_pids` walks a real child + grandchild, so the orphan-kill path has teeth.
- SIGTERM cleanup is installed.
- The shell script is asserted to bound the phase (`timeout --kill-after`, `python -u`, distinct `TIMED OUT` branch).

The driver loads with a stubbed `playwright.sync_api` when the package is absent, so CI pins these guards without a browser stack.

## Verification

- `isort --check-only` + `flake8` + `mypy` clean on the changed files (the 2 remaining `mypy` findings in `src/kiro_crew/transcribe.py` are identical on `main`).
- `bash -n` clean on `pod-e2e.sh`.
- `pytest test/test_pod_e2e_video_guard.py` → 10 passed.
- Not yet run: a live `--video` pod run against this branch. Every guard here is unit-pinned, but the end-to-end "record a real session, finalize under the cap" path has not been exercised on this host in this PR (no Playwright interpreter is provisioned for the live fleet right now). Worth doing before merge if a reviewer wants belt-and-braces.
