### PR TITLE
feat(security): let policy pin the update source and minimum version

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -111,6 +111,59 @@ is **pure-Python and structural** (it does not depend on `jsonschema`, which is
 an optional, possibly-absent dependency) so a malformed policy never silently
 degrades to ungoverned.
 
+## Update pins (`updates`) — policy-only
+
+Replacing the running code is the widest privileged action the host performs: a
+self-update rewrites every other ceiling in this document, because the deny
+catalog, the sensitive-path list and the evaluator are *code*. Two enterprise
+pins ride in the policy file for it:
+
+```json
+"updates": {
+  "source": "https://git.corp.example/platform/*",
+  "min_version": "1.4.0"
+}
+```
+
+- **`source`** — an fnmatch glob over the git remote URL new code may come from
+  (a glob so one pin covers a mirror set, and so non-URL remote shapes —
+  SCP-style, local path — are pinnable). Empty = unpinned. A checkout whose
+  remote cannot be resolved is **denied when a pin exists**: an admin's pin must
+  not be satisfied by "we could not tell".
+- **`min_version`** — the minimum version the fleet may run. A host below it
+  takes a **mandatory** update, overriding the user's `auto_update=false`
+  (user config sits under the enterprise ceiling). It never refuses to *boot*:
+  bricking a fleet on a policy typo would remove the surface an admin needs to
+  fix it. An unparseable floor imposes none, for the same reason.
+
+**Not an archetype, by design.** Every archetype answers "is X permitted?"; a
+remote URL and a version number are *values the core consumes*. So they ride
+outside `controls` — no `SCOPE_CATALOG` row, no matcher, no evaluator change.
+What makes them enterprise-*pinnable* is the file they live in: the trust-root
+`security_policy.json` is on the `security._SENSITIVE_HOME_DIRS` keystone, so the
+agent can neither read nor write its own ceiling. A `config.json` field or an env
+var would only be a suggestion.
+
+**Policy-only — rejected in a Level-2 profile** (`parse_profile` raises). A
+profile is narrow-only and there is no narrower version of *pointing somewhere
+else*; a per-app profile that could redirect the update source would be
+privilege escalation.
+
+`platform/update_governance.py` is the one seam the three update paths share
+(`POST /api/update`, `kirocrew update`, the gateway-boot auto-apply) so they
+cannot drift. It resolves the remote git would *actually* fetch from — reading
+`branch.<name>.remote` rather than assuming `origin`, via `ls-remote --get-url`
+so `url.<base>.insteadOf` rewriting is applied — and returns a blocking reason or
+`""`. **A pin blocks; an unresolvable pin does not:** if governance cannot be read
+at all the update proceeds, because refusing one would strand a host on a build
+that may need a patch. These are a routing constraint for a managed fleet, not a
+boundary against a local operator who could edit the checkout directly.
+
+**Roll the build before the pin.** The parser fails closed on an unknown key, so a
+build predating `updates` refuses to boot on a pinned policy — which inverts the
+`min_version` case, since the stale hosts a floor targets are exactly the ones
+that would stop booting. Recovery is a manual `kirocrew update`.
+
 ## Policy authenticity (`identity.signature`)
 
 Without a signature check, a policy's integrity rests entirely on **filesystem
@@ -992,6 +1045,9 @@ carve-out stay as code. It expects `CONTRACT_VERSION == 1` (pinned pre-launch).
 - `platform/admission.py` — `canonical_signing_bytes` / `hmac_signature` (shared
   by both trust roots), `require_policy_signature` / `trust_keys`, and
   `read_policy_trust_root` (the side-effect-free trust-root reader).
+- `platform/update_governance.py` — the shared update seam (`resolve_remote_url`,
+  `update_blocked_reason`, `update_required`, `min_version`) called by
+  `dashboard/handlers/updates.py`, `cli_server.py` and `slack/gateway.py`.
 - `platform/governance_profiles.py` — `ProfileStore` (hot-reload),
   `resolve_active_scope`, `governance_permits`, `governance_floor_ordinal`,
   `GOVERNANCE_ERROR_REASON` (the eval-error marker consumers match on),
@@ -1023,4 +1079,6 @@ the `policy show` provenance reporting), `test_platform_admission.py`
 the per-transport inbound gates), `test_governance_channels_endpoint.py`
 (`/api/governance/channels`, incl. the eval-error→`null` distinction),
 `test_governance_policy_viewer.py` (`/api/governance/policy` posture-only, incl.
-`test_detail_never_leaks_rule_contents`).
+`test_detail_never_leaks_rule_contents`), `test_governance_updates.py` (the
+`updates` pins, the shared seam's fail-open-on-error disposition, and the
+tracked-remote resolution).

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -913,6 +913,16 @@ def _update() -> None:
     if branch == "HEAD":
         branch = "mainline"
 
