### PR TITLE
fix(dashboard): restore sessions off the event loop, with a snapshot floor

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -915,6 +915,14 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
     if row is None:
         return
     _write_brief(cid, row)
+    # This creates from a stable, caller-derived key without loading the session
+    # window, so a key the startup replay has not reached yet must be restored
+    # first: an empty slot registered under it would be flushed over that
+    # campaign session's transcript. Same guard as /api/chat and the
+    # OpenAI-compat endpoint.
+    from kiro_crew.dashboard.chat_persistence import ensure_pending_slot_restored
+
+    await ensure_pending_slot_restored(state, f"research-{cid}")
     slot = state.get_or_create_slot(
         name=f"research-{cid}", agent=_RESEARCH_AGENT, app="auto-research"
     )

--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -83,12 +83,14 @@ from kiro_crew.dashboard.chat_orchestrator import (  # noqa: F401
     api_chat_plan_action,
 )
 from kiro_crew.dashboard.chat_persistence import (  # noqa: F401
+    _apply_recent_session,
     _attach_variants,
     _build_history_prefix,
     _rehydrate_slot_from_history,
     _save_slot_to_history,
     restore_open_slots,
     restore_recent_sessions,
+    restore_sessions_at_startup,
     save_all_slots_to_history,
 )
 from kiro_crew.dashboard.chat_regenerate import (  # noqa: F401

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -31,6 +31,7 @@ from kiro_crew.dashboard.chat_persistence import (
     _attach_variants,
     _redact_meta,
     _redact_meta_for_role,
+    ensure_pending_slot_restored,
     get_reasoning_effort_values,
     save_slot_off_loop,
 )
@@ -157,6 +158,12 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     requested_memory_mode = body.get("memory_mode")
     if requested_memory_mode not in ("persistent", "incognito", "temporary"):
         requested_memory_mode = None
+
+    # This handler creates from a request-supplied key and never loads the
+    # session window itself, so a key the startup replay has not reached yet
+    # must be restored first — an empty slot registered under it would be
+    # flushed over that session's transcript.
+    await ensure_pending_slot_restored(state, slot_name)
 
     try:
         slot = state.get_or_create_slot(
@@ -697,6 +704,9 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
         memory_mode = body.get("memory_mode", "persistent")
         if memory_mode not in ("persistent", "incognito", "temporary"):
             return web.json_response({"error": "invalid memory_mode"}, status=400)
+        # Same reason as api_chat: creating under a key the startup replay still
+        # owns must restore it rather than register an empty slot over it.
+        await ensure_pending_slot_restored(state, name)
         slot = state.get_or_create_slot(
             name,
             agent=agent,

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -9,6 +9,11 @@ import re
 import time
 import uuid
 from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from aiohttp import web
 
 from kiro_crew import model_registry
 from kiro_crew.agent import KIRO_AGENTS_DIR
@@ -26,6 +31,11 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import ARTIFACT_SLUG_RE
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable, Iterator
+
+    from kiro_crew.history import ConversationLog
 
 
 def _redact_value(v):  # type: ignore[no-untyped-def]
@@ -174,6 +184,221 @@ def save_all_slots_to_history(state: DashboardState) -> None:
         logger.debug("Shutdown: open_slots snapshot failed", exc_info=True)
 
 
+def _kiro_model_map() -> dict[str, str]:
+    """Map kiro agent name/stem -> configured model, for restored slots."""
+    kiro_model_map: dict[str, str] = {}
+    try:
+        for f in KIRO_AGENTS_DIR.glob("*.json"):
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                model = data.get("model", "")
+                if data.get("name"):
+                    kiro_model_map[data["name"]] = model
+                kiro_model_map[f.stem] = model
+            except (json.JSONDecodeError, OSError):
+                continue
+    except Exception:
+        logger.debug("Failed to build kiro model map", exc_info=True)
+    return kiro_model_map
+
+
+def _load_restore_cfg() -> "KiroCrewConfig | None":
+    try:
+        return KiroCrewConfig.load()
+    except Exception:
+        return None
+
+
+def _slot_name_from_history_key(key: str) -> str | None:
+    """Slot name for a ``list_sessions()`` key, or None if it is not a chat slot.
+
+    ``list_sessions()`` reports the FILENAME-folded form (``dashboard_x``) while
+    ``_history_key_for`` produces the canonical colon form (``dashboard:x``), so
+    anything keyed off one and looked up by the other silently misses. Both
+    prefixes are stripped here and every lookup goes through the slot name.
+
+    The result is folded through ``_normalize_slot_key`` — which also unwraps
+    STACKED ``dashboard_dashboard_x`` prefixes — so it equals the key
+    ``get_or_create_slot`` will actually register. Returning the unfolded name
+    would let a legacy stacked file miss the ``slot_name in state._slots`` dedup
+    guard and then replay its whole window onto the canonical slot that guard
+    was meant to protect, duplicating that session's messages on the next save.
+    """
+    if key.startswith("dashboard:"):
+        stripped = key.removeprefix("dashboard:")
+    elif key.startswith("dashboard_"):
+        stripped = key.removeprefix("dashboard_")
+    else:
+        return None
+    return _normalize_slot_key(stripped) or None
+
+
+@dataclass
+class RestorePlan:
+    """Everything a restore needs, read from disk with no state touched.
+
+    Produced by :func:`_collect_restore_plan` — deliberately a plain data
+    object built from a ``ConversationLog`` rather than a ``DashboardState``, so
+    the collect phase *cannot* mutate slots even by accident. That is what makes
+    it safe to run in a worker thread while the event loop keeps serving.
+    """
+
+    open_keys: list[str]
+    """Keys read from open_slots.json, validated and folded. Also the floor."""
+    listing: dict[str, dict]
+    """slot name -> list_sessions() row, so no applier re-walks the directory."""
+    sessions: list[tuple[str, dict, dict]]
+    """(slot_name, listing row, metadata) for eligible non-open-tab sessions."""
+    kiro_model_map: dict[str, str]
+    cfg: "KiroCrewConfig | None"
+
+    @property
+    def total(self) -> int:
+        return len(self.open_keys) + len(self.sessions)
+
+
+def _read_open_slots_keys() -> list[str]:
+    """Validated, folded keys from open_slots.json. Pure file read, no log needed.
+
+    Split out from :func:`_collect_open_keys` so the startup path can install the
+    snapshot floor from these keys BEFORE it yields to the loop. The file holds
+    one short string per open tab, so this read is bounded by the tab count
+    rather than by accumulated history.
+    """
+    keys: list[str] = []
+    path = config_dir() / "open_slots.json"
+    if not path.exists():
+        return keys
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.debug("open_slots.json unreadable; skipping", exc_info=True)
+        return keys
+    raw_keys = data.get("keys") if isinstance(data, dict) else None
+    if not isinstance(raw_keys, list):
+        return keys
+    for raw in raw_keys:
+        if not isinstance(raw, str) or not raw:
+            continue
+        # Defense-in-depth: slot keys flow into _history_key_for() ->
+        # filesystem path construction. open_slots.json is 0o600 so the threat
+        # is small, but a key smuggled in (symlink attack at write time or a
+        # separate vuln) could escape the sessions directory (e.g.
+        # "../../etc/passwd"). Live-gateway slot keys never contain path
+        # separators; reject any that do, warn so an attempted breakout is
+        # visible, and keep restoring the rest.
+        if "/" in raw or "\\" in raw:
+            logger.warning("restore_open_slots: rejecting key with path separators: %r", raw)
+            continue
+        # Fold to the canonical (filename-charset) key. Snapshots written
+        # before slot-key normalization landed may carry a raw display-style
+        # key (e.g. "Artifact: My Doc") alongside its sanitized twin — after
+        # folding, the second form is deduped here instead of restoring a
+        # duplicate sidebar session backed by the same transcript.
+        folded = _normalize_slot_key(raw)
+        if folded and folded not in keys:
+            keys.append(folded)
+    return keys
+
+
+def _collect_open_keys(
+    log: "ConversationLog", *, keys: list[str] | None = None
+) -> tuple[list[str], dict[str, dict]]:
+    """Open-tab keys plus the session listing, both read from disk.
+
+    The listing is ALWAYS built — a missing or malformed snapshot yields no open
+    keys but still returns the full listing, because the recent-session half of a
+    plan reads it too. Returning an empty listing here would silently reduce a
+    fresh home's restore to nothing. Pass *keys* to reuse an earlier read.
+    """
+    listing: dict[str, dict] = {}
+    for s in log.list_sessions():
+        name = _slot_name_from_history_key(s.get("key", ""))
+        if name:
+            listing[name] = s
+    return (keys if keys is not None else _read_open_slots_keys()), listing
+
+
+def _collect_recent_sessions(
+    log: "ConversationLog",
+    window_minutes: int,
+    *,
+    folders_only: bool,
+    listing: dict[str, dict] | None = None,
+    skip: set[str] | None = None,
+) -> list[tuple[str, dict, dict]]:
+    """Filter the session listing down to the sessions a restore should replay.
+
+    Pure I/O plus filtering: mtime cutoff, ``folders_only``, pinned/foldered
+    exemption and ``closed``. *skip* holds slot names already covered by the
+    open-tab list, so the two halves of a plan never collect the same session
+    twice.
+    """
+    cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
+    if listing is None:
+        rows = list(log.list_sessions())
+    else:
+        rows = list(listing.values())
+    out: list[tuple[str, dict, dict]] = []
+    for s in rows:
+        key = s.get("key", "")
+        slot_name = _slot_name_from_history_key(key)
+        if not slot_name:
+            continue
+        if skip and slot_name in skip:
+            continue
+        meta = log.get_metadata(key)
+        has_folder = bool(meta.get("folder_id"))
+        has_pin = bool(meta.get("pinned"))
+        if folders_only and not has_folder and not has_pin:
+            continue
+        if meta.get("closed"):
+            continue
+        if not has_folder and not has_pin:
+            if cutoff is not None and s.get("modified", 0) < cutoff:
+                continue
+        out.append((slot_name, s, meta))
+    return out
+
+
+def _collect_restore_plan(
+    log: "ConversationLog",
+    window_minutes: int,
+    *,
+    folders_only: bool,
+    open_keys: list[str] | None = None,
+) -> RestorePlan:
+    """Build the whole startup restore plan off the event loop.
+
+    One ``list_sessions()`` walk feeds both halves; the recent-session half
+    skips anything the open-tab half already covers.
+
+    *open_keys* reuses a read the caller already did: the startup path reads the
+    snapshot first so it can install the floor before it yields to the loop.
+    """
+    resolved_keys, listing = _collect_open_keys(log, keys=open_keys)
+    # No skip= against open_keys. Deduplication happens at APPLY time, against
+    # state._slots, and it has to: an open-tab key whose only file on disk is a
+    # legacy stacked "dashboard_dashboard_x.jsonl" cannot be resolved by the
+    # canonical rehydrate (it looks for dashboard_x.jsonl and finds nothing), so
+    # skipping it here as "already covered" would drop that tab from BOTH paths.
+    # Collecting it twice costs one extra metadata read off the loop; the
+    # open-tab half runs first, so the second pass hits the _slots guard.
+    sessions = _collect_recent_sessions(
+        log,
+        window_minutes,
+        folders_only=folders_only,
+        listing=listing,
+    )
+    return RestorePlan(
+        open_keys=resolved_keys,
+        listing=listing,
+        sessions=sessions,
+        kiro_model_map=_kiro_model_map(),
+        cfg=_load_restore_cfg(),
+    )
+
+
 def restore_open_slots(state: DashboardState) -> int:
     """Restore the tabs the user had open at the previous shutdown.
 
@@ -195,67 +420,50 @@ def restore_open_slots(state: DashboardState) -> int:
     """
     if not state.conversation_log:
         return 0
-    path = config_dir() / "open_slots.json"
-    if not path.exists():
-        return 0
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        logger.debug("open_slots.json unreadable; skipping", exc_info=True)
-        return 0
-    keys = data.get("keys") if isinstance(data, dict) else None
-    if not isinstance(keys, list):
-        return 0
+    keys, listing = _collect_open_keys(state.conversation_log)
+    kiro_model_map = _kiro_model_map()
+    restore_cfg = _load_restore_cfg()
     restored = 0
     for raw in keys:
-        if not isinstance(raw, str) or not raw:
-            continue
-        # Defense-in-depth: slot keys flow into _history_key_for() ->
-        # filesystem path construction. open_slots.json is 0o600 so the threat
-        # is small, but a key smuggled in (symlink attack at write time or a
-        # separate vuln) could escape the sessions directory (e.g.
-        # "../../etc/passwd"). Live-gateway slot keys never contain path
-        # separators; reject any that do, warn so an attempted breakout is
-        # visible, and keep restoring the rest.
-        if "/" in raw or "\\" in raw:
-            logger.warning(
-                "restore_open_slots: rejecting key with path separators: %r", raw
-            )
-            continue
-        # Fold to the canonical (filename-charset) key. Snapshots written
-        # before slot-key normalization landed may carry a raw display-style
-        # key (e.g. "Artifact: My Doc") alongside its sanitized twin — after
-        # folding, the second form hits the dedup guard below instead of
-        # restoring a duplicate sidebar session backed by the same transcript.
-        raw = _normalize_slot_key(raw)
         if raw in state._slots:
             continue
         try:
-            slot = _rehydrate_slot_from_history(state, raw)
+            slot = _rehydrate_slot_from_history(
+                state,
+                raw,
+                session_info=listing.get(raw, {}),
+                kiro_model_map=kiro_model_map,
+                restore_cfg=restore_cfg,
+            )
         except Exception:
             logger.debug("restore_open_slots: rehydrate failed for %s", raw, exc_info=True)
-            # Roll back any partial slot leaked by _rehydrate_slot_from_history.
-            # It calls state.get_or_create_slot() BEFORE its fallible work
-            # (read_messages, redaction, slot.append), so a failure there
-            # leaves an empty slot registered in state._slots. Without this
-            # pop, restore_recent_sessions runs next, hits its
-            # `if slot_name in state._slots: continue` dedup guard, and skips
-            # the proper restore — the user would see a tab with the right
-            # title/agent but empty or wrong message history.
-            state._slots.pop(raw, None)
-            # _rehydrate_slot_from_history also adds `dashboard:{slot_name}`
-            # to _restricted_keys before that fallible work for any
-            # non-persistent memory_mode. Roll it back too, else a later
-            # get_or_create_slot(slot_name) (default memory_mode='persistent')
-            # silently inherits restricted status, blocking
-            # consolidation/lessons for what should be a normal session.
-            state._restricted_keys.discard(f"dashboard:{raw}")
+            _rollback_partial_slot(state, raw)
             continue
         if slot is not None:
             restored += 1
     if restored:
         logger.info("Restored %d open tab(s) from open_slots.json", restored)
     return restored
+
+
+def _rollback_partial_slot(state: DashboardState, slot_name: str) -> None:
+    """Undo a slot registration leaked by a failed rehydrate.
+
+    ``_rehydrate_slot_from_history`` calls ``state.get_or_create_slot()`` BEFORE
+    its fallible work (read_messages, redaction, slot.append), so a failure
+    there leaves an empty slot registered in ``state._slots``. Without this pop,
+    the recent-session pass runs next, hits its ``if slot_name in state._slots``
+    dedup guard and skips the proper restore — the user would see a tab with the
+    right title/agent but empty or wrong message history.
+
+    It also adds ``dashboard:{slot_name}`` to ``_restricted_keys`` before that
+    fallible work for any non-persistent memory_mode. Roll that back too, else a
+    later ``get_or_create_slot(slot_name)`` (default ``memory_mode='persistent'``)
+    silently inherits restricted status, blocking consolidation/lessons for what
+    should be a normal session.
+    """
+    state._slots.pop(slot_name, None)
+    state._restricted_keys.discard(f"dashboard:{slot_name}")
 
 
 def _attach_variants(slot: _ChatSlot, m: dict) -> None:
@@ -272,7 +480,16 @@ def _attach_variants(slot: _ChatSlot, m: dict) -> None:
         slot.messages[-1]["variant_idx"] = m.get("variant_idx", 0)
 
 
-def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _ChatSlot | None:
+def _rehydrate_slot_from_history(
+    state: DashboardState,
+    slot_name: str,
+    *,
+    messages: list[dict] | None = None,
+    session_info: dict | None = None,
+    meta: dict | None = None,
+    kiro_model_map: dict[str, str] | None = None,
+    restore_cfg: "KiroCrewConfig | None" = None,
+) -> _ChatSlot | None:
     """Rehydrate a single dashboard slot from persisted history.
 
     Unlike ``state.get_or_create_slot`` (which creates a fresh, empty slot with
@@ -285,6 +502,18 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
 
     Intended for targeted resume paths (e.g. cron→origin injection after
     gateway restart). Bulk startup restore still uses ``restore_recent_sessions``.
+
+    *messages* and *session_info* let a caller supply the two large disk reads
+    this would otherwise do inline — the chained message window and this
+    session's ``list_sessions()`` row. *kiro_model_map* and *restore_cfg* supply
+    the two small but repeated ones: the config load and the agent-directory
+    glob, which are per-process facts, not per-session, and would otherwise be
+    redone for every key in a bulk restore. The async restore pass passes all
+    four — the windows read in a worker thread, the rest once per plan — keeping
+    the I/O off the event loop while the slot mutation (loop-affine:
+    ``slot.append`` sets an ``asyncio.Event`` and ``get_or_create_slot``
+    broadcasts through the SSE queues) still happens on it. Every one defaults
+    to the inline read, so standalone callers are unchanged.
     """
     if not state.conversation_log:
         return None
@@ -296,38 +525,38 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     if slot_name in state._slots:
         return state._slots[slot_name]
     history_key = _history_key_for(slot_name)
-    meta = state.conversation_log.get_metadata(history_key)
-    # No metadata → session was never persisted. Don't create a phantom slot.
+    if meta is None:
+        # get_metadata reads the WHOLE file to take its first line, and the
+        # mtime cache is cold on the first read after boot — so on a large
+        # session this is a multi-megabyte synchronous read. A bulk restore
+        # passes it in, read off the loop alongside the message window.
+        meta = state.conversation_log.get_metadata(history_key)
+    # No metadata → session was never persisted, or it was deleted while a
+    # caller was reading its window. Don't create a phantom slot, and don't let
+    # the tab_id backfill below recreate a file the user just deleted.
     if not meta:
         return None
     if meta.get("closed"):
         return None
-    try:
-        _restore_cfg = KiroCrewConfig.load()
-    except Exception:
-        _restore_cfg = None
-    # Build the same kiro-agent model map as restore_recent_sessions so
-    # legacy sessions without persisted `model` still resolve correctly.
-    kiro_model_map: dict[str, str] = {}
-    try:
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    kiro_model_map[data["name"]] = model
-                kiro_model_map[f.stem] = model
-            except (json.JSONDecodeError, OSError):
-                continue
-    except Exception:
-        logger.debug("Failed to build kiro model map", exc_info=True)
+    _restore_cfg = restore_cfg if restore_cfg is not None else _load_restore_cfg()
+    # The same kiro-agent model map restore_recent_sessions builds, so legacy
+    # sessions without a persisted `model` still resolve correctly. Both this and
+    # the config load above are per-process facts: a bulk restore passes them in
+    # once rather than reloading the config and re-globbing the agent directory
+    # on the event loop for every single key.
+    if kiro_model_map is None:
+        kiro_model_map = _kiro_model_map()
     slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
     # Pull display fields from session listing for title parity with bulk restore.
-    sessions = state.conversation_log.list_sessions()
-    session_info = next(
-        (s for s in sessions if s.get("key") == history_key),
-        {},
-    )
+    if session_info is None:
+        session_info = next(
+            (
+                s
+                for s in state.conversation_log.list_sessions()
+                if s.get("key") == history_key
+            ),
+            {},
+        )
     # Titles may have been auto-generated by an LLM (_generate_title_via_kiro)
     # and are surfaced on the dashboard, so apply the same redaction passes
     # used on assistant content before setting. Defence-in-depth — the title
@@ -413,7 +642,11 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     # read_messages alone caps visible history at 200 lines from THIS file and
     # drops the ancestor chain — long-running forked sessions would lose 200+
     # messages of context on every gateway restart.
-    messages = state.conversation_log.read_messages_chained(history_key)
+    messages = (
+        state.conversation_log.read_messages_chained(history_key)
+        if messages is None
+        else messages
+    )
     # Only the recent window is loaded into memory; older on-disk lines become
     # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
     # therefore count those older lines so the save model preserves them.
@@ -446,157 +679,625 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     return slot
 
 
+def _apply_recent_session(
+    state: DashboardState,
+    s: dict,
+    slot_name: str,
+    meta: dict,
+    kiro_model_map: dict[str, str],
+    _restore_cfg: "KiroCrewConfig | None",
+    *,
+    messages: list[dict] | None = None,
+) -> _ChatSlot:
+    """Materialize one listed session as a chat slot (metadata + message window).
+
+    The expensive half of a recent-session restore, split out so the async pass
+    replays the *same* code path as the sync wrapper rather than a parallel copy.
+    Callers own filtering, the restored counter and the log line.
+
+    *messages* lets the caller supply the chained window instead of reading it
+    here, so the async pass can do that read in a worker thread while the slot
+    mutation (loop-affine) stays on the event loop.
+    """
+    key = s.get("key", "")
+    log = state.conversation_log
+    if log is None:
+        # Unreachable via either caller (both guard on conversation_log), but the
+        # attribute is Optional and this function reads through it twice.
+        raise RuntimeError("restore requires a conversation log")
+    slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+    # Titles can be LLM-generated (auto-title) and are surfaced on the
+    # dashboard — apply the same redaction as assistant content. Matches
+    # the treatment in _rehydrate_slot_from_history above.
+    raw_title = s.get("title", slot_name)
+    raw_title, _ = redact_exfiltration_urls(raw_title)
+    raw_title, _ = redact_credentials(raw_title)
+    slot.title = raw_title
+    slot._titled = bool(s.get("title"))
+    if meta.get("created_at"):
+        slot.created_at = meta["created_at"]
+    if meta.get("agent"):
+        slot.agent = meta["agent"]
+    if meta.get("model"):
+        # Canonicalize a pre-migration claude_code provider id to the
+        # canonical dropdown key (no-op for other providers); reuse the
+        # already-loaded _restore_cfg provider.
+        _prov = _restore_cfg.agent.provider if _restore_cfg else ""
+        slot.model = model_registry.canonicalize_for_provider(
+            _normalize_model(meta["model"]), _prov
+        )
+    elif slot.agent:
+        try:
+            mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
+            kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
+            slot.model = kiro_model_map.get(kiro_name, "")
+        except Exception:
+            logger.debug(
+                "Failed to resolve model for restored slot %s", slot_name, exc_info=True
+            )
+    if meta.get("reasoning_effort"):
+        slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
+    if meta.get("workspace"):
+        slot.workspace = meta["workspace"]
+    if meta.get("project"):
+        slot.project = meta["project"]
+    if meta.get("mode"):
+        slot.mode = meta["mode"]
+    if meta.get("folder_id"):
+        slot.folder_id = meta["folder_id"]
+    if meta.get("app"):
+        slot._app = meta["app"]
+    # Same tamper gate as _rehydrate_slot_from_history: re-validate the
+    # companion binding against the slug grammar before it reaches
+    # to_dict()/WS broadcasts.
+    _artifact_meta = meta.get("artifact")
+    if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
+        slot._artifact = _artifact_meta
+    if meta.get("pinned"):
+        slot.pinned = True
+    if meta.get("color_index") is not None:
+        slot.color_index = meta["color_index"]
+    if meta.get("color_theme"):
+        slot.color_theme = meta["color_theme"]
+    raw_tags = meta.get("tags")
+    if isinstance(raw_tags, list):
+        slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+    mm = meta.get("memory_mode", "persistent")
+    slot.memory_mode = mm
+    if mm != "persistent":
+        state._restricted_keys.add(f"dashboard:{slot_name}")
+    if meta.get("forked_from") is not None:
+        slot.forked_from = meta["forked_from"]
+    tab_id = meta.get("tab_id")
+    if not tab_id:
+        tab_id = uuid.uuid4().hex[:12]
+        # This runs with the event loop live, and update_metadata enters
+        # _locked (flock + os.close) — a blocking-on-loop-prohibited op, so
+        # backfill the tab_id off the loop rather than on it.
+        update_metadata_off_loop(log, key, {"tab_id": tab_id})
+    slot._tab_id = tab_id
+    if messages is None:
+        messages = log.read_messages_chained(key)
+    slot._disk_older_count = max(0, len(messages) - 500)
+    for m in messages[-500:]:
+        role = m.get("role", "assistant")
+        cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
+        content = m.get("content", "")
+        if role != "user":
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
+        slot.append(
+            role,
+            content,
+            cls,
+            ts=m.get("ts", ""),
+            meta=(
+                _redact_meta_for_role(role, m["meta"])
+                if isinstance(m.get("meta"), dict)
+                else None
+            ),
+        )
+        _attach_variants(slot, m)
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    # Loaded window is the on-disk window region; older lines (counted in
+    # _disk_older_count above) are the frozen prefix saves never rewrite.
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+    return slot
+
+
 def restore_recent_sessions(
     state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
 ) -> int:
-    """Restore sessions as chat slots."""
+    """Restore sessions as chat slots (synchronous, restores everything).
+
+    Startup uses :func:`restore_sessions_at_startup` instead, which does the
+    same work with the reads off the event loop. This wrapper stays for targeted
+    and test callers that want the whole thing done by the time it returns.
+    """
     if not state.conversation_log:
         return 0
-    cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
+    kiro_model_map = _kiro_model_map()
+    _restore_cfg = _load_restore_cfg()
     restored = 0
-
-    kiro_model_map: dict[str, str] = {}
-    try:
-
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    kiro_model_map[data["name"]] = model
-                kiro_model_map[f.stem] = model
-            except (json.JSONDecodeError, OSError):
-                continue
-    except Exception:
-        logger.debug("Failed to build kiro model map", exc_info=True)
-    try:
-        _restore_cfg = KiroCrewConfig.load()
-    except Exception:
-        _restore_cfg = None
-    for s in state.conversation_log.list_sessions():
-        key = s.get("key", "")
-        if key.startswith("dashboard:"):
-            slot_name = key.removeprefix("dashboard:")
-        elif key.startswith("dashboard_"):
-            slot_name = key.removeprefix("dashboard_")
-        else:
-            continue
+    for slot_name, s, meta in _collect_recent_sessions(
+        state.conversation_log, window_minutes, folders_only=folders_only
+    ):
         if slot_name in state._slots:
             continue
-        meta = state.conversation_log.get_metadata(key)
-        has_folder = bool(meta.get("folder_id"))
-        has_pin = bool(meta.get("pinned"))
-        if folders_only and not has_folder and not has_pin:
-            continue
-        if meta.get("closed"):
-            continue
-        if not has_folder and not has_pin:
-            if cutoff is not None and s.get("modified", 0) < cutoff:
-                continue
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
-        # Titles can be LLM-generated (auto-title) and are surfaced on the
-        # dashboard — apply the same redaction as assistant content. Matches
-        # the treatment in _rehydrate_slot_from_history above.
-        raw_title = s.get("title", slot_name)
-        raw_title, _ = redact_exfiltration_urls(raw_title)
-        raw_title, _ = redact_credentials(raw_title)
-        slot.title = raw_title
-        slot._titled = bool(s.get("title"))
-        if meta.get("created_at"):
-            slot.created_at = meta["created_at"]
-        if meta.get("agent"):
-            slot.agent = meta["agent"]
-        if meta.get("model"):
-            # Canonicalize a pre-migration claude_code provider id to the
-            # canonical dropdown key (no-op for other providers); reuse the
-            # already-loaded _restore_cfg provider.
-            _prov = _restore_cfg.agent.provider if _restore_cfg else ""
-            slot.model = model_registry.canonicalize_for_provider(
-                _normalize_model(meta["model"]), _prov
-            )
-        elif slot.agent:
-            try:
-                mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
-                kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
-                slot.model = kiro_model_map.get(kiro_name, "")
-            except Exception:
-                logger.debug(
-                    "Failed to resolve model for restored slot %s", slot_name, exc_info=True
-                )
-        if meta.get("reasoning_effort"):
-            slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
-        if meta.get("workspace"):
-            slot.workspace = meta["workspace"]
-        if meta.get("project"):
-            slot.project = meta["project"]
-        if meta.get("mode"):
-            slot.mode = meta["mode"]
-        if meta.get("folder_id"):
-            slot.folder_id = meta["folder_id"]
-        if meta.get("app"):
-            slot._app = meta["app"]
-        # Same tamper gate as _rehydrate_slot_from_history: re-validate the
-        # companion binding against the slug grammar before it reaches
-        # to_dict()/WS broadcasts.
-        _artifact_meta = meta.get("artifact")
-        if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
-            slot._artifact = _artifact_meta
-        if meta.get("pinned"):
-            slot.pinned = True
-        if meta.get("color_index") is not None:
-            slot.color_index = meta["color_index"]
-        if meta.get("color_theme"):
-            slot.color_theme = meta["color_theme"]
-        raw_tags = meta.get("tags")
-        if isinstance(raw_tags, list):
-            slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
-        mm = meta.get("memory_mode", "persistent")
-        slot.memory_mode = mm
-        if mm != "persistent":
-            state._restricted_keys.add(f"dashboard:{slot_name}")
-        if meta.get("forked_from") is not None:
-            slot.forked_from = meta["forked_from"]
-        tab_id = meta.get("tab_id")
-        if not tab_id:
-            tab_id = uuid.uuid4().hex[:12]
-            # restore_recent_sessions runs during on_startup (event loop live)
-            # — keep the _locked flock/os.close off the loop via the off-loop
-            # backfill helper.
-            update_metadata_off_loop(
-                state.conversation_log, key, {"tab_id": tab_id}
-            )
-        slot._tab_id = tab_id
-        messages = state.conversation_log.read_messages_chained(key)
-        slot._disk_older_count = max(0, len(messages) - 500)
-        for m in messages[-500:]:
-            role = m.get("role", "assistant")
-            cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
-            content = m.get("content", "")
-            if role != "user":
-                content, _ = redact_exfiltration_urls(content)
-                content, _ = redact_credentials(content)
-            slot.append(
-                role,
-                content,
-                cls,
-                ts=m.get("ts", ""),
-                meta=(
-                    _redact_meta_for_role(role, m["meta"])
-                    if isinstance(m.get("meta"), dict)
-                    else None
-                ),
-            )
-            _attach_variants(slot, m)
-        slot.drain()
-        slot._resumed_count = len(slot.messages)
-        # Loaded window is the on-disk window region; older lines (counted in
-        # _disk_older_count above) are the frozen prefix saves never rewrite.
-        slot._disk_window_len = len(slot.messages)
-        slot._dirty = False
+        slot = _apply_recent_session(state, s, slot_name, meta, kiro_model_map, _restore_cfg)
         restored += 1
         logger.info("Restored session %s (%s)", slot_name, slot.title)
     _sync_dashboard_slots(state)
     return restored
+
+
+async def restore_sessions_at_startup(
+    state: DashboardState, window_minutes: int, *, folders_only: bool = False
+) -> int:
+    """Restore the user's tabs and recent sessions without stalling the loop.
+
+    Startup rehydration used to run unbounded and synchronously while the
+    loop-stall watchdog was already armed: the heartbeat could not be petted, so
+    ``LoopStallWatchdog`` ``_exit(1)``'d the gateway mid-boot on any home with
+    enough history, and the failure got more certain as history accumulated.
+
+    Two changes close that outright rather than moving its threshold:
+
+    * The whole eligibility scan (``list_sessions()`` + per-session metadata +
+      filtering) runs in a worker thread via :func:`_collect_restore_plan`,
+      which takes a ``ConversationLog`` rather than the state and so cannot
+      mutate slots.
+    * The replay then runs as a background task that yields to the loop between
+      sessions and reads each message window off-loop, leaving only bounded CPU
+      (redact + append of at most 500 in-memory messages) on the loop per
+      session. No session shape can stretch that to the 25s watchdog budget.
+
+    The collect is awaited rather than backgrounded so the slot counter is
+    reseeded past every known key BEFORE this returns — a new chat minted while
+    the replay is still running must not take an index a returning tab is about
+    to claim.
+
+    Returns the number of sessions the plan will restore (the replay itself
+    finishes in the background).
+    """
+    log = state.conversation_log
+    if not log:
+        return 0
+    # Install the snapshot floor BEFORE the first await, not after the scan.
+    # The scan yields the loop, and the 5s flush fires during it with _slots
+    # still empty — so installing the floor afterwards would let that flush
+    # write an empty open_slots.json over the very file the floor exists to
+    # protect, permanently dropping every old tab. Reading the snapshot here is
+    # bounded by the tab count (one short string per tab), not by history, so it
+    # is safe to do inline; the expensive walk stays off the loop below.
+    open_keys = _read_open_slots_keys()
+    state._restore_floor = tuple(open_keys)
+    # Reserve the open-tab keys here too, for the same reason and in the same
+    # breath: the scan below yields, and a returning browser tab holds exactly
+    # these keys in its local state, so it is the most likely thing to arrive
+    # during it. Without the reservation that request registers an EMPTY slot,
+    # the replay skips it, and a later flush writes the empty window over the
+    # transcript. The recent-session keys are not knowable until the scan
+    # returns, and are added below.
+    state._pending_restore_keys.update(open_keys)
+    plan = await asyncio.to_thread(
+        _collect_restore_plan,
+        log,
+        window_minutes,
+        folders_only=folders_only,
+        open_keys=open_keys,
+    )
+    state.reseed_slot_counter([*plan.open_keys, *(name for name, _, _ in plan.sessions)])
+    # Reserve the remaining planned keys before the replay is scheduled. Until
+    # the replay reaches a key, any request handler that creates from a
+    # caller-supplied key would otherwise register an EMPTY slot under it, which
+    # a later flush writes over the real transcript. With the reservation in
+    # place, such a handler awaits ensure_pending_slot_restored() and gets the
+    # real session instead. The open-tab keys were reserved above, pre-scan.
+    state._pending_restore_keys.update(plan.open_keys)
+    state._pending_restore_keys.update(name for name, _, _ in plan.sessions)
+    # Publish the listing the scan already paid for, so an on-demand replay gets
+    # its title-parity row for free instead of re-walking the session directory.
+    # The config and model map ride along for the same reason: both are
+    # per-process, and re-deriving them per request would glob the agent
+    # directory on the loop.
+    state._restore_shared = (plan.listing, plan.kiro_model_map, plan.cfg)
+    if plan.total:
+        task = asyncio.create_task(_run_restore_plan(state, plan))
+        state._background_tasks.add(task)
+        task.add_done_callback(state._background_tasks.discard)
+    else:
+        state._restore_floor = ()
+    return plan.total
+
+
+async def _run_restore_plan(state: DashboardState, plan: RestorePlan) -> int:
+    """Replay a :class:`RestorePlan`, one session per loop iteration.
+
+    Every step is best-effort: a session that fails to rehydrate is logged and
+    skipped, and slots that appeared in the meantime (a client resumed the tab,
+    or the other half of the plan got there first) are left alone.
+    """
+    log = state.conversation_log
+    if not log:
+        return 0
+    restored = 0
+    failed: set[str] = set()
+    # Slot names the RECENT half will replay. A tab backed only by a legacy
+    # stacked file appears in both halves: its folded name is in open_keys, but
+    # the canonical history key has no file, so only the listing row in
+    # plan.sessions can actually restore it. The open-tab half must therefore not
+    # release such a key when it finishes empty-handed.
+    deferred_to_recent = {name for name, _, _ in plan.sessions}
+    logger.info("Restoring %d session(s) in the background", plan.total)
+
+    for raw in plan.open_keys:
+        await asyncio.sleep(0)
+        if raw in state._slots:
+            state._pending_restore_keys.discard(raw)
+            continue
+        history_key = _history_key_for(raw)
+        try:
+            window = await asyncio.to_thread(log.read_messages_chained, history_key)
+            # Read metadata off-loop too, and AFTER the window: get_metadata
+            # reads the whole file to take its first line, and reading it last
+            # means a session deleted during the window read comes back empty
+            # here, so the rehydrate returns None instead of resurrecting it.
+            meta = await asyncio.to_thread(log.get_metadata, history_key)
+            # Re-check after the awaits: a client can resume this tab while the
+            # reads are in flight, and _rehydrate_slot_from_history would then
+            # hand back the live slot — counted here as a restore that never
+            # happened.
+            if raw in state._slots:
+                continue
+            with _replaying(state, raw):
+                slot = _rehydrate_slot_from_history(
+                    state,
+                    raw,
+                    messages=window,
+                    meta=meta,
+                    session_info=plan.listing.get(raw, {}),
+                    kiro_model_map=plan.kiro_model_map,
+                    restore_cfg=plan.cfg,
+                )
+            if slot is not None:
+                restored += 1
+        except Exception:
+            logger.debug("restore: rehydrate failed for %s", raw, exc_info=True)
+            failed.add(raw)
+            _rollback_partial_slot(state, raw)
+        finally:
+            # Release the reservation only once this key is SETTLED. Holding it
+            # across the off-loop reads is the point: a request arriving mid-read
+            # rehydrates on demand instead of registering an empty slot, and the
+            # post-await _slots re-check above then skips it here.
+            #
+            # Two states are not settled, and both have to be RE-ASSERTED rather
+            # than merely left alone, because _replaying claims the key on entry:
+            #
+            # * the recent half still owns it — a stacked-only tab restores
+            #   nothing here, so only its listing row can, and
+            # * this key FAILED — the transcript is intact on disk, so letting a
+            #   request register an empty slot over it is the data loss the
+            #   reservation exists to prevent. A retained key means requests for
+            #   it get a retryable 503 until a retry succeeds, which is the right
+            #   trade against destroying the session.
+            #
+            # There is no await between the _replaying claim and this line, so no
+            # request can observe the intermediate state.
+            if raw not in state._slots and (raw in failed or raw in deferred_to_recent):
+                state._pending_restore_keys.add(raw)
+            else:
+                state._pending_restore_keys.discard(raw)
+
+    for slot_name, s, _collected_meta in plan.sessions:
+        await asyncio.sleep(0)
+        if slot_name in state._slots:
+            state._pending_restore_keys.discard(slot_name)
+            continue
+        key = s.get("key", "")
+        try:
+            window = await asyncio.to_thread(log.read_messages_chained, key)
+            # Metadata is re-read AFTER the window, not reused from the plan, so
+            # a session deleted or closed while the read was in flight is caught
+            # here: empty metadata means the JSONL is gone, and applying stale
+            # metadata would let the tab_id backfill recreate the file the user
+            # just deleted. No await between this check and the apply.
+            meta = await asyncio.to_thread(log.get_metadata, key)
+            if not meta or meta.get("closed"):
+                continue
+            if slot_name in state._slots:
+                continue
+            with _replaying(state, slot_name):
+                _apply_recent_session(
+                    state, s, slot_name, meta, plan.kiro_model_map, plan.cfg, messages=window
+                )
+            restored += 1
+        except Exception:
+            logger.debug("restore: session %s failed", slot_name, exc_info=True)
+            # Retain the floor entry, same rule as the open-tab half: since the
+            # open-key skip was dropped, a tab backed only by a legacy stacked
+            # file arrives here, and its folded slot name can be a floor key.
+            # Releasing it on a transient read error would let the next snapshot
+            # write an open_slots.json without it and lose the tab for good.
+            failed.add(slot_name)
+            _rollback_partial_slot(state, slot_name)
+        finally:
+            # Same hold-across-the-reads rule as the open-tab half above, and the
+            # same re-assert on failure: a key whose restore raised still has its
+            # transcript on disk, so releasing it would let the next request
+            # register an empty slot over that session.
+            if slot_name in failed and slot_name not in state._slots:
+                state._pending_restore_keys.add(slot_name)
+            else:
+                state._pending_restore_keys.discard(slot_name)
+
+    # Release the floor for everything this pass SETTLED — restored (now in
+    # _slots and snapshotted on its own merit), already live, or absent from
+    # disk (a rehydrate that returns None cleans a dead entry out of the file).
+    # A key whose restore RAISED stays in the floor: the failure may be transient
+    # (a read error under load), and releasing it would let the next flush write
+    # an open_slots.json without it and lose the tab for good. Worst case a
+    # permanently broken key stays in the file for this gateway's lifetime — one
+    # dead entry, which the collect phase already tolerates, and no lost data.
+    #
+    # Deliberately NOT in a finally: if this task is cancelled (gateway shutdown
+    # mid-replay) or raises, the WHOLE floor must stay so the shutdown snapshot
+    # still records every tab that never got its turn.
+    state._restore_floor = tuple(k for k in state._restore_floor if k in failed)
+    # No key is pending now, so nothing can consult these again. An on-demand
+    # replay still in flight falls back to its own off-loop reads.
+    state._restore_shared = None
+    _sync_dashboard_slots(state)
+    logger.info("Restore complete: %d/%d session(s)", restored, plan.total)
+    return restored
+
+
+@contextmanager
+def _replaying(state: DashboardState, slot_name: str) -> "Iterator[None]":
+    """Hide a slot from the persistence sweeps while its window is replayed.
+
+    ``get_or_create_slot`` registers the slot before the replay fills it, and
+    ``slot.append`` marks it ``_dirty`` — so a 5s flush or a shutdown save
+    landing inside the replay would persist a partial window whose
+    ``_disk_older_count`` / ``_disk_window_len`` still describe the pre-replay
+    slot, and the next flush would duplicate those lines. Skipping the save is
+    lossless: the window being replayed was read from that same file.
+
+    Entering also CLAIMS the key out of ``_pending_restore_keys``, marking it
+    settled: the bulk pass and an on-demand replay can both be holding this key
+    across their reads, and the first one to reach this point owns the apply.
+    There is no ``await`` between either caller's post-read ``_slots`` re-check
+    and this claim, so the loser's re-check sees the registered slot and
+    discards its own copy of the window rather than appending it twice.
+    """
+    state._pending_restore_keys.discard(slot_name)
+    state._restoring_keys.add(slot_name)
+    try:
+        yield
+    finally:
+        state._restoring_keys.discard(slot_name)
+
+
+def _listing_row(state: DashboardState, log: "ConversationLog", slot_name: str) -> dict:
+    """This session's ``list_sessions()`` row, for title parity with the bulk pass.
+
+    Prefers the row the startup scan already collected. The fallback walk is
+    only reached when the pass has finished and cleared the listing, and it is
+    the caller's job to run this off the loop.
+    """
+    shared = getattr(state, "_restore_shared", None)
+    if shared is not None:
+        row = shared[0].get(slot_name)
+        if row is not None:
+            return row
+    history_key = _history_key_for(slot_name)
+    return next((s for s in log.list_sessions() if s.get("key") == history_key), {})
+
+
+async def ensure_pending_slot_restored(state: DashboardState, name: str | None) -> None:
+    """Replay a key the startup plan owns but has not reached yet, off the loop.
+
+    Await this from an async handler BEFORE ``get_or_create_slot`` whenever the
+    key is caller-supplied and the handler does not load the window itself.
+    Registering an empty slot under a planned key destroys data: the slot has
+    ``_disk_older_count=0`` and ``_disk_window_len=0``, ``_restoring_keys`` does
+    not cover it, and the next 5s flush writes that empty window over the
+    session's transcript.
+
+    ``get_or_create_slot`` deliberately does not do this itself. It cannot know
+    whether its caller is about to rehydrate: the resume handler does, and
+    handing it a populated slot made it append the same window a second time and
+    flush a doubled transcript. Putting the decision at the call site makes the
+    two cases distinguishable, and it also lets the reads run in a worker thread
+    while only the apply — which touches ``asyncio.Event`` and the SSE queues —
+    stays on the loop.
+
+    Returns nothing: the caller's own ``get_or_create_slot`` then finds the
+    restored slot, or creates the fresh one it asked for if the session is
+    genuinely gone from disk.
+
+    Raises ``web.HTTPServiceUnavailable`` if the restore FAILED (a transient read
+    error, say). Failing the request is the only safe outcome: returning would
+    let the caller create an empty slot over an intact transcript, which the next
+    flush destroys. The reservation is retained so the bulk pass still replays
+    the key, and the status is retryable because the next attempt usually wins.
+    """
+    if not name:
+        return
+    slot_name = _normalize_slot_key(name)
+    if not slot_name or slot_name in state._slots:
+        return
+    if slot_name not in getattr(state, "_pending_restore_keys", ()):
+        return
+    tasks = getattr(state, "_pending_rehydrate_tasks", None)
+    if tasks is None:
+        tasks = state._pending_rehydrate_tasks = {}
+    task = tasks.get(slot_name)
+    if task is None:
+        # A task rather than a bare await, for two reasons: a client that
+        # disconnects mid-read must not abandon a half-applied replay, and the
+        # next request for this key joins this same one instead of starting a
+        # second read of the same window. 67 returning tabs are 67 keys, not 67
+        # reads of one key.
+        task = asyncio.ensure_future(_replay_one_key(state, slot_name))
+        tasks[slot_name] = task
+    # shield: cancelling THIS request (client went away) must not cancel a
+    # replay that other requests are waiting on, or that is mid-apply.
+    try:
+        await asyncio.shield(task)
+    except Exception as exc:
+        raise web.HTTPServiceUnavailable(
+            reason=f"session {slot_name} is still being restored"
+        ) from exc
+
+
+async def _replay_one_key(state: DashboardState, slot_name: str) -> None:
+    """One-key mirror of the open-tab step in :func:`_run_restore_plan`."""
+    log = state.conversation_log
+    if log is None:
+        return
+    info = await asyncio.to_thread(_listing_row, state, log, slot_name)
+    # Read from the key the LISTING reports, not the canonical fold. A tab backed
+    # only by a legacy stacked file (``dashboard_dashboard_x``) has no canonical
+    # file, so reading the folded key would come back empty and the caller would
+    # then create an empty slot over a session that does exist on disk.
+    history_key = info.get("key") or _history_key_for(slot_name)
+    # Per-process facts, taken from the plan when the replay published them. The
+    # fallbacks run in a worker thread because _kiro_model_map globs the agent
+    # directory and _load_restore_cfg reads config from disk — deriving either on
+    # the loop is the read class this PR exists to remove.
+    shared = getattr(state, "_restore_shared", None)
+    if shared is not None:
+        _, model_map, cfg = shared
+    else:
+        model_map = await asyncio.to_thread(_kiro_model_map)
+        cfg = await asyncio.to_thread(_load_restore_cfg)
+    try:
+        # Same read order as the bulk pass: window first, metadata second, so a
+        # session deleted while the window was in flight comes back with empty
+        # metadata and the rehydrate declines instead of resurrecting the file.
+        window = await asyncio.to_thread(log.read_messages_chained, history_key)
+        meta = await asyncio.to_thread(log.get_metadata, history_key)
+        # The reservation is held across those reads rather than claimed up
+        # front, exactly as the bulk pass holds it, so the bulk pass may be
+        # replaying this same key concurrently. Re-check _slots and keep the
+        # apply await-free: whoever registers the slot first owns it and the
+        # loser drops its window here. The cost of losing is one wasted read;
+        # the cost of not checking would be a doubled transcript.
+        if slot_name in state._slots:
+            state._pending_restore_keys.discard(slot_name)
+            return
+        with _replaying(state, slot_name):
+            _rehydrate_slot_from_history(
+                state,
+                slot_name,
+                messages=window,
+                meta=meta,
+                session_info=info,
+                kiro_model_map=model_map,
+                restore_cfg=cfg,
+            )
+        state._pending_restore_keys.discard(slot_name)
+    except Exception:
+        logger.warning("on-demand restore failed for %s", slot_name, exc_info=True)
+        _rollback_partial_slot(state, slot_name)
+        # RETAIN the reservation and re-raise, rather than settling the key.
+        # Swallowing here let the caller's get_or_create_slot register an empty
+        # slot under a key whose transcript is intact on disk, and the next
+        # flush wrote that empty window over it — the exact data loss this
+        # function exists to prevent, reached through a transient read error.
+        # "The bulk pass will retry it" only holds while no slot exists: once
+        # one does, the bulk pass skips the key. Re-added explicitly because
+        # _replaying already claimed it on entry.
+        state._pending_restore_keys.add(slot_name)
+        raise
+    finally:
+        # Always clear the in-flight entry, so a later request can retry a key
+        # whose first attempt failed.
+        tasks = getattr(state, "_pending_rehydrate_tasks", None)
+        if tasks is not None:
+            tasks.pop(slot_name, None)
+
+
+def ensure_restored_before_inject(
+    state: DashboardState, name: str | None, retry: "Callable[[], object]"
+) -> bool:
+    """Gate a non-async, loop-resident caller on a pending key's restore.
+
+    The cron and workflow injectors run on the event loop but are plain
+    functions, called from the Slack gateway and the workflow watcher, so they
+    cannot await. They still must not register an empty slot under a key the
+    startup replay owns, because the next flush writes that empty window over
+    the session's transcript.
+
+    Reading inline would put an unbounded history-scaled read back on the loop —
+    the very thing this PR removes. So when the key is still pending this
+    schedules the off-loop restore and re-runs *retry* (the caller itself) once
+    it lands. The second entry finds the key settled and proceeds normally, so
+    there is no recursion beyond one hop.
+
+    Returns True when the work was deferred, meaning the caller must return
+    immediately and do nothing else.
+
+    With no running loop there is no loop to protect and no watchdog armed, so
+    the restore happens inline and this returns False.
+    """
+    if not name:
+        return False
+    slot_name = _normalize_slot_key(name)
+    if not slot_name or slot_name in state._slots:
+        return False
+    if slot_name not in getattr(state, "_pending_restore_keys", ()):
+        return False
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _restore_pending_slot_inline(state, slot_name)
+        return False
+
+    async def _restore_then_retry() -> None:
+        try:
+            await ensure_pending_slot_restored(state, slot_name)
+        except Exception:
+            # Deliberately do NOT fall through to the injection: that would put
+            # an empty slot over the transcript. The result is still on the job
+            # record and the notification path is unaffected.
+            logger.warning(
+                "deferred restore failed for %s; skipping injection", slot_name, exc_info=True
+            )
+            return
+        retry()
+
+    task = loop.create_task(_restore_then_retry())
+    state._background_tasks.add(task)
+    task.add_done_callback(state._background_tasks.discard)
+    return True
+
+
+def _restore_pending_slot_inline(state: DashboardState, slot_name: str) -> None:
+    """Inline restore for the no-running-loop case only. See the caller."""
+    # Reuse whatever the replay published, so this does not re-derive per-process
+    # facts either. Each kwarg defaults to an inline read when absent.
+    shared = getattr(state, "_restore_shared", None)
+    try:
+        with _replaying(state, slot_name):
+            _rehydrate_slot_from_history(
+                state,
+                slot_name,
+                kiro_model_map=shared[1] if shared is not None else None,
+                restore_cfg=shared[2] if shared is not None else None,
+            )
+    except Exception:
+        logger.warning("inline restore failed for %s", slot_name, exc_info=True)
+        _rollback_partial_slot(state, slot_name)
+        # Same rule as the async path: retain the reservation on failure rather
+        # than settling a key whose transcript is still intact on disk.
+        state._pending_restore_keys.add(slot_name)
+    else:
+        state._pending_restore_keys.discard(slot_name)
 
 
 def _diff_dropped_message_lines(old_lines: list[str], new_lines: list[str]) -> list[str]:
@@ -982,6 +1683,16 @@ def _save_slot_to_history(
     legacy no-tab_id sessions stay isolated.
     """
     if not state.conversation_log:
+        return
+    # A slot whose window is still being replayed is not in a saveable state: it
+    # is registered and already _dirty, but its _disk_older_count /
+    # _disk_window_len still describe the pre-replay slot, so the frozen-prefix
+    # arithmetic below would write a partial window that the next flush then
+    # duplicates. Skipping loses nothing — that window was read from this very
+    # file. This is the choke point, so it covers the shutdown sweep
+    # (save_all_slots_to_history, force=True) and any future caller;
+    # _flush_dirty_slots skips earlier so it does not clear _dirty either.
+    if slot.key in state._restoring_keys:
         return
     # An explicit message snapshot always means "this is the full authoritative
     # window state" → rewrite. Edit paths (rewind/regenerate/fork) pass a snapshot.

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.dashboard.chat_persistence import ensure_restored_before_inject
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -22,6 +23,17 @@ def inject_cron_result_to_dashboard(
 ) -> None:
     """Inject cron result into linked dashboard chat slot (shared by to-chat and auto-inject)."""
     slot_name = f"cron-{job.id}"
+    # A cron slot is a real dashboard session, so its key can be one the startup
+    # replay owns and has not reached. Registering an empty slot under it would
+    # be flushed over that session's transcript, and reading the history inline
+    # would put an unbounded read back on the event loop — so hand off to the
+    # off-loop restore and let it re-enter this function once the slot is real.
+    if ensure_restored_before_inject(
+        state,
+        slot_name,
+        lambda: inject_cron_result_to_dashboard(state, job, result_text, history=history),
+    ):
+        return
     slot = state.get_or_create_slot(name=slot_name, agent=job.agent_id or "")
     safe_name, _ = redact_exfiltration_urls(job.name)
     safe_name, _ = redact_credentials(safe_name)

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -13,6 +13,7 @@ from aiohttp import web
 
 from kiro_crew import model_registry
 from kiro_crew.cron import CronStoreBusy, is_valid_timezone
+from kiro_crew.dashboard.chat_persistence import ensure_pending_slot_restored
 from kiro_crew.dashboard.cron_inject import (
     hydrate_slot_from_history,
     inject_cron_result_to_dashboard,
@@ -549,6 +550,7 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             if state.conversation_log else []
         )
         if history:
+            await ensure_pending_slot_restored(state, slot_name)
             slot = state.get_or_create_slot(name=slot_name, agent="")
             if not slot.linked_session_key:
                 slot.linked_session_key = session_key
@@ -561,6 +563,7 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             )
             if not notif:
                 return web.json_response({"error": "job not found"}, status=404)
+            await ensure_pending_slot_restored(state, slot_name)
             slot = state.get_or_create_slot(name=slot_name, agent="")
             body = notif.get("body", "")
             if body:

--- a/src/kiro_crew/dashboard/openai_compat.py
+++ b/src/kiro_crew/dashboard/openai_compat.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.dashboard.chat_persistence import ensure_pending_slot_restored
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_not_ready
 from kiro_crew.dashboard.state import DashboardState, _normalize_slot_key
@@ -225,6 +226,12 @@ async def api_completions(request: web.Request) -> web.StreamResponse:
     completion_id = _make_id()
 
     if slot_id:
+        # Like /api/chat, this creates from a caller-supplied key without loading
+        # the window, so a key the startup replay has not reached must be
+        # restored before the create rather than materialized empty over it.
+        # Ordered BEFORE the freshly_created probe below: a slot this restores is
+        # a returning session, not a new one.
+        await ensure_pending_slot_restored(state, slot_id)
         # Membership must be checked on the canonical (filename-charset) key —
         # get_or_create_slot folds unsafe chars, so a raw slot_id may map to an
         # existing slot even when the raw string is absent from _slots.

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2463,21 +2463,30 @@ async def start_dashboard(
     # Restore exactly the tabs the user had open at last shutdown — these
     # come back regardless of mtime, so long-running tabs don't silently
     # fall off into History on every gateway restart. Closed tabs (meta.closed)
-    # are still excluded by the rehydrate guard. restore_open_slots() logs
-    # its own info line on success, so no caller-side log here.
-    chat.restore_open_slots(state)
-    restored = chat.restore_recent_sessions(
+    # are still excluded by the rehydrate guard.
+    #
+    # This awaits only the eligibility SCAN, which runs in a worker thread; the
+    # replay itself is a background task that yields between sessions. The
+    # loop-stall watchdog armed above _exit(1)s the gateway after 25s without a
+    # heartbeat, and doing either of those on the loop blew that budget outright
+    # on a large home (~70 open tabs + hundreds of sessions killed the gateway
+    # mid-startup, every boot). Awaiting the scan — rather than backgrounding it
+    # too — is what lets reseed_slot_counter run past every known key before any
+    # client can mint a new chat. restore_sessions_at_startup logs its own
+    # progress lines, so no caller-side log here.
+    await chat.restore_sessions_at_startup(
         state,
         cfg.dashboard.restore_window_minutes if cfg.dashboard.restore_sessions else 0,
         folders_only=not cfg.dashboard.restore_sessions,
     )
-    if restored:
-        logger.info("Restored %d session(s)", restored)
 
     # Both restore paths above rehydrate tabs under their original
     # "chat-<N>-<ts>" keys but leave _slot_counter at its boot value of 0.
     # Reseed it past the highest restored index so the next new chat can't
     # re-mint a colliding low index (which scrambles the tab -> session map).
+    # restore_sessions_at_startup already reseeded past every key in its plan,
+    # including the ones the background replay has not reached; this call is the
+    # idempotent, monotonic backstop for anything created since.
     state.reseed_slot_counter()
 
     # Relaunch agents in non-archived channels

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -40,6 +40,7 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
 if TYPE_CHECKING:
+    from kiro_crew.config.loader import KiroCrewConfig  # noqa: F401
     from kiro_crew.dashboard._types import (  # noqa: F401
         ContextBuilder,
         ConversationLog,
@@ -1666,6 +1667,49 @@ class DashboardState:
         self._flush_task: asyncio.Task | None = None  # type: ignore[type-arg]
         # Update progress tracking (shared across all connected clients)
         self._update_progress: dict[str, str] | None = None  # {step, detail}
+        # Restore bookkeeping. Both are read by _persist_open_slots /
+        # _flush_dirty_slots, which also run from the 5s flush executor thread
+        # and the shutdown thread — so both are used with WHOLE-VALUE rebinding
+        # (the tuple) or MEMBERSHIP TESTS ONLY (the set). Neither is ever
+        # iterated from those threads, where a concurrent mutation would raise.
+        #
+        # _restore_floor: the keys read out of open_slots.json at boot.
+        # _persist_open_slots unions them into every snapshot it writes until
+        # the background replay finishes, so a flush (or a crash, or a shutdown
+        # save) landing mid-replay cannot rewrite that file NARROWER than it
+        # already was and silently drop tabs the replay had not reached.
+        self._restore_floor: tuple[str, ...] = ()
+        # _restoring_keys: slots whose message window is being replayed right
+        # now. The persistence sweeps skip them; see chat_persistence._replaying.
+        self._restoring_keys: set[str] = set()
+        # _pending_restore_keys: slots the startup plan owns but has not replayed
+        # yet. An empty slot registered under one of these carries
+        # _disk_older_count=0, is not covered by _restoring_keys, and the next
+        # flush writes it over the user's real history — so a handler that
+        # creates from a caller-supplied key and does NOT rehydrate for itself
+        # must first await chat_persistence.ensure_pending_slot_restored().
+        # Membership marks the key UNSETTLED and is held across the replay's
+        # off-loop reads, so both the bulk pass and an on-demand replay can be
+        # working the same key; each re-checks _slots and applies without
+        # awaiting, so the loser discards its window instead of doubling it.
+        # Loop-only (the replay and the request handlers); never read from the
+        # flush thread, unlike the two above.
+        self._pending_restore_keys: set[str] = set()
+        # In-flight on-demand replays, keyed by slot name. Concurrent requests
+        # for one key share a single read instead of each replaying the window:
+        # 67 returning tabs must not become 67 reads of the same session.
+        self._pending_rehydrate_tasks: dict[str, "asyncio.Future[None]"] = {}
+        # The restore plan's shared facts, published for the duration of the
+        # replay so an on-demand rehydrate reuses them: the list_sessions() rows,
+        # the kiro-agent model map, and the loaded config. The model map and the
+        # listing are legitimately EMPTY on a home with no agents or no sessions,
+        # so this is one nullable tuple rather than three containers — testing a
+        # container for truthiness would re-derive them on exactly those homes,
+        # putting the agent-directory glob back on the request path.
+        # ``None`` means "no replay is publishing", not "empty".
+        self._restore_shared: tuple[dict[str, dict], dict[str, str], "KiroCrewConfig | None"] | None = (  # noqa: E501
+            None
+        )
         # Restricted (incognito/temporary): session keys with memory writes disabled
         self._restricted_keys: set[str] = set()
         # Ephemeral: session keys with no memory writes at all
@@ -2137,6 +2181,11 @@ class DashboardState:
         from kiro_crew.dashboard.chat import _save_slot_to_history
 
         for slot in list(self._slots.values()):
+            # Skip before the _dirty check, not after: the branch below clears
+            # _dirty on the assumption the save ran, so continuing later would
+            # drop the flag without a write.
+            if slot.key in self._restoring_keys:
+                continue
             if not slot._dirty or not slot.messages:
                 continue
             try:
@@ -2171,6 +2220,19 @@ class DashboardState:
         """
         try:
             path = config_dir() / "open_slots.json"
+            # Read the restore floor BEFORE enumerating _slots, and never the
+            # other way round. The replay inserts a restored slot and only then
+            # releases it, so with this order a key missing from the floor read
+            # is guaranteed to be present in the _slots read that follows:
+            #
+            #   key absent from floor(t1)  =>  released before t1
+            #                              =>  inserted before t1 < t2
+            #                              =>  key present in slots(t2)
+            #
+            # Reversing the two reads breaks that: a key absent from slots(t1)
+            # can be inserted AND released before floor(t2), and the tab is lost
+            # from the file.
+            floor = self._restore_floor
             # Only snapshot persistent-memory slots. Incognito/temporary tabs
             # are ephemeral by contract ("closes when I'm done", no
             # consolidation/lessons); persisting their keys would resurrect
@@ -2181,7 +2243,16 @@ class DashboardState:
                 name
                 for name, slot in list(self._slots.items())
                 if getattr(slot, "memory_mode", "persistent") == "persistent"
+                # A slot mid-replay has not had memory_mode applied yet, so it
+                # would read as persistent here. Skip it: if it belongs in the
+                # file it is in the floor, which is unioned in below.
+                and name not in self._restoring_keys
             ]
+            # The floor keys came OUT of this file, and every one of them was
+            # persistent when it was written, so unioning them back can only
+            # preserve — never widen the file to something it never held.
+            live = set(keys)
+            keys.extend(k for k in floor if k not in live)
             payload = json.dumps({"keys": keys, "ts": time.time()})
             # Use the canonical atomic_write helper, not a deterministic
             # ".json.tmp" name — _persist_open_slots can run concurrently from
@@ -2530,6 +2601,16 @@ class DashboardState:
                     f"Slot {name!r} already exists with memory_mode={existing.memory_mode!r}"
                 )
             return existing
+        if name and name in getattr(self, "_pending_restore_keys", ()):
+            # The startup plan owns this key but has not replayed it yet. This
+            # factory deliberately does NOT rehydrate here: it cannot know
+            # whether its caller is about to load the window itself. The resume
+            # handler does, and handing it a populated slot made it append the
+            # same window a second time. Handlers that do NOT rehydrate must
+            # await chat_persistence.ensure_pending_slot_restored() before
+            # calling this — see that function for why an empty slot under a
+            # pending key is destructive.
+            logger.debug("creating slot %s while its restore is still pending", name)
         if not name:
             self._slot_counter += 1
             ts = int(time.time())
@@ -2575,7 +2656,7 @@ class DashboardState:
         self.push_slots_update()
         return slot
 
-    def reseed_slot_counter(self) -> None:
+    def reseed_slot_counter(self, extra_keys: "list[str] | None" = None) -> None:
         """Advance ``_slot_counter`` past the highest index among live slots.
 
         ``__init__`` resets ``_slot_counter`` to 0 on every gateway boot, but
@@ -2592,9 +2673,14 @@ class DashboardState:
         observed index so subsequent auto-minted slots always get fresh,
         collision-proof indices. Monotonic: only ever advances the counter,
         never lowers it, so it is safe to call regardless of restore order.
+
+        *extra_keys* names slots that are KNOWN but not in ``_slots`` yet — the
+        sessions a background replay has still to restore. Counting them here
+        means the counter is already past them, so a new chat minted while the
+        replay is running cannot take an index a returning tab is about to claim.
         """
         max_idx = self._slot_counter
-        for name in self._slots:
+        for name in (*self._slots, *(extra_keys or ())):
             # Parse via the shared helper so this stays in lock-step with the
             # key minter (_mint_slot_key). Custom keys return None and skip.
             idx = _slot_index_from_key(name)

--- a/src/kiro_crew/dashboard/workflow_inject.py
+++ b/src/kiro_crew/dashboard/workflow_inject.py
@@ -17,6 +17,7 @@ import json
 import re
 from typing import Any, Callable, Optional
 
+from kiro_crew.dashboard.chat_persistence import ensure_restored_before_inject
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -136,7 +137,22 @@ def inject_workflow_result(
 
         # 2. Fall back to a dedicated workflow slot only if the chat is gone.
         if slot is None:
-            slot = state.get_or_create_slot(name=f"workflow-{run_id}")
+            fallback_key = f"workflow-{run_id}"
+            # Same hazard as the cron injector: this key can be one the startup
+            # replay still owns, and an empty slot under it would be flushed
+            # over that session's transcript. Deferred rather than read inline,
+            # because this runs on the loop and cannot await.
+            if ensure_restored_before_inject(
+                state,
+                fallback_key,
+                lambda: inject_workflow_result(
+                    state, run_id, snapshot, on_injected=on_injected
+                ),
+            ):
+                # Not injected yet — the deferred retry will report its own
+                # outcome. False keeps the "did I inject" contract truthful.
+                return False
+            slot = state.get_or_create_slot(name=fallback_key)
             if not getattr(slot, "linked_session_key", ""):
                 slot.linked_session_key = session_key
             slot.title = f"Workflow: {snapshot.get('name') or run_id}"

--- a/test/test_async_session_restore.py
+++ b/test/test_async_session_restore.py
@@ -1,0 +1,1050 @@
+"""Durability tests for the async startup session restore.
+
+Startup rehydration used to run unbounded and synchronously on the event loop
+while the loop-stall watchdog was already armed, so a home with enough history
+killed its own gateway on every boot. The restore now collects its plan in a
+worker thread and replays it as a background task that yields between sessions.
+
+Making the restore concurrent puts it alongside machinery that previously could
+never observe it — the 5s flush, the shutdown save, live client requests. These
+tests pin the three invariants that keep that safe, and they are written as
+*invariants checked under adversarial timing* rather than one test per race:
+
+1. MONOTONE SNAPSHOT -- ``open_slots.json`` is never written narrower than the
+   key set it already held, at any point during the replay.
+2. CRASH SAFETY -- killing the replay at any index leaves the file complete, and
+   a second boot restores everything.
+3. CONTENT INTEGRITY -- the session JSONL bytes are unchanged by a restore plus
+   a flush. No duplicated or dropped message lines.
+4. CONCURRENT FLUSH -- (1) and (3) hold with a real flush thread running
+   throughout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.dashboard.chat_persistence import (
+    _collect_restore_plan,
+    _run_restore_plan,
+    restore_open_slots,
+    restore_recent_sessions,
+    restore_sessions_at_startup,
+    save_all_slots_to_history,
+)
+from kiro_crew.dashboard.chat_utils import _history_key_for
+
+
+def _seed(state, slot_key: str, *, messages: int = 1, closed: bool = False) -> None:
+    """Write session metadata plus *messages* lines so a rehydrate succeeds."""
+    history_key = _history_key_for(slot_key)
+    log = state.conversation_log
+    assert log is not None
+    for i in range(messages):
+        log.append(history_key, "user" if i % 2 == 0 else "assistant", f"m{i} {slot_key}")
+    if closed:
+        log.update_metadata(history_key, {"closed": True})
+
+
+def _write_open_slots(tmp_path, keys: list[str]) -> None:
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": keys, "ts": 0.0}), encoding="utf-8"
+    )
+
+
+def _snapshot_keys(tmp_path) -> set[str]:
+    return set(json.loads((tmp_path / "open_slots.json").read_text(encoding="utf-8"))["keys"])
+
+
+def _session_messages(state) -> dict[str, list[tuple[str, str]]]:
+    """Per-file ordered ``(role, content)`` of every message line.
+
+    Not raw bytes: a forced save legitimately enriches records (``tab_id`` on
+    the metadata line, ``source_thread`` / ``source_user`` on messages), and it
+    does so on the unchanged synchronous restore path too. What must never
+    change is the message sequence itself — a partial-window save corrupts the
+    frozen-prefix accounting and shows up here as dropped or duplicated lines.
+    """
+    out: dict[str, list[tuple[str, str]]] = {}
+    for p in sorted(state.conversation_log._dir.glob("*.jsonl")):
+        rows: list[tuple[str, str]] = []
+        for line in p.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                rows.append(("<unparseable>", line))
+                continue
+            if rec.get("_type") == "metadata":
+                continue
+            rows.append((rec.get("role", ""), rec.get("content", "")))
+        out[p.name] = rows
+    return out
+
+
+# ── invariant 1: the snapshot is monotone at EVERY yield ──────────────────────
+
+
+def test_snapshot_never_narrows_at_any_point_during_the_replay(tmp_path, monkeypatch):
+    """The floor invariant. A flush landing at any instant of the replay must
+    write a key set that still contains everything the file already held."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 13)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+    original = set(keys)
+
+    observed: list[set[str]] = []
+    real_create = state.get_or_create_slot
+
+    def _snapshot_after_every_apply(name=None, *a, **kw):
+        # get_or_create_slot is the first thing each apply does, so firing the
+        # snapshot from here samples mid-replay as well as between sessions.
+        slot = real_create(name, *a, **kw)
+        state._persist_open_slots()
+        observed.append(_snapshot_keys(tmp_path))
+        return slot
+
+    monkeypatch.setattr(state, "get_or_create_slot", _snapshot_after_every_apply)
+
+    async def _run() -> None:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+
+    assert observed, "no snapshot was taken during the replay"
+    for i, seen in enumerate(observed):
+        assert original <= seen, f"snapshot {i} dropped {sorted(original - seen)}"
+    state._persist_open_slots()
+    assert original <= _snapshot_keys(tmp_path)
+    assert state._restore_floor == (), "floor not released after a completed pass"
+
+
+def test_floor_is_seeded_from_the_file_not_from_the_plan(tmp_path, monkeypatch):
+    """The floor must survive a plan that under-collects. Seeding it from the
+    file's own bytes is what makes a collection bug non-fatal."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t", "chat-3-t"]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+    assert set(plan.open_keys) == set(keys)
+    # Simulate a collection that lost a key, then snapshot mid-replay.
+    state._restore_floor = tuple(plan.open_keys)
+    plan.open_keys = plan.open_keys[:1]
+    state._persist_open_slots()
+    assert _snapshot_keys(tmp_path) == set(keys)
+
+
+# ── invariant 2: crash at any index loses nothing ─────────────────────────────
+
+
+@pytest.mark.parametrize("die_at", [0, 1, 2, 3, 4])
+def test_crash_at_any_index_keeps_every_tab(tmp_path, monkeypatch, die_at):
+    """Cancellation mid-replay is the shutdown case. The floor must NOT be
+    released on the way out, so the snapshot still records the un-restored
+    tabs and the next boot brings them all back."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 6)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    applied = 0
+    real_create = state.get_or_create_slot
+
+    def _die_midway(name=None, *a, **kw):
+        nonlocal applied
+        if applied == die_at:
+            applied += 1
+            raise asyncio.CancelledError()
+        applied += 1
+        return real_create(name, *a, **kw)
+
+    monkeypatch.setattr(state, "get_or_create_slot", _die_midway)
+
+    async def _run() -> None:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        with pytest.raises(asyncio.CancelledError):
+            await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+
+    assert state._restore_floor != (), "floor released on a cancelled pass"
+    # A shutdown save landing right now still records the full tab set.
+    save_all_slots_to_history(state)
+    assert _snapshot_keys(tmp_path) == set(keys)
+
+    # Second boot: everything comes back.
+    state2 = _make_state(tmp_path / "sessions")
+    assert restore_open_slots(state2) == len(keys)
+    assert set(state2._slots) == set(keys)
+
+
+# ── invariant 3: the session files are byte-identical afterwards ──────────────
+
+
+def test_restore_plus_flush_preserves_every_message(tmp_path, monkeypatch):
+    """Restore is a read. A save landing mid-replay would write a partial window
+    with the wrong frozen-prefix accounting, so this compares the message
+    sequence on disk rather than trusting the guard."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 7)]
+    for k in keys:
+        _seed(state, k, messages=6)
+    _write_open_slots(tmp_path, keys)
+    before = _session_messages(state)
+    assert all(len(v) == 6 for v in before.values()), "seeding did not land"
+
+    async def _run() -> None:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+
+    assert _session_messages(state) == before, "restore changed session content"
+    # And the restore actually happened, so the comparison is not vacuous.
+    assert set(state._slots) == set(keys)
+    assert all(len(s.messages) == 6 for s in state._slots.values())
+
+
+def test_flush_during_a_replay_is_skipped_without_losing_the_dirty_flag(tmp_path, monkeypatch):
+    """The skip has to land before _flush_dirty_slots clears _dirty, or the flag
+    is dropped without a write and real messages never reach disk."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    slot = state.get_or_create_slot("chat-1-t")
+    slot.append("user", "mid-replay")
+    slot._dirty = True
+
+    state._restoring_keys.add("chat-1-t")
+    state._flush_dirty_slots()
+    assert slot._dirty is True, "dirty cleared without a save"
+
+    state._restoring_keys.discard("chat-1-t")
+    state._flush_dirty_slots()
+    assert slot._dirty is False
+
+
+# ── invariant 4: both hold with a real flush thread running ───────────────────
+
+
+def test_concurrent_flush_thread_holds_both_invariants(tmp_path, monkeypatch):
+    """_persist_open_slots and _flush_dirty_slots really do run from the flush
+    executor, so drive them from a thread for the whole replay."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 11)]
+    for k in keys:
+        _seed(state, k, messages=4)
+    _write_open_slots(tmp_path, keys)
+    original = set(keys)
+    before = _session_messages(state)
+
+    stop = threading.Event()
+    violations: list[str] = []
+
+    def _flusher() -> None:
+        while not stop.is_set():
+            try:
+                state._flush_dirty_slots()
+                seen = _snapshot_keys(tmp_path)
+                if not original <= seen:
+                    violations.append(f"snapshot dropped {sorted(original - seen)}")
+            except Exception as exc:  # pragma: no cover - reported, not raised
+                violations.append(f"flush raised {exc!r}")
+
+    async def _run() -> None:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        t = threading.Thread(target=_flusher, daemon=True)
+        t.start()
+        try:
+            await _run_restore_plan(state, plan)
+        finally:
+            stop.set()
+            t.join(timeout=5)
+
+    asyncio.run(_run())
+
+    assert violations == []
+    assert _session_messages(state) == before, "concurrent flush changed session content"
+    assert set(state._slots) == set(keys)
+
+
+# ── the collect phase cannot mutate state, structurally ──────────────────────
+
+
+def test_collect_is_read_only_and_dedup_happens_at_apply_time(tmp_path, monkeypatch):
+    """Collect takes a ConversationLog, not a DashboardState, so it cannot touch
+    slots. It intentionally does NOT pre-skip open keys — a stacked-file tab
+    needs the recent half as its fallback — so the guarantee that each session is
+    materialized once lives in the apply-time ``in state._slots`` guard."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    for k in ("chat-1-t", "chat-2-t", "chat-3-t"):
+        _seed(state, k, messages=4)
+    _write_open_slots(tmp_path, ["chat-1-t", "chat-2-t"])
+
+    plan = _collect_restore_plan(state.conversation_log, 60, folders_only=False)
+
+    assert state._slots == {}, "collect mutated state"
+    assert set(plan.open_keys) == {"chat-1-t", "chat-2-t"}
+    # Both halves see the shared keys; dedup is the applier's job.
+    assert {name for name, _, _ in plan.sessions} == {"chat-1-t", "chat-2-t", "chat-3-t"}
+
+    before = _session_messages(state)
+
+    async def _run() -> int:
+        state._restore_floor = tuple(plan.open_keys)
+        return await _run_restore_plan(state, plan)
+
+    # 3 distinct slots, not 5 applies — the shared keys are restored once.
+    assert asyncio.run(_run()) == 3
+    assert set(state._slots) == {"chat-1-t", "chat-2-t", "chat-3-t"}
+    assert all(len(s.messages) == 4 for s in state._slots.values())
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before, "a session was replayed twice"
+
+
+def test_closed_and_path_traversal_keys_are_rejected_by_collect(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-t")
+    _seed(state, "chat-2-t", closed=True)
+    _write_open_slots(tmp_path, ["chat-1-t", "../../etc/passwd", "", "chat-1-t"])
+
+    plan = _collect_restore_plan(state.conversation_log, 60, folders_only=False)
+
+    assert plan.open_keys == ["chat-1-t"], "traversal, empty or duplicate key survived"
+    # closed sessions never reach the recent-session half
+    assert {name for name, _, _ in plan.sessions} == {"chat-1-t"}
+
+
+# ── startup entry point ───────────────────────────────────────────────────────
+
+
+def test_api_create_during_replay_does_not_truncate_the_session(tmp_path, monkeypatch):
+    """The replay window is reachable by any client: /api/chat and the
+    OpenAI-compat endpoint both create a slot from a request-supplied key and do
+    NOT rehydrate on a miss. An empty slot registered under a pending key has
+    _disk_older_count=0 / _disk_window_len=0, is not covered by _restoring_keys,
+    and would be flushed over the victim's history.
+
+    Those handlers therefore await ensure_pending_slot_restored() first. Driven
+    through the real endpoint rather than get_or_create_slot, because the guard
+    now lives at the call site: calling the factory directly would pass here
+    while the shipped request path stayed broken.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t", "chat-3-t"]
+    for k in keys:
+        _seed(state, k, messages=6)
+    _write_open_slots(tmp_path, keys)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    async def _run() -> None:
+        await cp.restore_sessions_at_startup(state, 0)
+        assert "chat-3-t" in state._pending_restore_keys, "key was not reserved"
+        await cp.ensure_pending_slot_restored(state, "chat-3-t")
+        hijacked = state.get_or_create_slot("chat-3-t")
+        assert len(hijacked.messages) == 6, "slot materialized empty"
+        for task in list(state._background_tasks):
+            await task
+
+    asyncio.run(_run())
+
+    assert set(state._slots) == set(keys)
+    counts = {k: len(s.messages) for k, s in sorted(state._slots.items())}
+    assert all(v == 6 for v in counts.values()), counts
+
+    # And a flush must not rewrite any file from that slot.
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before, "session history was truncated"
+
+
+@pytest.mark.asyncio
+async def test_send_to_a_pending_key_restores_it_through_the_real_endpoint(
+    tmp_path, monkeypatch
+):
+    """End-to-end of the above over POST /api/chat.
+
+    Guards the wiring, not the helper: a future refactor that drops the awaited
+    call from the handler leaves the helper's own tests green.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-9-t", messages=6)
+    _write_open_slots(tmp_path, ["chat-9-t"])
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    await cp.restore_sessions_at_startup(state, 0)
+    assert "chat-9-t" in state._pending_restore_keys
+
+    app = _make_app(state)
+    async with TestClient(TestServer(app)) as client:
+        # The send itself needs no agent to run: the restore happens before the
+        # handler dispatches, so a failure to launch still exercises the guard.
+        with contextlib.suppress(Exception):
+            await client.post("/api/chat", json={"slot": "chat-9-t", "message": "hi"})
+
+    assert len(state._slots["chat-9-t"].messages) >= 6, "session was not restored"
+    for task in list(state._background_tasks):
+        await task
+    state._flush_dirty_slots()
+    assert _session_messages(state)["dashboard_chat-9-t.jsonl"][:6] == (
+        before["dashboard_chat-9-t.jsonl"]
+    ), "restored prefix was rewritten"
+
+
+@pytest.mark.asyncio
+async def test_resume_during_replay_does_not_double_the_transcript(tmp_path, monkeypatch):
+    """A slot factory must not rehydrate on behalf of a caller that rehydrates.
+
+    api_chat_slot_resume looks the slot up in _slots, misses on a pending key
+    (it is reserved but not yet replayed), falls through to get_or_create_slot,
+    and then reads the window and appends it itself. When the factory rehydrated
+    the pending key, the handler received a slot already holding N messages and
+    appended the same N again, leaving 2N with _disk_older_count = max(0, N-N) =
+    0. The on-demand path never entered _restoring_keys, so the next flush wrote
+    every line twice and the transcript was permanently doubled on disk.
+
+    This test fails with 12 messages against that branch.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-7-t", messages=6)
+    _write_open_slots(tmp_path, ["chat-7-t"])
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    await cp.restore_sessions_at_startup(state, 0)
+    assert "chat-7-t" in state._pending_restore_keys, "key was not reserved"
+
+    app = _make_app(state)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/api/chat/slots/chat-7-t/resume", json={"key": "dashboard:chat-7-t"}
+        )
+        assert resp.status == 200, await resp.text()
+
+    assert len(state._slots["chat-7-t"].messages) == 6, "resume replayed the window twice"
+
+    for task in list(state._background_tasks):
+        await task
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before, "transcript was doubled on disk"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_for_one_pending_key_share_one_read(tmp_path, monkeypatch):
+    """Single-flight: N tabs on one key must not each replay its window.
+
+    Relocating the rehydrate to the handlers made the claim-to-apply window
+    interruptible — every waiter awaits between its own reads. Without the task
+    map each concurrent request would read and apply the same window, which is
+    the doubling above by a different route.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-5-t", messages=6)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    reads = []
+    real = state.conversation_log.read_messages_chained
+
+    def _counted(key, *a, **kw):
+        reads.append(key)
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _counted)
+
+    # Reserve by hand rather than running a plan: the bulk pass legitimately
+    # reads this key too, and counting its read would measure the concurrent-race
+    # allowance (one wasted read, asserted by the content-integrity tests) rather
+    # than the dedup this test is about.
+    state._pending_restore_keys.add("chat-5-t")
+    await asyncio.gather(*(cp.ensure_pending_slot_restored(state, "chat-5-t") for _ in range(8)))
+
+    assert reads.count("dashboard:chat-5-t") == 1, f"window read {len(reads)}x: {reads}"
+    assert len(state._slots["chat-5-t"].messages) == 6
+    state._flush_dirty_slots()
+    assert _session_messages(state) == before
+
+
+@pytest.mark.asyncio
+async def test_a_failed_on_demand_restore_refuses_the_request(tmp_path, monkeypatch):
+    """A failed on-demand restore must not let the caller create a fresh slot.
+
+    Swallowing the error and settling the key was the original data loss by
+    another route: the handler proceeds to get_or_create_slot, registers an empty
+    slot under a key whose transcript is intact, and the next flush writes the
+    empty window over it. "The bulk pass will retry" only holds while no slot
+    exists, because the bulk pass skips a key that is already in _slots.
+
+    So the failure propagates as a retryable 503 and the reservation is retained.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-8-t", messages=6)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    def _boom(*a, **kw):
+        raise OSError("transient read failure")
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _boom)
+    state._pending_restore_keys.add("chat-8-t")
+
+    with pytest.raises(web.HTTPServiceUnavailable):
+        await cp.ensure_pending_slot_restored(state, "chat-8-t")
+
+    assert "chat-8-t" in state._pending_restore_keys, "reservation was released on failure"
+    assert "chat-8-t" not in state._slots, "a partial slot survived the failure"
+
+    # And the transcript is untouched: nothing was written over it.
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before
+
+
+def test_sync_injector_defers_instead_of_reading_on_the_loop(tmp_path, monkeypatch):
+    """The cron and workflow injectors run on the loop and cannot await.
+
+    Reading the history inline would put the unbounded history-scaled read back
+    on the loop, which is what this PR removes. They hand off to the off-loop
+    restore instead and are re-entered once the slot is real.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "cron-job1", messages=6)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    calls: list[str] = []
+
+    async def _run() -> None:
+        state._pending_restore_keys.add("cron-job1")
+        deferred = cp.ensure_restored_before_inject(
+            state, "cron-job1", lambda: calls.append("retried")
+        )
+        assert deferred is True, "injector read on the loop instead of deferring"
+        assert "cron-job1" not in state._slots, "slot was materialized synchronously"
+        for task in list(state._background_tasks):
+            await task
+        assert calls == ["retried"], "the caller was never re-entered"
+        assert len(state._slots["cron-job1"].messages) == 6
+
+    asyncio.run(_run())
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before, "session history was truncated"
+
+
+def test_injector_restores_inline_when_no_loop_is_running(tmp_path, monkeypatch):
+    """With no running loop there is nothing to stall, so the read is inline.
+
+    Keeps the guard correct for synchronous callers rather than leaving the key
+    unprotected when there is no loop to schedule onto.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "cron-job2", messages=6)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    state._pending_restore_keys.add("cron-job2")
+    assert cp.ensure_restored_before_inject(state, "cron-job2", lambda: None) is False
+    assert len(state._slots["cron-job2"].messages) == 6, "slot materialized empty"
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before
+
+
+def test_floor_is_installed_before_the_scan_yields(tmp_path, monkeypatch):
+    """The scan yields the loop and the 5s flush fires during it with _slots
+    still empty. If the floor is installed after the scan, that flush writes an
+    empty open_slots.json over the file the floor exists to protect."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 5)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    real_collect = cp._collect_restore_plan
+    during: list[set[str]] = []
+
+    def _flush_during_collect(*a, **kw):
+        # Stand in for the periodic flush landing inside the scan.
+        state._persist_open_slots()
+        during.append(_snapshot_keys(tmp_path))
+        return real_collect(*a, **kw)
+
+    monkeypatch.setattr(cp, "_collect_restore_plan", _flush_during_collect)
+
+    async def _run() -> None:
+        await cp.restore_sessions_at_startup(state, 0)
+        for task in list(state._background_tasks):
+            await task
+
+    asyncio.run(_run())
+
+    assert during, "the flush never ran during the scan"
+    assert during[0] == set(keys), "snapshot was wiped before the floor was installed"
+    assert set(state._slots) == set(keys)
+
+
+def test_open_keys_are_reserved_before_the_scan_yields(tmp_path, monkeypatch):
+    """A returning browser tab holds exactly the open-tab keys, so it is the most
+    likely thing to arrive during the scan. Reserving them only after the scan
+    would let that request register an empty slot over a real transcript."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t", "chat-3-t"]
+    for k in keys:
+        _seed(state, k, messages=6)
+    _write_open_slots(tmp_path, keys)
+    before = _session_messages(state)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    real_collect = cp._collect_restore_plan
+    hijacked: list[int] = []
+
+    def _client_arrives_during_the_scan(*a, **kw):
+        # The scan runs in a worker thread, but the request it races runs on the
+        # loop; asserting the reservation is live here is the loop-safe way to
+        # prove the ordering without driving slot mutation off-loop.
+        hijacked.append(len(state._pending_restore_keys))
+        return real_collect(*a, **kw)
+
+    monkeypatch.setattr(cp, "_collect_restore_plan", _client_arrives_during_the_scan)
+
+    async def _run() -> None:
+        await cp.restore_sessions_at_startup(state, 0)
+        for task in list(state._background_tasks):
+            await task
+
+    asyncio.run(_run())
+
+    assert hijacked == [len(keys)], "open keys were not reserved before the scan"
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state) == before
+
+
+def test_recent_sessions_still_restore_without_an_open_slots_file(tmp_path, monkeypatch):
+    """A fresh home has no snapshot. The listing must still be built, or the
+    recent-session half iterates nothing and the restore silently does nothing."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t", "chat-3-t"]
+    for k in keys:
+        _seed(state, k)
+    assert not (tmp_path / "open_slots.json").exists()
+
+    plan = _collect_restore_plan(state.conversation_log, 60, folders_only=False)
+
+    assert plan.open_keys == []
+    assert set(plan.listing) == set(keys), "listing was not built without a snapshot"
+    assert {name for name, _, _ in plan.sessions} == set(keys)
+
+    async def _run() -> int:
+        return await _run_restore_plan(state, plan)
+
+    assert asyncio.run(_run()) == len(keys)
+    assert set(state._slots) == set(keys)
+
+
+def test_stacked_history_prefix_folds_to_the_canonical_slot(tmp_path, monkeypatch):
+    """A legacy ``dashboard_dashboard_x`` file must resolve to the slot name
+    get_or_create_slot registers, so it lands in ONE slot rather than missing the
+    dedup guard and later colliding with the canonical key.
+
+    Note this does not assert content stability for a canonical/stacked pair:
+    ``list_sessions()`` deduplicates stacked prefixes keeping the NEWER file, so
+    a newer twin's window legitimately becomes the canonical session's content.
+    That policy predates this change and the unfolded path on main produces the
+    same outcome.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    _seed(state, "chat-1-t", messages=4)
+    for i in range(4):
+        log.append("dashboard_dashboard_chat-1-t", "user", f"stacked{i}")
+
+    plan = _collect_restore_plan(log, 60, folders_only=False)
+    names = [name for name, _, _ in plan.sessions]
+
+    assert all(not n.startswith("dashboard") for n in names), names
+    assert names.count("chat-1-t") == 1, "stacked twin produced a second slot name"
+
+    async def _run() -> None:
+        await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+
+    # One slot, not two, and no dashboard_-prefixed key in the sidebar.
+    assert list(state._slots) == ["chat-1-t"]
+
+
+def test_open_tab_replay_loads_config_and_agents_once_not_per_key(tmp_path, monkeypatch):
+    """The config load and the agent-directory glob are per-process facts. Doing
+    them per key put an unbounded, avoidable scan back on the event loop."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 9)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    calls = {"cfg": 0, "agents": 0}
+    real_cfg, real_agents = cp._load_restore_cfg, cp._kiro_model_map
+
+    def _count_cfg():
+        calls["cfg"] += 1
+        return real_cfg()
+
+    def _count_agents():
+        calls["agents"] += 1
+        return real_agents()
+
+    monkeypatch.setattr(cp, "_load_restore_cfg", _count_cfg)
+    monkeypatch.setattr(cp, "_kiro_model_map", _count_agents)
+
+    async def _run() -> int:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        return await _run_restore_plan(state, plan)
+
+    assert asyncio.run(_run()) == len(keys)
+    # One collect builds both; the replay must reuse them for all 8 keys.
+    assert calls["cfg"] <= 1, calls
+    assert calls["agents"] <= 1, calls
+
+
+def test_open_tab_backed_only_by_a_legacy_stacked_file_is_still_restored(tmp_path, monkeypatch):
+    """An open-slot key whose only file on disk is a stacked
+    ``dashboard_dashboard_x.jsonl`` cannot be resolved by the canonical
+    rehydrate. Skipping it in the recent half as "already covered" would drop
+    that tab from both paths."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    # Only the stacked twin exists; no dashboard_chat-9-t.jsonl.
+    for i in range(3):
+        log.append("dashboard_dashboard_chat-9-t", "user", f"legacy{i}")
+    _write_open_slots(tmp_path, ["chat-9-t"])
+
+    plan = _collect_restore_plan(log, 60, folders_only=False)
+    assert plan.open_keys == ["chat-9-t"]
+    assert "chat-9-t" in {name for name, _, _ in plan.sessions}, "stacked session skipped"
+
+    async def _run() -> int:
+        state._restore_floor = tuple(plan.open_keys)
+        return await _run_restore_plan(state, plan)
+
+    assert asyncio.run(_run()) == 1
+    assert "chat-9-t" in state._slots
+    assert len(state._slots["chat-9-t"].messages) == 3
+
+
+def test_a_stacked_only_tab_stays_reserved_until_the_recent_half_replays_it(
+    tmp_path, monkeypatch
+):
+    """A tab in BOTH halves must not be released by the first one to finish.
+
+    A tab backed only by a legacy stacked file has its folded name in
+    ``open_keys``, but the canonical history key has no file, so the open-tab
+    half restores nothing. Releasing the reservation in its ``finally`` left the
+    key unguarded across every remaining yield until the recent half reached it.
+    A request landing in that window registers an empty slot, the recent half
+    then skips the key as already-live, and the history is gone.
+
+    The probe interleaves with the replay's own yields, so every witnessed moment
+    is exactly a point where a request could arrive.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    for i in range(3):
+        log.append("dashboard_dashboard_chat-9-t", "user", f"legacy{i}")
+    # A couple of ordinary tabs so the replay actually yields more than once.
+    for k in ("chat-1-t", "chat-2-t"):
+        _seed(state, k, messages=4)
+    _write_open_slots(tmp_path, ["chat-9-t", "chat-1-t", "chat-2-t"])
+
+    plan = _collect_restore_plan(log, 60, folders_only=False)
+    assert "chat-9-t" in {name for name, _, _ in plan.sessions}
+
+    witnessed: list[tuple[bool, bool]] = []
+
+    async def _run() -> int:
+        state._restore_floor = tuple(plan.open_keys)
+        state._pending_restore_keys.update(plan.open_keys)
+        state._pending_restore_keys.update(name for name, _, _ in plan.sessions)
+        task = asyncio.ensure_future(_run_restore_plan(state, plan))
+        while not task.done():
+            await asyncio.sleep(0)
+            witnessed.append(
+                ("chat-9-t" in state._pending_restore_keys, "chat-9-t" in state._slots)
+            )
+        return await task
+
+    assert asyncio.run(_run()) >= 1
+    unguarded = [i for i, (reserved, live) in enumerate(witnessed) if not reserved and not live]
+    assert not unguarded, f"key was unguarded at yields {unguarded} of {len(witnessed)}"
+    assert len(state._slots["chat-9-t"].messages) == 3, "stacked history was not restored"
+
+
+@pytest.mark.asyncio
+async def test_on_demand_replay_does_not_reglob_the_agent_directory(tmp_path, monkeypatch):
+    """The on-demand path must reuse the plan's per-process facts.
+
+    ``_kiro_model_map`` globs the agent directory and ``_load_restore_cfg`` reads
+    config from disk. Neither is per-session, and the bulk pass already passes
+    both down — an on-demand replay that re-derived them would put a filesystem
+    walk back on the very path this PR clears.
+
+    Both facts are EMPTY on a home with no kiro agents and no config, which is
+    exactly the CI environment, so the published-vs-absent test must be a
+    ``None`` sentinel and not container truthiness. Testing truthiness re-derived
+    them on precisely the homes where the glob finds nothing.
+
+    Scoped to the model map, which is the directory walk. A published ``cfg`` of
+    ``None`` still falls through to a config read inside
+    ``_rehydrate_slot_from_history``, whose kwargs treat ``None`` as unset. That
+    is a single bounded file read, it only happens on a home with no config at
+    all, and the bulk pass behaves identically when ``plan.cfg`` is ``None`` — so
+    it is pre-existing and not history-scaled.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-4-t", messages=5)
+    _write_open_slots(tmp_path, ["chat-4-t"])
+
+    import kiro_crew.dashboard.chat_persistence as cp
+
+    await cp.restore_sessions_at_startup(state, 0)
+    assert "chat-4-t" in state._pending_restore_keys
+    # Force the empty shape the CI host produces, so this asserts the sentinel
+    # rather than whatever this machine's agent directory happens to hold.
+    state._restore_shared = ({}, {}, None)
+
+    derived: list[str] = []
+    monkeypatch.setattr(cp, "_kiro_model_map", lambda: derived.append("map") or {})
+
+    await cp.ensure_pending_slot_restored(state, "chat-4-t")
+
+    assert "map" not in derived, "on-demand replay re-globbed the agent directory"
+    assert len(state._slots["chat-4-t"].messages) == 5
+    for task in list(state._background_tasks):
+        await task
+
+
+def test_a_failed_bulk_restore_keeps_its_reservation(tmp_path, monkeypatch):
+    """A key whose bulk restore raised still has its transcript on disk.
+
+    Releasing the reservation there let the next request register an empty slot
+    over that session — the same data loss the on-demand path already refuses.
+    The floor retention added earlier protects ``open_slots.json``; this protects
+    the transcript itself.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path / "sessions")
+    for k in ("chat-1-t", "chat-2-t"):
+        _seed(state, k, messages=4)
+    _write_open_slots(tmp_path, ["chat-1-t", "chat-2-t"])
+    before = _session_messages(state)
+
+    log = state.conversation_log
+    real = log.read_messages_chained
+
+    def _boom_for_one(key, *a, **kw):
+        if key.endswith("chat-2-t"):
+            raise OSError("transient read failure")
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(log, "read_messages_chained", _boom_for_one)
+
+    plan = _collect_restore_plan(log, 0, folders_only=False)
+
+    async def _run() -> None:
+        state._restore_floor = tuple(plan.open_keys)
+        state._pending_restore_keys.update(plan.open_keys)
+        await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+
+    assert "chat-2-t" in state._pending_restore_keys, "failed key lost its reservation"
+    assert "chat-2-t" not in state._slots
+    assert "chat-1-t" not in state._pending_restore_keys, "healthy key was not released"
+    # The transcript of the failed key is untouched.
+    state._flush_dirty_slots()
+    save_all_slots_to_history(state)
+    assert _session_messages(state)["dashboard_chat-2-t.jsonl"] == (
+        before["dashboard_chat-2-t.jsonl"]
+    )
+
+
+def test_metadata_is_read_off_the_event_loop_for_open_tabs(tmp_path, monkeypatch):
+    """get_metadata reads the whole file to take its first line and the mtime
+    cache is cold on the first read after boot, so it must not run on the loop."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-t", "chat-2-t"]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    loop_thread = threading.current_thread()
+    read_threads: list[threading.Thread] = []
+    real = state.conversation_log.get_metadata
+
+    def _spy(key, *a, **kw):
+        read_threads.append(threading.current_thread())
+        return real(key, *a, **kw)
+
+    async def _run() -> int:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        # Patch AFTER collect so only the replay's reads are observed.
+        monkeypatch.setattr(state.conversation_log, "get_metadata", _spy)
+        return await _run_restore_plan(state, plan)
+
+    assert asyncio.run(_run()) == len(keys)
+    assert read_threads, "no metadata was read during the replay"
+    assert all(t is not loop_thread for t in read_threads)
+
+
+def test_a_failed_open_tab_keeps_its_floor_entry(tmp_path, monkeypatch):
+    """A read that raises may be transient. Releasing its floor entry would let
+    the next flush write a snapshot without it and lose the tab for good, while
+    everything that actually settled must still release."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 6)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    real = state.conversation_log.read_messages_chained
+
+    def _boom(key, *a, **kw):
+        if "chat-3-t" in key:
+            raise OSError("transient disk gremlin")
+        return real(key, *a, **kw)
+
+    monkeypatch.setattr(state.conversation_log, "read_messages_chained", _boom)
+
+    async def _run() -> None:
+        plan = _collect_restore_plan(state.conversation_log, 0, folders_only=False)
+        state._restore_floor = tuple(plan.open_keys)
+        await _run_restore_plan(state, plan)
+
+    asyncio.run(_run())
+
+    assert "chat-3-t" not in state._slots
+    assert state._restore_floor == ("chat-3-t",), state._restore_floor
+    # So it survives the very next snapshot, and a later boot retries it.
+    state._persist_open_slots()
+    assert _snapshot_keys(tmp_path) == set(keys)
+
+
+def test_startup_reseeds_past_keys_the_replay_has_not_reached(tmp_path, monkeypatch):
+    """A new chat minted while the replay is running must not collide with a tab
+    about to come back, so the reseed happens before the entry point returns."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-41-t")
+    _write_open_slots(tmp_path, ["chat-41-t"])
+
+    async def _run() -> int:
+        total = await restore_sessions_at_startup(state, 0)
+        # Counter is already past the pending key, before any replay ran.
+        assert state._slot_counter >= 41
+        for task in list(state._background_tasks):
+            await task
+        return total
+
+    # The key is in both halves of the plan (collect does not pre-skip), so the
+    # count is the planned applies, not the distinct sessions.
+    assert asyncio.run(_run()) >= 1
+    assert "chat-41-t" in state._slots
+
+
+def test_startup_with_nothing_to_restore_releases_the_floor(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    assert asyncio.run(restore_sessions_at_startup(state, 0)) == 0
+    assert state._restore_floor == ()
+
+
+def test_sync_wrappers_still_restore_everything_inline(tmp_path, monkeypatch):
+    """The sync wrappers keep their old contract for targeted and test callers:
+    everything is restored by the time they return."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-t" for i in range(1, 6)]
+    for k in keys:
+        _seed(state, k)
+    _write_open_slots(tmp_path, keys)
+
+    assert restore_open_slots(state) == len(keys)
+    assert set(state._slots) == set(keys)
+
+    state2 = _make_state(tmp_path / "sessions")
+    assert restore_recent_sessions(state2, 60) == len(keys)
+    assert set(state2._slots) == set(keys)


