### PR TITLE
feat(knowledge): auto-add the Kiro CLI knowledge folder as a Library source

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1186,7 +1186,9 @@
         "embed_content_budget": 0,
         "pool_idle_ttl_secs": 300,
         "auto_ingest_doc_links": false,
-        "doc_ingest_hosts": []
+        "doc_ingest_hosts": [],
+        "auto_discover_folder": false,
+        "auto_discover_dirname": "knowledge-docs"
       }
     },
     {
@@ -1333,6 +1335,34 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": null
+    },
+    {
+      "path": "knowledge.auto_discover_folder",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Auto-Discover Documents Folder",
+      "help": "Watch for a documents folder inside the active workspace and register it as a Knowledge source automatically, so files dropped there become searchable without adding the source by hand. The folder is never created for you: its absence means you have not opted in, and it is picked up within one watcher sweep of being created -- no restart needed. Off by default because ingestion spends LLM extraction on every supported file in the folder.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "knowledge.auto_discover_dirname",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Documents Folder Name",
+      "help": "Name of the folder inside the workspace that auto-discovery looks for. A single path segment -- separators and traversal are rejected so the source cannot be redirected outside the workspace. Avoid 'knowledge': that is where the Library's own SQLite store lives and it always exists, which would defeat discovery.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": "knowledge-docs"
     },
     {
       "path": "skills",
@@ -2823,6 +2853,173 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": null
+    },
+    {
+      "path": "weixin",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "WeChat",
+      "help": "Weixin (iLink personal WeChat) integration settings.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {
+        "enabled": false,
+        "token": "",
+        "account_id": "",
+        "base_url": "https://ilinkai.weixin.qq.com",
+        "dm_policy": "allowlist",
+        "allowed_user_ids": [],
+        "soft_threshold_pct": 80,
+        "hard_threshold_pct": 95
+      }
+    },
+    {
+      "path": "weixin.enabled",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Enabled",
+      "help": "Enable the Weixin (iLink personal WeChat) channel (long-polling). Requires a bot token + account id from the Settings QR flow.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "weixin.token",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": true,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Bot Token",
+      "help": "iLink bot token (from QR login). Prefer the WEIXIN_TOKEN credential (env/.env / cred store) over storing it here.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
+      "path": "weixin.account_id",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Account ID",
+      "help": "iLink bot account id captured during QR login.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
+      "path": "weixin.base_url",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "iLink Base URL",
+      "help": "iLink API base URL (per-account, returned by QR login).",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": "https://ilinkai.weixin.qq.com"
+    },
+    {
+      "path": "weixin.dm_policy",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "DM Policy",
+      "help": "Who may DM the bot: 'allowlist' (only allowed_user_ids, the default), 'open' (any sender), or 'disabled'. Defaults to allowlist with an empty list, so a freshly connected bot authorizes NOBODY until you add an id.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": "allowlist"
+    },
+    {
+      "path": "weixin.allowed_user_ids",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Allowed User IDs",
+      "help": "Weixin user ids permitted to DM the bot when dm_policy='allowlist'. Empty = deny all (fail closed).",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": []
+    },
+    {
+      "path": "weixin.allowed_user_ids.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
+    },
+    {
+      "path": "weixin.soft_threshold_pct",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Soft Context Threshold %",
+      "help": "Prompt the user to /compact or /new when context passes this percentage.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 80
+    },
+    {
+      "path": "weixin.hard_threshold_pct",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "weixin"
+      ],
+      "label": "Hard Context Threshold %",
+      "help": "Force a compaction when context passes this percentage.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 95
     },
     {
       "path": "discord",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1168,6 +1168,30 @@ class KnowledgeConfig:
             "endpoint or arbitrary host from being fetched.",
         ),
     )
+    auto_discover_folder: bool = field(
+        default=False,
+        metadata=_meta(
+            "Auto-Discover Documents Folder",
+            "Watch for a documents folder inside the active workspace and "
+            "register it as a Knowledge source automatically, so files dropped "
+            "there become searchable without adding the source by hand. The "
+            "folder is never created for you: its absence means you have not "
+            "opted in, and it is picked up within one watcher sweep of being "
+            "created -- no restart needed. Off by default because ingestion "
+            "spends LLM extraction on every supported file in the folder.",
+        ),
+    )
+    auto_discover_dirname: str = field(
+        default="knowledge-docs",
+        metadata=_meta(
+            "Documents Folder Name",
+            "Name of the folder inside the workspace that auto-discovery looks "
+            "for. A single path segment -- separators and traversal are rejected "
+            "so the source cannot be redirected outside the workspace. Avoid "
+            "'knowledge': that is where the Library's own SQLite store lives and "
+            "it always exists, which would defeat discovery.",
+        ),
+    )
 
 
 @dataclass
@@ -3726,6 +3750,10 @@ class KiroCrewConfig:
                     for h in knowledge_data.get("doc_ingest_hosts", [])
                     if isinstance(h, str) and h.strip()
                 ],
