### PR TITLE
feat(desktop): Enable auto-update on Windows (Squirrel.Windows)

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -16,14 +16,20 @@
 
 // Default update feed host: updates.crew.kiro.dev, the pointer hostname of
 // the public distribution CDN (CloudFront + OAC over the kirocrew-updates
-// bucket). The feed is a STATIC JSON file at <base>/<channel>/latest-mac.json
-// written by CI after notarization; the artifact URLs inside it point at the
-// byte hostname (download.crew.kiro.dev, CI's CLI_CDN_BASE). There is no
-// 200/204 server endpoint: safeCheck() fetches the feed itself and compares
-// versions CLIENT-SIDE, engaging Squirrel.Mac only when the feed version
-// differs from the running app. (Squirrel treats any 200 feed response as
-// "update available", so gating on the client compare is what prevents a
-// re-download loop against a static file.)
+// bucket). The feed is a STATIC JSON file at
+// <base>/<channel>/<latest-mac.json | latest-win.json> written by CI after
+// the platform's publish lane; the artifact URLs inside it point at the byte
+// hostname (download.crew.kiro.dev, CI's CLI_CDN_BASE). There is no 200/204
+// server endpoint: safeCheck() fetches the pointer itself and compares
+// versions CLIENT-SIDE, engaging Squirrel only when the feed version differs
+// from the running app. (Squirrel treats any 200 feed response as "update
+// available", so gating on the client compare is what prevents a re-download
+// loop against a static file.)
+//
+// One asymmetry, contained to configureFeed()/startDownload(): Squirrel.Mac
+// consumes this JSON directly, while Squirrel.Windows consumes a DIRECTORY
+// (RELEASES + .nupkg resolved relative to it) that the feed body names in
+// its `releases` field.
 const DEFAULT_FEED_BASE = "https://updates.crew.kiro.dev/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
@@ -88,13 +94,41 @@ function resolveChannel(stamped, preference) {
 }
 
 /**
- * Build the static feed URL for a channel. Pure + testable.
- * @param {{base:string, channel:string}} o
+ * Per-platform channel-pointer filename. The pointer is OUR json (version +
+ * payload URLs + sha256), written by CI per channel; it is what drives the
+ * client-side version compare and the consent card on every platform. The
+ * platform-specific part is only which file and which payload field:
+ *
+ *   darwin -> latest-mac.json  { version, url (zip), dmg, ... }
+ *   win32  -> latest-win.json  { version, setup, releases (Squirrel dir), nupkg, sha256, ... }
+ *
+ * Linux has no pointer yet (no updater consumes one), so it is absent here
+ * and the platform guard in initAutoUpdate keeps auto-update disabled there.
+ */
+const FEED_FILENAME = Object.freeze({
+  darwin: "latest-mac.json",
+  win32: "latest-win.json",
+});
+
+/**
+ * Build the static channel-pointer URL for a platform + channel. Pure + testable.
+ *
+ * `platform` is REQUIRED and is an os key (process.platform), not a
+ * "darwin-arm64" display string. It is deliberately not defaulted: silently
+ * falling back to the mac pointer would serve Windows clients a feed whose
+ * payload field they cannot use, and the failure would surface as a confusing
+ * "feed missing ..." error rather than a wiring mistake.
+ *
+ * @param {{base:string, channel:string, platform:string}} o
  * @returns {string}
  */