### PR DESCRIPTION
## Description

Startup session rehydration ran **unbounded and synchronously on the event loop**, and the loop-stall watchdog is armed before it runs. `LoopStallWatchdog(exit_after=25.0)` arms a C-level `faulthandler.dump_traceback_later(25, exit=True)`; the heartbeat cannot be petted while the loop is blocked inside `restore_open_slots()` / `restore_recent_sessions()`. On a large data home the gateway therefore **killed itself mid-startup on every boot**, and the failure gets more certain as history accumulates.

Reproduced on a home with **67 open tabs and 676 sessions (500 MB)**:

```
crash-dumps/loopstall-20260728T183426Z.txt
  Timeout (0:00:25)!
  Thread 0x…740 (most recent call first):     ← main thread
    history.py:1477 in list_sessions
    chat_persistence.py:476 in restore_recent_sessions
    server.py:2402 in start_dashboard
gateway.log  last line 18:34:51 "Restored 67 open tab(s)"  then nothing
crash.log    no entry  (os._exit skips atexit)
```

The watchdog armed at 18:34:26 (last heartbeat) and the timer fired exactly 25s later.

> Supersedes #674, which capped the *inline* restore at 10 sessions and deferred the rest. Reviewers were right that a session **count** cannot bound a **25-second wall clock**, and that the pre-limit eligibility scan still ran on the loop — so that approach moved the threshold instead of closing the class. This one closes it, and is smaller.

