### PR TITLE
fix(browser): render the live Playwright mirror in the Browser panel

### DIFF
--- a/src/kiro_crew/browser/cli.py
+++ b/src/kiro_crew/browser/cli.py
@@ -61,10 +61,12 @@ def run_browse(args: list[str]) -> None:
 
 
 def _print_help() -> None:
-    print("""kirocrew browse — Playwright MCP browser setup
+    print(
+        """kirocrew browse — Playwright MCP browser setup
 
 Commands:
-  setup                Generate the Playwright MCP config (OSS)
+  setup                Configure the Browser panel: write config, register the
+                       proxy, and check the @playwright/mcp launcher (OSS)
   auth health          not available in OSS
   auth inject          not available in OSS
   auth refresh         not available in OSS
@@ -77,21 +79,49 @@ Modes:
     with all existing auth — no cookie injection needed. Requires the Playwright
     Chrome extension: https://chromewebstore.google.com/detail/mmlmfjhmonkocbjadbfplnigmagldckm
   Headless mode (default on Linux): Launches separate Chromium.
-""")
+"""
+    )
 
 
 def _cmd_setup() -> None:
-    """Generate the Playwright MCP config (OSS).
+    """Guided one-command Playwright MCP setup for the Browser panel.
 
-    Automated Playwright MCP installation is not available in the open-source
-    build. Install the public ``@playwright/mcp`` package yourself (for example
-    via ``npx @playwright/mcp``); this command only writes the local config.
+    Writes the headless Chromium config, registers the compression proxy in
+    kiro's ``mcp.json`` (creating it if absent), and checks that a Playwright
+    launcher is resolvable — then prints a ✓/✗ checklist and the single
+    remaining action (restart the gateway). The public ``@playwright/mcp``
+    package still installs separately in the OSS build; this reports whether it
+    is resolvable and gives the exact install command when it is not.
     """
-    print("Generating Playwright MCP config...")
-    _setup.ensure_playwright_installed()
-    _setup.generate_playwright_config()
-    print(f"Done. Wrote Playwright MCP config to {config_dir() / 'playwright-config.json'}.")
-    print("Install the public @playwright/mcp package separately (e.g. npx @playwright/mcp).")
+    print("Setting up Playwright MCP for the Browser panel...\n")
+
+    cfg = _setup.generate_playwright_config()
+    print(f"  \u2713 Playwright config (headless)   {cfg}")
+
+    mcp_json, reg_status = _setup.register_playwright_proxy()
+    if reg_status == "kept-user-entry":
+        print(f"  \u00b7 Proxy NOT registered           {mcp_json}")
+        print("    (you already have your own 'playwright-mcp' server — left untouched)")
+    else:
+        print(f"  \u2713 Proxy registered               {mcp_json}")
+
+    ok, detail = _setup.check_playwright_launchable()
+    mark = "\u2713" if ok else "\u2717"
+    print(f"  {mark} @playwright/mcp launcher       {detail}")
+
+    storage_state = config_dir() / "playwright-storage-state.json"
+    if storage_state.exists():
+        print(f"  \u2713 Storage state                  {storage_state}")
+    else:
+        print("  \u00b7 Storage state (optional)       not set — public sites work without it")
+
+    print()
+    if not ok:
+        print("Action needed — install the Playwright MCP package, then re-run this:")
+        print("  npm install -g @playwright/mcp        # or: npx @playwright/mcp\n")
+    print("Restart the gateway to apply:   kirocrew stop && kirocrew gateway\n")
+    print("The Browser panel is a read-only live mirror (view-only). Toggle")
+    print('"Browser use" (the Globe) to let the agent operate the page.')
 
 
 def _cmd_extension(action: str) -> None:

--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -23,6 +23,7 @@ from kiro_crew.agent_files import OWNED_CC_AGENT_FILES, OWNED_KIRO_AGENT_FILES
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser.auth import parse_netscape_cookies
 from kiro_crew.config.paths import config_dir
+from kiro_crew.mcp_playwright_proxy import _resolve_playwright_cmd
 from kiro_crew.mcp_utils import mcp_server_alias
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,12 @@ def generate_playwright_config() -> Path:
             "isolated": True,
             "launchOptions": {
                 "channel": "chromium",
+                # Run headless: the live mirror in the dashboard Browser panel is
+                # the intended view surface, so a separate visible OS window is
+                # redundant (and breaks on display-less Linux hosts). Auth is
+                # seeded via ``storageState`` below, so no interactive SSO window
+                # is needed.
+                "headless": True,
                 "args": [],
             },
             "contextOptions": {
@@ -682,6 +689,78 @@ def patch_mcp_headless() -> None:
         _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
         pass
+
+
+def check_playwright_launchable() -> tuple[bool, str]:
+    """Best-effort check that a Playwright MCP launcher is resolvable.
+
+    Reuses the proxy's own resolution order (``KIROCREW_PLAYWRIGHT_CMD`` →
+    a ``mcp-server-playwright``/``playwright-mcp`` binary → ``npx``), so the
+    check agrees with what the proxy would actually spawn. Returns
+    ``(ok, detail)`` where ``detail`` is the resolved launcher, or an install
+    hint when nothing is resolvable (e.g. Node/npm absent).
+    """
+    cmd = _resolve_playwright_cmd()
+    if cmd is None:
+        return (
+            False,
+            "not found — install Node.js then `npm i -g @playwright/mcp` "
+            "(or ensure `npx` is on PATH)",
+        )
+    return True, cmd
+
+
+def register_playwright_proxy() -> tuple[Path, str]:
+    """Register KiroCrew's Playwright proxy in kiro's ``mcp.json``.
+
+    Unlike the boot-time converge helpers, this is the explicit ``browse setup``
+    entry point: it CREATES ``~/.kiro/settings/mcp.json`` when absent (so a fresh
+    user gets a wired server from one command) and then writes the canonical
+    proxy entry via the mode-appropriate patch (extension vs headless config).
+
+    Returns ``(mcp_json_path, status)`` where ``status`` is ``"registered"``
+    (KiroCrew's proxy was written/refreshed) or ``"kept-user-entry"`` (a
+    user-authored NON-proxy server already holds the canonical ``playwright-mcp``
+    key, so we left it untouched rather than clobber their config — authorship is
+    by launch target, not key name, mirroring the boot-time migration guard).
+    """
+    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
+    mcp_json.parent.mkdir(parents=True, exist_ok=True)
+    # Serialize with the other writers of this SAME file — the dashboard MCP
+    # handler and the app bridges both take an exclusive flock on the shared
+    # ``mcp.lock`` sidecar (via platform_compat.file_lock) before mutating
+    # mcp.json. Hold that lock across our read + create + patch_mcp_* write so a
+    # concurrent gateway/bridge update can't be clobbered (which would drop the
+    # other writer's server entries).
+    lock_path = mcp_json.with_suffix(".lock")
+    lock_path.touch(exist_ok=True)
+    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+    # "r+" (not "r"): Windows msvcrt.locking requires a writable fd.
+    with open(lock_path, "r+") as lf:
+        with platform_compat.file_lock(lf.fileno(), exclusive=True):
+            if mcp_json.exists():
+                try:
+                    existing = json.loads(mcp_json.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    existing = {}
+                servers = existing.get("mcpServers") if isinstance(existing, dict) else None
+                canon = servers.get(canonical) if isinstance(servers, dict) else None
+                # A user may hand-author their OWN direct (non-proxy) server under
+                # the canonical key. patch_mcp_* would overwrite it, silently
+                # losing their config — so leave it untouched and report back.
+                if canon is not None and not _spec_is_proxy(canon):
+                    return mcp_json, "kept-user-entry"
+            else:
+                mcp_json.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
+            if has_playwright_extension():
+                token = get_extension_token() or ""
+                if token:
+                    patch_mcp_extension(token)
+                else:
+                    patch_mcp_headless()
+            else:
+                patch_mcp_headless()
+    return mcp_json, "registered"
 
 
 def inject_cookies_via_playwright(cookie_file: str | None = None) -> dict[str, Any]:

--- a/src/kiro_crew/builtin_skills/web-browse/SKILL.md
+++ b/src/kiro_crew/builtin_skills/web-browse/SKILL.md
@@ -16,6 +16,16 @@ This is the **view** path. It is deliberately narrow: open the URL and show it,
 nothing more. It does NOT require the user to turn on the "Browser use" (Globe)
 toggle — this one screenshot is self-authorizing.
 
+## How the panel works (so you set expectations correctly)
+
+The panel is a **read-only live mirror**: a headless Chromium renders the page
+out of view, each screenshot is streamed into the panel, and the panel paints
+the latest frame. There is **no OS browser window** (headless) and **no input
+channel from the panel back to the page** — clicking or typing in the panel
+image does nothing. To actually *operate* the page, the user turns on **Browser
+use** (the Globe), which authorizes *you* (the agent) to drive Playwright via
+MCP tools; the panel still just shows screenshots of what you do.
+
 ## Precondition — Playwright must be available (the guard)
 
 The Playwright browser tools (`browser_navigate`, `browser_take_screenshot`, …)
@@ -23,8 +33,11 @@ come from the external `@playwright/mcp` package, which may not be installed.
 
 - If the `browser_*` tools are **not** in your tool list, do NOT attempt this.
   Fall back to `web_fetch` to read the page, and tell the user:
-  > "The built-in browser isn't installed. Run `kirocrew browse setup` to enable
-  >  the live Browser panel; for now here's what I read from the page."
+  > "The built-in browser isn't set up. Run `kirocrew browse setup` — it writes
+  >  the config, registers the proxy, and tells you if `@playwright/mcp` needs
+  >  installing (`npm i -g @playwright/mcp`). Then restart the gateway
+  >  (`kirocrew stop && kirocrew gateway`). For now, here's what I read from the
+  >  page."
 - Only proceed with the steps below when the `browser_*` tools are present.
 
 ## Steps

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.browser.auth import ensure as browser_auth_ensure
 from kiro_crew.browser.screencast import BROWSER_FRAME_EVENT, build_frame_payload
 from kiro_crew.browser.setup import (
@@ -36,6 +37,7 @@ from kiro_crew.notifications.bus import (
     NotificationValidationError,
 )
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
+from kiro_crew.session_pid_sig import verify_session_pid
 from kiro_crew.slack.format import build_options_blocks, extract_options
 from kiro_crew.subagent_persistence import _agent_dir, read_state
 from kiro_crew.validation import (
@@ -138,8 +140,8 @@ async def api_spawn(request: web.Request) -> web.Response:
         # this member as a lost submission (double-count would close the
         # wave early).
         return web.json_response(
-            {"error": f"capacity reached ({state.subagents.max_concurrent})",
-             "counted": True}, status=429
+            {"error": f"capacity reached ({state.subagents.max_concurrent})", "counted": True},
+            status=429,
         )
     if info.done and info.error:
         # Rejected INSIDE mgr.spawn: already counted as submitted and (for
@@ -689,9 +691,7 @@ async def api_notification_agent_push(request: web.Request) -> web.Response:
             source="notifications_api",
             error="internal-secret authentication required (cookie callers forbidden)",
         )
-        return web.json_response(
-            {"error": "internal-secret authentication required"}, status=403
-        )
+        return web.json_response({"error": "internal-secret authentication required"}, status=403)
     # Bound the body BEFORE decoding, mirroring the app push endpoint:
     # without this the strict-internal route inherits the server-wide
     # client_max_size, and a large JSON object would be buffered and decoded
@@ -720,9 +720,7 @@ async def api_notification_agent_push(request: web.Request) -> web.Response:
     for field_name in ("title", "body", "priority", "url", "group_key"):
         value = body.get(field_name)
         if value is not None and not isinstance(value, str):
-            return web.json_response(
-                {"error": f"{field_name} must be a string"}, status=400
-            )
+            return web.json_response({"error": f"{field_name} must be a string"}, status=400)
     actions = body.get("actions")
     if actions is not None and not isinstance(actions, list):
         return web.json_response({"error": "actions must be a list"}, status=400)
@@ -1559,6 +1557,42 @@ async def api_browser_event(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+def _resolve_browse_session_key(host_pid: Any) -> str:
+    """Resolve the authoritative session key for a browse frame from the posting
+    proxy's ``host_pid``, walking process ancestors and verifying each one's
+    gateway-signed ``session_pid_<pid>.txt`` sidecar.
+
+    Warm-pool ``kiro-cli`` workers are pre-spawned before a slot is assigned, so
+    ``KIROCREW_SESSION_KEY`` is never in their env and the Playwright proxy's
+    frozen-env key (``session_key`` in the POST body) is empty. The reliable
+    source is the signed pid->key mapping the gateway publishes on session claim
+    — the same per-turn mechanism every managed MCP tool resolves (see
+    ``kiro_crew.mcp_core._resolve_session_key``). The proxy's immediate parent
+    (``kiro-cli-chat``) has no PID file, so we walk up to the ``kiro-cli`` worker
+    that does. ``verify_session_pid`` requires the HMAC sidecar (agents cannot
+    forge it) and binds the pid into the MAC, so a wrong/forged pid can't cross a
+    session boundary. Returns ``""`` when no ancestor has a verifiable mapping.
+    """
+    try:
+        pid = int(host_pid)
+    except (TypeError, ValueError):
+        return ""
+    seen: set[int] = set()
+    steps = 0
+    # Bounded walk: guards against a cycle (seen) or a pathological chain (steps).
+    while pid > 1 and pid not in seen and steps < 40:
+        seen.add(pid)
+        steps += 1
+        key = verify_session_pid(pid)
+        if key:
+            return key
+        try:
+            pid = platform_compat.get_ppid(pid)
+        except Exception:
+            break
+    return ""
+
+
 async def api_browser_frame(request: web.Request) -> web.Response:
     """POST /api/browser/frame — receive a browse screenshot and rebroadcast it.
 