-function buildFeedUrl({ base, channel }) {
+function buildFeedUrl({ base, channel, platform }) {
+  const filename = FEED_FILENAME[platform];
+  if (!filename) {
+    throw new Error(`no update feed for platform ${String(platform)}`);
+  }
   const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
-  return `${b}/${encodeURIComponent(channel)}/latest-mac.json`;
+  return `${b}/${encodeURIComponent(channel)}/${filename}`;
 }
 
 /**
@@ -222,10 +256,17 @@ function initAutoUpdate(deps) {
     log.info("[update] dev build — auto-update disabled");
     return { check: () => {}, install: async () => {}, getInfo, disabled: "dev" };
   }
-  if (process.platform !== "darwin") {
-    log.info("[update] non-darwin — auto-update disabled (Squirrel.Mac only)");
+  // Platforms with a published channel pointer AND a Squirrel implementation
+  // Electron's built-in autoUpdater can drive: macOS (Squirrel.Mac) and
+  // Windows (Squirrel.Windows). Linux has neither a pointer nor an updater
+  // (the AppImage is replaced by hand), so it stays disabled and the About
+  // panel reports `disabled: "platform"` rather than showing dead controls.
+  const osPlatform = process.platform;
+  if (!FEED_FILENAME[osPlatform]) {
+    log.info(`[update] ${osPlatform} — auto-update disabled (no channel feed / updater)`);
     return { check: () => {}, install: async () => {}, getInfo, disabled: "platform" };
   }
+  const isWindows = osPlatform === "win32";
 
   let updateReady = false;
   let downloading = false; // Squirrel download/extract in flight
@@ -234,12 +275,51 @@ function initAutoUpdate(deps) {
   let installing = false;
   let quitHandled = false;
 
+  /**
+   * Resolve this check's channel-pointer URL, and on macOS also hand it to
+   * Squirrel.
+   *
+   * The platforms diverge here, and only here. Squirrel.MAC consumes a JSON
+   * feed, so the pointer URL IS its feed URL. Squirrel.WINDOWS consumes a
+   * DIRECTORY: it fetches `RELEASES` from it and resolves each `.nupkg`
+   * relative to it. That directory is not derivable from the pointer host --
+   * pointers live on the updates hostname, the Squirrel directory on the byte
+   * hostname (its protocol couples RELEASES and the payloads into one prefix,
+   * so publish-windows.yml puts the whole directory on the byte host). Rather
+   * than hardcode a second base in the client, the feed body TELLS us the
+   * directory (`releases`), and it is applied at consent time in
+   * startDownload(). That keeps the server authoritative: the directory can
+   * move without shipping a client.
+   */
   function configureFeed() {
     const channel = currentChannel();
-    const url = buildFeedUrl({ base: feedBase, channel });
-    autoUpdater.setFeedURL({ url });
+    const url = buildFeedUrl({ base: feedBase, channel, platform: osPlatform });
+    if (!isWindows) {
+      autoUpdater.setFeedURL({ url });
+    }
     log.info(`[update] feed: ${url}`);
     return url;
+  }
+
+  /**
+   * Validate + normalize the Squirrel.Windows directory URL taken from the
+   * feed body. Same transport discipline as fetchFeedHttps: HTTPS everywhere,
+   * plain HTTP only for loopback so the local update harness works. A
+   * trailing slash is required by Squirrel's relative resolution, so add one
+   * if the feed omitted it.
+   * @param {string} raw
+   * @returns {string}
+   */
+  function squirrelDirFromFeed(raw) {
+    if (typeof raw !== "string" || !raw) {
+      throw new Error("feed missing releases (Squirrel directory) for win32");
+    }
+    const parsed = new URL(raw);
+    const isLoopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
+    if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+      throw new Error(`refusing non-HTTPS Squirrel directory: ${parsed.protocol}//${parsed.hostname}`);
+    }
+    return raw.endsWith("/") ? raw : `${raw}/`;
   }
 
   let checking = false;