## Fix

Split **collect** (pure I/O) from **apply** (loop-affine).

- **`_collect_restore_plan()`** does every read and every filter — `open_slots.json`, one `list_sessions()` walk, per-session metadata, mtime cutoff / `folders_only` / pinned / `closed` — and runs in a worker thread. It takes a `ConversationLog` rather than a `DashboardState`, so it *cannot* mutate slots even by accident. One walk feeds both halves and the recent-session half skips keys the open-tab half already covers, so the double-collection is gone.
- **`restore_sessions_at_startup()`** awaits that scan, reseeds the slot counter past every known key, then replays as a background task that yields between sessions and reads each message window off-loop.

What remains on the loop per session is bounded CPU — redact + append of at most 500 in-memory messages — with a yield before each. No session shape can stretch that to 25s, so the crash class is closed rather than narrowed. The scan is awaited rather than backgrounded because that is what lets `reseed_slot_counter` run past the pending keys **before** any client can mint a new chat that would collide with a returning tab.

A larger fixed timeout was considered and rejected: startup cost scales with accumulated history, so any constant is eventually crossed. Not arming the watchdog until after rehydration was also rejected — it would leave startup itself unwatched.

## Durability

Making the restore concurrent puts it alongside machinery that previously could never observe it: the 5s flush, the shutdown save, live client requests. Restore is a **read** — the session JSONL is the source of truth — so the only ways to lose state are the writes the restore path touches.

