### PR TITLE
fix(dashboard): stop the startup session restore killing the gateway

### DIFF
--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -83,12 +83,14 @@ from kiro_crew.dashboard.chat_orchestrator import (  # noqa: F401
     api_chat_plan_action,
 )
 from kiro_crew.dashboard.chat_persistence import (  # noqa: F401
+    INLINE_RESTORE_LIMIT,
     _attach_variants,
     _build_history_prefix,
     _rehydrate_slot_from_history,
     _save_slot_to_history,
     restore_open_slots,
     restore_recent_sessions,
+    resume_deferred_restores,
     save_all_slots_to_history,
 )
 from kiro_crew.dashboard.chat_regenerate import (  # noqa: F401

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -174,7 +174,57 @@ def save_all_slots_to_history(state: DashboardState) -> None:
         logger.debug("Shutdown: open_slots snapshot failed", exc_info=True)
 
 
-def restore_open_slots(state: DashboardState) -> int:
+INLINE_RESTORE_LIMIT = 10
+"""Sessions rehydrated synchronously during startup before the rest are deferred.
+
+Each rehydrate reads a session's message window off disk, redacts it and replays
+it into a slot — order 0.25s apiece on a large home. The loop-stall watchdog
+``_exit(1)``s the gateway after 25s without a heartbeat, so an unbounded restore
+turns "lots of history" into a startup crash loop. 10 keeps the inline cost to a
+few seconds while still filling the sidebar before the first client connects.
+"""
+
+
+def _kiro_model_map() -> dict[str, str]:
+    """Map kiro agent name/stem -> configured model, for restored slots."""
+    kiro_model_map: dict[str, str] = {}
+    try:
+        for f in KIRO_AGENTS_DIR.glob("*.json"):
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                model = data.get("model", "")
+                if data.get("name"):
+                    kiro_model_map[data["name"]] = model
+                kiro_model_map[f.stem] = model
+            except (json.JSONDecodeError, OSError):
+                continue
+    except Exception:
+        logger.debug("Failed to build kiro model map", exc_info=True)
+    return kiro_model_map
+
+
+def _mark_pending_restore(state: DashboardState, *names: str) -> None:
+    """Record slot keys handed to the deferred pass but not yet in ``_slots``.
+
+    ``_persist_open_slots`` unions these into the open-tab snapshot, so a
+    periodic flush or a shutdown save that lands while the background pass is
+    still running cannot truncate ``open_slots.json`` to the inline set (which
+    would silently and permanently drop the not-yet-restored tabs on the next
+    boot). Tuple rebinding, not in-place mutation — the snapshot also runs from
+    the flush executor thread.
+    """
+    existing = state._pending_restore_keys
+    fresh = tuple(n for n in names if n and n not in existing)
+    if fresh:
+        state._pending_restore_keys = existing + fresh
+
+
+def restore_open_slots(
+    state: DashboardState,
+    *,
+    limit: int | None = None,
+    deferred: list[str] | None = None,
+) -> int:
     """Restore the tabs the user had open at the previous shutdown.
 
     Reads ``<config_dir>/open_slots.json`` (written by
@@ -192,6 +242,16 @@ def restore_open_slots(state: DashboardState) -> int:
     no-op (returns 0). Sessions that have been explicitly closed
     (``meta.closed``) are skipped via _rehydrate_slot_from_history's own
     guard, so closing a tab and then restarting still loses the tab.
+
+    Rehydrating a slot reads and re-appends that session's message window, so
+    a large tab set costs seconds of *synchronous* work — and this runs on the
+    event loop during ``on_startup``, where it starves the loop-stall
+    watchdog's heartbeat (:class:`~kiro_crew.dashboard.loop_watchdog.LoopStallWatchdog`
+    ``_exit(1)``s the gateway after 25s of silence). ``limit`` caps how many
+    slots are restored inline; every remaining key is appended to *deferred*
+    for :func:`resume_deferred_restores` to finish off-loop-friendly, one
+    session per loop iteration. Both default to the historical unbounded
+    behaviour.
     """
     if not state.conversation_log:
         return 0
@@ -230,6 +290,14 @@ def restore_open_slots(state: DashboardState) -> int:
         raw = _normalize_slot_key(raw)
         if raw in state._slots:
             continue
+        if limit is not None and restored >= limit:
+            # Budget spent. Hand the rest to the deferred pass rather than
+            # dropping them — with no deferred sink, fall through and restore
+            # inline so a bare limit= never silently loses tabs.
+            if deferred is not None:
+                deferred.append(raw)
+                _mark_pending_restore(state, raw)
+                continue
         try:
             slot = _rehydrate_slot_from_history(state, raw)
         except Exception:
@@ -254,7 +322,14 @@ def restore_open_slots(state: DashboardState) -> int:
         if slot is not None:
             restored += 1
     if restored:
-        logger.info("Restored %d open tab(s) from open_slots.json", restored)
+        if deferred:
+            logger.info(
+                "Restored %d open tab(s) from open_slots.json (%d deferred)",
+                restored,
+                len(deferred),
+            )
+        else:
+            logger.info("Restored %d open tab(s) from open_slots.json", restored)
     return restored
 
 
@@ -272,7 +347,13 @@ def _attach_variants(slot: _ChatSlot, m: dict) -> None:
         slot.messages[-1]["variant_idx"] = m.get("variant_idx", 0)
 
 
-def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _ChatSlot | None:
+def _rehydrate_slot_from_history(
+    state: DashboardState,
+    slot_name: str,
+    *,
+    messages: list[dict] | None = None,
+    session_info: dict | None = None,
+) -> _ChatSlot | None:
     """Rehydrate a single dashboard slot from persisted history.
 
     Unlike ``state.get_or_create_slot`` (which creates a fresh, empty slot with
@@ -285,6 +366,14 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
 
     Intended for targeted resume paths (e.g. cron→origin injection after
     gateway restart). Bulk startup restore still uses ``restore_recent_sessions``.
+
+    *messages* and *session_info* let a caller supply the two large disk reads
+    this function would otherwise do inline — the chained message window and
+    this session's row from ``list_sessions()``. ``resume_deferred_restores``
+    passes both after reading them in a worker thread, so the background pass
+    keeps the bulk I/O off the event loop while the slot mutation (which
+    touches ``asyncio.Event``/queue objects and is therefore loop-affine)
+    still happens on it. Both default to reading inline, unchanged.
     """
     if not state.conversation_log:
         return None
@@ -323,11 +412,11 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
         logger.debug("Failed to build kiro model map", exc_info=True)
     slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
     # Pull display fields from session listing for title parity with bulk restore.
-    sessions = state.conversation_log.list_sessions()
-    session_info = next(
-        (s for s in sessions if s.get("key") == history_key),
-        {},
-    )
+    if session_info is None:
+        session_info = next(
+            (s for s in state.conversation_log.list_sessions() if s.get("key") == history_key),
+            {},
+        )
     # Titles may have been auto-generated by an LLM (_generate_title_via_kiro)
     # and are surfaced on the dashboard, so apply the same redaction passes
     # used on assistant content before setting. Defence-in-depth — the title
@@ -413,7 +502,8 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     # read_messages alone caps visible history at 200 lines from THIS file and
     # drops the ancestor chain — long-running forked sessions would lose 200+
     # messages of context on every gateway restart.
-    messages = state.conversation_log.read_messages_chained(history_key)
+    if messages is None:
+        messages = state.conversation_log.read_messages_chained(history_key)
     # Only the recent window is loaded into memory; older on-disk lines become
     # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
     # therefore count those older lines so the save model preserves them.
@@ -446,29 +536,161 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     return slot
 
 
+def _apply_recent_session(
+    state: DashboardState,
+    s: dict,
+    slot_name: str,
+    meta: dict,
+    kiro_model_map: dict[str, str],
+    _restore_cfg: "KiroCrewConfig | None",
+    *,
+    messages: list[dict] | None = None,
+) -> "_ChatSlot":
+    """Materialize one listed session as a chat slot (metadata + message window).
+
+    The expensive half of :func:`restore_recent_sessions` — split out so the
+    deferred pass can replay it one session at a time between loop
+    iterations. Callers own filtering, the restored counter and the log line.
+
+    *messages* lets the caller supply the chained message window instead of
+    reading it here; ``resume_deferred_restores`` reads it in a worker thread
+    so the large disk read stays off the event loop while the slot mutation
+    (loop-affine — ``slot.append`` sets an ``asyncio.Event``) stays on it.
+    """
+    # The history key the message-window read and the tab_id backfill use. In
+    # the pre-split code this was the enclosing loop's variable; deriving it
+    # from the session dict keeps both call sites (inline + deferred) honest.
+    key = s.get("key", "")
+    log = state.conversation_log
+    if log is None:
+        # Unreachable via the two callers (both guard on conversation_log), but
+        # the type is Optional and this function does two reads through it.
+        raise RuntimeError("restore requires a conversation log")
+    slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+    # Titles can be LLM-generated (auto-title) and are surfaced on the
+    # dashboard — apply the same redaction as assistant content. Matches
+    # the treatment in _rehydrate_slot_from_history above.
+    raw_title = s.get("title", slot_name)
+    raw_title, _ = redact_exfiltration_urls(raw_title)
+    raw_title, _ = redact_credentials(raw_title)
+    slot.title = raw_title
+    slot._titled = bool(s.get("title"))
+    if meta.get("created_at"):
+        slot.created_at = meta["created_at"]
+    if meta.get("agent"):
+        slot.agent = meta["agent"]
+    if meta.get("model"):
+        # Canonicalize a pre-migration claude_code provider id to the
+        # canonical dropdown key (no-op for other providers); reuse the
+        # already-loaded _restore_cfg provider.
+        _prov = _restore_cfg.agent.provider if _restore_cfg else ""
+        slot.model = model_registry.canonicalize_for_provider(
+            _normalize_model(meta["model"]), _prov
+        )
+    elif slot.agent:
+        try:
+            mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
+            kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
+            slot.model = kiro_model_map.get(kiro_name, "")
+        except Exception:
+            logger.debug(
+                "Failed to resolve model for restored slot %s", slot_name, exc_info=True
+            )
+    if meta.get("reasoning_effort"):
+        slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
+    if meta.get("workspace"):
+        slot.workspace = meta["workspace"]
+    if meta.get("project"):
+        slot.project = meta["project"]
+    if meta.get("mode"):
+        slot.mode = meta["mode"]
+    if meta.get("folder_id"):
+        slot.folder_id = meta["folder_id"]
+    if meta.get("app"):
+        slot._app = meta["app"]
+    # Same tamper gate as _rehydrate_slot_from_history: re-validate the
+    # companion binding against the slug grammar before it reaches
+    # to_dict()/WS broadcasts.
+    _artifact_meta = meta.get("artifact")
+    if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
+        slot._artifact = _artifact_meta
+    if meta.get("pinned"):
+        slot.pinned = True
+    if meta.get("color_index") is not None:
+        slot.color_index = meta["color_index"]
+    if meta.get("color_theme"):
+        slot.color_theme = meta["color_theme"]
+    raw_tags = meta.get("tags")
+    if isinstance(raw_tags, list):
+        slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+    mm = meta.get("memory_mode", "persistent")
+    slot.memory_mode = mm
+    if mm != "persistent":
+        state._restricted_keys.add(f"dashboard:{slot_name}")
+    if meta.get("forked_from") is not None:
+        slot.forked_from = meta["forked_from"]
+    tab_id = meta.get("tab_id")
+    if not tab_id:
+        tab_id = uuid.uuid4().hex[:12]
+        # restore_recent_sessions runs during on_startup (event loop live)
+        # — keep the _locked flock/os.close off the loop via the off-loop
+        # backfill helper.
+        update_metadata_off_loop(log, key, {"tab_id": tab_id})
+    slot._tab_id = tab_id
+    if messages is None:
+        messages = log.read_messages_chained(key)
+    slot._disk_older_count = max(0, len(messages) - 500)
+    for m in messages[-500:]:
+        role = m.get("role", "assistant")
+        cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
+        content = m.get("content", "")
+        if role != "user":
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
+        slot.append(
+            role,
+            content,
+            cls,
+            ts=m.get("ts", ""),
+            meta=(
+                _redact_meta_for_role(role, m["meta"])
+                if isinstance(m.get("meta"), dict)
+                else None
+            ),
+        )
+        _attach_variants(slot, m)
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    # Loaded window is the on-disk window region; older lines (counted in
+    # _disk_older_count above) are the frozen prefix saves never rewrite.
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+    return slot
+
+
 def restore_recent_sessions(
-    state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
+    state: DashboardState,
+    window_minutes: int = 30,
+    *,
+    folders_only: bool = False,
+    limit: int | None = None,
+    deferred: list[tuple[str, dict]] | None = None,
 ) -> int:
-    """Restore sessions as chat slots."""
+    """Restore sessions as chat slots.
+
+    ``limit`` / *deferred* work as in :func:`restore_open_slots`: at most
+    ``limit`` sessions are restored inline and the rest are appended to
+    *deferred* as ``(slot_name, session)`` pairs for
+    :func:`resume_deferred_restores`. Filtering (mtime window, folders_only,
+    closed) always runs for every session, so deferral only moves the
+    expensive rehydrate — never changes which sessions are eligible.
+    """
     if not state.conversation_log:
         return 0
     cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
     restored = 0
 
-    kiro_model_map: dict[str, str] = {}
-    try:
-
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    kiro_model_map[data["name"]] = model
-                kiro_model_map[f.stem] = model
-            except (json.JSONDecodeError, OSError):
-                continue
-    except Exception:
-        logger.debug("Failed to build kiro model map", exc_info=True)
+    kiro_model_map = _kiro_model_map()
     try:
         _restore_cfg = KiroCrewConfig.load()
     except Exception:
@@ -493,109 +715,165 @@ def restore_recent_sessions(
         if not has_folder and not has_pin:
             if cutoff is not None and s.get("modified", 0) < cutoff:
                 continue
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
-        # Titles can be LLM-generated (auto-title) and are surfaced on the
-        # dashboard — apply the same redaction as assistant content. Matches
-        # the treatment in _rehydrate_slot_from_history above.
-        raw_title = s.get("title", slot_name)
-        raw_title, _ = redact_exfiltration_urls(raw_title)
-        raw_title, _ = redact_credentials(raw_title)
-        slot.title = raw_title
-        slot._titled = bool(s.get("title"))
-        if meta.get("created_at"):
-            slot.created_at = meta["created_at"]
-        if meta.get("agent"):
-            slot.agent = meta["agent"]
-        if meta.get("model"):
-            # Canonicalize a pre-migration claude_code provider id to the
-            # canonical dropdown key (no-op for other providers); reuse the
-            # already-loaded _restore_cfg provider.
-            _prov = _restore_cfg.agent.provider if _restore_cfg else ""
-            slot.model = model_registry.canonicalize_for_provider(
-                _normalize_model(meta["model"]), _prov
-            )
-        elif slot.agent:
-            try:
-                mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
-                kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
-                slot.model = kiro_model_map.get(kiro_name, "")
-            except Exception:
-                logger.debug(
-                    "Failed to resolve model for restored slot %s", slot_name, exc_info=True
-                )
-        if meta.get("reasoning_effort"):
-            slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
-        if meta.get("workspace"):
-            slot.workspace = meta["workspace"]
-        if meta.get("project"):
-            slot.project = meta["project"]
-        if meta.get("mode"):
-            slot.mode = meta["mode"]
-        if meta.get("folder_id"):
-            slot.folder_id = meta["folder_id"]
-        if meta.get("app"):
-            slot._app = meta["app"]
-        # Same tamper gate as _rehydrate_slot_from_history: re-validate the
-        # companion binding against the slug grammar before it reaches
-        # to_dict()/WS broadcasts.
-        _artifact_meta = meta.get("artifact")
-        if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
-            slot._artifact = _artifact_meta
-        if meta.get("pinned"):
-            slot.pinned = True
-        if meta.get("color_index") is not None:
-            slot.color_index = meta["color_index"]
-        if meta.get("color_theme"):
-            slot.color_theme = meta["color_theme"]
-        raw_tags = meta.get("tags")
-        if isinstance(raw_tags, list):
-            slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
-        mm = meta.get("memory_mode", "persistent")
-        slot.memory_mode = mm
-        if mm != "persistent":
-            state._restricted_keys.add(f"dashboard:{slot_name}")
-        if meta.get("forked_from") is not None:
-            slot.forked_from = meta["forked_from"]
-        tab_id = meta.get("tab_id")
-        if not tab_id:
-            tab_id = uuid.uuid4().hex[:12]
-            # restore_recent_sessions runs during on_startup (event loop live)
-            # — keep the _locked flock/os.close off the loop via the off-loop
-            # backfill helper.
-            update_metadata_off_loop(
-                state.conversation_log, key, {"tab_id": tab_id}
-            )
-        slot._tab_id = tab_id
-        messages = state.conversation_log.read_messages_chained(key)
-        slot._disk_older_count = max(0, len(messages) - 500)
-        for m in messages[-500:]:
-            role = m.get("role", "assistant")
-            cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
-            content = m.get("content", "")
-            if role != "user":
-                content, _ = redact_exfiltration_urls(content)
-                content, _ = redact_credentials(content)
-            slot.append(
-                role,
-                content,
-                cls,
-                ts=m.get("ts", ""),
-                meta=(
-                    _redact_meta_for_role(role, m["meta"])
-                    if isinstance(m.get("meta"), dict)
-                    else None
-                ),
-            )
-            _attach_variants(slot, m)
-        slot.drain()
-        slot._resumed_count = len(slot.messages)
-        # Loaded window is the on-disk window region; older lines (counted in
-        # _disk_older_count above) are the frozen prefix saves never rewrite.
-        slot._disk_window_len = len(slot.messages)
-        slot._dirty = False
+        if limit is not None and restored >= limit and deferred is not None:
+            deferred.append((slot_name, s))
+            # Only persistent slots belong in the open_slots.json snapshot
+            # (_persist_open_slots filters _slots the same way), so an
+            # incognito/temporary session is deferred without being pinned
+            # into the snapshot.
+            if meta.get("memory_mode", "persistent") == "persistent":
+                _mark_pending_restore(state, slot_name)
+            continue
+        slot = _apply_recent_session(
+            state, s, slot_name, meta, kiro_model_map, _restore_cfg
+        )
         restored += 1
         logger.info("Restored session %s (%s)", slot_name, slot.title)
     _sync_dashboard_slots(state)
+    return restored
+
+
+async def resume_deferred_restores(
+    state: DashboardState,
+    slot_keys: list[str],
+    sessions: list[tuple[str, dict]],
+) -> int:
+    """Finish the restores that :func:`restore_open_slots` /
+    :func:`restore_recent_sessions` deferred past their inline budget.
+
+    Replays one session per loop iteration, yielding with ``asyncio.sleep(0)``
+    in between, so the loop gets control between sessions and the loop-stall
+    watchdog no longer ``_exit(1)``s the gateway partway through a large
+    startup restore.
+
+    The bulk disk I/O is also moved off the loop with ``asyncio.to_thread``:
+    the chained message window per session, the one-shot ``list_sessions()``
+    listing (hoisted out of the per-key loop, where it was O(keys × sessions)
+    of re-reading), the per-session metadata read and the config/agent-map
+    loads. What stays on the loop is the slot mutation itself, which is
+    loop-affine by construction — ``slot.append`` sets an ``asyncio.Event`` and
+    ``get_or_create_slot`` broadcasts through the SSE ``asyncio.Queue``s, and
+    neither is safe to touch from a worker thread. That residue is bounded
+    per-session CPU (redact + append of at most 500 messages), not an unbounded
+    read.
+
+    Returns the number of slots restored. Every step is best-effort: a session
+    that fails to rehydrate is logged and skipped, and slots that appeared in
+    the meantime (a client opened the tab, or the other restore path got there
+    first) are left alone.
+    """
+    log = state.conversation_log
+    if not log or (not slot_keys and not sessions):
+        return 0
+    restored = 0
+    failed: set[str] = set()
+    total = len(slot_keys) + len(sessions)
+    logger.info("Resuming %d deferred session restore(s) in the background", total)
+
+    listing: list[dict] = []
+    if slot_keys:
+        listing = await asyncio.to_thread(log.list_sessions)
+    for raw in slot_keys:
+        await asyncio.sleep(0)
+        if raw in state._slots:
+            continue
+        history_key = _history_key_for(raw)
+        try:
+            window = await asyncio.to_thread(log.read_messages_chained, history_key)
+            # Re-check after the await: a client can resume this tab while the
+            # read is in flight, and _rehydrate_slot_from_history would then
+            # hand back the live slot (its own guard) — counted here as a
+            # restore that never happened.
+            if raw in state._slots:
+                continue
+            info = next((s for s in listing if s.get("key") == history_key), {})
+            # Hide the slot from the persistence sweeps for the duration of the
+            # replay (see DashboardState._restoring_keys). Registered here and
+            # not inside the applier because only this pass yields to the loop:
+            # the inline restores run without an await, so no flush thread can
+            # observe them mid-replay.
+            state._restoring_keys.add(raw)
+            try:
+                slot = _rehydrate_slot_from_history(
+                    state, raw, messages=window, session_info=info
+                )
+            finally:
+                state._restoring_keys.discard(raw)
+            if slot is not None:
+                restored += 1
+        except Exception:
+            logger.debug("deferred restore: rehydrate failed for %s", raw, exc_info=True)
+            failed.add(raw)
+            # Same partial-slot rollback as restore_open_slots: the rehydrate
+            # registers the slot before its fallible work.
+            state._slots.pop(raw, None)
+            state._restricted_keys.discard(f"dashboard:{raw}")
+
+    if sessions:
+        kiro_model_map = await asyncio.to_thread(_kiro_model_map)
+        try:
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+        except Exception:
+            cfg = None
+        for slot_name, s in sessions:
+            await asyncio.sleep(0)
+            if slot_name in state._slots:
+                continue
+            key = s.get("key", "")
+            try:
+                window = await asyncio.to_thread(log.read_messages_chained, key)
+                # Metadata is read AFTER the window, not before, so a session
+                # deleted or closed while that read was in flight is caught
+                # here: empty metadata means the JSONL is gone, and applying
+                # stale metadata would let _apply_recent_session's tab_id
+                # backfill recreate the file the user just deleted. No await
+                # between this check and the apply, so nothing can interleave.
+                # Cost: a closed-since-collection session pays for one wasted
+                # window read, which is rare — restore_recent_sessions already
+                # filtered closed sessions when it collected them.
+                meta = await asyncio.to_thread(log.get_metadata, key)
+                if not meta or meta.get("closed"):
+                    continue
+                # Re-check after the awaits. get_or_create_slot returns an
+                # EXISTING slot, so if a client resumed this tab while the
+                # reads were in flight, applying now would replay the whole
+                # window onto a live slot and duplicate its history.
+                if slot_name in state._slots:
+                    continue
+                # Same hide-from-persistence window as the open-slots half above.
+                state._restoring_keys.add(slot_name)
+                try:
+                    _apply_recent_session(
+                        state, s, slot_name, meta, kiro_model_map, cfg, messages=window
+                    )
+                finally:
+                    state._restoring_keys.discard(slot_name)
+                restored += 1
+            except Exception:
+                logger.debug(
+                    "deferred restore: session %s failed", slot_name, exc_info=True
+                )
+                failed.add(slot_name)
+                state._slots.pop(slot_name, None)
+
+    # Release the snapshot pin for everything this pass settled — restored (now
+    # in _slots and snapshotted on its own merit), already live, closed, or
+    # absent from disk. A key whose restore *failed* stays pinned: the failure
+    # may be transient (a read error under load) and unpinning it would let the
+    # next flush write an open_slots.json without it, losing the tab for good.
+    # Worst case a permanently-broken key stays pinned for this gateway's
+    # lifetime — one dead entry in the snapshot, which restore_open_slots
+    # already tolerates, and no lost data.
+    #
+    # Deliberately NOT in a finally — if this task is cancelled (gateway
+    # shutdown mid-pass) or raises, every pin must stay so the shutdown /
+    # periodic snapshot still records the tabs that never got their turn.
+    state._pending_restore_keys = tuple(
+        k for k in state._pending_restore_keys if k in failed
+    )
+
+    _sync_dashboard_slots(state)
+    logger.info("Deferred restore complete: %d/%d session(s)", restored, total)
     return restored
 
 
@@ -982,6 +1260,16 @@ def _save_slot_to_history(
     legacy no-tab_id sessions stay isolated.
     """
     if not state.conversation_log:
+        return
+    # A slot whose deferred replay is still in flight is not in a saveable
+    # state: it is registered in _slots and already _dirty, but its
+    # _disk_older_count / _disk_window_len still describe the pre-replay slot,
+    # so the frozen-prefix arithmetic below would write a partial window that
+    # the next flush then duplicates. Skipping loses nothing — the window being
+    # replayed was read from this very file. Covers the shutdown sweep
+    # (save_all_slots_to_history, force=True) and any future caller;
+    # _flush_dirty_slots skips earlier so it does not clear _dirty either.
+    if slot.key in state._restoring_keys:
         return
     # An explicit message snapshot always means "this is the full authoritative
     # window state" → rewrite. Edit paths (rewind/regenerate/fork) pass a snapshot.

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2435,20 +2435,45 @@ async def start_dashboard(
     # fall off into History on every gateway restart. Closed tabs (meta.closed)
     # are still excluded by the rehydrate guard. restore_open_slots() logs
     # its own info line on success, so no caller-side log here.
-    chat.restore_open_slots(state)
+    #
+    # Only the first INLINE_RESTORE_LIMIT sessions are rehydrated inline: the
+    # loop-stall watchdog armed above _exit(1)s the gateway after 25s without a
+    # heartbeat, and rehydrating a large tab set synchronously here blows that
+    # budget outright (a home with ~70 open tabs + hundreds of sessions took
+    # >25s and killed the gateway mid-startup, every boot). The remainder is
+    # finished by a background task that yields between sessions, so the
+    # heartbeat keeps beating and nothing is dropped.
+    _deferred_keys: list[str] = []
+    _deferred_sessions: list[tuple[str, dict]] = []
+    _inline = chat.restore_open_slots(
+        state, limit=chat.INLINE_RESTORE_LIMIT, deferred=_deferred_keys
+    )
     restored = chat.restore_recent_sessions(
         state,
         cfg.dashboard.restore_window_minutes if cfg.dashboard.restore_sessions else 0,
         folders_only=not cfg.dashboard.restore_sessions,
+        limit=max(0, chat.INLINE_RESTORE_LIMIT - _inline),
+        deferred=_deferred_sessions,
     )
     if restored:
         logger.info("Restored %d session(s)", restored)
+    if _deferred_keys or _deferred_sessions:
+        _resume = asyncio.create_task(
+            chat.resume_deferred_restores(state, _deferred_keys, _deferred_sessions)
+        )
+        state._background_tasks.add(_resume)
+        _resume.add_done_callback(state._background_tasks.discard)
 
     # Both restore paths above rehydrate tabs under their original
     # "chat-<N>-<ts>" keys but leave _slot_counter at its boot value of 0.
     # Reseed it past the highest restored index so the next new chat can't
     # re-mint a colliding low index (which scrambles the tab -> session map).
-    state.reseed_slot_counter()
+    # Deferred names are included even though those slots do not exist yet —
+    # otherwise a new chat opened while the background pass is still running
+    # could take an index a returning tab is about to claim.
+    state.reseed_slot_counter(
+        [*_deferred_keys, *(name for name, _ in _deferred_sessions)]
+    )
 
     # Relaunch agents in non-archived channels
     from kiro_crew.channel import ChannelManager, run_channel_agent

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1658,6 +1658,30 @@ class DashboardState:
         self._flush_task: asyncio.Task | None = None  # type: ignore[type-arg]
         # Update progress tracking (shared across all connected clients)
         self._update_progress: dict[str, str] | None = None  # {step, detail}
+        # Startup restores handed to the background deferred pass: named, but
+        # not in _slots yet. _persist_open_slots unions them into the snapshot
+        # so a flush (or a crash/restart) partway through the pass cannot
+        # rewrite open_slots.json down to just the inline set and permanently
+        # drop the tabs that had not come back yet.
+        #
+        # Rebound wholesale, never mutated in place: _persist_open_slots also
+        # runs from the 5s flush executor thread, and a tuple swap is atomic
+        # under the GIL, so a reader always sees a consistent snapshot.
+        self._pending_restore_keys: tuple[str, ...] = ()
+        # Slot keys whose deferred replay is IN FLIGHT. get_or_create_slot
+        # registers a slot in _slots before its ~500-message window is replayed
+        # into it, and the deferred pass yields to the loop, so the 5s flush
+        # executor (and a shutdown save) can observe a slot mid-replay: _dirty
+        # is already set but _disk_older_count / _disk_window_len are not, so a
+        # save would write a partial window with the wrong frozen-prefix
+        # accounting and the next flush would duplicate those lines. The
+        # persistence sweeps skip these keys; nothing is lost, because a
+        # restoring slot's window is read FROM disk and is already there.
+        #
+        # Membership tests only, never iterated: the loop mutates this while
+        # the flush executor thread reads it, and `in` is safe under a
+        # concurrent add/discard where iteration would raise.
+        self._restoring_keys: set[str] = set()
         # Restricted (incognito/temporary): session keys with memory writes disabled
         self._restricted_keys: set[str] = set()
         # Ephemeral: session keys with no memory writes at all
@@ -2129,6 +2153,11 @@ class DashboardState:
         from kiro_crew.dashboard.chat import _save_slot_to_history
 
         for slot in list(self._slots.values()):
+            # Skip before the _dirty check, not after: the branch below clears
+            # _dirty on the assumption the save ran, so `continue`-ing later
+            # would drop the flag without a write.
+            if slot.key in self._restoring_keys:
+                continue
             if not slot._dirty or not slot.messages:
                 continue
             try:
@@ -2163,6 +2192,14 @@ class DashboardState:
         """
         try:
             path = config_dir() / "open_slots.json"
+            # Read the pending-restore pins BEFORE enumerating _slots. The
+            # deferred pass inserts a restored slot and then clears its pin, so
+            # reading _slots first would let the final restore land in between
+            # the two reads: its key is absent from the _slots snapshot AND the
+            # pin tuple is already empty, and the tab drops out of the file.
+            # Reading the pins first can only ever over-report (a key that is
+            # about to appear in _slots too), which the de-dup below absorbs.
+            pending = self._pending_restore_keys
             # Only snapshot persistent-memory slots. Incognito/temporary tabs
             # are ephemeral by contract ("closes when I'm done", no
             # consolidation/lessons); persisting their keys would resurrect
@@ -2173,7 +2210,20 @@ class DashboardState:
                 name
                 for name, slot in list(self._slots.items())
                 if getattr(slot, "memory_mode", "persistent") == "persistent"
+                # A slot mid-replay has not had memory_mode applied yet, so it
+                # reads as "persistent" and an incognito session would be
+                # snapshotted. Every restoring key that DOES belong here is
+                # already pinned in _pending_restore_keys (deferral pins only
+                # persistent sessions), so skipping is lossless.
+                and name not in self._restoring_keys
             ]
+            # Union the still-pending deferred restores (see
+            # _pending_restore_keys). They are legitimately open tabs that the
+            # background pass has not replayed yet, so omitting them here would
+            # make this snapshot a truncation — and the next boot would restore
+            # only what happened to be back in _slots when it was written.
+            live = set(keys)
+            keys.extend(k for k in pending if k not in live)
             payload = json.dumps({"keys": keys, "ts": time.time()})
             # Use the canonical atomic_write helper, not a deterministic
             # ".json.tmp" name — _persist_open_slots can run concurrently from
@@ -2567,7 +2617,7 @@ class DashboardState:
         self.push_slots_update()
         return slot
 
-    def reseed_slot_counter(self) -> None:
+    def reseed_slot_counter(self, extra_keys: "list[str] | None" = None) -> None:
         """Advance ``_slot_counter`` past the highest index among live slots.
 
         ``__init__`` resets ``_slot_counter`` to 0 on every gateway boot, but
@@ -2584,9 +2634,15 @@ class DashboardState:
         observed index so subsequent auto-minted slots always get fresh,
         collision-proof indices. Monotonic: only ever advances the counter,
         never lowers it, so it is safe to call regardless of restore order.
+
+        *extra_keys* names slots that are known but not yet in ``_slots`` —
+        the restores deferred to the background pass. Counting them here rather
+        than reseeding again on completion means the counter is already past
+        them, so a new chat minted while the deferred pass is still running
+        cannot collide with a tab that is about to come back.
         """
         max_idx = self._slot_counter
-        for name in self._slots:
+        for name in (*self._slots, *(extra_keys or ())):
             # Parse via the shared helper so this stays in lock-step with the
             # key minter (_mint_slot_key). Custom keys return None and skip.
             idx = _slot_index_from_key(name)

--- a/test/test_deferred_session_restore.py
+++ b/test/test_deferred_session_restore.py
@@ -1,0 +1,551 @@
+"""Tests for the split inline / deferred startup session restore.
+
+Rehydrating a session reads its message window off disk, redacts it and replays
+it into a slot. Doing that for every open tab and every in-window session
+*synchronously* on the event loop during ``on_startup`` starves the loop-stall
+watchdog's heartbeat, and ``LoopStallWatchdog`` ``_exit(1)``s the gateway after
+25s of silence — so a home with enough history killed its own gateway on every
+boot, mid-restore.
+
+``restore_open_slots`` / ``restore_recent_sessions`` therefore take a ``limit``
+and a ``deferred`` sink: the first ``INLINE_RESTORE_LIMIT`` sessions come back
+inline (so the sidebar is populated before the first client connects) and the
+rest are replayed by ``resume_deferred_restores``, which yields to the loop
+between sessions.
+
+These tests cover:
+
+* The inline budget is honored and the overflow lands in ``deferred``.
+* Nothing is lost: the deferred pass restores exactly the overflow.
+* The deferred pass yields between sessions (the whole point).
+* Already-present and closed sessions are skipped by the deferred pass.
+* A failing rehydrate does not abort the rest, and leaks no partial slot.
+* ``reseed_slot_counter`` counts deferred names, closing the collision window.
+* The open-tab snapshot keeps pinning the not-yet-restored keys, so a flush or
+  a shutdown save landing mid-pass cannot truncate ``open_slots.json``.
+* The bulk message-window reads happen off the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_persistence import (
+    INLINE_RESTORE_LIMIT,
+    restore_open_slots,
+    restore_recent_sessions,
+    resume_deferred_restores,
+    save_all_slots_to_history,
+)
+from kiro_crew.dashboard.chat_utils import _history_key_for
+
+
+def _seed(state, slot_key: str, *, closed: bool = False) -> None:
+    """Write minimal session metadata + one message so a rehydrate succeeds."""
+    history_key = _history_key_for(slot_key)
+    log = state.conversation_log
+    assert log is not None
+    log.append(history_key, "user", f"hello {slot_key}")
+    if closed:
+        log.update_metadata(history_key, {"closed": True})
+
+
+def _write_open_slots(tmp_path, keys: list[str]) -> None:
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": keys, "ts": 0.0}), encoding="utf-8"
+    )
+
+
+def test_open_slots_restores_inline_budget_and_defers_rest(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 26)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restored = restore_open_slots(state, limit=10, deferred=deferred)
+
+    assert restored == 10
+    assert len(deferred) == 15
+    # Inline set and deferred set partition the input, in order, with no overlap.
+    assert deferred == keys[10:]
+    assert set(state._slots) == set(keys[:10])
+
+
+def test_deferred_pass_restores_exactly_the_overflow(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 16)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restore_open_slots(state, limit=5, deferred=deferred)
+    restored = asyncio.run(resume_deferred_restores(state, deferred, []))
+
+    assert restored == 10
+    # Nothing dropped: every key from open_slots.json is back as a slot.
+    assert set(state._slots) == set(keys)
+
+
+def test_deferred_pass_yields_between_sessions(tmp_path, monkeypatch):
+    """The loop must get control between sessions — that is what keeps the
+    watchdog heartbeat alive during a long restore."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 6)]
+    for k in keys:
+        _seed(state, k)
+
+    ticks = 0
+
+    async def _observer() -> None:
+        # Runs concurrently with the restore; each iteration only advances if
+        # the restore hands the loop back.
+        nonlocal ticks
+        for _ in range(200):
+            await asyncio.sleep(0)
+            ticks += 1
+
+    async def _run() -> int:
+        obs = asyncio.create_task(_observer())
+        n = await resume_deferred_restores(state, keys, [])
+        obs.cancel()
+        return n
+
+    restored = asyncio.run(_run())
+
+    assert restored == 5
+    # One yield per session, minus the final iteration's (the observer is
+    # cancelled as soon as the restore returns). A non-yielding implementation
+    # never lets the observer run at all, so this is the discriminating check.
+    assert ticks >= len(keys) - 1
+
+
+def test_deferred_pass_skips_present_and_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-t")
+    _seed(state, "chat-2-t", closed=True)
+    _seed(state, "chat-3-t")
+    # chat-1 is already live (a client opened it while the pass was queued).
+    state.get_or_create_slot("chat-1-t")
+
+    restored = asyncio.run(
+        resume_deferred_restores(state, ["chat-1-t", "chat-2-t", "chat-3-t"], [])
+    )
+
+    assert restored == 1  # only chat-3
+    assert "chat-3-t" in state._slots
+    assert "chat-2-t" not in state._slots  # closed stays closed
+
+
+def test_deferred_pass_survives_a_failing_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    for k in ("chat-1-t", "chat-2-t", "chat-3-t"):
+        _seed(state, k)
+
+    real = state.conversation_log.read_messages_chained
+
+    def _boom(key, *a, **kw):
+        if "chat-2-t" in key:
+            raise OSError("disk gremlin")
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _boom)
+
+    restored = asyncio.run(
+        resume_deferred_restores(state, ["chat-1-t", "chat-2-t", "chat-3-t"], [])
+    )
+
+    assert restored == 2
+    # The failure must not leave a half-built slot behind: restore paths call
+    # get_or_create_slot before the fallible read.
+    assert "chat-2-t" not in state._slots
+    assert {"chat-1-t", "chat-3-t"} <= set(state._slots)
+
+
+def test_recent_sessions_defers_past_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 13)]
+    for k in keys:
+        _seed(state, k)
+
+    deferred: list[tuple[str, dict]] = []
+    restored = restore_recent_sessions(state, 60, limit=4, deferred=deferred)
+
+    assert restored == 4
+    assert len(deferred) == len(keys) - 4
+    assert all(isinstance(name, str) and isinstance(sess, dict) for name, sess in deferred)
+
+    finished = asyncio.run(resume_deferred_restores(state, [], deferred))
+    assert finished == len(keys) - 4
+    assert set(state._slots) == set(keys)
+
+
+def test_reseed_counts_deferred_names(tmp_path, monkeypatch):
+    """A new chat minted while the deferred pass is still running must not take
+    an index a returning tab is about to claim."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    state.get_or_create_slot("chat-3-t")  # restored inline
+
+    state.reseed_slot_counter(["chat-41-t"])  # still deferred
+
+    assert state._slot_counter >= 41
+
+
+def test_limit_without_deferred_sink_restores_everything(tmp_path, monkeypatch):
+    """A bare ``limit`` with nowhere to defer to must not silently drop tabs."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 6)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    restored = restore_open_slots(state, limit=2)
+
+    assert restored == len(keys)
+    assert set(state._slots) == set(keys)
+
+
+def test_inline_limit_default_is_ten():
+    """The startup wiring in server.py passes this; 10 is the documented
+    trade-off between a populated sidebar and the 25s watchdog budget."""
+    assert INLINE_RESTORE_LIMIT == 10
+
+
+@pytest.mark.parametrize("keys,sessions", [([], []), ([], None)])
+def test_resume_is_a_noop_with_nothing_deferred(tmp_path, monkeypatch, keys, sessions):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    assert asyncio.run(resume_deferred_restores(state, keys, sessions or [])) == 0
+
+
+def _snapshot_keys(tmp_path) -> list[str]:
+    return json.loads((tmp_path / "open_slots.json").read_text(encoding="utf-8"))["keys"]
+
+
+def test_snapshot_taken_mid_pass_keeps_deferred_tabs(tmp_path, monkeypatch):
+    """The regression this guards: a 5s flush (or a restart save) landing while
+    the background pass is still running used to rewrite open_slots.json from a
+    partial ``_slots``, so the un-restored tabs vanished for good on the next
+    boot."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 9)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restore_open_slots(state, limit=3, deferred=deferred)
+
+    # Snapshot now — mid-pass, only 3 slots are live.
+    state._persist_open_slots()
+    assert len(state._slots) == 3
+    assert set(_snapshot_keys(tmp_path)) == set(keys), "deferred tabs were truncated out"
+
+    # After the pass completes the pin is released and the live slots alone
+    # carry the full set.
+    asyncio.run(resume_deferred_restores(state, deferred, []))
+    assert state._pending_restore_keys == ()
+    state._persist_open_slots()
+    assert set(_snapshot_keys(tmp_path)) == set(keys)
+
+
+def test_pins_survive_a_cancelled_pass(tmp_path, monkeypatch):
+    """Cancellation is the dangerous case (gateway shutdown mid-pass), so the
+    pin must NOT be released on the way out."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 7)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restore_open_slots(state, limit=2, deferred=deferred)
+
+    async def _run() -> None:
+        task = asyncio.create_task(resume_deferred_restores(state, deferred, []))
+        await asyncio.sleep(0)  # let it start, then kill it partway
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_run())
+
+    # Whatever did not come back is still pinned, so a shutdown snapshot taken
+    # right now still records every open tab.
+    state._persist_open_slots()
+    assert set(_snapshot_keys(tmp_path)) == set(keys)
+
+
+def test_incognito_session_is_deferred_but_not_snapshot_pinned(tmp_path, monkeypatch):
+    """open_slots.json only tracks persistent tabs; deferring must not smuggle
+    an incognito session into it."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    for k in ("chat-1-t", "chat-2-t"):
+        _seed(state, k)
+    state.conversation_log.update_metadata(
+        _history_key_for("chat-2-t"), {"memory_mode": "incognito"}
+    )
+
+    deferred: list[tuple[str, dict]] = []
+    restore_recent_sessions(state, 60, limit=0, deferred=deferred)
+
+    # Both are deferred (nothing restores inline at limit=0) but only the
+    # persistent one is pinned into the snapshot.
+    assert {name for name, _ in deferred} == {"chat-1-t", "chat-2-t"}
+    assert state._pending_restore_keys == ("chat-1-t",)
+
+
+def test_message_window_is_read_off_the_event_loop(tmp_path, monkeypatch):
+    """``asyncio.to_thread`` is the point: the loop must not be the thread doing
+    the multi-hundred-message reads."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t"]
+    for k in keys:
+        _seed(state, k)
+
+    loop_thread = threading.current_thread()
+    read_threads: list[threading.Thread] = []
+    real = state.conversation_log.read_messages_chained
+
+    def _spy(key, *a, **kw):
+        read_threads.append(threading.current_thread())
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _spy)
+
+    assert asyncio.run(resume_deferred_restores(state, keys, [])) == 2
+    assert read_threads, "no message window was read"
+    assert all(t is not loop_thread for t in read_threads)
+
+
+def test_replay_is_hidden_from_the_persistence_sweeps(tmp_path, monkeypatch):
+    """The slot is registered in _slots before its window is replayed into it,
+    and the deferred pass yields, so the 5s flush thread can see it mid-replay:
+    _dirty set, but _disk_older_count / _disk_window_len not yet. Saving then
+    writes a partial window the next flush duplicates."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-t")
+
+    real_create = state.get_or_create_slot
+    seen_during_replay: list[bool] = []
+
+    def _spy(name=None, *a, **kw):
+        # get_or_create_slot is the first thing the replay does, so this
+        # observes the guard exactly when the flush thread could.
+        seen_during_replay.append(name in state._restoring_keys)
+        return real_create(name, *a, **kw)
+
+    monkeypatch.setattr(state, "get_or_create_slot", _spy)
+    assert asyncio.run(resume_deferred_restores(state, ["chat-1-t"], [])) == 1
+
+    assert seen_during_replay == [True], "replay ran unguarded"
+    assert state._restoring_keys == set(), "guard leaked past the replay"
+
+
+def test_flush_skips_a_restoring_slot_without_clearing_dirty(tmp_path, monkeypatch):
+    """The skip has to happen before _flush_dirty_slots clears _dirty, or the
+    flag is dropped without a write and the messages never get saved."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    slot = state.get_or_create_slot("chat-1-t")
+    slot.append("user", "half-replayed")
+    slot._dirty = True
+
+    state._restoring_keys.add("chat-1-t")
+    state._flush_dirty_slots()
+    assert slot._dirty is True, "dirty cleared without a save"
+
+    # Same slot, guard released: now it does flush.
+    state._restoring_keys.discard("chat-1-t")
+    state._flush_dirty_slots()
+    assert slot._dirty is False
+
+
+def test_shutdown_save_skips_a_restoring_slot(tmp_path, monkeypatch):
+    """save_all_slots_to_history passes force=True, so it needs the choke-point
+    guard in _save_slot_to_history rather than the flush-loop skip."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    slot = state.get_or_create_slot("chat-1-t")
+    slot.append("user", "half-replayed")
+
+    calls: list[str] = []
+    real_locked = state.conversation_log._locked
+
+    def _spy_locked(key, *a, **kw):
+        # _locked wraps the whole read-modify-atomic_write, so entering it is
+        # the observable "this slot is being persisted".
+        calls.append(key)
+        return real_locked(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "_locked", _spy_locked)
+
+    state._restoring_keys.add("chat-1-t")
+    save_all_slots_to_history(state)
+    assert calls == [], "a mid-replay slot was persisted"
+
+    # Guard released: the same slot does get written, so the assertion above is
+    # about the guard and not about save_all_slots_to_history being inert here.
+    state._restoring_keys.discard("chat-1-t")
+    save_all_slots_to_history(state)
+    assert calls, "shutdown save never persisted the slot"
+
+    # And the snapshot leaves the restoring key to the pin, not to _slots.
+    state._restoring_keys.add("chat-1-t")
+    state._pending_restore_keys = ("chat-1-t",)
+    state._persist_open_slots()
+    assert _snapshot_keys(tmp_path) == ["chat-1-t"]
+
+
+def test_pin_is_read_before_slots_so_the_last_restore_cannot_slip_through(tmp_path, monkeypatch):
+    """The flush reads _slots and the pins at two different instants. If _slots
+    went first, the final deferred restore could land in between — absent from
+    the _slots snapshot, pin already cleared — and the tab would drop out."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t"]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restore_open_slots(state, limit=1, deferred=deferred)
+    assert deferred == ["chat-2-t"]
+
+    # Simulate the interleaving: the restore completes (slot in, pin cleared)
+    # between the snapshot's two reads. A dict subclass fires it on the _slots
+    # enumeration, which is the second of the two reads.
+    fired = False
+
+    class _InterleavingSlots(dict):
+        def items(self):  # type: ignore[override]
+            nonlocal fired
+            if not fired:
+                fired = True
+                state.get_or_create_slot("chat-2-t")
+                state._pending_restore_keys = ()
+            return super().items()
+
+    state._slots = _InterleavingSlots(state._slots)
+    state._persist_open_slots()
+
+    assert fired
+    assert set(_snapshot_keys(tmp_path)) == set(keys)
+
+
+def test_failed_restore_stays_pinned_in_the_snapshot(tmp_path, monkeypatch):
+    """A read that blows up may be transient. Unpinning the key would let the
+    next flush write an open_slots.json without it and lose the tab for good,
+    so a failure keeps its pin while everything settled releases its own."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 7)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    deferred: list[str] = []
+    restore_open_slots(state, limit=2, deferred=deferred)
+    assert "chat-4-t" in deferred
+
+    real = state.conversation_log.read_messages_chained
+
+    def _boom(key, *a, **kw):
+        if "chat-4-t" in key:
+            raise OSError("transient disk gremlin")
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _boom)
+    asyncio.run(resume_deferred_restores(state, deferred, []))
+
+    assert "chat-4-t" not in state._slots
+    assert state._pending_restore_keys == ("chat-4-t",)
+    # And therefore it survives the very next snapshot.
+    state._persist_open_slots()
+    assert set(_snapshot_keys(tmp_path)) == set(keys)
+
+
+def test_session_deleted_during_the_read_is_not_recreated(tmp_path, monkeypatch):
+    """Deleting a session mid-pass must win. Applying stale metadata would let
+    the tab_id backfill write the JSONL back."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-t")
+    log = state.conversation_log
+    sessions = [
+        (s["key"].removeprefix("dashboard:").removeprefix("dashboard_"), s)
+        for s in log.list_sessions()
+    ]
+    assert sessions
+
+    real_read = log.read_messages_chained
+    gone = False
+
+    def _delete_midway(key, *a, **kw):
+        # Stand in for the delete-session handler landing during the off-loop read.
+        nonlocal gone
+        gone = True
+        return real_read(key, *a, **kw)
+
+    real_meta = log.get_metadata
+    monkeypatch.setattr(log, "read_messages_chained", _delete_midway)
+    monkeypatch.setattr(log, "get_metadata", lambda k, *a, **kw: {} if gone else real_meta(k))
+
+    assert asyncio.run(resume_deferred_restores(state, [], sessions)) == 0
+    assert state._slots == {}
+
+
+@pytest.mark.parametrize("path", ["open_slots", "recent_sessions"])
+def test_slot_resumed_during_the_read_is_not_replayed(tmp_path, monkeypatch, path):
+    """Moving the reads off the loop puts an ``await`` between the
+    "already live?" guard and the apply. A client resuming the tab in that
+    window must not get its history appended a second time."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-t")
+    _seed(state, "chat-1-t")  # two messages on disk
+
+    real = state.conversation_log.read_messages_chained
+
+    def _resume_midway(key, *a, **kw):
+        # Stand in for a client opening the tab while the read is in flight.
+        state.get_or_create_slot("chat-1-t")
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _resume_midway)
+
+    if path == "open_slots":
+        restored = asyncio.run(resume_deferred_restores(state, ["chat-1-t"], []))
+    else:
+        sessions = [
+            # Same derivation restore_recent_sessions uses: list_sessions() can
+            # report either the "dashboard:" key or its "dashboard_" filename fold.
+            (s["key"].removeprefix("dashboard:").removeprefix("dashboard_"), s)
+            for s in state.conversation_log.list_sessions()
+            if s.get("key", "").endswith("chat-1-t")
+        ]
+        assert sessions, "seeded session not listed"
+        restored = asyncio.run(resume_deferred_restores(state, [], sessions))
+
+    assert restored == 0, "a slot that came back on its own was counted as restored"
+    assert state._slots["chat-1-t"].messages == [], "history replayed onto a live slot"


### PR DESCRIPTION
## Description

Startup session rehydration ran **unbounded and synchronously on the event loop**, and the loop-stall watchdog is armed before it runs. `LoopStallWatchdog(exit_after=25.0)` arms a C-level `faulthandler.dump_traceback_later(25, exit=True)`; the heartbeat cannot be petted while the loop is blocked in `restore_open_slots()` / `restore_recent_sessions()`. On a large data home the gateway therefore **killed itself mid-startup on every boot**, and the failure gets more certain as history accumulates.

Reproduced on a home with **67 open tabs and 676 sessions (500 MB)**:

```
crash-dumps/loopstall-20260728T183426Z.txt
  Timeout (0:00:25)!
  Thread 0x…740 (most recent call first):     ← main thread
    history.py:1477 in list_sessions
    chat_persistence.py:476 in restore_recent_sessions
    server.py:2402 in start_dashboard
gateway.log  last line 18:34:51 "Restored 67 open tab(s)"  then nothing
crash.log    no entry  (os._exit skips atexit)
```

The watchdog armed at 18:34:26 (last heartbeat) and the timer fired exactly 25s later. `restore_open_slots` spent ~8s scanning and ~17s rehydrating; `restore_recent_sessions` then re-entered `list_sessions()` and never returned in time.

### Fix

Restore the first `INLINE_RESTORE_LIMIT` (10) sessions inline so the sidebar is populated before the first client connects, then finish the rest in `resume_deferred_restores()`, which rehydrates one session per loop iteration (`await asyncio.sleep(0)` between). Per-session cost is unchanged — what changes is that the loop gets control between sessions, so the heartbeat keeps beating.

- `restore_open_slots` / `restore_recent_sessions` take `limit=` and `deferred=`. Filtering (mtime window, `folders_only`, `closed`) still runs for **every** session, so deferral only moves the expensive rehydrate — it never changes which sessions are eligible. A `limit=` with no `deferred` sink falls through to restoring inline rather than silently dropping tabs.
- Extracted `_apply_recent_session()` so the deferred pass replays the *same* code path rather than a parallel copy, plus `_kiro_model_map()` which both paths now share.
- `reseed_slot_counter()` takes `extra_keys` and startup passes the deferred names. Without this the counter is reseeded before those slots exist, and a new chat opened while the background pass is still running can mint an index a returning tab is about to claim.
- Deferred pass is best-effort per item: a failing session is logged and skipped with the same partial-slot rollback `restore_open_slots` performs, and slots that appeared meanwhile (client opened the tab, or the other restore path got there first) are left alone.

A larger fixed timeout was considered and rejected: startup cost scales with accumulated history, so any constant is eventually crossed. Not arming the watchdog until after rehydration was also rejected — it would leave startup itself unwatched.

## Related Issues

<!-- none filed; discovered while diagnosing a gateway that self-killed on every boot -->

## Testing

- [x] Existing tests pass (`make test`) — full backend suite in the worktree: **19395 passed, 82 skipped, 5 xfailed, 1 failed**. The one failure is `test_cli.py::TestInstallPidfdChildWatcher::test_real_subprocess_works_after_install_on_linux`, which fails identically on a clean `origin/main` checkout on this host (it spawns a real subprocess the sandbox blocks) — pre-existing, unrelated.
- [x] `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`, `mypy src/kiro_crew/` (506 files) all clean.
- [x] New tests added — `test/test_deferred_session_restore.py`, 11 cases: inline budget honored and overflow partitioned in order; deferred pass restores exactly the overflow with nothing lost; an interleaving observer task proves the yields happen (a non-yielding implementation never lets it run); present/closed sessions skipped; a failing session neither aborts the batch nor leaks a partial slot; `reseed_slot_counter` counts deferred names; `limit=` without a sink restores everything.
- [x] Manual verification on the affected home (67 tabs, 676 sessions, `restore_window_minutes: 1440` — the exact config that was killing it):

```
19:02:09  Restored 10 open tab(s) from open_slots.json (57 deferred)
19:02:10  Reseeded slot counter 0 -> 40 past highest restored slot index
19:02:10  Resuming 114 deferred session restore(s) in the background
19:02:24  event-loop heartbeat: lag 1.2s (loop was blocked)
19:02:30  event-loop heartbeat: lag 1.4s (loop was blocked)
19:02:36  Deferred restore complete: 57/114 session(s)
```

Port bound in **10s** (previously killed at 25s before binding). Heartbeat lag peaked at **1.4s** against a 25s budget. This boot's stall dump is header-only — 0 thread-stack lines, so no stall fired. All **67** tabs came back, and querying the live gateway (`GET /api/chat/slots`) confirms the deferred slots are fully populated, not degraded:

| | n | messages non-zero | real title | last_message |
|---|---|---|---|---|
| inline | 10 | 10/10 (39–500) | 10/10 | 10/10 |
| deferred | 57 | 57/57 (8–500) | 57/57 | 57/57 |

Cross-checked against on-disk history for 8 sampled deferred sessions: live message count equals `min(disk_messages, 500)` (the window cap) in 8/8 cases. No `deferred restore:` failure lines.

The `57/114` is dedup, not loss: `restore_recent_sessions` runs while only 10 slots exist, so it re-collects the already-deferred tabs as candidates too; the resume pass restores the 57 keys and skips the 53 duplicates. Correct but wasteful bookkeeping — worth a follow-up that has `restore_recent_sessions` skip names already in the deferred-keys list.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — no user-facing surface changed; the trade-off is documented on `INLINE_RESTORE_LIMIT` and in the startup comment
- [x] No secrets, credentials, or internal references in the diff
