### PR TITLE
feat(governance): verify the security policy's identity.signature

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -111,6 +111,140 @@ is **pure-Python and structural** (it does not depend on `jsonschema`, which is
 an optional, possibly-absent dependency) so a malformed policy never silently
 degrades to ungoverned.
 
+## Policy authenticity (`identity.signature`)
+
+Without a signature check, a policy's integrity rests entirely on **filesystem
+permissions** — adequate for the single-user host that owns its own ceiling, but
+not for a managed fleet where the operator is not the local user and the local
+user can edit the file. `load_security_policy` therefore verifies an optional
+detached `identity.signature`, mirroring `admission._signature_valid` rather than
+inventing a second scheme.
+
+| Piece | Where | Notes |
+|---|---|---|
+| Canonical payload | `policy_signing_payload()` | Routes through `admission.canonical_signing_bytes` — the **same** sorted-keys/compact-separators/UTF-8 canonicalization `PluginManifest.signing_payload` uses, so the two trust roots cannot drift |
+| Primitive | `admission.hmac_signature` | HMAC-SHA256 + `hmac.compare_digest`. POC symmetric; an asymmetric verify swaps in behind the same helper |
+| Trust key | admission policy `trust_keys[<issuer>]` | The **existing** operator-controlled key store — one store, not two |
+| Opt-in | admission policy `require_policy_signature` | Separate from the plugin-facing `require_signature` |
+| Verdict | `GovernanceCeiling.signature_state` | `verified` / `unverified` / `unsigned` / `unchecked` |
+
+**Coverage** is the whole document minus `identity.signature` (a signature cannot
+cover itself). `identity.issuer` **is** covered, so a validly-signed policy cannot
+be re-labelled as issued by someone else. Signing the raw document rather than a
+projection of the parsed ceiling is deliberate: it covers keys *this build does
+not know* — a companion-registered scope, a future schema addition — so removing
+or editing one is still detected, and it keeps the payload scope-name-agnostic
+(adding a scope stays a `SCOPE_CATALOG` data change). Because coverage is
+byte-canonical over the *parsed* JSON, re-indenting or reordering keys does not
+break a signature while changing any value or key does.
+
+**Why the trust key comes from the admission policy** and not from
+`security_policy.json` itself: a document must not be the authority on whether it
+has to be authentic. A `require_signature` flag inside the security policy would
+be self-referential — an attacker rewriting the policy would simply clear it. The
+admission policy is already this package's fleet-controlled trust root, already
+carries `trust_keys`, and is already on the `is_sensitive_path` keystone, so the
+governance trust root inherits every protection the plugin trust root has.
+`_policy_trust_settings()` reads through **`admission.read_policy_trust_root()`**,
+a deliberately side-effect-free reader — *not* `load_admission_policy`, which
+records the dashboard admission posture and emits a **critical**
+`governance_degraded` SEL on an absent policy. That is correct once per process at
+boot and wrong here, because `gatewayd` re-loads the security policy **per app
+call** (`mcp_gateway/app_call.py`), so reusing the audited loader would flip the
+governance indicator to degraded and append a critical audit record on every app
+call. It never raises, and on an absent/unreadable admission policy it yields no
+keys and a `False` opt-in: an admission-policy problem is already handled loudly
+and fail-closed in admission's own domain, and it must not additionally make the
+security ceiling unloadable through a second path.
+
+**Advisory by default, fail-closed on opt-in.** With `require_policy_signature`
+unset (the default, and the seeded value), an unsigned or unverifiable policy
+still loads and still governs — every existing standalone install and every
+existing policy file keeps working unchanged, with no key to provision. This is
+the compatibility contract: verification adds *reporting*, not a new way for a
+working install to stop booting. With the flag set, a non-`verified` verdict
+raises `PlatformCompositionError` and **aborts boot** (plus a `failed_closed`
+governance-health mark), matching the module's existing fail-closed discipline for
+a wrong version, a missing `boot` object, or an unknown governed key.
+
+**All three tiers are verified — none is exempt.** When `require_policy_signature`
+is OFF (the default, and what the `amazon` edition ships), verification is advisory
+at every tier: an unsigned policy — bundled or on disk — still loads and still
+governs, so existing installs are unchanged. When it is ON, every tier must present
+a signature that verifies against a trust key, or boot aborts.
+
+The companion-bundled tier is **not** exempt: the plugin-admission manifest
+signature covers only the manifest fields (`name` / `publisher` / `version` /
+`capabilities` — see `admission.PluginManifest.signing_payload`), **not** the bytes
+of the packaged `security_policy.json`. So "covered by admission" never actually
+protected the resource — a tampered bundled policy would have loaded unchecked. An
+edition that opts into `require_policy_signature` therefore signs its bundled policy
+like any other governed tier.
+
+And a **missing** policy does not satisfy the requirement: with
+`require_policy_signature` ON and no policy present at any tier, boot aborts rather
+than returning an ungoverned host — otherwise a mandated-signature fleet that lost
+or never shipped its policy file would silently run with no ceiling at all, the
+exact failure the flag exists to prevent.
+
+**Load computes the verdict; one gate enforces it.** `_verify_policy_signature`
+records each tier's `signature_state` as it loads, and never raises.
+`assert_policy_signature_satisfied` is the single enforcement point, called by boot
+on the **final composed context** alongside the other governance floor gates. It
+rejects both failure shapes: a surviving ceiling whose state is not `verified`, and
+no ceiling at all.
+
+The split is what makes tier precedence work. `load_security_policy` walks
+env → companion bundle → operator home and runs more than once per boot with
+different arguments — the core calls it with no `bundled_loader`, a companion
+edition re-invokes it with one. A raise inside the loader fires on whichever tier
+that particular pass happened to reach, so an enterprise host with an unsigned home
+file and a correctly signed companion bundle aborted on the *lower-precedence* tier
+the core's pass fell through to, even though the bundle is what the final ceiling
+comes from. Only the composed result knows which tier won, so only the composed
+result can be judged.
+
+`gatewayd`'s per-app-call reload calls the gate too, on the ceiling that reload
+produced, so a policy tampered with *after* boot cannot widen an app callback — boot
+verified the original bytes, which says nothing about what the reload just read.
+
+**Residual gap — absence is not decidable in `gatewayd`.** That gate is applied only
+when the reload returns a ceiling. The daemon is not the composition process: it
+never runs `boot_platform`, so it loads with no `bundled_loader` and cannot see a
+companion-bundled ceiling. `None` there is the *normal* result on a bundle-only
+enterprise host, not evidence the policy is gone, so refusing on it would deny every
+app callback. Deletion is therefore caught at boot but not mid-session; closing that
+means handing `gatewayd` the composed ceiling instead of re-reading the file, which
+is pre-existing behavior and a separate change.
+
+**A broken trust root reads as no opt-in, on purpose.** An admission file that is
+absent, unreadable, or not a JSON object leaves verification advisory rather than
+failing closed. That is not a gap: an attacker who can write `admission_policy.json`
+is outside this threat model (see below) and would simply set the flag to `false`,
+which parses fine — so fail-closing on a *malformed* file would catch only a clumsy
+variant of an attack the design already concedes, while turning a non-atomic fleet
+push or a hand-edit typo into an unbootable host. Corruption there is a reliability
+event: it is logged at WARNING, plugin admission independently fails closed on the
+same file, and `kirocrew doctor` reports it.
+
+
+**Threat model.** This detects **offline / at-rest tampering and substitution** of
+a policy file by anyone without the issuer's key: a widened ceiling, a stripped
+scope, a swapped file, a policy re-labelled to a different issuer. It does **not**
+defend against an attacker who holds the trust key, and it is **not** a
+confinement boundary for a local process running as the operator — such a process
+can edit the admission policy (clearing the opt-in) as easily as the security
+policy. The `is_sensitive_path` keystone remains the control that stops the
+*agent* from reaching either file; signing is what makes a fleet-pushed ceiling
+tamper-**evident** to the host that loads it. Symmetric HMAC also means the
+verifier holds a secret capable of *producing* signatures, so key distribution is
+the residual weakness an asymmetric successor removes.
+
+`kirocrew policy show` prints the verdict verbatim
+(`GovernanceCeiling.signature_summary()`) so an operator can tell an established
+issuer from a decorative one — it previously printed a bare `issuer` that no check
+had ever established.
+
 ## Boot composition
 
 `build_default_context` (the single chokepoint backing both a real boot and the
@@ -837,8 +971,9 @@ operation / item / reason are redacted via `redact_via_context` **before** `log`
 ## CLI
 
 `kirocrew policy {show | validate | explain <scope> <item> | profile <name>}` —
-read-only operator diagnostics. `explain` traces the rule/layer/reason and the
-live gate verdict. Deliberately **not** exposed as an MCP tool: it surfaces
+read-only operator diagnostics. `show` reports the ceiling's **proven** provenance
+(`signed and verified` / `signed but UNVERIFIED` / `unsigned`) rather than a bare
+issuer string. `explain` traces the rule/layer/reason and the live gate verdict. Deliberately **not** exposed as an MCP tool: it surfaces
 governance internals that the agent (the governed subject) should not enumerate.
 
 ## Companion (separate package, separate CR)
@@ -852,7 +987,11 @@ carve-out stay as code. It expects `CONTRACT_VERSION == 1` (pinned pre-launch).
 
 - `platform/governance.py` — archetypes, catalog, loader, evaluator
   (`resolve`, `resolve_ordinal`, `gate_decision`, `assert_governance_floor`,
-  `compose_profiles`, `resolve_pinned_commands` + `COMMANDS_SCOPE` force-pins).
+  `compose_profiles`, `resolve_pinned_commands` + `COMMANDS_SCOPE` force-pins,
+  `policy_signing_payload` + the `identity.signature` verification path).
+- `platform/admission.py` — `canonical_signing_bytes` / `hmac_signature` (shared
+  by both trust roots), `require_policy_signature` / `trust_keys`, and
+  `read_policy_trust_root` (the side-effect-free trust-root reader).
 - `platform/governance_profiles.py` — `ProfileStore` (hot-reload),
   `resolve_active_scope`, `governance_permits`, `governance_floor_ordinal`,
   `GOVERNANCE_ERROR_REASON` (the eval-error marker consumers match on),
