### PR TITLE
fix(dashboard): let `kirocrew logout` reach its own auth check

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -363,6 +363,14 @@ _BYPASS_EXACT = {
     "/pcm-worklet.js",
     "/api/token/local",
     "/api/shutdown",
+    # `kirocrew logout` (CLI) authenticates with loopback + the local secret via
+    # an X-Local-Secret header, exactly like /api/token/local and /api/shutdown
+    # above — api_logout re-checks BOTH itself before revoking anything. It must
+    # bypass the cookie/token gate for the same reason they do: the CLI holds no
+    # dashboard token, and the middleware only honors X-Internal-Secret, so
+    # without this entry every `kirocrew logout` is denied 403 by the middleware
+    # before the handler (and its audit events) ever run.
+    "/api/logout",
     "/api/theme/boot",
     # Liveness/readiness probes (rec #6): orchestrators / load balancers carry
     # no auth cookie, so these must be reachable without a token. Each exposes

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -414,6 +414,41 @@ async def test_static_assets_bypass_auth(path: str) -> None:
     assert resp.status == 200
 
 
+# -- Property 8a: CLI endpoints that self-authenticate must bypass the gate --
+#
+# These three carry NO dashboard token: the `kirocrew` CLI authenticates to them
+# with loopback + the local secret in an X-Local-Secret header, and each handler
+# re-checks both itself. The middleware only honors X-Internal-Secret, so if one
+# of them is missing from _BYPASS_EXACT the middleware denies it 403 before the
+# handler ever runs — which is exactly how `kirocrew logout` broke.
+
+_CLI_LOCAL_SECRET_PATHS = ("/api/token/local", "/api/shutdown", "/api/logout")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", _CLI_LOCAL_SECRET_PATHS)
+async def test_cli_local_secret_endpoints_bypass_auth(path: str) -> None:
+    mw = token_auth_middleware()
+    # No token, no cookie — only the header the CLI actually sends.
+    req = _make_request(
+        path=path, method="POST", headers={"X-Local-Secret": "irrelevant-here"}
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200, (
+        f"{path} was denied by the auth middleware; the CLI sends no dashboard "
+        f"token, so the handler's own loopback + local-secret check never runs. "
+        f"Add {path!r} to _BYPASS_EXACT in token_auth.py."
+    )
+
+
+def test_cli_local_secret_endpoints_are_in_bypass_exact() -> None:
+    """The set membership itself, independent of middleware behaviour."""
+    import kiro_crew.dashboard.token_auth as ta
+
+    missing = [p for p in _CLI_LOCAL_SECRET_PATHS if p not in ta._BYPASS_EXACT]
+    assert not missing, f"CLI local-secret endpoints missing from _BYPASS_EXACT: {missing}"
+
+
 # -- Property 8b: /api/apps/* still requires auth (security boundary) --
 
 
@@ -1680,6 +1715,37 @@ async def test_api_logout_rejects_missing_secret() -> None:
         assert resp.status == 403
         data = await resp.json()
         assert data["error"] == "invalid secret"
+
+
+@pytest.mark.asyncio
+async def test_api_logout_success_revokes_sessions() -> None:
+    """POST /api/logout with loopback + the right secret actually revokes.
+
+    The reject paths above are covered; this locks in the success path, which is
+    what makes the /api/logout entry in _BYPASS_EXACT meaningful -- the endpoint
+    has to be reachable AND still do its job. revoke_all_sessions is patched so
+    the test never touches the real nonce store / persisted generation.
+    """
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from kiro_crew.dashboard.handlers import api_logout
+
+    app = web.Application()
+    app["local_secret"] = "correct-secret"
+    app.router.add_post("/api/logout", api_logout)
+
+    with patch("kiro_crew.dashboard.token_auth.revoke_all_sessions") as mock_revoke:
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/logout",
+                json={},
+                headers={"X-Local-Secret": "correct-secret"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+            mock_revoke.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Problem

`kirocrew logout` always fails:

```
$ kirocrew logout
❌ Failed to revoke sessions: HTTP 403
```

It fails on every install, not just a misconfigured one, and it leaves no trace: because the denial happens in the auth middleware, `api_logout`'s own audit calls never run, so a failed logout writes **no** `operation: "logout"` entry to the security event log. From an operator's view the command simply refuses and the log is silent about it.

# Why it matters

`kirocrew logout` is the only supported way to revoke dashboard sessions, and revocation is a security control — it is what you reach for when a dashboard link leaks, when you want to force re-authentication after changing identity configuration, or when a session is carrying a stale identity you need to invalidate.

With this broken, the documented remedy does not exist. The remaining options are to hand-clear browser cookies (client-side only — it does not revoke anything server-side) or to overwrite the session by exchanging a fresh one-time link. Neither actually revokes the outstanding session, so a leaked link stays valid for its full lifetime.

The silent-audit part compounds it: an operator running logout as an incident response step gets a 403 with no logged reason, and nothing in the event log says revocation was attempted and refused.

# Fix (symptoms -> root cause -> change)

**Symptom.** Every `POST /api/logout` from the CLI returns 403, and no logout audit event is ever written.

**Root cause.** `/api/logout` is missing from `_BYPASS_EXACT` in `src/kiro_crew/dashboard/token_auth.py` — the set of paths exempt from the dashboard token/cookie middleware. The CLI authenticates with loopback + the local secret in an `X-Local-Secret` header (`cli_server.py`), but the middleware honors only `X-Internal-Secret`, and the CLI holds no dashboard session token. So the middleware fails closed and returns `_deny(...)` -> 403 before `api_logout` — and therefore before both of the handler's own audit branches — ever runs.

Two sibling endpoints with the *identical* self-authenticating model are already exempt: `/api/token/local` and `/api/shutdown`. `api_logout`'s docstring even asserts it uses the "same auth as `/api/token/local`". The bypass list simply never implemented that stated parity.

**Change.** Add `"/api/logout"` to `_BYPASS_EXACT`, with a comment recording why it belongs there.

This restores the documented design rather than widening the boundary. The exemption is safe because `api_logout` enforces its own auth, verified in `handlers/core.py`:

- The loopback gate runs first (`is_loopback(request.remote)` -> 403), then the secret gate, then `revoke_all_sessions()`. Both checks are unconditional and correctly ordered.
- The secret gate is the fail-closed form — `if not expected or not provided or not hmac.compare_digest(expected, provided)` — so an unset `local_secret` denies rather than admits, and the comparison is constant-time.
- All three paths (both denials and success) emit a SEL audit event.
- The bypass is method-agnostic, but only `POST /api/logout` is routed, so nothing else becomes reachable.

`/api/shutdown`, already exempt under the same model, is strictly more dangerous than logout — it stops the gateway.

Worth stating explicitly for reviewers: once the token gate is bypassed, `is_loopback(request.remote)` plus the local secret are the only controls. Behind a same-host reverse proxy, `request.remote` is the proxy's loopback address, so a remote caller clears that check and only the local secret remains. That is **not new** — it is exactly the posture of the already-exempt `/api/token/local` (which mints a full dashboard token) and `/api/shutdown`. This change adds no new exposure class. Tightening it would mean changing untouched code and is deliberately out of scope here.

# Tests

All in `test/test_token_auth.py`:

- `test_cli_local_secret_endpoints_bypass_auth` — parametrized over all three CLI local-secret endpoints (`/api/token/local`, `/api/shutdown`, `/api/logout`). Asserts each passes the middleware with no token or cookie, carrying only the header the CLI actually sends. This is the regression guard: the next such omission fails loudly instead of silently, and the failure message names the fix.
- `test_cli_local_secret_endpoints_are_in_bypass_exact` — direct set-membership assertion, so the failure is unambiguous even if middleware behaviour changes shape.
- `test_api_logout_success_revokes_sessions` — the previously-missing success path. The three existing `api_logout` tests covered only rejections (non-loopback, wrong secret, missing header), so nothing proved the endpoint still *works* once reachable. `revoke_all_sessions` is patched, so the test never touches the real nonce store or the persisted revocation counter.

Confirmed these fail without the fix: reverting the single source line fails exactly the two `/api/logout` assertions while the `/api/token/local` and `/api/shutdown` cases still pass.

Known limitation, stated rather than hidden: the middleware tests construct `token_auth_middleware()` with default (empty) `internal_paths` / `mixed_internal_paths`, so production wiring is not exercised. If `/api/logout` were later added to `_STRICT_INTERNAL_API_PATHS`, the internal-secret branch would preempt the bypass and the CLI would 403 again in production while these tests stayed green. Closing that would require importing `server.py` into a test module that deliberately avoids it for import side effects, so it is left out of scope.

# Manual verification

Local gate, all green on the CI-parity toolchain (mypy 1.14.1, no `faiss`):

| Gate | Result |
|---|---|
| `pytest` (affected modules) | 235 passed |
| `isort --check-only src/kiro_crew test` | clean |
| `flake8 -j 1 src/kiro_crew test` | exit 0 |
| `mypy src/kiro_crew/` | Success, 506 source files |

`tsc` / `vitest` are not implicated — no frontend files changed.

The end-to-end CLI path was traced through the code rather than executed: `csrf_middleware` runs outside `token_auth_middleware`, and `check_origin` accepts a header-less loopback request, so the CLI's `urllib` POST clears CSRF and host validation — `_BYPASS_EXACT` was genuinely the last barrier. `/api/logout` is absent from both `_STRICT_INTERNAL_API_PATHS` and `_MIXED_INTERNAL_API_PATHS`, so the internal-secret branch does not preempt the new entry.

Not yet done: running the real `kirocrew logout` against a gateway built from this branch. That needs an isolated instance (the repo convention forbids testing against the live gateway), which is available on request if a reviewer wants end-to-end proof rather than the unit-level proof above.

# Screenshots

N/A — no user-visible UI change. This is a CLI/HTTP-layer fix; the only observable difference is `kirocrew logout` printing `✅ All dashboard sessions revoked.` instead of `❌ Failed to revoke sessions: HTTP 403`.
