### PR TITLE
feat(import): user-selectable conflict strategies with restore copies

### DIFF
--- a/docs/system-specs/modules/onboarding-import.md
+++ b/docs/system-specs/modules/onboarding-import.md
@@ -160,7 +160,7 @@ Applicability and rename derivation per category:
 |----------|-----------|-------------|
 | `skills` | skip · rename · overwrite | `<name>-imported-<source>`, then `<name>-<fingerprint[:8]>` |
 | `mcp_servers` | skip · rename · overwrite | `<name>-<source>`, then `<name>-<fingerprint[:8]>` |
-| `workspaces` | skip · rename | existing three-step ladder (`base` → `base-<source>` → `base-<fp[:8]>`) |
+| `workspaces` | skip · rename | `base-<source>`, then `base-<fp[:8]>`. **Behavior change:** the pre-existing three-step ladder silently suffixed on a name collision; that is a rename, so it now requires `rename`. Plain `skip` reports the collision. |
 | `instructions`, `memories` | n/a — merge-only, never collide destructively | — |
 | `denied_commands`, `settings` | n/a — merge-missing only | — |
 | `schedules` | skip only — a duplicate schedule is matched by `_same_schedule` | — |
@@ -168,8 +168,27 @@ Applicability and rename derivation per category:
 Rules:
 
 - `overwrite` MUST write a restore copy under
-  `imports/replaced/<timestamp>/<category>/` before replacing anything, and MUST
-  record the restore path in the item outcome.
+  `imports/replaced/<run-stamp>/<category>/` before replacing anything, and MUST
+  record the restore path in the item outcome. The stamp is taken ONCE per apply
+  run (`%Y%m%dT%H%M%SZ`), so everything a single import replaced is found
+  together. **If the restore copy cannot be written, the overwrite is abandoned
+  and the item reports `conflict`** — an unrecoverable replace is worse than a
+  reported conflict.
+- The strategy is validated at the API boundary: absent means `skip`, but a
+  present-but-unrecognized value is a **400**, never a silent downgrade.
+  Quietly treating a typo'd `overwrite` as `skip` would report success while
+  replacing nothing. `_normalize_strategy` in the backend is a second,
+  fail-safe layer for non-HTTP callers.
+- A writer returns `_WriteOutcome(status, renamed_to, restored_to)`. The two
+  detail fields are populated ONLY when a strategy actually took effect, so a
+  plain `skip` apply produces exactly the payload it did before strategies
+  existed.
+- `renamed_to` / `restored_to` are **backend-only**. They are filesystem
+  details and MUST NOT cross into the browser; the HTTP response carries
+  `conflict_strategy` plus `conflicts` / `resolvable_conflicts` **counts** only.
+- A conflict entry carries `resolvable: bool` (true iff the category is in
+  `STRATEGY_CATEGORIES`), so a client can offer a retry only when one could
+  actually help.
 - A strategy is chosen **per apply request**, applying to every item in it. A
   finer-grained per-item choice is a UI concern layered on top: the UI may issue
   several apply requests with different strategies.
@@ -288,7 +307,7 @@ be `""` — an app token is never a dashboard user.
 | Endpoint | Phase | Body |
 |----------|-------|------|
 | `GET /api/onboarding/import/scan` | detect + dry run | — |
-| `POST /api/onboarding/import/apply` | apply | `{selection: [{source_id, category_id}], conflict_strategy?, workspace_target?}` |
+| `POST /api/onboarding/import/apply` | apply | `{sources: [{id, categories: [...]}], conflict_strategy?}` — `conflict_strategy` is one of `skip`/`rename`/`overwrite`; absent = `skip`, unrecognized = 400 |
 | `POST /api/onboarding/import/state` | onboarding bookkeeping | `{completed: bool}` |
 
 Concurrency: apply holds a module-level import lock. Config-writing categories

--- a/src/kiro_crew/dashboard/handlers/onboarding_import.py
+++ b/src/kiro_crew/dashboard/handlers/onboarding_import.py
@@ -65,6 +65,7 @@ _CATEGORY_DESCRIPTIONS = {
     "schedules": "Compatible schedules, imported paused",
     "settings": "Compatible display and timezone settings",
 }
+_CONFLICT_STRATEGIES = frozenset({"skip", "rename", "overwrite"})
 _ITEM_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 _ITEM_OUTCOMES = frozenset({"accepted", "deduplicated", "rejected"})
 _IMPORT_LOCK = asyncio.Lock()
@@ -123,6 +124,24 @@ def _caller(request: web.Request, operation: str) -> tuple[str | None, web.Respo
         )
         return None, web.json_response({"error": "authentication required"}, status=401)
     return str(request["user"]), None
+
+
+def _parse_conflict_strategy(body: object) -> str:
+    """Read the requested strategy, rejecting anything unrecognized.
+
+    Absent means ``skip`` (the safe default), but a PRESENT-but-unknown value is
+    a hard 400: silently downgrading "overwrite" to "skip" would tell the client
+    its destructive request succeeded when nothing was replaced.
+    """
+
+    if not isinstance(body, dict):
+        raise _InvalidSelection
+    raw = body.get("conflict_strategy")
+    if raw is None:
+        return "skip"
+    if not isinstance(raw, str) or raw not in _CONFLICT_STRATEGIES:
+        raise _InvalidSelection
+    return raw
 
 
 def _parse_selection(body: object) -> tuple[list[str], set[tuple[str, str]]]:
@@ -320,8 +339,16 @@ def _apply_response(result: object) -> dict[str, Any]:
     if not isinstance(skipped, list) or not isinstance(conflicts, list):
         raise RuntimeError("invalid import result")
 
+    # A conflict the user can act on (rename/overwrite) vs one they cannot.
+    # Counts only — never the restore/rename PATHS: those are filesystem details
+    # and this response crosses into the browser.
+    resolvable = sum(
+        1 for entry in conflicts if isinstance(entry, dict) and entry.get("resolvable")
+    )
+    strategy = result.get("conflict_strategy")
     return {
         "ok": True,
+        "conflict_strategy": strategy if isinstance(strategy, str) else "skip",
         "summary": {
             "imported": _nonnegative_count(imported_count),
             "deduplicated": _nonnegative_count(
@@ -333,6 +360,9 @@ def _apply_response(result: object) -> dict[str, Any]:
                 + len(conflicts)
                 + _nonnegative_count(result.get("secret_count"), default=0)
             ),
+            "conflicts": len(conflicts),
+            # How many of those a retry with rename/overwrite could clear.
+            "resolvable_conflicts": resolvable,
         },
     }
 
@@ -343,6 +373,7 @@ def _apply_import(
     cron_service: object | None,
     vector_store: object | None,
     lesson_store: object | None,
+    conflict_strategy: str,
 ) -> object:
     backend = _backend()
     plan = _select_fresh_plan(
@@ -354,11 +385,16 @@ def _apply_import(
         cron_service=cron_service,
         vector_store=vector_store,
         lesson_store=lesson_store,
+        conflict_strategy=conflict_strategy,
     )
 
 
-def _merge_import_results(results: list[object]) -> dict[str, Any]:
+def _merge_import_results(
+    results: list[object],
+    conflict_strategy: str = "skip",
+) -> dict[str, Any]:
     merged: dict[str, Any] = {
+        "conflict_strategy": conflict_strategy,
         "imported": {},
         "imported_count": 0,
         "already_imported": 0,
@@ -479,6 +515,7 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
     try:
         body = await request.json()
         source_ids, selected = _parse_selection(body)
+        conflict_strategy = _parse_conflict_strategy(body)
     except (ValueError, TypeError):
         _audit(caller=caller, operation=operation, outcome="failed", error="invalid_request")
         return web.json_response({"error": "invalid request"}, status=400)
@@ -506,6 +543,7 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
                             cron_service,
                             vector_store,
                             lesson_store,
+                            conflict_strategy,
                         )
                     )
             if mcp_selected:
@@ -519,10 +557,11 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
                         cron_service,
                         vector_store,
                         lesson_store,
+                        conflict_strategy,
                     )
                 )
                 await asyncio.to_thread(_rebuild_agent_config)
-            result = _merge_import_results(results)
+            result = _merge_import_results(results, conflict_strategy)
             response = web.json_response(_apply_response(result))
     except _InvalidSelection:
         _audit(caller=caller, operation=operation, outcome="failed", error="invalid_request")

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -73,6 +73,18 @@ class _NoAliasSafeLoader(yaml.SafeLoader):
 
 
 SOURCE_IDS = ("codex", "claude_code", "meshclaw", "openclaw", "hermes")
