### PR TITLE
feat(sidebar): make the session PR chip a link to the pull request

### DIFF
--- a/website/integration/ChatSidebar.integration.test.tsx
+++ b/website/integration/ChatSidebar.integration.test.tsx
@@ -109,8 +109,8 @@ describe('ChatSidebar Folder Grouping', () => {
     ]
     renderWithProviders(<ChatSidebar {...defaultProps} slots={slotsWithSources} />)
 
-    const githubChip = (await screen.findByText('#113')).closest('span')
-    const gitlabChip = screen.getByText('!7').closest('span')
+    const githubChip = (await screen.findByText('#113')).closest('a')
+    const gitlabChip = screen.getByText('!7').closest('a')
     expect(githubChip?.querySelector('[data-provider-mark="github"]')).toBeInTheDocument()
     expect(gitlabChip?.querySelector('[data-provider-mark="gitlab"]')).toBeInTheDocument()
     expect(githubChip?.querySelector('[aria-label="Merged"]')).toHaveClass('text-aim')
@@ -129,8 +129,8 @@ describe('ChatSidebar Folder Grouping', () => {
     ]
     renderWithProviders(<ChatSidebar {...defaultProps} slots={slotsWithSources} />)
 
-    const mergedChip = (await screen.findByText('#284')).closest('span')
-    const openChip = screen.getByText('#285').closest('span')
+    const mergedChip = (await screen.findByText('#284')).closest('a')
+    const openChip = screen.getByText('#285').closest('a')
     // Merged chip keeps the merge icon but drops the CI check — merged is terminal.
     expect(mergedChip?.querySelector('[aria-label="Merged"]')).toBeInTheDocument()
     expect(mergedChip?.querySelector('[aria-label="Checks passed"]')).not.toBeInTheDocument()

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1970,7 +1970,22 @@ function ChatSidebar({
             {s.source_links && s.source_links.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1">
                 {s.source_links.map(link => (
-                  <span key={link.url} className="inline-flex items-center gap-1 px-1.5 py-[1px] rounded-[4px] text-[10px] leading-none font-medium text-muted border border-border bg-bg-elevated/60" title={link.url}>
+                  // The chip is a real link to the PR/MR. `link.url` is always
+                  // an `https://` URL on an allowlisted host (state.py scans for
+                  // the literal "https://" then validates via parse_source_url),
+                  // so no scheme sanitising is needed here.
+                  //
+                  // The row itself is a click-to-switch button AND a dnd-kit
+                  // draggable, so the anchor has to opt out of both: stop the
+                  // click from bubbling into the row's switchSlot handler, and
+                  // disable the anchor's own native HTML5 drag, which would
+                  // otherwise put the URL on the dataTransfer instead of the
+                  // slot key in the board/flat scopes that use native drag.
+                  <a key={link.url} href={link.url} target="_blank" rel="noopener noreferrer"
+                    draggable={false}
+                    onClick={e => e.stopPropagation()}
+                    className="inline-flex items-center gap-1 px-1.5 py-[1px] rounded-[4px] text-[10px] leading-none font-medium text-muted no-underline border border-border bg-bg-elevated/60 hover:text-text hover:border-accent"
+                    title={`Open ${link.url}`}>
                     {link.provider === 'github' ? <GithubLogo size={10} className="shrink-0" /> : <GitlabLogo size={10} className="shrink-0" />}
                     {link.provider === 'github' ? `#${link.number}` : `!${link.number}`}
                     {link.state === 'merged' && (
@@ -1983,7 +1998,7 @@ function ChatSidebar({
                     {link.state !== 'merged' && link.ci === 'running' && <Loader2 className="lucide-inline shrink-0 animate-spin" aria-label="Checks running" />}
                     {link.state !== 'merged' && link.ci === 'passed' && <Check className="lucide-inline shrink-0 text-ok" aria-label="Checks passed" />}
                     {link.state !== 'merged' && link.ci === 'failed' && <X className="lucide-inline shrink-0 text-danger" aria-label="Checks failed" />}
-                  </span>
+                  </a>
                 ))}
                 {typeof s.source_links_total === 'number' && s.source_links_total > s.source_links.length && (
                   <span className="inline-flex items-center px-1.5 py-[1px] rounded-[4px] text-[10px] leading-none font-medium text-muted border border-border bg-bg-elevated/60" title={`${s.source_links_total - s.source_links.length} more pull request${s.source_links_total - s.source_links.length === 1 ? '' : 's'} in this session`}>

--- a/website/src/test/ChatSidebar.sourceLinkChip.test.tsx
+++ b/website/src/test/ChatSidebar.sourceLinkChip.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Test: the sidebar PR/MR chip is a real link.
+ *
+ * The chip used to be a plain <span> with the URL only in its tooltip, so the
+ * PR it names was not reachable from the sidebar. It is now an <a> that opens
+ * the pull request in a new tab. Because the session row itself is a
+ * click-to-switch button, the anchor must also stop the click from bubbling —
+ * otherwise opening the PR would switch sessions at the same time.
+ *
+ * Mock setup mirrors ChatSidebar.offline.test.tsx: the chat slice's switchSlot
+ * thunk is mocked so we can assert whether a click reached the row handler.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+const { switchSlotMock } = vi.hoisted(() => ({
+  switchSlotMock: vi.fn(() => ({ type: 'chat/switchSlot/pending', meta: {} })),
+}))
+
+vi.mock('../store/chatSlice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store/chatSlice')>()
+  return { ...actual, switchSlot: (...args: unknown[]) => switchSlotMock(...args) }
+})
+
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: Object.fromEntries(
+      [
+        'sessions', 'chatSlots', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot',
+        'resumeChatSlot', 'deleteSession', 'agentDetail', 'spawnList', 'fetchHistory',
+        'renameSlot', 'forkSession', 'chatTags', 'chatFolders',
+      ].map(k => [k, vi.fn().mockResolvedValue({})]),
+    ),
+  }
+})
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatSidebar from '../pages/ChatSidebar'
+import type { ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+const PR_URL = 'https://github.com/kirodotdev/KiroCrew/pull/634'
+
+const slots = [
+  { key: 's1', title: 'Other', messages: 1, running: false, mode: '', created: '', last_ts: '2026-01-01T00:00:00Z' },
+  {
+    key: 's2', title: 'PR session', messages: 1, running: false, mode: '', created: '', last_ts: '2026-01-01T00:00:00Z',
+    source_links: [{ provider: 'github', number: 634, url: PR_URL, state: 'open', ci: 'passed' }],
+    source_links_total: 1,
+  },
+] as unknown as ChatSlot[]
+
+function renderSidebar() {
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' },
+      connected: true,
+      slots,
+      approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+      slotsLoaded: true,
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot: 's1',
+      messages: [], slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={'s1'} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent={'default'} installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+const chip = () => screen.getByTitle(`Open ${PR_URL}`)
+
+describe('ChatSidebar – PR chip link', () => {
+  beforeEach(() => switchSlotMock.mockClear())
+
+  it('renders the chip as an anchor that opens the pull request in a new tab', () => {
+    renderSidebar()
+    const a = chip()
+    expect(a.tagName).toBe('A')
+    expect(a).toHaveAttribute('href', PR_URL)
+    expect(a).toHaveAttribute('target', '_blank')
+    expect(a.getAttribute('rel')).toContain('noopener')
+    expect(a).toHaveTextContent('#634')
+  })
+
+  it('clicking the chip does NOT switch sessions, while clicking the row still does', () => {
+    renderSidebar()
+    // Positive control first: the row handler IS reachable in this harness, so
+    // the negative assertion below is meaningful and not vacuous.
+    const row = chip().closest('.session-row') as HTMLElement
+    fireEvent.click(row)
+    expect(switchSlotMock).toHaveBeenCalledWith('s2')
+
+    switchSlotMock.mockClear()
+    fireEvent.click(chip())
+    expect(switchSlotMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Sessions in the sidebar carry a PR/MR chip (`#634`, `!12`) with the pull-request
URL hidden in the chip's tooltip. The chip is a plain `<span>`, so the pull
request it names cannot be opened from the sidebar. To reach the PR you have to
read the URL out of the tooltip and retype it, or open the session and hunt for
the link in the transcript.

## Why it matters

The chip already carries live PR state (open / merged / closed plus CI
running / passed / failed), so it is the place people look when they want to go
to the PR. Naming a resource and then not linking to it is a dead end on the
most common wayfinding path in the sidebar.

## Fix (symptoms -> root cause -> change)

- Symptom: nothing happens when you click the chip; clicking it just switches
  session like any other click on the row.
- Root cause: the chip is rendered as a `<span>` with `title={link.url}` — the
  URL is present in the payload (`slot.source_links[].url`) but never wired to
  an anchor.
- Change: render the chip as `<a href={link.url} target="_blank"
  rel="noopener noreferrer">`, plus the two opt-outs the surrounding row needs:
  - `onClick={e => e.stopPropagation()}` — the session row is itself a
    click-to-switch button, so without this, opening the PR would also switch
    sessions.
  - `draggable={false}` — the row is draggable (dnd-kit in list scope, native
    HTML5 drag in board scope). An anchor is natively draggable, so dragging
    from the chip would put the URL on the `dataTransfer` instead of the slot
    key.

No scheme sanitising is added because the URL cannot be non-`https`:
`ChatSlot._pr_source_links` in `state.py` scans message text for the literal
`https://`, then validates each candidate through `parse_source_url` (provider
host allowlist + numeric PR/MR id) before it ever reaches the payload.

Keyboard behaviour needs no new code: the row's `onKeyDown` already ignores
Enter/Space when `e.target !== e.currentTarget`, so Enter on a focused chip
activates the link and does not also switch sessions.

The `+N` overflow chip stays a `<span>` — it stands for several links, so there
is no single URL to point it at.

## Tests

`website/src/test/ChatSidebar.sourceLinkChip.test.tsx` (new, 2 tests):

- The chip renders as an `<a>` with the PR `href`, `target="_blank"`,
  `rel` containing `noopener`, and the `#634` label.
- Clicking the chip does **not** dispatch `switchSlot`, while clicking the
  session row still does. The positive control is asserted first so the
  negative assertion cannot pass vacuously.

`website/integration/ChatSidebar.integration.test.tsx` — two existing chip tests
located the chip with `.closest('span')`; retargeted to `.closest('a')` now that
the chip is an anchor. No assertion was weakened: both still check the provider
mark, the merge icon and the CI-icon suppression inside the chip.

Verified the second test fails without the fix: with
`onClick={e => e.stopPropagation()}` removed it reports
`expected "spy" to not be called at all, but actually been called 1 times`.

Gates run locally: `tsc --noEmit` clean, `eslint` clean on both touched files
(only pre-existing warnings elsewhere in `ChatSidebar.tsx`), and all 15
`ChatSidebar*` test files pass (70 passed, 1 skipped).

## Manual verification

N/A — unit coverage is sufficient. The assertions cover exactly the two
behaviours that changed (link target, click isolation), and the browser
supplies the rest (following an `href`).

## Screenshots

N/A — no visual change. The chip keeps the same markup, size, spacing, icons
and colour tokens; the only additions are the link behaviour and a hover
recolour (`hover:text-text hover:border-accent`), matching how the session row
itself responds to hover.
