### PR TITLE
feat(ci): Publish Windows desktop + update feed on all channels

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -161,6 +161,33 @@ jobs:
       appimage_artifact: build-linux-x64
     secrets: inherit
 
+  # ── Windows desktop publish ───────────────────────────────────────────
+  # Publishes the Squirrel.Windows installer + update package + RELEASES
+  # pointer + feed/nightly/latest-win.json. Its own lane beside
+  # publish-linux for the same reason: Windows takes no part in the macOS
+  # trust chain, and needing only build-desktop means neither a wheel nor a
+  # macOS signing failure can block it (per-platform releases).
+  #
+  # NOTE the interaction with build-desktop's windows_soft_fail: that flag
+  # keeps a Windows PACKAGING failure from skipping this run's other
+  # publish lanes, which means this job can be reached with no artifact.
+  # It fails loudly in that case by design -- a silent skip would serve a
+  # stale Windows feed under a green run.
+  publish-windows:
+    name: Publish Windows Desktop (nightly channel)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-windows.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      publish: true
+      windows_artifact: build-windows-x64
+    secrets: inherit
+
   # ── Docker image publish ──────────────────────────────────────────────
   # Builds the multi-arch gateway image FROM THE SAME WHEEL publish-cli
   # ships and pushes it to ghcr.io (GITHUB_TOKEN only — no AWS credentials,

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -1,0 +1,364 @@
+name: Publish Windows Desktop (reusable)
+
+# Reusable workflow: publish an already-built Windows desktop release to a
+# channel on the distribution CDN. Called by nightly.yml (channel: nightly)
+# and release.yml (channel: insider | stable) as its own lane BESIDE
+# publish-linux.yml and the macOS sign-and-notarize workflow. Windows takes
+# no part in the macOS trust chain, so it does not live in that workflow;
+# depending only on build-desktop at the caller means neither a wheel build
+# nor a macOS signing failure can block the Windows artifacts
+# (per-platform releases, see docs/RELEASE_AUTOMATION.md).
+#
+# WHAT SQUIRREL.WINDOWS REQUIRES, AND WHY THE LAYOUT LOOKS LIKE THIS
+#
+# Squirrel.Windows' updater is handed ONE directory URL. It fetches
+# `RELEASES` from that directory and resolves each entry's `.nupkg`
+# filename RELATIVE to the same directory. Pointer and bytes are therefore
+# coupled into a single prefix by the protocol -- our usual
+# updates.crew.kiro.dev (pointers) / download.crew.kiro.dev (bytes) split
+# cannot be honored inside it. Resolution: the whole Squirrel directory
+# lives on the BYTE host (the .nupkg payloads dominate it), and the true
+# pointer a client or a download button reads --
+# feed/<channel>/latest-win.json -- stays on the feed prefix like every
+# other channel. Published keys:
+#
+#   desktop/<channel>/<version>/KiroCrew-Setup-x64.exe   immutable installer
+#   desktop/<channel>/latest/KiroCrew-Setup-x64.exe      mutable permalink
+#   desktop/<channel>/win/<Product>-<ver>-full.nupkg     immutable update payload
+#   desktop/<channel>/win/RELEASES                       mutable Squirrel pointer
+#   feed/<channel>/latest-win.json                       mutable channel pointer
+#
+# The Squirrel feed URL for a channel is the DIRECTORY:
+#   <CDN>/desktop/<channel>/win/
+#
+# Key properties:
+#   - Versioned keys are immutable-cached by CloudFront and are never
+#     republished with different bytes (--if-none-match conditional write;
+#     a 412 on a job re-run verifies the published bytes are identical
+#     before continuing, and refuses to repoint any alias if they are not).
+#     The .nupkg is immutable by FILENAME (it carries the version), which is
+#     what lets Squirrel's directory accumulate versions safely.
+#   - Mutable pointers (latest alias, RELEASES, latest-win.json) are written
+#     AFTER the bytes they describe, so a pointer never references bytes
+#     that are not yet live. RELEASES is written after its .nupkg;
+#     latest-win.json is written last of all.
+#   - Arch-qualified published filename (KiroCrew-Setup-x64.exe): Windows
+#     has no universal binary, so per-arch filenames are the contract. A
+#     future arm64 lane publishes KiroCrew-Setup-arm64.exe beside this one.
+#   - RELEASES is published AS BUILT (single full entry, no deltas). We ship
+#     full packages only, so one entry is sufficient: Squirrel compares the
+#     installed version against the newest entry and downloads that full
+#     package from any older version. Accumulating entries would be needed
+#     only for delta updates, and would require a read-modify-write of a
+#     mutable object -- a race we deliberately avoid. If deltas are ever
+#     wanted, that merge needs a conditional write and its own design.
+#   - Unsigned by design for now, exactly like the AppImage: SmartScreen
+#     shows an "unrecognized app" interstitial. Authenticode signing is a
+#     tracked follow-up; when it lands it slots in before the attestation
+#     step below, and this lane's keys/pointers do not change.
+#   - HARD dependency on the build artifact, on purpose. build-desktop.yml
+#     marks its Windows matrix leg continue-on-error for publishing callers
+#     (so a Windows packaging failure cannot skip the Linux/mac publish
+#     lanes). The cost of that isolation is that this lane can be reached
+#     with no artifact to publish -- and a silent skip there would leave a
+#     STALE Windows feed while the run looked green. So a missing artifact
+#     fails this job loudly: the other lanes still publish, the run goes
+#     red, and nobody is served a stale pointer. (Closes the revisit item
+#     recorded in issue #487.)
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Release channel: nightly | insider | stable"
+        required: true
+        type: string
+      version:
+        description: "Version label used in S3 keys and the feed body"
+        required: true
+        type: string
+      publish:
+        description: "Publish to the public CDN; false skips the job entirely"
+        required: false
+        type: boolean
+        default: true
+      windows_artifact:
+        description: "Name of the uploaded artifact containing Setup.exe + .nupkg + RELEASES"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  publish-windows:
+    name: Publish Windows Desktop (${{ inputs.channel }})
+    # Public-distribution gates: skipped when the caller runs publish-less or
+    # the CDN is not configured (fork). BOTH variables are required -- the
+    # bucket receives the upload and the CDN base is baked into the public
+    # URLs and used by the 412 re-run byte-verify; with either missing the
+    # job skips rather than publishing objects it cannot verify or address.
+    if: ${{ inputs.publish && vars.CLI_DIST_BUCKET != '' && vars.CLI_CDN_BASE != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # REQUIRED: the publish role's OIDC trust accepts exactly two subjects,
+    # ref:refs/heads/main and environment:prod. Declaring the environment
+    # keeps tag-triggered (release) runs on the accepted subject, same as
+    # publish-cli.yml, publish-linux.yml, and sign-and-notarize.yml.
+    environment: prod
+    env:
+      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      # Pinned published basename, arch-qualified. The BUILT name varies
+      # (electron-builder's default embeds productName + version, and the
+      # nightly channel builds under a different product name), so the
+      # published contract is pinned here and the built file is located by
+      # glob below.
+      WIN_SETUP_BASENAME: KiroCrew-Setup-x64
+    steps:
+      - name: Configure AWS credentials
+        if: env.HAS_SIGNING_SECRETS
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Download desktop build artifact
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.windows_artifact }}
+          path: artifacts
+
+      # Locate all three Squirrel outputs and fail loudly on anything
+      # unexpected. A missing artifact means the Windows build leg
+      # soft-failed upstream (see the header): failing here is deliberate --
+      # it keeps a stale feed from being served under a green run.
+      - name: Locate Windows release outputs
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          mapfile -t SETUPS < <(find artifacts -type f -name '*.exe')
+          mapfile -t NUPKGS < <(find artifacts -type f -name '*-full.nupkg')
+          mapfile -t RELEASES_FILES < <(find artifacts -type f -name 'RELEASES')
+
+          fail=0
+          if [ "${#SETUPS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Setup .exe in the Windows artifact, found ${#SETUPS[@]}"
+            printf '  %s\n' "${SETUPS[@]:-<none>}"; fail=1
+          fi
+          if [ "${#NUPKGS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one *-full.nupkg in the Windows artifact, found ${#NUPKGS[@]}"
+            printf '  %s\n' "${NUPKGS[@]:-<none>}"; fail=1
+          fi
+          if [ "${#RELEASES_FILES[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one RELEASES file in the Windows artifact, found ${#RELEASES_FILES[@]}"
+            printf '  %s\n' "${RELEASES_FILES[@]:-<none>}"; fail=1
+          fi
+          [ "$fail" -eq 0 ] || exit 1
+
+          echo "SETUP_PATH=${SETUPS[0]}" >> "$GITHUB_ENV"
+          echo "NUPKG_PATH=${NUPKGS[0]}" >> "$GITHUB_ENV"
+          echo "NUPKG_NAME=$(basename "${NUPKGS[0]}")" >> "$GITHUB_ENV"
+          echo "RELEASES_PATH=${RELEASES_FILES[0]}" >> "$GITHUB_ENV"
+          ls -la "${SETUPS[0]}" "${NUPKGS[0]}" "${RELEASES_FILES[0]}"
+
+      # The RELEASES entry Squirrel will read must name the .nupkg we are
+      # about to publish, or every client update 404s against the published
+      # directory. electron-builder generates both together, so a mismatch
+      # means the artifact was assembled wrongly -- check before publishing
+      # rather than discovering it from a user's failed update.
+      - name: Verify RELEASES references the published nupkg
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          echo "RELEASES contents:"; cat "${RELEASES_PATH}"
+          if ! grep -Fq "${NUPKG_NAME}" "${RELEASES_PATH}"; then
+            echo "::error::RELEASES does not reference ${NUPKG_NAME}; Squirrel clients would 404 on update."
+            exit 1
+          fi
+          # Squirrel resolves entries relative to the RELEASES directory, so
+          # an entry carrying a path separator or an absolute URL would
+          # escape the published prefix.
+          if grep -Eq '(https?://|[\\]|/)' <<< "$(awk '{print $2}' "${RELEASES_PATH}")"; then
+            echo "::error::RELEASES contains a non-relative filename; refusing to publish."
+            exit 1
+          fi
+          echo "RELEASES references the published nupkg by bare filename: OK"
+
+      # Signed SLSA provenance for the EXACT bytes this lane uploads,
+      # attested BEFORE anything reaches S3 -- same discipline as
+      # publish-linux.yml. Both payloads are attested: the installer humans
+      # download and the update package Squirrel downloads. If attestation
+      # fails, the job fails and nothing is published.
+      - name: Attest Windows artifact provenance
+        if: env.HAS_SIGNING_SECRETS
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            ${{ env.SETUP_PATH }}
+            ${{ env.NUPKG_PATH }}
+
+      - name: Publish Setup.exe to distribution bucket
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          SETUP_KEY="desktop/${CHANNEL}/${VERSION}/${WIN_SETUP_BASENAME}.exe"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${SETUP_KEY}" \
+            --body "${SETUP_PATH}" \
+            --if-none-match '*' \
+            --content-type application/vnd.microsoft.portable-executable \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              # Job re-run: the immutable key exists. Verify the published
+              # bytes are IDENTICAL before continuing -- a re-run can build
+              # different bytes for the same version, and proceeding would
+              # let the mutable pointers diverge from the immutable key.
+              # The compare goes through the public CDN because the publish
+              # role's S3 read-back grant covers cli/* only.
+              echo "Key already published (job re-run) -- verifying bytes match: ${SETUP_KEY}"
+              curl -fsSL --retry 3 "${{ vars.CLI_CDN_BASE }}/${SETUP_KEY}" -o /tmp/published-setup.exe
+              PUBLISHED_SHA=$(sha256sum /tmp/published-setup.exe | awk '{print $1}')
+              LOCAL_SHA=$(sha256sum "${SETUP_PATH}" | awk '{print $1}')
+              rm -f /tmp/published-setup.exe
+              if [ "$PUBLISHED_SHA" != "$LOCAL_SHA" ]; then
+                echo "::error::Immutable key ${SETUP_KEY} already holds DIFFERENT bytes (published ${PUBLISHED_SHA}, this build ${LOCAL_SHA}). The version string is burned -- cut a new version instead of re-running. Refusing to repoint any pointer."
+                exit 1
+              fi
+              echo "Published bytes identical -- keeping existing object and continuing."
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "SETUP_KEY=${SETUP_KEY}" >> "$GITHUB_ENV"
+          echo "SETUP_SHA256=$(sha256sum "${SETUP_PATH}" | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "Public installer: ${{ vars.CLI_CDN_BASE }}/${SETUP_KEY}"
+
+      # The update payload lands in the Squirrel directory under its BUILT
+      # filename (which carries the version), so the directory accumulates
+      # one immutable object per release -- exactly what Squirrel's
+      # RELEASES-relative resolution expects. Written BEFORE RELEASES so
+      # the pointer never names bytes that are not yet live.
+      - name: Publish update package to Squirrel directory
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          NUPKG_KEY="desktop/${CHANNEL}/win/${NUPKG_NAME}"
+          set +e
+          PUT_OUT=$(aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${NUPKG_KEY}" \
+            --body "${NUPKG_PATH}" \
+            --if-none-match '*' \
+            --content-type application/octet-stream \
+            --cache-control "public, max-age=31536000, immutable" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$PUT_OUT" | grep -q "PreconditionFailed"; then
+              echo "Package already published (job re-run) -- verifying bytes match: ${NUPKG_KEY}"
+              curl -fsSL --retry 3 "${{ vars.CLI_CDN_BASE }}/${NUPKG_KEY}" -o /tmp/published.nupkg
+              PUBLISHED_SHA=$(sha256sum /tmp/published.nupkg | awk '{print $1}')
+              LOCAL_SHA=$(sha256sum "${NUPKG_PATH}" | awk '{print $1}')
+              rm -f /tmp/published.nupkg
+              if [ "$PUBLISHED_SHA" != "$LOCAL_SHA" ]; then
+                echo "::error::Immutable key ${NUPKG_KEY} already holds DIFFERENT bytes (published ${PUBLISHED_SHA}, this build ${LOCAL_SHA}). Refusing to publish a RELEASES pointer that would disagree with it."
+                exit 1
+              fi
+              echo "Published bytes identical -- keeping existing object and continuing."
+            else
+              echo "$PUT_OUT"
+              exit $RC
+            fi
+          fi
+          echo "NUPKG_KEY=${NUPKG_KEY}" >> "$GITHUB_ENV"
+          echo "Update package: ${{ vars.CLI_CDN_BASE }}/${NUPKG_KEY}"
+
+      # RELEASES is the Squirrel updater's go-live switch for this channel:
+      # a mutable pointer, written only after its .nupkg is live. Short TTL
+      # so a published update is discoverable within minutes, matching the
+      # other mutable pointers in this system.
+      - name: Update Squirrel RELEASES pointer
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          RELEASES_KEY="desktop/${CHANNEL}/win/RELEASES"
+          aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${RELEASES_KEY}" \
+            --body "${RELEASES_PATH}" \
+            --content-type text/plain \
+            --cache-control "public, max-age=300" > /dev/null
+          echo "RELEASES_KEY=${RELEASES_KEY}" >> "$GITHUB_ENV"
+          echo "Squirrel feed directory: ${{ vars.CLI_CDN_BASE }}/desktop/${CHANNEL}/win/"
+
+      # Human-clickable permalink to the current installer:
+      #   <CDN>/desktop/<channel>/latest/KiroCrew-Setup-x64.exe
+      # Same mutable-alias semantics as the latest DMG/AppImage aliases:
+      # plain overwrite, max-age=300, written AFTER the versioned key.
+      - name: Update latest installer alias
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          LATEST_SETUP_KEY="desktop/${CHANNEL}/latest/${WIN_SETUP_BASENAME}.exe"
+          aws s3api put-object \
+            --bucket "${{ vars.CLI_DIST_BUCKET }}" \
+            --key "${LATEST_SETUP_KEY}" \
+            --body "${SETUP_PATH}" \
+            --content-type application/vnd.microsoft.portable-executable \
+            --cache-control "public, max-age=300" > /dev/null
+          echo "LATEST_SETUP_KEY=${LATEST_SETUP_KEY}" >> "$GITHUB_ENV"
+          echo "Latest installer alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_SETUP_KEY}"
+
+      # The channel pointer, written LAST -- after every byte it names is
+      # live. Mirrors latest-mac.json's shape and adds what a Windows client
+      # needs: `releases` is the DIRECTORY URL Squirrel is handed (its
+      # protocol resolves RELEASES and each .nupkg relative to it), and
+      # `sha256` covers the installer so a download can be verified
+      # fail-closed without trusting the transport.
+      - name: Write update feed
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          cat > /tmp/latest-win.json <<EOF
+          {
+            "version": "${VERSION}",
+            "setup": "${{ vars.CLI_CDN_BASE }}/${SETUP_KEY}",
+            "releases": "${{ vars.CLI_CDN_BASE }}/desktop/${CHANNEL}/win/",
+            "nupkg": "${{ vars.CLI_CDN_BASE }}/${NUPKG_KEY}",
+            "sha256": "${SETUP_SHA256}",
+            "name": "${VERSION}",
+            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat /tmp/latest-win.json
+          aws s3 cp /tmp/latest-win.json \
+            "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-win.json" \
+            --content-type application/json \
+            --cache-control "public, max-age=300"
+          echo "Feed written: feed/${CHANNEL}/latest-win.json"
+
+      - name: Summary
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          {
+            echo "## Publish Windows (${CHANNEL})"
+            echo "- Version: ${VERSION}"
+            echo "- Installer: ${{ vars.CLI_CDN_BASE }}/${SETUP_KEY}"
+            echo "- Latest installer alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_SETUP_KEY}"
+            echo "- Squirrel feed directory: ${{ vars.CLI_CDN_BASE }}/desktop/${CHANNEL}/win/"
+            echo "- Update package: ${{ vars.CLI_CDN_BASE }}/${NUPKG_KEY}"
+            echo "- Channel pointer: ${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/latest-win.json"
+            echo ""
+            echo "Unsigned installer: SmartScreen shows an \"unrecognized app\" interstitial (More info > Run anyway). Authenticode signing is a tracked follow-up."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,33 @@ jobs:
       appimage_artifact: build-linux-x64
     secrets: inherit
 
+  # ── Windows desktop publish ───────────────────────────────────────────
+  # Publishes the Squirrel.Windows installer + update package + RELEASES
+  # pointer + feed/<channel>/latest-win.json for insider|stable. Its own
+  # lane beside publish-linux: Windows takes no part in the macOS trust
+  # chain, and needing only build-desktop means neither a wheel nor a macOS
+  # signing failure can block it (per-platform releases).
+  #
+  # NOTE the interaction with build-desktop's windows_soft_fail: that flag
+  # keeps a Windows PACKAGING failure from skipping this release's other
+  # publish lanes, which means this job can be reached with no artifact. It
+  # fails loudly in that case by design -- a silent skip would leave a
+  # channel's Windows feed stale while the release looked green.
+  publish-windows:
+    name: Publish Windows Desktop (${{ needs.version.outputs.channel }} channel)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-windows.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.version }}
+      publish: true
+      windows_artifact: build-windows-x64
+    secrets: inherit
+
   # ── Docker image publish ──────────────────────────────────────────────
   # Multi-arch gateway image from the SAME wheel publish-cli ships, pushed
   # to ghcr.io with the workflow's own GITHUB_TOKEN (no AWS credentials).

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -5,22 +5,50 @@ The cross-platform process / signal / file-lock / metrics behavior is routed
 through `kiro_crew.platform_compat`, so macOS + Linux behavior is unchanged and
 the same code path also runs on Windows.
 
-## Desktop installer (preview, CI-built)
+## Desktop installer (download)
 
-CI's desktop lane (`build-desktop.yml`) also builds a Windows desktop app:
+CI's desktop lane (`build-desktop.yml`) builds a Windows desktop app —
 `KiroCrew Setup.exe` plus the Squirrel.Windows `RELEASES`/`.nupkg` pair, with
-the backend bundled (no separate Python install needed). Current status:
+the backend bundled (no separate Python install needed) — and
+`publish-windows.yml` publishes it to the download CDN on every channel.
 
-- **CI artifact only** — produced on nightly/release runs and the manual
-  `workflow_dispatch` probe; not yet published to the download CDN (that is
-  the upcoming `publish-windows.yml` lane).
+Direct download (installer, ~arch-qualified, always the newest build on that
+channel):
+
+```
+https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup-x64.exe
+https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-Setup-x64.exe
+https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-Setup-x64.exe
+```
+
+A specific build stays available forever at its immutable versioned key:
+
+```
+https://download.crew.kiro.dev/desktop/<channel>/<version>/KiroCrew-Setup-x64.exe
+```
+
+Machine-readable channel pointer (version, installer URL, sha256, publish
+date), same role as `latest-mac.json`:
+
+```
+https://updates.crew.kiro.dev/feed/<channel>/latest-win.json
+```
+
+Current caveats:
+
 - **Unsigned** — SmartScreen shows an "unrecognized app" interstitial
   (More info > Run anyway). Authenticode signing is a tracked follow-up.
-- **No auto-update yet** — the app does not consume the Squirrel feed on
-  win32 until the publish + updater lane lands; installs update by running a
-  newer Setup.exe.
+- **In-app auto-update is not wired yet.** The publish lane produces the
+  Squirrel update feed (`RELEASES` + `.nupkg` under
+  `desktop/<channel>/win/`), but `auto-update.js` does not consume it on
+  win32 yet, so installs update by running a newer `Setup.exe`. The feed is
+  published ahead of the client so the client change is a pure client
+  change.
+- A channel only has these URLs once it has published at least one Windows
+  build; `nightly` publishes on every nightly run, `insider`/`stable` on tag.
 
-The source install below remains the fully supported path.
+The source install below remains fully supported and is the fastest path for
+development work.
 
 ## Prerequisites
 

--- a/test/test_publish_windows_contract.py
+++ b/test/test_publish_windows_contract.py
@@ -1,0 +1,229 @@
+"""Contract tests for the publish-windows lane's ordering and immutability.
+
+The lane's documented guarantees, each pinned structurally because a
+plausible-looking edit re-opens a failure mode that only manifests in the
+field (a client mid-update, a job re-run, a soft-failed build leg):
+
+* **No pointer ever names bytes that are not live.** Squirrel's `RELEASES`
+  must be written only after its `.nupkg`; the `latest` installer alias only
+  after the immutable versioned key; `latest-win.json` last of all. Reorder
+  any of these and a client can read a pointer to a 404.
+* **Immutable keys are never republished with different bytes.** Both
+  payload writes use a conditional put and, on the 412 re-run path, verify
+  the published bytes are identical before letting any pointer move --
+  otherwise a re-run that produces different bytes leaves the mutable
+  pointers disagreeing with the immutable key (the CloudFront
+  edge-divergence class fixed for `cli/*` in #62).
+* **`RELEASES` is validated against the package being published.** Squirrel
+  resolves each entry relative to the RELEASES directory, so an entry naming
+  a different file -- or carrying a path/URL -- breaks or escapes the
+  published prefix.
+* **A missing build artifact fails loudly.** `build-desktop.yml` marks its
+  Windows leg continue-on-error for publishing callers, so this lane can be
+  reached with nothing to publish; a silent skip would serve a stale feed
+  under a green run (issue #487's revisit item).
+* **Both callers wire it identically to the Linux lane** (`needs:
+  [version, build-desktop]`, `environment: prod` via the reusable workflow,
+  publish gates on the CDN vars).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-windows.yml"
+CALLERS = (
+    ROOT / ".github" / "workflows" / "nightly.yml",
+    ROOT / ".github" / "workflows" / "release.yml",
+)
+
+
+def _text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _step_index(name_fragment: str) -> int:
+    """Line index of the step whose name contains the fragment."""
+    lines = _text().splitlines()
+    for i, line in enumerate(lines):
+        if re.match(r"\s*- name: ", line) and name_fragment.lower() in line.lower():
+            return i
+    raise AssertionError(f"no step matching {name_fragment!r} in publish-windows.yml")
+
+
+def test_releases_pointer_is_written_after_its_package() -> None:
+    """Squirrel reads RELEASES then fetches the .nupkg it names."""
+    assert _step_index("Publish update package") < _step_index("Update Squirrel RELEASES"), (
+        "RELEASES is written before its .nupkg is live -- a client that polls in "
+        "between reads a pointer to a 404"
+    )
+
+
+def test_latest_alias_is_written_after_the_versioned_key() -> None:
+    assert _step_index("Publish Setup.exe") < _step_index("Update latest installer alias"), (
+        "the latest alias is written before the immutable versioned key -- the "
+        "permalink can serve bytes that are not yet published"
+    )
+
+
+def test_feed_is_written_last() -> None:
+    """The channel pointer is the terminal go-live switch."""
+    feed = _step_index("Write update feed")
+    for earlier in (
+        "Publish Setup.exe",
+        "Publish update package",
+        "Update Squirrel RELEASES",
+        "Update latest installer alias",
+    ):
+        assert _step_index(earlier) < feed, (
+            f"{earlier!r} runs AFTER the feed write; the feed must be the last "
+            "pointer moved so it never names bytes or pointers that are not live"
+        )
+
+
+def test_immutable_writes_are_conditional_and_verify_on_reruns() -> None:
+    """Both payloads: conditional put + identical-bytes check on the 412 path."""
+    text = _text()
+    conditional = text.count("--if-none-match '*'")
+    assert conditional == 2, (
+        f"expected exactly 2 conditional writes (Setup.exe + .nupkg), found "
+        f"{conditional}; an unconditional put can republish an immutable key"
+    )
+    precondition_paths = text.count("PreconditionFailed")
+    assert precondition_paths == 2, (
+        f"expected a 412 re-run path for each immutable write, found " f"{precondition_paths}"
+    )
+    # Each 412 path must compare hashes and refuse rather than continue.
+    assert text.count("already holds DIFFERENT bytes") == 2, (
+        "a 412 path continues without proving the published bytes match this "
+        "build; the mutable pointers would then disagree with the immutable key"
+    )
+
+
+def _step_body(name_fragment: str) -> str:
+    """Text of one step, from its `- name:` line to the next step."""
+    lines = _text().splitlines()
+    start = _step_index(name_fragment)
+    for j in range(start + 1, len(lines)):
+        if re.match(r"\s*- name: ", lines[j]):
+            return "\n".join(lines[start:j])
+    return "\n".join(lines[start:])
+
+
+def test_mutable_pointers_use_short_ttl() -> None:
+    """Every pointer must be re-writable: no immutable cache on a pointer."""
+    for pointer in (
+        "Update Squirrel RELEASES",
+        "Update latest installer alias",
+        "Write update feed",
+    ):
+        body = _step_body(pointer)
+        assert "max-age=300" in body, (
+            f"{pointer!r} does not set a short TTL; a pointer cached as "
+            "immutable cannot be updated for a year"
+        )
+        assert (
+            "immutable" not in body
+        ), f"{pointer!r} is cached as immutable -- it is a mutable pointer"
+
+
+def test_releases_is_validated_against_the_published_package() -> None:
+    """Guard the RELEASES <-> .nupkg agreement before publishing."""
+    text = _text()
+    verify_idx = _step_index("Verify RELEASES references")
+    assert verify_idx < _step_index(
+        "Publish update package"
+    ), "RELEASES is validated after the package is published"
+    assert 'grep -Fq "${NUPKG_NAME}"' in text, (
+        "the lane does not assert RELEASES names the .nupkg it publishes; "
+        "Squirrel clients would 404 on update"
+    )
+    assert "non-relative filename" in text, (
+        "the lane does not reject a RELEASES entry carrying a path or URL, "
+        "which would escape the published prefix"
+    )
+
+
+def test_provenance_is_attested_before_any_upload() -> None:
+    """Un-attested bytes must never reach the CDN."""
+    attest = _step_index("Attest Windows artifact provenance")
+    assert attest < _step_index("Publish Setup.exe")
+    assert attest < _step_index("Publish update package")
+    text = _text()
+    assert "${{ env.SETUP_PATH }}" in text and "${{ env.NUPKG_PATH }}" in text, (
+        "attestation must cover BOTH payloads -- the installer humans download "
+        "and the package Squirrel downloads"
+    )
+
+
+def test_missing_artifact_fails_rather_than_skipping() -> None:
+    """A soft-failed Windows build leg must not yield a silently stale feed."""
+    text = _text()
+    assert re.search(
+        r"::error::Expected exactly one Setup", text
+    ), "the lane does not fail loudly when the Setup.exe is absent"
+    assert re.search(r"::error::Expected exactly one \*-full\.nupkg", text)
+    assert re.search(r"::error::Expected exactly one RELEASES", text)
+    # No continue-on-error KEY anywhere in this lane: the whole point is
+    # loudness. (Matched as a YAML key, not a substring -- the header prose
+    # legitimately explains build-desktop's continue-on-error interaction.)
+    assert not re.search(r"^\s*continue-on-error:", text, re.MULTILINE), (
+        "publish-windows must not tolerate its own failures -- that is how a "
+        "stale channel pointer survives a green run"
+    )
+
+
+def test_publish_gates_require_both_cdn_vars() -> None:
+    text = _text()
+    assert "vars.CLI_DIST_BUCKET != ''" in text and "vars.CLI_CDN_BASE != ''" in text, (
+        "both CDN vars must gate the job: the bucket receives the upload and "
+        "the CDN base is baked into public URLs and the 412 byte-verify"
+    )
+
+
+def test_prod_environment_is_declared() -> None:
+    """The publish role's OIDC trust only accepts main or environment:prod."""
+    assert re.search(r"^    environment: prod$", _text(), re.MULTILINE), (
+        "without environment: prod, tag-triggered release runs present a "
+        "subject the publish role's trust policy rejects"
+    )
+
+
+def test_both_callers_wire_the_lane_like_the_linux_lane() -> None:
+    for caller in CALLERS:
+        text = caller.read_text(encoding="utf-8")
+        assert "uses: ./.github/workflows/publish-windows.yml" in text, (
+            f"{caller.name} does not call publish-windows.yml -- a channel would "
+            "publish mac/Linux but silently never publish Windows"
+        )
+        block = re.search(r"  publish-windows:\n(.*?)(?=\n  [a-z][a-z0-9-]*:\n)", text, re.DOTALL)
+        assert block, f"{caller.name}: cannot isolate the publish-windows job block"
+        body = block.group(1)
+        assert "needs: [version, build-desktop]" in body, (
+            f"{caller.name}: publish-windows must depend on version + build-desktop "
+            "only -- depending on the wheel or the macOS chain would re-couple lanes"
+        )
+        assert (
+            "windows_artifact: build-windows-x64" in body
+        ), f"{caller.name}: publish-windows is not passed the Windows build artifact"
+        assert "id-token: write" in body and "attestations: write" in body, (
+            f"{caller.name}: publish-windows needs OIDC + attestation permissions; "
+            "a reusable workflow cannot widen the caller's grant"
+        )
+
+
+def test_feed_body_carries_the_windows_client_contract() -> None:
+    """latest-win.json must give a client everything it needs."""
+    text = _text()
+    for field in ('"version"', '"setup"', '"releases"', '"nupkg"', '"sha256"', '"pub_date"'):
+        assert field in text, f"latest-win.json is missing {field}"
+    # `releases` must be the DIRECTORY Squirrel is handed, not the file: its
+    # protocol resolves both RELEASES and each .nupkg relative to that base.
+    assert re.search(
+        r'"releases": "\$\{\{ vars\.CLI_CDN_BASE \}\}/desktop/\$\{CHANNEL\}/win/"', text
+    ), (
+        "the feed's `releases` value must be the trailing-slash directory URL "
+        "Squirrel resolves against, not a path to the RELEASES file itself"
+    )


### PR DESCRIPTION
## What this does

Windows has been building green since #584, but nothing shipped — the installer existed only as a CI artifact. This adds `publish-windows.yml` and wires it into `nightly.yml` (nightly) and `release.yml` (insider | stable), so **all three channels get a download URL and an update feed**.

| Key | Mutability |
|---|---|
| `desktop/<channel>/<version>/KiroCrew-Setup-x64.exe` | immutable installer |
| `desktop/<channel>/latest/KiroCrew-Setup-x64.exe` | mutable permalink (download button) |
| `desktop/<channel>/win/<Product>-<ver>-full.nupkg` | immutable update payload |
| `desktop/<channel>/win/RELEASES` | mutable Squirrel pointer |
| `feed/<channel>/latest-win.json` | mutable channel pointer |

Download, once a channel has published a Windows build:

```
https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup-x64.exe
https://updates.crew.kiro.dev/feed/nightly/latest-win.json
```

## Why the layout looks like this

Squirrel.Windows' updater is handed **one directory URL**. It fetches `RELEASES` from that directory and resolves each entry's `.nupkg` filename *relative to the same directory*. Its protocol couples pointer and bytes into a single prefix, so our `updates.` (pointers) / `download.` (bytes) split **cannot be honored inside it**.

Resolution: the Squirrel directory lives on the **byte host** — the `.nupkg` payloads dominate it — and the true channel pointer, `latest-win.json`, stays on the feed prefix like every other channel. The `.nupkg` is immutable *by filename* (it carries the version), which is exactly what lets the directory accumulate versions safely under Squirrel's relative resolution.

## Discipline carried over from the Linux lane

- Versioned keys use `--if-none-match`; the **412 re-run path verifies the published bytes are identical** before letting any pointer move. A re-run can build different bytes for the same version, and proceeding would leave the mutable pointers disagreeing with the immutable key — the CloudFront edge-divergence class fixed for `cli/*` in #62.
- Every pointer is written **after** the bytes it names: `.nupkg` → `RELEASES`, versioned installer → `latest` alias, and `latest-win.json` last of all.
- SLSA provenance attested for **both** payloads before anything reaches S3.
- `environment: prod` declared (the publish role's OIDC trust accepts only `ref:refs/heads/main` or `environment:prod`), and both CDN vars gate the job.

## Two Windows-specific guards the other lanes don't need

**1. `RELEASES` is validated against the package being published.** It must name that `.nupkg` by bare filename, with no path or URL that would escape the published prefix. A mismatch here 404s *every* client update, and we'd learn about it from a user rather than from CI.

**2. A missing build artifact fails loudly.** `build-desktop.yml` marks its Windows leg `continue-on-error` for publishing callers, so a Windows packaging failure can't skip the Linux/mac publish lanes. The cost of that isolation is that this lane can be reached with nothing to publish — and a silent skip would serve a **stale Windows feed under a green run**. Failing loudly keeps the other lanes publishing while the run goes red. This closes the revisit item recorded in issue #487.

## Deliberate scope limits

- **`RELEASES` is published as built: one full entry, no deltas.** We ship full packages only, so one entry suffices — Squirrel compares the installed version against the newest entry and downloads that full package from any older version. Accumulating entries is needed only for deltas and would require a read-modify-write of a mutable object, a race I deliberately avoided. If deltas are ever wanted, that merge needs a conditional write and its own design.
- **Unsigned**, exactly like the AppImage. SmartScreen shows an "unrecognized app" interstitial. Authenticode slots in *before* the attestation step when it lands, with no key or pointer changes.
- **In-app auto-update is NOT wired.** `auto-update.js` still has no win32 branch, so the feed is published ahead of its consumer — which makes the client change a pure client change with a live feed to develop against. Called out explicitly in `docs/windows-install.md` rather than left implied.

## Verification

12 new contract tests (`test/test_publish_windows_contract.py`) pin the guarantees structurally, because none of them are visible to a YAML linter: pointer-after-bytes ordering for all three pointers, conditional writes with identical-bytes verification on both 412 paths, short TTL on every pointer, `RELEASES`/`.nupkg` agreement checked pre-publish, provenance before upload, loud failure on a missing artifact, both CDN vars gating, `environment: prod`, both callers wiring `needs` + artifact + permissions, and the feed body carrying the client contract (including that `releases` is the trailing-slash **directory** Squirrel resolves against, not the `RELEASES` file path).

31/31 pass across all three workflow-contract suites (windows + docker + nightly-version); black/isort/flake8 clean; all three workflows YAML-parse. Step-ordering assertions verified non-vacuous by printing the resolved step indices (139 → 173 → 196 → 204 → 251 → 290 → 308 → 328).

`docs/windows-install.md` previously claimed the installer was a CI artifact "not yet published to the download CDN" — now false, so it documents the real URLs and the remaining caveats.

**First real proof lands on the next nightly**, which will publish nightly Windows keys for the first time; insider/stable fill in on their next tag.