+# Conflict strategies. ``skip`` is the default and the only non-destructive one;
+# the other two require an explicit user choice per apply request. See
+# docs/system-specs/modules/onboarding-import.md -> "Conflict strategy".
+STRATEGY_SKIP = "skip"
+STRATEGY_RENAME = "rename"
+STRATEGY_OVERWRITE = "overwrite"
+CONFLICT_STRATEGIES = (STRATEGY_SKIP, STRATEGY_RENAME, STRATEGY_OVERWRITE)
+# Categories whose destination collisions a strategy can actually resolve. The
+# rest are merge-only (instructions, memories, denied_commands, settings) or
+# semantically deduplicated (schedules), so a strategy has nothing to act on.
+STRATEGY_CATEGORIES = frozenset({"skills", "mcp_servers", "workspaces"})
+
 CATEGORY_IDS = (
     "instructions",
     "memories",
@@ -140,6 +152,9 @@ _MIN_INSTRUCTION_CHARS = 10
 _LEDGER_VERSION = 1
 _PLAN_VERSION = 1
 _LEDGER_RELATIVE_PATH = Path("imports") / "foreign-agent-imports.json"
+# ``overwrite`` never destroys without a restore copy. One dir per apply run so a
+# user can find everything a single import replaced together.
+_REPLACED_RELATIVE_DIR = Path("imports") / "replaced"
 _MAX_FILES = 500
 _MAX_FILE_BYTES = 8 * 1024 * 1024
 _MAX_SKILL_BYTES = 256 * 1024
@@ -301,6 +316,21 @@ class _Item:
     def fingerprint(self) -> str:
         material = f"{self.source_id}\0{self.category}\0{self.key}".encode("utf-8")
         return hashlib.sha256(material).hexdigest()
+
+
+@dataclass(frozen=True)
+class _WriteOutcome:
+    """One writer's result plus the details the API must report back.
+
+    ``status`` is the four-value writer vocabulary (imported/existing/conflict/
+    rejected). ``renamed_to`` and ``restored_to`` are set only when a strategy
+    actually took effect, so a plain ``skip`` apply reports exactly what it did
+    before this existed.
+    """
+
+    status: str
+    renamed_to: str = ""
+    restored_to: str = ""
 
 
 @dataclass
@@ -2950,7 +2980,50 @@ def _record_ledger(
     records[item.fingerprint] = record
 
 
-def _write_instruction(item: _Item, lesson_store: Any) -> str:
+def _normalize_strategy(value: Any) -> str:
+    """Coerce a client-supplied strategy to a known one, defaulting to skip."""
+
+    candidate = str(value or "").strip().lower()
+    return candidate if candidate in CONFLICT_STRATEGIES else STRATEGY_SKIP
+
+
+def _rename_candidates(base: str, item: _Item) -> list[str]:
+    """Derived non-colliding names, most readable first.
+
+    A user who renames wants to recognize the result, so the source-suffixed
+    form is tried before the digest-suffixed fallback.
+    """
+
+    suffixed = f"{base}-{item.source_id}"
+    digest = f"{base}-{item.fingerprint[:8]}"
+    return [name for name in (suffixed, digest) if name != base]
+
+
+def _restore_dir(data_home: Path, run_stamp: str, category: str) -> Path:
+    return data_home / _REPLACED_RELATIVE_DIR / run_stamp / category
+
+
+def _preserve_replaced_tree(source: Path, destination: Path) -> str:
+    """Copy a directory aside before it is replaced. Returns the restore path.
+
+    Raises so the caller can refuse to overwrite: losing the restore copy is the
+    one failure that makes ``overwrite`` unrecoverable.
+    """
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination, symlinks=True, dirs_exist_ok=False)
+    return str(destination)
+
+
+def _preserve_replaced_json(payload: Any, destination: Path) -> str:
+    """Write a replaced JSON fragment aside. Returns the restore path."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _write_json(destination, payload)
+    return str(destination)
+
+
+def _write_instruction(item: _Item, lesson_store: Any) -> _WriteOutcome:
     """Append one imported directive to the highest-priority durable tier.
 
     ``LessonStore.save`` is itself exact-rule deduplicating, so a re-import is
@@ -2960,10 +3033,10 @@ def _write_instruction(item: _Item, lesson_store: Any) -> str:
     """
 
     if lesson_store is None:
-        return "rejected"
+        return _WriteOutcome("rejected")
     rule = str(item.payload.get("rule", "")).strip()
     if not rule:
-        return "rejected"
+        return _WriteOutcome("rejected")
     from kiro_crew.learn import Lesson
 
     load_all = getattr(lesson_store, "load_all", None)
@@ -2971,7 +3044,7 @@ def _write_instruction(item: _Item, lesson_store: Any) -> str:
         normalized = rule.lower()
         for existing in load_all():
             if str(getattr(existing, "rule", "")).lower().strip() == normalized:
-                return "existing"
+                return _WriteOutcome("existing")
     lesson_store.save(
         Lesson(
             ts=datetime.now(timezone.utc).isoformat(),
@@ -2979,17 +3052,17 @@ def _write_instruction(item: _Item, lesson_store: Any) -> str:
             category="preference",
         )
     )
-    return "imported"
+    return _WriteOutcome("imported")
 
 
 def _write_memory(
     item: _Item,
     data_home: Path,
     vector_store: VectorMemoryStore | None,
-) -> str:
+) -> _WriteOutcome:
     if isinstance(item.payload, dict) and item.payload.get("kind") == "semantic":
         if vector_store is None:
-            return "rejected"
+            return _WriteOutcome("rejected")
         key = str(item.payload["key"])
         value = item.payload["value"]
         outcome = vector_store.set_semantic_if_absent(
@@ -2999,20 +3072,21 @@ def _write_memory(
             "import",
         )
         if outcome == "imported":
-            return "imported"
+            return _WriteOutcome("imported")
         existing = vector_store.get_semantic(key)
         if existing is not None:
             try:
-                return "existing" if json.loads(existing["value_json"]) == value else "conflict"
+                same = json.loads(existing["value_json"]) == value
+                return _WriteOutcome("existing" if same else "conflict")
             except (KeyError, TypeError, json.JSONDecodeError, RecursionError):
-                return "conflict"
-        return "rejected"
+                return _WriteOutcome("conflict")
+        return _WriteOutcome("rejected")
     if isinstance(item.payload, dict) and item.payload.get("kind") == "episodic":
         if vector_store is None:
-            return "rejected"
+            return _WriteOutcome("rejected")
         text = str(item.payload["text"])
         if vector_store.has_episodic_text(text):
-            return "existing"
+            return _WriteOutcome("existing")
         written = vector_store.write_episodic(
             text,
             tags=["imported", item.source_id],
@@ -3021,14 +3095,26 @@ def _write_memory(
             preserve_existing=True,
         )
         if written:
-            return "imported"
-        return "existing" if vector_store.has_episodic_text(text) else "rejected"
+            return _WriteOutcome("imported")
+        present = vector_store.has_episodic_text(text)
+        return _WriteOutcome("existing" if present else "rejected")
 
-    return "rejected"
+    return _WriteOutcome("rejected")
 
 
-def _write_workspace(item: _Item, data_home: Path) -> str:
-    workspace = Path(str(item.payload)).resolve(strict=True)
+def _write_workspace(
+    item: _Item,
+    data_home: Path,
+    *,
+    strategy: str = STRATEGY_SKIP,
+) -> _WriteOutcome:
+    workspace = Path(str(item.payload))
+    try:
+        workspace = workspace.resolve(strict=True)
+    except OSError:
+        # A configured workspace that no longer exists is a normal skip, not a
+        # write failure.
+        return _WriteOutcome("rejected")
     destination = data_home.resolve()
     if (
         not workspace.is_dir()
@@ -3036,7 +3122,7 @@ def _write_workspace(item: _Item, data_home: Path) -> str:
         or workspace == destination
         or destination in workspace.parents
     ):
-        return "rejected"
+        return _WriteOutcome("rejected")
 
     path = data_home / "config.json"
     data = _load_json_dict(path, fail_closed=True)
@@ -3045,7 +3131,7 @@ def _write_workspace(item: _Item, data_home: Path) -> str:
         workspaces = {}
         data["workspaces"] = workspaces
     if not isinstance(workspaces, dict):
-        return "conflict"
+        return _WriteOutcome("conflict")
 
     canonical = str(workspace)
     for existing in workspaces.values():
@@ -3058,23 +3144,31 @@ def _write_workspace(item: _Item, data_home: Path) -> str:
             continue
         try:
             if str(Path(existing_dir).expanduser().resolve()) == canonical:
-                return "existing"
+                return _WriteOutcome("existing")
         except (OSError, RuntimeError):
             continue
 
     base_name = _SAFE_NAME_RE.sub("-", workspace.name).strip("-._").lower()
     base_name = base_name[:64] or f"imported-{item.source_id}"
-    name = base_name
-    if name in workspaces:
-        name = f"{base_name}-{item.source_id}"[:64]
-    if name in workspaces:
-        suffix = item.fingerprint[:8]
-        name = f"{base_name[:55]}-{suffix}"
-    if name in workspaces:
-        return "conflict"
-    workspaces[name] = {"dir": canonical}
-    _write_json(path, data)
-    return "imported"
+    if base_name not in workspaces:
+        workspaces[base_name] = {"dir": canonical}
+        _write_json(path, data)
+        return _WriteOutcome("imported")
+
+    # The name is taken by a DIFFERENT directory. Deriving a suffixed name is a
+    # rename, so it now requires the user to have asked for one; a plain skip
+    # reports the collision instead of quietly inventing a name.
+    if strategy != STRATEGY_RENAME:
+        return _WriteOutcome("conflict")
+    for candidate in (
+        f"{base_name}-{item.source_id}"[:64],
+        f"{base_name[:55]}-{item.fingerprint[:8]}",
+    ):
+        if candidate not in workspaces:
+            workspaces[candidate] = {"dir": canonical}
+            _write_json(path, data)
+            return _WriteOutcome("imported", renamed_to=candidate)
+    return _WriteOutcome("conflict")
 
 
 @contextmanager
@@ -3090,7 +3184,14 @@ def _mcp_lock(_path: Path) -> Iterator[None]:
         yield
 
 
-def _write_mcp(item: _Item, data_home: Path, user_home: Path) -> str:
+def _write_mcp(
+    item: _Item,
+    data_home: Path,
+    user_home: Path,
+    *,
+    strategy: str = STRATEGY_SKIP,
+    run_stamp: str = "",
+) -> _WriteOutcome:
     path = data_home / "mcp.json"
     with _mcp_lock(path):
         data = _load_json_dict(path, fail_closed=True)
@@ -3100,21 +3201,60 @@ def _write_mcp(item: _Item, data_home: Path, user_home: Path) -> str:
         else:
             servers = data["mcpServers"]
             if not isinstance(servers, dict):
-                return "conflict"
-        name = item.payload["name"]
+                return _WriteOutcome("conflict")
+        name = str(item.payload["name"])
         spec = item.payload["spec"]
-        if name in servers:
-            return "existing" if servers[name] == spec else "conflict"
         from kiro_crew.mcp_discovery import configured_mcp_aliases
 
-        if mcp_server_alias(name) in configured_mcp_aliases(
-            data_home=data_home,
-            user_home=user_home,
-        ):
-            return "conflict"
-        servers[name] = spec
-        _write_json(path, data)
-    return "imported"
+        reserved = configured_mcp_aliases(data_home=data_home, user_home=user_home)
+
+        def _install(target_name: str) -> None:
+            servers[target_name] = spec
+            _write_json(path, data)
+
+        if name not in servers:
+            # An alias collision means some OTHER effective MCP source already
+            # owns this name, so writing it here would shadow a server the user
+            # did not import. A rename is a legitimate way out.
+            if mcp_server_alias(name) not in reserved:
+                _install(name)
+                return _WriteOutcome("imported")
+        elif servers[name] == spec:
+            return _WriteOutcome("existing")
+
+        if strategy == STRATEGY_RENAME:
+            for candidate in _rename_candidates(name, item):
+                if candidate in servers:
+                    if servers[candidate] == spec:
+                        return _WriteOutcome("existing", renamed_to=candidate)
+                    continue
+                if mcp_server_alias(candidate) in reserved:
+                    continue
+                _install(candidate)
+                return _WriteOutcome("imported", renamed_to=candidate)
+            return _WriteOutcome("conflict")
+
+        if strategy == STRATEGY_OVERWRITE:
+            # Only an entry WE can see in this file is replaceable; a name
+            # reserved by another source is not ours to overwrite.
+            if name not in servers:
+                return _WriteOutcome("conflict")
+            try:
+                restored = _preserve_replaced_json(
+                    {name: servers[name]},
+                    _restore_dir(data_home, run_stamp, "mcp_servers")
+                    / f"{_SAFE_NAME_RE.sub('-', name)}.json",
+                )
+            except OSError:
+                logger.warning(
+                    "Could not preserve the MCP server being replaced; refusing to overwrite",
+                    exc_info=True,
+                )
+                return _WriteOutcome("conflict")
+            _install(name)
+            return _WriteOutcome("imported", restored_to=restored)
+
+        return _WriteOutcome("conflict")
 
 
 def _has_symlink_component(path: Path, anchor: Path) -> bool:
@@ -3136,35 +3276,51 @@ def _has_symlink_component(path: Path, anchor: Path) -> bool:
     return False
 
 
-def _write_skill(item: _Item, data_home: Path) -> str:
-    destination = data_home / "skills" / "imported" / item.source_id / item.payload["name"]
-    files = item.payload.get("files")
+def _skill_files_are_valid(files: Any) -> bool:
     if not isinstance(files, dict) or "SKILL.md" not in files:
-        return "rejected"
-    if _has_symlink_component(destination, data_home):
-        return "rejected"
-    existing_count = 0
+        return False
     for relative, content in files.items():
         if not isinstance(relative, str) or not isinstance(content, str):
-            return "rejected"
+            return False
         relative_path = Path(relative)
         if relative_path.is_absolute() or ".." in relative_path.parts:
-            return "rejected"
-        target = destination / relative_path
+            return False
+    return True
+
+
+def _skill_tree_state(
+    destination: Path,
+    files: dict[str, str],
+    data_home: Path,
+) -> str:
+    """Classify a candidate skill destination: absent / existing / conflict."""
+
+    present = 0
+    for relative, content in files.items():
+        target = destination / Path(relative)
         if _has_symlink_component(target, data_home):
             return "rejected"
         if not target.exists():
             continue
-        existing_count += 1
+        present += 1
         try:
             if target.read_bytes() != content.encode("utf-8"):
                 return "conflict"
         except OSError:
             return "conflict"
-    if existing_count == len(files):
+    if present == len(files):
         return "existing"
-    if existing_count:
+    if present:
         return "conflict"
+    # A destination dir that exists but holds none of our files is still occupied.
+    if destination.exists() or _is_link_like(destination):
+        return "conflict"
+    return "absent"
+
+
+def _install_skill_tree(destination: Path, files: dict[str, str], data_home: Path) -> str:
+    """Stage the package in a sibling temp dir and move it into place atomically."""
+
     destination.parent.mkdir(parents=True, exist_ok=True)
     if _has_symlink_component(destination, data_home):
         return "rejected"
@@ -3179,6 +3335,8 @@ def _write_skill(item: _Item, data_home: Path) -> str:
             target = staging / Path(relative)
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(content.encode("utf-8"))
+        # Re-check immediately before the move: the plan-time check is a TOCTOU
+        # window, and this is the last moment we can still refuse.
         if _has_symlink_component(destination, data_home):
             return "rejected"
         if destination.exists() or _is_link_like(destination):
@@ -3187,6 +3345,67 @@ def _write_skill(item: _Item, data_home: Path) -> str:
         return "imported"
     finally:
         shutil.rmtree(staging, ignore_errors=True)
+
+
+def _write_skill(
+    item: _Item,
+    data_home: Path,
+    *,
+    strategy: str = STRATEGY_SKIP,
+    run_stamp: str = "",
+) -> _WriteOutcome:
+    files = item.payload.get("files")
+    if not _skill_files_are_valid(files):
+        return _WriteOutcome("rejected")
+    name = str(item.payload["name"])
+    root = data_home / "skills" / "imported" / item.source_id
+    destination = root / name
+    if _has_symlink_component(destination, data_home):
+        return _WriteOutcome("rejected")
+
+    state = _skill_tree_state(destination, files, data_home)
+    if state in ("rejected", "existing"):
+        return _WriteOutcome(state)
+    if state == "absent":
+        return _WriteOutcome(_install_skill_tree(destination, files, data_home))
+
+    # state == "conflict": a different package already occupies this name.
+    if strategy == STRATEGY_RENAME:
+        for candidate in _rename_candidates(name, item):
+            alternate = root / candidate
+            if _has_symlink_component(alternate, data_home):
+                continue
+            alternate_state = _skill_tree_state(alternate, files, data_home)
+            if alternate_state == "existing":
+                # The renamed copy is already installed and identical.
+                return _WriteOutcome("existing", renamed_to=candidate)
+            if alternate_state == "absent":
+                status = _install_skill_tree(alternate, files, data_home)
+                return _WriteOutcome(
+                    status,
+                    renamed_to=candidate if status == "imported" else "",
+                )
+        return _WriteOutcome("conflict")
+
+    if strategy == STRATEGY_OVERWRITE:
+        # The restore copy is written FIRST and its failure aborts the
+        # overwrite: an unrecoverable replace is worse than a reported conflict.
+        try:
+            restored = _preserve_replaced_tree(
+                destination,
+                _restore_dir(data_home, run_stamp, "skills") / item.source_id / name,
+            )
+        except (OSError, shutil.Error):
+            logger.warning(
+                "Could not preserve the skill being replaced; refusing to overwrite",
+                exc_info=True,
+            )
+            return _WriteOutcome("conflict")
+        shutil.rmtree(destination, ignore_errors=True)
+        status = _install_skill_tree(destination, files, data_home)
+        return _WriteOutcome(status, restored_to=restored if status == "imported" else "")
+
+    return _WriteOutcome("conflict")
 
 
 def _same_schedule(job: Any, payload: dict[str, Any]) -> bool:
@@ -3206,7 +3425,7 @@ def _same_schedule(job: Any, payload: dict[str, Any]) -> bool:
     return getattr(schedule, "at_ts", None) == payload.get("at_ts")
 
 
-def _write_schedule(item: _Item, cron_service: Any) -> str:
+def _write_schedule(item: _Item, cron_service: Any) -> _WriteOutcome:
     payload = item.payload
     add_if_absent = getattr(cron_service, "add_job_if_absent", None)
     if callable(add_if_absent) and "add_job" not in vars(cron_service):
@@ -3221,10 +3440,10 @@ def _write_schedule(item: _Item, cron_service: Any) -> str:
             enabled=False,
             timezone=payload.get("timezone", ""),
         )
-        return "existing" if job is None else "imported"
+        return _WriteOutcome("existing" if job is None else "imported")
     for job in cron_service.list_jobs(include_disabled=True):
         if _same_schedule(job, payload):
-            return "existing"
+            return _WriteOutcome("existing")
     cron_service.add_job(
         name=payload["name"],
         message=payload["message"],
@@ -3235,17 +3454,17 @@ def _write_schedule(item: _Item, cron_service: Any) -> str:
         enabled=False,
         timezone=payload.get("timezone", ""),
     )
-    return "imported"
+    return _WriteOutcome("imported")
 
 
-def _write_settings(item: _Item, data_home: Path) -> str:
+def _write_settings(item: _Item, data_home: Path) -> _WriteOutcome:
     path = data_home / "config.json"
     data = _load_json_dict(path, fail_closed=True)
     changed = _merge_missing(data, item.payload)
     if not changed:
-        return "existing"
+        return _WriteOutcome("existing")
     _write_json(path, data)
-    return "imported"
+    return _WriteOutcome("imported")
 
 
 def apply_import(
@@ -3255,8 +3474,17 @@ def apply_import(
     cron_service: Any = None,
     vector_store: VectorMemoryStore | None = None,
     lesson_store: Any = None,
+    conflict_strategy: str = STRATEGY_SKIP,
 ) -> dict[str, Any]:
-    """Apply selected source/category pairs with merge-only, idempotent writes."""
+    """Apply selected source/category pairs with merge-only, idempotent writes.
+
+    ``conflict_strategy`` decides what happens when a destination already holds a
+    DIFFERENT item under the same identity. ``skip`` (the default) leaves it
+    alone and reports a conflict; ``rename`` installs alongside it under a
+    derived name; ``overwrite`` replaces it after writing a restore copy under
+    ``imports/replaced/<timestamp>/``. Only ``skills``, ``mcp_servers``, and
+    ``workspaces`` have resolvable collisions — the rest are merge-only.
+    """
     destination = Path(data_home) if data_home is not None else config_dir()
     destination.mkdir(parents=True, exist_ok=True)
     selected = _selected_pairs(plan)
@@ -3264,6 +3492,10 @@ def apply_import(
     user_homes = _plan_user_homes(plan)
     config_paths = _plan_private_paths(plan, "_config_paths")
     workspace_paths = _plan_private_paths(plan, "_workspace_paths")
+    strategy = _normalize_strategy(conflict_strategy)
+    # One restore dir per apply run, so everything a single import replaced is
+    # found together. Stamped once here rather than per item.
+    run_stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     ledger_path = destination / _LEDGER_RELATIVE_PATH
     ledger = _load_ledger(ledger_path)
     records = ledger["records"]
@@ -3351,22 +3583,37 @@ def apply_import(
                     already_imported += 1
                     item_outcomes.append({**outcome, "outcome": "deduplicated"})
                     continue
-                status = "skipped"
+                written = _WriteOutcome("skipped")
                 try:
                     if category == "instructions":
-                        status = _write_instruction(item, lesson_store)
+                        written = _write_instruction(item, lesson_store)
                     elif category == "memories":
-                        status = _write_memory(item, destination, vector_store)
+                        written = _write_memory(item, destination, vector_store)
                     elif category == "workspaces":
-                        status = _write_workspace(item, destination)
+                        written = _write_workspace(
+                            item,
+                            destination,
+                            strategy=strategy,
+                        )
                     elif category == "mcp_servers":
-                        status = _write_mcp(item, destination, scan.user_home)
+                        written = _write_mcp(
+                            item,
+                            destination,
+                            scan.user_home,
+                            strategy=strategy,
+                            run_stamp=run_stamp,
+                        )
                     elif category == "skills":
-                        status = _write_skill(item, destination)
+                        written = _write_skill(
+                            item,
+                            destination,
+                            strategy=strategy,
+                            run_stamp=run_stamp,
+                        )
                     elif category == "schedules":
-                        status = _write_schedule(item, cron_service)
+                        written = _write_schedule(item, cron_service)
                     elif category == "settings":
-                        status = _write_settings(item, destination)
+                        written = _write_settings(item, destination)
                 except (OSError, ValueError, TypeError, sqlite3.Error):
                     logger.warning(
                         "Foreign-agent import failed for %s/%s",
@@ -3383,21 +3630,35 @@ def apply_import(
                     )
                     item_outcomes.append({**outcome, "outcome": "rejected"})
                     continue
+                status = written.status
+                # Only set when a strategy actually took effect, so a plain skip
+                # apply reports exactly the shape it did before strategies existed.
+                details = {
+                    key: value
+                    for key, value in (
+                        ("renamed_to", written.renamed_to),
+                        ("restored_to", written.restored_to),
+                    )
+                    if value
+                }
                 if status in ("imported", "existing"):
                     _record_ledger(ledger, item)
                     ledger_dirty = True
                     if status == "imported":
                         imported[category] += 1
-                        item_outcomes.append({**outcome, "outcome": "accepted"})
+                        item_outcomes.append({**outcome, **details, "outcome": "accepted"})
                     else:
                         already_imported += 1
-                        item_outcomes.append({**outcome, "outcome": "deduplicated"})
+                        item_outcomes.append({**outcome, **details, "outcome": "deduplicated"})
                 elif status == "conflict":
                     conflicts.append(
                         {
                             "source_id": source_id,
                             "category_id": category,
                             "reason": "destination_conflict",
+                            # Tell the client which strategies could resolve this
+                            # one, so a retry is an informed choice.
+                            "resolvable": category in STRATEGY_CATEGORIES,
                         }
                     )
                     item_outcomes.append({**outcome, "outcome": "rejected"})
@@ -3432,4 +3693,5 @@ def apply_import(
             sum(scan.unsupported_count for scan in scans.values()),
         ),
         "ledger": str(_LEDGER_RELATIVE_PATH).replace("\\", "/"),
+        "conflict_strategy": strategy,
     }

--- a/test/test_api_onboarding_import.py
+++ b/test/test_api_onboarding_import.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import threading
 import time
 from types import SimpleNamespace
@@ -262,6 +263,7 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
         cron_service=None,
         vector_store=None,
         lesson_store=None,
+        conflict_strategy="skip",
     ):
         received.update(
             {
@@ -272,6 +274,7 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
                 "has_cron_service": cron_service is state.crons,
                 "has_vector_store": vector_store is state.context_builder.memory.vector_store,
                 "has_lesson_store": lesson_store is state.lessons,
+                "conflict_strategy": conflict_strategy,
                 "off_thread": threading.get_ident() != event_loop_thread,
             }
         )
@@ -316,10 +319,15 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
     assert response.status == 200
     assert response_body == {
         "ok": True,
+        "conflict_strategy": "skip",
         "summary": {
             "imported": 3,
             "deduplicated": 1,
             "skipped": 4,
+            "conflicts": 1,
+            # The stub's conflict carries no ``resolvable`` flag, so it counts as
+            # unresolvable — the UI must not offer a retry that cannot help.
+            "resolvable_conflicts": 0,
         },
     }
     assert received == {
@@ -331,6 +339,9 @@ async def test_apply_runs_off_thread_with_state_dependencies(monkeypatch) -> Non
         "has_cron_service": True,
         "has_vector_store": True,
         "has_lesson_store": True,
+        # Absent from the request body -> the safe default, never a silent
+        # promotion to a destructive strategy.
+        "conflict_strategy": "skip",
         "off_thread": True,
     }
     assert preview_calls == [["claude_code"]]
@@ -453,6 +464,7 @@ async def test_apply_uses_none_for_unavailable_state_dependencies(monkeypatch) -
         cron_service=None,
         vector_store=None,
         lesson_store=None,
+        conflict_strategy="skip",
     ):
         received.update(
             {
@@ -460,6 +472,7 @@ async def test_apply_uses_none_for_unavailable_state_dependencies(monkeypatch) -
                 "cron_service": cron_service,
                 "vector_store": vector_store,
                 "lesson_store": lesson_store,
+                "conflict_strategy": conflict_strategy,
             }
         )
         return {"ok": True}
@@ -504,6 +517,7 @@ async def test_apply_uses_none_for_unavailable_state_dependencies(monkeypatch) -
         "cron_service": None,
         "vector_store": None,
         "lesson_store": None,
+        "conflict_strategy": "skip",
     }
 
 
@@ -616,3 +630,204 @@ async def test_state_failure_is_generic_and_credential_free(monkeypatch) -> None
     assert response_body == {"error": "request failed"}
     assert private_detail not in str(audit.events)
     assert audit.events[-1]["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "strategy",
+    ["obliterate", "SKIP", "", 1, True],
+    ids=["unknown", "wrong-case", "empty", "int", "bool"],
+)
+async def test_apply_rejects_an_unrecognized_conflict_strategy(monkeypatch, strategy) -> None:
+    """A present-but-unknown strategy is a 400, never a silent downgrade.
+
+    Quietly treating ``overwrite`` typo'd as ``obliterate`` like ``skip`` would
+    report success while replacing nothing, so the client would believe a
+    destructive request had been honoured.
+    """
+    module = _handler_module()
+    audit = _AuditLog()
+    called: list[object] = []
+
+    monkeypatch.setattr(
+        module,
+        "_backend",
+        lambda: SimpleNamespace(
+            preview_import=lambda source_ids=None: called.append(source_ids),
+            apply_import=lambda *a, **k: called.append(k),
+        ),
+    )
+    monkeypatch.setattr(module, "_sel", lambda: audit)
+
+    async with TestClient(TestServer(_make_app(module, SimpleNamespace()))) as client:
+        response = await client.post(
+            "/api/onboarding/import/apply",
+            json={
+                "sources": [{"id": "codex", "categories": ["settings"]}],
+                "conflict_strategy": strategy,
+            },
+            headers={"X-Test-User": "owner"},
+        )
+        body = await response.json()
+
+    assert response.status == 400
+    assert body == {"error": "invalid request"}
+    # Nothing was applied.
+    assert called == []
+    assert audit.events[-1]["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy", ["skip", "rename", "overwrite"])
+async def test_apply_forwards_each_recognized_strategy(monkeypatch, strategy) -> None:
+    module = _handler_module()
+    received: dict[str, object] = {}
+
+    def apply_import(plan, **kwargs):
+        received.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        module,
+        "_backend",
+        lambda: SimpleNamespace(
+            preview_import=lambda source_ids=None: {
+                "sources": [{"id": "codex", "categories": [{"id": "settings", "selected": True}]}],
+                "selection": [{"source_id": "codex", "category_id": "settings"}],
+            },
+            apply_import=apply_import,
+        ),
+    )
+    monkeypatch.setattr(module, "_sel", lambda: _AuditLog())
+
+    async with TestClient(TestServer(_make_app(module, SimpleNamespace()))) as client:
+        response = await client.post(
+            "/api/onboarding/import/apply",
+            json={
+                "sources": [{"id": "codex", "categories": ["settings"]}],
+                "conflict_strategy": strategy,
+            },
+            headers={"X-Test-User": "owner"},
+        )
+
+    assert response.status == 200
+    assert received["conflict_strategy"] == strategy
+
+
+@pytest.mark.asyncio
+async def test_apply_response_never_leaks_restore_or_rename_paths(monkeypatch) -> None:
+    """Restore paths are filesystem details and must not cross into the browser."""
+    module = _handler_module()
+    secret_path = "/Users/alice/private/.kiro/crew/imports/replaced/20260728T000000Z"
+
+    monkeypatch.setattr(
+        module,
+        "_backend",
+        lambda: SimpleNamespace(
+            preview_import=lambda source_ids=None: {
+                "sources": [{"id": "codex", "categories": [{"id": "skills", "selected": True}]}],
+                "selection": [{"source_id": "codex", "category_id": "skills"}],
+            },
+            apply_import=lambda plan, **kwargs: {
+                "imported": {"skills": 1},
+                "imported_count": 1,
+                "already_imported": 0,
+                "conflicts": [],
+                "skipped": [],
+                "secret_count": 0,
+                "conflict_strategy": "overwrite",
+                "item_outcomes": [
+                    {
+                        "source_id": "codex",
+                        "category_id": "skills",
+                        "item_hash": "a" * 64,
+                        "outcome": "accepted",
+                        "renamed_to": "review-codex",
+                        "restored_to": secret_path,
+                    }
+                ],
+            },
+        ),
+    )
+    monkeypatch.setattr(module, "_sel", lambda: _AuditLog())
+
+    async with TestClient(TestServer(_make_app(module, SimpleNamespace()))) as client:
+        response = await client.post(
+            "/api/onboarding/import/apply",
+            json={
+                "sources": [{"id": "codex", "categories": ["skills"]}],
+                "conflict_strategy": "overwrite",
+            },
+            headers={"X-Test-User": "owner"},
+        )
+        body = await response.json()
+
+    assert response.status == 200
+    serialized = json.dumps(body)
+    assert secret_path not in serialized
+    assert "review-codex" not in serialized
+    # The strategy that ran IS reported, so the UI can state what happened.
+    assert body["conflict_strategy"] == "overwrite"
+
+
+@pytest.mark.asyncio
+async def test_apply_omitting_the_strategy_means_skip(monkeypatch) -> None:
+    """An old client that never sends the field keeps the safe behaviour."""
+    module = _handler_module()
+    received: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        module,
+        "_backend",
+        lambda: SimpleNamespace(
+            preview_import=lambda source_ids=None: {
+                "sources": [{"id": "codex", "categories": [{"id": "settings", "selected": True}]}],
+                "selection": [{"source_id": "codex", "category_id": "settings"}],
+            },
+            apply_import=lambda plan, **kwargs: received.update(kwargs) or {"ok": True},
+        ),
+    )
+    monkeypatch.setattr(module, "_sel", lambda: _AuditLog())
+
+    async with TestClient(TestServer(_make_app(module, SimpleNamespace()))) as client:
+        response = await client.post(
+            "/api/onboarding/import/apply",
+            json={"sources": [{"id": "codex", "categories": ["settings"]}]},
+            headers={"X-Test-User": "owner"},
+        )
+        body = await response.json()
+
+    assert response.status == 200
+    assert received["conflict_strategy"] == "skip"
+    assert body["conflict_strategy"] == "skip"
+
+
+@pytest.mark.asyncio
+async def test_scan_never_writes(monkeypatch, tmp_path) -> None:
+    """The dry run is hard: previewing must not open a destination for writing."""
+    module = _handler_module()
+    import kiro_crew.onboarding_import as backend
+
+    monkeypatch.setattr(module, "_backend", lambda: backend)
+    monkeypatch.setattr(module, "_sel", lambda: _AuditLog())
+    home = tmp_path / "home"
+    skill = home / ".codex" / "skills" / "review"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Review\n", encoding="utf-8")
+    destination = tmp_path / "destination"
+    destination.mkdir()
+
+    def refuse_write(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("preview wrote to a destination")
+
+    monkeypatch.setattr(backend, "_write_json", refuse_write)
+    monkeypatch.setattr(backend, "apply_import", refuse_write)
+
+    async with TestClient(TestServer(_make_app(module, SimpleNamespace()))) as client:
+        response = await client.get(
+            "/api/onboarding/import/scan",
+            headers={"X-Test-User": "owner"},
+        )
+
+    assert response.status == 200
+    assert list(destination.iterdir()) == []

--- a/test/test_onboarding_import.py
+++ b/test/test_onboarding_import.py
@@ -1914,7 +1914,9 @@ class TestApply:
             },
         )
 
-        assert api._write_mcp(item, tmp_path / "destination", tmp_path / "home") == "imported"
+        assert (
+            api._write_mcp(item, tmp_path / "destination", tmp_path / "home").status == "imported"
+        )
         assert entered == [True]
 
     @pytest.mark.parametrize(
@@ -1982,6 +1984,9 @@ class TestApply:
                 "source_id": "meshclaw",
                 "category_id": "mcp_servers",
                 "reason": "destination_conflict",
+                # An alias collision IS resolvable — a rename gives the user a
+                # way out without shadowing the other source's server.
+                "resolvable": True,
             }
         ]
         assert not (data_home / "mcp.json").exists()
@@ -3177,7 +3182,7 @@ class TestApply:
         }
         (data_home / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
-        status = api._write_workspace(item, data_home)
+        status = api._write_workspace(item, data_home).status
         written = json.loads((data_home / "config.json").read_text(encoding="utf-8"))
 
         assert status == "conflict"
@@ -3208,7 +3213,7 @@ class TestApply:
             },
         )
 
-        status = api._write_memory(item, tmp_path, store)
+        status = api._write_memory(item, tmp_path, store).status
 
         assert status == "conflict"
         existing = store.get_semantic("pref.editor")
@@ -3271,7 +3276,7 @@ class TestApply:
             },
         )
 
-        status = api._write_memory(item, tmp_path, store)
+        status = api._write_memory(item, tmp_path, store).status
 
         active = store.get_episodic_list(limit=10)
         deleted = store.db.execute(
@@ -3302,7 +3307,7 @@ class TestApply:
             },
         )
 
-        status = api._write_memory(item, tmp_path, store)
+        status = api._write_memory(item, tmp_path, store).status
 
         active = store.get_episodic_list(limit=10)
         deleted = store.db.execute(
@@ -3340,7 +3345,7 @@ class TestApply:
             },
         )
 
-        status = api._write_memory(item, tmp_path, store)
+        status = api._write_memory(item, tmp_path, store).status
 
         assert status == "existing"
         assert lookups == [text]
@@ -3363,7 +3368,7 @@ class TestApply:
                 api._write_schedule(
                     api._Item(source_id, "schedules", source_id, payload),
                     service,
-                )
+                ).status
             )
 
         threads = [
@@ -3821,3 +3826,232 @@ class TestTransitiveReimport:
             for path in (destination / "skills" / "imported").rglob("SKILL.md")
         )
         assert skill_dirs == ["claude_code/foo"]
+
+
+def _skill_source(home: Path, source_dir: str, name: str, body: str) -> None:
+    skill = home / source_dir / "skills" / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+class TestConflictStrategies:
+    """A destination collision is a user decision, not a terminal failure.
+
+    See docs/system-specs/modules/onboarding-import.md -> "Conflict strategy".
+    ``skip`` is the default; ``rename`` and ``overwrite`` require an explicit
+    choice, and ``overwrite`` always writes a restore copy first.
+    """
+
+    def _import_skill(self, tmp_path: Path, body: str, **kwargs: object) -> dict:
+        api = _api()
+        home = tmp_path / "home"
+        _skill_source(home, ".codex", "review", body)
+        plan = api.preview_import(home=home, env={})
+        return api.apply_import(plan, data_home=tmp_path / "destination", **kwargs)
+
+    def _installed(self, destination: Path) -> dict[str, str]:
+        root = destination / "skills" / "imported"
+        return {
+            str(path.parent.relative_to(root)): path.read_text(encoding="utf-8")
+            for path in root.rglob("SKILL.md")
+        }
+
+    def test_skip_is_the_default_and_preserves_the_existing_item(self, tmp_path: Path) -> None:
+        destination = tmp_path / "destination"
+        first = self._import_skill(tmp_path, "# Original\n")
+        assert first["imported"]["skills"] == 1
+        assert first["conflict_strategy"] == "skip"
+
+        # Same name, different content: an upstream edit.
+        second = self._import_skill(tmp_path, "# Edited upstream\n")
+
+        assert second["imported"]["skills"] == 0
+        assert second["conflicts"] == [
+            {
+                "source_id": "codex",
+                "category_id": "skills",
+                "reason": "destination_conflict",
+                "resolvable": True,
+            }
+        ]
+        # KiroCrew's copy is untouched.
+        assert self._installed(destination) == {"codex/review": "# Original\n"}
+
+    def test_rename_installs_alongside_and_reports_the_new_name(self, tmp_path: Path) -> None:
+        destination = tmp_path / "destination"
+        self._import_skill(tmp_path, "# Original\n")
+
+        result = self._import_skill(tmp_path, "# Edited upstream\n", conflict_strategy="rename")
+
+        assert result["imported"]["skills"] == 1
+        assert result["conflicts"] == []
+        assert self._installed(destination) == {
+            "codex/review": "# Original\n",
+            "codex/review-codex": "# Edited upstream\n",
+        }
+        renamed = [
+            entry for entry in result["item_outcomes"] if entry.get("renamed_to") == "review-codex"
+        ]
+        assert len(renamed) == 1
+        assert renamed[0]["outcome"] == "accepted"
+
+    def test_overwrite_replaces_only_after_writing_a_restore_copy(self, tmp_path: Path) -> None:
+        destination = tmp_path / "destination"
+        self._import_skill(tmp_path, "# Original\n")
+
+        result = self._import_skill(tmp_path, "# Edited upstream\n", conflict_strategy="overwrite")
+
+        assert result["imported"]["skills"] == 1
+        assert self._installed(destination) == {"codex/review": "# Edited upstream\n"}
+        restored = [
+            entry["restored_to"] for entry in result["item_outcomes"] if entry.get("restored_to")
+        ]
+        assert len(restored) == 1
+        # The replaced bytes are recoverable, under a per-run stamped dir.
+        preserved = Path(restored[0]) / "SKILL.md"
+        assert preserved.read_text(encoding="utf-8") == "# Original\n"
+        assert (destination / "imports" / "replaced") in preserved.parents
+
+    def test_overwrite_refuses_when_the_restore_copy_cannot_be_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = _api()
+        destination = tmp_path / "destination"
+        self._import_skill(tmp_path, "# Original\n")
+
+        def fail_copytree(*_args: object, **_kwargs: object) -> None:
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(api.shutil, "copytree", fail_copytree)
+
+        result = self._import_skill(tmp_path, "# Edited upstream\n", conflict_strategy="overwrite")
+
+        # An unrecoverable replace is worse than a reported conflict.
+        assert result["imported"]["skills"] == 0
+        assert result["conflicts"][0]["reason"] == "destination_conflict"
+        assert self._installed(destination) == {"codex/review": "# Original\n"}
+
+    def test_unchanged_reimport_is_still_deduplicated_under_every_strategy(
+        self, tmp_path: Path
+    ) -> None:
+        for strategy in ("skip", "rename", "overwrite"):
+            root = tmp_path / strategy
+            self._import_skill_at(root, "# Same\n")
+            again = self._import_skill_at(root, "# Same\n", conflict_strategy=strategy)
+
+            assert again["imported"]["skills"] == 0, strategy
+            assert again["conflicts"] == [], strategy
+            # No rename, no restore copy: nothing collided.
+            assert not (root / "destination" / "imports" / "replaced").exists(), strategy
+            assert self._installed(root / "destination") == {"codex/review": "# Same\n"}, strategy
+
+    def _import_skill_at(self, root: Path, body: str, **kwargs: object) -> dict:
+        api = _api()
+        home = root / "home"
+        _skill_source(home, ".codex", "review", body)
+        plan = api.preview_import(home=home, env={})
+        return api.apply_import(plan, data_home=root / "destination", **kwargs)
+
+    def test_unknown_strategy_falls_back_to_skip_in_the_backend(self, tmp_path: Path) -> None:
+        # The API rejects an unknown strategy with a 400; the backend is the
+        # second line of defence for a non-HTTP caller and must fail SAFE.
+        destination = tmp_path / "destination"
+        self._import_skill(tmp_path, "# Original\n")
+
+        result = self._import_skill(tmp_path, "# Edited upstream\n", conflict_strategy="obliterate")
+
+        assert result["conflict_strategy"] == "skip"
+        assert self._installed(destination) == {"codex/review": "# Original\n"}
+
+    def test_mcp_rename_avoids_shadowing_another_sources_server(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        (codex / "config.toml").write_text(
+            '[mcp_servers.helper]\ncommand = "codex-helper"\n', encoding="utf-8"
+        )
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        # A server the user already has under that name, with a different spec.
+        (destination / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"helper": {"command": "mine"}}}), encoding="utf-8"
+        )
+
+        plan = api.preview_import(home=home, env={})
+        result = api.apply_import(plan, data_home=destination, conflict_strategy="rename")
+
+        servers = json.loads((destination / "mcp.json").read_text(encoding="utf-8"))["mcpServers"]
+        assert result["imported"]["mcp_servers"] == 1
+        # The user's own entry is untouched; the import lands beside it.
+        assert servers["helper"] == {"command": "mine"}
+        # Imported servers always land disabled.
+        assert servers["helper-codex"] == {"command": "codex-helper", "disabled": True}
+
+    def test_mcp_overwrite_preserves_the_replaced_spec(self, tmp_path: Path) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        (codex / "config.toml").write_text(
+            '[mcp_servers.helper]\ncommand = "codex-helper"\n', encoding="utf-8"
+        )
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        (destination / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"helper": {"command": "mine"}}}), encoding="utf-8"
+        )
+
+        plan = api.preview_import(home=home, env={})
+        result = api.apply_import(plan, data_home=destination, conflict_strategy="overwrite")
+
+        servers = json.loads((destination / "mcp.json").read_text(encoding="utf-8"))["mcpServers"]
+        assert servers["helper"] == {"command": "codex-helper", "disabled": True}
+        restored = next(
+            entry["restored_to"] for entry in result["item_outcomes"] if entry.get("restored_to")
+        )
+        assert json.loads(Path(restored).read_text(encoding="utf-8")) == {
+            "helper": {"command": "mine"}
+        }
+
+    def test_workspace_name_collision_needs_rename_not_silent_suffixing(
+        self, tmp_path: Path
+    ) -> None:
+        api = _api()
+        home = tmp_path / "home"
+        codex = home / ".codex"
+        codex.mkdir(parents=True)
+        project = tmp_path / "shared" / "demo"
+        project.mkdir(parents=True)
+        (codex / "config.toml").write_text(
+            f'[projects."{str(project).replace(chr(92), chr(92) * 2)}"]\n'
+            'trust_level = "trusted"\n',
+            encoding="utf-8",
+        )
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        other = tmp_path / "other" / "demo"
+        other.mkdir(parents=True)
+        # The name "demo" is taken by a DIFFERENT directory.
+        (destination / "config.json").write_text(
+            json.dumps({"workspaces": {"demo": {"dir": str(other)}}}), encoding="utf-8"
+        )
+
+        plan = api.preview_import(home=home, env={})
+        skipped = api.apply_import(plan, data_home=destination)
+
+        assert skipped["imported"]["workspaces"] == 0
+        assert skipped["conflicts"][0]["category_id"] == "workspaces"
+        config = json.loads((destination / "config.json").read_text(encoding="utf-8"))
+        assert config["workspaces"] == {"demo": {"dir": str(other)}}
+
+        renamed = api.apply_import(
+            api.preview_import(home=home, env={}),
+            data_home=destination,
+            conflict_strategy="rename",
+        )
+        config = json.loads((destination / "config.json").read_text(encoding="utf-8"))
+
+        assert renamed["imported"]["workspaces"] == 1
+        assert config["workspaces"]["demo"] == {"dir": str(other)}
+        assert config["workspaces"]["demo-codex"] == {"dir": str(project.resolve())}

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -715,18 +715,27 @@ export interface AgentImportSelection {
   categories: string[]
 }
 
+/** Skip keeps KiroCrew's item; rename installs alongside; overwrite replaces it
+ *  after the backend writes a restore copy. Omitting the field means 'skip'. */
+export type AgentImportConflictStrategy = 'skip' | 'rename' | 'overwrite'
+
 export interface AgentImportApplyRequest {
   sources: AgentImportSelection[]
+  conflict_strategy?: AgentImportConflictStrategy
 }
 
 export interface AgentImportSummary {
   imported: number
   deduplicated: number
   skipped: number
+  conflicts: number
+  /** How many of `conflicts` a retry with rename/overwrite could clear. */
+  resolvable_conflicts: number
 }
 
 export interface AgentImportApplyResponse {
   ok: true
+  conflict_strategy: AgentImportConflictStrategy
   summary: AgentImportSummary
 }
 

--- a/website/src/components/AgentImportFlow.test.tsx
+++ b/website/src/components/AgentImportFlow.test.tsx
@@ -72,10 +72,25 @@ const SCAN_RESPONSE: AgentImportScanResponse = {
 
 const APPLY_RESPONSE: AgentImportApplyResponse = {
   ok: true,
+  conflict_strategy: 'skip',
   summary: {
     imported: 10,
     deduplicated: 1,
     skipped: 2,
+    conflicts: 0,
+    resolvable_conflicts: 0,
+  },
+}
+
+const CONFLICTED_APPLY_RESPONSE: AgentImportApplyResponse = {
+  ok: true,
+  conflict_strategy: 'skip',
+  summary: {
+    imported: 0,
+    deduplicated: 0,
+    skipped: 2,
+    conflicts: 2,
+    resolvable_conflicts: 2,
   },
 }
 
@@ -178,6 +193,9 @@ describe('AgentImportFlow', () => {
           { id: 'claude_code', categories: ['skills'] },
           { id: 'meshclaw', categories: ['skills'] },
         ],
+        // The first apply is always the non-destructive strategy; rename and
+        // overwrite require an explicit click on the conflict notice.
+        conflict_strategy: 'skip',
       })
     })
   })
@@ -329,5 +347,39 @@ describe('AgentImportFlow', () => {
     )
     expect(screen.getByRole('dialog', { name: 'Import agent setup' })).toBeInTheDocument()
     expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('offers a resolution when items conflict, and does not by default', async () => {
+    mockSuccessfulRequests()
+    vi.mocked(api.onboardingImportApply).mockResolvedValue(CONFLICTED_APPLY_RESPONSE)
+
+    renderWithProviders(<AgentImportFlow initialOpen onComplete={vi.fn()} />)
+    await startImport()
+    await screen.findByText('Import complete')
+
+    // The user is told nothing changed, and given both ways out.
+    await screen.findByText('2 items already exist with different content.')
+    const keepBoth = screen.getByRole('button', { name: 'Keep both' })
+    expect(screen.getByRole('button', { name: 'Replace mine' })).toBeInTheDocument()
+
+    await userEvent.click(keepBoth)
+
+    // The retry re-sends the SAME selection with the chosen strategy.
+    await waitFor(() => {
+      expect(api.onboardingImportApply).toHaveBeenLastCalledWith(
+        expect.objectContaining({ conflict_strategy: 'rename' }),
+      )
+    })
+  })
+
+  it('shows no conflict resolution when nothing conflicted', async () => {
+    mockSuccessfulRequests()
+
+    renderWithProviders(<AgentImportFlow initialOpen onComplete={vi.fn()} />)
+    await startImport()
+    await screen.findByText('Import complete')
+
+    expect(screen.queryByRole('button', { name: 'Keep both' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Replace mine' })).not.toBeInTheDocument()
   })
 })

--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -25,6 +25,7 @@ import {
 import {
   api,
   type AgentImportApplyRequest,
+  type AgentImportConflictStrategy,
   type AgentImportSource,
 } from '../api/client'
 import { GhostVar1, GhostVar2 } from '../assets/onboarding/GhostIcons'
@@ -89,6 +90,7 @@ export default function AgentImportFlow({
   const [stage, setStage] = useState<Stage>(1)
   const [scanGeneration, setScanGeneration] = useState(0)
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set())
+  const [strategy, setStrategy] = useState<AgentImportConflictStrategy>('skip')
   const [selectedCategories, setSelectedCategories] = useState<Record<string, Set<string>>>({})
   const dialogRef = useRef<HTMLDivElement>(null)
   const headingRef = useRef<HTMLHeadingElement>(null)
@@ -112,6 +114,7 @@ export default function AgentImportFlow({
     setStage(1)
     setSelectedSources(new Set())
     setSelectedCategories({})
+    setStrategy('skip')
     applyMutation.reset()
     completionMutation.reset()
     if (refresh) setScanGeneration(value => value + 1)
@@ -127,7 +130,8 @@ export default function AgentImportFlow({
           .map(category => category.id),
       }))
       .filter(source => source.categories.length > 0),
-  }), [selectedCategories, selectedSources, sources])
+    conflict_strategy: strategy,
+  }), [selectedCategories, selectedSources, sources, strategy])
 
   const applyMutation = useMutation({
     mutationFn: () => api.onboardingImportApply(applyPayload),
@@ -590,6 +594,38 @@ export default function AgentImportFlow({
             <dd className="mt-1 text-2xl font-semibold text-text-strong">{summary?.skipped ?? 0}</dd>
           </div>
         </dl>
+        {!!summary?.resolvable_conflicts && (
+          <div
+            className="mt-5 rounded-lg border border-warn/30 bg-warn/10 p-3 text-sm"
+            role="status"
+          >
+            <p className="font-medium text-text-strong">
+              {summary.resolvable_conflicts === 1
+                ? '1 item already exists with different content.'
+                : `${summary.resolvable_conflicts} items already exist with different content.`}
+            </p>
+            <p className="mt-1 text-[13px] text-muted">
+              Nothing was changed. Import the new copy alongside yours, or replace yours
+              (a restore copy is kept on the gateway).
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Btn
+                type="button"
+                disabled={isBusy}
+                onClick={() => { setStrategy('rename'); applyMutation.mutate() }}
+              >
+                Keep both
+              </Btn>
+              <Btn
+                type="button"
+                disabled={isBusy}
+                onClick={() => { setStrategy('overwrite'); applyMutation.mutate() }}
+              >
+                Replace mine
+              </Btn>
+            </div>
+          </div>
+        )}
         {completionError && (
           <div className="mt-5 rounded-lg border border-danger/20 bg-danger/10 p-3 text-sm text-danger" role="alert">
             {errorMessage(completionError, 'Could not save onboarding state.')}


### PR DESCRIPTION
> **Stacked on #695.** Base is `feat/import-consensus-scope`, not `main`, so this PR
> shows only its own commit. Merge #695 first; GitHub will retarget this to `main`
> automatically.

## Problem

A destination collision was **terminal**. The item fingerprint is
`sha256(source_id \0 category \0 key)`, and for skills and MCP servers the `key`
embeds a content digest. So an upstream edit to an already-imported item produced a
fingerprint the ledger had never seen, which then hit a destination holding different
bytes → reported `conflict`, with no way forward.

The user could not keep both copies and could not replace their own. Re-running the
import produced the same dead end every time. Editing one line of a `SKILL.md` in Claude
Code was enough to create a permanently unimportable item.

## Why it matters

Users edit their skills and MCP configs — that's the normal case, not an edge case. The
importer handled first-run cleanly and then had no answer for any subsequent run where
anything had changed. The UI could only report the failure.

## Fix

A `conflict_strategy`, chosen **per apply request**, defaulting to the safe one:

| Strategy | Behavior |
|---|---|
| `skip` (**default**) | Leave KiroCrew's item alone; report the conflict |
| `rename` | Install alongside as `<name>-<source>`, then `<name>-<fingerprint[:8]>` |
| `overwrite` | Replace it — but only after a restore copy is written |

**`overwrite` writes the restore copy first, and abandons the overwrite if it can't.**
An unrecoverable replace is worse than a reported conflict. Restore copies land under
`imports/replaced/<run-stamp>/<category>/`, stamped once per apply run so everything a
single import replaced is found together.

**Scope.** Strategies apply to `skills`, `mcp_servers`, `workspaces` — the only
categories with resolvable collisions. `instructions` / `memories` /
`denied_commands` / `settings` are merge-only and `schedules` dedupes semantically, so
a strategy has nothing to act on. Each conflict entry now carries `resolvable`, so a
client offers a retry only when one could actually help.

**An unrecognized strategy is a 400, not a silent downgrade.** Quietly treating a
typo'd `overwrite` as `skip` would report success while replacing nothing — the client
would believe a destructive request was honoured. `_normalize_strategy` in the backend
is a second, fail-safe layer for non-HTTP callers.

**MCP rename respects other sources.** An alias collision means some *other* effective
MCP source owns that name; a rename avoids shadowing a server the user never imported.
`overwrite` refuses in that case — a name reserved elsewhere is not ours to replace.

Writers now return `_WriteOutcome(status, renamed_to, restored_to)`. The detail fields
populate **only** when a strategy took effect, so a plain `skip` apply produces exactly
the payload it did before this change.

### Security note

`renamed_to` / `restored_to` are **backend-only**. They are filesystem paths and the
HTTP response crosses into the browser, so the response carries `conflict_strategy`
plus `conflicts` / `resolvable_conflicts` **counts** only. There's a regression test
asserting neither path appears in the serialized response.

### Behavior change worth a reviewer's eye

`_write_workspace` previously walked a three-step name ladder on collision, silently
suffixing a workspace name the user had not asked to rename. That *is* a rename, so it
now requires the `rename` strategy; plain `skip` reports the collision. This is the one
place existing behavior narrows rather than widens — covered by
`test_workspace_name_collision_needs_rename_not_silent_suffixing`.

## Tests

**Backend** — `TestConflictStrategies` (9): skip is the default and preserves the
existing item; rename installs alongside and reports the new name; overwrite replaces
only after a restore copy, with the replaced bytes recoverable; **overwrite refuses when
the restore copy can't be written** (monkeypatched `copytree` failure); an unchanged
re-import is still deduplicated under all three strategies with no stray restore dir; an
unknown strategy fails safe in the backend; MCP rename avoids shadowing another source's
server; MCP overwrite preserves the replaced spec; workspace collision needs rename.

**API** (6 new): each of the three strategies is forwarded; five malformed values
(`obliterate`, wrong case, empty, int, bool) are each a 400 with nothing applied;
omitting the field means `skip`; the response leaks neither restore nor rename paths;
and `test_scan_never_writes` asserts the dry run is hard — previewing with `_write_json`
and `apply_import` monkeypatched to raise still returns 200 and leaves the destination
empty.

**Frontend** (2 new): the conflict notice offers "Keep both" / "Replace mine" and the
retry re-sends the same selection with the chosen strategy; nothing is offered when
nothing conflicted.

## Manual verification

N/A — the flow is covered end-to-end by the backend strategy tests (which exercise real
filesystem writes through `apply_import`) plus the frontend interaction tests. No new
surface needs a human to drive it.

## Screenshots

The one visible addition is a conditional notice inside the existing "Import complete"
panel — it renders only when `resolvable_conflicts > 0`, which requires a pre-populated
data home to reproduce live. Its content and both buttons are asserted in
`AgentImportFlow.test.tsx`. Happy to attach a capture if you'd prefer one before merge.