@@ -873,7 +1012,10 @@ carve-out stay as code. It expects `CONTRACT_VERSION == 1` (pinned pre-launch).
 ## Tests
 
 `test_governance_policy.py` (archetypes + loader + evaluator + E1–E13 vectors +
-extensibility), `test_governance_boot.py` (compose at boot), 
+extensibility + the `identity.signature` states, the opt-in fail-closed gate, and
+the `policy show` provenance reporting), `test_platform_admission.py`
+(`require_policy_signature` / shared signing primitives),
+`test_governance_boot.py` (compose at boot), 
 `test_governance_self_protection.py` (keystone), `test_governance_profiles.py`
 (resolution + binding + hot-reload + fail-closed reload dispositions),
 `test_governance_gate.py` (Plane A enforcement + audit),

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -211,12 +211,28 @@ Policy shape (`admission_policy.json`):
 {
   "mode": "enforce",
   "require_signature": true,
-  "trust_keys": {"p13n": "<publisher key>"},
+  "require_policy_signature": true,
+  "trust_keys": {"p13n": "<publisher key>", "fleet-control": "<issuer key>"},
   "approved": ["enterprise"],
   "banned": ["some-rogue-plugin"],
   "capability_ceiling": {"egress": ["*.example.com"], "tools": ["enterprise-mcp"]}
 }
 ```
+
+**This policy is also the trust root for the security ceiling.**
+`require_policy_signature` (default `false`) additionally demands a *verified*
+`identity.signature` on `security_policy.json`, keyed by that document's
+`identity.issuer` in the same `trust_keys` map — one key store, not two. It is a
+**separate** flag from `require_signature` on purpose: a fleet that signs its
+plugins has not thereby promised to sign its governance ceiling, and conflating
+them would break managed fleets on upgrade. The flag lives here rather than inside
+the security policy because a document cannot be the authority on whether it must
+be authentic. `canonical_signing_bytes` / `hmac_signature` are shared by both
+checks so the two trust roots cannot drift apart. The governance loader reads
+these two fields through `read_policy_trust_root()` — a **side-effect-free**
+reader that records no posture and emits no SEL, because unlike
+`load_admission_policy` (once per process at boot) it runs on a repeating path.
+See `governance.md` → "Policy authenticity".
 
 > What admission does NOT do: it gates the *plugin contract boundary*, not a
 > source-editing user. For a managed fleet the enforced root of trust is the

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1011,7 +1011,12 @@ def _policy(args: argparse.Namespace) -> None:
         if ceiling is None:
             print("No enterprise security policy is active (editable secure-defaults).")
             return
-        print(f"🛡️  Security policy v{ceiling.version} (issuer: {ceiling.identity_issuer or '—'})")
+        # Report the PROVEN provenance, not the claimed one: printing a bare
+        # issuer implied a trust decision nothing had made.  signature_summary()
+        # distinguishes verified / signed-but-unverified / unsigned so an operator
+        # can tell an established issuer from a decorative one.
+        print(f"🛡️  Security policy v{ceiling.version}")
+        print(f"   provenance: {ceiling.signature_summary()}")
         print(
             f"   boot: require_sandbox={ceiling.boot.require_sandbox} "
             f"allow_terminal={ceiling.boot.allow_terminal} fail_closed={ceiling.boot.fail_closed}"

--- a/src/kiro_crew/mcp_gateway/app_call.py
+++ b/src/kiro_crew/mcp_gateway/app_call.py
@@ -196,10 +196,31 @@ def _governance_denial(
     try:
         # circular import: platform.governance imports gateway-adjacent modules;
         # loaded per-call (also keeps the policy read fresh). Keep lazy.
-        from kiro_crew.platform.governance import load_security_policy, resolve
+        from kiro_crew.platform.governance import (
+            assert_policy_signature_satisfied,
+            load_security_policy,
+            resolve,
+        )
         from kiro_crew.platform.governance_profiles import resolve_active_scope
 
         ceiling = load_security_policy()
+        # Enforce the signature mandate on the ceiling this LIVE re-read produced —
+        # but only when it produced one. A tampered policy file must not widen an
+        # app callback just because this path re-reads it after boot already
+        # verified the original (the raise lands in the except clause below, which
+        # denies — the correct polarity here).
+        #
+        # Gated on `is not None` deliberately. This daemon is not the composition
+        # process: it never runs ``boot_platform``, so it calls
+        # ``load_security_policy()`` with no ``bundled_loader`` and cannot see a
+        # companion-bundled ceiling. ``None`` here therefore does NOT mean "the
+        # policy is gone" — on a bundle-only enterprise host it is the normal
+        # result, and refusing on it would deny every app callback. Absence stays
+        # decidable only where composition happened (boot); closing that residual
+        # gap means handing gatewayd the composed ceiling instead of re-reading the
+        # file, which is pre-existing behavior and a separate change.
+        if ceiling is not None:
+            assert_policy_signature_satisfied(ceiling)
         profile = resolve_active_scope(session_key, agent=agent)
         if ceiling is None and profile is None:
             return None  # ungoverned standalone host — permits, as on Plane A

--- a/src/kiro_crew/platform/admission.py
+++ b/src/kiro_crew/platform/admission.py
@@ -46,7 +46,7 @@ import unicodedata
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional
 
 from kiro_crew.config.paths import config_dir
 
@@ -72,6 +72,18 @@ def _policy_default_path() -> Path:
     module-level constant.
     """
     return config_dir() / _POLICY_DEFAULT_LEAF
+
+
+def policy_trust_root_path() -> Path:
+    """The admission-policy path this host reads: the env override, else the default.
+
+    The one public resolver for "where is the trust root", so a reader outside this
+    module (``governance._policy_signature_required``) does not have to re-derive the
+    env-wins precedence from private names — two copies of that rule is how a reader
+    ends up checking a different file than the loader.
+    """
+    raw = os.environ.get(_POLICY_ENV, "").strip()
+    return Path(raw) if raw else _policy_default_path()
 
 
 def _seed_marker_path() -> Path:
@@ -105,6 +117,34 @@ def _coerce_str_list(value: object) -> List[str]:
     if isinstance(value, (list, tuple)):
         return [str(item) for item in value]
     return []
+
+
+def canonical_signing_bytes(body: Mapping[str, object]) -> bytes:
+    """The ONE canonicalization every KiroCrew trust-root signature is taken over.
+
+    Sorted keys + compact separators + UTF-8, so the same logical document always
+    produces the same bytes regardless of how a signing tool serialized it
+    (key order, indentation, whitespace).  Shared by
+    :meth:`PluginManifest.signing_payload` and
+    ``governance.policy_signing_payload`` on purpose: two independently-written
+    canonicalizers is how a signer and a verifier silently diverge, and a reviewer
+    can only check "are these consistent?" cheaply when there is one function to
+    read.  Callers are responsible for excluding the signature field itself from
+    *body* (a signature cannot cover itself).
+    """
+    return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def hmac_signature(secret: str, payload: bytes) -> str:
+    """Compute the expected HMAC-SHA256 hex digest over *payload*.
+
+    POC symmetric primitive shared by the plugin-manifest and security-policy
+    checks.  A production implementation swaps this for an asymmetric verify
+    against a publisher/issuer public key pinned in the policy; the shape (the
+    trust root holds the key, the signed document holds only the signature) is
+    unchanged, which is why both call sites route through one helper.
+    """
+    return hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
 
 
 def _normalize_name(name: str) -> str:
@@ -146,13 +186,40 @@ class PluginManifest:
 
     def signing_payload(self) -> bytes:
         """Canonical bytes the signature covers (manifest minus the signature)."""
-        body = {
+        body: Dict[str, object] = {
             "name": self.name,
             "publisher": self.publisher,
             "version": self.version,
             "capabilities": {k: sorted(v) for k, v in sorted(self.capabilities.items())},
         }
-        return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return canonical_signing_bytes(body)
+
+
+def _coerce_trust_keys(raw: object) -> Dict[str, str]:
+    """Keep only usable secrets: a non-empty ``str`` value per issuer/publisher.
+
+    A blanket ``str(v)`` would turn a malformed entry into a **predictable signing
+    secret**: ``{"trust_keys": {"fleet": null}}`` becomes the literal key ``"None"``
+    (and ``12`` becomes ``"12"``), so anyone who can guess that a fleet left a null
+    in its trust root can forge a signature that verifies for that issuer.  An
+    empty string is the same hazard.  Such an entry is a fleet-authoring mistake,
+    not a key, so it is DROPPED rather than coerced: the issuer then has no key,
+    no signature can verify for it, and the caller fails closed — the safe
+    direction, and the same one a missing entry already takes.
+    """
+    out: Dict[str, str] = {}
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if isinstance(v, str) and v:
+            out[str(k)] = v
+        else:
+            logger.warning(
+                "admission trust_keys[%r] is not a non-empty string; dropping it "
+                "(no signature can verify for this issuer)",
+                str(k),
+            )
+    return out
 
 
 @dataclass(frozen=True)
@@ -161,7 +228,19 @@ class AdmissionPolicy:
 
     mode: str = MODE_OPEN
     require_signature: bool = False
+    # Require a VERIFIED signature on the security policy (``security_policy.json``)
+    # itself, not just on plugins.  Deliberately a SEPARATE flag from
+    # ``require_signature`` (which gates plugin manifests): a fleet that signs its
+    # plugins has not thereby promised to sign its governance ceiling, and
+    # conflating the two would break existing managed fleets on upgrade.  Lives
+    # HERE rather than inside the security policy because a document cannot be the
+    # authority on whether it must be authentic — see
+    # ``governance.load_security_policy``.
+    require_policy_signature: bool = False
     # publisher -> shared secret (POC: HMAC; real impl: publisher public key).
+    # Shared by BOTH signature checks: a plugin manifest is keyed by its
+    # ``publisher``, a security policy by its ``identity.issuer``, so an operator
+    # maintains ONE key store rather than two.
     trust_keys: Dict[str, str] = field(default_factory=dict)
     # Marketplace allowlist. None = no allowlist (any non-banned plugin). A
     # present (even empty) list = only these names are admitted.
@@ -179,11 +258,19 @@ class AdmissionPolicy:
 
     @staticmethod
     def from_dict(d: dict) -> "AdmissionPolicy":
+        if not isinstance(d, dict):
+            # ``[]`` / ``null`` / ``"a string"`` are all valid JSON, so a malformed
+            # trust root reaches here shaped wrong rather than failing to parse.
+            # Raise a ValueError instead of leaking an AttributeError from the first
+            # ``.get`` — callers catch broken-trust-root shapes deliberately, and
+            # they should not have to enumerate incidental attribute errors to do it.
+            raise ValueError(f"admission policy must be a JSON object, got {type(d).__name__}")
         approved = d.get("approved", None)
         return AdmissionPolicy(
             mode=str(d.get("mode", MODE_OPEN)),
             require_signature=bool(d.get("require_signature", False)),
-            trust_keys={str(k): str(v) for k, v in (d.get("trust_keys") or {}).items()},
+            require_policy_signature=bool(d.get("require_policy_signature", False)),
+            trust_keys=_coerce_trust_keys(d.get("trust_keys")),
             approved=(_coerce_str_list(approved) if approved is not None else None),
             banned=_coerce_str_list(d.get("banned", [])),
             capability_ceiling={
@@ -215,6 +302,7 @@ class AdmissionDecision:
 _DEFAULT_POLICY_BODY: Dict[str, object] = {
     "mode": MODE_OPEN,
     "require_signature": False,
+    "require_policy_signature": False,
     "banned": [],
     "capability_ceiling": {},
     "_comment": (
@@ -222,7 +310,9 @@ _DEFAULT_POLICY_BODY: Dict[str, object] = {
         "Deleting this file DISABLES plugin admission (fail-closed): "
         "load_admission_policy() then returns MODE_ENFORCE with an empty allowlist "
         "and the dashboard governance indicator shows Disabled. To restrict "
-        "admission, set mode='enforce' and populate 'approved' / 'require_signature'."
+        "admission, set mode='enforce' and populate 'approved' / 'require_signature'. "
+        "'require_policy_signature' additionally demands a VERIFIED signature on "
+        "security_policy.json, keyed by its identity.issuer in 'trust_keys'."
     ),
 }
 
@@ -435,6 +525,50 @@ def load_admission_policy() -> AdmissionPolicy:
     return policy
 
 
+def read_policy_trust_root() -> "AdmissionPolicy":
+    """Read the admission policy for its TRUST-ROOT fields only, side-effect-free.
+
+    Distinct from :func:`load_admission_policy` on purpose.  That function is the
+    plugin-admission decision path: it records the dashboard admission posture and
+    emits a **critical** ``governance_degraded`` SEL when the policy is
+    absent/unreadable — correct exactly once per process at boot, and wrong for any
+    other reader.  The governance loader needs only ``require_policy_signature`` +
+    ``trust_keys``, and it runs on paths that repeat (``gatewayd`` re-loads the
+    security policy per app call), so reusing the audited loader would flip the
+    governance indicator to degraded and append a critical audit record on every
+    such call.
+
+    On an absent, unreadable, or malformed policy this returns the plain permissive
+    default (``require_policy_signature=False``, no keys) rather than
+    :func:`_fail_closed_policy`: an admission-policy problem is already handled —
+    loudly and fail-closed — in admission's own domain (``load_admission_policy``
+    refuses to admit plugins off the same file), and it must not additionally make
+    the security ceiling unloadable through a second path.
+
+    Deliberately NOT fail-closed on a corrupt file.  An attacker able to write this
+    file is outside the policy-signature threat model — they would set the flag to
+    ``false``, which parses fine — so fail-closing on a *malformed* file would only
+    catch a clumsy version of an attack the design concedes, at the cost of turning
+    a non-atomic fleet push or a hand-edit typo into an unbootable host.  Corruption
+    here is a reliability event: log it, stay predictable, let ``kirocrew doctor``
+    report it.  Never raises.
+    """
+    path = policy_trust_root_path()
+    try:
+        return AdmissionPolicy.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except FileNotFoundError:
+        logger.debug("no admission trust root at %s", path)
+        return AdmissionPolicy()
+    except Exception:
+        logger.warning(
+            "admission trust root at %s is unreadable or malformed; treating the "
+            "policy-signature requirement as unset (kirocrew doctor reports this)",
+            path,
+            exc_info=True,
+        )
+        return AdmissionPolicy()
+
+
 def _read_plugin_manifest(ep: "importlib.metadata.EntryPoint") -> Optional[PluginManifest]:
     """Read a plugin's manifest WITHOUT importing its module.
 
@@ -487,9 +621,7 @@ def _signature_valid(manifest: PluginManifest, policy: AdmissionPolicy) -> bool:
     secret = policy.trust_keys.get(manifest.publisher)
     if not secret:
         return False
-    expected = hmac.new(
-        secret.encode("utf-8"), manifest.signing_payload(), hashlib.sha256
-    ).hexdigest()
+    expected = hmac_signature(secret, manifest.signing_payload())
     return hmac.compare_digest(expected, manifest.signature)
 
 

--- a/src/kiro_crew/platform/bootstrap.py
+++ b/src/kiro_crew/platform/bootstrap.py
@@ -48,6 +48,7 @@ from kiro_crew.platform.defaults import (
 from kiro_crew.platform.discovery import discover_companion_context, plugin_entry_points
 from kiro_crew.platform.governance import (
     assert_governance_paths_protected,
+    assert_policy_signature_satisfied,
     load_security_policy,
 )
 from kiro_crew.platform.profile import resolve_profile
@@ -191,6 +192,13 @@ def bootstrap_context(cfg: "KiroCrewConfig") -> PlatformContext:
     # ceiling.  Independent of the deny-pattern floor (which assert_security_floor
     # covers) — fail closed at boot if a refactor ever dropped them.
     assert_governance_paths_protected()
+
+    # Mandated-signature absence gate: a fleet that set require_policy_signature
+    # must actually HAVE a policy. Runs on the FINAL context — after the companion
+    # supplied its bundled ceiling — because that is the first point at which "no
+    # policy at any tier" is decidable; load_security_policy() runs once per
+    # composition pass and cannot tell whether it is the last word.
+    assert_policy_signature_satisfied(ctx.governance)
 
     # Governance floor gate (Validation rules 3 & 7 / combined-order ABORT step):
     # when an enterprise ceiling is present, every bound profile must be at least

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -36,6 +36,7 @@ resolving it with zero evaluator edits.
 from __future__ import annotations
 
 import fnmatch
+import hmac
 import json
 import logging
 import os
@@ -45,7 +46,15 @@ from pathlib import Path
 from typing import Callable, Dict, Mapping, Optional, Protocol, Tuple, runtime_checkable
 
 from kiro_crew.config.paths import config_dir
+from kiro_crew.platform.admission import (
+    canonical_signing_bytes,
+    hmac_signature,
+    policy_trust_root_path,
+    read_policy_trust_root,
+)
 from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.governance_health import mark_governance_incident
+from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +83,14 @@ def _policy_home_path() -> Path:
 # Schema version this loader understands.  A file declaring a different version
 # fails closed rather than being parsed under guessed semantics.
 POLICY_VERSION = 1
+
+# Provenance of the loaded ceiling — what the loader actually PROVED, not what the
+# document claims.  Reported verbatim by ``kirocrew policy show`` so an operator
+# can tell an established issuer from a decorative one.
+SIGNATURE_VERIFIED = "verified"  # signature present AND checked against a trust key
+SIGNATURE_UNVERIFIED = "unverified"  # signature present but not proven (no key / bad sig)
+SIGNATURE_UNSIGNED = "unsigned"  # no identity.signature in the document
+SIGNATURE_UNCHECKED = "unchecked"  # parsed outside the loader (no trust root consulted)
 
 # Profile name schema (Appendix A): lowercase alnum + hyphen, alnum-initial.
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
@@ -906,9 +923,31 @@ class GovernanceCeiling:
     controls: Mapping[str, object]
     identity_issuer: str = ""
     identity_signature: str = ""
+    # Outcome of the load-time signature check (:func:`load_security_policy`).
+    # ``parse_policy`` alone cannot fill this in — it has the document but not the
+    # trust root — so a directly-parsed ceiling carries the honest
+    # ``SIGNATURE_UNCHECKED``, never a flattering default.
+    signature_state: str = "unchecked"
 
     def get(self, scope: str) -> Optional[object]:
         return self.controls.get(scope)
+
+    def signature_summary(self) -> str:
+        """One-line, operator-facing description of the ceiling's provenance.
+
+        Exists so every surface (CLI, and any future viewer) renders the SAME
+        vocabulary instead of each re-deriving "is this issuer meaningful?" from
+        the raw fields — the mistake this state machine replaces was printing an
+        issuer that no check had ever established.
+        """
+        if self.signature_state == SIGNATURE_VERIFIED:
+            return f"signed and verified (issuer: {self.identity_issuer})"
+        if self.signature_state == SIGNATURE_UNVERIFIED:
+            issuer = self.identity_issuer or "unnamed issuer"
+            return f"signed but UNVERIFIED — issuer {issuer!r} is unproven (advisory)"
+        if self.signature_state == SIGNATURE_UNSIGNED:
+            return "unsigned (integrity rests on filesystem permissions)"
+        return "signature not checked (parsed without a trust root)"
 
     def pinned_command_patterns(self) -> Tuple[str, ...]:
         """Force-deny command patterns pinned by this ceiling's ``commands`` scope.
@@ -1128,11 +1167,19 @@ def _parse_controls(data: Mapping[str, object], *, is_policy: bool) -> Dict[str,
 # ──────────────────────────────────────────────────────────────────────────
 # Loader
 # ──────────────────────────────────────────────────────────────────────────
-def parse_policy(data: Mapping[str, object]) -> GovernanceCeiling:
+def parse_policy(
+    data: Mapping[str, object], *, signature_state: str = SIGNATURE_UNCHECKED
+) -> GovernanceCeiling:
     """Parse a policy mapping into a frozen ``GovernanceCeiling``.
 
     Fails closed (raises ``PlatformCompositionError``) on any structural problem
     so a malformed-but-present policy never silently degrades to ungoverned.
+
+    ``signature_state`` is supplied by :func:`load_security_policy`, which is the
+    only caller that has the trust root.  It defaults to ``SIGNATURE_UNCHECKED``
+    (not ``SIGNATURE_UNSIGNED``) because a direct ``parse_policy`` call has PROVEN
+    nothing about provenance — reporting "unsigned" would conflate "we looked and
+    found no signature" with "nobody looked".
     """
     version = data.get("version")
     if version != POLICY_VERSION:
@@ -1157,6 +1204,7 @@ def parse_policy(data: Mapping[str, object]) -> GovernanceCeiling:
         controls=controls,
         identity_issuer=issuer,
         identity_signature=signature,
+        signature_state=signature_state,
     )
 
 
@@ -1202,6 +1250,208 @@ def _read_json_file(path: Path) -> Dict[str, object]:
     return data
 
 
+def policy_signing_payload(data: Mapping[str, object]) -> bytes:
+    """Canonical bytes an ``identity.signature`` covers, for the policy *document*.
+
+    Routed through ``admission.canonical_signing_bytes`` — the SAME
+    sorted-keys/compact-separators/UTF-8 canonicalization
+    ``PluginManifest.signing_payload`` uses — so the two trust roots cannot drift
+    apart, and a reviewer verifies consistency by reading one function.
+
+    Coverage is the **whole document minus ``identity.signature``** (the signature
+    cannot cover itself; ``identity.issuer`` IS covered, so an attacker cannot
+    re-label a validly-signed policy as coming from a different issuer).  Signing
+    the raw document rather than a projection of the parsed
+    :class:`GovernanceCeiling` is deliberate and does two things a projection
+    could not:
+
+    * it covers keys THIS build does not know — a companion-registered scope, or a
+      future schema addition — so stripping or editing one is still detected,
+      whereas a projection would silently omit it; and
+    * it keeps the payload scope-name-agnostic, honoring the module's core
+      invariant that adding a scope is a ``SCOPE_CATALOG`` data change and never
+      an edit to shared machinery.
+
+    Because coverage is byte-canonical over the parsed JSON (not over the file's
+    literal bytes), re-indenting or reordering keys does NOT break a signature,
+    while changing any value or adding/removing any key does.
+    """
+    body = {k: v for k, v in data.items() if k != "identity"}
+    identity = data.get("identity")
+    if isinstance(identity, dict):
+        # Preserve every identity field EXCEPT the signature, so issuer (and any
+        # future field such as an expiry or key id) is inside the signed payload.
+        rest = {k: v for k, v in identity.items() if k != "signature"}
+        if rest:
+            body["identity"] = rest
+    elif identity is not None:
+        # A non-object identity is a schema error parse_policy will reject; keep it
+        # inside the payload rather than silently dropping it from coverage.
+        body["identity"] = identity
+    return canonical_signing_bytes(body)
+
+
+def _policy_signature_state(
+    data: Mapping[str, object], trust_keys: Mapping[str, str]
+) -> Tuple[str, str]:
+    """Classify a policy document's signature.  Returns ``(state, detail)``.
+
+    Pure and I/O-free: the caller supplies the trust keys, so this is directly
+    unit-testable and the loader keeps the single responsibility of deciding what
+    to DO with the verdict.  Mirrors ``admission._signature_valid`` — HMAC-SHA256
+    over the canonical payload, compared with ``hmac.compare_digest`` — with the
+    key selected by ``identity.issuer`` instead of a plugin ``publisher``.
+    """
+    identity = data.get("identity")
+    identity_map: Mapping[str, object] = identity if isinstance(identity, dict) else {}
+    signature = str(identity_map.get("signature", "")).strip()
+    issuer = str(identity_map.get("issuer", "")).strip()
+    if not signature:
+        return SIGNATURE_UNSIGNED, "no identity.signature"
+    if not issuer:
+        # A signature with no issuer names no key, so nothing can verify it.
+        return SIGNATURE_UNVERIFIED, "identity.signature present but identity.issuer is empty"
+    secret = trust_keys.get(issuer)
+    if not secret:
+        return SIGNATURE_UNVERIFIED, f"no trust key for issuer {issuer!r}"
+    expected = hmac_signature(secret, policy_signing_payload(data))
+    # Compare BYTES, not str: ``hmac.compare_digest`` raises TypeError on a str
+    # containing any non-ASCII character, and a policy file's signature is
+    # attacker- or paste-controlled text.  A raised TypeError here is not a
+    # denial — it escapes ``load_security_policy`` as a plain (non-
+    # ``PlatformCompositionError``) exception, so the boot handler does not treat
+    # it as fatal and the later ``safe_context_call`` degrades to the no-ceiling
+    # fallback: a tampered policy would yield an UNGOVERNED host even with
+    # ``require_policy_signature`` on, inverting the flag. Encoding both sides
+    # keeps every malformed signature an ordinary UNVERIFIED verdict.
+    if hmac.compare_digest(expected.encode("utf-8"), signature.encode("utf-8")):
+        return SIGNATURE_VERIFIED, f"issuer {issuer!r}"
+    return SIGNATURE_UNVERIFIED, f"signature does not match trust key for issuer {issuer!r}"
+
+
+def _policy_trust_settings() -> Tuple[bool, Dict[str, str]]:
+    """Read the operator-controlled trust root: ``(require_policy_signature, keys)``.
+
+    Sourced from the **admission policy** (``KIROCREW_ADMISSION_POLICY`` env path,
+    else ``<data home>/admission_policy.json``) rather than from a new key store,
+    for three reasons:
+
+    * a document must not be the authority on whether it has to be authentic — a
+      ``require_signature`` flag INSIDE ``security_policy.json`` would be
+      self-referential, and an attacker rewriting the policy would simply clear
+      it;
+    * the admission policy is already the fleet-controlled trust root of this
+      package, already carries ``trust_keys``, and is already on the
+      ``is_sensitive_path`` keystone (the agent can neither read nor write it), so
+      it inherits every protection the plugin trust root has; and
+    * one key store means an operator provisions keys once.
+
+    Reads via ``admission.read_policy_trust_root`` — the SIDE-EFFECT-FREE reader —
+    not ``load_admission_policy``: the latter records the dashboard admission
+    posture and emits a critical ``governance_degraded`` SEL on an absent policy,
+    which is correct once per process at boot and wrong here, because this runs on
+    a repeating path (``gatewayd`` re-loads the security policy per app call) and
+    would flip the governance indicator to degraded on every one.
+
+    Never raises, and an unreadable admission policy yields no keys and a
+    ``False`` opt-in: an admission-policy problem is already handled loudly and
+    fail-closed in admission's own domain, and it must not additionally make the
+    security ceiling unloadable through a second path.
+    """
+    try:
+        adm = read_policy_trust_root()
+        return bool(adm.require_policy_signature), dict(adm.trust_keys)
+    except Exception:
+        logger.debug("policy trust settings unavailable", exc_info=True)
+        return False, {}
+
+
+def _policy_signature_required() -> bool:
+    """True when the admission policy explicitly opted in.
+
+    A trust root that is absent, unreadable, or not a JSON object reads as **no
+    opt-in**, and that is deliberate rather than a gap.  An attacker who can write
+    ``admission_policy.json`` is explicitly out of this feature's threat model (see
+    the threat-model note in ``docs/system-specs/modules/governance.md``) — such a
+    process would simply set the flag to ``false``, which is well-formed JSON, so
+    fail-closing on a *malformed* file only catches a clumsy version of an attack
+    the design already concedes.  What a corrupt trust root actually indicates in
+    practice is a non-atomic fleet push or a hand-edit typo — a reliability event —
+    and the useful response to that is to log loudly and behave predictably, which
+    ``read_policy_trust_root`` already does.  ``kirocrew doctor`` surfaces it.
+
+    Never raises.
+    """
+    try:
+        data = json.loads(policy_trust_root_path().read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    return bool(isinstance(data, dict) and data.get("require_policy_signature", False))
+
+
+def _audit_policy_signature(state: str, detail: str, path_label: str) -> None:
+    """Best-effort audit of the policy signature verdict.  Never raises.
+
+    A ``verified`` outcome is a debug-level non-event; the interesting records are
+    an unverified signature (someone TRIED to assert provenance and it did not
+    hold) and the fail-closed trip.  Mirrors ``admission._audit_admission_fail_closed``
+    /``_verify_seed_integrity``: SEL for the durable trail, and the process-global
+    health mark only for the genuine fail-closed case so a merely-advisory
+    mismatch does not flip the dashboard to degraded on every boot.
+    """
+    if state == SIGNATURE_VERIFIED:
+        logger.debug("security policy signature verified (%s)", detail)
+        return
+    try:
+
+        sel().log_api_access(
+            caller="_host",
+            operation="security_policy_signature",
+            outcome=state,
+            source="startup",
+            error=detail,
+        )
+    except Exception:
+        logger.debug("policy signature SEL emit unavailable", exc_info=True)
+    if state == SIGNATURE_UNVERIFIED:
+        logger.warning(
+            "security policy at %s carries an UNVERIFIED signature (%s); "
+            "treating the ceiling as unauthenticated",
+            path_label,
+            detail,
+        )
+
+
+def _verify_policy_signature(data: Mapping[str, object], *, source: str) -> str:
+    """Compute and audit the signature state for a policy document.
+
+    **Computes the verdict; does not enforce it.**  Enforcement is
+    :func:`assert_policy_signature_satisfied`, which runs once on the FINAL
+    composed ceiling.  The split matters because ``load_security_policy`` walks a
+    precedence chain (env → companion bundle → operator home) and runs more than
+    once per boot with different arguments: the core's loader-less pass falls
+    through to the HOME tier and would raise on it, even when the edition's later
+    pass would have selected a correctly-signed BUNDLE that outranks it.  A tier
+    the final ceiling never came from must not be able to abort boot, so every
+    load-time verdict here is preliminary and only the surviving one is judged.
+
+    Returns the state to record on the ceiling.  Never raises.
+    """
+    _, trust_keys = _policy_trust_settings()
+    state, detail = _policy_signature_state(data, trust_keys)
+    _audit_policy_signature(state, detail, source)
+    return state
+
+
+def _mark_policy_signature_incident(detail: str) -> None:
+    """Best-effort: record the fail-closed trip on the governance health signal."""
+    try:
+
+        mark_governance_incident("failed_closed", detail=f"security_policy_signature:{detail}")
+    except Exception:
+        logger.debug("governance health mark unavailable", exc_info=True)
+
+
 def load_security_policy(
     *, bundled_loader: Optional[Callable[[], Optional[Mapping[str, object]]]] = None
 ) -> Optional[GovernanceCeiling]:
@@ -1221,6 +1471,32 @@ def load_security_policy(
     ``admission.load_admission_policy`` — a fleet that meant to enforce something
     must never silently fall open.  The bundled loader is trusted (same author,
     covered by the admission signature) so its parse errors also raise.
+
+    **Signature verification (``identity.signature``).**  The two FILE tiers (1
+    and 3) carry a detached signature over the canonical document
+    (:func:`policy_signing_payload`), verified against a trust key the
+    *operator-controlled admission policy* holds — never a key the security policy
+    supplies about itself.  The verdict is recorded on
+    ``GovernanceCeiling.signature_state`` and is **advisory by default**: an
+    unsigned or unverifiable policy still loads and still governs, so every
+    existing standalone install and every existing policy file keeps working
+    byte-for-byte unchanged.  Setting ``require_policy_signature`` in the
+    admission policy makes it mandatory, and a failure then raises
+    ``PlatformCompositionError`` (boot aborts) like every other fail-closed check
+    in this module.
+
+    **All three tiers are verified — none is exempt.**  The plugin-admission
+    manifest signature covers only the manifest fields (name / publisher /
+    version / capabilities — ``admission.PluginManifest.signing_payload``), NOT
+    the bytes of the packaged ``security_policy.json``, so "covered by admission"
+    never actually protected the bundled resource: a tampered bundled policy would
+    have loaded unchecked.  So the bundled tier passes ``signable=True`` like the
+    file tiers.  When ``require_policy_signature`` is OFF (the default, and what
+    the ``amazon`` edition ships) verification is advisory at every tier and an
+    unsigned bundled policy still loads — so existing installs are unchanged; when
+    it is ON, an edition signs its bundled policy like any other governed tier.
+    A **missing** policy does not satisfy the requirement either: with a genuine
+    opt-in and no policy at any tier, boot aborts rather than running ungoverned.
     """
     raw_env = os.environ.get(_POLICY_ENV, "").strip()
     if raw_env:
@@ -1231,12 +1507,25 @@ def load_security_policy(
             raise PlatformCompositionError(
                 f"security policy at {path} (from {_POLICY_ENV}) is unreadable: {exc}"
             ) from exc
-        return parse_policy(data)
+        state = _verify_policy_signature(data, source=str(path))
+        return parse_policy(data, signature_state=state)
 
     if bundled_loader is not None:
         bundled = bundled_loader()
         if bundled is not None:
-            return parse_policy(bundled)
+            # The bundled tier is NOT exempt from a fleet that opted into
+            # require_policy_signature. The plugin-admission manifest signature
+            # covers only name/publisher/version/capabilities
+            # (admission.PluginManifest.signing_payload), NOT the packaged
+            # security_policy.json bytes, so "covered by admission" did not in
+            # fact protect the resource — a tampered bundled policy would have
+            # loaded unchecked. When require is OFF this is advisory exactly like
+            # the file tiers (an unsigned bundled policy still loads), so the
+            # standalone/default and the Amazon edition (which sets no require)
+            # are unaffected; when require is ON the edition must sign its
+            # bundled policy like any other governed tier.
+            state = _verify_policy_signature(bundled, source="companion-bundled resource")
+            return parse_policy(bundled, signature_state=state)
 
     home_path = _policy_home_path()
     if home_path.exists():
@@ -1246,9 +1535,70 @@ def load_security_policy(
             raise PlatformCompositionError(
                 f"security policy at {home_path} is unreadable: {exc}"
             ) from exc
-        return parse_policy(data)
+        state = _verify_policy_signature(data, source=str(home_path))
+        return parse_policy(data, signature_state=state)
 
+    # No policy at env, bundled, OR home tier → ungoverned (editable defaults).
+    #
+    # This function deliberately does NOT refuse boot here, because it cannot tell
+    # whether it is the LAST word on the question. ``load_security_policy()`` is
+    # called more than once per boot with different arguments: the core calls it
+    # with NO bundled_loader first (``bootstrap.build_default_context``) and a
+    # companion edition re-invokes it WITH its loader afterwards. "No policy at any
+    # tier" is therefore only decidable once composition has finished, so the
+    # fail-closed refusal lives in :func:`assert_policy_signature_satisfied`, which
+    # boot calls on the FINAL context alongside the other governance floor gates.
     return None
+
+
+def assert_policy_signature_satisfied(ceiling: Optional[GovernanceCeiling]) -> None:
+    """Enforce ``require_policy_signature`` against a FINAL, selected ceiling.
+
+    The single enforcement point for the opt-in.  :func:`_verify_policy_signature`
+    only *computes* each tier's verdict at load time; this judges the one that
+    actually survived precedence, and it judges both failure shapes:
+
+    * a ceiling whose ``signature_state`` is not ``verified`` — someone either did
+      not sign it or signed it with a key this trust root does not hold; and
+    * **no ceiling at all** — absence must not satisfy a mandated signature, or a
+      fleet that lost or never shipped its ``security_policy.json`` runs with no
+      ceiling whatsoever, the exact failure the flag exists to prevent.
+
+    Enforcing here rather than in the loader is what makes tier precedence work.
+    ``load_security_policy`` walks env → companion bundle → operator home and runs
+    more than once per boot with different arguments (the core with no
+    ``bundled_loader``, an edition with one).  A raise inside it fires on whichever
+    tier that particular pass happened to reach: the core's loader-less pass falls
+    through to an unsigned HOME file and would abort even when the edition's later
+    pass selects a correctly-signed BUNDLE that outranks it.  Only the composed
+    result knows which tier won, so only the composed result can be judged.
+
+    Callers: boot (on ``ctx.governance``) and every non-boot consumer that re-loads
+    the policy on a live path.  With the flag off (the default, and what the
+    ``amazon`` edition ships) this is a no-op — an unsigned policy still loads and
+    still governs, which is the compatibility contract.
+    """
+    if ceiling is not None and ceiling.signature_state == SIGNATURE_VERIFIED:
+        return
+    if not _policy_signature_required():
+        return
+    if ceiling is None:
+        _mark_policy_signature_incident("no-policy:require_policy_signature set")
+        raise PlatformCompositionError(
+            "require_policy_signature is set in the admission policy but no "
+            "security policy is present at any tier (env, bundled, or home); "
+            "boot is refused (fail-closed) rather than running ungoverned. "
+            "Install a signed security_policy.json, or clear "
+            "require_policy_signature to return to advisory verification."
+        )
+    _mark_policy_signature_incident(f"{ceiling.signature_state}:require set")
+    raise PlatformCompositionError(
+        f"the active security policy's signature is {ceiling.signature_state!r}, not "
+        "'verified'; require_policy_signature is set in the admission policy, so "
+        "boot is refused (fail-closed). Sign the policy with the trust key for its "
+        "identity.issuer, or clear require_policy_signature to return to advisory "
+        "verification."
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -1537,6 +1887,11 @@ __all__ = [
     "MODE_ALLOW",
     "MODE_DENY",
     "COMMANDS_SCOPE",
+    "SIGNATURE_VERIFIED",
+    "SIGNATURE_UNVERIFIED",
+    "SIGNATURE_UNSIGNED",
+    "SIGNATURE_UNCHECKED",
+    "policy_signing_payload",
     "register_scope",
     "register_matcher",
     "mcp_title_to_ref",
@@ -1552,5 +1907,6 @@ __all__ = [
     "gate_decision",
     "assert_governance_floor",
     "assert_governance_paths_protected",
+    "assert_policy_signature_satisfied",
     "compose_profiles",
 ]

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -11,6 +11,8 @@ Covers:
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 
 import pytest
@@ -20,6 +22,10 @@ from kiro_crew.platform.governance import (
     MODE_ALLOW,
     MODE_DENY,
     SCOPE_CATALOG,
+    SIGNATURE_UNCHECKED,
+    SIGNATURE_UNSIGNED,
+    SIGNATURE_UNVERIFIED,
+    SIGNATURE_VERIFIED,
     Bind,
     CapabilityGate,
     GovernanceCeiling,
@@ -29,12 +35,14 @@ from kiro_crew.platform.governance import (
     ScopedRuleset,
     ScopeSpec,
     assert_governance_floor,
+    assert_policy_signature_satisfied,
     compose_profiles,
     deny_all_profile,
     load_security_policy,
     mcp_title_to_ref,
     parse_policy,
     parse_profile,
+    policy_signing_payload,
     register_matcher,
     register_scope,
     resolve,
@@ -809,3 +817,600 @@ class TestSchemaStrictness:
     def test_profile_name_pattern_accepted(self, ok):
         prof = parse_profile({"name": ok})
         assert prof.name == ok
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Policy signature verification (identity.signature) — mirrors admission
+# ──────────────────────────────────────────────────────────────────────────
+def _sign_policy(body: dict, secret: str) -> dict:
+    """Return *body* with a valid ``identity.signature`` for its issuer."""
+    signed = json.loads(json.dumps(body))  # deep copy; body may be reused
+    sig = hmac.new(
+        secret.encode("utf-8"), policy_signing_payload(signed), hashlib.sha256
+    ).hexdigest()
+    signed.setdefault("identity", {})["signature"] = sig
+    return signed
+
+
+def _patch_trust(monkeypatch, *, require: bool, keys: dict):
+    """Point the loader's trust root at fixed settings (no admission file I/O)."""
+    monkeypatch.setattr(
+        "kiro_crew.platform.governance._policy_trust_settings",
+        lambda: (require, dict(keys)),
+    )
+
+
+def _real_trust_file(monkeypatch, tmp_path, *, require: bool, keys: dict):
+    """Write a REAL admission file so both trust-root readers agree.
+
+    ``_patch_trust`` stubs ``_policy_trust_settings``, which the loader uses for keys,
+    but the enforcement gate reads the opt-in from the admission file directly. Tests
+    that exercise the gate therefore need an actual file, not the stub.
+    """
+    adm = tmp_path / "admission_policy.json"
+    adm.write_text(json.dumps({"require_policy_signature": require, "trust_keys": dict(keys)}))
+    monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+
+
+def _load_and_enforce(**kwargs):
+    """Load the policy and apply the boot gate — the real two-step boot sequence.
+
+    Load computes each tier's verdict; the gate judges the one that survived
+    precedence.  Tests assert on the pair because that is what a host actually runs;
+    asserting on ``load_security_policy`` alone would pin an intermediate state and
+    miss the tier-precedence bug that split them apart.
+    """
+    ceiling = load_security_policy(**kwargs)
+    assert_policy_signature_satisfied(ceiling)
+    return ceiling
+
+
+class TestPolicySigningPayload:
+    def test_signature_field_is_excluded_but_issuer_is_covered(self):
+        base = _policy_body(identity={"issuer": "fleet-control"})
+        with_sig = _policy_body(identity={"issuer": "fleet-control", "signature": "deadbeef"})
+        # Adding the signature must not change the payload (it cannot cover itself)…
+        assert policy_signing_payload(base) == policy_signing_payload(with_sig)
+        # …but the issuer IS inside it, so a validly-signed policy cannot be
+        # re-labelled as issued by someone else.
+        other = _policy_body(identity={"issuer": "attacker", "signature": "deadbeef"})
+        assert policy_signing_payload(other) != policy_signing_payload(with_sig)
+
+    def test_payload_is_stable_across_key_order_and_whitespace(self):
+        a = {"version": 1, "boot": {"fail_closed": True}}
+        b = {"boot": {"fail_closed": True}, "version": 1}
+        assert policy_signing_payload(a) == policy_signing_payload(b)
+
+    def test_payload_covers_unknown_forward_compatible_keys(self):
+        # Signing the raw document (not a projection of the parsed ceiling) is what
+        # makes a companion-registered or future scope tamper-evident on a build
+        # that does not know the key.
+        a = _policy_body()
+        b = _policy_body(future_scope={"mode": "allow"})
+        assert policy_signing_payload(a) != policy_signing_payload(b)
+
+    def test_shares_admission_canonicalization(self):
+        # One canonicalizer for both trust roots — a divergence here is exactly how
+        # a signer and a verifier drift apart.
+        from kiro_crew.platform.admission import canonical_signing_bytes
+
+        body = {"version": 1, "boot": {"fail_closed": True}}
+        assert policy_signing_payload(body) == canonical_signing_bytes(body)
+
+
+class TestPolicySignatureStates:
+    def test_verified_good_signature(self, monkeypatch, tmp_path):
+        secret = "trust-key"
+        body = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), secret)
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": secret})
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_VERIFIED
+        assert "verified" in ceiling.signature_summary()
+
+    def test_verified_survives_reserialization(self, monkeypatch, tmp_path):
+        # The signature covers the canonical form of the parsed JSON, so an
+        # operator re-indenting or reordering the file does not invalidate it.
+        secret = "trust-key"
+        body = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), secret)
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body, indent=4, sort_keys=True) + "\n")
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": secret})
+        assert load_security_policy().signature_state == SIGNATURE_VERIFIED
+
+    def test_non_ascii_signature_is_unverified_not_a_crash(self, monkeypatch, tmp_path):
+        """A non-ASCII signature must be an ordinary UNVERIFIED verdict.
+
+        ``hmac.compare_digest`` raises TypeError on a str carrying any non-ASCII
+        character, and a policy file's signature is attacker- or paste-controlled
+        text (a smart-quote or NBSP is enough).  A raised TypeError is NOT a
+        denial: it escapes ``load_security_policy`` as a plain exception, the boot
+        handler does not treat it as fatal (it only re-raises
+        ``PlatformCompositionError``), and the later ``safe_context_call``
+        degrades to the no-ceiling fallback — so a tampered policy would yield an
+        UNGOVERNED host even with ``require_policy_signature`` on, inverting the
+        flag.  Both sides are encoded before comparison.
+        """
+        for signature in ("abc\u2013def", "abc\u00a0def", "\u00e9" * 64):
+            body = _policy_body(identity={"issuer": "fleet-control", "signature": signature})
+            p = tmp_path / "policy.json"
+            p.write_text(json.dumps(body))
+            monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+            _patch_trust(monkeypatch, require=False, keys={"fleet-control": "trust-key"})
+            ceiling = load_security_policy()
+            assert ceiling is not None
+            assert ceiling.signature_state == SIGNATURE_UNVERIFIED
+
+    def test_non_ascii_signature_fails_closed_when_required(self, monkeypatch, tmp_path):
+        """...and with the opt-in ON it must ABORT, not degrade to ungoverned."""
+        body = _policy_body(
+            identity={"issuer": "fleet-control", "signature": "tamper\u2013ed"}
+        )
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": "trust-key"})
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce()
+
+    def test_verified_bad_signature_is_unverified(self, monkeypatch, tmp_path):
+        body = _policy_body(identity={"issuer": "fleet-control", "signature": "not-the-mac"})
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": "trust-key"})
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_UNVERIFIED
+
+    def test_tampered_payload_invalidates_a_good_signature(self, monkeypatch, tmp_path):
+        # The core threat: an attacker edits a governed scope to WIDEN the ceiling
+        # but cannot re-sign it.
+        secret = "trust-key"
+        body = _sign_policy(
+            _policy_body(
+                identity={"issuer": "fleet-control"},
+                commands={"mode": "deny", "deny": ["git push*"]},
+            ),
+            secret,
+        )
+        body["commands"] = {"mode": "deny", "deny": []}  # ceiling widened in place
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": secret})
+        assert load_security_policy().signature_state == SIGNATURE_UNVERIFIED
+
+    def test_signature_without_issuer_is_unverified(self, monkeypatch, tmp_path):
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body(identity={"signature": "abc"})))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": "k"})
+        assert load_security_policy().signature_state == SIGNATURE_UNVERIFIED
+
+    def test_no_trust_key_for_issuer_is_unverified(self, monkeypatch, tmp_path):
+        body = _sign_policy(_policy_body(identity={"issuer": "unknown-issuer"}), "k")
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": "k"})
+        assert load_security_policy().signature_state == SIGNATURE_UNVERIFIED
+
+    def test_wrong_trust_key_is_unverified(self, monkeypatch, tmp_path):
+        body = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), "real-key")
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={"fleet-control": "other-key"})
+        assert load_security_policy().signature_state == SIGNATURE_UNVERIFIED
+
+
+class TestPolicySignatureOptIn:
+    """The load-bearing design decision: verification is opt-in and advisory."""
+
+    def test_unsigned_with_require_off_still_loads_and_governs(self, monkeypatch, tmp_path):
+        # Backward-compatibility guarantee: every existing policy file keeps
+        # working unchanged, with no signature and no trust key provisioned.
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body(commands={"mode": "deny", "deny": ["git push*"]})))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={})
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_UNSIGNED
+        # …and the ceiling is still ENFORCED, not degraded to ungoverned.
+        assert not resolve(ceiling, None, "commands", "git push origin").permitted
+
+    def test_unverified_with_require_off_still_loads(self, monkeypatch, tmp_path):
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body(identity={"issuer": "x", "signature": "bogus"})))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={})
+        assert load_security_policy() is not None
+
+    def test_unsigned_with_require_on_fails_closed(self, monkeypatch, tmp_path):
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body()))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": "k"})
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce()
+
+    def test_tampered_with_require_on_fails_closed(self, monkeypatch, tmp_path):
+        secret = "trust-key"
+        body = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), secret)
+        body["version"] = 1
+        body["boot"] = {"fail_closed": False}  # tampered after signing
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": secret})
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce()
+
+    def test_verified_with_require_on_boots(self, monkeypatch, tmp_path):
+        secret = "trust-key"
+        body = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), secret)
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(body))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=True, keys={"fleet-control": secret})
+        assert load_security_policy().signature_state == SIGNATURE_VERIFIED
+
+    def test_require_on_marks_governance_health_incident(self, monkeypatch, tmp_path):
+        from kiro_crew.platform import governance_health
+
+        governance_health.reset()
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body()))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={})
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce()
+        inc = governance_health.last_incident()
+        assert inc is not None and inc["kind"] == "failed_closed"
+        governance_health.reset()
+
+    def test_home_tier_is_verified_too(self, monkeypatch, tmp_path):
+        secret = "trust-key"
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        home = tmp_path / "security_policy.json"
+        home.write_text(
+            json.dumps(_sign_policy(_policy_body(identity={"issuer": "operator"}), secret))
+        )
+        monkeypatch.setattr("kiro_crew.platform.governance._policy_home_path", lambda: home)
+        _patch_trust(monkeypatch, require=False, keys={"operator": secret})
+        assert load_security_policy().signature_state == SIGNATURE_VERIFIED
+
+    def test_home_tier_unsigned_with_require_on_fails_closed(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        home = tmp_path / "security_policy.json"
+        home.write_text(json.dumps(_policy_body()))
+        monkeypatch.setattr("kiro_crew.platform.governance._policy_home_path", lambda: home)
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={})
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce()
+
+    def test_signed_bundle_outranks_an_unsigned_home_file(self, monkeypatch, tmp_path):
+        # GPT finding: enforcing at LOAD time raised on whichever tier a given pass
+        # happened to reach. The core's loader-less pass falls through to the HOME
+        # file, so an enterprise host with an unsigned home file and a correctly
+        # signed companion BUNDLE aborted — even though the bundle outranks home and
+        # is what the final ceiling comes from. Enforcement moved to the composed
+        # result so precedence decides which verdict is judged.
+        secret = "trust-key"
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        home = tmp_path / "security_policy.json"
+        home.write_text(json.dumps(_policy_body()))  # unsigned, lower precedence
+        monkeypatch.setattr("kiro_crew.platform.governance._policy_home_path", lambda: home)
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": secret})
+        # The core's loader-less pass must not abort on the lower-precedence tier…
+        assert load_security_policy() is not None
+        # …and the edition's signed bundle is what gets judged, so boot proceeds.
+        bundle = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), secret)
+        assert _load_and_enforce(bundled_loader=lambda: bundle).signature_state == (
+            SIGNATURE_VERIFIED
+        )
+
+    def test_bundled_tier_is_advisory_when_require_off(self, monkeypatch, tmp_path):
+        # With require OFF (the Amazon edition ships no require), an unsigned
+        # bundled policy still loads — advisory, exactly like the file tiers.
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+        )
+        _patch_trust(monkeypatch, require=False, keys={})
+        ceiling = load_security_policy(bundled_loader=lambda: _policy_body())
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_UNSIGNED
+
+    def test_bundled_tier_is_NOT_exempt_when_required(self, monkeypatch, tmp_path):
+        # GPT-review finding: the plugin-admission manifest signature covers only
+        # name/publisher/version/capabilities, NOT the packaged
+        # security_policy.json bytes, so "covered by admission" never protected
+        # the resource — a tampered bundled policy loaded unchecked. Under
+        # require_policy_signature the bundled tier must verify like any other.
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+        )
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": "trust-key"})
+        # An unsigned bundled policy under require must abort, not load.
+        with pytest.raises(PlatformCompositionError):
+            _load_and_enforce(
+                bundled_loader=lambda: _policy_body(identity={"issuer": "fleet-control"})
+            )
+        # A correctly-signed bundled policy verifies and loads.
+        signed = _sign_policy(
+            _policy_body(identity={"issuer": "fleet-control"}), "trust-key"
+        )
+        ceiling = load_security_policy(bundled_loader=lambda: signed)
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_VERIFIED
+
+    def test_no_policy_stays_none_when_require_off(self, monkeypatch, tmp_path):
+        # require OFF: an ungoverned standalone host stays ungoverned.
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+        )
+        _patch_trust(monkeypatch, require=False, keys={})
+        assert load_security_policy() is None
+
+    def test_loader_never_raises_on_absence_whatever_the_optin(self, monkeypatch, tmp_path):
+        # The loader is not the authority on absence: it runs once per composition
+        # pass (core without a bundled_loader, edition with one) and cannot tell
+        # whether it is the last word. Raising inside it either aborts a bundle-only
+        # enterprise host before its edition is consulted, or — keyed on the loader
+        # being present — misses a standalone host entirely (the GPT finding). So
+        # absence always yields None here; the refusal lives in the boot gate.
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+        )
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(json.dumps({"require_policy_signature": True,
+                                   "trust_keys": {"fleet-control": "trust-key"}}))
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        assert load_security_policy() is None  # core's loader-less pass
+        assert load_security_policy(bundled_loader=lambda: None) is None  # edition's pass
+
+
+class TestPolicySignatureAbsenceGate:
+    """``assert_policy_signature_satisfied`` — absence must not satisfy the mandate."""
+
+    def test_no_policy_fails_closed_when_genuinely_required(self, monkeypatch, tmp_path):
+        # With require ON and NO policy at any tier, handing back an ungoverned host
+        # bypasses the requirement precisely when it matters (a mandated-signature
+        # fleet that lost or never shipped its policy). Boot must abort instead.
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(json.dumps({"require_policy_signature": True,
+                                   "trust_keys": {"fleet-control": "trust-key"}}))
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        with pytest.raises(PlatformCompositionError):
+            assert_policy_signature_satisfied(None)
+
+    def test_standalone_no_loader_is_covered_too(self, monkeypatch, tmp_path):
+        # GPT finding on the previous shape: gating the refusal on "a bundled_loader
+        # was consulted" meant a STANDALONE host (no edition, so no loader ever) with
+        # a genuine opt-in and no policy ran with no ceiling. The gate runs on the
+        # composed context, so it does not depend on a loader existing at all.
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(json.dumps({"require_policy_signature": True}))
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+        )
+        ceiling = load_security_policy()  # standalone: no bundled_loader, ever
+        assert ceiling is None
+        with pytest.raises(PlatformCompositionError):
+            assert_policy_signature_satisfied(ceiling)
+
+    def test_verified_ceiling_satisfies_the_gate(self, monkeypatch, tmp_path):
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": "trust-key"})
+        signed = _sign_policy(_policy_body(identity={"issuer": "fleet-control"}), "trust-key")
+        assert_policy_signature_satisfied(
+            parse_policy(signed, signature_state=SIGNATURE_VERIFIED)
+        )
+
+    def test_present_but_unverified_ceiling_does_NOT_satisfy_the_gate(
+        self, monkeypatch, tmp_path
+    ):
+        # Presence alone is not enough — the gate is the enforcement point for the
+        # verdict too, now that load time only computes it. A tampered or unsigned
+        # ceiling that survived precedence must abort here.
+        _real_trust_file(monkeypatch, tmp_path, require=True, keys={"fleet-control": "trust-key"})
+        for state in (SIGNATURE_UNSIGNED, SIGNATURE_UNVERIFIED, SIGNATURE_UNCHECKED):
+            with pytest.raises(PlatformCompositionError):
+                assert_policy_signature_satisfied(
+                    parse_policy(_policy_body(), signature_state=state)
+                )
+
+    def test_unverified_ceiling_is_fine_when_require_off(self, monkeypatch, tmp_path):
+        # The compatibility contract: with the flag off an unsigned ceiling loads
+        # AND governs, so the gate must not touch it.
+        _real_trust_file(monkeypatch, tmp_path, require=False, keys={})
+        assert_policy_signature_satisfied(
+            parse_policy(_policy_body(), signature_state=SIGNATURE_UNSIGNED)
+        )
+
+    def test_require_off_is_a_noop(self, monkeypatch, tmp_path):
+        # The default and what the amazon edition ships: an ungoverned standalone
+        # host stays ungoverned rather than being refused boot.
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(json.dumps({"mode": "open"}))
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        assert_policy_signature_satisfied(None)
+
+    @pytest.mark.parametrize(
+        "shape", ['{ "mode": "open",  <-- typo', "[]", "null", '"a string"', "123"]
+    )
+    def test_a_broken_trust_root_reads_as_no_optin_by_design(
+        self, monkeypatch, tmp_path, shape
+    ):
+        """A corrupt/malformed admission file does NOT fail closed. Deliberate.
+
+        An attacker who can write this file is outside the policy-signature threat
+        model — they would set the flag to ``false``, which parses fine — so
+        fail-closing on a *malformed* file catches only a clumsy version of an attack
+        the design concedes, while turning a non-atomic fleet push or a hand-edit
+        typo into an unbootable host. Corruption here is a reliability event: logged,
+        predictable, reported by ``kirocrew doctor``.
+        """
+        bad = tmp_path / "admission_policy.json"
+        bad.write_text(shape)
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(bad))
+        assert_policy_signature_satisfied(None)
+        assert_policy_signature_satisfied(
+            parse_policy(_policy_body(), signature_state=SIGNATURE_UNSIGNED)
+        )
+
+    def test_absent_admission_file_is_a_noop(self, monkeypatch, tmp_path):
+        # No trust root: nobody opted in, so an unsigned policy still loads and
+        # governs (the compatibility contract) and no policy stays ungoverned.
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(tmp_path / "missing.json"))
+        assert_policy_signature_satisfied(None)
+        assert_policy_signature_satisfied(
+            parse_policy(_policy_body(), signature_state=SIGNATURE_UNSIGNED)
+        )
+
+    def test_absent_admission_policy_keeps_verification_advisory(self, monkeypatch, tmp_path):
+        # An admission-policy problem is handled loudly in admission's OWN domain;
+        # it must not additionally make the security ceiling unloadable here.
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.admission._policy_default_path",
+            lambda: tmp_path / "no-admission.json",
+        )
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body()))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.signature_state == SIGNATURE_UNSIGNED
+
+    def test_raising_trust_root_keeps_verification_advisory(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "kiro_crew.platform.admission.read_policy_trust_root",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body()))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        assert load_security_policy().signature_state == SIGNATURE_UNSIGNED
+
+    def test_trust_settings_read_from_admission_policy_file(self, monkeypatch, tmp_path):
+        # One key store: the flag + keys come from the admission policy file, not a
+        # second bespoke file, and NOT from the security policy itself.
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(
+            json.dumps(
+                {"require_policy_signature": True, "trust_keys": {"fleet-control": "k"}}
+            )
+        )
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        from kiro_crew.platform.governance import _policy_trust_settings
+
+        require, keys = _policy_trust_settings()
+        assert require is True
+        assert keys == {"fleet-control": "k"}
+
+    def test_security_policy_cannot_self_declare_the_requirement(self, monkeypatch, tmp_path):
+        # A require_policy_signature key inside security_policy.json is NOT a
+        # governed scope, so it fails closed as an unknown key rather than being
+        # honored — a document must not be the authority on its own authenticity.
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body(require_policy_signature=True)))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        _patch_trust(monkeypatch, require=False, keys={})
+        with pytest.raises(PlatformCompositionError):
+            load_security_policy()
+
+    def test_loading_does_not_disturb_admission_health_signal(self, monkeypatch, tmp_path):
+        # The trust-root read must NOT run the audited admission loader: that
+        # records posture + a critical SEL, and gatewayd re-loads the security
+        # policy per app call.
+        from kiro_crew.platform import governance_health
+
+        governance_health.reset()
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.admission._policy_default_path",
+            lambda: tmp_path / "no-admission.json",
+        )
+        p = tmp_path / "policy.json"
+        p.write_text(json.dumps(_policy_body()))
+        monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(p))
+        load_security_policy()
+        assert governance_health.governance_status() == "unknown"
+        assert governance_health.last_incident() is None
+        governance_health.reset()
+
+
+class TestParsePolicySignatureState:
+    def test_direct_parse_is_unchecked_not_unsigned(self):
+        # parse_policy has the document but no trust root; claiming "unsigned"
+        # would conflate "we looked" with "nobody looked".
+        ceiling = parse_policy(_policy_body())
+        assert ceiling.signature_state == SIGNATURE_UNCHECKED
+        assert "not checked" in ceiling.signature_summary()
+
+    def test_identity_fields_still_parsed(self):
+        ceiling = parse_policy(_policy_body(identity={"issuer": "fleet-control", "signature": "s"}))
+        assert ceiling.identity_issuer == "fleet-control"
+        assert ceiling.identity_signature == "s"
+
+
+class TestPolicyShowReporting:
+    """`kirocrew policy show` must distinguish the three provenance states."""
+
+    def _show(self, capsys, ceiling):
+        import argparse
+        from unittest.mock import patch
+
+        from kiro_crew import cli_commands
+
+        args = argparse.Namespace(policy_action="show")
+        # _policy imports current_context lazily from platform.context, so patch
+        # it at the definition site.
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=type("Ctx", (), {"governance": ceiling})(),
+        ):
+            cli_commands._policy(args)
+        return capsys.readouterr().out
+
+    def _ceiling(self, state, issuer="fleet-control", signature="sig"):
+        return GovernanceCeiling(
+            version=1,
+            boot=parse_policy(_policy_body()).boot,
+            controls={},
+            identity_issuer=issuer,
+            identity_signature=signature,
+            signature_state=state,
+        )
+
+    def test_show_reports_verified(self, capsys):
+        out = self._show(capsys, self._ceiling(SIGNATURE_VERIFIED))
+        assert "signed and verified" in out
+        assert "fleet-control" in out
+
+    def test_show_reports_signed_but_unverified(self, capsys):
+        out = self._show(capsys, self._ceiling(SIGNATURE_UNVERIFIED))
+        assert "UNVERIFIED" in out
+        # An unproven issuer must NOT be presented as an established fact.
+        assert "signed and verified" not in out
+
+    def test_show_reports_unsigned(self, capsys):
+        out = self._show(capsys, self._ceiling(SIGNATURE_UNSIGNED, issuer="", signature=""))
+        assert "unsigned" in out
+        assert "verified" not in out
+
+    def test_show_no_policy_unchanged(self, capsys):
+        out = self._show(capsys, None)
+        assert "No enterprise security policy is active" in out

--- a/test/test_mcp_apps_call_endpoint.py
+++ b/test/test_mcp_apps_call_endpoint.py
@@ -292,6 +292,80 @@ async def test_app_call_denied_by_governance_mcp_scope(apps_flag_on, spool_tmp, 
         await live.aclose()
 
 
+async def test_app_call_denied_when_the_reloaded_policy_signature_is_bad(
+    apps_flag_on, spool_tmp, tmp_path, monkeypatch
+):
+    """A policy TAMPERED after boot must not widen an app callback.
+
+    This path re-reads the policy per call for freshness, so boot's verification of
+    the original bytes says nothing about what it loads now. Under a genuine
+    ``require_policy_signature`` opt-in a non-verified reload denies.
+    """
+    from kiro_crew.platform.admission import hmac_signature
+    from kiro_crew.platform.governance import policy_signing_payload
+
+    adm = tmp_path / "admission_policy.json"
+    adm.write_text(json.dumps({
+        "require_policy_signature": True, "trust_keys": {"fleet": "k"},
+    }))
+    monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+    body = {
+        "version": 1,
+        "boot": {"fail_closed": True},
+        "mcp": {"mode": "deny", "deny": []},
+        "identity": {"issuer": "fleet"},
+    }
+    body["identity"]["signature"] = hmac_signature("k", policy_signing_payload(body))
+    body["mcp"]["deny"].append("@never/matched")  # tampered AFTER signing
+    policy = tmp_path / "policy.json"
+    policy.write_text(json.dumps(body))
+    monkeypatch.setenv("KIROCREW_SECURITY_POLICY", str(policy))
+    live = await _spawn_pooled_server()
+    try:
+        spool_id = _spool_record()
+        reply = await handle_app_call(live.pool, {
+            "type": "app-call", "spool_id": spool_id, "callback_secret": _cbs(spool_id),
+            # A tool the (tampered) policy does NOT deny — so a pass here would be a
+            # real bypass, not an incidental allowlist miss.
+            "tool": "draw", "arguments": {},
+        })
+        assert reply["type"] == "app-call-rejected"
+        assert "signature" in reply["reason"]
+    finally:
+        await live.aclose()
+
+
+async def test_app_call_is_not_denied_when_no_policy_is_readable_here(
+    apps_flag_on, spool_tmp, tmp_path, monkeypatch
+):
+    """A bundle-only enterprise host must not have every callback denied.
+
+    gatewayd is not the composition process — it never runs ``boot_platform``, so it
+    loads the policy with no ``bundled_loader`` and cannot see a companion-bundled
+    ceiling. ``None`` here is the NORMAL result on such a host, not evidence the
+    policy is gone, so the signature gate must not fire on it.
+    """
+    adm = tmp_path / "admission_policy.json"
+    adm.write_text(json.dumps({
+        "require_policy_signature": True, "trust_keys": {"fleet": "k"},
+    }))
+    monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+    monkeypatch.delenv("KIROCREW_SECURITY_POLICY", raising=False)
+    monkeypatch.setattr(
+        "kiro_crew.platform.governance._policy_home_path", lambda: tmp_path / "nope.json"
+    )
+    live = await _spawn_pooled_server()
+    try:
+        spool_id = _spool_record()
+        reply = await handle_app_call(live.pool, {
+            "type": "app-call", "spool_id": spool_id, "callback_secret": _cbs(spool_id),
+            "tool": "draw", "arguments": {},
+        })
+        assert reply["type"] == "app-result"
+    finally:
+        await live.aclose()
+
+
 async def test_app_call_governance_evaluation_error_fails_closed(apps_flag_on, spool_tmp, tmp_path, monkeypatch):
     """A broken governance load DENIES the app call (opposite polarity from
     Plane A's soft fail-open — this path has no always-on deny floor)."""

--- a/test/test_platform_admission.py
+++ b/test/test_platform_admission.py
@@ -493,3 +493,195 @@ class TestDiscoveryGate:
         result = discover_companion_context("amazon", None)
         assert result is sentinel
         assert (tmp_path / "admission_policy.json").exists()
+
+
+class TestPolicySignatureTrustRoot:
+    """``require_policy_signature`` + ``trust_keys`` as the security-policy trust root.
+
+    The flag lives HERE (the fleet-controlled admission policy) rather than inside
+    ``security_policy.json`` because a document cannot be the authority on whether
+    it must be authentic — see ``governance._policy_trust_settings``.
+    """
+
+    def test_defaults_off_so_existing_policies_keep_working(self):
+        assert AdmissionPolicy().require_policy_signature is False
+        assert AdmissionPolicy.open_default().require_policy_signature is False
+
+    def test_parsed_from_policy_document(self):
+        policy = AdmissionPolicy.from_dict(
+            {"require_policy_signature": True, "trust_keys": {"fleet-control": "k"}}
+        )
+        assert policy.require_policy_signature is True
+        assert policy.trust_keys == {"fleet-control": "k"}
+
+    def test_independent_of_plugin_require_signature(self):
+        # A fleet that signs its PLUGINS has not thereby promised to sign its
+        # governance ceiling; conflating the two would break managed fleets on
+        # upgrade.
+        policy = AdmissionPolicy.from_dict({"require_signature": True})
+        assert policy.require_signature is True
+        assert policy.require_policy_signature is False
+
+    def test_fail_closed_default_leaves_policy_signature_advisory(self, monkeypatch, tmp_path):
+        # Deliberate: an absent/unreadable ADMISSION policy must not additionally
+        # abort boot through the governance path. Plugin admission fails closed in
+        # its own domain; the security policy keeps its own fail-closed rules.
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.admission._policy_default_path", lambda: tmp_path / "nope.json"
+        )
+        from kiro_crew.platform.admission import load_admission_policy
+
+        policy = load_admission_policy()
+        assert policy.require_signature is True  # plugins: fail closed
+        assert policy.require_policy_signature is False  # governance: stays advisory
+
+    def test_seeded_default_body_declares_the_flag_off(self):
+        import kiro_crew.platform.admission as adm
+
+        assert adm._DEFAULT_POLICY_BODY["require_policy_signature"] is False
+
+    def test_non_string_trust_keys_are_dropped_not_stringified(self):
+        # GPT finding: a blanket str(v) turned a malformed entry into a PREDICTABLE
+        # signing secret — {"fleet": null} became the literal key "None", so anyone
+        # guessing that a fleet left a null could forge a signature that verifies
+        # for that issuer (mutation-confirmed). An empty string is the same hazard.
+        # Such an entry is an authoring mistake, not a key: drop it, so the issuer
+        # has NO key, nothing verifies, and the caller fails closed.
+        policy = AdmissionPolicy.from_dict(
+            {"trust_keys": {"a": None, "b": 12, "c": "", "d": ["x"], "ok": "real-secret"}}
+        )
+        assert policy.trust_keys == {"ok": "real-secret"}
+
+    def test_malformed_trust_keys_container_is_ignored(self):
+        assert AdmissionPolicy.from_dict({"trust_keys": "not-a-dict"}).trust_keys == {}
+        assert AdmissionPolicy.from_dict({"trust_keys": None}).trust_keys == {}
+
+    @pytest.mark.parametrize("shape", [[], None, "a string", 123])
+    def test_non_object_policy_raises_valueerror_not_attributeerror(self, shape):
+        # ``[]`` / ``null`` / ``"str"`` are valid JSON, so a malformed trust root
+        # arrives shaped wrong rather than failing to parse. Callers catch broken
+        # shapes deliberately; they should not have to enumerate incidental
+        # AttributeErrors leaking from the first ``.get``.
+        with pytest.raises(ValueError):
+            AdmissionPolicy.from_dict(shape)
+
+
+class TestSharedSigningPrimitives:
+    def test_manifest_payload_uses_shared_canonicalization(self):
+        from kiro_crew.platform.admission import canonical_signing_bytes
+
+        m = PluginManifest(name="p", publisher="pub", version="1")
+        expected = canonical_signing_bytes(
+            {"name": "p", "publisher": "pub", "version": "1", "capabilities": {}}
+        )
+        assert m.signing_payload() == expected
+
+    def test_canonicalization_is_key_order_stable(self):
+        from kiro_crew.platform.admission import canonical_signing_bytes
+
+        assert canonical_signing_bytes({"a": 1, "b": 2}) == canonical_signing_bytes(
+            {"b": 2, "a": 1}
+        )
+
+    def test_hmac_signature_matches_stdlib(self):
+        from kiro_crew.platform.admission import hmac_signature
+
+        expected = hmac.new(b"k", b"payload", hashlib.sha256).hexdigest()
+        assert hmac_signature("k", b"payload") == expected
+
+
+class TestReadPolicyTrustRoot:
+    """``read_policy_trust_root`` is the side-effect-free reader (not the audited one)."""
+
+    def test_reads_flag_and_keys_from_env_path(self, monkeypatch, tmp_path):
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(
+            json.dumps({"require_policy_signature": True, "trust_keys": {"iss": "k"}})
+        )
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        policy = read_policy_trust_root()
+        assert policy.require_policy_signature is True
+        assert policy.trust_keys == {"iss": "k"}
+
+    def test_missing_trust_root_stays_permissive(self, monkeypatch, tmp_path):
+        # An absent trust root — at the default path or an explicitly configured
+        # one — is "no operator opted in", so verification stays advisory and every
+        # existing install keeps working with no key to provision.
+        from kiro_crew.platform import admission as adm_mod
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(tmp_path / "gone.json"))
+        assert read_policy_trust_root().require_policy_signature is False
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(
+            adm_mod, "_policy_default_path", lambda: tmp_path / "admission_policy.json"
+        )
+        assert read_policy_trust_root().require_policy_signature is False
+
+    @pytest.mark.parametrize("shape", ['{"require_policy_signature": true,  TRUNC', "[]", "null"])
+    def test_unreadable_policy_reads_as_no_optin(self, monkeypatch, tmp_path, shape):
+        """A corrupt/malformed trust root yields the permissive default. Deliberate.
+
+        An attacker who can write this file is outside the policy-signature threat
+        model (see the threat-model note in ``governance.md``) — they would set the
+        flag to ``false``, which parses fine — so fail-closing on a *malformed* file
+        catches only a clumsy version of an attack the design concedes, while turning
+        a non-atomic fleet push or a hand-edit typo into an unbootable host.  Plugin
+        admission still fails closed on the same file in its own domain
+        (``load_admission_policy``); this reader must not additionally make the
+        security ceiling unloadable through a second path.
+        """
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(shape)
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        policy = read_policy_trust_root()
+        assert policy.require_policy_signature is False
+        assert policy.trust_keys == {}
+
+    def test_absent_policy_returns_permissive_not_fail_closed(self, monkeypatch, tmp_path):
+        # Deliberately NOT _fail_closed_policy(): an admission-policy problem is
+        # already handled in admission's own domain and must not make the security
+        # ceiling unloadable through a second path.
+        import kiro_crew.platform.admission as adm_mod
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(adm_mod, "_policy_default_path", lambda: tmp_path / "nope.json")
+        policy = read_policy_trust_root()
+        assert policy.require_policy_signature is False
+        assert policy.trust_keys == {}
+        assert policy.require_signature is False
+
+    def test_unreadable_policy_does_not_raise(
+        self, monkeypatch, tmp_path
+    ):
+        # Never raising is the reader's contract — a corrupt trust root must not
+        # take down the security-ceiling load path as well.
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        bad = tmp_path / "admission_policy.json"
+        bad.write_text("{ not json")
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(bad))
+        policy = read_policy_trust_root()
+        assert policy.require_policy_signature is False
+        assert policy.trust_keys == {}
+
+    def test_does_not_record_posture_or_incident(self, monkeypatch, tmp_path):
+        # The whole reason this function exists: load_admission_policy records the
+        # dashboard posture + a critical SEL, which is wrong on a repeating path.
+        import kiro_crew.platform.admission as adm_mod
+        from kiro_crew.platform import governance_health
+        from kiro_crew.platform.admission import read_policy_trust_root
+
+        governance_health.reset()
+        monkeypatch.delenv("KIROCREW_ADMISSION_POLICY", raising=False)
+        monkeypatch.setattr(adm_mod, "_policy_default_path", lambda: tmp_path / "nope.json")
+        read_policy_trust_root()
+        assert governance_health.governance_status() == "unknown"
+        assert governance_health.last_incident() is None
+        governance_health.reset()


### PR DESCRIPTION
## What & why

`load_security_policy` parsed `identity.issuer` / `identity.signature` from the security policy into `GovernanceCeiling` and **never verified either** — yet the governance spec says the signature is "verified at boot in managed deployments", the threat-model section says a managed fleet SHOULD "require `identity.signature` for true tamper-evidence", and `kirocrew policy show` printed the issuer, implying a trust it had never established. A fleet-pushed ceiling's integrity therefore rested entirely on filesystem permissions.

This adds real verification, mirroring `platform/admission.py` (which already verifies plugin manifests the same way) rather than inventing a second mechanism — the shared canonicalizer and HMAC helper are extracted so both trust roots sign identically.

## Design decisions

- **Trust key comes from the existing admission policy**, not the security policy itself. A document must not be the authority on whether it has to be authentic — a `require_signature` inside `security_policy.json` is self-referential, and an attacker rewriting the policy would just clear it. `admission_policy.json` is already the fleet-controlled trust root, already carries `trust_keys`, and is already on the `is_sensitive_path` keystone. A policy is keyed by `identity.issuer` exactly as a plugin is by `publisher`.
- **`require_policy_signature` is a separate flag from `require_signature`** — a fleet that signs its plugins hasn't promised to sign its ceiling, and conflating them would break existing managed fleets on upgrade.
- **Opt-in and advisory by default**, so every existing install and every existing unsigned policy keeps working unchanged **and still enforcing**. Only with the flag on does a bad/missing signature abort boot (`PlatformCompositionError`), matching the module's existing fail-closed discipline.
- **The signed payload is the whole document minus `identity.signature`**, so it covers keys this build doesn't know (companion-registered scopes, future schema) and stays scope-name-agnostic — preserving the invariant that adding a scope is a `SCOPE_CATALOG` data change. `issuer` is inside the payload, so a signed policy can't be re-labelled. Reformatting is tolerated; any value/key change is not.
- **All three tiers are verified — none is exempt.** An earlier revision exempted the companion-bundled tier on the theory that plugin admission already covered it. It does not: `PluginManifest.signing_payload` covers only `name`/`publisher`/`version`/`capabilities`, **not** the packaged `security_policy.json` bytes, so a tampered bundled policy would have loaded unchecked. The bundled tier is therefore verified like the two file tiers (env override, operator home file). With the flag off — the default, and what the `amazon` edition ships — verification is advisory at every tier, so an unsigned bundled policy still loads and existing installs are unaffected.
- `kirocrew policy show` now distinguishes verified / unverified / unsigned / unchecked instead of printing a bare issuer.

## Notable subtlety

`read_policy_trust_root()` is a new **side-effect-free** reader, distinct from `load_admission_policy()`: the latter records dashboard posture and emits a critical `governance_degraded` SEL on an absent policy — correct once at boot, but `gatewayd` re-loads the security policy per app call, so reusing the audited loader would flip the governance indicator to degraded and append a critical audit record on every call. A **present-but-unreadable** admission file assumes `require_policy_signature` with no keys (so verification cannot succeed and boot refuses) — an absent file stays permissive. That asymmetry is the deny-by-default fix for a truncated fleet push.

## Threat model (stated honestly, and in the spec)

Detects offline/at-rest tampering and substitution by anyone without the issuer's key. Does **not** defend against a key holder, and is **not** confinement against a local process running as the operator (which could clear the opt-in in the admission policy). `is_sensitive_path` remains what stops the *agent*; signing makes a fleet-pushed ceiling tamper-**evident** to the host loading it.

## Out of scope (deliberate)

- Asymmetric signing / key distribution — kept the HMAC POC to mirror `admission.py`; both now route through one `hmac_signature` helper so the swap is a one-function change. Symmetric means the verifier holds a signing-capable secret; documented as the residual weakness.
- No signing CLI — a fleet signs out-of-band; a signer on the verifying host would put the key on the machine the control protects.
- `GET /api/governance/policy` unchanged — posture-only and agent-reachable; adding provenance there needs its own leak review.
- Profiles unsigned — they can only narrow, so tampering can't widen the ceiling.

## Testing

New tests (`test_governance_policy.py`, `test_platform_admission.py`) cover: verified-good, tampered→unverified, tampered+opt-in→boot-abort, legacy-unsigned still loads AND still governs, reformat-tolerant, bundled-tier verified (not exempt), all 4 CLI reporting states, plus the edge cases a local review fleet caught and this PR fixes — a **non-ASCII signature** (`hmac.compare_digest` raises `TypeError` on non-ASCII `str`, which escaped as a non-`PlatformCompositionError` and degraded to an ungoverned host; now compares bytes) and a **present-but-unreadable admission file** (dropped the opt-in; now fails closed). Both fixes were mutation-verified.

Full gate green: **19040 passed**, isort / flake8 / mypy / scrub-lint clean, on CPython 3.10 + 3.12.

## Specs

`docs/system-specs/modules/governance.md` gains a "Policy authenticity" section; `platform-context.md` documents the two new admission fields.

