### PR TITLE
chore(version): bump dev base to 0.1.2 after v0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.1.0"
+version = "0.1.2"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, Slack, or desktop app"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-electron-mac",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## What

Bump the in-code version `0.1.0 → 0.1.2` across the three manifests that carry it:

- `pyproject.toml` `[project].version`
- `src/kiro_crew/__init__.py` `__version__`
- `website/electron/package.json` `version`

## Why

The committed version is **not** the source of truth for tagged releases — `release.yml` stamps all three files from the tag at build time. But it *is* load-bearing for the two build paths that have no tag to read from:

- **Nightly** (`nightly.yml`) reads `__version__` from `src/kiro_crew/__init__.py` as its **base**, then emits `<base>-nightly.<date>t<time>` (semver, Electron/S3) and `<base>.dev<stamp>` (PEP 440, wheel).
- **Local / source installs** report the committed value.

It was left at `0.1.0` while both **v0.1.0** and **v0.1.1** shipped. So tonight's nightly would stamp `0.1.0-nightly.<...>`, a prerelease that sorts **below** the already-shipped `0.1.1` — the nightly channel would advertise builds numbered under stable. Source/dev builds likewise reported a version that already shipped.

Bumping the base to the next target **0.1.2** makes nightlies read as previews of the upcoming release and stops the disconnect.

## Why `0.1.2` and not `0.1.1` or `0.1.1.dev0`

- Not `0.1.1`: a nightly stamped `0.1.1-nightly.<...>` sorts below the released `0.1.1` (prerelease < release).
- Not `0.1.1.dev0`: `nightly.yml` builds `<base>-nightly.…` and `<base>.dev…` from the base, so it **requires a bare `X.Y.Z`** — a `.devN` suffix would produce invalid semver/PEP 440.
- `0.1.2` is the next patch target. If the next release turns out to be a minor, this is a one-line change to `0.2.0`.

## Scope / safety

- **No effect on tagged releases** — the tag still overrides these values at build time.
- No workflow changes.
- Dynamic version readers stay in sync (`/api/health` returns `__version__`, asserted in `test_api_health.py`).
- `test_nightly_version_contract.py` uses its own synthetic `0.1.0` base to validate format rules and is unaffected.

Follow-up (separate discussion): encode the "bump the dev base each cycle" step into the release runbook/SOP.
