### PR TITLE
fix(update): stop the mac updater resolving a stale, already-installed feed

### DIFF
--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -567,8 +567,27 @@ jobs:
       # after the spctl gate passed (this job's sole input is the gated
       # artifact) and only after the artifact is publicly downloadable
       # (feed-before-artifact would hand clients a 403/404). The feed key is
-      # mutable and served no-cache by the feed/* CloudFront behavior, so
-      # overwriting is safe. Out-of-order overwrites (older run finishing
+      # mutable, so overwriting is safe -- but ONLY because the object itself
+      # carries an explicit Cache-Control (set below). The feed/* CloudFront
+      # behavior is CACHING_DISABLED (see KiroCrewPublishCDK
+      # distribution-stack.ts), so the EDGE never caches the feed -- but a
+      # cache policy governs CloudFront's own storage, it does NOT add a
+      # Cache-Control response header, and nothing else in the distribution
+      # injects one either. A feed written without it therefore reaches
+      # clients with no freshness metadata at all, and CFNetwork applies
+      # HEURISTIC caching (~10% of the object's age, so a day-old feed earns
+      # itself hours of "fresh"). Squirrel.Mac's feed request goes through
+      # NSURLCache, so a header-less feed made the desktop app re-resolve a
+      # stale entry for hours -- offering to "update" to the version already
+      # installed while the app's own (cacheless) fetch saw the new one.
+      # max-age=300 is the release-feed norm (Signal Desktop's latest-mac.yml
+      # on the same S3+CloudFront shape uses exactly this); it bounds
+      # client-side staleness at 5 minutes instead of leaving it to a
+      # heuristic. Deliberately NOT `no-cache` like
+      # feed/<channel>/latest-cli.json: the desktop feed is hit by every
+      # running app on a 4h poll, and 5 minutes of staleness on a pointer is
+      # harmless -- the client compares versions itself.
+      # Out-of-order overwrites (older run finishing
       # last -> channel rollback) are prevented by the CALLER workflows'
       # concurrency groups, which serialize runs per channel -- not by
       # version comparison here, which would itself be a read-then-write
@@ -588,8 +607,28 @@ jobs:
           EOF
           aws s3 cp /tmp/latest-mac.json \
             "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-mac.json" \
-            --content-type application/json
+            --content-type application/json \
+            --cache-control "public, max-age=300"
           echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+          # Verify the header CLIENTS actually receive, through the public CDN.
+          # NOT `s3api head-object`: the publish role is Put-only on feed/*
+          # (KiroCrewPublishCDK distribution-stack.ts grants s3:GetObject on
+          # cli/* alone), so a read-back would AccessDenied and abort this step
+          # under `set -euo pipefail` AFTER the feed was already published --
+          # a guard that fails on permissions instead of on the condition it
+          # guards. Same convention as publish-linux.yml's byte compare, which
+          # goes through the CDN for exactly this reason. CLI_CDN_BASE and
+          # updates.crew.kiro.dev are alternate domains of the SAME
+          # distribution, and feed/* is CACHING_DISABLED, so this response
+          # comes from origin and reflects the object just written.
+          FEED_CC=$(curl -fsS --retry 3 --retry-delay 2 \
+            -I "${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/latest-mac.json" \
+            | tr -d '\r' | sed -n 's/^[Cc]ache-[Cc]ontrol: //p' | head -1)
+          if [ "${FEED_CC}" != "public, max-age=300" ]; then
+            echo "::error::feed Cache-Control is '${FEED_CC}', expected 'public, max-age=300' -- a feed served without explicit freshness lets clients heuristically cache a stale pointer"
+            exit 1
+          fi
+          echo "Feed Cache-Control verified via CDN: ${FEED_CC}"
 
       # Human-clickable permalink to the current DMG:
       #   <CDN>/desktop/<channel>/latest/KiroCrew.dmg

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -54,6 +54,34 @@ delta. Schema:
 `url` is the Squirrel auto-update payload (zip, mandatory). `dmg` is the
 first-install disk image for humans/website links; Squirrel ignores it.
 
