### PR TITLE
fix(mcp): report an unresolvable MCP command once, not every probe cycle

### DIFF
--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -51,6 +51,66 @@ def _get_probe_timeout() -> int:
 # Probe results expire after 30 minutes → status becomes "outdated"
 _PROBE_TTL_SECS = 1800
 
+# An MCP command that does not resolve is a STABLE fact: it stays unresolved
+# until someone edits the config or installs the binary, yet the probe re-runs
+# on every discovery cycle and re-emits an identical warning each time. A config
+# carried between machines (a Linux dev box's servers opened on a Mac, say)
+# therefore prints the same handful of warnings forever, burying the transient
+# failures that actually deserve attention.
+#
+# Warn the FIRST time a given (server, command) fails to resolve and demote the
+# repeats to DEBUG. Deliberately scoped to unresolvable commands only —
+# timeouts and handshake errors stay at WARNING on every occurrence, because a
+# server that NEWLY starts timing out is news, whereas one whose binary is
+# absent is not.
+#
+# The ledger is self-healing, which is what keeps it both correct and bounded:
+# a key is dropped as soon as that command resolves (so a binary that is
+# installed and later disappears warns AGAIN rather than staying silent for the
+# life of the process), and `probe_all` prunes keys no longer present in the
+# config (so editing a command string does not retain the old one forever).
+_unresolvable_warned: set[tuple[str, str]] = set()
+
+
+def _warn_unresolvable_once(name: str, command: str) -> None:
+    """WARNING on first sight of an unresolvable command, DEBUG thereafter."""
+    key = (name, command)
+    if key in _unresolvable_warned:
+        logger.debug(
+            "MCP probe [%s]: command still not found: %s (already reported)", name, command
+        )
+        return
+    _unresolvable_warned.add(key)
+    logger.warning("MCP probe failed [%s]: command not found: %s", name, command)
+
+
+def _clear_unresolvable(name: str, command: str) -> None:
+    """Forget a command that now resolves, so a later outage is reported afresh."""
+    _unresolvable_warned.discard((name, command))
+
+
+def _prune_unresolvable(live: set[tuple[str, str]]) -> None:
+    """Drop ledger keys that the current config no longer names.
+
+    Without this, editing a server's command to another missing binary would
+    keep the superseded string forever, so the ledger would grow with config
+    churn instead of staying bounded by config size.
+    """
+    for stale in _unresolvable_warned - live:
+        _unresolvable_warned.discard(stale)
+
+
+def reset_unresolvable_warnings() -> None:
+    """Clear the whole warn-once ledger.
+
+    A test seam, and a manual escape hatch. Production does NOT rely on this:
+    routine recovery is handled by `_clear_unresolvable` (on a successful
+    probe) and `_prune_unresolvable` (on config churn), both of which run
+    automatically inside the probe path.
+    """
+    _unresolvable_warned.clear()
+
+
 # Well-known MCP config locations, tagged by scope.  Scope names match
 # the dashboard badges (kirocrew / kiroGlobal / ccGlobal) and are the
 # source of truth for the ``presence`` field on each server.
@@ -792,10 +852,17 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
         if not resolved:
             server.status = "error"
             server.error = f"command not found: {server.command}"
-            logger.warning(
-                "MCP probe failed [%s]: command not found: %s", server.name, server.command
-            )
+            _warn_unresolvable_once(server.name, server.command)
             return server
+
+        # The command resolved, so forget any prior "not found" report — keyed on
+        # resolvability, NOT on handshake health. Clearing this at the end of the
+        # success path instead would skip the four exits that resolve fine but
+        # fail later (no response, a JSON-RPC error reply, a timeout, any other
+        # exception), leaving a stale key that silences the WARNING if the binary
+        # is removed again. `command` is necessarily a str here, since
+        # `shutil.which` returned truthy for it.
+        _clear_unresolvable(server.name, server.command)
 
         # A hostile MCP-config entry names the binary spawned here, so route it
         # through the sandbox chokepoint: OS-level isolation plus a
@@ -925,7 +992,7 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
     except FileNotFoundError:
         server.status = "error"
         server.error = f"command not found: {server.command}"
-        logger.warning("MCP probe failed [%s]: command not found: %s", server.name, server.command)
+        _warn_unresolvable_once(server.name, server.command)
     except Exception as exc:
         server.status = "error"
         server.error = str(exc)[:200]