@@ -1601,6 +1635,25 @@ async def api_browser_frame(request: web.Request) -> web.Response:
             resources="no-frame-data",
         )
         return web.json_response({"error": "no frame data"}, status=400)
+    # Stamp the AUTHORITATIVE session key resolved from the posting proxy's host
+    # pid (gateway-signed session_pid sidecar), overriding the proxy's frozen-env
+    # key which is empty under the warm pool. This is what lets the client-side
+    # panel (scoped by frameSessionKey === sessionKey) render the mirror and
+    # keeps a background session's frames from surfacing in the wrong panel. When
+    # no ancestor has a verifiable mapping we leave the proxy-provided fallback
+    # (empty on warm pool → client drops it, same as before — never worse).
+    resolved_key = await asyncio.to_thread(
+        _resolve_browse_session_key,
+        body.get("host_pid") if isinstance(body, dict) else None,
+    )
+    if resolved_key:
+        # verify_session_pid returns the FULL namespaced session key
+        # (e.g. "dashboard:chat-70-<ts>"), but the client panel filters frames
+        # by `frame.session_key === activeSlot`, where activeSlot is the BARE
+        # slot key ("chat-70-<ts>"). Without stripping the "dashboard:" prefix
+        # every frame is dropped on the mismatch and the mirror never renders.
+        # (Same normalization as the Slack slot-key resolution below.)
+        payload["session_key"] = resolved_key.removeprefix("dashboard:")
     state.broadcast_ws(BROWSER_FRAME_EVENT, payload)
     # Label the audit event by frame origin so the proxy's active pump frames are
     # distinguishable from agent-initiated screenshots. Bounded to a known set so