+    # Source pin, checked before the fetch so a blocked update never touches the
+    # tree. A human at a terminal is not the authorization: the fleet decides
+    # which remote this host may take code from.
+    from kiro_crew.platform.update_governance import resolve_remote_url, update_blocked_reason
+
+    _blocked = update_blocked_reason(resolve_remote_url(proj, remote="origin"))
+    if _blocked:
+        print(f"  🛡️  Update blocked by security policy: {_blocked}")
+        sys.exit(1)
+
     # Fetch + reset --hard: no merge conflicts, untracked files preserved
     print("  ⬇️  git fetch…")
     result = subprocess.run(

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -19,6 +19,12 @@ from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
 from kiro_crew.config.loader import KiroCrewConfig, config_path
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.platform.update_governance import (
+    min_version,
+    resolve_remote_url,
+    update_blocked_reason,
+    update_required,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -42,7 +48,16 @@ async def api_update_check(request: web.Request) -> web.Response:
     """GET /api/update/check — check if git remote has new commits."""
     await _do_update_check()
     cfg = KiroCrewConfig.load()
-    return web.json_response({**_update_info, "auto_update": cfg.auto_update})
+    return web.json_response(
+        {
+            **_update_info,
+            "auto_update": cfg.auto_update,
+            # Surface the pin so the dashboard can say WHY an update is mandatory
+            # rather than showing a bare button.
+            "min_version": min_version(),
+            "update_required": update_required(_local_version),
+        }
+    )
 
 
 def _version_tuple(v: str) -> tuple[int, ...]:
@@ -375,6 +390,17 @@ async def api_update_apply(request: web.Request) -> web.Response:
             {"error": "Not a git checkout — update by redeploying (e.g. `kirocrew cloud launch`)"},
             status=409,
         )
+
+    # Source pin, checked before any state is pushed so a blocked update leaves
+    # no "updating" spinner behind. A dashboard token proves the caller is the
+    # operator, not that the fleet permits this host to pull from this remote.
+    # Offloaded: the seam shells out to git.
+    blocked = await asyncio.get_running_loop().run_in_executor(
+        None, lambda: update_blocked_reason(resolve_remote_url(proj))
+    )
+    if blocked:
+        logger.warning("Update refused: %s", blocked)
+        return web.json_response({"error": blocked, "governance": True}, status=403)
 
     # Signal updating state via SSE
     state.push_refresh("updating")

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -908,6 +908,116 @@ class BootControls:
     fail_closed: bool = True
 
 
+def _version_tuple(value: str) -> Tuple[int, ...]:
+    """Parse a version's numeric core into a comparable tuple.
+
+    The pre-release/build suffix is split off the WHOLE string before splitting
+    on dots, because this project's CI stamps a dot INSIDE the pre-release
+    (``0.2.0-nightly.20260728t184500``, ``0.3.0-insider.2``) — splitting
+    per-component would leave ``nightly.20260728t184500`` as its own component
+    and read every nightly as version ``0``.
+    """
+    core = re.split(r"[-+]", str(value).strip(), maxsplit=1)[0]
+    try:
+        return tuple(int(chunk) for chunk in core.split("."))
+    except ValueError:
+        return ()
+
+
+@dataclass(frozen=True)
+class UpdatePins:
+    """Policy-only update pins: WHERE new code comes from, and the MINIMUM version.
+
+    **Not a governed scope, deliberately.** Every archetype answers "is X
+    permitted?"; a remote URL and a version number are *values the core
+    consumes*, not permission decisions. So they ride outside ``controls`` — no
+    ``SCOPE_CATALOG`` row, no matcher, no evaluator change, no new archetype.
+
+    Read from the trust-root ``security_policy.json``, which sits in
+    ``security._SENSITIVE_HOME_DIRS`` — that keystone (the agent can neither read
+    nor write its own ceiling) is what makes these enterprise-*pinnable* where a
+    ``config.json`` field or an env var would only be a suggestion.
+
+    **Policy-only: rejected in a Level-2 profile** (see :func:`parse_profile`).
+    Profiles are narrow-only, and there is no "narrower" version of pointing
+    somewhere else — a per-app profile that could redirect the update source
+    would be privilege escalation.
+    """
+
+    # The git remote new code may come from, as an fnmatch glob so one pin can
+    # cover a mirror set. Empty = unpinned (the standalone default: any remote).
+    source: str = ""
+    # The minimum version this fleet may run. Empty = no floor.
+    min_version: str = ""
+
+    def permits_source(self, url: str) -> bool:
+        """Does *url* satisfy the source pin? An empty pin permits anything.
+
+        An empty *url* (the checkout has no resolvable remote) DENIES when a pin
+        exists: an admin's pin must not be satisfied by "we could not tell". So
+        does a ``.``/``..`` component — ``*`` spans separators, so
+        ``/srv/approved/../evil.git`` would otherwise match ``/srv/approved/*``.
+
+        ``fnmatchcase``, not ``fnmatch``: the latter normcases via
+        ``os.path.normcase``, a no-op on POSIX but lowercasing on Windows — the
+        same pin must not be case-sensitive on one OS and not the other.
+        """
+        if not self.source:
+            return True
+        candidate = url.strip()
+        if not candidate or any(
+            part in (".", "..") for part in candidate.replace("\\", "/").split("/")
+        ):
+            return False
+        return fnmatch.fnmatchcase(candidate, self.source.strip())
+
+    def meets_min_version(self, version: str) -> bool:
+        """Is *version* at or above the floor? An empty floor is always met.
+
+        An unparseable floor imposes none (a typo must not brick a fleet); an
+        unparseable *version* is treated as below the floor, which makes the host
+        take the update rather than sit on a build it cannot identify.
+        """
+        floor = _version_tuple(self.min_version) if self.min_version else ()
+        if not floor:
+            return True
+        current = _version_tuple(version)
+        if not current:
+            return False
+        width = max(len(current), len(floor))
+        return current + (0,) * (width - len(current)) >= floor + (0,) * (width - len(floor))
+
+    @staticmethod
+    def from_dict(d: Mapping[str, object]) -> "UpdatePins":
+        _reject_unknown_keys(d, {"source", "min_version"}, "updates")
+        for key in ("source", "min_version"):
+            # `str(raw or "")` would coerce `"source": false` to "" — silently
+            # UNPINNING a policy that plainly meant to pin. Fail closed instead.
+            if d.get(key) is not None and not isinstance(d[key], str):
+                raise PlatformCompositionError(f"updates.{key} must be a string")
+        return UpdatePins(
+            source=str(d.get("source") or "").strip(),
+            min_version=str(d.get("min_version") or "").strip(),
+        )
+
+
+def active_update_pins() -> UpdatePins:
+    """The boot-frozen ceiling's update pins — empty (unpinned) when ungoverned.
+
+    The single read point for the three update call sites, so they cannot drift.
+    Returns unpinned on any error: a governance glitch must not block an update,
+    because refusing one strands a host on a build that may need a patch.
+    """
+    try:
+        from kiro_crew.platform.context import current_context
+
+        pins = getattr(current_context().governance, "updates", None)
+    except Exception:
+        logger.debug("update pins unavailable; treating as unpinned", exc_info=True)
+        return UpdatePins()
+    return pins if isinstance(pins, UpdatePins) else UpdatePins()
+
+
 @dataclass(frozen=True)
 class GovernanceCeiling:
     """Level 1 — the enterprise security ceiling, frozen at boot.
@@ -928,6 +1038,8 @@ class GovernanceCeiling:
     # trust root — so a directly-parsed ceiling carries the honest
     # ``SIGNATURE_UNCHECKED``, never a flattering default.
     signature_state: str = "unchecked"
+    # Policy-only update pins (outside ``controls`` — see UpdatePins).
+    updates: UpdatePins = field(default_factory=UpdatePins)
 
     def get(self, scope: str) -> Optional[object]:
         return self.controls.get(scope)
@@ -1069,7 +1181,7 @@ def _parse_control(scope: str, spec: ScopeSpec, raw: object, *, is_policy: bool)
 # Structural (non-governed) keys consumed by parse_policy/parse_profile, not as
 # governed scopes.
 _STRUCTURAL_KEYS = frozenset(
-    {"version", "boot", "identity", "name", "bind", "extends", "description"}
+    {"version", "boot", "identity", "name", "bind", "extends", "description", "updates"}
 )
 
 
@@ -1198,6 +1310,9 @@ def parse_policy(
     identity = data.get("identity") or {}
     issuer = str(identity.get("issuer", "")) if isinstance(identity, dict) else ""
     signature = str(identity.get("signature", "")) if isinstance(identity, dict) else ""
+    raw_updates = data.get("updates")
+    if raw_updates is not None and not isinstance(raw_updates, dict):
+        raise PlatformCompositionError("security policy 'updates' must be an object")
     return GovernanceCeiling(
         version=POLICY_VERSION,
         boot=boot,
@@ -1205,6 +1320,7 @@ def parse_policy(
         identity_issuer=issuer,
         identity_signature=signature,
         signature_state=signature_state,
+        updates=UpdatePins.from_dict(raw_updates or {}),
     )
 
 
@@ -1223,6 +1339,16 @@ def parse_profile(data: Mapping[str, object]) -> Profile:
     # most-restrictive deny-all built-in (Validation rule 5), never the ceiling.
     if not _PROFILE_NAME_RE.match(name):
         raise PlatformCompositionError(f"profile name {name!r} must match ^[a-z0-9][a-z0-9-]*$")
+    # ``updates`` is POLICY-ONLY. It is in _STRUCTURAL_KEYS (so _parse_controls
+    # skips it rather than failing as an unknown scope), which would make a
+    # profile's copy silently inert — so reject it loudly here instead. A profile
+    # is narrow-only and there is no narrower version of pointing somewhere else:
+    # a per-app profile redirecting the update source would be escalation.
+    if "updates" in data:
+        raise PlatformCompositionError(
+            "profiles may not set 'updates' — update pins are policy-only "
+            "(a profile redirecting the update source would be privilege escalation)"
+        )
     bind: Optional[Bind] = None
     raw_bind = data.get("bind")
     if isinstance(raw_bind, dict):
@@ -1881,6 +2007,8 @@ __all__ = [
     "SCOPE_CATALOG",
     "GovernanceCeiling",
     "BootControls",
+    "UpdatePins",
+    "active_update_pins",
     "Profile",
     "Bind",
     "POLICY_VERSION",

--- a/src/kiro_crew/platform/update_governance.py
+++ b/src/kiro_crew/platform/update_governance.py
@@ -1,0 +1,113 @@
+"""The update seam: where new code may come from, and the minimum version.
+
+Two enterprise pins, read from the trust-root ``security_policy.json`` (see
+``governance.UpdatePins``), applied at the three places KiroCrew replaces its own
+code: ``POST /api/update``, ``kirocrew update``, and the unattended gateway-boot
+auto-apply. This module exists so those three share one implementation and
+cannot drift.
+
+Deliberately NOT a governance archetype: a remote URL and a version number are
+values the core consumes, not "is X permitted?" decisions, so they need no
+``SCOPE_CATALOG`` row, no matcher, and no evaluator change.
+
+**A pin blocks; an unresolvable pin does not.** If governance cannot be read at
+all the update proceeds — refusing one would strand a host on a build that may
+need a patch, and the pins are a routing constraint, not a security boundary
+against a local operator who could edit the checkout directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_GIT_TIMEOUT_SECS = 10
+
+
+def resolve_remote_url(proj: str, *, remote: str = "", branch: str = "") -> str:
+    """The URL of the remote an update would fetch from in *proj* (``""`` if unknown).
+
+    Pass *remote* for a FIXED remote name: the CLI and gateway paths run
+    ``git fetch origin <branch>``, so they must validate ``origin`` rather than
+    whatever the branch tracks. With no *remote*, ``branch.<name>.remote`` is
+    resolved instead — that is the API path's bare ``git pull``, which follows the
+    tracked remote. Validating a different remote than the one fetched would
+    approve one source and install another.
+
+    ``ls-remote --get-url`` (not ``remote get-url``) additionally applies
+    ``url.<base>.insteadOf`` rewriting, so the value checked is the URL git
+    resolves rather than the one merely written down.
+
+    Returns ``""`` on any failure, which a source pin then treats as "not
+    permitted" and an unpinned host ignores.
+    """
+
+    def _git(*args: str) -> str:
+        try:
+            out = subprocess.run(
+                ["git", *args],
+                cwd=proj,
+                capture_output=True,
+                text=True,
+                timeout=_GIT_TIMEOUT_SECS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return out.stdout.strip() if out.returncode == 0 else ""
+
+    if not remote:
+        if not branch:
+            branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+        if not branch or branch == "HEAD":  # detached HEAD tracks nothing
+            return ""
+        remote = _git("config", "--get", f"branch.{branch}.remote") or "origin"
+    url = _git("ls-remote", "--get-url", "--", remote)
+    # `--get-url` echoes its argument back for an unknown remote; that is a bare
+    # name, not a URL, and must not be checked as one.
+    return "" if url == remote else url
+
+
+def update_blocked_reason(remote_url: str) -> str:
+    """Why this update is not allowed, or ``""`` when it is.
+
+    The one gate the three update paths call. The returned string is
+    operator-facing (it reaches an API 403 body and the CLI's stderr), so it names
+    neither the remote nor the pin: a git remote can embed a token
+    (``https://x-access-token:<pat>@host/…``, ``?access_token=…``) and so can the
+    pin. The operator can read both from `git remote -v` and the policy file; the
+    log/response needs only to say which check failed.
+    """
+    from kiro_crew.platform.governance import active_update_pins
+
+    if not active_update_pins().permits_source(remote_url):
+        return (
+            "this checkout's git remote does not match the update source pinned "
+            "by the security policy"
+        )
+    return ""
+
+
+def update_required(current_version: str) -> bool:
+    """Is this build below the fleet's pinned minimum version?
+
+    ``True`` makes an update MANDATORY — it overrides the user's
+    ``auto_update=False``, because user config sits under the enterprise ceiling
+    and an operator opting out must not be able to hold a fleet on a build the
+    policy forbids. It never refuses to boot: bricking a fleet on a policy typo
+    would remove the very surface an admin needs to fix it.
+    """
+    from kiro_crew.platform.governance import active_update_pins
+
+    return not active_update_pins().meets_min_version(current_version)
+
+
+def min_version() -> str:
+    """The pinned minimum version, or ``""`` when unpinned (for display)."""
+    from kiro_crew.platform.governance import active_update_pins
+
+    return active_update_pins().min_version
+
+
+__all__ = ["resolve_remote_url", "update_blocked_reason", "update_required", "min_version"]

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4822,9 +4822,33 @@ class GatewayOrchestrator:
     async def _check_for_updates(self) -> None:
         """Blocking update check — auto-applies if enabled, otherwise notifies."""
         try:
+            from kiro_crew import __version__ as _running_version
             from kiro_crew.dashboard.handlers import _do_update_check, _update_info
 
             await _do_update_check()
+            from kiro_crew.platform.update_governance import min_version, update_required
+
+            # A policy-pinned minimum version makes the update MANDATORY: it
+            # overrides the user's auto_update=False, because user config sits
+            # under the enterprise ceiling and an operator opting out must not
+            # hold a fleet on a build the policy forbids.
+            #
+            # Checked BEFORE the `available` branch: that flag comes from
+            # `_do_update_check`'s `_version_tuple`, which returns (0,) for any
+            # pre-release — so a `1.4.0-nightly.<stamp>` remote reads as "nothing
+            # available" and a 1.3.0 host would never satisfy a 1.4.0 floor.
+            # `_auto_apply_update` still applies the source pin and its own
+            # no-new-commits early return, so this cannot bypass the ceiling or loop.
+            if update_required(_running_version):
+                logger.warning(
+                    "Version compliance: running %s is below the policy minimum %s — "
+                    "applying a mandatory update (overrides auto_update)",
+                    _running_version,
+                    min_version(),
+                )
+                await self._auto_apply_update()
+                return
+
             if _update_info.get("available"):
                 logger.info("Updates available from remote")
                 from kiro_crew.config import KiroCrewConfig
@@ -4877,6 +4901,23 @@ class GatewayOrchestrator:
             # Only auto-update on mainline — beta/feature branches need manual update
             if branch != "mainline":
                 logger.debug("Auto-update: skipping — on branch %s, not mainline", branch)
+                return
+
+            # Source pin, checked before the fetch. This is the most privileged
+            # update path in the product — no auth, no click, `git reset --hard`
+            # + pip + execv on boot — so a blocked host must not touch its tree.
+            from kiro_crew.platform.update_governance import (
+                resolve_remote_url,
+                update_blocked_reason,
+            )
+
+            blocked = await asyncio.get_running_loop().run_in_executor(
+                None, lambda: update_blocked_reason(resolve_remote_url(proj, remote="origin"))
+            )
+            if blocked:
+                logger.warning("Auto-update refused: %s", blocked)
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
                 return
 
             if self.dashboard_state:

--- a/test/test_governance_updates.py
+++ b/test/test_governance_updates.py
@@ -1,0 +1,296 @@
+"""Update pins: where new code may come from, and the minimum version.
+
+Covers the two enterprise pins (``governance.UpdatePins``) and the shared seam
+the three update paths call (``platform.update_governance``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.platform import update_governance
+from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.governance import (
+    UpdatePins,
+    active_update_pins,
+    parse_policy,
+    parse_profile,
+)
+
+
+def _policy(**updates: str) -> dict:
+    body: dict = {"version": 1, "boot": {}}
+    if updates:
+        body["updates"] = updates
+    return body
+
+
+class TestSourcePin:
+    def test_unpinned_permits_anything(self):
+        pins = UpdatePins()
+        assert pins.permits_source("https://github.com/anyone/anything")
+        assert pins.permits_source("")
+
+    def test_glob_matches(self):
+        pins = UpdatePins(source="https://github.com/acme/*")
+        assert pins.permits_source("https://github.com/acme/kirocrew")
+        assert not pins.permits_source("https://github.com/acme-evil/kirocrew")
+
+    def test_unresolvable_source_is_denied_when_pinned(self):
+        """An admin's pin must not be satisfied by "we could not tell"."""
+        pins = UpdatePins(source="https://git.corp.example/*")
+        assert not pins.permits_source("")
+        assert not pins.permits_source("   ")
+
+    def test_scp_and_path_remotes_are_matchable(self):
+        """`updates.source` is a glob, so non-URL remote shapes work too."""
+        assert UpdatePins(source="git@corp:*").permits_source("git@corp:team/repo")
+        assert UpdatePins(source="/srv/repos/*").permits_source("/srv/repos/approved")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/srv/repos/approved/../evil/repo.git",  # git resolves this outside
+            "/srv/repos/approved/./ok.git",
+            "/srv/repos/approved/..\\evil/repo.git",  # `\` separates on Windows
+        ],
+    )
+    def test_traversal_cannot_escape_the_pin(self, url):
+        """`*` spans separators, so a glob alone does not confine the path."""
+        assert not UpdatePins(source="/srv/repos/approved/*").permits_source(url)
+
+    def test_a_dot_inside_a_name_is_not_a_traversal(self):
+        pins = UpdatePins(source="https://github.com/acme/*")
+        assert pins.permits_source("https://github.com/acme/my.repo.git")
+        assert pins.permits_source("https://github.com/acme/.hidden")
+
+    def test_matching_is_case_sensitive_on_every_platform(self):
+        """`fnmatch` normcases (lowercases on Windows); `fnmatchcase` does not.
+
+        `…/APPROVED` must not satisfy an `…/approved` pin — git and every
+        case-sensitive forge treat those as different repositories, and a ceiling
+        must not change verdict with the OS. Fails on Windows if it regresses.
+        """
+        assert not UpdatePins(source="https://git.corp/approved").permits_source(
+            "https://git.corp/APPROVED"
+        )
+
+
+class TestMinVersion:
+    def test_unpinned_always_met(self):
+        assert UpdatePins().meets_min_version("0.0.1")
+        assert UpdatePins().meets_min_version("")
+
+    @pytest.mark.parametrize(
+        "current,floor,expected",
+        [
+            ("1.2.3", "1.2.3", True),
+            ("1.2.4", "1.2.3", True),
+            ("1.2.2", "1.2.3", False),
+            ("2.0.0", "1.9.9", True),
+            # Shorter tuples zero-extend: 1.2 == 1.2.0.
+            ("1.2", "1.2.0", True),
+            ("1.2", "1.2.1", False),
+            ("1.10.0", "1.9.0", True),  # numeric, not lexical
+        ],
+    )
+    def test_ordering(self, current, floor, expected):
+        assert UpdatePins(min_version=floor).meets_min_version(current) is expected
+
+    def test_prerelease_suffix_is_stripped_off_the_whole_string(self):
+        """This project's CI stamps a dot INSIDE the pre-release.
+
+        A per-component strip would leave `nightly.20260728t184500` as its own
+        component and read every nightly build as version 0 — permanently
+        non-compliant, which at boot means a forced-update loop.
+        """
+        pins = UpdatePins(min_version="0.2.0")
+        assert pins.meets_min_version("0.2.0-nightly.20260728t184500")
+        assert pins.meets_min_version("0.3.0-insider.2")
+        assert pins.meets_min_version("0.2.0+build.7")
+        assert not pins.meets_min_version("0.1.9-nightly.20260728t184500")
+
+    def test_unparseable_floor_imposes_none(self):
+        """A typo must not brick a fleet."""
+        assert UpdatePins(min_version="not-a-version").meets_min_version("0.0.1")
+
+    def test_unparseable_current_is_below_the_floor(self):
+        """Take the update rather than sit on a build we cannot identify."""
+        assert not UpdatePins(min_version="1.0.0").meets_min_version("dev")
+
+
+class TestPolicyParsing:
+    def test_absent_updates_is_unpinned(self):
+        ceiling = parse_policy(_policy())
+        assert ceiling.updates == UpdatePins()
+
+    def test_pins_are_parsed(self):
+        ceiling = parse_policy(_policy(source="https://git.corp/*", min_version="1.2.3"))
+        assert ceiling.updates.source == "https://git.corp/*"
+        assert ceiling.updates.min_version == "1.2.3"
+
+    def test_unknown_key_fails_closed(self):
+        with pytest.raises(PlatformCompositionError, match="unknown key"):
+            parse_policy(_policy(sources="typo"))
+
+    def test_non_object_fails_closed(self):
+        with pytest.raises(PlatformCompositionError, match="must be an object"):
+            parse_policy({"version": 1, "boot": {}, "updates": "https://git.corp"})
+
+    def test_profile_may_not_set_updates(self):
+        """Policy-only: a profile redirecting the source would be escalation."""
+        with pytest.raises(PlatformCompositionError, match="policy-only"):
+            parse_profile({"name": "app-x", "updates": {"source": "https://evil/*"}})
+
+    def test_profile_without_updates_still_parses(self):
+        assert parse_profile({"name": "app-x"}).name == "app-x"
+
+    @pytest.mark.parametrize("bad", [False, 0, [], {}])
+    def test_falsy_non_string_pin_is_rejected_not_coerced(self, bad):
+        """`"source": false` must not silently mean "unpinned"."""
+        with pytest.raises(PlatformCompositionError, match="must be a string"):
+            parse_policy(_policy(source=bad))
+
+    def test_null_is_a_valid_no_pin(self):
+        ceiling = parse_policy({"version": 1, "boot": {}, "updates": {"source": None}})
+        assert ceiling.updates.source == ""
+
+
+class TestSeam:
+    """The shared gate the API, CLI and boot paths call."""
+
+    def test_ungoverned_host_is_unpinned(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance.active_update_pins", lambda: UpdatePins()
+        )
+        assert update_governance.update_blocked_reason("https://anywhere") == ""
+        assert update_governance.update_required("0.0.1") is False
+        assert update_governance.min_version() == ""
+
+    def test_source_mismatch_is_blocked_with_a_reason(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance.active_update_pins",
+            lambda: UpdatePins(source="https://git.corp/*"),
+        )
+        reason = update_governance.update_blocked_reason("https://github.com/evil/x")
+        # Names neither the remote nor the pin: both can embed a token.
+        assert "does not match" in reason
+        assert "github.com" not in reason and "git.corp" not in reason
+
+    def test_unresolvable_source_reports_so(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance.active_update_pins",
+            lambda: UpdatePins(source="https://git.corp/*"),
+        )
+        assert "does not match" in update_governance.update_blocked_reason("")
+
+    def test_below_floor_requires_an_update(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance.active_update_pins",
+            lambda: UpdatePins(min_version="2.0.0"),
+        )
+        assert update_governance.update_required("1.9.9") is True
+        assert update_governance.update_required("2.0.0") is False
+
+    def test_governance_error_does_not_block(self, monkeypatch):
+        """A glitch must not strand a host on a build that may need a patch."""
+
+        def _boom():
+            raise RuntimeError("context unavailable")
+
+        monkeypatch.setattr("kiro_crew.platform.context.current_context", _boom)
+        assert active_update_pins() == UpdatePins()
+        assert update_governance.update_blocked_reason("https://anywhere") == ""
+        assert update_governance.update_required("0.0.1") is False
+
+
+class TestRemoteResolution:
+    def test_reads_the_tracked_remote_not_origin(self, monkeypatch):
+        """`git pull` follows branch.<name>.remote, so that is what we check."""
+        calls: list[list[str]] = []
+
+        class _R:
+            returncode = 0
+
+            def __init__(self, out: str) -> None:
+                self.stdout = out
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            if "config" in argv:
+                return _R("upstream\n")
+            if "ls-remote" in argv:
+                return _R("https://git.corp/team/repo\n")
+            return _R("")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        url = update_governance.resolve_remote_url("/proj", branch="main")
+        assert url == "https://git.corp/team/repo"
+        assert ["git", "ls-remote", "--get-url", "--", "upstream"] in calls
+
+    def test_unknown_remote_echo_is_not_a_url(self, monkeypatch):
+        """`--get-url` echoes its argument back for an unknown remote."""
+
+        class _R:
+            returncode = 0
+            stdout = "origin\n"
+
+        monkeypatch.setattr("subprocess.run", lambda argv, **kw: _R())
+        assert update_governance.resolve_remote_url("/proj", branch="main") == ""
+
+    def test_detached_head_is_unresolvable(self, monkeypatch):
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: pytest.fail("must not run git"))
+        assert update_governance.resolve_remote_url("/proj", branch="HEAD") == ""
+
+    def test_fixed_remote_ignores_the_tracked_remote(self, monkeypatch):
+        """CLI/boot fetch a hardcoded `origin`, so they must validate `origin`.
+
+        Otherwise a branch tracking an approved upstream green-lights an `origin`
+        fetch from elsewhere — approving one source and installing another.
+        """
+        calls: list[list[str]] = []
+
+        class _R:
+            returncode = 0
+            stdout = "https://git.corp/origin-repo\n"
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return _R()
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        assert (
+            update_governance.resolve_remote_url("/proj", remote="origin")
+            == "https://git.corp/origin-repo"
+        )
+        # Neither the branch nor its tracked remote is consulted.
+        assert calls == [["git", "ls-remote", "--get-url", "--", "origin"]]
+
+    def test_resolves_the_branch_itself_when_not_given(self, monkeypatch):
+        """The API path passes no branch; the seam resolves it (one impl)."""
+        calls: list[list[str]] = []
+
+        class _R:
+            returncode = 0
+
+            def __init__(self, out: str) -> None:
+                self.stdout = out
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            if "rev-parse" in argv:
+                return _R("main\n")
+            if "config" in argv:
+                return _R("origin\n")
+            return _R("https://git.corp/team/repo\n")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        assert update_governance.resolve_remote_url("/proj") == "https://git.corp/team/repo"
+        assert ["git", "rev-parse", "--abbrev-ref", "HEAD"] in calls
+
+    def test_missing_git_is_unresolvable_not_an_error(self, monkeypatch):
+        def _no_git(*a, **k):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr("subprocess.run", _no_git)
+        assert update_governance.resolve_remote_url("/proj", branch="main") == ""

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -840,6 +840,32 @@ class TestCheckForUpdates:
         ds.push_refresh.assert_called_with("update_available")
 
     @pytest.mark.asyncio
