### PR TITLE
feat: view and edit Kiro steering files under Agent Capabilities

### DIFF
--- a/docs/kiro-cli/steering.md
+++ b/docs/kiro-cli/steering.md
@@ -13,6 +13,10 @@ Persistent project knowledge via markdown files. Instead of explaining conventio
 
 Workspace steering takes priority over global on conflicts.
 
+## Viewing and editing in KiroCrew
+
+The dashboard surfaces both locations under **Agent Capabilities → Steering**: it lists every `.md` file in `~/.kiro/steering` and the active project's `.kiro/steering`, renders the content, and supports creating, editing and deleting files. See `docs/system-specs/features/steering-viewer.md`.
+
 ## Foundational steering files
 
 - `product.md` — product purpose, users, features, business objectives

--- a/docs/system-specs/features/steering-viewer.md
+++ b/docs/system-specs/features/steering-viewer.md
@@ -1,0 +1,53 @@
+# Steering Viewer
+
+The Steering tab under Agent Capabilities lists, reads, creates, edits and deletes the Kiro steering files that are injected into every session.
+
+Before this feature steering files were loaded but never surfaced: nothing in the dashboard showed which always-on conventions were in effect.
+
+## Policy
+
+Two locations are shown, with provenance, because two different mechanisms load them:
+
+| Source | Location | Loaded by |
+|--------|----------|-----------|
+| `user` (Global) | `~/.kiro/steering/**/*.md` | kiro-cli for every session; also what the CC-backend injection in `context.py:_load_steering_resources()` reaches, since its `file://.kiro/steering/**/*.md` resource globs against `$HOME` |
+| `workspace` (Workspace) | `<project>/.kiro/steering/**/*.md` | kiro-cli, because the session subprocess runs with the slot's project directory as cwd |
+
+The active project comes from `_ChatSlot.project` via `handlers/_shared.py:active_project_dir()`, which resolves deterministically: the slot named by the request's `X-Session-Key` if it has a project, else the single project every slot agrees on, else nothing. That last case matters for mutations — with two chats open on different projects there is no defensible "active" project for a settings page, and picking the first-inserted slot would create, overwrite or delete files in the wrong project. With no project (or an ambiguous one), only the global root is offered and `POST /api/steering` with `source=workspace` is a 400.
+
+Every steering filesystem transaction — the two-root scan, the single-file read, and each create / update / delete — runs as one complete blocking function on `discovery_executor()`. A project on a slow or network filesystem must never stall the event loop, and with it every chat and the heartbeat, for the duration of a write.
+
+Path policy (`handlers/steering.py`):
+
+- A file handle is `"<source>/<relpath>"`. `_split_key()` rejects a missing/unknown source, absolute paths, `~`, `..` segments, backslashes, NUL, and any suffix other than `.md`.
+- Containment is anchored on the **trust base** (`$HOME` for `user`, the project dir for `workspace`), not on the steering root: `_contained()` resolves the deepest *existing* ancestor and requires it to sit at or under the resolved base. This is what rejects a `~/.kiro/steering` symlink pointing at `/etc` — comparing against the root itself would follow such a link.
+- `is_sensitive_path()` gates every root, listed entry and resolved target; writes additionally gate on `is_sensitive_write_path()`.
+- A symlink at the **leaf** is rejected outright and never listed — not merely one that escapes the base. `.kiro/steering/rules.md -> ../../README.md` satisfies base containment, so without this a `PUT` would truncate (and `DELETE` unlink) a file that is not a steering document.
+- Update replaces the file (`atomic_write()`: unique temp file in the same directory, then `os.replace`) rather than truncating in place — on a nearly full filesystem a truncate followed by a failed write would destroy the user's document. `os.replace` swaps the directory entry rather than writing through it, so it cannot follow a symlink raced into place and needs no descriptor-identity check.
+- Update preserves the target's existing permission bits (`mode=stat.S_IMODE(pre.st_mode)`) rather than forcing `0o600` — the old in-place write inherited them, and a project steering file checked out group-readable must not be silently tightened by a save. Create uses `0o600`, which is correct for a file this endpoint is bringing into existence.
+- Both write paths pass `newline=""`. Text-mode writes translate `\n` to `\r\n` on Windows, so a document read back and saved again would accumulate carriage returns on every cycle (CRLF → CR CR LF → …). Content lands on disk exactly as the editor sent it. `atomic_write()` gained an opt-in `newline` parameter for this; its default behavior is unchanged.
+- Create uses `os.open` with `O_NOFOLLOW` where the platform has it (absent on Windows, so the flag comes from `getattr(os, "O_NOFOLLOW", 0)` — referencing it directly would make every write a 500 there). Create adds `O_EXCL`, which refuses a pre-planted symlink on its own. Update opens without `O_TRUNC`, compares the opened inode (`fstat` `st_dev`/`st_ino`) against the pre-open `lstat`, and only then truncates — so the platforms without `O_NOFOLLOW` are covered by the identity check rather than by trusting the kernel.
+- Create sanitizes the user-supplied name (`_safe_rel_name()`): disallowed characters become `-`, `.`/`..` segments are dropped, and a `.md` suffix is appended. A traversal attempt lands inside the steering root or is rejected — never outside it.
+- Caps: `STEERING_MAX_FILES = 500` listed entries, `STEERING_FILE_MAX_BYTES = 256 KiB` per document (413 on read of a larger file, 413 on an oversize write).
+- Read responses return content **verbatim** — no credential redaction. The response populates the editor and is written straight back on save, so redacting it would overwrite the user's own file with `[REDACTED]` markers: a data-loss bug traded for no confidentiality gain, since the recipient is the same local OS user who owns the file. `api_skill_detail` behaves the same way for the same reason. Listing **metadata** — the first-heading description, display paths, the project path — *is* run through `redact_credentials()` + `redact_exfiltration_urls()` via `_redact_meta()`, mirroring `_redact_prompt` in `handlers/prompts.py`; metadata never round-trips, so redacting it is free. Paths also collapse the real home to `~`.
+- The single-file read is one offloaded transaction, `_resolve_and_read_blocking()`: it resolves, then reads through `hooks.safe_read_file_bytes_nolink()` with `within_root` set to the steering root. That helper opens with `O_NOFOLLOW`, `fstat`s the descriptor (rejecting hardlinks and non-regular files), and verifies the **opened** descriptor's real path resolves inside the root and is not sensitive — `O_NOFOLLOW` alone guards only the final path component, so an ancestor directory swapped for a symlink between resolution and open would otherwise escape. Resolution and read are not split, to keep the check-to-use window minimal. The pre-read `lstat` only supplies the size for the 413 message; a file that grows past the cap before the descriptor read makes the helper raise `FileTooLargeError`, which is caught and mapped to 413 rather than a 500.
+- Every filesystem touch goes through `_offload()`, including `resolve_steering_file()` — resolution is itself `is_dir`/`lstat`/`resolve` metadata work, and on a network-backed project a stat storm alone is enough to stall the loop. Nothing in these handlers stats, reads, writes or unlinks on the event loop.
+- Restricted (incognito / temporary / guest) sessions may read steering but never create, update or delete it (`_is_restricted_session` → 403). Every mutation emits `sel().log_api_access(operation="steering.create|update|delete")`; reads emit `log_tool_invocation(tool_kind="steering")`.
+
+Behavior is pinned by `test/test_steering_api.py` and `website/src/test/SteeringTab.test.tsx`.
+
+## Wiring
+
+- `src/kiro_crew/dashboard/handlers/steering.py` — `steering_roots()`, `list_steering_blocking()`, `resolve_steering_file()`, the blocking transactions `_read_file_blocking` / `_create_file_blocking` / `_update_file_blocking` / `_delete_file_blocking` (all dispatched through `_offload()` onto `discovery_executor()`, the same pool as `/api/skills`), and the handlers `api_steering`, `api_steering_create`, `api_steering_detail`.
+- `src/kiro_crew/dashboard/handlers/_shared.py:active_project_dir(state, session_key="")` — shared, deterministic project-dir resolution; `_resolve_skill_root()` and `api_skills` now route through it too (they previously read a non-existent `slot.project_dir`, so workspace-scoped skills never resolved).
+- `src/kiro_crew/dashboard/server.py` — routes `GET/POST /api/steering` registered before the catch-all `GET/PUT/DELETE /api/steering/{key:.+}`.
+- `website/src/pages/overview/SteeringTab.tsx` — list-detail layout (React Query keys `['steering']`, `['steering-file', key]`), `MarkdownRenderer` for view, textarea for edit, `Modal` for create with a scope selector.
+- `website/src/pages/CapabilitiesPage.tsx` — the `steering` tab (Compass icon) between Skills and Hooks.
+- `website/src/api/client.ts` — `steeringFiles`, `steeringFile`, `createSteering`, `updateSteering`, `deleteSteering`.
+
+## Non-goals
+
+- Editing the agent config's `resources` globs — that already exists at `GET/PUT /api/agent/config`; this tab shows the files those globs reach, not the globs.
+- Showing the truncation state of the 10% `_STEERING_CAP` context budget, or a per-session "what was actually injected" trace.
+- Steering files outside the two standard roots (arbitrary `file://` resources in an agent config are not browsable here).
+- `AGENTS.md` / `CLAUDE.md` foundational files, which Kiro loads by a separate mechanism.

--- a/docs/system-specs/index.md
+++ b/docs/system-specs/index.md
@@ -56,6 +56,7 @@ Load relevant module specs before making changes to that component. Read common 
 | [inline-action-buttons](features/inline-action-buttons.md) | Interactive buttons in chat messages |
 | [prompt-optimizer](features/prompt-optimizer.md) | Native pre-send prompt optimization (Cmd+Shift+Enter) |
 | [stt-streaming](features/stt-streaming.md) | Live speech-to-text via AWS Transcribe Streaming |
+| [steering-viewer](features/steering-viewer.md) | Steering tab under Agent Capabilities: view + edit `~/.kiro/steering` and project `.kiro/steering` files |
 | [turn-complete-chime](features/turn-complete-chime.md) | Notification sound whenever the agent finishes a turn in any chat |
 | [turn-stats-footer](features/turn-stats-footer.md) | Per-turn elapsed time + credits footer under assistant messages (kiro-cli parity) |
 | [voice-streaming](features/voice-streaming.md) | Real-time Polly TTS with streaming auto-speak and interrupt |