@@ -1008,6 +1075,18 @@ async def probe_all() -> list[McpServerInfo]:
     and a disabled server must never run until the user enables it.
     """
     servers = [s for s in list_servers() if not s.disabled]
+    # Keep the warn-once ledger bounded by the config rather than by config
+    # churn: a command edited to a different missing binary must not retain the
+    # superseded string. Runs before the early return so emptying the config
+    # (or disabling every server) also clears it.
+    #
+    # `command` is whatever the config JSON held (`spec.get("command", "")`,
+    # unvalidated), so a malformed entry can be a dict or list. Those are
+    # unhashable and would abort this whole pass — not just their own server —
+    # because this runs outside the per-server `gather`. Only string commands
+    # can be ledger keys anyway, so skip the rest and let each malformed server
+    # keep failing in isolation inside `probe_server`.
+    _prune_unresolvable({(s.name, s.command) for s in servers if isinstance(s.command, str)})
     if not servers:
         return []
     # Per-call semaphore: bounds the fan-out within this discovery pass while

--- a/test/test_mcp_probe_warn_once.py
+++ b/test/test_mcp_probe_warn_once.py
@@ -1,0 +1,213 @@
+"""An unresolvable MCP command must be reported once, not every probe cycle.
+
+The contract this pins: a command that does not resolve is a STABLE fact, so it
+warns the first time and drops to DEBUG afterwards; a command that resolves
+later (or a different command under the same server name) is news again; and
+clearing the ledger restores first-warn behaviour. Transient failure classes
+(timeouts, handshake errors) are deliberately NOT routed through the ledger and
+keep warning on every occurrence.
+"""
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from kiro_crew import mcp_discovery
+
+
+@pytest.fixture(autouse=True)
+def _clean_ledger():
+    """Each test starts and ends with an empty ledger (it is module state)."""
+    mcp_discovery.reset_unresolvable_warnings()
+    yield
+    mcp_discovery.reset_unresolvable_warnings()
+
+
+def _levels_for(caplog, needle):
+    return [r.levelno for r in caplog.records if needle in r.getMessage()]
+
+
+def test_first_unresolvable_command_warns(caplog):
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        mcp_discovery._warn_unresolvable_once("slack-mcp", "slack-mcp")
+    assert _levels_for(caplog, "slack-mcp") == [logging.WARNING]
+
+
+def test_repeat_of_the_same_command_drops_to_debug(caplog):
+    # The reported symptom: a config carried from another machine re-emitted the
+    # same handful of warnings on every discovery cycle, burying real ones.
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        for _ in range(5):
+            mcp_discovery._warn_unresolvable_once("slack-mcp", "slack-mcp")
+    levels = _levels_for(caplog, "slack-mcp")
+    assert levels[0] == logging.WARNING
+    assert set(levels[1:]) == {logging.DEBUG}
+    assert levels.count(logging.WARNING) == 1
+
+
+def test_a_different_command_under_the_same_name_warns_again(caplog):
+    # Keyed on (name, command): editing the config to a new binary that is ALSO
+    # missing is a new fact and must not be swallowed by the old entry.
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        mcp_discovery._warn_unresolvable_once("arcc", "/usr/bin/arcc")
+        mcp_discovery._warn_unresolvable_once("arcc", "/opt/bin/arcc")
+    assert _levels_for(caplog, "/usr/bin/arcc") == [logging.WARNING]
+    assert _levels_for(caplog, "/opt/bin/arcc") == [logging.WARNING]
+
+
+def test_distinct_servers_each_warn_once(caplog):
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        mcp_discovery._warn_unresolvable_once("a", "cmd-a")
+        mcp_discovery._warn_unresolvable_once("b", "cmd-b")
+        mcp_discovery._warn_unresolvable_once("a", "cmd-a")
+    assert _levels_for(caplog, "cmd-a") == [logging.WARNING, logging.DEBUG]
+    assert _levels_for(caplog, "cmd-b") == [logging.WARNING]
+
+
+def test_reset_restores_first_warn_behaviour(caplog):
+    # Callers reset after a config change so a regression is reported afresh
+    # rather than silently swallowed for the life of the process.
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        mcp_discovery._warn_unresolvable_once("x", "cmd-x")
+        mcp_discovery.reset_unresolvable_warnings()
+        mcp_discovery._warn_unresolvable_once("x", "cmd-x")
+    assert _levels_for(caplog, "cmd-x") == [logging.WARNING, logging.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_malformed_command_does_not_abort_the_whole_probe_pass(caplog):
+    """A malformed config entry must fail alone, not take down bulk probing.
+
+    `command` is read straight from config JSON (`spec.get("command", "")`)
+    with no validation, so it can be a dict or list. Those are unhashable, and
+    the ledger prune runs OUTSIDE the per-server `gather` — so without a guard
+    one bad entry raises `TypeError` out of `probe_all()` and `/api/mcp/probe`
+    returns 500 with nothing probed at all.
+    """
+    bad = mcp_discovery.McpServerInfo(name="malformed", command={"not": "a string"})  # type: ignore[arg-type]
+    good = mcp_discovery.McpServerInfo(
+        name="ghost", command="kirocrew-no-such-binary-2f8a1c", args=[]
+    )
+
+    with mock.patch.object(mcp_discovery, "list_servers", return_value=[bad, good]):
+        with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+            results = await mcp_discovery.probe_all()
+
+    # Every server still gets a verdict — the malformed one included.
+    assert {r.name for r in results} == {"malformed", "ghost"}
+    by_name = {r.name: r for r in results}
+    assert by_name["ghost"].status == "error"
+    assert "command not found" in (by_name["ghost"].error or "")
+    # The malformed entry fails visibly in isolation rather than silently.
+    assert by_name["malformed"].status == "error"
+    assert by_name["malformed"].error, "a malformed entry must still report an error"
+
+
+@pytest.mark.asyncio
+async def test_a_resolving_command_clears_the_ledger_even_if_the_handshake_fails():
+    """The ledger tracks RESOLVABILITY, not handshake health.
+
+    Without this, a server whose binary was missing, then got installed but
+    failed its handshake, would keep a stale key — so when the binary is
+    removed again the user sees only DEBUG, never the WARNING.
+    """
+    server = mcp_discovery.McpServerInfo(name="flaky", command="flaky-bin", args=[])
+    mcp_discovery._warn_unresolvable_once("flaky", "flaky-bin")
+    assert ("flaky", "flaky-bin") in mcp_discovery._unresolvable_warned
+
+    # Resolves fine, then dies during the handshake — the timeout path.
+    with mock.patch.object(mcp_discovery.shutil, "which", return_value="/usr/bin/flaky-bin"):
+        with mock.patch.object(
+            mcp_discovery, "sandboxed_spawn_argv", side_effect=asyncio.TimeoutError()
+        ):
+            result = await mcp_discovery.probe_server(server)
+
+    assert result.status == "error"
+    assert ("flaky", "flaky-bin") not in mcp_discovery._unresolvable_warned, (
+        "a command that resolved must leave no stale key, even when the probe then failed"
+    )
+
+
+def test_ledger_is_bounded_by_config_size_not_cycle_count():
+    # Repeated cycles over the same servers must not grow the ledger — that is
+    # what makes it safe to keep for the life of the process.
+    for _ in range(50):
+        for name in ("s1", "s2", "s3"):
+            mcp_discovery._warn_unresolvable_once(name, f"cmd-{name}")
+    assert len(mcp_discovery._unresolvable_warned) == 3
+
+
+def test_a_command_that_resolves_clears_its_entry():
+    # missing -> installed -> missing must warn again on the second outage,
+    # not stay silent for the life of the process.
+    mcp_discovery._warn_unresolvable_once("srv", "cmd")
+    assert ("srv", "cmd") in mcp_discovery._unresolvable_warned
+    mcp_discovery._clear_unresolvable("srv", "cmd")
+    assert ("srv", "cmd") not in mcp_discovery._unresolvable_warned
+
+
+def test_prune_drops_keys_the_config_no_longer_names():
+    # Editing a command to another missing binary must not retain the old
+    # string, otherwise the ledger grows with config churn.
+    mcp_discovery._warn_unresolvable_once("srv", "/old/bin")
+    mcp_discovery._warn_unresolvable_once("keep", "/keep/bin")
+    mcp_discovery._prune_unresolvable({("srv", "/new/bin"), ("keep", "/keep/bin")})
+    assert mcp_discovery._unresolvable_warned == {("keep", "/keep/bin")}
+
+
+def test_clearing_an_absent_key_is_a_no_op():
+    mcp_discovery._clear_unresolvable("never", "seen")  # must not raise
+    assert mcp_discovery._unresolvable_warned == set()
+
+
+@pytest.mark.asyncio
+async def test_probe_server_warns_once_across_cycles(caplog):
+    """End-to-end through probe_server: the real dedup path, not a source grep.
+
+    Uses a command that genuinely does not resolve, so this exercises the
+    `shutil.which` pre-check and its early return.
+    """
+    server = mcp_discovery.McpServerInfo(
+        name="ghost", command="kirocrew-no-such-binary-2f8a1c", args=[]
+    )
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        for _ in range(3):
+            result = await mcp_discovery.probe_server(server)
+    # The machine-readable failure state is unchanged by the dedup — this is
+    # what doctor and the dashboard actually read.
+    assert result.status == "error"
+    assert "command not found" in (result.error or "")
+    levels = _levels_for(caplog, "kirocrew-no-such-binary-2f8a1c")
+    assert levels.count(logging.WARNING) == 1, f"expected exactly one WARNING, got {levels}"
+
+
+@pytest.mark.asyncio
+async def test_timeouts_still_warn_on_every_cycle(caplog):
+    """The scope line, asserted behaviourally: transient failures are NOT deduped.
+
+    A server that exists but hangs must warn every cycle — a newly-hanging
+    server is news, unlike a permanently absent binary. The timeout is injected
+    at the spawn boundary, which lands in the same `except asyncio.TimeoutError`
+    handler that a real readline timeout reaches.
+    """
+    server = mcp_discovery.McpServerInfo(name="hanger", command="sleep", args=["999"])
+
+    with caplog.at_level(logging.DEBUG, logger=mcp_discovery.logger.name):
+        with mock.patch.object(mcp_discovery.shutil, "which", return_value="/bin/sleep"):
+            with mock.patch.object(
+                mcp_discovery,
+                "sandboxed_spawn_argv",
+                side_effect=asyncio.TimeoutError(),
+            ):
+                for _ in range(3):
+                    result = await mcp_discovery.probe_server(server)
+
+    assert result.status == "error"
+    assert result.error == "timeout"
+    timeout_warnings = [
+        r for r in caplog.records if "timeout" in r.getMessage() and r.levelno == logging.WARNING
+    ]
+    assert len(timeout_warnings) == 3, f"timeouts must not be deduped, got {len(timeout_warnings)}"
+    assert mcp_discovery._unresolvable_warned == set(), "timeouts must not enter the ledger"


### PR DESCRIPTION
## Problem

One `config.json` is shared across machines, so a config authored on a Linux dev box and opened on a Mac names MCP servers whose binaries do not exist there. Every discovery cycle re-probes them, re-resolves nothing, and re-emits an identical warning.

From a real launch log — the same four servers at `11:50:46`, then again at `11:56:23` and `11:56:27`:

```
WARNING kiro_crew.mcp_discovery: MCP probe failed [slack-mcp]: command not found: slack-mcp
WARNING kiro_crew.mcp_discovery: MCP probe failed [arcc-governance]: command not found: ...
... x4 servers, repeating every cycle
```

## Why it matters

An unresolvable command is a **stable** fact: it stays unresolved until someone edits the config or installs the binary. Repeating the warning adds no information, and it buries the transient failures that *do* deserve attention — in that same log, genuine 15-second handshake timeouts for `aws-api-mcp` and `playwright-mcp` sit among the noise. The signal-to-noise ratio of the launch log is what a user reads when something is actually wrong.

## Fix (symptom → root cause → change)

**Symptom:** the same handful of "command not found" warnings on every cycle.
**Root cause:** the probe is stateless about *reporting*. It correctly re-derives the failure each cycle (which it must, since the config can change), but it also re-*announces* an unchanged conclusion.
**Change:** separate deriving the fact from announcing it. Warn the first time a given `(server, command)` fails to resolve; demote repeats to `DEBUG`.

- `_warn_unresolvable_once()` + a `(name, command)` ledger.
- `_clear_unresolvable()` on a successful probe — a binary that is installed and later disappears warns **again** rather than staying silent for the life of the process.
- `_prune_unresolvable()` in `probe_all` — editing a command to another missing binary does not retain the superseded string, so the ledger stays bounded by config *size*, not config *churn*.
- Both unresolvable-command sites (the `shutil.which` pre-check and the `FileNotFoundError` handler) route through the helper.

**Deliberately scoped to unresolvable commands only.** Timeouts and handshake errors keep warning on every occurrence: a server that *newly* starts timing out is news, whereas one whose binary is absent is not. A test asserts that scope line so the ledger cannot quietly grow to cover transient classes.

**Nothing observable changes.** `server.status` and `server.error` are still assigned unconditionally on every probe, *before* the helper is called, so `doctor` and the dashboard (`dashboard/handlers/mcp.py:438-454`) show the same text as before. Only the log stream gets quieter.

## Tests

New `test/test_mcp_probe_warn_once.py` (11 tests) drives `probe_server` end-to-end rather than inspecting source text:

| Test | Locks in |
|---|---|
| `test_probe_server_warns_once_across_cycles` | a genuinely unresolvable command warns once across three real probe cycles; `status`/`error` still set |
| `test_timeouts_still_warn_on_every_cycle` | an injected timeout warns all three times and never enters the ledger — the scope line |
| `test_repeat_of_the_same_command_drops_to_debug` | first WARNING, subsequent DEBUG |
| `test_a_command_that_resolves_clears_its_entry` | missing → installed → missing warns again |
| `test_prune_drops_keys_the_config_no_longer_names` | config churn does not grow the ledger |
| `test_a_different_command_under_the_same_name_warns_again` | keyed on `(name, command)`, not name alone |

Verified **load-bearing by mutation**: neutering the dedup (`if key in ledger` → `if False`) fails three of them, including the end-to-end one.

## Manual verification

N/A — unit coverage is sufficient. The behaviour is a log-level decision on a path the new tests drive end-to-end through `probe_server`, including the real `shutil.which` early return.

## Screenshots

N/A — no user-visible UI change. The dashboard's MCP error text is deliberately unchanged (verified: it reads `server.error`, which this diff does not touch).

## Scope notes — what this does NOT do, and why

Three things were investigated and deliberately left alone. Recording them because two of them correct claims made earlier in the investigation:

- **The probe does not waste a timeout on a missing binary.** `mcp_discovery` already pre-resolves via `shutil.which(server.command, path=env.get("PATH"))` and returns early, so an unresolvable entry costs one log line, not 15 seconds. An earlier read of this issue assumed otherwise; the 15s timeouts in the log belong to servers that *do* exist and hang.
- **`dashboard.mcp_probe_timeout_secs` is left at 15s.** It is already configurable. Lowering the default would trade this log noise for false "unreachable" verdicts on genuinely slow-starting servers.
- **`agent.py`'s parallel "Dropping MCP server" warning is untouched.** It runs when an agent config is built, not on a repeating probe cycle — a different lifecycle, and its own change if it is worth doing.

## Review notes

Both local reviewers cleared this (`block_merge: false`) and each raised the same two non-blocking findings, both fixed above: the ledger did not self-heal (`missing → installed → missing` stayed silent), and one test asserted on `inspect.getsource` string counts with an `A or B` clause whose `B` passed vacuously. That test is now behavioural.

Two verified points worth recording:

- **The lockless `set` needs no lock.** Production probes mutate it on the single gateway event loop; the CLI `doctor` runs in its own process.
- **Precedent exists for the pattern.** `apps/module_loader.py:25` is `_warned_third_party_apps: set[str] = set()`, a warn-once ledger guarding a SEC-012 trust warning — a strictly stronger use than this one.

Both `blocking: true` backend AUTOSDE rules (`backend-security-controls`, `no-blocking-call-on-event-loop`) match `src/kiro_crew/**/*.py` and were checked clause-by-clause (`top-level-imports` is `blocking: false`): no new subprocess site (the early `return` on an unresolved command still precedes the `sandboxed_spawn_argv` chokepoint, so the dedup cannot cause an unsandboxed spawn), the stderr redactors are untouched, and no blocking call is added to the event loop — net log IO on the loop strictly *decreases*.

## Gates

`isort` clean · `flake8` clean · `mypy` clean (519 source files) · `pytest` 119 passed across `test_mcp_probe_warn_once.py` + `test_mcp_discovery.py`.

The full 16k-test backend suite was not run locally: this host's sandbox blocks `multiprocessing` semaphores (`PermissionError`), so `pytest -n auto` and parallel `flake8` cannot run here and both were run single-process. CI runs them normally.

