### PR TITLE
feat(dashboard): click PR head branch name to copy it

### DIFF
--- a/website/src/components/PullRequestPanel.tsx
+++ b/website/src/components/PullRequestPanel.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   Circle,
+  Copy,
   ExternalLink,
   GitCommitHorizontal,
   GitMerge,
@@ -33,6 +34,7 @@ import {
   type PullRequestLink,
 } from '../utils/pullRequestLinks'
 import { parseUnifiedDiff } from '../utils/parseUnifiedDiff'
+import { copyToClipboard } from '../utils/clipboard'
 import hljs from '../utils/hljs'
 import DOMPurify from 'dompurify'
 import { DIFF_BG, DIFF_FG } from '../utils/diffUtils'
@@ -540,6 +542,52 @@ export function pullRequestIsLive(source: PullRequestSource): boolean {
   return state === 'open' || state === 'opened' || state === 'draft'
 }
 
+/** The head branch name in the panel header, rendered as a click-to-copy
+ * affordance. Clicking copies the raw branch name to the clipboard via the
+ * shared {@link copyToClipboard} helper (which falls back to a hidden textarea +
+ * execCommand on non-secure origins where navigator.clipboard is absent) and
+ * briefly swaps the trailing copy glyph for a check. If the copy genuinely
+ * fails, the failure is swallowed and the label stays put rather than falsely
+ * announcing success. */
+export function CopyBranchButton({ branch }: { branch: string }) {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    },
+    [],
+  )
+  const handleCopy = async () => {
+    try {
+      await copyToClipboard(branch)
+    } catch {
+      // Both clipboard paths failed (no clipboard API and execCommand denied):
+      // leave the label as-is rather than announcing a copy that did not happen.
+      return
+    }
+    setCopied(true)
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="group/branch min-w-0 inline-flex items-center gap-1 truncate rounded px-1 -mx-1 border-none bg-transparent text-inherit hover:bg-bg-hover cursor-pointer"
+      aria-label={copied ? `Copied branch name ${branch}` : `Copy branch name ${branch}`}
+      title={copied ? 'Copied!' : 'Copy branch name'}
+    >
+      <span className="truncate">{branch}</span>
+      {copied ? (
+        <Check className="lucide-inline shrink-0 text-ok" />
+      ) : (
+        <Copy className="lucide-inline shrink-0 opacity-0 group-hover/branch:opacity-70 transition-opacity" />
+      )}
+    </button>
+  )
+}
+
 /** Provider-write actions on the loaded pull request: take it out of draft, and
  * arm auto-merge. Both are owner-only server-side; failures surface inline
  * rather than as a toast, so the reason stays next to the button that caused it.
@@ -1007,7 +1055,7 @@ export default function PullRequestPanel({
               <span className={`px-1.5 py-0.5 rounded font-medium ${stateTone(source)}`}>{stateLabel(source)}</span>
               <span className="capitalize">{source.provider}</span>
               {source.headBranch && source.baseBranch && (
-                <span className="min-w-0 flex items-center gap-1 truncate"><span className="truncate">{source.headBranch}</span><ArrowRight className="lucide-inline shrink-0" /><span className="truncate">{source.baseBranch}</span></span>
+                <span className="min-w-0 flex items-center gap-1 truncate"><CopyBranchButton branch={source.headBranch} /><ArrowRight className="lucide-inline shrink-0" /><span className="truncate">{source.baseBranch}</span></span>
               )}
               <Btn
                 type="button"

--- a/website/src/test/PullRequestPanel.test.tsx
+++ b/website/src/test/PullRequestPanel.test.tsx
@@ -124,6 +124,22 @@ describe('PullRequestPanel', () => {
     expect(gitlabTab.querySelector('[data-provider-mark="gitlab"]')).toBeInTheDocument()
   })
 
+  it('copies the head branch name to the clipboard when the branch chip is clicked', async () => {
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    try {
+      renderPanel()
+      const copyBtn = await screen.findByRole('button', { name: /Copy branch name feature\/source-tabs/i })
+      fireEvent.click(copyBtn)
+      expect(writeText).toHaveBeenCalledWith('feature/source-tabs')
+      await screen.findByRole('button', { name: /Copied branch name feature\/source-tabs/i })
+    } finally {
+      if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+      else delete (navigator as { clipboard?: unknown }).clipboard
+    }
+  })
+
   it('shows lifecycle and CI state on every source tab, not just the selected one', async () => {
     mockApi.pullRequestStatuses.mockResolvedValue({
       statuses: {


### PR DESCRIPTION
## Problem
In the pull-request preview panel header, the head branch name (e.g. `fix/background-approval-cx`) was rendered as static text. To check the branch out, paste it into a chat, or reference it elsewhere, the user had to hand-retype it — error-prone for long, slash-heavy branch names.

## Why it matters
Copying the branch name is a frequent, low-value-if-manual action. Retyping invites typos (wrong checkout target) and adds friction to a routine step in the PR workflow.

## Fix (symptom → root cause → change)
- Symptom: branch name in the panel header can't be copied by clicking it.
- Root cause: it was plain `<span>` text with no interaction affordance.
- Change: the head branch is now a `CopyBranchButton` — a text button that, on click, copies the raw branch name to the clipboard and briefly swaps the trailing copy glyph for a green check ("Copied!"). The copy routes through the codebase's existing `copyToClipboard` helper (`website/src/utils/clipboard.ts`), which the other copy affordances (`DiffPanel`, `DiffBlock`, `SelectionToolbar`, `MarkdownPanel`, `ArtifactPanel`) already use. That helper falls back to a hidden `<textarea>` + `execCommand('copy')` on non-secure origins where `navigator.clipboard` is absent, so the "Copied!" state is truthful rather than announcing success when nothing was written. A genuine copy failure leaves the label unchanged. The base branch after the arrow stays plain text; only the PR's own (head) branch is copyable.

## Tests
- `website/src/test/PullRequestPanel.test.tsx`: new test "copies the head branch name to the clipboard when the branch chip is clicked" — stubs `navigator.clipboard`, clicks the branch chip, asserts `writeText` was called with the exact branch name and that the button flips to its "Copied" state. The stub captures and restores the original `clipboard` descriptor in a `finally`, so it does not leak onto `navigator` for later tests.

## Manual verification
N/A — component unit coverage plus `tsc`/eslint/vitest are sufficient for this inline affordance. Behavior verified locally: `tsc --noEmit` clean, eslint clean, 39/39 `PullRequestPanel` vitest cases pass.

## Screenshots
Minor inline affordance in an existing header (a faint copy glyph appears on hover next to the head branch; clicking it shows a green check + "Copied!" tooltip for ~1.5s). No new panels, layouts, or themes. Faithfully capturing it requires a running instance with a real PR loaded into the panel; happy to attach a captured shot on request.