+    async def test_min_version_mandate_fires_even_when_not_available(self):
+        """The mandate is about THIS host, not the availability heuristic.
+
+        `_do_update_check`'s `_version_tuple` returns (0,) for any pre-release, so
+        a `1.4.0-nightly.<stamp>` remote reads as `available=False`. Nested inside
+        that branch, a host below a pinned 1.4.0 floor would never update.
+        """
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._auto_apply_update = AsyncMock()
+        import kiro_crew.dashboard.handlers as _h
+
+        orig = _h._update_info.copy()
+        try:
+            _h._update_info.update({"available": False})
+            with patch.object(_h, "_do_update_check", new_callable=AsyncMock):
+                with patch(
+                    "kiro_crew.platform.update_governance.update_required", return_value=True
+                ):
+                    await orch._check_for_updates()
+        finally:
+            _h._update_info.clear()
+            _h._update_info.update(orig)
+        orch._auto_apply_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_update_check_exception_handled(self):
         orch = _make_orchestrator()
         with patch(

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -215,6 +215,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "mcp_gateway/manager.py::_spawn_once",
         "mcp_gateway/stub.py::main",
         "mcp_playwright_proxy.py::run_proxy",
+        # Read-only `git config` / `git ls-remote --get-url` resolving which
+        # remote the update would fetch from, for the `updates.source` pin. Fixed
+        # list-argv (no shell=True), no agent input: the branch lands mid-key
+        # (`branch.<x>.remote`) so it cannot lead with a dash, and the remote
+        # name — which is read out of git config and COULD — is passed after
+        # `--`. Must NOT be sandboxed: it reads the real checkout's git metadata.
+        "platform/update_governance.py::_git",
         "mcp_shared.py::_get_ppid",
         "platform_compat.py::_current_user_sid",
         "platform_compat.py::find_listening_pids",


### PR DESCRIPTION
## Problem

An enterprise ceiling could govern what the agent does, but not where this host gets its own code. There was no way to say "this fleet updates from our mirror" or "this fleet must be on at least 1.4.0" — and `docs/release-process-design.md:49` had specified a minimum-version floor as **P5 "Designed, not built."**

## Fix

Two policy-only pins in the trust-root `security_policy.json`:

```json
"updates": {
  "source": "https://git.corp.example/platform/*",
  "min_version": "1.4.0"
}
```

- **`source`** — an fnmatch glob over the git remote new code may come from. A glob so one pin covers a mirror set, and so non-URL remote shapes (SCP-style, local path) are pinnable too.
- **`min_version`** — makes an update **mandatory** when the running build is below it, overriding the user's `auto_update: false` (user config sits *under* the enterprise ceiling). It never refuses to *boot*: bricking a fleet on a policy typo would remove the very surface an admin needs to fix it.

Both empty by default, so an unpinned host behaves exactly as before.

Applied at the three places KiroCrew replaces its own code — `POST /api/update`, `kirocrew update`, and the unattended gateway-boot auto-apply — through one shared seam (`platform/update_governance.py`, ~110 lines) so they cannot drift.

## Design decisions

**1. Not a fifth archetype.** Every archetype answers "is X permitted?". A remote URL and a version number are *values the core consumes*, not decisions — so they ride outside `controls`: no `SCOPE_CATALOG` row, no matcher, **no evaluator change**. `AGENTS.md` still says four archetypes.

**2. What makes them enforceable is the file, not a new mechanism.** `security_policy.json` is on the `security._SENSITIVE_HOME_DIRS` keystone, so the agent can neither read nor write its own ceiling. A `config.json` field or an env var would only be a suggestion.

**3. Policy-only.** `parse_profile` rejects `updates`. A profile is narrow-only and there is no narrower version of *pointing somewhere else*; a per-app profile redirecting the update source would be privilege escalation.

**4. A pin blocks; an unresolvable pin does not.** If governance can't be read at all, the update proceeds. Refusing one would strand a host on a build that may need a patch. These are a **routing constraint for a managed fleet** — not a boundary against a local operator, who can edit the checkout directly regardless (the source tree is not write-protected).

## Implementation notes

**The remote is resolved, not assumed.** `git pull` follows `branch.<name>.remote`, which need not be `origin`, and `ls-remote --get-url` also applies `insteadOf` rewriting — so each path validates the remote *it* actually fetches: the CLI and boot paths pass `remote="origin"` because they run `git fetch origin <branch>`; the API path resolves the tracked remote because it runs a bare `git pull`.

**Version parsing splits the pre-release suffix off the whole string.** CI stamps a dot *inside* it (`0.2.0-nightly.20260728t184500`), so a per-component split would read every nightly as version `0` → permanently non-compliant → forced-update loop at boot.

**The rejection reason names neither the remote nor the pin.** Both can embed a token (`https://x-access-token:<pat>@host/…`, `?access_token=…`), and the reason reaches an API body, a log and the CLI's stderr. The operator can read both from `git remote -v` and the policy file.

**Deployment ordering:** roll the build before the pin. The parser fails closed on an unknown key, so a build predating `updates` refuses to boot on a pinned policy — which inverts the `min_version` case, since the stale hosts a floor targets are the ones that would stop booting. Documented in `governance.md`.

## Tests

`test/test_governance_updates.py` — 40 tests: source globbing (unresolvable-denies-when-pinned, traversal, case-sensitivity on every platform), version ordering and the CI-stamp shapes, policy parsing + profile rejection + non-string-pin rejection, the seam's fail-open-on-error disposition, and remote resolution in both modes. Plus one in `test_slack_gateway.py` for the mandate firing independently of the availability heuristic (verified it fails if the check is re-nested).

## Gates

`black`, `isort`, `flake8`, `mypy` (519 files) clean. Full backend suite **19783 passed** — the 3 `AF_UNIX path too long` failures are environmental (long worktree path) and reproduce on a clean tree. No frontend change, so no screenshots.

## Note on scope

An earlier revision was much larger — a fifth `VersionFloor` archetype, three `SCOPE_CATALOG` scopes, a `capabilities.self_update` gate with per-trigger rulesets, SEL audit-or-deny, credential-redaction helpers, plus folded-in desktop-updater and `PackageManager` work. That was ~3650 insertions for a two-value feature. This is the deliberately minimal version: **the seam and nothing else.**

Four real bugs surfaced during review and are fixed here (validating a different remote than the one fetched; `fnmatch` being case-insensitive on Windows; falsy pin values silently unpinning; the `min_version` mandate never firing for a pre-release remote). Hardening that only mattered against an attacker who already has local write access — and who could therefore edit the source tree directly — was **not** carried over.

The desktop-updater feed/artifact URL validation from the earlier revision is worth landing on its own. It is not in this PR.
