### PR TITLE
fix(cli): restart respawns the kirocrew it was invoked as, not PATH's

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -526,6 +526,29 @@ def _stop(cli_port: int | None = None) -> None:
 _KIROCREW_SERVER_SUBCOMMANDS = frozenset({"gateway", "dashboard", "start"})
 
 
+def _basename_stem(tok: str) -> str:
+    """Basename of *tok* without a Windows ``.exe`` suffix.
+
+    Lets the venv launchers ``python.exe`` / ``kirocrew.exe`` match the same
+    checks as their POSIX ``python`` / ``kirocrew`` counterparts. ``shlex.split``
+    with ``posix=False`` leaves quotes on some tokens, so strip them too.
+
+    Split on BOTH separators explicitly rather than via ``os.path.basename``:
+    that is host-dependent (``posixpath`` on Linux does NOT split backslashes),
+    so a Windows cmdline classified on the Linux CI fleet would keep its full
+    ``D:\\...\\kirocrew.exe`` path and never match. This is host-independent — a
+    basename is whatever follows the last ``/`` or ``\\``.
+
+    Module scope rather than nested in :func:`_args_look_like_kirocrew` so
+    :func:`_own_console_script` shares the one definition.
+    """
+    cleaned = tok.strip('"')
+    base = cleaned.replace("\\", "/").rsplit("/", 1)[-1]
+    if base.lower().endswith(".exe"):
+        base = base[:-4]
+    return base
+
+
 def _args_look_like_kirocrew(args: str) -> bool:
     """Return ``True`` if a process command-line *args* string is a KiroCrew server.
 
@@ -570,23 +593,6 @@ def _args_look_like_kirocrew(args: str) -> bool:
         tokens = shlex.split(args, posix=not platform_compat.IS_WINDOWS)
     except ValueError:
         tokens = args.split()
-
-    def _basename_stem(tok: str) -> str:
-        # Basename without a Windows ``.exe`` suffix, so the venv launchers
-        # ``python.exe`` / ``kirocrew.exe`` match the same checks as their POSIX
-        # ``python`` / ``kirocrew`` counterparts. posix=False leaves quotes on
-        # some tokens, so strip them too.
-        #
-        # Split on BOTH separators explicitly rather than os.path.basename:
-        # os.path.basename is host-dependent (posixpath on Linux does NOT split
-        # backslashes), so a Windows cmdline classified on the Linux CI fleet
-        # would keep its full ``D:\...\kirocrew.exe`` path and never match. This
-        # is host-independent — a basename is whatever follows the last / or \.
-        cleaned = tok.strip('"')
-        base = cleaned.replace("\\", "/").rsplit("/", 1)[-1]
-        if base.lower().endswith(".exe"):
-            base = base[:-4]
-        return base
 
     for index, token in enumerate(tokens):
         # --- Module form: "<python> -m kiro_crew <subcmd>" / "-m kiro_crew.<subcmd>"
@@ -655,6 +661,52 @@ def _pid_exited(pid: int) -> bool:
     return not platform_compat.pid_exists(pid)
 
 
+def _own_console_script() -> str | None:
+    """Absolute path of the console script *this* CLI process was invoked as.
+
+    Returns ``None`` unless ``sys.argv[0]`` is an existing executable file
+    basenamed ``kirocrew``.
+
+    :func:`_spawn_detached_gateway` prefers this over ``shutil.which("kirocrew")``
+    so a restart replaces the gateway with the *same* entry point that asked for
+    the restart. ``which`` returns whatever ``kirocrew`` sits earliest on
+    ``PATH``, which is not necessarily this one: a downstream edition composes
+    this core behind its own ``[project.scripts]`` entry point of the same name,
+    so an editable install of the stock core in another interpreter (mise, a
+    stray venv) shadows it. Respawning that one starts a gateway with different
+    composed providers than the one just stopped — a silent edition downgrade,
+    from a command whose only job was to restart what was already running.
+
+    ``which`` remains the fallback for invocations whose argv[0] is not a script
+    path (``python -m kiro_crew restart``, a frozen bundle, a launcher that
+    rewrites argv).
+    """
+    argv0 = sys.argv[0] if sys.argv else ""
+    if not argv0 or _basename_stem(argv0) != "kirocrew":
+        return None
+    path = Path(argv0)
+    if not path.is_absolute():
+        # argv[0] may be a bare name found on PATH ("kirocrew") or a relative
+        # path; resolve it the way the shell did.
+        resolved = shutil.which(argv0)
+        if not resolved:
+            return None
+        # MUST be absolutized. ``shutil.which`` returns an argument that already
+        # has a directory component *unchanged*, so ``.venv/bin/kirocrew``
+        # (a `cd ~/checkout && .venv/bin/kirocrew restart` invocation) comes back
+        # still relative. :func:`_spawn_detached_gateway` passes ``cwd=$HOME`` to
+        # ``Popen``, which chdirs the child BEFORE exec, so a relative program
+        # path would resolve under ``$HOME`` and raise ``FileNotFoundError`` —
+        # after ``_stop()`` has already SIGTERMed the gateway, leaving nothing
+        # running. ``absolute()`` and not ``resolve()``: prepending the cwd is the
+        # whole fix, while following symlinks could exec under a different
+        # basename than the one the user invoked.
+        path = Path(resolved).absolute()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        return None
+    return str(path)
+
+
 def _spawn_detached_gateway(port: int | None = None) -> int:
     """Spawn a detached ``kirocrew gateway`` so the calling shell returns.
 