@@ -266,8 +346,15 @@ function initAutoUpdate(deps) {
       const url = configureFeed(); // re-read flavor/channel each check
       emit("checking");
       const feed = await fetchFeed(url);
-      if (!feed || typeof feed.version !== "string" || typeof feed.url !== "string") {
-        throw new Error("feed missing version/url");
+      // Per-platform payload field. Rejecting the wrong shape here (rather
+      // than discovering it when Squirrel is engaged) is what turns a
+      // mis-published feed into a visible error instead of a silent
+      // no-op download. mac: `url` is the zip Squirrel.Mac fetches.
+      // win32: `releases` is the DIRECTORY Squirrel.Windows resolves
+      // RELEASES and the .nupkg against.
+      const payloadField = isWindows ? "releases" : "url";
+      if (!feed || typeof feed.version !== "string" || typeof feed[payloadField] !== "string") {
+        throw new Error(`feed missing version/${payloadField}`);
       }
       if (feed.version === app.getVersion()) {
         log.info(`[update] up to date (${feed.version})`);
@@ -326,20 +413,40 @@ function initAutoUpdate(deps) {
       stagedNotes = "";
     }
     configureFeed();
+    if (isWindows) {
+      // Squirrel.Windows is handed the DIRECTORY the feed named, not the
+      // pointer URL (see configureFeed). Applied here, at consent time,
+      // because it is only knowable after the pointer has been fetched --
+      // and a validation failure must abort BEFORE any download starts.
+      let dir;
+      try {
+        dir = squirrelDirFromFeed(foundFeed && foundFeed.releases);
+      } catch (err) {
+        log.error("[update] refusing to download", err);
+        emit("error", { message: String(err && err.message || err) });
+        return;
+      }
+      autoUpdater.setFeedURL({ url: dir });
+      log.info(`[update] squirrel directory: ${dir}`);
+    }
     log.info("[update] user consented — engaging Squirrel download");
     downloading = true;
     emit("downloading");
     autoUpdater.checkForUpdates();
   }
 
-  // ShipIt aborts the bundle swap with "App Still Running Error" (Code=-9)
-  // if ANY instance of the app is alive during its ~25s install window — and
-  // the user silently relaunches into the OLD version. If anything blocks the
-  // Electron quit (a renderer beforeunload, a lingering child holding the
-  // process open), force-exit so this instance is guaranteed gone.
+  // The installer needs this process GONE before it can replace the app.
+  //   macOS: ShipIt aborts the bundle swap with "App Still Running Error"
+  //     (Code=-9) if ANY instance is alive during its ~25s window, and the
+  //     user silently relaunches into the OLD version.
+  //   Windows: Update.exe cannot overwrite files that are still open, so a
+  //     lingering process yields a half-applied update instead.
+  // Either way, if anything blocks the Electron quit (a renderer
+  // beforeunload, a lingering child holding the process open), force-exit so
+  // the installer can proceed.
   function forceExitFailsafe(reason) {
     const t = setTimeout(() => {
-      log.error(`[update] process still alive ${FORCE_EXIT_AFTER_MS}ms after quitAndInstall (${reason}) — forcing exit so ShipIt can swap`);
+      log.error(`[update] process still alive ${FORCE_EXIT_AFTER_MS}ms after quitAndInstall (${reason}) — forcing exit so the installer can replace the app`);
       try { app.exit(0); } catch { process.exit(0); }
     }, FORCE_EXIT_AFTER_MS);
     if (typeof t.unref === "function") t.unref();
@@ -349,7 +456,11 @@ function initAutoUpdate(deps) {
     if (installing) return;
     installing = true;
     // STRICT ORDER: stop the gateway and await its exit, THEN quitAndInstall.
-    // A live gateway child during the bundle swap can leave a half-replaced app.
+    // A live gateway child during the swap can leave a half-replaced app --
+    // and on Windows this is not merely likely but mandatory: the bundled
+    // backend's files are OPEN while it runs, and Update.exe cannot overwrite
+    // open files, so skipping the stop produces a broken install rather than
+    // a retry.
     log.info("[update] stopping gateway before install");
     try {
       await stopGateway();

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1815,11 +1815,13 @@ app.whenReady().then(async () => {
   await startGateway();
   await showLoadingThenConnect(win);
 
-  // Desktop auto-update (Squirrel.Mac). No-op in dev / non-darwin. KiroCrew
+  // Desktop auto-update (Squirrel.Mac on macOS, Squirrel.Windows on win32).
+  // No-op in dev and on Linux, which has no channel feed or updater. KiroCrew
   // ships a single "stable" channel. The gateway is stopped gracefully before
-  // any bundle swap. Update state is mirrored to the renderer so the in-app
-  // UpdateModal + Settings > About can drive the prompt; the native dialog
-  // stays as the fallback only when no UI is wired.
+  // any bundle swap -- mandatory on Windows, where Update.exe cannot overwrite
+  // the bundled backend's open files. Update state is mirrored to the renderer
+  // so the in-app UpdateModal + Settings > About can drive the prompt; the
+  // native dialog stays as the fallback only when no UI is wired.
   function broadcastUpdateState(payload) {
     try {
       for (const wc of webContents.getAllWebContents()) {

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -37,17 +37,36 @@ test("channelForFlavor defaults non-beta to stable", () => {
 });
 
 test("buildFeedUrl points at the channel's static latest-mac.json", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "insider" });
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "insider", platform: "darwin" });
   assert.strictEqual(url, "https://cdn.example.dev/feed/insider/latest-mac.json");
 });
 
+test("buildFeedUrl points win32 at latest-win.json", () => {
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "insider", platform: "win32" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/insider/latest-win.json");
+});
+
+test("buildFeedUrl refuses a platform with no published feed", () => {
+  // Not defaulted on purpose: silently falling back to the mac pointer would
+  // serve Windows a payload field it cannot use, surfacing as a confusing
+  // "feed missing ..." error instead of the wiring mistake it is.
+  assert.throws(
+    () => buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable", platform: "linux" }),
+    /no update feed for platform linux/,
+  );
+  assert.throws(
+    () => buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable" }),
+    /no update feed for platform undefined/,
+  );
+});
+
 test("buildFeedUrl strips trailing slashes from base", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed///", channel: "stable" });
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed///", channel: "stable", platform: "darwin" });
   assert.strictEqual(url, "https://cdn.example.dev/feed/stable/latest-mac.json");
 });
 
 test("buildFeedUrl url-encodes the channel segment", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "a b" });
+  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "a b", platform: "darwin" });
   assert.strictEqual(url, "https://cdn.example.dev/feed/a%20b/latest-mac.json");
 });
 
