### PR TITLE
feat(import): rescope foreign-agent import to industry consensus

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1,6 +1,6 @@
 # Self-Learning, Cron & Dashboard Modules
 
-Last Updated: 2026-07-27 (the Kiro prerequisite gate no longer flashes first-run setup at returning users: the dashboard mounts immediately with sessions paused instead of rendering setup chrome for an unresolved check, `initial_setup_complete` is readable before any probe (derived from the data home) and survives the probe-failure backstop. Gateway boot also no longer scales with installed-app count — app backends spawn concurrently with an ownership-confirmed early exit (~5.6s → ~2.9s on one real home). Prior — provider CLI resolution relaxed to a user-trust model: `gh`/`glab` are resolved from the well-known install dirs and then the ambient `PATH`, the user's own Homebrew/asdf install is accepted, and only foreign-owned, world-writable, or agent-writable-tree binaries are refused — `KIROCREW_PROVIDER_BIN_STRICT=1` restores the old root-owned rule. Prior — pull-request merge state resolves on first load: both providers compute mergeability lazily, so full fetches bound-re-read the merge fields until they settle, the chip-status cache carries the settled pair, and the panel folds a fresher poll answer into its pinned payload — the conflict banner no longer waits for a manual refresh. Prior — 2026-07-26 foreign-agent first-run scan/review/apply flow, authenticated API contract, disabled schedule import, and onboarding order — the import gate runs after the cross-platform Kiro CLI prerequisite gate and before the theme tour. Prior — 2026-07-26 cross-platform Kiro CLI prerequisite status/install/login service, first-run SPA gate, and readiness-resumable post-fan-out synthesis. Prior — 2026-07-23 source payloads gain normalized `mergeable`/`mergeStateStatus` merge-state fields for GitHub and GitLab; PullRequestPanel surfaces a merge-blocker banner for open PRs — conflicts/behind carry an agent chat handoff, branch-protection blocks do not. Prior: left-nav IA restructure: sidebar toggle moved into the rail's menu row; Sessions label; Apps header with accent Explore link; per-frame Apps scrolling; bottom-pinned Agent Capabilities/Settings/Contact Us; Agents + Capabilities merged into the /capabilities panel — /agents redirects there. Prior: independent source-tabs hardening: provider binaries must be canonical root-owned non-writable paths; command-specific output ceilings and task-lifetime retained-byte reservations bound provider memory; only durable messages contribute sources; backend/frontend/panel retain at most 64 first-seen sources per slot. Prior: pull-request source links, source/check/resolve APIs, bounded sidebar CI refresh, SidePanel Changes view; learn_add session-recovery resolver now probes cron JSONL names; artifact companion-chat updates; silent-cron failure-alert suppression; CHAT_TURN_TIMEOUT remains aligned with ACP. Prior — pull-request merge state resolves on first load: both providers compute mergeability lazily, so full fetches bound-re-read the merge fields until they settle, the chip-status cache carries the settled pair, and the panel folds a fresher poll answer into its pinned payload — the conflict banner no longer waits for a manual refresh. Prior — 2026-07-26 foreign-agent first-run scan/review/apply flow, authenticated API contract, disabled schedule import, and onboarding order — the import gate runs after the cross-platform Kiro CLI prerequisite gate and before the theme tour. Prior — 2026-07-26 cross-platform Kiro CLI prerequisite status/install/login service, first-run SPA gate, and readiness-resumable post-fan-out synthesis. Prior — 2026-07-23 source payloads gain normalized `mergeable`/`mergeStateStatus` merge-state fields for GitHub and GitLab; PullRequestPanel surfaces a merge-blocker banner for open PRs — conflicts/behind carry an agent chat handoff, branch-protection blocks do not. Prior: left-nav IA restructure: sidebar toggle moved into the rail's menu row; Sessions label; Apps header with accent Explore link; per-frame Apps scrolling; bottom-pinned Agent Capabilities/Settings/Contact Us; Agents + Capabilities merged into the /capabilities panel — /agents redirects there. Prior: independent source-tabs hardening: provider binaries must be canonical root-owned non-writable paths; command-specific output ceilings and task-lifetime retained-byte reservations bound provider memory; only durable messages contribute sources; backend/frontend/panel retain at most 64 first-seen sources per slot. Prior: pull-request source links, source/check/resolve APIs, bounded sidebar CI refresh, SidePanel Changes view; learn_add session-recovery resolver now probes cron JSONL names; artifact companion-chat updates; silent-cron failure-alert suppression; CHAT_TURN_TIMEOUT remains aligned with ACP)
+Last Updated: 2026-07-28 (foreign-agent import rescoped to the industry-consensus set: conversation-transcript import removed, `instructions` and `denied_commands` added, imported instruction/persona-directive text rewritten into the memory hierarchy, a hard dry-run contract, and user-selectable skip/rename/overwrite conflict strategies; the authoritative contract now lives in `docs/system-specs/modules/onboarding-import.md`. Prior — the Kiro prerequisite gate no longer flashes first-run setup at returning users: the dashboard mounts immediately with sessions paused instead of rendering setup chrome for an unresolved check, `initial_setup_complete` is readable before any probe (derived from the data home) and survives the probe-failure backstop. Gateway boot also no longer scales with installed-app count — app backends spawn concurrently with an ownership-confirmed early exit (~5.6s → ~2.9s on one real home). Prior — provider CLI resolution relaxed to a user-trust model: `gh`/`glab` are resolved from the well-known install dirs and then the ambient `PATH`, the user's own Homebrew/asdf install is accepted, and only foreign-owned, world-writable, or agent-writable-tree binaries are refused — `KIROCREW_PROVIDER_BIN_STRICT=1` restores the old root-owned rule. Prior — pull-request merge state resolves on first load: both providers compute mergeability lazily, so full fetches bound-re-read the merge fields until they settle, the chip-status cache carries the settled pair, and the panel folds a fresher poll answer into its pinned payload — the conflict banner no longer waits for a manual refresh. Prior — 2026-07-26 foreign-agent first-run scan/review/apply flow, authenticated API contract, disabled schedule import, and onboarding order — the import gate runs after the cross-platform Kiro CLI prerequisite gate and before the theme tour. Prior — 2026-07-26 cross-platform Kiro CLI prerequisite status/install/login service, first-run SPA gate, and readiness-resumable post-fan-out synthesis. Prior — 2026-07-23 source payloads gain normalized `mergeable`/`mergeStateStatus` merge-state fields for GitHub and GitLab; PullRequestPanel surfaces a merge-blocker banner for open PRs — conflicts/behind carry an agent chat handoff, branch-protection blocks do not. Prior: left-nav IA restructure: sidebar toggle moved into the rail's menu row; Sessions label; Apps header with accent Explore link; per-frame Apps scrolling; bottom-pinned Agent Capabilities/Settings/Contact Us; Agents + Capabilities merged into the /capabilities panel — /agents redirects there. Prior: independent source-tabs hardening: provider binaries must be canonical root-owned non-writable paths; command-specific output ceilings and task-lifetime retained-byte reservations bound provider memory; only durable messages contribute sources; backend/frontend/panel retain at most 64 first-seen sources per slot. Prior: pull-request source links, source/check/resolve APIs, bounded sidebar CI refresh, SidePanel Changes view; learn_add session-recovery resolver now probes cron JSONL names; artifact companion-chat updates; silent-cron failure-alert suppression; CHAT_TURN_TIMEOUT remains aligned with ACP. Prior — pull-request merge state resolves on first load: both providers compute mergeability lazily, so full fetches bound-re-read the merge fields until they settle, the chip-status cache carries the settled pair, and the panel folds a fresher poll answer into its pinned payload — the conflict banner no longer waits for a manual refresh. Prior — 2026-07-26 foreign-agent first-run scan/review/apply flow, authenticated API contract, disabled schedule import, and onboarding order — the import gate runs after the cross-platform Kiro CLI prerequisite gate and before the theme tour. Prior — 2026-07-26 cross-platform Kiro CLI prerequisite status/install/login service, first-run SPA gate, and readiness-resumable post-fan-out synthesis. Prior — 2026-07-23 source payloads gain normalized `mergeable`/`mergeStateStatus` merge-state fields for GitHub and GitLab; PullRequestPanel surfaces a merge-blocker banner for open PRs — conflicts/behind carry an agent chat handoff, branch-protection blocks do not. Prior: left-nav IA restructure: sidebar toggle moved into the rail's menu row; Sessions label; Apps header with accent Explore link; per-frame Apps scrolling; bottom-pinned Agent Capabilities/Settings/Contact Us; Agents + Capabilities merged into the /capabilities panel — /agents redirects there. Prior: independent source-tabs hardening: provider binaries must be canonical root-owned non-writable paths; command-specific output ceilings and task-lifetime retained-byte reservations bound provider memory; only durable messages contribute sources; backend/frontend/panel retain at most 64 first-seen sources per slot. Prior: pull-request source links, source/check/resolve APIs, bounded sidebar CI refresh, SidePanel Changes view; learn_add session-recovery resolver now probes cron JSONL names; artifact companion-chat updates; silent-cron failure-alert suppression; CHAT_TURN_TIMEOUT remains aligned with ACP)
 
 ## Overview
 
@@ -251,6 +251,12 @@ unsupported schedule semantics and are never approximated into cron.
 
 ## Foreign-Agent First-Run Import
 
+**Authoritative contract:** `docs/system-specs/modules/onboarding-import.md`.
+That spec owns the scope (including the explicit non-goals), the destination
+mapping into the memory hierarchy, the dry-run contract, the conflict
+strategies, and the per-source layout assumptions. This section covers only how
+the flow is surfaced through the dashboard and where it sits in onboarding.
+
 The dashboard can scan and selectively merge local setup from exactly five
 foreign agents: **Codex, Claude Code, MeshClaw, OpenClaw, and Hermes**. Quick is
 not a source and must not appear as an import option.
@@ -259,13 +265,25 @@ The only selectable categories are:
 
 | Category | Import contract |
 |----------|-----------------|
-| Sessions | Visible user/assistant text only; closed generated keys via `ConversationLog` |
+| Instructions | User-authored rules + persona *directives* → `lessons.jsonl` (capped at 50 so import cannot evict the user's own lessons) |
 | Memories | Durable memories/preferences through native writers and limits |
 | Workspaces | Valid, existing, non-sensitive local directories only |
 | MCP servers | Secret-free stdio/HTTP definitions; managed servers protected |
 | Skills | User-authored only; source-namespaced and symlink-safe |
+| Denied commands | Deny rules only — an allow-list is never imported |
 | Schedules | Compatible native schedules; always imported disabled; semantic dedup |
 | Settings | Explicit non-security allowlist only; existing KiroCrew values win |
+
+**Sessions are not a category.** Conversation transcripts are deliberately not
+imported — see `onboarding-import.md` → "Not migrated" for the rationale, and
+"Session-import removal" for what that removal covers.
+
+The dashboard MUST present a dry-run review before any apply, and MUST offer the
+conflict strategy (`skip` default, `rename`, `overwrite`) for the categories that
+support it. Item state is exactly the four writer statuses mapped to three
+outcomes (`accepted` / `deduplicated` / `rejected`) plus non-attempted
+`skipped` entries; the UI must not invent a fifth state, and aggregate counts
+must be derived from `item_outcomes` rather than reported independently.
 
 ### Supported foreign format snapshot
 
@@ -278,18 +296,21 @@ diagnostics rather than guessed.
 
 | Source | Root resolution | Recognized layouts |
 |--------|-----------------|--------------------|
-| Codex | `CODEX_HOME`, else `~/.codex` | `sessions/**/*.jsonl` and `archived_sessions/**/*.jsonl` (sessions/workspaces); `config.toml` (workspaces/MCP/settings); `skills/**/SKILL.md` except `.system` (skills). `sqlite/codex-dev.db` automations and unstable memory stores are diagnostic-only. |
-| Claude Code | `CLAUDE_CONFIG_DIR`, then `CLAUDE_HOME`, else `~/.claude`; `~/.claude.json` is also recognized | `projects/**/*.jsonl` except runtime/subagent/tool-result trees (sessions/workspaces); root and discovered-workspace settings/MCP JSON files (workspaces/MCP/settings); root and `<workspace>/.claude/skills` packages (skills); root/project `memory` or `memories` Markdown (memories). `CLAUDE.md`, rules, tasks, and schedules are not imported. |
-| MeshClaw | `MESHCLAW_HOME`, else `~/.meshclaw` | `sessions/**/*.jsonl` (sessions/workspaces); `config.json` and `mcp.json` (workspaces/MCP/settings); `recent_projects.json`, `workspace_dir`, and `project_dir` (workspaces); resolved workspace `skills` and Markdown memory trees (skills/memories); supported `memory.db` semantic/episodic tables (memories); `crons.json` and `cron/jobs.json` (schedules). |
-| OpenClaw | `OPENCLAW_STATE_DIR`; else `OPENCLAW_HOME/.openclaw[-profile]`; else `~/.openclaw[-profile]`, with existing `~/.clawdbot` fallback for the default profile | Explicit/default JSON5 config (workspaces/MCP/settings); human-owned `agents/<agent>/sessions/*.jsonl` with matching `sessions.json` provenance (sessions/workspaces); explicit, configured, profile, state, and per-agent workspace roots containing `skills`, `memory`, or `MEMORY.md` (skills/memories); `cron/jobs.json` (schedules). Native session/schedule SQLite stores are diagnostic-only. |
-| Hermes Agent | `HERMES_HOME`, then `HERMES_AGENT_HOME`, then `HERMES_CONFIG_DIR`; else existing `%LOCALAPPDATA%/hermes`; else `~/.hermes`. Scan the root plus at most 50 non-link directories from a bounded `profiles/*` enumeration; report overflow without consuming the rest of a large directory. | First supported `state.db`, `hermes.db`, or `sessions.db` session schema (sessions/workspaces); exact `memories/MEMORY.md` and `memories/USER.md` (memories); `config.yaml` or `config.yml` (MCP/settings); active local `skills/**/SKILL.md` packages after managed/cache exclusions (skills); `cron/jobs.json` (schedules). `memory_store.db` is diagnostic-only. |
+| Codex | `CODEX_HOME`, else `~/.codex` | `config.toml` (workspaces/MCP/settings); `AGENTS.md` (instructions); `memories/*.md` (memories); `skills/**/SKILL.md` except `.system` (skills). Session trees, `sqlite/codex-dev.db` automations, and unstable memory stores are not imported. |
+| Claude Code | `CLAUDE_CONFIG_DIR`, then `CLAUDE_HOME`, else `~/.claude`; `~/.claude.json` is also recognized | Root and workspace settings/MCP JSON files (workspaces/MCP/settings, and `permissions.deny` Bash rules → denied commands); root and `<workspace>/.claude/skills` packages (skills); root/project `memory` or `memories` Markdown (memories); `CLAUDE.md` and `rules/*.md` (instructions). Session trees (`projects/**/*.jsonl`), tasks, and schedules are not imported. |
+| MeshClaw | `MESHCLAW_HOME`, else `~/.meshclaw` | `config.json` and `mcp.json` (workspaces/MCP/settings); `recent_projects.json`, `workspace_dir`, and `project_dir` (workspaces); resolved workspace `skills` and Markdown memory trees (skills/memories); supported `memory.db` semantic/episodic tables (memories); `crons.json` and `cron/jobs.json` (schedules). |
+| OpenClaw | `OPENCLAW_STATE_DIR`; else `OPENCLAW_HOME/.openclaw[-profile]`; else `~/.openclaw[-profile]`, with existing `~/.clawdbot` fallback for the default profile | Explicit/default JSON5 config (workspaces/MCP/settings); `SOUL.md` directive body, `MEMORY.md`, and `USER.md` (instructions/memories); explicit, configured, profile, state, and per-agent workspace roots containing `skills`, `memory`, or `MEMORY.md` (skills/memories); `cron/jobs.json` (schedules). Native session/schedule SQLite stores are not imported. |
+| Hermes Agent | `HERMES_HOME`, then `HERMES_AGENT_HOME`, then `HERMES_CONFIG_DIR`; else existing `%LOCALAPPDATA%/hermes`; else `~/.hermes`. Scan the root plus at most 50 non-link directories from a bounded `profiles/*` enumeration; report overflow without consuming the rest of a large directory. | Exact `memories/MEMORY.md` and `memories/USER.md` (memories), plus `SOUL.md` (instructions); `config.yaml` or `config.yml` (MCP/settings); active local `skills/**/SKILL.md` packages after managed/cache and `*-imports/` re-import exclusions (skills); `cron/jobs.json` (schedules). `memory_store.db` is diagnostic-only. |
 
 The import is merge-only, idempotent, and provenance-tracked. It never
-overwrites an existing KiroCrew item; conflicts preserve the KiroCrew version.
-A durable ledger records imported source-item identity so a retry or later
-manual import reports already-imported/deduplicated items rather than copying
-them again. Scan and apply treat every source tree as read-only and leave it
-byte-for-byte untouched.
+overwrites an existing KiroCrew item **under the default `skip` strategy**;
+conflicts preserve the KiroCrew version. `rename` imports alongside the existing
+item under a derived name, and `overwrite` replaces it only after writing a
+restore copy under `imports/replaced/<timestamp>/` — both require an explicit
+user choice, and neither is reachable by default. A durable ledger records
+imported source-item identity so a retry or later manual import reports
+already-imported/deduplicated items rather than copying them again. Scan and
+apply treat every source tree as read-only and leave it byte-for-byte untouched.
 
 Traversal is bounded by the importer file and directory-entry ceilings. A
 skill package is rejected when the ceiling prevents observing its complete
@@ -298,10 +319,12 @@ contain exactly one representable trigger family (cron, interval, or one-shot);
 mixed triggers are skipped as ambiguous.
 
 Unsupported and secret-bearing items are included only in skipped/reporting
-counts and reasons; they are not copied. The excluded set includes hooks, native
-agents/personas, raw instructions/system prompts, credentials and secret-bearing
-MCP fields, security/governance configuration, and scheduler/provider/runtime
-state.
+counts and reasons; they are not copied. The excluded set includes conversation
+transcripts, hooks, native agent definitions, a foreign persona's *identity*
+role (its directive text is imported as memory instead — see
+`onboarding-import.md`), foreign system prompts, allow-lists, credentials and
+secret-bearing MCP fields, security/governance configuration, and
+scheduler/provider/runtime state.
 
 ### Authenticated API contract
 

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -1,6 +1,6 @@
 # Memory, Skills & Hooks Modules
 
-Last Updated: 2026-07-26 (foreign-agent import boundaries for memories/preferences, MCP servers, user-authored skills, and hooks. Prior — 2026-07-19 in-process embeddings: always-on with no disable path, non-blocking background model load, download robustness — daemon-thread HTTPS download, Ollama-blob salvage, retry ladder — and the `EmbeddingBackend` swap seam; skills lazy-load usage-ranked top-K + skill_search + SkillUsageLedger, /api/skills discovery_executor offload)
+Last Updated: 2026-07-28 (foreign-agent instruction/persona-directive text is rewritten into the durable memory tiers — directives to `lessons.jsonl`, narrative knowledge to episodic memory — and import may never write the consolidator-replaced `preferences.md`/`projects.md`; full contract in `docs/system-specs/modules/onboarding-import.md`. Prior — 2026-07-26 foreign-agent import boundaries for memories/preferences, MCP servers, user-authored skills, and hooks. Prior — 2026-07-19 in-process embeddings: always-on with no disable path, non-blocking background model load, download robustness — daemon-thread HTTPS download, Ollama-blob salvage, retry ladder — and the `EmbeddingBackend` swap seam; skills lazy-load usage-ranked top-K + skill_search + SkillUsageLedger, /api/skills discovery_executor offload)
 
 ## Overview
 
@@ -229,6 +229,11 @@ The model download requires only outbound HTTPS (no git/git-lfs) on all platform
 
 ### Foreign-agent memory import
 
+The full import contract — scope, destination mapping, dry run, conflict
+strategies, and per-source assumptions — lives in
+`docs/system-specs/modules/onboarding-import.md`. This section covers only the
+memory-side invariants the destination writers enforce.
+
 The selectable `memories` category covers durable memories and preferences from
 supported foreign agents. It is not a raw file-copy path. Imported values pass
 through the same KiroCrew memory writers, key allowlists, per-entry size/count
@@ -246,10 +251,26 @@ SQLite immediate transaction, so separate store instances cannot both claim the
 last slot. Exact-text classification goes through the store's lock-safe lookup
 instead of reading its shared connection from the importer.
 
-The importer cannot turn a foreign system prompt, raw instruction, persona,
-tool transcript, credential, or runtime record into memory. Items that cannot
-be represented within the destination writers and limits are reported as
-unsupported or skipped rather than copied around those writers.
+The importer cannot turn a foreign system prompt, tool transcript, credential, or
+runtime record into memory. Items that cannot be represented within the
+destination writers and limits are reported as unsupported or skipped rather than
+copied around those writers.
+
+User-authored **instruction** documents (`CLAUDE.md`, `AGENTS.md`,
+`~/.claude/rules/*.md`, a workspace's own `CLAUDE.md`) and the directive body of
+a **persona** document (`SOUL.md`) ARE in scope, and are rewritten into
+KiroCrew's own tiers by the `instructions` category: each directive paragraph
+becomes a `Lesson(category="preference")` in `lessons.jsonl` — the highest-priority
+durable tier — while narrative knowledge continues to go to episodic memory via
+the `memories` category. Import contributes at most 50 lessons
+(`_MAX_IMPORTED_LESSONS`) because `LessonStore` prunes oldest-first at 200; an
+unbounded import would silently evict the user's own accumulated corrections. What is excluded
+is the persona *role*: a foreign persona document never becomes KiroCrew's
+persona (that surface is theme-pack persona, gated by
+`capabilities.theme_persona`), and no foreign text is injected as system-prompt
+identity. Import MUST NOT write `preferences.md` or `projects.md` — the
+consolidator replaces both wholesale, so an import there is silently destroyed.
+See `onboarding-import.md` → "Destination mapping".
 
 Markdown and supported database memory values are injection-screened before they
 become selectable, then screened again by the destination writer. When an

--- a/docs/system-specs/modules/onboarding-import.md
+++ b/docs/system-specs/modules/onboarding-import.md
@@ -1,0 +1,363 @@
+# Foreign-Agent Import Module
+
+Last Updated: 2026-07-28 (initial spec: industry-consensus scope, session-import
+removal, memory-hierarchy destination mapping, dry-run contract, and
+user-selectable conflict strategies)
+
+## Overview
+
+`onboarding_import.py` migrates a user's setup from another AI agent into
+KiroCrew. It runs from the first-run onboarding flow (after the Kiro CLI
+prerequisite gate, before the theme tour) and from Settings on demand.
+
+The module is a **projection**, not a mirror: it reads a foreign layout and
+writes only into KiroCrew's own containers through KiroCrew's own APIs. It never
+invents a storage format, never writes a file KiroCrew does not otherwise read,
+and never copies a foreign store verbatim.
+
+Three phases, always in this order:
+
+| Phase | Entry point | Writes? |
+|-------|-------------|---------|
+| Detect | `detect_sources()` | no |
+| Dry run (preview) | `preview_import()` | **no — never touches disk** |
+| Apply | `apply_import()` | yes, merge-only |
+
+**Sources:** `codex`, `claude_code`, `meshclaw`, `openclaw`, `hermes`.
+
+## Scope: what is migrated
+
+The scope follows the de-facto industry consensus (cross-checked against
+Codex CLI, Claude Code, OpenClaw, and Hermes Agent migration tooling). Only
+data that is (a) user-authored, (b) portable across agents, and (c) expensive to
+recreate by hand is in scope.
+
+| Category | Rationale | Destination |
+|----------|-----------|-------------|
+| `instructions` | User-authored rules — the single least replaceable asset | memory hierarchy (below) |
+| `memories` | Plain-Markdown knowledge; semantically stable across agents | memory hierarchy (below) |
+| `skills` | Self-contained dir + `SKILL.md`; near-identical format everywhere | `skills/imported/<source>/<name>/` |
+| `mcp_servers` | De-facto standard shape (`mcpServers` / `[mcp_servers.*]`) | `mcp.json` → `mcpServers` |
+| `denied_commands` | Hand-tuned deny rules; recreating them is tedious and error-prone | `config.json` → `hooks.denied_commands.user_added` |
+| `settings` | Only unambiguous scalars: timezone, theme mode, theme color | `config.json` |
+| `workspaces` | Project dirs, but **only** from explicit config — see below | `config.json` → `workspaces` |
+| `schedules` | Portable cron/interval specs | `CronService`, always `enabled=False` |
+
+### Not migrated (explicit non-goals)
+
+Each of these is a deliberate exclusion. Do **not** "restore" one because it
+looks like a gap — reopen the decision in this spec first.
+
+| Excluded | Why |
+|----------|-----|
+| **Sessions / conversation transcripts** | Not industry practice — no surveyed agent migrates transcripts. A transcript is a record of a conversation with a *different* model under a *different* system prompt; replayed into KiroCrew it is misleading context, not useful memory. Reading it also requires hard-coding each source's private JSONL/SQLite schema, which fails **silently** when upstream drifts. Removing it deletes the module's largest and most fragile surface. See "Session-import removal". |
+| **Persona / `SOUL.md` as a persona** | KiroCrew's persona surface is theme-pack persona, governed by `capabilities.theme_persona`. Importing a foreign persona document *as a persona* would inject third-party text into the agent's identity through a path that bypasses that gate. The **directive content** of such a file is still migrated — as memory (below) — but its persona role is dropped. |
+| **Credentials of any kind** | `~/.claude/.credentials.json`, `~/.codex/auth.json`, `.env`, `auth-profiles.json`, gateway tokens, provider API keys. Never read. MCP `env`/`headers` keys matching the secret patterns are stripped and counted into `secret_count`. |
+| **Runtime state** | Subagent records, tool results, checkpoints, hook state, in-flight task state. Not user data. |
+| **Architecture-specific config** | Plugin/hook/binding/agent-list configs, memory-backend selection, provider and model mappings. KiroCrew is KiroACP-only, so provider/model translation has no destination. |
+| **Opaque binary stores** | Foreign SQLite memory stores are reported as `unsupported_memory_database`, never parsed. |
+| **Allow-lists (as opposed to deny-lists)** | A foreign `permissions.allow` *widens* the security boundary. Importing it would let a foreign config grant tool access inside KiroCrew's own gate. Deny rules only. |
+
+## Destination mapping: the memory hierarchy
+
+Imported instruction/knowledge content is rewritten into KiroCrew's existing
+memory tiers. Tier choice is driven by two properties — **context priority**
+(`context.py` per-section caps) and **durability**.
+
+### Durability constraint (read before choosing a tier)
+
+`preferences.md` and `projects.md` are **replaced wholesale by the memory
+consolidator**. Anything written there by import is destroyed on the next
+consolidation run. **Import MUST NOT write to `preferences.md` or
+`projects.md`.**
+
+Durable tiers only:
+
+| Tier | Context cap | Durability |
+|------|-------------|------------|
+| `lessons.jsonl` (`LessonStore`) | 22.6% — highest of any tier | Append-only; pruned oldest-first at `_MAX_LESSONS_TOTAL` (200) |
+| Semantic memory (`VectorMemoryStore`) | 7.7% | Durable; key-addressed, confidence-gated |
+| Episodic memory (`VectorMemoryStore`) | 7.7% | Durable; append-only |
+| `.kiro/steering/*.md` | 10% | Durable, but **workspace-scoped** |
+
+### Mapping rules
+
+1. **Top-tier directives → `lessons.jsonl`.** The highest-priority durable
+   always-injected tier (22.6% of the context budget). Applies to the
+   *directive* content of a source's instruction documents — `CLAUDE.md`,
+   `AGENTS.md`, `~/.claude/rules/*.md`, each workspace's own `CLAUDE.md`, and
+   the directive body of a persona document (`SOUL.md`). `_instruction_paragraphs`
+   splits a document into individually-injectable directives: it reuses
+   `_memory_chunks` for bounding, then drops anything shorter than
+   `_MIN_INSTRUCTION_CHARS` (10) and any paragraph whose every line is a
+   Markdown heading (a heading carries no directive alone). Each surviving
+   paragraph becomes one `Lesson(category="preference", rule=<text>)`;
+   `negative` stays `None`. `LessonStore.save` is itself exact-rule
+   deduplicating, so a re-import reports `existing` → `deduplicated` rather than
+   a false `accepted`. Because the store prunes **oldest-first at 200**, import
+   caps its own contribution at `_MAX_IMPORTED_LESSONS` (50) and emits an
+   `instruction_count_limit` diagnostic on overflow — otherwise a large foreign
+   instruction file would silently evict the user's own accumulated corrections.
+   Instruction content passes the same two gates as memory: a *redaction* (not a
+   size truncation) drops the file as `credential_bearing_instruction`, and
+   `contains_injection` drops it as `injection_instruction_excluded`.
+2. **Narrative knowledge → episodic memory.** Prose and notes that are not
+   directives: `MEMORY.md`, `USER.md`, `memories/*.md`, project-local memory
+   dirs. Chunked by `_memory_chunks` (paragraph-packed, ≤2000 chars),
+   `importance=0.5`, `tags=["imported", <source_id>]`, `source="import"`.
+3. **Key-value facts → semantic memory.** Only where a source already stores
+   an explicit key/value pair whose key matches `_SEMANTIC_KEY_RE` and carries
+   one of `_SEMANTIC_PREFIXES` (`pref.` / `project.` / `user.` / `lesson.`).
+   Written with `set_semantic_if_absent` so a concurrent native write is never
+   overwritten.
+4. **Workspace-scoped rules → `.kiro/steering/`, opt-in only.** A per-project
+   instruction file (a workspace's own `CLAUDE.md`/`AGENTS.md`) may be written
+   to `<workspace>/.kiro/steering/imported-<source>.md` **only** when the user
+   supplies an explicit workspace target. Import MUST NOT default the target to
+   the current directory, the data home, or the user's home. Absent an explicit
+   target the item is reported `skipped` with reason
+   `workspace_target_required` — a missing target is never implicit consent.
+
+Every imported memory item passes the existing content gates before it is
+written: `_sanitize_text` (truncate + credential redaction; a *redacted* file is
+dropped, a merely *truncated* one is not) and `contains_injection` (dropped as
+`injection_memory_excluded`).
+
+## Dry run
+
+`preview_import()` is a **hard** dry run: it performs the full scan and produces
+the complete per-item plan without opening any destination for writing. The API
+never applies as a side effect of previewing, and there is no flag that turns a
+preview into an apply.
+
+The plan is per-item, not per-category: each entry carries `source_id`,
+`category_id`, `item_hash`, a human-readable label, the projected destination,
+and the **predicted** status (see status vocabulary). A category-level count
+alone is not a valid plan.
+
+**The plan is advisory, not authoritative.** `apply_import()` re-scans the
+source from disk and never trusts payloads echoed back by the client; only
+`(source_id, category_id)` pairs are read out of the submitted plan, filtered
+against `SOURCE_IDS`/`CATEGORY_IDS`. Consequently a preview status may differ
+from the applied status when the source changed in between. `apply_import()`
+returns per-item outcomes so the caller can report exactly which items diverged
+from their prediction; it MUST NOT silently present the preview as the result.
+
+## Conflict strategy (user-selectable)
+
+A destination collision is a **user decision**, not a hard failure. The apply
+request carries a strategy; the default is the safest one.
+
+| Strategy | Behavior |
+|----------|----------|
+| `skip` (**default**) | Keep KiroCrew's existing item untouched; report the incoming one as `conflict`. |
+| `rename` | Import alongside the existing item under a derived non-colliding name. |
+| `overwrite` | Replace the existing item, after writing a restore copy. |
+
+Applicability and rename derivation per category:
+
+| Category | Strategies | Rename form |
+|----------|-----------|-------------|
+| `skills` | skip · rename · overwrite | `<name>-imported-<source>`, then `<name>-<fingerprint[:8]>` |
+| `mcp_servers` | skip · rename · overwrite | `<name>-<source>`, then `<name>-<fingerprint[:8]>` |
+| `workspaces` | skip · rename | existing three-step ladder (`base` → `base-<source>` → `base-<fp[:8]>`) |
+| `instructions`, `memories` | n/a — merge-only, never collide destructively | — |
+| `denied_commands`, `settings` | n/a — merge-missing only | — |
+| `schedules` | skip only — a duplicate schedule is matched by `_same_schedule` | — |
+
+Rules:
+
+- `overwrite` MUST write a restore copy under
+  `imports/replaced/<timestamp>/<category>/` before replacing anything, and MUST
+  record the restore path in the item outcome.
+- A strategy is chosen **per apply request**, applying to every item in it. A
+  finer-grained per-item choice is a UI concern layered on top: the UI may issue
+  several apply requests with different strategies.
+- `rename` exists specifically to give the user a way out of an otherwise
+  terminal conflict. Before it existed, an upstream edit to an
+  already-imported skill or MCP server produced a permanent `conflict` with no
+  resolution path, because the item fingerprint covers the content digest and
+  therefore did not match the ledger.
+
+## Idempotency and deduplication
+
+Three independent layers. All three are required; none subsumes another.
+
+### 1. Within one scan — `_deduplicate_items()`
+
+Removes duplicate `_Item`s by `fingerprint` inside a single scan. Runs at the
+end of every `_scan_source()`.
+
+### 2. Across applies — the ledger
+
+`<data_home>/imports/foreign-agent-imports.json`, shape
+`{"version": <int>, "records": {<fingerprint>: {...}}}`. An item whose
+fingerprint is already recorded is reported `deduplicated` and skipped without
+touching the destination.
+
+`fingerprint = sha256(source_id \0 category \0 key)`. The payload is **not**
+part of the fingerprint; content participates only where a category folds a
+content digest into its `key`.
+
+The ledger MUST be flushed at least once per category and on every exit path
+(including exceptions), so an interrupted apply cannot re-import already-written
+items. It MUST NOT be rewritten once per item — the file is rewritten whole, so
+per-item flushing is O(n²) in serialization and rename cost.
+
+### 3. At the destination — per-writer collision checks
+
+Each writer decides its own collision semantics and returns one status.
+Destination checks are authoritative over the ledger: an item absent from the
+ledger but already present at the destination is `existing`, not a re-import.
+
+| Category | Destination check |
+|----------|-------------------|
+| `instructions` | Exact-text match against existing lessons → `existing` |
+| `memories` | episodic: `has_episodic_text()` exact match. semantic: `set_semantic_if_absent()`; same key + different value → `conflict` |
+| `skills` | Per-file byte comparison. All files present and identical → `existing`; a subset present → `conflict` |
+| `mcp_servers` | Same name → deep-equal spec? `existing` : `conflict`. Plus `configured_mcp_aliases()` alias-collision check across every effective MCP source |
+| `denied_commands` | Rule already present (by pattern) → `existing` |
+| `workspaces` | Resolved path already registered → `existing` |
+| `schedules` | `_same_schedule()` (name + message + timezone + trigger) |
+| `settings` | `_merge_missing()` — never overwrites an existing value |
+
+**Known limitation.** Exact-match dedupe for episodic memory means an upstream
+edit of one character produces a new chunk and therefore a second, near-identical
+episodic row. Similarity-based dedupe is possible (the vector store is already
+present) and is a candidate improvement; it is deliberately not in this version
+because a false "already have it" silently drops user knowledge, which is worse
+than a near-duplicate.
+
+## Status vocabulary
+
+Writers return one of four statuses; the API maps them to three item outcomes.
+This vocabulary is the frontend contract — the UI MUST NOT invent a fifth state.
+
+| Writer status | Outcome | Meaning |
+|---------------|---------|---------|
+| `imported` | `accepted` | Written |
+| `existing` | `deduplicated` | Already present, identical; nothing written |
+| `conflict` | `rejected` | Destination holds a different item; resolvable via strategy |
+| `rejected` | `rejected` | Refused by a safety or validity gate; not resolvable via strategy |
+
+Apply also returns `skipped` entries (source unavailable, scan diagnostics,
+`workspace_target_required`) which are **not** item outcomes — they describe
+things never attempted.
+
+## Per-source assumptions
+
+Every source parser hard-codes assumptions about a private upstream layout.
+These fail **silently** when upstream drifts, so each is recorded here and each
+MUST be covered by a fixture-based regression test.
+
+| Source | Root (env override → default) | Layout assumptions |
+|--------|------------------------------|--------------------|
+| `codex` | `CODEX_HOME` → `~/.codex` | `config.toml`; `AGENTS.md` (instructions); `memories/*.md`; `skills/` (excl. `.system`); `memories*.sqlite*` reported unsupported |
+| `claude_code` | `CLAUDE_CONFIG_DIR`/`CLAUDE_HOME` → `~/.claude`; also `~/.claude.json` | `CLAUDE.md`; `rules/*.md`; `settings.json`/`settings.local.json` (`permissions.deny`); `memory/`; `skills/`; per-workspace `.claude/` |
+| `meshclaw` | `MESHCLAW_HOME` → `~/.meshclaw` | SQLite memory DB; skills; config; `workspace/AGENTS.md` + `workspace/CLAUDE.md` and the same two per configured workspace. Only those canonical filenames are read — the MeshClaw workspace holds arbitrary user documents, so a blind `*.md` sweep there is wrong |
+| `openclaw` | `OPENCLAW_STATE_DIR` → `OPENCLAW_HOME`/`<state>` → `~/.openclaw-<profile>` → `~/.openclaw` → `~/.clawdbot` | `openclaw.json` (+ legacy `clawdbot.json`); `SOUL.md`, `MEMORY.md`, `USER.md`, `memory/*.md` under `workspace/` \| `workspace-main/` \| `workspace-<agentId>/`; `skills/`, `.agents/skills/`; `exec-approvals.json` |
+| `hermes` | `HERMES_HOME`/`HERMES_AGENT_HOME`/`HERMES_CONFIG_DIR` → `%LOCALAPPDATA%/hermes` (Windows) → `~/.hermes` | `config.yaml`/`.yml`; `memories/MEMORY.md`, `memories/USER.md`; `SOUL.md`; `skills/` (excl. managed + re-import dirs); `cron/jobs.json`; `memory_store.db` reported unsupported |
+
+### Transitive re-import (Hermes)
+
+Hermes's own import tooling writes foreign skills into
+`skills/claude-code-imports/`, `skills/codex-imports/`, and
+`skills/openclaw-imports/`, and merges foreign `MEMORY.md`/`USER.md` into its
+own. A user who migrated Claude Code → Hermes → KiroCrew would otherwise import
+the same skill twice under two different `source_id`s — which **neither** the
+fingerprint (source-scoped) **nor** the destination check (different target dir)
+can catch.
+
+Therefore those three directory names live in `_FOREIGN_REIMPORT_SKILL_DIRS` and
+are folded into `_HERMES_SKILL_EXCLUDED_PARTS`, alongside the existing
+managed-skill exclusions (`.bundled_manifest`, `.hub/lock.json`). Nothing is lost:
+the originals are still on disk, so the original source imports them normally.
+
+The same overlap exists for Hermes **memory** (its importer merges foreign
+`MEMORY.md`/`USER.md` into its own using a `§` delimiter). That case is NOT
+excluded: the collision is content-level rather than a directory name, and
+dropping Hermes's `MEMORY.md` wholesale would lose real data for a
+Hermes-native user. Near-duplicate episodic rows are accepted as the lesser
+evil (see the dedupe limitation above).
+
+## API contract
+
+All three endpoints are dashboard-owner-only and audited. `request["app"]` MUST
+be `""` — an app token is never a dashboard user.
+
+| Endpoint | Phase | Body |
+|----------|-------|------|
+| `GET /api/onboarding/import/scan` | detect + dry run | — |
+| `POST /api/onboarding/import/apply` | apply | `{selection: [{source_id, category_id}], conflict_strategy?, workspace_target?}` |
+| `POST /api/onboarding/import/state` | onboarding bookkeeping | `{completed: bool}` |
+
+Concurrency: apply holds a module-level import lock. Config-writing categories
+run under the config lock; `mcp_servers` runs in a separate phase **outside**
+the config lock (the MCP handlers take the MCP file lock before the config lock,
+so holding both in the other order would invert). MCP writes reuse the
+dashboard's MCP sidecar lock.
+
+Response: `{imported: {<category>: <count>}, imported_count, already_imported,
+item_outcomes: [...], conflicts: [...], skipped: [...], secret_count,
+unsupported_count, ledger}`. `item_outcomes` is authoritative; the aggregate
+counts MUST be derived from it and MUST NOT be reported independently.
+
+## Session-import removal
+
+Session/transcript import is removed. The removal deletes the categories'
+scanners, writers, and their supporting machinery:
+
+- `sessions` from `CATEGORY_IDS`; `_write_session`, `_session_destination_key`
+- `_jsonl_session_items`, `_message_from_record`, `_extract_visible_content`,
+  `_claude_record_is_excluded`, `_without_runtime_sessions`,
+  `_add_sessions_and_workspaces`, `_record_workspaces`
+- the OpenClaw session-provenance set: `_OPENCLAW_RUNTIME_NAMESPACES`,
+  `_OPENCLAW_SESSION_OWNERSHIP_FIELDS`, `_OPENCLAW_CHECKPOINT_RE`,
+  `_OPENCLAW_CREATED_VIA`, `_openclaw_session_provenance_is_user_owned`,
+  `_openclaw_session_paths`, `_openclaw_session_artifact`,
+  `_openclaw_entry_matches_file`, `_openclaw_registry_map`
+- session reads in `_scan_hermes_db` / `_scan_meshclaw_memory_db`, and
+  `_HERMES_RUNTIME_SESSION_SOURCES`
+- the `sessions` branch of `_deduplicate_items` (transcript-hash canonicalization)
+- session-only limits: `_MAX_JSONL_LINES`, `_MAX_MESSAGES_PER_SESSION`,
+  `_MAX_LINE_BYTES`, `_VISIBLE_ROLES`, `_VISIBLE_TEXT_TYPES`, `_NON_TEXT_TYPES`
+- `conversation_log` plumbing through `apply_import` and the handler
+
+**Consequence for workspace discovery.** Workspaces were partly discovered by
+reading workspace paths out of session records. After removal, workspace
+discovery comes only from explicit configuration (`_collect_project_paths` and
+each source's config-declared workspace values). This narrows coverage; it does
+not break it. Do not reintroduce a session read to widen it.
+
+**Ledger compatibility.** Existing ledgers may contain `category_id:
+"sessions"` records. They are inert: no scanner produces a `sessions` item, so
+the records are never consulted. The ledger version is NOT bumped — a bump
+would discard every other category's records and cause a full re-import.
+Already-imported sessions are left in place; import does not delete data it
+wrote under a previous version.
+
+## Security invariants
+
+These are load-bearing. Changing any of them requires a security review.
+
+1. **Apply re-scans from disk.** No payload from the HTTP client is ever
+   written. Only `(source_id, category_id)` pairs, allowlist-filtered, are read
+   from the submitted plan.
+2. **Credentials are never read.** Known credential files are not opened;
+   secret-shaped MCP `env`/`headers` keys and URL-embedded secrets are stripped
+   and counted, never stored.
+3. **YAML aliases are rejected.** `_NoAliasSafeLoader` refuses anchors/aliases —
+   `yaml.safe_load` alone still expands them, which is a billion-laughs vector
+   on untrusted input.
+4. **Symlink components are re-checked immediately before every write**, not
+   only at plan time (TOCTOU).
+5. **Skill packages land atomically** — staged in a sibling temp dir, then
+   `os.replace`; failure leaves nothing partial.
+6. **`is_sensitive_path` gates workspace registration**, and the data home may
+   never be registered as a workspace.
+7. **Deny-only for command rules.** An allow-list is never imported.
+8. **Bounded everywhere.** File count, per-file bytes, total bytes, walk
+   entries, chunk size, workspace count, MCP server count, schedule count, DB
+   size and row count all carry explicit ceilings.
+9. **Imported schedules are always disabled** (`enabled=False`), so no imported
+   job can execute without an explicit user action.

--- a/src/kiro_crew/dashboard/handlers/onboarding_import.py
+++ b/src/kiro_crew/dashboard/handlers/onboarding_import.py
@@ -26,7 +26,7 @@ _SOURCE_IDS = frozenset(
 )
 _CATEGORY_IDS = frozenset(
     {
-        "sessions",
+        "instructions",
         "memories",
         "workspaces",
         "mcp_servers",
@@ -43,7 +43,6 @@ _SOURCE_NAMES = {
     "hermes": "Hermes Agent",
 }
 _CATEGORY_NAMES = {
-    "sessions": "Sessions",
     "memories": "Memories",
     "workspaces": "Workspaces",
     "mcp_servers": "MCP servers",
@@ -55,9 +54,10 @@ _CATEGORY_NAMES = {
     "instructions": "Instructions",
     "credentials": "Credentials",
     "runtime": "Runtime state",
+    "sessions": "Conversation history",
 }
 _CATEGORY_DESCRIPTIONS = {
-    "sessions": "Visible user and assistant messages",
+    "instructions": "Your own rules, as high-priority memory",
     "memories": "Durable preferences and memories",
     "workspaces": "Existing local project folders",
     "mcp_servers": "Server definitions, imported disabled",
@@ -340,9 +340,9 @@ def _apply_response(result: object) -> dict[str, Any]:
 def _apply_import(
     source_ids: list[str],
     selected: set[tuple[str, str]],
-    conversation_log: object | None,
     cron_service: object | None,
     vector_store: object | None,
+    lesson_store: object | None,
 ) -> object:
     backend = _backend()
     plan = _select_fresh_plan(
@@ -351,9 +351,9 @@ def _apply_import(
     )
     return backend.apply_import(
         plan,
-        conversation_log=conversation_log,
         cron_service=cron_service,
         vector_store=vector_store,
+        lesson_store=lesson_store,
     )
 
 
@@ -484,8 +484,8 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid request"}, status=400)
 
     state = request.app.get("state")
-    conversation_log = getattr(state, "conversation_log", None)
     cron_service = getattr(state, "crons", None)
+    lesson_store = getattr(state, "lessons", None)
     vector_store = getattr(state, "vector_memory", None)
     if vector_store is None:
         context_builder = getattr(state, "context_builder", None)
@@ -503,9 +503,9 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
                             _apply_import,
                             source_ids,
                             config_selected,
-                            conversation_log,
                             cron_service,
                             vector_store,
+                            lesson_store,
                         )
                     )
             if mcp_selected:
@@ -516,9 +516,9 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
                         _apply_import,
                         source_ids,
                         mcp_selected,
-                        conversation_log,
                         cron_service,
                         vector_store,
+                        lesson_store,
                     )
                 )
                 await asyncio.to_thread(_rebuild_agent_config)

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import heapq
 import json
 import logging
 import math
@@ -14,7 +13,7 @@ import sqlite3
 import stat
 import tempfile
 from collections.abc import Iterable, Mapping
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import islice
@@ -75,7 +74,7 @@ class _NoAliasSafeLoader(yaml.SafeLoader):
 
 SOURCE_IDS = ("codex", "claude_code", "meshclaw", "openclaw", "hermes")
 CATEGORY_IDS = (
-    "sessions",
+    "instructions",
     "memories",
     "workspaces",
     "mcp_servers",
@@ -92,7 +91,7 @@ _SOURCE_NAMES = {
     "hermes": "Hermes Agent",
 }
 _CATEGORY_LABELS = {
-    "sessions": "Sessions",
+    "instructions": "Instructions",
     "memories": "Memories",
     "workspaces": "Workspaces",
     "mcp_servers": "MCP servers",
@@ -107,37 +106,37 @@ _SOURCE_ROOTS = {
     "hermes": (("HERMES_HOME", "HERMES_AGENT_HOME", "HERMES_CONFIG_DIR"), ".hermes"),
 }
 _OPENCLAW_LEGACY_ROOTS = (".clawdbot",)
-_CLAUDE_RUNTIME_PARTS = frozenset({"subagents", "subagent", "runtime", "tool-results"})
+# Directory names a foreign agent's OWN importer uses for skills it pulled in
+# from a third agent (Hermes: ``hermes import-agent`` / ``hermes claw migrate``).
+_FOREIGN_REIMPORT_SKILL_DIRS = (
+    "claude-code-imports",
+    "codex-imports",
+    "openclaw-imports",
+)
 _OPENCLAW_PROFILE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-_OPENCLAW_CREATED_VIA = frozenset({"operator", "channel", "talk"})
-_OPENCLAW_RUNTIME_NAMESPACES = frozenset(
-    {
-        "cron",
-        "subagent",
-        "acp",
-        "acp-bridge",
-        "hook",
-        "node",
-        "heartbeat",
-        "internal-session-effects",
-    }
-)
-_OPENCLAW_SESSION_OWNERSHIP_FIELDS = frozenset(
-    {
-        "completionownersessionkey",
-        "forkedfromparent",
-        "forksource",
-        "pluginownerid",
-    }
-)
-_OPENCLAW_CHECKPOINT_RE = re.compile(
-    r"\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" r"[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$",
-    re.IGNORECASE,
-)
-_HERMES_RUNTIME_SESSION_SOURCES = frozenset({"subagent", "tool", "cron"})
 _HERMES_SKILL_EXCLUDED_PARTS = frozenset(
-    {".archive", ".hub", "dependency", "dependencies", "cache", ".cache"}
+    {
+        ".archive",
+        ".hub",
+        "dependency",
+        "dependencies",
+        "cache",
+        ".cache",
+        # Hermes ships its own importer, which writes FOREIGN skills into these
+        # dirs. Importing them from Hermes would duplicate what the original
+        # source already contributes, and neither dedupe layer can catch it: the
+        # fingerprint is source-scoped (``hermes`` != ``claude_code``) and the
+        # destination differs too (``skills/imported/hermes/`` vs
+        # ``skills/imported/claude_code/``), so not even a conflict is reported.
+        # The originals are still on disk, so excluding these loses nothing.
+        *_FOREIGN_REIMPORT_SKILL_DIRS,
+    }
 )
+# Import's own ceiling on lessons. ``LessonStore`` prunes OLDEST-first at 200,
+# so an unbounded instruction import would silently evict the user's own
+# accumulated corrections. See docs/system-specs/modules/onboarding-import.md.
+_MAX_IMPORTED_LESSONS = 50
+_MIN_INSTRUCTION_CHARS = 10
 _LEDGER_VERSION = 1
 _PLAN_VERSION = 1
 _LEDGER_RELATIVE_PATH = Path("imports") / "foreign-agent-imports.json"
@@ -146,9 +145,6 @@ _MAX_FILE_BYTES = 8 * 1024 * 1024
 _MAX_SKILL_BYTES = 256 * 1024
 _MAX_YAML_BYTES = 1024 * 1024
 _MAX_TOTAL_BYTES = 64 * 1024 * 1024
-_MAX_JSONL_LINES = 10_000
-_MAX_LINE_BYTES = 256 * 1024
-_MAX_MESSAGES_PER_SESSION = 1_000
 _MAX_TEXT_CHARS = 100_000
 _MAX_DB_BYTES = 64 * 1024 * 1024
 _MAX_DB_ROWS = 10_000
@@ -290,23 +286,6 @@ _MANAGED_MCP_NAMES = frozenset(
         "meshclaw-cron",
         "openclaw-core",
         "openclaw-cron",
-    }
-)
-_VISIBLE_ROLES = frozenset({"user", "assistant"})
-_VISIBLE_TEXT_TYPES = frozenset(
-    {"text", "input_text", "output_text", "user_message", "assistant_message"}
-)
-_NON_TEXT_TYPES = frozenset(
-    {
-        "thinking",
-        "reasoning",
-        "tool",
-        "tool_call",
-        "tool_use",
-        "tool_result",
-        "function_call",
-        "function_result",
-        "computer_initialize_state",
     }
 )
 
@@ -568,7 +547,6 @@ def _walk_files(
         return []
     remaining = max(0, _MAX_FILES - scan.files_seen.get(category, 0)) if count_files else _MAX_FILES
     candidates: list[Path] = []
-    session_candidates: list[tuple[float, str, Path]] = []
     omitted = 0
     excluded_count = 0
     visited_entries = 0
@@ -581,7 +559,7 @@ def _walk_files(
             break
         kept_dirs: list[str] = []
         exhausted = False
-        for dirname in sorted(dirnames, reverse=category == "sessions"):
+        for dirname in sorted(dirnames):
             if visited_entries >= _MAX_WALK_ENTRIES:
                 traversal_omitted += len(dirnames) - len(kept_dirs) + len(filenames)
                 exhausted = True
@@ -598,7 +576,7 @@ def _walk_files(
         if exhausted:
             dirnames[:] = []
             break
-        for index, filename in enumerate(sorted(filenames, reverse=category == "sessions")):
+        for index, filename in enumerate(sorted(filenames)):
             if visited_entries >= _MAX_WALK_ENTRIES:
                 traversal_omitted += len(filenames) - index
                 exhausted = True
@@ -621,40 +599,15 @@ def _walk_files(
                 if parts & excluded_parts:
                     excluded_count += 1
                     continue
-            if category == "sessions":
-                try:
-                    candidate_mtime = candidate.stat().st_mtime
-                except OSError:
-                    candidate_mtime = 0
-                entry = (candidate_mtime, str(candidate), candidate)
-                if len(session_candidates) < remaining:
-                    heapq.heappush(session_candidates, entry)
-                elif remaining and entry > session_candidates[0]:
-                    heapq.heapreplace(session_candidates, entry)
-                else:
-                    omitted += 1
+            if len(candidates) < remaining:
+                candidates.append(candidate)
             else:
-                if len(candidates) < remaining:
-                    candidates.append(candidate)
-                else:
-                    omitted += 1
+                omitted += 1
         if exhausted:
             break
-    if category == "sessions":
-        candidates = [entry[2] for entry in session_candidates]
     if excluded_count and excluded_category and excluded_reason:
         scan.diagnostic(excluded_category, excluded_reason, count=excluded_count)
-    if category == "sessions":
-
-        def _mtime(path: Path) -> float:
-            try:
-                return path.stat().st_mtime
-            except OSError:
-                return 0
-
-        candidates.sort(key=_mtime, reverse=True)
-    else:
-        candidates.sort(key=lambda path: str(path).casefold())
+    candidates.sort(key=lambda path: str(path).casefold())
     if omitted and count_files:
         scan.diagnostic(category, "file_count_limit", count=omitted)
     if traversal_omitted:
@@ -875,166 +828,6 @@ def _read_simple_yaml(path: Path, anchor: Path, scan: _Scan) -> dict[str, Any]:
         scan.diagnostic("settings", "invalid_config")
         return {}
     return result if isinstance(result, dict) else {}
-
-
-def _extract_visible_content(value: Any) -> str:
-    if isinstance(value, str):
-        return value
-    if not isinstance(value, list):
-        return ""
-    parts: list[str] = []
-    for block in value:
-        if isinstance(block, str):
-            parts.append(block)
-            continue
-        if not isinstance(block, dict):
-            continue
-        block_type = str(block.get("type", "")).lower()
-        if block_type in _NON_TEXT_TYPES:
-            continue
-        if block_type and block_type not in _VISIBLE_TEXT_TYPES:
-            continue
-        text = block.get("text")
-        if not isinstance(text, str) and block_type in _VISIBLE_TEXT_TYPES:
-            text = block.get("content")
-        if isinstance(text, str):
-            parts.append(text)
-    return "\n".join(part for part in parts if part)
-
-
-def _message_from_record(record: Any, scan: _Scan) -> tuple[str, str] | None:
-    if not isinstance(record, dict):
-        return None
-    record_type = str(record.get("type", "")).lower()
-    if record_type in _NON_TEXT_TYPES:
-        return None
-    candidates = [record]
-    for key in ("payload", "message"):
-        child = record.get(key)
-        if isinstance(child, dict):
-            candidates.insert(0, child)
-    for candidate in candidates:
-        candidate_type = str(candidate.get("type", "")).lower()
-        if candidate_type in _NON_TEXT_TYPES:
-            continue
-        role = candidate.get("role")
-        if not isinstance(role, str) or role.lower() not in _VISIBLE_ROLES:
-            fallback_type = record.get("type")
-            role = fallback_type if isinstance(fallback_type, str) else ""
-        role = role.lower()
-        if role not in _VISIBLE_ROLES:
-            continue
-        content = candidate.get("content")
-        if content is None:
-            content = candidate.get("text")
-        text = _extract_visible_content(content)
-        if not text and isinstance(content, str):
-            text = content
-        cleaned = _sanitize_text(text, scan) if text else ""
-        if cleaned:
-            return role, cleaned
-    return None
-
-
-def _claude_record_is_excluded(record: Any) -> bool:
-    if not isinstance(record, dict):
-        return False
-    if record.get("isMeta") is True or record.get("isSidechain") is True:
-        return True
-    if "toolUseResult" in record:
-        return True
-    if "userType" in record:
-        user_type = record.get("userType")
-        return not isinstance(user_type, str) or user_type.casefold() != "external"
-    return False
-
-
-def _record_workspaces(record: Any) -> list[str]:
-    if not isinstance(record, dict):
-        return []
-    workspaces: list[str] = []
-    for container in (record, record.get("payload"), record.get("message")):
-        if not isinstance(container, dict):
-            continue
-        for key in ("cwd", "project", "project_path", "workspace_path", "projectPath"):
-            value = container.get(key)
-            if isinstance(value, str) and value.strip():
-                workspaces.append(value.strip())
-        roots = container.get("workspace_roots")
-        if isinstance(roots, list):
-            workspaces.extend(
-                value.strip() for value in roots if isinstance(value, str) and value.strip()
-            )
-    return workspaces
-
-
-def _jsonl_session_items(
-    paths: list[Path],
-    anchor: Path,
-    scan: _Scan,
-) -> tuple[list[_Item], set[str]]:
-    items: list[_Item] = []
-    workspaces: set[str] = set()
-    for path in paths:
-        content = _read_bytes(path, anchor, scan, "sessions")
-        if content is None:
-            continue
-        groups: dict[str, list[tuple[str, str]]] = {}
-        file_workspaces: set[str] = set()
-        incomplete_file = False
-        capped_groups: set[str] = set()
-        for line_number, raw_line in enumerate(content.splitlines()):
-            if line_number >= _MAX_JSONL_LINES:
-                scan.diagnostic("sessions", "line_count_limit")
-                incomplete_file = True
-                break
-            if not raw_line.strip():
-                continue
-            if len(raw_line) > _MAX_LINE_BYTES:
-                scan.diagnostic("sessions", "line_too_large")
-                incomplete_file = True
-                continue
-            try:
-                record = json.loads(raw_line)
-            except json.JSONDecodeError:
-                scan.diagnostic("sessions", "invalid_jsonl_record")
-                incomplete_file = True
-                continue
-            if scan.source_id == "claude_code" and _claude_record_is_excluded(record):
-                continue
-            for record_workspace in _record_workspaces(record):
-                if len(workspaces) + len(file_workspaces) >= _MAX_WORKSPACES:
-                    break
-                file_workspaces.add(record_workspace)
-            message = _message_from_record(record, scan)
-            if message is None:
-                continue
-            group_value = ""
-            if isinstance(record, dict):
-                for key in ("session_id", "sessionId", "conversation_id", "conversationId"):
-                    if isinstance(record.get(key), (str, int)):
-                        group_value = str(record[key])
-                        break
-            group = group_value or "file"
-            messages = groups.setdefault(group, [])
-            if len(messages) < _MAX_MESSAGES_PER_SESSION:
-                messages.append(message)
-            else:
-                scan.diagnostic("sessions", "message_count_limit")
-                capped_groups.add(group)
-        if incomplete_file:
-            continue
-        workspaces.update(file_workspaces)
-        try:
-            relative = str(path.relative_to(anchor))
-        except ValueError:
-            relative = path.name
-        for group, messages in groups.items():
-            if not messages or group in capped_groups:
-                continue
-            key = f"session\0{group}" if group != "file" else f"file\0{relative}"
-            items.append(_Item(scan.source_id, "sessions", key, messages))
-    return items, workspaces
 
 
 def _workspace_item(scan: _Scan, workspace: str) -> str | None:
@@ -1458,6 +1251,83 @@ def _add_memory_files(scan: _Scan, paths: list[tuple[Path, Path]]) -> None:
                     "importance": 0.5,
                 },
             )
+
+
+def _instruction_paragraphs(text: str, scan: _Scan) -> list[str]:
+    """Split an instruction document into individually-injectable directives.
+
+    Reuses the memory chunker's paragraph packing so a directive and its
+    memory-tier sibling are bounded identically, then keeps only paragraphs that
+    read as instructions rather than narrative. A heading-only line carries no
+    directive on its own and is dropped.
+    """
+
+    directives: list[str] = []
+    for chunk in _memory_chunks(text, scan):
+        for paragraph in chunk.split("\n\n"):
+            candidate = paragraph.strip()
+            if len(candidate) < _MIN_INSTRUCTION_CHARS:
+                continue
+            lines = [line.strip() for line in candidate.splitlines() if line.strip()]
+            if not lines or all(line.startswith("#") for line in lines):
+                continue
+            directives.append(candidate)
+    return directives
+
+
+def _add_instruction_files(
+    scan: _Scan,
+    paths: list[tuple[Path, Path]],
+) -> None:
+    """Project user-authored instruction documents onto KiroCrew's memory tiers.
+
+    ``CLAUDE.md`` / ``AGENTS.md`` and the DIRECTIVE body of a persona document
+    (OpenClaw / Hermes ``SOUL.md``) are the least replaceable thing a user owns,
+    so they land in ``lessons.jsonl`` — the highest-priority durable tier
+    (see docs/system-specs/modules/onboarding-import.md). The persona *role* is
+    deliberately NOT imported: KiroCrew's persona surface is theme-pack persona,
+    governed by ``capabilities.theme_persona``, and no foreign text may become
+    system-prompt identity through this path.
+
+    ``preferences.md`` / ``projects.md`` are NOT valid destinations — the memory
+    consolidator replaces both wholesale, so an import there is destroyed on the
+    next consolidation run.
+    """
+
+    seen: set[str] = set()
+    emitted = 0
+    for path, anchor in paths:
+        marker = os.path.normcase(os.path.abspath(str(path)))
+        if marker in seen or not path.is_file():
+            continue
+        seen.add(marker)
+        content = _read_text(path, anchor, scan, "instructions")
+        if content is None:
+            continue
+        cleaned = _sanitize_text(content, scan)
+        # Mirror the memory gate: only an actual redaction drops the file, not
+        # the size-cap truncation of an otherwise clean one.
+        if cleaned != content[:_MAX_TEXT_CHARS].strip():
+            scan.diagnostic("instructions", "credential_bearing_instruction")
+            continue
+        if contains_injection(cleaned):
+            scan.diagnostic("instructions", "injection_instruction_excluded")
+            continue
+        try:
+            relative = str(path.relative_to(anchor))
+        except ValueError:
+            relative = path.name
+        for index, directive in enumerate(_instruction_paragraphs(cleaned, scan)):
+            if emitted >= _MAX_IMPORTED_LESSONS:
+                scan.diagnostic("instructions", "instruction_count_limit")
+                return
+            digest = hashlib.sha256(directive.encode()).hexdigest()
+            scan.add(
+                "instructions",
+                f"{relative}\0{index}\0{digest}",
+                {"kind": "lesson", "rule": directive},
+            )
+            emitted += 1
 
 
 def _add_memories(scan: _Scan, roots: list[Path]) -> None:
@@ -1911,38 +1781,6 @@ def _diagnose_unsupported_config(scan: _Scan, configs: list[dict[str, Any]]) -> 
             scan.diagnostic("settings", "security_setting_excluded")
 
 
-def _add_sessions_and_workspaces(
-    scan: _Scan,
-    paths: list[Path],
-    anchor: Path,
-) -> set[str]:
-    items, workspaces = _jsonl_session_items(paths, anchor, scan)
-    scan.items["sessions"].extend(items)
-    accepted: set[str] = set()
-    for workspace in sorted(workspaces)[:_MAX_WORKSPACES]:
-        canonical = _workspace_item(scan, workspace)
-        if canonical:
-            accepted.add(canonical)
-    return accepted
-
-
-def _without_runtime_sessions(scan: _Scan, paths: list[Path], anchor: Path) -> list[Path]:
-    accepted: list[Path] = []
-    excluded = 0
-    for path in paths:
-        try:
-            parts = {part.casefold() for part in path.relative_to(anchor).parts}
-        except ValueError:
-            parts = set()
-        if parts & {"subagents", "subagent", "runtime", "tool-results"}:
-            excluded += 1
-            continue
-        accepted.append(path)
-    if excluded:
-        scan.diagnostic("runtime", "runtime_sessions_excluded", count=excluded)
-    return accepted
-
-
 def _scan_codex_automations(scan: _Scan) -> None:
     path = scan.root / "sqlite" / "codex-dev.db"
     if not path.is_file():
@@ -1985,14 +1823,6 @@ def _scan_codex_automations(scan: _Scan) -> None:
 
 def _scan_codex(scan: _Scan) -> None:
     root = scan.root
-    session_paths = _walk_files(root / "sessions", scan, "sessions", suffixes=(".jsonl",))
-    session_paths += _walk_files(
-        root / "archived_sessions",
-        scan,
-        "sessions",
-        suffixes=(".jsonl",),
-    )
-    _add_sessions_and_workspaces(scan, session_paths, root)
     configs = _parse_configs(scan, [(root / "config.toml", root, "toml")])
     _diagnose_unsupported_config(scan, configs)
     for config in configs:
@@ -2012,8 +1842,7 @@ def _scan_codex(scan: _Scan) -> None:
         scan.diagnostic("hooks", "unsupported_category", unsupported=True)
     if (root / "agents").exists():
         scan.diagnostic("agents", "unsupported_category", unsupported=True)
-    if (root / "AGENTS.md").exists():
-        scan.diagnostic("instructions", "unsupported_category", unsupported=True)
+    _add_instruction_files(scan, [(root / "AGENTS.md", root)])
     _scan_codex_automations(scan)
     settings: dict[str, Any] = {}
     for config in configs:
@@ -2024,16 +1853,23 @@ def _scan_codex(scan: _Scan) -> None:
 
 def _scan_claude(scan: _Scan) -> None:
     root = scan.root
-    sessions = _walk_files(
-        root / "projects",
+    # Workspaces come from explicit configuration ONLY. Session transcripts are
+    # not imported (see docs/system-specs/modules/onboarding-import.md), so the
+    # former "reverse the workspace list out of session records" path is gone.
+    # That means the root configs must be parsed FIRST to learn the workspaces,
+    # then each workspace's own config files are parsed in a second pass.
+    root_configs = _parse_configs(
         scan,
-        "sessions",
-        suffixes=(".jsonl",),
-        excluded_parts=_CLAUDE_RUNTIME_PARTS,
-        excluded_category="runtime",
-        excluded_reason="runtime_sessions_excluded",
+        [
+            (root / "settings.local.json", root, "json"),
+            (root / "settings.json", root, "json"),
+            (root / ".claude.json", root, "json"),
+            (root.parent / ".claude.json", root.parent, "json"),
+        ],
     )
-    workspaces = _add_sessions_and_workspaces(scan, sessions, root)
+    workspaces: set[str] = set()
+    for config in root_configs:
+        workspaces.update(_collect_project_paths(config))
     project_configs: list[tuple[Path, Path, str]] = []
     for workspace_value in sorted(workspaces):
         workspace_path = Path(workspace_value)
@@ -2044,16 +1880,7 @@ def _scan_claude(scan: _Scan) -> None:
                 (workspace_path / ".mcp.json", workspace_path, "json"),
             ]
         )
-    configs = _parse_configs(
-        scan,
-        project_configs
-        + [
-            (root / "settings.local.json", root, "json"),
-            (root / "settings.json", root, "json"),
-            (root / ".claude.json", root, "json"),
-            (root.parent / ".claude.json", root.parent, "json"),
-        ],
-    )
+    configs = root_configs + _parse_configs(scan, project_configs)
     _diagnose_unsupported_config(scan, configs)
     for config in configs:
         for configured_workspace in _collect_project_paths(config):
@@ -2072,25 +1899,20 @@ def _scan_claude(scan: _Scan) -> None:
     _add_memories(scan, memory_roots)
     if (root / "tasks").exists():
         scan.diagnostic("runtime", "runtime_state_excluded")
-    instruction_count = int((root / "CLAUDE.md").is_file())
-    instruction_count += len(
-        _walk_files(
+    instruction_paths: list[tuple[Path, Path]] = [(root / "CLAUDE.md", root)]
+    instruction_paths += [
+        (path, root)
+        for path in _walk_files(
             root / "rules",
             scan,
             "instructions",
             suffixes=(".md", ".markdown"),
         )
-    )
-    instruction_count += sum(
-        1 for workspace in workspaces if (Path(workspace) / "CLAUDE.md").is_file()
-    )
-    if instruction_count:
-        scan.diagnostic(
-            "instructions",
-            "unsupported_category",
-            unsupported=True,
-            count=instruction_count,
-        )
+    ]
+    instruction_paths += [
+        (Path(workspace) / "CLAUDE.md", Path(workspace)) for workspace in sorted(workspaces)
+    ]
+    _add_instruction_files(scan, instruction_paths)
     settings: dict[str, Any] = {}
     for config in configs:
         _merge_missing(settings, _settings_from(config, "claude_code"))
@@ -2100,8 +1922,7 @@ def _scan_claude(scan: _Scan) -> None:
 
 def _scan_meshclaw(scan: _Scan) -> None:
     root = scan.root
-    sessions = _walk_files(root / "sessions", scan, "sessions", suffixes=(".jsonl",))
-    workspaces = _add_sessions_and_workspaces(scan, sessions, root)
+    workspaces: set[str] = set()
     configs = _parse_configs(
         scan,
         [
@@ -2136,6 +1957,16 @@ def _scan_meshclaw(scan: _Scan) -> None:
     skill_roots = [root / "workspace" / "skills"]
     skill_roots.extend(Path(workspace) / "skills" for workspace in sorted(workspaces))
     _add_skills(scan, skill_roots)
+    # MeshClaw's workspace holds arbitrary user documents, so only the canonical
+    # instruction filenames are read — never a blind sweep of every .md there.
+    _add_instruction_files(
+        scan,
+        [
+            (base / filename, base)
+            for base in (root / "workspace", *(Path(w) for w in sorted(workspaces)))
+            for filename in ("AGENTS.md", "CLAUDE.md")
+        ],
+    )
     has_memory_db = _scan_meshclaw_memory_db(scan)
     _add_memories(scan, [root / "workspace" / "memory"])
     if not has_memory_db:
@@ -2212,7 +2043,7 @@ def _openclaw_agent_dirs(scan: _Scan) -> list[Path]:
     agents_root = scan.root / "agents"
     if not agents_root.is_dir() or _is_link_like(agents_root):
         if _is_link_like(agents_root):
-            scan.diagnostic("sessions", "symlink_rejected")
+            scan.diagnostic("workspaces", "symlink_rejected")
         return []
     children: list[Path] = []
     truncated = False
@@ -2225,139 +2056,15 @@ def _openclaw_agent_dirs(scan: _Scan) -> list[Path]:
     except OSError:
         return []
     if truncated:
-        scan.diagnostic("sessions", "agent_count_limit", count=1)
+        scan.diagnostic("workspaces", "agent_count_limit", count=1)
     agent_dirs: list[Path] = []
     for child in sorted(children, key=lambda path: path.name.casefold()):
         if _is_link_like(child):
-            scan.diagnostic("sessions", "symlink_rejected")
+            scan.diagnostic("workspaces", "symlink_rejected")
             continue
         if child.is_dir():
             agent_dirs.append(child)
     return agent_dirs
-
-
-def _openclaw_session_artifact(path: Path) -> bool:
-    name = path.name.casefold()
-    return (
-        name.endswith(".trajectory.jsonl")
-        or _OPENCLAW_CHECKPOINT_RE.search(name) is not None
-        or ".deleted." in name
-        or name.endswith(".deleted.jsonl")
-        or ".reset." in name
-        or name.endswith(".reset.jsonl")
-    )
-
-
-def _openclaw_registry_map(data: Any) -> dict[str, Any]:
-    if not isinstance(data, dict):
-        return {}
-    sessions = data.get("sessions")
-    if isinstance(sessions, dict):
-        return sessions
-    return data
-
-
-def _openclaw_entry_matches_file(entry: dict[str, Any], path: Path) -> bool:
-    references: list[Path] = []
-    session_id = entry.get("sessionId")
-    if isinstance(session_id, str) and session_id:
-        references.append(path.parent / f"{session_id}.jsonl")
-    session_file = entry.get("sessionFile")
-    if isinstance(session_file, str) and session_file:
-        referenced_file = Path(session_file)
-        references.append(
-            referenced_file if referenced_file.is_absolute() else path.parent / referenced_file
-        )
-    if not references:
-        return False
-    path_marker = os.path.normcase(os.path.abspath(str(path)))
-    return all(
-        os.path.normcase(os.path.abspath(str(reference))) == path_marker for reference in references
-    )
-
-
-def _openclaw_session_provenance_is_user_owned(
-    session_key: str,
-    entry: dict[str, Any],
-) -> bool:
-    namespaces = {part for part in re.split(r"[:/]", session_key.casefold()) if part}
-    if namespaces & _OPENCLAW_RUNTIME_NAMESPACES:
-        return False
-    created_via = entry.get("createdVia")
-    if not isinstance(created_via, str) or created_via.casefold() not in _OPENCLAW_CREATED_VIA:
-        return False
-    actor = entry.get("createdActor")
-    if not isinstance(actor, dict) or str(actor.get("type", "")).casefold() != "human":
-        return False
-    for key, value in entry.items():
-        folded = key.casefold().replace("_", "")
-        if (
-            folded.startswith("parent")
-            or folded.startswith("spawn")
-            or folded.startswith("runtime")
-            or folded in _OPENCLAW_SESSION_OWNERSHIP_FIELDS
-        ) and value not in (None, "", False, [], {}):
-            return False
-    return True
-
-
-def _openclaw_session_paths(scan: _Scan, agent_dirs: list[Path]) -> list[Path]:
-    accepted: list[Path] = []
-    remaining_entries = _MAX_FILES
-    for agent_dir in agent_dirs:
-        if remaining_entries <= 0:
-            break
-        sessions_root = agent_dir / "sessions"
-        if not sessions_root.is_dir() or _is_link_like(sessions_root):
-            if _is_link_like(sessions_root):
-                scan.diagnostic("sessions", "symlink_rejected")
-            continue
-        registry_path = sessions_root / "sessions.json"
-        registry: dict[str, Any] = {}
-        if registry_path.is_file():
-            registry = _openclaw_registry_map(
-                _read_json(registry_path, scan.root, scan, "sessions")
-            )
-        candidates: list[Path] = []
-        truncated = False
-        try:
-            for child in sessions_root.iterdir():
-                if remaining_entries <= 0:
-                    truncated = True
-                    break
-                remaining_entries -= 1
-                if child.name.casefold().endswith(".jsonl"):
-                    candidates.append(child)
-        except OSError:
-            continue
-        if truncated:
-            scan.diagnostic("sessions", "file_count_limit", count=1)
-        for path in sorted(candidates, key=lambda path: path.name.casefold()):
-            if _openclaw_session_artifact(path):
-                scan.diagnostic("sessions", "session_artifact_excluded")
-                continue
-            matches = [
-                (session_key, entry)
-                for session_key, entry in registry.items()
-                if isinstance(session_key, str)
-                and isinstance(entry, dict)
-                and _openclaw_entry_matches_file(entry, path)
-            ]
-            if len(matches) != 1:
-                scan.diagnostic(
-                    "sessions",
-                    "session_provenance_missing_or_ambiguous",
-                )
-                continue
-            session_key, entry = matches[0]
-            if not _openclaw_session_provenance_is_user_owned(session_key, entry):
-                scan.diagnostic("sessions", "session_provenance_rejected")
-                continue
-            if _safe_regular_file(path, scan.root, scan, "sessions"):
-                accepted.append(path)
-    if remaining_entries == 0:
-        scan.diagnostic("sessions", "file_count_limit", count=1)
-    return accepted
 
 
 def _openclaw_workspace_source(scan: _Scan, raw_path: str | Path) -> Path | None:
@@ -2399,15 +2106,6 @@ def _diagnose_openclaw_database(
 def _scan_openclaw(scan: _Scan) -> None:
     root = scan.root
     agent_dirs = _openclaw_agent_dirs(scan)
-    sessions = _openclaw_session_paths(scan, agent_dirs)
-    _add_sessions_and_workspaces(scan, sessions, root)
-    for agent_dir in agent_dirs:
-        _diagnose_openclaw_database(
-            scan,
-            agent_dir / "agent" / "openclaw-agent.sqlite",
-            "sessions",
-            "unsupported_session_database",
-        )
     _diagnose_openclaw_database(
         scan,
         root / "openclaw.sqlite",
@@ -2453,6 +2151,16 @@ def _scan_openclaw(scan: _Scan) -> None:
     _add_memory_files(
         scan,
         [(workspace / "MEMORY.md", workspace) for workspace in ordered_workspaces],
+    )
+    # SOUL.md's DIRECTIVE text becomes lessons; its persona ROLE is not imported
+    # (see _add_instruction_files). AGENTS.md is a plain instruction document.
+    _add_instruction_files(
+        scan,
+        [
+            (workspace / filename, workspace)
+            for workspace in ordered_workspaces
+            for filename in ("SOUL.md", "AGENTS.md")
+        ],
     )
     if (root / "agents").exists():
         scan.diagnostic("agents", "unsupported_category", unsupported=True)
@@ -2783,29 +2491,6 @@ def _scan_meshclaw_memory_db(scan: _Scan) -> bool:
     return True
 
 
-def _sqlite_visible_text(content: str) -> str:
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        return content
-    except RecursionError:
-        return ""
-    if isinstance(parsed, str):
-        return parsed
-    if isinstance(parsed, list):
-        return _extract_visible_content(parsed)
-    if isinstance(parsed, dict):
-        block_type = str(parsed.get("type", "")).lower()
-        if block_type in _NON_TEXT_TYPES:
-            return ""
-        if block_type in _VISIBLE_TEXT_TYPES:
-            return _extract_visible_content([parsed])
-        value = parsed.get("content")
-        if isinstance(value, (str, list)):
-            return _extract_visible_content(value) if isinstance(value, list) else value
-    return ""
-
-
 def _sqlite_workspace_values(
     connection: sqlite3.Connection,
     table: str,
@@ -2822,116 +2507,6 @@ def _sqlite_workspace_values(
         for (workspace,) in rows:
             if isinstance(workspace, str):
                 _workspace_item(scan, workspace)
-
-
-def _scan_hermes_db(scan: _Scan, root: Path) -> None:
-    candidates = [
-        path
-        for path in (root / "state.db", root / "hermes.db", root / "sessions.db")
-        if path.is_file()
-    ]
-    if not candidates:
-        return
-    path = candidates[0]
-    with _open_snapshot_db(path, root, scan, "sessions") as connection:
-        if connection is None:
-            return
-        try:
-            tables = {
-                str(row[0]) for row in connection.execute(_SQLITE_TABLE_NAMES_QUERY).fetchall()
-            }
-            if "messages" not in tables:
-                scan.diagnostic("sessions", "unsupported_database_schema", unsupported=True)
-                return
-            message_columns = _sqlite_columns(connection, "messages")
-            if not {"session_id", "role", "content"} <= message_columns:
-                scan.diagnostic("sessions", "missing_session_provenance", unsupported=True)
-                return
-            if "sessions" not in tables:
-                scan.diagnostic("sessions", "missing_session_provenance", unsupported=True)
-                return
-            session_columns = _sqlite_columns(connection, "sessions")
-            if not {"id", "source", "parent_session_id"} <= session_columns:
-                scan.diagnostic("sessions", "missing_session_provenance", unsupported=True)
-                return
-
-            workspace_columns = [
-                name
-                for name in ("cwd", "git_repo_root", "project_path", "workdir", "workspace")
-                if name in session_columns
-            ]
-            selected_session_columns = ["id", "source", "parent_session_id", *workspace_columns]
-            connection.execute("BEGIN")
-            session_rows = connection.execute(
-                "SELECT "
-                + ", ".join(f'"{name}"' for name in selected_session_columns)
-                + ' FROM "sessions" ORDER BY "id" LIMIT ?',
-                (_MAX_DB_ROWS + 1,),
-            ).fetchall()
-            if len(session_rows) > _MAX_DB_ROWS:
-                scan.diagnostic("sessions", "row_count_limit")
-                return
-
-            filters = ['"session_id" IS ?']
-            if "active" in message_columns:
-                filters.append('"active" = 1')
-            where = " WHERE " + " AND ".join(filters)
-            ordering = [
-                name for name in ("timestamp", "created_at", "id") if name in message_columns
-            ]
-            order_by = (
-                " ORDER BY " + ", ".join(f'"{name}"' for name in ordering) if ordering else ""
-            )
-            remaining_rows = _MAX_DB_ROWS
-            for row in session_rows:
-                values = dict(zip(selected_session_columns, row))
-                session_id = values["id"]
-                source = values["source"]
-                parent_session_id = values["parent_session_id"]
-                if not isinstance(source, str) or not source.strip():
-                    scan.diagnostic("sessions", "runtime_session_excluded")
-                    continue
-                if source.strip().casefold() in _HERMES_RUNTIME_SESSION_SOURCES:
-                    scan.diagnostic("sessions", "runtime_session_excluded")
-                    continue
-                if parent_session_id is not None:
-                    scan.diagnostic("sessions", "parented_session_excluded")
-                    continue
-
-                for column in workspace_columns:
-                    workspace = values.get(column)
-                    if isinstance(workspace, str):
-                        _workspace_item(scan, workspace)
-
-                rows = connection.execute(
-                    f'SELECT "role", "content" FROM "messages"{where}{order_by} LIMIT ?',
-                    (session_id, remaining_rows + 1),
-                ).fetchall()
-                if len(rows) > remaining_rows:
-                    scan.diagnostic("sessions", "row_count_limit")
-                    continue
-                remaining_rows -= len(rows)
-                messages: list[tuple[str, str]] = []
-                capped = False
-                for role, content in rows:
-                    if not isinstance(role, str) or role.casefold() not in _VISIBLE_ROLES:
-                        continue
-                    if not isinstance(content, str):
-                        continue
-                    cleaned = _sanitize_text(_sqlite_visible_text(content), scan)
-                    if not cleaned:
-                        continue
-                    if len(messages) >= _MAX_MESSAGES_PER_SESSION:
-                        capped = True
-                        continue
-                    messages.append((role.casefold(), cleaned))
-                if capped:
-                    scan.diagnostic("sessions", "message_count_limit")
-                    continue
-                if messages:
-                    scan.add("sessions", f"sqlite\0{session_id}", messages)
-        except sqlite3.Error:
-            scan.diagnostic("sessions", "unsupported_database_schema", unsupported=True)
 
 
 def _scan_hermes_projects_db(scan: _Scan, root: Path) -> None:
@@ -3045,8 +2620,6 @@ def _hermes_managed_skill_names(scan: _Scan, root: Path) -> frozenset[str]:
 
 def _scan_hermes(scan: _Scan) -> None:
     roots = _hermes_roots(scan)
-    for root in roots:
-        _scan_hermes_db(scan, root)
     _add_memory_files(
         scan,
         [
@@ -3055,6 +2628,7 @@ def _scan_hermes(scan: _Scan) -> None:
             for filename in ("MEMORY.md", "USER.md")
         ],
     )
+    _add_instruction_files(scan, [(root / "SOUL.md", root) for root in roots])
     unsupported_memory_databases = sum(
         int(os.path.lexists(root / "memory_store.db")) for root in roots
     )
@@ -3110,19 +2684,6 @@ def _scan_hermes(scan: _Scan) -> None:
 def _deduplicate_items(scan: _Scan) -> None:
     for category in CATEGORY_IDS:
         items = scan.items[category]
-        if category == "sessions":
-            canonical_by_transcript: dict[str, _Item] = {}
-            for item in items:
-                transcript = hashlib.sha256(
-                    json.dumps(item.payload, ensure_ascii=False, separators=(",", ":")).encode(
-                        "utf-8"
-                    )
-                ).hexdigest()
-                existing = canonical_by_transcript.get(transcript)
-                if existing is None or item.key < existing.key:
-                    canonical_by_transcript[transcript] = item
-            canonical_ids = {id(item) for item in canonical_by_transcript.values()}
-            items = [item for item in items if id(item) in canonical_ids]
         unique: list[_Item] = []
         seen: set[str] = set()
         for item in items:
@@ -3389,56 +2950,36 @@ def _record_ledger(
     records[item.fingerprint] = record
 
 
-def _session_destination_key(item: _Item) -> str:
-    return f"imported-{item.source_id}-{item.fingerprint[:16]}"
+def _write_instruction(item: _Item, lesson_store: Any) -> str:
+    """Append one imported directive to the highest-priority durable tier.
 
+    ``LessonStore.save`` is itself exact-rule deduplicating, so a re-import is
+    naturally idempotent; this reports ``existing`` for that case so the ledger
+    still records it and the outcome is ``deduplicated`` rather than a false
+    ``accepted``.
+    """
 
-def _write_session(item: _Item, conversation_log: Any) -> str:
-    key = _session_destination_key(item)
-    update_metadata = getattr(conversation_log, "update_metadata", None)
-    if not callable(update_metadata):
-        raise TypeError("conversation log does not support metadata updates")
-    lock_factory = getattr(conversation_log, "_locked", None)
-    lock = lock_factory(key) if callable(lock_factory) else nullcontext()
-    with lock:
-        has_log = getattr(conversation_log, "has_log", None)
-        if callable(has_log) and has_log(key):
-            read_messages = getattr(conversation_log, "read_messages", None)
-            rewrite_session = getattr(conversation_log, "rewrite_session", None)
-            if not callable(read_messages) or not callable(rewrite_session):
-                update_metadata(key, {"closed": True})
+    if lesson_store is None:
+        return "rejected"
+    rule = str(item.payload.get("rule", "")).strip()
+    if not rule:
+        return "rejected"
+    from kiro_crew.learn import Lesson
+
+    load_all = getattr(lesson_store, "load_all", None)
+    if callable(load_all):
+        normalized = rule.lower()
+        for existing in load_all():
+            if str(getattr(existing, "rule", "")).lower().strip() == normalized:
                 return "existing"
-            existing = read_messages(key)
-            expected = [{"role": role, "content": content} for role, content in item.payload]
-            normalized = [
-                {"role": message.get("role"), "content": message.get("content")}
-                for message in existing
-                if isinstance(message, dict)
-            ]
-            if normalized == expected:
-                update_metadata(key, {"closed": True})
-                return "existing"
-            if len(normalized) < len(expected) and normalized == expected[: len(normalized)]:
-                rewrite_session(key, expected)
-                update_metadata(key, {"closed": True})
-                return "imported"
-            return "conflict"
-        init = getattr(conversation_log, "init", None)
-        if callable(init):
-            init()
-        try:
-            for role, content in item.payload:
-                conversation_log.append(key, role, content)
-            update_metadata(key, {"closed": True})
-        except BaseException:
-            delete_session = getattr(conversation_log, "delete_session", None)
-            if callable(delete_session):
-                try:
-                    delete_session(key)
-                except Exception:
-                    logger.warning("Failed to roll back imported session", exc_info=True)
-            raise
-        return "imported"
+    lesson_store.save(
+        Lesson(
+            ts=datetime.now(timezone.utc).isoformat(),
+            rule=rule,
+            category="preference",
+        )
+    )
+    return "imported"
 
 
 def _write_memory(
@@ -3711,9 +3252,9 @@ def apply_import(
     plan: dict[str, Any],
     *,
     data_home: Path | None = None,
-    conversation_log: Any = None,
     cron_service: Any = None,
     vector_store: VectorMemoryStore | None = None,
+    lesson_store: Any = None,
 ) -> dict[str, Any]:
     """Apply selected source/category pairs with merge-only, idempotent writes."""
     destination = Path(data_home) if data_home is not None else config_dir()
@@ -3726,6 +3267,12 @@ def apply_import(
     ledger_path = destination / _LEDGER_RELATIVE_PATH
     ledger = _load_ledger(ledger_path)
     records = ledger["records"]
+    # The ledger is rewritten WHOLE (atomic temp-file + rename), so flushing it
+    # once per item is O(n**2) in serialization and rename cost for a large
+    # import. Flush once per source/category instead, and once more in the
+    # ``finally`` below, so an interrupted apply still cannot re-import an item
+    # it already wrote.
+    ledger_dirty = False
     imported = {category: 0 for category in CATEGORY_IDS}
     already_imported = 0
     item_outcomes: list[dict[str, str]] = []
@@ -3761,14 +3308,14 @@ def apply_import(
                 if diagnostic not in skipped:
                     skipped.append(diagnostic)
 
-    if conversation_log is None and any(category == "sessions" for _source, category in selected):
-        from kiro_crew.history import ConversationLog
-
-        conversation_log = ConversationLog(destination / "sessions")
     if cron_service is None and any(category == "schedules" for _source, category in selected):
         from kiro_crew.cron import CronService
 
         cron_service = CronService(base_dir=destination)
+    if lesson_store is None and any(category == "instructions" for _source, category in selected):
+        from kiro_crew.learn import LessonStore
+
+        lesson_store = LessonStore(base_dir=destination)
 
     owned_vector_store: VectorMemoryStore | None = None
     needs_vector_store = any(
@@ -3782,6 +3329,12 @@ def apply_import(
         owned_vector_store.embed_fn = make_sync_embed_fn()
         owned_vector_store.init()
         vector_store = owned_vector_store
+
+    def _flush_ledger() -> None:
+        nonlocal ledger_dirty
+        if ledger_dirty:
+            _write_json(ledger_path, ledger)
+            ledger_dirty = False
 
     try:
         for source_id, category in sorted(selected):
@@ -3800,8 +3353,8 @@ def apply_import(
                     continue
                 status = "skipped"
                 try:
-                    if category == "sessions":
-                        status = _write_session(item, conversation_log)
+                    if category == "instructions":
+                        status = _write_instruction(item, lesson_store)
                     elif category == "memories":
                         status = _write_memory(item, destination, vector_store)
                     elif category == "workspaces":
@@ -3831,14 +3384,8 @@ def apply_import(
                     item_outcomes.append({**outcome, "outcome": "rejected"})
                     continue
                 if status in ("imported", "existing"):
-                    _record_ledger(
-                        ledger,
-                        item,
-                        destination_key=(
-                            _session_destination_key(item) if category == "sessions" else ""
-                        ),
-                    )
-                    _write_json(ledger_path, ledger)
+                    _record_ledger(ledger, item)
+                    ledger_dirty = True
                     if status == "imported":
                         imported[category] += 1
                         item_outcomes.append({**outcome, "outcome": "accepted"})
@@ -3863,7 +3410,9 @@ def apply_import(
                         }
                     )
                     item_outcomes.append({**outcome, "outcome": "rejected"})
+            _flush_ledger()
     finally:
+        _flush_ledger()
         if owned_vector_store is not None:
             owned_vector_store.close()
 

--- a/test/test_api_onboarding_import.py
+++ b/test/test_api_onboarding_import.py
@@ -92,8 +92,8 @@ async def test_scan_runs_preview_off_event_loop_and_returns_result(monkeypatch) 
                     "root": "/Users/alice/.claude",
                     "categories": [
                         {
-                            "id": "sessions",
-                            "label": "Sessions",
+                            "id": "skills",
+                            "label": "Skills",
                             "count": 2,
                             "selected": True,
                         }
@@ -102,7 +102,7 @@ async def test_scan_runs_preview_off_event_loop_and_returns_result(monkeypatch) 
             ],
             "source_ids": source_ids,
             "off_thread": threading.get_ident() != event_loop_thread,
-            "selection": [{"source_id": "claude_code", "category_id": "sessions"}],
+            "selection": [{"source_id": "claude_code", "category_id": "skills"}],
             "skipped": [
                 {
                     "source_id": "claude_code",
@@ -131,10 +131,10 @@ async def test_scan_runs_preview_off_event_loop_and_returns_result(monkeypatch) 
                 "detected": True,
                 "categories": [
                     {
-                        "id": "sessions",
-                        "label": "Sessions",
+                        "id": "skills",
+                        "label": "Skills",
                         "count": 2,
-                        "description": "Visible user and assistant messages",
+                        "description": "User-authored skills and supporting files",
                     }
                 ],
             }
@@ -167,10 +167,10 @@ async def test_scan_runs_preview_off_event_loop_and_returns_result(monkeypatch) 
         {},
         {"sources": "claude_code"},
         {"sources": []},
-        {"sources": [{"id": "", "categories": ["sessions"]}]},
-        {"sources": [{"id": "claude_code", "categories": "sessions"}]},
+        {"sources": [{"id": "", "categories": ["skills"]}]},
+        {"sources": [{"id": "claude_code", "categories": "skills"}]},
         {"sources": [{"id": "claude_code", "categories": []}]},
-        {"sources": [{"id": "unknown", "categories": ["sessions"]}]},
+        {"sources": [{"id": "unknown", "categories": ["skills"]}]},
         {"sources": [{"id": "claude_code", "categories": ["unknown"]}]},
     ],
 )
@@ -220,17 +220,17 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
     module = _handler_module()
     audit = _AuditLog()
     event_loop_thread = threading.get_ident()
-    conversation_log = object()
     cron_service = object()
     vector_memory = object()
+    lesson_store = object()
     state = SimpleNamespace(
-        conversation_log=conversation_log,
         crons=cron_service,
+        lessons=lesson_store,
         context_builder=SimpleNamespace(memory=SimpleNamespace(vector_store=vector_memory)),
     )
     request_body = {
         "sources": [
-            {"id": "claude_code", "categories": ["sessions", "memories"]},
+            {"id": "claude_code", "categories": ["skills", "memories"]},
         ]
     }
     fresh_plan = {
@@ -238,16 +238,16 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
             {
                 "id": "claude_code",
                 "categories": [
-                    {"id": "sessions", "selected": True},
-                    {"id": "memories", "selected": True},
                     {"id": "skills", "selected": True},
+                    {"id": "memories", "selected": True},
+                    {"id": "workspaces", "selected": True},
                 ],
             }
         ],
         "selection": [
-            {"source_id": "claude_code", "category_id": "sessions"},
-            {"source_id": "claude_code", "category_id": "memories"},
             {"source_id": "claude_code", "category_id": "skills"},
+            {"source_id": "claude_code", "category_id": "memories"},
+            {"source_id": "claude_code", "category_id": "workspaces"},
         ],
     }
     preview_calls: list[list[str] | None] = []
@@ -259,9 +259,9 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
 
     def apply_import(
         received_plan,
-        conversation_log=None,
         cron_service=None,
         vector_store=None,
+        lesson_store=None,
     ):
         received.update(
             {
@@ -269,14 +269,14 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
                 "category_selections": [
                     category["selected"] for category in received_plan["sources"][0]["categories"]
                 ],
-                "has_conversation_log": conversation_log is state.conversation_log,
                 "has_cron_service": cron_service is state.crons,
                 "has_vector_store": vector_store is state.context_builder.memory.vector_store,
+                "has_lesson_store": lesson_store is state.lessons,
                 "off_thread": threading.get_ident() != event_loop_thread,
             }
         )
         return {
-            "imported": {"sessions": 2, "memories": 1},
+            "imported": {"skills": 2, "memories": 1},
             "imported_count": 3,
             "already_imported": 1,
             "conflicts": [{"reason": "destination_conflict"}],
@@ -285,13 +285,13 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
             "item_outcomes": [
                 {
                     "source_id": "claude_code",
-                    "category_id": "sessions",
+                    "category_id": "skills",
                     "item_hash": "a" * 64,
                     "outcome": "accepted",
                 },
                 {
                     "source_id": "claude_code",
-                    "category_id": "sessions",
+                    "category_id": "skills",
                     "item_hash": "b" * 64,
                     "outcome": "deduplicated",
                 },
@@ -324,13 +324,13 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
     }
     assert received == {
         "selection": [
-            {"source_id": "claude_code", "category_id": "sessions"},
+            {"source_id": "claude_code", "category_id": "skills"},
             {"source_id": "claude_code", "category_id": "memories"},
         ],
         "category_selections": [True, True, False],
-        "has_conversation_log": True,
         "has_cron_service": True,
         "has_vector_store": True,
+        "has_lesson_store": True,
         "off_thread": True,
     }
     assert preview_calls == [["claude_code"]]
@@ -338,7 +338,7 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
         event for event in audit.events if event["operation"] == "onboarding.import.item"
     ]
     assert [event["outcome"] for event in item_events] == ["accepted", "deduplicated"]
-    assert item_events[0]["resources"] == f"claude_code:sessions:{'a' * 64}"
+    assert item_events[0]["resources"] == f"claude_code:skills:{'a' * 64}"
     assert audit.events[-1]["outcome"] == "completed"
 
 
@@ -450,16 +450,16 @@ async def test_apply_uses_none_for_unavailable_state_dependencies(monkeypatch) -
 
     def apply_import(
         plan,
-        conversation_log=None,
         cron_service=None,
         vector_store=None,
+        lesson_store=None,
     ):
         received.update(
             {
                 "plan": plan,
-                "conversation_log": conversation_log,
                 "cron_service": cron_service,
                 "vector_store": vector_store,
+                "lesson_store": lesson_store,
             }
         )
         return {"ok": True}
@@ -501,9 +501,9 @@ async def test_apply_uses_none_for_unavailable_state_dependencies(monkeypatch) -
             ],
             "selection": [{"source_id": "codex", "category_id": "settings"}],
         },
-        "conversation_log": None,
         "cron_service": None,
         "vector_store": None,
+        "lesson_store": None,
     }
 
 
@@ -580,7 +580,7 @@ async def test_import_failures_do_not_expose_private_details(
     monkeypatch.setattr(module, "_sel", lambda: audit)
     kwargs: dict[str, object] = {"headers": {"X-Test-User": "owner"}}
     if method == "post":
-        kwargs["json"] = {"sources": [{"id": "claude_code", "categories": ["sessions"]}]}
+        kwargs["json"] = {"sources": [{"id": "claude_code", "categories": ["skills"]}]}
 
     async with TestClient(TestServer(_make_app(module))) as client:
         response = await getattr(client, method)(path, **kwargs)

--- a/test/test_onboarding_import.py
+++ b/test/test_onboarding_import.py
@@ -15,7 +15,6 @@ from typing import Any
 import pytest
 
 from kiro_crew.cron import CronService
-from kiro_crew.history import ConversationLog
 from kiro_crew.vector_memory import VectorMemoryStore
 
 
@@ -148,7 +147,7 @@ class TestSourceDetection:
             "hermes",
         )
         assert api.CATEGORY_IDS == (
-            "sessions",
+            "instructions",
             "memories",
             "workspaces",
             "mcp_servers",
@@ -325,28 +324,7 @@ class TestPreview:
         project.mkdir(parents=True)
         secret = "sk-ant-api03-this-must-never-leave-preview"
         project_toml = str(project).replace("\\", "\\\\")
-        _write_jsonl(
-            codex / "sessions" / "2026" / "rollout.jsonl",
-            [
-                {
-                    "type": "response_item",
-                    "payload": {
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": "private prompt"}],
-                    },
-                    "cwd": str(project),
-                },
-                {
-                    "type": "response_item",
-                    "payload": {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [{"type": "output_text", "text": "private answer"}],
-                    },
-                },
-            ],
-        )
+        codex.mkdir(parents=True, exist_ok=True)
         (codex / "config.toml").write_text(
             "\n".join(
                 [
@@ -371,7 +349,6 @@ class TestPreview:
         serialized = json.dumps(plan)
 
         assert counts == {
-            "sessions": 1,
             "workspaces": 1,
             "skills": 1,
         }
@@ -385,8 +362,6 @@ class TestPreview:
         )
         assert "telemetry" not in serialized
         assert secret not in serialized
-        assert str(project) not in serialized
-        assert "private prompt" not in serialized
         assert plan["secret_count"] >= 2
 
     def test_codex_archives_user_skills_and_unstable_memory_are_classified(
@@ -394,10 +369,7 @@ class TestPreview:
     ) -> None:
         home = tmp_path / "home"
         codex = home / ".codex"
-        _write_jsonl(
-            codex / "archived_sessions" / "archived.jsonl",
-            [{"role": "user", "content": "archived question"}],
-        )
+        codex.mkdir(parents=True, exist_ok=True)
         (codex / "memories_1.sqlite").write_bytes(b"not a stable public schema")
         bundled_skill = codex / "skills" / ".system" / "bundled"
         bundled_skill.mkdir(parents=True)
@@ -408,7 +380,7 @@ class TestPreview:
 
         plan = _api().preview_import(home=home, env={})
 
-        assert _categories(plan, "codex") == {"sessions": 1, "skills": 1}
+        assert _categories(plan, "codex") == {"skills": 1}
         assert plan["unsupported_count"] >= 1
         assert any(
             item["source_id"] == "codex"
@@ -486,161 +458,12 @@ class TestPreview:
             for item in plan["skipped"]
         )
 
-    def test_jsonl_line_limit_excludes_entire_incomplete_file(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_JSONL_LINES", 2)
-        _write_jsonl(
-            tmp_path / "home" / ".meshclaw" / "sessions" / "truncated.jsonl",
-            [
-                {"session_id": "chat", "role": "user", "content": "first message"},
-                {"session_id": "chat", "role": "assistant", "content": "second message"},
-                {"session_id": "chat", "role": "user", "content": "unread message"},
-            ],
-        )
-
-        plan = api.preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "meshclaw")
-        assert any(
-            item["source_id"] == "meshclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "line_count_limit"
-            for item in plan["skipped"]
-        )
-
-    def test_malformed_jsonl_excludes_entire_file_and_its_workspaces(self, tmp_path: Path) -> None:
-        workspace = tmp_path / "project"
-        workspace.mkdir()
-        transcript = tmp_path / "home" / ".meshclaw" / "sessions" / "partial.jsonl"
-        transcript.parent.mkdir(parents=True)
-        transcript.write_text(
-            json.dumps(
-                {
-                    "role": "user",
-                    "content": "valid prefix",
-                    "cwd": str(workspace),
-                }
-            )
-            + "\n"
-            + '{"role":"assistant","content":"partial',
-            encoding="utf-8",
-        )
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "meshclaw")
-        assert "workspaces" not in _categories(plan, "meshclaw")
-        assert any(
-            item["source_id"] == "meshclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "invalid_jsonl_record"
-            for item in plan["skipped"]
-        )
-
-    def test_jsonl_message_limit_excludes_only_capped_conversation(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_MESSAGES_PER_SESSION", 1)
-        _write_jsonl(
-            tmp_path / "home" / ".meshclaw" / "sessions" / "capped.jsonl",
-            [
-                {"session_id": "capped", "role": "user", "content": "first capped message"},
-                {"session_id": "capped", "role": "assistant", "content": "second capped message"},
-                {"session_id": "complete", "role": "user", "content": "complete message"},
-            ],
-        )
-
-        plan = _select(
-            api.preview_import(home=tmp_path / "home", env={}),
-            ("meshclaw", "sessions"),
-        )
-        result = api.apply_import(plan, data_home=tmp_path / "destination")
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
-
-        assert _categories(api.preview_import(home=tmp_path / "home", env={}), "meshclaw") == {
-            "sessions": 1
-        }
-        assert "complete message" in persisted
-        assert "first capped message" not in persisted
-        assert "second capped message" not in persisted
-        assert result["imported"]["sessions"] == 1
-        assert any(
-            item["source_id"] == "meshclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "message_count_limit"
-            for item in result["skipped"]
-        )
-
-    def test_mirrored_transcripts_deduplicate_without_changing_growing_file_identity(
-        self, tmp_path: Path
-    ) -> None:
-        home = tmp_path / "home"
-        sessions = home / ".meshclaw" / "sessions"
-        primary = sessions / "a-primary.jsonl"
-        mirror = sessions / "z-mirror.jsonl"
-        _write_jsonl(
-            primary,
-            [
-                {"role": "user", "content": "What is the release status?"},
-                {"role": "assistant", "content": "The release is ready."},
-            ],
-        )
-        _write_jsonl(
-            mirror,
-            [
-                {
-                    "payload": {
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": "What is the release status?"}],
-                    }
-                },
-                {
-                    "payload": {
-                        "role": "assistant",
-                        "content": [{"type": "output_text", "text": "The release is ready."}],
-                    }
-                },
-            ],
-        )
-        primary_stat = primary.stat()
-        os.utime(mirror, ns=(primary_stat.st_atime_ns, primary_stat.st_mtime_ns + 1_000_000))
-
-        first_plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-        )
-        first = _api().apply_import(first_plan, data_home=tmp_path / "destination")
-        mirror.unlink()
-        with primary.open("a", encoding="utf-8") as stream:
-            stream.write(json.dumps({"role": "assistant", "content": "A later update."}) + "\n")
-        second_plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-        )
-        second = _api().apply_import(second_plan, data_home=tmp_path / "destination")
-        session_files = list((tmp_path / "destination" / "sessions").glob("*.jsonl"))
-        persisted = "\n".join(path.read_text(encoding="utf-8") for path in session_files)
-
-        assert _categories(_api().preview_import(home=home, env={}), "meshclaw") == {"sessions": 1}
-        assert first["imported"]["sessions"] == 1
-        assert second["imported"]["sessions"] == 0
-        assert second["already_imported"] >= 1
-        assert len(session_files) == 1
-        assert "A later update." not in persisted
-
     def test_source_filter_limits_preview_and_selection(self, tmp_path: Path) -> None:
         home = tmp_path / "home"
-        _write_jsonl(home / ".codex" / "sessions" / "a.jsonl", [{"role": "user", "content": "x"}])
-        _write_jsonl(
-            home / ".meshclaw" / "sessions" / "b.jsonl",
-            [{"role": "user", "content": "y"}],
-        )
+        for root, name in ((home / ".codex", "codex-skill"), (home / ".meshclaw", "mc-skill")):
+            skill = root / ("skills" if name.startswith("codex") else "workspace/skills") / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
 
         plan = _api().preview_import(source_ids=["meshclaw"], home=home, env={})
 
@@ -759,37 +582,24 @@ class TestPreview:
         plan = _api().preview_import(home=home, env={})
 
         assert _categories(plan, "claude_code") == {
-            "sessions": 1,
             "memories": 1,
             "workspaces": 1,
             "mcp_servers": 1,
             "skills": 1,
         }
         assert _categories(plan, "openclaw") == {
-            "sessions": 1,
             "mcp_servers": 1,
             "schedules": 1,
             "settings": 1,
         }
+        # Hermes workspaces used to be recovered from the session database's
+        # ``cwd`` column; with transcripts out of scope only ``projects.db`` and
+        # explicit config contribute workspaces, and this fixture has neither.
         assert _categories(plan, "hermes") == {
-            "sessions": 1,
-            "workspaces": 1,
             "mcp_servers": 1,
             "skills": 1,
             "settings": 1,
         }
-
-    def test_unknown_hermes_database_schema_is_diagnosed_not_guessed(self, tmp_path: Path) -> None:
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "hermes.db") as connection:
-            connection.execute("CREATE TABLE opaque_state (payload BLOB)")
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "hermes")
-        assert plan["unsupported_count"] >= 1
-        assert any(item["source_id"] == "hermes" for item in plan["skipped"])
 
     def test_openclaw_nested_mcp_and_current_session_db_are_classified(
         self, tmp_path: Path
@@ -808,12 +618,9 @@ class TestPreview:
         plan = _api().preview_import(home=tmp_path / "home", env={})
 
         assert _categories(plan, "openclaw") == {"mcp_servers": 1}
-        assert any(
-            item["source_id"] == "openclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "unsupported_session_database"
-            for item in plan["skipped"]
-        )
+        # Conversation history is not an import category, so the agent's session
+        # database is neither opened nor reported.
+        assert not any(item["category_id"] == "sessions" for item in plan["skipped"])
 
     def test_openclaw_reads_explicit_and_legacy_config_paths(self, tmp_path: Path) -> None:
         state = tmp_path / "openclaw-state"
@@ -939,155 +746,6 @@ class TestPreview:
             for item in plan["skipped"]
         )
 
-    @pytest.mark.parametrize("created_via", ["operator", "channel", "talk"])
-    def test_openclaw_imports_registry_backed_human_sessions(
-        self, tmp_path: Path, created_via: str
-    ) -> None:
-        state = tmp_path / "home" / ".openclaw"
-        _write_openclaw_session(
-            state,
-            session_id=created_via,
-            entry_updates={"createdVia": created_via},
-        )
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert _categories(plan, "openclaw") == {"sessions": 1}
-
-    @pytest.mark.parametrize(
-        ("session_key", "entry_updates"),
-        [
-            ("agent:main:main", {"createdVia": "api"}),
-            ("agent:main:main", {"createdActor": {"type": "agent"}}),
-            ("agent:main:main", {"parentSessionKey": "agent:main:parent"}),
-            ("agent:main:main", {"spawnedBy": "agent:main:parent"}),
-            ("agent:main:main", {"runtimeOwner": "gateway"}),
-            ("agent:main:main", {"completionOwnerSessionKey": "agent:main:parent"}),
-            ("agent:main:main", {"pluginOwnerId": "runtime-plugin"}),
-            (
-                "agent:main:main",
-                {
-                    "forkSource": {
-                        "sessionKey": "agent:main:parent",
-                        "sessionId": "parent-session",
-                    }
-                },
-            ),
-            ("cron:daily", {}),
-            ("agent:main:subagent:worker", {}),
-            ("acp:main", {}),
-            ("acp-bridge:main", {}),
-            ("hook:stop", {}),
-            ("node:worker", {}),
-            ("heartbeat:main", {}),
-            ("internal-session-effects:main", {}),
-        ],
-        ids=[
-            "created-via",
-            "nonhuman-actor",
-            "parented",
-            "spawned",
-            "runtime-owned",
-            "completion-owned",
-            "plugin-owned",
-            "fork-lineage",
-            "cron-key",
-            "subagent-key",
-            "acp-key",
-            "acp-bridge-key",
-            "hook-key",
-            "node-key",
-            "heartbeat-key",
-            "internal-effects-key",
-        ],
-    )
-    def test_openclaw_rejects_non_user_session_provenance(
-        self,
-        tmp_path: Path,
-        session_key: str,
-        entry_updates: dict[str, object],
-    ) -> None:
-        state = tmp_path / "home" / ".openclaw"
-        _write_openclaw_session(
-            state,
-            session_key=session_key,
-            entry_updates=entry_updates,
-        )
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "openclaw")
-        assert any(
-            item["source_id"] == "openclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "session_provenance_rejected"
-            for item in plan["skipped"]
-        )
-
-    def test_openclaw_rejects_missing_and_ambiguous_session_provenance(
-        self, tmp_path: Path
-    ) -> None:
-        missing_state = tmp_path / "missing-home" / ".openclaw"
-        _write_jsonl(
-            missing_state / "agents" / "main" / "sessions" / "orphan.jsonl",
-            [{"role": "user", "content": "orphaned session"}],
-        )
-        ambiguous_state = tmp_path / "ambiguous-home" / ".openclaw"
-        transcript = _write_openclaw_session(ambiguous_state)
-        entry = {
-            "sessionId": transcript.stem,
-            "sessionFile": transcript.name,
-            "createdVia": "operator",
-            "createdActor": {"type": "human"},
-        }
-        (transcript.parent / "sessions.json").write_text(
-            json.dumps(
-                {
-                    "agent:main:one": entry,
-                    "agent:main:two": entry,
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        missing_plan = _api().preview_import(home=tmp_path / "missing-home", env={})
-        ambiguous_plan = _api().preview_import(home=tmp_path / "ambiguous-home", env={})
-
-        for plan in (missing_plan, ambiguous_plan):
-            assert "sessions" not in _categories(plan, "openclaw")
-            assert any(
-                item["source_id"] == "openclaw"
-                and item["category_id"] == "sessions"
-                and item["reason"] == "session_provenance_missing_or_ambiguous"
-                for item in plan["skipped"]
-            )
-
-    @pytest.mark.parametrize(
-        "filename",
-        [
-            "session.trajectory.jsonl",
-            "session.checkpoint.123e4567-e89b-12d3-a456-426614174000.jsonl",
-            "session.deleted.2026-07-26.jsonl",
-            "session.reset.2026-07-26.jsonl",
-        ],
-        ids=["trajectory", "checkpoint", "deleted-archive", "reset-archive"],
-    )
-    def test_openclaw_excludes_session_artifacts_and_archives(
-        self, tmp_path: Path, filename: str
-    ) -> None:
-        state = tmp_path / "home" / ".openclaw"
-        transcript = _write_openclaw_session(state)
-        artifact = transcript.with_name(filename)
-        transcript.rename(artifact)
-        registry = json.loads((artifact.parent / "sessions.json").read_text(encoding="utf-8"))
-        registry["agent:main:main"]["sessionId"] = artifact.name[: -len(".jsonl")]
-        registry["agent:main:main"]["sessionFile"] = artifact.name
-        (artifact.parent / "sessions.json").write_text(json.dumps(registry), encoding="utf-8")
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "openclaw")
-
     def test_openclaw_canonical_databases_are_safely_diagnosed_not_opened(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1108,12 +766,18 @@ class TestPreview:
 
         plan = api.preview_import(home=tmp_path / "home", env={})
 
+        # The agent session database is no longer probed at all (transcripts are
+        # out of scope), so only the schedule database is diagnosed here. The
+        # monkeypatched ``sqlite3.connect`` still guards the real invariant: an
+        # unsupported database must be classified from its filesystem metadata
+        # without ever being opened.
         assert any(
             item["source_id"] == "openclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "unsafe_database_sidecar"
+            and item["category_id"] == "schedules"
+            and item["reason"] == "unsupported_schedule_database"
             for item in plan["skipped"]
         )
+        assert not any(item["category_id"] == "sessions" for item in plan["skipped"])
         assert any(
             item["source_id"] == "openclaw"
             and item["category_id"] == "schedules"
@@ -1141,7 +805,7 @@ class TestPreview:
                 f"Remember {skill_name}.",
                 encoding="utf-8",
             )
-            (workspace / "AGENTS.md").write_text("Do not import instructions.\n", encoding="utf-8")
+            (workspace / "AGENTS.md").write_text("Always run the tests.\n", encoding="utf-8")
         state.mkdir(parents=True, exist_ok=True)
         (state / "openclaw.json").write_text(
             json.dumps(
@@ -1164,11 +828,15 @@ class TestPreview:
         plan = _api().preview_import(home=tmp_path / "home", env={})
 
         assert _categories(plan, "openclaw") == {
+            "instructions": 1,
             "memories": 3,
             "workspaces": 3,
             "skills": 3,
         }
-        assert not any(
+        # Identical AGENTS.md text across three workspaces collapses to ONE
+        # directive: the instruction key carries a content digest, so the
+        # in-scan dedupe folds the duplicates.
+        assert any(
             item["source_id"] == "openclaw" and item["category_id"] == "instructions"
             for item in plan["selection"]
         )
@@ -1536,245 +1204,43 @@ class TestPreview:
             for item in plan["skipped"]
         )
 
-    def test_claude_runtime_files_do_not_consume_the_session_file_cap(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_claude_rules_and_project_instructions_are_imported(self, tmp_path: Path) -> None:
         api = _api()
-        monkeypatch.setattr(api, "_MAX_FILES", 1)
-        projects = tmp_path / "home" / ".claude" / "projects" / "project"
-        live = projects / "chat.jsonl"
-        runtime = projects / "subagents" / "worker.jsonl"
-        _write_jsonl(live, [{"role": "user", "content": "live conversation"}])
-        _write_jsonl(runtime, [{"role": "user", "content": "runtime conversation"}])
-        os.utime(live, ns=(1_000_000_000, 1_000_000_000))
-        os.utime(runtime, ns=(2_000_000_000, 2_000_000_000))
-
-        plan = api.preview_import(home=tmp_path / "home", env={})
-
-        assert _categories(plan, "claude_code") == {"sessions": 1}
-        assert any(
-            item["source_id"] == "claude_code"
-            and item["category_id"] == "runtime"
-            and item["reason"] == "runtime_sessions_excluded"
-            and item["count"] == 1
-            for item in plan["skipped"]
-        )
-
-    def test_session_file_cap_keeps_newest_files(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_FILES", 1)
-        projects = tmp_path / "home" / ".claude" / "projects" / "project"
-        older = projects / "a-old.jsonl"
-        newer = projects / "z-new.jsonl"
-        _write_jsonl(older, [{"role": "user", "content": "old"}])
-        _write_jsonl(newer, [{"role": "user", "content": "new"}])
-        os.utime(older, ns=(1_000_000_000, 1_000_000_000))
-        os.utime(newer, ns=(2_000_000_000, 2_000_000_000))
-
-        scan = api._scan_source(
-            "claude_code",
-            tmp_path / "home" / ".claude",
-            tmp_path / "home",
-        )
-
-        assert [message[1] for message in scan.items["sessions"][0].payload] == ["new"]
-
-    def test_claude_excludes_synthetic_sidechain_meta_and_tool_result_records(
-        self, tmp_path: Path
-    ) -> None:
-        home = tmp_path / "home"
-        transcript = home / ".claude" / "projects" / "project" / "chat.jsonl"
-        _write_jsonl(
-            transcript,
-            [
-                {
-                    "type": "user",
-                    "userType": "external",
-                    "message": {"role": "user", "content": "visible external question"},
-                },
-                {
-                    "type": "assistant",
-                    "message": {"role": "assistant", "content": "visible assistant answer"},
-                },
-                {
-                    "type": "user",
-                    "isMeta": True,
-                    "message": {"role": "user", "content": "hidden metadata text"},
-                },
-                {
-                    "type": "assistant",
-                    "isSidechain": True,
-                    "message": {"role": "assistant", "content": "hidden sidechain text"},
-                },
-                {
-                    "type": "user",
-                    "toolUseResult": {"status": "complete"},
-                    "message": {"role": "user", "content": "hidden tool result text"},
-                },
-                {
-                    "type": "user",
-                    "userType": "internal",
-                    "message": {"role": "user", "content": "hidden internal user text"},
-                },
-            ],
-        )
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("claude_code", "sessions"),
-        )
-
-        _api().apply_import(plan, data_home=tmp_path / "destination")
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
-
-        assert "visible external question" in persisted
-        assert "visible assistant answer" in persisted
-        assert "hidden metadata text" not in persisted
-        assert "hidden sidechain text" not in persisted
-        assert "hidden tool result text" not in persisted
-        assert "hidden internal user text" not in persisted
-
-    def test_claude_discovers_user_skills_from_transcript_workspace(self, tmp_path: Path) -> None:
-        home = tmp_path / "home"
-        workspace = tmp_path / "project"
-        workspace.mkdir()
-        _write_jsonl(
-            home / ".claude" / "projects" / "encoded-project" / "chat.jsonl",
-            [{"role": "user", "content": "hello", "cwd": str(workspace)}],
-        )
-        skill = workspace / ".claude" / "skills" / "review"
-        skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text("# Workspace review\n", encoding="utf-8")
-
-        plan = _api().preview_import(home=home, env={})
-
-        assert _categories(plan, "claude_code") == {
-            "sessions": 1,
-            "workspaces": 1,
-            "skills": 1,
-        }
-
-    def test_codex_session_record_contributes_all_scalar_and_workspace_roots(
-        self, tmp_path: Path
-    ) -> None:
-        home = tmp_path / "home"
-        workspaces = [tmp_path / f"workspace-{index}" for index in range(7)]
-        for workspace in workspaces:
-            workspace.mkdir()
-        _write_jsonl(
-            home / ".codex" / "sessions" / "rollout.jsonl",
-            [
-                {
-                    "type": "response_item",
-                    "cwd": str(workspaces[0]),
-                    "project": str(workspaces[1]),
-                    "payload": {
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": "inspect every workspace"}],
-                        "project_path": str(workspaces[2]),
-                        "workspace_path": str(workspaces[3]),
-                        "projectPath": str(workspaces[4]),
-                        "workspace_roots": [
-                            str(workspaces[5]),
-                            str(workspaces[6]),
-                        ],
-                    },
-                }
-            ],
-        )
-
-        plan = _api().preview_import(home=home, env={})
-
-        assert _categories(plan, "codex") == {
-            "sessions": 1,
-            "workspaces": 7,
-        }
-
-    def test_claude_loads_project_configs_from_transcript_workspace(self, tmp_path: Path) -> None:
         home = tmp_path / "home"
         claude = home / ".claude"
         workspace = tmp_path / "project"
         workspace.mkdir()
-        _write_jsonl(
-            claude / "projects" / "encoded-project" / "chat.jsonl",
-            [
-                {
-                    "type": "user",
-                    "message": {"role": "user", "content": "workspace question"},
-                    "cwd": str(workspace),
-                }
-            ],
+        claude.mkdir(parents=True, exist_ok=True)
+        (claude / ".claude.json").write_text(
+            json.dumps({"projects": {str(workspace): {}}}), encoding="utf-8"
         )
-        (workspace / ".mcp.json").write_text(
-            json.dumps({"mcpServers": {"workspace-helper": {"command": "workspace-mcp"}}}),
-            encoding="utf-8",
-        )
-        project_settings = workspace / ".claude"
-        project_settings.mkdir()
-        (project_settings / "settings.json").write_text(
-            json.dumps({"dashboard": {"theme_mode": "dark"}}),
-            encoding="utf-8",
-        )
-        (project_settings / "settings.local.json").write_text(
-            json.dumps({"dashboard": {"theme_mode": "light"}}),
-            encoding="utf-8",
-        )
-
-        plan = _api().preview_import(home=home, env={})
-        selected = _select(
-            plan,
-            ("claude_code", "mcp_servers"),
-            ("claude_code", "settings"),
-        )
-        _api().apply_import(selected, data_home=tmp_path / "destination")
-        mcp = json.loads((tmp_path / "destination" / "mcp.json").read_text(encoding="utf-8"))
-        config = json.loads((tmp_path / "destination" / "config.json").read_text(encoding="utf-8"))
-
-        assert _categories(plan, "claude_code") == {
-            "sessions": 1,
-            "workspaces": 1,
-            "mcp_servers": 1,
-            "settings": 1,
-        }
-        assert mcp["mcpServers"]["workspace-helper"]["command"] == "workspace-mcp"
-        assert config["dashboard"]["theme_mode"] == "light"
-
-    def test_claude_rules_and_project_instructions_are_diagnosed(self, tmp_path: Path) -> None:
-        home = tmp_path / "home"
-        claude = home / ".claude"
-        workspace = tmp_path / "project"
-        workspace.mkdir()
-        _write_jsonl(
-            claude / "projects" / "encoded-project" / "chat.jsonl",
-            [{"role": "user", "content": "hello", "cwd": str(workspace)}],
-        )
+        (claude / "CLAUDE.md").write_text("Always squash before opening a PR.\n", encoding="utf-8")
         rules = claude / "rules"
         rules.mkdir()
-        (rules / "global.md").write_text("# Global instructions\n", encoding="utf-8")
-        (workspace / "CLAUDE.md").write_text("# Project instructions\n", encoding="utf-8")
+        (rules / "global.md").write_text("Never force-push a shared branch.\n", encoding="utf-8")
+        (workspace / "CLAUDE.md").write_text("Run the linter first.\n", encoding="utf-8")
 
-        plan = _api().preview_import(home=home, env={})
+        plan = api.preview_import(home=home, env={})
 
-        diagnostics = [
-            item
+        # Root CLAUDE.md, rules/global.md, and the workspace CLAUDE.md all become
+        # directives — no longer reported as an unsupported category.
+        assert _categories(plan, "claude_code")["instructions"] == 3
+        assert not any(
+            item["category_id"] == "instructions" and item["reason"] == "unsupported_category"
             for item in plan["skipped"]
-            if item["source_id"] == "claude_code"
-            and item["category_id"] == "instructions"
-            and item["reason"] == "unsupported_category"
-        ]
-        assert diagnostics == [
-            {
-                "source_id": "claude_code",
-                "category_id": "instructions",
-                "reason": "unsupported_category",
-                "count": 2,
-            }
-        ]
+        )
+
+        destination = tmp_path / "destination"
+        result = api.apply_import(plan, data_home=destination)
+
+        assert result["imported"]["instructions"] == 3
+        rules_text = (destination / "lessons.jsonl").read_text(encoding="utf-8")
+        assert "Always squash before opening a PR." in rules_text
+        assert "Never force-push a shared branch." in rules_text
+        assert "Run the linter first." in rules_text
+        # Instructions must NEVER land in the consolidator-replaced tiers.
+        assert not (destination / "workspace" / "memory" / "preferences.md").exists()
+        assert not (destination / "workspace" / "memory" / "projects.md").exists()
 
     def test_claude_package_mcp_names_receive_stable_safe_aliases(self, tmp_path: Path) -> None:
         home = tmp_path / "home"
@@ -1808,14 +1274,7 @@ class TestPreview:
     ) -> None:
         home = tmp_path / "home"
         claude = home / ".claude"
-        _write_jsonl(
-            claude / "projects" / "project" / "chat.jsonl",
-            [{"role": "user", "content": "live conversation"}],
-        )
-        _write_jsonl(
-            claude / "projects" / "project" / "subagents" / "worker.jsonl",
-            [{"role": "user", "content": "runtime subagent conversation"}],
-        )
+        claude.mkdir(parents=True, exist_ok=True)
         (claude / "settings.json").write_text(
             json.dumps({"dashboard": {"theme_mode": "dark"}}),
             encoding="utf-8",
@@ -1826,22 +1285,15 @@ class TestPreview:
         )
         plan = _select(
             _api().preview_import(home=home, env={}),
-            ("claude_code", "sessions"),
             ("claude_code", "settings"),
         )
 
         result = _api().apply_import(plan, data_home=tmp_path / "destination")
         config = json.loads((tmp_path / "destination" / "config.json").read_text(encoding="utf-8"))
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
 
         assert config["dashboard"]["theme_mode"] == "light"
-        assert "live conversation" in persisted
-        assert "runtime subagent conversation" not in persisted
         assert result["imported"] == {
-            "sessions": 1,
+            "instructions": 0,
             "memories": 0,
             "workspaces": 0,
             "mcp_servers": 0,
@@ -1849,122 +1301,8 @@ class TestPreview:
             "schedules": 0,
             "settings": 1,
         }
-        assert any(
-            item["source_id"] == "claude_code"
-            and item["category_id"] == "runtime"
-            and item["reason"] == "runtime_sessions_excluded"
-            for item in result["skipped"]
-        )
-
-    def test_hermes_uses_user_sessions_for_messages_workspaces_and_jobs(
-        self, tmp_path: Path
-    ) -> None:
-        home = tmp_path / "home"
-        hermes = home / ".hermes"
-        hermes.mkdir(parents=True)
-        project = tmp_path / "project"
-        project.mkdir()
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                f"""
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT,
-                    cwd TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT,
-                    timestamp INTEGER,
-                    active INTEGER,
-                    compacted INTEGER
-                );
-                INSERT INTO sessions VALUES ('chat-1', 'cli', NULL, '{project.as_posix()}');
-                INSERT INTO messages VALUES
-                    (2, 'chat-1', 'assistant', 'second active message', 20, 1, 0),
-                    (1, 'chat-1', 'user', 'first active message', 10, 1, 0),
-                    (3, 'chat-1', 'user', 'inactive message', 30, 0, 0),
-                    (4, 'chat-1', 'assistant', 'compacted message', 40, 1, 1);
-                """
-            )
-        jobs = hermes / "cron" / "jobs.json"
-        jobs.parent.mkdir()
-        jobs.write_text(
-            json.dumps(
-                {
-                    "jobs": [
-                        {
-                            "name": "status review",
-                            "prompt": "review status",
-                            "schedule": {
-                                "kind": "cron",
-                                "expr": "0 9 * * *",
-                                "timezone": "UTC",
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("hermes", "sessions"),
-            ("hermes", "workspaces"),
-            ("hermes", "schedules"),
-        )
-
-        result = _api().apply_import(plan, data_home=tmp_path / "destination")
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
-        config = json.loads((tmp_path / "destination" / "config.json").read_text(encoding="utf-8"))
-        jobs = CronService(base_dir=tmp_path / "destination").list_jobs(include_disabled=True)
-
-        assert persisted.index("first active message") < persisted.index("second active message")
-        assert "inactive message" not in persisted
-        assert "compacted message" in persisted
-        assert config["workspaces"]["project"]["dir"] == str(project.resolve())
-        assert [(job.name, job.enabled) for job in jobs] == [("status review", False)]
-        assert result["imported"]["sessions"] == 1
-        assert result["imported"]["workspaces"] == 1
-        assert result["imported"]["schedules"] == 1
-
-    def test_hermes_database_uses_database_size_cap_not_generic_file_cap(
-        self, tmp_path: Path
-    ) -> None:
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        database = hermes / "state.db"
-        with sqlite3.connect(database) as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES ('chat', 'cli', NULL);
-                INSERT INTO messages VALUES (1, 'chat', 'user', 'large database message');
-                CREATE TABLE padding (data BLOB);
-                """
-            )
-            connection.execute("INSERT INTO padding VALUES (zeroblob(?))", (9 * 1024 * 1024,))
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert 8 * 1024 * 1024 < database.stat().st_size < 64 * 1024 * 1024
-        assert _categories(plan, "hermes") == {"sessions": 1}
+        # No session transcript is ever written to the destination.
+        assert not (tmp_path / "destination" / "sessions").exists()
 
     def test_hermes_unreadable_profiles_directory_is_diagnosed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2018,189 +1356,6 @@ class TestPreview:
             and item["reason"] == "profile_count_limit"
             for item in plan["skipped"]
         )
-
-    @pytest.mark.parametrize(
-        "database_name",
-        [
-            "state.db",
-            "profiles/review/state.db",
-        ],
-    )
-    def test_hermes_databases_reject_unsafe_sidecars_before_open(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        database_name: str,
-    ) -> None:
-        api = _api()
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        database = hermes / database_name
-        database.parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(database) as connection:
-            connection.execute("CREATE TABLE messages (role TEXT, content TEXT)")
-            connection.execute(
-                "INSERT INTO messages VALUES (?, ?)",
-                ("user", "database message"),
-            )
-        Path(f"{database}-shm").mkdir()
-
-        def fail_if_opened(*_args: object, **_kwargs: object) -> None:
-            raise AssertionError("unsafe SQLite database was opened")
-
-        monkeypatch.setattr(api.sqlite3, "connect", fail_if_opened)
-
-        plan = api.preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "hermes")
-        assert any(
-            item["source_id"] == "hermes"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "unsafe_database_sidecar"
-            for item in plan["skipped"]
-        )
-
-    def test_hermes_database_row_cap_excludes_all_partial_transcripts(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_DB_ROWS", 2)
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES ('chat', 'cli', NULL);
-                INSERT INTO messages VALUES
-                    (1, 'chat', 'user', 'first message'),
-                    (2, 'chat', 'assistant', 'second message'),
-                    (3, 'chat', 'user', 'third message');
-                """
-            )
-
-        plan = api.preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "hermes")
-        assert any(
-            item["source_id"] == "hermes"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "row_count_limit"
-            for item in plan["skipped"]
-        )
-
-    def test_openclaw_session_enumeration_has_one_shared_budget(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_FILES", 2)
-        root = tmp_path / "home" / ".openclaw"
-        for agent_id in ("first", "second"):
-            sessions = root / "agents" / agent_id / "sessions"
-            sessions.mkdir(parents=True)
-            _write_openclaw_session(
-                root,
-                agent_id=agent_id,
-                session_id=f"{agent_id}-session",
-                session_key=f"agent:{agent_id}:main",
-            )
-
-        plan = api.preview_import(home=tmp_path / "home", env={})
-
-        assert _categories(plan, "openclaw").get("sessions", 0) <= 2
-        assert any(
-            item["source_id"] == "openclaw"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "file_count_limit"
-            for item in plan["skipped"]
-        )
-
-    def test_hermes_message_cap_excludes_only_the_capped_transcript(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        api = _api()
-        monkeypatch.setattr(api, "_MAX_MESSAGES_PER_SESSION", 1)
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES
-                    ('capped', 'cli', NULL),
-                    ('complete', 'cli', NULL);
-                INSERT INTO messages VALUES
-                    (1, 'capped', 'user', 'capped first message'),
-                    (2, 'capped', 'assistant', 'capped second message'),
-                    (3, 'complete', 'user', 'complete message');
-                """
-            )
-        plan = _select(
-            api.preview_import(home=tmp_path / "home", env={}),
-            ("hermes", "sessions"),
-        )
-
-        result = api.apply_import(plan, data_home=tmp_path / "destination")
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
-
-        assert _categories(plan, "hermes") == {"sessions": 1}
-        assert "complete message" in persisted
-        assert "capped first message" not in persisted
-        assert "capped second message" not in persisted
-        assert result["imported"]["sessions"] == 1
-
-    def test_hermes_deeply_nested_message_is_skipped(self, tmp_path: Path) -> None:
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        nested_json = "[" * 2000 + "]" * 2000
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                """
-            )
-            connection.execute("INSERT INTO sessions VALUES ('deep', 'cli', NULL)")
-            connection.execute(
-                "INSERT INTO messages VALUES (1, 'deep', 'user', ?)",
-                (nested_json,),
-            )
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "hermes")
 
     def test_hermes_cron_output_markdown_is_not_a_schedule(self, tmp_path: Path) -> None:
         output = tmp_path / "home" / ".hermes" / "cron" / "output" / "run.md"
@@ -2321,98 +1476,6 @@ class TestPreview:
         plan = api.preview_import(home=tmp_path / "home", env={})
 
         assert _categories(plan, "hermes") == {}
-
-    def test_hermes_sessions_require_user_provenance_and_source_workspaces(
-        self, tmp_path: Path
-    ) -> None:
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        accepted_workspace = tmp_path / "accepted-workspace"
-        rejected_workspace = tmp_path / "rejected-workspace"
-        accepted_workspace.mkdir()
-        rejected_workspace.mkdir()
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                f"""
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT,
-                    cwd TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES
-                    ('accepted', 'cli', NULL, '{accepted_workspace.as_posix()}'),
-                    ('parented', 'cli', 'accepted', '{rejected_workspace.as_posix()}'),
-                    ('subagent', 'subagent', NULL, '{rejected_workspace.as_posix()}'),
-                    ('tool', 'tool', NULL, '{rejected_workspace.as_posix()}'),
-                    ('cron', 'cron', NULL, '{rejected_workspace.as_posix()}'),
-                    ('empty', '', NULL, '{rejected_workspace.as_posix()}');
-                INSERT INTO messages(session_id, role, content) VALUES
-                    ('accepted', 'user', 'accepted user session'),
-                    ('parented', 'user', 'parented runtime session'),
-                    ('subagent', 'assistant', 'subagent runtime session'),
-                    ('tool', 'assistant', 'tool runtime session'),
-                    ('cron', 'assistant', 'cron runtime session'),
-                    ('empty', 'user', 'unattributed session');
-                """
-            )
-
-        plan = _select(
-            _api().preview_import(home=tmp_path / "home", env={}),
-            ("hermes", "sessions"),
-            ("hermes", "workspaces"),
-        )
-        _api().apply_import(plan, data_home=tmp_path / "destination")
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in (tmp_path / "destination" / "sessions").glob("*.jsonl")
-        )
-
-        assert _categories(plan, "hermes") == {"sessions": 1, "workspaces": 1}
-        assert "accepted user session" in persisted
-        assert "runtime session" not in persisted
-        assert "unattributed session" not in persisted
-        assert any(
-            item["source_id"] == "hermes"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "runtime_session_excluded"
-            for item in plan["skipped"]
-        )
-        assert any(
-            item["source_id"] == "hermes"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "parented_session_excluded"
-            for item in plan["skipped"]
-        )
-
-    def test_hermes_legacy_messages_without_sessions_are_diagnosed_not_imported(
-        self, tmp_path: Path
-    ) -> None:
-        hermes = tmp_path / "home" / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.execute(
-                "CREATE TABLE messages (conversation_id TEXT, role TEXT, content TEXT)"
-            )
-            connection.execute(
-                "INSERT INTO messages VALUES ('legacy', 'user', 'legacy guessed session')"
-            )
-
-        plan = _api().preview_import(home=tmp_path / "home", env={})
-
-        assert "sessions" not in _categories(plan, "hermes")
-        assert any(
-            item["source_id"] == "hermes"
-            and item["category_id"] == "sessions"
-            and item["reason"] == "missing_session_provenance"
-            for item in plan["skipped"]
-        )
 
     def test_hermes_native_schedules_import_with_runtime_fields_ignored(
         self, tmp_path: Path
@@ -3083,275 +2146,6 @@ class TestApply:
             ]["disabled"]
             is True
         )
-
-    def test_sessions_import_visible_text_only_and_are_idempotent(self, tmp_path: Path) -> None:
-        home = tmp_path / "home"
-        source = home / ".meshclaw" / "sessions" / "chat.jsonl"
-        _write_jsonl(
-            source,
-            [
-                {"role": "user", "content": "visible question", "tools": ["shell rm -rf /"]},
-                {
-                    "role": "assistant",
-                    "content": [
-                        {"type": "thinking", "thinking": "private reasoning"},
-                        {"type": "text", "text": "visible answer"},
-                        {"type": "tool_use", "name": "shell", "input": {"command": "secret cmd"}},
-                    ],
-                },
-                {"role": "tool", "content": "private tool output"},
-                {"role": "system", "content": "private system prompt"},
-            ],
-        )
-        data_home = tmp_path / "destination"
-        conversation_log = ConversationLog(data_home / "sessions")
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-        )
-
-        first = _api().apply_import(
-            plan,
-            data_home=data_home,
-            conversation_log=conversation_log,
-        )
-        second = _api().apply_import(
-            plan,
-            data_home=data_home,
-            conversation_log=conversation_log,
-        )
-        messages = []
-        for path in (data_home / "sessions").glob("*.jsonl"):
-            messages.extend(
-                json.loads(line)
-                for line in path.read_text(encoding="utf-8").splitlines()
-                if line and json.loads(line).get("_type") != "metadata"
-            )
-
-        assert [(message["role"], message["content"]) for message in messages] == [
-            ("user", "visible question"),
-            ("assistant", "visible answer"),
-        ]
-        assert "private reasoning" not in json.dumps(messages)
-        assert "private tool output" not in json.dumps(messages)
-        assert "secret cmd" not in json.dumps(messages)
-        assert first["imported"]["sessions"] == 1
-        assert second["imported"]["sessions"] == 0
-        assert second["already_imported"] >= 1
-        ledger = json.loads(
-            (data_home / "imports" / "foreign-agent-imports.json").read_text(encoding="utf-8")
-        )
-        records = list(ledger["records"].values())
-        assert len(records) == 1
-        destination_key = records[0]["destination_key"]
-        assert destination_key.startswith("imported-meshclaw-")
-        assert conversation_log.has_log(destination_key)
-        session_path = next((data_home / "sessions").glob("*.jsonl"))
-        metadata = json.loads(session_path.read_text(encoding="utf-8").splitlines()[0])
-        assert metadata["closed"] is True
-
-    def test_non_text_envelopes_are_excluded_from_jsonl_and_sqlite(self, tmp_path: Path) -> None:
-        home = tmp_path / "home"
-        _write_jsonl(
-            home / ".meshclaw" / "sessions" / "chat.jsonl",
-            [
-                {"role": "user", "content": "visible JSONL message"},
-                {
-                    "type": "tool_result",
-                    "role": "user",
-                    "content": "private JSONL tool result",
-                },
-            ],
-        )
-        hermes = home / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "state.db") as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES ('chat', 'cli', NULL);
-                """
-            )
-            connection.executemany(
-                "INSERT INTO messages VALUES (?, 'chat', 'user', ?)",
-                [
-                    (1, "visible SQLite message"),
-                    (
-                        2,
-                        json.dumps(
-                            {
-                                "type": "tool_result",
-                                "content": "private SQLite tool result",
-                            }
-                        ),
-                    ),
-                ],
-            )
-        data_home = tmp_path / "destination"
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-            ("hermes", "sessions"),
-        )
-
-        _api().apply_import(plan, data_home=data_home)
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8") for path in (data_home / "sessions").glob("*.jsonl")
-        )
-
-        assert "visible JSONL message" in persisted
-        assert "visible SQLite message" in persisted
-        assert "private JSONL tool result" not in persisted
-        assert "private SQLite tool result" not in persisted
-
-    def test_partial_deterministic_session_is_repaired_before_ledgering(
-        self, tmp_path: Path
-    ) -> None:
-        home = tmp_path / "home"
-        _write_jsonl(
-            home / ".meshclaw" / "sessions" / "chat.jsonl",
-            [
-                {"role": "user", "content": "first visible message"},
-                {"role": "assistant", "content": "second visible message"},
-            ],
-        )
-        data_home = tmp_path / "destination"
-        conversation_log = ConversationLog(data_home / "sessions")
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-        )
-        item = (
-            _api()
-            ._scan_source(
-                "meshclaw",
-                home / ".meshclaw",
-                home,
-            )
-            .items["sessions"][0]
-        )
-        destination_key = _api()._session_destination_key(item)
-        conversation_log.append(destination_key, "user", "first visible message")
-
-        result = _api().apply_import(
-            plan,
-            data_home=data_home,
-            conversation_log=conversation_log,
-        )
-
-        assert [
-            (message["role"], message["content"])
-            for message in conversation_log.read_messages(destination_key)
-        ] == [
-            ("user", "first visible message"),
-            ("assistant", "second visible message"),
-        ]
-        assert result["imported"]["sessions"] == 1
-        assert (data_home / "imports" / "foreign-agent-imports.json").is_file()
-
-    def test_session_append_failure_removes_partial_session_and_skips_ledger(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        home = tmp_path / "home"
-        _write_jsonl(
-            home / ".meshclaw" / "sessions" / "chat.jsonl",
-            [
-                {"role": "user", "content": "first visible message"},
-                {"role": "assistant", "content": "second visible message"},
-            ],
-        )
-        data_home = tmp_path / "destination"
-        conversation_log = ConversationLog(data_home / "sessions")
-        real_append = conversation_log.append
-        append_count = 0
-
-        def fail_second_append(*args: object, **kwargs: object) -> None:
-            nonlocal append_count
-            append_count += 1
-            if append_count == 2:
-                raise OSError("injected append failure")
-            real_append(*args, **kwargs)
-
-        monkeypatch.setattr(conversation_log, "append", fail_second_append)
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("meshclaw", "sessions"),
-        )
-
-        result = _api().apply_import(
-            plan,
-            data_home=data_home,
-            conversation_log=conversation_log,
-        )
-
-        assert append_count == 2
-        assert list((data_home / "sessions").glob("*.jsonl")) == []
-        assert not (data_home / "imports" / "foreign-agent-imports.json").exists()
-        assert result["imported"]["sessions"] == 0
-        assert result["item_outcomes"][0]["outcome"] == "rejected"
-
-    def test_hermes_sqlite_json_blocks_import_visible_text_only(self, tmp_path: Path) -> None:
-        home = tmp_path / "home"
-        hermes = home / ".hermes"
-        hermes.mkdir(parents=True)
-        with sqlite3.connect(hermes / "hermes.db") as connection:
-            connection.executescript(
-                """
-                CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY,
-                    source TEXT,
-                    parent_session_id TEXT
-                );
-                CREATE TABLE messages (
-                    id INTEGER PRIMARY KEY,
-                    session_id TEXT,
-                    role TEXT,
-                    content TEXT
-                );
-                INSERT INTO sessions VALUES ('c1', 'cli', NULL);
-                """
-            )
-            connection.execute(
-                "INSERT INTO messages(session_id, role, content) VALUES (?, ?, ?)",
-                (
-                    "c1",
-                    "assistant",
-                    json.dumps(
-                        [
-                            {"type": "text", "text": "visible database answer"},
-                            {
-                                "type": "tool_use",
-                                "name": "shell",
-                                "input": {"command": "private database command"},
-                            },
-                        ]
-                    ),
-                ),
-            )
-        data_home = tmp_path / "destination"
-        plan = _select(
-            _api().preview_import(home=home, env={}),
-            ("hermes", "sessions"),
-        )
-
-        _api().apply_import(plan, data_home=data_home)
-        persisted = "\n".join(
-            path.read_text(encoding="utf-8") for path in (data_home / "sessions").glob("*.jsonl")
-        )
-
-        assert "visible database answer" in persisted
-        assert "private database command" not in persisted
-        assert "tool_use" not in persisted
 
     def test_mcp_secret_fields_reject_the_entire_server_definition(self, tmp_path: Path) -> None:
         secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
@@ -4708,3 +3502,322 @@ class TestConservativeParsingRegressions:
         scan = api._Scan("hermes", tmp_path, tmp_path)
         data = api._read_simple_yaml(config, anchor, scan)
         assert data.get("mcpServers", {}).get("docs", {}).get("command") == "docs-mcp"
+
+
+class TestSessionImportRemoved:
+    """Conversation transcripts are deliberately out of scope.
+
+    See docs/system-specs/modules/onboarding-import.md → "Not migrated". These
+    tests are the regression floor for that decision: an upstream sync that
+    re-adds a session scanner or writer must fail here.
+    """
+
+    def test_sessions_is_not_a_public_category(self) -> None:
+        api = _api()
+
+        assert "sessions" not in api.CATEGORY_IDS
+        assert "sessions" not in api._CATEGORY_LABELS
+
+    def test_no_session_scanner_or_writer_remains(self) -> None:
+        api = _api()
+
+        for removed in (
+            "_jsonl_session_items",
+            "_add_sessions_and_workspaces",
+            "_write_session",
+            "_session_destination_key",
+            "_openclaw_session_paths",
+            "_openclaw_session_provenance_is_user_owned",
+            "_scan_hermes_db",
+            "_message_from_record",
+        ):
+            assert not hasattr(api, removed), f"{removed} was re-introduced"
+
+    def test_transcripts_are_never_scanned_or_written(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        # A transcript in every source's canonical session location.
+        _write_jsonl(
+            home / ".codex" / "sessions" / "a.jsonl",
+            [{"role": "user", "content": "codex secret talk"}],
+        )
+        _write_jsonl(
+            home / ".claude" / "projects" / "p" / "c.jsonl",
+            [{"role": "user", "content": "claude secret talk"}],
+        )
+        _write_jsonl(
+            home / ".meshclaw" / "sessions" / "m.jsonl",
+            [{"role": "user", "content": "meshclaw secret talk"}],
+        )
+        _write_openclaw_session(home / ".openclaw")
+
+        plan = api.preview_import(home=home, env={})
+        serialized = json.dumps(plan)
+
+        for source_id in ("codex", "claude_code", "meshclaw", "openclaw"):
+            assert "sessions" not in _categories(plan, source_id)
+        assert "secret talk" not in serialized
+
+        # Selecting everything the plan offers must still write no session log.
+        destination = tmp_path / "destination"
+        api.apply_import(plan, data_home=destination)
+        assert not (destination / "sessions").exists()
+
+    def test_claude_workspaces_come_from_configuration_not_transcripts(
+        self, tmp_path: Path
+    ) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        claude = home / ".claude"
+        claude.mkdir(parents=True)
+        transcript_only = tmp_path / "transcript-only"
+        transcript_only.mkdir()
+        configured = tmp_path / "configured"
+        configured.mkdir()
+        # A workspace that exists ONLY in a transcript's cwd must not be picked
+        # up; one declared in configuration must be.
+        _write_jsonl(
+            claude / "projects" / "p" / "c.jsonl",
+            [{"role": "user", "content": "hi", "cwd": str(transcript_only)}],
+        )
+        (claude / ".claude.json").write_text(
+            json.dumps({"projects": {str(configured): {}}}), encoding="utf-8"
+        )
+
+        plan = api.preview_import(home=home, env={})
+
+        # The preview deliberately does not expose workspace paths, so assert on
+        # what actually lands in config.json after apply.
+        assert _categories(plan, "claude_code")["workspaces"] == 1
+        destination = tmp_path / "destination"
+        api.apply_import(plan, data_home=destination)
+        registered = {
+            entry["dir"]
+            for entry in json.loads((destination / "config.json").read_text(encoding="utf-8"))[
+                "workspaces"
+            ].values()
+        }
+
+        assert registered == {str(configured.resolve())}
+        assert str(transcript_only.resolve()) not in registered
+
+    def test_stale_session_ledger_records_are_inert(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        skill = home / ".codex" / "skills" / "review"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# Review\n", encoding="utf-8")
+        destination = tmp_path / "destination"
+        ledger_path = destination / api._LEDGER_RELATIVE_PATH
+        ledger_path.parent.mkdir(parents=True)
+        # A ledger written by a version that still imported sessions. The
+        # version is NOT bumped, so every other category's records survive.
+        ledger_path.write_text(
+            json.dumps(
+                {
+                    "version": api._LEDGER_VERSION,
+                    "records": {
+                        "f"
+                        * 64: {
+                            "source_id": "codex",
+                            "category_id": "sessions",
+                            "imported_at": "2026-07-01T00:00:00+00:00",
+                            "destination_key": "imported-codex-ffffffffffffffff",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        plan = api.preview_import(home=home, env={})
+        result = api.apply_import(plan, data_home=destination)
+
+        assert result["imported"]["skills"] == 1
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        # The stale record is preserved, never consulted, and never re-imported.
+        assert "f" * 64 in ledger["records"]
+
+    def test_ledger_is_not_rewritten_once_per_item(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        for name in ("one", "two", "three"):
+            skill = home / ".codex" / "skills" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+        destination = tmp_path / "destination"
+        plan = api.preview_import(home=home, env={})
+        ledger_path = destination / api._LEDGER_RELATIVE_PATH
+
+        writes: list[str] = []
+        real_write_json = api._write_json
+
+        def counting_write_json(path: Path, data: object) -> None:
+            if Path(path) == ledger_path:
+                writes.append(str(path))
+            real_write_json(path, data)
+
+        original = api._write_json
+        api._write_json = counting_write_json  # type: ignore[assignment]
+        try:
+            result = api.apply_import(plan, data_home=destination)
+        finally:
+            api._write_json = original  # type: ignore[assignment]
+
+        assert result["imported"]["skills"] == 3
+        # Flushed per source/category (plus the final ``finally`` flush), NOT
+        # once per item — a whole-file rewrite per item is O(n**2).
+        assert len(writes) < 3
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        assert len(ledger["records"]) == 3
+
+
+class TestInstructionImport:
+    """Instructions land in the durable memory tiers, never in prefs/projects.
+
+    See docs/system-specs/modules/onboarding-import.md → "Destination mapping".
+    """
+
+    def test_soul_directives_import_but_persona_role_does_not(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        hermes = home / ".hermes"
+        hermes.mkdir(parents=True)
+        (hermes / "SOUL.md").write_text(
+            "# Identity\n\nYou are Aria, a laconic assistant.\n\n"
+            "Always cite a file path when you reference code.\n",
+            encoding="utf-8",
+        )
+
+        plan = api.preview_import(home=home, env={})
+        destination = tmp_path / "destination"
+        result = api.apply_import(plan, data_home=destination)
+
+        assert result["imported"]["instructions"] >= 1
+        lessons = (destination / "lessons.jsonl").read_text(encoding="utf-8")
+        assert "Always cite a file path" in lessons
+        # The DIRECTIVE text is imported as a lesson; the persona ROLE is not —
+        # nothing is written to a persona/system-prompt surface. That surface is
+        # theme-pack persona, gated by capabilities.theme_persona.
+        for forbidden in ("persona.md", "prompt.md", "SOUL.md"):
+            assert not (destination / forbidden).exists()
+
+    def test_instruction_import_cannot_evict_the_users_own_lessons(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        # Far more directives than import is allowed to contribute.
+        paragraphs = "\n\n".join(
+            f"Directive number {index} that is long enough to be kept." for index in range(200)
+        )
+        (codex / "AGENTS.md").write_text(paragraphs + "\n", encoding="utf-8")
+
+        plan = api.preview_import(home=home, env={})
+        count = _categories(plan, "codex")["instructions"]
+
+        # LessonStore prunes OLDEST-first at 200, so an unbounded import would
+        # silently evict the user's own accumulated corrections.
+        assert count == api._MAX_IMPORTED_LESSONS
+        assert any(
+            item["category_id"] == "instructions" and item["reason"] == "instruction_count_limit"
+            for item in plan["skipped"]
+        )
+
+    def test_credential_bearing_instruction_is_dropped(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        (codex / "AGENTS.md").write_text(
+            "Deploy with the key AKIAIOSFODNN7EXAMPLE when releasing.\n",
+            encoding="utf-8",
+        )
+
+        plan = api.preview_import(home=home, env={})
+
+        assert "instructions" not in _categories(plan, "codex")
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(plan)
+        assert any(
+            item["category_id"] == "instructions"
+            and item["reason"] == "credential_bearing_instruction"
+            for item in plan["skipped"]
+        )
+
+    def test_reimport_of_the_same_directive_is_idempotent(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        (codex / "AGENTS.md").write_text("Prefer stdlib over new deps.\n", encoding="utf-8")
+        destination = tmp_path / "destination"
+
+        first = api.apply_import(api.preview_import(home=home, env={}), data_home=destination)
+        second = api.apply_import(api.preview_import(home=home, env={}), data_home=destination)
+
+        assert first["imported"]["instructions"] == 1
+        assert second["imported"]["instructions"] == 0
+        assert second["already_imported"] >= 1
+        lines = [
+            line
+            for line in (destination / "lessons.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+
+
+class TestTransitiveReimport:
+    """A source's OWN importer output must not be re-imported through it.
+
+    Hermes ships `hermes import-agent` / `hermes claw migrate`, which write
+    foreign skills into `skills/<source>-imports/`. Importing those from Hermes
+    duplicates what the original source already contributes, and NEITHER dedupe
+    layer catches it: the fingerprint is source-scoped and the destination dirs
+    differ, so not even a conflict is reported.
+    """
+
+    def test_hermes_reimport_dirs_are_excluded(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        hermes = home / ".hermes"
+        # Hermes's own skill, plus three it imported from other agents.
+        own = hermes / "skills" / "hermes-own"
+        own.mkdir(parents=True)
+        (own / "SKILL.md").write_text("# Hermes own\n", encoding="utf-8")
+        for directory in api._FOREIGN_REIMPORT_SKILL_DIRS:
+            imported = hermes / "skills" / directory / "foo"
+            imported.mkdir(parents=True)
+            (imported / "SKILL.md").write_text("# Foo\n", encoding="utf-8")
+
+        plan = api.preview_import(home=home, env={})
+
+        # Only Hermes's own skill is offered.
+        assert _categories(plan, "hermes") == {"skills": 1}
+        destination = tmp_path / "destination"
+        api.apply_import(plan, data_home=destination)
+        installed = {
+            path.parent.name for path in (destination / "skills" / "imported").rglob("SKILL.md")
+        }
+        assert installed == {"hermes-own"}
+
+    def test_the_original_source_still_imports_the_shared_skill(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        # Same skill present in Claude Code (the original) and in Hermes's
+        # claude-code-imports/ (Hermes's copy). Exactly one must be imported.
+        original = home / ".claude" / "skills" / "foo"
+        original.mkdir(parents=True)
+        (original / "SKILL.md").write_text("# Foo\n", encoding="utf-8")
+        copied = home / ".hermes" / "skills" / "claude-code-imports" / "foo"
+        copied.mkdir(parents=True)
+        (copied / "SKILL.md").write_text("# Foo\n", encoding="utf-8")
+
+        plan = api.preview_import(home=home, env={})
+        destination = tmp_path / "destination"
+        api.apply_import(plan, data_home=destination)
+
+        skill_dirs = sorted(
+            str(path.parent.relative_to(destination / "skills" / "imported"))
+            for path in (destination / "skills" / "imported").rglob("SKILL.md")
+        )
+        assert skill_dirs == ["claude_code/foo"]

--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
+  BookOpen,
   Brain,
   CalendarClock,
   Check,
@@ -14,7 +15,6 @@ import {
   FolderOpen,
   Import,
   Loader2,
-  MessageCircle,
   Plug,
   RefreshCw,
   Settings2,
@@ -41,7 +41,7 @@ const SUPPORTED_SOURCE_IDS = new Set([
   'hermes',
 ])
 const SUPPORTED_CATEGORY_IDS = new Set([
-  'sessions',
+  'instructions',
   'memories',
   'workspaces',
   'mcp_servers',
@@ -50,7 +50,7 @@ const SUPPORTED_CATEGORY_IDS = new Set([
   'settings',
 ])
 const CATEGORY_ICONS: Record<string, LucideIcon> = {
-  sessions: MessageCircle,
+  instructions: BookOpen,
   memories: Brain,
   workspaces: FolderOpen,
   mcp_servers: Plug,
@@ -651,8 +651,8 @@ export default function AgentImportFlow({
                 Bring your crew with you.
               </h1>
               <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
-                Move supported sessions, memories, workspaces, MCP servers, skills,
-                schedules, and safe settings into KiroCrew.
+                Move supported instructions, memories, workspaces, MCP servers,
+                skills, schedules, and safe settings into KiroCrew.
               </p>
             </div>
             <p className="mt-8 text-[12px] font-medium text-accent-fg/75">


### PR DESCRIPTION
## Problem

Two problems in the foreign-agent importer, pulling in opposite directions.

**Sessions were imported but shouldn't be.** Conversation-transcript import was the
largest and most fragile part of the module. No surveyed agent does it — Codex CLI,
Claude Code, OpenClaw, and Hermes all migrate config, memory, skills, and rules, and
none migrate transcripts. A transcript is a record of a conversation with a *different*
model under a *different* system prompt; replayed into KiroCrew it is misleading
context, not useful memory. Reading it also meant hard-coding each source's private
JSONL and SQLite schemas — `_OPENCLAW_RUNTIME_NAMESPACES`, `_HERMES_RUNTIME_SESSION_SOURCES`,
a checkpoint-filename regex — which fail **silently** when upstream drifts, producing
quietly-wrong imports rather than errors.

**Instructions weren't imported but should be.** The thing users most want to carry
over — their own written rules — was counted and then discarded with an
`unsupported_category` diagnostic, even though KiroCrew already has a durable, always-
injected home for exactly that content.

## Why it matters

A user migrating from another agent lost their hand-written rules (`CLAUDE.md`,
`AGENTS.md`, `rules/*.md`) while gaining transcripts they can't use. Separately, anyone
who had migrated *through* Hermes silently received duplicate skills, with no warning
and no way to resolve it.

## Root cause

The category set was assembled from "what can we parse out of these directories"
rather than "what is portable and worth carrying." That let transcripts in (parseable,
but not portable in any meaningful sense) and kept instructions out (trivially
portable, but with no destination chosen at the time).

The Hermes duplicate is a dedupe blind spot rather than a missing check. Hermes ships
its own importer, which writes foreign skills into `skills/claude-code-imports/` etc.
When KiroCrew then imports from both Claude Code and Hermes, **all three** dedupe layers
miss it: the in-scan pass only compares within one source; the ledger fingerprint is
`sha256(source_id \0 category \0 key)` so `claude_code` and `hermes` never collide; and
the destination check compares `skills/imported/claude_code/foo/` against
`skills/imported/hermes/foo/`, which don't overlap — so not even a conflict is reported.

## Fix

**Remove session import.** Drops the `sessions` category, 15 functions, 12 constants,
the OpenClaw session-provenance machinery, the Hermes session-DB reader, the
transcript-hash dedupe branch, and all `conversation_log` plumbing.

**Add `instructions` in its place**, mapped onto the memory hierarchy:

- Directives → `lessons.jsonl` (`category="preference"`), the highest-priority durable
  tier at 22.6% of the context budget.
- **Capped at 50** (`_MAX_IMPORTED_LESSONS`). `LessonStore` prunes **oldest-first** at
  200, so an unbounded import would silently evict the user's own accumulated
  corrections. Overflow emits `instruction_count_limit`.
- **Never writes `preferences.md` / `projects.md`** — the consolidator replaces both
  wholesale, so an import there is destroyed on the next consolidation run. This is the
  reason lessons, not prefs, is "highest tier".
- Persona **directives** are imported; the persona **role** is not. That surface is
  theme-pack persona, gated by `capabilities.theme_persona`; letting a foreign document
  become system-prompt identity would route third-party text around that gate. This is a
  deliberate divergence from the three surveyed products, which all treat `SOUL.md` as
  first-class persona migration — rationale recorded in the spec so it reads as a
  decision, not an oversight.

**Exclude Hermes's re-import dirs** via `_FOREIGN_REIMPORT_SKILL_DIRS`. Nothing is lost:
the originals are still on disk, so the original source imports them normally. The
analogous *memory* overlap is deliberately not excluded — that collision is
content-level, and dropping Hermes's `MEMORY.md` wholesale would lose real data for a
Hermes-native user.

**Fix the ledger write pattern.** It was rewritten whole (`atomic_write`: mkstemp +
full serialize + rename) once **per item**, i.e. quadratic. Now flushed per category
plus a `finally` flush, so an interrupted apply still can't re-import.

### Two things that needed solving, not just deleting

**Claude workspace discovery was circular.** Workspaces came from session records, but
per-workspace configs needed the workspace list first. Restructured into two passes:
root configs → learn workspaces → per-workspace configs.

**Hermes workspaces genuinely narrow.** They were recovered from the session DB's `cwd`
column; now only `projects.db` + explicit config contribute. Documented as accepted in
the spec, with an explicit "do not reintroduce a session read to widen it."

### Ledger compatibility

Version deliberately **not** bumped. Stale `category_id: "sessions"` records are inert
(no scanner produces that category). Bumping would discard every other category's
records and trigger a full re-import.

## Tests

- **`TestSessionImportRemoved`** (6 tests) — the regression floor against an upstream
  sync re-adding transcripts: asserts the removed symbols stay absent, that a transcript
  in every source's canonical location is neither scanned nor written, that Claude
  workspaces come from config and *not* from a transcript `cwd`, that a stale sessions
  ledger record is inert, and that the ledger isn't rewritten per item.
- **`TestInstructionImport`** (4 tests) — SOUL directives import while the persona role
  does not; the 50-lesson cap can't evict user lessons; a credential-bearing instruction
  is dropped and its secret never appears in the plan; re-import is idempotent.
- **`TestTransitiveReimport`** (2 tests) — Hermes re-import dirs excluded; the original
  source still imports the shared skill (exactly `claude_code/foo`, not both).
- Deleted 29 session-only tests; adjusted 9 that used sessions incidentally. The codex
  privacy test now proves secret/path redaction via config rather than a transcript, so
  that coverage is preserved rather than dropped.

Net: **910 insertions, 2037 deletions**. `onboarding_import.py` 3886 → ~3200 lines.

## Manual verification

Not applicable — no user-visible flow changed beyond the category list, which is covered
by the frontend test. The removed surface has no UI of its own.

## Screenshots

N/A — the only frontend change is the category list and its icon in an existing flow
(one entry removed, one added); no layout or component change.
