### PR TITLE
fix(desktop): say which machine to mint a dashboard token on

### DIFF
--- a/website/electron/gateway-auth-hint.js
+++ b/website/electron/gateway-auth-hint.js
@@ -1,0 +1,82 @@
+"use strict";
+//
+// gateway-auth-hint.js — WHICH machine should the user act on?
+//
+// Pure logic only (mirrors instance-guard.js / gateway-recovery.js); the shell
+// owns the page load and the port probe.
+//
+// PROBLEM: when the app cannot mint a dashboard token it shows a "Token
+// Required" page telling the user to run `kirocrew token` "on your dev
+// desktop". That instruction is CORRECT for the case it was written for — an
+// `ssh -L <port>:localhost:<port>` forward, where the gateway lives on another
+// machine, so the CLI must run THERE (it authenticates with that host's own
+// .local_secret, and the token it prints is signed by that gateway, which is
+// the gateway this app is talking to through the tunnel).
+//
+// What the page never said is WHY it is asking, or how to tell which machine
+// "your dev desktop" means. Two very different situations produce the same
+// page:
+//
+//   foreign — the port is held by a gateway that is not this app's: an SSH
+//             forward to another host, or an externally-started gateway. Our
+//             own .local_secret cannot mint against it (the secret is
+//             per-data-home and regenerated at each gateway start), so the
+//             command has to run on the machine that gateway runs on.
+//   local   — the port is held by OUR own local gateway and the mint still
+//             failed. Telling that user to go to a "dev desktop" is nonsense;
+//             the machine to act on is this one.
+//
+// This module picks between them from facts the shell already has after the
+// boot-time port-owner probe (see classifyPortOwner in gateway-stop.js).
+
+/**
+ * Which machine hosts the gateway the user must mint a token on?
+ *
+ * Three outcomes, not two, because "we could not determine the owner" is a
+ * genuinely different thing to tell the user than "the owner is not us". The
+ * probe resolves to "unknown" on any platform without lsof (Windows), so
+ * collapsing that into "foreign" would state an inference as fact and send a
+ * purely-local user looking for another machine.
+ *
+ * @param {object} [facts]
+ * @param {"kirocrew"|"foreign"|"none"|"unknown"} [facts.localOwner="unknown"]
+ *        who owns the port's LISTEN socket locally
+ * @param {string} [facts.remoteHost=""] a remote host configured for this port
+ * @returns {"local"|"foreign"|"unknown"}
+ *   "local"   — confirmed OUR gateway: act on THIS machine
+ *   "foreign" — confirmed someone else's (a tunnel's `ssh`, an external
+ *               gateway): act on the OTHER machine
+ *   "unknown" — could not confirm either way: describe the likely case
+ *               without asserting it
+ */
+function classifyAuthBlock({ localOwner = "unknown", remoteHost = "" } = {}) {
+  // An explicitly configured remote host is the least ambiguous signal there
+  // is: the user already told us the gateway lives elsewhere.
+  if (typeof remoteHost === "string" && remoteHost !== "") return "foreign";
+  if (localOwner === "kirocrew") return "local";
+  if (localOwner === "foreign") return "foreign";
+  // "none" (nothing listening locally, yet something answered) and "unknown"
+  // (the probe could not run) both mean unconfirmed. Do not guess.
+  return "unknown";
+}
+
+/**
+ * The port of `rawUrl`, with a default-port URL resolved to its scheme's port.
+ *
+ * `URL.port` is deliberately "" when the URL uses the scheme default, so
+ * `http://host/` on :80 yields no port. Every consumer here needs a concrete
+ * number — the remote-host config is keyed by port, the owner probe takes a
+ * port, and the page builds its submit URL from one — so an empty value would
+ * silently address a different gateway than the one that returned the 403.
+ *
+ * @param {string} rawUrl
+ * @returns {string} port digits, or "" if rawUrl is unparseable
+ */
+function defaultedPort(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return ""; }
+  if (u.port) return u.port;
+  return u.protocol === "https:" ? "443" : "80";
+}
+
+module.exports = { classifyAuthBlock, defaultedPort };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -44,6 +44,7 @@ const http = require("http");
 const { findKirocrewBin } = require("./find-bin");
 const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