**`open_slots.json` (a derived cache, and the only user-visible loss):**

- `_restore_floor` holds the keys read out of the file at boot. Until the replay finishes, `_persist_open_slots` unions them into every snapshot it writes, so a flush, a crash or a shutdown save landing mid-replay cannot rewrite that file **narrower** than it already was. Seeded from the file's own bytes rather than from any derived set, so a bug in collection is not fatal either — and because every key in that file was persistent when written, the incognito filter question does not arise.
- `_persist_open_slots` reads the floor **before** `_slots`, and the replay **inserts before releasing**. A key absent from the floor read was therefore released, which means it was inserted, which means it is present in the `_slots` read that follows. Reversing the two reads breaks the proof: a key absent from `slots(t1)` can be inserted and released before `floor(t2)`.
- The floor is released only on a **completed** pass, deliberately not in a `finally`. Cancellation (gateway shutdown mid-replay) must retain it so the shutdown snapshot still records the tabs that never got their turn; the next boot re-derives and retries them, which is free because restore is idempotent.

**Message content:**

- `_restoring_keys` hides a slot from the persistence sweeps while its window is replayed. `get_or_create_slot` registers the slot before the replay fills it and `slot.append` marks it `_dirty`, so a save inside the replay would persist a partial window whose `_disk_older_count` / `_disk_window_len` still describe the pre-replay slot — and the next flush would duplicate those lines. Skipping is lossless: that window was read from the same file. `_flush_dirty_slots` skips **before** its `_dirty` check (the branch below clears the flag assuming the save ran) and `_save_slot_to_history` returns early as the choke point, covering the shutdown sweep and any future caller.
- Metadata is re-read **after** the window read, so a session deleted during the replay is not resurrected by the `tab_id` backfill.

