### PR TITLE
fix(agent): use python -m for out-of-env kirocrew MCP launcher

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -286,27 +286,57 @@ def _resolve_kirocrew_bin() -> str:
     return "kirocrew"
 
 
+def _bin_in_running_env(bin_path: str) -> bool:
+    """True if ``bin_path`` lives inside the running interpreter's environment.
+
+    A launcher outside ``sys.prefix`` -- e.g. a ``bin/kirocrew`` resolved by
+    walking the source tree whose own ``.venv`` was never built, or an edition
+    whose console script is named differently (``kirocrew-amazon``) so only a
+    foreign ``kirocrew`` shim is found -- can pass the file/exec-bit usability
+    check yet fail at spawn (``KiroCrew venv not found``), silently dropping the
+    ``kirocrew-core`` / ``kirocrew-cron`` MCP servers. Only an in-env launcher
+    is trusted; anything else uses the interpreter-module fallback.
+    """
+    try:
+        resolved = os.path.realpath(bin_path)
+        prefix = os.path.realpath(sys.prefix)
+        return resolved == prefix or resolved.startswith(prefix + os.sep)
+    except OSError:
+        return False
+
+
 def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
     """Resolve a CWD- and shebang-independent invocation for a built-in
     MCP server (``kirocrew-cron`` / ``kirocrew-core``).
 
-    Prefers a standalone ``kirocrew`` binary when one resolves. Falls back
-    to ``<interpreter> -m kiro_crew <subcommand>`` when
-    :func:`_resolve_kirocrew_bin` cannot find a usable standalone binary --
-    e.g. an install whose launcher is not on the service PATH (the gateway
-    running as a systemd user service is the common case): there
-    ``_resolve_kirocrew_bin`` returns the bare ``"kirocrew"`` sentinel, the
-    command fails to validate, and the server gets dropped from
-    ``kirocrew.json`` on every config refresh.
+    Prefers a standalone ``kirocrew`` binary only when it is the frozen app OR
+    lives inside the running interpreter's environment; otherwise falls back to
+    ``<interpreter> -m kiro_crew <subcommand>``. Two cases need the fallback:
+
+    1. :func:`_resolve_kirocrew_bin` cannot find a usable standalone binary and
+       returns the bare ``"kirocrew"`` sentinel -- e.g. an install whose
+       launcher is not on the service PATH (the gateway running as a systemd
+       user service is the common case): the command fails to validate and the
+       server gets dropped from ``kirocrew.json`` on every config refresh.
+    2. It resolves a launcher OUTSIDE the running interpreter's environment --
+       e.g. a ``bin/kirocrew`` found by walking the source tree whose own
+       ``.venv`` was never built, or an edition whose console script is named
+       ``kirocrew-amazon`` so only a foreign ``kirocrew`` is found. Such a
+       launcher passes the file/exec-bit usability check yet dies at spawn
+       (``KiroCrew venv not found``), silently dropping kirocrew-core /
+       kirocrew-cron.
 
     ``sys.executable`` is the absolute path of the running interpreter, so it
-    needs no PATH entry and ignores any broken launcher. ``python -m
-    kiro_crew`` dispatches the same CLI as the ``kirocrew`` console script.
+    needs no PATH entry, ignores any broken launcher, and works regardless of
+    the edition's console-script name. ``python -m kiro_crew`` dispatches the
+    same CLI as the ``kirocrew`` console script.
     """
     bin_path = _resolve_kirocrew_bin()
