### PR TITLE
fix(chat): stop streaming response bubble from flashing

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -656,24 +656,41 @@ function rehypeStreamingGlow(options?: { tailChars?: number }) {
 /** Split a text run into individual characters for per-char animation. */
 const REVEAL_CHAR_RE = /[\s\S]/g
 
+/** How many trailing characters of the streaming tail get wrapped in per-char
+ *  `.ft-word` fade spans. Only this growing EDGE animates; text that has
+ *  settled behind it is left as plain text nodes.
+ *
+ *  Why bounded (streaming-flash fix): react-markdown re-parses the whole tail
+ *  block every streamed frame. When a newly-revealed char COMPLETES a markdown
+ *  token (inline `code`, **bold**, a [link], …) the subtree restructures, so
+ *  React unmounts/remounts the `.ft-word` spans for text that was already on
+ *  screen — re-firing the mount `ft-fade` and making already-visible words
+ *  flash. Confirmed by src/test/streamingFlashRepro.test.tsx (append remounts
+ *  0 spans; a completing token remounts already-visible spans). Wrapping only
+ *  the trailing edge means settled text carries no animated span, so a re-parse
+ *  can no longer re-fade it — the flash is confined to (and masked by) the
+ *  actively-arriving edge. The budget is generous enough to cover the smooth
+ *  buffer's per-frame reveal wave so genuinely-new text still fades in fully. */
+const REVEAL_TAIL_CHARS = 240
+
 /**
- * Rehype plugin: wrap streaming text in `<span class="ft-word">` so each
- * character plays a one-shot CSS entrance (fade) as it is
- * revealed.
+ * Rehype plugin: wrap the streaming tail's TRAILING EDGE in `<span
+ * class="ft-word">` so each newly-revealed character plays a one-shot CSS
+ * entrance (fade). Only the last REVEAL_TAIL_CHARS characters (across the
+ * trailing text nodes, cut on a word boundary) are wrapped; text that has
+ * settled behind the edge stays as plain text nodes.
  *
- * Wraps EVERY eligible text node in the streaming tail block (headers, list
- * items, table cells, paragraphs, blockquotes, link/emphasis text) — not just
- * the trailing run — so all markdown text fades, not only plain prose. Text
- * inside `code`/`pre` (rendered by the code components) and `.streaming-glow`
- * is skipped. Atomic block components (fenced code, widgets, mermaid, diffs)
- * are separate non-text blocks and are not char-faded here.
+ * Text inside `code`/`pre` (rendered by the code components) and
+ * `.streaming-glow` is skipped. Atomic block components (fenced code, widgets,
+ * mermaid, diffs) are separate non-text blocks and are not char-faded here.
  *
- * Safe against react-markdown re-parsing every frame: React reconciles the
- * per-char spans by position, so already-streamed chars reuse their DOM nodes
- * (no re-animation) and only newly-arrived trailing chars mount and fade. The
- * MarkdownBlock memo skips re-render of unchanged blocks, so a completed block
- * never re-fades when content changes elsewhere. On stream end the plugin
- * drops out and the tail reverts to plain text (clean for selection/copy).
+ * Safe against react-markdown re-parsing every frame on TWO levels: (a) within
+ * the edge, React reconciles the per-char spans by position so append-only
+ * growth only mounts new trailing chars; (b) bounding to the edge means a
+ * markdown-token completion behind it restructures only PLAIN text nodes (no
+ * `.ft-word`), so the mount `ft-fade` cannot re-fire on already-visible text —
+ * the streaming-flash root cause. On stream end the plugin drops out and the
+ * tail reverts to plain text (clean for selection/copy).
  */
 function rehypeStreamingReveal() {
   return (tree: HastRoot) => {
@@ -698,20 +715,39 @@ function rehypeStreamingReveal() {
     }
     for (let i = 0; i < tree.children.length; i++) walk(tree.children[i], tree, i, false)
     if (candidates.length === 0) return
-    // Splice in reverse document order so that replacing one text node with N
-    // char spans doesn't invalidate the indices of earlier candidates that
-    // share the same parent (higher indices are spliced first).
-    for (let c = candidates.length - 1; c >= 0; c--) {
+    // Wrap only the trailing REVEAL_TAIL_CHARS characters, walking candidates
+    // from the last (deepest in document order) backward and spending a shared
+    // budget. Everything before the edge is left as-is (plain text) so a
+    // re-parse behind the edge cannot re-fade already-visible text.
+    let budget = REVEAL_TAIL_CHARS
+    for (let c = candidates.length - 1; c >= 0 && budget > 0; c--) {
       const { parent, index, value } = candidates[c]
-      const tokens = value.match(REVEAL_CHAR_RE)
+      // For the boundary node, keep the leading (settled) portion as a plain
+      // text node and only wrap its trailing chars. Cut BACKWARD to the prior
+      // space (wrap a whole word rather than split one) — this consumes >=
+      // budget, so the budget is spent here and does not leak onto earlier
+      // (settled) candidates, keeping settled tokens plain.
+      let cut = 0
+      if (value.length > budget) {
+        const start = value.length - budget
+        const sp = value.lastIndexOf(' ', start)
+        cut = sp >= 0 ? sp + 1 : start
+      }
+      budget -= (value.length - cut)
+      const head = value.slice(0, cut)
+      const tail = value.slice(cut)
+      const tokens = tail.match(REVEAL_CHAR_RE)
       if (!tokens || tokens.length === 0) continue
-      const spans: HastElement[] = tokens.map(tok => ({
+      const spans: Array<HastElement | HastText> = tokens.map(tok => ({
         type: 'element',
         tagName: 'span',
         properties: { className: ['ft-word'] },
         children: [{ type: 'text', value: tok }],
       }))
-      spliceChildren(parent, index, spans)
+      // Splice highest index first (candidates ascend in document order, so
+      // walking c downward gives descending indices within a shared parent),
+      // keeping earlier candidates' indices valid.
+      spliceChildren(parent, index, head ? [{ type: 'text', value: head } as HastText, ...spans] : spans)
     }
   }
 }

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1030,8 +1030,14 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
    `.ft-anim-smooth` class (set on MarkdownRenderer's root) selects the
    entrance animation. Reverts to plain text when streaming ends. */
 @keyframes ft-fade{from{opacity:0}to{opacity:1}}
+/* Char reveal uses a SHORTER, SOFTER fade than the shared ft-fade block
+   entrance: streaming re-parse can briefly remount an edge char (a completing
+   markdown token), and a 0->1 / 0.6s pop makes that read as a flash. Fading
+   from 0.55 over 0.3s keeps new text legible on arrival while making any
+   residual edge re-fade a subtle blip rather than a full appear. */
+@keyframes ft-char-fade{from{opacity:.55}to{opacity:1}}
 .ft-word{white-space:pre-wrap}
-.ft-anim-smooth .ft-word{animation:ft-fade .6s ease-in-out both}
+.ft-anim-smooth .ft-word{animation:ft-char-fade .3s ease-out both}
 @media (prefers-reduced-motion:reduce){
   .ft-anim-smooth .ft-word{animation:none}
 }

--- a/website/src/test/streamingFlashRepro.test.tsx
+++ b/website/src/test/streamingFlashRepro.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * Root-cause probe for the "response bubble flashes while streaming" report.
+ *
+ * Hypothesis: `rehypeStreamingReveal` wraps EVERY char of the streaming tail
+ * block in `<span class="ft-word">` (each carrying `animation: ft-fade` on
+ * mount). The design assumes React reconciles those keyless spans by position
+ * so already-visible chars keep their DOM node and never re-animate. That
+ * holds for pure append, but when a newly-revealed char COMPLETES a markdown
+ * token (inline `code`, **bold**, a link, ...), react-markdown restructures
+ * the subtree, so React unmounts/remounts the spans for text that was already
+ * on screen — re-firing ft-fade → a visible flash.
+ *
+ * We can't see a CSS animation in jsdom, but a remount is exactly equivalent:
+ * the mount-triggered `ft-fade` only re-fires when the DOM node instance is
+ * replaced. So we compare `.ft-word` node IDENTITY across a streaming re-parse.
+ * Survived nodes (same instance) do NOT re-animate; replaced nodes DO.
+ */
+
+const STREAM = { streaming: true, glow: true, smooth: true } as const
+
+function ftWords(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('.ft-word'))
+}
+
+describe('streaming flash root cause', () => {
+  it('BASELINE: pure text append keeps already-revealed char nodes stable', () => {
+    // Tail is plain prose. Revealing more prose should only MOUNT new char
+    // spans; every previously-rendered char span must be the same instance.
+    const { container, rerender } = render(
+      <MarkdownRenderer content={'See code and more text here'} {...STREAM} />,
+    )
+    const before = ftWords(container)
+    expect(before.length).toBeGreaterThan(0)
+
+    rerender(<MarkdownRenderer content={'See code and more text here now'} {...STREAM} />)
+    const after = ftWords(container)
+
+    const survived = after.filter((n) => before.includes(n))
+    const remounted = before.filter((n) => !after.includes(n))
+
+    // Design intent: append-only reveal is stable — nothing already shown is
+    // torn down. All the original char nodes survive.
+    expect(survived.length).toBe(before.length)
+    expect(remounted.length).toBe(0)
+  })
+
+  it('BUG: completing an inline `code` token remounts the already-visible trailing text', () => {
+    // Tail before completion: an unclosed backtick renders as literal text, so
+    // "code and more text here" are all ft-word spans in one <p>.
+    const { container, rerender } = render(
+      <MarkdownRenderer content={'See `code and more text here'} {...STREAM} />,
+    )
+    const before = ftWords(container)
+    expect(before.length).toBeGreaterThan(0)
+
+    // Closing the backtick turns `code` into a <code> element, splitting the
+    // paragraph's children. Everything after the code span shifts position and
+    // type, so React remounts it — even though the text "and more text here"
+    // is UNCHANGED and was already on screen.
+    rerender(<MarkdownRenderer content={'See `code` and more text here'} {...STREAM} />)
+    const after = ftWords(container)
+
+    const survived = after.filter((n) => before.includes(n))
+    const remounted = before.filter((n) => !after.includes(n))
+
+    // Diagnostic output so the confirmation is legible in the run log.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[flash-repro] before=${before.length} after=${after.length} ` +
+        `survived=${survived.length} remounted=${remounted.length}`,
+    )
+
+    // If the bug is real, a large chunk of already-visible chars are remounted
+    // (their mount-time ft-fade re-fires → flash), NOT reconciled in place.
+    expect(remounted.length).toBeGreaterThan(0)
+  })
+
+  it('FIX: a token completing BEHIND the reveal edge renders plain (no fade span) so already-visible text cannot re-fade', () => {
+    // Inline-code token near the START, then a long plain tail so the token
+    // sits well behind the 240-char reveal edge. When it completes it must
+    // restructure PLAIN text (no .ft-word), so nothing already on screen
+    // re-fades. Only the trailing edge stays animated.
+    const tail = 'more '.repeat(70) // ~350 chars of plain, growing tail
+    const c1 = `start see \`code and then ${tail}`
+    const c2 = `start see \`code\` and then ${tail}extra ` // token completes + tail grows
+
+    const { container, rerender } = render(<MarkdownRenderer content={c1} {...STREAM} />)
+    rerender(<MarkdownRenderer content={c2} {...STREAM} />)
+    const after = ftWords(container)
+
+    // 1. Reveal is EDGE-BOUNDED: only ~REVEAL_TAIL_CHARS (240) chars are
+    //    wrapped, not the whole ~380-char block (pre-fix this was the full count).
+    expect(after.length).toBeGreaterThan(0)
+    expect(after.length).toBeLessThanOrEqual(245)
+
+    // 2. The completed token materializes a <code> element in the SETTLED
+    //    region, and it sits BEFORE the first fade span in document order —
+    //    i.e. the settled token carries no .ft-word and therefore cannot flash.
+    const code = container.querySelector('code')
+    const firstFtWord = container.querySelector('.ft-word')
+    expect(code).not.toBeNull()
+    expect(firstFtWord).not.toBeNull()
+    expect(
+      !!(code!.compareDocumentPosition(firstFtWord!) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true)
+
+    // 3. No fade span contains the settled token's text.
+    expect(after.some((n) => (n.textContent || '').includes('c'))).toBeDefined()
+    const settledHasFade = Array.from(container.querySelectorAll('code .ft-word')).length
+    expect(settledHasFade).toBe(0)
+
+    // eslint-disable-next-line no-console
+    console.log(`[flash-fix] edge-bounded ft-word count=${after.length}; settled token plain (code before first fade span)`)
+  })
+})


### PR DESCRIPTION
## Problem
While an assistant reply is streaming, the response bubble **flashes** — text that is already on screen briefly re-fades/re-brightens as more of the reply arrives. It's most noticeable on replies containing inline `code`, **bold**, or links.

## Why it matters
The flashing is distracting and makes streaming feel unstable/janky on every streamed reply — a high-frequency polish issue in the most-used surface of the app. (Users with `prefers-reduced-motion` never saw it, since the char fade is disabled there.)

## Fix (symptom → root cause → change)
- **Symptom:** already-visible words re-fade mid-stream.
- **Root cause:** `rehypeStreamingReveal` wrapped **every** character of the streaming tail block in `<span class="ft-word">`, each carrying a mount-triggered `ft-fade` animation. The design relied on React reconciling those keyless spans in place so only new chars animate — which holds for pure text append, but **not** when a newly-revealed character completes a markdown token. Closing a token (e.g. `` `code` ``, `**bold**`, `[link]()`) makes react-markdown restructure that part of the tree, so React unmounts/remounts the spans for text that was already visible, re-firing `ft-fade` → the flash. Confirmed with a DOM-node-identity probe: pure append remounts **0** already-visible char spans; completing an inline-code token remounts several.
- **Change:**
  1. Bound the per-char reveal to only the **growing trailing edge** (`REVEAL_TAIL_CHARS = 240`, cut on a word boundary). Text that has settled behind the edge is left as plain text nodes, so a re-parse behind the edge no longer has any `.ft-word` span to re-fade. The flash is confined to (and masked by) the actively-arriving edge.
  2. Give the char reveal a dedicated, shorter/softer keyframe `ft-char-fade` (fade `0.55 → 1` over `0.3s`) instead of the shared `ft-fade` (`0 → 1` over `0.6s`), so any residual edge re-fade is a subtle blip rather than a full pop. The shared `ft-fade` (used by `.ft-block-reveal`) is intentionally left unchanged, and the `prefers-reduced-motion` guard still applies (it targets the selector, not the animation name).

## Tests
- `website/src/test/streamingFlashRepro.test.tsx` (new):
  - **BASELINE** — pure text append keeps already-revealed char-span DOM nodes stable (remounted = 0).
  - **BUG** — completing an inline-code token remounts already-visible char spans (the flash), documenting the root cause.
  - **FIX** — a token completing behind the reveal edge renders as plain text (no `.ft-word`), and the reveal is bounded to the ~240-char edge, so already-visible text cannot re-fade.
- Existing `MarkdownRenderer` / streaming suites still pass (66 related tests green); `tsc -b` and eslint clean.

## Manual verification
N/A for a static artifact — the change is **streaming-motion timing**. A still frame of the bubble is identical before/after (same text, same colors); the only difference is transient per-frame opacity while text streams in. The behavior is instead locked in deterministically by the DOM-remount-identity assertions in the new test (a remount is exactly what re-fires the CSS mount animation), so unit coverage stands in for the visual. A full live-stream visual check was not run here (the dev sandbox blocks minting a dashboard session token).

## Screenshots
N/A — motion-only change with no altered static layout, colors, or components; see Manual verification above.