**Also fixed — a latent bug the content test caught.** `list_sessions()` reports the filename-folded `dashboard_x` key while `_history_key_for` produces the canonical `dashboard:x`, so a listing keyed by one and looked up by the other silently missed and restored slots lost their titles. Both prefixes now go through `_slot_name_from_history_key`.

`restore_open_slots` / `restore_recent_sessions` keep their signatures and their "everything is restored by the time I return" contract for targeted and test callers; they are thin wrappers over the same collect and apply helpers, so the ~60 existing call sites are untouched.

## Testing

`test/test_async_session_restore.py` (15 tests) is written as invariants checked under adversarial timing rather than one test per race:

1. **Monotone snapshot** — a snapshot is forced after *every single apply* and asserted to still contain the original key set; plus a case where the plan deliberately under-collects and the floor still saves the file.
2. **Crash safety** — parametrized over the index to die at, asserting the floor is retained, a shutdown save still writes the complete set, and a second boot restores everything.
3. **Content integrity** — the message sequence on disk is unchanged by restore + flush + forced save. (Byte identity is *not* the invariant: a forced save legitimately adds `tab_id` / `source_thread`, and does so on the unchanged sync path too. This test caught the listing-key bug above.)
4. **Concurrent flush** — 1 and 3 re-checked with a real flush thread running for the whole replay.