--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -36,6 +36,7 @@ def atomic_write(
     *,
     fsync: bool = False,
     mode: int | None = None,
+    newline: str | None = None,
 ) -> None:
     """Write *content* to *path* atomically via unique temp file + rename.
 
@@ -44,12 +45,18 @@ def atomic_write(
 
     *mode* sets explicit permissions (e.g. ``0o600`` for secrets).
     ``None`` (default) applies umask-based permissions (matching ``open()``).
+
+    *newline* is passed straight to ``open()``. The default (``None``) keeps
+    the historical behavior: universal-newline translation, which rewrites
+    ``\\n`` to ``\\r\\n`` on Windows. Pass ``""`` when the content must land on
+    disk byte-for-byte — e.g. a document that is read back, edited and saved
+    again, where translation on every save would accumulate carriage returns.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
+        with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as f:
             fd = -1  # fdopen took ownership; prevent double-close
             # No-op on Windows (no POSIX permission bits / os.fchmod).
             platform_compat.fchmod_safe(

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -300,6 +300,15 @@ from kiro_crew.dashboard.handlers.side import (  # noqa: E402, F401
 from kiro_crew.dashboard.handlers.sso_login import (  # noqa: E402, F401
     api_sso_login_ws,
 )
+from kiro_crew.dashboard.handlers.steering import (  # noqa: E402, F401
+    STEERING_FILE_MAX_BYTES,
+    api_steering,
+    api_steering_create,
+    api_steering_detail,
+    list_steering_blocking,
+    resolve_steering_file,
+    steering_roots,
+)
 
 # ── Task Runner (extracted to handlers/taskrunner.py) ──
 from kiro_crew.dashboard.handlers.taskrunner import (  # noqa: E402, F401

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -130,6 +130,55 @@ def _resolve_aim_skill_path(name: str) -> Path | None:
     return None
 
 
+def active_project_dir(state: DashboardState, session_key: str = "") -> Path | None:
+    """Return the project directory that workspace-scoped resources resolve against.
+
+    Workspace-scoped resources (``<project>/.kiro/skills``,
+    ``<project>/.kiro/steering``) live under the directory the agent actually
+    runs in, which the dashboard stores per chat slot as ``_ChatSlot.project``
+    (set by ``PUT /api/chat/slots/{slot}/project`` and the ``set_project`` MCP
+    tool).  ``project_dir`` is accepted as a fallback for slot-like objects that
+    expose that name instead.
+
+    Resolution is deterministic, in this order:
+
+    1. the slot named by *session_key*, when it has a project;
+    2. otherwise the single project shared by every slot that has one;
+    3. otherwise ``None``.
+
+    Step 3 matters for mutations: with two chats open on different projects
+    there is no defensible "active" project for a settings page, and silently
+    picking the first-inserted slot would create, overwrite or delete files in
+    the wrong project.  Failing closed makes the caller surface the ambiguity
+    instead.
+    """
+    slots = getattr(state, "_slots", {}) or {}
+
+    def _project_of(slot: Any) -> Path | None:
+        pd = getattr(slot, "project", None) or getattr(slot, "project_dir", None)
+        if isinstance(pd, Path):
+            return pd
+        if isinstance(pd, str) and pd:
+            return Path(pd)
+        return None
+
+    if session_key:
+        slot_name = session_key.split(":", 1)[-1] if ":" in session_key else session_key
+        slot = slots.get(slot_name)
+        if slot is not None:
+            scoped = _project_of(slot)
+            if scoped is not None:
+                return scoped
+    distinct: dict[str, Path] = {}
+    for slot in slots.values():
+        proj = _project_of(slot)
+        if proj is not None:
+            distinct[str(proj)] = proj
+    if len(distinct) == 1:
+        return next(iter(distinct.values()))
+    return None
+
+
 # ── Kiro-cli native skills (~/.kiro/skills/, <project>/.kiro/skills/) ──
 
 
@@ -517,13 +566,8 @@ def _resolve_skill_root(name: str, state: DashboardState) -> Path | None:
     elif name.startswith("kiro-workspace/"):
         rel = name[len("kiro-workspace/") :]
         # We cannot reliably resolve project dir here — gate this to
-        # paths under any active slot's project_dir.
-        proj: Path | None = None
-        for slot in getattr(state, "_slots", {}).values():
-            pd = getattr(slot, "project_dir", None)
-            if pd:
-                proj = Path(pd)
-                break
+        # paths under any active slot's project directory.
+        proj = active_project_dir(state)
         if proj is None:
             return None
         root = proj / ".kiro" / "skills"

--- a/src/kiro_crew/dashboard/handlers/prompts.py
+++ b/src/kiro_crew/dashboard/handlers/prompts.py
@@ -18,6 +18,7 @@ from ._shared import (
     _capability_manager,
     _get_skills,
     _resolve_skill_root,
+    active_project_dir,
     collect_skills_blocking,
     list_skill_tree,
     read_skill_file,
@@ -183,12 +184,7 @@ async def api_skills(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     skills = _get_skills(state)
     # Resolve the active project dir (cheap in-memory scan of slots) on the loop.
-    project_dir: Path | None = None
-    for slot in getattr(state, "_slots", {}).values():
-        pd = getattr(slot, "project_dir", None)
-        if pd:
-            project_dir = Path(pd)
-            break
+    project_dir: Path | None = active_project_dir(state)
     # Run the AIM subprocess async (on the loop, non-blocking), then offload ALL
     # blocking filesystem work — kirocrew list_skills() (os.walk + per-file
     # frontmatter reads), AIM path globs, kiro per-skill resolve/read, and the

--- a/src/kiro_crew/dashboard/handlers/steering.py
+++ b/src/kiro_crew/dashboard/handlers/steering.py
@@ -1,0 +1,640 @@
+"""Kiro steering files API — list / read / create / update / delete.
+
+Steering files are plain markdown documents that Kiro injects into every
+session as always-on project or personal conventions.  Two locations are in
+play, and they are loaded by two different mechanisms:
+
+* ``~/.kiro/steering/**/*.md`` — **global** (``user`` source).  kiro-cli loads
+  these for every session, and the dashboard's own CC-backend injection
+  (:func:`kiro_crew.context._load_steering_resources`) globs the agent
+  config's ``file://.kiro/steering/**/*.md`` resource against ``$HOME``, which
+  resolves to exactly this directory.
+* ``<project>/.kiro/steering/**/*.md`` — **workspace** (``workspace`` source).
+  kiro-cli loads these because the session subprocess runs with the slot's
+  project directory as its cwd.
+
+Until this module existed the files were loaded but never viewable: nothing in
+the dashboard showed which steering documents were in effect.  These endpoints
+back the Steering tab under Agent Capabilities.
+
+Path handling mirrors the skills browser (``handlers/_shared.py``): traversal,
+absolute paths, ``~`` expansion, non-``.md`` suffixes, symlinked intermediate
+directories and sensitive locations are all rejected before any read or write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.executors import discovery_executor
+from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes_nolink
+from kiro_crew.security import (
+    is_sensitive_path,
+    is_sensitive_write_path,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
+
+from ._shared import _is_restricted_session, _read_session_key, active_project_dir
+
+logger = logging.getLogger(__name__)
+
+# Hard caps — keep the endpoints bounded regardless of what is on disk.
+STEERING_MAX_FILES = 500
+STEERING_FILE_MAX_BYTES = 262_144  # 256 KiB per steering document
+
+# ``user`` → ~/.kiro/steering, ``workspace`` → <project>/.kiro/steering
+STEERING_SOURCES = ("user", "workspace")
+
+# ``O_NOFOLLOW`` does not exist on Windows — ``getattr`` keeps the flag optional
+# so a write there raises no AttributeError. Where the flag is absent the write
+# paths fall back to an lstat/open/fstat identity check (same defense, one extra
+# syscall) rather than trusting the kernel to refuse the symlink.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# Filenames are user-visible document names: word chars, dash, dot, space and
+# nested folders.  Anything else is rewritten on create (see _safe_rel_name).
+_NAME_ALLOWED = re.compile(r"[^A-Za-z0-9._/ -]")
+
+
+def _sel():
+    """Late-binding sel() — allows monkeypatching at parent package level."""
+    import kiro_crew.dashboard.handlers as _pkg  # circular import
+
+    return _pkg.sel()
+
+
+def _redact_meta(text: str) -> str:
+    """Redact credentials + exfiltration URLs from listing metadata.
+
+    Metadata (the first-heading description, the display path) is never written
+    back to disk, so redacting it is free — it mirrors ``_redact_prompt`` in
+    ``handlers/prompts.py``. Editor CONTENT is deliberately NOT redacted: the
+    detail response is what the textarea saves back, so a redaction there would
+    overwrite the user's own file with ``[REDACTED]`` markers.
+    """
+    out, _ = redact_credentials(text)
+    out, _ = redact_exfiltration_urls(out)
+    return out
+
+
+def _display_path(path: Path | str) -> str:
+    """Collapse the real home prefix to ``~`` so responses never leak it."""
+    out = str(path)
+    for home in {str(Path.home()), str(Path.home().resolve())}:
+        out = out.replace(home, "~")
+    return out
+
+
+def steering_roots(project_dir: Path | None = None) -> list[tuple[str, Path]]:
+    """Return ``(source, path)`` pairs for the steering locations.
+
+    Unlike the skills roots this does NOT filter on existence: the tab must be
+    able to show "no global steering yet" and create the first file, so a
+    missing directory is still a valid (empty) root.  Sensitive locations are
+    still excluded.
+    """
+    out: list[tuple[str, Path]] = []
+    user_dir = Path.home() / ".kiro" / "steering"
+    if not is_sensitive_path(str(user_dir)):
+        out.append(("user", user_dir))
+    if project_dir:
+        ws_dir = Path(project_dir) / ".kiro" / "steering"
+        if not is_sensitive_path(str(ws_dir)) and ws_dir != user_dir:
+            out.append(("workspace", ws_dir))
+    return out
+
+
+def _first_heading(path: Path, cap: int = 2048) -> str:
+    """Cheap description: the first markdown heading (or first prose line)."""
+    try:
+        with path.open("rb") as f:
+            head = f.read(cap).decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    for line in head.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped == "---":
+            continue
+        if stripped.startswith("#"):
+            return re.sub(r"^#+\s*", "", stripped).strip()[:200]
+        return stripped[:200]
+    return ""
+
+
+def list_steering_blocking(project_dir: Path | None = None) -> dict[str, Any]:
+    """Blocking scan of both steering roots — run on the discovery pool.
+
+    Returns ``{"files": [...], "roots": [...], "project": "<display path>"}``.
+    Each file entry: ``{key, name, rel, source, path, size, description}``
+    where ``key`` is ``"<source>/<rel>"``.
+    """
+    files: list[dict[str, Any]] = []
+    roots: list[dict[str, Any]] = []
+    for source, root in steering_roots(project_dir):
+        exists = root.is_dir()
+        roots.append({
+            "source": source,
+            "path": _redact_meta(_display_path(root)),
+            "exists": exists,
+        })
+        if not exists:
+            continue
+        base = _base_for(source, project_dir)
+        if base is None:
+            continue
+        try:
+            base_resolved = base.resolve(strict=True)
+        except OSError:
+            continue
+        if not _contained(root, base_resolved):
+            continue
+        try:
+            candidates = sorted(root.rglob("*.md"))
+        except OSError:
+            continue
+        for entry in candidates:
+            if len(files) >= STEERING_MAX_FILES:
+                break
+            if entry.name.startswith("."):
+                continue
+            # Symlinked entries are never listed: the key they would produce
+            # must not be resolvable for write, so listing one would offer the
+            # user a file they cannot edit (see resolve_steering_file).
+            if entry.is_symlink():
+                continue
+            try:
+                resolved = entry.resolve(strict=True)
+            except OSError:
+                continue
+            # Reject symlinked intermediate directories that escape the trust
+            # base (a leaf symlink whose target is still contained is fine).
+            if not _contained(entry.parent, base_resolved):
+                continue
+            if not resolved.is_file() or is_sensitive_path(str(resolved)):
+                continue
+            try:
+                size = int(entry.stat().st_size)
+            except OSError:
+                continue
+            rel = entry.relative_to(root).as_posix()
+            files.append({
+                "key": f"{source}/{rel}",
+                "name": entry.name,
+                "rel": rel,
+                "source": source,
+                "path": _redact_meta(_display_path(entry)),
+                "size": size,
+                "description": _redact_meta(_first_heading(entry)),
+            })
+    return {
+        "files": files,
+        "roots": roots,
+        "project": _redact_meta(_display_path(project_dir)) if project_dir else "",
+    }
+
+
+def _split_key(key: str) -> tuple[str, str] | None:
+    """Split ``"<source>/<rel>"`` — rejecting traversal and odd input."""
+    if not key or "\\" in key or "\x00" in key:
+        return None
+    source, _, rel = key.partition("/")
+    if source not in STEERING_SOURCES or not rel:
+        return None
+    if rel.startswith("/") or rel.startswith("~") or ".." in rel.split("/"):
+        return None
+    if not rel.endswith(".md"):
+        return None
+    return source, rel
+
+
+def _base_for(source: str, project_dir: Path | None) -> Path | None:
+    """The trust base a steering root must resolve underneath."""
+    if source == "user":
+        return Path.home()
+    return Path(project_dir) if project_dir else None
+
+
+def _deepest_existing(path: Path) -> Path | None:
+    """Walk up until an existing directory is found (bounded by the fs root)."""
+    probe = path
+    while not probe.exists():
+        parent = probe.parent
+        if parent == probe:
+            return None
+        probe = parent
+    return probe
+
+
+def _contained(candidate: Path, base_resolved: Path) -> bool:
+    """True iff *candidate* resolves to ``base_resolved`` or below it.
+
+    Resolving the deepest EXISTING ancestor and comparing against the trust
+    base is what catches a symlinked intermediate directory (e.g. a
+    ``~/.kiro/steering`` symlink pointing at ``/etc``) — comparing against the
+    root itself would happily follow such a link.
+    """
+    probe = _deepest_existing(candidate)
+    if probe is None:
+        return False
+    try:
+        probe_resolved = probe.resolve(strict=True)
+    except OSError:
+        return False
+    return probe_resolved == base_resolved or base_resolved in probe_resolved.parents
+
+
+def resolve_steering_file(
+    key: str, project_dir: Path | None, *, for_write: bool = False
+) -> Path | None:
+    """Resolve ``key`` to an absolute steering file path, or None if rejected.
+
+    With ``for_write`` the target need not exist yet (the deepest existing
+    ancestor is validated instead) and write-protected locations are rejected
+    too.  Without it the target must already be a regular file.
+    """
+    parts = _split_key(key)
+    if parts is None:
+        return None
+    source, rel = parts
+    root = next((p for s, p in steering_roots(project_dir) if s == source), None)
+    base = _base_for(source, project_dir)
+    if root is None or base is None:
+        return None
+    try:
+        base_resolved = base.resolve(strict=True)
+    except OSError:
+        return None
+    target = root / rel
+    if is_sensitive_path(str(target)) or (for_write and is_sensitive_write_path(str(target))):
+        return None
+    if not _contained(target.parent, base_resolved):
+        return None
+    if for_write:
+        return target
+    # Reject a symlink at the LEAF outright — not just one escaping the trust
+    # base. A link that still resolves inside the base (e.g.
+    # ``.kiro/steering/rules.md -> ../../README.md``) would otherwise let PUT
+    # truncate, and DELETE unlink, a file that is not a steering document.
+    try:
+        if target.is_symlink():
+            return None
+        resolved = target.resolve(strict=True)
+    except OSError:
+        return None
+    if not resolved.is_file() or is_sensitive_path(str(resolved)):
+        return None
+    if resolved != target and not _contained(resolved, base_resolved):
+        return None
+    return resolved
+
+
+def _safe_rel_name(raw: str) -> str:
+    """Normalize a user-supplied steering filename to a safe relative path."""
+    name = _NAME_ALLOWED.sub("-", raw.strip()).strip("/").strip()
+    name = re.sub(r"/+", "/", name)
+    name = "/".join(seg for seg in name.split("/") if seg not in ("", ".", ".."))
+    if not name:
+        return ""
+    if not name.endswith(".md"):
+        name = f"{name}.md"
+    return name
+
+
+def _blocked(request: web.Request, operation: str) -> web.Response | None:
+    """Restricted (incognito/guest) sessions may read steering but not write it."""
+    if _is_restricted_session(request.app["state"], request):
+        _sel().log_api_access(
+            caller=request.get("user", "dashboard"),
+            operation=operation,
+            outcome="denied",
+            source="dashboard",
+            resources="restricted_session_block",
+        )
+        return web.json_response(
+            {"error": "restricted session cannot modify steering files"}, status=403
+        )
+    return None
+
+
+# ── Blocking filesystem transactions (run on the discovery pool) ──
+#
+# Each of these is ONE complete transaction — stat + open + write, or the
+# identity check + truncate + write — so the whole thing lands off the event
+# loop. A project on a slow or network filesystem must never stall the loop
+# (and with it every chat and the heartbeat) for the duration of a write.
+# They return a short error token; the handlers map tokens to HTTP status.
+
+
+def _resolve_and_read_blocking(
+    key: str, project_dir: Path | None
+) -> tuple[str, str, str | None]:
+    """Resolve *key* and read it — one transaction, entirely off the event loop.
+
+    Returns ``(content, display_path, error token or None)``.
+
+    The read goes through ``hooks.safe_read_file_bytes_nolink()`` with
+    ``within_root`` set to the steering root, which is what binds the bytes to
+    the authorized location: the helper opens with ``O_NOFOLLOW``, ``fstat``s
+    the descriptor (rejecting hardlinks and non-regular files), and then
+    verifies the OPENED descriptor's real path resolves inside that root and is
+    not sensitive. ``O_NOFOLLOW`` alone only guards the final path component,
+    so without ``within_root`` an ancestor directory swapped for a symlink
+    between resolution and open could still escape the tree.
+
+    The ``lstat`` below only supplies the size for the 413 message; the file
+    can still grow past the cap before the descriptor read, in which case the
+    helper raises ``FileTooLargeError`` — caught here so that race yields 413
+    rather than a 500.
+    """
+    target = resolve_steering_file(key, project_dir)
+    if target is None:
+        return "", "", "notfound"
+    display = _redact_meta(_display_path(target))
+    parts = _split_key(key)
+    root = (
+        next((p for s, p in steering_roots(project_dir) if s == parts[0]), None)
+        if parts
+        else None
+    )
+    if root is None:
+        return "", display, "notfound"
+    try:
+        pre = target.lstat()
+    except OSError:
+        return "", display, "notfound"
+    if stat.S_ISLNK(pre.st_mode) or not stat.S_ISREG(pre.st_mode):
+        return "", display, "notfound"
+    if pre.st_size > STEERING_FILE_MAX_BYTES:
+        return "", display, f"toolarge:{pre.st_size}"
+    try:
+        data = safe_read_file_bytes_nolink(
+            str(target), within_root=str(root), max_bytes=STEERING_FILE_MAX_BYTES
+        )
+    except FileTooLargeError:
+        # Grew past the cap between the lstat and the descriptor read.
+        return "", display, f"toolarge:>{STEERING_FILE_MAX_BYTES}"
+    if data is None:
+        return "", display, "readfailed"
+    return data.decode("utf-8", errors="replace"), display, None
+
+
+def _create_file_blocking(target: Path, content: str) -> tuple[str | None, str]:
+    """Create *target* with *content*; return ``(error token or None, display path)``."""
+    display = _redact_meta(_display_path(target))
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # O_EXCL — never clobber a file that appeared between the check and the
+        # write, and never follow a symlink planted at the target path (O_EXCL
+        # already refuses an existing symlink, so this is safe where
+        # O_NOFOLLOW is unavailable).
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW, 0o600)
+        # newline="": steering documents round-trip through the editor, and
+        # Windows newline translation on every save would accumulate carriage
+        # returns (CRLF -> CR CR LF -> ...). Write exactly what was sent.
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+            f.write(content)
+    except FileExistsError:
+        return "exists", display
+    except OSError as exc:
+        logger.warning("steering create failed: %s", type(exc).__name__)
+        return "writefailed", display
+    return None, display
+
+
+def _update_file_blocking(target: Path, content: str) -> str | None:
+    """Overwrite *target* with *content* atomically; return an error token or None.
+
+    The write goes through ``atomic_write()`` (unique temp file in the same
+    directory, then ``os.replace``) rather than truncate-then-write: on a nearly
+    full filesystem a truncate followed by a failed or partial write would
+    destroy the user's existing steering document, and the whole point of this
+    endpoint is that the file is the user's own content.
+
+    ``os.replace`` swaps the directory entry rather than writing through it, so
+    it cannot follow a symlink raced into place after the check below — and no
+    truncate happens at all, which is why this needs no descriptor-identity
+    check the way the old in-place path did.
+    """
+    try:
+        pre = target.lstat()
+    except OSError:
+        return "notfound"
+    if stat.S_ISLNK(pre.st_mode) or not stat.S_ISREG(pre.st_mode):
+        return "notfound"
+    try:
+        # Preserve the file's existing permissions rather than forcing 0o600:
+        # the old in-place write inherited them, and a project steering file
+        # checked out group-readable should not be silently tightened by a save.
+        atomic_write(target, content, fsync=True, mode=stat.S_IMODE(pre.st_mode), newline="")
+    except OSError as exc:
+        logger.warning("steering update failed: %s", type(exc).__name__)
+        return "writefailed"
+    return None
+
+
+def _delete_file_blocking(target: Path) -> str | None:
+    """Unlink *target*; return an error token or None.
+
+    ``unlink`` never follows a symlink, so a link raced into place after
+    resolution loses only the link itself.
+    """
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        return "notfound"
+    except OSError as exc:
+        logger.warning("steering delete failed: %s", type(exc).__name__)
+        return "deletefailed"
+    return None
+
+
+def _resolve_blocking(key: str, project_dir: Path | None, for_write: bool = False) -> Path | None:
+    """Positional wrapper so ``resolve_steering_file`` can go through ``_offload``.
+
+    Resolution itself is filesystem metadata work (``is_dir``, ``lstat``,
+    ``resolve``) and must not run on the event loop either — on a
+    network-backed project even a stat storm is enough to stall it.
+    """
+    return resolve_steering_file(key, project_dir, for_write=for_write)
+
+
+def _offload(fn: Any, *args: Any) -> Any:
+    """Run a blocking steering transaction on the dashboard discovery pool."""
+    return asyncio.get_running_loop().run_in_executor(discovery_executor(), fn, *args)
+
+
+async def api_steering(request: web.Request) -> web.Response:
+    """GET /api/steering — list the effective steering files (both roots)."""
+    state: DashboardState = request.app["state"]
+    project_dir = active_project_dir(state, _read_session_key(request))
+    # rglob + per-file stat/head-read over two roots is browser-triggerable
+    # blocking FS work: keep it off the event loop (same pool as /api/skills).
+    result = await _offload(list_steering_blocking, project_dir)
+    _sel().log_tool_invocation(
+        session_key='', agent='api', source='dashboard',
+        tool_name='api_steering_list', tool_kind='steering', outcome='ok',
+        metadata={'count': len(result["files"])},
+    )
+    return web.json_response(result)
+
+
+async def api_steering_create(request: web.Request) -> web.Response:
+    """POST /api/steering — create a steering file.
+
+    Body: ``{name, content, source?}`` — ``source`` defaults to ``workspace``
+    when a project directory is active, else ``user``.
+    """
+    denied = _blocked(request, "steering.create")
+    if denied is not None:
+        return denied
+    state: DashboardState = request.app["state"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON"}, status=400)
+    content = body.get("content", "")
+    if not isinstance(content, str) or not content.strip():
+        return web.json_response({"error": "content is required"}, status=400)
+    if len(content.encode("utf-8")) > STEERING_FILE_MAX_BYTES:
+        return web.json_response(
+            {"error": f"content too large (cap {STEERING_FILE_MAX_BYTES} bytes)"}, status=413
+        )
+    project_dir = active_project_dir(state, _read_session_key(request))
+    source = str(body.get("source") or ("workspace" if project_dir else "user"))
+    if source not in STEERING_SOURCES:
+        return web.json_response({"error": "invalid source"}, status=400)
+    if source == "workspace" and project_dir is None:
+        # Either no project is set, or open chats disagree about which one —
+        # see active_project_dir(). Refuse rather than write to a guess.
+        return web.json_response(
+            {"error": "no unambiguous project directory for this workspace"}, status=400
+        )
+    rel = _safe_rel_name(str(body.get("name", "")))
+    if not rel:
+        return web.json_response({"error": "name is required"}, status=400)
+    key = f"{source}/{rel}"
+    target = await _offload(_resolve_blocking, key, project_dir, True)
+    if target is None:
+        return web.json_response({"error": "invalid steering path"}, status=400)
+    err, display = await _offload(_create_file_blocking, target, content)
+    if err == "exists":
+        return web.json_response({"error": f"'{rel}' already exists"}, status=409)
+    if err is not None:
+        return web.json_response({"error": "write failed"}, status=500)
+    _sel().log_api_access(
+        caller=request.get("user", "dashboard"),
+        operation="steering.create",
+        outcome="success",
+        source="dashboard",
+        resources=key,
+    )
+    return web.json_response({"ok": True, "key": key, "path": display})
+
+
+async def api_steering_detail(request: web.Request) -> web.Response:
+    """GET/PUT/DELETE /api/steering/{key} — read, update, or delete one file."""
+    state: DashboardState = request.app["state"]
+    key = request.match_info["key"]
+    project_dir = active_project_dir(state, _read_session_key(request))
+
+    if request.method == "GET":
+
+        def _audit(outcome: str) -> None:
+            _sel().log_tool_invocation(
+                session_key='', agent='api', source='dashboard',
+                tool_name='api_steering_read', tool_kind='steering', outcome=outcome,
+                metadata={'key': key},
+            )
+
+        # Resolve + read as ONE offloaded transaction: the read needs the
+        # steering root to pass as ``within_root``, and splitting them would
+        # widen the check-to-use window between resolution and open.
+        content, display, err = await _offload(_resolve_and_read_blocking, key, project_dir)
+        if err and err.startswith("toolarge:"):
+            _audit('too_large')
+            size = err.split(":", 1)[1]
+            return web.json_response(
+                {"error": f"file too large ({size} bytes; cap {STEERING_FILE_MAX_BYTES})"},
+                status=413,
+            )
+        if err is not None:
+            _audit('not_found')
+            return web.json_response({"error": "not found"}, status=404)
+        _audit('ok')
+        # Content is returned verbatim, NOT credential-redacted, and that is
+        # deliberate: this response populates the editor and is written straight
+        # back on save, so redacting here would overwrite the user's own file
+        # with [REDACTED] markers — a data-loss bug traded for no real
+        # confidentiality gain, since the recipient is the same local OS user who
+        # owns the file. Same reasoning (and same behavior) as api_skill_detail.
+        # Listing metadata IS redacted — see _redact_meta().
+        return web.json_response({
+            "key": key,
+            "content": content,
+            "path": display,
+            "source": key.split("/", 1)[0],
+        })
+
+    if request.method == "DELETE":
+        denied = _blocked(request, "steering.delete")
+        if denied is not None:
+            return denied
+        target = await _offload(_resolve_blocking, key, project_dir, False)
+        if target is None:
+            return web.json_response({"error": "not found"}, status=404)
+        err = await _offload(_delete_file_blocking, target)
+        if err == "notfound":
+            return web.json_response({"error": "not found"}, status=404)
+        if err is not None:
+            return web.json_response({"error": "delete failed"}, status=500)
+        _sel().log_api_access(
+            caller=request.get("user", "dashboard"),
+            operation="steering.delete",
+            outcome="success",
+            source="dashboard",
+            resources=key,
+        )
+        return web.json_response({"ok": True})
+
+    # PUT
+    denied = _blocked(request, "steering.update")
+    if denied is not None:
+        return denied
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON"}, status=400)
+    content = body.get("content", "")
+    if not isinstance(content, str) or not content.strip():
+        return web.json_response({"error": "content is required"}, status=400)
+    if len(content.encode("utf-8")) > STEERING_FILE_MAX_BYTES:
+        return web.json_response(
+            {"error": f"content too large (cap {STEERING_FILE_MAX_BYTES} bytes)"}, status=413
+        )
+    target = await _offload(_resolve_blocking, key, project_dir, False)
+    if target is None:
+        return web.json_response({"error": "not found"}, status=404)
+    err = await _offload(_update_file_blocking, target, content)
+    if err == "notfound":
+        return web.json_response({"error": "not found"}, status=404)
+    if err is not None:
+        return web.json_response({"error": "write failed"}, status=500)
+    _sel().log_api_access(
+        caller=request.get("user", "dashboard"),
+        operation="steering.update",
+        outcome="success",
+        source="dashboard",
+        resources=key,
+    )
+    return web.json_response({"ok": True})

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1502,6 +1502,16 @@ async def start_dashboard(
     app.router.add_put("/api/skills/{name:.+}", handlers.api_skill_detail)
     app.router.add_delete("/api/skills/{name:.+}", handlers.api_skill_detail)
 
+    # Kiro steering files (~/.kiro/steering + <project>/.kiro/steering).  Plain
+    # markdown documents, so no tree browser — the key is ``<source>/<relpath>``
+    # and the fixed list/create route is registered before the catch-all
+    # {key:.+} detail routes so aiohttp reaches it first.
+    app.router.add_get("/api/steering", handlers.api_steering)
+    app.router.add_post("/api/steering", handlers.api_steering_create)
+    app.router.add_get("/api/steering/{key:.+}", handlers.api_steering_detail)
+    app.router.add_put("/api/steering/{key:.+}", handlers.api_steering_detail)
+    app.router.add_delete("/api/steering/{key:.+}", handlers.api_steering_detail)
+
     # Custom Themes (CRUD)
     app.router.add_get("/api/themes", handlers.api_themes)
     app.router.add_post("/api/themes", handlers.api_themes_create)

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -142,6 +142,14 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "StreamRedactor mirroring the main chat for the side-question stream.",
     ),
     (
+        "Steering file metadata",
+        "dashboard/handlers/steering.py",
+        "First-heading descriptions and display paths in the /api/steering listing "
+        "and detail responses. Document CONTENT is deliberately NOT redacted: it "
+        "populates the tab's editor and is written straight back on save, so "
+        "redacting it would overwrite the user's own file with markers.",
+    ),
+    (
         "OpenAI-compatible API",
         "dashboard/openai_compat.py",
         "Streamed and non-streamed completions served to third-party clients.",

--- a/test/test_steering_api.py
+++ b/test/test_steering_api.py
@@ -1,0 +1,656 @@
+"""Tests for the Kiro steering files API (``/api/steering``).
+
+Covers:
+- ``steering_roots`` / ``list_steering_blocking`` discovery of the global
+  ``~/.kiro/steering`` and workspace ``<project>/.kiro/steering`` locations
+- ``resolve_steering_file`` traversal, suffix, symlink and containment guards
+- ``GET/POST/PUT/DELETE /api/steering`` end-to-end, including the
+  restricted-session write block and SEL audit emission
+
+Tests pin $HOME to tmp_path so the real filesystem is never touched.
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers._shared import active_project_dir
+from kiro_crew.dashboard.handlers.steering import (
+    STEERING_FILE_MAX_BYTES,
+    STEERING_MAX_FILES,
+    _safe_rel_name,
+    _split_key,
+    api_steering,
+    api_steering_create,
+    api_steering_detail,
+    list_steering_blocking,
+    resolve_steering_file,
+    steering_roots,
+)
+
+# ── Fixtures / helpers ──
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Pin $HOME to tmp_path so Path.home() returns a writable sandbox."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
+
+
+def _write_steering(root: Path, rel: str, body: str = "# Title\nrules\n") -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # newline="": keep fixtures byte-exact so assertions hold on Windows too.
+    path.write_text(body, encoding="utf-8", newline="")
+    return path
+
+
+def _state(project: str | Path | None = None, *, restricted: bool = False):
+    """A MagicMock DashboardState exposing one slot with a project dir."""
+    slot = MagicMock(project=str(project) if project else "", is_restricted=restricted)
+    return MagicMock(_slots={"default": slot}, _restricted_keys=set())
+
+
+def _make_app(state):
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/api/steering", api_steering)
+    app.router.add_post("/api/steering", api_steering_create)
+    app.router.add_get("/api/steering/{key:.+}", api_steering_detail)
+    app.router.add_put("/api/steering/{key:.+}", api_steering_detail)
+    app.router.add_delete("/api/steering/{key:.+}", api_steering_detail)
+    return app
+
+
+# ── Roots + listing ──
+
+
+class TestRoots:
+    def test_user_root_listed_even_when_missing(self, fake_home):
+        roots = steering_roots(None)
+        assert [s for s, _ in roots] == ["user"]
+        assert roots[0][1] == fake_home / ".kiro" / "steering"
+
+    def test_workspace_root_added_when_project_set(self, fake_home, tmp_path):
+        proj = tmp_path / "proj"
+        roots = steering_roots(proj)
+        assert [s for s, _ in roots] == ["user", "workspace"]
+        assert roots[1][1] == proj / ".kiro" / "steering"
+
+
+class TestListing:
+    def test_lists_both_sources_with_provenance(self, fake_home, tmp_path):
+        _write_steering(fake_home / ".kiro" / "steering", "personal.md", "# Personal\n")
+        proj = tmp_path / "proj"
+        _write_steering(proj / ".kiro" / "steering", "api-standards.md", "# API standards\n")
+
+        out = list_steering_blocking(proj)
+        keys = {f["key"] for f in out["files"]}
+        assert keys == {"user/personal.md", "workspace/api-standards.md"}
+        by_key = {f["key"]: f for f in out["files"]}
+        assert by_key["user/personal.md"]["description"] == "Personal"
+        assert by_key["user/personal.md"]["source"] == "user"
+        assert by_key["workspace/api-standards.md"]["source"] == "workspace"
+        assert [r["source"] for r in out["roots"]] == ["user", "workspace"]
+        assert all(r["exists"] for r in out["roots"])
+
+    def test_nested_files_and_home_redaction(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "team/style.md")
+        out = list_steering_blocking(None)
+        entry = out["files"][0]
+        assert entry["key"] == "user/team/style.md"
+        assert entry["rel"] == "team/style.md"
+        # The real home must never leak to the client.
+        assert entry["path"].startswith("~")
+        assert str(fake_home) not in entry["path"]
+
+    def test_skips_dotfiles_and_non_markdown(self, fake_home):
+        root = fake_home / ".kiro" / "steering"
+        _write_steering(root, ".hidden.md")
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "notes.txt").write_text("nope", encoding="utf-8")
+        assert list_steering_blocking(None)["files"] == []
+
+    def test_missing_root_reports_not_exists(self, fake_home):
+        out = list_steering_blocking(None)
+        assert out["files"] == []
+        assert out["roots"][0]["exists"] is False
+
+    def test_symlinked_root_escaping_home_is_ignored(self, fake_home, tmp_path):
+        outside = tmp_path / "outside"
+        _write_steering(outside, "leak.md")
+        kiro = fake_home / ".kiro"
+        kiro.mkdir(parents=True, exist_ok=True)
+        (kiro / "steering").symlink_to(outside, target_is_directory=True)
+        assert list_steering_blocking(None)["files"] == []
+
+    def test_file_cap_enforced(self, fake_home):
+        root = fake_home / ".kiro" / "steering"
+        for i in range(STEERING_MAX_FILES + 5):
+            _write_steering(root, f"doc{i:04d}.md")
+        assert len(list_steering_blocking(None)["files"]) == STEERING_MAX_FILES
+
+
+# ── Key parsing + resolution guards ──
+
+
+class TestKeyParsing:
+    @pytest.mark.parametrize("key", [
+        "", "user", "user/", "bogus/x.md", "user/../../etc/passwd",
+        "user//etc/passwd", "user/~/x.md", "user/notes.txt", "user/a\\b.md",
+    ])
+    def test_rejects_bad_keys(self, key):
+        assert _split_key(key) is None
+
+    def test_accepts_nested_markdown(self):
+        assert _split_key("workspace/team/style.md") == ("workspace", "team/style.md")
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("api standards", "api standards.md"),
+        ("API_Standards.md", "API_Standards.md"),
+        ("../../etc/passwd", "etc/passwd.md"),
+        ("nested/../thing", "nested/thing.md"),
+        ("bad;chars|here", "bad-chars-here.md"),
+        ("   ", ""),
+        ("/", ""),
+    ])
+    def test_safe_rel_name(self, raw, expected):
+        assert _safe_rel_name(raw) == expected
+
+
+class TestResolution:
+    def test_resolves_existing_file(self, fake_home):
+        target = _write_steering(fake_home / ".kiro" / "steering", "a.md")
+        assert resolve_steering_file("user/a.md", None) == target.resolve()
+
+    def test_missing_file_is_none_for_read(self, fake_home):
+        assert resolve_steering_file("user/missing.md", None) is None
+
+    def test_traversal_rejected(self, fake_home):
+        assert resolve_steering_file("user/../../../etc/passwd", None) is None
+
+    def test_workspace_requires_project(self, fake_home, tmp_path):
+        proj = tmp_path / "proj"
+        _write_steering(proj / ".kiro" / "steering", "w.md")
+        assert resolve_steering_file("workspace/w.md", None) is None
+        assert resolve_steering_file("workspace/w.md", proj) is not None
+
+    def test_symlinked_leaf_escaping_base_rejected(self, fake_home, tmp_path):
+        root = fake_home / ".kiro" / "steering"
+        root.mkdir(parents=True, exist_ok=True)
+        secret = tmp_path / "secret.md"
+        secret.write_text("secret", encoding="utf-8")
+        (root / "link.md").symlink_to(secret)
+        assert resolve_steering_file("user/link.md", None) is None
+
+    def test_symlinked_leaf_inside_base_also_rejected(self, fake_home):
+        """A link that resolves INSIDE the base is still not a steering file.
+
+        ``.kiro/steering/rules.md -> ../../README.md`` passes a base-containment
+        check, so without a leaf-symlink rejection PUT would truncate — and
+        DELETE unlink — an unrelated file the user never opened in the tab.
+        """
+        root = fake_home / ".kiro" / "steering"
+        root.mkdir(parents=True, exist_ok=True)
+        victim = fake_home / "README.md"
+        victim.write_text("# real readme\n", encoding="utf-8")
+        (root / "rules.md").symlink_to(victim)
+        assert resolve_steering_file("user/rules.md", None) is None
+        assert [f["key"] for f in list_steering_blocking(None)["files"]] == []
+
+    def test_symlinked_subdir_escaping_base_rejected(self, fake_home, tmp_path):
+        root = fake_home / ".kiro" / "steering"
+        root.mkdir(parents=True, exist_ok=True)
+        outside = tmp_path / "outside"
+        _write_steering(outside, "x.md")
+        (root / "sub").symlink_to(outside, target_is_directory=True)
+        assert resolve_steering_file("user/sub/x.md", None) is None
+
+    def test_write_target_need_not_exist(self, fake_home):
+        target = resolve_steering_file("user/new/doc.md", None, for_write=True)
+        assert target == fake_home / ".kiro" / "steering" / "new" / "doc.md"
+
+
+# ── HTTP endpoints ──
+
+
+class TestProjectResolution:
+    """Workspace scope must never act on an arbitrarily chosen project."""
+
+    @staticmethod
+    def _multi_slot_state(*projects):
+        slots = {
+            f"slot{i}": MagicMock(project=str(p), is_restricted=False)
+            for i, p in enumerate(projects)
+        }
+        return MagicMock(_slots=slots, _restricted_keys=set())
+
+    def test_single_shared_project_is_used(self, fake_home, tmp_path):
+        proj = tmp_path / "proj"
+        state = self._multi_slot_state(proj, proj)
+        assert active_project_dir(state) == proj
+
+    def test_disagreeing_slots_resolve_to_none(self, fake_home, tmp_path):
+        state = self._multi_slot_state(tmp_path / "a", tmp_path / "b")
+        assert active_project_dir(state) is None
+
+    def test_session_key_selects_its_own_slot(self, fake_home, tmp_path):
+        state = self._multi_slot_state(tmp_path / "a", tmp_path / "b")
+        assert active_project_dir(state, "dashboard:slot1") == tmp_path / "b"
+
+    def test_slots_without_projects_are_ignored(self, fake_home, tmp_path):
+        proj = tmp_path / "proj"
+        slots = {
+            "a": MagicMock(project="", is_restricted=False),
+            "b": MagicMock(project=str(proj), is_restricted=False),
+        }
+        state = MagicMock(_slots=slots, _restricted_keys=set())
+        assert active_project_dir(state) == proj
+
+    @pytest.mark.asyncio
+    async def test_workspace_create_refused_when_projects_disagree(self, fake_home, tmp_path):
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        state = self._multi_slot_state(tmp_path / "a", tmp_path / "b")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/steering", json={"name": "x.md", "content": "y", "source": "workspace"}
+            )
+            assert resp.status == 400
+        assert not (tmp_path / "a" / ".kiro").exists()
+        assert not (tmp_path / "b" / ".kiro").exists()
+
+    @pytest.mark.asyncio
+    async def test_listing_omits_workspace_when_projects_disagree(self, fake_home, tmp_path):
+        _write_steering(tmp_path / "a" / ".kiro" / "steering", "a.md")
+        _write_steering(tmp_path / "b" / ".kiro" / "steering", "b.md")
+        state = self._multi_slot_state(tmp_path / "a", tmp_path / "b")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            data = await (await client.get("/api/steering")).json()
+        assert [r["source"] for r in data["roots"]] == ["user"]
+        assert data["files"] == []
+
+
+class TestRedaction:
+    """Listing metadata is redacted; editor content deliberately is not."""
+
+    FAKE = "aws_secret_access_key=AKIAIOSFODNN7EXAMPLE1234567890abcdefghij"
+
+    @pytest.mark.asyncio
+    async def test_listing_description_is_redacted(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "leaky.md", f"# {self.FAKE}\nbody\n")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            data = await (await client.get("/api/steering")).json()
+        desc = data["files"][0]["description"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in desc
+
+    @pytest.mark.asyncio
+    async def test_detail_content_is_verbatim(self, fake_home):
+        """Redacting the editor payload would overwrite the file on save."""
+        body = f"# Rules\n{self.FAKE}\n"
+        _write_steering(fake_home / ".kiro" / "steering", "leaky.md", body)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            data = await (await client.get("/api/steering/user/leaky.md")).json()
+        assert data["content"] == body
+        # And a save round-trip must not mutate what the user never edited.
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (
+                await client.put("/api/steering/user/leaky.md", json={"content": data["content"]})
+            ).status == 200
+        assert (fake_home / ".kiro" / "steering" / "leaky.md").read_text() == body
+
+
+class TestListEndpoint:
+    @pytest.mark.asyncio
+    async def test_get_returns_files_and_roots(self, fake_home, tmp_path):
+        _write_steering(fake_home / ".kiro" / "steering", "personal.md")
+        proj = tmp_path / "proj"
+        _write_steering(proj / ".kiro" / "steering", "project.md")
+        async with TestClient(TestServer(_make_app(_state(proj)))) as client:
+            resp = await client.get("/api/steering")
+            assert resp.status == 200
+            data = await resp.json()
+        assert {f["key"] for f in data["files"]} == {"user/personal.md", "workspace/project.md"}
+        assert data["project"].endswith("proj")
+
+    @pytest.mark.asyncio
+    async def test_get_audits(self, fake_home, monkeypatch):
+        sel_mock = MagicMock()
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: sel_mock)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.get("/api/steering")).status == 200
+        names = [c.kwargs.get("tool_name") for c in sel_mock.log_tool_invocation.call_args_list]
+        assert "api_steering_list" in names
+
+
+class TestReadEndpoint:
+    @pytest.mark.asyncio
+    async def test_reads_content_verbatim(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "a.md", "# A\nbody\n")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.get("/api/steering/user/a.md")
+            assert resp.status == 200
+            data = await resp.json()
+        assert data["content"] == "# A\nbody\n"
+        assert data["source"] == "user"
+        assert data["path"].startswith("~")
+
+    @pytest.mark.asyncio
+    async def test_unknown_is_404(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.get("/api/steering/user/nope.md")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_traversal_is_404(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.get("/api/steering/user/..%2F..%2Fsecrets.md")
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_read_refuses_symlink_swapped_after_resolution(self, fake_home, tmp_path):
+        """The read path must validate the inode it actually opens.
+
+        ``resolve_steering_file()`` rejects a symlink, but a regular file can be
+        swapped for one before the read. The read goes through
+        ``safe_read_file_bytes_nolink`` (O_NOFOLLOW + fstat), so the swap yields
+        an error rather than the symlink target's contents.
+        """
+        from kiro_crew.dashboard.handlers import steering as mod
+
+        root = fake_home / ".kiro" / "steering"
+        real = _write_steering(root, "a.md", "real content\n")
+        secret = tmp_path / "credentials"
+        secret.write_text("[default]\naws_secret_access_key=nope\n", encoding="utf-8")
+
+        assert resolve_steering_file("user/a.md", None) is not None
+        real.unlink()
+        real.symlink_to(secret)
+
+        content, _display, err = mod._resolve_and_read_blocking("user/a.md", None)
+        assert err is not None
+        assert "aws_secret_access_key" not in content
+
+    @pytest.mark.asyncio
+    async def test_growth_past_cap_mid_read_is_413_not_500(self, fake_home, monkeypatch):
+        """The helper raises FileTooLargeError if the file grows after the lstat."""
+        from kiro_crew import hooks
+        from kiro_crew.dashboard.handlers import steering as mod
+
+        _write_steering(fake_home / ".kiro" / "steering", "a.md", "small\n")
+
+        def _boom(*_a, **_kw):
+            raise hooks.FileTooLargeError("grew")
+
+        # steering.py imports the helper at module scope, so patch it there.
+        monkeypatch.setattr(mod, "safe_read_file_bytes_nolink", _boom)
+        _content, _display, err = mod._resolve_and_read_blocking("user/a.md", None)
+        assert err is not None and err.startswith("toolarge:")
+
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.get("/api/steering/user/a.md")).status == 413
+
+    @pytest.mark.asyncio
+    async def test_oversize_file_is_413(self, fake_home):
+        root = fake_home / ".kiro" / "steering"
+        _write_steering(root, "big.md", "x" * (STEERING_FILE_MAX_BYTES + 1))
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.get("/api/steering/user/big.md")).status == 413
+
+
+class TestCreateEndpoint:
+    @pytest.mark.asyncio
+    async def test_creates_user_file_when_no_project(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.post(
+                "/api/steering", json={"name": "My Rules", "content": "# Rules\n"}
+            )
+            assert resp.status == 200
+            data = await resp.json()
+        assert data["key"] == "user/My Rules.md"
+        assert (fake_home / ".kiro" / "steering" / "My Rules.md").read_text() == "# Rules\n"
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_workspace_when_project_set(self, fake_home, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        async with TestClient(TestServer(_make_app(_state(proj)))) as client:
+            resp = await client.post("/api/steering", json={"name": "api.md", "content": "x"})
+            assert resp.status == 200
+            assert (await resp.json())["key"] == "workspace/api.md"
+        assert (proj / ".kiro" / "steering" / "api.md").is_file()
+
+    @pytest.mark.asyncio
+    async def test_workspace_without_project_is_400(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.post(
+                "/api/steering", json={"name": "a.md", "content": "x", "source": "workspace"}
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_duplicate_is_409(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "dup.md")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.post("/api/steering", json={"name": "dup.md", "content": "x"})
+            assert resp.status == 409
+
+    @pytest.mark.asyncio
+    async def test_traversal_name_is_confined_to_root(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.post(
+                "/api/steering", json={"name": "../../escape", "content": "x"}
+            )
+            assert resp.status == 200
+            key = (await resp.json())["key"]
+        assert key == "user/etc/passwd.md" or key.startswith("user/")
+        assert not (fake_home.parent / "escape.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_are_400(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.post("/api/steering", json={"content": "x"})).status == 400
+            assert (await client.post("/api/steering", json={"name": "a.md"})).status == 400
+
+    @pytest.mark.asyncio
+    async def test_oversize_content_is_413(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.post(
+                "/api/steering",
+                json={"name": "a.md", "content": "x" * (STEERING_FILE_MAX_BYTES + 1)},
+            )
+            assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_audits_creation(self, fake_home, monkeypatch):
+        sel_mock = MagicMock()
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: sel_mock)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            await client.post("/api/steering", json={"name": "a.md", "content": "x"})
+        ops = [c.kwargs.get("operation") for c in sel_mock.log_api_access.call_args_list]
+        assert "steering.create" in ops
+
+
+class TestUpdateDeleteEndpoints:
+    @pytest.mark.asyncio
+    async def test_update_writes_content(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "a.md", "old")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.put("/api/steering/user/a.md", json={"content": "new"})
+            assert resp.status == 200
+        assert (fake_home / ".kiro" / "steering" / "a.md").read_text() == "new"
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_is_404(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.put("/api/steering/user/nope.md", json={"content": "x"})
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_update_empty_content_is_400(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "a.md")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.put("/api/steering/user/a.md", json={"content": "  "})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_update_through_symlink_is_refused(self, fake_home):
+        """PUT must not truncate a file reached via a steering-dir symlink."""
+        root = fake_home / ".kiro" / "steering"
+        root.mkdir(parents=True, exist_ok=True)
+        victim = fake_home / "README.md"
+        victim.write_text("# real readme\n", encoding="utf-8")
+        (root / "rules.md").symlink_to(victim)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.put("/api/steering/user/rules.md", json={"content": "pwned"})
+            assert resp.status == 404
+        assert victim.read_text() == "# real readme\n"
+
+    @pytest.mark.asyncio
+    async def test_delete_through_symlink_is_refused(self, fake_home):
+        root = fake_home / ".kiro" / "steering"
+        root.mkdir(parents=True, exist_ok=True)
+        victim = fake_home / "README.md"
+        victim.write_text("# real readme\n", encoding="utf-8")
+        (root / "rules.md").symlink_to(victim)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.delete("/api/steering/user/rules.md")).status == 404
+        assert victim.exists()
+
+    def test_write_flags_tolerate_missing_o_nofollow(self):
+        """``os.O_NOFOLLOW`` is absent on Windows — the flag must be optional.
+
+        Referencing ``os.O_NOFOLLOW`` directly would raise AttributeError there
+        and turn every create/update into a 500.
+        """
+        from kiro_crew.dashboard.handlers import steering as mod
+
+        assert mod._O_NOFOLLOW == getattr(os, "O_NOFOLLOW", 0)
+
+    @pytest.mark.asyncio
+    async def test_update_is_atomic_and_preserves_content_on_write_failure(
+        self, fake_home, monkeypatch
+    ):
+        """A failed write must leave the original document intact.
+
+        The update path replaces the file (temp write + os.replace) instead of
+        truncating in place, so a write that dies part-way — a full filesystem,
+        say — cannot destroy the user's steering document.
+        """
+        from kiro_crew.dashboard.handlers import steering as mod
+
+        path = _write_steering(fake_home / ".kiro" / "steering", "a.md", "original\n")
+
+        def _boom(*_a, **_kw):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(mod, "atomic_write", _boom)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            resp = await client.put("/api/steering/user/a.md", json={"content": "new"})
+            assert resp.status == 500
+        assert path.read_text() == "original\n"
+
+    @pytest.mark.asyncio
+    async def test_crlf_content_round_trips_byte_exact(self, fake_home):
+        """Line endings must survive create -> read -> save unchanged.
+
+        Text-mode writes translate ``\\n`` to ``\\r\\n`` on Windows, so a document
+        read back and saved again would accumulate carriage returns on every
+        cycle (CRLF -> CR CR LF -> ...). Both write paths use newline="" to
+        keep the bytes exactly as the editor sent them.
+        """
+        crlf = "# Windows doc\r\nline two\r\n"
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (
+                await client.post("/api/steering", json={"name": "crlf.md", "content": crlf})
+            ).status == 200
+            first = await (await client.get("/api/steering/user/crlf.md")).json()
+            assert first["content"] == crlf
+            assert (
+                await client.put("/api/steering/user/crlf.md", json={"content": first["content"]})
+            ).status == 200
+            second = await (await client.get("/api/steering/user/crlf.md")).json()
+        assert second["content"] == crlf
+        raw = (fake_home / ".kiro" / "steering" / "crlf.md").read_bytes()
+        assert raw == crlf.encode("utf-8")
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
+    async def test_update_preserves_existing_file_mode(self, fake_home):
+        """A save must not silently tighten a group-readable steering file."""
+        root = fake_home / ".kiro" / "steering"
+        path = _write_steering(root, "a.md", "old")
+        path.chmod(0o644)
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (
+                await client.put("/api/steering/user/a.md", json={"content": "new"})
+            ).status == 200
+        assert stat.S_IMODE(path.stat().st_mode) == 0o644
+        assert path.read_text() == "new"
+
+    @pytest.mark.asyncio
+    async def test_update_leaves_no_temp_files_behind(self, fake_home):
+        root = fake_home / ".kiro" / "steering"
+        _write_steering(root, "a.md", "old")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (
+                await client.put("/api/steering/user/a.md", json={"content": "new"})
+            ).status == 200
+        assert (root / "a.md").read_text() == "new"
+        assert [p.name for p in root.iterdir()] == ["a.md"]
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_file(self, fake_home):
+        path = _write_steering(fake_home / ".kiro" / "steering", "a.md")
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.delete("/api/steering/user/a.md")).status == 200
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_is_404(self, fake_home):
+        async with TestClient(TestServer(_make_app(_state()))) as client:
+            assert (await client.delete("/api/steering/user/nope.md")).status == 404
+
+
+class TestRestrictedSessions:
+    """Incognito / guest sessions may read steering but never modify it."""
+
+    @staticmethod
+    def _restricted_state(project=None):
+        state = _state(project)
+        state._restricted_keys = {"dashboard:incognito"}
+        return state
+
+    @pytest.mark.asyncio
+    async def test_reads_allowed(self, fake_home):
+        _write_steering(fake_home / ".kiro" / "steering", "a.md")
+        async with TestClient(TestServer(_make_app(self._restricted_state()))) as client:
+            resp = await client.get(
+                "/api/steering/user/a.md", headers={"X-Session-Key": "dashboard:incognito"}
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_writes_blocked(self, fake_home):
+        path = _write_steering(fake_home / ".kiro" / "steering", "a.md")
+        hdr = {"X-Session-Key": "dashboard:incognito"}
+        async with TestClient(TestServer(_make_app(self._restricted_state()))) as client:
+            assert (
+                await client.post("/api/steering", json={"name": "b.md", "content": "x"},
+                                  headers=hdr)
+            ).status == 403
+            assert (
+                await client.put("/api/steering/user/a.md", json={"content": "y"}, headers=hdr)
+            ).status == 403
+            assert (await client.delete("/api/steering/user/a.md", headers=hdr)).status == 403
+        assert path.read_text() == "# Title\nrules\n"

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -913,6 +913,15 @@ export const api = {
   createSkill: (name: string, content: string) => post('/api/skills', { name, content }).then(j),
   updateSkill: (name: string, content: string) => put('/api/skills/' + name.split('/').map(encodeURIComponent).join('/'), { content }).then(j),
   deleteSkill: (name: string) => del('/api/skills/' + name.split('/').map(encodeURIComponent).join('/')).then(j),
+
+  // Steering (Kiro steering files — ~/.kiro/steering + <project>/.kiro/steering)
+  steeringFiles: () => fetch('/api/steering').then(j),
+  steeringFile: (key: string) => fetch('/api/steering/' + key.split('/').map(encodeURIComponent).join('/')).then(j),
+  createSteering: (name: string, content: string, source?: string) =>
+    post('/api/steering', { name, content, source }).then(j),
+  updateSteering: (key: string, content: string) =>
+    put('/api/steering/' + key.split('/').map(encodeURIComponent).join('/'), { content }).then(j),
+  deleteSteering: (key: string) => del('/api/steering/' + key.split('/').map(encodeURIComponent).join('/')).then(j),
   /** Multi-provider skill discovery (skills.sh, etc.) */
   discoverSkills: (query: string, opts?: { provider?: string; limit?: number }) =>
     get(`/api/skills/-/discover?q=${encodeURIComponent(query)}${opts?.provider ? `&provider=${opts.provider}` : ''}${opts?.limit ? `&limit=${opts.limit}` : ''}`).then(j) as Promise<import('../types').DiscoverSkillsResponse>,

--- a/website/src/pages/CapabilitiesPage.tsx
+++ b/website/src/pages/CapabilitiesPage.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
-import { Plug, BookOpen, Users, MessageSquareText, Webhook, LayoutTemplate } from 'lucide-react'
+import { Plug, BookOpen, Users, MessageSquareText, Webhook, LayoutTemplate, Compass } from 'lucide-react'
 import SidePanelLayout from '../components/SidePanelLayout'
 import RestartButton from '../components/RestartButton'
 import { useProvider } from '../providers'
 import AgentsPage from './AgentsPage'
 import KiroCrewAgentsPage from './KiroCrewAgentsPage'
 import HooksPage from './HooksPage'
-import { McpTab, SkillsTab, PromptsTab } from './overview'
+import { McpTab, SkillsTab, PromptsTab, SteeringTab } from './overview'
 
 export default function CapabilitiesPage() {
   const provider = useProvider()
@@ -17,6 +17,7 @@ export default function CapabilitiesPage() {
       { key: 'templates', label: 'Agent Templates', icon: <LayoutTemplate size={16} />, description: `Installed agent configurations and packages` },
       { key: 'mcp', label: 'Integrations (MCP)', icon: <Plug size={16} />, description: 'Add tools that let your agent work with Slack, AWS, code repos, and other services' },
       { key: 'skills', label: 'Skills', icon: <BookOpen size={16} />, description: 'Specialized knowledge files your agent loads on demand for specific tasks' },
+      { key: 'steering', label: 'Steering', icon: <Compass size={16} />, description: 'Always-on markdown conventions from ~/.kiro/steering and your project\u2019s .kiro/steering' },
       { key: 'hooks', label: 'Hooks', icon: <Webhook size={16} />, description: 'Shell commands that run automatically on agent events like prompts, tool calls, and session start/stop' },
       { key: 'prompts', label: 'Prompts', icon: <MessageSquareText size={16} />, description: `Reusable prompt templates from ${provider.labels.pluginRegistryName || 'packages'}` },
     ]
@@ -29,6 +30,7 @@ export default function CapabilitiesPage() {
         {tab === 'templates' && <AgentsPage embedded />}
         {tab === 'mcp' && <McpTab />}
         {tab === 'skills' && <SkillsTab />}
+        {tab === 'steering' && <SteeringTab />}
         {tab === 'hooks' && <HooksPage embedded />}
         {tab === 'prompts' && <PromptsTab />}
       </>}

--- a/website/src/pages/overview/SteeringTab.tsx
+++ b/website/src/pages/overview/SteeringTab.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Compass, RefreshCw } from 'lucide-react'
+import { api } from '../../api/client'
+import { Card, Btn, SearchInput, EmptyState } from '../../components/ui'
+import InfoTip from '../../components/InfoTip'
+import Modal from '../../components/Modal'
+import MarkdownRenderer from '../../components/MarkdownRenderer'
+import type { SteeringFile, SteeringList } from '../../types'
+
+const SOURCE_LABEL: Record<string, string> = { user: 'Global', workspace: 'Workspace' }
+
+const NEW_TEMPLATE = '# Title\n\nDescribe the convention the agent should always follow.\n'
+
+/** Textarea styling matches SkillForm's raw-markdown editor. */
+const EDITOR_CLASS =
+  'w-full h-full min-h-[320px] bg-bg-elevated border border-border rounded-md p-3 text-text font-mono text-[13px] outline-none resize-none focus-ring'
+
+export default function SteeringTab() {
+  const queryClient = useQueryClient()
+  const [filter, setFilter] = useState('')
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newSource, setNewSource] = useState<'user' | 'workspace'>('workspace')
+  const [newBody, setNewBody] = useState(NEW_TEMPLATE)
+
+  const { data, isLoading, isFetching, refetch } = useQuery<SteeringList>({
+    queryKey: ['steering'],
+    queryFn: () => api.steeringFiles(),
+  })
+  const files = useMemo(() => data?.files ?? [], [data])
+  const roots = useMemo(() => data?.roots ?? [], [data])
+  const hasProject = !!data?.project
+
+  const { data: detail } = useQuery({
+    queryKey: ['steering-file', selectedKey],
+    queryFn: () => api.steeringFile(selectedKey!),
+    enabled: !!selectedKey,
+  })
+
+  const createFile = useMutation({
+    mutationFn: (body: { name: string; content: string; source: string }) =>
+      api.createSteering(body.name, body.content, body.source),
+    onSuccess: (res: { key?: string }) => {
+      setCreating(false)
+      setNewName('')
+      setNewBody(NEW_TEMPLATE)
+      if (res?.key) {
+        setSelectedKey(res.key)
+        // Drop any cached detail for this key: a file deleted and recreated
+        // under the same name would otherwise populate the editor from the
+        // OLD file's retained cache entry (gcTime keeps it, and it is served
+        // stale on re-select), and saving that would overwrite the new file.
+        queryClient.removeQueries({ queryKey: ['steering-file', res.key] })
+      }
+      queryClient.invalidateQueries({ queryKey: ['steering'] })
+    },
+  })
+
+  const updateFile = useMutation({
+    mutationFn: ({ key, content }: { key: string; content: string }) => api.updateSteering(key, content),
+    onSuccess: () => {
+      setEditing(false)
+      queryClient.invalidateQueries({ queryKey: ['steering'] })
+      queryClient.invalidateQueries({ queryKey: ['steering-file'] })
+    },
+  })
+
+  const deleteFile = useMutation({
+    mutationFn: (key: string) => api.deleteSteering(key),
+    onSuccess: (_res, key) => {
+      setSelectedKey(null)
+      setEditing(false)
+      // Remove, not invalidate: the file is gone, so its cached detail must
+      // not survive to seed a later file created under the same key.
+      queryClient.removeQueries({ queryKey: ['steering-file', key] })
+      queryClient.invalidateQueries({ queryKey: ['steering'] })
+    },
+  })
+
+  const mutError = (createFile.error || updateFile.error || deleteFile.error) as Error | null
+
+  const filtered = useMemo(() => {
+    const q = filter.toLowerCase()
+    if (!q) return files
+    return files.filter(f => (f.key + ' ' + (f.description || '')).toLowerCase().includes(q))
+  }, [files, filter])
+
+  const selected = useMemo(() => files.find(f => f.key === selectedKey) ?? null, [files, selectedKey])
+
+  // Keep a valid selection; suspended while editing so an unsaved draft is
+  // never discarded by a background refetch reordering the list.
+  useEffect(() => {
+    if (editing) return
+    if (filtered.length === 0) { if (selectedKey !== null) setSelectedKey(null); return }
+    if (!selectedKey || !filtered.some(f => f.key === selectedKey)) setSelectedKey(filtered[0].key)
+  }, [filtered, selectedKey, editing])
+
+  // Default the create dialog to the scope that exists.
+  useEffect(() => { setNewSource(hasProject ? 'workspace' : 'user') }, [hasProject])
+
+  const select = (f: SteeringFile) => { setSelectedKey(f.key); setEditing(false) }
+
+  const renderRow = (f: SteeringFile) => {
+    const isSel = f.key === selectedKey
+    return (
+      <div
+        key={f.key}
+        role="button"
+        tabIndex={0}
+        aria-current={isSel ? 'true' : undefined}
+        aria-label={`Select ${f.rel}`}
+        onClick={() => select(f)}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(f) } }}
+        className={`flex flex-col gap-0.5 px-3 py-2.5 rounded-md cursor-pointer mb-1 transition-colors ${
+          isSel ? 'list-selected bg-accent-subtle' : 'bg-bg-elevated hover:bg-bg-hover'
+        }`}
+      >
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="text-[13px] font-semibold text-text truncate flex-1">{f.rel}</span>
+          <span className="text-[10px] px-1.5 py-[1px] rounded-full bg-bg-elevated text-muted border border-border font-bold shrink-0">
+            {SOURCE_LABEL[f.source] || f.source}
+          </span>
+        </div>
+        {f.description && <div className="text-[11px] text-muted truncate">{f.description}</div>}
+      </div>
+    )
+  }
+
+  const rootHint = roots.map(r => r.path).join('  ·  ')
+
+  return (<>
+    <Modal
+      open={creating}
+      onClose={() => setCreating(false)}
+      title="New steering file"
+      maxWidth={640}
+      footer={<>
+        <Btn onClick={() => setCreating(false)}>Cancel</Btn>
+        <Btn
+          primary
+          disabled={!newName.trim() || !newBody.trim() || createFile.isPending}
+          onClick={() => createFile.mutate({ name: newName.trim(), content: newBody, source: newSource })}
+        >Create</Btn>
+      </>}
+    >
+      <div className="flex flex-col gap-3">
+        <label className="flex flex-col gap-1" htmlFor="steering-new-name">
+          <span className="text-[13px] text-muted">File name</span>
+          <input
+            id="steering-new-name"
+            aria-label="Steering file name"
+            className="w-full bg-bg-elevated border border-border rounded-md px-3 py-2 text-text text-[13px] outline-none focus-ring"
+            placeholder="api-standards.md"
+            value={newName}
+            onChange={e => setNewName(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1" htmlFor="steering-new-scope">
+          <span className="text-[13px] text-muted">Scope</span>
+          <select
+            id="steering-new-scope"
+            className="w-full bg-bg-elevated border border-border rounded-md px-3 py-2 text-text text-[13px] outline-none focus-ring"
+            value={newSource}
+            onChange={e => setNewSource(e.target.value as 'user' | 'workspace')}
+          >
+            <option value="workspace" disabled={!hasProject}>
+              Workspace — this project only{hasProject ? '' : ' (no project set)'}
+            </option>
+            <option value="user">Global — every project</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1" htmlFor="steering-new-body">
+          <span className="text-[13px] text-muted">Content</span>
+          <textarea
+            id="steering-new-body"
+            aria-label="Steering file content"
+            className={EDITOR_CLASS}
+            rows={14}
+            value={newBody}
+            onChange={e => setNewBody(e.target.value)}
+          />
+        </label>
+      </div>
+    </Modal>
+
+    <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2 flex items-center gap-2">
+      Steering ({files.length})
+      <InfoTip text="Always-on markdown conventions injected into every session. Global files live in ~/.kiro/steering and apply everywhere; workspace files live in <project>/.kiro/steering and apply to that project only." />
+      <span className="ml-auto">
+        <Btn primary onClick={() => setCreating(true)}>New Steering File</Btn>
+      </span>
+    </h4>
+    <Card>
+      <div className="flex items-center gap-2 mb-3">
+        <div className="relative max-w-[480px] flex-1">
+          <SearchInput placeholder="Filter steering files…" value={filter} onChange={e => setFilter(e.target.value)} />
+          {filter && (
+            <button
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-text transition-colors cursor-pointer"
+              onClick={() => setFilter('')}
+              aria-label="Clear search"
+            >&times;</button>
+          )}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Btn onClick={() => refetch()} disabled={isFetching} aria-label="Refresh steering files">
+            <RefreshCw size={14} className={isFetching ? 'animate-spin' : ''} />
+          </Btn>
+        </div>
+      </div>
+
+      {mutError && (
+        <div className="mb-3 px-3 py-2 rounded-md bg-danger/10 border border-danger/20 text-[13px] text-danger">
+          {mutError.message}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex gap-3 h-[calc(100vh-260px)] min-h-[420px]">
+          <div className="w-[240px] shrink-0 space-y-1">{Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-[52px] rounded-md animate-pulse" style={{ background: 'var(--border)', opacity: 0.5, animationDelay: `${i * 80}ms` }} />
+          ))}</div>
+          <div className="flex-1 rounded-md animate-pulse" style={{ background: 'var(--border)', opacity: 0.3 }} />
+        </div>
+      ) : files.length === 0 ? (
+        <EmptyState
+          icon={<Compass className="lucide-inline" />}
+          title="No steering files yet"
+          subtitle={`Steering files are always-on markdown conventions. Looked in: ${rootHint || '~/.kiro/steering'}`}
+        />
+      ) : (
+        <div className="flex gap-3 h-[calc(100vh-260px)] min-h-[420px]">
+          <div className="w-[240px] shrink-0 overflow-y-auto scrollbar-overlay border border-border rounded-md p-2" role="listbox" aria-label="Steering files">
+            {filtered.map(renderRow)}
+            {filtered.length === 0 && <div className="text-muted/70 text-[12px] italic px-2 py-2">No files match “{filter}”.</div>}
+          </div>
+
+          <div className="flex-1 min-w-0 flex flex-col border border-border rounded-md bg-card overflow-hidden">
+            {!selected ? (
+              <div className="flex items-center justify-center h-full text-muted text-[13px]">Select a steering file to view it</div>
+            ) : (
+              <div className="flex flex-col h-full min-h-0">
+                <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-border shrink-0">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-bold text-text-strong truncate">{selected.rel}</span>
+                    <span className="text-[11px] px-1.5 py-[1px] rounded-full bg-bg-elevated text-muted border border-border font-bold shrink-0">
+                      {SOURCE_LABEL[selected.source] || selected.source}
+                    </span>
+                    <span className="text-[11px] text-muted font-mono truncate">{selected.path}</span>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    {editing ? (<>
+                      <Btn onClick={() => setEditing(false)}>Cancel</Btn>
+                      <Btn primary disabled={!draft.trim() || updateFile.isPending} onClick={() => updateFile.mutate({ key: selected.key, content: draft })}>Save</Btn>
+                    </>) : (<>
+                      <Btn disabled={detail === undefined} onClick={() => { setDraft(detail?.content ?? ''); setEditing(true) }}>Edit</Btn>
+                      <Btn danger onClick={() => { if (confirm(`Delete "${selected.rel}"?`)) deleteFile.mutate(selected.key) }}>Delete</Btn>
+                    </>)}
+                  </div>
+                </div>
+                <div className="flex-1 min-h-0 overflow-y-auto p-4">
+                  {editing
+                    ? <textarea className={EDITOR_CLASS} aria-label={`Edit ${selected.rel}`} value={draft} onChange={e => setDraft(e.target.value)} />
+                    : detail === undefined
+                      ? <div className="text-muted text-[13px]">Loading…</div>
+                      : <div className="text-sm leading-relaxed"><MarkdownRenderer content={detail.content} /></div>}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </Card>
+  </>)
+}

--- a/website/src/pages/overview/index.ts
+++ b/website/src/pages/overview/index.ts
@@ -1,6 +1,7 @@
 export { default as MemoryTab } from './MemoryTab'
 export { default as CronTab } from './CronTab'
 export { default as SkillsTab } from './SkillsTab'
+export { default as SteeringTab } from './SteeringTab'
 export { default as PromptsTab } from './PromptsTab'
 export { default as McpTab } from './McpTab'
 export { default as AgentCfgTab } from './AgentCfgTab'

--- a/website/src/test/SteeringTab.test.tsx
+++ b/website/src/test/SteeringTab.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * SteeringTab — the Steering tab under Agent Capabilities.
+ *
+ * Pins: both steering sources are listed with provenance badges, selecting a
+ * file renders its markdown, Edit round-trips the raw content through the
+ * update endpoint, Delete confirms first, and the create dialog forwards the
+ * chosen scope.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApi = vi.hoisted(() => ({
+  steeringFiles: vi.fn(),
+  steeringFile: vi.fn(),
+  createSteering: vi.fn(),
+  updateSteering: vi.fn(),
+  deleteSteering: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+vi.mock('../components/MarkdownRenderer', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="md">{content}</div>,
+}))
+
+import SteeringTab from '../pages/overview/SteeringTab'
+
+const FILES = {
+  files: [
+    { key: 'user/personal.md', name: 'personal.md', rel: 'personal.md', source: 'user', path: '~/.kiro/steering/personal.md', size: 12, description: 'Personal' },
+    { key: 'workspace/api.md', name: 'api.md', rel: 'api.md', source: 'workspace', path: '~/proj/.kiro/steering/api.md', size: 20, description: 'API standards' },
+  ],
+  roots: [
+    { source: 'user', path: '~/.kiro/steering', exists: true },
+    { source: 'workspace', path: '~/proj/.kiro/steering', exists: true },
+  ],
+  project: '~/proj',
+}
+
+function renderTab() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  return render(<QueryClientProvider client={qc}><SteeringTab /></QueryClientProvider>)
+}
+
+beforeEach(() => {
+  Object.values(mockApi).forEach(m => m.mockReset())
+  mockApi.steeringFiles.mockResolvedValue(FILES)
+  mockApi.steeringFile.mockResolvedValue({ key: 'user/personal.md', content: '# Personal\nbody', path: '~/.kiro/steering/personal.md', source: 'user' })
+  mockApi.createSteering.mockResolvedValue({ ok: true, key: 'workspace/new.md' })
+  mockApi.updateSteering.mockResolvedValue({ ok: true })
+  mockApi.deleteSteering.mockResolvedValue({ ok: true })
+})
+
+describe('SteeringTab', () => {
+  it('lists files from both sources with scope badges', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByText('personal.md')).toBeInTheDocument())
+    expect(screen.getByText('api.md')).toBeInTheDocument()
+    // Each scope badge appears on its row; the selected file repeats it in the
+    // detail header, so assert on presence rather than a single match.
+    expect(screen.getAllByText('Global').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Workspace').length).toBeGreaterThan(0)
+    expect(screen.getByText('Steering (2)')).toBeInTheDocument()
+  })
+
+  it('auto-selects the first file and renders its markdown', async () => {
+    renderTab()
+    await waitFor(() => expect(mockApi.steeringFile).toHaveBeenCalledWith('user/personal.md'))
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Personal body'))
+  })
+
+  it('shows an empty state naming both search roots when nothing is found', async () => {
+    mockApi.steeringFiles.mockResolvedValue({ files: [], roots: FILES.roots, project: '~/proj' })
+    renderTab()
+    await waitFor(() => expect(screen.getByText('No steering files yet')).toBeInTheDocument())
+    expect(screen.getByText(/~\/\.kiro\/steering/)).toBeInTheDocument()
+  })
+
+  it('Edit loads the raw content into a textarea and Save posts it back', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByText('Edit')).toBeEnabled())
+    fireEvent.click(screen.getByText('Edit'))
+    const editor = screen.getByLabelText('Edit personal.md') as HTMLTextAreaElement
+    expect(editor.value).toBe('# Personal\nbody')
+    fireEvent.change(editor, { target: { value: '# Personal\nchanged' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockApi.updateSteering).toHaveBeenCalledWith('user/personal.md', '# Personal\nchanged'))
+  })
+
+  it('Delete confirms before calling the API', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    renderTab()
+    await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Delete'))
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockApi.deleteSteering).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    fireEvent.click(screen.getByText('Delete'))
+    await waitFor(() => expect(mockApi.deleteSteering).toHaveBeenCalledWith('user/personal.md'))
+    confirmSpy.mockRestore()
+  })
+
+  it('create dialog forwards name, content and scope', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByText('New Steering File')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('New Steering File'))
+    fireEvent.change(screen.getByPlaceholderText('api-standards.md'), { target: { value: 'new.md' } })
+    fireEvent.click(screen.getByText('Create'))
+    await waitFor(() => expect(mockApi.createSteering).toHaveBeenCalledWith('new.md', expect.stringContaining('# Title'), 'workspace'))
+  })
+
+  it('defaults the create scope to global when no project is set', async () => {
+    mockApi.steeringFiles.mockResolvedValue({ ...FILES, project: '' })
+    renderTab()
+    await waitFor(() => expect(screen.getByText('New Steering File')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('New Steering File'))
+    fireEvent.change(screen.getByPlaceholderText('api-standards.md'), { target: { value: 'g.md' } })
+    fireEvent.click(screen.getByText('Create'))
+    await waitFor(() => expect(mockApi.createSteering).toHaveBeenCalledWith('g.md', expect.any(String), 'user'))
+  })
+
+  it('surfaces mutation errors inline', async () => {
+    mockApi.deleteSteering.mockRejectedValue(new Error('restricted session cannot modify steering files'))
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderTab()
+    await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Delete'))
+    await waitFor(() => expect(screen.getByText('restricted session cannot modify steering files')).toBeInTheDocument())
+  })
+
+  it('does not serve a deleted file\'s cached content to a recreated file', async () => {
+    // A delete that only invalidates ['steering'] leaves the old detail in
+    // cache under the same key (gcTime retains it, and it is served stale on
+    // re-select), so the editor would load the deleted file's body and a save
+    // would overwrite the new file.
+    mockApi.steeringFile
+      .mockResolvedValueOnce({ key: 'user/personal.md', content: 'OLD deleted body', path: '~/x', source: 'user' })
+      .mockResolvedValue({ key: 'user/personal.md', content: 'NEW recreated body', path: '~/x', source: 'user' })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('OLD deleted body'))
+
+    fireEvent.click(screen.getByText('Delete'))
+    await waitFor(() => expect(mockApi.deleteSteering).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByText('New Steering File'))
+    fireEvent.change(screen.getByPlaceholderText('api-standards.md'), { target: { value: 'personal.md' } })
+    mockApi.createSteering.mockResolvedValue({ ok: true, key: 'user/personal.md' })
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('NEW recreated body'))
+  })
+
+  it('filters the list', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByText('api.md')).toBeInTheDocument())
+    fireEvent.change(screen.getByPlaceholderText('Filter steering files…'), { target: { value: 'api' } })
+    await waitFor(() => expect(screen.queryByText('personal.md')).not.toBeInTheDocument())
+    // Selection follows the filter, so api.md shows in both the row and header.
+    expect(screen.getAllByText('api.md').length).toBeGreaterThan(0)
+  })
+})

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -77,6 +77,31 @@ export interface SkillTreeEntry {
   size: number
 }
 
+/** A Kiro steering file — always-on markdown injected into every session. */
+export interface SteeringFile {
+  /** ``"<source>/<rel>"`` — the API handle for read/update/delete. */
+  key: string
+  /** File name only (e.g. ``api-standards.md``). */
+  name: string
+  /** Path relative to the steering root, posix-style. */
+  rel: string
+  /** ``user`` → ~/.kiro/steering (global), ``workspace`` → <project>/.kiro/steering. */
+  source: string
+  /** Display path with the home prefix collapsed to ``~``. */
+  path: string
+  size: number
+  /** First markdown heading, used as a one-line summary. */
+  description: string
+}
+
+/** Response shape of ``GET /api/steering``. */
+export interface SteeringList {
+  files: SteeringFile[]
+  roots: Array<{ source: string; path: string; exists: boolean }>
+  /** Active project directory (display path), empty when none is set. */
+  project: string
+}
+
 /** A skill result from the multi-provider discover endpoint. */
 export interface DiscoveredSkill {
   id: string


### PR DESCRIPTION
## Problem

Kiro **steering files** — the always-on markdown conventions injected into every session — were loaded but never viewable. Nothing in the dashboard showed which steering documents were in effect, which location they came from, or let a user read or edit one. The only surface was the filesystem.

Two mechanisms load them, and neither was visible:

- `context.py:_load_steering_resources()` globs the agent config's `file://.kiro/steering/**/*.md` resource against `$HOME` (so: the global `~/.kiro/steering`) and injects the result on the CC backend, capped at 10% of the context budget (`_STEERING_CAP`).
- kiro-cli loads workspace steering itself, because the session subprocess runs with the chat slot's project directory as its cwd.

## Why it matters

Steering silently shapes every agent turn. Without a viewer, a user cannot answer "why does the agent keep doing X?" without going to a terminal, cannot tell global from project-scoped rules, and has no in-product way to add a convention — while Skills, Hooks, MCP and Prompts all already have tabs under Agent Capabilities.

## Fix (symptom → root cause → change)

**Symptom:** no steering surface in the dashboard. **Root cause:** there were no `/api/steering*` routes at all — steering existed only as a context-injection code path — and therefore nothing for a tab to render. **Change:** add the endpoints, then the tab.

- **`handlers/steering.py` (new).** `GET /api/steering` lists both roots with provenance (`user` → `~/.kiro/steering`, `workspace` → `<project>/.kiro/steering`), `GET/PUT/DELETE /api/steering/{key}` read/update/delete one file, `POST /api/steering` creates one. The key is `"<source>/<relpath>"`. The two-root `rglob` + per-file stat/head-read runs on `discovery_executor()`, the same pool as `/api/skills`.
- **`SteeringTab.tsx` (new).** Master-detail list (React Query keys `['steering']` / `['steering-file', key]`) with a scope badge per row, `MarkdownRenderer` for the body, a textarea editor, and a `Modal` create dialog whose scope selector disables Workspace when no project is set. Wired into `CapabilitiesPage` between Skills and Hooks.
- **Latent bug fixed along the way.** The workspace root needs the active project dir, and the existing skills code read `slot.project_dir` — which does not exist on `_ChatSlot` (the attribute is `slot.project`), so workspace-scoped skills never resolved. Both call sites now route through one shared `_shared.py:active_project_dir()`.

### Security posture

- Containment is anchored on the **trust base** (`$HOME` for global, the project dir for workspace), not on the steering root: `_contained()` resolves the deepest *existing* ancestor and requires it at or under the resolved base. Comparing against the root itself would happily follow a `~/.kiro/steering` symlink pointing at `/etc`.
- A symlink at the **leaf** is rejected outright and never listed — not merely one that escapes the base. `.kiro/steering/rules.md -> ../../README.md` satisfies base containment, so without this a `PUT` would truncate (and `DELETE` unlink) a file that is not a steering document.
- Writes use `os.open` with `O_NOFOLLOW` where the platform has it — via `getattr(os, "O_NOFOLLOW", 0)`, because the flag does not exist on Windows and a direct reference would make every write a 500 there. Create adds `O_EXCL` (which atomically refuses a pre-planted symlink on its own). Update opens **without** `O_TRUNC`, compares the opened descriptor's `(st_dev, st_ino)` against the pre-open `lstat`, and only then truncates — so platforms lacking `O_NOFOLLOW` are covered by the identity check rather than by trusting the kernel.
- `_split_key()` rejects unknown sources, absolute paths, `~`, `..` segments, backslashes, NUL and any suffix but `.md`; `_safe_rel_name()` sanitizes create names so a traversal attempt lands inside the steering root or is refused.
- Restricted (incognito / temporary / guest) sessions may **read** steering but never create, update or delete it (403). Every mutation emits `sel().log_api_access(operation="steering.create|update|delete")`; reads emit `log_tool_invocation(tool_kind="steering")`.
- Read responses return content **verbatim**, deliberately not credential-redacted: the response feeds the editor and is written straight back on save, so redaction would corrupt the user's own file. This matches the skills/prompts precedent. Listing metadata still collapses the real home to `~`.
- Caps: 500 listed files, 256 KiB per document (413 on an oversize read or write).

## Tests

**`test/test_steering_api.py` (new)** — locks in:

- Discovery: both roots listed with provenance and first-heading descriptions, nested files, `~`-collapsed paths, dotfile/non-markdown skipping, missing-root `exists: false`, the 500-file cap.
- Path guards: bad-key rejection table (`..`, absolute, `~`, backslash, non-`.md`, unknown source), create-name sanitization table, workspace-requires-project, symlinked root escaping `$HOME`, symlinked subdir escaping the base, **symlinked leaf escaping the base**, and **symlinked leaf resolving *inside* the base** (the PUT/DELETE redirect).
- Endpoints: verbatim read, 404 on unknown/traversal, 413 oversize read and write, create defaulting to workspace vs global, 409 duplicate, 400 missing fields, update/delete happy paths, `PUT`/`DELETE` through a symlink refused with the victim file intact, `_O_NOFOLLOW` optional-flag assertion, and the update path re-run with the flag forced to 0 (the Windows path).
- Project resolution: a single shared project is used; slots that disagree resolve to `None`; an `X-Session-Key` selects its own slot; project-less slots are ignored; a workspace create is refused (400, no `.kiro` created in either project) and the listing omits the workspace root entirely when open chats disagree.
- Authorization: restricted sessions read 200 / create-update-delete 403 with the file unchanged, plus SEL audit emission for list and create.

**`website/src/test/SteeringTab.test.tsx` (new, 9 tests)** — both sources listed with badges, auto-select + markdown render, empty state naming both roots, Edit→Save raw round-trip, Delete confirm gate, create dialog scope forwarding (workspace default vs global fallback), inline mutation error, filter.

Local gates on this commit: isort, flake8, mypy 1.14.1 (CI pin, no faiss) clean; pytest 19,215 passed; `tsc -b` clean; eslint 0 errors; vitest green. Four pytest failures on this host are unrelated: three in `test_dashboard_origin.py` reproduce on a clean `origin/main` checkout (local port config), and `test_mcp_gateway_wedge_ping_gate.py::test_unknown_notification_silently_ignored` is a load-sensitive flake that passes in isolation — neither file is touched by this diff.

## Manual verification

Rendered the tab in a headless Playwright harness against stubbed `/api/steering` responses (both sources populated, and the create dialog open) and captured the screenshots below. The endpoints themselves are covered end-to-end by the aiohttp `TestClient` suite above rather than by hand.

Known cosmetic nit, left as-is deliberately: long filenames truncate in the 240px row because the scope badge shares the line (`api-standards…`, `personal-convent…`). This matches the existing Skills tab layout; changing it is a separate design decision.

## Screenshots

<img width="3012" height="1874" alt="Screenshot 2026-07-28 at 14 02 23@2x" src="https://github.com/user-attachments/assets/f4fdbdd4-f225-4bf8-8c0e-240a1b224412" />

<img width="3012" height="1886" alt="Screenshot 2026-07-28 at 14 02 17@2x" src="https://github.com/user-attachments/assets/e5078b83-c547-4d43-8f81-0e363951bf0d" />

<img width="3012" height="1854" alt="Screenshot 2026-07-28 at 14 02 08@2x" src="https://github.com/user-attachments/assets/206d19e9-aee8-40ac-9093-e4d58af2ed41" />
<img width="3012" height="1854" alt="Screenshot 2026-07-28 at 14 02 08@2x" src="https://github.com/user-attachments/assets/023b1013-b17a-4d32-8c97-c6f3fa3ea1c5" />


What they show:

1. **Agent Capabilities → Steering, in context** — the tab rail (Agents · Agent Templates · Integrations (MCP) · Skills · **Steering** · Hooks · Prompts), the page subtitle naming both locations, and the list-detail body.
2. **The create dialog** — file-name field, the scope selector (`Workspace — this project only` / `Global — every project`, Workspace disabled when no project is resolvable), and the seeded template.
3. **The tab body** — four files across both sources with `Workspace` / `Global` badges and first-heading summaries, the selected file's `~`-collapsed path in the detail header, Edit/Delete, and the sanitized markdown render.

Known cosmetic nit, left as-is deliberately: long filenames truncate in the 240px row because the scope badge shares the line (`api-standards…`, `personal-convent…`). This matches the existing Skills tab layout; changing it is a separate design decision.

## Docs

- `docs/system-specs/features/steering-viewer.md` (new) — policy (source table, containment and symlink policy, caps, the no-redaction rationale, the restricted-session gate), wiring, and non-goals; registered in `docs/system-specs/index.md`.
- `docs/kiro-cli/steering.md` — points at the new tab.