+const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { createDisplayMediaHandler } = require("./display-media");
 const { initAutoUpdate } = require("./auto-update");
 const { stopGatewayGracefully: _stopGatewayGracefully, forceStopPort, classifyPortOwner } = require("./gateway-stop");
@@ -1389,7 +1390,25 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
       });
       if (win.isDestroyed()) return;
       if (status === 403) {
-        wc.loadFile(path.join(__dirname, "token-prompt.html"), { query: { port: new URL(backendUrl).port } });
+        // The page has to say WHICH machine to mint on. A gateway we did not
+        // spawn (an `ssh -L` forward, or an externally-started one) has its own
+        // .local_secret, so our CLI can only mint against it FROM that machine;
+        // pointing the user at this one would send them where the gateway is
+        // not. Reuse the boot-time port-owner probe rather than guessing.
+        //
+        // NOTE `URL.port` is "" for a default-port URL (http://host/ on :80).
+        // Left empty it would look up the wrong remote-host entry, probe no
+        // port at all, and let the page fall back to :5476 — i.e. describe and
+        // submit to a gateway that isn't the one we just got a 403 from.
+        const promptPort = defaultedPort(backendUrl);
+        const remoteHost = getRemoteHostConfig(store, promptPort)?.host || "";
+        const localOwner = remoteHost ? "foreign" : await probeGatewayPortOwner(promptPort);
+        const kind = classifyAuthBlock({ localOwner, remoteHost });
+        glog(`token prompt: kind=${kind} owner=${localOwner} port=${promptPort} host=${remoteHost || "(none)"}`);
+        if (win.isDestroyed()) return;
+        wc.loadFile(path.join(__dirname, "token-prompt.html"), {
+          query: { port: promptPort, kind, host: remoteHost },
+        });
       } else {
         wc.loadURL(backendUrl);
         if (backendUrl === BACKEND_URL) startLivenessMonitor(win);

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -59,6 +59,7 @@
       "find-bin.js",
       "data-home.js",
       "auto-update.js",
+      "gateway-auth-hint.js",
       "gateway-stop.js",
       "gateway-wait.js",
       "home-dir.js",

--- a/website/electron/test/gateway-auth-hint.test.js
+++ b/website/electron/test/gateway-auth-hint.test.js
@@ -1,0 +1,71 @@
+"use strict";
+// Which machine must the user mint a dashboard token on? Three outcomes, not
+// two: "could not determine" is a different thing to tell the user than "not
+// this app". The probe returns "unknown" on any platform without lsof, so
+// collapsing that into "foreign" would state an inference as fact and send a
+// purely-local user hunting for another machine.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { classifyAuthBlock, defaultedPort } = require("../gateway-auth-hint");
+
+test("our own local gateway points at THIS machine", () => {
+  assert.equal(classifyAuthBlock({ localOwner: "kirocrew" }), "local");
+});
+
+test("a confirmed tunnel (ssh owns the socket) points at the OTHER machine", () => {
+  // The reported scenario: `ssh -NL 5476:localhost:5476 dev-host`. The remote
+  // gateway's access key is its own, so our CLI can only mint from there.
+  assert.equal(classifyAuthBlock({ localOwner: "foreign" }), "foreign");
+});
+
+test("a configured remote host is decisive, whatever the socket says", () => {
+  assert.equal(
+    classifyAuthBlock({ localOwner: "kirocrew", remoteHost: "dev-host.example.com" }),
+    "foreign",
+  );
+});
+
+test("an unconfirmed owner is 'unknown' — never asserted as foreign", () => {
+  // Regression pin: on Windows there is no lsof, so the probe yields "unknown".
+  // Reporting that as "foreign" told every such user their own gateway belonged
+  // to someone else. "none" (nothing listening, yet something answered) is
+  // equally unconfirmed.
+  for (const owner of ["none", "unknown", "", undefined, "weird-new-value"]) {
+    assert.equal(classifyAuthBlock({ localOwner: owner }), "unknown", String(owner));
+  }
+});
+
+test("no facts at all yields the hedged verdict, not a guess", () => {
+  assert.equal(classifyAuthBlock(), "unknown");
+  assert.equal(classifyAuthBlock({}), "unknown");
+});
+
+test("an empty remoteHost does not force the foreign verdict", () => {
+  // Guard against treating "" as "a host was configured" — that would mislabel
+  // every local-gateway failure as a tunnel.
+  assert.equal(classifyAuthBlock({ localOwner: "kirocrew", remoteHost: "" }), "local");
+});
+
+// ── defaultedPort: a default-port URL must not read as "no port" ────────────
+
+test("defaultedPort resolves a scheme-default URL to a real port", () => {
+  // URL.port is "" for http://host/ and https://host/. Left empty it would key
+  // the remote-host lookup wrong, probe no port, and let the page fall back to
+  // :5476 — describing and submitting to a different gateway than the one that
+  // just returned 403.
+  assert.equal(defaultedPort("http://localhost/"), "80");
+  assert.equal(defaultedPort("https://localhost/"), "443");
+});
+
+test("defaultedPort passes an explicit port through unchanged", () => {
+  assert.equal(defaultedPort("http://localhost:5476/"), "5476");
+  assert.equal(defaultedPort("http://127.0.0.1:7811/?x=1"), "7811");
+  assert.equal(defaultedPort("https://example.com:8443/"), "8443");
+});
+
+test("defaultedPort returns '' for an unparseable URL rather than guessing", () => {
+  for (const bad of ["", "not a url", undefined, null]) {
+    assert.equal(defaultedPort(bad), "", String(bad));
+  }
+});

--- a/website/electron/token-prompt.html
+++ b/website/electron/token-prompt.html
@@ -44,12 +44,40 @@
   <div class="container">
     <div class="logo">👻</div>
     <h2>Token Required</h2>
-    <p>Run <code>kirocrew token</code> on your dev desktop, then paste the URL below.</p>
+    <p id="why"></p>
     <input id="url" type="text" placeholder="Paste token URL or raw token…" autofocus>
     <button onclick="go()">Connect</button>
     <div class="error" id="err">Invalid URL — must be http://localhost with a ?token= parameter</div>
   </div>
   <script>
+    // WHICH machine to act on depends on who holds the port. main.js probes the
+    // listening socket and passes the verdict in as ?kind=. Three cases, not
+    // two: on a platform without lsof the probe cannot determine an owner, and
+    // asserting "not this app" there would be a confident guess. Default to the
+    // hedged wording, which is right whenever we are unsure.
+    (function explain() {
+      const q = new URLSearchParams(window.location.search);
+      const port = q.get('port') || '5476';
+      const host = q.get('host') || '';
+      const where = host ? host : 'the machine running that gateway';
+      const kind = q.get('kind');
+      var msg;
+      if (kind === 'local') {
+        msg = 'Port ' + port + ' is served by this app\u2019s own gateway, but it could not issue a '
+          + 'dashboard token. Run kirocrew token on THIS machine and paste the URL below.';
+      } else if (kind === 'foreign') {
+        msg = 'Port ' + port + ' is held by a gateway this app did not start \u2014 most often an SSH '
+          + 'tunnel to another machine. Its access key is its own, so a token has to come from '
+          + 'there: run kirocrew token on ' + where + ', then paste the URL below.';
+      } else {
+        msg = 'The gateway on port ' + port + ' would not issue a dashboard token, and this app '
+          + 'could not determine which machine it is running on. If you reached it through an SSH '
+          + 'tunnel, run kirocrew token on ' + where + '; otherwise run it on this machine. Then '
+          + 'paste the URL below.';
+      }
+      document.getElementById('why').textContent = msg;
+    })();
+
     function go() {
       const v = document.getElementById('url').value.trim();
       if (!v) return;


### PR DESCRIPTION
## Problem

When the desktop app cannot mint a dashboard token it shows a "Token Required" page reading:

> Run `kirocrew token` on your dev desktop, then paste the URL below.

That instruction is **correct for the case it was written for** — an `ssh -L <port>:localhost:<port>` forward, where the gateway lives on another host. The CLI must run *there*: it authenticates with that host's own `.local_secret`, and the token it prints is signed by that gateway, which is the one this app reaches through the tunnel. Pasting that URL works.

What the page never said is **why** it was asking, or how to tell which machine "your dev desktop" means. Three different situations render the identical page:

| State | Which machine to act on |
|---|---|
| **foreign** — port held by a gateway this app didn't start (SSH forward, external gateway) | the other one |
| **local** — port held by *our own* gateway, mint still failed | this one |
| **unknown** — owner could not be determined | can't say |

That third state is not a corner case: the owner probe needs `lsof`, which Windows does not have.

## Why it matters

A user in the foreign case, on a laptop with no working local CLI, has no way to tell which situation they're in — so the page reads as a dead end. And this is now the **default** landing spot for tunnel users: #633 made the app *reuse* a tunnelled gateway instead of evicting it, which is the right behaviour, but it means more people arrive here.

## Fix (symptom → root cause → change)

Symptom: a page that names a machine without knowing which one. Root cause: the copy was static, written for one scenario, with no signal about who actually holds the port. Change: determine the owner, and say only what was confirmed.

- **New `website/electron/gateway-auth-hint.js`** — pure `classifyAuthBlock({ localOwner, remoteHost })` → `local | foreign | unknown`. Only a positively identified owner yields a definite verdict; `none` and `unknown` stay unknown so the page can describe the likely case *without asserting it*. A configured remote host is decisive on its own.
- **`main.js`** reuses the boot-time port-owner probe (`classifyPortOwner`, added in #633) at the 403 branch instead of guessing, and logs the verdict.
- **`defaultedPort()`** resolves a scheme-default URL to a concrete port before the config lookup, the probe, and the page query.
- **`token-prompt.html`** explains what was detected — naming the port, and the host when one is configured — and points at the right machine, hedging only when the owner is genuinely unconfirmed.

## Tests

11 cases in `website/electron/test/gateway-auth-hint.test.js`. The two that carry the most weight:

- **`an unconfirmed owner is 'unknown' — never asserted as foreign`** — pins the fix for the Windows/no-`lsof` path, where reporting `unknown` as `foreign` told users their own gateway belonged to someone else.
- **`defaultedPort resolves a scheme-default URL to a real port`** — `URL.port` is `""` for `http://host/` on :80; left empty it keyed the remote-host lookup wrong, probed no port, and let the page fall back to `:5476` — describing *and submitting to* a different gateway than the one that returned the 403.

## Manual verification

N/A — unit coverage is sufficient. The decision logic is pure and fully covered; the surrounding effects (the probe, `loadFile`) are existing, already-tested paths, and the 403 branch cannot be reached without a live foreign gateway on the port.

## Screenshots

N/A — the change replaces the text of one `<p>` on an internal Electron page (not part of the React app) that is only reachable when the gateway returns 403 and no token can be minted. No layout or component change.

## Reviewer notes

Local review ran both gate mirrors before this was pushed (`gpt-5.6-sol` against `codex-review.yml`, `claude-opus-5` against `claude-review.yml` + both `AUTOSDE.yaml`). Neither returned a blocking finding; both advisories were fixed rather than deferred:

1. The `foreign` copy asserted "is held by a gateway that is not this app" **as fact**, but Windows resolves to `unknown` → previously mapped to `foreign`, so a local-only user was told their gateway was foreign. Fixed by making the verdict tri-state rather than by watering down the accurate case.
2. An empty `URL.port` propagated into the config lookup, the probe, and the page (above).

Opus separately verified — by reading the code, not inferring — that the page's only sink is `textContent` (no `innerHTML`/`insertAdjacentHTML`/`document.write`, and Electron URL-encodes `loadFile({query})`), and that the new `await probeGatewayPortOwner` **cannot reject**: `_lsofListenPids` rejects only on ENOENT/EACCES, `classifyPortOwner` catches that and returns `"unknown"`, and `_psCommand` resolves unconditionally. So a 403 cannot be diverted into the gateway-error dialog.

Known trade, accepted deliberately: the probe is awaited before `loadFile`, so in the worst case the loading screen persists for the `lsof`/`ps` timeout ceilings where the prompt used to appear immediately. Typical cost is tens of milliseconds — those are ceilings, not norms — and the configured-remote-host path skips the probe entirely. Caching the boot verdict would need new module-level state, which is out of scope here.

Scope note: `createTokenRetryHandler` was checked and is already bounded (2 retries, reset on 200), so there is no retry loop to fix; this change is confined to identifying and explaining the situation.