-    if bin_path == "kirocrew":  # unresolved sentinel from _resolve_kirocrew_bin
-        return sys.executable, ["-m", "kiro_crew", subcommand]
-    return bin_path, [subcommand]
+    if bin_path != "kirocrew" and (
+        getattr(sys, "frozen", False) or _bin_in_running_env(bin_path)
+    ):
+        return bin_path, [subcommand]
+    return sys.executable, ["-m", "kiro_crew", subcommand]
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1046,11 +1046,16 @@ class TestKirocrewMcpInvocation:
     every refresh.
     """
 
-    def test_uses_standalone_binary_when_resolved(self):
+    def test_uses_standalone_binary_when_in_running_env(self):
         from kiro_crew.agent import _kirocrew_mcp_invocation
 
-        with patch("kiro_crew.agent._resolve_kirocrew_bin", return_value="/opt/bin/kirocrew"):
-            cmd, args = _kirocrew_mcp_invocation("mcp-cron")
+        # A standalone launcher is trusted only when it lives inside the
+        # running interpreter's environment.
+        with patch(
+            "kiro_crew.agent._resolve_kirocrew_bin", return_value="/opt/bin/kirocrew"
+        ):
+            with patch("kiro_crew.agent._bin_in_running_env", return_value=True):
+                cmd, args = _kirocrew_mcp_invocation("mcp-cron")
         assert cmd == "/opt/bin/kirocrew"
         assert args == ["mcp-cron"]
 
@@ -1062,6 +1067,50 @@ class TestKirocrewMcpInvocation:
             cmd, args = _kirocrew_mcp_invocation("mcp-core")
         assert cmd == sys.executable
         assert args == ["-m", "kiro_crew", "mcp-core"]
+
+    def test_foreign_env_binary_falls_back_to_interpreter_module(self):
+        """A resolved launcher OUTSIDE the running interpreter's env is not
+        trusted -- it can be a source-tree ``bin/kirocrew`` with no built
+        ``.venv`` (or an edition whose script is ``kirocrew-amazon``) that
+        passes the exec-bit check but dies at spawn. Fall back to the
+        interpreter-module form, which always launches under the current venv.
+        """
+        from kiro_crew.agent import _kirocrew_mcp_invocation
+
+        with patch(
+            "kiro_crew.agent._resolve_kirocrew_bin",
+            return_value="/some/other/tree/bin/kirocrew",
+        ):
+            with patch("kiro_crew.agent._bin_in_running_env", return_value=False):
+                with patch.object(sys, "frozen", False, create=True):
+                    cmd, args = _kirocrew_mcp_invocation("mcp-core")
+        assert cmd == sys.executable
+        assert args == ["-m", "kiro_crew", "mcp-core"]
+
+    def test_frozen_app_binary_is_trusted_outside_env(self):
+        """In a frozen (PyInstaller) build ``sys.executable`` IS the kirocrew
+        CLI and accepts the subcommands, but it need not sit under
+        ``sys.prefix``; it must still be trusted rather than fed to a
+        nonexistent ``-m`` module runner.
+        """
+        from kiro_crew.agent import _kirocrew_mcp_invocation
+
+        with patch(
+            "kiro_crew.agent._resolve_kirocrew_bin",
+            return_value="/frozen/app/kirocrew-backend",
+        ):
+            with patch("kiro_crew.agent._bin_in_running_env", return_value=False):
+                with patch.object(sys, "frozen", True, create=True):
+                    cmd, args = _kirocrew_mcp_invocation("mcp-cron")
+        assert cmd == "/frozen/app/kirocrew-backend"
+        assert args == ["mcp-cron"]
+
+    def test_bin_in_running_env_detects_prefix_membership(self):
+        from kiro_crew.agent import _bin_in_running_env
+
+        inside = os.path.join(sys.prefix, "bin", "kirocrew")
+        assert _bin_in_running_env(inside) is True
+        assert _bin_in_running_env("/definitely/not/in/prefix/kirocrew") is False
 
 
 class TestKiroHooksMerge:


### PR DESCRIPTION
## Problem
`spawn_run` / `cron_add` / `learn_add` silently disappear from the agent in installs where the running interpreter's venv exposes the kirocrew console script under a different name (editions ship `kirocrew-amazon`, not `kirocrew`), or where a source-tree `bin/kirocrew` exists whose own `.venv` was never built. kiro-cli logs `MCP server init failure … kirocrew-core / kirocrew-cron` every session and drops those servers.

## Why it matters
`kirocrew-core` / `kirocrew-cron` provide the core autonomy tools (spawn_run, cron_*, learn_*, monitor_start, task_run, wait). When they fail to launch, the agent loses subagent orchestration, scheduling, and self-learning with no error surfaced to the user — it just looks like the tools "aren't available".

## Fix (symptom → root cause → change)
- **Symptom:** `MCP server init failure … kirocrew-core`; the configured command is a standalone `bin/kirocrew` that prints "KiroCrew venv not found" at spawn.
- **Root cause:** `_resolve_kirocrew_bin()` walks up from `kiro_crew.__file__` and accepts a `bin/kirocrew` that lives **outside** the running interpreter's environment (it validates only file/exec bits, not that the launcher can actually run). `_kirocrew_mcp_invocation()` then emitted that broken launcher.
- **Change:** trust a standalone launcher only when it is the frozen app **or** lives inside `sys.prefix`; otherwise fall back to `<interpreter> -m kiro_crew <subcommand>`, which always launches under the current venv regardless of the console-script name. Standalone/dev installs where `bin/kirocrew` sits under the venv, and frozen desktop builds, are unchanged.

## Tests
`test/test_agent.py::TestKirocrewMcpInvocation`:
- `test_uses_standalone_binary_when_in_running_env` — updated to the new in-env contract.
- `test_falls_back_to_interpreter_module_when_unresolved` — unchanged sentinel case.
- `test_foreign_env_binary_falls_back_to_interpreter_module` — **new** (the core regression).
- `test_frozen_app_binary_is_trusted_outside_env` — **new** (frozen build must not be fed to `-m`).
- `test_bin_in_running_env_detects_prefix_membership` — **new** (helper unit test).

## Manual verification
Verified out-of-band that `<venv>/bin/python -m kiro_crew mcp-core` starts the MCP server and advertises the full core tool set (spawn_run, learn_add, monitor_start, task_run, …) in an edition whose console script is `kirocrew-amazon`, where the standalone `bin/kirocrew` launcher fails at spawn.

> Note: the local gate commands (pytest/isort/flake8/mypy) could not be executed in the authoring sandbox (no dev venv available and setup was environment-blocked); relying on CI for the canonical gate. The change adds no new imports, stays within the line-length limit, and is bool-typed.

## Screenshots
N/A — backend-only change.