@@ -667,9 +719,12 @@ def _spawn_detached_gateway(port: int | None = None) -> int:
       ``~/.kirocrew/gateway.log`` (same file the existing ``logs``
       command tails for foreground gateways), so the user has one
       place to look regardless of how the gateway was started.
-    - Resolves ``kirocrew`` via ``shutil.which`` first, falling back
-      to ``sys.executable -m kiro_crew`` so editable/source-tree dev
-      installs also work without a global ``kirocrew`` symlink.
+    - Resolves the console script this CLI was invoked as
+      (:func:`_own_console_script`) first, so a restart respawns the
+      *same* ``kirocrew`` rather than whichever one happens to sit
+      earliest on ``PATH``; then ``shutil.which("kirocrew")``, falling
+      back to ``sys.executable -m kiro_crew`` so editable/source-tree
+      dev installs also work without a global ``kirocrew`` symlink.
     - Closes all inherited file descriptors so it does not pin sockets
       or pipes from the parent CLI process.
     - Binds *port* when given (``--port N``).
@@ -691,7 +746,7 @@ def _spawn_detached_gateway(port: int | None = None) -> int:
     # one log file. The fd is owned by the child after Popen returns.
     log_fh = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
 
-    bin_path = shutil.which("kirocrew")
+    bin_path = _own_console_script() or shutil.which("kirocrew")
     if bin_path:
         argv: list[str] = [bin_path, "gateway"]
     else:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1988,6 +1988,98 @@ class TestRestart:
         # a detached terminal would block the new gateway.
         assert kw["stdin"] == subprocess.DEVNULL
 
+    def test_spawn_detached_gateway_prefers_own_console_script(self, tmp_path, monkeypatch):
+        # Two `kirocrew` scripts can exist at once — an edition composes this
+        # core behind an entry point of the same name, and a stock editable
+        # install in another interpreter puts a second one on PATH. A restart
+        # must respawn the one that was invoked, not whichever which() finds
+        # first, or the replacement gateway composes different providers than
+        # the one just stopped.
+        from kiro_crew.cli_server import _spawn_detached_gateway
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        own = tmp_path / "kirocrew"
+        own.write_text("#!/bin/sh\n")
+        own.chmod(0o755)
+        monkeypatch.setattr(sys, "argv", [str(own), "restart"])
+        proc = MagicMock(pid=7777)
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/kirocrew"),
+            patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen,
+        ):
+            _spawn_detached_gateway()
+        assert mock_popen.call_args.args[0] == [str(own), "gateway"]
+
+    def test_spawn_detached_gateway_ignores_non_kirocrew_argv0(self, tmp_path, monkeypatch):
+        # argv[0] is only trusted when it names the kirocrew console script.
+        # Anything else (a test runner, a wrapper, `python -m kiro_crew restart`)
+        # must fall through to the documented which()/module resolution.
+        from kiro_crew.cli_server import _spawn_detached_gateway
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        other = tmp_path / "pytest"
+        other.write_text("#!/bin/sh\n")
+        other.chmod(0o755)
+        monkeypatch.setattr(sys, "argv", [str(other), "restart"])
+        proc = MagicMock(pid=6666)
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/kirocrew"),
+            patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen,
+        ):
+            _spawn_detached_gateway()
+        assert mock_popen.call_args.args[0] == ["/usr/local/bin/kirocrew", "gateway"]
+
+    def test_spawn_detached_gateway_ignores_missing_argv0_path(self, tmp_path, monkeypatch):
+        # Fails closed on a correctly-named but non-existent argv[0] (frozen
+        # bundles and some launchers rewrite it), rather than handing Popen a
+        # path that cannot be executed.
+        from kiro_crew.cli_server import _spawn_detached_gateway
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(sys, "argv", [str(tmp_path / "ghost" / "kirocrew"), "restart"])
+        proc = MagicMock(pid=5555)
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/kirocrew"),
+            patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen,
+        ):
+            _spawn_detached_gateway()
+        assert mock_popen.call_args.args[0] == ["/usr/local/bin/kirocrew", "gateway"]
+
+    def test_spawn_detached_gateway_absolutizes_relative_argv0(self, tmp_path, monkeypatch):
+        # Regression: `cd ~/checkout && .venv/bin/kirocrew restart`. shutil.which()
+        # returns an argument that already has a directory component *unchanged*,
+        # so it stays relative — and Popen gets cwd=$HOME, which chdirs the child
+        # before exec, so a relative program path resolves under $HOME and raises
+        # FileNotFoundError with no gateway running (_stop() already killed it).
+        # Deliberately exercises the real which() rather than patching it.
+        from kiro_crew.cli_server import _spawn_detached_gateway
+
+        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        # Use the real per-platform venv console-script layout: `bin/kirocrew` on
+        # POSIX, `Scripts\kirocrew.exe` on Windows. shutil.which() only accepts a
+        # directory-qualified argument on Windows with a PATHEXT extension
+        # attached, so an extensionless name there would miss and fall through to
+        # the which()/module chain instead of exercising this path.
+        if sys.platform == "win32":
+            venv_bin = tmp_path / ".venv" / "Scripts"
+            script_name = "kirocrew.exe"
+        else:
+            venv_bin = tmp_path / ".venv" / "bin"
+            script_name = "kirocrew"
+        venv_bin.mkdir(parents=True)
+        own = venv_bin / script_name
+        own.write_text("#!/bin/sh\n")
+        own.chmod(0o755)
+        monkeypatch.chdir(tmp_path)
+        rel = os.path.join(".venv", venv_bin.name, script_name)
+        monkeypatch.setattr(sys, "argv", [rel, "restart"])
+        proc = MagicMock(pid=4444)
+        with patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen:
+            _spawn_detached_gateway()
+        spawned = Path(mock_popen.call_args.args[0][0])
+        assert spawned.is_absolute()
+        assert spawned.resolve() == own.resolve()
+
     def test_spawn_detached_gateway_falls_back_to_python_m(self, tmp_path, monkeypatch):
         # Dev/Brazil-workspace installs may not have ``kirocrew`` on
         # PATH globally. Fall back to ``python -m kiro_crew`` so the


