### PR TITLE
fix(acp): keep context % consistent with the popover Used/Total counts

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2971,10 +2971,12 @@ class AcpClient:
         prev_pct = self.last_prompt_stats.context_pct
         _prev_used = self.last_prompt_stats.context_used_tokens
         _prev_window = self.last_prompt_stats.context_window_tokens
+        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
         self.last_prompt_stats = AcpPromptStats(
             context_pct=prev_pct,
             context_used_tokens=_prev_used,
             context_window_tokens=_prev_window,
+            context_tokens_from_usage=_prev_from_usage,
         )
 
         # aclosing(): _prompt_loop holds _turn_lock and releases it in its
@@ -3050,10 +3052,12 @@ class AcpClient:
         prev_pct = self.last_prompt_stats.context_pct
         _prev_used = self.last_prompt_stats.context_used_tokens
         _prev_window = self.last_prompt_stats.context_window_tokens
+        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
         self.last_prompt_stats = AcpPromptStats(
             context_pct=prev_pct,
             context_used_tokens=_prev_used,
             context_window_tokens=_prev_window,
+            context_tokens_from_usage=_prev_from_usage,
         )
         self._tool_call_inputs.clear()
         self._tool_call_is_shell.clear()
@@ -3627,10 +3631,12 @@ class AcpClient:
         prev_pct = self.last_prompt_stats.context_pct
         _prev_used = self.last_prompt_stats.context_used_tokens
         _prev_window = self.last_prompt_stats.context_window_tokens
+        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
         self.last_prompt_stats = AcpPromptStats(
             context_pct=prev_pct,
             context_used_tokens=_prev_used,
             context_window_tokens=_prev_window,
+            context_tokens_from_usage=_prev_from_usage,
         )
 
         async for action, msg in self._prompt_loop(req_id, timeout):
@@ -3761,6 +3767,9 @@ class AcpClient:
                 # served window (size) instead of re-deriving it from the model id.
                 self.last_prompt_stats.context_used_tokens = int(used)
                 self.last_prompt_stats.context_window_tokens = int(size)
+                # Mark the counts authoritative so a later metadata
+                # contextUsagePercentage cannot clobber this token-derived pct.
+                self.last_prompt_stats.context_tokens_from_usage = True
             else:
                 logger.debug("usage_update missing used/size: %s", update)
         elif kind == UPDATE_CONFIG_OPTION:
@@ -4454,8 +4463,8 @@ class AcpClient:
         guess. kiro's real ``usage_update.size`` always wins when present (this
         no-ops once it has set the window).
         """
-        if self.last_prompt_stats.context_window_tokens > 0:
-            return  # a real usage_update already set it
+        if self.last_prompt_stats.context_tokens_from_usage:
+            return  # a real usage_update already set authoritative counts
         model_id = self._resolved_model_id or self._model
         if not model_id or not model_registry.has_known_window(model_id):
             return
@@ -4463,14 +4472,29 @@ class AcpClient:
         if not win or win <= 0:
             return
         self.last_prompt_stats.context_window_tokens = win
-        self.last_prompt_stats.context_used_tokens = round(win * pct / 100.0)
+        # A malformed metadata percentage (NaN, ±inf, or a huge finite value
+        # like 1e308) would overflow ``round(win * pct / 100)`` and abort the
+        # turn. Sanitize to a sane [0, 100] before deriving used tokens (NaN
+        # -> 0); this also keeps used <= window.
+        safe_pct = 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
+        self.last_prompt_stats.context_used_tokens = round(win * safe_pct / 100.0)
 
     def _track_metadata(self, msg: JsonRpcMessage) -> None:
         params = msg.params or {}
         pct = params.get("contextUsagePercentage")
-        if pct is not None:
+        # A real usage_update is authoritative for both the token counts AND the
+        # pct derived from them. kiro's metadata percentage can measure a
+        # different window, so applying it here would desync the headline % from
+        # the "used / total" token text (e.g. 73% shown next to 408K / 1000K).
+        if pct is not None and not self.last_prompt_stats.context_tokens_from_usage:
             try:
                 pct_f = float(pct)
+                # Sanitize a malformed metadata percentage (NaN/±inf/out-of-range,
+                # e.g. 1e308) at the source so context_pct is always a real
+                # [0, 100] value: keeps compaction comparisons sane and the
+                # diagnostic /api/sessions JSON standard (Infinity/NaN are not
+                # valid JSON). NaN is caught by its self-inequality.
+                pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
                 self.last_prompt_stats.context_pct = pct_f
                 self._backfill_context_window(pct_f)
             except (TypeError, ValueError):

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -381,6 +381,7 @@ class AcpSessionHandle:
             context_pct=self.last_prompt_stats.context_pct,
             context_used_tokens=self.last_prompt_stats.context_used_tokens,
             context_window_tokens=self.last_prompt_stats.context_window_tokens,
+            context_tokens_from_usage=self.last_prompt_stats.context_tokens_from_usage,
         )
 
         # send_request must be inside the turn-state guard: _turn_done was just
@@ -1326,9 +1327,18 @@ class AcpSessionHandle:
         """
         params = msg.params or {}
         pct, credits = parse_metadata(params)