Plus: collect is read-only and dedupes the halves; path-traversal, empty and duplicate keys are rejected; the startup entry point reseeds before returning; the sync wrappers still restore inline.

- [x] `test/test_async_session_restore.py` — 15 passed
- [x] Pre-existing callers of the wrappers (`test_session_restore.py`, `test_open_slots_persistence.py`, `test_artifact_companion.py`, `test_ephemeral_sessions.py`, `test_fixtures_helper.py`, `test_session_key_slug.py`) — 206 passed, unmodified
- [x] Full backend suite — **19548 passed**, 136 skipped, 5 xfailed, 18 failed. All 18 are environment-shaped on this host and none are in the dashboard restore or persistence modules: `test_sandbox_argv.py` (9, `userns` EPERM in the sandbox), `test_dashboard_origin.py` (3, a local `dashboard.port` pin), `test_source_providers.py` + `test_issue_radar_gh_bin.py` (4, PATH/ownership probes), `test_cli.py` (1, real subprocess), `test_deploy_round30_fixes.py` (1, hardlink probe). The same 18 fail on a clean checkout on this host.
- [x] `flake8 src/kiro_crew test`, `isort --check-only src/kiro_crew test`, `mypy src/kiro_crew/` (518 files) all clean

## Follow-ups (not in this PR)

- `push_slots_update()` serializes and broadcasts the full slot list per restored slot. With the loop now free, clients are connected and receive one payload per session instead of dropping them on a blocked loop — worth coalescing to one push per chunk.
- Several HTTP handlers (`handlers/sessions.py`, `chat_folders.py`, `chat_handlers.py`) still call `list_sessions()` on the loop. Pre-existing and out of scope here.