+                auto_discover_folder=bool(knowledge_data.get("auto_discover_folder", False)),
+                auto_discover_dirname=str(
+                    knowledge_data.get("auto_discover_dirname", "knowledge-docs")
+                ).strip()[:128],
             ),
             telegram=TelegramConfig(
                 enabled=bool(telegram_data.get("enabled", False)),

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -21,6 +21,7 @@ from kiro_crew.dashboard.handlers.files import _ZIP_CONTAINER_EXTS, _content_mat
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.knowledge.agent_fetch import fetch_url_content
 from kiro_crew.knowledge.artifact_ingest import ArtifactKnowledgeSync
+from kiro_crew.knowledge.autosource import AUTO_ADDED_PROP
 from kiro_crew.knowledge.chunker import HeadingAwareChunker
 from kiro_crew.knowledge.connectors.base import BaseConnector
 from kiro_crew.knowledge.connectors.local_folder import LocalFolderConnector
@@ -884,11 +885,31 @@ async def delete_source(request: web.Request) -> web.Response:
     row = store.db.execute("SELECT * FROM sources WHERE id = ?", (source_id,)).fetchone()
     if not row:
         return web.json_response({"error": "not found"}, status=404)
+    # An auto-discovered source must not come back on the next watcher sweep just
+    # because its folder still exists -- tombstone the URI. This is passed INTO
+    # the cascade so the tombstone and the delete share one transaction: written
+    # afterwards, a sweep landing in between would see neither a source row nor a
+    # tombstone and re-create what was just deleted. Only auto-added rows get a
+    # tombstone; a hand-added source has no discovery loop to resurrect it.
+    dismiss_uri = None
     try:
-        store.delete_source_cascade(source_id)
+        props = json.loads(row["properties"]) if isinstance(row["properties"], str) else (row["properties"] or {})
+        if isinstance(props, dict) and props.get(AUTO_ADDED_PROP):
+            dismiss_uri = row["uri"]
+    except Exception:
+        logger.warning("Could not read source properties for dismissal", exc_info=True)
+    try:
+        # BEGIN IMMEDIATE takes the write lock eagerly and the connection's
+        # busy_timeout is 10s, so a concurrent ingestion writer could park this
+        # call for that long -- never on the event loop.
+        await asyncio.to_thread(
+            store.delete_source_cascade, source_id, dismiss_uri=dismiss_uri
+        )
     except Exception:
         logger.exception("delete_source failed: source_id=%s", source_id)
         return web.json_response({"error": "internal server error"}, status=500)
+    if dismiss_uri:
+        _sel_log("source.auto_dismiss", source_id=source_id, uri=dismiss_uri)
     _sel_log("source.delete", source_id=source_id)
     return web.json_response({"status": "deleted"})
 
@@ -963,6 +984,12 @@ async def pause_source(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
     props = json.loads(row["properties"]) if isinstance(row["properties"], str) else (row["properties"] or {})
     props["scan_paused"] = True
+    # Keep the JSON copy in sync with the column: the watcher's pre-scan skip
+    # reads properties["sync_status"] (it selects `properties`, not the column),
+    # so leaving this stale meant a paused folder was still fully walked and
+    # delete-reconciled every sweep -- only the deeper scan_paused gate in
+    # folder_watcher stopped the ingestion. confirm/resume already do this.
+    props["sync_status"] = "paused"
     store.update_source(source_id, properties=props, sync_status="paused")
     _sel_log("source.pause", source_id=source_id)
     return web.json_response({"status": "paused"})

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -134,6 +134,8 @@ Set via `kirocrew config set sandbox.mode auto`.
 | `skills.max_triggered` | Maximum skills loaded per message (≥1) | `3` |
 | `knowledge.auto_ingest_artifacts` | Auto-ingest content-bearing local artifacts into the Knowledge Library (searchable "Artifacts" source); kept in sync and removed when the artifact is deleted (see [Knowledge Library](knowledge-library-how-it-works.md)) | `true` |
 | `knowledge.auto_ingest_artifact_kinds` | Artifact kinds eligible for auto-ingest (`widget` excluded as UI/dashboards; `svg` excluded — no reader support) | `["markdown", "text", "html", "json"]` |
+| `knowledge.auto_discover_folder` | Watch for a documents folder inside the active workspace and register it as a Knowledge source automatically, so files dropped there become searchable without adding the source by hand. The folder is never created for you — its absence means you have not opted in — and it is picked up within one watcher sweep (default 300s) of being created, with no restart. Deleting the auto-added source records a dismissal, so it stays gone instead of reappearing on the next sweep; pausing it also persists. Off by default because ingestion spends LLM extraction on every supported file | `false` |
+| `knowledge.auto_discover_dirname` | Folder name inside the workspace that auto-discovery looks for. A single path segment; separators and traversal are rejected so the source cannot be redirected outside the workspace. Avoid `knowledge` — that is where the Library's own SQLite store lives and it always exists, which would defeat discovery | `"knowledge-docs"` |
 
 ## Environment Variables
 

--- a/src/kiro_crew/knowledge/autosource.py
+++ b/src/kiro_crew/knowledge/autosource.py
@@ -1,0 +1,179 @@
+"""Auto-discovery of the workspace drop folder as a Knowledge source.
+
+A convention folder under the active workspace ("drop documents here and they
+become searchable") that is registered as a watched ``local_folder`` source
+without the user adding it by hand.
+
+Discovery is **recurring, not one-shot**: it runs on every
+:class:`~kiro_crew.knowledge.watcher.KnowledgeWatcher` sweep, so a folder
+created after the gateway started is picked up on the next sweep rather than
+requiring a restart. Registration is idempotent -- the source row's existence is
+the marker, so repeated sweeps re-use it.
+
+Why the folder is NOT named ``knowledge``: the Library's own SQLite store lives
+at ``<workspace>/knowledge/``, created eagerly by the dashboard state
+(``os.makedirs(..., exist_ok=True)``). A drop folder by that name would always
+exist, which would make "discover it when it appears" vacuous and would mix
+user documents with the store's own DB files. Hence a distinct default name,
+overridable via ``knowledge.auto_discover_dirname``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from kiro_crew.security import is_sensitive_path
+
+logger = logging.getLogger(__name__)
+
+# Convention folder name under the active workspace. Deliberately not
+# "knowledge" -- see module docstring.
+DEFAULT_DROP_DIRNAME = "knowledge-docs"
+
+# Display name of the auto-registered source.
+DROP_SOURCE_NAME = "Workspace Documents"
+
+# Marker in source properties identifying a row this module created. Lets the
+# UI label it and lets a future migration find auto-added rows.
+AUTO_ADDED_PROP = "auto_added"
+
+
+def _is_within(candidate: Path, base: Path) -> bool:
+    """True when ``candidate`` is ``base`` or lives underneath it.
+
+    Both paths must already be resolved. ``Path.is_relative_to`` is 3.9+, which
+    the project targets, but ``commonpath`` is used so the comparison is on
+    normalized strings and a sibling like ``/ws-evil`` cannot pass a naive
+    ``startswith`` test against ``/ws``.
+    """
+    try:
+        return os.path.commonpath([str(candidate), str(base)]) == str(base)
+    except ValueError:
+        # Different drives on Windows -- definitionally not contained.
+        return False
+
+
+def resolve_drop_folder(base: str, dirname: str = DEFAULT_DROP_DIRNAME) -> str:
+    """Return the drop folder path if it currently exists, else ``""``.
+
+    ``base`` is the active workspace directory. Returns the resolved absolute
+    path only when the folder exists, is a directory, and clears the
+    sensitive-path gate -- otherwise the empty string, which callers treat as
+    "nothing to add yet". The folder is never created: it exists because the
+    user made it, and its absence is the signal that they have not opted in.
+
+    ``dirname`` is treated as a single path segment; anything containing a
+    separator or traversal is rejected so a config value cannot redirect the
+    source outside the workspace.
+    """
+    if not base or not dirname:
+        return ""
+    if dirname != Path(dirname).name or dirname in (".", ".."):
+        logger.warning("Ignoring invalid knowledge drop dirname: %r", dirname)
+        return ""
+    try:
+        base_real = Path(base).resolve()
+        candidate = (base_real / dirname).resolve()
+    except OSError:
+        return ""
+    # Containment: the segment check above only constrains the config STRING. A
+    # symlink at <workspace>/<dirname> pointing outside the workspace would
+    # survive it, and is_sensitive_path() does not help -- it only classifies
+    # credential/trust dirs, so a link to an unrelated home or system tree
+    # passes. Without this check the whole target tree would be walked and
+    # LLM-extracted into the graph. Compare with the manual POST flow, where
+    # escaping the workspace is the user's explicit intent; here the contract is
+    # "a folder inside the active workspace", so escape is always a defect.
+    if not _is_within(candidate, base_real):
+        logger.warning(
+            "Knowledge drop folder resolves outside the workspace, skipping: %s", candidate
+        )
+        return ""
+    if not candidate.is_dir():
+        return ""
+    resolved = str(candidate)
+    if is_sensitive_path(resolved):
+        logger.warning("Knowledge drop folder is a restricted path, skipping: %s", resolved)
+        return ""
+    return resolved
+
+
+def ensure_drop_source(store, uri: str) -> tuple[str | None, bool]:
+    """Get-or-create the drop-folder source row, unless the URI is dismissed.
+
+    Returns ``(source_id, created)``, or ``(None, False)`` when the user has
+    dismissed this URI by deleting the auto-added source.
+
+    The tombstone check, the existing-row check and the INSERT are delegated to
+    ``store.create_auto_source_unless_dismissed`` so all three share ONE
+    transaction. Doing them as separate statements here would let a concurrent
+    delete land in between: discovery would see no source row and no tombstone
+    yet, and re-create the source the user just deleted.
+
+    A folder the user already registered by hand at the same path is re-used,
+    never shadowed. ``sync_status`` is seeded ``active`` rather than the
+    ``pending_confirmation`` the POST endpoint uses, because no user is present
+    to confirm: the watcher's gate skips only ``paused`` and
+    ``pending_confirmation``.
+    """
+    props = {"sync_status": "active", AUTO_ADDED_PROP: True}
+    try:
+        return store.create_auto_source_unless_dismissed(
+            name=DROP_SOURCE_NAME,
+            source_type="local_folder",
+            uri=uri,
+            properties=props,
+        )
+    except Exception:
+        # Lost a race on the UNIQUE uri -- re-read and treat as pre-existing.
+        existing = store.get_source_by_uri(uri)
+        if existing:
+            return existing["id"], False
+        raise
+
+
+def auto_source_still_contained(uri: str, base: str) -> bool:
+    """Re-validate a REGISTERED auto source before each scan.
+
+    Registration-time containment is not sufficient. When
+    ``<workspace>/<dirname>`` is a real directory, the persisted URI is that
+    literal path -- so replacing the directory with a symlink to an external
+    tree afterwards makes ``os.walk`` follow it out of the workspace on the next
+    sweep, and outside files get ingested and LLM-extracted. The stored URI is
+    only trustworthy if it is re-checked every time it is used.
+
+    Applies to auto-added sources only: for a folder the user registered by hand,
+    pointing outside the workspace is their explicit choice, not a defect.
+    """
+    if not uri or not base:
+        return False
+    try:
+        base_real = Path(base).resolve()
+        target = Path(uri).resolve()
+    except OSError:
+        return False
+    if not _is_within(target, base_real):
+        return False
+    if is_sensitive_path(str(target)):
+        return False
+    return True
+
+
+def discover_and_register(store, base: str, dirname: str = DEFAULT_DROP_DIRNAME) -> str | None:
+    """Register the drop folder if it exists and is not already a source.
+
+    Returns the new source id when a row was created, otherwise ``None`` (folder
+    absent, already registered, or previously dismissed by the user).
+    Synchronous: callers on the event loop should hand this to
+    ``asyncio.to_thread`` -- it stats the filesystem and writes SQLite.
+    """
+    uri = resolve_drop_folder(base, dirname)
+    if not uri:
+        return None
+    source_id, created = ensure_drop_source(store, uri)
+    if not created:
+        return None
+    logger.info("Auto-discovered knowledge drop folder: %s (source %s)", uri, source_id)
+    return source_id

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -280,6 +280,17 @@ class KnowledgeStore:
                 PRIMARY KEY (source_id, slug)
             );
 
+            -- Tombstones for auto-discovered sources the user deleted. Keyed by
+            -- URI (not source_id) and deliberately NOT touched by
+            -- delete_source_cascade: auto-discovery's only idempotency marker is
+            -- the source row, so without a tombstone that survives deletion a
+            -- deleted auto-source would be re-created (and re-ingested) on the
+            -- next watcher sweep while the folder still exists on disk.
+            CREATE TABLE IF NOT EXISTS dismissed_auto_sources (
+                uri TEXT PRIMARY KEY,
+                dismissed_at TEXT NOT NULL
+            );
+
         """)
         self.db.commit()
 
@@ -359,9 +370,22 @@ class KnowledgeStore:
             if "name" not in ais_cols:
                 self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN name TEXT")
         # Clean orphan sources (no items), entities (no mentions/relations), and stale relations
+        #
+        # Folder sources are EXCLUDED: a watched folder with zero discovered
+        # files is legitimately empty, not orphaned. Deleting it here loses
+        # user-set state -- notably a paused empty folder would be dropped on
+        # restart and then re-created as active by auto-discovery, silently
+        # un-pausing it. The row is user-registered configuration, not derived
+        # data, so only its items are reclaimable.
         self.db.execute("BEGIN")
         try:
-            orphan_sources_q = "SELECT id FROM sources WHERE id NOT IN (SELECT DISTINCT source_id FROM items WHERE source_id IS NOT NULL) AND id NOT IN (SELECT source_id FROM ingestion_jobs WHERE status IN ('pending', 'processing')) AND id NOT IN (SELECT DISTINCT source_id FROM folder_file_state) AND id NOT IN (SELECT DISTINCT source_id FROM artifact_item_state)"
+            orphan_sources_q = (
+                "SELECT id FROM sources WHERE id NOT IN (SELECT DISTINCT source_id FROM items WHERE source_id IS NOT NULL) "
+                "AND source_type NOT IN ('local_folder', 'obsidian_vault') "
+                "AND id NOT IN (SELECT source_id FROM ingestion_jobs WHERE status IN ('pending', 'processing')) "
+                "AND id NOT IN (SELECT DISTINCT source_id FROM folder_file_state) "
+                "AND id NOT IN (SELECT DISTINCT source_id FROM artifact_item_state)"
+            )
             self.db.execute(f"DELETE FROM source_locations WHERE source_id IN ({orphan_sources_q})")
             self.db.execute(f"DELETE FROM ingestion_jobs WHERE source_id IN ({orphan_sources_q})")
             self.db.execute(f"DELETE FROM sources WHERE id IN ({orphan_sources_q})")
@@ -500,10 +524,91 @@ class KnowledgeStore:
             raise
         self._load_graph()
 
-    def delete_source_cascade(self, source_id):
-        """Delete a source and all its items in a single transaction (batch SQL)."""
-        self.db.execute("BEGIN")
+    def dismiss_auto_source(self, uri: str) -> None:
+        """Record that the user deleted an auto-discovered source at ``uri``.
+
+        Survives ``delete_source_cascade`` on purpose -- see the table comment.
+        Idempotent: re-dismissing keeps the original timestamp semantics simple
+        by overwriting, which is fine since only presence is consulted.
+        """
+        self.db.execute(
+            "INSERT OR REPLACE INTO dismissed_auto_sources (uri, dismissed_at) VALUES (?, ?)",
+            (uri, datetime.now().isoformat()),
+        )
+        self.db.commit()
+
+    def is_auto_source_dismissed(self, uri: str) -> bool:
+        """True when ``uri`` was previously dismissed via ``dismiss_auto_source``."""
+        row = self.db.execute(
+            "SELECT 1 FROM dismissed_auto_sources WHERE uri = ?", (uri,)
+        ).fetchone()
+        return row is not None
+
+    def undismiss_auto_source(self, uri: str) -> None:
+        """Clear a dismissal so auto-discovery may register ``uri`` again."""
+        self.db.execute("DELETE FROM dismissed_auto_sources WHERE uri = ?", (uri,))
+        self.db.commit()
+
+    def create_auto_source_unless_dismissed(
+        self, name: str, source_type: str, uri: str, properties: dict,
+    ) -> tuple[str | None, bool]:
+        """Atomically: reuse, refuse-if-dismissed, or insert an auto source.
+
+        Returns ``(source_id, created)``, or ``(None, False)`` when ``uri`` is
+        tombstoned. The tombstone check, the existing-row check and the INSERT
+        all happen inside ONE ``BEGIN IMMEDIATE`` transaction so a concurrent
+        ``delete_source_cascade(..., dismiss_uri=uri)`` cannot interleave: either
+        the delete's tombstone is visible here and nothing is created, or this
+        insert lands first and the delete then removes it and tombstones the URI.
+        Doing the check and the insert as two transactions would leave exactly
+        the window that lets a deleted auto source come back.
+        """
+        self.db.execute("BEGIN IMMEDIATE")
         try:
+            dismissed = self.db.execute(
+                "SELECT 1 FROM dismissed_auto_sources WHERE uri = ?", (uri,)
+            ).fetchone()
+            if dismissed:
+                self.db.execute("COMMIT")
+                return None, False
+            existing = self.db.execute(
+                "SELECT id FROM sources WHERE uri = ?", (uri,)
+            ).fetchone()
+            if existing:
+                sid = existing["id"]
+                self.db.execute("COMMIT")
+                return sid, False
+            sid = str(uuid4())
+            now = datetime.now().isoformat()
+            self.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (sid, name, source_type, uri, json.dumps(properties), now, now),
+            )
+            self.db.execute("COMMIT")
+            return sid, True
+        except Exception:
+            self.db.execute("ROLLBACK")
+            raise
+
+    def delete_source_cascade(self, source_id, dismiss_uri: str | None = None):
+        """Delete a source and all its items in a single transaction (batch SQL).
+
+        ``dismiss_uri`` writes an auto-discovery tombstone for that URI inside
+        the SAME transaction as the delete. That atomicity is required, not a
+        convenience: auto-discovery runs on a recurring watcher sweep, so a
+        tombstone written in a separate transaction after the cascade leaves a
+        window where a sweep observes neither a source row nor a tombstone and
+        re-creates (and re-ingests) the source the user just deleted.
+        """
+        self.db.execute("BEGIN IMMEDIATE")
+        try:
+            if dismiss_uri:
+                self.db.execute(
+                    "INSERT OR REPLACE INTO dismissed_auto_sources (uri, dismissed_at) "
+                    "VALUES (?, ?)",
+                    (dismiss_uri, datetime.now().isoformat()),
+                )
             # Batch FTS cleanup
             rows = self.db.execute(
                 "SELECT rowid, title, content, tags FROM items WHERE source_id = ?", (source_id,)

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -8,9 +8,16 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+from kiro_crew.config.loader import KiroCrewConfig, default_project_dir
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
+from .autosource import (
+    AUTO_ADDED_PROP,
+    DEFAULT_DROP_DIRNAME,
+    auto_source_still_contained,
+    discover_and_register,
+)
 from .embedder import embedder_signature
 from .folder_watcher import FolderWatcher
 from .ingestion import (
@@ -43,6 +50,8 @@ class KnowledgeWatcher:
         self._stop_event = asyncio.Event()
         self._folder_watcher = FolderWatcher(store, pipeline)
         self._reembed_task: asyncio.Task | None = None
+        # Last discovery error signature, for log dedup across sweeps.
+        self._discover_error_sig: str | None = None
 
     async def start(self):
         logger.info("Source watcher started: interval=%ds", self.interval)
@@ -60,8 +69,54 @@ class KnowledgeWatcher:
         self._stop_event.set()
         logger.info("Source watcher stopped")
 
+    async def _discover_drop_folder(self) -> None:
+        """Register the workspace drop folder if it has appeared.
+
+        Runs every sweep so a folder created after startup is picked up without
+        a restart (within one ``interval``). Gated on
+        ``knowledge.auto_discover_folder``; re-reads config each sweep so
+        toggling the flag takes effect without a restart, matching KiroCrew's
+        live-config behaviour. Never raises into the sweep: a discovery failure
+        must not stop registered sources from being scanned.
+        """
+        try:
+            cfg = KiroCrewConfig.load()
+            if not cfg.knowledge.auto_discover_folder:
+                return
+            dirname = cfg.knowledge.auto_discover_dirname or DEFAULT_DROP_DIRNAME
+            base = await asyncio.to_thread(default_project_dir)
+            if not base:
+                return
+            source_id = await asyncio.to_thread(
+                discover_and_register, self.store, base, dirname
+            )
+            self._discover_error_sig = None
+            if source_id:
+                # Registering a source that will spend LLM extraction on the
+                # user's files is an auditable mutation -- the manual POST path
+                # SEL-logs it, so the automatic path must too.
+                sel().log_tool_invocation(
+                    session_key="gateway", agent="knowledge-watcher",
+                    tool_name="knowledge.source.auto_add", outcome="completed",
+                    resources=f"source_id={source_id} dirname={dirname}",
+                )
+        except Exception as exc:
+            # Contained so a discovery failure cannot stop the sweep from
+            # scanning already-registered sources. Repeats are deduped: this runs
+            # every interval, and an unanticipated persistent error would
+            # otherwise emit a full traceback forever.
+            sig = f"{type(exc).__name__}:{exc}"
+            if sig != getattr(self, "_discover_error_sig", None):
+                self._discover_error_sig = sig
+                logger.warning("Knowledge drop-folder discovery failed", exc_info=True)
+            else:
+                logger.debug("Knowledge drop-folder discovery still failing: %s", sig)
+
     async def _scan(self):
         """Check all watched sources for changes."""
+        # Pick up a newly-created workspace drop folder before scanning, so a
+        # folder made since the last sweep is ingested in this same pass.
+        await self._discover_drop_folder()
         # Folder sources (local_folder, obsidian_vault)
         folder_rows = self.store.db.execute(
             "SELECT id, uri, source_type, properties FROM sources WHERE source_type IN ({})".format(
@@ -69,12 +124,34 @@ class KnowledgeWatcher:
             ),
             tuple(FOLDER_SOURCE_TYPES),
         ).fetchall()
+        ws_base: str | None = None
         for row in folder_rows:
             try:
                 source = dict(row)
                 props = self._parse_props(source.get("properties"))
                 if props.get("sync_status") in ("paused", "pending_confirmation"):
                     continue
+                if props.get(AUTO_ADDED_PROP):
+                    # Re-validate containment on EVERY sweep, not just at
+                    # registration: the stored URI is a path that can be swapped
+                    # for a symlink to an external tree after the fact, and
+                    # os.walk would then follow it out of the workspace.
+                    if ws_base is None:
+                        ws_base = await asyncio.to_thread(default_project_dir)
+                    if not await asyncio.to_thread(
+                        auto_source_still_contained, source["uri"], ws_base or ""
+                    ):
+                        logger.warning(
+                            "Skipping auto-added source %s: %s no longer resolves inside "
+                            "the workspace", source["id"], source["uri"],
+                        )
+                        sel().log_tool_invocation(
+                            session_key="gateway", agent="knowledge-watcher",
+                            tool_name="knowledge.source.auto_scan_denied",
+                            outcome="denied",
+                            resources=f"source_id={source['id']} reason=not_contained",
+                        )
+                        continue
                 stats = await self._folder_watcher.scan_source(source)
                 if stats.get("error"):
                     logger.warning("Folder scan error for %s: %s", source["uri"], stats["error"])

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2979,6 +2979,56 @@ def test_heartbeat_default_deliver_invalid_falls_back_to_slack():
     assert cfg.heartbeat.default_deliver == "slack"
 
 
+class TestKnowledgeAutoDiscover:
+    """``knowledge.auto_discover_folder`` / ``auto_discover_dirname`` parsing."""
+
+    def test_discovery_defaults_off(self) -> None:
+        cfg = _load_from_dict({})
+        assert cfg.knowledge.auto_discover_folder is False
+
+    def test_discovery_reads_value(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"auto_discover_folder": True}})
+        assert cfg.knowledge.auto_discover_folder is True
+
+    def test_dirname_default(self) -> None:
+        cfg = _load_from_dict({})
+        assert cfg.knowledge.auto_discover_dirname == "knowledge-docs"
+
+    def test_dirname_reads_value(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"auto_discover_dirname": "docs"}})
+        assert cfg.knowledge.auto_discover_dirname == "docs"
+
+    def test_dirname_is_stripped(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"auto_discover_dirname": "  docs \n"}})
+        assert cfg.knowledge.auto_discover_dirname == "docs"
+
+    def test_dirname_is_clamped_to_128(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"auto_discover_dirname": "x" * 500}})
+        assert len(cfg.knowledge.auto_discover_dirname) == 128
+
+    def test_dirname_non_string_is_coerced(self) -> None:
+        # str() coercion, not a crash -- the value is validated at use time by
+        # resolve_drop_folder (which rejects anything with a separator).
+        cfg = _load_from_dict({"knowledge": {"auto_discover_dirname": 42}})
+        assert cfg.knowledge.auto_discover_dirname == "42"
+
+    def test_traversal_dirname_is_kept_but_inert(self) -> None:
+        # Validation is deliberately runtime-only: the config retains what the
+        # user typed, and resolve_drop_folder refuses to act on it.
+        cfg = _load_from_dict({"knowledge": {"auto_discover_dirname": "../../etc"}})
+        assert cfg.knowledge.auto_discover_dirname == "../../etc"
+
+    def test_both_keys_round_trip(self) -> None:
+        from dataclasses import asdict
+
+        original = _load_from_dict(
+            {"knowledge": {"auto_discover_folder": True, "auto_discover_dirname": "docs"}}
+        )
+        reloaded = _load_from_dict({"knowledge": asdict(original.knowledge)})
+        assert reloaded.knowledge.auto_discover_folder is True
+        assert reloaded.knowledge.auto_discover_dirname == "docs"
+
+
 class TestKnowledgePoolIdleTtl:
     """``knowledge.pool_idle_ttl_secs`` parsing: default, override, explicit 0,
     and rejection of negative / bool / typed-wrong values back to the default."""

