### PR TITLE
fix(chat): never drop a message when creating its session fails

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -21,7 +21,7 @@ import {
   setActiveSlot, truncateAfterIndex, replaceMessages,
   requestStop, pendingQuestionFor, clearFollowupCard, dismissFollowupItem,
 } from '../store/chatSlice'
-import { removeNotificationByTs } from '../store/notificationsSlice'
+import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import { onTerminalReady, sendToTerminalSession } from '../utils/terminalRegistry'
 import { interceptSlashCommand } from './chat/ChatInput'
 import { sseSlotTitle } from '../store/dashboardSlice'
@@ -45,7 +45,7 @@ import type { DisplayItem, TurnItem } from './chat/types'
 import { useScrollManager } from './chat/useScrollManager'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
 import { parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, findUnreferencedAttachments } from '../utils/fileTokens'
-import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
+import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, remapCarriedBlocks, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
 import { extractPromptFromToken, extractSlackContextFromToken } from '../utils/tokenPrompt'
 // Roles that fold into a collapsible group in the turn view. Thinking is NOT
 // here: it carries real content and renders as its own standalone block (a
@@ -149,6 +149,28 @@ import WorkflowProgressBar from './chat/WorkflowProgressBar'
 import { tryQuickSend } from '../lib/quickSend'
 import { rewindWithRollback } from '../lib/rewindCall'
 
