### PR TITLE
test(e2e): un-darken the suite and cover the uncovered routes

### DIFF
--- a/src/kiro_crew/testing/fake_acp_backend.py
+++ b/src/kiro_crew/testing/fake_acp_backend.py
@@ -24,6 +24,23 @@ Prompt-driven behaviour on ``session/prompt`` (the reply is always sent last):
   permission needs the dashboard/UI, so this path is for Playwright E2E and
   live demos -- NOT the headless backend suite (a headless host has nothing to
   resolve the modal and the turn would stall).
+* ``[[GATED]]`` in the prompt -> like ``[[PERMISSION]]`` but the fake WAITS for
+  the host's answer (bounded by ``PERMISSION_WAIT_SECS``) and reflects it: a
+  reject/cancel outcome yields ``status: "failed"`` on the tool_call_update.
+  On timeout it reports ``completed``, preserving the never-block guarantee.
+* ``[[SLOW]]`` -> stream ``SLOW_CHUNKS`` chunks with a delay, checking for a
+  ``session/cancel`` between each. A cancel ends the turn early with
+  ``stopReason: "cancelled"`` (the ACP soft-stop ack the host waits for).
+* ``[[SLOW_NOACK]]`` -> the same slow stream but deliberately DEAF to cancel,
+  so the host's ``soft_stop_budget_secs`` expires. Models an agent wedged in a
+  long tool call, which is the "Stop Failed, Session Reset" path.
+* ``[[ERROR]]`` -> reply with a JSON-RPC error instead of a result.
+* ``[[MAXTOKENS]]`` / ``[[REFUSAL]]`` -> alternate terminal ``stopReason``.
+
+Observing a cancel mid-turn requires reading stdin while a prompt is streaming,
+so ``main()`` reads on a background thread into a queue rather than looping
+read->handle. Calling ``_handle`` directly (as the unit tests do) leaves that
+queue empty, every wait times out, and the default behaviour is unchanged.
 
 Deterministic, offline, no network, no auth, stdlib-only. Reachable ONLY via
 the ``KIROCREW_KIRO_BIN`` override (the provider stays ``acp``); it is never
@@ -39,8 +56,11 @@ offline gateway exercises the same first-run readiness gate as production.
 from __future__ import annotations
 
 import json
+import queue
 import sys
-from typing import Any
+import threading
+import time
+from typing import Any, Callable
 
 PROTOCOL_VERSION = "2025-08-22"
 
@@ -53,6 +73,34 @@ FAKE_IDENTITY = "fake-e2e-user"
 # Prompt sentinels. Absent by default so a plain prompt stays text-only.
 TOOL_TRIGGER = "[[TOOL]]"
 PERMISSION_TRIGGER = "[[PERMISSION]]"
+# Permission that actually GATES: the fake waits for the host's answer and
+# reflects it in the tool_call_update status. Distinct from PERMISSION_TRIGGER,
+# whose fire-and-forget behaviour existing specs rely on.
+GATED_PERMISSION_TRIGGER = "[[GATED]]"
+# A turn long enough for a host to press Stop mid-flight. SLOW honours
+# session/cancel; SLOW_NOACK deliberately ignores it so the host's soft-stop
+# budget expires (the "Stop Failed, Session Reset" path).
+SLOW_TRIGGER = "[[SLOW]]"
+SLOW_NOACK_TRIGGER = "[[SLOW_NOACK]]"
+# Terminal outcomes other than end_turn.
+ERROR_TRIGGER = "[[ERROR]]"
+MAX_TOKENS_TRIGGER = "[[MAXTOKENS]]"
+REFUSAL_TRIGGER = "[[REFUSAL]]"
+
+# Slow-stream shape. Module-level so unit tests can shrink them to run fast:
+# 30 x 0.5s = ~15s, comfortably longer than the 0.5s-60s soft_stop_budget_secs
+# range the dashboard allows, so a NOACK turn always outlives the budget.
+SLOW_CHUNKS = 30
+SLOW_CHUNK_DELAY_SECS = 0.5
+SLOW_CHUNK_TEXT = "fake slow chunk "
+# How long a gated permission waits for the host's answer before giving up.
+# Bounded on purpose: the headless backend suite has nothing to resolve a modal,
+# and a hang there would stall the whole turn.
+PERMISSION_WAIT_SECS = 15.0
+_POLL_INTERVAL_SECS = 0.02
+
+ERROR_CODE = -32603
+ERROR_MESSAGE = "fake ACP backend: injected failure"
 
 _SESSION_ID = "fake-1"
 _TOOL_CALL_ID = "fake-tool-1"
@@ -76,6 +124,75 @@ def _update(session_id: str, update: dict[str, Any]) -> None:
     _notify("session/update", {"sessionId": session_id, "update": update})
 
 
+def _error(req_id: Any, code: int = ERROR_CODE, message: str = ERROR_MESSAGE) -> None:
+    _send({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}})
+
+
+# --------------------------------------------------------------------------- #
+# Mid-turn inbox
+#
+# The original loop was strictly read -> handle, so a session/cancel arriving
+# DURING a session/prompt could not be observed until the turn had already
+# finished. main() now reads on a background thread and pushes into this queue,
+# which lets a handler poll for cancels / permission answers while it streams.
+#
+# Direct _handle() callers (the unit tests) leave the queue empty: every wait
+# below then simply times out and the default behaviour is unchanged.
+# --------------------------------------------------------------------------- #
+_INBOX: queue.Queue[dict[str, Any] | None] = queue.Queue()
+
+
+def _poll_inbox(match: Callable[[dict[str, Any]], bool]) -> dict[str, Any] | None:
+    """Scan everything queued right now for a match, without blocking.
+
+    Non-matching messages (and the EOF sentinel) are put back in order so the
+    main loop still handles them. Returns the first match, else None.
+    """
+    deferred: list[dict[str, Any] | None] = []
+    found: dict[str, Any] | None = None
+    while True:
+        try:
+            msg = _INBOX.get_nowait()
+        except queue.Empty:
+            break
+        if found is None and msg is not None and match(msg):
+            found = msg
+            continue
+        deferred.append(msg)
+    for m in deferred:
+        _INBOX.put(m)
+    return found
+
+
+def _await_inbox(
+    match: Callable[[dict[str, Any]], bool], timeout: float
+) -> dict[str, Any] | None:
+    """Poll for a matching message until `timeout` elapses. Never blocks forever."""
+    deadline = time.monotonic() + timeout
+    while True:
+        hit = _poll_inbox(match)
+        if hit is not None:
+            return hit
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(_POLL_INTERVAL_SECS)
+
+
+def _is_cancel_for(session_id: str) -> Callable[[dict[str, Any]], bool]:
+    def _match(msg: dict[str, Any]) -> bool:
+        if msg.get("method") != "session/cancel":
+            return False
+        params = msg.get("params") or {}
+        # A cancel without a sessionId is treated as "cancel the current turn".
+        return str(params.get("sessionId", session_id)) == session_id
+
+    return _match
+
+
+def _cancel_requested(session_id: str) -> bool:
+    return _poll_inbox(_is_cancel_for(session_id)) is not None
+
+
 def _read_message() -> dict[str, Any] | None:
     """Read one newline-delimited JSON-RPC message, or None at EOF."""
     while True:
@@ -97,12 +214,36 @@ def _prompt_text(params: dict[str, Any]) -> str:
     if not isinstance(blocks, list):
         return ""
     parts = [
-        str(b.get("text", "")) for b in blocks if isinstance(b, dict) and b.get("type") == "text"
+        str(b.get("text", ""))
+        for b in blocks
+        if isinstance(b, dict) and b.get("type") == "text"
     ]
     return "".join(parts)
 
 
-def _emit_tool_call(session_id: str, *, with_permission: bool) -> None:
+def _permission_status(session_id: str) -> str:
+    """Wait for the host's permission answer and map it to a tool_call status.
+
+    Bounded by PERMISSION_WAIT_SECS. On timeout we report "completed" so a
+    headless host that cannot resolve a modal still sees a finished turn --
+    the same never-block guarantee the fire-and-forget path gives.
+    """
+    answer = _await_inbox(
+        lambda m: m.get("method") is None and m.get("id") == _PERMISSION_REQ_ID,
+        PERMISSION_WAIT_SECS,
+    )
+    if answer is None:
+        return "completed"
+    outcome = ((answer.get("result") or {}).get("outcome") or {}).get("outcome")
+    option = ((answer.get("result") or {}).get("outcome") or {}).get("optionId", "")
+    if outcome == "cancelled" or "reject" in str(option):
+        return "failed"
+    return "completed"
+
+
+def _emit_tool_call(
+    session_id: str, *, with_permission: bool, gated: bool = False
+) -> None:
     """Emit a tool_call (+ optional approval modal) then a completed update."""
     _update(
         session_id,
@@ -115,10 +256,13 @@ def _emit_tool_call(session_id: str, *, with_permission: bool) -> None:
             "rawInput": {"command": "echo hello-from-fake"},
         },
     )
+    status = "completed"
     if with_permission:
-        # Surface an approval modal for UI E2E / demos. Fire-and-forget: the
-        # fake does not wait for the outcome (a real backend would). The host
-        # answers on its own channel; that response is ignored by the loop.
+        # Surface an approval modal for UI E2E / demos. Fire-and-forget by
+        # default: the fake does not wait for the outcome (a real backend
+        # would). The host answers on its own channel; that response is ignored
+        # by the loop. With gated=True we DO wait and reflect the answer, which
+        # is what a negative-path spec needs.
         _send(
             {
                 "jsonrpc": "2.0",
@@ -132,20 +276,51 @@ def _emit_tool_call(session_id: str, *, with_permission: bool) -> None:
                         "kind": "execute",
                     },
                     "options": [
-                        {"optionId": "allow_once", "name": "Allow once", "kind": "allow_once"},
-                        {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+                        {
+                            "optionId": "allow_once",
+                            "name": "Allow once",
+                            "kind": "allow_once",
+                        },
+                        {
+                            "optionId": "reject_once",
+                            "name": "Reject",
+                            "kind": "reject_once",
+                        },
                     ],
                 },
             }
         )
+        if gated:
+            status = _permission_status(session_id)
     _update(
         session_id,
         {
             "sessionUpdate": "tool_call_update",
             "toolCallId": _TOOL_CALL_ID,
-            "status": "completed",
+            "status": status,
         },
     )
+
+
+def _stream_slowly(session_id: str, *, cancel_aware: bool) -> bool:
+    """Stream SLOW_CHUNKS chunks with a delay. True if cancelled mid-stream.
+
+    cancel_aware=False models an agent stuck in a long tool call that cannot
+    acknowledge a stop, so the host's soft-stop budget expires.
+    """
+    for i in range(SLOW_CHUNKS):
+        if cancel_aware and _cancel_requested(session_id):
+            return True
+        _update(
+            session_id,
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": f"{SLOW_CHUNK_TEXT}{i} "},
+            },
+        )
+        time.sleep(SLOW_CHUNK_DELAY_SECS)
+    # A cancel arriving during the final sleep still counts.
+    return bool(cancel_aware and _cancel_requested(session_id))
 
 
 def _handle(msg: dict[str, Any]) -> None:
@@ -173,22 +348,51 @@ def _handle(msg: dict[str, Any]) -> None:
         params = msg.get("params") or {}
         session_id = str(params.get("sessionId", _SESSION_ID))
         text = _prompt_text(params)
-        if PERMISSION_TRIGGER in text:
+        if ERROR_TRIGGER in text:
+            # A JSON-RPC error instead of a result: the turn fails, not stops.
+            _error(req_id)
+            return
+        if GATED_PERMISSION_TRIGGER in text:
+            _emit_tool_call(session_id, with_permission=True, gated=True)
+        elif PERMISSION_TRIGGER in text:
             _emit_tool_call(session_id, with_permission=True)
         elif TOOL_TRIGGER in text:
             _emit_tool_call(session_id, with_permission=False)
-        _update(
-            session_id,
-            {
-                "sessionUpdate": "agent_message_chunk",
-                "content": {"type": "text", "text": REPLY_TEXT},
-            },
-        )
-        _result(req_id, {"stopReason": "end_turn"})
+
+        if SLOW_NOACK_TRIGGER in text:
+            _stream_slowly(session_id, cancel_aware=False)
+            stop_reason = "end_turn"
+        elif SLOW_TRIGGER in text:
+            cancelled = _stream_slowly(session_id, cancel_aware=True)
+            stop_reason = "cancelled" if cancelled else "end_turn"
+        else:
+            _update(
+                session_id,
+                {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": REPLY_TEXT},
+                },
+            )
+            if MAX_TOKENS_TRIGGER in text:
+                stop_reason = "max_tokens"
+            elif REFUSAL_TRIGGER in text:
+                stop_reason = "refusal"
+            else:
+                stop_reason = "end_turn"
+        _result(req_id, {"stopReason": stop_reason})
     else:
         # session/set_mode, session/set_model, or any other awaited request:
         # reply empty so the turn never blocks.
         _result(req_id, {})
+
+
+def _pump_stdin() -> None:
+    """Read stdin into _INBOX until EOF, then push the None sentinel."""
+    while True:
+        msg = _read_message()
+        _INBOX.put(msg)
+        if msg is None:
+            return
 
 
 def main() -> None:
@@ -199,8 +403,13 @@ def main() -> None:
     if args == ["whoami"]:
         print(FAKE_IDENTITY)
         return
+    # Read on a daemon thread so _handle can poll _INBOX for a session/cancel
+    # that arrives WHILE a prompt is streaming. select() on stdin is not an
+    # option: the backend suite also runs on Windows.
+    reader = threading.Thread(target=_pump_stdin, name="fake-acp-stdin", daemon=True)
+    reader.start()
     while True:
-        msg = _read_message()
+        msg = _INBOX.get()
         if msg is None:
             break
         _handle(msg)

--- a/test/test_fake_acp_backend.py
+++ b/test/test_fake_acp_backend.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import io
 import json
+import queue
+import time
 from typing import Any
+
+import pytest
 
 from kiro_crew.testing import fake_acp_backend as fake
 
@@ -44,7 +48,9 @@ def test_session_new_returns_session_id(monkeypatch):
 
 def test_unknown_request_gets_empty_result(monkeypatch):
     buf = _capture(monkeypatch)
-    fake._handle({"jsonrpc": "2.0", "id": 3, "method": "session/set_mode", "params": {}})
+    fake._handle(
+        {"jsonrpc": "2.0", "id": 3, "method": "session/set_mode", "params": {}}
+    )
     (msg,) = _messages(buf)
     assert msg == {"jsonrpc": "2.0", "id": 3, "result": {}}
 
@@ -52,7 +58,9 @@ def test_unknown_request_gets_empty_result(monkeypatch):
 def test_response_and_notification_are_ignored(monkeypatch):
     buf = _capture(monkeypatch)
     # A response to one of our requests (has id, no method) -> ignored.
-    fake._handle({"jsonrpc": "2.0", "id": fake._PERMISSION_REQ_ID, "result": {"outcome": {}}})
+    fake._handle(
+        {"jsonrpc": "2.0", "id": fake._PERMISSION_REQ_ID, "result": {"outcome": {}}}
+    )
     # A notification (has method, no id) -> nothing to answer.
     fake._handle({"jsonrpc": "2.0", "method": "session/cancel", "params": {}})
     assert _messages(buf) == []
@@ -65,7 +73,10 @@ def test_plain_prompt_streams_reply_then_end_turn(monkeypatch):
             "jsonrpc": "2.0",
             "id": 4,
             "method": "session/prompt",
-            "params": {"sessionId": "s1", "prompt": [{"type": "text", "text": "hello"}]},
+            "params": {
+                "sessionId": "s1",
+                "prompt": [{"type": "text", "text": "hello"}],
+            },
         }
     )
     msgs = _messages(buf)
@@ -84,12 +95,16 @@ def test_tool_prompt_emits_tool_call_without_permission(monkeypatch):
             "jsonrpc": "2.0",
             "id": 5,
             "method": "session/prompt",
-            "params": {"prompt": [{"type": "text", "text": f"go {fake.TOOL_TRIGGER} now"}]},
+            "params": {
+                "prompt": [{"type": "text", "text": f"go {fake.TOOL_TRIGGER} now"}]
+            },
         }
     )
     msgs = _messages(buf)
     updates = [
-        m["params"]["update"]["sessionUpdate"] for m in msgs if m.get("method") == "session/update"
+        m["params"]["update"]["sessionUpdate"]
+        for m in msgs
+        if m.get("method") == "session/update"
     ]
     assert updates == ["tool_call", "tool_call_update", "agent_message_chunk"]
     assert not any(m.get("method") == "session/request_permission" for m in msgs)
