### PR TITLE
fix(cli): wait for the incumbent gateway to exit before restart spawns

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -661,6 +661,38 @@ def _pid_exited(pid: int) -> bool:
     return not platform_compat.pid_exists(pid)
 
 
+def _wait_for_pids_exit(pids: list[int], timeout: float) -> list[int]:
+    """Block until every pid in *pids* is gone. Return the ones still alive.
+
+    An empty return means they all exited. :func:`_restart` uses this to keep a
+    replacement gateway from starting while the incumbent is still shutting down.
+
+    The incumbent holds an exclusive ``flock`` on ``<KIROCREW_HOME>/gateway.lock``
+    (see :mod:`kiro_crew.gateway_lock`) for its whole lifetime, and the release
+    happens only after ``asyncio.run(_gateway(...))`` returns — so the lock
+    outlives dashboard teardown, cron-scheduler stop, conversation-log flushes,
+    and MCP child reaping. The replacement's acquire is a single non-blocking
+    attempt that prints a refusal and exits 1, so spawning it too early leaves NO
+    gateway running at all. ``_stop`` waits at most 1s and reports nothing back,
+    which is why restart does its own bounded wait.
+
+    Pid reuse is possible but fails SAFE: the caller classifies the pids as
+    KiroCrew gateways once, before the stop, and a pid recycled onto an unrelated
+    process only makes this wait time out. That produces a loud refusal, never a
+    premature "the incumbent is gone" all-clear. Re-classifying inside the loop
+    would invert that -- a recycled pid would read as "not a gateway" and let the
+    replacement spawn while the real incumbent still holds the lock.
+    """
+    if not pids:
+        return []
+    deadline = time.monotonic() + timeout
+    while True:
+        alive = [p for p in pids if not _pid_exited(p)]
+        if not alive or time.monotonic() >= deadline:
+            return alive
+        time.sleep(0.1)
+
+
 def _own_console_script() -> str | None:
     """Absolute path of the console script *this* CLI process was invoked as.
 
@@ -781,6 +813,11 @@ def _spawn_detached_gateway(port: int | None = None) -> int:
 
 _RESTART_TOKEN_TTL = "20h"
 _RESTART_READY_TIMEOUT = 15  # seconds to wait for gateway to become ready
+# Seconds to wait for the incumbent gateway to exit before spawning its
+# replacement. Generous because a graceful shutdown reaps MCP servers and
+# kiro-cli children; the wait ends as soon as the pids are gone, so the common
+# case costs a fraction of a second.
+_RESTART_STOP_TIMEOUT = 30.0
 
 
 def _print_token_url(port: int) -> None:
@@ -855,10 +892,16 @@ def _restart(cli_port: int | None = None) -> None:
     # only on a truthy result would skip the stop and double-spawn a second
     # gateway on a lsof-less POSIX host. _stop() surfaces the distinct
     # "lsof not found" diagnostic (and exits) in that case.
-    if (
-        platform_compat.find_listening_pids(port)
-        or not platform_compat.listening_pid_tool_available()
-    ):
+    #
+    # Capture the incumbent pids HERE, before the stop, so we can wait for them
+    # afterwards: the replacement must not start while the old gateway still owns
+    # the KIROCREW_HOME lock (see _wait_for_pids_exit). Filter with _stop()'s own
+    # kirocrew-process predicate so an unrelated listener on this port never
+    # becomes something we block on. The entry condition below stays on the
+    # UNFILTERED lookup so _stop() keeps emitting its existing diagnostics.
+    listeners = platform_compat.find_listening_pids(port)
+    incumbents = [p for p in listeners if _is_kirocrew_process(p)]
+    if listeners or not platform_compat.listening_pid_tool_available():
         # TOCTOU: the gateway can exit between the check above and _stop()'s own
         # lookup. _stop() raises SystemExit(1) when it finds nothing — for restart
         # that's the wrong behavior. Swallow SystemExit so we always proceed to
@@ -868,6 +911,29 @@ def _restart(cli_port: int | None = None) -> None:
             _stop(cli_port)
         except SystemExit:
             pass
+
+        alive = _wait_for_pids_exit(incumbents, _RESTART_STOP_TIMEOUT)
+        if alive:
+            # Refuse rather than spawn a replacement that the lock would reject.
+            # Aborting leaves the user with a (slow) gateway; spawning anyway
+            # would leave them with none, reported as a success.
+            pids = ", ".join(str(p) for p in alive)
+            sel().log_api_access(
+                caller="cli",
+                operation="gateway_restart",
+                outcome="denied",
+                source="cli",
+                resources=f"port={port} reason=incumbent_still_running pids={alive}",
+            )
+            print(
+                f"❌ Gateway (pid {pids}) did not exit within "
+                f"{int(_RESTART_STOP_TIMEOUT)}s. Not starting a replacement.\n"
+                f"   The old gateway still owns {config_dir()}, so a new one "
+                f"would be refused and exit immediately.\n"
+                f"   To inspect the shutdown, run: kirocrew logs -f\n"
+                f"   If the process is wedged, force it: kill -9 {pids}"
+            )
+            sys.exit(1)
 
     pid = _spawn_detached_gateway(port)
     sel().log_api_access(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1774,6 +1774,29 @@ class TestStop:
         assert "No Kiro Crew gateway" in capsys.readouterr().out
 
 
+class TestWaitForPidsExit:
+    """Tests for the bounded ``_wait_for_pids_exit`` helper."""
+
+    def test_empty_pid_list_returns_immediately(self):
+        from kiro_crew.cli_server import _wait_for_pids_exit
+
+        assert _wait_for_pids_exit([], timeout=99) == []
+
+    def test_zero_timeout_still_probes_once(self):
+        """A zero timeout must not skip the check and report a false all-clear."""
+        from kiro_crew.cli_server import _wait_for_pids_exit
+
+        with patch("kiro_crew.cli_server._pid_exited", return_value=False) as mock_exited:
+            assert _wait_for_pids_exit([7], timeout=0) == [7]
+        mock_exited.assert_called_once_with(7)
+
+    def test_returns_only_the_pids_still_alive(self):
+        from kiro_crew.cli_server import _wait_for_pids_exit
+
+        with patch("kiro_crew.cli_server._pid_exited", side_effect=lambda p: p != 9):
+            assert _wait_for_pids_exit([8, 9], timeout=0) == [9]
+
+
 class TestRestart:
     """Tests for the service-aware ``_restart`` CLI function.
 
