### PR TITLE
refactor(apps): resolve capability deps via CPP seam, gate AIM markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,9 @@ jobs:
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
             ${{ matrix.python-version == '3.12' && '--cov=kiro_crew' || '--no-cov' }} \
             --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=test/test_run_aim_path.py
+            --deselect=test/test_cron_script.py
         # Deselected tests require capabilities unavailable on GH Actions:
         #   test_script_hooks, test_cron_script: Linux namespace sandbox (unshare NEWNS)
-        #   test_run_aim_path: `aim` CLI binary (Amazon-internal tool)
 
       - name: Stage shard coverage data
         if: matrix.python-version == '3.12'
@@ -200,10 +198,9 @@ jobs:
           pytest -q -n auto --timeout=180 --no-cov \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
             --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=test/test_run_aim_path.py
-        # Same deselects as backend-test (Linux-namespace sandbox tests and
-        # the Amazon-internal `aim` CLI are unavailable here too).
+            --deselect=test/test_cron_script.py
+        # Same deselects as backend-test (the Linux-namespace sandbox tests are
+        # unavailable here too).
 
   # Runs the tests the sharded matrix deselects. They need unprivileged user
   # namespaces (unshare NEWNS), which ubuntu-24.04 restricts via AppArmor --
@@ -211,9 +208,6 @@ jobs:
   # this job the ~/.kiro/crew sensitive-path keystone has no CI coverage at all,
   # even though branch protection treats breaking it as a blocking offence.
   #
-  # test_run_aim_path stays deselected everywhere: it needs the `aim` CLI, an
-  # Amazon-internal binary that does not exist in this fork. Consider deleting
-  # it from the public tree rather than carrying a permanently-skipped test.
   backend-test-sandbox:
     name: Backend Tests (namespace sandbox)
     runs-on: ubuntu-latest

--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -51,8 +51,7 @@ jobs:
         run: |
           pytest -q -n auto --timeout=120 --no-cov --store-durations \
             --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=test/test_run_aim_path.py || true
+            --deselect=test/test_cron_script.py || true
           test -f .test_durations || { echo "::error::no .test_durations produced"; exit 1; }
 
       - name: Open PR if durations changed

--- a/docs/app-classification-redesign.md
+++ b/docs/app-classification-redesign.md
@@ -21,7 +21,7 @@ This makes it impossible to express valid combinations like:
 The setup hooks are also incomplete — only `onInstall` and `onUninstall`
 exist, with no support for update or enable/disable scripts.
 
-Finally, apps can declare `mcpServers` and AIM dependencies in their
+Finally, apps can declare `mcpServers` and capability dependencies in their
 manifest, but KiroCrew never auto-installs them.
 
 ---