@@ -2549,9 +2602,7 @@ async def _telegram_config_save_locked(request: web.Request) -> web.Response:
                 if any(ch.isspace() for ch in tok):
                     return _deny("bot_token must not contain whitespace")
                 if not _TELEGRAM_TOKEN_RE.match(tok):
-                    return _deny(
-                        "bot_token must look like <bot_id>:<secret> from @BotFather"
-                    )
+                    return _deny("bot_token must look like <bot_id>:<secret> from @BotFather")
                 env_updates[CRED_TELEGRAM_BOT_TOKEN] = tok
 
     # Config → config.json under "telegram" (staged, applied only after Phase 1).
@@ -3195,9 +3246,7 @@ async def api_wecom_config_get(request: web.Request) -> web.Response:
     secret = creds.get(CRED_WECOM_SECRET, "")
     wc = cfg.wecom
     userids = [
-        str(u.get("userid"))
-        for u in wc.allowed_users
-        if isinstance(u, dict) and u.get("userid")
+        str(u.get("userid")) for u in wc.allowed_users if isinstance(u, dict) and u.get("userid")
     ]
     state: DashboardState = request.app["state"]
     return web.json_response(

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -239,7 +239,23 @@ def _post_frame_to_gateway(img_bytes: bytes, fmt: str, source: str = "agent") ->
         try:
             b64 = base64.b64encode(img_bytes).decode("ascii")
             body = json.dumps(
-                {"data": b64, "format": fmt, "source": source, "session_key": _SESSION_KEY}
+                {
+                    "data": b64,
+                    "format": fmt,
+                    "source": source,
+                    # Frozen-env session key: correct for per-session spawns, but
+                    # empty for warm-pool workers (pre-spawned before a slot is
+                    # assigned, so KIROCREW_SESSION_KEY was never set). Sent as a
+                    # fallback only.
+                    "session_key": _SESSION_KEY,
+                    # This proxy's pid, so the gateway can resolve the AUTHORITATIVE
+                    # session key by walking our process ancestry to the kiro-cli
+                    # worker and verifying its gateway-signed session_pid sidecar
+                    # (the same per-turn mapping every managed MCP tool resolves).
+                    # This is what makes the live mirror work under the warm pool,
+                    # where the frozen env key above is empty.
+                    "host_pid": os.getpid(),
+                }
             ).encode("utf-8")
             headers = {"Content-Type": "application/json"}
             secret = _internal_secret()

--- a/test/test_browser_screencast.py
+++ b/test/test_browser_screencast.py
@@ -161,7 +161,7 @@ def _make_frame_app(state) -> web.Application:
     app.router.add_post("/api/browser/frame", api_browser_frame)
     app["state"] = state
     # ws_client_count() must return an int for json_response serialization.
-    if not hasattr(state.ws_client_count, 'return_value') or not isinstance(
+    if not hasattr(state.ws_client_count, "return_value") or not isinstance(
         state.ws_client_count.return_value, int
     ):
         state.ws_client_count.return_value = 0
@@ -240,11 +240,133 @@ class TestApiBrowserFrameHandler:
         state.broadcast_ws.assert_not_called()
 
 
+class TestBrowseSessionKeyResolution:
+    """Warm-pool fix: the proxy sends its host pid, and the gateway resolves the
+    authoritative session key by walking process ancestors + verifying the
+    signed session_pid sidecar — overriding the (empty on warm pool) env key."""
+
+    def test_post_frame_body_includes_host_pid_and_env_key(self, monkeypatch):
+        import json as _json
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        captured = {}
+
+        class _Resp:
+            def read(self):
+                return b'{"ok": true, "subscribers": 1}'
+
+            def close(self):
+                pass
+
+        def _fake_urlopen(req, timeout=2):
+            captured["body"] = req.data
+            return _Resp()
+
+        class _Thread:  # run the daemon send synchronously
+            def __init__(self, *a, **k):
+                self._t = k.get("target")
+
+            def start(self):
+                self._t()
+
+        monkeypatch.setattr(proxy, "_EXTENSION_MODE", False)
+        monkeypatch.setattr(proxy.threading, "Thread", _Thread)
+        monkeypatch.setattr(proxy.urllib.request, "urlopen", _fake_urlopen)
+        monkeypatch.setattr(proxy, "_internal_secret", lambda: "secret")
+        monkeypatch.setattr(proxy, "_SESSION_KEY", "env-key")
+
+        proxy._post_frame_to_gateway(b"\xff\xd8\xff", "jpeg")
+
+        payload = _json.loads(captured["body"])
+        assert payload["host_pid"] == os.getpid()
+        assert payload["session_key"] == "env-key"  # fallback still sent
+
+    def test_resolver_walks_ancestors_and_verifies(self, monkeypatch):
+        from kiro_crew.dashboard.handlers.messaging import _resolve_browse_session_key
+
+        # ppid chain: 100 -> 200 -> 300 -> 1; only 300 has a verifiable sidecar.
+        ppids = {100: 200, 200: 300, 300: 1}
+        verified = {300: "sess-live"}
+        monkeypatch.setattr("kiro_crew.platform_compat.get_ppid", lambda pid: ppids.get(pid, -1))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.messaging.verify_session_pid",
+            lambda pid: verified.get(int(pid), ""),
+        )
+        assert _resolve_browse_session_key(100) == "sess-live"
+        assert _resolve_browse_session_key("100") == "sess-live"
+
+    def test_resolver_returns_empty_on_bad_or_unmapped_pid(self, monkeypatch):
+        from kiro_crew.dashboard.handlers.messaging import _resolve_browse_session_key
+
+        monkeypatch.setattr("kiro_crew.platform_compat.get_ppid", lambda pid: 1)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.messaging.verify_session_pid", lambda pid: ""
+        )
+        assert _resolve_browse_session_key(None) == ""
+        assert _resolve_browse_session_key("not-an-int") == ""
+        assert _resolve_browse_session_key(4242) == ""  # no ancestor mapping
+
+    @pytest.mark.asyncio
+    async def test_resolved_key_overrides_payload(self):
+        state = MagicMock()
+        app = _make_frame_app(state)
+        with (
+            patch("kiro_crew.dashboard.handlers.messaging.is_loopback", return_value=True),
+            patch("kiro_crew.dashboard.handlers.messaging._sel"),
+            patch(
+                "kiro_crew.dashboard.handlers.messaging._resolve_browse_session_key",
+                return_value="sess-authoritative",
+            ),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/browser/frame", json={**_VALID_FRAME, "host_pid": 12345}
+                )
+                assert resp.status == 200
+        _event, payload = state.broadcast_ws.call_args[0]
+        assert payload["session_key"] == "sess-authoritative"
+
+    @pytest.mark.asyncio
+    async def test_resolved_key_strips_dashboard_prefix(self):
+        # verify_session_pid returns the full namespaced key ("dashboard:<slot>"),
+        # but the client panel filters by the BARE slot key. The handler must strip
+        # the "dashboard:" prefix so the frame matches the on-screen slot; otherwise
+        # every frame is dropped on the mismatch and the mirror never renders.
+        state = MagicMock()
+        app = _make_frame_app(state)
+        with (
+            patch("kiro_crew.dashboard.handlers.messaging.is_loopback", return_value=True),
+            patch("kiro_crew.dashboard.handlers.messaging._sel"),
+            patch(
+                "kiro_crew.dashboard.handlers.messaging._resolve_browse_session_key",
+                return_value="dashboard:chat-70-1785264224",
+            ),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/browser/frame", json={**_VALID_FRAME, "host_pid": 12345}
+                )
+                assert resp.status == 200
+        _event, payload = state.broadcast_ws.call_args[0]
+        assert payload["session_key"] == "chat-70-1785264224"
+
+
 class TestActivePump:
     """B′ active pump: idle-gated self-issued screenshots that keep the mirror current."""
 
