### PR TITLE
fix: make dead CPP seams visible instead of silently inert

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -36,27 +36,27 @@ boot holding the chosen adapter for every extension point, plus three carriers:
 | `cfg` | carrier (`KiroCrewConfig`) | loaded config | same |
 | `providers` | adapter | `DefaultProviderRegistry` (Kiro-CLI-ACP only) | re-registers a companion-registered backend |
 | `publish` | adapter | `DefaultPublishRegistry` (registers no provider → publish unavailable) | registers enterprise artifact/publish providers |
-| `agent_runtime` | adapter | `DefaultAgentRuntime` (`_MANAGED_MCP_SERVERS`) | internal servers + backend env |
+| `agent_runtime` | adapter | `DefaultAgentRuntime` (`run_first_run_setup` wired; `managed_mcp_servers` **RESERVED**) | extra one-time first-run provisioning |
 | `agent_executable` | adapter | `DefaultAgentExecutableResolver` (identity) | resolves an edition-managed launcher to its direct executable before core sandboxing |
 | `sandbox` | settings | `DefaultSandboxPolicy` (`_STRICT_DIRS`/`_CC_DIRS`) | additional edition-specific credential dirs |
 | `credentials` | adapter | `DefaultCredentialPolicy` (AKIA/ASIA redaction; `exempt_exact_hosts()` → `frozenset()`) | internal token regexes + trusted-tenant exempt hosts |
 | `security` | **concrete** | `PolicyAuthority()` (baseline only) | `PolicyAuthority(overlay=…)` ADD-only |
 | `slack_gate` | adapter | `DefaultSlackEnterpriseGate` (default-open) | fail-closed enterprise allowlist |
-| `identity` | adapter | `DefaultIdentityProvider` (`sso_status.py` stub) | enterprise SSO / directory |
-| `embeddings` | adapter | `DefaultEmbeddingSource` (dormant seam — the public runtime is the bundled in-process llama-cpp model via `embeddings.register_embedding_backend`; `endpoint_url`/`sign_request` kept for contract stability) | internal source + SigV4 |
+| `identity` | adapter | `DefaultIdentityProvider` (`sso_status.py` stub; `whoami`/`issuer` **RESERVED**) | enterprise SSO / directory |
+| `embeddings` | adapter | **RESERVED** — `DefaultEmbeddingSource`; the public runtime is the bundled in-process llama-cpp model, so no method is consumed (swap via `embeddings.register_embedding_backend`) | — (slot inert) |
 | `mcp_tooling` | adapter | `DefaultMcpToolingProvider` (all methods empty) | enterprise MCP server + skills + provider MCP scopes |
 | `agent_catalog` | adapter | `DefaultAgentCatalogProvider` (`builtin_agents()` → `[]`) | edition agent-catalog rows |
 | `prompt_sources` | adapter | `DefaultPromptSourceProvider` (`prompt_source_roots()` → `[]`) | edition prompt/SOP roots |
 | `capability_manager` | adapter | `DefaultCapabilityManager` (`available()` → `False`) | operations-based external package/skill/MCP manager |
 | `registry` | adapter | `DefaultAppRegistryPolicy` (public-forge baseline) | internal git hosts |
 | `apps_loader` | adapter | `DefaultAppsLoader` (OSS builtins) | internal app sources (code-reviewer; team_manager/mimir follow-on) |
-| `package_manager` | adapter | `DefaultPackageManager` (brew/pip) | managed installer |
+| `package_manager` | adapter | **RESERVED** — `DefaultPackageManager`; installs are inline in `cli_doctor.py` (use `CapabilityManager`) | — (slot inert) |
 | `knowledge` | adapter | `DefaultKnowledgeProvider` (no extra connectors) | enterprise doc connector (`extra_connectors`) |
 | `tunnel` | adapter | `DefaultTunnelProvider` (no-op) | internal tunnel supervisor |
 | `telemetry` | adapter | `DefaultTelemetryProvider` (no-op, RUM off) | RUM/Cognito config |
 | `dashboard` | adapter | `DefaultDashboardContributor` (no routes/services, no login handler) | secretary/taskkeeper routes + enterprise SSO PTY login |
 | `jail` | adapter | `DefaultJailProvider` (no-op, never jails) | enterprise process isolation |
-| `feature_apps` | tuple | `()` | (provenance map only — not consumed; apps register via `apps_loader`) |
+| `feature_apps` | tuple | **RESERVED** — `()`; apps register via `apps_loader` (provenance record only) | — (slot inert) |
 
 > `registry` note — the public `DefaultAppRegistryPolicy` encodes the
 > public-forge baseline and ships no internal-host set. The enterprise companion
@@ -288,6 +288,16 @@ delegates to that same global. Wired sites:
 
 - `cli.py:main` / `slack/gateway.py:run_gateway` — `boot_platform(cfg)` once at
   startup (gateway raises fail-closed; cli is defensive — standalone never raises).
+- `slack/gateway.py` gateway boot — `AgentRuntime.run_first_run_setup()` through
+  `safe_context_call`. Previously this imported `agent.run_first_run_setup`
+  directly, bypassing the seam; routing it through the context makes first-run
+  provisioning genuinely extensible (an edition adds its own one-time steps).
+  The Default adapter delegates to that same function, so standalone behavior is
+  byte-identical — asserted in `test_cpp_wiring_standalone.py`
+  (`test_default_agent_runtime_delegates_to_agent_first_run_setup` +
+  `test_gateway_first_run_setup_routes_through_the_seam`). Best-effort: the
+  gateway's surrounding `except` keeps a failure non-fatal to startup, and
+  `PlatformCompositionError` still propagates fail-closed.
 - `sandbox.py` — `_build_launcher_script` / `_build_seatbelt_profile` source the
   sensitive-dir lists from `current_context().sandbox` (the `.aws`-exclusion at
   the cc branch is preserved). `namespace_argv` / `sandbox_exec_argv` resolve
@@ -370,9 +380,6 @@ delegates to that same global. Wired sites:
   `current_context().apps_loader` sources.
 - `apps/registry.py` / `apps/routes.py` — clone-sandbox-mode decision routes
   through `current_context().registry` (`_context_clone_sandbox_mode`).