@@ -326,8 +326,8 @@ New `dependencies` field in `app.json`:
   "dependencies": {
     "managedBy": "gateway",
 
-    "aim": {
-      "mcp": ["aws-documentation-mcp-server"],
+    "capabilities": {
+      "mcp": ["some-documentation-mcp-server"],
       "skills": ["SomeSkillPackage"],
       "agents": ["SomeAgentPackage"]
     },
@@ -345,12 +345,12 @@ on `InstalledApp` which controls **resource registration** (agents/skills/crons)
 
 | Concept | Field | Scope |
 |---------|-------|-------|
-| Who installs external dependencies (AIM packages) | `dependencies.managedBy` | manifest |
+| Who installs external dependencies (capability packages) | `dependencies.managedBy` | manifest |
 | Who registers app-provided resources (symlinks) | `InstalledApp.resources` | installed metadata |
 
 | Value | Behavior |
 |-------|----------|
-| `"gateway"` (default) | KiroCrew runs `aim install` for each dependency |
+| `"gateway"` (default) | KiroCrew installs each dependency through the edition's `CapabilityManager` seam |
 | `"app"` | KiroCrew only checks existence, does not install |
 
 Per-dependency override is supported for mixed cases:
@@ -359,9 +359,9 @@ Per-dependency override is supported for mixed cases:
 {
   "dependencies": {
     "managedBy": "gateway",
-    "aim": {
+    "capabilities": {
       "mcp": [
-        "aws-documentation-mcp-server",
+        "some-documentation-mcp-server",
         { "id": "my-custom-mcp", "managedBy": "app" }
       ]
     }
@@ -375,10 +375,20 @@ String entries use the default `managedBy`. Object entries can override.
 
 | Type | Install mechanism | Uninstall mechanism |
 |------|-------------------|---------------------|
-| `aim.mcp` | `aim mcp install {id}` | `aim mcp uninstall {id}` |
-| `aim.skills` | `aim skills install {pkg}` | `aim skills uninstall {pkg}` |
-| `aim.agents` | `aim agents install {pkg}` | `aim agents uninstall {pkg}` |
+| `capability.mcp` | `CapabilityManager.install_mcp({id})` | `CapabilityManager.uninstall_mcp({id})` |
+| `capability.skills` | `CapabilityManager.install_skill({pkg})` | `CapabilityManager.uninstall_skill({pkg})` |
+| `capability.agents` | *(none — declarable but never gateway-installed)* | *(none)* |
 | `commands` | Check only (`shutil.which`) | Never removed |
+
+The core names no external binary: resolution goes through the
+`CapabilityManager` CPP seam, and the edition owns which package manager (if
+any) backs it. The public edition ships none (`available()` → `False`), so
+capability entries report as unresolved and the app still installs.
+`capability.agents` has no seam install op, so it always reports unresolved —
+declare it `managedBy: app` or install it out of band.
+
+The wire key is `capabilities`; the former `aim` key is still READ as a
+deprecated alias but is never written back, so a manifest round-trip migrates it.
 
 For `commands`: if a required command is missing, `resolve_dependencies()`
 adds it to the `missing` list in `DependencyResult`. The install proceeds
@@ -386,7 +396,7 @@ adds it to the `missing` list in `DependencyResult`. The install proceeds
 some features may not work. Install Node.js to resolve." The app is
 responsible for graceful degradation when optional commands are absent.
 
-### 4.4 Key Distinction: `dependencies.aim.mcp` vs `mcpServers`
+### 4.4 Key Distinction: `dependencies.capabilities.mcp` vs `mcpServers`
 
 These are different things:
 
@@ -394,13 +404,13 @@ These are different things:
   (e.g. Mochi's `mochi-pet` server at `localhost:7778`). Registered into
   the agent config by bridges.py.
 
-- **`dependencies.aim.mcp`** — External MCP servers the app needs but
-  doesn't provide. Installed system-wide via AIM CLI.
+- **`dependencies.capabilities.mcp`** — External MCP servers the app needs but
+  doesn't provide. Installed system-wide through the `CapabilityManager` seam.
 
 ### 4.5 Install Failure Policy
 
 Dependency install failures are **non-blocking**. Reasons:
-- AIM CLI may not be available (Cloud Desktop)
+- No capability manager may be available (public edition, Cloud Desktop)
 - Network issues cause transient failures
 - Some dependencies may be optional for degraded operation
 
@@ -431,15 +441,15 @@ the same dependency.
 
 ```jsonc
 {
-  "aim/mcp/aws-documentation-mcp-server": {
+  "capability/mcp/some-documentation-mcp-server": {
     "installedBy": ["oncall-watchtower"],
     "installedAt": "2026-04-20T10:00:00Z",
-    "type": "aim.mcp"
+    "type": "capability.mcp"
   },
-  "aim/skills/SomeSkillPackage": {
+  "capability/skills/SomeSkillPackage": {
     "installedBy": ["oncall-watchtower", "another-app"],
     "installedAt": "2026-04-18T08:00:00Z",
-    "type": "aim.skills"
+    "type": "capability.skills"
   }
 }
 ```
@@ -474,14 +484,14 @@ Returns an impact analysis classifying each dependency:
     "removable": [
       {
         "id": "aws-documentation-mcp-server",
-        "type": "aim.mcp",
+        "type": "capability.mcp",
         "reason": "Only used by this app"
       }
     ],
     "shared": [
       {
         "id": "SomeSkillPackage",
-        "type": "aim.skills",
+        "type": "capability.skills",
         "usedBy": ["another-app"],
         "reason": "Also used by another-app"
       }
@@ -489,7 +499,7 @@ Returns an impact analysis classifying each dependency:
     "userInstalled": [
       {
         "id": "some-other-mcp",
-        "type": "aim.mcp",
+        "type": "capability.mcp",
         "reason": "Installed by user (not tracked)"
       }
     ]
@@ -561,7 +571,7 @@ show a Lock icon and cannot be toggled.
 ```python
 # manifest.py
 @dataclass
-class AimDependencies:
+class CapabilityDependencies:
     mcp: list[str | dict[str, str]] = field(default_factory=list)
     skills: list[str | dict[str, str]] = field(default_factory=list)
     agents: list[str | dict[str, str]] = field(default_factory=list)
@@ -569,7 +579,7 @@ class AimDependencies:
 @dataclass
 class Dependencies:
     managedBy: str = "gateway"
-    aim: AimDependencies = field(default_factory=AimDependencies)
+    capabilities: CapabilityDependencies = field(default_factory=CapabilityDependencies)
     commands: list[str] = field(default_factory=list)
 
 # dependency_ledger.py (new file)
@@ -577,7 +587,7 @@ class Dependencies:
 class LedgerEntry:
     installedBy: list[str]
     installedAt: str
-    type: str  # "aim.mcp" | "aim.skills" | "aim.agents"
+    type: str  # "capability.mcp" | "capability.skills" | "capability.agents"
 
 def record_install(dep_key: str, app_name: str, dep_type: str) -> None: ...
 def record_uninstall(dep_key: str, app_name: str) -> None: ...
@@ -654,7 +664,7 @@ register_app(app_name)
 
 ```
 1. Clone repo → ~/.kirocrew/app-sources/{repo}/
-2. resolve_dependencies()          ← aim install for managedBy=gateway deps
+2. resolve_dependencies()          ← capability install for managedBy=gateway deps
 3. Copy to ~/.kirocrew/apps/{name}/
 4. register_app()                  ← symlink agents/skills/crons + register MCP
 5. Run onInstall script            ← compile, initialize
@@ -665,7 +675,7 @@ register_app(app_name)
 
 ```
 1. Clone repo → ~/.kirocrew/app-sources/{repo}/
-2. resolve_dependencies()          ← aim install for managedBy=gateway deps
+2. resolve_dependencies()          ← capability install for managedBy=gateway deps
 3. Run onInstall script            ← build + package .app + copy to ~/Applications
 4. App launches → SDK authenticate() → register_external_app()
    (resources=app, so no bridges.py registration)
@@ -686,12 +696,12 @@ register_app(app_name)
 | File | Changes |
 |------|---------|
 | `apps/manager.py` | `InstalledApp` dataclass: replace `managed` with `origin`/`resources`/`lifecycle`; update `register_builtin_apps()`, `register_external_app()`, `install_app()`, `uninstall_app()` |
-| `apps/manifest.py` | Add `SetupConfig.onUpdate`/`onEnable`/`onDisable`; add `Dependencies`, `AimDependencies` dataclasses; add to `_KNOWN_FIELDS` |
+| `apps/manifest.py` | Add `SetupConfig.onUpdate`/`onEnable`/`onDisable`; add `Dependencies`, `CapabilityDependencies` dataclasses; add to `_KNOWN_FIELDS` |
 | `apps/bridges.py` | Add `_register_mcp_servers()` / `_deregister_mcp_servers()`; update `register_app()` / `deregister_app()` |
 | `apps/routes.py` | Update all `managed` checks to use new fields; add `GET .../uninstall/preview`; update uninstall to support `keep_dependencies`/`keep_specific`; run `onEnable`/`onDisable`/`onUpdate` scripts |
 | `apps/registry.py` | Update `_enrich_with_install_status()` to use new fields; update `install_from_registry()` to call `resolve_dependencies()` |
 | `apps/dependency_ledger.py` | New file: ledger CRUD, `classify_for_uninstall()` |
-| `apps/dependencies.py` | New file: `resolve_dependencies()` using AIM CLI |
+| `apps/dependencies.py` | New file: `resolve_dependencies()` via the `CapabilityManager` seam |
 | `apps/app-registry.json` | Replace `managed` with `resources`/`lifecycle` for Mochi entry |
 | `KiroCrewWebsite/src/pages/AppsPage.tsx` | Update badge logic, button visibility; update uninstall dialog with dependency preview |
 | `KiroCrewWebsite/src/api/client.ts` | Add `uninstallPreview()` API call |
@@ -736,10 +746,10 @@ longer read.
 | Module | Test focus |
 |--------|-----------|
 | `manager.py` | `InstalledApp` serialization round-trip with new fields; migration from old `managed`; `uninstall_app()` with `lifecycle=locked` rejection |
-| `manifest.py` | `SetupConfig` with new hooks; `Dependencies` / `AimDependencies` parsing; validation of `managedBy` values |
+| `manifest.py` | `SetupConfig` with new hooks; `Dependencies` / `CapabilityDependencies` parsing; validation of `managedBy` values |
 | `bridges.py` | `_register_mcp_servers()` writes correct entries to mcp.json; `_deregister_mcp_servers()` removes only namespaced entries; colon separator parsing |
 | `dependency_ledger.py` | CRUD operations; `classify_for_uninstall()` with removable/shared/userInstalled cases; concurrent access with file locking |
-| `dependencies.py` | `resolve_dependencies()` with AIM CLI mocked; `managedBy` override logic; missing commands detection |
+| `dependencies.py` | `resolve_dependencies()` with the capability manager faked; `managedBy` override logic; missing commands detection |
 | `routes.py` | Enable/disable with `onEnable`/`onDisable` scripts; update with `onUpdate` + rollback; uninstall preview + confirm flow |
 | `registry.py` | `_enrich_with_install_status()` with new fields; `install_from_registry()` calling `resolve_dependencies()` |
 
@@ -762,4 +772,4 @@ longer read.
 Lifecycle scripts are tested via integration tests with minimal shell
 scripts that create/check marker files. The sandbox (`wrap_argv`) is
 tested separately in existing test infrastructure. CI does not execute
-real AIM CLI commands — `_run_aim()` is mocked in all dependency tests.
+any real package manager — the `CapabilityManager` seam is faked in all dependency tests.

--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -274,7 +274,7 @@ only one app is uninstalled.
 {
   "dependencies": {
     "managedBy": "gateway",
-    "aim": {
+    "capabilities": {
       "mcp": [
         { "id": "some-mcp-server", "source": "registry" }
       ],
@@ -293,11 +293,15 @@ only one app is uninstalled.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `dependencies.managedBy` | string | `"gateway"` | Who manages dependency lifecycle: `"gateway"` or `"app"` |
-| `dependencies.aim` | object | `{}` | Capability-package dependencies (MCP servers, skills, agents) installed via the optional `aim` package manager. If the `aim` CLI is not on PATH, these are skipped gracefully. |
-| `dependencies.aim.mcp` | object[] | `[]` | Required MCP server dependencies |
-| `dependencies.aim.skills` | object[] | `[]` | Required skill dependencies |
-| `dependencies.aim.agents` | object[] | `[]` | Required agent dependencies |
+| `dependencies.capabilities` | object | `{}` | Capability-package dependencies (MCP servers, skills, agents) resolved through the edition's capability manager. The open-source edition ships none, so these entries are reported as **unresolved** (they appear in the install result's `failed` list) and the app still installs — design for graceful degradation. |
+| `dependencies.capabilities.mcp` | object[] | `[]` | Required MCP server dependencies |
+| `dependencies.capabilities.skills` | object[] | `[]` | Required skill dependencies |
+| `dependencies.capabilities.agents` | object[] | `[]` | **Deprecated for `managedBy: "gateway"`** — no capability-manager install operation exists for agents in any edition, so a gateway-managed entry can never succeed and is always reported unresolved. Declare `managedBy: "app"` (or install out of band) instead. |
 | `dependencies.commands` | string[] | `[]` | System commands that must be on PATH (checked via `which`) |
+
+> The former `dependencies.aim` key is still accepted as a deprecated alias, but
+> it is never written back — a manifest round-trip migrates it to
+> `dependencies.capabilities`. Use `capabilities` in new manifests.
 
 ## Lifecycle & Resource Management
 

--- a/docs/app-store-guidelines.md
+++ b/docs/app-store-guidelines.md
@@ -153,14 +153,16 @@ Rules:
 
 ### Dependencies
 
-Declare external dependencies that KiroCrew should install for your app:
+Declare external dependencies that KiroCrew should install for your app.
+The open-source edition ships no capability manager, so `capabilities` entries
+are reported as unresolved and the app still installs — degrade gracefully:
 
 ```json
 {
   "dependencies": {
     "managedBy": "gateway",
-    "aim": {
-      "mcp": ["aws-documentation-mcp-server"],
+    "capabilities": {
+      "mcp": ["some-documentation-mcp-server"],
       "skills": ["SomeSkillPackage"],
       "agents": ["SomeAgentPackage"]
     },
@@ -171,10 +173,10 @@ Declare external dependencies that KiroCrew should install for your app:
 
 | Field | Description |
 |-------|-------------|
-| `managedBy` | `"gateway"` (default) = KiroCrew installs via AIM CLI. `"app"` = app handles its own deps, KiroCrew only checks existence. |
-| `aim.mcp` | AIM MCP servers to install. |
-| `aim.skills` | AIM skill packages to install. |
-| `aim.agents` | AIM agent packages to install. |
+| `managedBy` | `"gateway"` (default) = KiroCrew resolves deps through the edition's capability manager. `"app"` = app handles its own deps, KiroCrew only checks existence. |
+| `capabilities.mcp` | MCP servers to install. |
+| `capabilities.skills` | Skill packages to install. |
+| `capabilities.agents` | Declarable, but never gateway-installed — always reported unresolved. |
 | `commands` | System commands to check (not installed, just verified). Missing commands produce a warning. |
 
 Per-dependency override: use object format to override `managedBy` for individual entries:
@@ -183,9 +185,9 @@ Per-dependency override: use object format to override `managedBy` for individua
 {
   "dependencies": {
     "managedBy": "gateway",
-    "aim": {
+    "capabilities": {
       "mcp": [
-        "aws-docs-mcp",
+        "some-docs-mcp",
         { "id": "my-custom-mcp", "managedBy": "app" }
       ]
     }

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -650,7 +650,24 @@ is byte-identical) with no `CONTRACT_VERSION` bump.
   `DefaultCapabilityManager.available()` is `False` → the handlers return HTTP 503;
   a companion implements registry-backed management. This is the operations-based
   Protocol the prior binary-name seam's contract note anticipated — chosen now,
-  pre-launch, so no Amazon CLI grammar fossilizes in the core.
+  pre-launch, so no external CLI grammar fossilizes in the core.
+
+  **Second consumer — App Kit dependency resolution.** `apps/dependencies.py`
+  resolves an app manifest's `dependencies.capabilities.{mcp,skills}` through
+  `install_mcp`/`install_skill` (and `uninstall_*` on cleanup) rather than
+  shelling out to a named binary, reading the manager via `current_context()` so
+  it inherits the `BoundedCapabilityManager` timeout wrapper. The seam is probed
+  **lazily** — a commands-only manifest never touches it. When `available()` is
+  `False` the entries are recorded as `failed` (unresolved) and the app still
+  installs, so a public install surfaces the unmet dependency instead of silently
+  reporting success. `dependencies.capabilities.agents` is **declarable but never
+  gateway-installed**: the Protocol exposes `list_agents` only (package/agent
+  install routes were removed), so those entries always report unresolved —
+  declare them `managedBy: app` or install them out of band. The wire key `aim`
+  is a deprecated READ alias (`Dependencies.from_dict`) that is never
+  re-emitted, so a manifest round-trip migrates it; ledger keys/types likewise
+  resolve the pre-rename `aim/*` / `aim.*` spellings so an upgraded install does
+  not orphan tracked dependencies.
 - `McpToolingProvider.extra_mcp_scopes() -> List[McpScope]` — provider-specific
   GLOBAL MCP config scopes. `/api/mcp/apply` and the MCP uninstall path write
   each returned scope's `global_json` (and strip its `agent_mcp_file`) IN

--- a/scripts/scrub-allowlist.txt
+++ b/scripts/scrub-allowlist.txt
@@ -117,3 +117,36 @@ src/kiro_crew/apps/builtins/code_review_sage/tests/
 test/test_deploy_web_profiles.py
 test/test_deploy_web_handlers.py
 test/test_deploy_web_iam.py
+
+# The ``~/.aim`` skill-discovery scan in agent.py (``_all_skill_paths`` and the
+# managed-MCP path note) is OSS-inert — no such tree exists on a vanilla install
+# — and carries its own TODO(aim-governance follow-up) to route through the
+# ``McpToolingProvider.extra_skills()`` CPP seam. That move is deferred to its
+# own PR because of the security-sensitive symlink-resolution and sensitive-path
+# gating around it.
+#
+# These MUST stay path+pattern anchored, never a bare ``src/kiro_crew/agent.py``:
+# the allowlist is applied as a plain ``grep -v`` to BOTH the internal-marker
+# scan and the employee-alias scan, so a path-only entry would drop every line of
+# this 2000+ line file from BOTH gates — a future ``code.amazon``/``brazil-build``
+# /``CR-######``/alias in agent.py would then ship with CI green, exactly the
+# failure mode AIM_PATTERN was added to close.
+# Remove these entries when that follow-up lands.
+src/kiro_crew/agent.py:.*~/\.aim
+src/kiro_crew/agent.py:.*aim mcp install
+src/kiro_crew/agent.py:.*AIM skills
+src/kiro_crew/agent.py:.*AIM-installed
+src/kiro_crew/agent.py:.*AIM install neutralized
+src/kiro_crew/agent.py:.*Path.home() / "\.aim"
+src/kiro_crew/agent.py:.*pkg / "\.aim"
+
+# Two more pre-existing, OSS-inert ``.aim`` reads that the path-BUILDING half of
+# AIM_PATTERN newly surfaces (the ``~/.aim`` literal alone missed them). Both are
+# the same deferred follow-up as agent.py above, allowlisted line-anchored so the
+# gate still catches a NEW one:
+#   - slack/handler.py: reads ``~/.aim/cc-plugins`` for cc-plugin agent names.
+#   - dashboard/handlers/files.py: ``.aim`` is one element of a directory-SKIP set
+#     (a file-indexer exclusion), so it is an inert name, not a coupling.
+src/kiro_crew/slack/handler.py:.*~/\.aim/cc-plugins
+src/kiro_crew/slack/handler.py:.*Path.home() / "\.aim" / "cc-plugins"
+src/kiro_crew/dashboard/handlers/files.py:.*"\.kirocrew", "\.kiro", "\.aim"

--- a/scripts/scrub-lint.sh
+++ b/scripts/scrub-lint.sh
@@ -32,16 +32,37 @@ if [[ "${1:-}" == "--test" ]]; then
   dim "Running self-test..."
   MARKER_FILE="src/__scrub_test_marker.py"
 
-  # Plant a marker that should trigger the scan
-  echo '# test marker: code.amazon.com/packages/FakePackage' > "$MARKER_FILE"
-  if "$SELF" >/dev/null 2>&1; then
-    red "SELF-TEST FAIL: planted marker was not detected"
+  # Plant markers that should each trigger the scan. One probe per pattern
+  # FAMILY, so a typo that silently breaks a family is caught here rather than
+  # discovered when an internal marker ships green.
+  probe_fail=0
+  PROBES=(
+    'internal-domain|# test marker: code.amazon.com/packages/FakePackage'
+    'aim-invocation|# test marker: aim mcp install some-server'
+    'aim-dep-contract|TYPE = "aim.mcp"'
+    'aim-home-tree|P = "~/.aim/skills"'
+  )
+  for probe in "${PROBES[@]}"; do
+    probe_label="${probe%%|*}"
+    probe_line="${probe#*|}"
+    printf '%s\n' "$probe_line" > "$MARKER_FILE"
+    # --no-history: the probes only exercise the working-tree scan, and the
+    # history pass is slow enough that running it per-probe dominates runtime.
+    # </dev/null so the child cannot consume this shell's stdin.
+    if "$SELF" --no-history >/dev/null 2>&1 </dev/null; then
+      red "SELF-TEST FAIL: planted $probe_label marker was not detected"
+      probe_fail=1
+    else
+      green "  ✓ Planted $probe_label marker correctly detected"
+    fi
+    rm -f "$MARKER_FILE"
+  done
+  if [[ $probe_fail -ne 0 ]]; then
     rm -f "$MARKER_FILE"
     exit 1
   fi
-  green "  ✓ Planted marker correctly detected (scan failed as expected)"
 
-  # Remove marker — scan should pass (ignoring git history which always fails pre-rewrite)
+  # Markers removed — scan should pass (ignoring git history which always fails pre-rewrite)
   rm -f "$MARKER_FILE"
   # Run checks 1+2 only (history will fail until rewrite)
   output=$("$SELF" 2>&1 || true)
@@ -64,6 +85,22 @@ fi
 dim "[1/4] Scanning working tree for internal markers..."
 
 INTERNAL_PATTERN='amazon\.com|a2z\.com|aws\.dev|\.amazon\.|code\.amazon|t\.corp|sim\.amazon|isengard|phonetool|midway-auth|mwinit|brazil ws|brazil-build|brazil-runtime|brazil-pkg-cache|meshclaw|Mesh-[0-9]|AVP-[0-9]|account.?[0-9]{12}|CR-[0-9]{6,}|\bP[0-9]{6,}\b'
+
+# The internal package manager (AIM) needs a NARROW pattern, not a bare word:
+# ``--aim``/``bg-aim``/``text-aim`` is an unrelated CSS color token used ~40
+# places in the frontend, and English "aim" appears in prose ("aim an artifact
+# at"). So match only the shapes that constitute a real coupling: the invocation
+# grammar, the ``~/.aim`` home tree, and the ``aim.<type>``/``aim/<type>``
+# dependency-contract strings. A bare ``\baim\b`` would be unusable here.
+# The quoted ``".aim"`` alternative catches the path-BUILDING form
+# (``Path.home() / ".aim" / ...``), which the ``~/.aim`` literal misses.
+#
+# NOT yet covered: the ``~/.aim`` skill scan in agent.py carries its own
+# TODO(aim-governance follow-up) to route through the McpToolingProvider seam;
+# until that lands its call sites are allowlisted by path below.
+AIM_PATTERN='\baim (mcp|skills|agents|install|uninstall)\b|\baim\.(mcp|skills|agents)\b|\baim/(mcp|skills|agents)\b|~/\.aim|\bAIM CLI\b|"\.aim"'
+
+INTERNAL_PATTERN="$INTERNAL_PATTERN|$AIM_PATTERN"
 
 matches=$(grep -rniE "$INTERNAL_PATTERN" \
   src/ website/src/ website/docs/ docs/ skills/ scripts/ config/ packaging/ \

--- a/src/kiro_crew/apps/dependencies.py
+++ b/src/kiro_crew/apps/dependencies.py
@@ -1,23 +1,34 @@
-"""Dependency resolver — install and clean up app dependencies via AIM CLI.
+"""Dependency resolver — install and clean up app dependencies.
 
-Handles three types of AIM dependencies (mcp, skills, agents) and system
+Handles three types of capability dependencies (mcp, skills, agents) and system
 command checks. Non-blocking — failures are recorded but don't prevent
 app installation.
+
+Capability dependencies resolve through the ``CapabilityManager`` CPP seam
+(``platform/interfaces.py``): the edition owns which package manager backs them,
+its invocation grammar, and its error translation — the core only calls an
+operation and records the outcome.  The public edition ships no capability
+manager (``available()`` is ``False``), so such entries are recorded as
+unresolved instead of shelling out to any named binary.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import shutil
 from dataclasses import dataclass, field
 from typing import Any
 
-from kiro_crew.apps.dependency_ledger import record_install, record_uninstall
+from kiro_crew.apps.dependency_ledger import (
+    CAPABILITY_DEP_TYPES,
+    CAPABILITY_UNCLEANABLE_TYPES,
+    capability_dep_key,
+    capability_dep_type,
+    record_install,
+    record_uninstall,
+)
 from kiro_crew.apps.manifest import Dependencies
 
 logger = logging.getLogger(__name__)
-
-_AIM_TIMEOUT = 120  # seconds per aim install command
 
 
 @dataclass
@@ -56,40 +67,66 @@ def _get_managed_by(entry: str | dict, default: str) -> str:
     return default
 
 
-async def _run_aim(*args: str, timeout: int = _AIM_TIMEOUT) -> tuple[int, str]:
-    """Run an ``aim`` CLI command. Returns (returncode, output)."""
-    aim = shutil.which("aim")
-    if not aim:
-        return (1, "aim CLI not found")
-    proc = await asyncio.create_subprocess_exec(
-        aim, *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    )
+_CAPABILITY_UNAVAILABLE = "no capability manager available in this edition"
+
+#: Dependency types the ``CapabilityManager`` seam can install/uninstall.
+#: ``agents`` is declarable (it is in ``CAPABILITY_DEP_TYPES``) but has no seam op
+#: — the Protocol exposes ``list_agents`` only, and package/agent install routes
+#: were removed — so it is never gateway-installed and is recorded as unresolved
+#: rather than silently dropped. Derived from the canonical tuple so adding a type
+#: there cannot silently skip this list.
+_INSTALLABLE_TYPES = tuple(
+    t for t in CAPABILITY_DEP_TYPES if t not in CAPABILITY_UNCLEANABLE_TYPES
+)
+
+
+def _capability_manager() -> Any:
+    """The edition's capability manager, or ``None`` when unavailable.
+
+    Read through ``current_context()`` so the ``BoundedCapabilityManager``
+    timeout wrapper applied at context composition is inherited (a slow
+    companion op must not stall an app install).
+    """
     try:
-        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        try:
-            proc.kill()
-        except ProcessLookupError:
-            pass
-        await proc.communicate()
-        return (1, f"aim command timed out after {timeout}s")
-    return (proc.returncode or 0, (out or b"").decode(errors="replace"))
+        # circular import: platform.defaults imports kiro_crew.apps.registry, so
+        # apps -> platform at module scope closes the cycle. Deferred to call time,
+        # the same pattern every other core seam reader uses (agent_discovery.py,
+        # mcp_discovery.py, dashboard/handlers/_shared.py).
+        from kiro_crew.platform.context import current_context
+
+        mgr = current_context().capability_manager
+    except Exception:
+        logger.warning("capability_manager lookup failed; treating as unavailable", exc_info=True)
+        return None
+    try:
+        if not mgr.available():
+            return None
+    except Exception:
+        logger.warning("capability_manager.available() raised; treating as unavailable")
+        return None
+    return mgr
 
 
-# Map dependency type to aim CLI subcommand
-_AIM_TYPE_MAP = {
-    "mcp": ("mcp", "install"),
-    "skills": ("skills", "install"),
-    "agents": ("agents", "install"),
-}
+async def _capability_install(mgr: Any, dep_type: str, dep_id: str) -> tuple[bool, str]:
+    """Install one dependency through the seam. Returns (ok, message)."""
+    if dep_type == "mcp":
+        res = await mgr.install_mcp(dep_id)
+    elif dep_type == "skills":
+        res = await mgr.install_skill(dep_id)
+    else:  # pragma: no cover - guarded by _INSTALLABLE_TYPES
+        return (False, f"no install operation for dependency type {dep_type!r}")
+    return (bool(res.ok), str(res.message or ""))
 
-_AIM_UNINSTALL_MAP = {
-    "mcp": ("mcp", "uninstall"),
-    "skills": ("skills", "uninstall"),
-    "agents": ("agents", "uninstall"),
-}
+
+async def _capability_uninstall(mgr: Any, dep_type: str, dep_id: str) -> tuple[bool, str]:
+    """Uninstall one dependency through the seam. Returns (ok, message)."""
+    if dep_type == "mcp":
+        res = await mgr.uninstall_mcp(dep_id)
+    elif dep_type == "skills":
+        res = await mgr.uninstall_skill(dep_id)
+    else:  # pragma: no cover - guarded by _INSTALLABLE_TYPES
+        return (False, f"no uninstall operation for dependency type {dep_type!r}")
+    return (bool(res.ok), str(res.message or ""))
 
 
 async def resolve_dependencies(
@@ -98,50 +135,74 @@ async def resolve_dependencies(
 ) -> DependencyResult:
     """Resolve and install app dependencies. Non-blocking — failures don't prevent install.
 
-    For ``managedBy="gateway"`` entries: runs ``aim install``.
+    For ``managedBy="gateway"`` entries: installs via the ``CapabilityManager`` seam.
     For ``managedBy="app"`` entries: only checks existence (no install).
     For ``commands``: checks ``shutil.which()`` and reports missing.
+
+    When the edition provides no capability manager, gateway-managed capability
+    entries are recorded as ``failed`` (unresolved) — the app still installs, and
+    the caller surfaces the unmet dependency to the user.
     """
     result = DependencyResult()
     default_managed = deps.managedBy
 
-    # Process AIM dependencies
-    for dep_type, entries in [
-        ("mcp", deps.aim.mcp),
-        ("skills", deps.aim.skills),
-        ("agents", deps.aim.agents),
-    ]:
-        aim_cmds = _AIM_TYPE_MAP.get(dep_type)
-        if not aim_cmds:
-            continue
+    mgr: Any = None
+    mgr_probed = False
+
+    for dep_type in CAPABILITY_DEP_TYPES:
+        # CAPABILITY_DEP_TYPES names the CapabilityDependencies fields 1:1; a new
+        # type added there without a matching field would silently resolve to no
+        # entries, so default defensively rather than raising mid-install.
+        entries = getattr(deps.capabilities, dep_type, [])
         for entry in entries:
             dep_id = _get_dep_id(entry)
             if not dep_id:
                 continue
             managed_by = _get_managed_by(entry, default_managed)
-            dep_key = f"aim/{dep_type}/{dep_id}"
+            dep_key = capability_dep_key(dep_type, dep_id)
 
             if managed_by == "app":
                 # App manages this dep — just note it
                 result.skipped.append(dep_key)
                 continue
 
-            # Gateway manages — try to install via AIM
+            if dep_type not in _INSTALLABLE_TYPES:
+                result.failed.append(dep_key)
+                logger.warning(
+                    "Dependency %s for app %s has no capability install operation — "
+                    "declare it as managedBy=app or install it out of band",
+                    dep_key, app_name,
+                )
+                continue
+
+            # Probe the seam once, lazily — only when there is work for it.
+            if not mgr_probed:
+                mgr = _capability_manager()
+                mgr_probed = True
+            if mgr is None:
+                result.failed.append(dep_key)
+                logger.info(
+                    "Cannot resolve dependency %s for app %s: %s",
+                    dep_key, app_name, _CAPABILITY_UNAVAILABLE,
+                )
+                continue
+
+            # Gateway manages — install through the edition's capability manager
             try:
-                rc, output = await _run_aim(aim_cmds[0], aim_cmds[1], dep_id)
+                ok, message = await _capability_install(mgr, dep_type, dep_id)
             except Exception as exc:
                 result.failed.append(dep_key)
                 logger.warning("Exception installing %s: %s", dep_key, exc)
                 continue
-            if rc == 0:
+            if ok:
                 result.installed.append(dep_key)
-                record_install(dep_key, app_name, f"aim.{dep_type}")
+                record_install(dep_key, app_name, capability_dep_type(dep_type))
                 logger.info("Installed dependency %s for app %s", dep_key, app_name)
             else:
                 result.failed.append(dep_key)
                 logger.warning(
                     "Failed to install dependency %s for app %s: %s",
-                    dep_key, app_name, output[:200],
+                    dep_key, app_name, message[:200],
                 )
 
     # Check system commands
@@ -170,30 +231,39 @@ async def clean_dependencies(
         List of successfully uninstalled dependency keys.
     """
     cleaned: list[str] = []
+    mgr: Any = None
+    mgr_probed = False
+
     for dep in removable_deps:
         dep_id = dep.get("id", "")
         dep_type = dep.get("type", "")
         if not dep_id:
             continue
 
-        # Parse type to get aim subcommand
-        # dep_type is like "aim.mcp" → we need "mcp"
-        aim_type = dep_type.split(".")[-1] if "." in dep_type else ""
-        aim_cmds = _AIM_UNINSTALL_MAP.get(aim_type)
-
-        if not aim_cmds:
-            logger.warning("Unknown dependency type %r for %s — skipping uninstall", dep_type, dep_id)
+        # dep_type is like "capability.mcp" (or a legacy-prefixed equivalent) → "mcp"
+        base_type = dep_type.split(".")[-1] if "." in dep_type else ""
+        if base_type not in _INSTALLABLE_TYPES:
+            logger.warning(
+                "Unknown dependency type %r for %s — skipping uninstall", dep_type, dep_id
+            )
             continue
 
-        # Extract the package name from the dep_id (which is the full key like "aim/mcp/name")
+        if not mgr_probed:
+            mgr = _capability_manager()
+            mgr_probed = True
+        if mgr is None:
+            logger.info("Cannot uninstall %s: %s", dep_id, _CAPABILITY_UNAVAILABLE)
+            continue
+
+        # dep_id is the full ledger key ("capability/mcp/name") — take the id.
         pkg_name = dep_id.split("/")[-1] if "/" in dep_id else dep_id
         try:
-            rc, output = await _run_aim(aim_cmds[0], aim_cmds[1], pkg_name)
+            ok, message = await _capability_uninstall(mgr, base_type, pkg_name)
         except Exception as exc:
             logger.warning("Exception uninstalling %s: %s", dep_id, exc)
             continue
-        if rc != 0:
-            logger.warning("Failed to uninstall %s: %s", dep_id, output[:200])
+        if not ok:
+            logger.warning("Failed to uninstall %s: %s", dep_id, message[:200])
             continue
 
         record_uninstall(dep_id, app_name)

--- a/src/kiro_crew/apps/dependency_ledger.py
+++ b/src/kiro_crew/apps/dependency_ledger.py
@@ -1,8 +1,8 @@
 """Dependency ledger — reference-counted tracking for app dependencies.
 
-Tracks which apps installed which external dependencies (AIM MCP servers,
-skills, agents) so that uninstall can safely clean up dependencies that
-are no longer referenced by any app.
+Tracks which apps installed which external dependencies (capability-manager
+MCP servers, skills, agents) so that uninstall can safely clean up dependencies
+that are no longer referenced by any app.
 
 All reads/writes use ``fcntl.flock()`` for concurrency safety, consistent
 with KiroCrew's existing file locking patterns.  Read-modify-write cycles
@@ -32,13 +32,127 @@ def _ledger_path() -> Path:
     return config_dir() / "dependency-ledger.json"
 
 
+#: Key namespace for capability-manager-provided dependencies.
+CAPABILITY_KEY_PREFIX = "capability"
+
+#: Pre-rename namespace, still read so ledgers written by older builds resolve.
+_LEGACY_KEY_PREFIX = "aim"
+
+#: Every capability dependency type a manifest may declare, in emit order.
+#: Single source of truth — ``dependencies.py`` derives its installable subset
+#: from this rather than re-spelling the tuple.
+CAPABILITY_DEP_TYPES = ("mcp", "skills", "agents")
+
+#: Types the ``CapabilityManager`` seam exposes NO install/uninstall op for, so
+#: KiroCrew can neither install nor clean them up. Their ledger rows must SURVIVE
+#: an uninstall: deleting the row for something we cannot actually remove would
+#: leave the installed package on disk with no record that anything referenced it
+#: (an untraceable orphan). Ownership is dropped instead, so the dep reads as
+#: user-installed and a future uninstall op — or the user — can still reclaim it.
+CAPABILITY_UNCLEANABLE_TYPES = ("agents",)
+
+
+def _is_uncleanable(dep_type: str) -> bool:
+    """True when *dep_type* has no cleanup operation, so its ledger row must be
+    preserved. Accepts a bare type (``agents``) or any prefixed spelling,
+    canonical or legacy, since ledger rows carry whichever was written."""
+    base = dep_type.split(".")[-1] if "." in dep_type else dep_type
+    return base in CAPABILITY_UNCLEANABLE_TYPES
+
+
+def capability_dep_key(dep_type: str, dep_id: str) -> str:
+    """Ledger key for a capability dependency (``capability/<type>/<id>``)."""
+    return f"{CAPABILITY_KEY_PREFIX}/{dep_type}/{dep_id}"
+
+
+def capability_dep_type(dep_type: str) -> str:
+    """Ledger ``type`` value for a capability dependency (``capability.<type>``)."""
+    return f"{CAPABILITY_KEY_PREFIX}.{dep_type}"
+
+
+def canonical_dep_key(dep_key: str) -> str:
+    """Normalize a caller-supplied dependency key to the canonical prefix.
+
+    Client-supplied keys (an uninstall request's ``keep_specific``) may carry the
+    pre-rename prefix: a dashboard session that loaded its uninstall preview from
+    an OLDER build echoes those ids straight back. Classification emits canonical
+    ids, so an un-normalized legacy key would silently miss the ``keep`` membership
+    test and delete a dependency the user explicitly chose to keep. Idempotent for
+    already-canonical keys, and leaves unrelated strings untouched.
+
+    Non-string input is returned unchanged rather than raising: callers sanitize
+    at their own boundary, but this is consumed mid-uninstall (after the
+    onUninstall script and deregistration have run), so raising here would leave
+    an app partially uninstalled instead of failing cleanly.
+    """
+    if not isinstance(dep_key, str):
+        return dep_key
+    prefix = f"{_LEGACY_KEY_PREFIX}/"
+    if dep_key.startswith(prefix):
+        return f"{CAPABILITY_KEY_PREFIX}/{dep_key[len(prefix):]}"
+    return dep_key
+
+
+def declared_capability_keys(deps_data: dict[str, Any]) -> list[str]:
+    """Ledger keys for every capability dependency declared in a raw manifest dict.
+
+    Reads the ``capabilities`` wire key, falling back to the deprecated ``aim``
+    alias (see :class:`kiro_crew.apps.manifest.Dependencies`).  Shared by the
+    uninstall-preview and uninstall paths so both derive identical keys.
+    """
+    raw = deps_data.get("capabilities")
+    if not isinstance(raw, dict):
+        raw = deps_data.get("aim")
+    if not isinstance(raw, dict):
+        return []
+    keys: list[str] = []
+    for dep_type in CAPABILITY_DEP_TYPES:
+        entries = raw.get(dep_type)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            dep_id = entry.get("id") if isinstance(entry, dict) else entry
+            if not dep_id:
+                continue
+            keys.append(capability_dep_key(dep_type, str(dep_id)))
+    return keys
+
+
+def _legacy_key(dep_key: str) -> str | None:
+    """The pre-rename spelling of *dep_key*, or ``None`` if it has none.
+
+    Lets a ledger written by an older build keep resolving after the rename
+    without a migration pass: lookups fall back to the legacy key, and writes
+    reuse whichever spelling already exists.
+    """
+    if dep_key.startswith(f"{CAPABILITY_KEY_PREFIX}/"):
+        return f"{_LEGACY_KEY_PREFIX}/{dep_key[len(CAPABILITY_KEY_PREFIX) + 1:]}"
+    return None
+
+
+def _resolve_key(ledger: dict[str, Any], dep_key: str) -> str:
+    """Return the key *dep_key* is actually stored under in *ledger*.
+
+    Prefers the canonical key; falls back to the legacy spelling only when the
+    canonical one is absent and the legacy one is present.
+    """
+    if dep_key in ledger:
+        return dep_key
+    legacy = _legacy_key(dep_key)
+    if legacy is not None and legacy in ledger:
+        return legacy
+    return dep_key
+
+
 @dataclass
 class LedgerEntry:
     """A single dependency tracked in the ledger."""
 
     installedBy: list[str] = field(default_factory=list)  # noqa: N815
     installedAt: str = ""  # noqa: N815
-    type: str = ""  # "aim.mcp" | "aim.skills" | "aim.agents"
+    #: ``"capability.mcp"`` | ``"capability.skills"`` | ``"capability.agents"``
+    #: (legacy ledgers may carry the pre-rename ``"aim.*"`` spelling).
+    type: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -112,14 +226,18 @@ def record_install(dep_key: str, app_name: str, dep_type: str) -> None:
     """
     with _locked_ledger():
         ledger = _read_ledger_unlocked()
-        entry = ledger.get(dep_key)
+        # Reuse the legacy spelling when that is where the entry already lives,
+        # so an older ledger accrues refcounts in one place instead of splitting
+        # across two keys for the same dependency.
+        key = _resolve_key(ledger, dep_key)
+        entry = ledger.get(key)
         if entry:
             installed_by = entry.get("installedBy", [])
             if app_name not in installed_by:
                 installed_by.append(app_name)
                 entry["installedBy"] = installed_by
         else:
-            ledger[dep_key] = {
+            ledger[key] = {
                 "installedBy": [app_name],
                 "installedAt": _now_iso(),
                 "type": dep_type,
@@ -135,14 +253,15 @@ def record_uninstall(dep_key: str, app_name: str) -> None:
     """
     with _locked_ledger():
         ledger = _read_ledger_unlocked()
-        entry = ledger.get(dep_key)
+        key = _resolve_key(ledger, dep_key)
+        entry = ledger.get(key)
         if not entry:
             return
         installed_by = entry.get("installedBy", [])
         if app_name in installed_by:
             installed_by.remove(app_name)
         if not installed_by:
-            del ledger[dep_key]
+            del ledger[key]
         else:
             entry["installedBy"] = installed_by
         _write_ledger_unlocked(ledger)
@@ -150,9 +269,13 @@ def record_uninstall(dep_key: str, app_name: str) -> None:
 
 
 def get_entry(dep_key: str) -> LedgerEntry | None:
-    """Get a single dependency's ledger entry, or None."""
+    """Get a single dependency's ledger entry, or None.
+
+    Falls back to the pre-rename key spelling so entries written by an older
+    build remain visible.
+    """
     ledger = _read_ledger()
-    raw = ledger.get(dep_key)
+    raw = ledger.get(_resolve_key(ledger, dep_key))
     if not raw:
         return None
     return LedgerEntry.from_dict(raw)
@@ -196,7 +319,10 @@ def classify_and_clean_for_uninstall(
     cycle to prevent TOCTOU races when two apps sharing a dependency
     are uninstalled concurrently.
 
-    - Removable deps not in *keep_specific* have their ledger entry deleted.
+    - Removable deps not in *keep_specific* have their ledger entry deleted,
+      EXCEPT uncleanable types (see :data:`CAPABILITY_UNCLEANABLE_TYPES`), which
+      only lose this app's ownership — dropping the row for a dependency no
+      cleanup op can remove would orphan the installed package untraceably.
     - Shared deps have the current app removed from ``installedBy``.
     - User-installed deps are untouched.
 
@@ -209,26 +335,30 @@ def classify_and_clean_for_uninstall(
 
         # Update ledger for removable deps
         for dep in result["removable"]:
-            dep_key = dep["id"]
-            if dep_key in keep:
-                # User chose to keep this dep — still remove the app's
-                # ownership so the dep is classified as "user installed"
-                # in future uninstalls (no orphaned reference).
+            dep_key = _resolve_key(ledger, dep["id"])
+            uncleanable = _is_uncleanable(str(dep.get("type", "")))
+            if dep["id"] in keep or uncleanable:
+                # Either the user chose to keep this dep, or nothing can clean it
+                # up. Drop this app's ownership so it classifies as
+                # "user installed" next time (no orphaned reference).
                 entry = ledger.get(dep_key)
                 if entry:
                     installed_by = entry.get("installedBy", [])
                     if app_name in installed_by:
                         installed_by.remove(app_name)
-                    if not installed_by:
+                    entry["installedBy"] = installed_by
+                    # An emptied row is normally pruned — but for an UNCLEANABLE
+                    # type the row is the only remaining record that the package
+                    # was installed at all (KiroCrew has no operation to remove
+                    # it), so retain it ownerless instead of orphaning the package.
+                    if not installed_by and not uncleanable:
                         del ledger[dep_key]
-                    else:
-                        entry["installedBy"] = installed_by
                 continue
             ledger.pop(dep_key, None)
 
         # Update ledger for shared deps (remove this app's reference)
         for dep in result["shared"]:
-            dep_key = dep["id"]
+            dep_key = _resolve_key(ledger, dep["id"])
             entry = ledger.get(dep_key)
             if entry:
                 installed_by = entry.get("installedBy", [])
@@ -254,7 +384,7 @@ def _classify_deps(
     user_installed: list[dict[str, Any]] = []
 
     for dep_key in declared_deps:
-        raw = ledger.get(dep_key)
+        raw = ledger.get(_resolve_key(ledger, dep_key))
         if not raw:
             user_installed.append({
                 "id": dep_key,

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -411,8 +411,14 @@ class SetupConfig:
 
 
 @dataclass
-class AimDependencies:
-    """AIM CLI-managed dependencies (MCP servers, skills, agents)."""
+class CapabilityDependencies:
+    """Capability-manager-provided dependencies (MCP servers, skills, agents).
+
+    Resolved through the ``CapabilityManager`` CPP seam, NOT a named external
+    binary — the edition owns which package manager (if any) backs these and its
+    invocation grammar.  The public edition ships no capability manager, so these
+    entries are reported as unresolved rather than installed.
+    """
 
     mcp: list[Any] = field(default_factory=list)  # str or {"id": str, "managedBy": str}
     skills: list[Any] = field(default_factory=list)
@@ -429,7 +435,7 @@ class AimDependencies:
         return d
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> AimDependencies:
+    def from_dict(cls, data: dict[str, Any]) -> CapabilityDependencies:
         return cls(
             mcp=list(data.get("mcp", [])),
             skills=list(data.get("skills", [])),
@@ -442,35 +448,47 @@ class Dependencies:
     """External dependencies that KiroCrew should resolve during install.
 
     ``managedBy`` controls the default installation strategy:
-      - ``"gateway"``: KiroCrew runs ``aim install`` for each dependency
+      - ``"gateway"``: KiroCrew resolves each dependency through the edition's
+        ``CapabilityManager`` seam
       - ``"app"``: KiroCrew only checks existence, does not install
 
     Individual entries can override via object format:
     ``{"id": "some-mcp", "managedBy": "app"}``
+
+    The wire key is ``capabilities``.  ``aim`` is accepted as a DEPRECATED read
+    alias so manifests authored against the pre-rename schema keep loading; it is
+    never re-emitted by :meth:`to_dict`, so a round-trip migrates the manifest.
     """
 
     managedBy: str = "gateway"  # noqa: N815
-    aim: AimDependencies = field(default_factory=AimDependencies)
+    capabilities: CapabilityDependencies = field(default_factory=CapabilityDependencies)
     commands: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
         if self.managedBy != "gateway":
             d["managedBy"] = self.managedBy
-        aim_d = self.aim.to_dict()
-        if aim_d:
-            d["aim"] = aim_d
+        cap_d = self.capabilities.to_dict()
+        if cap_d:
+            d["capabilities"] = cap_d
         if self.commands:
             d["commands"] = self.commands
         return d
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Dependencies:
-        aim_raw = data.get("aim", {})
-        aim = AimDependencies.from_dict(aim_raw) if isinstance(aim_raw, dict) else AimDependencies()
+        raw = data.get("capabilities")
+        if not isinstance(raw, dict):
+            # Deprecated alias — read-only, never written back.
+            raw = data.get("aim")
+        capabilities = (
+            CapabilityDependencies.from_dict(raw)
+            if isinstance(raw, dict)
+            else CapabilityDependencies()
+        )
         return cls(
             managedBy=str(data.get("managedBy", "gateway")),  # noqa: N815
-            aim=aim,
+            capabilities=capabilities,
             commands=[str(c) for c in data.get("commands", [])],
         )
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -38,7 +38,14 @@ from kiro_crew.apps.bridges import (
     reregister_app_mcp_servers,
 )
 from kiro_crew.apps.builtins import BUILTIN_NAMES
+from kiro_crew.apps.dependencies import clean_dependencies
 from kiro_crew.apps.dependencies import resolve_dependencies as _resolve_deps
+from kiro_crew.apps.dependency_ledger import (
+    canonical_dep_key,
+    classify_and_clean_for_uninstall,
+    classify_for_uninstall,
+    declared_capability_keys,
+)
 from kiro_crew.apps.hooks_integration import on_app_disable, on_app_enable
 from kiro_crew.apps.manager import (
     app_lifecycle_lock,
@@ -660,17 +667,9 @@ async def handle_uninstall_preview(request: web.Request) -> web.Response:
     deps_data = manifest.get("dependencies", {})
 
     # Collect declared dependency keys
-    declared_deps: list[str] = []
-    aim_deps = deps_data.get("aim", {})
-    for dep_type in ("mcp", "skills", "agents"):
-        for entry in aim_deps.get(dep_type, []):
-            dep_id = entry.get("id") if isinstance(entry, dict) else entry
-            if not dep_id:
-                continue
-            declared_deps.append(f"aim/{dep_type}/{dep_id}")
+    declared_deps = declared_capability_keys(deps_data)
 
     # Classify dependencies
-    from kiro_crew.apps.dependency_ledger import classify_for_uninstall
     dep_classification = classify_for_uninstall(name, declared_deps)
 
     return web.json_response({
@@ -723,7 +722,13 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         body = await request.json()
         keep_data = body.get("keep_data", False)
         keep_dependencies = body.get("keep_dependencies", False)
-        keep_specific = body.get("keep_specific", [])
+        # Sanitize here, at the parse boundary: this is unvalidated client JSON,
+        # and the dependency step that consumes it runs AFTER the onUninstall
+        # script and deregistration — so a `{"keep_specific": [null]}` body that
+        # raised downstream would leave the app half-removed.
+        raw_keep = body.get("keep_specific", [])
+        if isinstance(raw_keep, list):
+            keep_specific = [k for k in raw_keep if isinstance(k, str) and k]
     except Exception:
         pass
 
@@ -841,25 +846,21 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         cleaned_deps: list[str] = []
         if not keep_dependencies:
             deps_data = manifest.get("dependencies", {})
-            aim_deps = deps_data.get("aim", {})
-            declared_deps: list[str] = []
-            for dep_type in ("mcp", "skills", "agents"):
-                for entry in aim_deps.get(dep_type, []):
-                    dep_id = entry.get("id") if isinstance(entry, dict) else entry
-                    if not dep_id:
-                        continue
-                    declared_deps.append(f"aim/{dep_type}/{dep_id}")
+            declared_deps = declared_capability_keys(deps_data)
 
-            from kiro_crew.apps.dependency_ledger import classify_and_clean_for_uninstall
+            # Normalize client-supplied keep ids: a dashboard session whose
+            # uninstall preview came from a pre-rename build echoes legacy keys,
+            # and classification emits canonical ones — comparing the two raw
+            # would drop the keep and delete a dep the user chose to keep.
+            keep_canonical = [canonical_dep_key(k) for k in keep_specific]
             classification = classify_and_clean_for_uninstall(
-                name, declared_deps, keep_specific=list(keep_specific),
+                name, declared_deps, keep_specific=keep_canonical,
             )
             removable = [
                 d for d in classification.get("removable", [])
-                if d.get("id") not in keep_specific
+                if d.get("id") not in keep_canonical
             ]
             if removable:
-                from kiro_crew.apps.dependencies import clean_dependencies
                 cleaned_deps = await clean_dependencies(name, removable)
                 if cleaned_deps:
                     uninstall_log.append(f"Cleaned {len(cleaned_deps)} dependency(ies)")

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -100,8 +100,8 @@ def _edition_skill_roots() -> list[Path]:
 
     Reads ``McpToolingProvider.extra_skills()`` fail-closed through
     ``safe_context_call`` (public Default: ``[]``), so on a vanilla OSS install
-    there are no roots to discover and the AIM-flavored skill helpers below
-    return "nothing found" rather than globbing a hardcoded ``~/.aim``.
+    there are no roots to discover and the edition skill helpers below
+    return "nothing found" rather than globbing a hardcoded home-dir tree.
     Deferred import (sel.py pattern) so this module never imports the platform
     package at module load.
     """
@@ -119,7 +119,8 @@ def _resolve_aim_skill_path(name: str) -> Path | None:
     """Find SKILL.md for an edition-contributed skill by leaf name.
 
     Iterates the edition skill roots (``McpToolingProvider.extra_skills()``)
-    instead of globbing ``~/.aim`` directly. Within each root a skill lives at
+    instead of globbing an edition home-dir tree directly. Within each root a
+    skill lives at
     either ``<root>/<pkg>/<name>/SKILL.md`` or ``<root>/<name>/SKILL.md``; the
     first match (roots in seam order) wins.
     """

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -944,7 +944,7 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
             logger.warning("SEL logging failed for agent sync noop", exc_info=True)
 
     if pruned:
-        logger.info("Pruned %d stale AIM agents: %s", len(pruned), ", ".join(pruned))
+        logger.info("Pruned %d stale package agents: %s", len(pruned), ", ".join(pruned))
 
     return web.json_response({"ok": True, "synced": synced, "pruned": pruned})
 

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 # in AIM / kiro-cli (alphanumerics, dashes, underscores, slashes, dots,
 # and ``@`` for scoped names like ``@org/server``) and defends against
 # command-injection into subprocess calls that pass the name as an argv
-# element (e.g. `aim mcp uninstall <name>`).
+# element (e.g. a capability-manager `uninstall <name>` argv).
 #
 # The leading char must be alphanumeric or ``@`` so a name can't begin
 # with ``.`` or ``/``.  Path-traversal sequences (``..``) are rejected
@@ -1455,7 +1455,7 @@ async def _do_mcp_apply(request: web.Request) -> web.Response:
                 if not name:
                     results.append({"error": "empty name", "change": change})
                     continue
-                # Defense-in-depth: name flows into subprocess argv (aim mcp
+                # Defense-in-depth: name flows into subprocess argv (capability
                 # uninstall) and filesystem paths via scope helpers.  Even
                 # though we use list-form subprocess (no shell), reject names
                 # that contain argv-injection chars or path traversal.
@@ -1647,7 +1647,7 @@ async def _do_mcp_apply(request: web.Request) -> web.Response:
         # Rebuild failures can surface file paths, env var contents, or
         # credential fragments (e.g. JSON decode errors that echo file
         # contents).  Apply the same redaction pipeline we use for the
-        # AIM uninstall error before handing it to the dashboard.
+        # capability-manager uninstall error before handing it to the dashboard.
         _urls_clean, _ = redact_exfiltration_urls(str(exc))
         rebuild_error, _ = redact_credentials(_urls_clean)
         logger.warning("rebuild_agent_config failed after apply: %s", exc)

--- a/src/kiro_crew/dashboard/handlers/prompts.py
+++ b/src/kiro_crew/dashboard/handlers/prompts.py
@@ -75,9 +75,9 @@ def _redact_prompt(p: dict[str, Any]) -> None:
 
 async def api_prompts(request: web.Request) -> web.Response:
     """GET /api/prompts — list available prompts and agent SOPs."""
-    # _list_aim_prompts() walks ~/.aim/packages (rglob *.sop.md + per-file
-    # resolve/read + frontmatter parse) on a cold cache — blocking FS work that
-    # can stall the event loop on a large ~/.aim tree. It has a 5s TTL cache,
+    # _list_aim_prompts() walks the edition package tree (rglob *.sop.md +
+    # per-file resolve/read + frontmatter parse) on a cold cache — blocking FS
+    # work that can stall the event loop on a large tree. It has a 5s TTL cache,
     # but the cold/expired build must run off the loop. (The cache lives in the
     # parent package; the executor call still benefits from it on warm builds.)
     prompts = await asyncio.get_running_loop().run_in_executor(

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1656,7 +1656,7 @@ async def start_dashboard(
     app.router.add_post("/api/agents/sync", handlers.api_kirocrew_agents_sync)
     app.router.add_put("/api/agents/{name}", handlers.api_kirocrew_agent_update)
     app.router.add_delete("/api/agents/{name}", handlers.api_kirocrew_agent_delete)
-    # AIM agents
+    # Edition capability agents
     app.router.add_get("/api/capability/agents", handlers.api_capability_agents_list)
     # Agent metadata (Phase 1)
     app.router.add_get("/api/agent-metadata/{name}", handlers.api_agent_metadata_get)

--- a/src/kiro_crew/executors.py
+++ b/src/kiro_crew/executors.py
@@ -32,7 +32,7 @@ Three pools, deliberately split:
 * :func:`discovery_executor` -- browser-triggerable, read-only filesystem
   discovery for dashboard list endpoints (``GET /api/skills``,
   ``/api/agents/installed``, ``/api/prompts``): ``os.walk`` of skill/agent/SOP
-  trees, per-file frontmatter reads, ``~/.aim`` globs.  A large catalog makes
+  trees, per-file frontmatter reads, edition skill-root globs.  A large catalog
   one such scan take seconds, and a ``run_in_executor`` future cannot be
   cancelled once started, so N concurrent dashboard tabs would each pin a
   worker for the full scan.  This gets its OWN pool so those user-triggerable

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import pathlib
 import shutil
 import sys
 
@@ -16,7 +17,7 @@ from kiro_crew.slack.client import SlackClientOps
 from kiro_crew.slack.handler import _PHASE_EMOJIS, _build_phase_emojis
 
 # ── Hypothesis profiles ─────────────────────────────────────────────────
-# Default (CI): fast iteration.  Run ``HYPOTHESIS_PROFILE=thorough brazil-build test``
+# Default (CI): fast iteration.  Run ``HYPOTHESIS_PROFILE=thorough python -m pytest``
 # for deeper coverage.
 settings.register_profile("default", max_examples=20, suppress_health_check=[HealthCheck.too_slow], deadline=None)
 settings.register_profile("thorough", max_examples=100)
@@ -695,3 +696,31 @@ def _reset_platform_context(monkeypatch):
     yield
     reset_context()
     _reset_boot_state()
+
+
+@pytest.fixture
+def short_sock_dir(tmp_path):
+    """A temp dir short enough to hold an AF_UNIX socket path.
+
+    ``sockaddr_un.sun_path`` caps a unix-socket path at ~104 bytes on macOS (108
+    on Linux). pytest's ``tmp_path`` is derived from the platform temp root plus
+    the test name, and on macOS that root is ``/private/var/folders/<...>/T``,
+    which already blows the cap before a filename is appended — so binding under
+    ``tmp_path`` fails with ``OSError: AF_UNIX path too long`` on a developer
+    machine while passing in CI (Linux, short ``/tmp``).
+
+    Yields a short-rooted dir instead, cleaned up afterwards. Falls back to
+    ``tmp_path`` where no short root exists (notably Windows, where AF_UNIX tests
+    are skipped anyway), so this never hard-fails on an unusual platform.
+    """
+    import tempfile
+
+    short_root = "/tmp" if os.path.isdir("/tmp") else None
+    if short_root is None:
+        yield tmp_path
+        return
+    path = tempfile.mkdtemp(dir=short_root, prefix="kcsock-")
+    try:
+        yield pathlib.Path(path)
+    finally:
+        shutil.rmtree(path, ignore_errors=True)

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -8,8 +8,8 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from kiro_crew.apps.manifest import (
-    AimDependencies,
     AppManifest,
+    CapabilityDependencies,
     Dependencies,
     SetupConfig,
 )
@@ -224,7 +224,7 @@ class TestValidation:
             "agents": ["agents/ticket-analyst.json"],
             "skills": ["skills/ticket-triage"],
             "sops": ["sops/ticket-rca.sop.md"],
-            "mcpServers": {"cw-mcp": {"command": "aim", "args": ["mcp", "run", "cw"]}},
+            "mcpServers": {"cw-mcp": {"command": "capmgr", "args": ["mcp", "run", "cw"]}},
             "crons": [{"name": "refresh", "every": 3600, "message": "refresh data"}],
             "ui": {"pages": [{"route": "/apps/owt", "label": "Dashboard", "icon": "Shield"}]},
             "backend": {"entryPoint": "backend/app.py"},
@@ -496,13 +496,13 @@ class TestDependencies:
     def test_empty_dependencies(self):
         deps = Dependencies.from_dict({})
         assert deps.managedBy == "gateway"
-        assert deps.aim.mcp == []
+        assert deps.capabilities.mcp == []
         assert deps.commands == []
 
     def test_full_dependencies_round_trip(self):
         data = {
             "managedBy": "app",
-            "aim": {
+            "capabilities": {
                 "mcp": ["aws-docs-mcp"],
                 "skills": ["SomeSkill"],
                 "agents": ["SomeAgent"],
@@ -511,48 +511,48 @@ class TestDependencies:
         }
         deps = Dependencies.from_dict(data)
         assert deps.managedBy == "app"
-        assert deps.aim.mcp == ["aws-docs-mcp"]
+        assert deps.capabilities.mcp == ["aws-docs-mcp"]
         assert deps.commands == ["node", "python3"]
         d = deps.to_dict()
         restored = Dependencies.from_dict(d)
         assert restored.managedBy == deps.managedBy
-        assert restored.aim.mcp == deps.aim.mcp
+        assert restored.capabilities.mcp == deps.capabilities.mcp
         assert restored.commands == deps.commands
 
     def test_default_managed_by_omitted(self):
-        deps = Dependencies(aim=AimDependencies(mcp=["x"]))
+        deps = Dependencies(capabilities=CapabilityDependencies(mcp=["x"]))
         d = deps.to_dict()
         assert "managedBy" not in d  # default "gateway" omitted
 
     def test_mixed_string_and_object_entries(self):
         deps = Dependencies.from_dict({
-            "aim": {
+            "capabilities": {
                 "mcp": [
                     "simple-mcp",
                     {"id": "custom-mcp", "managedBy": "app"},
                 ]
             }
         })
-        assert len(deps.aim.mcp) == 2
-        assert deps.aim.mcp[0] == "simple-mcp"
-        assert deps.aim.mcp[1] == {"id": "custom-mcp", "managedBy": "app"}
+        assert len(deps.capabilities.mcp) == 2
+        assert deps.capabilities.mcp[0] == "simple-mcp"
+        assert deps.capabilities.mcp[1] == {"id": "custom-mcp", "managedBy": "app"}
 
     def test_manifest_with_dependencies(self):
         m = AppManifest.from_dict(_valid_manifest(
             dependencies={
                 "managedBy": "gateway",
-                "aim": {"mcp": ["aws-docs"]},
+                "capabilities": {"mcp": ["aws-docs"]},
                 "commands": ["node"],
             }
         ))
         assert m.dependencies.managedBy == "gateway"
-        assert m.dependencies.aim.mcp == ["aws-docs"]
+        assert m.dependencies.capabilities.mcp == ["aws-docs"]
         assert m.dependencies.commands == ["node"]
         # Round-trip through manifest
         d = m.to_dict()
         assert "dependencies" in d
         m2 = AppManifest.from_dict(d)
-        assert m2.dependencies.aim.mcp == ["aws-docs"]
+        assert m2.dependencies.capabilities.mcp == ["aws-docs"]
 
 
 # ---------------------------------------------------------------------------
@@ -644,15 +644,15 @@ class TestManifestNewProperties:
         """**Validates: Requirements 5.2**"""
         deps = Dependencies(
             managedBy=managed_by,
-            aim=AimDependencies(mcp=mcp_deps, skills=skill_deps),
+            capabilities=CapabilityDependencies(mcp=mcp_deps, skills=skill_deps),
             commands=commands,
         )
         d = deps.to_dict()
         restored = Dependencies.from_dict(d)
         # Semantic equivalence: field values match even if dict structure differs
         assert restored.managedBy == deps.managedBy
-        assert restored.aim.mcp == deps.aim.mcp
-        assert restored.aim.skills == deps.aim.skills
+        assert restored.capabilities.mcp == deps.capabilities.mcp
+        assert restored.capabilities.skills == deps.capabilities.skills
         assert restored.commands == deps.commands
 
     # Feature: app-classification-redesign, Property 4: 单依赖项 managedBy 覆盖
@@ -665,7 +665,7 @@ class TestManifestNewProperties:
         """**Validates: Requirements 5.5**"""
         deps = Dependencies.from_dict({
             "managedBy": default_managed,
-            "aim": {
+            "capabilities": {
                 "mcp": [
                     "simple-dep",
                     {"id": "override-dep", "managedBy": override_managed},
@@ -673,9 +673,29 @@ class TestManifestNewProperties:
             }
         })
         # String entry uses default
-        entry0 = deps.aim.mcp[0]
+        entry0 = deps.capabilities.mcp[0]
         assert isinstance(entry0, str)
         # Object entry preserves its own managedBy
-        entry1 = deps.aim.mcp[1]
+        entry1 = deps.capabilities.mcp[1]
         assert isinstance(entry1, dict)
         assert entry1["managedBy"] == override_managed
+
+
+class TestCapabilityDepTypesContract:
+    """``CAPABILITY_DEP_TYPES`` drives the resolver loop via ``getattr``, so it
+    must name the ``CapabilityDependencies`` fields exactly — a drift would
+    silently resolve a whole dependency type to nothing."""
+
+    def test_types_match_dataclass_fields(self):
+        import dataclasses
+
+        from kiro_crew.apps.dependency_ledger import CAPABILITY_DEP_TYPES
+
+        fields = {f.name for f in dataclasses.fields(CapabilityDependencies)}
+        assert set(CAPABILITY_DEP_TYPES) == fields
+
+    def test_installable_subset_is_derived(self):
+        from kiro_crew.apps.dependencies import _INSTALLABLE_TYPES
+        from kiro_crew.apps.dependency_ledger import CAPABILITY_DEP_TYPES
+
+        assert set(_INSTALLABLE_TYPES) <= set(CAPABILITY_DEP_TYPES)

--- a/test/test_apps_uninstall_keep_specific.py
+++ b/test/test_apps_uninstall_keep_specific.py
@@ -1,0 +1,78 @@
+"""Uninstall `keep_specific` body parsing — malformed client input must not
+leave an app partially uninstalled.
+
+The dependency-cleanup step runs AFTER the onUninstall script has executed and
+resources have been deregistered, so anything that raises there is not a clean
+400 — it is a 500 with the app half-removed. `keep_specific` is unvalidated
+client JSON, so it is sanitized at the parse boundary.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.apps.dependency_ledger import canonical_dep_key
+
+
+class TestCanonicalDepKeyRobustness:
+    @pytest.mark.parametrize("bad", [None, 5, 0, {"a": 1}, ["x"], True])
+    def test_non_string_input_does_not_raise(self, bad):
+        """Defense in depth for the boundary filter: a non-string must degrade,
+        not raise, so no future caller can turn bad input into a 500."""
+        assert canonical_dep_key(bad) == bad  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+class TestUninstallKeepSpecificParsing:
+    async def _run(self, body: object) -> MagicMock:
+        """Drive handle_uninstall_app with *body* and return the deps mock."""
+        fake_app = {
+            "name": "test-app",
+            "manifest": {"dependencies": {"capabilities": {"mcp": ["dep-a"]}}},
+            "resources": "gateway",
+            "lifecycle": "normal",
+            "enabled": False,
+        }
+        request = MagicMock()
+        request.match_info = {"name": "test-app"}
+        request.app = {"state": MagicMock()}
+        request.json = AsyncMock(return_value=body)
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value=fake_app),
+            patch("kiro_crew.apps.routes.uninstall_app", return_value=MagicMock(
+                ok=True, to_dict=lambda: {"ok": True})),
+            patch("kiro_crew.apps.routes.stop_app_backend", return_value=None),
+            patch("kiro_crew.apps.routes.deregister_app", return_value=None),
+            patch("kiro_crew.apps.routes.on_app_disable", new_callable=AsyncMock,
+                  return_value=None),
+            patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
+            patch("kiro_crew.apps.routes.classify_and_clean_for_uninstall",
+                  return_value={"removable": [], "shared": [], "userInstalled": []}) as m,
+            patch("kiro_crew.apps.routes.clean_dependencies", new_callable=AsyncMock,
+                  return_value=[]),
+        ):
+            from kiro_crew.apps.routes import handle_uninstall_app
+
+            resp = await handle_uninstall_app(request)
+        assert resp.status < 500, f"malformed body produced {resp.status}"
+        return m
+
+    async def test_null_entry_does_not_500(self):
+        """The reported crash: [null] reached canonical_dep_key and raised."""
+        m = await self._run({"keep_specific": [None]})
+        assert m.call_args.kwargs["keep_specific"] == []
+
+    async def test_mixed_junk_is_filtered_to_strings(self):
+        m = await self._run({"keep_specific": ["capability/mcp/a", None, 5, "", {"x": 1}]})
+        assert m.call_args.kwargs["keep_specific"] == ["capability/mcp/a"]
+
+    async def test_non_list_is_ignored(self):
+        m = await self._run({"keep_specific": "capability/mcp/a"})
+        assert m.call_args.kwargs["keep_specific"] == []
+
+    async def test_legacy_key_is_still_normalized(self):
+        """Sanitizing must not break the legacy-id normalization it wraps."""
+        m = await self._run({"keep_specific": ["aim/mcp/a"]})
+        assert m.call_args.kwargs["keep_specific"] == ["capability/mcp/a"]

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -9,9 +9,11 @@ from kiro_crew.apps.dependencies import (
     DependencyResult,
     _get_dep_id,
     _get_managed_by,
+    clean_dependencies,
     resolve_dependencies,
 )
-from kiro_crew.apps.manifest import AimDependencies, Dependencies
+from kiro_crew.apps.manifest import CapabilityDependencies, Dependencies
+from kiro_crew.platform.interfaces import CapabilityResult
 
 
 @pytest.fixture(autouse=True)
@@ -59,13 +61,13 @@ class TestResolveDependencies:
         assert "nonexistent-cmd-xyz" in result.missing
 
     async def test_app_managed_deps_skipped(self):
-        """managedBy=app deps are skipped without calling aim."""
+        """managedBy=app deps are skipped without touching the capability seam."""
         deps = Dependencies(
             managedBy="app",
-            aim=AimDependencies(mcp=["some-mcp"]),
+            capabilities=CapabilityDependencies(mcp=["some-mcp"]),
         )
         result = await resolve_dependencies("test-app", deps)
-        assert "aim/mcp/some-mcp" in result.skipped
+        assert "capability/mcp/some-mcp" in result.skipped
         assert result.installed == []
 
     async def test_empty_deps(self):
@@ -102,3 +104,294 @@ class TestDependencyProperties:
             assert f"command:{cmd}" in result.skipped
         for cmd in missing:
             assert cmd in result.missing
+
+
+# ---------------------------------------------------------------------------
+# Capability-seam resolution (replaces the former external-CLI shell-out)
+# ---------------------------------------------------------------------------
+
+
+class _FakeManager:
+    """CapabilityManager stand-in recording the ops it received.
+
+    Implements the FULL Protocol (not just the ops this module calls) and returns
+    the REAL ``CapabilityResult`` — a fake that drifts from
+    ``platform/interfaces.py`` can keep these tests green while production breaks,
+    and the Protocol is not ``runtime_checkable`` so nothing else would notice.
+    """
+
+    def __init__(self, *, available: bool = True, ok: bool = True) -> None:
+        self._available = available
+        self._ok = ok
+        self.calls: list[tuple[str, str]] = []
+
+    def _result(self) -> CapabilityResult:
+        return CapabilityResult(ok=self._ok, message="" if self._ok else "boom")
+
+    def available(self) -> bool:
+        return self._available
+
+    # -- read ops (unused by the resolver, present for Protocol fidelity) --
+    async def list_mcp(self) -> list[dict]:
+        return []
+
+    async def registry(self) -> list[dict]:
+        return []
+
+    async def list_skills(self) -> list[dict]:
+        return []
+
+    async def list_agents(self) -> list[dict]:
+        return []
+
+    async def install_mcp(self, server_id: str):
+        self.calls.append(("install_mcp", server_id))
+        return self._result()
+
+    async def install_skill(self, package: str):
+        self.calls.append(("install_skill", package))
+        return self._result()
+
+    async def uninstall_mcp(self, server_id: str):
+        self.calls.append(("uninstall_mcp", server_id))
+        return self._result()
+
+    async def uninstall_skill(self, package: str):
+        self.calls.append(("uninstall_skill", package))
+        return self._result()
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    """Install a fake capability manager into the resolver's seam lookup."""
+    def _install(**kwargs):
+        mgr = _FakeManager(**kwargs)
+        monkeypatch.setattr(
+            "kiro_crew.apps.dependencies._capability_manager",
+            lambda: mgr if mgr.available() else None,
+        )
+        return mgr
+    return _install
+
+
+@pytest.mark.asyncio
+class TestCapabilitySeamResolution:
+    async def test_installs_mcp_and_skills_through_seam(self, fake_manager):
+        mgr = fake_manager()
+        deps = Dependencies(
+            capabilities=CapabilityDependencies(mcp=["some-mcp"], skills=["SomeSkill"]),
+        )
+        result = await resolve_dependencies("test-app", deps)
+        assert mgr.calls == [("install_mcp", "some-mcp"), ("install_skill", "SomeSkill")]
+        assert result.installed == ["capability/mcp/some-mcp", "capability/skills/SomeSkill"]
+        assert result.failed == []
+
+    async def test_unavailable_manager_records_failure_not_crash(self, fake_manager):
+        """The public edition has no capability manager: the app still installs,
+        but the unmet dep must be reported rather than silently 'succeeding'."""
+        fake_manager(available=False)
+        deps = Dependencies(capabilities=CapabilityDependencies(mcp=["some-mcp"]))
+        result = await resolve_dependencies("test-app", deps)
+        assert result.failed == ["capability/mcp/some-mcp"]
+        assert result.installed == []
+
+    async def test_failed_op_is_recorded(self, fake_manager):
+        fake_manager(ok=False)
+        deps = Dependencies(capabilities=CapabilityDependencies(mcp=["some-mcp"]))
+        result = await resolve_dependencies("test-app", deps)
+        assert result.failed == ["capability/mcp/some-mcp"]
+
+    async def test_agents_have_no_install_op(self, fake_manager):
+        """``agents`` is declarable but the seam exposes no install op — it must
+        report as unresolved instead of being dropped on the floor."""
+        mgr = fake_manager()
+        deps = Dependencies(capabilities=CapabilityDependencies(agents=["SomePkg"]))
+        result = await resolve_dependencies("test-app", deps)
+        assert result.failed == ["capability/agents/SomePkg"]
+        assert mgr.calls == []
+
+    async def test_no_seam_probe_when_nothing_to_install(self, monkeypatch):
+        """Commands-only manifests must not touch the capability seam at all."""
+        probed = []
+        monkeypatch.setattr(
+            "kiro_crew.apps.dependencies._capability_manager",
+            lambda: probed.append(1) or None,
+        )
+        await resolve_dependencies("test-app", Dependencies(commands=["sh"]))
+        assert probed == []
+
+    async def test_clean_dependencies_uninstalls_through_seam(self, fake_manager):
+        mgr = fake_manager()
+        cleaned = await clean_dependencies(
+            "test-app",
+            [{"id": "capability/mcp/some-mcp", "type": "capability.mcp"}],
+        )
+        assert mgr.calls == [("uninstall_mcp", "some-mcp")]
+        assert cleaned == ["capability/mcp/some-mcp"]
+
+    async def test_clean_dependencies_accepts_legacy_type(self, fake_manager):
+        """A ledger row written before the rename still carries ``aim.mcp``; its
+        cleanup must still dispatch, or the dep leaks forever."""
+        mgr = fake_manager()
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/mcp/old", "type": "aim.mcp"}],
+        )
+        assert mgr.calls == [("uninstall_mcp", "old")]
+        assert cleaned == ["capability/mcp/old"]
+
+    async def test_clean_skips_unknown_type(self, fake_manager):
+        mgr = fake_manager()
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/bogus/x", "type": "capability.bogus"}],
+        )
+        assert mgr.calls == []
+        assert cleaned == []
+
+
+class TestDeprecatedManifestAlias:
+    def test_aim_alias_still_loads(self):
+        """Manifests authored against the pre-rename schema must keep working."""
+        deps = Dependencies.from_dict({"aim": {"mcp": ["legacy-mcp"]}})
+        assert deps.capabilities.mcp == ["legacy-mcp"]
+
+    def test_alias_is_not_re_emitted(self):
+        """Round-tripping migrates the manifest to the canonical key."""
+        d = Dependencies.from_dict({"aim": {"mcp": ["legacy-mcp"]}}).to_dict()
+        assert "aim" not in d
+        assert d["capabilities"] == {"mcp": ["legacy-mcp"]}
+
+    def test_canonical_key_wins_over_alias(self):
+        deps = Dependencies.from_dict({
+            "capabilities": {"mcp": ["new"]}, "aim": {"mcp": ["old"]},
+        })
+        assert deps.capabilities.mcp == ["new"]
+
+
+class TestCapabilityManagerAccessor:
+    """Covers the REAL ``_capability_manager()`` body (the seam read itself).
+
+    The seam-resolution tests above replace this accessor wholesale, so without
+    these the ``current_context()`` read, the ``available()`` gate, and both
+    fail-closed handlers would have no coverage at all — dropping the
+    ``available()`` gate entirely would still leave that suite green.
+    """
+
+    def test_reads_context_and_preserves_bound(self, monkeypatch):
+        """Returns the context-provided manager as-is, so the
+        ``BoundedCapabilityManager`` timeout wrapper applied at context
+        composition is inherited rather than stripped."""
+        from kiro_crew.apps import dependencies as deps_mod
+        from kiro_crew.platform import context as platform_context
+        from kiro_crew.platform.capability_bound import BoundedCapabilityManager
+
+        class _Inner:
+            def available(self) -> bool:
+                return True
+
+        sentinel = BoundedCapabilityManager(_Inner())
+
+        class _Ctx:
+            capability_manager = sentinel
+
+        monkeypatch.setattr(platform_context, "current_context", lambda: _Ctx())
+        assert deps_mod._capability_manager() is sentinel
+
+    def test_unavailable_manager_yields_none(self, monkeypatch):
+        from kiro_crew.apps import dependencies as deps_mod
+        from kiro_crew.platform import context as platform_context
+
+        class _Unavailable:
+            def available(self) -> bool:
+                return False
+
+        class _Ctx:
+            capability_manager = _Unavailable()
+
+        monkeypatch.setattr(platform_context, "current_context", lambda: _Ctx())
+        assert deps_mod._capability_manager() is None
+
+    def test_context_lookup_failure_fails_closed(self, monkeypatch):
+        """A broken context must degrade to "unavailable", never propagate."""
+        from kiro_crew.apps import dependencies as deps_mod
+        from kiro_crew.platform import context as platform_context
+
+        def _boom():
+            raise RuntimeError("no context")
+
+        monkeypatch.setattr(platform_context, "current_context", _boom)
+        assert deps_mod._capability_manager() is None
+
+    def test_available_probe_raising_fails_closed(self, monkeypatch):
+        from kiro_crew.apps import dependencies as deps_mod
+        from kiro_crew.platform import context as platform_context
+
+        class _Raising:
+            def available(self) -> bool:
+                raise RuntimeError("probe exploded")
+
+        class _Ctx:
+            capability_manager = _Raising()
+
+        monkeypatch.setattr(platform_context, "current_context", lambda: _Ctx())
+        assert deps_mod._capability_manager() is None
+
+
+@pytest.mark.asyncio
+class TestCleanDependenciesFailurePaths:
+    """``clean_dependencies``' failure branches — the resolve side has these
+    covered, the cleanup side had none."""
+
+    async def test_unavailable_manager_cleans_nothing(self, monkeypatch):
+        monkeypatch.setattr("kiro_crew.apps.dependencies._capability_manager", lambda: None)
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
+        )
+        assert cleaned == []
+
+    async def test_failed_uninstall_is_not_reported_clean(self, fake_manager):
+        fake_manager(ok=False)
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
+        )
+        assert cleaned == []
+
+    async def test_raising_op_is_swallowed(self, monkeypatch):
+        class _Exploding(_FakeManager):
+            async def uninstall_mcp(self, server_id: str):
+                raise RuntimeError("boom")
+
+        mgr = _Exploding()
+        monkeypatch.setattr("kiro_crew.apps.dependencies._capability_manager", lambda: mgr)
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
+        )
+        assert cleaned == []
+
+    async def test_skill_uninstall_dispatches(self, fake_manager):
+        mgr = fake_manager()
+        cleaned = await clean_dependencies(
+            "test-app", [{"id": "capability/skills/Pkg", "type": "capability.skills"}],
+        )
+        assert mgr.calls == [("uninstall_skill", "Pkg")]
+        assert cleaned == ["capability/skills/Pkg"]
+
+    async def test_blank_id_is_skipped(self, fake_manager):
+        mgr = fake_manager()
+        assert await clean_dependencies("test-app", [{"id": "", "type": "capability.mcp"}]) == []
+        assert mgr.calls == []
+
+
+@pytest.mark.asyncio
+class TestLedgerTypeRecorded:
+    async def test_install_records_canonical_type(self, fake_manager):
+        """Pins the ledger ``type`` string written on install — nothing else
+        asserted it, so a wrong type could be written undetected."""
+        from kiro_crew.apps.dependency_ledger import get_entry
+
+        fake_manager()
+        deps = Dependencies(capabilities=CapabilityDependencies(mcp=["m"], skills=["s"]))
+        await resolve_dependencies("test-app", deps)
+        mcp_entry = get_entry("capability/mcp/m")
+        skill_entry = get_entry("capability/skills/s")
+        assert mcp_entry is not None and mcp_entry.type == "capability.mcp"
+        assert skill_entry is not None and skill_entry.type == "capability.skills"

--- a/test/test_dependency_ledger.py
+++ b/test/test_dependency_ledger.py
@@ -7,6 +7,7 @@ from hypothesis import strategies as st
 
 from kiro_crew.apps.dependency_ledger import (
     LedgerEntry,
+    classify_and_clean_for_uninstall,
     classify_for_uninstall,
     get_entry,
     list_by_app,
@@ -27,53 +28,53 @@ def _ledger_home(tmp_path, monkeypatch):
 
 class TestLedgerCRUD:
     def test_record_and_get(self):
-        record_install("aim/mcp/aws-docs", "app-a", "aim.mcp")
-        entry = get_entry("aim/mcp/aws-docs")
+        record_install("capability/mcp/aws-docs", "app-a", "capability.mcp")
+        entry = get_entry("capability/mcp/aws-docs")
         assert entry is not None
         assert entry.installedBy == ["app-a"]
-        assert entry.type == "aim.mcp"
+        assert entry.type == "capability.mcp"
         assert entry.installedAt != ""
 
     def test_record_multiple_apps(self):
-        record_install("aim/mcp/shared", "app-a", "aim.mcp")
-        record_install("aim/mcp/shared", "app-b", "aim.mcp")
-        entry = get_entry("aim/mcp/shared")
+        record_install("capability/mcp/shared", "app-a", "capability.mcp")
+        record_install("capability/mcp/shared", "app-b", "capability.mcp")
+        entry = get_entry("capability/mcp/shared")
         assert entry is not None
         assert sorted(entry.installedBy) == ["app-a", "app-b"]
 
     def test_record_idempotent(self):
-        record_install("aim/mcp/x", "app-a", "aim.mcp")
-        record_install("aim/mcp/x", "app-a", "aim.mcp")
-        entry = get_entry("aim/mcp/x")
+        record_install("capability/mcp/x", "app-a", "capability.mcp")
+        record_install("capability/mcp/x", "app-a", "capability.mcp")
+        entry = get_entry("capability/mcp/x")
         assert entry is not None
         assert entry.installedBy == ["app-a"]  # no duplicate
 
     def test_uninstall_removes_reference(self):
-        record_install("aim/mcp/x", "app-a", "aim.mcp")
-        record_install("aim/mcp/x", "app-b", "aim.mcp")
-        record_uninstall("aim/mcp/x", "app-a")
-        entry = get_entry("aim/mcp/x")
+        record_install("capability/mcp/x", "app-a", "capability.mcp")
+        record_install("capability/mcp/x", "app-b", "capability.mcp")
+        record_uninstall("capability/mcp/x", "app-a")
+        entry = get_entry("capability/mcp/x")
         assert entry is not None
         assert entry.installedBy == ["app-b"]
 
     def test_uninstall_last_reference_deletes_entry(self):
-        record_install("aim/mcp/x", "app-a", "aim.mcp")
-        record_uninstall("aim/mcp/x", "app-a")
-        assert get_entry("aim/mcp/x") is None
+        record_install("capability/mcp/x", "app-a", "capability.mcp")
+        record_uninstall("capability/mcp/x", "app-a")
+        assert get_entry("capability/mcp/x") is None
 
     def test_uninstall_nonexistent_noop(self):
-        record_uninstall("aim/mcp/nonexistent", "app-a")  # should not raise
+        record_uninstall("capability/mcp/nonexistent", "app-a")  # should not raise
 
     def test_get_nonexistent(self):
-        assert get_entry("aim/mcp/nonexistent") is None
+        assert get_entry("capability/mcp/nonexistent") is None
 
     def test_list_by_app(self):
-        record_install("aim/mcp/a", "app-x", "aim.mcp")
-        record_install("aim/skills/b", "app-x", "aim.skills")
-        record_install("aim/mcp/c", "app-y", "aim.mcp")
+        record_install("capability/mcp/a", "app-x", "capability.mcp")
+        record_install("capability/skills/b", "app-x", "capability.skills")
+        record_install("capability/mcp/c", "app-y", "capability.mcp")
         entries = list_by_app("app-x")
         keys = {k for k, _ in entries}
-        assert keys == {"aim/mcp/a", "aim/skills/b"}
+        assert keys == {"capability/mcp/a", "capability/skills/b"}
 
     def test_list_by_app_empty(self):
         assert list_by_app("nonexistent") == []
@@ -81,34 +82,34 @@ class TestLedgerCRUD:
 
 class TestClassifyForUninstall:
     def test_removable(self):
-        record_install("aim/mcp/only-mine", "app-a", "aim.mcp")
-        result = classify_for_uninstall("app-a", ["aim/mcp/only-mine"])
+        record_install("capability/mcp/only-mine", "app-a", "capability.mcp")
+        result = classify_for_uninstall("app-a", ["capability/mcp/only-mine"])
         assert len(result["removable"]) == 1
-        assert result["removable"][0]["id"] == "aim/mcp/only-mine"
+        assert result["removable"][0]["id"] == "capability/mcp/only-mine"
         assert result["shared"] == []
         assert result["userInstalled"] == []
 
     def test_shared(self):
-        record_install("aim/mcp/shared", "app-a", "aim.mcp")
-        record_install("aim/mcp/shared", "app-b", "aim.mcp")
-        result = classify_for_uninstall("app-a", ["aim/mcp/shared"])
+        record_install("capability/mcp/shared", "app-a", "capability.mcp")
+        record_install("capability/mcp/shared", "app-b", "capability.mcp")
+        result = classify_for_uninstall("app-a", ["capability/mcp/shared"])
         assert len(result["shared"]) == 1
         assert result["shared"][0]["usedBy"] == ["app-b"]
         assert result["removable"] == []
 
     def test_user_installed(self):
-        result = classify_for_uninstall("app-a", ["aim/mcp/user-dep"])
+        result = classify_for_uninstall("app-a", ["capability/mcp/user-dep"])
         assert len(result["userInstalled"]) == 1
         assert result["removable"] == []
         assert result["shared"] == []
 
     def test_mixed(self):
-        record_install("aim/mcp/mine", "app-a", "aim.mcp")
-        record_install("aim/mcp/shared", "app-a", "aim.mcp")
-        record_install("aim/mcp/shared", "app-b", "aim.mcp")
+        record_install("capability/mcp/mine", "app-a", "capability.mcp")
+        record_install("capability/mcp/shared", "app-a", "capability.mcp")
+        record_install("capability/mcp/shared", "app-b", "capability.mcp")
         result = classify_for_uninstall(
             "app-a",
-            ["aim/mcp/mine", "aim/mcp/shared", "aim/mcp/user-dep"],
+            ["capability/mcp/mine", "capability/mcp/shared", "capability/mcp/user-dep"],
         )
         assert len(result["removable"]) == 1
         assert len(result["shared"]) == 1
@@ -117,7 +118,7 @@ class TestClassifyForUninstall:
 
 class TestLedgerEntry:
     def test_round_trip(self):
-        entry = LedgerEntry(installedBy=["a", "b"], installedAt="2026-01-01", type="aim.mcp")
+        entry = LedgerEntry(installedBy=["a", "b"], installedAt="2026-01-01", type="capability.mcp")
         d = entry.to_dict()
         restored = LedgerEntry.from_dict(d)
         assert restored.installedBy == entry.installedBy
@@ -129,7 +130,7 @@ class TestLedgerEntry:
 # ---------------------------------------------------------------------------
 
 _app_name = st.from_regex(r"[a-z][a-z0-9\-]{0,15}", fullmatch=True)
-_dep_key = st.from_regex(r"aim/(mcp|skills|agents)/[a-z][a-z0-9\-]{0,20}", fullmatch=True)
+_dep_key = st.from_regex(r"capability/(mcp|skills|agents)/[a-z][a-z0-9\-]{0,20}", fullmatch=True)
 
 
 def _clear_ledger() -> None:
@@ -151,7 +152,7 @@ class TestLedgerProperties:
         """**Validates: Requirements 6.2, 6.3**"""
         _clear_ledger()
         for app in apps:
-            record_install(dep, app, "aim.mcp")
+            record_install(dep, app, "capability.mcp")
         entry = get_entry(dep)
         assert entry is not None
         assert sorted(entry.installedBy) == sorted(apps)
@@ -176,14 +177,14 @@ class TestLedgerProperties:
 
         # Setup: removable deps only have target_app
         for dep in removable_deps:
-            record_install(dep, target_app, "aim.mcp")
+            record_install(dep, target_app, "capability.mcp")
         # Setup: shared deps have target_app + at least one other
         for dep in shared_deps:
-            record_install(dep, target_app, "aim.mcp")
+            record_install(dep, target_app, "capability.mcp")
             for other in other_apps[:1] or ["other-app"]:
-                record_install(dep, other, "aim.mcp")
+                record_install(dep, other, "capability.mcp")
 
-        user_deps = ["aim/mcp/USER-only-dep"]
+        user_deps = ["capability/mcp/USER-only-dep"]
         all_deps = removable_deps + shared_deps + user_deps
 
         result = classify_for_uninstall(target_app, all_deps)
@@ -198,3 +199,345 @@ class TestLedgerProperties:
             assert dep in shared_ids
         for dep in user_deps:
             assert dep in user_ids
+
+
+# ---------------------------------------------------------------------------
+# Legacy key compatibility (pre-rename ledgers)
+# ---------------------------------------------------------------------------
+
+
+def _write_raw_ledger(entries: dict) -> None:
+    """Seed the ledger file directly, bypassing the record_* helpers."""
+    import json
+
+    from kiro_crew.apps.dependency_ledger import _ledger_path
+
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+
+def _read_raw_ledger() -> dict:
+    """Read the ledger file directly, bypassing key-resolution helpers."""
+    import json
+
+    from kiro_crew.apps.dependency_ledger import _ledger_path
+
+    path = _ledger_path()
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestLegacyKeyCompat:
+    """A ledger written before the ``aim/*`` → ``capability/*`` rename must keep
+    resolving — otherwise an upgrade orphans every tracked dependency, and the
+    refcount that guards shared deps silently resets to zero."""
+
+    def test_get_entry_reads_legacy_key(self):
+        _write_raw_ledger({
+            "aim/mcp/legacy-dep": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            }
+        })
+        entry = get_entry("capability/mcp/legacy-dep")
+        assert entry is not None
+        assert entry.installedBy == ["app-a"]
+
+    def test_record_install_accrues_onto_legacy_key(self):
+        """A second app must join the EXISTING legacy entry, not fork a new
+        canonical one — two keys for one dep would let uninstall remove a dep
+        another app still uses."""
+        _write_raw_ledger({
+            "aim/mcp/shared-dep": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            }
+        })
+        record_install("capability/mcp/shared-dep", "app-b", "capability.mcp")
+        entry = get_entry("capability/mcp/shared-dep")
+        assert entry is not None
+        assert entry.installedBy == ["app-a", "app-b"]
+
+    def test_record_uninstall_prunes_legacy_key(self):
+        """Assert on the RAW ledger, not via get_entry: get_entry shares the same
+        legacy-key fallback, so a broken fallback would make it return None for the
+        wrong reason and hide a leaked entry."""
+        _write_raw_ledger({
+            "aim/mcp/gone": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            }
+        })
+        record_uninstall("capability/mcp/gone", "app-a")
+        assert _read_raw_ledger() == {}
+
+    def test_classify_sees_legacy_entry_as_removable(self):
+        """Without legacy resolution this would classify as 'user installed' and
+        the dep would never be cleaned up."""
+        _write_raw_ledger({
+            "aim/mcp/mine": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            }
+        })
+        result = classify_for_uninstall("app-a", ["capability/mcp/mine"])
+        assert len(result["removable"]) == 1
+        assert result["userInstalled"] == []
+
+    def test_canonical_key_wins_when_both_present(self):
+        _write_raw_ledger({
+            "aim/mcp/dup": {
+                "installedBy": ["old-app"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            },
+            "capability/mcp/dup": {
+                "installedBy": ["new-app"], "installedAt": "2026-02-02", "type": "capability.mcp",
+            },
+        })
+        entry = get_entry("capability/mcp/dup")
+        assert entry is not None
+        assert entry.installedBy == ["new-app"]
+        # A second app must accrue onto the CANONICAL row, leaving the legacy
+        # row untouched — otherwise the two spellings drift apart.
+        record_install("capability/mcp/dup", "app-c", "capability.mcp")
+        raw = _read_raw_ledger()
+        assert raw["capability/mcp/dup"]["installedBy"] == ["new-app", "app-c"]
+        assert raw["aim/mcp/dup"]["installedBy"] == ["old-app"]
+
+
+class TestDeclaredCapabilityKeys:
+    def test_reads_capabilities_key(self):
+        from kiro_crew.apps.dependency_ledger import declared_capability_keys
+
+        keys = declared_capability_keys({"capabilities": {"mcp": ["a"], "skills": ["b"]}})
+        assert keys == ["capability/mcp/a", "capability/skills/b"]
+
+    def test_reads_deprecated_alias(self):
+        from kiro_crew.apps.dependency_ledger import declared_capability_keys
+
+        assert declared_capability_keys({"aim": {"mcp": ["a"]}}) == ["capability/mcp/a"]
+
+    def test_canonical_key_takes_precedence_over_alias(self):
+        from kiro_crew.apps.dependency_ledger import declared_capability_keys
+
+        keys = declared_capability_keys({"capabilities": {"mcp": ["new"]}, "aim": {"mcp": ["old"]}})
+        assert keys == ["capability/mcp/new"]
+
+    def test_object_entries_and_blanks(self):
+        from kiro_crew.apps.dependency_ledger import declared_capability_keys
+
+        keys = declared_capability_keys({
+            "capabilities": {"mcp": [{"id": "obj"}, "", {"id": ""}, "plain"]}
+        })
+        assert keys == ["capability/mcp/obj", "capability/mcp/plain"]
+
+    def test_malformed_shapes_do_not_raise(self):
+        from kiro_crew.apps.dependency_ledger import declared_capability_keys
+
+        assert declared_capability_keys({}) == []
+        assert declared_capability_keys({"capabilities": "nope"}) == []
+        assert declared_capability_keys({"capabilities": {"mcp": "nope"}}) == []
+
+
+class TestClassifyAndCleanForUninstall:
+    """The only ledger WRITE path taken on uninstall (``routes.py``), and the one
+    this change edited to add legacy-key resolution — previously untested."""
+
+    def test_sole_owner_dep_is_pruned(self):
+        _write_raw_ledger({
+            "capability/mcp/mine": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "capability.mcp",
+            }
+        })
+        result = classify_and_clean_for_uninstall("app-a", ["capability/mcp/mine"])
+        assert [d["id"] for d in result["removable"]] == ["capability/mcp/mine"]
+        assert _read_raw_ledger() == {}
+
+    def test_shared_dep_keeps_other_owner(self):
+        """The refcount that stops one app's uninstall from deleting a dep
+        another app still uses."""
+        _write_raw_ledger({
+            "capability/mcp/shared": {
+                "installedBy": ["app-a", "app-b"],
+                "installedAt": "2026-01-01",
+                "type": "capability.mcp",
+            }
+        })
+        result = classify_and_clean_for_uninstall("app-a", ["capability/mcp/shared"])
+        assert [d["id"] for d in result["shared"]] == ["capability/mcp/shared"]
+        assert _read_raw_ledger()["capability/mcp/shared"]["installedBy"] == ["app-b"]
+
+    def test_legacy_shared_dep_keeps_other_owner(self):
+        """Same guarantee across the rename: without legacy resolution this
+        would classify as untracked and app-b's dependency would be dropped."""
+        _write_raw_ledger({
+            "aim/mcp/shared": {
+                "installedBy": ["app-a", "app-b"],
+                "installedAt": "2026-01-01",
+                "type": "aim.mcp",
+            }
+        })
+        result = classify_and_clean_for_uninstall("app-a", ["capability/mcp/shared"])
+        assert result["userInstalled"] == []
+        assert [d["id"] for d in result["shared"]] == ["capability/mcp/shared"]
+        assert _read_raw_ledger()["aim/mcp/shared"]["installedBy"] == ["app-b"]
+
+    def test_legacy_sole_owner_dep_is_pruned(self):
+        _write_raw_ledger({
+            "aim/mcp/mine": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "aim.mcp",
+            }
+        })
+        classify_and_clean_for_uninstall("app-a", ["capability/mcp/mine"])
+        assert _read_raw_ledger() == {}
+
+    def test_keep_specific_drops_ownership_on_legacy_key(self):
+        """``keep`` is matched on the CANONICAL declared id while the ledger row
+        is legacy-spelled; the ownership drop must still land."""
+        _write_raw_ledger({
+            "aim/mcp/keepme": {
+                "installedBy": ["app-a", "app-b"],
+                "installedAt": "2026-01-01",
+                "type": "aim.mcp",
+            }
+        })
+        classify_and_clean_for_uninstall(
+            "app-a", ["capability/mcp/keepme"], keep_specific=["capability/mcp/keepme"],
+        )
+        # Shared row: app-a's reference removed, app-b retained.
+        assert _read_raw_ledger()["aim/mcp/keepme"]["installedBy"] == ["app-b"]
+
+    def test_untracked_dep_is_left_alone(self):
+        _write_raw_ledger({
+            "capability/mcp/theirs": {
+                "installedBy": ["other-app"], "installedAt": "2026-01-01",
+                "type": "capability.mcp",
+            }
+        })
+        result = classify_and_clean_for_uninstall("app-a", ["capability/mcp/theirs"])
+        assert [d["id"] for d in result["userInstalled"]] == ["capability/mcp/theirs"]
+        assert _read_raw_ledger()["capability/mcp/theirs"]["installedBy"] == ["other-app"]
+
+
+class TestCanonicalDepKey:
+    """``keep_specific`` arrives from the CLIENT (an uninstall request body). A
+    dashboard whose uninstall preview was fetched from a pre-rename build echoes
+    legacy ids back, so the uninstall path must normalize them before comparing
+    against classification output — otherwise an explicit "keep this dependency"
+    is silently ignored and the dep is deleted."""
+
+    def test_normalizes_legacy_prefix(self):
+        from kiro_crew.apps.dependency_ledger import canonical_dep_key
+
+        assert canonical_dep_key("aim/mcp/x") == "capability/mcp/x"
+        assert canonical_dep_key("aim/skills/Pkg") == "capability/skills/Pkg"
+
+    def test_is_idempotent_for_canonical_keys(self):
+        from kiro_crew.apps.dependency_ledger import canonical_dep_key
+
+        assert canonical_dep_key("capability/mcp/x") == "capability/mcp/x"
+
+    def test_leaves_unrelated_strings_untouched(self):
+        from kiro_crew.apps.dependency_ledger import canonical_dep_key
+
+        for s in ("command:node", "", "aimless/mcp/x", "other/mcp/x"):
+            assert canonical_dep_key(s) == s
+
+    def test_legacy_keep_id_preserves_the_dependency(self):
+        """The regression itself: a legacy keep id must still spare the dep."""
+        from kiro_crew.apps.dependency_ledger import canonical_dep_key
+
+        _write_raw_ledger({
+            "capability/mcp/keepme": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01",
+                "type": "capability.mcp",
+            }
+        })
+        # Client sends the PRE-RENAME id; declared deps are canonical.
+        legacy_keep = ["aim/mcp/keepme"]
+        keep_canonical = [canonical_dep_key(k) for k in legacy_keep]
+        result = classify_and_clean_for_uninstall(
+            "app-a", ["capability/mcp/keepme"], keep_specific=keep_canonical,
+        )
+        removable = [
+            d for d in result["removable"] if d.get("id") not in keep_canonical
+        ]
+        # Nothing is handed to the uninstaller — the user's keep is honored.
+        assert removable == []
+
+
+class TestUncleanableTypesArePreserved:
+    """A dependency type with no cleanup operation must keep its ledger row.
+
+    Deleting the row for something KiroCrew cannot actually uninstall leaves the
+    installed package on disk with nothing recording that it was ever referenced —
+    an untraceable orphan. Ownership is dropped instead, so it reads as
+    user-installed and stays reclaimable."""
+
+    def test_sole_owner_agents_row_is_retained_ownerless(self):
+        """The orphan case: sole owner -> classified REMOVABLE -> the row would be
+        popped. It must survive ownerless, because nothing can uninstall it."""
+        _write_raw_ledger({
+            "capability/agents/Pkg": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01",
+                "type": "capability.agents",
+            }
+        })
+        result = classify_and_clean_for_uninstall("app-a", ["capability/agents/Pkg"])
+        assert [d["id"] for d in result["removable"]] == ["capability/agents/Pkg"]
+        raw = _read_raw_ledger()
+        assert "capability/agents/Pkg" in raw, "agents row was orphaned"
+        assert raw["capability/agents/Pkg"]["installedBy"] == []
+
+    def test_retained_row_reclassifies_as_user_installed(self):
+        """The ownerless row must not re-appear as removable for the same app."""
+        _write_raw_ledger({
+            "capability/agents/Pkg": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01",
+                "type": "capability.agents",
+            }
+        })
+        classify_and_clean_for_uninstall("app-a", ["capability/agents/Pkg"])
+        again = classify_and_clean_for_uninstall("app-a", ["capability/agents/Pkg"])
+        assert again["removable"] == []
+        assert [d["id"] for d in again["userInstalled"]] == ["capability/agents/Pkg"]
+
+    def test_agents_row_with_other_owner_is_not_deleted(self):
+        _write_raw_ledger({
+            "capability/agents/Pkg": {
+                "installedBy": ["app-a", "app-b"], "installedAt": "2026-01-01",
+                "type": "capability.agents",
+            }
+        })
+        classify_and_clean_for_uninstall("app-a", ["capability/agents/Pkg"])
+        assert _read_raw_ledger()["capability/agents/Pkg"]["installedBy"] == ["app-b"]
+
+    def test_legacy_agents_row_is_not_orphaned(self):
+        """The reported case: a pre-rename ``aim/agents/X`` row must not be
+        dropped, since cleanup skips ``agents`` and cannot remove the package."""
+        _write_raw_ledger({
+            "aim/agents/Pkg": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01",
+                "type": "aim.agents",
+            }
+        })
+        classify_and_clean_for_uninstall("app-a", ["capability/agents/Pkg"])
+        raw = _read_raw_ledger()
+        assert "aim/agents/Pkg" in raw, "legacy agents row was orphaned"
+        assert raw["aim/agents/Pkg"]["installedBy"] == []
+
+    def test_mcp_rows_are_still_deleted(self):
+        """Cleanable types keep the original delete behavior."""
+        _write_raw_ledger({
+            "capability/mcp/Dep": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01",
+                "type": "capability.mcp",
+            }
+        })
+        classify_and_clean_for_uninstall("app-a", ["capability/mcp/Dep"])
+        assert _read_raw_ledger() == {}
+
+    def test_is_uncleanable_accepts_every_spelling(self):
+        from kiro_crew.apps.dependency_ledger import _is_uncleanable
+
+        for spelling in ("agents", "capability.agents", "aim.agents"):
+            assert _is_uncleanable(spelling) is True
+        for spelling in ("mcp", "capability.mcp", "aim.skills", "", "unknown"):
+            assert _is_uncleanable(spelling) is False

--- a/test/test_enable_deps_resolution.py
+++ b/test/test_enable_deps_resolution.py
@@ -1,6 +1,6 @@
 """Tests for dependency resolution during app enable.
 
-Verifies that handle_enable_app() resolves dependencies.aim when a user
+Verifies that handle_enable_app() resolves dependencies.capabilities when a user
 enables an app (builtin or otherwise).
 """
 from __future__ import annotations
@@ -20,18 +20,18 @@ def _mock_dashboard_server():
 
 
 class TestEnableDepsResolution:
-    """Verify dependencies.aim is resolved when an app is enabled."""
+    """Verify dependencies.capabilities is resolved when an app is enabled."""
 
     @pytest.mark.asyncio
     async def test_dependencies_resolved_on_enable(self) -> None:
-        """When manifest has dependencies.aim, resolve_dependencies is called."""
+        """When the manifest declares capability deps, resolve_dependencies is called."""
         from kiro_crew.apps.dependencies import DependencyResult
 
         fake_app_info = {
             "name": "test-app",
             "manifest": {
                 "dependencies": {
-                    "aim": ["TestAICapabilities"],
+                    "capabilities": {"agents": ["TestCapabilityPkg"]},
                 },
             },
             "resources": "gateway",
@@ -39,7 +39,7 @@ class TestEnableDepsResolution:
             "origin": "builtin",
         }
 
-        mock_dep_result = DependencyResult(installed=["aim/agents/TestAICapabilities"])
+        mock_dep_result = DependencyResult(installed=["capability/agents/TestCapabilityPkg"])
 
         with (
             patch("kiro_crew.apps.routes.get_app", return_value=fake_app_info),
@@ -67,7 +67,7 @@ class TestEnableDepsResolution:
             import json
             body = json.loads(response.body)
             assert "dependencies" in body
-            assert body["dependencies"]["installed"] == ["aim/agents/TestAICapabilities"]
+            assert body["dependencies"]["installed"] == ["capability/agents/TestCapabilityPkg"]
 
     @pytest.mark.asyncio
     async def test_no_dependencies_skips_resolution(self) -> None:
@@ -107,7 +107,7 @@ class TestEnableDepsResolution:
             "name": "partial-app",
             "manifest": {
                 "dependencies": {
-                    "aim": ["GoodPkg", "BadPkg"],
+                    "capabilities": {"agents": ["GoodPkg", "BadPkg"]},
                 },
             },
             "resources": "gateway",
@@ -115,8 +115,8 @@ class TestEnableDepsResolution:
         }
 
         mock_dep_result = DependencyResult(
-            installed=["aim/agents/GoodPkg"],
-            failed=["aim/agents/BadPkg"],
+            installed=["capability/agents/GoodPkg"],
+            failed=["capability/agents/BadPkg"],
         )
 
         with (
@@ -142,8 +142,8 @@ class TestEnableDepsResolution:
             assert body["ok"] is True
             # But reports the failure
             assert "dependencies" in body
-            assert "aim/agents/BadPkg" in body["dependencies"]["failed"]
-            assert "aim/agents/GoodPkg" in body["dependencies"]["installed"]
+            assert "capability/agents/BadPkg" in body["dependencies"]["failed"]
+            assert "capability/agents/GoodPkg" in body["dependencies"]["installed"]
 
     @pytest.mark.asyncio
     async def test_deps_resolved_before_on_enable_script(self) -> None:
@@ -155,7 +155,7 @@ class TestEnableDepsResolution:
         fake_app_info = {
             "name": "ordered-app",
             "manifest": {
-                "dependencies": {"aim": ["SomePkg"]},
+                "dependencies": {"capabilities": {"agents": ["SomePkg"]}},
                 "setup": {"onEnable": "echo post-install"},
             },
             "resources": "gateway",
@@ -164,7 +164,7 @@ class TestEnableDepsResolution:
 
         async def mock_resolve(*args, **kwargs):
             call_order.append("resolve_deps")
-            return DependencyResult(installed=["aim/agents/SomePkg"])
+            return DependencyResult(installed=["capability/agents/SomePkg"])
 
         async def mock_script(*args, **kwargs):
             call_order.append("on_enable_script")

--- a/test/test_mcp_apps_call_endpoint.py
+++ b/test/test_mcp_apps_call_endpoint.py
@@ -477,7 +477,7 @@ async def test_relay_rejects_session_mismatch(relay_env, spool_tmp):
 
 
 @pytest.fixture
-def relay_env(tmp_path, monkeypatch):
+def relay_env(short_sock_dir, monkeypatch):
     """Client factory for an app exposing ONLY the relay route, with the
     gateway socket redirected at a tmp path via the config override hook.
 
@@ -486,8 +486,13 @@ def relay_env(tmp_path, monkeypatch):
     pytest-asyncio (its wrapper reads ``fixturedef.unittest``, removed in
     pytest 8.1), so the suite avoids ``@pytest_asyncio.fixture`` by
     convention (see test_denied_commands_api.py).
+
+    Uses ``short_sock_dir`` rather than ``tmp_path``: an AF_UNIX path is capped
+    at ~104 bytes by ``sockaddr_un.sun_path``, and pytest's ``tmp_path`` under
+    macOS's ``/private/var/folders/...`` temp root already exceeds that before
+    the filename is appended.
     """
-    sock = tmp_path / "gateway.sock"
+    sock = short_sock_dir / "gateway.sock"
     monkeypatch.setattr(mcp_apps_handlers, "_socket_path", lambda: str(sock))
 
     @web.middleware

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -148,7 +148,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # git rev-parse at startup, no agent input, no sandbox needed).
         "apps/builtins/dev_fleet/server.py::_resolve_primary_checkout",
         "apps/builtins/dev_fleet/server.py::worker",
-        "apps/dependencies.py::_run_aim",
+        # (apps/dependencies.py::_run_aim removed — App Kit capability deps now
+        # resolve through the CapabilityManager seam, so the resolver spawns no
+        # subprocess at all and needs no allowlist entry.)
         "cli.py::_consolidate_cmd",
         "cli.py::_ensure_node",
         "cli.py::_node_ok",

--- a/website/src/components/commandPalette/providers/skillsProvider.ts
+++ b/website/src/components/commandPalette/providers/skillsProvider.ts
@@ -112,7 +112,7 @@ export function createSkillsProvider(deps: SkillsProviderDeps): ResourceProvider
 
       const results: Result[] = []
       // Dedup by name: /api/skills can return the same skill more than once
-      // when the shared AIM skills dir is enumerated by multiple source loaders
+      // when a shared package skills dir is enumerated by multiple source loaders
       // (e.g. source "kirocrew" + "aim"). Keep the first occurrence.
       const seen = new Set<string>()
       for (const s of skills) {


### PR DESCRIPTION
## Problem

The App Kit's dependency resolver shelled out to an external `aim` binary, and
that internal package manager was baked into the **public** app-manifest schema:

```jsonc
{ "dependencies": { "aim": { "mcp": [...], "skills": [...], "agents": [...] } } }
```

A third-party app author reading the manifest contract saw an Amazon-internal
tool by name, with no way to satisfy it. The same name leaked into the dependency
ledger on disk (keys `aim/<type>/<id>`, types `aim.<type>`), and
`apps/dependencies.py::_run_aim` was an unsandboxed `create_subprocess_exec` of a
`PATH`-resolved binary — carried as an explicit entry in `test_spawn_audit`'s
`BENIGN_SPAWNS` allowlist.

`scripts/scrub-lint.sh` — the CI gate that fails on Amazon-internal markers in the
public tree — had **no coverage for `aim` at all**. Its allowlist even contains a
comment naming AIM as an internal marker word while the scan never looked for one.
That gap is why this schema shipped with CI green.

Separately, three workflows still passed `--deselect=test/test_run_aim_path.py` for
a file that no longer exists, and the author-facing docs third-party app authors
are pointed at still published `dependencies.aim` as *the* schema.

## Why it matters

`AGENTS.md` names "AIM hooks" under **"never reintroduce"**. On a public machine
`shutil.which("aim")` is empty, so nothing crashed — the coupling was inert but
real, and it was **written into a contract we ask external authors to code
against**. Left alone, every future manifest, ledger file, and app-authoring doc
propagates it further, and the un-gated scrub-lint guarantees the next one lands
green too.

## Fix (symptoms → root cause → change)

The symptom is an internal binary name in a public schema. The root cause is that
the resolver named a *binary* where the codebase already has a seam for exactly
this: `platform/interfaces.py::CapabilityManager`, whose own spec says it exists
so that "no external CLI grammar fossilizes in the core." The resolver predated
that seam and was never migrated.

- **Resolve through the seam.** `_run_aim` is deleted. Capability dependencies go
  through `install_mcp` / `install_skill` (and `uninstall_*` on cleanup), read via
  `current_context()` so the `BoundedCapabilityManager` timeout wrapper applied at
  context composition is inherited — a slow companion op can't stall an app
  install. The seam is probed **lazily**, so a commands-only manifest never
  touches it. Deleting the subprocess also removes an unsandboxed-spawn entry
  from `BENIGN_SPAWNS`: the resolver now spawns nothing.
- **Fail visibly, not silently.** With no capability manager (the public edition),
  entries are recorded as `failed`/unresolved and the app still installs, so the
  unmet dependency surfaces instead of reporting phantom success.
  `capabilities.agents` stays declarable but is never gateway-installed — the
  Protocol exposes `list_agents` only — and reports unresolved rather than being
  dropped on the floor.
- **Rename the contract, keep both readable.** Wire key → `capabilities`, ledger →
  `capability/<type>/<id>` and `capability.<type>`. The `aim` manifest key remains
  a **deprecated read-only alias** that is never re-emitted, so a round-trip
  migrates a manifest; ledger lookups fall back to the pre-rename spelling.
  That fallback is load-bearing, not cosmetic: without it an upgrade would
  classify every tracked dependency as untracked, resetting the refcount that
  stops one app's uninstall from deleting a dependency another app still uses.
- **Close the gate.** New `AIM_PATTERN` in `scrub-lint.sh`. Deliberately narrow —
  `--aim`/`bg-aim`/`text-aim` is an unrelated CSS color token used ~40 places and
  English "aim" appears in prose ("aim an artifact at"), so a bare `\baim\b` is
  unusable here. It matches the invocation grammar, `~/.aim`, and the
  dependency-contract strings — i.e. the couplings this PR removes. To be precise
  about scope: it does **not** match the separate `label: 'AIM'` theme-token leak
  in `themeEditor.tsx`, which is left for its own change.
- **Anchor the allowlist.** The `agent.py` entries are path **+ pattern**, never a
  bare path. `scrub-lint.sh` applies the allowlist as a plain `grep -v` to *both*
  the marker scan and the employee-alias scan, so a bare path would drop all 2000+
  lines of that actively-edited file from both gates — a future `code.amazon`,
  `brazil-build`, `CR-######`, or alias there would ship green. Verified by
  planting each of those four marker classes: all are caught, while the eight real
  `~/.aim` lines still pass.
- **Fix the CI/doc fallout.** Drop the three stale `--deselect` lines (and the
  internal marker words in their comments), and rename the schema in
  `docs/app-kit/manifest-reference.md` + `docs/app-store-guidelines.md`, including
  the now-false "if the `aim` CLI is not on PATH these are skipped gracefully" —
  the code no longer consults PATH, and unresolved entries land in `failed`.

**Deliberately out of scope:** `agent.py`'s `~/.aim` skill scan is allowlisted by
path, keeping its existing `TODO(aim-governance follow-up)`. Its migration to the
`McpToolingProvider.extra_skills()` seam is security-sensitive (symlink
resolution + sensitive-path gating) and belongs in its own PR. The allowlist entry
is by path, not pattern, so the gate still catches any **new** coupling elsewhere.

## Tests

- `test_dependencies.py::TestCapabilitySeamResolution` — installs dispatch to the
  right seam op; an unavailable manager records `failed` rather than crashing or
  faking success; a failed op is recorded; `agents` reports unresolved and calls
  nothing; a commands-only manifest never probes the seam; uninstall dispatches,
  and still dispatches for a legacy `aim.mcp` ledger row (else the dep leaks
  forever); an unknown type is skipped.
- `test_dependencies.py::TestDeprecatedManifestAlias` — the old key still loads,
  is never re-emitted (round-trip migrates), and the canonical key wins.
- `test_dependency_ledger.py::TestLegacyKeyCompat` — a pre-rename ledger resolves
  on read; a second app **accrues onto the existing legacy entry** instead of
  forking a second key for one dep; uninstall prunes it; classification sees it as
  removable rather than "user installed"; the canonical key wins when both exist.
- `test_dependency_ledger.py::TestDeclaredCapabilityKeys` — key derivation from
  both spellings, object/blank entries, and malformed shapes that must not raise.
- `test_dependencies.py::TestCapabilityManagerAccessor` — covers the **real**
  `_capability_manager()` body: the `current_context()` read preserves the
  bound wrapper (not re-wrapped), an unavailable manager yields `None`, and both a
  broken context and a raising `available()` fail closed. Without these the
  seam-resolution tests (which replace the accessor wholesale) left the
  `available()` gate provably invisible — deleting it kept that suite green.
- `test_dependencies.py::TestCleanDependenciesFailurePaths` — the cleanup side's
  unavailable/failed/raising branches and `uninstall_skill` dispatch, which the
  resolve side had but cleanup did not.
- `test_dependency_ledger.py::TestClassifyAndCleanForUninstall` — the only ledger
  *write* path uninstall takes, and the one this change edits; previously untested.
  Includes the legacy-key + `keep_specific` combination.
- `test_app_manifest.py::TestCapabilityDepTypesContract` — pins
  `CAPABILITY_DEP_TYPES` against the dataclass fields, since the resolver loop
  reads those fields by name.
- `test_spawn_audit.py` — the stale `_run_aim` allowlist entry is removed; this
  test is what flagged it, and it fails if a future change re-adds an
  unsandboxed spawn without justification.

Each new test was mutation-checked rather than assumed: breaking the legacy-key
fallback fails four of the compat tests, and dropping the `available()` gate fails
two accessor tests. Two of my first-draft ledger tests asserted through
`get_entry`, which shares the fallback under test — they passed even with the
fallback broken, so they now assert on the raw ledger file instead. `_FakeManager`
implements the full `CapabilityManager` Protocol and returns the real
`CapabilityResult`, so fake/Protocol drift can't hide a break.

## Manual verification

Unit coverage coincidentally can't prove the upgrade path end-to-end, so I drove
it directly against a seeded pre-rename ledger (a real `KIROCREW_HOME`, not a
mock): a dep shared by `app-a`/`app-b` plus one owned only by `app-a`, declared
via an **old-style** `aim` manifest. Result: classification correctly split
removable vs shared with nothing mis-filed as untracked, the removable legacy key
was pruned, and **`app-b`'s reference to the shared dep survived** — the exact
data-loss case the fallback exists to prevent. Also verified `keep_specific`
resolves a legacy key without crashing or orphaning a reference.

Scrub-lint gate verified by planting probes: all five real shapes
(`aim mcp install`, `aim.mcp`, `aim/skills/…`, `~/.aim/skills`, `aim CLI`) are
caught, and five near-misses (`bg-aim/15 text-aim`, `--aim-subtle`, prose "aim",
bare `"aim"`) produce no false positive. `./scripts/scrub-lint.sh --test`
self-test passes.

Scrub-lint's own `--test` self-test now plants one probe per pattern family; I
confirmed it fails when `AIM_PATTERN` is typo'd (it previously could not detect
that at all).

Full gates green locally: pytest 19419 passed, isort / flake8 / mypy (506 files)
clean, `tsc -b` clean, vitest 5406 passed, `scrub-lint --no-history` + `--test`
clean, and `jscpd` reports 0 clones. Three
pre-existing `AF_UNIX path too long` failures in `test_mcp_apps_call_endpoint.py`
are environment-only — they fail identically on unmodified `origin/main` (long
checkout path exceeds the ~104-byte socket limit) and are unrelated to this change.