-    def _reset(self, proxy, monkeypatch, *, enabled=True, pending=None, inflight=None,
-               sent_at=0.0, activity=None, subs=1):
+    def _reset(
+        self,
+        proxy,
+        monkeypatch,
+        *,
+        enabled=True,
+        pending=None,
+        inflight=None,
+        sent_at=0.0,
+        activity=None,
+        subs=1,
+    ):
         now = 1000.0
         monkeypatch.setattr(proxy, "_pump_enabled", enabled)
         monkeypatch.setattr(proxy, "_PENDING_REQUESTS", pending if pending is not None else {})
@@ -290,8 +412,9 @@ class TestActivePump:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         # stuck pump older than _PUMP_TIMEOUT no longer blocks
-        now = self._reset(proxy, monkeypatch, inflight="__mc_pump_1",
-                          sent_at=1000.0 - proxy._PUMP_TIMEOUT - 1)
+        now = self._reset(
+            proxy, monkeypatch, inflight="__mc_pump_1", sent_at=1000.0 - proxy._PUMP_TIMEOUT - 1
+        )
         assert proxy._should_pump(now) is True
 
     def test_should_pump_blocked_when_session_idle_cold(self, monkeypatch):
@@ -311,7 +434,9 @@ class TestActivePump:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         monkeypatch.setattr(proxy, "_last_browse_activity", 0.0)
-        proxy._note_browse_activity({"method": "tools/call", "params": {"name": "browser_navigate"}})
+        proxy._note_browse_activity(
+            {"method": "tools/call", "params": {"name": "browser_navigate"}}
+        )
         assert proxy._last_browse_activity > 0.0  # browser_* updates it
 
         monkeypatch.setattr(proxy, "_last_browse_activity", 0.0)