@@ -443,3 +462,169 @@ test("a throwing nudge callback does not break the check (found still emitted)",
     await new Promise((r) => setImmediate(r));
     assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
   }));
+
+// ---------------------------------------------------------------------------
+// win32 (Squirrel.Windows). Same discovery/consent flow as macOS -- the ONLY
+// divergence is what Squirrel is handed: macOS gets the JSON pointer URL,
+// Windows gets the DIRECTORY the pointer names in `releases` (its protocol
+// resolves RELEASES and each .nupkg relative to that base). That directory
+// lives on the byte hostname while pointers live on the updates hostname, so
+// it is NOT derivable client-side -- the feed is authoritative and the value
+// is applied at consent time.
+// ---------------------------------------------------------------------------
+
+function withWin32(fn) {
+  const orig = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "win32" });
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => Object.defineProperty(process, "platform", orig));
+}
+
+const WIN_FEED = {
+  version: "1.0.1",
+  setup: "https://dl.example.dev/desktop/stable/1.0.1/KiroCrew-Setup-x64.exe",
+  releases: "https://dl.example.dev/desktop/stable/win/",
+  nupkg: "https://dl.example.dev/desktop/stable/win/KiroCrew-1.0.1-full.nupkg",
+  sha256: "0".repeat(64),
+};
+
+test("win32 auto-update is enabled (not disabled by platform)", () =>
+  withWin32(async () => {
+    const { deps } = makeDeps({ appVersion: "1.0.0", feed: WIN_FEED });
+    const u = initAutoUpdate(deps);
+    assert.strictEqual(u.disabled, undefined, "win32 must not report disabled");
+    assert.strictEqual(typeof u.download, "function", "win32 must expose the consent action");
+  }));
+
+test("win32 reads latest-win.json, not the mac pointer", () =>
+  withWin32(async () => {
+    const seen = [];
+    const { deps } = makeDeps({ appVersion: "1.0.0", feed: WIN_FEED });
+    deps.fetchFeed = async (url) => { seen.push(url); return WIN_FEED; };
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(
+      seen.some((u2) => u2.endsWith("/stable/latest-win.json")),
+      `expected latest-win.json, fetched: ${seen}`,
+    );
+    assert.ok(!seen.some((u2) => u2.includes("latest-mac.json")), "must not read the mac pointer");
+  }));
+
+test("win32 discovery does NOT engage Squirrel until consent", () =>
+  withWin32(async () => {
+    const { deps, calls } = makeDeps({ appVersion: "1.0.0", feed: WIN_FEED });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
+    assert.strictEqual(calls.checkForUpdates, 0, "discovery must not download");
+    // The Squirrel directory must NOT be set during discovery -- only at
+    // consent time, after the pointer has been fetched and validated.
+    assert.ok(
+      !calls.setFeedURL.includes(WIN_FEED.releases),
+      "squirrel directory set before consent",
+    );
+  }));
+
+test("win32 consent hands Squirrel the feed-named DIRECTORY", () =>
+  withWin32(async () => {
+    const { deps, calls } = makeDeps({ appVersion: "1.0.0", feed: WIN_FEED });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1, "consent must engage Squirrel");
+    assert.ok(
+      calls.setFeedURL.includes(WIN_FEED.releases),
+      `expected the Squirrel directory, saw: ${calls.setFeedURL}`,
+    );
+    // The JSON pointer must never be handed to Squirrel.Windows: it would
+    // read it as a directory and 404 on RELEASES.
+    assert.ok(
+      !calls.setFeedURL.some((u2) => u2.endsWith(".json")),
+      `a JSON pointer was handed to Squirrel.Windows: ${calls.setFeedURL}`,
+    );
+  }));
+
+test("win32 appends the trailing slash Squirrel's relative resolution needs", () =>
+  withWin32(async () => {
+    const feed = { ...WIN_FEED, releases: "https://dl.example.dev/desktop/stable/win" };
+    const { deps, calls } = makeDeps({ appVersion: "1.0.0", feed });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(
+      calls.setFeedURL.includes("https://dl.example.dev/desktop/stable/win/"),
+      `expected a trailing slash, saw: ${calls.setFeedURL}`,
+    );
+  }));
+
+test("win32 refuses a non-HTTPS Squirrel directory and does not download", () =>
+  withWin32(async () => {
+    const feed = { ...WIN_FEED, releases: "http://evil.example.dev/desktop/stable/win/" };
+    const { deps, calls } = makeDeps({ appVersion: "1.0.0", feed });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 0, "must not download over cleartext");
+    assert.ok(calls.states.includes("error"), `states: ${calls.states}`);
+  }));
+
+test("win32 allows loopback http so the local update harness works", () =>
+  withWin32(async () => {
+    const feed = { ...WIN_FEED, releases: "http://127.0.0.1:8799/desktop/stable/win/" };
+    const { deps, calls } = makeDeps({ appVersion: "1.0.0", feed });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(calls.checkForUpdates, 1);
+    assert.ok(calls.setFeedURL.includes("http://127.0.0.1:8799/desktop/stable/win/"));
+  }));
+
+test("win32 rejects a mac-shaped feed (no releases directory)", () =>
+  withWin32(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      // A mis-published pointer carrying only the mac payload field.
+      feed: { version: "1.0.1", url: "https://dl.example.dev/x.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.states.includes("error"), `states: ${calls.states}`);
+    assert.strictEqual(calls.checkForUpdates, 0);
+  }));
+
+test("win32 same version is up to date (no download loop on a static feed)", () =>
+  withWin32(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.1",
+      feed: WIN_FEED,
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.states.includes("not-available"), `states: ${calls.states}`);
+    assert.strictEqual(calls.checkForUpdates, 0);
+  }));
+
+test("linux stays disabled (no feed, no updater)", () => {
+  const orig = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "linux" });
+  try {
+    const { deps } = makeDeps({ appVersion: "1.0.0", feed: WIN_FEED });
+    const u = initAutoUpdate(deps);
+    assert.strictEqual(u.disabled, "platform");
+  } finally {
+    Object.defineProperty(process, "platform", orig);
+  }
+});