-        if pct is not None:
+        # A real usage_update is authoritative for context_pct + token counts;
+        # kiro's metadata percentage can measure a different window, so applying
+        # it here would desync the headline % from the "used / total" token text.
+        if pct is not None and not self.last_prompt_stats.context_tokens_from_usage:
             try:
                 pct_f = float(pct)
+                # Sanitize a malformed metadata percentage (NaN/±inf/out-of-range,
+                # e.g. 1e308) at the source so context_pct is always a real
+                # [0, 100] value: keeps compaction comparisons sane and the
+                # diagnostic /api/sessions JSON standard (Infinity/NaN are not
+                # valid JSON). NaN is caught by its self-inequality.
+                pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
                 self.last_prompt_stats.context_pct = pct_f
                 self._backfill_context_window(pct_f)
             except (TypeError, ValueError):
@@ -1350,8 +1360,8 @@ class AcpSessionHandle:
         authoritative window drives the meter. kiro's real usage_update.size
         always wins when present.
         """
-        if self.last_prompt_stats.context_window_tokens > 0:
-            return  # a real usage_update already set it
+        if self.last_prompt_stats.context_tokens_from_usage:
+            return  # a real usage_update already set authoritative counts
         model_id = self._resolved_model_id or self._model
         if not model_id or not model_registry.has_known_window(model_id):
             return
@@ -1359,7 +1369,12 @@ class AcpSessionHandle:
         if not win or win <= 0:
             return
         self.last_prompt_stats.context_window_tokens = win
-        self.last_prompt_stats.context_used_tokens = round(win * pct / 100.0)
+        # A malformed metadata percentage (NaN, ±inf, or a huge finite value
+        # like 1e308) would overflow ``round(win * pct / 100)`` and abort the
+        # turn. Sanitize to a sane [0, 100] before deriving used tokens (NaN
+        # -> 0); this also keeps used <= window.
+        safe_pct = 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
+        self.last_prompt_stats.context_used_tokens = round(win * safe_pct / 100.0)
 
     def _emit_tool_interrupted_sel(self, site: str) -> None:
         """Emit a SEL audit + WARNING when kiro-cli's security filter cancels tools.
@@ -1489,6 +1504,8 @@ class AcpSessionHandle:
                         self.last_prompt_stats.context_pct = round((used / size) * 100, 1)
                         self.last_prompt_stats.context_used_tokens = int(used)
                         self.last_prompt_stats.context_window_tokens = int(size)
+                        # Mark authoritative so metadata pct cannot clobber it.
+                        self.last_prompt_stats.context_tokens_from_usage = True
                 except (TypeError, ValueError, ZeroDivisionError):
                     pass
             return []

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -335,6 +335,16 @@ class AcpPromptStats:
     # actually divided by, inflating the displayed "X / Y tokens". 0 = unknown.
     context_used_tokens: int = 0
     context_window_tokens: int = 0
+    # True once a real ``usage_update {used, size}`` has set the token counts
+    # above. When set, those counts (and the ``context_pct`` derived from them)
+    # are AUTHORITATIVE: kiro's separately-streamed ``_kiro.dev/metadata``
+    # ``contextUsagePercentage`` must NOT overwrite ``context_pct`` (it can
+    # disagree with used/size — measuring a different window — which would make
+    # the dashboard show a headline % inconsistent with the "used / total"
+    # token text). Also gates the pct-only ``_backfill_context_window`` so a
+    # registry-derived window never clobbers real served counts. Defaults False
+    # and re-inits per turn, carried across turns alongside the counts.
+    context_tokens_from_usage: bool = False
     # Per-turn billing credits summed from kiro's _kiro.dev/metadata
     # meteringUsage (unit="credit"). 0 for providers that bill in tokens.
     credits: float = 0.0

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -1471,6 +1471,30 @@ class TestAcpClientTrackMetadata:
         client._track_metadata(msg)
         assert client.last_prompt_stats.context_pct == 42.5
 