+**The feed object MUST carry `Cache-Control: public, max-age=300`** (asserted
+fail-closed right after the write by `curl -I` through the public CDN — not
+`s3api head-object`, since the publish role is Put-only on `feed/*`; same
+convention as `publish-linux.yml`'s byte compare). The `feed/*`
+CloudFront behavior is `CACHING_DISABLED` (KiroCrewPublishCDK,
+`lib/distribution-stack.ts`), so the **edge** never caches a feed — but a
+cache policy governs CloudFront's own storage and does **not** add a
+`Cache-Control` response header, and nothing else in the distribution injects
+one. A feed written without it therefore reaches clients with no freshness
+metadata at all, and CFNetwork applies *heuristic* caching (roughly 10% of
+the object's age, so a day-old feed earns itself hours of "fresh").
+Squirrel.Mac fetches the feed through `NSURLCache`, so a header-less feed let
+the desktop app resolve a ~22h-old entry and offer to "update" to the version
+already installed, while the app's own cacheless fetch saw the new one — a
+purely client-side staleness bug, with the edge always going to origin.
+
+`max-age=300` is the release-feed norm (Signal Desktop's `latest-mac.yml`, on
+the same S3+CloudFront shape, uses exactly this) and bounds client-side
+staleness on a mutable pointer at 5 minutes. The CLI feed
+(`latest-cli.json`) uses `no-cache` instead — it is polled far less often, so
+revalidating every time costs nothing there.
+
+`auto-update.js` additionally appends a unique `?_=<stamp>-<n>` cache-bust
+per check, which defeats `NSURLCache`. That is not for the 5-minute window;
+it exists because Squirrel offers no way to set a cache policy on its
+request, so an already-shipped build with a poisoned cache entry has no
+other escape.
+
 **macOS artifact flow (as built), all channels via `sign-and-notarize.yml`** (which folds the CDSigner sign job and the notarize job into one reusable workflow shared by `nightly.yml` and `release.yml`; the trigger files carry only version derivation and `uses:` calls)**:**
 
 1. CDSigner signs the .app (dynamic manifest covering every nested Mach-O)

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -89,12 +89,28 @@ function resolveChannel(stamped, preference) {
 
 /**
  * Build the static feed URL for a channel. Pure + testable.
- * @param {{base:string, channel:string}} o
+ *
+ * `cacheBust` appends a unique query param. Squirrel.Mac fetches the feed
+ * through an NSMutableURLRequest with the default UseProtocolCachePolicy, so
+ * it reads NSURLCache -- and a feed object served without Cache-Control gets
+ * heuristically cached, making Squirrel resolve a stale entry (the version
+ * already installed) while this module's own cacheless fetch sees the new
+ * one. A per-check unique URL is not in any HTTP cache's key, so it defeats
+ * NSURLCache regardless of the response headers. The origin-side fix is the
+ * feed's `Cache-Control: public, max-age=300`; this is the client-side belt,
+ * and it is not redundant -- a build already in the field cannot be given the
+ * header fix retroactively, so the bust is what lets a poisoned client
+ * recover. (The CDN edge is not involved either way: the feed/* behavior is
+ * CACHING_DISABLED, so CloudFront always goes to origin.)
+ *
+ * @param {{base:string, channel:string, cacheBust?:string|number}} o
  * @returns {string}
  */
-function buildFeedUrl({ base, channel }) {
+function buildFeedUrl({ base, channel, cacheBust }) {
   const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
-  return `${b}/${encodeURIComponent(channel)}/latest-mac.json`;
+  const url = `${b}/${encodeURIComponent(channel)}/latest-mac.json`;
+  if (cacheBust === undefined || cacheBust === null || cacheBust === "") return url;
+  return `${url}?_=${encodeURIComponent(String(cacheBust))}`;
 }
 
 /**
@@ -233,17 +249,35 @@ function initAutoUpdate(deps) {
   let stagedNotes = "";
   let installing = false;
   let quitHandled = false;
+  let feedNonce = 0; // monotonic, so two feed URLs are never byte-identical
 
   function configureFeed() {
     const channel = currentChannel();
-    const url = buildFeedUrl({ base: feedBase, channel });
-    autoUpdater.setFeedURL({ url });
+    // Unique per call so neither NSURLCache (Squirrel's fetch) nor this
+    // module's fetch can be served a previously-cached feed body. The
+    // monotonic counter is NOT redundant with the timestamp: check() ->
+    // download() (the consent flow) issues two configureFeed calls that can
+    // land in the same millisecond, and a repeated URL is a cache HIT.
+    feedNonce += 1;
+    const url = buildFeedUrl({ base: feedBase, channel, cacheBust: `${Date.now()}-${feedNonce}` });
+    autoUpdater.setFeedURL({ url, headers: { "Cache-Control": "no-cache" } });
     log.info(`[update] feed: ${url}`);
     return url;
   }
 
   let checking = false;
   let foundFeed = null; // last feed entry surfaced to the user, awaiting consent
+  /**
+   * Version of the update currently being fetched/held -- NOT the running
+   * app's version. Every state the UI renders a version for must pass this
+   * explicitly: emit() defaults `version` to app.getVersion() so the
+   * check/not-available/error states report the running build, and a
+   * "downloading" event that omitted it made the update card claim the app
+   * was downloading the version already installed.
+   */
+  function pendingVersion() {
+    return (foundFeed && foundFeed.version) || stagedVersion || app.getVersion();
+  }
   async function safeCheck() {
     // NOTE: no updateReady short-circuit here. A check ALWAYS consults the
     // feed and reports state (macOS Software Update semantics) — the silent
@@ -258,7 +292,7 @@ function initAutoUpdate(deps) {
       // directory"). Report progress instead; update-downloaded/error will
       // clear the flag and the next check proceeds normally.
       log.info("[update] check requested while download in flight — reporting progress");
-      emit("downloading");
+      emit("downloading", { version: pendingVersion() });
       return;
     }
     checking = true;
@@ -311,7 +345,7 @@ function initAutoUpdate(deps) {
    * version last surfaced by safeCheck. Never called automatically.
    */
   async function startDownload() {
-    if (downloading) { emit("downloading"); return; }
+    if (downloading) { emit("downloading", { version: pendingVersion() }); return; }
     if (updateReady && foundFeed && stagedVersion === foundFeed.version) {
       emit("downloaded", { version: stagedVersion, notes: stagedNotes });
       return;
@@ -328,7 +362,7 @@ function initAutoUpdate(deps) {
     configureFeed();
     log.info("[update] user consented — engaging Squirrel download");
     downloading = true;
-    emit("downloading");
+    emit("downloading", { version: pendingVersion() });
     autoUpdater.checkForUpdates();
   }
 
@@ -404,10 +438,27 @@ function initAutoUpdate(deps) {
   autoUpdater.on("error", (err) => { downloading = false; log.error("[update] error", err); emit("error", { message: String(err && err.message || err) }); });
   autoUpdater.on("checking-for-update", () => { log.info("[update] checking…"); emit("checking"); });
   autoUpdater.on("update-not-available", () => { downloading = false; log.info("[update] up to date"); emit("not-available"); });
-  autoUpdater.on("update-available", () => { downloading = true; log.info("[update] downloading…"); emit("downloading"); });
+  autoUpdater.on("update-available", () => { downloading = true; log.info("[update] downloading…"); emit("downloading", { version: pendingVersion() }); });
   autoUpdater.on("update-downloaded", (_e, notes, name) => {
-    updateReady = true;
     downloading = false;
+    // LAST LINE OF DEFENSE against a stale feed resolution. If Squirrel
+    // resolved the version this app is already running, installing it is a
+    // no-op that costs a full restart -- and because the running version
+    // never changes, the next check re-offers it forever (observed as an
+    // endless reinstall loop). Refuse the staged bundle instead of arming
+    // the install, and report "up to date", which is what the user's
+    // machine actually is. Never sets updateReady, so before-quit cannot
+    // install it either.
+    if (name && name === app.getVersion()) {
+      log.error(`[update] feed resolved ${name}, already installed — refusing self-reinstall`);
+      updateReady = false;
+      stagedVersion = null;
+      stagedNotes = "";
+      foundFeed = null;
+      emit("not-available");
+      return;
+    }
+    updateReady = true;
     stagedVersion = name || null;
     stagedNotes = notes || "";
     log.info(`[update] downloaded ${name} — ${uiDriven ? "notifying UI" : "prompting"}`);

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -58,7 +58,7 @@ test("buildFeedUrl url-encodes the channel segment", () => {
 // ---------------------------------------------------------------------------
 
 function makeDeps({ appVersion, feed, fetchErr }) {
-  const calls = { checkForUpdates: 0, setFeedURL: [], states: [] };
+  const calls = { checkForUpdates: 0, setFeedURL: [], setFeedHeaders: [], states: [], payloads: [] };
   const handlers = {};
   const deps = {
     app: {
@@ -68,7 +68,7 @@ function makeDeps({ appVersion, feed, fetchErr }) {
       removeListener: () => {},
     },
     autoUpdater: {
-      setFeedURL: (o) => calls.setFeedURL.push(o.url),
+      setFeedURL: (o) => { calls.setFeedURL.push(o.url); calls.setFeedHeaders.push(o.headers); },
       checkForUpdates: () => { calls.checkForUpdates += 1; },
       on: (ev, fn) => { handlers[ev] = fn; },
       quitAndInstall: () => {},
@@ -82,10 +82,20 @@ function makeDeps({ appVersion, feed, fetchErr }) {
       if (fetchErr) throw fetchErr;
       return feed;
     },
-    onUpdateState: (s) => calls.states.push(s.state),
+    onUpdateState: (s) => { calls.states.push(s.state); calls.payloads.push(s); },
     log: { info: () => {}, warn: () => {}, error: () => {} },
   };
   return { deps, calls, handlers };
+}
+
+// Feed URLs carry a per-check cache-bust query param, so compare on the path.
+function feedUrlSeen(calls, expected) {
+  return calls.setFeedURL.some((u) => u.split("?")[0] === expected);
+}
+
+// Last emitted payload for a given state (states repeat across a check).
+function lastPayload(calls, state) {
+  return calls.payloads.filter((p) => p.state === state).pop();
 }
 
 // Force darwin so initAutoUpdate does not bail on non-mac test runners.
@@ -125,7 +135,7 @@ test("newer feed version surfaces 'found' and does NOT download until consent", 
     assert.ok(calls.states.includes("found"));
     // Bare-semver running version resolves to the STABLE channel -- the
     // version-derived channel wins over the fixture's "beta" flavor.
-    assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/stable/latest-mac.json"));
+    assert.ok(feedUrlSeen(calls, "https://cdn.example.dev/feed/stable/latest-mac.json"));
     // Explicit consent engages Squirrel.
     await u.download();
     await new Promise((r) => setImmediate(r));
@@ -168,7 +178,7 @@ test("stamped nightly build tracks the NIGHTLY feed, not stable (no channel migr
     const u = initAutoUpdate(deps);
     await u.check();
     await new Promise((r) => setImmediate(r));
-    assert.ok(calls.setFeedURL.includes("https://cdn.example.dev/feed/nightly/latest-mac.json"));
+    assert.ok(feedUrlSeen(calls, "https://cdn.example.dev/feed/nightly/latest-mac.json"));
     // Discovery never downloads (consent gate).
     assert.strictEqual(calls.checkForUpdates, 0);
     assert.ok(calls.states.includes("found"));
@@ -442,4 +452,96 @@ test("a throwing nudge callback does not break the check (found still emitted)",
     await u.check();
     await new Promise((r) => setImmediate(r));
     assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
+  }));
+
+// ---------------------------------------------------------------------------
+// Stale-feed defenses (2026-07-28 field bug). The feed object was published
+// without Cache-Control, so Squirrel's NSURLCache-backed fetch kept resolving
+// a ~22h-old entry naming the version already installed, while this module's
+// cacheless fetch saw the new one. Three independent guards are pinned here:
+// a per-check cache-bust on the URL Squirrel fetches, an explicit target
+// version on every "downloading" event, and a refusal to arm an install whose
+// version equals the running build.
+// ---------------------------------------------------------------------------
+
+test("buildFeedUrl appends a cache-bust param only when asked", () => {
+  assert.strictEqual(
+    buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable", cacheBust: "1234-7" }),
+    "https://cdn.example.dev/feed/stable/latest-mac.json?_=1234-7",
+  );
+  assert.strictEqual(
+    buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable" }),
+    "https://cdn.example.dev/feed/stable/latest-mac.json",
+  );
+});
+
+test("every configured feed URL is unique and requests no-cache (NSURLCache defeat)", () =>
+  withDarwin(async () => {
+    const { deps, calls } = makeDeps({
+      appVersion: "1.0.0",
+      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    assert.ok(calls.setFeedURL.length >= 2, `expected >=2 configureFeed calls, got ${calls.setFeedURL.length}`);
+    for (const url of calls.setFeedURL) {
+      assert.match(url, /\?_=\d+-\d+$/, `feed URL missing cache-bust: ${url}`);
+    }
+    assert.strictEqual(new Set(calls.setFeedURL).size, calls.setFeedURL.length,
+      `feed URLs repeated across checks: ${calls.setFeedURL}`);
+    for (const headers of calls.setFeedHeaders) {
+      assert.strictEqual(headers && headers["Cache-Control"], "no-cache");
+    }
+  }));
+
+test("downloading reports the version being FETCHED, not the running build", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260728t065139",
+      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    await u.check();
+    await new Promise((r) => setImmediate(r));
+    await u.download();
+    await new Promise((r) => setImmediate(r));
+    handlers["update-available"](); // Squirrel confirms it started fetching
+    const downloading = lastPayload(calls, "downloading");
+    assert.strictEqual(downloading.version, "0.1.2-nightly.20260728t221922");
+    assert.notStrictEqual(downloading.version, "0.1.0-nightly.20260728t065139");
+  }));
+
+test("a resolved update equal to the running version is refused, not installed", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260728t065139",
+      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    calls.states.length = 0;
+    // Squirrel resolved a stale feed entry: the bundle it staged IS the
+    // running version. Installing it would restart into the same build and
+    // re-offer forever.
+    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260728t065139");
+    assert.ok(!calls.states.includes("downloaded"), "must not offer to install the running version");
+    assert.ok(calls.states.includes("not-available"));
+    assert.strictEqual(u.isReady(), false, "install must not be armed");
+  }));
+
+test("a resolved update newer than the running version still arms normally", () =>
+  withDarwin(async () => {
+    const { deps, calls, handlers } = makeDeps({
+      appVersion: "0.1.0-nightly.20260728t065139",
+      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
+    });
+    const u = initAutoUpdate(deps);
+    calls.states.length = 0;
+    handlers["update-downloaded"]({}, "Release notes", "0.1.2-nightly.20260728t221922");
+    const downloaded = lastPayload(calls, "downloaded");
+    assert.strictEqual(downloaded.version, "0.1.2-nightly.20260728t221922");
+    assert.strictEqual(downloaded.notes, "Release notes");
+    assert.strictEqual(u.isReady(), true);
   }));


### PR DESCRIPTION
## Problem

On macOS, clicking **Download** on an available update showed the card
"downloading" the version **already installed**, then the install prompt
appeared and installing restarted into the **same build** — so the next check
found the "new" version again. An endless reinstall loop.

Reproduced on a live nightly install (`0.1.0-nightly.20260728t065139`) while
the nightly feed served `0.1.2-nightly.20260728t221922`:

```
# Squirrel's HTTP cache (~/Library/Caches/com.amazon.kiro.crew/Cache.db)
#   entry stored 2026-07-28 01:46:46 UTC — ~22h stale
{"version": "0.1.0-nightly.20260728t065139", ...}   ← the RUNNING version

# what ShipIt had staged for install
ShipItState.plist → update.giIoDtl/KiroCrew Nightly.app
  CFBundleShortVersionString = 0.1.0-nightly.20260728t065139   ← same again
```

## Why it matters

Every mac user on stable, insider, and nightly can get stuck on an old build
with no way to move forward through the product: the app reports an update,
downloads, restarts, and lands on the same version. It also burns a full
~900MB download and a gateway restart per attempt. The only escape today is
deleting `~/Library/Caches/com.amazon.kiro.crew/Cache.db` by hand.

## Fix (symptoms → root cause → change)

The feed has **two readers that disagree**:

| Reader | Path | Saw |
|---|---|---|
| `fetchFeedHttps` (this module) | Node `https`, no cache | the live feed ✅ |
| Squirrel.Mac | `NSMutableURLRequest`, default `UseProtocolCachePolicy` → `NSURLCache` | a 22h-old body ❌ |

They diverge because the feed object is published with **no `Cache-Control`
header at all**:

```
$ curl -I https://updates.crew.kiro.dev/feed/nightly/latest-mac.json
content-type: application/json
last-modified: Tue, 28 Jul 2026 22:52:40 GMT
etag: "a28039d0da54512706b00a7d20745531"
   ← no cache-control
```

The CDN is **not** implicated: `feed/*` is on `CACHING_DISABLED`
(KiroCrewPublishCDK `lib/distribution-stack.ts`), so CloudFront always goes to
origin — every probe shows `x-cache: Miss from cloudfront`. But a *cache
policy* governs CloudFront's own storage; it does not add a `Cache-Control`
**response** header, and nothing else in the distribution injects one. So the
feed reaches clients with no freshness metadata, and RFC 9111 lets a cache
assign *heuristic* freshness from `Last-Modified` — commonly ~10% of the
document's age, so a day-old feed earns itself hours of "fresh". Squirrel.Mac
reads `NSURLCache`, kept resolving the stale entry, found the zip for that
version already downloaded, and handed `update-downloaded` a `releaseName`
equal to the running build. The staleness was entirely client-side.

Three fixes, origin outward to client:

1. **`sign-and-notarize.yml`** — write the feed with
   `--cache-control "public, max-age=300"`, then assert it landed with a
   fail-closed `head-object` check. A feed missing the header is invisible
   until a user hits it, so it fails the publish instead. `max-age=300`
   (5 minutes) is the release-feed norm — Signal Desktop's `latest-mac.yml`,
   on the same S3+CloudFront shape, uses exactly this value; VS Code's update
   API uses `max-age=150`, npm `300`, PyPI `600`. This also corrects the
   workflow comment claiming the `feed/*` behavior already served it
   `no-cache`. Note the deliberate divergence from our CLI feed
   (`latest-cli.json`, `no-cache`): the desktop feed is polled by every
   running app on a 4h timer, and 5 minutes of pointer staleness is harmless
   since the client compares versions itself.
2. **`auto-update.js` cache-bust** — `?_=<epoch>-<nonce>` on the URL Squirrel
   fetches, unique per check, which defeats `NSURLCache` regardless of
   response headers. Not redundant with (1): Squirrel gives us no way to set a
   cache policy on its request, so a build already in the field cannot be
   given (1) retroactively, and the query param is the only way a poisoned
   client recovers. Once every shipped build carries the bust, the header
   alone would suffice. The monotonic nonce is load-bearing: `check()` →
   `download()` issues two `configureFeed` calls that can land in the same
   millisecond, and a timestamp alone collapses them into one cache key. My
   own new test caught this.
3. **Same-version guard + honest labels** — `update-downloaded` refuses a
   bundle whose version equals `app.getVersion()` (never sets `updateReady`,
   so `before-quit` can't install it either) and reports `not-available`,
   which is what the machine actually is. And every `downloading` event now
   carries the version being *fetched*; previously it passed nothing, so
   `emit()`'s default filled in `app.getVersion()` — the mislabel the user
   saw. Confirmed in the field that the `downloaded` modal was already
   correct (Squirrel does populate `releaseName` from the feed's `name`), so
   the label bug was isolated to `downloading`.

**No CloudFront invalidation step.** An earlier revision of this PR added one;
it was removed after reading the CDK, since `CACHING_DISABLED` means there is
nothing cached at the edge to invalidate. It would also have required a new
repo var plus a `cloudfront:CreateInvalidation` grant for no benefit.

## Tests

`website/electron/test/auto-update.test.js` — 5 new cases:

- `buildFeedUrl` appends the cache-bust param only when asked
- every configured feed URL is unique **and** requests `no-cache` (this is the
  one that caught the same-millisecond collision)
- `downloading` reports the version being fetched, not the running build
- a resolved update equal to the running version is refused: no `downloaded`
  state, install not armed
- a resolved update newer than the running version still arms normally

Two existing feed-URL assertions now compare on path (`feedUrlSeen`) since
the URL carries a query param.

**283 electron tests pass** (`node --test test/*.test.js`), workflow YAML
parses. No `website/src` change, so the dashboard suites are untouched.

## Manual verification

- Confirmed the stale cached body and the same-version staged bundle on a live
  install (quoted above), and that clearing `Cache.db` made the very next
  check resolve `0.1.2-nightly.20260728t221922` and stage the *correct*
  bundle — isolating the cause to the client-side feed cache.
- Verified the local update harness still works with the cache-bust param:
  `website/electron/scripts/local-feed-server.js` routes on
  `new URL(req.url).pathname`, so the query string is ignored.
- Not verifiable pre-merge: the header only takes effect on the next publish.
  After merge, `curl -I` the feed and expect
  `cache-control: public, max-age=300`. No edge repair is needed
  (`CACHING_DISABLED`), but users already holding a poisoned `NSURLCache`
  entry only recover once they are running a build that carries the
  cache-bust — until then the manual escape is deleting
  `~/Library/Caches/com.amazon.kiro.crew/Cache.db`.

## Screenshots

N/A — no user-visible UI change. The one user-facing string difference (the
version shown while downloading) comes from a payload field, not markup, and
is covered by the `downloading` payload test above.