@@ -324,13 +449,19 @@ class TestActivePump:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         posted = []
-        monkeypatch.setattr(proxy, "_post_frame_to_gateway",
-                            lambda b, fmt, source="agent": posted.append((b, fmt, source)))
+        monkeypatch.setattr(
+            proxy,
+            "_post_frame_to_gateway",
+            lambda b, fmt, source="agent": posted.append((b, fmt, source)),
+        )
         png_b64 = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAQAB"
             "GqQ4QAAAAABJRU5ErkJggg=="
         )
-        msg = {"id": "__mc_pump_3", "result": {"content": [{"type": "image", "data": png_b64, "mimeType": "image/png"}]}}
+        msg = {
+            "id": "__mc_pump_3",
+            "result": {"content": [{"type": "image", "data": png_b64, "mimeType": "image/png"}]},
+        }
         proxy._relay_pump_frame(msg)
         # pump frames are tagged source="pump" so the gateway can label them in SEL
         assert len(posted) == 1 and isinstance(posted[0][0], bytes) and posted[0][0]
@@ -340,8 +471,12 @@ class TestActivePump:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         posted = []
-        monkeypatch.setattr(proxy, "_post_frame_to_gateway", lambda b, fmt, source="agent": posted.append(b))
-        proxy._relay_pump_frame({"id": "__mc_pump_4", "result": {"content": [{"type": "text", "text": "x"}]}})
+        monkeypatch.setattr(
+            proxy, "_post_frame_to_gateway", lambda b, fmt, source="agent": posted.append(b)
+        )
+        proxy._relay_pump_frame(
+            {"id": "__mc_pump_4", "result": {"content": [{"type": "text", "text": "x"}]}}
+        )
         proxy._relay_pump_frame({"id": "__mc_pump_5", "error": {"code": -32000}})  # error response
         assert posted == []
 
@@ -349,11 +484,16 @@ class TestActivePump:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         posted = []
-        monkeypatch.setattr(proxy, "_post_frame_to_gateway",
-                            lambda b, fmt, source="agent": posted.append(b))
+        monkeypatch.setattr(
+            proxy, "_post_frame_to_gateway", lambda b, fmt, source="agent": posted.append(b)
+        )
         # malformed base64 makes _encode_frame raise; the main relay loop must not crash
-        msg = {"id": "__mc_pump_6",
-               "result": {"content": [{"type": "image", "data": "!!!not base64!!!", "mimeType": "image/png"}]}}
+        msg = {
+            "id": "__mc_pump_6",
+            "result": {
+                "content": [{"type": "image", "data": "!!!not base64!!!", "mimeType": "image/png"}]
+            },
+        }
         proxy._relay_pump_frame(msg)  # must not raise
         assert posted == []
 