+    def test_backfill_clamps_malformed_pct(self, tmp_path, monkeypatch):
+        """A degenerate metadata percentage (huge finite / inf / NaN) must not
+        overflow round() and abort the turn; derived used stays in [0, window]."""
+        import kiro_crew.acp.client as c
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        monkeypatch.setattr(c.model_registry, "has_known_window", lambda mid: True)
+        monkeypatch.setattr(c.model_registry, "model_window", lambda mid, **kw: 200000)
+        for bad in (1e308, float("inf"), float("nan")):
+            client = AcpClient(work_dir=tmp_path)
+            client._model = "some-model"
+            # Must not raise OverflowError/ValueError.
+            client._track_metadata(
+                JsonRpcMessage(
+                    method="_kiro.dev/metadata",
+                    params={"contextUsagePercentage": bad},
+                )
+            )
+            used = client.last_prompt_stats.context_used_tokens
+            assert 0 <= used <= 200000
+            # context_pct is sanitized at the source, never left non-finite.
+            pct = client.last_prompt_stats.context_pct
+            assert 0.0 <= pct <= 100.0
+
 
 class TestAcpClientTrackUsageUpdate:
     """claude-agent-acp usage_update {used, size}: derives context_pct and
@@ -1491,6 +1515,49 @@ class TestAcpClientTrackUsageUpdate:
         assert stats.context_pct == 25.0  # 50000 / 200000 * 100
         assert stats.context_used_tokens == 50000
         assert stats.context_window_tokens == 200000
+        # A real usage_update marks the counts authoritative.
+        assert stats.context_tokens_from_usage is True
+
+    def test_metadata_pct_does_not_clobber_authoritative_tokens(self, tmp_path):
+        """Regression: a real usage_update (408K/1000K → 40.8%) followed by a
+        kiro metadata contextUsagePercentage=73 must NOT leave the headline pct
+        at 73 while the token text still reads 408K/1000K (the desync the user
+        saw in the context-window popover). usage_update wins for BOTH."""
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        client = AcpClient(work_dir=tmp_path)
+        client._track_usage_update(self._usage_msg(408_000, 1_000_000))
+        assert client.last_prompt_stats.context_pct == 40.8
+
+        client._track_metadata(
+            JsonRpcMessage(
+                method="_kiro.dev/metadata",
+                params={"contextUsagePercentage": 73},
+            )
+        )
+        stats = client.last_prompt_stats
+        assert stats.context_pct == 40.8  # NOT clobbered to 73
+        assert stats.context_used_tokens == 408_000
+        assert stats.context_window_tokens == 1_000_000
+
+    def test_metadata_credits_still_captured_when_tokens_authoritative(self, tmp_path):
+        """The pct guard must not drop kiro billing credits — those accumulate
+        regardless of whether token counts are authoritative."""
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        client = AcpClient(work_dir=tmp_path)
+        client._track_usage_update(self._usage_msg(408_000, 1_000_000))
+        client._track_metadata(
+            JsonRpcMessage(
+                method="_kiro.dev/metadata",
+                params={
+                    "contextUsagePercentage": 73,
+                    "meteringUsage": [{"unit": "credit", "value": 1.5}],
+                },
+            )
+        )
+        assert client.last_prompt_stats.credits == 1.5
+        assert client.last_prompt_stats.context_pct == 40.8
 
     def test_missing_fields_leave_tokens_zero(self, tmp_path):
         client = AcpClient(work_dir=tmp_path)
@@ -1547,6 +1614,7 @@ class TestAcpClientTrackUsageUpdate:
         prev_pct = client.last_prompt_stats.context_pct
         prev_used = client.last_prompt_stats.context_used_tokens
         prev_window = client.last_prompt_stats.context_window_tokens
+        prev_from_usage = client.last_prompt_stats.context_tokens_from_usage
         from kiro_crew.acp.types import AcpPromptStats
 
         # Mirror the reset sites (send_message_stream / _dispatch_events / etc.)
@@ -1554,10 +1622,14 @@ class TestAcpClientTrackUsageUpdate:
             context_pct=prev_pct,
             context_used_tokens=prev_used,
             context_window_tokens=prev_window,
+            context_tokens_from_usage=prev_from_usage,
         )
         assert client.last_prompt_stats.context_used_tokens == 88000
         assert client.last_prompt_stats.context_window_tokens == 200000
         assert client.last_prompt_stats.context_pct == 44.0
+        # The authoritative flag must survive the reset, else the next turn's
+        # early metadata pct could clobber the carried token-derived pct.
+        assert client.last_prompt_stats.context_tokens_from_usage is True
 
 
 class TestAcpClientNoProcess:
@@ -7365,11 +7437,18 @@ class TestTrackMetadataWindowResolution:
     def test_does_not_overwrite_window_already_set_by_usage_update(self):
         client = AcpClient()
         client._resolved_model_id = "claude-opus-4.5"  # would resolve to 200K
+        # Simulate a real usage_update having established authoritative counts
+        # (1M window, 300K used -> 30%). context_tokens_from_usage marks them
+        # authoritative — the shape a real usage_update leaves behind.
         client.last_prompt_stats.context_window_tokens = 1_000_000
         client.last_prompt_stats.context_used_tokens = 300_000
+        client.last_prompt_stats.context_pct = 30.0
+        client.last_prompt_stats.context_tokens_from_usage = True
         client._track_metadata(self._metadata_msg(50.0))
+        # Metadata must neither re-resolve the window (no backfill once
+        # authoritative) nor clobber the usage-derived pct to its own 50%.
         assert client.last_prompt_stats.context_window_tokens == 1_000_000
-        assert client.last_prompt_stats.context_pct == pytest.approx(50.0)
+        assert client.last_prompt_stats.context_pct == pytest.approx(30.0)
 
     def test_no_model_resolvable_leaves_window_zero(self):
         client = AcpClient()

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -2947,10 +2947,15 @@ def test_backfill_context_window_from_pct(monkeypatch):
     assert handle.last_prompt_stats.context_window_tokens == 200000
     assert handle.last_prompt_stats.context_used_tokens == 50000
 
-    # A prior real usage_update wins — backfill must not override it.
+    # A prior real usage_update wins — metadata must override neither the
+    # window NOR the token-derived pct (else the headline % desyncs from the
+    # "used / total" token text shown in the dashboard popover).
     handle2 = AcpSessionHandle("sA", q["sA"], rt)
     handle2._model = "some-model"
+    handle2.last_prompt_stats.context_pct = 40.8
+    handle2.last_prompt_stats.context_used_tokens = 408000
     handle2.last_prompt_stats.context_window_tokens = 999
+    handle2.last_prompt_stats.context_tokens_from_usage = True
     handle2._track_metadata(
         JsonRpcMessage.from_dict(
             {
@@ -2960,6 +2965,76 @@ def test_backfill_context_window_from_pct(monkeypatch):
         )
     )
     assert handle2.last_prompt_stats.context_window_tokens == 999
+    assert handle2.last_prompt_stats.context_pct == 40.8
+    assert handle2.last_prompt_stats.context_used_tokens == 408000
+
+
+def test_session_handle_usage_update_sets_flag_and_metadata_cannot_clobber():
+    """SessionHandle parity with AcpClient: a real usage_update through
+    _handle_update sets context_tokens_from_usage, and a later metadata
+    contextUsagePercentage must not clobber the token-derived pct (the
+    408K/1000K-vs-73% desync on the shared-runtime path)."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle._handle_update(
+        JsonRpcMessage.from_dict(
+            {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "usage_update",
+                        "used": 408000,
+                        "size": 1000000,
+                    }
+                },
+            }
+        )
+    )
+    assert handle.last_prompt_stats.context_tokens_from_usage is True
+    assert handle.last_prompt_stats.context_pct == 40.8
+    assert handle.last_prompt_stats.context_used_tokens == 408000
+    assert handle.last_prompt_stats.context_window_tokens == 1000000
+
+    handle._track_metadata(
+        JsonRpcMessage.from_dict(
+            {
+                "method": "_kiro.dev/metadata",
+                "params": {"contextUsagePercentage": 73},
+            }
+        )
+    )
+    assert handle.last_prompt_stats.context_pct == 40.8  # NOT clobbered to 73
+    assert handle.last_prompt_stats.context_used_tokens == 408000
+
+
+def test_backfill_context_window_clamps_malformed_pct(monkeypatch):
+    """A degenerate metadata percentage (huge finite / inf / NaN) must not
+    overflow round() and abort the turn on the shared-runtime path; derived
+    used stays in [0, window]."""
+    import kiro_crew.acp.session_handle as sh
+
+    monkeypatch.setattr(sh.model_registry, "has_known_window", lambda mid: True)
+    monkeypatch.setattr(sh.model_registry, "model_window", lambda mid, **kw: 200000)
+    for bad in (1e308, float("inf"), float("nan")):
+        rt, _, _ = _make_runtime()
+        q = _register(rt, "sA")
+        handle = AcpSessionHandle("sA", q["sA"], rt)
+        handle._model = "some-model"
+        # Must not raise OverflowError/ValueError.
+        handle._track_metadata(
+            JsonRpcMessage.from_dict(
+                {
+                    "method": "_kiro.dev/metadata",
+                    "params": {"contextUsagePercentage": bad},
+                }
+            )
+        )
+        used = handle.last_prompt_stats.context_used_tokens
+        assert 0 <= used <= 200000
+        # context_pct is sanitized at the source, never left non-finite.
+        pct = handle.last_prompt_stats.context_pct
+        assert 0.0 <= pct <= 100.0
 
 
 def test_backfill_context_window_no_model_is_safe(monkeypatch):