+
+/**
+ * Human-readable reason from a rejected thunk. `unwrap()` rejects with RTK's
+ * SERIALIZED error — a plain object, never an `Error` instance — so an
+ * `instanceof Error` test always fails and every user would read the developer
+ * fallback. Read `message` structurally instead, with a plain-language fallback.
+ */
+/** Unique `ts` for a client-side notification that the feed can still PARSE.
+ *  `addNotification` dedupes on `ts`, so two entries in the same millisecond would
+ *  see the second silently dropped — which for a payload-carrying entry discards
+ *  the user's message. The disambiguator goes in FRACTIONAL digits because
+ *  `parseTs` only accepts `\d+(\.\d+)?`; a `<ms>-<n>` form falls through to
+ *  `new Date(string)`, which is Invalid Date in V8 → "Invalid Date" headers and
+ *  "NaNd ago" in the bell feed. */
+let notificationTsSeq = 0
+const uniqueNotificationTs = (): string => `${Date.now()}.${notificationTsSeq++}`
+
+
+const createFailReason = (e: unknown): string => {
+  const msg = typeof e === 'object' && e !== null ? (e as { message?: unknown }).message : undefined
+  return typeof msg === 'string' && msg.trim() ? msg : 'the server did not respond'
+}
 
 export function ChatHeaderMenu({ activeSlot, agent, onReveal, onRename, mode }: {
   activeSlot: string | null; agent?: string; onReveal?: () => void; onRename?: () => void; mode?: string
@@ -2139,6 +2161,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       return
     }
 
+    // Snapshot the staged attachments BEFORE the composer is cleared below, so a
+    // failed send can put them back (prepareSendPayload's `filePaths` drops
+    // images, which would silently lose them on restore).
+    const sentFiles = pendingFilesRef.current.slice()
     const { txt, displayTxt, filePaths } = prepareSendPayload(raw, pendingFilesRef.current)
     // Expand paste tokens for the LLM; UI-facing displayTxt keeps the tokens
     // intact so the user bubble can render them as clickable chips.
@@ -2177,7 +2203,164 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     }
     if (!slot || forceNew) {
       sendingRef.current = true;
-      const result = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap();
+      // The composer was cleared above, so a create failure here would destroy
+      // the user's text: `.unwrap()` rejects, send() unwinds, and nothing is
+      // ever sent — no error bubble, no draft to recover, and sendingRef stuck
+      // true (which suppresses the welcome state). Restore the composer, its
+      // paste blocks and attachments, surface the failure, and bail.
+      let created: { key: string } | null = null
+      try {
+        created = await dispatch(createSlot({ agent: pendingAgentRef.current || defaultAgent || undefined, model: pendingModelRef.current || undefined, mode: modeRef.current })).unwrap()
+      } catch (e: unknown) {
+        sendingRef.current = false
+        // Recover the payload WITHOUT clobbering anything newer. Two traps make a
+        // plain assignment lossy here:
+        //  - The composer is only cleared above when `!optionText`, and the
+        //    reachable forceNew path IS the optionText path (Projects / Dev Fleet /
+        //    Prompts navigate to ?autoSend=1&newSession=1), so the composer still
+        //    holds the user's own draft — overwriting it would destroy exactly the
+        //    kind of text this guard exists to protect.
+        //  - The create is awaited, so meanwhile the user may have typed, attached
+        //    files, or switched sessions.
+        // So MERGE into whatever the target slot holds now, and only touch live
+        // composer state while that slot is still the one on screen.
+        // Restore in place ONLY when the composer still belongs to the slot that
+        // issued the send. A no-slot send (auto-send that fires before the slot list
+        // resolves) must NOT fall back to whatever session auto-selection has since
+        // activated: that would splice a new-session payload into an unrelated
+        // session and send it there on retry. Those cases get a notification.
+        const sameSlot = activeSlotRef.current === uiSlot
+        const onScreen = sameSlot
+        // Un-consume the one-shot new-session intent while the user is still on the
+        // slot that issued the send — re-arming after they switched away would make
+        // THAT session's next message spawn an unintended new session. Also re-arm
+        // whenever there was no origin slot: the queued retry below MUST still create
+        // its own session, and `sameSlot` is false there as soon as auto-selection
+        // activates one mid-await, which would otherwise send the payload into an
+        // unrelated existing session.
+        // `|| !uiSlot` on the VALUE too, not just the condition: a slotless send also
+        // reaches the create branch via `!slot` with `forceNew === false` (the
+        // challenge-token flow, whose own createSlot failed), and arming `false` there
+        // would let the queued retry deliver the payload as a user turn in whatever
+        // unrelated session auto-selection activates. A send that had no origin slot
+        // must always create its own session on retry.
+        if (sameSlot || !uiSlot) newSessionRef.current = forceNew || !uiSlot
+        const keepFiles = onScreen ? pendingFilesRef.current : (uiSlot ? fileDrafts.current[uiSlot] ?? [] : [])
+        const restoredFiles = [...new Set([...keepFiles, ...sentFiles])]
+        const keepPastes = onScreen ? pasteBlocksRef.current : (uiSlot ? pasteDrafts.current[uiSlot] ?? [] : [])
+        const keptPasteIds = new Set(keepPastes.map(b => b.id))
+        // Collapsed pastes resolve by `seq`, not id, and a paste made while the
+        // composer was empty restarts at #1 — so a naive id-merge can leave two
+        // blocks sharing #1, with both markers resolving to one of them and
+        // silently swapping the user's content on retry. Re-sequence the carried
+        // blocks past the kept ones and rewrite their markers in the payload text.
+        const { text: payload, blocks: carriedPastes } = remapCarriedBlocks(
+          raw,
+          activePastes.filter(x => !keptPasteIds.has(x.id)),
+          new Set(keepPastes.map(b => b.seq)),
+        )
+        const restoredPastes = [...keepPastes, ...carriedPastes]
+        const keepText = onScreen ? inputRef.current : (uiSlot ? drafts.current[uiSlot] ?? '' : '')
+        // Don't append a payload the composer already holds: a synchronously
+        // rejected create can land before React flushes the clear, and the user may
+        // have typed AROUND the payload during a slow one (superset case). The match
+        // must be whitespace-delimited, not a bare substring — payload "test" inside
+        // a newer draft "latest" is a different message, and treating it as already
+        // restored would drop it.
+        // Dedupe ONLY on exact equality. A whitespace-delimited occurrence is not
+        // proof the payload was already restored — a draft like "please run tests
+        // first" contains the distinct payload "run tests" — and treating it as
+        // restored drops the message. Equality still covers the case this guard
+        // exists for (a synchronously rejected create landing before React flushes
+        // the clear), and errs toward a visible duplicate rather than silent loss.
+        const alreadyRestored = keepText.trim() === payload.trim()
+        const restoredText = !keepText.trim()
+          ? payload
+          : alreadyRestored
+            ? keepText
+            : `${keepText.replace(/\s+$/, '')}\n\n${payload}`
+        if (onScreen && uiSlot) {
+          setInput(restoredText); setPasteBlocks(restoredPastes); setPendingFiles(restoredFiles)
+          // clearPending() above already consumed the knowledge selection, so a
+          // retry would otherwise go out WITHOUT the context the user picked. Slot-
+          // gated: selection is per-slot, so re-injecting while the user views another
+          // session would smear it there. MERGE rather than skip-or-replace — `inject`
+          // replaces, so skipping when a newer selection exists would drop the failed
+          // turn's context, and replacing would drop what the user picked since. Newer
+          // items win on an id collision.
+          if (knowledgeBlock) {
+            const newer = knowledgeFetchRef.current.pendingKnowledge?.items ?? []
+            const newerIds = new Set(newer.map(i => i.id))
+            knowledgeFetchRef.current.inject([...knowledgeBlock.items.filter(i => !newerIds.has(i.id)), ...newer])
+          }
+          dispatch(appendMessage({ role: 'error', content: `Could not start a new session: ${createFailReason(e)}. Your message was restored — send it again to retry.`, cls: '' }))
+        }
+        // Announce the failure wherever the in-chat bubble could not. Two shapes:
+        //  - No origin slot at all: nothing durable can hold the text (a draft under
+        //    the session auto-selection just activated would splice this payload into
+        //    an unrelated conversation, and a composer restore lives in state the
+        //    next slot switch wipes). So the notification CARRIES the message —
+        //    expanded pastes and attachment paths included.
+        //  - Origin slot exists but the user moved on: the draft is parked there, so
+        //    point at it. An error bubble would land in the wrong session.
+        if (!uiSlot) {
+          // No session to restore into or persist to (a draft under the session
+          // auto-selection just activated would splice this into an unrelated
+          // conversation, and a notification body reaches the OS notification centre
+          // — `useNativeNotification` publishes the latest unacked body, and any entry
+          // can be re-marked unread, so `acked` is no barrier). Hand the payload back
+          // to the mechanism that produced it instead: re-arming `autoSendRef` makes
+          // the auto-send effect resend it. Text only — paste blocks and attachments
+          // cannot exist on this path (no composer renders without a slot).
+          //
+          // If a slot is ALREADY active, the effect's deps
+          // (`[send, connected, autoSendTick]`) will not change again on their own, so
+          // bump the tick to drive the retry now — and stay silent, because that
+          // retry reports its own outcome (it runs with a slot, so a second failure
+          // produces the error bubble or the moved-on notification below). Telling the
+          // user to retype while a retry is in flight invites a duplicate turn.
+          // Otherwise nothing can drive it until a real `connected`/slot change, so
+          // report it and be honest that the queue is tab-local.
+          const retryNow = !!activeSlotRef.current
+          autoSendRef.current = payload
+          if (retryNow) {
+            setAutoSendTick(t => t + 1)
+          } else {
+            dispatch(addNotification({
+              ts: uniqueNotificationTs(),
+              kind: 'agent',
+              priority: 'critical',
+              title: 'Could not start a new session',
+              body: `${createFailReason(e)}. Your message is queued and will be sent when a session is ready — but it is held in this tab only, so if you navigate away or reload you will need to retype it.`,
+            }))
+          }
+        } else if (!onScreen) {
+          // The knowledge selection is NOT restored here: `inject` writes to the slot
+          // the user is now viewing, so restoring it off-screen would attach the failed
+          // turn's context to an unrelated session. Re-selecting is a two-click library
+          // action (unlike typed text, which is unrecoverable), so this reports the gap
+          // instead of routing knowledge per-slot — but it must not be silent.
+          const lostContext = knowledgeBlock
+            ? ' Its knowledge context was not kept — re-pick it before you resend.'
+            : ''
+          dispatch(addNotification({
+            ts: uniqueNotificationTs(),
+            kind: 'agent',
+            priority: 'critical',
+            title: 'Could not start a new session',
+            body: `${createFailReason(e)}. Your message is saved as a draft in the session you sent it from.${lostContext}`,
+            slot: uiSlot,
+          }))
+        }
+        if (uiSlot) {
+          setDraft(drafts.current, uiSlot, restoredText)
+          setPasteDraft(pasteDrafts.current, uiSlot, restoredPastes)
+          setFileDraft(fileDrafts.current, uiSlot, restoredFiles)
+          saveDrafts()
+        }
+        return
+      }
+      const result = created
       slot = result.key;
       if (pendingProjectRef.current) {
         await api.chatSlotProject(result.key, pendingProjectRef.current).catch(e => {

--- a/website/src/test/ChatPageSendCreateFailure.test.tsx
+++ b/website/src/test/ChatPageSendCreateFailure.test.tsx
@@ -1,0 +1,451 @@
+/**
+ * A failed session-create must never eat the user's message.
+ *
+ * `send()` clears the composer (and deletes its drafts) BEFORE it creates the
+ * session for a new-session send. The create used to be a bare
+ * `.unwrap()`: when it rejected, send() unwound with the text already gone —
+ * nothing sent, no error surfaced, no draft to recover, and `sendingRef` left
+ * true. This pins the recovery: text, paste blocks and attachments come back,
+ * an error message is shown, and nothing is sent.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import type { RootState } from '../store'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../hooks/useTheme'
+import chatReducer, { setActiveSlot } from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (index: number, item: unknown) => ReactNode }) => (
+    <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div>
+  ),
+}))
+const createChatSlot = vi.fn()
+const sendChat = vi.fn()
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0 }),
+    sendChat: (...a: unknown[]) => sendChat(...a),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+    uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    screenshot: vi.fn().mockResolvedValue({ path: null }),
+    createChatSlot: (...a: unknown[]) => createChatSlot(...a),
+    setSlotColor: vi.fn().mockResolvedValue({ ok: true }),
+    setSlotFolder: vi.fn().mockResolvedValue({ ok: true }),
+    chatSlotProject: vi.fn().mockResolvedValue({ ok: true }),
+    suggestions: vi.fn().mockResolvedValue({ suggestions: [] }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+
+function makeStore(pendingInput = 'do not lose me') {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null, connected: true, slotsLoaded: true,
+        slots: [
+          { key: 'slot-a', messages: 0, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+          { key: 'slot-b', messages: 0, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+        ],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'slot-a', messages: [],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+/** Store with no active slot and no slot list — the pre-session window an
+ *  auto-send can fire in, before slot auto-selection resolves. */
+function makeSlotlessStore(pendingInput = 'do not lose me') {
+  const store = makeStore(pendingInput)
+  const state = store.getState()
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: { ...state.dashboard, slots: [], slotsLoaded: false } as unknown as RootState['dashboard'],
+      chat: { ...state.chat, activeSlot: null, pendingInput } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+/** Render without waiting for the composer: with no active slot ChatPage renders an
+ *  empty state instead, but the auto-send effect still fires. */
+async function renderSlotless(store: ReturnType<typeof makeStore>, route = '/chat?autoSend=1&newSession=1') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={[route]}><ChatPage /></MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+      </QueryClientProvider>,
+    )
+  })
+}
+
+async function renderPage(store: ReturnType<typeof makeStore>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat?autoSend=1&newSession=1']}><ChatPage /></MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+      </QueryClientProvider>,
+    )
+  })
+  await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  createChatSlot.mockReset()
+  sendChat.mockReset()
+  sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
+})
+
+describe('send() when creating the session fails', { timeout: 20_000 }, () => {
+  it('restores the message and reports the failure instead of dropping it', async () => {
+    createChatSlot.mockRejectedValue(new Error('gateway unavailable'))
+    const store = makeStore()
+    await renderPage(store)
+
+    // `pendingInput` + ?autoSend=1&newSession=1 is the reachable forceNew path
+    // (the "Chat" buttons on Projects / Dev Fleet / Prompts): it arms
+    // newSessionRef and auto-sends, so send() takes the create branch.
+    await act(async () => { await Promise.resolve() })
+
+    // Nothing was sent...
+    expect(sendChat).not.toHaveBeenCalled()
+    // ...the text is recovered into the composer and persisted per-slot...
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('do not lose me')
+    })
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')['slot-a']).toBe('do not lose me')
+    })
+
+    // ...and the failure is visible rather than silent.
+    const errs = store.getState().chat.messages.filter(m => m.role === 'error')
+    expect(errs.length).toBe(1)
+    expect(errs[0].content).toContain('Could not start a new session')
+  })
+
+  it('merges into an existing composer draft instead of overwriting it', async () => {
+    // The reachable forceNew path passes the prompt as optionText, so send()
+    // never clears the composer: the user's own draft is still sitting there.
+    // A failed create must not replace it.
+    localStorage.setItem('mc-chat-drafts', JSON.stringify({ 'slot-a': 'my own unsent draft' }))
+    createChatSlot.mockRejectedValue(new Error('gateway unavailable'))
+    const store = makeStore()
+    // renderPage's act() already drains the auto-send effect, so the failed
+    // create (and the recovery) has happened by the time it returns.
+    await renderPage(store)
+    await act(async () => { await Promise.resolve() })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+        .toBe('my own unsent draft\n\ndo not lose me')
+    })
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')['slot-a'])
+        .toBe('my own unsent draft\n\ndo not lose me')
+    })
+    expect(sendChat).not.toHaveBeenCalled()
+  })
+
+  it('merges around text typed while a slow create was in flight (no duplication)', async () => {
+    // A deferred rejection opens the real async window the instant-reject tests
+    // cannot reach: the user keeps typing while createSlot is pending.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    const store = makeStore()
+    await renderPage(store)
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'typed while waiting' } })
+    await act(async () => {
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+        .toBe('typed while waiting\n\ndo not lose me')
+    })
+    // The payload appears exactly once — the merge must not re-append it.
+    const value = (screen.getByLabelText('Message input') as HTMLTextAreaElement).value
+    expect(value.split('do not lose me').length - 1).toBe(1)
+    expect(sendChat).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a substring collision as already restored', async () => {
+    // GPT's case: payload "test" sits inside the newer draft "latest". A bare
+    // substring match calls that already-restored and drops the payload.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    const store = makeStore('test')
+    await renderPage(store)
+
+    fireEvent.change(screen.getByLabelText('Message input'), { target: { value: 'latest' } })
+    await act(async () => {
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+        .toBe('latest\n\ntest')
+    })
+  })
+
+  it('leaves the new-session intent disarmed when the user switched away', async () => {
+    // Re-arming newSessionRef after a slot switch makes the OTHER session's next
+    // message spawn an unintended new session — observable via createChatSlot.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    const store = makeStore()
+    await renderPage(store)
+
+    await act(async () => {
+      store.dispatch(setActiveSlot('slot-b'))
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+    // The payload is parked in the ORIGIN slot's draft; slot-b is untouched.
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')['slot-a']).toBe('do not lose me')
+    })
+    expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('')
+    // No error bubble in slot-b (the message never belonged there) — a notification
+    // carries the failure instead, so it is not silent.
+    expect(store.getState().chat.messages.filter(m => m.role === 'error')).toHaveLength(0)
+    const notes = store.getState().notifications.items
+    expect(notes).toHaveLength(1)
+    expect(notes[0].title).toBe('Could not start a new session')
+    expect(notes[0].slot).toBe('slot-a')
+
+    // Now send from slot-b: it must go to slot-b, NOT create a session.
+    createChatSlot.mockReset()
+    createChatSlot.mockResolvedValue({ key: 'slot-c', title: 'slot-c', messages: 0, running: false })
+    const input = screen.getByLabelText('Message input')
+    fireEvent.change(input, { target: { value: 'a normal message' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(createChatSlot).not.toHaveBeenCalled()
+    await waitFor(() => expect(sendChat).toHaveBeenCalled())
+    expect(sendChat.mock.calls[0][1]).toBe('slot-b')
+  })
+
+  it('does not double the payload when the composer already holds it', async () => {
+    // Pins the already-restored branch: the composer (restored from the slot's
+    // draft) is byte-identical to the auto-send payload, which is what a
+    // synchronously-rejected create looks like before React flushes the clear.
+    localStorage.setItem('mc-chat-drafts', JSON.stringify({ 'slot-a': 'do not lose me' }))
+    createChatSlot.mockRejectedValue(new Error('gateway unavailable'))
+    const store = makeStore()
+    await renderPage(store)
+    await act(async () => { await Promise.resolve() })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('do not lose me')
+    })
+    expect(sendChat).not.toHaveBeenCalled()
+  })
+
+  it('appends rather than drops when the draft merely contains the payload', async () => {
+    // Only an exact match proves the payload is already in the composer. "latest test"
+    // containing "test" is a different message, so the payload is appended — a visible
+    // duplicate is always preferable to silently losing the user's text.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    const store = makeStore('test')
+    await renderPage(store)
+
+    fireEvent.change(screen.getByLabelText('Message input'), { target: { value: 'latest test' } })
+    await act(async () => {
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+        .toBe('latest test\n\ntest')
+    })
+  })
+
+  it('surfaces the real failure reason, not the developer fallback', async () => {
+    // RTK unwrap() rejects with a SERIALIZED error (a plain object), so an
+    // `instanceof Error` test would always miss and every user would read the
+    // fallback. The thrown Error's message must reach the bubble.
+    createChatSlot.mockRejectedValue(new Error('Failed to fetch'))
+    const store = makeStore()
+    await renderPage(store)
+    await act(async () => { await Promise.resolve() })
+
+    await waitFor(() => {
+      const errs = store.getState().chat.messages.filter(m => m.role === 'error')
+      expect(errs).toHaveLength(1)
+      expect(errs[0].content).toContain('Failed to fetch')
+    })
+  })
+
+  it('re-queues a slotless payload so it sends once a session exists', async () => {
+    // No active slot at auto-send: nothing durable can hold the text, and a
+    // notification body would reach the OS notification centre. So the payload goes
+    // back to the auto-send mechanism, which resends it when a slot activates.
+    createChatSlot.mockRejectedValueOnce(new Error('Failed to fetch'))
+    createChatSlot.mockResolvedValue({ key: 'slot-z', title: 'slot-z', messages: 0, running: false })
+    const store = makeSlotlessStore('remember this exact sentence')
+    await renderSlotless(store)
+    await act(async () => { await Promise.resolve() })
+
+    // Reported, and no notification carries the message text (the OS-exposure path).
+    await waitFor(() => expect(store.getState().notifications.items).toHaveLength(1))
+    const note = store.getState().notifications.items[0]
+    expect(note.title).toBe('Could not start a new session')
+    expect(note.body).toContain('Failed to fetch')
+    for (const n of store.getState().notifications.items) {
+      expect(n.body).not.toContain('remember this exact sentence')
+    }
+    expect(note.ts).toMatch(/^\d+(\.\d+)?$/)
+    expect(note.kind).toBe('agent')
+    expect(sendChat).not.toHaveBeenCalled()
+
+    // A slot becoming available re-drives the auto-send, and the message goes out.
+    await act(async () => {
+      store.dispatch(setActiveSlot('slot-a'))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(sendChat).toHaveBeenCalled())
+    expect(String(sendChat.mock.calls[0][0])).toContain('remember this exact sentence')
+    // Destination matters: the retry must create its OWN session, never deliver into
+    // the slot that happened to activate.
+    expect(createChatSlot).toHaveBeenCalledTimes(2)
+    expect(sendChat.mock.calls[0][1]).toBe('slot-z')
+  })
+
+  it('does not treat a payload that is merely a phrase inside the draft as restored', async () => {
+    // "please run tests first" CONTAINS the distinct payload "run tests" as a
+    // whitespace-delimited phrase; treating that as already-restored drops it.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    const store = makeStore('run tests')
+    await renderPage(store)
+
+    fireEvent.change(screen.getByLabelText('Message input'), { target: { value: 'please run tests first' } })
+    await act(async () => {
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+        .toBe('please run tests first\n\nrun tests')
+    })
+  })
+
+  it('drives the queued retry even when a slot activated before the rejection', async () => {
+    // The auto-send effect only re-runs on `connected` / `send` identity / tick
+    // changes. If auto-selection activated a slot BEFORE the create rejected, none of
+    // those change again, so the queued payload would sit dormant until page close.
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementationOnce(() => new Promise((_res, rej) => { rejectCreate = rej }))
+    createChatSlot.mockResolvedValue({ key: 'slot-z', title: 'slot-z', messages: 0, running: false })
+    const store = makeSlotlessStore('queued sentence')
+    await renderSlotless(store)
+
+    // Slot activates first, THEN the create fails.
+    await act(async () => {
+      store.dispatch(setActiveSlot('slot-a'))
+      await Promise.resolve()
+    })
+    await act(async () => {
+      rejectCreate(new Error('Failed to fetch'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(sendChat).toHaveBeenCalled())
+    expect(String(sendChat.mock.calls[0][0])).toContain('queued sentence')
+    // Silent on this path: the retry fires immediately and reports its own outcome.
+    // A "you may need to retype it" notification here invites a duplicate turn.
+    expect(store.getState().notifications.items).toHaveLength(0)
+    // And it must go to a NEWLY created session, not the one auto-selection happened
+    // to activate — the new-session intent has to survive the failed attempt.
+    expect(createChatSlot).toHaveBeenCalledTimes(2)
+    expect(sendChat.mock.calls[0][1]).toBe('slot-z')
+  })
+
+  it('creates its own session on retry even when the failed send had no new-session intent', async () => {
+    // The slotless path is also reached with forceNew === false — ?autoSend=1 with no
+    // newSession=1 (the challenge-token flow, whose own createSlot already failed).
+    // Arming the retry with that `false` would deliver the payload as a user turn in
+    // whatever unrelated session auto-selection activates.
+    createChatSlot.mockRejectedValueOnce(new Error('Failed to fetch'))
+    createChatSlot.mockResolvedValue({ key: 'slot-z', title: 'slot-z', messages: 0, running: false })
+    const store = makeSlotlessStore('slack originated prompt')
+    await renderSlotless(store, '/chat?autoSend=1')
+    await act(async () => { await Promise.resolve() })
+
+    await act(async () => {
+      store.dispatch(setActiveSlot('slot-a'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(sendChat).toHaveBeenCalled())
+    expect(String(sendChat.mock.calls[0][0])).toContain('slack originated prompt')
+    expect(createChatSlot).toHaveBeenCalledTimes(2)
+    // NOT 'slot-a' — that session has nothing to do with this message.
+    expect(sendChat.mock.calls[0][1]).toBe('slot-z')
+  })
+})

--- a/website/src/test/ChatPageSendKnowledgeMerge.test.tsx
+++ b/website/src/test/ChatPageSendKnowledgeMerge.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * A failed session-create must not lose the knowledge context the user picked.
+ *
+ * `send()` consumes the pending selection (`clearPending()`) before creating the
+ * session, so the create-failure path has to put it back. Skipping that when a NEWER
+ * selection exists drops the failed turn's context; replacing drops what the user
+ * picked since. Both must survive the merge, newer winning on an id collision.
+ *
+ * The knowledge hook is mocked HERE (and only here) so the selection is
+ * controllable; the rest of the create-failure suite exercises the real hook.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import type { RootState } from '../store'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../hooks/useTheme'
+import chatReducer, { setActiveSlot } from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import type { KnowledgeBlock, KnowledgeResult } from '../pages/chat/useKnowledgeFetch'
+
+const item = (id: string, content = `body-${id}`): KnowledgeResult => ({
+  id, title: `T-${id}`, source: null, match_type: 'fts', tokens: 5, summary: '', content,
+})
+
+/** Mutable stand-in for the knowledge hook's state. */
+const knowledge: { pendingKnowledge: KnowledgeBlock | null; injected: KnowledgeResult[][] } = {
+  pendingKnowledge: null,
+  injected: [],
+}
+
+vi.mock('../pages/chat/useKnowledgeFetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../pages/chat/useKnowledgeFetch')>()
+  return {
+    ...actual,
+    useKnowledgeFetch: () => ({
+      results: [],
+      query: '',
+      loading: false,
+      get pendingKnowledge() { return knowledge.pendingKnowledge },
+      searchKnowledge: vi.fn(),
+      inject: (items: KnowledgeResult[]) => {
+        knowledge.injected.push(items)
+        knowledge.pendingKnowledge = { items, totalTokens: items.length }
+      },
+      clearPending: () => { knowledge.pendingKnowledge = null },
+      clearResults: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (index: number, item: unknown) => ReactNode }) => (
+    <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div>
+  ),
+}))
+const createChatSlot = vi.fn()
+const sendChat = vi.fn()
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0 }),
+    sendChat: (...a: unknown[]) => sendChat(...a),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+    uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    screenshot: vi.fn().mockResolvedValue({ path: null }),
+    createChatSlot: (...a: unknown[]) => createChatSlot(...a),
+    setSlotColor: vi.fn().mockResolvedValue({ ok: true }),
+    setSlotFolder: vi.fn().mockResolvedValue({ ok: true }),
+    chatSlotProject: vi.fn().mockResolvedValue({ ok: true }),
+    suggestions: vi.fn().mockResolvedValue({ suggestions: [] }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+
+function makeStore() {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null, connected: true, slotsLoaded: true,
+        slots: [
+          { key: 'slot-a', messages: 0, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+          { key: 'slot-b', messages: 0, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+        ],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'slot-a', messages: [],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: 'context-bearing message',
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  createChatSlot.mockReset()
+  sendChat.mockReset()
+  sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  knowledge.pendingKnowledge = null
+  knowledge.injected = []
+})
+
+describe('create-failure knowledge recovery', { timeout: 20_000 }, () => {
+  it('merges the failed selection with a newer one, newer winning on id collision', async () => {
+    // Selection A is pending when the auto-send fires; B (sharing one id) is chosen
+    // while the create is still in flight.
+    knowledge.pendingKnowledge = { items: [item('a'), item('shared', 'OLD-shared')], totalTokens: 10 }
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+
+    const store = makeStore()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    await act(async () => {
+      render(
+        <QueryClientProvider client={qc}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <MemoryRouter initialEntries={['/chat?autoSend=1&newSession=1']}><ChatPage /></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+        </QueryClientProvider>,
+      )
+    })
+    await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+    // send() consumed A via clearPending(); the user then picks B mid-flight.
+    knowledge.pendingKnowledge = { items: [item('b'), item('shared', 'NEW-shared')], totalTokens: 10 }
+
+    await act(async () => {
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(knowledge.injected.length).toBeGreaterThan(0))
+    const merged = knowledge.injected[knowledge.injected.length - 1]
+    const ids = merged.map(i => i.id)
+    // Both selections survive...
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    // ...and the colliding id appears once, taking the NEWER item.
+    expect(ids.filter(id => id === 'shared')).toHaveLength(1)
+    // Distinct content on each side, so reversing precedence fails this.
+    expect(merged.find(i => i.id === 'shared')?.content).toBe('NEW-shared')
+    expect(sendChat).not.toHaveBeenCalled()
+  })
+
+  it('reports the lost knowledge context when the user switched away', async () => {
+    // Off-screen, `inject` would attach the failed turn's context to whatever session
+    // the user is now viewing, so it is deliberately not restored — but the
+    // notification must say so rather than leaving the retry quietly context-free.
+    knowledge.pendingKnowledge = { items: [item('a')], totalTokens: 5 }
+    let rejectCreate: (e: Error) => void = () => {}
+    createChatSlot.mockImplementation(() => new Promise((_res, rej) => { rejectCreate = rej }))
+
+    const store = makeStore()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    await act(async () => {
+      render(
+        <QueryClientProvider client={qc}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <MemoryRouter initialEntries={['/chat?autoSend=1&newSession=1']}><ChatPage /></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+        </QueryClientProvider>,
+      )
+    })
+    await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+
+    await act(async () => {
+      store.dispatch(setActiveSlot('slot-b'))
+      rejectCreate(new Error('gateway unavailable'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(store.getState().notifications.items).toHaveLength(1))
+    const note = store.getState().notifications.items[0]
+    expect(note.slot).toBe('slot-a')
+    expect(note.body).toContain('saved as a draft')
+    expect(note.body).toContain('knowledge context was not kept')
+    // And it was NOT injected into slot-b's selection.
+    expect(knowledge.injected).toHaveLength(0)
+  })
+})

--- a/website/src/test/remapCarriedBlocks.test.ts
+++ b/website/src/test/remapCarriedBlocks.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { remapCarriedBlocks, formatToken, expandAll, type PasteBlock } from '../utils/pasteTokens'
+
+const blk = (id: string, seq: number, lines: number, content: string): PasteBlock =>
+  ({ id, seq, lines, content })
+
+describe('remapCarriedBlocks', () => {
+  it('leaves text and blocks untouched when no seq collides', () => {
+    const carried = [blk('a', 3, 5, 'AAA'), blk('b', 4, 5, 'BBB')]
+    const text = `x ${formatToken(carried[0])} y ${formatToken(carried[1])}`
+    const out = remapCarriedBlocks(text, carried, new Set([1, 2]))
+    expect(out.text).toBe(text)
+    expect(out.blocks.map(b => b.seq)).toEqual([3, 4])
+  })
+
+  it('does not fuse markers when carried blocks share a line count (cascade guard)', () => {
+    // The bug: rewriting per block with split/join re-matches the marker a previous
+    // iteration emitted, because the needle only carries seq + line count. Two
+    // 5-line blocks then collapse onto one seq, so on expansion one blob's content
+    // is duplicated and the other is silently dropped.
+    const b1 = blk('b1', 1, 5, 'FIRST')
+    const b2 = blk('b2', 2, 5, 'SECOND')
+    const text = `${formatToken(b1)} and ${formatToken(b2)}`
+    const { text: out, blocks } = remapCarriedBlocks(text, [b1, b2], new Set([1]))
+
+    // Every carried block keeps a distinct seq...
+    expect(new Set(blocks.map(b => b.seq)).size).toBe(2)
+    // ...each has exactly one marker in the text...
+    for (const b of blocks) {
+      expect(out.split(formatToken(b)).length - 1).toBe(1)
+    }
+    // ...and expansion restores BOTH original contents, in order.
+    const expanded = expandAll(out, blocks)
+    expect(expanded).toContain('FIRST')
+    expect(expanded).toContain('SECOND')
+    expect(expanded.indexOf('FIRST')).toBeLessThan(expanded.indexOf('SECOND'))
+  })
+
+  it('cascades safely across three equal-length blocks', () => {
+    const bs = [blk('b1', 1, 5, 'ONE'), blk('b2', 2, 5, 'TWO'), blk('b3', 3, 5, 'THREE')]
+    const text = bs.map(formatToken).join(' | ')
+    const { text: out, blocks } = remapCarriedBlocks(text, bs, new Set([1, 2, 3]))
+    expect(new Set(blocks.map(b => b.seq)).size).toBe(3)
+    const expanded = expandAll(out, blocks)
+    for (const want of ['ONE', 'TWO', 'THREE']) {
+      expect(expanded.split(want).length - 1).toBe(1)
+    }
+  })
+
+  it('records assigned seqs in the used set so later callers cannot reuse them', () => {
+    const used = new Set([1])
+    const { blocks } = remapCarriedBlocks(formatToken(blk('a', 1, 2, 'X')), [blk('a', 1, 2, 'X')], used)
+    expect(used.has(blocks[0].seq)).toBe(true)
+    expect(blocks[0].seq).not.toBe(1)
+  })
+
+  it('never reuses a seq a kept block already holds (stale free-cursor guard)', () => {
+    // Reachable via a second failed recovery: the live list has a gap (a paste chip
+    // was deleted, seqs are not renumbered) and the carried list is non-ascending
+    // because an earlier recovery re-sequenced it. Seeding `free` once from
+    // max(used) then only incrementing hands a later block a seq that an earlier
+    // KEPT block just claimed.
+    const carried = [blk('c2', 2, 5, 'TWO'), blk('c1', 1, 5, 'ONE'), blk('c3', 3, 5, 'THREE')]
+    const text = carried.map(formatToken).join(' | ')
+    const { text: out, blocks } = remapCarriedBlocks(text, carried, new Set([1]))
+
+    expect(new Set(blocks.map(b => b.seq)).size).toBe(3)
+    const expanded = expandAll(out, blocks)
+    for (const want of ['ONE', 'TWO', 'THREE']) {
+      expect(expanded.split(want).length - 1).toBe(1)
+    }
+  })
+})

--- a/website/src/utils/pasteTokens.ts
+++ b/website/src/utils/pasteTokens.ts
@@ -53,6 +53,57 @@ export function nextSeq(blocks: PasteBlock[]): number {
   return max + 1
 }
 
+/**
+ * Re-sequence `carried` blocks whose `seq` is already taken by `used`, and rewrite
+ * their markers in `text` to match.
+ *
+ * Markers resolve by `seq` alone, so re-using a seq makes two blocks collapse onto
+ * one on expansion — one blob's content is sent twice and the other is dropped.
+ * Rewriting must therefore happen in a SINGLE right-to-left pass over the located
+ * ranges: a naive per-block `split/join` re-matches markers an earlier iteration
+ * just emitted (the needle `[ Paste #N · M lines ]` collides whenever two blocks
+ * share a line count), which cascades every marker onto the last block.
+ *
+ * `used` is mutated to include the assigned seqs. Blocks keep their identity and
+ * content; only `seq` changes, and only when it has to.
+ */
+export function remapCarriedBlocks(
+  text: string,
+  carried: PasteBlock[],
+  used: Set<number>,
+): { text: string; blocks: PasteBlock[] } {
+  let free = 0
+  for (const v of used) if (v > free) free = v
+  free += 1
+  const remap = new Map<number, number>()
+  const blocks: PasteBlock[] = []
+  for (const b of carried) {
+    // Re-derive `free` against `used` on every allocation. A block that KEEPS its
+    // seq also lands in `used`, so a single max()-seed goes stale the moment a kept
+    // seq is >= free — and the next block needing a new seq would be handed one the
+    // kept block already holds, recreating the duplicate this function exists to
+    // prevent. (Reachable when the live list has a seq gap, e.g. after a paste chip
+    // is deleted, then a second failed recovery runs.)
+    while (used.has(free)) free++
+    const seq = used.has(b.seq) ? free++ : b.seq
+    used.add(seq)
+    if (seq !== b.seq) remap.set(b.seq, seq)
+    blocks.push(seq === b.seq ? b : { ...b, seq })
+  }
+  if (!remap.size) return { text, blocks }
+  // Right-to-left so each splice leaves the earlier ranges' offsets valid, and so
+  // no marker written by this pass is ever re-examined.
+  let out = text
+  const ranges = findTokenRanges(text, carried)
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const { start, end, block } = ranges[i]
+    const mapped = remap.get(block.seq)
+    if (mapped === undefined) continue
+    out = out.slice(0, start) + formatToken({ ...block, seq: mapped }) + out.slice(end)
+  }
+  return { text: out, blocks }
+}
+
 /** Ranges for each token whose seq is present in `blocks`, in document order. */
 export function findTokenRanges(
   text: string,


### PR DESCRIPTION
## Problem

A message typed for a **new session** could vanish with no trace. `send()` clears
the composer (and deletes that slot's text/attachment/paste drafts) *before* it
creates the session, and the create was a bare `.unwrap()`. When it rejected —
gateway restarting, 5xx, transient network — `send()` unwound with the text
already gone: nothing was sent, no error bubble appeared, no draft was left to
recover from, and `sendingRef` stayed `true` (which suppresses the welcome state).

This is the reachable auto-send path: the **Chat** buttons on Projects and Dev
Fleet and the Prompts tab navigate to `/chat?autoSend=1&newSession=1`, which arms
`newSessionRef` and immediately sends — so the create-then-send branch is the one
real users hit.

## Why it matters

Silent data loss on the primary compose surface. The user sees their message
disappear with no error and no way to get it back, and has to retype it from
memory — the worst possible failure mode for a chat composer.

## Fix (symptom → root cause → change)

Symptom: message disappears when starting a new session. Root cause: the composer
is cleared before the session exists, and the create's rejection path had no
recovery. Change: wrap the create in `try/catch` and recover the whole payload.

The recovery is a **merge**, not an assignment, because two things can be true
when it runs:

- The clear above is gated on `if (!optionText)`, and the reachable `forceNew`
  path *is* the `optionText` path — so the composer often still holds the user's
  own unsent draft. Overwriting it would recreate the same data loss this PR
  exists to fix.
- The create is awaited, so the user may have typed, attached files, pasted, or
  switched sessions in the meantime.

So the catch:

- merges the payload into whatever the target slot holds now (text joined, files
  unioned, paste blocks merged) and only touches live composer state while that
  slot is still on screen; otherwise it writes only that slot's persisted drafts,
  so nothing smears into an unrelated session;
- treats "no session at all" (`uiSlot === null`) as on-screen, because the visible
  composer is then the only recovery destination — otherwise the payload *and* the
  failure notice would both vanish;
- re-sequences carried paste blocks past the kept ones and rewrites their markers
  in the payload text. Collapsed pastes resolve by `seq`, not id, and a paste made
  while the composer was empty restarts at `#1`, so an id-only merge could leave
  two blocks sharing `#1` with both markers resolving to one of them — silently
  swapping the user's content on retry;
- re-injects the consumed Knowledge Library selection (`clearPending()` already
  ran, so a retry would otherwise go out without the context the user picked),
  skipping it when a newer selection exists because `inject()` replaces rather
  than merges;
- skips the join when the composer already contains the payload, covering both a
  synchronously-rejected create (before React flushes the clear) and the user
  typing *around* the payload during a slow one;
- re-arms the one-shot `newSessionRef`, resets `sendingRef`, and appends a
  `role: 'error'` message telling the user the text was restored and to press
  Enter to retry.

## Tests

`website/src/test/ChatPageSendCreateFailure.test.tsx` (new, 3 cases), all driving
the real reachable path (`chat.pendingInput` + `?autoSend=1&newSession=1`):

1. **Nothing is dropped** — `api.sendChat` is never called, the text is back in
   the composer and persisted under the slot, and exactly one `role: 'error'`
   message is present. Revert-verified against `main`.
2. **No clobber** — with a pre-existing `mc-chat-drafts` entry for the slot, the
   recovery merges (`my own unsent draft\n\ndo not lose me`) instead of replacing
   it. Revert-verified against the pre-merge revision of this commit.
3. **Slow create** — a *deferred* rejection opens the real async window: the user
   keeps typing while the create is pending, and the result merges around that
   text with the payload appearing exactly once.

Full frontend suite green: 450 files / 5471 tests, `tsc -b` and eslint clean
(only pre-existing warnings in this file).

## Manual verification

Not done for the failure path itself: reaching it live requires forcing
`POST /api/chat/slots` to fail, which needs a fault-injected instance rather than
a normal pod run. The three cases above simulate rejection directly at the API
boundary, which is where the failure enters `send()`.

## Screenshots

N/A — no layout, panel, or component change. The only new user-visible surface is
one `role: 'error'` chat message on a failure path, rendered by the existing error
bubble styling.