@@ -451,9 +591,7 @@ class TestPumpAudit:
 
         calls = []
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", True)
-        monkeypatch.setattr(
-            proxy.urllib.request, "urlopen", lambda *a, **k: calls.append("post")
-        )
+        monkeypatch.setattr(proxy.urllib.request, "urlopen", lambda *a, **k: calls.append("post"))
         # Extension mode: the user sees their own Chrome; no audit POST, and the
         # caller treats the False return as "do not inject".
         assert proxy._post_pump_audit() is False

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -22,6 +22,7 @@ from kiro_crew.browser.setup import (
     _converge_playwright_agent_files,
     _drop_superseded_playwright,
     _entry_is_playwright_proxy,
+    check_playwright_launchable,
     converge_playwright_servers,
     ensure_playwright_installed,
     generate_playwright_config,
@@ -33,6 +34,7 @@ from kiro_crew.browser.setup import (
     patch_mcp_extension,
     patch_mcp_headless,
     refresh_storage_state,
+    register_playwright_proxy,
 )
 from kiro_crew.config.paths import config_dir
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -227,6 +229,81 @@ class TestGeneratePlaywrightConfig:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         config = json.loads(generate_playwright_config().read_text(encoding="utf-8"))
         assert config["browser"]["launchOptions"]["channel"] == "chromium"
+
+    def test_config_runs_headless(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # The dashboard Browser panel mirror is the view surface, so the browser
+        # runs headless — no visible OS window (and works on display-less Linux).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config = json.loads(generate_playwright_config().read_text(encoding="utf-8"))
+        assert config["browser"]["launchOptions"]["headless"] is True
+
+
+# ── TestBrowseSetupHelpers (guided one-command setup) ────────────────────────
+
+
+class TestCheckPlaywrightLaunchable:
+    def test_ok_when_resolver_returns_cmd(self, monkeypatch: pytest.MonkeyPatch):
+        # setup.py imports _resolve_playwright_cmd at module scope, so patch the
+        # name where it is looked up (setup_mod), not on the origin module.
+        monkeypatch.setattr(setup_mod, "_resolve_playwright_cmd", lambda: "/usr/bin/npx")
+        ok, detail = check_playwright_launchable()
+        assert ok is True
+        assert detail == "/usr/bin/npx"
+
+    def test_not_ok_with_install_hint_when_unresolvable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(setup_mod, "_resolve_playwright_cmd", lambda: None)
+        ok, detail = check_playwright_launchable()
+        assert ok is False
+        assert "@playwright/mcp" in detail
+
+
+class TestRegisterPlaywrightProxy:
+    def test_creates_mcp_json_and_registers_canonical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A fresh user has no ~/.kiro/settings/mcp.json; register creates it and
+        # writes the canonical proxy entry so one command fully wires the panel.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = tmp_path / ".kiro" / "settings" / "mcp.json"
+        assert not mcp_json.exists()
+        returned, status = register_playwright_proxy()
+        assert returned == mcp_json and mcp_json.exists()
+        assert status == "registered"
+        servers = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"]
+        assert _CANONICAL in servers
+        assert "mcp-playwright-proxy" in servers[_CANONICAL]["args"]
+
+    def test_registers_into_existing_mcp_json_without_clobbering_user(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(tmp_path, {"other-mcp": {"command": "foo"}})
+        _, status = register_playwright_proxy()
+        assert status == "registered"
+        servers = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"]
+        assert _CANONICAL in servers
+        assert servers["other-mcp"] == {"command": "foo"}
+
+    def test_keeps_user_direct_server_under_canonical_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A user hand-authored their OWN direct (non-proxy) server under the
+        # canonical `playwright-mcp` key. `browse setup` must NOT overwrite it —
+        # authorship is by launch target, not key name. Leave it byte-identical
+        # and report kept-user-entry.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        mcp_json = _write_mcp_json(tmp_path, {_CANONICAL: dict(direct)})
+        before = mcp_json.read_text(encoding="utf-8")
+        _, status = register_playwright_proxy()
+        assert status == "kept-user-entry"
+        assert mcp_json.read_text(encoding="utf-8") == before
 
 
 # ── TestRefreshStorageState ──────────────────────────────────────────────────
@@ -851,7 +928,9 @@ class TestConvergePlaywrightAgentFiles:
         # The .bak file was NOT swept (still holds the duplicate).
         assert (
             "playwright-proxy-mcp"
-            in json.loads((kiro_dir / "kirocrew.json.bak.123").read_text(encoding="utf-8"))["mcpServers"]
+            in json.loads((kiro_dir / "kirocrew.json.bak.123").read_text(encoding="utf-8"))[
+                "mcpServers"
+            ]
         )
 
     def test_no_error_when_dirs_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -895,11 +974,21 @@ class TestConvergePlaywrightAgentFiles:
 
         # KiroCrew-owned files converged to one server.
         assert set(json.loads(owned.read_text(encoding="utf-8"))["mcpServers"]) == {_CANONICAL}
-        assert set(json.loads(owned_variant.read_text(encoding="utf-8"))["mcpServers"]) == {_CANONICAL}
+        assert set(json.loads(owned_variant.read_text(encoding="utf-8"))["mcpServers"]) == {
+            _CANONICAL
+        }
         # User-owned files byte-identical (both proxies preserved).
-        assert "playwright-proxy-mcp" in json.loads(user_prefixed.read_text(encoding="utf-8"))["mcpServers"]
-        assert "playwright-proxy-mcp" in json.loads(user_kiro.read_text(encoding="utf-8"))["mcpServers"]
-        assert "playwright-proxy-mcp" in json.loads(user_cc.read_text(encoding="utf-8"))["mcpServers"]
+        assert (
+            "playwright-proxy-mcp"
+            in json.loads(user_prefixed.read_text(encoding="utf-8"))["mcpServers"]
+        )
+        assert (
+            "playwright-proxy-mcp"
+            in json.loads(user_kiro.read_text(encoding="utf-8"))["mcpServers"]
+        )
+        assert (
+            "playwright-proxy-mcp" in json.loads(user_cc.read_text(encoding="utf-8"))["mcpServers"]
+        )
 
     @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
     def test_preserves_0600_file_mode_on_sweep(
@@ -928,7 +1017,9 @@ class TestConvergePlaywrightAgentFiles:
         _converge_playwright_agent_files()
 
         # Converged (one server left) AND still owner-only readable.
-        assert set(json.loads(secret_file.read_text(encoding="utf-8"))["mcpServers"]) == {_CANONICAL}
+        assert set(json.loads(secret_file.read_text(encoding="utf-8"))["mcpServers"]) == {
+            _CANONICAL
+        }
         assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
 
 

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -100,9 +100,7 @@ class ProcessTopology:
 
     def write_session_pid(self, host_pid: int, session_key: str = SESSION_KEY) -> None:
         """The gateway-side contract: files keyed by HOST pid, always."""
-        (self.cfg_dir / f"session_pid_{host_pid}.txt").write_text(
-            session_key, encoding="utf-8"
-        )
+        (self.cfg_dir / f"session_pid_{host_pid}.txt").write_text(session_key, encoding="utf-8")
 
     # -- what a given process observes under a view ------------------------
 
@@ -138,10 +136,10 @@ class ProcessTopology:
 
 # Canonical subagent tree. Host pids are chosen above any real test-host
 # process range concern because all lookups are routed through the fixture.
-GATEWAY = 100          # writes session_pid files; outside any namespace
-SESSION_HOST = 110     # ns PID 1 when the sandbox adds a pid namespace
-KIRO_CLI = 120         # ns PID 2
-MCP_SERVER = 130       # ns PID 3 — the process running the resolvers below
+GATEWAY = 100  # writes session_pid files; outside any namespace
+SESSION_HOST = 110  # ns PID 1 when the sandbox adds a pid namespace
+KIRO_CLI = 120  # ns PID 2
+MCP_SERVER = 130  # ns PID 3 — the process running the resolvers below
 
 
 @pytest.fixture()
@@ -164,9 +162,7 @@ def _wire_common(monkeypatch: pytest.MonkeyPatch, topo: ProcessTopology, view: s
     # sandbox whose launcher exports it) would short-circuit the /proc walk
     # under test and flip the strict pidns xfails to XPASS.
     monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
-    monkeypatch.setattr(
-        "os.getppid", lambda: topo.observed_ppid(MCP_SERVER, view)
-    )
+    monkeypatch.setattr("os.getppid", lambda: topo.observed_ppid(MCP_SERVER, view))
     # Reset the fork's process-lifetime from_env cache: a previously-resolved
     # identity from an earlier test (or the host-view run of this test) would
     # otherwise short-circuit the walk and XPASS the strict pidns variants.
@@ -185,9 +181,7 @@ def test_from_env_resolves_session_key(topo, monkeypatch, view) -> None:
     _wire_common(monkeypatch, topo, view)
     monkeypatch.setattr(mcp_caller, "_parent_pid", topo.parent_lookup(view))
     # from_env imports config_dir lazily from the loader module.
-    monkeypatch.setattr(
-        "kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir
-    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir)
 
     ctx = mcp_caller.CallerContext.from_env()
     assert ctx.session_key == SESSION_KEY
@@ -236,9 +230,7 @@ def test_mcp_shared_policy_walk_reaches_gateway(topo, monkeypatch, view) -> None
 
     cfg = MagicMock()
     cfg.dashboard.url = "http://localhost:5476/"
-    monkeypatch.setattr(
-        mcp_shared.KiroCrewConfig, "load", classmethod(lambda cls: cfg)
-    )
+    monkeypatch.setattr(mcp_shared.KiroCrewConfig, "load", classmethod(lambda cls: cfg))
     monkeypatch.setattr(mcp_shared, "parse_dashboard_url", lambda url: ("localhost", 5476))
     monkeypatch.setattr(mcp_shared, "config_dir", lambda: topo.cfg_dir)
     (topo.cfg_dir / ".local_secret").write_text("s")
@@ -273,9 +265,7 @@ def test_stub_caller_block_carries_session_key(topo, monkeypatch, view) -> None:
 
     _wire_common(monkeypatch, topo, view)
     monkeypatch.setattr(mcp_caller, "_parent_pid", topo.parent_lookup(view))
-    monkeypatch.setattr(
-        "kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir
-    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir)
 
     caller = stub._build_caller_block(None)
     assert caller["session_key"] == SESSION_KEY
@@ -315,9 +305,7 @@ def test_from_env_host_pid_env_resolves_in_any_view(topo, monkeypatch, view) -> 
 
     _wire_common(monkeypatch, topo, view)
     monkeypatch.setattr(mcp_caller, "_parent_pid", topo.parent_lookup(view))
-    monkeypatch.setattr(
-        "kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir
-    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir)
     # The launcher (session host) exported its HOST pid before unshare.
     monkeypatch.setenv("KIROCREW_HOST_PID", str(SESSION_HOST))
 
@@ -382,9 +370,7 @@ def test_from_env_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
     _plant_symlink(topo, SESSION_HOST)
     _wire_common(monkeypatch, topo, "host")
     monkeypatch.setattr(mcp_caller, "_parent_pid", topo.parent_lookup("host"))
-    monkeypatch.setattr(
-        "kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir
-    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: topo.cfg_dir)
 
     ctx = mcp_caller.CallerContext.from_env()
     assert ctx.session_key == ""
@@ -400,9 +386,7 @@ def test_mcp_shared_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
 
     cfg = MagicMock()
     cfg.dashboard.url = "http://localhost:5476/"
-    monkeypatch.setattr(
-        mcp_shared.KiroCrewConfig, "load", classmethod(lambda cls: cfg)
-    )
+    monkeypatch.setattr(mcp_shared.KiroCrewConfig, "load", classmethod(lambda cls: cfg))
     monkeypatch.setattr(mcp_shared, "parse_dashboard_url", lambda url: ("localhost", 5476))
     monkeypatch.setattr(mcp_shared, "config_dir", lambda: topo.cfg_dir)
     (topo.cfg_dir / ".local_secret").write_text("s")
@@ -485,8 +469,13 @@ _REGISTERED_CALL_SITES: dict[str, str] = {
         "session_pid_sig.read_session_pid_txt (hardened, unsigned)"
     ),
     "mcp_gateway/stub.py": "reader via CallerContext.from_env; register-time caller block — assumes HOST pids",
+    "dashboard/handlers/messaging.py": (
+        "reader (STRICT): api_browser_frame resolves the browse-mirror session "
+        "key from the posting Playwright proxy's host_pid by walking process "
+        "ancestry and calling session_pid_sig.verify_session_pid (HMAC-verified) "
+        "on each ancestor — HOST-pid-keyed, no unsigned .txt read"
+    ),
     "mcp_gateway/gatewayd.py": (
-        "reader: SERVER-side /proc ancestry walk from the SO_PEERCRED peer pid "
         "(_resolve_peer_identity) — runs in gatewayd's own (host) pid namespace, "
         "so it is immune to client-side namespace divergence; also indexes the "
         "host ancestor chain for claim-push matching; .txt reads via "

--- a/website/src/hooks/useBrowserFrame.ts
+++ b/website/src/hooks/useBrowserFrame.ts
@@ -24,6 +24,35 @@ export interface BrowserFrameState {
   sessionName: string | null
 }
 
+// Module-scope last-frame buffer. Frames are live-only window events with no
+// replay, so a panel mounting AFTER a frame arrived (the common case: the
+// Browser tab auto-opens when the agent starts browsing) would otherwise show
+// nothing until the next frame. Buffering the latest frame lets a freshly
+// mounted hook paint immediately. Session scoping + the live-TTL in the panel
+// still gate what actually renders, so a stale or cross-session cached frame
+// never displays.
+let cachedFrame: string | null = null
+let cachedTs: number | null = null
+let cachedSessionKey: string | null = null
+
+// Populate the buffer from the moment this module loads — BEFORE any component
+// using the hook mounts. The very first frame arrives as the Browser tab is
+// auto-opening (the panel's own per-mount listener isn't installed yet), so
+// without this module-load listener that first frame would be missed and the
+// freshly mounted panel would paint blank until the next pump frame. The hook's
+// useState initializers read this buffer, so a late-mounting panel paints the
+// last frame immediately. Session scoping + the panel's live-TTL still gate
+// what actually renders.
+if (typeof window !== 'undefined') {
+  window.addEventListener('kirocrew-browser-frame', (e: Event) => {
+    const d = (e as CustomEvent<BrowserFrameDetail>).detail
+    if (!d?.data) return
+    cachedFrame = `data:image/${d.format || 'jpeg'};base64,${d.data}`
+    cachedTs = Date.now()
+    cachedSessionKey = d.session_key || null
+  })
+}
+
 /**
  * Subscribe to the live browse-mirror frame stream.
  *
@@ -35,17 +64,26 @@ export interface BrowserFrameState {
  * (WebPreviewPanel).
  */
 export function useBrowserFrame(): BrowserFrameState {
-  const [frame, setFrame] = useState<string | null>(null)
-  const [lastTs, setLastTs] = useState<number | null>(null)
-  const [sessionKey, setSessionKey] = useState<string | null>(null)
+  const [frame, setFrame] = useState<string | null>(() => cachedFrame)
+  const [lastTs, setLastTs] = useState<number | null>(() => cachedTs)
+  const [sessionKey, setSessionKey] = useState<string | null>(() => cachedSessionKey)
 
   useEffect(() => {
     const onFrame = (e: Event) => {
       const d = (e as CustomEvent<BrowserFrameDetail>).detail
       if (!d?.data) return
-      setFrame(`data:image/${d.format || 'jpeg'};base64,${d.data}`)
-      setLastTs(Date.now())
-      setSessionKey(d.session_key || null)
+      const uri = `data:image/${d.format || 'jpeg'};base64,${d.data}`
+      const ts = Date.now()
+      const sk = d.session_key || null
+      // Buffer at module scope so a panel that mounts AFTER this frame (e.g. the
+      // Browser tab auto-opening when the agent starts browsing) paints it
+      // immediately instead of waiting for the next active-pump frame.
+      cachedFrame = uri
+      cachedTs = ts
+      cachedSessionKey = sk
+      setFrame(uri)
+      setLastTs(ts)
+      setSessionKey(sk)
     }
     window.addEventListener('kirocrew-browser-frame', onFrame)
     return () => window.removeEventListener('kirocrew-browser-frame', onFrame)


### PR DESCRIPTION
<!-- prepare-pr:browse-mirror -->
## Problem
The dashboard's right-side **Browser** panel stayed blank when the agent browsed a page — no live mirror appeared. Under the warm-pool worker model, opening a page either showed nothing or (with the config gap below) popped a visible OS Chrome window while the panel still rendered nothing. First-time Playwright MCP setup was also under-specified: `kirocrew browse setup` only wrote a config file and left the user to wire the rest.

## Why it matters
The Browser panel is the intended surface for viewing agent browsing (and, with the Globe toggle, operating a page). If frames never render, the feature is effectively broken, and the unexplained OS window is confusing. Hard-to-set-up tooling turns a one-command feature into a multi-step debugging session.

## Fix (symptoms -> root cause -> change)
- **Blank panel -> key mismatch.** Warm-pool `kiro-cli` workers have no `KIROCREW_SESSION_KEY` at proxy import, so frames carried an empty key and the client filter dropped them. The proxy already POSTs its `host_pid` and the gateway resolves the authoritative key from the signed `session_pid` ancestry (`verify_session_pid`) — but that returns the **namespaced** key `dashboard:<slot>`, while the client compares against the **bare** slot key (`<slot>`). Every frame was dropped on the prefix mismatch. Fix: strip the `dashboard:` prefix when stamping the frame's `session_key` (same normalization already used for Slack slot keys).
- **Visible window -> missing headless.** `generate_playwright_config()` never set `headless`, so `@playwright/mcp` launched headed. The panel mirror is the view surface, so the browser should be headless (this also fixes display-less Linux hosts). Added `launchOptions.headless: true`.
- **Instant paint.** The frontend buffers the last frame at module scope so a late-mounting panel paints immediately instead of waiting for the next pump frame.
- **Setup friction.** `kirocrew browse setup` is now a guided one-command flow: it writes the (headless) config, **registers** the proxy in `~/.kiro/settings/mcp.json` (creating the file if absent — previously registration was left to a separate boot-time converge), checks whether a Playwright launcher is resolvable (reusing the proxy's own `_resolve_playwright_cmd()`), and prints a checklist plus the exact install/restart steps. Two reusable helpers were factored out (`check_playwright_launchable`, `register_playwright_proxy`). Registration holds the shared `mcp.lock` exclusive flock (the same interlock the dashboard MCP handler and app bridges use) across its read/create/patch so a concurrent writer can't be clobbered, and it **refuses to overwrite a user-authored non-proxy `playwright-mcp` entry** (reports `kept-user-entry` and leaves their config untouched).
- **Docs.** The `web-browse` skill now states plainly that the panel is a read-only screenshot mirror (Globe authorizes the agent to operate; there is no input channel from the panel) and gives the accurate setup steps.

## Tests
- `test/test_browser_screencast.py::TestApiBrowserFrameHandler::test_resolved_key_strips_dashboard_prefix` — locks in that a `dashboard:`-prefixed resolved key is stamped as the bare slot key so the client gate matches.
- `test/test_browser_setup.py`: `test_config_runs_headless` (headless config), `TestCheckPlaywrightLaunchable` (resolvable / install-hint paths), `TestRegisterPlaywrightProxy` (creates `mcp.json` and registers the canonical proxy without clobbering user servers; `test_keeps_user_direct_server_under_canonical_key` locks in that a user's own non-proxy `playwright-mcp` entry is left byte-identical).
- `test/test_identity_topology.py`: `dashboard/handlers/messaging.py` registered as a legitimate `session_pid` reader call site (the browse-frame key resolver), keeping the topology governance test green.
- Full `test_browser_screencast.py` (45) and `test_browser_setup.py` (82) suites pass; black/isort/flake8 clean; frontend `tsc` clean.

## Manual verification
Reproduced end-to-end in the desktop app: `open a page` -> the Browser panel now auto-opens and mirrors the page live (no OS window). Confirmed the diagnosis via gateway logs showing the resolved key was `dashboard:chat-...` while the client compared against the bare `chat-...` slot key; after the prefix strip the frame matches and renders.

## Screenshots
N/A — no UI component/layout changed. This is a backend/config fix that makes the existing panel receive frames; the panel component itself is untouched.