### PR DESCRIPTION
## Problem

The context-window popover (the pill above the chat composer) could show a
headline percentage that contradicted its own numbers — e.g. **73%** displayed
next to **Used 408K / Total 1000K**, which is actually ~41%.

## Why it matters

The percentage is the at-a-glance signal users rely on to judge how close a
session is to compaction. A headline % that disagrees with the token counts it
sits beside erodes trust in the meter and can mislead a user into thinking they
have far less (or more) headroom than they do.

## Fix (symptom → root cause → change)

**Symptom:** headline % out of sync with the Used/Total token text in the same
popover.

**Root cause:** two independent writers to `AcpPromptStats`, and only one of
them was governed by the intended "usage_update wins" rule:

- A real ACP `usage_update {used, size}` sets `context_pct`, `context_used_tokens`,
  and `context_window_tokens` together and consistently (`used/size*100`).
- kiro-cli's `_kiro.dev/metadata` `contextUsagePercentage` then overwrote
  `context_pct` **unconditionally**, while leaving the token counts untouched.
  Its percentage can be measured against a different effective window, so once
  a real `usage_update` had landed, a subsequent metadata frame desynced the
  headline % from the (still-correct) token counts.

The "usage_update is authoritative" invariant was already enforced for the
token counts (the `_backfill_context_window` window guard) but **never for
`context_pct`**.

