### PR TITLE
feat(onboarding): redesign first-run import setup + customize chapters

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1724,6 +1724,15 @@ export default function App() {
           }
           continueTourAfterImport.current = false
         }}
+        onSkipAll={() => {
+          // Skip the entire first-run flow: mark both import + onboarding tour
+          // done and close both so the user lands in the product (new chat).
+          markImportOnboarded()
+          markOnboarded()
+          setShowAgentImport(false)
+          setShowOnboarding(false)
+          continueTourAfterImport.current = false
+        }}
       />
 
       {/* First-run onboarding: 4-step flow (theme → Schedule → Apps → Sessions).

--- a/website/src/components/AgentImportFlow.test.tsx
+++ b/website/src/components/AgentImportFlow.test.tsx
@@ -87,13 +87,13 @@ function mockSuccessfulRequests(scan = SCAN_RESPONSE) {
 
 async function goToCategories() {
   await screen.findByRole('heading', { name: 'Choose sources' })
-  await userEvent.click(screen.getByRole('button', { name: 'Choose categories' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
   return screen.findByRole('heading', { name: 'Select items to import' })
 }
 
 async function goToReview() {
   await goToCategories()
-  await userEvent.click(screen.getByRole('button', { name: 'Review import' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
   return screen.findByRole('heading', { name: 'Review import' })
 }
 
@@ -164,7 +164,7 @@ describe('AgentImportFlow', () => {
     await goToCategories()
     await userEvent.click(screen.getByRole('checkbox', { name: /MCP servers.*2/ }))
     await userEvent.click(screen.getByRole('checkbox', { name: /Workspaces.*6/ }))
-    await userEvent.click(screen.getByRole('button', { name: 'Review import' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(screen.getByText(/existing KiroCrew setup is never overwritten/i)).toBeInTheDocument()
     expect(screen.getByText(/matching items are deduplicated/i)).toBeInTheDocument()
@@ -192,7 +192,7 @@ describe('AgentImportFlow', () => {
     await startImport()
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Import service unavailable')
-    await userEvent.click(screen.getByRole('button', { name: 'Retry import' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Import selected' }))
     expect(await screen.findByText('Import complete')).toBeInTheDocument()
     expect(api.onboardingImportApply).toHaveBeenCalledTimes(2)
     expect(screen.getByText('10')).toBeInTheDocument()
@@ -207,7 +207,7 @@ describe('AgentImportFlow', () => {
     renderWithProviders(<AgentImportFlow initialOpen onComplete={vi.fn()} />)
 
     await startImport()
-    expect(screen.getByRole('button', { name: 'Skip import and close' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Skip all setup and onboarding' })).toBeDisabled()
 
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(api.onboardingImportState).not.toHaveBeenCalled()
@@ -322,7 +322,7 @@ describe('AgentImportFlow', () => {
     renderWithProviders(<AgentImportFlow initialOpen onComplete={onComplete} />)
 
     await screen.findByRole('heading', { name: 'Choose sources' })
-    await userEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Skip import' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Could not save onboarding state',

--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -1,18 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { motion, useReducedMotion } from 'framer-motion'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import {
   AlertTriangle,
-  ArrowLeft,
   ArrowRight,
   Brain,
   CalendarClock,
-  Check,
-  CheckCircle2,
-  CopyCheck,
   FileSearch,
   FolderOpen,
-  Import,
   Loader2,
   MessageCircle,
   Plug,
@@ -27,7 +23,7 @@ import {
   type AgentImportApplyRequest,
   type AgentImportSource,
 } from '../api/client'
-import { GhostVar1, GhostVar2 } from '../assets/onboarding/GhostIcons'
+import { KiroGhost } from './KiroGhost'
 import { Btn, SendBtn } from './ui'
 
 type Stage = 1 | 2 | 3 | 4
@@ -78,12 +74,69 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback
 }
 
+// Floating decorative mascot — an exact copy of the Kiro CLI setup gate's
+// FloatingGhost (components/KiroPrerequisiteGate.tsx): same KiroGhost art,
+// staggered fade + spring scale entrance, and an infinite easeInOut bob.
+// Honors the OS reduce-motion setting.
+function FloatingGhost({
+  className,
+  delay,
+  rotate = 0,
+}: {
+  className: string
+  delay: number
+  rotate?: number
+}) {
+  const reduceMotion = useReducedMotion()
+  return (
+    <motion.div
+      aria-hidden="true"
+      className={`pointer-events-none absolute z-0 text-white drop-shadow-[0_12px_20px_rgba(24,20,38,0.26)] ${className}`}
+      initial={reduceMotion ? false : { opacity: 0, scale: 0.72 }}
+      animate={{
+        opacity: 1,
+        scale: 1,
+        y: reduceMotion ? 0 : [-5, 5, -5],
+        rotate,
+      }}
+      transition={{
+        opacity: { delay, duration: 0.35 },
+        scale: { delay, duration: 0.45, type: 'spring', bounce: 0.45 },
+        y: { delay, duration: 3.8, ease: 'easeInOut', repeat: Infinity },
+      }}
+    >
+      <KiroGhost size={160} className="h-full w-full" />
+    </motion.div>
+  )
+}
+
+// Animated "Importing…" label — cycles the trailing dots between ".", ".." and
+// "..." while an import is in flight. The dots span reserves width so the
+// button doesn't jitter as they grow.
+function ImportingLabel() {
+  const [dots, setDots] = useState('.')
+  useEffect(() => {
+    const id = setInterval(() => setDots(d => (d.length >= 3 ? '.' : `${d}.`)), 400)
+    return () => clearInterval(id)
+  }, [])
+  return (
+    <>
+      Importing<span className="inline-block w-3 text-left">{dots}</span>
+    </>
+  )
+}
+
 export default function AgentImportFlow({
   initialOpen,
   onComplete,
+  onSkipAll,
 }: {
   initialOpen: boolean
   onComplete: () => void
+  // "Skip all" abandons the whole first-run flow (import + onboarding tour) and
+  // drops the user straight into the product. Falls back to onComplete when the
+  // host does not provide a distinct skip-all path.
+  onSkipAll?: () => void
 }) {
   const [open, setOpen] = useState(initialOpen)
   const [stage, setStage] = useState<Stage>(1)
@@ -131,12 +184,21 @@ export default function AgentImportFlow({
 
   const applyMutation = useMutation({
     mutationFn: () => api.onboardingImportApply(applyPayload),
+    onSuccess: () => setStage(4),
   })
   const completionMutation = useMutation({
     mutationFn: () => api.onboardingImportState({ completed: true }),
     onSuccess: () => {
       setOpen(false)
       onComplete()
+    },
+  })
+  const skipAllMutation = useMutation({
+    mutationFn: () => api.onboardingImportState({ completed: true }),
+    onSuccess: () => {
+      setOpen(false)
+      if (onSkipAll) onSkipAll()
+      else onComplete()
     },
   })
 
@@ -203,8 +265,13 @@ export default function AgentImportFlow({
   }, [open, stage, scanQuery.isPending, scanQuery.isError, applyMutation.status])
 
   const skip = () => {
-    if (!completionMutation.isPending && !applyMutation.isPending) {
+    if (!completionMutation.isPending && !applyMutation.isPending && !skipAllMutation.isPending) {
       completionMutation.mutate()
+    }
+  }
+  const skipAll = () => {
+    if (!completionMutation.isPending && !applyMutation.isPending && !skipAllMutation.isPending) {
+      skipAllMutation.mutate()
     }
   }
 
@@ -236,7 +303,7 @@ export default function AgentImportFlow({
     return () => document.removeEventListener('keydown', onKeyDown)
     // `skip` intentionally follows the current mutation state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, completionMutation.isPending, applyMutation.isPending])
+  }, [open, completionMutation.isPending, applyMutation.isPending, skipAllMutation.isPending])
 
   if (!open) return null
 
@@ -265,12 +332,112 @@ export default function AgentImportFlow({
     0,
   )
   const beginImport = () => {
-    setStage(4)
     applyMutation.mutate()
   }
   const importAnother = () => resetFlow(true)
   const completionError = completionMutation.error
-  const isBusy = completionMutation.isPending || applyMutation.isPending
+  const isBusy = completionMutation.isPending || applyMutation.isPending || skipAllMutation.isPending
+  const hasSelection = applyPayload.sources.length > 0
+
+  // Per-stage navigation buttons, rendered in the shared pinned footer bar
+  // (right side). The footer's left side shows the stage indicator.
+  const stepFooterNav = (() => {
+    if (stage === 1) {
+      return (
+        <>
+          <Btn type="button" className="h-9 rounded-lg px-4" disabled={isBusy} onClick={skip}>Skip import</Btn>
+          <SendBtn
+            type="button"
+            disabled={selectedSources.size === 0}
+            onClick={() => setStage(2)}
+          >
+            Continue
+          </SendBtn>
+        </>
+      )
+    }
+    if (stage === 2) {
+      return (
+        <>
+          <Btn type="button" className="h-9 rounded-lg px-4" onClick={() => setStage(1)}>
+            Back
+          </Btn>
+          <SendBtn type="button" disabled={!hasSelection} onClick={() => setStage(3)}>
+            Continue
+          </SendBtn>
+        </>
+      )
+    }
+    if (stage === 3) {
+      return (
+        <>
+          <Btn type="button" className="h-9 rounded-lg px-4" disabled={applyMutation.isPending} onClick={() => setStage(2)}>
+            Back
+          </Btn>
+          <SendBtn type="button" disabled={applyMutation.isPending} onClick={beginImport}>
+            {applyMutation.isPending ? <ImportingLabel /> : 'Import selected'}
+          </SendBtn>
+        </>
+      )
+    }
+    return (
+      <>
+        <Btn type="button" className="h-9 rounded-lg px-4" disabled={completionMutation.isPending} onClick={importAnother}>
+          <RefreshCw className="lucide-inline" /> Import another
+        </Btn>
+        <SendBtn
+          type="button"
+          disabled={completionMutation.isPending}
+          onClick={() => completionMutation.mutate()}
+        >
+          {completionMutation.isPending && <Loader2 className="lucide-inline animate-spin" />}
+          Continue
+        </SendBtn>
+      </>
+    )
+  })()
+
+  // The stepper footer shows for the four real stages, but not for the
+  // full-panel scanning / error / empty states or the mid-import spinner.
+  const showStepFooter =
+    !scanQuery.isPending
+    && !scanQuery.isError
+    && sources.length > 0
+
+  // Stage title + description, rendered in the FIXED header region (not the
+  // scroll body) so they stay put while the stage content scrolls. Returns null
+  // for the results stage and the full-panel scanning / error / empty states,
+  // which carry their own centered headings in the body.
+  const stageHeader = (() => {
+    if (!showStepFooter) return null
+    const headings: Record<Stage, { title: string; description: string }> = {
+      1: {
+        title: 'Choose sources',
+        description: 'KiroCrew found agent setup on this gateway host. Select the sources to review.',
+      },
+      2: {
+        title: 'Select items to import',
+        description: 'Import all your supported work or handpick what to bring over.',
+      },
+      3: {
+        title: 'Review import',
+        description: 'Review the merge before KiroCrew changes local setup.',
+      },
+      4: {
+        title: 'Import complete',
+        description: 'Your selected setup is ready in KiroCrew.',
+      },
+    }
+    const { title, description } = headings[stage]
+    return (
+      <div className="mt-6">
+        <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-muted">{description}</p>
+      </div>
+    )
+  })()
 
   const stageContent = (() => {
     if (scanQuery.isPending) {
@@ -330,18 +497,12 @@ export default function AgentImportFlow({
     if (stage === 1) {
       return (
         <>
-          <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
-            Choose sources
-          </h1>
-          <p className="mt-2 text-sm leading-relaxed text-muted">
-            KiroCrew found agent setup on this gateway host. Select the sources to review.
-          </p>
           {completionError && (
-            <p className="mt-4 text-sm text-danger" role="alert">
+            <p className="mb-4 text-sm text-danger" role="alert">
               {errorMessage(completionError, 'Could not save onboarding state.')}
             </p>
           )}
-          <div className="mt-6 space-y-3">
+          <div className="space-y-3">
             {sources.map(source => {
               const count = supportedCategories(source).reduce((sum, category) => sum + category.count, 0)
               const inputId = `agent-import-source-${source.id}`
@@ -372,39 +533,13 @@ export default function AgentImportFlow({
               )
             })}
           </div>
-          <div className="mt-7 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-            <Btn type="button" disabled={isBusy} onClick={skip}>Skip for now</Btn>
-            <SendBtn
-              type="button"
-              disabled={selectedSources.size === 0}
-              onClick={() => setStage(2)}
-            >
-              Choose categories <ArrowRight className="lucide-inline" />
-            </SendBtn>
-          </div>
         </>
       )
     }
     if (stage === 2) {
-      const hasSelection = applyPayload.sources.length > 0
       return (
         <>
-          <div className="mb-8 flex items-center justify-center gap-5" aria-hidden="true">
-            <span className="flex h-16 w-16 items-center justify-center rounded-lg bg-accent text-accent-fg shadow-sm">
-              <FolderOpen className="lucide-inline" />
-            </span>
-            <ArrowRight className="lucide-inline text-muted" />
-            <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border bg-card text-text-strong shadow-sm">
-              <CopyCheck className="lucide-inline" />
-            </span>
-          </div>
-          <h1 ref={headingRef} tabIndex={-1} className="text-center text-4xl font-semibold text-text-strong outline-none">
-            Select items to import
-          </h1>
-          <p className="mt-3 text-center text-base leading-relaxed text-muted">
-            Import all your supported work or handpick what to bring over.
-          </p>
-          <div className="mt-10 space-y-5">
+          <div className="space-y-5">
             {sources.filter(source => selectedSources.has(source.id)).map(source => (
               <fieldset key={source.id} aria-label={`${source.name} categories`}>
                 <legend className="mb-2 text-sm font-semibold text-text-strong">{source.name}</legend>
@@ -446,27 +581,18 @@ export default function AgentImportFlow({
           <p className="mt-5 text-center text-[13px] text-muted">
             Your existing KiroCrew setup will not be affected.
           </p>
-          <div className="mt-7 flex items-center justify-between gap-3 border-t border-border pt-5">
-            <Btn type="button" onClick={() => setStage(1)}>
-              <ArrowLeft className="lucide-inline" /> Back
-            </Btn>
-            <SendBtn type="button" disabled={!hasSelection} onClick={() => setStage(3)}>
-              Review import <ArrowRight className="lucide-inline" />
-            </SendBtn>
-          </div>
         </>
       )
     }
     if (stage === 3) {
       return (
         <>
-          <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
-            Review import
-          </h1>
-          <p className="mt-2 text-sm leading-relaxed text-muted">
-            Review the merge before KiroCrew changes local setup.
-          </p>
-          <section className="mt-6 rounded-lg border border-ok/30 bg-ok-subtle p-4">
+          {applyMutation.isError && (
+            <p className="mb-4 text-sm text-danger" role="alert">
+              {errorMessage(applyMutation.error, 'The import did not finish. Please try again.')}
+            </p>
+          )}
+          <section className="rounded-lg border border-ok/30 bg-ok-subtle p-4">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-text-strong">
               <ShieldCheck className="lucide-inline text-ok" /> Merge only
             </h2>
@@ -521,62 +647,14 @@ export default function AgentImportFlow({
               </div>
             )}
           </section>
-          <div className="mt-7 flex items-center justify-between gap-3 border-t border-border pt-5">
-            <Btn type="button" onClick={() => setStage(2)}>
-              <ArrowLeft className="lucide-inline" /> Back
-            </Btn>
-            <SendBtn type="button" onClick={beginImport}>
-              <Import className="lucide-inline" /> Import selected
-            </SendBtn>
-          </div>
         </>
-      )
-    }
-
-    if (applyMutation.isPending) {
-      return (
-        <div className="flex min-h-[360px] flex-col items-center justify-center text-center" aria-live="polite">
-          <Loader2 className="lucide-inline animate-spin text-accent" />
-          <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
-            Importing setup
-          </h1>
-          <p className="mt-2 text-sm text-muted">Merging selected items into KiroCrew.</p>
-        </div>
-      )
-    }
-    if (applyMutation.isError) {
-      return (
-        <div className="flex min-h-[360px] flex-col items-center justify-center text-center">
-          <AlertTriangle className="lucide-inline text-danger" />
-          <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
-            Import did not finish
-          </h1>
-          <p className="mt-3 max-w-lg text-sm text-danger" role="alert">
-            {errorMessage(applyMutation.error, 'The gateway returned an unexpected error.')}
-          </p>
-          <div className="mt-5 flex flex-wrap justify-center gap-2">
-            <Btn type="button" onClick={() => setStage(3)}>
-              <ArrowLeft className="lucide-inline" /> Back to review
-            </Btn>
-            <SendBtn type="button" onClick={() => applyMutation.mutate()}>
-              <RefreshCw className="lucide-inline" /> Retry import
-            </SendBtn>
-          </div>
-        </div>
       )
     }
 
     const summary = applyMutation.data?.summary
     return (
       <>
-        <div className="text-center">
-          <CheckCircle2 className="lucide-inline text-ok" />
-          <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
-            Import complete
-          </h1>
-          <p className="mt-2 text-sm text-muted">Your selected setup is ready in KiroCrew.</p>
-        </div>
-        <dl className="mt-7 grid grid-cols-1 divide-y divide-border rounded-xl border border-border bg-bg sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+        <dl className="grid grid-cols-1 divide-y divide-border rounded-xl border border-border bg-bg sm:grid-cols-3 sm:divide-x sm:divide-y-0">
           <div className="p-4 text-center">
             <dt className="text-[13px] text-muted">Imported</dt>
             <dd className="mt-1 text-2xl font-semibold text-text-strong">{summary?.imported ?? 0}</dd>
@@ -595,21 +673,6 @@ export default function AgentImportFlow({
             {errorMessage(completionError, 'Could not save onboarding state.')}
           </div>
         )}
-        <div className="mt-7 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-          <Btn type="button" disabled={completionMutation.isPending} onClick={importAnother}>
-            <RefreshCw className="lucide-inline" /> Import another
-          </Btn>
-          <SendBtn
-            type="button"
-            disabled={completionMutation.isPending}
-            onClick={() => completionMutation.mutate()}
-          >
-            {completionMutation.isPending
-              ? <Loader2 className="lucide-inline animate-spin" />
-              : <Check className="lucide-inline" />}
-            Continue
-          </SendBtn>
-        </div>
       </>
     )
   })()
@@ -620,39 +683,26 @@ export default function AgentImportFlow({
       role="dialog"
       aria-modal="true"
       aria-label="Import agent setup"
-      className="fixed inset-0 z-[140] flex min-h-0 overflow-y-auto bg-bg-elevated p-0 text-text sm:items-center sm:justify-center sm:p-6"
+      className="fixed inset-0 z-[140] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6"
     >
-      <div className="relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:min-h-[min(760px,calc(100vh-48px))] sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border">
+      <div className="relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:h-[min(760px,calc(100vh-48px))] sm:min-h-0 sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border">
         <aside className="relative flex min-h-[248px] w-full shrink-0 overflow-hidden bg-accent text-accent-fg sm:min-h-0 sm:w-[36%]">
-          <div className="pointer-events-none absolute inset-0 opacity-90" aria-hidden="true">
-            <div className="absolute -left-12 top-[-72px]">
-              <GhostVar1 width={170} />
-            </div>
-            <div className="absolute -right-10 top-10">
-              <GhostVar2 width={150} />
-            </div>
-            <div className="absolute -bottom-16 -right-16">
-              <GhostVar1 width={190} />
-            </div>
-            <div className="absolute -bottom-10 -left-14">
-              <GhostVar2 width={124} />
-            </div>
-          </div>
+          <FloatingGhost className="-left-8 top-[24%] h-24 w-20 rotate-90 lg:h-28 lg:w-24" delay={0.15} rotate={90} />
+          <FloatingGhost className="-right-5 top-5 h-28 w-20 -rotate-12 lg:h-36 lg:w-28" delay={0.35} rotate={-12} />
+          <FloatingGhost className="bottom-[-5.5rem] right-[-12%] hidden h-64 w-48 lg:block" delay={0.55} />
+          <FloatingGhost className="-top-20 left-[40%] hidden h-48 w-36 rotate-180 lg:block" delay={0.75} rotate={180} />
           <div className="relative z-10 flex w-full flex-col p-7 sm:p-10">
             <div className="flex items-center gap-3">
-              <GhostVar1 width={32} />
+              <KiroGhost size={28} className="h-8 w-7" />
               <span className="text-[15px] font-semibold tracking-wide">Kiro Crew</span>
             </div>
             <div className="mt-auto max-w-[290px]">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-accent-fg/75">
-                Import setup
-              </p>
-              <h1 className="mt-3 text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
+              <h1 className="text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
                 Bring your crew with you.
               </h1>
               <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
-                Move supported sessions, memories, workspaces, MCP servers, skills,
-                schedules, and safe settings into KiroCrew.
+                Bring your supported setup—sessions, memories, workspaces, MCP servers,
+                skills, schedules, and safe settings—into Kiro Crew.
               </p>
             </div>
             <p className="mt-8 text-[12px] font-medium text-accent-fg/75">
@@ -661,34 +711,33 @@ export default function AgentImportFlow({
           </div>
         </aside>
         <section className="flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0">
-          <header className="flex shrink-0 items-start justify-between gap-4 px-6 pb-0 pt-7 sm:px-10 sm:pt-10">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-accent">
-                Setup <span className="px-1 text-muted">→</span> Import
+          <header className="shrink-0 px-6 pt-7 sm:px-10 sm:pt-10">
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                Import setup{showStepFooter && ` · ${stage} of ${STAGE_LABELS.length}`}
               </p>
-              <p className="mt-2 text-[13px] text-muted">
-                Bring supported setup into your KiroCrew workspace.
-              </p>
-            </div>
-            <div className="flex shrink-0 flex-col items-end gap-2">
-              <span className="text-[12px] font-medium text-muted">
-                {stage} / {STAGE_LABELS.length} · {STAGE_LABELS[stage - 1]}
-              </span>
-              <Btn
+              <button
                 type="button"
-                aria-label="Skip import and close"
+                aria-label="Skip all setup and onboarding"
                 disabled={isBusy}
-                onClick={skip}
+                onClick={skipAll}
+                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted transition-colors hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
               >
-                Skip
-              </Btn>
+                Skip all <ArrowRight className="lucide-inline" />
+              </button>
             </div>
+            {stageHeader}
           </header>
           <div className="min-h-0 flex-1 overflow-y-auto">
-            <main className="w-full px-6 py-8 sm:px-10 sm:py-10">
+            <main className="w-full px-6 pb-8 pt-6 sm:px-10 sm:pb-10 sm:pt-6">
               <div className="mx-auto max-w-2xl">{stageContent}</div>
             </main>
           </div>
+          {showStepFooter && (
+            <footer className="flex shrink-0 flex-wrap items-center justify-end gap-3 px-6 pt-4 pb-6 sm:px-10 sm:pb-10">
+              {stepFooterNav}
+            </footer>
+          )}
         </section>
       </div>
     </div>,

--- a/website/src/components/OnboardingChapterShell.tsx
+++ b/website/src/components/OnboardingChapterShell.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode, RefObject } from 'react'
+import { createPortal } from 'react-dom'
+import { motion, useReducedMotion } from 'framer-motion'
+import { ArrowRight } from 'lucide-react'
+import { KiroGhost } from './KiroGhost'
+
+// Floating decorative mascot — the same treatment as the Kiro CLI setup gate
+// (KiroPrerequisiteGate's FloatingGhost) and the Import setup panel: staggered
+// fade + spring scale entrance and an infinite easeInOut bob. Honors the OS
+// reduce-motion setting.
+function FloatingGhost({
+  className,
+  delay,
+  rotate = 0,
+}: {
+  className: string
+  delay: number
+  rotate?: number
+}) {
+  const reduceMotion = useReducedMotion()
+  return (
+    <motion.div
+      aria-hidden="true"
+      className={`pointer-events-none absolute z-0 text-white drop-shadow-[0_12px_20px_rgba(24,20,38,0.26)] ${className}`}
+      initial={reduceMotion ? false : { opacity: 0, scale: 0.72 }}
+      animate={{
+        opacity: 1,
+        scale: 1,
+        y: reduceMotion ? 0 : [-5, 5, -5],
+        rotate,
+      }}
+      transition={{
+        opacity: { delay, duration: 0.35 },
+        scale: { delay, duration: 0.45, type: 'spring', bounce: 0.45 },
+        y: { delay, duration: 3.8, ease: 'easeInOut', repeat: Infinity },
+      }}
+    >
+      <KiroGhost size={160} className="h-full w-full" />
+    </motion.div>
+  )
+}
+
+/**
+ * Two-column onboarding "chapter" shell, mirroring the Import setup layout
+ * (components/AgentImportFlow.tsx): a translucent scrim, an accent left panel
+ * with the brand lockup + floating mascots, and a right column with a FIXED
+ * header (eyebrow "<chapter> · N of M" + "Skip all") and stage title/description,
+ * a SCROLLABLE body, and a PINNED footer for the step navigation.
+ */
+export default function OnboardingChapterShell({
+  chapterLabel,
+  stepIndex,
+  stepCount,
+  panelHeadline,
+  panelBody,
+  panelFootnote,
+  title,
+  description,
+  onSkipAll,
+  skipDisabled,
+  footer,
+  dialogRef,
+  ariaLabel,
+  children,
+}: {
+  chapterLabel: string
+  stepIndex: number
+  stepCount: number
+  panelHeadline: string
+  panelBody: string
+  panelFootnote: string
+  title: string
+  description: string
+  onSkipAll: () => void
+  skipDisabled?: boolean
+  footer: ReactNode
+  dialogRef: RefObject<HTMLDivElement>
+  ariaLabel: string
+  children: ReactNode
+}) {
+  return createPortal(
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+      className="fixed inset-0 z-[120] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6"
+    >
+      <div className="relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:h-[min(760px,calc(100vh-48px))] sm:min-h-0 sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border">
+        <aside className="relative flex min-h-[248px] w-full shrink-0 overflow-hidden bg-accent text-accent-fg sm:min-h-0 sm:w-[36%]">
+          <FloatingGhost className="-left-8 top-[24%] h-24 w-20 rotate-90 lg:h-28 lg:w-24" delay={0.15} rotate={90} />
+          <FloatingGhost className="-right-5 top-5 h-28 w-20 -rotate-12 lg:h-36 lg:w-28" delay={0.35} rotate={-12} />
+          <FloatingGhost className="bottom-[-5.5rem] right-[-12%] hidden h-64 w-48 lg:block" delay={0.55} />
+          <FloatingGhost className="-top-20 left-[40%] hidden h-48 w-36 rotate-180 lg:block" delay={0.75} rotate={180} />
+          <div className="relative z-10 flex w-full flex-col p-7 sm:p-10">
+            <div className="flex items-center gap-3">
+              <KiroGhost size={28} className="h-8 w-7" />
+              <span className="text-[15px] font-semibold tracking-wide">Kiro Crew</span>
+            </div>
+            <div className="mt-auto max-w-[290px]">
+              <h1 className="text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
+                {panelHeadline}
+              </h1>
+              <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
+                {panelBody}
+              </p>
+            </div>
+            <p className="mt-8 text-[12px] font-medium text-accent-fg/75">{panelFootnote}</p>
+          </div>
+        </aside>
+        <section className="flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0">
+          <header className="shrink-0 px-6 pt-7 sm:px-10 sm:pt-10">
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                {chapterLabel} · {stepIndex} of {stepCount}
+              </p>
+              <button
+                type="button"
+                aria-label="Skip all setup and onboarding"
+                disabled={skipDisabled}
+                onClick={onSkipAll}
+                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted transition-colors hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Skip all <ArrowRight className="lucide-inline" />
+              </button>
+            </div>
+            <div className="mt-6">
+              <h1 tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
+                {title}
+              </h1>
+              <p className="mt-2 text-sm leading-relaxed text-muted">{description}</p>
+            </div>
+          </header>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <main className="w-full px-6 pb-8 pt-6 sm:px-10 sm:pb-10 sm:pt-6">
+              <div className="mx-auto max-w-2xl">{children}</div>
+            </main>
+          </div>
+          <footer className="flex shrink-0 flex-wrap items-center justify-end gap-3 px-6 pt-4 pb-6 sm:px-10 sm:pb-10">
+            {footer}
+          </footer>
+        </section>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/website/src/components/OnboardingFlow.tsx
+++ b/website/src/components/OnboardingFlow.tsx
@@ -4,8 +4,9 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowRight, Check, Monitor, Sun, Moon } from 'lucide-react'
 import { useTheme, type ModePreference, type ColorTheme } from '../hooks/useTheme'
-import { GhostVar1, GhostVar2 } from '../assets/onboarding/GhostIcons'
-import { SettingsSelect } from '../components/settings'
+import { GhostVar2 } from '../assets/onboarding/GhostIcons'
+import { Btn, SendBtn } from './ui'
+import OnboardingChapterShell from './OnboardingChapterShell'
 import { api } from '../api/client'
 
 /**
@@ -351,74 +352,64 @@ export default function OnboardingFlow({
     else finish()
   }
 
-  // ── Step 1: Pick your look (centered modal) ──────────────────────────────
+  // ── Step 1: Pick your look (Customize chapter — import-setup layout) ──────
   if (step === 1) {
-    return createPortal(
-      <div className="fixed inset-0 z-[120] flex items-center justify-center bg-bg/70 backdrop-blur-sm animate-rise">
-        <div
-          ref={dialogRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="onboarding-look-title"
-          className="relative bg-card border border-accent p-6 w-[412px] max-w-[92vw]"
-          style={{ boxShadow: RING_SHADOW, borderRadius: '0px 16px 16px 16px' }}
-        >
-          <div className="absolute" style={{ bottom: 'calc(100% + 6px)', left: 0 }}>
-            <GhostVar1 width={52} />
-          </div>
-          <div className="flex items-start justify-between">
-            <h2 id="onboarding-look-title" className="text-[22px] font-semibold text-text-strong">Pick your look</h2>
+    return (
+      <OnboardingChapterShell
+        chapterLabel="Customize"
+        stepIndex={1}
+        stepCount={2}
+        ariaLabel="Customize KiroCrew"
+        panelHeadline="Make it yours."
+        panelBody="Set your look and tell Kiro about you so responses fit the way you work."
+        panelFootnote="Change anything later in Settings."
+        title="Pick your look"
+        description="Choose a color theme and mode — you can change it anytime."
+        onSkipAll={finish}
+        dialogRef={dialogRef}
+        footer={<SendBtn type="button" onClick={next}>Continue</SendBtn>}
+      >
+        <div className="flex gap-1 border border-border rounded-[10px] p-1" style={{ background: 'var(--panel-strong)' }}>
+          {(['system', 'light', 'dark'] as ModePreference[]).map(m => (
             <button
-              onClick={finish}
-              className="flex items-center gap-1 text-[13px] text-muted hover:text-text-strong cursor-pointer bg-transparent border-none"
+              key={m}
+              onClick={() => setModePref(m)}
+              className={`flex-1 flex items-center justify-center gap-1.5 py-2 rounded-[7px] text-[13px] cursor-pointer border-none transition-colors ${
+                modePref === m ? 'font-medium' : 'bg-transparent text-muted hover:text-text'
+              }`}
+              style={modePref === m ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
             >
-              Skip <ArrowRight size={13} />
+              {m === 'system' ? <Monitor size={14} /> : m === 'light' ? <Sun size={14} /> : <Moon size={14} />}
+              {m[0].toUpperCase() + m.slice(1)}
             </button>
-          </div>
-          <p className="text-[13.5px] text-muted mt-2">
-            Choose a color theme and mode — you can change it anytime.
-          </p>
-
-          <div className="flex gap-1 border border-border rounded-[10px] p-1 mt-4" style={{ background: 'var(--panel-strong)' }}>
-            {(['system', 'light', 'dark'] as ModePreference[]).map(m => (
-              <button
-                key={m}
-                onClick={() => setModePref(m)}
-                className={`flex-1 flex items-center justify-center gap-1.5 py-2 rounded-[7px] text-[13px] cursor-pointer border-none transition-colors ${
-                  modePref === m ? 'font-medium' : 'bg-transparent text-muted hover:text-text'
-                }`}
-                style={modePref === m ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
-              >
-                {m === 'system' ? <Monitor size={14} /> : m === 'light' ? <Sun size={14} /> : <Moon size={14} />}
-                {m[0].toUpperCase() + m.slice(1)}
-              </button>
-            ))}
-          </div>
-
-          <div className="mt-4">
-            <SettingsSelect
-              label="Color Theme"
-              description="Select a color palette for the dashboard"
-              value={colorTheme}
-              options={allThemes.map(t => t.value)}
-              optionLabels={allThemes.map(t => t.label)}
-              onChange={v => setColorTheme(v as ColorTheme)}
-            />
-          </div>
-
-          <button
-            onClick={next}
-            className="w-full mt-5 py-3 rounded-[11px] bg-accent text-accent-fg text-[14.5px] font-semibold cursor-pointer border-none hover:opacity-90 transition-opacity"
-          >
-            Next
-          </button>
+          ))}
         </div>
-      </div>,
-      document.body,
+
+        <div className="mt-5 text-[11px] uppercase tracking-wide text-muted mb-1.5">
+          Color theme
+        </div>
+        <div className="grid grid-cols-3 gap-2" role="group" aria-label="Color theme">
+          {allThemes.map(t => (
+            <button
+              key={t.value}
+              onClick={() => setColorTheme(t.value as ColorTheme)}
+              aria-pressed={colorTheme === t.value}
+              className={`flex min-w-0 items-center justify-center gap-1.5 truncate rounded-lg border px-3 py-2.5 text-[13px] cursor-pointer transition-colors ${
+                colorTheme === t.value
+                  ? 'border-accent font-medium'
+                  : 'border-border bg-transparent text-text hover:text-text-strong'
+              }`}
+              style={colorTheme === t.value ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </OnboardingChapterShell>
     )
   }
 
-  // ── Step 2: About you (centered modal) ───────────────────────────────────
+  // ── Step 2: About you (Customize chapter — import-setup layout) ──────────
   if (step === 2) {
     // Freeze all inputs while a save is in flight: changing a chip after Next
     // snapshots the PATCH payload would advance the flow with a stale value
@@ -433,106 +424,94 @@ export default function OnboardingFlow({
       profileTouched.current = true
       setTechLevel(t => (t === v ? '' : v))
     }
-    return createPortal(
-      <div className="fixed inset-0 z-[120] flex items-center justify-center bg-bg/70 backdrop-blur-sm animate-rise">
+    return (
+      <OnboardingChapterShell
+        chapterLabel="Customize"
+        stepIndex={2}
+        stepCount={2}
+        ariaLabel="Customize KiroCrew"
+        panelHeadline="Make it yours."
+        panelBody="Set your look and tell Kiro about you so responses fit the way you work."
+        panelFootnote="Change anything later in Settings."
+        title="Tell Kiro about you"
+        description="Answers set how Kiro explains things — plain language or full technical detail. Saved on this device; change anytime in Settings → Chat."
+        onSkipAll={finish}
+        skipDisabled={savingProfile}
+        dialogRef={dialogRef}
+        footer={
+          <>
+            <Btn type="button" className="h-9 rounded-lg px-4" disabled={savingProfile} onClick={() => setStep(1)}>
+              Back
+            </Btn>
+            <SendBtn type="button" disabled={savingProfile} onClick={next}>
+              {savingProfile ? 'Saving…' : 'Continue'}
+            </SendBtn>
+          </>
+        }
+      >
         <div
-          ref={dialogRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="onboarding-profile-title"
-          className="relative bg-card border border-accent p-6 w-[412px] max-w-[92vw]"
-          style={{ boxShadow: RING_SHADOW, borderRadius: '0px 16px 16px 16px' }}
+          id="onboarding-role-label"
+          className="text-[11px] uppercase tracking-wide text-muted mb-1.5"
         >
-          <div className="absolute" style={{ bottom: 'calc(100% + 6px)', left: 0 }}>
-            <GhostVar1 width={52} />
-          </div>
-          <div className="flex items-start justify-between">
-            <h2 id="onboarding-profile-title" className="text-[22px] font-semibold text-text-strong">Tell Kiro about you</h2>
-            <button
-              onClick={finish}
-              disabled={savingProfile}
-              className="flex items-center gap-1 text-[13px] text-muted hover:text-text-strong cursor-pointer bg-transparent border-none disabled:opacity-60 disabled:cursor-default"
-            >
-              Skip <ArrowRight size={13} />
-            </button>
-          </div>
-          <p className="text-[13.5px] text-muted mt-2">
-            Answers set how Kiro explains things — plain language or full
-            technical detail. Saved on this device; change anytime in
-            Settings&nbsp;&rarr;&nbsp;Chat.
-          </p>
-
-          <div
-            id="onboarding-role-label"
-            className="text-[11px] uppercase tracking-wide text-muted mt-4 mb-1.5"
-          >
-            Your role
-          </div>
-          <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby="onboarding-role-label">
-            {ROLE_OPTIONS.map(o => (
-              <button
-                key={o.value}
-                onClick={() => pickRole(o.value)}
-                disabled={savingProfile}
-                aria-pressed={role === o.value}
-                className={`flex items-center gap-1 rounded-full px-3 py-1.5 text-[13px] cursor-pointer transition-colors border ${
-                  role === o.value
-                    ? 'border-accent font-medium'
-                    : 'border-border bg-transparent text-text hover:text-text-strong'
-                }`}
-                style={role === o.value ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
-              >
-                {role === o.value && <Check size={13} aria-hidden />}
-                {o.label}
-              </button>
-            ))}
-          </div>
-
-          <div
-            id="onboarding-tech-label"
-            className="text-[11px] uppercase tracking-wide text-muted mt-4 mb-1.5"
-          >
-            How technical are you?
-          </div>
-          <div
-            className="flex gap-1 border border-border rounded-[10px] p-1"
-            style={{ background: 'var(--panel-strong)' }}
-            role="group"
-            aria-labelledby="onboarding-tech-label"
-          >
-            {TECH_OPTIONS.map(o => (
-              <button
-                key={o.value}
-                onClick={() => pickTech(o.value)}
-                disabled={savingProfile}
-                aria-pressed={techLevel === o.value}
-                className={`flex-1 flex items-center justify-center py-2 rounded-[7px] text-[13px] cursor-pointer border-none transition-colors ${
-                  techLevel === o.value ? 'font-medium' : 'bg-transparent text-muted hover:text-text'
-                }`}
-                style={techLevel === o.value ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
-              >
-                {o.label}
-              </button>
-            ))}
-          </div>
-
-          {profileSaveError && (
-            <p role="alert" className="text-[12.5px] mt-3 mb-0" style={{ color: 'var(--danger)' }}>
-              Couldn't save your answers — press Next to retry, or Skip again to
-              continue without saving.
-            </p>
-          )}
-
-          <button
-            onClick={next}
-            disabled={savingProfile}
-            className="w-full mt-5 py-3 rounded-[11px] bg-accent text-accent-fg text-[14.5px] font-semibold cursor-pointer border-none hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-default"
-          >
-            {savingProfile ? 'Saving…' : 'Next'}
-          </button>
+          Your role
         </div>
-      </div>,
-      document.body,
+        <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby="onboarding-role-label">
+          {ROLE_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              onClick={() => pickRole(o.value)}
+              disabled={savingProfile}
+              aria-pressed={role === o.value}
+              className={`flex items-center gap-1 rounded-full px-3 py-1.5 text-[13px] cursor-pointer transition-colors border ${
+                role === o.value
+                  ? 'border-accent font-medium'
+                  : 'border-border bg-transparent text-text hover:text-text-strong'
+              }`}
+              style={role === o.value ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
+            >
+              {role === o.value && <Check size={13} aria-hidden />}
+              {o.label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          id="onboarding-tech-label"
+          className="text-[11px] uppercase tracking-wide text-muted mt-4 mb-1.5"
+        >
+          How technical are you?
+        </div>
+        <div
+          className="flex flex-col gap-1.5"
+          role="group"
+          aria-labelledby="onboarding-tech-label"
+        >
+          {TECH_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              onClick={() => pickTech(o.value)}
+              disabled={savingProfile}
+              aria-pressed={techLevel === o.value}
+              className={`flex items-center gap-2 rounded-lg border px-3 py-2.5 text-[13px] cursor-pointer transition-colors ${
+                techLevel === o.value
+                  ? 'border-accent font-medium'
+                  : 'border-border bg-transparent text-text hover:text-text-strong'
+              }`}
+              style={techLevel === o.value ? { background: ACCENT_20, color: 'var(--accent)' } : undefined}
+            >
+              {techLevel === o.value && <Check size={13} aria-hidden />}
+              {o.label}
+            </button>
+          ))}
+        </div>
+
+        {profileSaveError && (
+          <p role="alert" className="text-[12.5px] mt-3 mb-0" style={{ color: 'var(--danger)' }}>
+            Couldn't save your answers — press Next to retry, or Skip again to
+            continue without saving.
+          </p>
+        )}
+      </OnboardingChapterShell>
     )
   }
 

--- a/website/src/test/OnboardingFlow.test.tsx
+++ b/website/src/test/OnboardingFlow.test.tsx
@@ -25,7 +25,7 @@ const patchConfig = vi.mocked(api.patchConfig)
 const kirocrewConfig = vi.mocked(api.kirocrewConfig)
 
 const advanceToStep2 = () => {
-  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
   expect(screen.getByText('Tell Kiro about you')).toBeInTheDocument()
 }
 
@@ -56,7 +56,7 @@ describe('OnboardingFlow — About You step', () => {
     advanceToStep2()
     fireEvent.click(screen.getByRole('button', { name: 'UX Designer' }))
     fireEvent.click(screen.getByRole('button', { name: 'Somewhat' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     await waitFor(() => {
       expect(patchConfig).toHaveBeenCalledWith('dashboard.user_role', 'designer')
       expect(patchConfig).toHaveBeenCalledWith(
@@ -71,7 +71,7 @@ describe('OnboardingFlow — About You step', () => {
   it('does not write config when nothing was selected', async () => {
     renderWithProviders(<OnboardingFlow initialOpen onComplete={vi.fn()} />)
     advanceToStep2()
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     expect(await screen.findByText('Work that runs on time')).toBeInTheDocument()
     expect(patchConfig).not.toHaveBeenCalled()
   })
@@ -84,7 +84,7 @@ describe('OnboardingFlow — About You step', () => {
     expect(chip).toHaveAttribute('aria-pressed', 'true')
     fireEvent.click(chip) // toggle off — back to the initial ''
     expect(chip).toHaveAttribute('aria-pressed', 'false')
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     expect(await screen.findByText('Work that runs on time')).toBeInTheDocument()
     expect(patchConfig).not.toHaveBeenCalled()
   })
@@ -142,7 +142,7 @@ describe('OnboardingFlow — About You step', () => {
       )
     })
     // Unchanged answers → Next writes nothing
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     expect(await screen.findByText('Work that runs on time')).toBeInTheDocument()
     expect(patchConfig).not.toHaveBeenCalled()
   })
@@ -152,7 +152,7 @@ describe('OnboardingFlow — About You step', () => {
     renderWithProviders(<OnboardingFlow initialOpen onComplete={vi.fn()} />)
     advanceToStep2()
     fireEvent.click(screen.getByRole('button', { name: 'UX Designer' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     // Error surfaces, still on step 2, tour NOT shown
     expect(await screen.findByRole('alert')).toHaveTextContent(/Couldn't save/)
     expect(screen.getByText('Tell Kiro about you')).toBeInTheDocument()
@@ -164,10 +164,10 @@ describe('OnboardingFlow — About You step', () => {
     renderWithProviders(<OnboardingFlow initialOpen onComplete={vi.fn()} />)
     advanceToStep2()
     fireEvent.click(screen.getByRole('button', { name: 'UX Designer' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     await screen.findByRole('alert')
     // Baseline must NOT have advanced on failure — retry re-sends the field.
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     expect(await screen.findByText('Work that runs on time')).toBeInTheDocument()
     expect(patchConfig).toHaveBeenCalledTimes(2)
     expect(patchConfig).toHaveBeenLastCalledWith('dashboard.user_role', 'designer')
@@ -183,7 +183,7 @@ describe('OnboardingFlow — About You step', () => {
     renderWithProviders(<OnboardingFlow initialOpen onComplete={onComplete} />)
     advanceToStep2()
     fireEvent.click(screen.getByRole('button', { name: 'Developer' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
     // In-flight: every input frozen — changing a chip now would advance the
     // flow with a stale value persisted (GPT round-3 race).
     await screen.findByRole('button', { name: 'Saving…' })


### PR DESCRIPTION
## Problem

The first-run experience (the **Import setup** flow and the **theme + "Tell Kiro about you"** onboarding) was visually inconsistent and, in places, awkward:

- The four Import-setup steps rendered at different container sizes (step 2's category list made the box grow), so the modal resized as the user advanced.
- Stage chrome was scattered: a breadcrumb eyebrow, a per-stage counter, and per-stage in-body nav buttons that drifted in size/radius/padding between steps.
- The stage title/description scrolled away with the content on tall steps.
- The importing state and the "import complete" state were separate full-panel screens, and the theme/profile onboarding used a small centered card with a completely different visual language from Import setup.

## Why it matters

This is the very first thing a new user sees. Inconsistent container sizes, shifting button styles, and two unrelated modal languages back-to-back make the product feel unfinished at the exact moment first impressions form. Every new install hits this flow.

## Fix (symptoms → root cause → change)

- **Container resized between steps** → root cause: the panel used `sm:min-h-[…]` (a *floor*), so it grew to fit taller steps → changed to a fixed `sm:h-[min(760px,…)]` + `sm:min-h-0`, and let the existing `min-h-0 flex-1 overflow-y-auto` body do the scrolling. All four steps now match step 1's size.
- **Scattered/duplicated chrome** → root cause: nav + indicators lived per-stage in the body → lifted them into shared, fixed regions: one header eyebrow that carries `IMPORT SETUP · N OF 4`, a pinned footer holding the per-stage nav, and a fixed title/description block so only the list scrolls.
- **Two different modal languages** → root cause: theme/profile onboarding was a bespoke centered card → extracted a shared **`OnboardingChapterShell`** (translucent scrim, accent panel with brand lockup + floating Kiro ghosts, fixed header/title, scrollable body, pinned footer) and moved theme + "Tell Kiro about you" onto it as a **Customize · N of 2** chapter that mirrors Import setup.
- **Transient/complete screens felt bolted on** → the standalone "Importing…" page was removed; import now runs inline on the Review step (the primary button shows an animated "Importing…" label and both footer buttons disable), advancing to a unified "Import complete" step on success and showing an inline error with retry on failure.
- **Button inconsistency** → all footer buttons unified to `h-9 rounded-lg px-4`, directional arrows dropped from footer buttons, and both chapters' primary buttons standardized to "Continue".
- Also: "How technical are you?" became a vertical selectable list; the color-theme picker became a 3-column grid; "Skip all" (borderless) ends the whole first-run flow and lands the user in the product, while "Skip import" completes only the import step; the import backdrop is now the same translucent `bg-bg/70 backdrop-blur-sm` scrim as the theme step.

Product-name convention preserved: user-visible copy says "Kiro Crew"; code identifiers stay `KiroCrew`.

## Tests

- `AgentImportFlow.test.tsx` (12 tests) — updated button-name queries to the new "Continue" labels; still locks in: detected-source filtering, real category counts without unsupported toggles, the merge-only review + selected-category payload, failed-apply stays visible & retries inline, Skip/Escape disabled during apply, the focus trap (Shift+Tab wraps from the heading), completion-state persistence before `onComplete`, fresh-scan replay, auto-complete when nothing detected, and skip-state persistence failure keeping the gate open.
- `OnboardingFlow.test.tsx` (12 tests) — updated to the "Continue" primary label; still locks in the About-You role/tech options, profile persistence on advance, no-write when unchanged, Skip-persists-then-dismiss (incl. failing-save informed-discard), Escape dismissal, `/onboarding` replay preselection, failed-write keeps modal open, and the in-flight input freeze on both the Next and Skip save paths.

All 24 pass; `tsc --noEmit` clean; eslint 0 errors (one pre-existing `App.tsx` `onboarded`-dep warning on an untouched effect).

## Manual verification

Verified locally via `tsc` + the two vitest suites. Interactive verification (visual polish, the scroll behavior on tall steps, and the import→customize transition) is best done in the local dev preview — this is a pure frontend/UI change with no backend or API surface touched.

Note: this branch does **not** yet fix the modal *blink* when advancing from Import setup into Customize (the two chapters are still separate portal instances). That unification is intentionally scoped to a follow-up PR to keep this diff focused on the redesign.

## Screenshots

[kirocrew-first-run-flow.webm](https://github.com/user-attachments/assets/41ae7796-d4b1-436f-9ab2-82c085eef7ef)