--- a/test/test_folder_watch_handlers.py
+++ b/test/test_folder_watch_handlers.py
@@ -12,6 +12,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from kiro_crew.dashboard.handlers.knowledge import (
     add_source,
     confirm_source,
+    delete_source,
     list_source_files,
     pause_source,
     rename_source,
@@ -51,6 +52,7 @@ def _make_app(store, watcher=None):
     app.router.add_post("/api/knowledge/sources/{id}/files/retry", retry_file)
     app.router.add_post("/api/knowledge/sources/{id}/files/skip", skip_file)
     app.router.add_patch("/api/knowledge/sources/{id}", rename_source)
+    app.router.add_delete("/api/knowledge/sources/{id}", delete_source)
     return app
 
 
@@ -134,6 +136,47 @@ class TestPauseSource:
         props = json.loads(row["properties"])
         assert props["scan_paused"] is True
         assert row["sync_status"] == "paused"
+
+    @pytest.mark.asyncio
+    async def test_pause_syncs_sync_status_into_properties(self, store, tmp_path):
+        """The watcher's pre-scan skip reads properties["sync_status"], not the
+        column, so a paused folder was still walked every sweep when the JSON
+        copy stayed "active"."""
+        sid = store.add_source(
+            "test", "local_folder", str(tmp_path), properties={"sync_status": "active"},
+        )
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.post(f"/api/knowledge/sources/{sid}/pause")
+            assert resp.status == 200
+        row = store.db.execute("SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        props = json.loads(row["properties"])
+        assert props["sync_status"] == "paused"
+
+
+class TestDeleteSourceDismissal:
+    """Deleting an auto-discovered source must not let it come straight back."""
+
+    @pytest.mark.asyncio
+    async def test_delete_records_dismissal_for_auto_added(self, store, tmp_path):
+        sid = store.add_source(
+            "Workspace Documents", "local_folder", str(tmp_path),
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.delete(f"/api/knowledge/sources/{sid}")
+            assert resp.status == 200
+        assert store.is_auto_source_dismissed(str(tmp_path)) is True
+
+    @pytest.mark.asyncio
+    async def test_delete_does_not_dismiss_hand_added(self, store, tmp_path):
+        """A user-registered folder has no discovery loop to resurrect it."""
+        sid = store.add_source(
+            "My Docs", "local_folder", str(tmp_path), properties={"sync_status": "active"},
+        )
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.delete(f"/api/knowledge/sources/{sid}")
+            assert resp.status == 200
+        assert store.is_auto_source_dismissed(str(tmp_path)) is False
 
 
 class TestResumeSource:

--- a/test/test_knowledge_workspace_autosource.py
+++ b/test/test_knowledge_workspace_autosource.py
@@ -1,0 +1,661 @@
+"""Tests for auto-discovery of the workspace documents (drop) folder.
+
+Covers ``knowledge.autosource`` and the recurring discovery step the
+``KnowledgeWatcher`` sweep runs: the folder is never created, it is picked up
+when it appears later, and registration is idempotent.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.knowledge.autosource import (
+    DEFAULT_DROP_DIRNAME,
+    DROP_SOURCE_NAME,
+    auto_source_still_contained,
+    discover_and_register,
+    ensure_drop_source,
+    resolve_drop_folder,
+)
+from kiro_crew.knowledge.store import KnowledgeStore
+from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+_AUTOSOURCE = "kiro_crew.knowledge.autosource"
+_WATCHER = "kiro_crew.knowledge.watcher"
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "test.db"))
+    yield s
+    s.close()
+
+
+def _sources(store) -> list[dict]:
+    return [dict(r) for r in store.db.execute("SELECT * FROM sources").fetchall()]
+
+
+def _props(store, uri) -> dict:
+    raw = store.get_source_by_uri(uri)["properties"]
+    return json.loads(raw) if isinstance(raw, str) else (raw or {})
+
+
+def _cfg(enabled: bool = True, dirname: str = DEFAULT_DROP_DIRNAME):
+    cfg = MagicMock()
+    cfg.knowledge.auto_discover_folder = enabled
+    cfg.knowledge.auto_discover_dirname = dirname
+    return cfg
+
+
+def _watcher(store) -> KnowledgeWatcher:
+    pipeline = MagicMock()
+    # No embedder configured -> _scan skips the self-heal re-embed branch.
+    pipeline.embedder = None
+    return KnowledgeWatcher(store=store, pipeline=pipeline)
+
+
+class TestResolveDropFolder:
+    def test_returns_path_when_folder_exists(self, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        assert resolve_drop_folder(str(tmp_path)) == str(tmp_path / DEFAULT_DROP_DIRNAME)
+
+    def test_returns_empty_when_folder_absent(self, tmp_path):
+        assert resolve_drop_folder(str(tmp_path)) == ""
+
+    def test_does_not_create_the_folder(self, tmp_path):
+        resolve_drop_folder(str(tmp_path))
+        assert not (tmp_path / DEFAULT_DROP_DIRNAME).exists()
+
+    def test_returns_empty_for_a_file_of_the_same_name(self, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).write_text("not a dir")
+        assert resolve_drop_folder(str(tmp_path)) == ""
+
+    def test_returns_empty_when_base_is_empty(self):
+        assert resolve_drop_folder("") == ""
+
+    def test_empty_folder_still_resolves(self, tmp_path):
+        """An empty drop folder is a valid, registerable source."""
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        assert resolve_drop_folder(str(tmp_path)) != ""
+
+    def test_rejects_sensitive_path(self, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        with patch(f"{_AUTOSOURCE}.is_sensitive_path", return_value=True):
+            assert resolve_drop_folder(str(tmp_path)) == ""
+
+    @pytest.mark.parametrize("bad", ["../escape", "a/b", "..", ".", "/abs"])
+    def test_rejects_dirname_that_escapes_the_workspace(self, tmp_path, bad):
+        assert resolve_drop_folder(str(tmp_path), bad) == ""
+
+    def test_backslash_dirname_stays_confined(self, tmp_path):
+        """POSIX treats '\\' as a literal filename char, Windows as a separator.
+
+        Either way the result must not escape: on POSIX it resolves to a literal
+        file inside the workspace (not a dir -> ""), on Windows the segment guard
+        rejects it.
+        """
+        assert resolve_drop_folder(str(tmp_path), "a\\b") == ""
+
+    def test_symlink_pointing_outside_workspace_is_rejected(self, tmp_path):
+        """The segment guard only constrains the config STRING, not the FS."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.md").write_text("private")
+        (workspace / DEFAULT_DROP_DIRNAME).symlink_to(outside, target_is_directory=True)
+        assert resolve_drop_folder(str(workspace)) == ""
+
+    def test_symlink_inside_workspace_is_allowed(self, tmp_path):
+        """Containment, not symlink-phobia: a link that stays inside is fine."""
+        workspace = tmp_path / "ws"
+        (workspace / "real").mkdir(parents=True)
+        (workspace / DEFAULT_DROP_DIRNAME).symlink_to(
+            workspace / "real", target_is_directory=True
+        )
+        assert resolve_drop_folder(str(workspace)) == str((workspace / "real").resolve())
+
+    def test_sibling_prefix_directory_is_not_treated_as_contained(self, tmp_path):
+        """Guards against a naive startswith: /ws-evil must not pass for /ws."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        evil = tmp_path / "ws-evil"
+        evil.mkdir()
+        (workspace / DEFAULT_DROP_DIRNAME).symlink_to(evil, target_is_directory=True)
+        assert resolve_drop_folder(str(workspace)) == ""
+
+    def test_unreadable_folder_still_resolves(self, tmp_path):
+        """is_dir() stats the entry, not its contents -- pin the behaviour."""
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir(mode=0o000)
+        try:
+            assert resolve_drop_folder(str(tmp_path)) == str(drop.resolve())
+        finally:
+            drop.chmod(0o755)
+
+    def test_honours_custom_dirname(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        assert resolve_drop_folder(str(tmp_path), "docs") == str(tmp_path / "docs")
+
+
+class TestEnsureDropSource:
+    def test_creates_folder_source(self, store, tmp_path):
+        source_id, created = ensure_drop_source(store, str(tmp_path))
+        assert created is True
+        row = store.get_source_by_uri(str(tmp_path))
+        assert row["id"] == source_id
+        assert row["source_type"] == "local_folder"
+        assert row["name"] == DROP_SOURCE_NAME
+
+    def test_seeded_active_so_the_watcher_scans_it(self, store, tmp_path):
+        ensure_drop_source(store, str(tmp_path))
+        status = _props(store, str(tmp_path))["sync_status"]
+        assert status == "active"
+        assert status not in ("paused", "pending_confirmation")
+
+    def test_marks_source_auto_added(self, store, tmp_path):
+        ensure_drop_source(store, str(tmp_path))
+        assert _props(store, str(tmp_path))["auto_added"] is True
+
+    def test_second_call_reuses_the_row(self, store, tmp_path):
+        first, created_first = ensure_drop_source(store, str(tmp_path))
+        second, created_second = ensure_drop_source(store, str(tmp_path))
+        assert (created_first, created_second) == (True, False)
+        assert first == second
+        assert len(_sources(store)) == 1
+
+    def test_unique_uri_race_is_treated_as_pre_existing(self, store, tmp_path):
+        uri = str(tmp_path)
+        winner = store.add_source(
+            name="raced", source_type="local_folder", uri=uri, properties={},
+        )
+        real_get = store.get_source_by_uri
+        calls = {"n": 0}
+
+        def flaky_get(u):
+            calls["n"] += 1
+            return None if calls["n"] == 1 else real_get(u)
+
+        with patch.object(store, "get_source_by_uri", side_effect=flaky_get):
+            source_id, created = ensure_drop_source(store, uri)
+        assert (source_id, created) == (winner, False)
+
+    def test_user_registered_folder_is_not_shadowed(self, store, tmp_path):
+        existing = store.add_source(
+            name="My Docs", source_type="local_folder", uri=str(tmp_path),
+            properties={"sync_status": "paused"},
+        )
+        source_id, created = ensure_drop_source(store, str(tmp_path))
+        assert (source_id, created) == (existing, False)
+        assert _sources(store)[0]["name"] == "My Docs"
+
+    def test_existing_row_of_a_different_source_type_is_reused_not_duplicated(
+        self, store, tmp_path
+    ):
+        """get_source_by_uri matches on uri alone; pin that we never double-add."""
+        existing = store.add_source(
+            name="My Vault", source_type="obsidian_vault", uri=str(tmp_path),
+            properties={},
+        )
+        source_id, created = ensure_drop_source(store, str(tmp_path))
+        assert (source_id, created) == (existing, False)
+        rows = _sources(store)
+        assert len(rows) == 1
+        assert rows[0]["source_type"] == "obsidian_vault"
+
+
+class TestDiscoverAndRegister:
+    def test_registers_when_folder_present(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        assert discover_and_register(store, str(tmp_path)) is not None
+        assert len(_sources(store)) == 1
+
+    def test_no_op_when_folder_absent(self, store, tmp_path):
+        assert discover_and_register(store, str(tmp_path)) is None
+        assert _sources(store) == []
+
+    def test_returns_none_once_already_registered(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        assert discover_and_register(store, str(tmp_path)) is not None
+        assert discover_and_register(store, str(tmp_path)) is None
+        assert len(_sources(store)) == 1
+
+
+class TestDismissal:
+    """A deleted auto-source must stay deleted while the folder still exists."""
+
+    def test_dismissed_folder_is_not_re_registered(self, store, tmp_path):
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir()
+        discover_and_register(store, str(tmp_path))
+        # Simulate the delete handler: cascade removes the row, tombstone stays.
+        source_id = store.get_source_by_uri(str(drop.resolve()))["id"]
+        store.delete_source_cascade(source_id)
+        store.dismiss_auto_source(str(drop.resolve()))
+        assert discover_and_register(store, str(tmp_path)) is None
+        assert _sources(store) == []
+
+    def test_delete_without_dismissal_would_resurrect(self, store, tmp_path):
+        """Pins WHY the tombstone exists: the row is the only other marker."""
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir()
+        discover_and_register(store, str(tmp_path))
+        source_id = store.get_source_by_uri(str(drop.resolve()))["id"]
+        store.delete_source_cascade(source_id)
+        # No dismissal recorded -> rediscovered.
+        assert discover_and_register(store, str(tmp_path)) is not None
+
+    def test_dismissal_survives_cascade(self, store, tmp_path):
+        uri = str(tmp_path)
+        source_id = store.add_source(
+            name="x", source_type="local_folder", uri=uri, properties={},
+        )
+        store.dismiss_auto_source(uri)
+        store.delete_source_cascade(source_id)
+        assert store.is_auto_source_dismissed(uri) is True
+
+    def test_undismiss_re_opts_in(self, store, tmp_path):
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir()
+        store.dismiss_auto_source(str(drop.resolve()))
+        assert discover_and_register(store, str(tmp_path)) is None
+        store.undismiss_auto_source(str(drop.resolve()))
+        assert discover_and_register(store, str(tmp_path)) is not None
+
+    def test_dismiss_is_idempotent(self, store, tmp_path):
+        store.dismiss_auto_source(str(tmp_path))
+        store.dismiss_auto_source(str(tmp_path))
+        assert store.is_auto_source_dismissed(str(tmp_path)) is True
+
+    def test_unrelated_uri_is_not_dismissed(self, store, tmp_path):
+        store.dismiss_auto_source(str(tmp_path / "a"))
+        assert store.is_auto_source_dismissed(str(tmp_path / "b")) is False
+
+
+class TestDeleteDiscoveryAtomicity:
+    """The tombstone and the delete must land in ONE transaction.
+
+    Discovery runs on a recurring sweep, so a tombstone written *after* the
+    cascade commits leaves a window where a sweep sees neither a source row nor
+    a tombstone and re-creates the source the user just deleted.
+    """
+
+    def test_cascade_writes_tombstone_in_same_transaction(self, store, tmp_path):
+        uri = str(tmp_path)
+        sid = store.add_source(
+            name="Workspace Documents", source_type="local_folder", uri=uri,
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        store.delete_source_cascade(sid, dismiss_uri=uri)
+        assert store.get_source_by_uri(uri) is None
+        assert store.is_auto_source_dismissed(uri) is True
+
+    def test_cascade_without_dismiss_uri_leaves_no_tombstone(self, store, tmp_path):
+        uri = str(tmp_path)
+        sid = store.add_source(
+            name="My Docs", source_type="local_folder", uri=uri, properties={},
+        )
+        store.delete_source_cascade(sid)
+        assert store.is_auto_source_dismissed(uri) is False
+
+    def test_tombstone_is_written_inside_the_delete_transaction(self, store, tmp_path):
+        """Trace the real statement stream: BEGIN -> tombstone -> ... -> COMMIT.
+
+        The tombstone must be inside the transaction and precede the source
+        delete, so no committed state ever has the row gone without a tombstone
+        -- which is what a concurrent sweep would exploit to resurrect it.
+        """
+        uri = str(tmp_path)
+        sid = store.add_source(
+            name="Workspace Documents", source_type="local_folder", uri=uri,
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        stmts: list[str] = []
+        store.db.set_trace_callback(lambda s: stmts.append(" ".join(s.split()).upper()))
+        try:
+            store.delete_source_cascade(sid, dismiss_uri=uri)
+        finally:
+            store.db.set_trace_callback(None)
+
+        def index_of(needle: str) -> int:
+            for i, s in enumerate(stmts):
+                if needle in s:
+                    return i
+            raise AssertionError(f"{needle!r} not traced; got {stmts}")
+
+        begin = index_of("BEGIN IMMEDIATE")
+        tombstone = index_of("INSERT OR REPLACE INTO DISMISSED_AUTO_SOURCES")
+        src_delete = index_of("DELETE FROM SOURCES WHERE ID")
+        commit = index_of("COMMIT")
+        assert begin < tombstone < src_delete < commit
+
+    def test_failed_delete_rolls_back_the_tombstone_too(self, store, tmp_path):
+        """One transaction means a failure leaves neither effect behind."""
+        uri = str(tmp_path)
+        sid = store.add_source(
+            name="Workspace Documents", source_type="local_folder", uri=uri,
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        # An unsupported bind type fails the cascade partway through.
+        with pytest.raises(Exception):
+            store.delete_source_cascade(sid, dismiss_uri=object())  # type: ignore[arg-type]
+        assert store.get_source_by_uri(uri) is not None
+        assert store.is_auto_source_dismissed(uri) is False
+
+    def test_discovery_refuses_a_dismissed_uri_atomically(self, store, tmp_path):
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir()
+        uri = str(drop.resolve())
+        store.dismiss_auto_source(uri)
+        # The atomic store path must refuse, not just the caller-side check.
+        source_id, created = store.create_auto_source_unless_dismissed(
+            name="Workspace Documents", source_type="local_folder", uri=uri,
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        assert (source_id, created) == (None, False)
+        assert discover_and_register(store, str(tmp_path)) is None
+        assert _sources(store) == []
+
+    def test_atomic_create_reuses_existing_row(self, store, tmp_path):
+        uri = str(tmp_path)
+        existing = store.add_source(
+            name="My Docs", source_type="local_folder", uri=uri, properties={},
+        )
+        source_id, created = store.create_auto_source_unless_dismissed(
+            name="Workspace Documents", source_type="local_folder", uri=uri,
+            properties={},
+        )
+        assert (source_id, created) == (existing, False)
+
+    def test_atomic_create_inserts_when_clean(self, store, tmp_path):
+        source_id, created = store.create_auto_source_unless_dismissed(
+            name="Workspace Documents", source_type="local_folder",
+            uri=str(tmp_path), properties={"sync_status": "active"},
+        )
+        assert created is True
+        assert store.get_source_by_uri(str(tmp_path))["id"] == source_id
+
+
+class TestWatcherDiscovery:
+    @pytest.mark.asyncio
+    async def test_flag_off_registers_nothing(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg(enabled=False)), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=str(tmp_path)):
+            await _watcher(store)._discover_drop_folder()
+        assert _sources(store) == []
+
+    @pytest.mark.asyncio
+    async def test_registers_existing_folder(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg()), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=str(tmp_path)):
+            await _watcher(store)._discover_drop_folder()
+        assert len(_sources(store)) == 1
+
+    @pytest.mark.asyncio
+    async def test_folder_created_later_is_picked_up_on_a_later_sweep(self, store, tmp_path):
+        """The point of recurring discovery: no restart needed."""
+        w = _watcher(store)
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg()), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=str(tmp_path)):
+            await w._discover_drop_folder()
+            assert _sources(store) == []          # sweep 1: folder absent
+            (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+            await w._discover_drop_folder()
+            assert len(_sources(store)) == 1      # sweep 2: folder appeared
+
+    @pytest.mark.asyncio
+    async def test_repeated_sweeps_do_not_duplicate(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        w = _watcher(store)
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg()), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=str(tmp_path)):
+            for _ in range(4):
+                await w._discover_drop_folder()
+        assert len(_sources(store)) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_dir_is_a_no_op(self, store):
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg()), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=""):
+            await _watcher(store)._discover_drop_folder()
+        assert _sources(store) == []
+
+    @pytest.mark.asyncio
+    async def test_blank_dirname_falls_back_to_default(self, store, tmp_path):
+        (tmp_path / DEFAULT_DROP_DIRNAME).mkdir()
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", return_value=_cfg(dirname="")), \
+                patch(f"{_WATCHER}.default_project_dir", return_value=str(tmp_path)):
+            await _watcher(store)._discover_drop_folder()
+        assert len(_sources(store)) == 1
+
+    @pytest.mark.asyncio
+    async def test_discovery_failure_does_not_break_the_sweep(self, store, tmp_path):
+        """Registered sources must still be scanned when discovery blows up."""
+        drop = tmp_path / "already-registered"
+        drop.mkdir()
+        store.add_source(
+            name="Existing", source_type="local_folder", uri=str(drop),
+            properties={"sync_status": "active"},
+        )
+        w = _watcher(store)
+        w._folder_watcher = MagicMock()
+        w._folder_watcher.scan_source = AsyncMock(return_value={})
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", side_effect=RuntimeError("boom")):
+            await w._scan()
+        # Discovery raised, but the pre-existing source was still scanned.
+        w._folder_watcher.scan_source.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_repeated_identical_failures_log_once(self, store):
+        w = _watcher(store)
+        with patch(f"{_WATCHER}.KiroCrewConfig.load", side_effect=RuntimeError("boom")), \
+                patch(f"{_WATCHER}.logger") as log:
+            await w._discover_drop_folder()
+            await w._discover_drop_folder()
+            await w._discover_drop_folder()
+        assert log.warning.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_scan_runs_discovery_before_scanning_sources(self, store):
+        """Discovery is wired into the sweep, not just callable in isolation."""
+        w = _watcher(store)
+        w._discover_drop_folder = AsyncMock()
+        await w._scan()
+        w._discover_drop_folder.assert_awaited_once()
+
+
+class TestScanTimeContainment:
+    """Registration-time containment is not enough -- re-check every sweep.
+
+    The persisted URI is a literal path when the drop folder is a real
+    directory, so swapping it for a symlink to an external tree afterwards would
+    otherwise have os.walk follow it out of the workspace.
+    """
+
+    def test_contained_folder_passes(self, tmp_path):
+        ws = tmp_path / "ws"
+        drop = ws / DEFAULT_DROP_DIRNAME
+        drop.mkdir(parents=True)
+        assert auto_source_still_contained(str(drop), str(ws)) is True
+
+    def test_folder_swapped_for_external_symlink_fails(self, tmp_path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        drop = ws / DEFAULT_DROP_DIRNAME
+        drop.symlink_to(outside, target_is_directory=True)
+        assert auto_source_still_contained(str(drop), str(ws)) is False
+
+    def test_sibling_prefix_fails(self, tmp_path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        evil = tmp_path / "ws-evil"
+        evil.mkdir()
+        assert auto_source_still_contained(str(evil), str(ws)) is False
+
+    def test_sensitive_target_fails(self, tmp_path):
+        ws = tmp_path / "ws"
+        drop = ws / DEFAULT_DROP_DIRNAME
+        drop.mkdir(parents=True)
+        with patch(f"{_AUTOSOURCE}.is_sensitive_path", return_value=True):
+            assert auto_source_still_contained(str(drop), str(ws)) is False
+
+    def test_empty_base_fails(self, tmp_path):
+        assert auto_source_still_contained(str(tmp_path), "") is False
+
+    @pytest.mark.asyncio
+    async def test_sweep_skips_auto_source_that_escaped(self, store, tmp_path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.md").write_text("private")
+        drop = ws / DEFAULT_DROP_DIRNAME
+        drop.symlink_to(outside, target_is_directory=True)
+        store.add_source(
+            name=DROP_SOURCE_NAME, source_type="local_folder", uri=str(drop),
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        w = _watcher(store)
+        w._folder_watcher = MagicMock()
+        w._folder_watcher.scan_source = AsyncMock(return_value={})
+        w._discover_drop_folder = AsyncMock()
+        with patch(f"{_WATCHER}.default_project_dir", return_value=str(ws)):
+            await w._scan()
+        w._folder_watcher.scan_source.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sweep_still_scans_a_contained_auto_source(self, store, tmp_path):
+        ws = tmp_path / "ws"
+        drop = ws / DEFAULT_DROP_DIRNAME
+        drop.mkdir(parents=True)
+        store.add_source(
+            name=DROP_SOURCE_NAME, source_type="local_folder", uri=str(drop),
+            properties={"sync_status": "active", "auto_added": True},
+        )
+        w = _watcher(store)
+        w._folder_watcher = MagicMock()
+        w._folder_watcher.scan_source = AsyncMock(return_value={})
+        w._discover_drop_folder = AsyncMock()
+        with patch(f"{_WATCHER}.default_project_dir", return_value=str(ws)):
+            await w._scan()
+        w._folder_watcher.scan_source.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hand_added_source_outside_workspace_is_untouched(self, store, tmp_path):
+        """A user-registered folder outside the workspace is their choice."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        store.add_source(
+            name="My Docs", source_type="local_folder", uri=str(elsewhere),
+            properties={"sync_status": "active"},
+        )
+        w = _watcher(store)
+        w._folder_watcher = MagicMock()
+        w._folder_watcher.scan_source = AsyncMock(return_value={})
+        w._discover_drop_folder = AsyncMock()
+        with patch(f"{_WATCHER}.default_project_dir", return_value=str(ws)):
+            await w._scan()
+        w._folder_watcher.scan_source.assert_awaited_once()
+
+
+class TestPauseSurvivesRestart:
+    """An empty paused auto-source must not be orphan-cleaned on restart.
+
+    ``_migrate()`` runs on every KnowledgeStore construction (every gateway
+    start) and deletes sources with no items. An empty drop folder has none, so
+    without the folder-source carve-out a paused row would be deleted and then
+    re-created as ``active`` by discovery -- silently un-pausing it.
+    """
+
+    def test_empty_paused_auto_source_survives_reopen(self, tmp_path):
+        db = str(tmp_path / "k.db")
+        drop = tmp_path / DEFAULT_DROP_DIRNAME
+        drop.mkdir()
+        s1 = KnowledgeStore(db)
+        try:
+            sid = s1.add_source(
+                name=DROP_SOURCE_NAME, source_type="local_folder", uri=str(drop),
+                properties={"sync_status": "paused", "auto_added": True,
+                            "scan_paused": True},
+            )
+        finally:
+            s1.close()
+        # Reopening runs the orphan cleanup, as a gateway restart would.
+        s2 = KnowledgeStore(db)
+        try:
+            row = s2.get_source_by_uri(str(drop))
+            assert row is not None, "paused empty folder source was orphan-deleted"
+            assert row["id"] == sid
+            props = json.loads(row["properties"])
+            assert props["sync_status"] == "paused"
+        finally:
+            s2.close()
+
+    def test_empty_active_folder_source_also_survives(self, tmp_path):
+        db = str(tmp_path / "k.db")
+        s1 = KnowledgeStore(db)
+        try:
+            s1.add_source(
+                name="My Docs", source_type="local_folder", uri=str(tmp_path),
+                properties={"sync_status": "active"},
+            )
+        finally:
+            s1.close()
+        s2 = KnowledgeStore(db)
+        try:
+            assert s2.get_source_by_uri(str(tmp_path)) is not None
+        finally:
+            s2.close()
+
+    def test_non_folder_orphan_is_still_cleaned(self, tmp_path):
+        """The carve-out is folder-only; other empty sources still get reaped."""
+        db = str(tmp_path / "k.db")
+        s1 = KnowledgeStore(db)
+        try:
+            s1.add_source(
+                name="stale", source_type="local_file",
+                uri=str(tmp_path / "gone.md"), properties={},
+            )
+        finally:
+            s1.close()
+        s2 = KnowledgeStore(db)
+        try:
+            assert s2.get_source_by_uri(str(tmp_path / "gone.md")) is None
+        finally:
+            s2.close()
+
+
+class TestConfigContract:
+    """The two new knowledge.* keys parse, clamp, and round-trip.
+
+    The config-level parsing tests live in ``test/test_config_loader.py``
+    alongside the other ``knowledge.*`` key tests (they need that module's
+    ``_load_from_dict`` helper). What is asserted here is only the contract this
+    module depends on: the default dirname constant agrees with the config
+    default, so a config-less install discovers the documented folder.
+    """
+
+    def test_module_default_matches_config_default(self):
+        from dataclasses import fields
+
+        from kiro_crew.config.loader import KnowledgeConfig
+
+        field = next(f for f in fields(KnowledgeConfig) if f.name == "auto_discover_dirname")
+        assert field.default == DEFAULT_DROP_DIRNAME
+
+    def test_discovery_is_off_by_default(self):
+        from dataclasses import fields
+
+        from kiro_crew.config.loader import KnowledgeConfig
+
+        field = next(f for f in fields(KnowledgeConfig) if f.name == "auto_discover_folder")
+        assert field.default is False


### PR DESCRIPTION
## Scope

### What this adds

One thing: a conventional folder inside the KiroCrew workspace whose contents are auto-registered as a watched Knowledge Library source, so files dropped there become searchable without wiring up a source by hand.

```
<workspace>/knowledge-docs/          # e.g. ~/.kiro/crew/workspace/knowledge-docs/
```

That single path is the entire feature surface. One folder, one source row, opt-in and off by default.

### What it is not

- **Not** Kiro CLI's own knowledge-base store (`~/.local/share/kiro-cli/knowledge_bases`). That is a separate subsystem with its own index, and the directory is classified as a sensitive path in `security.py` because it holds a live SSO bearer token — `add_source` returns 403 for any URI beneath it. Nothing here reads or imports it. Bridging those bases into the Library would be separate work with its own security review.
- **Not** a general folder-scanner. It does not walk the workspace, discover arbitrary folders, or register more than this one path.
- **Not** the workspace root, and **not** `<workspace>/knowledge/` — that is where the Library's own SQLite store lives (created eagerly by `dashboard/state.py`), so a drop folder by that name would always exist and make "discover it when it appears" vacuous. The docs warn against overriding `auto_discover_dirname` to `knowledge`.

### Why the diff is bigger than the feature

The mechanism itself is small. Most of the change is the cost of making *recurring* auto-registration safe against the rest of the system — an auto-created row living in a table built for user-created rows. Reviewers should expect roughly this split (~420 production lines):

| File | +lines | What it carries |
|---|---:|---|
| `knowledge/autosource.py` (new) | 179 | Path resolution, workspace containment, get-or-create, per-sweep revalidation |
| `knowledge/store.py` | 109 | Dismissal tombstone table + accessors, atomic create-unless-dismissed, atomic tombstone-with-delete, orphan-sweep carve-out |
| `knowledge/watcher.py` | 77 | The recurring discovery hook, the containment gate, error-signature dedup |
| `dashboard/handlers/knowledge.py` | 28 | Tombstone on delete, off-loop cascade, pause `sync_status` sync |
| `config/loader.py` | 28 | The two config keys |

Four of the five blocking review findings on this PR were lifecycle edge cases — delete-resurrection, a delete/discovery race, a post-registration symlink swap, and pause loss across restart — not feature bugs. That is where the volume went.

### Deliberately one PR

Three of the changes fix **pre-existing** defects that are not specific to this feature. They are kept here rather than split out because the feature's correctness depends on each, but they stand alone and reviewers may prefer to read them as their own unit:

- `pause_source` never wrote `sync_status` into the `properties` JSON, only the column — and the watcher's pre-scan skip reads the JSON (it selects `properties`, not the column). Every folder source was therefore fully walked and delete-reconciled on every sweep while paused, with only the deeper `scan_paused` gate stopping ingestion.
- The orphan sweep in `_migrate()` deleted any empty folder source on restart, including **hand-added** ones.
- `delete_source_cascade` ran synchronously on the event loop, and this PR's upgrade to `BEGIN IMMEDIATE` would have made that worse.

## Problem

Making a local folder searchable in the Knowledge Library is entirely manual: `POST /api/knowledge/sources`, then a confirm step. There is no "drop files here and they become searchable" path, so the common case — a scratch folder of docs alongside your workspace — requires the same ceremony as wiring up an external vault, every time.

## Why it matters

The friction lands on the cheapest, most frequent case. A user who just wants a few design docs or runbooks retrievable has to know the source-registration flow exists, find it in the UI, and confirm it. Without a conventional location there is also nothing to point people at: no answer to "where do I put documents so Kiro can find them?"

## Fix (symptom → root cause → change)

**Symptom:** no zero-ceremony way to make workspace documents searchable.

**Root cause:** source registration is exclusively user-initiated. There is no code path that registers a source without an HTTP request, and no convention for where such a folder would live.

**Change:** an opt-in convention folder inside the workspace, registered as a watched `local_folder` source by the existing folder watcher. Two new config keys, both off by default:

| Key | Default | Meaning |
|---|---|---|
| `knowledge.auto_discover_folder` | `false` | Enable discovery of the one folder |
| `knowledge.auto_discover_dirname` | `"knowledge-docs"` | Its name inside the workspace |

Three properties of the design:

- **Never created for you.** The folder's absence *is* the opt-out — `resolve_drop_folder` only reads the filesystem, never `mkdir`s. Creating it is how you opt in.
- **Picked up if created later.** Discovery runs on every `KnowledgeWatcher` sweep (default 300s), not once at startup, so a folder made after the gateway booted is registered on the next sweep with no restart. Config is re-read each sweep, so toggling the flag also takes effect without a restart.
- **Registered at most once.** Get-or-create keyed on the resolved URI, mirroring `ensure_artifact_source`. A folder you already registered by hand at the same path is reused, never shadowed.

### Why not `knowledge`

The Library's own SQLite store lives at `<workspace>/knowledge/`, created eagerly by `dashboard/state.py` (`os.makedirs(..., exist_ok=True)`). A drop folder by that name would therefore *always* exist, making "discover it when it appears" vacuous, and would mix user documents with the store's own DB files. The docs warn against overriding `auto_discover_dirname` to `knowledge` for this reason.

## Review findings fixed

Three independent local reviewers ran before this was opened, and the server GPT gate then found a fourth issue. All are fixed.

**Delete/rediscovery race (BLOCKING, from GPT 5.6 on `74952985`).** The delete path committed the cascade and *then* wrote the dismissal tombstone in a second transaction. A watcher sweep landing between the two saw neither a source row nor a tombstone, so it re-created and re-ingested the source the user had just deleted — after the API had already returned 200. Both halves are now atomic: `delete_source_cascade(source_id, dismiss_uri=...)` writes the tombstone as the first statement inside the transaction (upgraded to `BEGIN IMMEDIATE`), and a new `store.create_auto_source_unless_dismissed()` does the tombstone check, the existing-row check and the `INSERT` in one `BEGIN IMMEDIATE` transaction. The non-atomic caller-side pre-check is gone.

**Workspace-containment escape (HIGH).** The single-path-segment guard on `dirname` only constrains the config *string*. A symlink at `<workspace>/knowledge-docs` pointing outside the workspace survived it, and `is_sensitive_path()` does not help — it classifies credential/trust directories only, so a link to an unrelated home or system tree passes, and the whole target would be walked and LLM-extracted. Fixed with a containment check (`commonpath`, so a sibling like `/ws-evil` cannot pass a prefix test) applied *in addition to* the sensitive-path check. Symlinks that stay inside the workspace are still allowed.

**Scan-time containment revalidation (BLOCKING, GPT round 3).** Registration-time validation is not sufficient. When `<workspace>/knowledge-docs` is a real directory the persisted URI is that literal path, so replacing the directory with a symlink to an external tree afterwards makes `os.walk` follow it out of the workspace on the next sweep. Containment is now re-validated on *every* sweep before an auto-added source is scanned (`auto_source_still_contained` re-resolves the URI and re-checks both `commonpath` containment and `is_sensitive_path`). An escaped source is skipped with a warning and a SEL `auto_scan_denied` event, not deleted. The gate is keyed on `auto_added`, so a folder registered by hand outside the workspace still scans — that is the user's explicit choice.

**Delete/rediscovery race (BLOCKING, GPT round 2).** The tombstone was written in a second transaction after the cascade committed, so a sweep landing in between saw neither a source row nor a tombstone and re-created the source the user had just deleted — after the API returned 200. Both sides are now atomic: `delete_source_cascade(source_id, dismiss_uri=...)` writes the tombstone as the first statement inside the transaction (upgraded to `BEGIN IMMEDIATE`), and `create_auto_source_unless_dismissed()` does the tombstone check, the existing-row check and the `INSERT` in one `BEGIN IMMEDIATE` transaction.

**Event-loop block (BLOCKING, GPT round 3).** `BEGIN IMMEDIATE` takes the write lock eagerly and the connection's `busy_timeout` is 10s, so a concurrent ingestion writer could park the delete handler on the event loop for that long. The handler now calls `await asyncio.to_thread(store.delete_source_cascade, ...)`.

**Paused empty auto-sources reactivating after restart (BLOCKING, GPT round 4).** `_migrate()` runs on every `KnowledgeStore` construction and its orphan sweep deletes sources with no items. An empty drop folder has none, so pausing it then restarting deleted the row and discovery re-created it as `active`, silently un-pausing it. Folder source types are now excluded from the orphan sweep — a watched folder with zero discovered files is legitimately empty, not orphaned.

**Delete-resurrection (HIGH).** Because discovery is recurring and the source row was its only idempotency marker, deleting the auto-added source while the folder still existed caused it to come back within one sweep, with no way to remove it permanently short of deleting the folder or turning the flag off. Fixed with a `dismissed_auto_sources` tombstone table, deliberately not touched by `delete_source_cascade`, written only for `auto_added` rows. `undismiss_auto_source` re-opts-in.

**Missing SEL audit (MEDIUM).** Every manual source mutation is SEL-audited; the automatic path created a source and flipped it to `active` with no auditable record. Registration and dismissal now both emit SEL events.

**Stale `properties["sync_status"]` on pause (MEDIUM).** Pre-existing for all folder sources, but this feature's docstring leaned on the gate. `pause_source` wrote `sync_status` only to the *column*, while the watcher's pre-scan skip reads it from the `properties` JSON (it selects `properties`, not the column) — so a paused folder was still fully walked and delete-reconciled every sweep, with only the deeper `scan_paused` gate stopping ingestion. `confirm`/`resume` already kept both in sync; `pause` was the outlier.

**Log spam on persistent failure (LOW).** Discovery failures are contained so they cannot stop the sweep from scanning registered sources, but an unanticipated persistent error emitted a full traceback every 300s forever. Now deduped by error signature.

Three reviewer items were **verified as already sound** and needed no change: the inline `KiroCrewConfig.load()` is fingerprint-cached (two `os.stat` calls on the steady path, ~4 orders of magnitude under the 30s loop-watchdog threshold); `KnowledgeStore` uses a per-thread connection via `threading.local`, so the `to_thread` worker gets its own and cross-thread SQLite use is safe; and discovery *is* reached at startup, because `start()` runs `_scan()` before its first interval wait.

## No UI surface

These are config-file keys only. There is no Settings control — `website/src/` contains no reference to any `knowledge.*` config key, and there is no schema-driven settings renderer. The `_meta()` labels feed `config-baseline.json` only.

## Tests

35+ new tests across three files:

- `test/test_knowledge_workspace_autosource.py` — the containment guard, symlink escape and sibling-prefix cases, backslash dirname (POSIX-literal vs Windows-separator divergence), unreadable folder, empty folder, different `source_type` at the same URI, idempotency and the `UNIQUE` race, the dismissal lifecycle, delete/discovery atomicity (statement-order traced via `set_trace_callback`), failure containment, and the sweep wiring.
- `test/test_config_loader.py` — parse / strip / 128-char clamp / round-trip for both new keys.
- `test/test_folder_watch_handlers.py` — delete-dismissal for auto-added vs hand-added sources, and the pause JSON sync.

6 guards are revert-verified: removing the containment check fails the symlink-escape and sibling-prefix tests; disabling the dismissal check fails the tombstone tests; moving the tombstone back out of the delete transaction fails 4 atomicity tests; unhooking discovery from the sweep fails the wiring test; making `resolve_drop_folder` create the folder fails 5 tests including later-pickup.

## Manual verification

Verified end-to-end on an isolated dev gateway (not the live one). With the flag on, a `knowledge-docs/` folder created **after** startup was discovered on a later sweep, registered as `Workspace Documents` with `sync_status: active` and `auto_added: true`, and both files were ingested — 2 items, 7 entities, 5 relations, 2/2 embedded. Screenshots were shared in the working session; the repo blocks committed binaries, so they are not embedded here.

## Gates

- 19532 pytest, 5406 vitest (447 frontend test files)
- `isort` / `flake8` / `mypy` (516 files) / `tsc -b` clean
- Pre-existing failures confirmed against a clean `origin/main` checkout: `test_dashboard_origin.py::TestParseDashboardUrlMalformed` (3). Two tests flake under parallel load and pass in isolation (`test_apps_registry` timeout, `test_terminal_handler` pty) — this diff touches neither area.

Opened as a draft.