### PR DESCRIPTION
## Description

`_spawn_detached_gateway()` (used by `kirocrew restart` when no platform service is active) resolved the replacement binary with `shutil.which("kirocrew")`. `which` returns whichever `kirocrew` sits earliest on `PATH` — which is not necessarily the one that just asked for the restart.

Two can coexist. A downstream edition composes this core behind its own `[project.scripts]` entry point of the same name, and an editable install of the stock core in another interpreter (mise, a stray venv) shadows it. `restart` then stops the running gateway and starts a **different** one, with different composed platform providers — a silent edition downgrade from a command whose only job was to restart what was already running. Where the stock wrapper isn't installed at all, `which` returns `None` and the fallback runs `python -m kiro_crew` from an interpreter that may not be the right one either.

## Fix

- New `_own_console_script()`: prefer `sys.argv[0]`, trusted only when it is basenamed `kirocrew` **and** is an existing executable file. Relative/bare argv[0] is resolved through `which` the way the shell did; a correctly-named but non-existent path fails closed.
- `_spawn_detached_gateway()` uses `_own_console_script() or shutil.which("kirocrew")`, so the previous `which()` → `python -m kiro_crew` chain remains the fallback for invocations whose argv[0] is not a script path (`python -m kiro_crew restart`, a frozen bundle, a launcher that rewrites argv).
- Lifts `_basename_stem` out of `_args_look_like_kirocrew` to module scope so both call sites share one definition.

**Scope note for review:** this changes only *which binary a restart spawns*. `_args_look_like_kirocrew` — the `os.kill` gate in `stop` — is behaviourally unchanged; the only edit to it is the helper moving to module scope. An earlier revision of this PR also widened that classifier to accept edition-suffixed names (`kirocrew-amazon`); that has been dropped, because the edition it was written for now ships its entry point as plain `kirocrew`, so the arm would have shipped with no consumer while widening a gate on `os.kill`.

## Related Issues

<!-- none filed -->

## Testing

- [x] `test/test_cli.py::TestArgsLookLikeKirocrew` and `::TestRestart` pass (35 passed) — including the pre-existing classifier and spawn cases, unchanged.
- [x] `isort --check-only`, `flake8`, `mypy src/kiro_crew/cli_server.py` all clean.
- [x] Three new `_spawn_detached_gateway` tests: prefers its own console script over a different `which()` result (two `kirocrew` scripts at different paths — the shadowing case), ignores a non-kirocrew argv[0], and fails closed to `which()` on a correctly-named but non-existent argv[0].

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — no user-facing surface changed; rationale is in the `_own_console_script` docstring
- [x] No secrets, credentials, or internal references in the diff