@@ -110,7 +125,10 @@ def test_permission_prompt_raises_request_permission(monkeypatch):
     assert len(perms) == 1
     assert perms[0]["id"] == fake._PERMISSION_REQ_ID
     assert perms[0]["params"]["toolCall"]["toolCallId"] == fake._TOOL_CALL_ID
-    assert {o["optionId"] for o in perms[0]["params"]["options"]} == {"allow_once", "reject_once"}
+    assert {o["optionId"] for o in perms[0]["params"]["options"]} == {
+        "allow_once",
+        "reject_once",
+    }
 
 
 def test_prompt_text_handles_missing_and_nontext_blocks():
@@ -164,3 +182,198 @@ def test_main_processes_messages_until_eof(monkeypatch):
     )
     fake.main()
     assert [m["id"] for m in _messages(buf)] == [1, 2]
+
+
+# --------------------------------------------------------------------------- #
+# Negative paths: cancel, errors, alternate stop reasons, gated permission.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _drain_inbox():
+    """The inbox is module state; keep it from leaking between tests."""
+    while True:
+        try:
+            fake._INBOX.get_nowait()
+        except queue.Empty:
+            break
+    yield
+    while True:
+        try:
+            fake._INBOX.get_nowait()
+        except queue.Empty:
+            break
+
+
+@pytest.fixture
+def fast_slow_stream(monkeypatch):
+    """Shrink the slow stream so the timing-based paths run instantly."""
+    monkeypatch.setattr(fake, "SLOW_CHUNKS", 3)
+    monkeypatch.setattr(fake, "SLOW_CHUNK_DELAY_SECS", 0)
+
+
+def _prompt(text: str, req_id: int = 100, session_id: str = "s1") -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "session/prompt",
+        "params": {"sessionId": session_id, "prompt": [{"type": "text", "text": text}]},
+    }
+
+
+def test_error_trigger_replies_with_jsonrpc_error(monkeypatch):
+    buf = _capture(monkeypatch)
+    fake._handle(_prompt(fake.ERROR_TRIGGER))
+    (msg,) = _messages(buf)
+    assert msg["id"] == 100
+    assert "result" not in msg
+    assert msg["error"]["code"] == fake.ERROR_CODE
+    assert msg["error"]["message"] == fake.ERROR_MESSAGE
+
+
+@pytest.mark.parametrize(
+    ("trigger", "expected"),
+    [("MAX_TOKENS_TRIGGER", "max_tokens"), ("REFUSAL_TRIGGER", "refusal")],
+)
+def test_alternate_stop_reasons(monkeypatch, trigger, expected):
+    buf = _capture(monkeypatch)
+    fake._handle(_prompt(getattr(fake, trigger)))
+    msgs = _messages(buf)
+    # The canned reply still streams; only the terminal stopReason differs.
+    assert msgs[0]["params"]["update"]["content"]["text"] == fake.REPLY_TEXT
+    assert msgs[-1]["result"]["stopReason"] == expected
+
+
+def test_slow_prompt_streams_many_chunks_then_end_turn(monkeypatch, fast_slow_stream):
+    buf = _capture(monkeypatch)
+    fake._handle(_prompt(fake.SLOW_TRIGGER))
+    msgs = _messages(buf)
+    chunks = [m for m in msgs if m.get("method") == "session/update"]
+    assert len(chunks) == 3
+    assert chunks[0]["params"]["update"]["content"]["text"].startswith(
+        fake.SLOW_CHUNK_TEXT
+    )
+    assert msgs[-1]["result"]["stopReason"] == "end_turn"
+
+
+def test_slow_prompt_honours_cancel_with_cancelled_stop_reason(
+    monkeypatch, fast_slow_stream
+):
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    )
+    fake._handle(_prompt(fake.SLOW_TRIGGER))
+    msgs = _messages(buf)
+    assert msgs[-1]["result"]["stopReason"] == "cancelled"
+
+
+def test_cancel_for_a_different_session_is_not_honoured(monkeypatch, fast_slow_stream):
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "other"}}
+    )
+    fake._handle(_prompt(fake.SLOW_TRIGGER))
+    assert _messages(buf)[-1]["result"]["stopReason"] == "end_turn"
+
+
+def test_slow_noack_ignores_cancel(monkeypatch, fast_slow_stream):
+    """The soft-stop-budget-expiry path: a queued cancel must NOT be acked."""
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    )
+    fake._handle(_prompt(fake.SLOW_NOACK_TRIGGER))
+    assert _messages(buf)[-1]["result"]["stopReason"] == "end_turn"
+
+
+def _permission_answer(option_id: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": fake._PERMISSION_REQ_ID,
+        "result": {"outcome": {"outcome": "selected", "optionId": option_id}},
+    }
+
+
+@pytest.mark.parametrize(
+    ("option_id", "expected_status"),
+    [("allow_once", "completed"), ("reject_once", "failed")],
+)
+def test_gated_permission_reflects_the_hosts_answer(
+    monkeypatch, option_id, expected_status
+):
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(_permission_answer(option_id))
+    fake._handle(_prompt(fake.GATED_PERMISSION_TRIGGER))
+    msgs = _messages(buf)
+    assert any(m.get("method") == "session/request_permission" for m in msgs)
+    updates = [m for m in msgs if m.get("method") == "session/update"]
+    tool_update = next(
+        u
+        for u in updates
+        if u["params"]["update"]["sessionUpdate"] == "tool_call_update"
+    )
+    assert tool_update["params"]["update"]["status"] == expected_status
+
+
+def test_gated_permission_cancelled_outcome_fails_the_tool_call(monkeypatch):
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {
+            "jsonrpc": "2.0",
+            "id": fake._PERMISSION_REQ_ID,
+            "result": {"outcome": {"outcome": "cancelled"}},
+        }
+    )
+    fake._handle(_prompt(fake.GATED_PERMISSION_TRIGGER))
+    tool_update = next(
+        m
+        for m in _messages(buf)
+        if m.get("method") == "session/update"
+        and m["params"]["update"]["sessionUpdate"] == "tool_call_update"
+    )
+    assert tool_update["params"]["update"]["status"] == "failed"
+
+
+def test_gated_permission_times_out_without_blocking(monkeypatch):
+    """No answer must never hang the turn -- it completes instead."""
+    monkeypatch.setattr(fake, "PERMISSION_WAIT_SECS", 0.05)
+    buf = _capture(monkeypatch)
+    fake._handle(_prompt(fake.GATED_PERMISSION_TRIGGER))
+    msgs = _messages(buf)
+    tool_update = next(
+        m
+        for m in msgs
+        if m.get("method") == "session/update"
+        and m["params"]["update"]["sessionUpdate"] == "tool_call_update"
+    )
+    assert tool_update["params"]["update"]["status"] == "completed"
+    assert msgs[-1]["result"]["stopReason"] == "end_turn"
+
+
+def test_ungated_permission_does_not_wait(monkeypatch):
+    """The pre-existing fire-and-forget path must stay non-blocking."""
+    monkeypatch.setattr(fake, "PERMISSION_WAIT_SECS", 30.0)
+    buf = _capture(monkeypatch)
+    started = time.monotonic()
+    fake._handle(_prompt(fake.PERMISSION_TRIGGER))
+    assert time.monotonic() - started < 1.0
+    assert _messages(buf)[-1]["result"]["stopReason"] == "end_turn"
+
+
+def test_poll_inbox_puts_back_non_matching_messages():
+    keep = {"jsonrpc": "2.0", "method": "session/other", "params": {}}
+    fake._INBOX.put(keep)
+    assert fake._poll_inbox(lambda m: m.get("method") == "session/cancel") is None
+    assert fake._INBOX.get_nowait() == keep
+
+
+def test_pump_stdin_forwards_messages_then_the_eof_sentinel(monkeypatch):
+    monkeypatch.setattr(
+        fake.sys,
+        "stdin",
+        io.StringIO('{"jsonrpc":"2.0","id":1,"method":"initialize"}\n'),
+    )
+    fake._pump_stdin()
+    assert fake._INBOX.get_nowait()["id"] == 1
+    assert fake._INBOX.get_nowait() is None

--- a/test/test_playwright_e2e.py
+++ b/test/test_playwright_e2e.py
@@ -17,22 +17,80 @@ Gating:
 from __future__ import annotations
 
 import glob
+import json
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import NoReturn
 
 import pytest
 
