### PR TITLE
fix(mcp-gateway): pool MCP servers via ACP session/new injection

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1928,7 +1928,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Overlay Dir",
-      "help": "Directory of rewritten agent JSON, bind-mounted over ~/.kiro/agents per session. Empty -> $KIROCREW_HOME/mcp-gateway/agents.",
+      "help": "Directory of rewritten agent JSON. Broker stubs from these specs are injected into each kiro-cli session via ACP session/new. Empty -> $KIROCREW_HOME/mcp-gateway/agents.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": ""
@@ -2928,6 +2928,173 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": null
+    },
+    {
+      "path": "weixin",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "WeChat",
+      "help": "Weixin (iLink personal WeChat) integration settings.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {
+        "enabled": false,
+        "token": "",
+        "account_id": "",
+        "base_url": "https://ilinkai.weixin.qq.com",
+        "dm_policy": "allowlist",
+        "allowed_user_ids": [],
+        "soft_threshold_pct": 80,
+        "hard_threshold_pct": 95
+      }
+    },
+    {
+      "path": "weixin.enabled",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Enabled",
+      "help": "Enable the Weixin (iLink personal WeChat) channel (long-polling). Requires a bot token + account id from the Settings QR flow.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "weixin.token",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": true,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Bot Token",
+      "help": "iLink bot token (from QR login). Prefer the WEIXIN_TOKEN credential (env/.env / cred store) over storing it here.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
+      "path": "weixin.account_id",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Account ID",
+      "help": "iLink bot account id captured during QR login.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
+      "path": "weixin.base_url",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "iLink Base URL",
+      "help": "iLink API base URL (per-account, returned by QR login).",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": "https://ilinkai.weixin.qq.com"
+    },
+    {
+      "path": "weixin.dm_policy",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "DM Policy",
+      "help": "Who may DM the bot: 'allowlist' (only allowed_user_ids, the default), 'open' (any sender), or 'disabled'. Defaults to allowlist with an empty list, so a freshly connected bot authorizes NOBODY until you add an id.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": "allowlist"
+    },
+    {
+      "path": "weixin.allowed_user_ids",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Allowed User IDs",
+      "help": "Weixin user ids permitted to DM the bot when dm_policy='allowlist'. Empty = deny all (fail closed).",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": []
+    },
+    {
+      "path": "weixin.allowed_user_ids.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
+    },
+    {
+      "path": "weixin.soft_threshold_pct",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Soft Context Threshold %",
+      "help": "Prompt the user to /compact or /new when context passes this percentage.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 80
+    },
+    {
+      "path": "weixin.hard_threshold_pct",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Hard Context Threshold %",
+      "help": "Force a compaction when context passes this percentage.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 95
     },
     {
       "path": "discord",

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -32,7 +32,7 @@ import time
 from collections import deque
 from contextlib import aclosing
 from pathlib import Path
-from typing import AsyncGenerator, AsyncIterator
+from typing import Any, AsyncGenerator, AsyncIterator
 
 from kiro_crew import model_registry, platform_compat
 from kiro_crew.acp._dispatch import parse_usage_update
@@ -101,6 +101,7 @@ from kiro_crew.hooks import (
 )
 from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.mcp_gateway.claim import schedule_claim
+from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
 from kiro_crew.sandbox import (
     cgroup_scope_argv,
     scrub_agent_denied_env,
@@ -1284,9 +1285,10 @@ class AcpClient:
         self._audit_source = audit_source
         self._channel_id = channel_id
         self._extra_env = extra_env or {}
-        # MCP gateway overlay: when set, the sandbox bind-mounts it over
-        # ~/.kiro/agents so kiro-cli reads broker-wired MCP entries; the gateway
-        # socket is bind-mounted in so stubs can reach the broker. None = off.
+        # MCP gateway overlay: when set, the broker stubs in its rewritten specs
+        # are injected into this session at ACP session/new, where they outrank
+        # the same-named entries in the agent spec. Nothing is written to the
+        # user's project or to ~/.kiro/agents. None = pooling off.
         self._mcp_gateway_overlay = str(mcp_gateway_overlay) if mcp_gateway_overlay else None
         self._mcp_gateway_settings_mcp_json = (
             str(mcp_gateway_settings_mcp_json) if mcp_gateway_settings_mcp_json else None
@@ -1415,6 +1417,16 @@ class AcpClient:
     @property
     def _is_claude(self) -> bool:
         return self.backend == ACP_BACKEND_CLAUDE
+
+    def _pooled_mcp_servers(self) -> list[dict[str, Any]]:
+        """Broker-stub ``mcpServers`` entries for this session's ``session/new``.
+
+        A session-injected server outranks the same-named entry in the resolved
+        agent spec, so injecting the stubs here is what actually pools the
+        servers — nothing is written to the user's project or to
+        ``~/.kiro/agents/``. Empty when the shared gateway is disabled.
+        """
+        return pooled_session_servers(self._mcp_gateway_overlay, self._agent)
 
     def _claude_session_mcp_servers(self) -> list:
         """MCP server array passed to a claude ``session/new`` / ``session/load``.
@@ -2070,7 +2082,13 @@ class AcpClient:
             # Default hook returns [] (kiro-cli path unchanged); an internal
             # companion that drives the _is_claude seam overrides
             # _claude_session_mcp_servers() to populate the claude MCP array.
-            "mcpServers": self._claude_session_mcp_servers(),
+            # Pooled broker stubs are appended for kiro-cli: a session-injected
+            # server outranks the same-named entry in the agent spec, which is
+            # how pooling takes effect without writing a spec anywhere.
+            "mcpServers": [
+                *self._claude_session_mcp_servers(),
+                *self._pooled_mcp_servers(),
+            ],
         }
         if self._is_claude:
             new_params["_meta"] = {"claudeCode": {"options": {}}}
@@ -2178,8 +2196,12 @@ class AcpClient:
                         # backend must receive them here (it does not read
                         # kirocrew.mcp.json itself). Default [] leaves kiro-cli
                         # unchanged; a companion overrides the hook (see
-                        # session/new above).
-                        "mcpServers": self._claude_session_mcp_servers(),
+                        # session/new above). Pooled stubs are re-declared so a
+                        # resumed session keeps talking to the broker.
+                        "mcpServers": [
+                            *self._claude_session_mcp_servers(),
+                            *self._pooled_mcp_servers(),
+                        ],
                     }
                     if self._is_claude:
                         load_params["_meta"] = {"claudeCode": {"options": {}}}

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -52,6 +52,7 @@ from kiro_crew.acp.types import (
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
 from kiro_crew.sandbox import (
     cgroup_scope_argv,
     scrub_agent_denied_env,
@@ -411,9 +412,9 @@ class AcpRuntime:
             argv += ["--model", self._model]
 
         # OSS sandbox.wrap_argv supports (argv, mode, strip_python_env). The
-        # MCP-gateway overlay / gateway-socket options remain absent (inert) in
-        # kiro_crew's sandbox — the _mcp_gateway_* attrs are retained for
-        # constructor/caller compatibility but do nothing here. strip_python_env
+        # MCP-gateway overlay is NOT delivered through the sandbox: its broker
+        # stubs are injected at ACP session/new (see new_session), so pooling
+        # needs no bind-mount and works with sandbox mode "off". strip_python_env
         # IS applied to keep the host PYTHONPATH/PYTHONHOME out of kiro-cli's
         # foreign MCP subprocesses (which bundle their own interpreter + deps).
         argv, self._sandbox_cleanup = wrap_argv(
@@ -949,6 +950,14 @@ class AcpRuntime:
         if not self._initialized:
             raise AcpRuntimeError("Runtime not initialized — call spawn() first")
 
+        # Inject the shared gateway's broker stubs unless the caller supplied an
+        # explicit list. A session-injected server outranks the same-named entry
+        # in the agent spec, so this is what actually pools the servers — no file
+        # is written anywhere. Empty when the gateway is disabled.
+        if mcp_servers is None:
+            mcp_servers = pooled_session_servers(
+                self._mcp_gateway_overlay, agent or self._agent
+            )
         params = build_session_new_params(
             cwd if cwd else self._work_dir,
             mcp_servers=mcp_servers,

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2341,7 +2341,8 @@ class McpGatewayConfig:
         default="",
         metadata=_meta(
             "Overlay Dir",
-            "Directory of rewritten agent JSON, bind-mounted over ~/.kiro/agents per session. "
+            "Directory of rewritten agent JSON. Broker stubs from these specs are "
+            "injected into each kiro-cli session via ACP session/new. "
             "Empty -> $KIROCREW_HOME/mcp-gateway/agents.",
         ),
     )

--- a/src/kiro_crew/mcp_gateway/__init__.py
+++ b/src/kiro_crew/mcp_gateway/__init__.py
@@ -8,8 +8,10 @@ sidecar subprocess. When enabled, it:
    ``~/.kiro/agents/`` files on disk.
 2. Spawns ``python -m kiro_crew.mcp_gateway.gatewayd`` at KiroCrew
    startup and supervises it.
-3. Cooperates with ``sandbox.py`` so sandboxed kiro-cli sessions see the
-   rewritten specs via a bind-mount while the host filesystem is unchanged.
+3. Injects the rewritten specs' broker stubs into each kiro-cli session
+   over ACP ``session/new``. A session-injected MCP server outranks the
+   same-named entry in the agent spec, so no file is delivered anywhere and
+   the user's ``~/.kiro/agents/`` is never read from or written to.
 
 Every component ships as Python under this package — no external
 binaries, no native extensions. See ``docs/system-specs/modules/acp-client.md``

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -2,8 +2,9 @@
 
 The rewriter reads ``~/.kiro/agents/*.json`` and writes modified copies into
 the overlay directory (``<config_dir>/mcp-gateway/agents/``). The host
-filesystem remains untouched — the sandbox layer bind-mounts the overlay
-over ``~/.kiro/agents/`` inside each kiro-cli session's mount namespace.
+filesystem remains untouched — the broker stubs in these specs are injected
+into each kiro-cli session over ACP ``session/new``, which outranks the
+same-named entry in the agent spec (see ``session_servers.py``).
 
 Servers in :data:`UNPOOLABLE_SERVERS` are left unwrapped because they bind
 to ``KIROCREW_SESSION_KEY`` and cannot be safely shared across sessions.

--- a/src/kiro_crew/mcp_gateway/session_servers.py
+++ b/src/kiro_crew/mcp_gateway/session_servers.py
@@ -1,0 +1,122 @@
+"""Session-scoped MCP server injection for the shared gateway.
+
+kiro-cli's ACP ``session/new`` accepts an ``mcpServers`` array, and a
+session-injected server takes precedence over the same-named entry in the
+resolved agent spec: the spec's own copy is never launched. That makes pooling
+a protocol-level operation. The broker stubs replace an agent's poolable
+servers for the lifetime of one session, and nothing is written to the user's
+project, to their ``~/.kiro/agents/``, or through a bind mount — so pooling
+works with ``agent.sandbox`` set to ``off`` (the default) and on macOS and
+Windows, neither of which can bind-mount.
+
+Only stub entries are injected. A non-poolable server is left entirely to the
+agent spec, so its ``env`` — which routinely holds tokens and API keys — never
+leaves the file it was declared in. Stub entries carry ``env: {}`` by
+construction (``rewriter._build_stub_entry``): the pooled backend is spawned by
+gatewayd, not by kiro-cli, so no credential is transmitted here either.
+
+Precedence caveat: same-name override is verified against the shipped binary
+(``test_mcp_gateway_session_inject.py`` pins it, including a live check when
+kiro-cli is on PATH) but is NOT documented by kiro-cli. The documented
+hierarchy covers only the three *file* tiers (agent config > workspace
+``mcp.json`` > global ``mcp.json``). If a future release made injection purely
+additive, an agent's own copy would launch alongside the stub, which is worse
+than not pooling — hence the pinning test.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.mcp_gateway.rewriter import _WRAPPER_MARKER
+
+logger = logging.getLogger(__name__)
+
+# Keys that are positional in the ACP element shape (``name``) or that we
+# always re-derive (``env``), so they must not be copied verbatim.
+_ACP_RESERVED = frozenset({"name", "env", _WRAPPER_MARKER})
+
+
+def _acp_env(raw: Any) -> list[dict[str, str]]:
+    """Convert a kiro-agent-JSON ``env`` mapping to ACP's array-of-pairs form.
+
+    Stub entries always carry an empty mapping, so this normally returns ``[]``.
+    It is still a faithful conversion rather than a hardcoded empty list so a
+    future caller that injects a non-stub entry cannot silently drop its env.
+    """
+    if not isinstance(raw, dict):
+        return []
+    return [{"name": str(k), "value": str(v)} for k, v in raw.items()]
+
+
+def _acp_server_entry(name: str, entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Shape one rewritten ``mcpServers`` entry into an ACP array element.
+
+    Operator-set passthrough keys (``timeout``, ``type``, ``disabledTools``,
+    ``autoApprove``, vendor keys) are preserved: kiro-cli tolerates them on the
+    session-injected element, and dropping ``autoApprove`` in particular would
+    re-prompt for tools the agent spec had already auto-approved.
+    """
+    command = entry.get("command")
+    if not isinstance(command, str) or not command:
+        # A stub without a command cannot be launched; injecting it would
+        # shadow the agent's working entry with a broken one. Skip instead,
+        # leaving the spec's own server in place.
+        return None
+    args = [a if isinstance(a, str) else json.dumps(a, sort_keys=True, default=str)
+            for a in (entry.get("args") or [])]
+    shaped: dict[str, Any] = {
+        k: v for k, v in entry.items() if k not in _ACP_RESERVED and k != "command"
+    }
+    shaped.update({
+        "name": name,
+        "command": command,
+        "args": args,
+        "env": _acp_env(entry.get("env")),
+    })
+    return shaped
+
+
+def pooled_session_servers(
+    overlay_dir: str | Path | None,
+    agent: str | None,
+) -> list[dict[str, Any]]:
+    """Return ACP ``session/new`` entries for *agent*'s broker stubs.
+
+    ``overlay_dir`` is the rewriter's output directory (usually
+    ``<config_dir>/mcp-gateway/agents/``); it is ``None`` when the shared
+    gateway is disabled, which is the natural off switch — this returns ``[]``
+    and the session runs entirely on the agent's own servers.
+
+    Fail-soft by design: any unreadable or malformed overlay yields ``[]``, so a
+    bad rewrite degrades to unpooled operation rather than breaking the spawn.
+    """
+    if not overlay_dir or not agent:
+        return []
+    src = Path(overlay_dir) / f"{agent}.json"
+    try:
+        spec = json.loads(src.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        # Normal for an agent the rewriter did not emit (e.g. it declared no
+        # poolable servers at all) — not worth a warning.
+        return []
+    except (OSError, ValueError):
+        logger.warning("MCP-gateway: cannot read overlay spec %s", src, exc_info=True)
+        return []
+    if not isinstance(spec, dict):
+        return []
+    servers = spec.get("mcpServers")
+    if not isinstance(servers, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for name, entry in sorted(servers.items()):
+        if not isinstance(entry, dict) or not entry.get(_WRAPPER_MARKER):
+            # Not a broker stub: leave it to the agent spec entirely.
+            continue
+        shaped = _acp_server_entry(str(name), entry)
+        if shaped is not None:
+            out.append(shaped)
+    return out

--- a/test/test_mcp_gateway_session_inject.py
+++ b/test/test_mcp_gateway_session_inject.py
@@ -1,0 +1,267 @@
+"""Tests for shared-MCP-gateway delivery via ACP ``session/new`` injection.
+
+The pooling mechanism under test: kiro-cli honours a server injected in
+``session/new`` AHEAD of the same-named entry in the resolved agent spec, so
+injecting broker stubs pools an agent's servers without writing a spec into the
+user's project, their ``~/.kiro/agents/``, or a bind mount.
+
+``test_real_kiro_cli_prefers_session_injected_server`` is the anti-drift guard:
+that precedence is verified but undocumented, so it is pinned against the
+shipped binary whenever one is on PATH.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway.rewriter import _WRAPPER_MARKER
+from kiro_crew.mcp_gateway.session_servers import (
+    _acp_env,
+    _acp_server_entry,
+    pooled_session_servers,
+)
+
+
+def _stub(**over):
+    entry = {
+        _WRAPPER_MARKER: True,
+        "command": "/data/mcp-gateway/stubs/mc-mcp-stub-wrapper.sh",
+        "args": ["--target-command=fetch", "--socket", "/data/gateway.sock"],
+        "env": {},
+        "autoApprove": ["fetch___fetch"],
+    }
+    entry.update(over)
+    return entry
+
+
+def _write_overlay(tmp_path: Path, agent: str, servers: dict) -> Path:
+    overlay = tmp_path / "agents"
+    overlay.mkdir(parents=True, exist_ok=True)
+    (overlay / f"{agent}.json").write_text(
+        json.dumps({"name": agent, "mcpServers": servers}), encoding="utf-8"
+    )
+    return overlay
+
+
+# ── selection: only stubs are injected ──────────────────────────────────────
+
+
+def test_injects_only_wrapped_stub_entries(tmp_path):
+    overlay = _write_overlay(tmp_path, "kirocrew", {
+        "pooled": _stub(),
+        "unpooled": {"command": "npx", "args": ["-y", "srv"], "env": {"TOKEN": "s3cr3t"}},
+    })
+    out = pooled_session_servers(overlay, "kirocrew")
+    assert [e["name"] for e in out] == ["pooled"]
+
+
+def test_unpooled_server_env_is_never_transmitted(tmp_path):
+    """A non-poolable server's credentials must stay in the spec file."""
+    overlay = _write_overlay(tmp_path, "kirocrew", {
+        "secretive": {"command": "npx", "env": {"API_KEY": "s3cr3t"}},
+    })
+    assert pooled_session_servers(overlay, "kirocrew") == []
+    assert "s3cr3t" not in json.dumps(pooled_session_servers(overlay, "kirocrew"))
+
+
+def test_stub_name_is_preserved_so_it_shadows_the_spec_entry(tmp_path):
+    """The injected name must equal the original server name — that identity is
+    what suppresses the agent spec's own copy (and keeps tool ids stable)."""
+    overlay = _write_overlay(tmp_path, "kirocrew", {"builder-mcp": _stub()})
+    (entry,) = pooled_session_servers(overlay, "kirocrew")
+    assert entry["name"] == "builder-mcp"
+
+
+def test_entries_are_name_sorted_for_deterministic_params(tmp_path):
+    overlay = _write_overlay(tmp_path, "kirocrew", {
+        "zeta": _stub(), "alpha": _stub(), "mid": _stub(),
+    })
+    assert [e["name"] for e in pooled_session_servers(overlay, "kirocrew")] == [
+        "alpha", "mid", "zeta",
+    ]
+
+
+# ── shaping into the ACP element form ───────────────────────────────────────
+
+
+def test_marker_is_stripped_from_the_injected_element(tmp_path):
+    """kiro-cli tolerates unknown keys today; a future strict parser would not."""
+    overlay = _write_overlay(tmp_path, "kirocrew", {"pooled": _stub()})
+    (entry,) = pooled_session_servers(overlay, "kirocrew")
+    assert _WRAPPER_MARKER not in entry
+
+
+def test_operator_passthrough_keys_survive(tmp_path):
+    """Dropping autoApprove would re-prompt for already-approved tools."""
+    overlay = _write_overlay(tmp_path, "kirocrew", {
+        "pooled": _stub(timeout=9000, type="stdio", disabledTools=["x"]),
+    })
+    (entry,) = pooled_session_servers(overlay, "kirocrew")
+    assert entry["autoApprove"] == ["fetch___fetch"]
+    assert entry["timeout"] == 9000
+    assert entry["type"] == "stdio"
+    assert entry["disabledTools"] == ["x"]
+
+
+def test_env_is_emitted_in_acp_array_form():
+    assert _acp_env({}) == []
+    assert _acp_env({"A": "1"}) == [{"name": "A", "value": "1"}]
+    assert _acp_env({"N": 5}) == [{"name": "N", "value": "5"}]
+    assert _acp_env(None) == []
+    assert _acp_env("nonsense") == []
+
+
+def test_stub_entries_carry_no_env(tmp_path):
+    """gatewayd spawns the pooled backend, so kiro-cli needs no env at all."""
+    overlay = _write_overlay(tmp_path, "kirocrew", {"pooled": _stub()})
+    (entry,) = pooled_session_servers(overlay, "kirocrew")
+    assert entry["env"] == []
+
+
+def test_non_string_args_are_coerced(tmp_path):
+    overlay = _write_overlay(tmp_path, "kirocrew", {"pooled": _stub(args=["ok", 7])})
+    (entry,) = pooled_session_servers(overlay, "kirocrew")
+    assert entry["args"] == ["ok", "7"]
+
+
+def test_entry_without_command_is_skipped():
+    """Injecting a commandless stub would shadow a working server with a broken
+    one; leaving it out keeps the spec's own entry live."""
+    assert _acp_server_entry("x", {_WRAPPER_MARKER: True, "command": ""}) is None
+    assert _acp_server_entry("x", {_WRAPPER_MARKER: True}) is None
+
+
+def test_commandless_stub_does_not_suppress_others(tmp_path):
+    overlay = _write_overlay(tmp_path, "kirocrew", {
+        "broken": _stub(command=""), "fine": _stub(),
+    })
+    assert [e["name"] for e in pooled_session_servers(overlay, "kirocrew")] == ["fine"]
+
+
+# ── the off switch and fail-soft behaviour ──────────────────────────────────
+
+
+def test_disabled_gateway_injects_nothing():
+    assert pooled_session_servers(None, "kirocrew") == []
+
+
+def test_missing_agent_name_injects_nothing(tmp_path):
+    assert pooled_session_servers(tmp_path, None) == []
+
+
+def test_absent_overlay_spec_is_not_an_error(tmp_path):
+    assert pooled_session_servers(tmp_path / "nope", "kirocrew") == []
+
+
+def test_corrupt_overlay_degrades_to_unpooled(tmp_path):
+    overlay = tmp_path / "agents"
+    overlay.mkdir()
+    (overlay / "kirocrew.json").write_text("{not json", encoding="utf-8")
+    assert pooled_session_servers(overlay, "kirocrew") == []
+
+
+@pytest.mark.parametrize("body", ["[]", '"str"', "null", '{"mcpServers": []}',
+                                  '{"mcpServers": "x"}', "{}"])
+def test_malformed_spec_shapes_degrade_to_unpooled(tmp_path, body):
+    overlay = tmp_path / "agents"
+    overlay.mkdir(exist_ok=True)
+    (overlay / "kirocrew.json").write_text(body, encoding="utf-8")
+    assert pooled_session_servers(overlay, "kirocrew") == []
+
+
+def test_non_dict_server_entry_is_skipped(tmp_path):
+    overlay = _write_overlay(tmp_path, "kirocrew", {"bad": "x", "good": _stub()})
+    assert [e["name"] for e in pooled_session_servers(overlay, "kirocrew")] == ["good"]
+
+
+# ── the mechanism itself, pinned against the shipped binary ─────────────────
+
+
+REAL_CLI = shutil.which("kiro-cli")
+
+_DRIVER = r"""
+import json, os, subprocess, sys, time
+w = sys.argv[1]
+p = subprocess.Popen(["kiro-cli", "acp", "--agent", "pooltest"], cwd=w + "/proj",
+                     stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     stderr=subprocess.PIPE, text=True,
+                     env={**os.environ, "KIRO_HOME": w + "/khome"})
+send = lambda o: (p.stdin.write(json.dumps(o) + "\n"), p.stdin.flush())
+send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+      "params": {"protocolVersion": 1, "clientCapabilities":
+                 {"fs": {"readTextFile": False, "writeTextFile": False}}}})
+time.sleep(3)
+send({"jsonrpc": "2.0", "id": 2, "method": "session/new",
+      "params": {"cwd": w + "/proj", "mcpServers": [
+          {"name": "shared", "command": "sh",
+           "args": ["-c", "touch " + w + "/marks/INJECTED; sleep 20"], "env": []}]}})
+time.sleep(8)
+p.kill()
+"""
+
+
+@pytest.mark.skipif(not REAL_CLI, reason="kiro-cli not on PATH")
+@pytest.mark.skipif(not sys.platform.startswith(("linux", "darwin")),
+                    reason="driver uses a POSIX shell")
+def test_real_kiro_cli_prefers_session_injected_server():
+    """ANTI-DRIFT GUARD. Pins the undocumented precedence pooling relies on.
+
+    kiro-cli documents priority only among the three *file* tiers (agent config
+    > workspace mcp.json > global mcp.json); it does not document that a
+    ``session/new`` server outranks the agent spec. If a release made injection
+    additive instead, the agent's own server would launch alongside the stub —
+    every poolable server would run twice, which is worse than not pooling. This
+    test fails loudly at that point instead of shipping a silent regression.
+    """
+    with tempfile.TemporaryDirectory() as w:
+        root = Path(w)
+        (root / "khome" / "agents").mkdir(parents=True)
+        (root / "proj").mkdir()
+        (root / "marks").mkdir()
+        (root / "khome" / "agents" / "pooltest.json").write_text(json.dumps({
+            "name": "pooltest",
+            "description": "precedence probe",
+            "model": "claude-haiku-4.5",
+            "tools": [],
+            "prompt": "probe",
+            "mcpServers": {"shared": {
+                "command": "sh",
+                "args": ["-c", f"touch {root / 'marks' / 'FROM_SPEC'}; sleep 20"],
+            }},
+        }), encoding="utf-8")
+        driver = root / "drive.py"
+        driver.write_text(_DRIVER, encoding="utf-8")
+        subprocess.run([sys.executable, str(driver), str(root)],
+                       capture_output=True, timeout=180, check=False)
+        deadline = time.time() + 5
+        while time.time() < deadline and not (root / "marks" / "INJECTED").exists():
+            time.sleep(0.2)
+        assert (root / "marks" / "INJECTED").exists(), (
+            "session/new-injected server never launched — ACP injection is not "
+            "taking effect at all; pooling cannot work through this channel"
+        )
+        assert not (root / "marks" / "FROM_SPEC").exists(), (
+            "the agent spec's same-named server ALSO launched: session/new "
+            "injection has become additive rather than overriding, so every "
+            "pooled server would run twice. Pooling delivery must change."
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX pathing in fixture")
+def test_injection_writes_nothing_to_the_work_dir(tmp_path):
+    """The whole point of this channel: no file lands in the user's project."""
+    work = tmp_path / "project"
+    (work / ".kiro").mkdir(parents=True)
+    overlay = _write_overlay(tmp_path, "kirocrew", {"pooled": _stub()})
+    before = {p for p in work.rglob("*")}
+    assert pooled_session_servers(overlay, "kirocrew")
+    assert {p for p in work.rglob("*")} == before


### PR DESCRIPTION
## Problem

Server pooling was inert. The rewriter generated broker-stub agent specs into
`<data-home>/mcp-gateway/agents/` on every gateway boot, but nothing ever handed
them to kiro-cli — so each session kept launching its own copy of every poolable
server (observed: 11 concurrent copies each of six servers, and zero stub
processes, with the broker running).

The delivery half was never ported. `git log -S overlay -- src/kiro_crew/sandbox.py`
returns no commits: the client-side plumbing arrived, the bind-mount that
consumed it did not. And that bind-mount would not help today regardless — it
only ran when `agent.sandbox` was `auto`, and the default has since become `off`,
so the sole delivery path was orphaned even on Linux.

## Why it matters

Pooling is the difference between one shared backend per server and one per
session. Without it, every new session re-pays full MCP startup and holds its own
duplicate process set for the session's lifetime.

A bind-mount also cannot be the answer: it needs a mount namespace, so it is
Linux-only and cannot work on macOS or Windows, and it is unavailable on Linux
under the default `agent.sandbox: off`. Any fix has to work on every platform and
every configuration, without privileged operations.

## Fix

Deliver the stubs over the protocol rather than the filesystem.

kiro-cli honours an MCP server injected in ACP `session/new` **ahead of the
same-named entry in the resolved agent spec** — the spec's own copy is never
launched. So injecting each broker stub under its original server name pools that
server for the lifetime of one session, with nothing written to the user's
project, to their global agent directory, or through a mount.

- `mcp_gateway/session_servers.py` — reads the rewriter's existing overlay spec
  and shapes its stub entries into ACP `session/new` elements.
- `acp/runtime.py`, `acp/client.py` — inject them at `session/new` (and at
  `session/load`, so a resumed session keeps talking to the broker). The
  `mcpServers` parameter and the `mcp_gateway_overlay` plumbing already existed
  and were unused.

Properties that follow:

- **Cross-platform** — a JSON-RPC field, not a filesystem mechanism. No
  namespace, no privilege, no platform branch.
- **Works with `agent.sandbox: off`**, the default.
- **Writes nothing.** The prior revision of this PR wrote a spec into
  `<cwd>/.kiro/agents/`, which a review found could carry a secret-bearing MCP
  `env` into a commit via TaskRunner's `git add -A`. That entire class of problem
  is gone, along with the machinery built to contain it: the delivery receipt,
  sha256 content-ownership tracking, non-clobber guards, `0600` enforcement, the
  Windows `icacls` lockdown, the path-traversal guard, and withdrawal-on-disable.
  All of that was added by an earlier revision of this PR and is now deleted, so
  `providers/acp.py` ends up **unchanged against `main`**. What remains is the
  122-line injection module, ~44 lines of wiring across the two spawn paths, 267
  lines of tests, and a baseline regeneration.
- **Only stubs are injected.** A non-poolable server is left entirely to the
  agent spec, so its declared `env` never leaves the file it was declared in.
  Stubs carry no `env` at all — the pooled backend is spawned by the gateway
  daemon, not by kiro-cli.
- **Agent identity unchanged.** Still `--agent kirocrew`, so the model-resolution
  branch in `config/loader.py` and governance spawn scoping in `subagent.py` are
  untouched. Preserving each server's *name* also keeps `autoApprove` and
  server-qualified tool ids stable.
- **Off switch is structural.** The overlay path is `None` when the gateway is
  disabled, so nothing is injected and the session runs unpooled.

### Known limitation (pre-existing, not introduced here)

A pooled server's declared `env` is not applied to the shared backend — gatewayd
spawns it with the daemon's own scrubbed environment. The rewriter already warns
and recommends `poolable: false` for servers that depend on their declared env.

### Risk: the precedence is undocumented

kiro-cli documents priority only among the three *file* tiers (agent config >
workspace `mcp.json` > global `mcp.json`). It does not document that a
`session/new` server outranks the agent spec. Verified against the shipped binary
(2.15.1), but if a future release made injection additive instead, every pooled
server would launch twice — worse than not pooling. `test_real_kiro_cli_prefers_
session_injected_server` pins the behaviour against the real binary and fails
loudly with that exact diagnosis, rather than letting it regress silently.

## Tests

`test/test_mcp_gateway_session_inject.py` — 24 tests:

- **Selection** — only marker-bearing stubs injected; unpooled servers excluded
  and their `env` asserted absent from the payload; deterministic name ordering.
- **Shaping** — marker stripped (kiro-cli tolerates unknown keys today, a strict
  parser would not); `autoApprove`/`timeout`/`type`/`disabledTools` preserved;
  `env` emitted in ACP array form; non-string args coerced; a commandless stub
  skipped rather than shadowing a working server.
- **Fail-soft** — disabled gateway, missing agent, absent spec, corrupt JSON, and
  six malformed spec shapes all degrade to unpooled instead of breaking spawn.
- **Anti-drift** — the real-binary precedence guard described above.
- **Invariant** — injection leaves the work dir byte-identical.

Removes `test/test_mcp_gateway_workspace_overlay.py` (363 lines) with the
mechanism it covered.

Full suite: **19,525 passed**, 123 skipped, 5 xfailed. The 11 failures are
pre-existing and environmental, identical on clean `main` (userns/fork probes,
`gh`/provider ownership checks, hardlink and pidfd tests). isort, flake8, mypy
clean.

## Manual verification

Drove a real `kiro-cli acp` session (2.15.1) by hand, with each MCP server
touching a marker file on launch:

- Different names → both servers launch (injection is additive for new names).
- **Same name → only the injected server launches; the agent spec's copy does
  not.** This is the mechanism the fix depends on.
- Extra keys (`autoApprove`, `timeout`, `disabledTools`) on the injected element
  are accepted, and `session/new` still returns a session.

Also confirmed the negative direction while ruling out alternatives: `--agent`
rejects a filepath in all three forms (absolute, extensionless, cwd-relative),
failing open to the default agent with exit status 0; and the workspace tier does
not search parent directories (verified three levels deep).

## Screenshots

N/A — no user-visible dashboard or app state changes. The effect is process
topology (stub processes replacing duplicate MCP servers), not UI.