### PR DESCRIPTION
## What this does

Auto-update was fully built but **gated to macOS** — `auto-update.js` returned a no-op stub with `disabled: "platform"` for anything non-darwin, so Windows installs could only update by downloading a newer `Setup.exe` by hand. This enables it on win32 via Squirrel.Windows.

Everything that makes the update UX work is already platform-agnostic: discovery, the client-side version compare, the consent card, channel routing + the switcher, the stop-gateway-then-install ordering, the deferred-install-on-quit path. What was missing was the per-platform pointer and the Squirrel handoff.

## The only divergence, contained to two functions

| | Squirrel consumes | Where it's set |
|---|---|---|
| **macOS** | the JSON feed itself — pointer URL *is* the feed URL | `configureFeed()` at boot, unchanged |
| **win32** | a **directory** — fetches `RELEASES` from it, resolves each `.nupkg` relative to it | `startDownload()`, at consent time |

The Windows directory is **not derivable client-side**: pointers live on the updates hostname while the Squirrel directory lives on the byte hostname (its protocol couples `RELEASES` and the payloads into one prefix, so #663 puts the whole directory on the byte host). Rather than hardcode a second base in the client, the feed body *names* the directory in its `releases` field and the client applies it at consent time. **That keeps the server authoritative** — the Squirrel directory can move without shipping a client.

## Changes

- **`buildFeedUrl` gains a required `platform` key**, dispatching the pointer filename (`latest-mac.json` | `latest-win.json`) through a `FEED_FILENAME` map. Deliberately *not* defaulted: silently falling back to the mac pointer would hand Windows a payload field it can't use, and the failure would surface as a confusing "feed missing …" error rather than the wiring mistake it is. Absence from that map is also what keeps Linux disabled — one source of truth for "does this platform have an update lane".
- **Feed-shape validation is per-platform**: mac requires `url` (the zip), win32 requires `releases`. A mis-published or wrong-platform pointer is now a visible error instead of a silent no-op download.
- **The Squirrel directory is validated before use**, with the same transport discipline as `fetchFeedHttps`: HTTPS everywhere, plain HTTP only for loopback (so the local update harness still works), and a trailing slash appended if the feed omitted one, since Squirrel's relative resolution needs it. A validation failure aborts *before* any download.
- **Comments corrected where they claimed darwin-only behavior**, including the install-ordering rationale: stopping the gateway before `quitAndInstall` is merely *important* on macOS (ShipIt's "App Still Running Error", Code=-9) but **mandatory** on Windows, where `Update.exe` cannot overwrite the bundled backend's open files — skipping it yields a broken install, not a retry.

The consent contract is unchanged on both platforms: background timers only ever **discover**, a check surfaces a card, and download/install require explicit user actions.

## Verification

**290/290 electron tests pass**, including 11 new win32 tests. They pin the things that would silently break: win32 is not `disabled`; it reads `latest-win.json` and *never* the mac pointer; discovery neither sets the Squirrel directory nor downloads; consent hands Squirrel the feed-named directory and never a `.json` URL (which it would read as a directory and 404 on `RELEASES`); the trailing slash is appended; a non-HTTPS directory is refused with no download; loopback http is allowed; a mac-shaped feed is rejected; same-version is up-to-date (no re-download loop against a static feed); and Linux still reports `disabled: "platform"`.

Mac behavior is unchanged — the existing suite passes untouched, and the three `buildFeedUrl` tests now pass `platform: "darwin"` explicitly.

## Not verified live, and what that means

**A real Windows update swap needs a Windows host, which this machine is not.** The mac DMG saga is the cautionary precedent for asserting a trust/install path that merely *looks* right (notarization passed while Gatekeeper still rejected the artifact). So the first real proof is: install from `Setup.exe` on a Windows box, then take an in-app update to a newer nightly. Everything up to the `autoUpdater` handoff is unit-covered; the handoff itself is Electron's own Squirrel.Windows integration.

## Merge ordering

**Merge #663 (the publish lane) first, or same-day.** This PR's client reads `feed/<channel>/latest-win.json`, which #663 creates. If this lands alone, Windows users would see an update *error* where they currently see "unavailable" — a small regression window until the next nightly publishes the feed. Nothing breaks permanently either way, but the ordering avoids the window entirely.