-# Gate behind KIROCREW_E2E so it never runs in the default unit-test pass.
-pytestmark = pytest.mark.skipif(
+# Gate the browser suite behind KIROCREW_E2E so it never runs in the default
+# unit-test pass. Applied as a decorator rather than a module-level pytestmark so
+# the floor helper's own tests below DO run in the default pass -- an unverified
+# guard against silent darkening is no guard.
+_requires_e2e = pytest.mark.skipif(
     not os.environ.get("KIROCREW_E2E"),
     reason="E2E Playwright suite. Set KIROCREW_E2E=1 to run.",
 )
 
 _WEBSITE = "website"
+
+# Executed-spec floor.
+#
+# This suite has been silently darkened before: 36 of 103 authored specs were
+# excluded by `grepInvert` in playwright.config.ts, so they were never collected
+# and never reported as skips. The gate stayed green while a third of the suite
+# did not run. An exit code alone cannot catch that, so assert the count.
+#
+# Every dark spec that was later un-darkened had ALSO rotted -- stale selectors
+# for UI that had moved -- because nothing exercised them. That is the argument
+# for a floor rather than a periodic audit.
+#
+# RAISE this when you add specs. Only LOWER it with a written reason in the
+# commit body: a drop means specs stopped running.
+MIN_EXECUTED_SPECS = 208
+
+# Skips are silent passes. A spec should seed its preconditions rather than skip
+# when they are absent, so the intended steady state is zero. Specs excluded by
+# tag (@needs-live-agent) are never collected, so they do not count here.
+MAX_SKIPPED_SPECS = 0
+
+
+def _assert_suite_not_darkened(report: Path) -> None:
+    """Fail if the run executed fewer specs than the floor, or skipped any.
+
+    Reads Playwright's JSON report rather than scraping stdout. `expected` and
+    `flaky` both mean "ran and ultimately passed"; counting only `expected` would
+    trip the floor whenever CI's retries absorb a flake.
+    """
+    try:
+        stats = json.loads(report.read_text()).get("stats") or {}
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        pytest.fail(f"could not read Playwright JSON report at {report}: {exc}")
+
+    executed = int(stats.get("expected", 0)) + int(stats.get("flaky", 0))
+    skipped = int(stats.get("skipped", 0))
+    print(
+        f"[test:e2e:playwright] executed={executed} skipped={skipped} stats={stats}",
+        flush=True,
+    )
+
+    assert executed >= MIN_EXECUTED_SPECS, (
+        f"only {executed} specs executed, floor is {MIN_EXECUTED_SPECS}. "
+        "Specs stopped running rather than failing. Check grepInvert in "
+        "website/playwright.config.ts for a newly excluded tag, and check that no "
+        "spec file was renamed out of the testDir. If the drop is intended, lower "
+        "MIN_EXECUTED_SPECS and say why in the commit body."
+    )
+    assert skipped <= MAX_SKIPPED_SPECS, (
+        f"{skipped} spec(s) skipped, ceiling is {MAX_SKIPPED_SPECS}. A skip reports "
+        "green while verifying nothing. Seed the precondition in a fixture instead "
+        "of skipping on its absence."
+    )
 
 
 def _node_major(node_bin: str) -> int | None:
@@ -87,6 +145,7 @@ def _resolve_website_dir() -> Path | None:
     return in_tree if (in_tree / "playwright").is_dir() else None
 
 
+@_requires_e2e
 def test_dashboard_playwright_suite() -> None:
     """Boot a gateway and run the credential-less Playwright spec set against it."""
 
@@ -123,36 +182,98 @@ def test_dashboard_playwright_suite() -> None:
     prev_kiro_bin = os.environ.get("KIROCREW_KIRO_BIN")
     os.environ["KIROCREW_KIRO_BIN"] = str(fake_acp_backend.__file__)
     try:
-        with spawn_feature_gateway(fixture="minimal", approval="reads") as gw:
-            env = dict(os.environ)
-            env.update(
-                {
-                    # Prepend a node>=18 bin dir so the playwright shebang
-                    # resolves it ahead of any cwd-pinned mise shim.
-                    "PATH": node_dir + os.pathsep + env.get("PATH", ""),
-                    "PLAYWRIGHT_BASE_URL": f"http://localhost:{gw.port}",
-                    "PLAYWRIGHT_TOKEN": gw.token,
-                    # Fake ACP backend is wired, so the agent specs (chat/fork)
-                    # can run headlessly -- opt them back in.
-                    "PLAYWRIGHT_RUN_AGENT_SPECS": "1",
-                    # Explicit ephemeral-harness marker: this gateway runs on an
-                    # isolated tmp KIROCREW_HOME (spawn_feature_gateway --test-mode),
-                    # so its slots are disposable.
-                    "KIROCREW_E2E_EPHEMERAL": "1",
-                    # CI mode: serial workers + retries:2 (absorbs gateway-load
-                    # timeout flakes) + html reporter, per playwright.config.ts.
-                    "CI": "1",
-                }
-            )
-            print(
-                f"[test:e2e:playwright] base={env['PLAYWRIGHT_BASE_URL']} "
-                f"node_dir={node_dir} fake_acp={fake_acp_backend.__file__} cwd={website}",
-                flush=True,
-            )
-            rc = subprocess.call([str(pw_bin), "test"], cwd=str(website), env=env)
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / "playwright-results.json"
+            with spawn_feature_gateway(fixture="minimal", approval="reads") as gw:
+                env = dict(os.environ)
+                env.update(
+                    {
+                        # Prepend a node>=18 bin dir so the playwright shebang
+                        # resolves it ahead of any cwd-pinned mise shim.
+                        "PATH": node_dir + os.pathsep + env.get("PATH", ""),
+                        "PLAYWRIGHT_BASE_URL": f"http://localhost:{gw.port}",
+                        "PLAYWRIGHT_TOKEN": gw.token,
+                        # Fake ACP backend is wired, so the agent specs (chat/fork)
+                        # can run headlessly -- opt them back in.
+                        "PLAYWRIGHT_RUN_AGENT_SPECS": "1",
+                        # Explicit ephemeral-harness marker: this gateway runs on an
+                        # isolated tmp KIROCREW_HOME (spawn_feature_gateway --test-mode),
+                        # so its slots are disposable.
+                        "KIROCREW_E2E_EPHEMERAL": "1",
+                        # CI mode: serial workers + retries:2 (absorbs gateway-load
+                        # timeout flakes) + html reporter, per playwright.config.ts.
+                        "CI": "1",
+                        # Machine-readable counts for the darkening floor below.
+                        "PLAYWRIGHT_JSON_OUTPUT_NAME": str(report),
+                    }
+                )
+                print(
+                    f"[test:e2e:playwright] base={env['PLAYWRIGHT_BASE_URL']} "
+                    f"node_dir={node_dir} fake_acp={fake_acp_backend.__file__} cwd={website}",
+                    flush=True,
+                )
+                # html keeps the CI artifact the config asks for; json adds the
+                # counts. A CLI --reporter replaces the config value, so name both.
+                rc = subprocess.call(
+                    [str(pw_bin), "test", "--reporter=html,json"],
+                    cwd=str(website),
+                    env=env,
+                )
+            # Assert the counts even on failure: a red run plus a collapsed spec
+            # count points at darkening rather than at the reported failure.
+            _assert_suite_not_darkened(report)
             assert rc == 0, f"playwright test exited {rc}"
     finally:
         if prev_kiro_bin is None:
             os.environ.pop("KIROCREW_KIRO_BIN", None)
         else:
             os.environ["KIROCREW_KIRO_BIN"] = prev_kiro_bin
+
+
+# --------------------------------------------------------------------------- #
+# Floor-helper unit tests. Ungated on purpose: these need no gateway and no
+# browser, and a silently broken floor would never fire when it matters.
+# --------------------------------------------------------------------------- #
+
+
+def _write_report(tmp_path: Path, **stats: int) -> Path:
+    report = tmp_path / "results.json"
+    report.write_text(json.dumps({"stats": stats}))
+    return report
+
+
+def test_floor_accepts_a_run_at_the_floor(tmp_path: Path) -> None:
+    report = _write_report(tmp_path, expected=MIN_EXECUTED_SPECS, flaky=0, skipped=0)
+    _assert_suite_not_darkened(report)  # must not raise
+
+
+def test_floor_counts_flaky_as_executed(tmp_path: Path) -> None:
+    """CI runs retries:2, so a flake absorbed by a retry still ran."""
+    report = _write_report(
+        tmp_path, expected=MIN_EXECUTED_SPECS - 1, flaky=1, skipped=0
+    )
+    _assert_suite_not_darkened(report)  # must not raise
+
+
+def test_floor_rejects_a_collapsed_spec_count(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path, expected=MIN_EXECUTED_SPECS - 1, flaky=0, skipped=0
+    )
+    with pytest.raises(AssertionError, match="specs executed, floor is"):
+        _assert_suite_not_darkened(report)
+
+
+def test_floor_rejects_any_skip(tmp_path: Path) -> None:
+    report = _write_report(tmp_path, expected=MIN_EXECUTED_SPECS, flaky=0, skipped=1)
+    with pytest.raises(AssertionError, match="skipped, ceiling is"):
+        _assert_suite_not_darkened(report)
+
+
+def test_floor_fails_when_the_report_is_missing(tmp_path: Path) -> None:
+    """A missing report must fail loudly, not pass for lack of evidence."""
+    # pytest.fail raises Failed, which derives from BaseException, so a plain
+    # `pytest.raises(Exception)` would not catch it.
+    with pytest.raises(
+        pytest.fail.Exception, match="could not read Playwright JSON report"
+    ):
+        _assert_suite_not_darkened(tmp_path / "absent.json")

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -15,16 +15,14 @@ export default defineConfig({
   // slowdown in any other spec still surfaces fast instead of silently passing
   // within a 3x window.
   // Gating: by default exclude @needs-agent (chat, fork — need a model/agent
-  // turn the credential-less CI gateway lacks) and @quarantine (session-tags-e2e
-  // — a known worker-crasher pending root-cause). The default run is therefore
-  // the credential-less, crash-free green set. PLAYWRIGHT_RUN_AGENT_SPECS=1 (set
+  // turn the credential-less CI gateway lacks). The default run is therefore
+  // the credential-less green set. PLAYWRIGHT_RUN_AGENT_SPECS=1 (set
   // by a harness that wires a fake ACP backend) re-includes the @needs-agent
   // specs. @needs-live-agent (soft-stop interruption) needs true live-agent
   // semantics a fake can't model yet, so it stays excluded either way.
-  // @quarantine also always stays excluded.
   grepInvert: process.env.PLAYWRIGHT_RUN_AGENT_SPECS
-    ? /@quarantine|@needs-live-agent/
-    : /@needs-agent|@quarantine|@needs-live-agent/,
+    ? /@needs-live-agent/
+    : /@needs-agent|@needs-live-agent/,
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5476',
     trace: 'on-first-retry',

--- a/website/playwright/active-slot-persistence.spec.ts
+++ b/website/playwright/active-slot-persistence.spec.ts
@@ -1,44 +1,78 @@
 import { test, expect } from '@playwright/test'
+import type { APIRequestContext } from '@playwright/test'
 
-test.describe('Active slot persistence across mode switches', () => {
-  test.beforeEach(async ({ page }) => {
+/**
+ * This test needs two sessions to be meaningful: it proves the SELECTED session
+ * is restored rather than the list falling back to the first row. It used to
+ * `test.skip` when fewer than two existed, which reported green while verifying
+ * nothing. It now seeds the precondition instead.
+ *
+ * Seeding is additive (POST /api/chat/slots), never destructive, so unlike the
+ * tag-column specs this needs no KIROCREW_E2E_EPHEMERAL guard. Only the missing
+ * slots are created, and each gets a distinct title so the restore assertion
+ * cannot pass by comparing two identical strings.
+ */
+async function seedTwoSessions(request: APIRequestContext) {
+  const existing = await (await request.get('/api/chat/slots')).json()
+  const stamp = Date.now()
+  for (let i = existing.length; i < 2; i++) {
+    const slot = await (
+      await request.post('/api/chat/slots', { data: { agent: 'default' } })
+    ).json()
+    await request.patch(`/api/chat/slots/${slot.key}/title`, {
+      data: { title: `active-slot-seed-${stamp}-${i}` },
+    })
+  }
+}
+
+test.describe('Active slot persistence across surface switches', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await seedTwoSessions(request)
     await page.goto('/chat', { waitUntil: 'domcontentloaded' })
     await expect(page.locator('.session-row').first()).toBeVisible({ timeout: 10000 })
   })
 
-  test('remembers selected session when switching Chat → Autopilot → Chat', async ({ page }) => {
+  test('remembers selected session when leaving /chat and returning', async ({ page }) => {
     const rows = page.locator('.session-row')
-    const count = await rows.count()
-    if (count < 2) test.skip(true, 'Need at least 2 chat sessions')
+    // Seeded above, so a shortfall is a seeding regression, not a reason to skip.
+    await expect(rows.nth(1)).toBeVisible({ timeout: 10000 })
 
-    // Click the second session (not the first, which is the default fallback)
+    // Click the second session (not the first, which is the default fallback).
+    // Identity comes from the row's data-slot-key wrapper, not from rendered
+    // title text: the title element's class has already churned (.font-mono no
+    // longer exists inside .session-row) and a slot key is a stronger identity
+    // than a display string.
+    const selectedKey = await rows
+      .nth(1)
+      .locator('xpath=ancestor-or-self::*[@data-slot-key][1]')
+      .getAttribute('data-slot-key')
+    expect(selectedKey).toBeTruthy()
     await rows.nth(1).click()
     await expect(rows.nth(1)).toHaveClass(/session-active/, { timeout: 2000 })
 
-    // Grab the title of the selected session
-    const selectedTitle = await rows.nth(1).locator('.font-mono').textContent()
-
     const nav = page.locator('nav[aria-label="Main navigation"]')
-    // Autopilot is an optional built-in surface; skip the round-trip if this
-    // instance doesn't expose it (rather than assert a surface that may be
-    // absent). When present, switch away and back to exercise slot restore.
-    const autopilot = nav.getByText('Autopilot')
-    if (!(await autopilot.isVisible({ timeout: 2000 }).catch(() => false))) {
-      test.skip(true, 'Autopilot surface not enabled on this instance')
-    }
-    await autopilot.click()
-    await page.waitForURL('**/orchestrated**')
+    // The original round-trip went via an "Autopilot" nav surface. That surface
+    // no longer exists: /orchestrated is now a redirect to /chat (App.tsx
+    // OrchestratedRedirect) and 'chat' is the only builtin declaring a slotMode,
+    // so there is no slot-mode counterpart left to switch to. The guard that
+    // skipped when Autopilot was absent was therefore dead code that could never
+    // pass. Settings is a always-present builtin, and leaving /chat and returning
+    // still exercises the behaviour under test: the sidebar must restore the
+    // selected slot instead of falling back to the first row.
+    await nav.getByText('Settings').click()
+    await page.waitForURL('**/settings**')
 
     // Switch back to Sessions (the chat surface)
     await nav.getByText('Sessions').click()
     await page.waitForURL('**/chat**')
     await expect(page.locator('.session-row').first()).toBeVisible({ timeout: 10000 })
 
-    // The previously selected session should still be active (not fallen back to first)
-    const activeRow = page.locator('.session-row.session-active')
-    await expect(activeRow).toBeVisible({ timeout: 5000 })
-    const restoredTitle = await activeRow.locator('.font-mono').textContent()
-    expect(restoredTitle).toBe(selectedTitle)
+    // The previously selected session should still be active, and be the ONLY
+    // active row: a fallback to the first row shows up either as the wrong key
+    // or as a second active row.
+    await expect(page.locator('.session-row.session-active')).toHaveCount(1, { timeout: 5000 })
+    await expect(
+      page.locator(`[data-slot-key="${selectedKey}"] .session-row.session-active`),
+    ).toBeVisible({ timeout: 5000 })
   })
-
 })

--- a/website/playwright/apps.spec.ts
+++ b/website/playwright/apps.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+
+/**
+ * Apps routes e2e — covers /apps, /apps/detail/:name, /apps/:name.
+ *
+ * The Apps page is a hybrid storefront (upstream #532): a "Discover" tab with an
+ * editorial layer (FeaturedSpotlight + FeatureCards) over a category-railed
+ * catalog, and a "Library" tab managing installed apps. It replaced the earlier
+ * Installed/Browse tabs.
+ *
+ * Harness state:
+ * - 1 installed & enabled builtin: "Task Runner" (name: "projects", route /projects)
+ * - Several disabled builtins populate the Discover catalog
+ * - Discover is the default tab on a fresh session (initialTab(), AppsPage.tsx:46)
+ *
+ * Tests assert the real harness state unconditionally. No conditional branches.
+ *
+ * FINDING: /apps/detail/:name is a client-side-only route — the server's SPA
+ * fallback regex (_APPS_SPA_EXCLUDED_RE) treats "detail" as an app name and the
+ * trailing segment as a sub-resource, returning 404 on direct navigation. Tests
+ * navigate via the SPA shell rather than hitting the bare URL.
+ */
+
+type AppEntry = {
+  name: string
+  displayName: string
+  enabled: boolean
+  origin?: string
+  manifest?: { description?: string; ui?: { pages?: { route: string }[] } }
+}
+
+/** Fetch the installed apps list from the API. */
+async function listApps(request: APIRequestContext): Promise<AppEntry[]> {
+  const res = await request.get('/api/apps')
+  expect(res.ok()).toBeTruthy()
+  return await res.json()
+}
+
+/**
+ * Locate a tab segment. SegmentedControl exposes no aria-label, role, or
+ * data-testid -- only title={label} -- so title is the sole stable handle. It is
+ * also the only one that survives both hazards: compact mode drops the label
+ * text from the DOM for inactive segments, and the Library segment renders a
+ * count badge inside the button, which makes its accessible name "Library 1".
+ */
+function tab(page: Page, label: 'Discover' | 'Library') {
+  return page.locator(`button[title="${label}"]`)
+}
+
+/**
+ * Catalog cards. The same aria-label is emitted by FeaturedSpotlight,
+ * FeatureCard AND AppListRow, so one app can legitimately match 2-3 times on
+ * the Discover landing view -- always scope with .first() or assert on count.
+ */
+function browseCards(page: Page) {
+  return page.locator('[role="button"][aria-label^="View details for"]')
+}
+
+/**
+ * An installed app in the Library. InstalledAppCard's root is a bare div with no
+ * testid or aria-label, but it renders the app name as a real <button> wired to
+ * onDetail -- so role-scope it rather than matching loose text.
+ *
+ * Scoped to the #main-content landmark (App.tsx:1984): an installed builtin also
+ * appears in the nav rail, so an unscoped role+name lookup resolves to 2
+ * elements. This mirrors the convention capabilities.spec.ts already uses.
+ */
+function libraryCard(page: Page, displayName: string) {
+  return page.locator('#main-content').getByRole('button', { name: displayName, exact: true })
+}
+
+async function gotoApps(page: Page) {
+  await page.goto('/apps', { waitUntil: 'domcontentloaded' })
+  // Ready-signal is the tab segment's title attribute, not the page subtitle:
+  // subtitle copy is prose a designer can reword, title is a stable handle.
+  await expect(tab(page, 'Discover')).toBeVisible({ timeout: 10000 })
+}
+
+/**
+ * Navigate to a detail page via client-side routing (avoids the server 404 on
+ * direct /apps/detail/:name — see FINDING above).
+ */
+async function gotoDetailViaRouter(page: Page, appName: string) {
+  await gotoApps(page)
+  await page.evaluate((name) => {
+    window.history.pushState({}, '', `/apps/detail/${name}`)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  }, appName)
+  // "Back to Apps" renders in both the found and not-found states.
+  await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible({ timeout: 10000 })
+}
+
+test.describe('Apps Page — /apps', () => {
+  test('renders the header, both tab segments, and the Discover catalog', async ({ page }) => {
+    await gotoApps(page)
+    await expect(tab(page, 'Discover')).toBeVisible({ timeout: 5000 })
+    await expect(tab(page, 'Library')).toBeVisible()
+    // Discover's two-column layout: the "All apps" heading (category === 'All'),
+    // the CategoryRail, and the catalog's sort control.
+    //
+    // Deliberately NOT asserting the "N apps" count line: that exact string is
+    // rendered twice -- once by the CategoryRail as its source total, once as the
+    // catalog result count -- so the locator is ambiguous, and .first() would
+    // silently assert the rail's total instead of the catalog's.
+    await expect(page.getByRole('heading', { name: 'All apps' })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: 'Add source' })).toBeVisible()
+    await expect(page.getByRole('combobox', { name: 'Sort apps' })).toBeVisible()
+  })
+
+  test('Discover is the default tab on a fresh session', async ({ page }) => {
+    // initialTab() (AppsPage.tsx:46) returns 'discover' when sessionStorage has
+    // no persisted tab. Playwright's storageState does not carry sessionStorage,
+    // so every test starts fresh -- this is deterministic, not incidental.
+    await gotoApps(page)
+    await expect(page.getByRole('heading', { name: 'All apps' })).toBeVisible({ timeout: 5000 })
+    await expect(browseCards(page).first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('Discover renders catalog cards for the available builtins', async ({ page }) => {
+    await gotoApps(page)
+    const cards = browseCards(page)
+    await expect(cards.first()).toBeVisible({ timeout: 10000 })
+    expect(await cards.count()).toBeGreaterThan(0)
+  })
+
+  test('Discover search filters the catalog down to its empty state', async ({ page }) => {
+    await gotoApps(page)
+    await expect(browseCards(page).first()).toBeVisible({ timeout: 10000 })
+
+    const search = page.getByRole('textbox', { name: 'Search apps' })
+    await search.fill('zzz_no_match_xyz')
+
+    // A non-empty query also clears the editorial layer (showEditorial requires
+    // !query.trim(), AppsPage.tsx:207), so every card unmounts -- not just the
+    // AppListRows.
+    await expect(page.getByText('No matching apps')).toBeVisible({ timeout: 5000 })
+    await expect(browseCards(page)).toHaveCount(0)
+  })
+
+  test('Library tab lists the installed Task Runner app', async ({ page }) => {
+    await gotoApps(page)
+    await tab(page, 'Library').click()
+    await expect(libraryCard(page, 'Task Runner')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('Library search narrows to matching installed apps', async ({ page }) => {
+    await gotoApps(page)
+    await tab(page, 'Library').click()
+    await expect(libraryCard(page, 'Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // One SearchInput serves both tabs; its placeholder switches per tab but the
+    // aria-label stays "Search apps".
+    const search = page.getByRole('textbox', { name: 'Search apps' })
+    await search.fill('zzz_no_match_xyz')
+    await expect(page.getByText('No matching apps')).toBeVisible({ timeout: 5000 })
+
+    await search.clear()
+    await expect(libraryCard(page, 'Task Runner')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('tab round-trip returns to the Discover catalog', async ({ page }) => {
+    await gotoApps(page)
+    await expect(page.getByRole('heading', { name: 'All apps' })).toBeVisible({ timeout: 5000 })
+
+    await tab(page, 'Library').click()
+    await expect(libraryCard(page, 'Task Runner')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('heading', { name: 'All apps' })).toHaveCount(0)
+
+    await tab(page, 'Discover').click()
+    await expect(page.getByRole('heading', { name: 'All apps' })).toBeVisible({ timeout: 5000 })
+  })
+})
+
+test.describe('App Detail Page — /apps/detail/:name', () => {
+  test('renders detail view for Task Runner', async ({ page }) => {
+    await gotoDetailViaRouter(page, 'projects')
+    // The detail page shows the display name
+    await expect(page.locator('text=Task Runner').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible()
+  })
+
+  test('shows "App Not Found" for a nonexistent app', async ({ page }) => {
+    await gotoDetailViaRouter(page, 'this-app-does-not-exist-zyx')
+    await expect(page.locator('text=App Not Found')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible()
+  })
+
+  test('navigating from a Discover catalog card reaches the detail page', async ({ page }) => {
+    await gotoApps(page)
+    // Discover is the default tab, so the catalog is already on screen.
+    const firstCard = browseCards(page).first()
+    await expect(firstCard).toBeVisible({ timeout: 10000 })
+    await firstCard.click()
+
+    await page.waitForURL('**/apps/detail/**', { timeout: 10000 })
+    await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible({ timeout: 5000 })
+  })
+
+  test('detail page shows Details metadata card', async ({ page }) => {
+    await gotoDetailViaRouter(page, 'projects')
+    await expect(page.locator('text=Task Runner').first()).toBeVisible({ timeout: 10000 })
+    // The Details card heading
+    await expect(page.locator('text=Details').first()).toBeVisible({ timeout: 5000 })
+  })
+})
+
+test.describe('App Page — /apps/:name', () => {
+  test('builtin app with native route redirects to its page', async ({ page }) => {
+    // Task Runner (name: "projects") has route /projects — navigate to /apps/projects
+    await page.goto('/apps/projects', { waitUntil: 'domcontentloaded' })
+    // Should redirect to the native route /projects
+    await page.waitForURL('**/projects', { timeout: 10000 })
+  })
+
+  test('nonexistent app shows not-found state via AppHost', async ({ page }) => {
+    await page.goto('/apps/this-definitely-does-not-exist-zyx', { waitUntil: 'domcontentloaded' })
+    // AppHost renders AppNotFound with subtitle containing "is not installed"
+    await expect(page.locator('text=is not installed')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/apps/:name does NOT collide with /:builtinApp catch-all', async ({ page }) => {
+    // React Router v6 ranks /apps/:name (two segments) higher than /:builtinApp
+    // (single segment), so there is no precedence conflict.
+    await page.goto('/apps/fake-precedence-test', { waitUntil: 'domcontentloaded' })
+    // Wait for AppPage to finish loading — renders not-found for unknown apps
+    await expect(page.locator('text=is not installed')).toBeVisible({ timeout: 10000 })
+    const url = page.url()
+    expect(url).not.toContain('/chat')
+  })
+})

--- a/website/playwright/artifacts.spec.ts
+++ b/website/playwright/artifacts.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type APIRequestContext } from '@playwright/test'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+const UNIQUE = `pw-${Date.now()}`
+
+/** Create an artifact via the REST API and return its slug.
+ * Uses a unique slug per call to avoid 409 conflicts between tests. */
+async function seedArtifact(request: APIRequestContext, overrides?: {
+  name?: string; slug?: string; content?: string; kind?: string; tags?: string[]
+}) {
+  // POST/PATCH /api/artifacts fire ArtifactKnowledgeSync.on_change
+  // (artifact_ingest.py:230, gated on knowledge.auto_ingest_artifacts which
+  // DEFAULTS TO TRUE). That chains to pipeline.ingest_file() ->
+  // delete_items_batch (ingestion.py:341) -> store.py:494, which runs an
+  // UNSCOPED sweep: DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM
+  // mentions) AND ... -- destroying pre-existing orphan entities in a real
+  // developer's Knowledge Library. Seeding an artifact is therefore not a local
+  // operation, so it requires the ephemeral harness gateway.
+  test.skip(
+    !HARNESS_GATEWAY,
+    'seeding artifacts requires the ephemeral harness gateway: artifact ingestion triggers a global orphan-entity sweep (store.py:494)',
+  )
+  const slug = overrides?.slug ?? `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const name = overrides?.name ?? `Test Artifact ${slug}`
+  const res = await request.post('/api/artifacts', {
+    data: {
+      name,
+      slug,
+      content: overrides?.content ?? `<h1>Hello from ${slug}</h1><p>E2E test content.</p>`,
+      kind: overrides?.kind ?? 'widget',
+      description: 'Seeded by Playwright artifacts spec',
+      tags: overrides?.tags ?? ['e2e-artifacts', 'pw-test'],
+    },
+  })
+  // 201 = created, 200 = dedup bumped existing (same source_path).
+  expect(res.status(), `seed artifact failed: ${await res.text()}`).toBeLessThan(300)
+  const body = await res.json()
+  return { slug: body.slug as string, name }
+}
+
+test.describe('Artifacts Page — /artifacts', () => {
+  test('renders the page with header and filter controls', async ({ page }) => {
+    await page.goto('/artifacts', { waitUntil: 'domcontentloaded' })
+    // PageHeader with title "Artifacts"
+    await expect(page.getByText('Artifacts', { exact: true }).first()).toBeVisible({ timeout: 10000 })
+    // Search input present
+    await expect(page.getByPlaceholder('Filter by name, slug, description…')).toBeVisible()
+    // Kind filter dropdown
+    await expect(page.locator('select[aria-label="Filter by kind"]')).toBeVisible()
+  })
+
+  test('seeded artifact appears in the list via search', async ({ page, request }) => {
+    const { slug, name } = await seedArtifact(request)
+    await page.goto('/artifacts', { waitUntil: 'domcontentloaded' })
+    const search = page.getByPlaceholder('Filter by name, slug, description…')
+    await search.fill(slug)
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('kind filter narrows results to matching artifacts', async ({ page, request }) => {
+    const { slug, name } = await seedArtifact(request, { kind: 'widget' })
+    await page.goto('/artifacts', { waitUntil: 'domcontentloaded' })
+    // Set kind filter to widget
+    await page.locator('select[aria-label="Filter by kind"]').selectOption('widget')
+    // Search for our specific artifact
+    const search = page.getByPlaceholder('Filter by name, slug, description…')
+    await search.fill(slug)
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('clicking an artifact navigates to its detail page', async ({ page, request }) => {
+    const { slug, name } = await seedArtifact(request)
+    await page.goto('/artifacts', { waitUntil: 'domcontentloaded' })
+    const search = page.getByPlaceholder('Filter by name, slug, description…')
+    await search.fill(slug)
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10000 })
+    // Click the artifact entry — it links to /artifacts/:slug
+    await page.getByText(name).first().click()
+    await expect(page).toHaveURL(new RegExp(`/artifacts/${slug}`), { timeout: 5000 })
+  })
+})
+
+test.describe('Artifact Detail Page — /artifacts/:slug', () => {
+  test('displays artifact name and slug in header', async ({ page, request }) => {
+    const { slug, name } = await seedArtifact(request)
+    await page.goto(`/artifacts/${slug}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(`Artifact: ${slug}`)).toBeVisible()
+  })
+
+  test('tags are rendered as individual badges', async ({ page, request }) => {
+    const { slug } = await seedArtifact(request, { tags: ['alpha-tag', 'beta-tag'] })
+    await page.goto(`/artifacts/${slug}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('alpha-tag', { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('beta-tag', { exact: true })).toBeVisible()
+  })
+
+  test('round-trip: update content creates version 2', async ({ page, request }) => {
+    const { slug, name } = await seedArtifact(request)
+    // Update the artifact via API — snapshot=true bumps the version
+    const updated = `<h1>Updated</h1><p>${slug} v2</p>`
+    const patchRes = await request.patch(`/api/artifacts/${encodeURIComponent(slug)}`, {
+      data: { content: updated, snapshot: true },
+    })
+    expect(patchRes.status()).toBe(200)
+    const patchBody = await patchRes.json()
+    expect(patchBody.version).toBe(2)
+
+    // Navigate to the detail page
+    await page.goto(`/artifacts/${slug}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10000 })
+
+    // Verify via the versions API that both v1 and v2 exist
+    const versionsRes = await request.get(`/api/artifacts/${encodeURIComponent(slug)}/versions`)
+    expect(versionsRes.status()).toBe(200)
+    const versions = await versionsRes.json()
+    expect(versions.versions).toContain(1)
+    expect(versions.versions).toContain(2)
+  })
+
+  test('404 page for non-existent slug', async ({ page }) => {
+    await page.goto('/artifacts/non-existent-slug-xyz', { waitUntil: 'domcontentloaded' })
+    // The detail page shows an error message containing the slug
+    await expect(page.getByText('artifact not found: non-existent-slug-xyz')).toBeVisible({ timeout: 10000 })
+  })
+})
+
+test.describe('Artifact Deploy Page — /deploy', () => {
+  test('renders with page header and stat cards', async ({ page }) => {
+    await page.goto('/deploy', { waitUntil: 'domcontentloaded' })
+    // Use exact match on the heading text to avoid strict-mode collision
+    await expect(page.getByText('Artifact Deploy', { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Active Deployments')).toBeVisible()
+    await expect(page.getByText('Ready to Deploy')).toBeVisible()
+  })
+})
+
+test.describe('/artifacts/deploy redirect', () => {
+  test('redirects to /deploy', async ({ page }) => {
+    await page.goto('/artifacts/deploy', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/deploy$/, { timeout: 5000 })
+    await expect(page.getByText('Artifact Deploy', { exact: true })).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/website/playwright/auth.setup.ts
+++ b/website/playwright/auth.setup.ts
@@ -6,7 +6,12 @@ import { test as setup } from '@playwright/test'
  * saved state so tokens never appear in test-level traces or videos.
  */
 
-const STATE_PATH = 'playwright/.auth/state.json'
+// Honour the same override playwright.config.ts reads for `storageState`, so a
+// caller can point writer and reader at one non-default path. Without this the
+// writer always clobbered the default file, which makes concurrent runs against
+// separate ephemeral gateways race: each run's cookies are bound to its own
+// port + token, so the last writer wins and the losers see "session expired".
+const STATE_PATH = process.env.PLAYWRIGHT_STORAGE_STATE || 'playwright/.auth/state.json'
 
 setup('authenticate', async ({ page }) => {
   const token = process.env.PLAYWRIGHT_TOKEN

--- a/website/playwright/builtin-apps.spec.ts
+++ b/website/playwright/builtin-apps.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Builtin App Route resolution e2e tests.
+ *
+ * Covers the /:builtinApp catch-all route (App.tsx ~line 2017) which resolves
+ * paths against BUILTIN_COMPONENT_REGISTRY (builtinRegistry.ts). Each registered
+ * route renders its lazy-loaded page component; unrecognised paths redirect to /chat.
+ *
+ * React Router v6 ranks static paths above parameterised ones, so explicitly
+ * declared routes (/settings, /apps, /artifacts, etc.) still win over the catch-all.
+ */
+
+test.describe('Builtin App Route resolution', () => {
+
+  // ── Route resolution contracts ───────────────────────────────────────────
+
+  test('unrecognised path redirects to /chat', async ({ page }) => {
+    await page.goto('/totally-unknown-xyz-route', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/chat/)
+  })
+
+  test('static route /settings is NOT caught by the catch-all', async ({ page }) => {
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
+    // Settings page renders — confirm we are NOT redirected to /chat
+    await expect(page).toHaveURL(/\/settings/)
+    // Settings page heading (inside #main-content, not the nav label)
+    await expect(page.locator('#main-content').getByText('Settings', { exact: true })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('static route /artifacts is NOT caught by the catch-all', async ({ page }) => {
+    await page.goto('/artifacts', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/artifacts/)
+    // Artifacts page should render without redirect. Scoped with .first():
+    // 'Artifacts' also appears as the nav rail label.
+    await expect(page.locator('text=Artifacts').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /worlds — WorldsPage ─────────────────────────────────────────────────
+
+  test('/worlds renders Agent Worlds page', async ({ page }) => {
+    await page.goto('/worlds', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/worlds/)
+    await expect(page.getByText('Agent Worlds')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('collapse-panel')).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /channels — ChannelPage ───────────────────────────────────────────────
+
+  test('/channels renders Channels page with empty state', async ({ page }) => {
+    await page.goto('/channels', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/channels/)
+    // PageHeader (ui.tsx:257) renders its title as a plain <div>, not a heading,
+    // so getByRole('heading') cannot match it and a bare getByText('Channels')
+    // resolves to 3 elements (nav label + header + sidebar) once earlier tests
+    // populate the sidebar -- a strict-mode violation that only reproduces when
+    // the whole file runs. Assert the unique subtitle instead.
+    await expect(page.getByText('Multi-agent collaboration spaces')).toBeVisible({ timeout: 10000 })
+    // Minimal fixture has no channels — assert the empty state
+    await expect(page.getByText('No channels yet')).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /auto-research — ResearchLabPage ──────────────────────────────────────
+
+  test('/auto-research renders Research Lab page', async ({ page }) => {
+    await page.goto('/auto-research', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/auto-research/)
+    await expect(page.getByRole('heading', { name: 'Research Lab' })).toBeVisible({ timeout: 10000 })
+    // Confirms the description text is present (unconditional render)
+    await expect(page.getByText('Research-only.')).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /code-review-sage — CodeReviewSagePage ────────────────────────────────
+
+  test('/code-review-sage renders Code Review Sage page', async ({ page }) => {
+    await page.goto('/code-review-sage', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/code-review-sage/)
+    await expect(page.getByText('Code Review Sage')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(/Self-evolving deep reviewer/)).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /workflows — WorkflowsPage ───────────────────────────────────────────
+
+  test('/workflows renders Workflows page', async ({ page }) => {
+    await page.goto('/workflows', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/workflows/)
+    await expect(page.getByText('Workflows', { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(/Author, run, and watch dynamic workflows/)).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /dev-fleet — DevFleetPage ─────────────────────────────────────────────
+
+  test('/dev-fleet renders Dev Fleet page', async ({ page }) => {
+    await page.goto('/dev-fleet', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/dev-fleet/)
+    await expect(page.getByText('Dev Fleet')).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /issue-radar — IssueRadarPage ─────────────────────────────────────────
+
+  test('/issue-radar renders Issue Radar welcome (no repos on fixture)', async ({ page }) => {
+    await page.goto('/issue-radar', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/issue-radar/)
+    await expect(page.getByText('Welcome to Issue Radar')).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── /file-explorer — FileExplorerPage ─────────────────────────────────────
+
+  test('/file-explorer renders File Explorer page', async ({ page }) => {
+    await page.goto('/file-explorer', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/file-explorer/)
+    // FileExplorerPage always renders the mc-fe-root container
+    await expect(page.locator('.mc-fe-root')).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/website/playwright/capabilities.spec.ts
+++ b/website/playwright/capabilities.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * /capabilities — Agent Capabilities page.
+ * SidePanelLayout with 6 tabs: Agents, Agent Templates, Integrations (MCP),
+ * Skills, Hooks, Prompts. Default tab is "agents" (KiroCrewAgentsPage).
+ *
+ * Covers: page load + heading, tab navigation with content change assertion,
+ * the agents table read + a create/delete round-trip mutation.
+ */
+
+test.describe('Capabilities Page — /capabilities', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/capabilities', { waitUntil: 'domcontentloaded' })
+    // Wait for the SidePanelLayout page title (in the nav panel, scoped to avoid ambiguity)
+    await expect(page.locator('#main-content .text-lg.font-bold').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('renders the page title and default Agents tab heading', async ({ page }) => {
+    // SidePanelLayout nav title "Agent Capabilities" — scoped inside main-content
+    await expect(page.locator('#main-content .text-lg.font-bold').first()).toHaveText('Agent Capabilities')
+    // Default tab description from the content area header
+    await expect(page.locator('#main-content').getByText('Manage agent → workspace → memory store bindings')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('shows all 6 tab buttons in the side nav', async ({ page }) => {
+    // Tab buttons inside the nav panel — look inside #main-content nav
+    const nav = page.locator('#main-content nav')
+    const tabs = ['Agents', 'Agent Templates', 'Integrations (MCP)', 'Skills', 'Hooks', 'Prompts']
+    for (const label of tabs) {
+      await expect(nav.getByRole('button', { name: label, exact: true })).toBeVisible({ timeout: 5000 })
+    }
+  })
+
+  test('agents tab shows the stats cards and agents table', async ({ page }) => {
+    // StatCard "Total Agents" rendered by KiroCrewAgentsPage
+    await expect(page.locator('#main-content').getByText('Total Agents')).toBeVisible({ timeout: 5000 })
+    // StatCard "Default" showing the default agent name
+    await expect(page.locator('#main-content').getByText('Default').first()).toBeVisible()
+    // The agents table has a header row with "Name" column
+    await expect(page.locator('#main-content th').filter({ hasText: 'Name' }).first()).toBeVisible()
+    // The minimal fixture seeds at least one agent (the "kirocrew" default)
+    await expect(page.locator('#main-content td').filter({ hasText: 'kirocrew' }).first()).toBeVisible({ timeout: 5000 })
+  })
+
+  test('switching to Skills tab renders skills content', async ({ page }) => {
+    // Click the Skills tab button in the side nav
+    await page.locator('#main-content nav').getByRole('button', { name: 'Skills', exact: true }).click()
+    // URL should update with ?tab=skills
+    await page.waitForURL('**/capabilities?tab=skills', { timeout: 5000 })
+    // Skills tab content renders "Filter skills…" search input
+    await expect(page.getByPlaceholder('Filter skills…')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('switching to Hooks tab renders hooks content', async ({ page }) => {
+    await page.locator('#main-content nav').getByRole('button', { name: 'Hooks', exact: true }).click()
+    await page.waitForURL('**/capabilities?tab=hooks', { timeout: 5000 })
+    // HooksPage shows the "+ New Hook" button
+    await expect(page.getByRole('button', { name: /\+ new hook/i })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('switching to Agent Templates tab renders installed agents', async ({ page }) => {
+    await page.locator('#main-content nav').getByRole('button', { name: 'Agent Templates', exact: true }).click()
+    await page.waitForURL('**/capabilities?tab=templates', { timeout: 5000 })
+    // AgentsPage renders "Installed Agents" heading text
+    await expect(page.locator('#main-content').getByText('Installed Agents')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('create and delete agent round-trip via API', async ({ page, request }) => {
+    // Use the API directly to create an agent, verify it appears in the table,
+    // then delete it and verify removal. This is a full mutation round-trip.
+    const agentName = `pw-cap-${Date.now()}`
+
+    // Create agent via API
+    const createRes = await request.post('/api/agents', {
+      data: { name: agentName, kiro_agent: 'kirocrew', workspace: 'default', memory_store: 'default' },
+    })
+    expect(createRes.ok()).toBeTruthy()
+
+    // Refresh the page to see the new agent
+    await page.goto('/capabilities', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('#main-content .text-lg.font-bold').first()).toBeVisible({ timeout: 10000 })
+
+    // Verify the created agent appears in the table
+    await expect(page.locator('#main-content td').filter({ hasText: agentName })).toBeVisible({ timeout: 10000 })
+
+    // Delete agent via API
+    const deleteRes = await request.delete(`/api/agents/${encodeURIComponent(agentName)}`)
+    expect(deleteRes.ok()).toBeTruthy()
+
+    // Refresh and verify the agent is gone
+    await page.goto('/capabilities', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('#main-content .text-lg.font-bold').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('#main-content td').filter({ hasText: agentName })).not.toBeVisible({ timeout: 5000 })
+  })
+})

--- a/website/playwright/chat.spec.ts
+++ b/website/playwright/chat.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test'
 
+// Prompt sentinels understood by the stub ACP backend. Keep in sync with
+// SLOW_TRIGGER / SLOW_NOACK_TRIGGER in src/kiro_crew/testing/fake_acp_backend.py.
+const SLOW = '[[SLOW]]'
+const SLOW_NOACK = '[[SLOW_NOACK]]'
+
 // @needs-agent: these specs drive a live agent turn (send/stream/soft-stop),
 // so they require model/agent credentials the credential-less CI gateway
 // lacks. Tagged so the default gating run (grepInvert /@needs-agent/ in
@@ -130,86 +135,87 @@ test.describe('Chat Page E2E Tests', { tag: '@needs-agent' }, () => {
 /**
  * Soft-stop E2E tests.
  *
- * These tests require the backend running with:
- *   KIROCREW_HOME=.kirocrew-dev KIROCREW_PORT=6777
- * per TEST_README.md. If the gateway is not running, tests will fail on
- * navigation timeout — that is acceptable for offline development.
+ * Driven by the stub ACP backend (src/kiro_crew/testing/fake_acp_backend.py), so
+ * these need no model credentials: [[SLOW]] streams a long turn that DOES honour
+ * session/cancel, answering stopReason:"cancelled" — the ack the host waits for.
+ * They were @needs-live-agent while the stub dropped session/cancel entirely.
+ *
+ * Assertions target the stop button's escalation testid and StopEventCard's
+ * data-state rather than label text: the state is the contract, the wording is
+ * not. The previous `/stop/i` role selector is now a strict-mode violation —
+ * three buttons carry "stop" in their accessible name.
  */
-test.describe('Soft-Stop E2E Tests', { tag: '@needs-live-agent' }, () => {
+const STOP_CARD = '[data-testid="stop-event-card"]'
+
+test.describe('Soft-Stop E2E Tests', { tag: '@needs-agent' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/chat', { waitUntil: 'domcontentloaded' })
     await expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 10000 })
   })
 
   test('stop mid-tool-call triggers pulsing', async ({ page }) => {
-    // Send a message that will trigger a tool call
+    // A cancel-aware slow turn, so the Stop button stays live long enough to click.
     const messageInput = page.getByPlaceholder(/message/i)
-    await messageInput.fill('Run a long command: sleep 30')
+    await messageInput.fill(`Run a long command: sleep 30 ${SLOW}`)
     await page.keyboard.press('Enter')
 
     // Wait for the stop button to appear (agent is running)
-    const stopButton = page.getByRole('button', { name: /stop/i })
+    const stopButton = page.getByTestId('stop-button-armed')
     await expect(stopButton).toBeVisible({ timeout: 15000 })
 
-    // Click stop — should enter pulsing state
+    // Click stop — should enter the pulsing "stopping" state
     await stopButton.click()
 
-    // The stop button or a stopping indicator should show pulsing/stopping state
-    // Check for the pulsing animation class or the Stopping text
-    await expect(
-      page.locator('[class*="pulse"], [class*="stopping"], :text("Stopping")')
-        .first()
-    ).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('stop-button-pulsing')).toBeVisible({ timeout: 5000 })
   })
 
   test('stop resolves to Stopped on soft ack', async ({ page }) => {
-    // Send a message to start a turn
     const messageInput = page.getByPlaceholder(/message/i)
-    await messageInput.fill('Hello, please respond slowly')
+    await messageInput.fill(`Hello, please respond slowly ${SLOW}`)
     await page.keyboard.press('Enter')
 
-    // Wait for agent to be running
-    const stopButton = page.getByRole('button', { name: /stop/i })
+    const stopButton = page.getByTestId('stop-button-armed')
     await expect(stopButton).toBeVisible({ timeout: 15000 })
-
-    // Click stop
     await stopButton.click()
 
-    // Wait for the stop event card to resolve — soft ack shows [Stopped]
-    await expect(
-      page.locator(':text("Stopped")').first()
-    ).toBeVisible({ timeout: 15000 })
-  })
-
-  test('stop resolves to Stop Failed on budget expiry', async ({ page }) => {
-    // Intercept the stop endpoint to simulate a timeout scenario by
-    // setting a very short budget that the agent cannot meet
-    await page.route('**/api/config', async (route) => {
-      const response = await route.fetch()
-      const json = await response.json()
-      // Override budget to minimum so timeout is near-certain
-      if (json.agent) {
-        json.agent.soft_stop_budget_secs = 0.5
-      }
-      await route.fulfill({ json })
+    // The stub acks the cancel, so the card resolves to [Stopped].
+    await expect(page.locator(`${STOP_CARD}[data-state="stopped"]`).first()).toBeVisible({
+      timeout: 15000,
     })
+  })
+})
 
-    // Send a message that triggers a long tool call
+/**
+ * Budget-expiry soft-stop, still excluded.
+ *
+ * The stub CAN withhold the cancel ack ([[SLOW_NOACK]] streams a long turn and
+ * ignores session/cancel), which is the agent half of this scenario. What blocks
+ * it is the host half: `agent.soft_stop_budget_secs` is read server-side in
+ * session.py stop_turn(), so the `page.route('**\/api/config')` override this
+ * test used to carry never changed the enforced budget. Observed behaviour with
+ * the default budget is that the card stays in `stopping` well past Playwright's
+ * 30s per-test timeout, so the run fails on timeout rather than on the assertion.
+ *
+ * To enable: give the harness gateway a small `agent.soft_stop_budget_secs`
+ * (config, not a client-side route intercept), then retag to @needs-agent and
+ * assert on data-state="stop_failed_reset". Left dark rather than shipped with a
+ * long sleep or a raised timeout that would only mask the timing question.
+ */
+test.describe('Soft-Stop budget expiry', { tag: '@needs-live-agent' }, () => {
+  test('stop resolves to Stop Failed on budget expiry', async ({ page }) => {
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 10000 })
+
     const messageInput = page.getByPlaceholder(/message/i)
-    await messageInput.fill('Run a very long command: sleep 120')
+    await messageInput.fill(`Run a very long command: sleep 120 ${SLOW_NOACK}`)
     await page.keyboard.press('Enter')
 
-    // Wait for agent to be running
-    const stopButton = page.getByRole('button', { name: /stop/i })
+    const stopButton = page.getByTestId('stop-button-armed')
     await expect(stopButton).toBeVisible({ timeout: 15000 })
-
-    // Click stop
     await stopButton.click()
 
-    // With a 0.5s budget the agent likely cannot ack in time →
-    // card should show [Stop Failed, Session Reset]
-    await expect(
-      page.locator(':text("Stop Failed"), :text("Session Reset")').first()
-    ).toBeVisible({ timeout: 15000 })
+    await expect(page.locator(`${STOP_CARD}[data-state="stop_failed_reset"]`).first()).toBeVisible({
+      timeout: 15000,
+    })
   })
 })

--- a/website/playwright/embed-popout.spec.ts
+++ b/website/playwright/embed-popout.spec.ts
@@ -1,0 +1,223 @@
+import { test, expect, type APIRequestContext } from '@playwright/test'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+// ─── Seed helpers ──────────────────────────────────────────────────────────
+
+/** Create a chat slot via API and return its key. */
+async function seedSlot(request: APIRequestContext, suffix: string): Promise<string> {
+  const res = await request.post('/api/chat/slots', {
+    data: { agent: 'default', title: `pw-embed-${suffix}-${Date.now()}` },
+  })
+  expect(res.status(), `slot seed failed: ${await res.text()}`).toBeLessThan(300)
+  const body = await res.json()
+  return body.key as string
+}
+
+/** Create an artifact via API and return its slug. */
+async function seedArtifact(request: APIRequestContext, suffix: string): Promise<string> {
+  // POST/PATCH /api/artifacts fire ArtifactKnowledgeSync.on_change
+  // (artifact_ingest.py:230, gated on knowledge.auto_ingest_artifacts which
+  // DEFAULTS TO TRUE). That chains to pipeline.ingest_file() ->
+  // delete_items_batch (ingestion.py:341) -> store.py:494, which runs an
+  // UNSCOPED sweep: DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM
+  // mentions) AND ... -- destroying pre-existing orphan entities in a real
+  // developer's Knowledge Library. Seeding an artifact is therefore not a local
+  // operation, so it requires the ephemeral harness gateway.
+  test.skip(
+    !HARNESS_GATEWAY,
+    'seeding artifacts requires the ephemeral harness gateway: artifact ingestion triggers a global orphan-entity sweep (store.py:494)',
+  )
+  const slug = `pw-embed-${suffix}-${Date.now()}`
+  const res = await request.post('/api/artifacts', {
+    data: {
+      name: `PW Embed Test ${suffix}`,
+      slug,
+      content: `<h1>Embed Test ${suffix}</h1><p>Seeded by embed-popout.spec.ts</p>`,
+      kind: 'widget',
+      description: 'Seeded by embed-popout spec',
+      tags: ['e2e-embed'],
+    },
+  })
+  expect(res.status(), `artifact seed failed: ${await res.text()}`).toBeLessThan(300)
+  const body = await res.json()
+  return body.slug as string
+}
+
+// ─── POPOUT route tree ─────────────────────────────────────────────────────
+
+test.describe('Popout route tree — /popout/*', () => {
+
+  test('popout chat renders without main app chrome', async ({ page, request }) => {
+    const slotKey = await seedSlot(request, 'popout-chat')
+    await page.goto(`/popout/chat/${slotKey}?sid=${slotKey}`, { waitUntil: 'domcontentloaded' })
+    // Popout shell: no dashboard-shell, no navigation sidebar
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0)
+    // ChatPage renders inside the popout frame
+    await expect(page.locator('.h-screen.w-screen')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('popout chat renders the chat input area', async ({ page, request }) => {
+    const slotKey = await seedSlot(request, 'popout-input')
+    await page.goto(`/popout/chat/${slotKey}?sid=${slotKey}`, { waitUntil: 'domcontentloaded' })
+    // The chat page contains a message input area (textarea or contenteditable)
+    const input = page.locator('textarea, [contenteditable="true"]').first()
+    await expect(input).toBeVisible({ timeout: 10000 })
+  })
+
+  test('popout chat without slug renders chat page shell', async ({ page }) => {
+    // /popout/chat/:slug? — the slug is optional
+    await page.goto('/popout/chat/', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    // Still renders the popout frame container
+    await expect(page.locator('.h-screen.w-screen')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('popout artifact renders the artifact detail with return button', async ({ page, request }) => {
+    const slug = await seedArtifact(request, 'popout-art')
+    await page.goto(`/popout/artifact/${slug}`, { waitUntil: 'domcontentloaded' })
+    // No main chrome
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0)
+    // ArtifactPopoutFrame renders the "Return to main window" button
+    await expect(
+      page.getByRole('button', { name: 'Return to main window and close this popout' })
+    ).toBeVisible({ timeout: 10000 })
+  })
+
+  test('popout artifact shows seeded artifact content', async ({ page, request }) => {
+    const slug = await seedArtifact(request, 'popout-content')
+    await page.goto(`/popout/artifact/${slug}`, { waitUntil: 'domcontentloaded' })
+    // ArtifactPopoutFrame sets document.title to include "Kiro Crew"
+    await expect.poll(
+      () => page.title(),
+      { timeout: 10000 }
+    ).toContain('Kiro Crew')
+  })
+
+  test('popout wildcard redirects SPA navigation back to initial path', async ({ page, request }) => {
+    // The wildcard <Route path="*" element={<Navigate to={initialPopoutPath} replace />} />
+    // redirects stray SPA navigations back to the initial load path.
+    const slotKey = await seedSlot(request, 'popout-wc')
+    await page.goto(`/popout/chat/${slotKey}?sid=${slotKey}`, { waitUntil: 'domcontentloaded' })
+    // Confirm we're on the valid popout page first
+    await expect(page.locator('.h-screen.w-screen')).toBeVisible({ timeout: 10000 })
+    // Capture the initial URL (may be rewritten by SPA from the loaded path)
+    const urlBeforePush = page.url()
+    // Trigger in-app navigation to a non-matching popout path
+    await page.evaluate(() => {
+      window.history.pushState({}, '', '/popout/stray-nav')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+    // The wildcard route catches this and redirects back via Navigate(to=initialPopoutPath).
+    // The initial path is set at document load (window.location.pathname + search).
+    // Verify the URL reverts away from /popout/stray-nav back to a /popout/chat/ path.
+    await expect.poll(
+      () => page.url(),
+      { timeout: 5000 }
+    ).toContain('/popout/chat/')
+    // Confirm it's not stuck on the stray path
+    expect(page.url()).not.toContain('/popout/stray-nav')
+  })
+})
+
+// ─── EMBED route tree ──────────────────────────────────────────────────────
+
+test.describe('Embed route tree — /embed/*', () => {
+
+  test('embed sessions renders without main app chrome but with tab strip', async ({ page }) => {
+    await page.goto('/embed/sessions', { waitUntil: 'domcontentloaded' })
+    // No dashboard-shell or navigation sidebar
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0)
+    // EmbedTabStrip renders tab elements and a "New tab" button
+    await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('embed sessions shows tab strip with at least one tab', async ({ page }) => {
+    await page.goto('/embed/sessions', { waitUntil: 'domcontentloaded' })
+    // The EmbedTabStrip renders role="tab" elements
+    await expect(page.getByRole('tab').first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('embed chat renders the chat view for a session', async ({ page, request }) => {
+    const slotKey = await seedSlot(request, 'embed-chat')
+    await page.goto(`/embed/chat/${slotKey}?sid=${slotKey}`, { waitUntil: 'domcontentloaded' })
+    // Embed shell: no main chrome
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0)
+    // Has the tab strip
+    await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible({ timeout: 10000 })
+    // Has the chat input
+    const input = page.locator('textarea, [contenteditable="true"]').first()
+    await expect(input).toBeVisible({ timeout: 10000 })
+  })
+
+  test('embed chat without slug navigates to sessions', async ({ page }) => {
+    // /embed/chat/:slug? — optional slug. Without it, the embed tab strip's
+    // mount logic navigates to /embed/sessions when it has no slug for the active tab.
+    await page.goto('/embed/chat/', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/embed/sessions', { timeout: 10000 })
+  })
+
+  /**
+   * FINDING (product bug, not fixed here): /embed/settings cannot be reached by
+   * URL, and cannot be held once reached. EmbedTabStrip is a sibling of <Routes>
+   * in the embed shell (App.tsx:1397), so it mounts on every /embed/* path and
+   * navigates away twice over:
+   *
+   *   1. a one-shot mount effect -> the restored tab (EmbedTabStrip.tsx:53-60);
+   *   2. an effect keyed on [activeSlot] that rewrites the empty "sessions" tab
+   *      into a chat tab -> /embed/chat/:slug (EmbedTabStrip.tsx:129-136).
+   *
+   * (2) fires whenever the store hydrates an activeSlot, so it can land after any
+   * client-side navigation and clobber it mid-render. That makes the render and
+   * tab-switching behaviour of EmbedSettingsPage untestable without a fixed
+   * sleep, which this suite bans. The page's only in-app entry point is
+   * VoiceDisabledModal's onOpenSettings (ChatPage.tsx:4096).
+   *
+   * What IS deterministic is the redirect contract itself, asserted below. When
+   * the deep link is fixed, replace this with render + tab-switching coverage.
+   */
+  test('embed settings deep link is redirected into the embed tab flow', async ({ page }) => {
+    await page.goto('/embed/settings', { waitUntil: 'domcontentloaded' })
+    // The shell never leaves the embed tree, and never shows main app chrome.
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0)
+    // EmbedTabStrip's mount effect takes over: the URL lands on a tab route.
+    await page.waitForURL(/\/embed\/(sessions|chat)/, { timeout: 15000 })
+    await expect(page).not.toHaveURL(/\/embed\/settings/)
+    // The tab strip is live, proving we landed in the tab flow.
+    await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('embed wildcard redirects to /embed/sessions', async ({ page }) => {
+    // Any non-matching path under /embed/* redirects to /embed/sessions
+    await page.goto('/embed/nonexistent-route', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/embed/sessions', { timeout: 10000 })
+    // After redirect, the sessions view renders
+    await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('embed new tab button creates a sessions tab', async ({ page }) => {
+    await page.goto('/embed/sessions', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible({ timeout: 10000 })
+    const initialTabCount = await page.getByRole('tab').count()
+    // Click "New tab" — adds an empty-slug tab that navigates to /embed/sessions
+    await page.getByRole('button', { name: 'New tab' }).click()
+    // Tab count increased
+    await expect(page.getByRole('tab')).toHaveCount(initialTabCount + 1, { timeout: 5000 })
+  })
+})
+
+// ─── Chrome presence on normal routes (contrast) ───────────────────────────
+
+test.describe('Normal route renders main app chrome (contrast)', () => {
+
+  test('main dashboard route has dashboard-shell and navigation', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('[data-testid="dashboard-shell"]')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/website/playwright/fork.spec.ts
+++ b/website/playwright/fork.spec.ts
@@ -3,11 +3,13 @@ import { test, expect } from '@playwright/test'
 /**
  * E2E test for the "Fork session" feature.
  *
- * Runs against a real gateway on localhost:5476. Exercises the full round-trip:
- * send message → wait for assistant reply → click fork button → verify new tab.
+ * Exercises the full round-trip: send message → wait for assistant reply →
+ * click fork button → verify new tab.
  *
- * Skipped gracefully if no assistant reply arrives within the timeout, since
- * the live kiro-cli session may be unavailable in some CI environments.
+ * Tagged @needs-agent, so it runs only when an agent turn is available. The e2e
+ * harness supplies one by pointing KIROCREW_KIRO_BIN at the stub ACP backend,
+ * which answers deterministically and offline. A missing reply is a failure, not
+ * an environment gap.
  */
 
 test.describe('Fork Session E2E', { tag: '@needs-agent' }, () => {
@@ -40,13 +42,12 @@ test.describe('Fork Session E2E', { tag: '@needs-agent' }, () => {
 
     // Fork button (title="Fork conversation from here") only renders on
     // assistant messages, so its visibility is a clean signal that the
-    // assistant replied. Skip if kiro-cli doesn't respond in time.
+    // assistant replied. This used to `test.skip` on a timeout, which reported
+    // green while verifying nothing. The spec is @needs-agent, so it only runs
+    // when an agent is wired, and the harness wires the stub ACP backend, which
+    // always answers. A missing reply is therefore a real failure.
     const forkButton = page.getByTitle('Fork conversation from here').first()
-    try {
-      await forkButton.waitFor({ state: 'visible', timeout: 60000 })
-    } catch {
-      test.skip(true, 'No assistant reply within 60s — skipping fork E2E')
-    }
+    await expect(forkButton).toBeVisible({ timeout: 60000 })
 
     await forkButton.hover()
     // GIF-only pauses: skip in normal CI to keep tests fast.

--- a/website/playwright/knowledge.spec.ts
+++ b/website/playwright/knowledge.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+/**
+ * Ids of knowledge items seeded by the current test, drained by afterEach.
+ * Module scope is safe here: playwright.config.ts runs a single worker in CI and
+ * afterEach drains the list after every test, so entries never leak across tests.
+ */
+const seededItemIds: string[] = []
+
+/** Generate an item id and register it for afterEach cleanup. */
+function trackedId(): string {
+  const id = randomUUID()
+  seededItemIds.push(id)
+  return id
+}
+
+test.describe('Knowledge Page E2E Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/knowledge', { waitUntil: 'domcontentloaded' })
+  })
+
+  // Cleanup deletes ONLY the ids this run created, never a title-prefix sweep.
+  // A `title.startsWith('Playwright_')` match cannot distinguish our seed data
+  // from a real item a user happens to have named that way, so pointing this
+  // suite at a live gateway to debug a failure would destroy their data. Every
+  // seeded item carries a client-generated id (trackedId), so scoping teardown
+  // to that set is both safe on any gateway and still effective in CI.
+  test.afterEach(async ({ request }) => {
+    const ids = seededItemIds.splice(0, seededItemIds.length)
+    for (const id of ids) {
+      try {
+        await request.delete(`/api/knowledge/items/${id}`)
+      } catch {
+        // best-effort teardown
+      }
+    }
+  })
+
+  test('renders list view with stats bar on fresh fixture', async ({ page }) => {
+    // The default statusFilter='active' prevents the onboarding empty-state from
+    // rendering (isEmpty requires !statusFilter which is false for 'active').
+    // The stats bar renders once /stats returns. With the minimal fixture there
+    // are 0 items and 0 entities, but sources may be >0 due to auto_ingest_artifacts.
+    await expect(page.getByText('Knowledge Library')).toBeVisible({ timeout: 10000 })
+    // Stats bar contains "{N} items" text — on fresh fixture items=0
+    await expect(page.getByText('0 items')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('0 entities')).toBeVisible()
+    await expect(page.getByText('0 relations')).toBeVisible()
+    // Verify the stats bar itself rendered (sources count may be >0 due to auto-ingest)
+    await expect(page.getByText(/\d+ sources/)).toBeVisible()
+  })
+
+  test('tabs switch between list, graph, and sources', async ({ page }) => {
+    // Wait for the page to fully load (stats bar visible means data fetched)
+    await expect(page.getByText('0 items')).toBeVisible({ timeout: 10000 })
+
+    // Click "Graph View" tab
+    await page.getByRole('button', { name: /Graph View/i }).click()
+    // The graph canvas (lazy-loaded) should appear or a loading skeleton.
+    // In graph view, the stats bar hint at the bottom changes.
+    await expect(page.getByText('/ to search')).not.toBeVisible()
+
+    // Click "Sources" tab
+    await page.getByRole('button', { name: /Sources/i }).click()
+    // Sources tab shows source management UI — the "+ Add Source" button is always visible
+    await expect(page.getByRole('button', { name: /\+ Add Source/i })).toBeVisible({ timeout: 5000 })
+
+    // Click back to "List View"
+    await page.getByRole('button', { name: /List View/i }).click()
+    await expect(page.getByText('/ to search')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('help dialog opens and closes', async ({ page }) => {
+    await expect(page.getByText('Knowledge Library')).toBeVisible({ timeout: 10000 })
+
+    // Click the Help button
+    await page.getByRole('button', { name: /Help/i }).click()
+
+    // The dialog should appear with keyboard shortcuts
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText('Keyboard Shortcuts')).toBeVisible()
+    await expect(page.getByText('Focus search')).toBeVisible()
+
+    // Close via the Close button (aria-label="Close")
+    await page.getByLabel('Close').click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('import bundle creates items visible via API', async ({ request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    const suffix = randomUUID().slice(0, 8)
+    const itemId = trackedId()
+    const itemTitle = `Playwright_Import_${suffix}`
+
+    // Import a knowledge bundle with one item (id is REQUIRED by store.import_bundle)
+    const importRes = await request.post('/api/knowledge/import', {
+      data: {
+        items: [
+          {
+            id: itemId,
+            title: itemTitle,
+            content: 'This is test content for the Playwright e2e test.',
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+        ],
+        entities: [],
+        relations: [],
+      },
+    })
+    expect(importRes.ok()).toBeTruthy()
+    const importBody = await importRes.json()
+    expect(importBody.items_imported).toBeGreaterThanOrEqual(1)
+
+    // Verify item appears in the API list
+    const listRes = await request.get('/api/knowledge/items?limit=100&status=active')
+    expect(listRes.ok()).toBeTruthy()
+    const listBody = await listRes.json()
+    const found = listBody.items.find((i: { title: string }) => i.title === itemTitle)
+    expect(found).toBeTruthy()
+    expect(found.content).toContain('Playwright e2e test')
+  })
+
+  test('imported item renders in the list view', async ({ page, request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    const suffix = randomUUID().slice(0, 8)
+    const itemId = trackedId()
+    const itemTitle = `Playwright_Visible_${suffix}`
+
+    // Seed an item via the import API
+    const importRes = await request.post('/api/knowledge/import', {
+      data: {
+        items: [
+          {
+            id: itemId,
+            title: itemTitle,
+            content: 'Visible content for the Playwright render test.',
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+        ],
+        entities: [],
+        relations: [],
+      },
+    })
+    expect(importRes.ok()).toBeTruthy()
+
+    // Reload the page to pick up the new data
+    await page.goto('/knowledge', { waitUntil: 'domcontentloaded' })
+
+    // With an imported item, the stats bar should now show >= 1 item.
+    // The source-first view groups by source -- our item has no source_id so it
+    // falls under the "no source" bucket. The source group is auto-expanded when
+    // it's the only one.
+    await expect(page.getByText(itemTitle)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('search filters items by query', async ({ page, request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    const suffix = randomUUID().slice(0, 8)
+    const targetId = trackedId()
+    const decoyId = trackedId()
+    const targetTitle = `Playwright_SearchTarget_${suffix}`
+    const decoyTitle = `Playwright_SearchDecoy_${suffix}`
+    const searchTerm = `UniqueSearchTerm_${suffix}`
+
+    // Seed two items with different content
+    await request.post('/api/knowledge/import', {
+      data: {
+        items: [
+          {
+            id: targetId,
+            title: targetTitle,
+            content: `${searchTerm} is in this document.`,
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+          {
+            id: decoyId,
+            title: decoyTitle,
+            content: 'This document has completely different content with no match.',
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+        ],
+        entities: [],
+        relations: [],
+      },
+    })
+
+    // Reload
+    await page.goto('/knowledge', { waitUntil: 'domcontentloaded' })
+    // Wait for items to appear (source group expands when single)
+    await expect(page.getByText(targetTitle)).toBeVisible({ timeout: 10000 })
+
+    // Type in the search box and press Enter
+    const searchInput = page.getByPlaceholder('Search knowledge... (press Enter to search)')
+    await searchInput.fill(searchTerm)
+    await searchInput.press('Enter')
+
+    // Target should be visible, decoy should not (search matches content)
+    await expect(page.getByText(targetTitle)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(decoyTitle)).not.toBeVisible({ timeout: 5000 })
+  })
+
+  test('stats endpoint returns correct counts after import', async ({ request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    const suffix = randomUUID().slice(0, 8)
+    const itemId = trackedId()
+    const entityId = randomUUID()
+
+    // Seed items with entities (id is required for both items and entities)
+    const importRes = await request.post('/api/knowledge/import', {
+      data: {
+        items: [
+          {
+            id: itemId,
+            title: `Playwright_StatsItem_${suffix}`,
+            content: 'Stats test content.',
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+        ],
+        entities: [
+          {
+            id: entityId,
+            name: `TestEntity_${suffix}`,
+            entity_type: 'concept',
+            description: 'A test entity.',
+          },
+        ],
+        relations: [],
+      },
+    })
+    expect(importRes.ok()).toBeTruthy()
+
+    // Verify stats
+    const statsRes = await request.get('/api/knowledge/stats')
+    expect(statsRes.ok()).toBeTruthy()
+    const stats = await statsRes.json()
+    expect(stats.items).toBeGreaterThanOrEqual(1)
+    expect(stats.entities).toBeGreaterThanOrEqual(1)
+  })
+
+  test('filter by type select narrows items', async ({ page, request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    const suffix = randomUUID().slice(0, 8)
+    const docId = trackedId()
+    const runbookId = trackedId()
+    const docTitle = `Playwright_TypeDoc_${suffix}`
+    const runbookTitle = `Playwright_TypeRunbook_${suffix}`
+
+    // Seed two items with different types
+    await request.post('/api/knowledge/import', {
+      data: {
+        items: [
+          {
+            id: docId,
+            title: docTitle,
+            content: 'A document item.',
+            item_type: 'document',
+            status: 'active',
+            namespace: 'default',
+          },
+          {
+            id: runbookId,
+            title: runbookTitle,
+            content: 'A runbook item.',
+            item_type: 'runbook',
+            status: 'active',
+            namespace: 'default',
+          },
+        ],
+        entities: [],
+        relations: [],
+      },
+    })
+
+    await page.goto('/knowledge', { waitUntil: 'domcontentloaded' })
+    // Wait for items to load
+    await expect(page.getByText(docTitle)).toBeVisible({ timeout: 10000 })
+
+    // Select type filter "runbook"
+    await page.getByLabel('Filter by type').selectOption('runbook')
+
+    // Runbook should remain, document should disappear
+    await expect(page.getByText(runbookTitle)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(docTitle)).not.toBeVisible({ timeout: 5000 })
+  })
+})

--- a/website/playwright/logs.spec.ts
+++ b/website/playwright/logs.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+// Every test here needs DEBUG so the stream actually emits lines, and
+// POST /api/logs/level PERSISTS: api_log_level writes cfg.agent.log_level and
+// calls cfg.save() (updates.py:542). There is no read-only way to raise the
+// level, so the whole suite is gated on the explicit ephemeral-harness marker
+// rather than permanently rewriting a developer's log level. Same contract as
+// session-tags-e2e; test/test_playwright_e2e.py sets the marker, so this still
+// runs in CI.
+test.describe('Logs Page', () => {
+  test.beforeEach(async ({ page, request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'persisting a DEBUG log level requires the ephemeral harness gateway (KIROCREW_E2E_EPHEMERAL)',
+    )
+    // Ensure log level is set to DEBUG so all gateway lines are visible.
+    // The minimal fixture defaults to WARNING which may show zero lines.
+    await request.post('/api/logs/level', { data: { level: 'DEBUG' } })
+    await page.goto('/logs', { waitUntil: 'domcontentloaded' })
+    // Wait for the page header to render, proving the route mounted
+    await expect(page.getByText('Live Logs')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('renders page header and subtitle', async ({ page }) => {
+    await expect(page.getByText('Live Logs')).toBeVisible()
+    await expect(page.getByText('Real-time application output')).toBeVisible()
+  })
+
+  test('displays log level buttons with current level highlighted', async ({ page }) => {
+    // The four level buttons: Debug, Info, Warning, Error
+    await expect(page.getByRole('button', { name: 'Debug' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Info' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Warning' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Error' })).toBeVisible()
+  })
+
+  test('renders the filter input and control buttons', async ({ page }) => {
+    await expect(page.getByLabel('Filter logs')).toBeVisible()
+    // Tail and Wrap toggle buttons
+    await expect(page.getByRole('button', { name: /Tail:/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Wrap:/ })).toBeVisible()
+    // Latest direction toggle
+    await expect(page.getByRole('button', { name: /Latest:/ })).toBeVisible()
+  })
+
+  test('receives live log lines from the gateway', async ({ page }) => {
+    // The gateway emits log lines. At DEBUG level, there will be many.
+    // Log lines are rendered as font-mono divs inside the Virtuoso container.
+    const logLine = page.locator('.font-mono').first()
+    await expect(logLine).toBeVisible({ timeout: 15000 })
+  })
+
+  test('changing log level via UI narrows displayed lines', async ({ page, request }) => {
+    // Confirm we have log lines visible at DEBUG level
+    const logLine = page.locator('.font-mono').first()
+    await expect(logLine).toBeVisible({ timeout: 15000 })
+
+    // Switch to ERROR level via the UI button -- this should filter display
+    await page.getByRole('button', { name: 'Error' }).click()
+
+    // Verify the level changed on the server (round-trip)
+    await expect.poll(async () => {
+      const resp = await (await request.get('/api/logs/level')).json()
+      return resp.level
+    }, { timeout: 5000 }).toBe('ERROR')
+  })
+
+  test('search filter shows match count when term matches log lines', async ({ page }) => {
+    // Wait for log lines to appear at DEBUG level
+    const logLine = page.locator('.font-mono').first()
+    await expect(logLine).toBeVisible({ timeout: 15000 })
+
+    // Every log line contains "kiro_crew" in the logger name field.
+    // Type the search term
+    const filterInput = page.getByLabel('Filter logs')
+    await filterInput.fill('kiro_crew')
+
+    // The match count indicator should appear (format: "N matches")
+    await expect(page.getByText(/\d+ matches/)).toBeVisible({ timeout: 5000 })
+  })
+
+  test('Matches only button activates and deactivates correctly', async ({ page }) => {
+    // Wait for log lines to appear
+    const logLine = page.locator('.font-mono').first()
+    await expect(logLine).toBeVisible({ timeout: 15000 })
+
+    // Search for a term that matches SOME lines (the logger name appears in all lines)
+    const filterInput = page.getByLabel('Filter logs')
+    await filterInput.fill('kiro_crew')
+
+    // Wait for the match count to appear (proves search works)
+    const matchCountEl = page.getByText(/\d+ matches/)
+    await expect(matchCountEl).toBeVisible({ timeout: 5000 })
+
+    // The "Matches only" button should now be visible (only shown when search is active)
+    const matchesOnlyBtn = page.getByRole('button', { name: 'Matches only' })
+    await expect(matchesOnlyBtn).toBeVisible()
+
+    // Click "Matches only" -- all remaining visible lines contain the search term
+    await matchesOnlyBtn.click()
+
+    // Verify lines are still shown (the search matched lines)
+    await expect(page.locator('.font-mono').first()).toBeVisible()
+
+    // Clear the search -- "Matches only" button should disappear
+    await filterInput.fill('')
+    await expect(matchesOnlyBtn).not.toBeVisible({ timeout: 3000 })
+  })
+
+  test('log level change via API round-trip persists correctly', async ({ request }) => {
+    // GET the current level
+    const before = await (await request.get('/api/logs/level')).json()
+    expect(before).toHaveProperty('level')
+
+    // Set to INFO via POST
+    const setResp = await request.post('/api/logs/level', { data: { level: 'INFO' } })
+    expect(setResp.ok()).toBeTruthy()
+    const setBody = await setResp.json()
+    expect(setBody.ok).toBe(true)
+    expect(setBody.level).toBe('INFO')
+
+    // Verify the level persisted
+    const after = await (await request.get('/api/logs/level')).json()
+    expect(after.level).toBe('INFO')
+
+    // Restore to DEBUG for consistency
+    await request.post('/api/logs/level', { data: { level: 'DEBUG' } })
+  })
+})

--- a/website/playwright/notifications.spec.ts
+++ b/website/playwright/notifications.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+test.describe('Notifications Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/notifications', { waitUntil: 'domcontentloaded' })
+    // Wait for the page subtitle to render -- unique to this page
+    await expect(page.getByText('All agent activity, cron results, webhooks, and approvals')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('renders page header and subtitle', async ({ page }) => {
+    // The page header title -- use the subtitle as the unique anchor since
+    // "Notifications" also appears in the topbar bell button text
+    // PageHeader (ui.tsx:257) renders its title as a plain <div>, not a heading, and
+    // "Notifications" also appears in the topbar bell button -- so the subtitle is the
+    // only unique, non-class-coupled anchor for "the header rendered".
+    await expect(page.getByText('All agent activity, cron results, webhooks, and approvals')).toBeVisible()
+  })
+
+  test('displays stat cards with zero counts on empty fixture', async ({ page }) => {
+    // The stat cards show Total, Unread, Cron, Hooks, Heartbeat -- all 0 on minimal fixture
+    const totalCard = page.locator('.stat-accent').filter({ hasText: 'Total' })
+    await expect(totalCard.locator('.text-2xl')).toContainText('0')
+    const unreadCard = page.locator('.stat-accent').filter({ hasText: 'Unread' })
+    await expect(unreadCard.locator('.text-2xl')).toContainText('0')
+    const cronCard = page.locator('.stat-accent').filter({ hasText: 'Cron' })
+    await expect(cronCard.locator('.text-2xl')).toContainText('0')
+  })
+
+  test('shows empty state message when no notifications', async ({ page }) => {
+    await expect(page.getByText('No notifications')).toBeVisible()
+    await expect(page.getByText('Activity will appear here')).toBeVisible()
+  })
+
+  test('renders category filter chips with correct labels', async ({ page }) => {
+    const filterGroup = page.getByRole('group', { name: 'Filter notifications by kind' })
+    await expect(filterGroup).toBeVisible()
+
+    const chipLabels = ['All', 'Cron', 'Hooks', 'Heartbeat', 'Agent', 'Approval', 'Subagent', 'Tasks']
+    for (const label of chipLabels) {
+      await expect(filterGroup.getByRole('button', { name: label, exact: true })).toBeVisible()
+    }
+  })
+
+  test('toggling a category chip changes its pressed state', async ({ page }) => {
+    const filterGroup = page.getByRole('group', { name: 'Filter notifications by kind' })
+    const cronChip = filterGroup.getByRole('button', { name: 'Cron' })
+
+    // Initially all chips are active (aria-pressed=true)
+    await expect(cronChip).toHaveAttribute('aria-pressed', 'true')
+
+    // Click to deactivate
+    await cronChip.click()
+    await expect(cronChip).toHaveAttribute('aria-pressed', 'false')
+
+    // Click again to re-activate
+    await cronChip.click()
+    await expect(cronChip).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('clicking All chip deselects all categories and shows appropriate empty state', async ({ page }) => {
+    const filterGroup = page.getByRole('group', { name: 'Filter notifications by kind' })
+    const allChip = filterGroup.getByRole('button', { name: 'All' })
+
+    // "All" acts as a toggle: when all are on, clicking clears all
+    await allChip.click()
+
+    // Now the empty state should mention categories
+    await expect(page.getByText('No categories selected')).toBeVisible()
+  })
+
+  test('GET /api/notifications returns correct structure for empty state', async ({ request }) => {
+    const resp = await request.get('/api/notifications')
+    expect(resp.ok()).toBeTruthy()
+    const body = await resp.json()
+    expect(body).toHaveProperty('notifications')
+    expect(body).toHaveProperty('unread')
+    expect(body.notifications).toEqual([])
+    expect(body.unread).toBe(0)
+  })
+
+  test('search input filters and shows appropriate empty message', async ({ page }) => {
+    const searchInput = page.getByRole('textbox', { name: 'Search…' })
+    await expect(searchInput).toBeVisible()
+
+    // Type a search term -- with no notifications, the empty state text changes
+    await searchInput.fill('nonexistent')
+    await expect(page.getByText('Try a different search')).toBeVisible()
+
+    // Clear the search -- empty state should revert
+    await searchInput.fill('')
+    await expect(page.getByText('Activity will appear here')).toBeVisible()
+  })
+
+  // /api/notifications/clear is global: it deletes EVERY notification, not just
+  // ones this spec created, and the endpoint offers no way to scope it. Gated on
+  // the explicit ephemeral-harness marker, same contract as session-tags-e2e.
+  // test/test_playwright_e2e.py sets KIROCREW_E2E_EPHEMERAL for the throwaway
+  // tmp-home gateway it spawns, so this still runs in CI. Token presence is NOT
+  // a safe signal -- it is also the normal state for a real token-protected
+  // gateway, so a developer pointing this suite at their live gateway to debug a
+  // failure must never lose their notification history.
+  test('POST /api/notifications/clear round-trips correctly on empty state', async ({ request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'destructive notification wipe requires the ephemeral harness gateway (KIROCREW_E2E_EPHEMERAL)',
+    )
+    // Clear on empty is idempotent -- verifies the full HTTP round-trip
+    const resp = await request.post('/api/notifications/clear')
+    expect(resp.ok()).toBeTruthy()
+    const body = await resp.json()
+    expect(body.ok).toBe(true)
+
+    // Verify state is still empty after the clear
+    const listResp = await (await request.get('/api/notifications')).json()
+    expect(listResp.notifications).toEqual([])
+    expect(listResp.unread).toBe(0)
+  })
+})

--- a/website/playwright/projects.spec.ts
+++ b/website/playwright/projects.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test'
+
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+/** Seed a planned run via from-chat API (does NOT execute). Returns task_id. */
+async function seedPlannedRun(
+  request: import('@playwright/test').APIRequestContext,
+  name: string,
+  steps: { title: string; description?: string }[] = [{ title: 'Step one' }, { title: 'Step two' }]
+) {
+  const res = await request.post('/api/taskrunner/from-chat', {
+    data: { steps, original_input: `Test: ${name}` },
+  })
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  expect(body.ok).toBe(true)
+  expect(body.task_id).toBeTruthy()
+  // Rename so it has a human-readable name in the sidebar
+  const renameRes = await request.patch(
+    `/api/taskrunner/${encodeURIComponent(body.task_id)}/name`,
+    { data: { name } }
+  )
+  expect(renameRes.ok()).toBeTruthy()
+  return body.task_id as string
+}
+
+/** Delete a run by task_id (best-effort). */
+async function deleteRun(request: import('@playwright/test').APIRequestContext, taskId: string) {
+  try {
+    await request.delete(`/api/taskrunner/${encodeURIComponent(taskId)}`)
+  } catch { /* best-effort */ }
+}
+
+test.describe('Projects (Task Runner) Page', () => {
+  test('renders page header with title and subtitle', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Autonomous multi-step task execution')).toBeVisible()
+  })
+
+  test('compose panel shows three mode tabs', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // Three mode tabs are visible as buttons
+    await expect(page.getByRole('button', { name: /Compose/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /From Spec/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /From YAML/i })).toBeVisible()
+  })
+
+  test('compose tab (default) has textarea and action buttons', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // The Compose tab textarea
+    await expect(page.getByLabel('Describe your task')).toBeVisible()
+
+    // Action buttons: Refine into Spec, Plan, Run
+    await expect(page.getByRole('button', { name: /Refine into Spec/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Plan', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Run', exact: true })).toBeVisible()
+  })
+
+  test('From Spec tab shows spec textarea and file upload', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // Switch to From Spec tab
+    await page.getByRole('button', { name: /From Spec/i }).click()
+
+    // The spec textarea appears with its placeholder as aria-label
+    const textarea = page.getByRole('textbox', { name: /Paste spec content/i })
+    await expect(textarea).toBeVisible({ timeout: 5000 })
+
+    // File upload input (use exact match to avoid the textarea's label collision)
+    const fileInput = page.locator('input[type="file"][aria-label="Upload a file"]')
+    await expect(fileInput).toBeAttached()
+
+    // Run and Plan buttons are present (use exact to avoid matching "Task Runner" nav)
+    await expect(page.getByRole('button', { name: 'Run', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Plan', exact: true })).toBeVisible()
+  })
+
+  test('From YAML tab shows yaml textarea and DAG banner', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // Switch to From YAML tab
+    await page.getByRole('button', { name: /From YAML/i }).click()
+
+    // YAML textarea with its placeholder
+    const textarea = page.getByRole('textbox', { name: /Paste YAML workflow/i })
+    await expect(textarea).toBeVisible({ timeout: 5000 })
+
+    // YAML-specific banner mentioning DAG constraint
+    await expect(page.getByText('YAML workflows bypass the LLM decomposer')).toBeVisible()
+  })
+
+  test('agent selector and workspace field are present', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
+
+    // Agent label is visible
+    await expect(page.getByText('Agent:')).toBeVisible()
+
+    // Workspace field
+    await expect(page.getByLabel('Workspace folder')).toBeVisible()
+  })
+
+  test('taskrunner status API returns available', async ({ request }) => {
+    const res = await request.get('/api/taskrunner')
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json()
+    expect(body.available).toBe(true)
+    // runs is an array (may not be empty due to other tests seeding data)
+    expect(Array.isArray(body.runs)).toBe(true)
+  })
+
+  test('seeding a planned run makes it visible in the sidebar', async ({ page, request }) => {
+    const taskName = `PW_Sidebar_${Date.now()}`
+    const taskId = await seedPlannedRun(request, taskName)
+
+    try {
+      await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+
+      // The run appears in the sidebar with the expected aria-label
+      const runBtn = page.getByRole('button', { name: `Open project ${taskName}` })
+      await expect(runBtn).toBeVisible({ timeout: 10000 })
+
+      // The "New Task" button is visible when sidebar has runs
+      await expect(page.getByRole('button', { name: /New Task/i })).toBeVisible()
+    } finally {
+      await deleteRun(request, taskId)
+    }
+  })
+
+  test('clicking a run shows its detail view', async ({ page, request }) => {
+    const taskName = `PW_Detail_${Date.now()}`
+    const taskId = await seedPlannedRun(request, taskName, [
+      { title: 'First step', description: 'Do the first thing' },
+      { title: 'Second step', description: 'Do the second thing' },
+    ])
+
+    try {
+      await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+
+      // Click the run in the sidebar
+      const runBtn = page.getByRole('button', { name: `Open project ${taskName}` })
+      await expect(runBtn).toBeVisible({ timeout: 10000 })
+      await runBtn.click()
+
+      // The detail view header shows the run name as a rename-able span
+      const headerName = page.locator('[aria-label="Rename project"]').first()
+      await expect(headerName).toBeVisible({ timeout: 5000 })
+      await expect(headerName).toHaveText(taskName)
+
+      // Status badge shows "planned" (use exact: true to avoid sidebar substring match)
+      await expect(page.getByText('planned', { exact: true })).toBeVisible()
+
+      // Execute button is present for planned runs
+      await expect(page.getByRole('button', { name: /Execute/i })).toBeVisible()
+    } finally {
+      await deleteRun(request, taskId)
+    }
+  })
+
+  test('renaming a run updates the sidebar and header', async ({ page, request }) => {
+    const taskName = `PW_Rename_${Date.now()}`
+    const taskId = await seedPlannedRun(request, taskName)
+    const newName = `PW_Renamed_${Date.now()}`
+
+    try {
+      await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+
+      // Click the run
+      const runBtn = page.getByRole('button', { name: `Open project ${taskName}` })
+      await expect(runBtn).toBeVisible({ timeout: 10000 })
+      await runBtn.click()
+
+      // Click the rename pencil icon to enter edit mode
+      const renameIcon = page.locator('[aria-label="Rename project"][title="Rename project"]')
+      await expect(renameIcon).toBeVisible({ timeout: 5000 })
+      await renameIcon.click()
+
+      // Rename input appears
+      const renameInput = page.getByLabel('Project name')
+      await expect(renameInput).toBeVisible()
+      await renameInput.fill(newName)
+      await renameInput.blur()
+
+      // After blur, the API persists the rename and the sidebar updates
+      const updatedBtn = page.getByRole('button', { name: `Open project ${newName}` })
+      await expect(updatedBtn).toBeVisible({ timeout: 10000 })
+    } finally {
+      await deleteRun(request, taskId)
+    }
+  })
+})

--- a/website/playwright/redirects.spec.ts
+++ b/website/playwright/redirects.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Redirect contract tests — routes that Navigate.replace to other pages.
+ *
+ * Covered here:
+ *  /agents      → /capabilities (Navigate replace)
+ *  /mc-agents   → /capabilities (Navigate replace)
+ *  /tasks       → /projects (TasksRedirect, preserves search params)
+ *  /orchestrated/:slug? → /chat/:slug? (OrchestratedRedirect, preserves slug + search)
+ *
+ * NOT covered (handled by sibling specs):
+ *  /overview    → /settings?tab=overview  (settings.spec.ts)
+ *  /instances   → /settings?tab=instances (settings.spec.ts)
+ *  /artifacts/deploy → /deploy            (artifacts.spec.ts)
+ */
+
+test.describe('Redirect contracts', () => {
+  test('/agents redirects to /capabilities and renders Agent Capabilities', async ({ page }) => {
+    await page.goto('/agents', { waitUntil: 'domcontentloaded' })
+    // React Router Navigate replace — URL should land on /capabilities
+    await page.waitForURL('**/capabilities', { timeout: 10000 })
+    // Verify the destination page actually rendered (not a blank error page)
+    await expect(page.locator('text=Agent Capabilities')).toBeVisible({ timeout: 10000 })
+    // Verify the default tab content (Agents table) is present
+    await expect(page.locator('text=Total Agents')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('/mc-agents redirects to /capabilities and renders Agent Capabilities', async ({ page }) => {
+    await page.goto('/mc-agents', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/capabilities', { timeout: 10000 })
+    await expect(page.locator('text=Agent Capabilities')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('text=Total Agents')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('/tasks redirects to /projects and renders Task Runner', async ({ page }) => {
+    await page.goto('/tasks', { waitUntil: 'domcontentloaded' })
+    // TasksRedirect: Navigate to="/projects" + search params
+    await page.waitForURL('**/projects', { timeout: 10000 })
+    // ProjectsPage renders "Task Runner" heading
+    await expect(page.locator('text=Task Runner')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/tasks preserves query params through redirect', async ({ page }) => {
+    await page.goto('/tasks?run=abc123', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/projects?run=abc123', { timeout: 10000 })
+    await expect(page.locator('text=Task Runner')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/orchestrated redirects to /chat and renders chat UI', async ({ page }) => {
+    await page.goto('/orchestrated', { waitUntil: 'domcontentloaded' })
+    // OrchestratedRedirect: Navigate to="/chat" + optional slug + search
+    await page.waitForURL('**/chat', { timeout: 10000 })
+    // Verify the chat page actually rendered — the ChatInput wrapper is present
+    await expect(page.locator('[data-testid="input-wrapper"]')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/orchestrated/:slug redirects to /chat/:slug', async ({ page }) => {
+    await page.goto('/orchestrated/my-session', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/chat/my-session', { timeout: 10000 })
+    await expect(page.locator('[data-testid="input-wrapper"]')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/orchestrated preserves search params through redirect', async ({ page }) => {
+    await page.goto('/orchestrated?intent=hello', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/chat?intent=hello', { timeout: 10000 })
+    await expect(page.locator('[data-testid="input-wrapper"]')).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/website/playwright/session-tags-e2e.spec.ts
+++ b/website/playwright/session-tags-e2e.spec.ts
@@ -2,8 +2,9 @@ import { test, expect, Page, APIRequestContext } from '@playwright/test'
 
 /**
  * Comprehensive headless-browser test of the Trello-style sidebar columns +
- * tag vocabulary. Each test is isolated — it creates its own columns/tags/
- * slots with unique names and cleans up at the end.
+ * tag vocabulary. Each test creates its own columns/tags/slots with unique
+ * names. Columns are wiped per test (see resetColumns + HARNESS_GATEWAY);
+ * seeded slots are NOT deleted, so this spec is harness-gateway only.
  */
 
 async function primeBrowser(page: Page, width = 1400) {
@@ -14,6 +15,34 @@ async function primeBrowser(page: Page, width = 1400) {
   }, width)
   await page.setViewportSize({ width: 1800, height: 1000 })
 }
+
+// The board/list view toggle is not a standalone control: it lives as a menu
+// item inside the sidebar header "More options" menu. Selector and 15s wait
+// mirror session-tags.spec.ts, which covers the same control.
+const HEADER_MENU = 'button[aria-haspopup="menu"][aria-label="More options"]'
+
+/** Wait for the sidebar header to render. Used as a "/chat is interactive" signal. */
+async function waitForSidebarHeader(page: Page) {
+  await page.locator(HEADER_MENU).first().waitFor({ timeout: 15_000 })
+}
+
+/** Flip board <-> list view via the header menu item. */
+async function toggleBoardView(page: Page) {
+  const headerMenu = page.locator(HEADER_MENU).first()
+  await headerMenu.waitFor({ timeout: 15_000 })
+  await headerMenu.click()
+  await page.getByRole('menuitem', { name: /switch to (board|list) view/i }).click()
+}
+
+// resetColumns() deletes EVERY tag column, not just ones this spec created, so
+// it is gated on an EXPLICIT ephemeral-harness marker -- same contract and same
+// reasoning as session-tags-folders.spec.ts. test/test_playwright_e2e.py sets
+// KIROCREW_E2E_EPHEMERAL for the throwaway tmp-home gateway it spawns. Token
+// presence alone is NOT a safe signal: it is also the normal state when
+// authenticating to a real token-protected gateway, so a developer pointing this
+// suite at their live gateway (to debug a failure) must never lose their columns.
+// Absent the marker the whole describe skips rather than wiping user state.
+const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
 
 async function resetColumns(request: APIRequestContext) {
   const list = await (await request.get('/api/chat/tag-columns')).json()
@@ -31,12 +60,12 @@ async function seedSlotWithTag(request: APIRequestContext, title: string, tagNam
 
 test.describe.configure({ mode: 'serial' })
 
-// @quarantine: this spec hard-crashes the chromium worker on its first failure
-// (a worker crash, not a retryable timeout), which aborts every subsequent
-// spec in the run. Excluded from the default gating set via grepInvert in
-// playwright.config.ts until the crash is root-caused. Tracked as a follow-up.
-test.describe('E2E: sidebar tag columns', { tag: '@quarantine' }, () => {
+test.describe('E2E: sidebar tag columns', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'destructive tag-column wipes require the ephemeral harness gateway (KIROCREW_E2E_EPHEMERAL)',
+    )
     await primeBrowser(page)
   })
 
@@ -50,7 +79,7 @@ test.describe('E2E: sidebar tag columns', { tag: '@quarantine' }, () => {
       localStorage.setItem('mc-chat-config', JSON.stringify(cfg))
     })
     await page.goto('/chat')
-    await page.waitForSelector('[data-testid="board-toggle"]')
+    await waitForSidebarHeader(page)
     await expect(page.locator('[data-testid="column-strip"]')).toHaveCount(0)
     const row = page.locator(`[data-slot-key="${slotKey}"]`)
     await expect(row).toBeVisible()
@@ -64,9 +93,9 @@ test.describe('E2E: sidebar tag columns', { tag: '@quarantine' }, () => {
       localStorage.setItem('mc-chat-config', JSON.stringify(cfg))
     })
     await page.goto('/chat')
-    await page.waitForSelector('[data-testid="board-toggle"]')
+    await waitForSidebarHeader(page)
     // Toggle ON
-    await page.click('[data-testid="board-toggle"]')
+    await toggleBoardView(page)
     await page.waitForSelector('[data-testid="column-strip"]', { timeout: 5_000 })
     await expect.poll(async () => (await (await request.get('/api/chat/tag-columns')).json()).length).toBeGreaterThan(0)
   })
@@ -103,7 +132,7 @@ test.describe('E2E: sidebar tag columns', { tag: '@quarantine' }, () => {
     await page.locator(`[data-testid="column-edit-${col.id}"]`).click()
     const tags2 = await (await request.get('/api/chat/tags')).json()
     const doneId2 = tags2.find((t: { name: string }) => t.name === 'Done').id
-    await page.locator(`[data-testid="tag-row-${doneId2}"] button[role="menuitemcheckbox"]`).click()
+    await page.locator(`[data-testid="tag-row-${doneId2}"] button[role="checkbox"]`).click()
     await page.waitForTimeout(300)
     // Column now shows only Done-tagged slot
     await expect(page.locator(`[data-testid="column-${col.id}"] [data-slot-key="${doneKey}"]`)).toBeVisible()
@@ -355,14 +384,14 @@ test.describe('E2E: sidebar tag columns', { tag: '@quarantine' }, () => {
     await expect(page.locator(`[data-testid="column-${colB.id}"]`)).toBeVisible()
 
     // Toggle OFF via header button
-    await page.click('[data-testid="board-toggle"]')
+    await toggleBoardView(page)
     await expect(page.locator('[data-testid="column-strip"]')).toHaveCount(0)
     // Backend columns are NOT deleted
     const persisted = await (await request.get('/api/chat/tag-columns')).json()
     expect(persisted.map((c: { id: string }) => c.id)).toEqual(expect.arrayContaining([colA.id, colB.id]))
 
     // Toggle ON again → both columns restored
-    await page.click('[data-testid="board-toggle"]')
+    await toggleBoardView(page)
     await page.waitForSelector(`[data-testid="column-${colA.id}"]`)
     await expect(page.locator(`[data-testid="column-${colB.id}"]`)).toBeVisible()
   })

--- a/website/playwright/settings.spec.ts
+++ b/website/playwright/settings.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test'
+
+// Mirrors MAX_RECENT_TINT_COUNT (website/src/utils/recencyTint.ts:13). Specs
+// cannot import from src/, so this is duplicated deliberately.
+const MAX_TINT = 50
+
+/**
+ * Settings page (/settings) — route-level Playwright coverage.
+ *
+ * Covers:
+ *  (a) Page load with tab strip rendering
+ *  (b) Tab navigation + ?tab= query-param round-trip
+ *  (c) Config mutation round-trip via the "Highlight recent sessions" stepper
+ *      (dashboard.recent_tint_count — server-persisted, cosmetic, test-safe)
+ *  (d) Redirect contracts: /overview → /settings?tab=overview,
+ *      /instances → /settings?tab=instances
+ */
+test.describe('Settings Page', () => {
+  test('loads and renders the tab strip with known tabs', async ({ page }) => {
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
+
+    // The page title rendered by SidePanelLayout inside the nav sidebar
+    await expect(page.getByText('Settings').first()).toBeVisible({ timeout: 10000 })
+
+    // Verify a selection of real tab labels exist as clickable buttons
+    await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Display', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Chat', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Instances', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'About', exact: true })).toBeVisible()
+  })
+
+  test('defaults to the overview tab when no ?tab= param', async ({ page }) => {
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
+    // Overview is the first tab and renders when no param is present.
+    // The content area heading should show "Overview"
+    await expect(page.getByRole('heading', { name: 'Overview' }).or(
+      page.locator('div').filter({ hasText: /^Overview$/ }).first()
+    )).toBeVisible({ timeout: 10000 })
+    // URL should NOT have ?tab=overview (SidePanelLayout strips the default)
+    expect(page.url()).not.toContain('tab=')
+  })
+
+  test('navigating between tabs updates the ?tab= query param', async ({ page }) => {
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
+
+    // Click Display tab button
+    const displayTab = page.getByRole('button', { name: 'Display', exact: true })
+    await expect(displayTab).toBeVisible({ timeout: 10000 })
+    await displayTab.click()
+
+    // URL should update to ?tab=display
+    await expect(page).toHaveURL(/[?&]tab=display/)
+
+    // Click About tab button
+    await page.getByRole('button', { name: 'About', exact: true }).click()
+    await expect(page).toHaveURL(/[?&]tab=about/)
+  })
+
+  test('direct navigation to ?tab=chat renders the Chat panel', async ({ page }) => {
+    await page.goto('/settings?tab=chat', { waitUntil: 'domcontentloaded' })
+
+    // The Chat panel should render its content — check for a known setting label
+    // ChatPanel contains the "Timestamps" toggle and other settings
+    await expect(page.locator('[data-setting-label]').first()).toBeVisible({ timeout: 10000 })
+    // URL should still have ?tab=chat
+    expect(page.url()).toContain('tab=chat')
+  })
+
+  test('config mutation round-trip: recent_tint_count via Display stepper', async ({ page, request }) => {
+    // Read the current value via API
+    const before = await (await request.get('/api/config/kirocrew')).json()
+    const originalCount: number = before?.dashboard?.recent_tint_count ?? 0
+
+    // Navigate to the Display tab
+    await page.goto('/settings?tab=display', { waitUntil: 'domcontentloaded' })
+
+    // Find the "Highlight recent sessions" stepper
+    const field = page.locator('[data-setting-label="Highlight recent sessions"]')
+    await expect(field).toBeVisible({ timeout: 10000 })
+
+    // Step in whichever direction is actually available. clampTintCount
+    // (recencyTint.ts:21) floors the value into [0, MAX_RECENT_TINT_COUNT=50],
+    // and DisplayPanel passes no `disabled` prop, so at 50 the Increase button
+    // is still clickable but the persisted value stays 50 -- an assertion of
+    // originalCount + 1 would then poll for 51 until it times out. The harness
+    // always starts at the 0 default so increment is the normal path, but a
+    // developer running this against a live gateway may sit at either bound.
+    const atMax = originalCount >= MAX_TINT
+    const delta = atMax ? -1 : 1
+    const btn = field.getByRole('button', { name: atMax ? 'Decrease' : 'Increase' })
+    await btn.click()
+
+    // Read back via API to verify server-side persistence. expect.poll owns the
+    // wait for the mutation to reach the server -- no fixed sleep needed.
+    await expect.poll(async () => {
+      const cfg = await (await request.get('/api/config/kirocrew')).json()
+      return cfg?.dashboard?.recent_tint_count
+    }, { timeout: 5000 }).toBe(originalCount + delta)
+
+    // Restore original value to not pollute other tests
+    await request.fetch('/api/config/kirocrew', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: JSON.stringify({ path: 'dashboard.recent_tint_count', value: originalCount }),
+    })
+  })
+
+  test('/overview redirects to /settings?tab=overview', async ({ page }) => {
+    await page.goto('/overview', { waitUntil: 'domcontentloaded' })
+    // React Router Navigate with replace — URL should land on /settings
+    // (overview is default so ?tab=overview may or may not be stripped)
+    await page.waitForURL('**/settings**', { timeout: 10000 })
+    // The Overview panel content should render (health status)
+    await expect(page.getByText(/All systems running|Connecting|Reconnecting/)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('/instances redirects to /settings?tab=instances', async ({ page }) => {
+    await page.goto('/instances', { waitUntil: 'domcontentloaded' })
+    await page.waitForURL('**/settings?tab=instances', { timeout: 10000 })
+    // Instances panel should render — check for the tab being active
+    await expect(page.getByRole('button', { name: 'Instances', exact: true })).toBeVisible({ timeout: 5000 })
+  })
+})


### PR DESCRIPTION
## What

The dashboard e2e suite executed **67 of 103** authored specs. The other 36 were excluded by `grepInvert` in `playwright.config.ts`, so they were never collected and never reported as skips. The gate stayed green while a third of the suite did not run. Thirteen more route trees had no coverage at all.

**Executed specs 67 → 208. Skips 1 → 0. Tag-excluded specs 36 → 1.**

- **De-quarantine `session-tags-e2e`** (33 specs). The quarantine comment blamed a chromium worker crash. Reproduction showed a plain `TimeoutError` on the first test, with the other 32 reported "did not run" only because the describe is `mode: 'serial'`. Two selectors were stale: the board toggle had moved into the sidebar header menu, and the tag-row filter is `role="checkbox"`, not `menuitemcheckbox`. Its destructive `resetColumns()` is now gated on `KIROCREW_E2E_EPHEMERAL`, mirroring the guard `session-tags-folders.spec.ts` already carried.
- **Teach the stub ACP backend the negative paths.** A daemon stdin reader makes it cancel-aware mid-stream, plus slow / error / max-tokens / refusal / gated sentinels. Two of the three soft-stop specs no longer need a live agent.
- **Scope destructive teardown to what the spec created.** `knowledge.spec.ts` cleaned up by deleting every item whose title began with `Playwright_`, which cannot distinguish seed data from a real item a user happened to name that way. It now deletes only the ids it generated. `notifications.spec.ts` called the global `/api/notifications/clear`, which the endpoint offers no way to scope, so that test is gated on `KIROCREW_E2E_EPHEMERAL`. Both would have destroyed user data on a developer pointing this suite at a live gateway.
- **Floor the executed count** at `expected + flaky >= 208` with zero skips, covered by 5 unit tests.
- **Seed the two self-skipping specs** instead of letting them skip.
- **Add specs** for Settings, Artifacts, Apps, Knowledge, Projects, Logs, Notifications, Capabilities, the redirect contracts, the builtin app routes, and the embed/popout shells.

## Why the floor, not a periodic audit

Every dark spec had also rotted, because nothing exercised it. Un-skipping them is what surfaced the stale selectors above, plus two assertions that could never have passed:

- `active-slot-persistence` round-tripped through `/orchestrated`, which is now a redirect to `/chat`, with `chat` the only builtin declaring a `slotMode`.
- The third soft-stop spec shrinks the stop budget via a `page.route` intercept, but `agent.soft_stop_budget_secs` is read server-side, so the override never applied. It stays tagged with an accurate reason rather than a raised timeout.

## Product findings (documented, not fixed)

Kept out of scope so this change stays test-only.

1. **`/apps/detail/:name` 404s on direct navigation or refresh.** `_APPS_SPA_EXCLUDED_RE` in `token_auth.py` parses the path as app-name `detail` with a sub-resource, so the SPA shell is withheld. `/apps/migrate/:name` shares the defect. `token_auth.py` is the auth/serving path and deserves its own review.
2. **The Knowledge onboarding empty state is unreachable.** `isEmpty` requires `!statusFilter` (`knowledge/index.tsx:403`) but `statusFilter` initialises to `'active'` (`:145`), so a fresh install never sees its own welcome screen.
3. **No `data-testid` on any page this PR covers**, and `PageHeader` renders its title as a plain `<div>`, not a heading (`ui.tsx:257`). A page title therefore collides with its own nav-rail label. That single ambiguity accounts for several of the fixes here. A follow-up adding test ids would let these specs drop their prose dependency entirely.

## Testing

`python setup.py test_e2e` (the CI entry point) on `origin/main@9062e36` with a fresh frontend build:

- **18 passed**. 208 Playwright specs executed, 0 skipped, 0 failed
- Stub backend unit tests: 25 passed
- Floor helper unit tests: 5 passed
- `tsc --noEmit` clean; `npm run lint` and `ruff` clean on every file touched here

Every gate this change is responsible for is green: E2E (stub ACP backend, offline), GPT 5.6 Review, Opus 5 Review, Arbiter, PR Hygiene, Frontend Tests.

One Windows backend shard fails, on a pre-existing load-dependent flake in a file this branch does not touch. `test_dashboard_chat.py::TestEmptyResponseRetry::test_first_empty_response_requeues_message` fails `assert mock_flush.call_count == 1` with `assert 6 == 1`. That signature is documented in the test's own source at `test_dashboard_chat.py:9458`: "Under build-fleet load the loop can schedule that task (and its own cascading re-drains) before the assertions run, each calling the patched _flush_file_changes again (observed flaking as `assert 6 == 1`)." The run also logs five `Task was destroyed but it is pending!` errors, which is the cascade that comment describes. The existing `_no_schedule` mitigation does not fully close the race on the slowest runner in the matrix. The prior revision hit a different Windows-only flake, `test_platform_compat.py::test_self_cmdline_mentions_python` (a 2-second PowerShell WMI query that returns `""` on timeout), so these are two distinct known flakes rather than one shard.

Written with an AI agent (Kiro), reviewed and verified by me.