-- `embeddings.py` — model/endpoint/sign_request source from
-  `current_context().embeddings` (explicit caller args win); BOTH the async
-  `EmbeddingClient` and the sync `make_sync_embed_fn` vector-memory path.
 - Telemetry `record_event` sites — `dashboard/server.py` records `gateway_start`
   at boot; `dashboard/chat_runner.py` and `slack/handler.py` record one
   `interaction` event per successful chat turn (immediately after the
@@ -777,12 +784,73 @@ new module/class names.
 
 ### Deferred / non-mapping sites
 
-- `cli_doctor.py` — `package_manager` is **not** wired: the ollama-install
-  diagnostic is inline step-by-step logic, not a single plan-resolution site
-  (TODO; Default `install_plan` returns `[]` = today's inline behavior).
 - `apps/routes.py` — `_fetch_git_blob`'s per-URL clone-sandbox-mode decision IS
   wired: it routes through `_context_clone_sandbox_mode` (same as the
   `apps/registry.py` clone sites), so a companion's extended trusted-host set
   applies to registry-blob fetches too. The other `wrap_argv` sites run local
   lifecycle scripts (no per-URL git host), so they have no clone decision to
   route.
+
+## Reserved (declared-inert) contract surface
+
+Some published extension points have **no consumption site** in the core:
+overriding them changes nothing. That is legitimate — the contract is kept stable
+pre-launch — but it MUST NOT be silent. An implementor reads `PlatformContext`,
+writes an adapter, `dataclasses.replace`s it in, and needs to find out
+immediately, not after a debugging session.
+
+Three arms make the inertness impossible to miss:
+
+1. **Declaration at the dataclass.** `context.RESERVED_SLOTS` (whole fields) and
+   `context.RESERVED_METHODS` (individual methods on otherwise-live fields) each
+   map a name → the reason it is inert **and the wired alternative**. Every
+   reserved field also carries a `[RESERVED]` marker comment on its declaration
+   in `PlatformContext`, so the fact is visible in the source an edition author
+   actually reads — not only in an `interfaces.py` docstring.
+2. **A loud runtime signal.** `PlatformContext.__post_init__` calls
+   `_warn_reserved_slots`, which logs ONE warning per reserved slot carrying a
+   non-default value, naming the offending adapter and the alternative. It
+   **warns rather than raises**: an edition may compose an adapter in
+   anticipation of a slot being wired, and refusing to compose would turn a
+   harmless forward-looking override into a boot failure (a breaking change for
+   an existing companion). Deduped per `(slot, adapter type)` per process, so a
+   composition root that rebuilds the context does not spam the log. Class
+   identity (not `isinstance`) decides "is default", so a companion **subclass**
+   of a `Default*` adapter still warns — it can change behavior.
+3. **An anti-rot gate.** `test/test_platform_cpp_seam_coverage.py` drives off
+   `dataclasses.fields(PlatformContext)` and discovers real consumption sites by
+   `ast` analysis of `src/kiro_crew` (excluding `platform/` itself and
+   `_vendor/`). It asserts, in both directions:
+   - every field is EITHER consumed by non-`platform` core code OR listed in
+     `RESERVED_SLOTS` — so a **new** field with no call site fails the build
+     instead of becoming the next dead seam;
+   - every `RESERVED_SLOTS`/`RESERVED_METHODS` entry has NO consumption site — so
+     **wiring** a reserved slot fails the build until its entry is deliberately
+     removed, and a marker can never go stale and mislead the next reader.
+
+   Two boot-protocol carriers (`contract_version`, `publish`) are consumed only
+   by `bootstrap.py` itself and are enumerated in the test's
+   `_BOOT_CONSUMED_IN_PLATFORM`; a companion test proves each is genuinely read
+   there, so the allowance cannot be used to park a dead field.
+
+Current reserved surface:
+
+| Slot / method | Why inert | Use instead |
+|---|---|---|
+| `embeddings` (whole slot) | the public embedding runtime is the bundled in-process llama.cpp model — there is no HTTP embed path to source a model/endpoint/signature from | `embeddings.register_embedding_backend()` |
+| `package_manager` (whole slot) | external-tool installs (ollama, ffmpeg, whisper) are inline step-by-step brew/curl/pip logic in `cli_doctor.py`, not a single plan-resolution point | `CapabilityManager` for registry-backed MCP/skill/agent installs |
+| `feature_apps` (whole slot) | bundled apps are discovered via `AppsLoader` and registered by `apps/manager.py`; the tuple is a provenance record only | `AppsLoader.manifest_sources()` / `bundled_app_names()` |
+| `AgentRuntime.managed_mcp_servers` | the agent config is built from the `agent._MANAGED_MCP_SERVERS` global directly | `McpToolingProvider.extra_mcp_servers()` (wired, ADD-only) |
+| `IdentityProvider.whoami` / `.issuer` | nothing in the core displays the principal or branches on the issuer | return them in the wired `status()` payload |
+
+`FeatureApp` is deliberately the ONE Protocol with no `Default*` adapter: it
+describes a single app (an item), not a policy the core queries, so there is no
+behavior for a default to reproduce — the default for the *slot* is the empty
+tuple `build_default_context` already composes. A `DefaultFeatureApp` would have
+to invent a fictional app to be instantiable.
+
+Removing a reserved slot outright would be a contract-narrowing change (an
+out-of-tree companion that composes it today would fail to compose), so the
+slots are kept and marked rather than deleted. None of this warrants a
+`CONTRACT_VERSION` bump: no field is added, removed, or renamed, and no
+interface semantics change — the version stays pinned at 1 pre-launch.

--- a/src/kiro_crew/platform/__init__.py
+++ b/src/kiro_crew/platform/__init__.py
@@ -21,6 +21,8 @@ from kiro_crew.platform.context import (
     CONTRACT_VERSION,
     PROFILE_ENTERPRISE,
     PROFILE_STANDALONE,
+    RESERVED_METHODS,
+    RESERVED_SLOTS,
     PlatformCompositionError,
     PlatformContext,
     async_safe_context_call,
@@ -46,6 +48,9 @@ __all__ = [
     "PLUGIN_GROUP",
     "PlatformContext",
     "PlatformCompositionError",
+    # Declared-inert contract surface (see context.py)
+    "RESERVED_SLOTS",
+    "RESERVED_METHODS",
     "boot_platform",
     "bootstrap_context",
     "build_default_context",

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -64,6 +64,8 @@ if TYPE_CHECKING:  # avoid import cycles — config.loader imports heavy modules
 # extension points — landed under this same v1, no bump.)
 CONTRACT_VERSION = 1
 
+_logger = logging.getLogger(__name__)
+
 # Valid profiles.  ``standalone`` is the public default; ``enterprise`` loads a
 # companion package that composes a non-default context (e.g. an SSO overlay).
 PROFILE_STANDALONE = "standalone"
@@ -79,6 +81,168 @@ class PlatformCompositionError(RuntimeError):
     """
 
 
+# ── Reserved (declared-inert) slots ──
+#
+# A field listed here is part of the published contract but has NO consumption
+# site in the core: overriding it changes NOTHING.  The declaration lives HERE,
+# next to the dataclass an implementor actually reads, because the previous
+# "NOT YET WIRED" notes were buried in ``interfaces.py``/``defaults.py``
+# docstrings — invisible from the composition root where an edition author
+# writes ``dataclasses.replace(ctx, package_manager=MyPackageManager())`` and
+# gets silence.
+#
+# Two enforcement arms keep this honest and rot-proof, both in
+# ``test_platform_cpp_seam_coverage.py``:
+#
+#   1. Every ``PlatformContext`` field must be EITHER consumed by non-platform
+#      core code OR listed here.  A new field with no consumption site fails the
+#      build instead of becoming the next dead seam.
+#   2. A field listed here must have NO non-platform consumption site.  So
+#      wiring a reserved slot fails the build until its entry is deliberately
+#      REMOVED from this map — the marker cannot silently outlive the inertness
+#      it documents.
+#
+# At runtime, ``PlatformContext.__post_init__`` logs one loud warning per
+# reserved slot that carries a non-default value (see ``_warn_reserved_slots``).
+# It WARNS rather than raises on purpose: an edition may legitimately compose an
+# adapter in anticipation of a slot being wired (its own composition root is
+# built in lockstep with the core), and refusing to compose would turn a
+# forward-looking, harmless override into a boot failure — a breaking change for
+# an out-of-tree companion that composes this seam today.  The warning is the
+# signal; the test suite is the gate.
+RESERVED_SLOTS: "dict[str, str]" = {
+    "embeddings": (
+        "no core call site: the public embedding runtime is the bundled "
+        "in-process llama.cpp model, so there is no HTTP embed path to source a "
+        "model/endpoint/signature from. Swap runtimes via "
+        "embeddings.register_embedding_backend() instead."
+    ),
+    "package_manager": (
+        "no core call site: install paths (ollama, ffmpeg, whisper) are inline "
+        "step-by-step brew/curl/pip logic in cli_doctor.py, not a single "
+        "plan-resolution point this seam could own."
+    ),
+    "feature_apps": (
+        "no core call site: bundled apps are discovered through "
+        "AppsLoader.manifest_sources()/bundled_app_names() and registered by "
+        "apps/manager.py. This slot is a provenance record only."
+    ),
+}
+
+# Reserved METHODS on an otherwise-live field.  Same contract as
+# ``RESERVED_SLOTS`` but one level finer: the field IS consumed, only these
+# methods are not.  Declared here (rather than only in an ``interfaces.py``
+# docstring) so the reserved surface of the contract is readable in ONE place,
+# and asserted by the same coverage test — which fails if a listed method gains
+# a non-platform caller, forcing the entry to be removed deliberately.
+RESERVED_METHODS: "dict[str, dict[str, str]]" = {
+    "agent_runtime": {
+        "managed_mcp_servers": (
+            "no core call site: the agent config is built from the "
+            "agent._MANAGED_MCP_SERVERS module global directly. Contribute extra "
+            "servers via McpToolingProvider.extra_mcp_servers(), which IS wired "
+            "and merges ADD-only into the same map. (The sibling "
+            "run_first_run_setup IS wired — see slack/gateway.py.)"
+        ),
+    },
+    "identity": {
+        "whoami": (
+            "no core call site: the resolved principal is not displayed or "
+            "authorized against anywhere in the core. IdentityProvider.status() "
+            "is the wired surface — return the principal in its payload."
+        ),
+        "issuer": (
+            "no core call site: nothing in the core branches on or displays the "
+            "identity issuer. Surface it through status() instead."
+        ),
+    },
+}
+
+
+def _reserved_slot_is_default(field_name: str, value: Any) -> bool:
+    """True when *value* is the stock ``Default*`` adapter for a reserved slot.
+
+    Compares by the adapter CLASS actually composed by
+    ``bootstrap.build_default_context``, resolved lazily from ``defaults`` so
+    this module stays import-light and cycle-free.  Class identity (not
+    ``isinstance``) is deliberate: a companion SUBCLASS of a ``Default*``
+    adapter is a real override — it can change behavior — so it must still warn.
+
+    Unknown/unresolvable adapters are treated as NON-default (warn), keeping the
+    signal loud rather than silently swallowing an override.
+    """
+    if field_name == "feature_apps":
+        # Not an adapter — the default is the empty tuple.
+        return value == ()
+    try:
+        # circular import: this module deliberately carries NO runtime
+        # ``kiro_crew`` import — every one above is inside ``TYPE_CHECKING`` —
+        # because it is the leaf the rest of the platform imports.  ``defaults``
+        # pulls in ``kiro_crew.security`` and ``sso_status``, which reach back
+        # into ``platform.context`` for ``current_context()`` (the documented
+        # ``sel.py`` deferred pattern), so importing it at module scope here
+        # would close that cycle at import time.
+        from kiro_crew.platform import defaults as _defaults
+    except Exception:  # pragma: no cover - defensive; defaults always importable
+        return False
+    default_cls = _RESERVED_DEFAULT_ADAPTERS.get(field_name)
+    if default_cls is None:
+        return False
+    return type(value) is getattr(_defaults, default_cls, None)
+
+
+# Reserved slot → the name of its stock ``Default*`` adapter class in
+# ``platform.defaults``.  Kept as NAMES (not imports) so ``context`` never
+# imports ``defaults`` at module load.  The coverage test asserts this map's
+# keys match ``RESERVED_SLOTS`` minus the non-adapter ``feature_apps`` slot, so
+# a new reserved slot cannot forget its default and silently warn on every boot.
+_RESERVED_DEFAULT_ADAPTERS: "dict[str, str]" = {
+    "embeddings": "DefaultEmbeddingSource",
+    "package_manager": "DefaultPackageManager",
+}
+
+# One warning per (slot, adapter type) per process.  ``dataclasses.replace`` may
+# rebuild the context several times during a composition root, and
+# ``current_context()``'s lazy default can run in short-lived subprocesses — a
+# per-construction warning would spam the log for one override.  Keyed by the
+# adapter type as well as the slot so a LATER, different override still reports.
+_RESERVED_WARNED: "set[Tuple[str, str]]" = set()
+
+
+def _warn_reserved_slots(ctx: "PlatformContext") -> None:
+    """Log one loud warning per reserved slot carrying a non-default adapter.
+
+    The runtime half of the reserved-slot contract: an edition that composes an
+    adapter into an inert slot gets a visible boot-time line naming the slot, the
+    adapter, why it is inert, and the wired alternative — instead of the silence
+    that made these seams look live.  Deduped per process (see
+    ``_RESERVED_WARNED``).
+
+    Never raises: this is diagnostics, and a composition-time crash here would
+    break the very boot path it is meant to annotate.  Called from
+    ``PlatformContext.__post_init__``, so it also covers the companion's
+    ``dataclasses.replace`` path.
+    """
+    try:
+        for field_name, reason in RESERVED_SLOTS.items():
+            value = getattr(ctx, field_name, None)
+            if _reserved_slot_is_default(field_name, value):
+                continue
+            key = (field_name, f"{type(value).__module__}.{type(value).__qualname__}")
+            if key in _RESERVED_WARNED:
+                continue
+            _RESERVED_WARNED.add(key)
+            _logger.warning(
+                "PlatformContext.%s is a RESERVED slot: %s composed a non-default "
+                "value into it, which the core NEVER reads, so it has NO effect. %s",
+                field_name,
+                key[1],
+                reason,
+            )
+    except Exception:  # pragma: no cover - diagnostics must never break boot
+        _logger.debug("reserved-slot warning pass failed", exc_info=True)
+
+
 @dataclass(frozen=True)
 class PlatformContext:
     """Immutable bundle of the chosen adapter for every extension point.
@@ -87,6 +251,15 @@ class PlatformContext:
     and never mutated.  The public edition composes a context whose every
     interface field is a ``Default*`` adapter; the Amazon companion replaces a
     subset via ``dataclasses.replace`` in its composition root.
+
+    **Reserved slots.**  Fields marked ``[RESERVED]`` below are published
+    contract but have NO consumption site in the core — overriding one changes
+    nothing.  ``RESERVED_SLOTS`` (above) carries the reason and the wired
+    alternative for each, ``RESERVED_METHODS`` does the same for individual
+    methods on otherwise-live fields, and composing a non-default value into a
+    reserved slot logs one loud warning at boot.  Both maps are asserted against
+    real consumption sites by ``test_platform_cpp_seam_coverage.py``, so a slot
+    cannot stay marked once it is wired (nor be added without a marker).
     """
 
     # ── carriers (not interfaces) ──
@@ -97,14 +270,17 @@ class PlatformContext:
     # ── boot-layer extension points ──
     providers: "ProviderRegistry"
     publish: "PublishRegistry"
+    # ``run_first_run_setup`` is wired (slack/gateway.py); ``managed_mcp_servers``
+    # is [RESERVED] — see RESERVED_METHODS.
     agent_runtime: "AgentRuntime"
     agent_executable: "AgentExecutableResolver"
     sandbox: "SandboxPolicy"
     credentials: "CredentialPolicy"
     security: "PolicyAuthority"
     slack_gate: "SlackEnterpriseGate"
+    # ``whoami``/``issuer`` are [RESERVED] — see RESERVED_METHODS.
     identity: "IdentityProvider"
-    embeddings: "EmbeddingSource"
+    embeddings: "EmbeddingSource"  # [RESERVED] — see RESERVED_SLOTS
     mcp_tooling: "McpToolingProvider"
     agent_catalog: "AgentCatalogProvider"
     prompt_sources: "PromptSourceProvider"
@@ -113,7 +289,7 @@ class PlatformContext:
     # ── install / structural extension points ──
     registry: "AppRegistryPolicy"
     apps_loader: "AppsLoader"
-    package_manager: "PackageManager"
+    package_manager: "PackageManager"  # [RESERVED] — see RESERVED_SLOTS
     knowledge: "KnowledgeProvider"
 
     # ── runtime-service / frontend extension points ──
@@ -123,7 +299,7 @@ class PlatformContext:
     jail: "JailProvider"
 
     # ── bundled feature apps ──
-    feature_apps: "Tuple[FeatureApp, ...]"
+    feature_apps: "Tuple[FeatureApp, ...]"  # [RESERVED] — see RESERVED_SLOTS
 
     # ── governance carrier (Level 1 enterprise security ceiling) ──
     # Frozen at boot from the trust-root policy path; ``None`` on a standalone
@@ -134,9 +310,19 @@ class PlatformContext:
     governance: "Optional[GovernanceCeiling]" = None
 
     def __post_init__(self) -> None:
-        """Enforce the ``CapabilityManager`` LIVENESS bound at composition time.
+        """Bind the ``CapabilityManager`` bound + warn on reserved-slot overrides.
 
-        Every ``CapabilityManager`` is wrapped ONCE here in
+        Two composition-time concerns, both of which must run on the single
+        constructor AND on the companion's ``dataclasses.replace`` path (which
+        re-invokes ``__init__``).
+
+        **Reserved-slot warning.** ``_warn_reserved_slots`` emits one loud
+        warning per :data:`RESERVED_SLOTS` field that carries a non-default
+        adapter, turning a silently-ignored override into a visible log line at
+        boot. It warns rather than raises — see the ``RESERVED_SLOTS`` comment
+        for why refusing to compose would be a breaking change.
+
+        **``CapabilityManager`` LIVENESS bound.** Every ``CapabilityManager`` is wrapped ONCE here in
         ``BoundedCapabilityManager`` so that EVERY reader of
         ``current_context().capability_manager`` — the dashboard handlers AND any
         future non-dashboard consumer that follows the documented CPP pattern of
@@ -159,6 +345,7 @@ class PlatformContext:
         object.__setattr__(
             self, "capability_manager", bind_capability_manager(self.capability_manager)
         )
+        _warn_reserved_slots(self)
 
     @property
     def is_enterprise(self) -> bool:
@@ -240,7 +427,6 @@ def reset_context() -> None:
 
 
 _T = TypeVar("_T")
-_logger = logging.getLogger(__name__)
 
 
 _UNSET: Any = object()

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -65,18 +65,23 @@ class DefaultAgentRuntime:
     """Today's managed MCP servers + first-run setup."""
 
     def managed_mcp_servers(self) -> Dict[str, dict]:
+        # RESERVED (see context.RESERVED_METHODS['agent_runtime']): no core call
+        # site reads this — the agent config is built from the
+        # ``agent._MANAGED_MCP_SERVERS`` global directly.  Kept faithful to that
+        # global so the method is correct if it is ever wired; contribute extra
+        # servers through the WIRED ``McpToolingProvider.extra_mcp_servers()``.
         from kiro_crew import agent  # circular import: agent imports platform
 
         return dict(agent._MANAGED_MCP_SERVERS)
 
     def run_first_run_setup(self) -> None:
-        # Delegate to the real ``agent.run_first_run_setup`` so that IF this
-        # NOT-YET-WIRED seam is ever consumed, the standalone Default reproduces
-        # today's first-run wiring (PATH shim + one-time stale managed-MCP purge)
-        # rather than silently no-op'ing.  Today nothing reads this adapter — the
-        # live path calls ``agent.run_first_run_setup()`` directly from the
-        # gateway boot — so this is inert; the Amazon companion overrides it to
-        # add internal first-run setup on top.
+        # WIRED: ``slack/gateway.py`` gateway boot calls this through the seam.
+        # Delegating to the real ``agent.run_first_run_setup`` makes the routing
+        # behavior-preserving for the standalone edition — byte-for-byte the same
+        # first-run wiring (PATH shim + admission-policy seed + one-time stale
+        # managed-MCP purge) the gateway used to invoke directly.  A companion
+        # overrides this to add its own one-time provisioning on top (and should
+        # call the same underlying function, or super(), to keep the core steps).
         from kiro_crew import agent  # circular import: agent imports platform
 
         agent.run_first_run_setup()
@@ -167,10 +172,12 @@ class DefaultIdentityProvider:
         return await sso_status.get_sso_status_line(prefix)
 
     def whoami(self) -> Optional[str]:
+        # RESERVED (see context.RESERVED_METHODS['identity']): no core call site.
         # The public edition has no SSO principal beyond what kiro-cli reports.
         return None
 
     def issuer(self) -> Optional[str]:
+        # RESERVED (see context.RESERVED_METHODS['identity']): no core call site.
         return None
 
     def preflight_checks(self) -> List[Callable[[], None]]:
@@ -188,11 +195,11 @@ class DefaultIdentityProvider:
 class DefaultEmbeddingSource:
     """Bundled in-process model (vendored llama.cpp), unsigned local inference.
 
-    Since the in-process embeddings landed the core no longer routes embed
-    requests over HTTP, so ``endpoint_url``/``sign_request`` have no active
-    consumption site — the seam stays for contract stability (a companion can
-    still supply a remote/signed source and compose a custom
-    ``EmbeddingBackend`` via ``embeddings.register_embedding_backend``).
+    RESERVED slot (see ``context.RESERVED_SLOTS['embeddings']``): the core has no
+    HTTP embed path, so NO method here is consumed.  Kept faithful to today's
+    model id so the adapter is correct if the slot is ever wired; a companion
+    supplying a different runtime composes an ``EmbeddingBackend`` via
+    ``embeddings.register_embedding_backend`` instead.
     """
 
     def registry_model(self) -> str:
@@ -310,7 +317,13 @@ class DefaultAppsLoader:
 
 
 class DefaultPackageManager:
-    """Public brew/curl/pip install strategy (delegated to cli_doctor logic)."""
+    """Public brew/curl/pip install strategy (delegated to cli_doctor logic).
+
+    RESERVED slot (see ``context.RESERVED_SLOTS['package_manager']``): no core
+    call site routes installs through this seam — ``cli_doctor.py`` keeps its
+    inline per-tool logic.  Use ``CapabilityManager`` for registry-backed
+    installs of MCP servers / skills / agent packages.
+    """
 
     def install_plan(self, tool: str) -> List[str]:
         # The public edition has no managed installer; callers fall back to

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -111,18 +111,36 @@ class PublishRegistry(Protocol):
 
 
 class AgentRuntime(Protocol):
-    """The agent runtime: managed MCP servers + first-run setup.
+    """The agent runtime: managed MCP servers + first-run setup."""
 
-    NOT YET WIRED: neither method is consumed by the core yet — managed servers
-    are assembled in ``agent.py`` and first-run setup is called directly via
-    ``agent.run_first_run_setup()``. The companion contributes internal MCP
-    servers through ``McpToolingProvider.extra_mcp_servers`` instead (which IS
-    wired). Staged for a later migration; overriding it has no effect yet.
-    """
+    def managed_mcp_servers(self) -> Dict[str, dict]:
+        """**RESERVED — not consumed by the core.** Overriding has NO effect.
 
-    def managed_mcp_servers(self) -> Dict[str, dict]: ...
+        The agent config is built from the ``agent._MANAGED_MCP_SERVERS`` module
+        global directly. Contribute extra servers through the WIRED
+        ``McpToolingProvider.extra_mcp_servers()``, which merges ADD-only into
+        the same map. Declared in ``context.RESERVED_METHODS`` and asserted by
+        ``test_platform_cpp_seam_coverage.py``, which fails if this gains a
+        caller without the reservation being removed.
+        """
+        ...
 
-    def run_first_run_setup(self) -> None: ...
+    def run_first_run_setup(self) -> None:
+        """One-time install-time provisioning, run once per gateway start.
+
+        WIRED: the gateway boot path (``slack/gateway.py``) calls this through
+        the seam instead of importing ``agent.run_first_run_setup`` directly, so
+        an edition can add its own one-time provisioning. The public Default
+        delegates to exactly that function (PATH shim + admission-policy seed +
+        one-time stale managed-MCP purge), so the standalone build is unchanged.
+
+        Best-effort by contract: the call site keeps a failure non-fatal to
+        gateway startup, so an implementation SHOULD swallow and log its own
+        errors rather than relying on the caller. An override SHOULD keep the
+        core steps (delegate to the same underlying function) — dropping them
+        would leave desktop installs without the PATH shim.
+        """
+        ...
 
 
 class AgentExecutableResolver(Protocol):
@@ -298,9 +316,28 @@ class IdentityProvider(Protocol):
 
     async def status_line(self, prefix: str = "*SSO:*") -> str: ...
 
-    def whoami(self) -> Optional[str]: ...
+    def whoami(self) -> Optional[str]:
+        """**RESERVED — not consumed by the core.** Overriding has NO effect.
 
-    def issuer(self) -> Optional[str]: ...
+        Nothing in the core displays the resolved principal or authorizes against
+        it. Return it inside the WIRED ``status()`` payload instead (the dashboard
+        renders that). Declared in ``context.RESERVED_METHODS`` and asserted by
+        ``test_platform_cpp_seam_coverage.py``.
+        """
+        ...
+
+    def issuer(self) -> Optional[str]:
+        """**RESERVED — not consumed by the core.** Overriding has NO effect.
+
+        Nothing in the core branches on or displays the identity issuer. Surface
+        it through the WIRED ``status()`` payload instead. Declared in
+        ``context.RESERVED_METHODS`` and asserted by
+        ``test_platform_cpp_seam_coverage.py``.
+
+        (Not to be confused with ``GovernanceCeiling.identity_issuer``, which is
+        parsed from the signed security policy and IS consumed.)
+        """
+        ...
 
     def preflight_checks(self) -> List[Callable[[], None]]:
         """Already-resolved pre-launch checks for ``gateway``/``token``.
@@ -319,14 +356,22 @@ class IdentityProvider(Protocol):
 
 
 class EmbeddingSource(Protocol):
-    """Where the embedding model comes from + request signing.
+    """**RESERVED extension point — not consumed by the core.**
 
-    Public default = the bundled in-process model (``qwen3-embedding:0.6b``
-    via vendored llama.cpp), no HTTP and no signing.  Since the in-process
-    runtime landed the core has no active HTTP embed path, so
-    ``endpoint_url``/``sign_request`` are a dormant seam — kept for contract
-    stability.  A companion supplying a different runtime should compose an
-    ``EmbeddingBackend`` via ``embeddings.register_embedding_backend``.
+    Composing an ``EmbeddingSource`` into ``PlatformContext.embeddings`` has NO
+    effect: since the in-process runtime landed (bundled ``qwen3-embedding:0.6b``
+    via vendored llama.cpp) the core has no HTTP embed path, so there is nothing
+    to source a model id, endpoint, or request signature from. All three methods
+    are inert.
+
+    **Swap runtimes through ``embeddings.register_embedding_backend()`` instead**
+    — that is the live seam (an ``EmbeddingBackend`` owns the whole embed call,
+    including any remote transport and signing it needs).
+
+    The slot is kept for contract stability and is declared in
+    ``context.RESERVED_SLOTS``: a non-default value logs a loud warning at boot,
+    and ``test_platform_cpp_seam_coverage.py`` fails if a consumption site is
+    added without the reservation being removed.
     """
 
     def registry_model(self) -> str: ...
@@ -623,14 +668,19 @@ class KnowledgeProvider(Protocol):
 
 
 class PackageManager(Protocol):
-    """Install strategy for external tools (ollama, etc.).
+    """**RESERVED extension point — not consumed by the core.**
 
-    Public default = brew/curl/pip fallbacks.  The companion uses the internal
-    toolbox / capability installer.
+    Composing a ``PackageManager`` into ``PlatformContext.package_manager`` has
+    NO effect: the external-tool install paths (ollama, ffmpeg, whisper) are
+    inline step-by-step brew/curl/pip logic in ``cli_doctor.py``, not a single
+    plan-resolution point this seam could own. Both methods are inert.
 
-    NOT YET WIRED: no core call site routes installs through this seam yet
-    (callers still use their inline brew/curl/pip logic). Staged for later;
-    overriding it has no effect yet.
+    For registry-backed installation of MCP servers / skills / agent packages,
+    use ``CapabilityManager`` — the live, operations-based seam.
+
+    Declared in ``context.RESERVED_SLOTS``: a non-default value logs a loud
+    warning at boot, and ``test_platform_cpp_seam_coverage.py`` fails if a
+    consumption site is added without the reservation being removed.
     """
 
     def install_plan(self, tool: str) -> List[str]: ...
@@ -891,15 +941,24 @@ class JailProvider(Protocol):
 
 
 class FeatureApp(Protocol):
-    """One bundled App-Kit app the active profile ships.
+    """**RESERVED item type — not consumed by the core.**
 
-    Public default set is empty (or the OSS builtins).  The companion bundles
-    internal feature apps (code reviewer, team manager, secretary, etc.).
+    Populating ``PlatformContext.feature_apps`` has NO effect: bundled apps are
+    discovered through ``AppsLoader.manifest_sources()`` / ``bundled_app_names()``
+    and registered by ``apps/manager.py``. Neither ``manifest_path`` nor
+    ``register`` is ever called; the tuple is a provenance record only.
 
-    NOT YET WIRED: the core does not yet read ``PlatformContext.feature_apps``;
-    edition apps are registered via ``AppsLoader.manifest_sources`` /
-    ``bundled_app_names`` instead. Staged for a later registration path;
-    populating it has no effect yet.
+    **Bundle apps through ``AppsLoader`` instead** — the live seam.
+
+    Unlike every other Protocol here this one ships NO ``Default*`` adapter, and
+    deliberately so: ``FeatureApp`` describes ONE app (an item), not a policy the
+    core asks a question of, so there is no behavior for a default to reproduce.
+    The default for the *slot* is the empty tuple ``()`` that
+    ``build_default_context`` already composes — a ``DefaultFeatureApp`` would
+    have to invent a fictional app to be instantiable, which is worse than
+    nothing. Declared in ``context.RESERVED_SLOTS``; a non-empty tuple logs a
+    loud warning at boot, and ``test_platform_cpp_seam_coverage.py`` fails if a
+    consumption site appears without the reservation being removed.
     """
 
     @property

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -131,7 +131,11 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.memory import MemoryStore
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
-from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.context import (
+    PlatformCompositionError,
+    current_context,
+    safe_context_call,
+)
 from kiro_crew.platform.governance_profiles import (
     HOST_SESSION_KEY,
     audit_governance_degraded,
@@ -443,8 +447,6 @@ def _is_heartbeat_safe_tool(event_title: str) -> bool:
     # deny-by-default boundary intact; the companion MUST pin "@server/Tool".
     if not qualified:
         return False
-    from kiro_crew.platform.context import current_context, safe_context_call
-
     empty: frozenset[str] = frozenset()
     extra: frozenset[str] = safe_context_call(
         lambda: current_context().slack_gate.heartbeat_safe_tools(),
@@ -1347,9 +1349,31 @@ class GatewayOrchestrator:
 
             # Deliver shim + one-time stale-MCP purge automatically — the
             # desktop app launches the gateway but never runs `kirocrew setup`.
-            from kiro_crew.agent import run_first_run_setup  # circular import
-
-            run_first_run_setup()
+            #
+            # Routed through the CPP seam (``AgentRuntime.run_first_run_setup``)
+            # rather than importing ``agent.run_first_run_setup`` directly, so
+            # first-run setup is genuinely extensible: an edition composes an
+            # adapter that adds its own one-time provisioning on top. The
+            # ``DefaultAgentRuntime`` delegates to exactly the same
+            # ``agent.run_first_run_setup()`` this line used to call, so the
+            # standalone build is behaviorally identical (asserted in
+            # test_cpp_wiring_standalone).
+            #
+            # ``safe_context_call`` keeps a transient adapter error from breaking
+            # startup (``fallback=None`` matches the seam's ``-> None`` contract),
+            # matching the pre-existing best-effort posture of this block.
+            # The fail-closed guarantee for a non-standalone host is already
+            # discharged EARLIER, by ``boot_platform`` in ``run_gateway``: it
+            # aborts before the orchestrator is built, so a companion that cannot
+            # compose never reaches this line. (Note the enclosing
+            # ``except Exception`` would itself absorb a PlatformCompositionError
+            # raised here — which is why boot, not this call site, is where that
+            # invariant is enforced.)
+            safe_context_call(
+                lambda: current_context().agent_runtime.run_first_run_setup(),
+                fallback=None,
+                log_message="agent_runtime.run_first_run_setup failed",
+            )
         except Exception:
             logger.warning("Agent config install failed", exc_info=True)
 

--- a/test/test_cpp_wiring_standalone.py
+++ b/test/test_cpp_wiring_standalone.py
@@ -93,6 +93,68 @@ def test_extra_mcp_servers_empty_standalone() -> None:
     assert ctx.mcp_tooling.extra_mcp_servers() == {}
 
 
+# ── AgentRuntime.run_first_run_setup (newly wired) ──
+#
+# The gateway boot path used to call ``agent.run_first_run_setup()`` directly,
+# bypassing the ``agent_runtime`` seam entirely. It now routes through
+# ``current_context().agent_runtime.run_first_run_setup()``. These two tests are
+# the behavior-preserving proof: the Default adapter must invoke the SAME
+# underlying function with the same (no) arguments, so a standalone install gets
+# byte-identical first-run behavior through the seam.
+
+
+def test_default_agent_runtime_delegates_to_agent_first_run_setup(monkeypatch) -> None:
+    """The Default adapter calls ``agent.run_first_run_setup`` verbatim.
+
+    Behavior-preserving proof for routing the gateway's direct call through the
+    seam: same target function, same argument list (none), called exactly once.
+    """
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        "kiro_crew.agent.run_first_run_setup",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+    current_context().agent_runtime.run_first_run_setup()
+    assert calls == [((), {})]
+
+
+def test_gateway_first_run_setup_routes_through_the_seam(monkeypatch) -> None:
+    """A composed adapter is what the gateway's wired call reaches.
+
+    Asserts the seam is genuinely load-bearing at the call site: an edition
+    adapter composed into ``agent_runtime`` is invoked INSTEAD of the module
+    function, which is exactly what the direct import made impossible.
+    """
+    import dataclasses
+
+    from kiro_crew.platform import build_default_context, reset_context, set_context
+    from kiro_crew.platform.context import safe_context_call
+
+    seen: list[str] = []
+
+    class _EditionAgentRuntime:
+        def managed_mcp_servers(self):
+            return {}
+
+        def run_first_run_setup(self) -> None:
+            seen.append("edition")
+
+    monkeypatch.setattr("kiro_crew.agent.run_first_run_setup", lambda: seen.append("core-direct"))
+    base = build_default_context(KiroCrewConfig())
+    composed = dataclasses.replace(base, agent_runtime=_EditionAgentRuntime())
+    set_context(composed)
+    try:
+        # The exact expression the gateway boot path evaluates.
+        safe_context_call(
+            lambda: current_context().agent_runtime.run_first_run_setup(),
+            fallback=None,
+            log_message="agent_runtime.run_first_run_setup failed",
+        )
+    finally:
+        reset_context()
+    assert seen == ["edition"]
+
+
 class _NoMarkerHome:
     """A fake home dir whose ``/ ".midway"`` never exists."""
 

--- a/test/test_platform_cpp_seam_coverage.py
+++ b/test/test_platform_cpp_seam_coverage.py
@@ -1,0 +1,562 @@
+"""Anti-rot gate for the CPP seam: every extension point is wired or RESERVED.
+
+The failure mode this suite exists to prevent: a ``PlatformContext`` field is
+added (or an interface method is), an edition author reads the dataclass, writes
+an adapter, ``dataclasses.replace``\\ s it in — and gets **silence**. No boot
+warning, no log line, no failing test, because nothing in the core ever reads
+the field. The seam looks like a contract but is inert.
+
+So the contract is made total here. For every field of ``PlatformContext``,
+exactly one of the following must hold:
+
+* it has at least one **consumption site** in non-``platform/`` core code, or
+* it is declared inert in ``context.RESERVED_SLOTS``.
+
+And the reservation cannot rot in either direction:
+
+* a reserved slot that GAINS a consumption site fails
+  :func:`test_reserved_slots_have_no_consumption_site` — so wiring a slot forces
+  its ``RESERVED_SLOTS`` entry to be deleted deliberately, in the same change;
+* a new field with NO consumption site fails
+  :func:`test_every_context_field_is_wired_or_reserved` — so it cannot quietly
+  become the next dead seam.
+
+``context.RESERVED_METHODS`` gets the same treatment one level finer, for
+individual methods on fields that are otherwise live (today: the unread
+``AgentRuntime.managed_mcp_servers`` and ``IdentityProvider.whoami``/``issuer``).
+
+Consumption sites are discovered by **static analysis of the real source tree**
+(``ast``), not from a hand-maintained list — a list would itself rot. See
+:func:`_find_seam_reads`.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import pytest
+
+import kiro_crew
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.platform import (
+    RESERVED_METHODS,
+    RESERVED_SLOTS,
+    build_default_context,
+)
+from kiro_crew.platform.context import (
+    _RESERVED_DEFAULT_ADAPTERS,
+    _RESERVED_WARNED,
+    PlatformContext,
+    _reserved_slot_is_default,
+)
+
+# ── Static-analysis configuration ──
+
+_SRC_ROOT = Path(kiro_crew.__file__).resolve().parent
+
+# Directories under the package that are NOT core consumption sites.
+#  - ``platform``: the seam's own definition/composition code. A read here is
+#    plumbing (``bootstrap`` validating ``contract_version``, ``defaults``
+#    delegating), never a core consumer, so it must not count as "wired".
+#  - ``_vendor``: vendored third-party source (llama-cpp-python) — not ours, and
+#    it has unrelated attributes named ``embeddings``/``cfg``.
+_EXCLUDED_DIRS = frozenset({"platform", "_vendor"})
+
+# Callables that return a ``PlatformContext``. An attribute access on a call to
+# one of these is a seam read: ``current_context().identity``.
+_CONTEXT_FACTORIES = frozenset(
+    {
+        "current_context",
+        "build_default_context",
+        "bootstrap_context",
+        "boot_platform",
+    }
+)
+
+# Local variable names that conventionally hold a ``PlatformContext``, for the
+# ``ctx = current_context(); ctx.jail`` two-step (used by ``cli.py`` and
+# ``cli_doctor.py``). Kept narrow on purpose: a broad name set would count
+# unrelated ``ctx.foo`` reads (e.g. an aiohttp request ctx) as seam wiring and
+# make this gate pass vacuously.
+_CONTEXT_VAR_NAMES = frozenset({"ctx", "_ctx", "pctx", "platform_ctx"})
+
+# Fields whose ONLY consumer is the composition root itself (``bootstrap.py``),
+# by design — they are boot-protocol carriers, not leaf-module extension points.
+# These are genuinely LIVE: overriding them changes real behavior at boot, which
+# is why they are neither "wired in a leaf module" nor "reserved/inert".
+#
+# This is a narrow, enumerated allowance, not an escape hatch: it names exactly
+# two fields with an explicit reason each, and
+# ``test_boot_consumed_fields_are_really_read_by_bootstrap`` proves each one is
+# actually read there — so a field cannot be parked here to dodge the gate.
+_BOOT_CONSUMED_IN_PLATFORM: Dict[str, str] = {
+    "contract_version": (
+        "bootstrap._assert_contract compares it against CONTRACT_VERSION and "
+        "refuses to compose a mismatched companion — a boot-protocol guard, not a "
+        "behavior adapter, so no leaf module reads it."
+    ),
+    "publish": (
+        "bootstrap_context calls publish.register_publish_providers() once after "
+        "the context installs; the override's effect is the registry side effect "
+        "it performs there, so there is no later read."
+    ),
+}
+
+
+def _is_context_expr(node: ast.expr) -> bool:
+    """True when *node* evaluates to a ``PlatformContext`` by our conventions."""
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name):
+            return func.id in _CONTEXT_FACTORIES
+        if isinstance(func, ast.Attribute):
+            return func.attr in _CONTEXT_FACTORIES
+        return False
+    if isinstance(node, ast.Name):
+        return node.id in _CONTEXT_VAR_NAMES
+    return False
+
+
+def _core_source_files() -> List[Path]:
+    """Every non-excluded ``.py`` file under ``src/kiro_crew``."""
+    return [
+        path
+        for path in sorted(_SRC_ROOT.rglob("*.py"))
+        if not _EXCLUDED_DIRS & set(path.relative_to(_SRC_ROOT).parts)
+    ]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(_SRC_ROOT.parent))
+
+
+def _find_seam_reads(field_names: Set[str]) -> Dict[str, List[str]]:
+    """Map each context field name → ``["module.py:LINE", ...]`` read sites.
+
+    Recognizes both documented CPP read shapes:
+
+        current_context().identity.status()      → identity
+        ctx = current_context(); ctx.jail        → jail
+
+    Deliberately conservative — it under-counts rather than over-counts. A
+    genuinely-wired field reached by some *other* shape would show up as an
+    unexpected failure here (loud, fixable by teaching this scanner the shape)
+    rather than as a silently-passing gate, which is the outcome that matters:
+    this test's job is to make inertness impossible to miss.
+    """
+    reads: Dict[str, List[str]] = {name: [] for name in field_names}
+    for path in _core_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            if node.attr in field_names and _is_context_expr(node.value):
+                reads[node.attr].append(f"{_rel(path)}:{node.lineno}")
+    return reads
+
+
+def _find_method_reads(field_names: Set[str]) -> Dict[str, List[str]]:
+    """Map ``"field.method"`` → read sites, for methods reached via the seam.
+
+    Shape: ``<ctx-expr>.<field>.<method>``. Only direct attribute access counts;
+    ``getattr(ctx.identity, name)`` is deliberately not chased (dynamic, and not
+    a documented read shape).
+    """
+    method_reads: Dict[str, List[str]] = {}
+    for path in _core_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            inner = node.value
+            if not isinstance(inner, ast.Attribute):
+                continue
+            if inner.attr in field_names and _is_context_expr(inner.value):
+                method_reads.setdefault(f"{inner.attr}.{node.attr}", []).append(
+                    f"{_rel(path)}:{node.lineno}"
+                )
+    return method_reads
+
+
+@pytest.fixture(scope="module")
+def context_field_names() -> Set[str]:
+    """Every ``PlatformContext`` field, driven off the dataclass itself."""
+    return {f.name for f in dataclasses.fields(PlatformContext)}
+
+
+@pytest.fixture(scope="module")
+def field_reads(context_field_names: Set[str]) -> Dict[str, List[str]]:
+    return _find_seam_reads(context_field_names)
+
+
+@pytest.fixture(scope="module")
+def method_reads(context_field_names: Set[str]) -> Dict[str, List[str]]:
+    return _find_method_reads(context_field_names)
+
+
+# ── The scanner must actually work (guards against a vacuous gate) ──
+
+
+class TestScannerCoherence:
+    """If the scanner silently found nothing, every other test here would pass
+    for the wrong reason. Pin its behavior on seams we know are wired."""
+
+    def test_scanner_finds_known_wired_fields(self, field_reads) -> None:
+        # A representative spread across the read shapes and file locations.
+        for field in ("identity", "slack_gate", "dashboard", "tunnel", "governance"):
+            assert field_reads[field], f"scanner found no read of the wired {field!r} seam"
+
+    def test_scanner_finds_two_step_ctx_var_shape(self, field_reads) -> None:
+        """``ctx = current_context()`` then ``ctx.jail`` must be recognized."""
+        assert any("cli.py" in site for site in field_reads["jail"]), field_reads["jail"]
+
+    def test_scanner_finds_method_level_reads(self, method_reads) -> None:
+        assert method_reads.get("identity.status_line"), "method-level scan found nothing"
+
+    def test_scanner_excludes_platform_package(self, field_reads) -> None:
+        """Seam-internal plumbing must never count as a consumption site."""
+        for sites in field_reads.values():
+            assert not [s for s in sites if "/platform/" in s.replace("\\", "/")]
+
+    def test_scanner_reads_a_nonempty_tree(self) -> None:
+        files = _core_source_files()
+        assert len(files) > 100, f"only {len(files)} core files scanned"
+
+
+# ── The gate: every field is wired or explicitly reserved ──
+
+
+class TestSeamCoverage:
+    def test_every_context_field_is_wired_or_reserved(
+        self, context_field_names, field_reads
+    ) -> None:
+        """No field may be silently inert.
+
+        A new ``PlatformContext`` field with no consumption site fails HERE —
+        either wire it, or declare it in ``RESERVED_SLOTS`` with the reason and
+        the wired alternative. (``_BOOT_CONSUMED_IN_PLATFORM`` covers the two
+        boot-protocol carriers whose only legitimate consumer is ``bootstrap``.)
+        """
+        accounted = set(RESERVED_SLOTS) | set(_BOOT_CONSUMED_IN_PLATFORM)
+        unaccounted = sorted(
+            name for name in context_field_names if not field_reads[name] and name not in accounted
+        )
+        assert not unaccounted, (
+            "PlatformContext field(s) with NO core consumption site and no "
+            f"RESERVED_SLOTS entry: {unaccounted}. Either wire the field to a real "
+            "call site, or add it to kiro_crew.platform.context.RESERVED_SLOTS with "
+            "the reason it is inert and the wired alternative — otherwise an edition "
+            "can override it and get silence."
+        )
+
+    def test_boot_consumed_fields_are_really_read_by_bootstrap(self, context_field_names) -> None:
+        """Prove the boot-protocol allowance is not a rubber stamp.
+
+        Each ``_BOOT_CONSUMED_IN_PLATFORM`` field must genuinely be read in
+        ``platform/bootstrap.py`` — so a future field cannot be parked there to
+        dodge :func:`test_every_context_field_is_wired_or_reserved`.
+        """
+        unknown = sorted(set(_BOOT_CONSUMED_IN_PLATFORM) - context_field_names)
+        assert not unknown, f"_BOOT_CONSUMED_IN_PLATFORM names non-fields: {unknown}"
+
+        bootstrap_src = (_SRC_ROOT / "platform" / "bootstrap.py").read_text(encoding="utf-8")
+        tree = ast.parse(bootstrap_src)
+        read_there = {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr in context_field_names
+            and _is_context_expr(node.value)
+        }
+        missing = sorted(set(_BOOT_CONSUMED_IN_PLATFORM) - read_there)
+        assert not missing, (
+            f"_BOOT_CONSUMED_IN_PLATFORM field(s) NOT actually read in "
+            f"platform/bootstrap.py: {missing}. The allowance exists only for "
+            "fields the composition root really consumes — wire it or reserve it."
+        )
+
+    def test_boot_consumed_and_reserved_are_disjoint(self) -> None:
+        overlap = sorted(set(_BOOT_CONSUMED_IN_PLATFORM) & set(RESERVED_SLOTS))
+        assert not overlap, (
+            f"field(s) both boot-consumed and RESERVED: {overlap} — a field cannot "
+            "be live at boot and inert at the same time."
+        )
+
+    def test_reserved_slots_have_no_consumption_site(self, field_reads) -> None:
+        """A RESERVED marker must not outlive the inertness it documents.
+
+        If a reserved slot gains a real consumption site, this fails until the
+        ``RESERVED_SLOTS`` entry (and the ``[RESERVED]`` field comment, and the
+        Protocol docstring) are removed — so the marker can never go stale and
+        mislead the next implementor into thinking a live seam is dead.
+        """
+        now_wired = {name: field_reads[name] for name in RESERVED_SLOTS if field_reads.get(name)}
+        assert not now_wired, (
+            f"RESERVED_SLOTS entries that now HAVE consumption sites: {now_wired}. "
+            "Wiring a reserved slot is good — now finish the job: delete its "
+            "RESERVED_SLOTS entry, drop the '[RESERVED]' comment on the "
+            "PlatformContext field, and update the Protocol docstring in "
+            "interfaces.py."
+        )
+
+    def test_reserved_slots_are_real_fields(self, context_field_names) -> None:
+        """A reservation for a field that no longer exists is dead weight."""
+        unknown = sorted(set(RESERVED_SLOTS) - context_field_names)
+        assert not unknown, f"RESERVED_SLOTS names non-existent field(s): {unknown}"
+
+    def test_reserved_slots_explain_themselves(self) -> None:
+        """Each reason must be substantive — a bare 'TODO' helps nobody."""
+        for name, reason in RESERVED_SLOTS.items():
+            assert len(reason) > 60, f"RESERVED_SLOTS[{name!r}] reason is too terse"
+            assert "no core call site" in reason, (
+                f"RESERVED_SLOTS[{name!r}] must state 'no core call site' so the "
+                "reason is greppable and unambiguous"
+            )
+
+    def test_reserved_slots_are_marked_on_the_dataclass(self) -> None:
+        """The marker must be visible in the source an implementor actually reads.
+
+        The whole point of this change: the inertness has to be legible from
+        ``PlatformContext`` itself, not only from a docstring three modules away.
+        A reserved field's declaration line — or the comment block immediately
+        above it — must carry the ``[RESERVED]`` token.
+        """
+        source = (_SRC_ROOT / "platform" / "context.py").read_text(encoding="utf-8")
+        # Isolate the dataclass body so a match inside RESERVED_SLOTS itself (or
+        # the class docstring) cannot satisfy the assertion.
+        body = source.split("class PlatformContext:", 1)[1].split("def __post_init__", 1)[0]
+        lines = body.splitlines()
+        for name in RESERVED_SLOTS:
+            decl = [i for i, ln in enumerate(lines) if ln.strip().startswith(f"{name}:")]
+            assert decl, f"reserved field {name!r} not found in the dataclass body"
+            idx = decl[0]
+            # The declaration line, plus any contiguous comment lines above it.
+            block = [lines[idx]]
+            probe = idx - 1
+            while probe >= 0 and lines[probe].strip().startswith("#"):
+                block.append(lines[probe])
+                probe -= 1
+            assert any("[RESERVED]" in ln for ln in block), (
+                f"reserved field {name!r} carries no '[RESERVED]' marker on its "
+                "declaration line or in the comment block directly above it — an "
+                "implementor reading the dataclass would not see that overriding "
+                "it does nothing"
+            )
+
+
+class TestReservedMethodCoverage:
+    """Same contract, one level finer: methods on otherwise-live fields."""
+
+    def test_reserved_methods_have_no_consumption_site(self, method_reads) -> None:
+        now_wired = {
+            f"{field}.{method}": method_reads[f"{field}.{method}"]
+            for field, methods in RESERVED_METHODS.items()
+            for method in methods
+            if method_reads.get(f"{field}.{method}")
+        }
+        assert not now_wired, (
+            f"RESERVED_METHODS entries that now HAVE consumption sites: {now_wired}. "
+            "Delete the RESERVED_METHODS entry and update the Protocol docstring in "
+            "interfaces.py."
+        )
+
+    def test_reserved_methods_name_real_fields(self, context_field_names) -> None:
+        unknown = sorted(set(RESERVED_METHODS) - context_field_names)
+        assert not unknown, f"RESERVED_METHODS names non-existent field(s): {unknown}"
+
+    def test_reserved_methods_exist_on_the_default_adapter(self) -> None:
+        """A reserved method must actually be part of the contract.
+
+        Catches a rename: if ``whoami`` were renamed and the reservation left
+        behind, the entry would silently protect nothing.
+        """
+        ctx = build_default_context(KiroCrewConfig())
+        for field, methods in RESERVED_METHODS.items():
+            adapter = getattr(ctx, field)
+            for method in methods:
+                assert callable(
+                    getattr(adapter, method, None)
+                ), f"RESERVED_METHODS[{field!r}] names missing method {method!r}"
+
+    def test_reserved_methods_are_not_whole_field_reservations(self) -> None:
+        """A field with EVERY method reserved should be a RESERVED_SLOT instead."""
+        overlap = sorted(set(RESERVED_METHODS) & set(RESERVED_SLOTS))
+        assert not overlap, (
+            f"field(s) in BOTH RESERVED_METHODS and RESERVED_SLOTS: {overlap}. A "
+            "reserved slot is already wholly inert — the per-method entry is "
+            "redundant and will drift."
+        )
+
+    def test_reserved_methods_explain_themselves(self) -> None:
+        for field, methods in RESERVED_METHODS.items():
+            for method, reason in methods.items():
+                assert "no core call site" in reason, (
+                    f"RESERVED_METHODS[{field!r}][{method!r}] must state " "'no core call site'"
+                )
+
+
+# ── The runtime signal: composing into a reserved slot is loud ──
+
+
+class TestReservedSlotWarning:
+    """A non-default value in a reserved slot logs once, loudly — and the
+    all-defaults standalone context stays silent."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_warn_dedup(self):
+        """The dedup set is process-global; isolate each test from the others."""
+        saved = set(_RESERVED_WARNED)
+        _RESERVED_WARNED.clear()
+        yield
+        _RESERVED_WARNED.clear()
+        _RESERVED_WARNED.update(saved)
+
+    def test_default_context_warns_about_nothing(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            build_default_context(KiroCrewConfig())
+        assert "RESERVED slot" not in caplog.text
+
+    def test_override_into_reserved_slot_warns(self, caplog) -> None:
+        class _MyPackageManager:
+            def install_plan(self, tool: str) -> List[str]:
+                return ["brew", "install", tool]
+
+            def which(self, tool: str) -> Optional[str]:
+                return None
+
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            dataclasses.replace(base, package_manager=_MyPackageManager())
+        assert "PlatformContext.package_manager is a RESERVED slot" in caplog.text
+        # The warning must be actionable: it names the offending adapter AND the
+        # wired alternative, so the reader knows what to do instead.
+        assert "_MyPackageManager" in caplog.text
+        assert "cli_doctor" in caplog.text
+
+    def test_non_empty_feature_apps_warns(self, caplog) -> None:
+        """``feature_apps`` is a tuple, not an adapter — its default is ``()``."""
+
+        class _App:
+            name = "demo"
+
+            def manifest_path(self) -> Path:
+                return Path("/nonexistent/manifest.json")
+
+            def register(self, ctx: object) -> None:
+                return None
+
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            dataclasses.replace(base, feature_apps=(_App(),))
+        assert "PlatformContext.feature_apps is a RESERVED slot" in caplog.text
+
+    def test_warning_is_deduped_per_adapter(self, caplog) -> None:
+        """A composition root that rebuilds the context must not spam the log."""
+
+        class _MyPackageManager:
+            def install_plan(self, tool: str) -> List[str]:
+                return []
+
+            def which(self, tool: str) -> Optional[str]:
+                return None
+
+        mine = _MyPackageManager()
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            first = dataclasses.replace(base, package_manager=mine)
+            dataclasses.replace(first, profile="enterprise")
+            dataclasses.replace(first, telemetry=first.telemetry)
+        assert caplog.text.count("PlatformContext.package_manager is a RESERVED slot") == 1
+
+    def test_a_different_override_still_warns(self, caplog) -> None:
+        """Dedup is keyed by adapter type, so a LATER, different override reports."""
+
+        class _First:
+            def install_plan(self, tool: str) -> List[str]:
+                return []
+
+            def which(self, tool: str) -> Optional[str]:
+                return None
+
+        class _Second(_First):
+            pass
+
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            dataclasses.replace(base, package_manager=_First())
+            dataclasses.replace(base, package_manager=_Second())
+        assert caplog.text.count("PlatformContext.package_manager is a RESERVED slot") == 2
+
+    def test_subclass_of_default_adapter_still_warns(self, caplog) -> None:
+        """A companion SUBCLASS of a ``Default*`` adapter is a real override.
+
+        It can change behavior, so class identity (not ``isinstance``) decides —
+        otherwise the loudest case (an edition extending the default) would be
+        the one case that stays silent.
+        """
+        from kiro_crew.platform.defaults import DefaultPackageManager
+
+        class _Extended(DefaultPackageManager):
+            def install_plan(self, tool: str) -> List[str]:
+                return ["managed-install", tool]
+
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            dataclasses.replace(base, package_manager=_Extended())
+        assert "PlatformContext.package_manager is a RESERVED slot" in caplog.text
+
+    def test_warning_never_breaks_composition(self, monkeypatch, caplog) -> None:
+        """Diagnostics must not be able to abort boot.
+
+        The warning pass is best-effort by contract, so if any part of it raises
+        the context must still compose. Forced here by making the
+        default-recognizer itself blow up — the same fail-safe that protects boot
+        from a hostile adapter whose ``type()``/``__qualname__`` misbehaves.
+        """
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("recognizer exploded")
+
+        monkeypatch.setattr("kiro_crew.platform.context._reserved_slot_is_default", _boom)
+        base = build_default_context(KiroCrewConfig())
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.context"):
+            ctx = dataclasses.replace(base, telemetry=base.telemetry)
+        assert isinstance(ctx, PlatformContext)
+        assert "RESERVED slot" not in caplog.text
+
+
+class TestReservedDefaultAdapterMap:
+    """``_RESERVED_DEFAULT_ADAPTERS`` must stay in step with ``RESERVED_SLOTS``,
+    or a new reserved slot would warn on every boot of the DEFAULT context."""
+
+    def test_map_covers_every_adapter_backed_reserved_slot(self) -> None:
+        # ``feature_apps`` is the one non-adapter slot (its default is ``()``).
+        expected = set(RESERVED_SLOTS) - {"feature_apps"}
+        assert set(_RESERVED_DEFAULT_ADAPTERS) == expected, (
+            "every RESERVED_SLOTS entry except feature_apps needs a "
+            "_RESERVED_DEFAULT_ADAPTERS entry naming its Default* class, else the "
+            "all-defaults standalone context warns spuriously at every boot"
+        )
+
+    def test_named_default_classes_exist_and_are_composed(self) -> None:
+        ctx = build_default_context(KiroCrewConfig())
+        for field, class_name in _RESERVED_DEFAULT_ADAPTERS.items():
+            assert type(getattr(ctx, field)).__name__ == class_name, (
+                f"_RESERVED_DEFAULT_ADAPTERS[{field!r}]={class_name!r} is not what "
+                "build_default_context actually composes"
+            )
+
+    def test_default_recognizer_agrees_with_the_default_context(self) -> None:
+        ctx = build_default_context(KiroCrewConfig())
+        for field in RESERVED_SLOTS:
+            assert _reserved_slot_is_default(field, getattr(ctx, field)) is True


### PR DESCRIPTION
## What & why

`PlatformContext` presents ~24 uniform adapter fields, but **four were read by no non-platform core code**, so an edition overriding them got silence — no boot warning, no log line, no test failure. This is the extension contract for editions; a dead slot in it is a trap. The "NOT YET WIRED" notes that existed were buried in `interfaces.py`/`defaults.py` docstrings, invisible from the dataclass an implementor actually reads.

Verified dead on `main` (0 non-platform read sites): `agent_runtime`, `feature_apps`, `package_manager`, `embeddings`, plus two dead methods on a live field — `IdentityProvider.whoami()` / `.issuer()`.

## Per-seam decision

| Seam | Decision | Why |
|---|---|---|
| `agent_runtime.run_first_run_setup` | **WIRED** | `slack/gateway.py` already called the underlying `agent.run_first_run_setup` via a direct import, bypassing the seam. Routing that one call through the context makes first-run provisioning genuinely extensible. |
| `agent_runtime.managed_mcp_servers` | RESERVED (method) | No correct site — the agent config is built from `_MANAGED_MCP_SERVERS` at four places with different merge semantics; `McpToolingProvider.extra_mcp_servers()` already covers contribution and is wired. |
| `embeddings` | RESERVED | The in-process llama.cpp runtime removed the HTTP embed path; nothing sources a model/endpoint/signature. `register_embedding_backend()` is the live seam. |
| `package_manager` | RESERVED | Installs are inline brew/curl/pip in `cli_doctor.py`, not a plan-resolution point. |
| `feature_apps` | RESERVED, no `Default*` added | `FeatureApp` describes one app (an item), not a policy the core queries — a `DefaultFeatureApp` would have to invent a fictional app. The slot default is the empty tuple already composed. |
| `identity.whoami` / `.issuer` | RESERVED (methods) | Nothing displays the principal or branches on the issuer; `status()` is the wired surface. |

## Making inertness impossible to miss

- The wiring is **behavior-preserving for the standalone default**: `DefaultAgentRuntime.run_first_run_setup` delegates to the exact same `agent.run_first_run_setup()` the gateway used to call directly. Two tests assert this — one that the default calls the same target once with no args, one that a composed edition adapter is reached *instead of* the module function (proving the seam is load-bearing, which the direct import made impossible).
- Reserved slots emit a **loud one-time boot log** when a non-default value is composed into them — it warns, never raises, so it can't break `dataclasses.replace` for an edition setting a slot in anticipation.
- **Anti-rot coverage test** (`test/test_platform_cpp_seam_coverage.py`): drives off `dataclasses.fields(PlatformContext)` and discovers consumption sites by AST-analysing `src/kiro_crew` (excluding `platform/` + `_vendor/`) — no hand-maintained list. Asserts both directions: a new field with no call site fails, and a reserved entry that *gains* a call site fails until the marker is deliberately removed. Mutation-verified (injected a dead field, wired `package_manager`, called `identity.whoami()` — each failed with an actionable message).

## Worth a reviewer's eye

- The gate surfaced a third category: `contract_version` and `publish` are consumed *only* by `bootstrap.py` itself yet genuinely live (`publish` has a registry side effect). They're enumerated in `_BOOT_CONSUMED_IN_PLATFORM` with a companion test proving each is actually read there, so that allowance can't park a dead field.
- The fail-closed invariant for a non-standalone host is discharged at boot by `boot_platform` in `run_gateway` (which aborts before the orchestrator is built), NOT at the wired call site — where the enclosing `except Exception` would absorb a `PlatformCompositionError`. The comment says so rather than implying the call site enforces it.

## Scope notes

`CONTRACT_VERSION` left at 1 (repo pins it pre-launch; no field added/renamed and no interface-semantics change warrants a bump). No reserved field removed — that would narrow the contract and break an out-of-tree edition composing this seam. `black` reformatting of untouched files not folded in (pre-existing drift; CI has `black --check` disabled). Spec `platform-context.md` updated to distinguish live / reserved / boot-consumed.

## Testing

Full gate green: **19027 passed**, isort / flake8 / mypy / scrub-lint clean, on CPython 3.10 + 3.12. New: `test_platform_cpp_seam_coverage.py` (27 tests) + 2 behavior-preserving wiring tests in `test_cpp_wiring_standalone.py`.