@@ -1912,6 +1935,116 @@ class TestRestart:
         mock_stop.assert_called_once_with(None)
         mock_spawn.assert_called_once()
         assert "9999" in capsys.readouterr().out
+
+    def test_waits_for_incumbent_to_exit_before_spawning(self):
+        """The replacement must not be spawned while the old gateway is alive.
+
+        The incumbent holds the ``KIROCREW_HOME`` flock for its whole graceful
+        shutdown, and ``_stop`` waits only ~1s for exit without reporting back.
+        A replacement spawned inside that window is refused by the lock and exits
+        1, leaving NO gateway running. Assert the spawn happens strictly after
+        the incumbent pid is observed gone.
+        """
+        from kiro_crew import cli_server
+
+        # Alive for the first two probes, gone from the third.
+        exited = iter([False, False, True, True, True])
+        probe_log: list[bool] = []
+
+        def fake_pid_exited(pid: int) -> bool:
+            val = next(exited, True)
+            probe_log.append(val)
+            return val
+
+        with (
+            self._mock_sel(),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                return_value=[1234],
+            ),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+            patch("kiro_crew.cli_server._stop"),
+            patch("kiro_crew.cli_server._pid_exited", side_effect=fake_pid_exited),
+            patch("kiro_crew.cli_server._print_token_url"),
+            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=5678) as mock_spawn,
+        ):
+            cli_server._restart(None)
+
+        mock_spawn.assert_called_once()
+        # The wait actually polled past the "still alive" answers rather than
+        # spawning on the first one.
+        assert probe_log[:3] == [False, False, True]
+
+    def test_refuses_to_spawn_when_incumbent_never_exits(self, capsys):
+        """A wedged incumbent must abort the restart, not produce zero gateways.
+
+        Spawning anyway would print a success line for a child the lock kills,
+        so the user ends up with nothing. Aborting leaves the (slow) gateway up
+        and names the pid to force.
+        """
+        from kiro_crew import cli_server
+
+        with (
+            self._mock_sel(),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                return_value=[1234],
+            ),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=True),
+            patch("kiro_crew.cli_server._stop"),
+            patch("kiro_crew.cli_server._pid_exited", return_value=False),
+            patch("kiro_crew.cli_server._RESTART_STOP_TIMEOUT", 0),
+            patch("kiro_crew.cli_server._spawn_detached_gateway") as mock_spawn,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cli_server._restart(None)
+
+        assert exc.value.code == 1
+        mock_spawn.assert_not_called()
+        out = capsys.readouterr().out
+        assert "1234" in out
+        assert "did not exit" in out
+
+    def test_unrelated_port_listener_is_not_waited_on(self):
+        """A non-KiroCrew listener must never gate the restart.
+
+        ``find_listening_pids`` reports whatever holds the port. Blocking on a
+        foreign process would make restart hang for the full timeout and then
+        refuse, so the wait set is filtered by ``_is_kirocrew_process``.
+        """
+        from kiro_crew import cli_server
+
+        with (
+            self._mock_sel(),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                return_value=[1234],
+            ),
+            patch("kiro_crew.cli_server._is_kirocrew_process", return_value=False),
+            patch("kiro_crew.cli_server._stop") as mock_stop,
+            patch("kiro_crew.cli_server._pid_exited", return_value=False) as mock_exited,
+            patch("kiro_crew.cli_server._print_token_url"),
+            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=5678) as mock_spawn,
+        ):
+            cli_server._restart(None)
+
+        # _stop still runs (it owns the "not a KiroCrew gateway" diagnostic)...
+        mock_stop.assert_called_once_with(None)
+        # ...but nothing is waited on, and the spawn proceeds.
+        mock_exited.assert_not_called()
+        mock_spawn.assert_called_once()
 
     def test_spawn_detached_gateway_binds_requested_port(self, tmp_path, monkeypatch):
         """The child must bind the port the parent resolved.


### PR DESCRIPTION
<!-- restart-wait-for-exit -->
## Problem

`kirocrew restart` can leave **no gateway running at all**, while printing a
success line.

The user sees:

```
✅ Started detached gateway (pid 41234). Logs: kirocrew logs -f

⚠️  Could not generate token (gateway still starting?). Run: kirocrew token
```

The dashboard never comes back. Pid 41234 is already dead. The real reason sits
in `gateway.log`, not on the terminal:

```
👻 another gateway (pid 40011) already owns /home/user/.kiro/crew; stop it first
   or set KIROCREW_HOME to an isolated directory
```

## Why it matters

A restart is the recovery action users reach for after a config change or a
wedge. When it silently produces zero gateways, the dashboard, Slack bridge,
and every cron stop until someone reads `gateway.log` and starts the gateway by
hand. The success line actively misleads: it names a pid that no longer exists.

Only the fork path is affected. The systemd/launchd path routes through
`systemctl restart`, which waits for the unit to reach inactive before starting.

## Fix (symptom -> root cause -> change)

**Symptom.** The replacement gateway exits 1 immediately with a lock refusal.

**Root cause.** A shutdown-duration race, not a stale lock. `gateway_lock.py`
uses an advisory `flock`, which the kernel releases on process death, so the
lock can never go stale. But the incumbent holds it for its *entire* graceful
shutdown -- `_gw_lock.release()` sits in a `finally` after
`asyncio.run(_gateway(...))` returns, so the lock outlives dashboard teardown,
cron-scheduler stop, conversation-log flushes, and MCP/kiro-cli child reaping.

`_stop()` sends SIGTERM and then waits **at most 1 second**:

```python
if sent:
    for _ in range(10):  # up to 1s
        time.sleep(0.1)
        if all(_pid_exited(p) for p in sent):
            break
```

That loop breaks on timeout exactly as it breaks on success, and returns
nothing. `_restart()` then calls `_spawn_detached_gateway(port)`
unconditionally. On a gateway with MCP servers loaded, a shutdown longer than
1s is ordinary. The child's `GatewayLock.acquire()` is a single non-blocking
attempt that prints to stderr and exits 1, so the refusal lands in
`gateway.log` while the terminal keeps its success line.

**Change.** Fix it at the restart driver, which is the layer that knows it just
asked the incumbent to die:

1. `_restart()` captures the incumbent pids *before* the stop, filtered by
   `_is_kirocrew_process` so an unrelated listener on the port cannot gate the
   restart.
2. New `_wait_for_pids_exit(pids, timeout)` blocks until they are gone, bounded
   at 30s, and returns whichever are still alive.
3. If any survive, `_restart()` **refuses** and exits 1 with the pid to force.
   Refusing leaves the user with a slow gateway. Spawning anyway leaves them
   with none, reported as success.

The lock keeps its fail-fast semantics: a genuine second gateway on the same
home must still be refused immediately and loudly. No retry was added there.

The entry condition into `_stop()` stays on the **unfiltered** lookup, so
`_stop()`'s existing diagnostics ("No Kiro Crew gateway currently running",
"`lsof` not found") are unchanged.

Pid reuse fails safe: classification happens once, before the stop, so a
recycled pid can only make the wait time out into a loud refusal -- never into a
premature "the incumbent is gone" all-clear.

## Tests

`test/test_cli.py`, 6 new tests:

| Test | Locks in |
|---|---|
| `test_waits_for_incumbent_to_exit_before_spawning` | The spawn happens strictly after the incumbent pid is observed gone -- the wait polls past "still alive" answers instead of spawning on the first one |
| `test_refuses_to_spawn_when_incumbent_never_exits` | A wedged incumbent exits 1 with the pid named, and **never** spawns a replacement the lock would kill |
| `test_unrelated_port_listener_is_not_waited_on` | A non-KiroCrew listener does not gate the restart (guards against the new filter causing a 30s hang + false refusal) |
| `test_empty_pid_list_returns_immediately` | No-incumbent path costs nothing |
| `test_zero_timeout_still_probes_once` | A zero timeout cannot skip the check and report a false all-clear |
| `test_returns_only_the_pids_still_alive` | Partial-exit reporting |

The two behavioral tests were verified to **fail against pre-fix
`cli_server.py`** and pass after, so they are not vacuous.

## Manual verification

N/A -- unit coverage is sufficient. The race is a timing window between two
processes; the tests drive it deterministically by controlling `_pid_exited`,
which is more reliable than trying to reproduce a >1s shutdown by hand.

Gates run locally: `pytest test/test_cli.py` (204 passed), `test_service.py`,
`test_restart_command.py`, `isort`, `flake8`, `mypy src/kiro_crew/` (518 files,
clean). One pre-existing failure,
`TestInstallPidfdChildWatcher::test_real_subprocess_works_after_install_on_linux`,
reproduces on a clean `origin/main` checkout in this sandbox and is unrelated.

## Screenshots

N/A -- CLI-only change, no user-visible UI surface.
