### PR TITLE
fix(dashboard): Unify cost formatting behind formatCost()

### DIFF
--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -14,6 +14,7 @@ import InfoTip from '../components/InfoTip'
 import { useProvider } from '../providers'
 import { useFilteredDropdown } from '../hooks/useFilteredDropdown'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
+import { formatCost } from '../utils/formatCost'
 
 function fmtTokens(n: number): string {
   return n >= 1_000_000 ? (n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1) + 'M' : (n / 1_000).toFixed(0) + 'K'
@@ -403,7 +404,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                       {hasOverage && <span className="text-muted">Overage credits: <span className="text-warn font-medium">{overage.toFixed(1)}</span></span>}
                     </div>
                     <div className="flex gap-3">
-                      <span className="text-muted">Est. cost: <span className="text-text-strong font-medium">${usage.cost_usd?.toFixed(2) ?? '—'}</span></span>
+                      <span className="text-muted">Est. cost: <span className="text-text-strong font-medium">{formatCost(usage.cost_usd)}</span></span>
                       {usage.overage_rate && <span className="text-muted">${usage.overage_rate}/req</span>}
                     </div>
                   </div>

--- a/website/src/pages/ArtifactDeployPage.tsx
+++ b/website/src/pages/ArtifactDeployPage.tsx
@@ -8,6 +8,7 @@ import { PageHeader, Card, CardTitle, StatCard, Btn, Input, Toggle , Badge} from
 import StyledSelect from '../components/StyledSelect'
 import InfoTip from '../components/InfoTip'
 import { safeHttpUrl } from '../lib/safeUrl'
+import { formatCost } from '../utils/formatCost'
 
 const BASE = '/api/deploy'
 
@@ -230,7 +231,7 @@ export default function ArtifactDeployPage() {
         <StatCard label="Profiles" value={profiles.length} />
         <StatCard label="Active Deployments" value={totalDeployments} accent />
         <StatCard label="Ready to Deploy" value={draftWebapps.length} delay={60} />
-        <StatCard label="Est. Cost (not a bill)" value={estCost > 0 ? `≤ $${estCost.toFixed(4)}` : '~$0'} delay={120} />
+        <StatCard label="Est. Cost (not a bill)" value={estCost > 0 ? `≤ ${formatCost(estCost)}` : formatCost(0)} delay={120} />
       </div>
 
       {notice && (

--- a/website/src/pages/overview/TokenDailyChart.tsx
+++ b/website/src/pages/overview/TokenDailyChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useState } from 'react'
+import { formatCost } from '../../utils/formatCost'
 
 export type TokenBucket = {
   input: number
@@ -201,7 +202,7 @@ export function TokenDailyChart({
                 <div>In: {fmtNum(d.input)} · Out: {fmtNum(d.output)}</div>
                 {d.cacheRead > 0 && <div>Cache read: {fmtNum(d.cacheRead)}</div>}
                 {d.cacheCreate > 0 && <div>Cache create: {fmtNum(d.cacheCreate)}</div>}
-                {d.costUsd > 0 && <div>Cost: ${d.costUsd.toFixed(4)}</div>}
+                {d.costUsd > 0 && <div>Cost: {formatCost(d.costUsd)}</div>}
                 {(providerSel !== ALL || effectiveModel !== ALL) && (
                   <div className="mt-1 pt-1 border-t border-border text-muted">
                     {providerSel !== ALL && <div>Provider: {providerSel}</div>}

--- a/website/src/pages/overview/UsageTab.tsx
+++ b/website/src/pages/overview/UsageTab.tsx
@@ -4,6 +4,7 @@ import { Card, CardTitle, Badge } from '../../components/ui'
 import { useProvider } from '../../providers'
 import type { NormalizedUsage } from '../../providers'
 import { TokenDailyChart } from './TokenDailyChart'
+import { formatCost } from '../../utils/formatCost'
 
 function fmtNum(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -61,7 +62,7 @@ export default function UsageTab() {
             {data.tokens.cacheCreation > 0 && <Row label="Cache creation" value={fmtNum(data.tokens.cacheCreation)} />}
             {data.tokens.cacheRead > 0 && <Row label="Cache read" value={fmtNum(data.tokens.cacheRead)} />}
             <Row label="Total tokens" value={fmtNum(data.tokens.total)} />
-            {data.costUsd != null && <Row label="Total cost" value={`$${data.costUsd.toFixed(4)}`} />}
+            {data.costUsd != null && <Row label="Total cost" value={formatCost(data.costUsd)} />}
             {data.totalTurns != null && data.totalTurns > 0 && <Row label="Total turns" value={data.totalTurns} />}
             {data.totalDurationMs != null && data.totalDurationMs > 0 && <Row label="Total API time" value={`${(data.totalDurationMs / 1000).toFixed(1)}s`} />}
           </div>

--- a/website/src/test/formatCost.test.ts
+++ b/website/src/test/formatCost.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { formatCost } from '../utils/formatCost'
+
+describe('formatCost', () => {
+  it('renders two decimal places for normal amounts', () => {
+    expect(formatCost(0.02)).toBe('$0.02')
+    expect(formatCost(1.5)).toBe('$1.50')
+    expect(formatCost(12.345)).toBe('$12.35')
+  })
+
+  it('floors non-zero dust to <$0.01 instead of leaking 4dp noise', () => {
+    // The pre-fix rendering was "$0.0004" / "$0.0023" — a precision no user
+    // decision needs.
+    expect(formatCost(0.0004)).toBe('<$0.01')
+    expect(formatCost(0.009)).toBe('<$0.01')
+  })
+
+  it('distinguishes an exact zero from too-small-to-show', () => {
+    expect(formatCost(0)).toBe('~$0')
+    expect(formatCost(0.0001)).toBe('<$0.01')
+  })
+
+  it('renders an em dash for missing or non-finite input, never $NaN', () => {
+    expect(formatCost(null)).toBe('—')
+    expect(formatCost(undefined)).toBe('—')
+    expect(formatCost(NaN)).toBe('—')
+    expect(formatCost(Infinity)).toBe('—')
+  })
+
+  it('surfaces a negative sign rather than flooring a bad value', () => {
+    expect(formatCost(-2.5)).toBe('-$2.50')
+    expect(formatCost(-0.001)).toBe('-<$0.01')
+  })
+})

--- a/website/src/utils/formatCost.ts
+++ b/website/src/utils/formatCost.ts
@@ -1,0 +1,26 @@
+/**
+ * Format a USD cost for display at a precision a user can actually act on.
+ *
+ * Cost surfaces previously formatted the same concept three different ways
+ * (`toFixed(4)` in Usage / daily-chart / deploy, `toFixed(2)` in Agents), so two
+ * screens showing one number could look like they disagreed. Four decimals also
+ * implies a precision no decision needs — "$0.0231" and "≤ $0.0004" read as
+ * noise where "$0.02" and "<$0.01" carry the information.
+ *
+ * Rules: 2dp, a `<$0.01` floor for non-zero dust, and `~$0` for a true zero
+ * (an exact-zero cost is a different fact from "too small to show").
+ * Non-finite / missing input renders as an em dash rather than "$NaN".
+ *
+ * NOTE: for MONEY only. Similarity scores (VectorMemoryCard) legitimately want
+ * 2–3dp — do not route those through here.
+ */
+export function formatCost(usd: number | null | undefined): string {
+  if (usd == null || !Number.isFinite(usd)) return '—'
+  if (usd === 0) return '~$0'
+  // Negative costs aren't a real domain value; surface the sign rather than
+  // silently flooring a bad input to <$0.01.
+  const abs = Math.abs(usd)
+  const sign = usd < 0 ? '-' : ''
+  if (abs < 0.01) return `${sign}<$0.01`
+  return `${sign}$${abs.toFixed(2)}`
+}


### PR DESCRIPTION
## Problem

Dollar costs render at four decimal places in three places and two in a fourth — the same concept formatted three different ways:

| Surface | Before |
|---|---|
| `website/src/pages/overview/UsageTab.tsx:64` | `$0.0231` |
| `website/src/pages/overview/TokenDailyChart.tsx:204` | `Cost: $0.0231` |
| `website/src/pages/ArtifactDeployPage.tsx:233` | `≤ $0.0004` |
| `website/src/pages/AgentsPage.tsx:406` | `$0.02` |

Two screens showing the same number could look like they disagreed, and four decimals implies a precision no user decision needs — `≤ $0.0004` is noise where `<$0.01` is the actual information.

Found by running the 12-lens UX rubric from `.github/workflows/ux-review.yml` against the dashboard (lens 11, information display — Few's "precision appropriate to the decision").

## Why it matters

Low individual severity, but it lands on the surfaces users check repeatedly (usage, cost estimates), and the inconsistency undermines trust in the numbers: a reader who sees `$0.0231` on one screen and `$0.02` on another cannot tell whether they are the same figure.

## Fix (symptom → root cause → change)

Symptom: inconsistent, over-precise money strings. Root cause: no shared cost formatter — each call site hand-rolled `toFixed(n)` inline, so the precision decision was made four times independently. Change: extract one helper and route every money display through it.

New `website/src/utils/formatCost.ts`, following the `utils/timeAgo.ts` precedent (one formatting util per file, JSDoc one-liner, non-finite guard):

- **2 decimal places** — matched to the decision the number supports.
- **`<$0.01` floor** for non-zero dust instead of leaking `$0.0004`.
- **`~$0` for an exact zero** — a true zero is a different fact from too-small-to-show, so it keeps its own rendering.
- **Em dash for missing/non-finite input** instead of `$NaN` (`UsageTab` could previously render `$NaN`; `AgentsPage` rendered `$--`).
- **Negative values surface their sign** rather than silently flooring to `<$0.01`, so a bad upstream value fails visibly instead of hiding.

All four call sites migrated. The pre-existing literal `$`/`$$` was removed at each site so the helper's own `$` does not double.

**Deliberately out of scope:** `website/src/pages/overview/VectorMemoryCard.tsx` similarity scores (`toFixed(2)`/`toFixed(3)`). Those are scores, not money — 2–3dp is correct there, and the helper's doc comment says so to stop a future change sweeping them in. The three duplicate local `fmtNum` definitions are also pre-existing on base and left alone rather than widening this PR.

## Tests

`website/src/test/formatCost.test.ts` — 5 cases locking in the contract:

- 2dp for normal amounts (`0.02` → `$0.02`, `12.345` → `$12.35`)
- the `<$0.01` floor for dust (`0.0004`, `0.009`) — the specific regression this PR fixes
- exact zero (`~$0`) stays distinct from too-small-to-show (`<$0.01`)
- `null` / `undefined` / `NaN` / `Infinity` → `—`, never `$NaN`
- negative values keep their sign

## Manual verification

N/A — unit coverage is sufficient. `formatCost` is a pure string function fully covered by the table above, and the four call sites are mechanical substitutions verified by `tsc -b` plus the existing page tests.

Verified locally: `tsc -b` clean, **5478 tests pass (452 files)**, eslint 0 errors on the changed files.

## Screenshots

N/A — no layout or component change. The only visual delta is the rendered numeral inside existing labels (`$0.0231` → `$0.02`, `≤ $0.0004` → `≤ <$0.01`), which the test table above documents exactly.

Closes #702