**Change:** make the invariant explicit with a `context_tokens_from_usage` flag
on `AcpPromptStats`. Once a real `usage_update` sets the counts, the flag is set
and metadata's percentage no longer overrides `context_pct` (billing `credits`
still accumulate unconditionally). The pct-only `_backfill_context_window` guard
now keys on the flag instead of `window > 0`, so it also refreshes the derived
`used` count across successive metadata updates instead of no-oping once a
window exists. Applied identically in both `AcpClient` and `AcpSessionHandle`,
and the flag is carried across the per-turn `AcpPromptStats` re-inits (3 sites
in `client.py`, 1 in `session_handle.py`) so authority isn't lost between turns.

## Tests

- `test_metadata_pct_does_not_clobber_authoritative_tokens` — reproduces the
  exact 408K/1000K-but-73% desync on the `AcpClient` path; asserts pct stays
  40.8 and counts stay 408K/1000K.
- `test_metadata_credits_still_captured_when_tokens_authoritative` — the pct
  guard must not drop kiro billing credits.
- `test_session_handle_usage_update_sets_flag_and_metadata_cannot_clobber` —
  same regression on the shared-runtime `AcpSessionHandle._handle_update` path,
  and asserts the flag is set there (parity is what the fix relies on).
- `test_backfill_context_window_from_pct` — updated to assert a prior real
  usage_update preserves both the window AND the token-derived pct against a
  later metadata frame.
- `test_tokens_carry_forward_across_prompt_reset` — extended to assert the
  authoritative flag survives the per-turn reset.
- `test_populates_pct_and_tokens` — asserts a real usage_update sets the flag.

## Manual verification

N/A — unit coverage is sufficient. This is a pure backend state-reconciliation
fix; the frontend popover math (`ContextBar` / `ChatInput`) was already correct
and is unchanged — it was simply being fed an internally-inconsistent pct. No
UI change, so no screenshots.
