### PR TITLE
feat(security): per-app WebSocket event scoping for app tokens

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -489,3 +489,152 @@ Writers: `apps/manager.py` (`_BUILTIN_APPS`, `_DEFAULT_ON_BUILTINS`,
 `apps/registry.py::_apply_trust_fields`;
 consumers: `website/src/pages/AppsPage.tsx` (`pickFeatured`),
 `website/src/components/appstore/types.ts` (`isVerified`, `sourceLabel`).
+
+## 13. An app token's WebSocket stream is scoped by its manifest, deny-by-default
+
+`/api/ws` is the third surface an app token reaches, alongside the HTTP API and
+MCP. Connecting grants no events by itself: the socket records the caller's app
+identity and its `permissions.events` declarations, and every fan-out is filtered
+per socket at ONE chokepoint — `DashboardState._send_ws_all` →
+`_ws_client_allowed` → `dashboard/ws_event_scope.py`. Both dispatch paths
+(`broadcast_ws` and the `_broadcast` `_type` translation) and the
+subagent-subscriber fan-out funnel through it. An event absent from the module's
+tables is DENIED, so a new event name is a silent loss of function for apps until
+it is classified — `test_ws_event_scoping.py` fails the build on an unclassified
+broadcast name rather than letting it reach production.
+
+Three tiers. Tier 0 (`dashboard`, `refresh`, `update_progress`) carries no
+sensitive payload and always delivers — and that classification is a claim about
+CONTENT, so it has to be maintained: `_push_status` writes the `dashboard` frame
+straight to each socket every few seconds, and its payload is deliberately
+counts-and-environment only. The checkout's `branch`/`commit` are stripped for app
+tokens (they say what the operator is working on and have no consumer outside the
+owner surfaces); `/api/status` and the SSE stream run on dashboard-user tokens and
+keep the full snapshot. Moving the whole frame behind a declaration was rejected:
+every client needs its `version` to force a reload across a gateway upgrade, so
+that would silently cut existing apps off from the upgrade signal. Tier 1 is slot-scoped: visibility follows
+the slot's `SlotOrigin` and the app's `slots:*` declarations (`slots:own` is the
+default, then `slots:user`, `slots:app:<name>`, `slots:all`), with `subagent:*` an
+independent dimension so an app can watch subagent status without receiving chat
+content. Tier 2 is global and needs an explicit declaration; notifications split
+by source, so `notification` covers the app's own pushes while gateway-internal
+ones (cron output, `send_message`, watchlist results) require
+`notification:system` — bundling them would make one declaration a broad grant.
+
+**`SlotOrigin` is declared by the layer that knows it, never derived.**
+`get_or_create_slot` cannot distinguish a person typing from a background
+injection, so it leaves an undeclared non-app slot UNTAGGED (`""`) instead of
+calling it USER. The request layer decides USER/APP because only it sees whether
+an app token was presented; background callers pass CRON/SYSTEM explicitly. `""`
+is invisible to every cross-slot scope, so a caller that forgets to declare loses
+visibility rather than leaking. The origin round-trips through session metadata:
+both the write (`_save_slot_to_history`) and the restore (the rehydrate paths) are
+required, or every slot comes back unattributed after a restart.
+
+**A socket's scope can only SHRINK while it stays open.** `permissions.events` is
+resolved at connect, and `disable_app` rewrites the registry without closing
+sockets, so every decision INTERSECTS the connect-time snapshot with the
+currently declared set (`ws_event_scope.effective_allowed_events`).
+
+**Revoking a disabled app takes TWO checks, because the own-slot default never
+consults declarations.** `disable_app` flips `enabled` in `installed.json` and
+leaves `app.json` intact, so a manifest-only read would report a disabled app's
+declarations unchanged — hence enablement is read as part of the declared set, and
+a disabled or uninstalled app declares nothing. That alone does not revoke it:
+`disable_app` does not invalidate the app token (`token_auth` has no enablement
+check; each app backend route gates on `is_app_enabled` itself), so the app can
+keep an authenticated `/api/ws` socket, and `_slot_visible` grants an app its OWN
+slots on the ownership check BEFORE `allowed_events` is read. Emptying the
+declaration set cannot reach that branch. So the enablement flag is also exposed
+as `ws_event_scope.app_events_revoked`, which the own-slot branches and the gate
+consult; only then does a disabled app actually collapse to Tier 0.
+
+The two facts come from ONE off-loop read and are cached as one entry, because a
+separately-keyed enablement cache could report `enabled` for a declaration set
+that was read while the app was disabled. They cannot be collapsed into the scope
+set either: a disabled app and an enabled app that declares no events both present
+an EMPTY set, and those must differ — the latter still sees its own slots.
+Revocation therefore requires POSITIVE evidence of disablement, so an unreadable
+`app.json` on a still-enabled app declares nothing but is NOT revoked; blanking a
+working app's own chat over a transient filesystem error is the more costly error.
+
+**The CONNECT path resolves enablement too, and refuses.** Since the token
+survives `disable_app`, a disabled app can reconnect at will, and a connect-time
+read of `app.json` alone would hand it a full snapshot from the intact manifest —
+which the initial `slots` push and the log replay are then judged against before
+any background refresh runs, with `app_events_revoked` reporting NOT revoked on
+the cold cache. So `ws_event_scope.load_declared_events_for_connect` returns the
+enablement flag with the scopes AND primes the cache, and `api_ws` closes the
+socket when the app is disabled. Refusing (rather than admitting at Tier 0, which
+is what an already-open socket narrows to) costs nothing at connect: there is no
+in-flight streaming turn to cut, which was the reason narrowing does not close
+live sockets. The read and the refusal both happen BEFORE `register_ws`, because
+refusing after registration would need the cleanup scope that only exists once
+registration succeeds.
+
+**Every decision is audited, grants included.** `AUTOSDE.yaml`
+(`backend-security-controls`) requires a SEL event for every permission
+decision, so the gate records the grants as well as the refusals. Because a
+decision is made per client per frame, both go through one deduplicated path
+(`_audit_decision`, 5-minute window per app/event/reason, carrying the suppressed
+count) — an un-deduplicated write per grant would be unbounded on the broadcast
+path. Grants and refusals use different dedup keys so neither starves the other
+out of the window, and the grant record is emitted from the `ws_event_allowed`
+wrapper rather than from each `return True`, so a branch added later is covered
+without having to remember to report itself.
+
+Four paths read the set and all four narrow: the gate, the `slots` payload
+filter, the subagent-batch payload filter, and the LOG fan-out. The log path is
+the odd one — `subscribe_logs` grants once and the ring handler then writes
+straight to `_ws_log_subscribers` without passing the chokepoint, so the re-check
+lives at the send (`handlers/updates._safe_ws_send`), which also drops the
+subscription. That check must stay on the event loop: the handler's `emit()` runs
+on arbitrary threads, where a cold cache miss would fall back to a synchronous
+manifest read.
+
+A NARROWED or deleted manifest therefore takes effect within one refresh
+interval, while a WIDENED one does not reach an open socket at all — that requires
+a reconnect, so a live session can only ever hold scopes it was authenticated for.
+The reload uses the same off-loop stale-while-revalidate shape as `exposeToApps`,
+with one deliberate difference: a cold miss falls back to the connect snapshot
+rather than to empty, because an empty fallback would withhold every event from
+every app on the first broadcast after a restart. Closing the socket instead was
+rejected — it would cut a streaming turn mid-flight and turn a manifest save into a
+reconnect storm without giving a tighter guarantee than withholding already does.
+
+**Cross-app visibility is mutual.** `slots:app:X` also requires X's manifest to
+name the observer in `permissions.exposeToApps`, so an app cannot name a sibling
+unilaterally. That list is read through a stale-while-revalidate cache because the
+gate is synchronous and sits on the broadcast hot path: it never reads the disk
+itself, a cold miss denies (fail-closed) and schedules an off-loop refresh, and a
+stale entry serves the previous value while refreshing.
+
+**A grant that is not a list denies.** `permissions.api`, `events`, `mcpTools` and
+`exposeToApps` are list-valued; a JSON scalar is refused rather than coerced,
+because iterating a string yields its characters (`"*"` → the wildcard, and
+`"/api/chat"` → the prefix `"/"`, which matches every path).
+
+**Filtering the frame is not always enough.** Two event shapes carry other
+tenants' data inside a payload the gate admits wholesale, so they are narrowed on
+the send path in `_serialize_for_client`: the `slots` re-push (a full slot list)
+and the coalesced `subagent_batch_*` frames (one frame, many subagents' rows, no
+single slot to judge). The `slots` envelope additionally carries global
+safety-posture booleans that no slot scope narrows — `yolo` rides the same
+declaration that gates `yolo_expired`, and `channelTrusted` is withheld from app
+tokens outright. A withheld field is OMITTED, never sent as `false`, because a
+falsy default still answers a question the app must not ask.
+
+`_APP_TOKEN_IMPLICIT_ALLOW` holds `/api/ws` alone. An endpoint belongs there only
+with a compensating per-response control — event scoping is that control for
+`/api/ws` — so `/api/status` is not in it despite being a liveness probe: it
+returns owner hash, host specs, cron and usage stats, and the live safety-override
+state, and an app that wants it declares it in `permissions.api`.
+
+Writers: `dashboard/ws_event_scope.py`, `dashboard/ws.py` (connect-time scope
+resolution), `dashboard/state.py` (`_send_ws_all`, `_ws_client_allowed`,
+`_serialize_for_client`, `SlotOrigin`), `dashboard/token_auth.py`
+(`_APP_TOKEN_IMPLICIT_ALLOW`, `app_token_path_allowed`), `apps/manifest.py`
+(`_granted_list`); consumers: `website/src/app-sdk/index.ts` (mirrors the tables
+for developer-facing diagnostics, drift-guarded by
+`website/src/test/appSdkEventScope.test.ts`). Runtime-facing summary for app
+authors: [../../../src/kiro_crew/docs/app-platform-trust-model.md](../../../src/kiro_crew/docs/app-platform-trust-model.md).

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -418,6 +418,21 @@ class BackendConfig:
         )
 
 
+def _granted_list(value: Any) -> list[str]:
+    """The entries of a list-valued GRANT, or nothing if it is not a list.
+
+    A JSON scalar must NOT be coerced. `[str(x) for x in value]` over a STRING
+    iterates its characters, so `"exposeToApps": "*"` would yield `["*"]` -- the
+    wildcard -- and any string containing `*` or `/` produces that token too:
+    `"api": "/api/chat"` gives the prefix `"/"`, which `app_token_path_allowed`
+    matches against every path. A malformed grant has to deny, the same direction
+    the boolean grants below fail in.
+    """
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if v]
+
+
 @dataclass
 class Permissions:
     """Declared permissions for an app."""
@@ -433,6 +448,10 @@ class Permissions:
     #: Declared rather than implicit so "which apps can start an agent" is
     #: auditable from the manifest instead of from an app's import graph.
     spawn: bool = False
+    # WS cross-app visibility opt-in: app names (or ["*"]) allowed to use
+    # slots:app:<this-app> / subagent:app:<this-app> declarations to observe
+    # this app's slots and subagents. Empty list = no cross-app visibility.
+    exposeToApps: list[str] = field(default_factory=list)  # noqa: N815
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
@@ -452,6 +471,8 @@ class Permissions:
             d["cron"] = True
         if self.spawn:
             d["spawn"] = True
+        if self.exposeToApps:
+            d["exposeToApps"] = self.exposeToApps
         return d
 
     @classmethod
@@ -468,14 +489,15 @@ class Permissions:
         # restriction ON. Same defect class, mirrored fix — the safe default
         # follows what the field grants or withholds, not the field's type.
         return cls(
-            api=[str(p) for p in data.get("api", []) if p],
-            events=[str(e) for e in data.get("events", []) if e],
-            mcpTools=[str(t) for t in data.get("mcpTools", []) if t],  # noqa: N815
+            api=_granted_list(data.get("api")),
+            events=_granted_list(data.get("events")),
+            mcpTools=_granted_list(data.get("mcpTools")),  # noqa: N815
             storage=data.get("storage") is True,
             network=data.get("network") is True,
             memory=str(data.get("memory", "")),
             cron=data.get("cron") is True,
             spawn=data.get("spawn") is True,
+            exposeToApps=_granted_list(data.get("exposeToApps")),  # noqa: N815
         )
 
 

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -13,7 +13,7 @@ from kiro_crew.dashboard.chat_utils import (
     effective_session_key,
     slot_history_key,
 )
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, request_slot_origin
 from kiro_crew.history import carry_provenance
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -208,6 +208,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
         name=None, agent=slot.agent, workspace=slot.workspace, model=slot.model,
         mode=mode_override if mode_override is not None else slot.mode,
         app=request_app,
+        origin=request_slot_origin(request_app),
     )
     new_slot.forked_from = effective_session_key(slot)
     new_slot.reasoning_effort = slot.reasoning_effort

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -72,6 +72,7 @@ from kiro_crew.dashboard.state import (
     _mark_permission_resolved,
     _normalize_slot_key,
     parse_cls_meta,
+    request_slot_origin,
 )
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.history import carry_provenance
@@ -185,6 +186,7 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         slot = state.get_or_create_slot(
             slot_name,
             app=request.get("app", ""),
+            origin=request_slot_origin(request.get("app", "")),
             memory_mode=requested_memory_mode,
         )
     except ValueError as exc:
@@ -1087,6 +1089,7 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
                 memory_mode=memory_mode,
                 ephemeral=body.get("ephemeral"),
                 app=request.get("app", ""),
+                origin=request_slot_origin(request.get("app", "")),
             )
         except ValueError as exc:
             return web.json_response({"error": str(exc)}, status=409)
@@ -3475,6 +3478,16 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             }
         )
 
+    # Read the history metadata BEFORE creating the slot: this endpoint RESUMES a
+    # persisted conversation, so its origin is a property of that conversation,
+    # not of whoever is resuming it. Deriving it from the request would label a
+    # resumed CRON slot as USER, and `slots:user` would then hand the dashboard
+    # user's private cron output to any app holding that scope. An absent
+    # persisted origin stays empty (get_or_create_slot then derives APP for an
+    # app token, otherwise leaves it untagged, which is invisible to cross-slot
+    # scopes) rather than claiming USER on a conversation we cannot attribute.
+    meta = state.conversation_log.get_metadata(history_key)
+
     slot = state.get_or_create_slot(
         name,
         app=request.get("app", ""),
@@ -3482,6 +3495,7 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         # that conversation, so the tab is channel-origin even when the session
         # map can no longer name its session.
         channel_origin=is_channel_session_key(history_key),
+        origin=str(meta.get("origin", "")),
     )
     # PERSISTED METADATA IS AUTHORITATIVE for the title. The sidebar's resume
     # call always sends a ``title`` (see website/src/api/client.ts
@@ -3771,7 +3785,12 @@ async def api_chat_mode(request: web.Request) -> web.Response:
                     # flag the slot or the write can be lost on restart.
                     if _mark_permission_resolved(slot.messages, aid, mode):
                         slot._dirty = True
-                    state.broadcast_ws("approval_resolved", {"id": aid, "approved": True})
+                    # ``slot`` keys the frame for the slot-scoped WS gate — an
+                    # app token cannot receive its own resolution without it.
+                    state.broadcast_ws(
+                        "approval_resolved",
+                        {"id": aid, "approved": True, "slot": slot.key},
+                    )
                     try:
                         sel().log_api_access(
                             caller=f"dashboard:{slot.key}",
@@ -3983,7 +4002,14 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
     # Broadcast first to ensure frontend is unblocked
     if request_id:
         state.broadcast_ws(
-            "approval_resolved", {"id": request_id, "approved": resolved != "rejected"}
+            "approval_resolved",
+            {
+                "id": request_id,
+                "approved": resolved != "rejected",
+                # Keys the frame for the slot-scoped WS gate (see
+                # ws_event_scope._SLOT_SCOPED_EVENTS).
+                "slot": owner.key,
+            },
         )
     state.push_slots_update()
     # SEL audit (best-effort — must not block the UI-unblocking path above)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -497,6 +497,11 @@ def _rehydrate_slot_from_history(
                 bool(meta.get("channel_origin"))
                 or bool(meta.get("linked_session_key"))
             ),
+            # Restore the persisted origin. Re-deriving it here would relabel
+            # every rehydrated slot on restart, so a cron slot would come back
+            # as USER (leak) and a real user slot as untagged (silently
+            # dropping `slots:user` for apps that legitimately hold it).
+            origin=str(meta.get("origin", "")),
         )
         # Title comes from the metadata line we already read above. We deliberately
         # do NOT consult ``list_sessions()`` here: that call globbed + stat'd + read
@@ -872,6 +877,11 @@ def _restore_recent_sessions_steps(
             # No channel_origin here: this loop `continue`s above for every
             # non-dashboard key, so a channel-born session never reaches it --
             # ``channel_slot_reconciler`` owns surfacing those.
+            # Restore the persisted origin. Re-deriving it here would relabel
+            # every rehydrated slot on restart, so a cron slot would come back
+            # as USER (leak) and a real user slot as untagged (silently
+            # dropping `slots:user` for apps that legitimately hold it).
+            origin=str(meta.get("origin", "")),
         )
         # Titles can be LLM-generated (auto-title) and are surfaced on the
         # dashboard — apply the same redaction as assistant content. Matches
@@ -1805,6 +1815,14 @@ def _save_slot_to_history(
                 meta_line["channel_folder_filed"] = True
             if slot._app:
                 meta_line["app"] = slot._app
+            # Slot ORIGIN (user / app / cron) must round-trip with ``app``:
+            # the rehydrate paths restore ``origin=meta.get("origin", "")`` and an
+            # untagged restore falls back to the fail-closed empty sentinel. Without
+            # this write every slot would come back unattributed after a restart —
+            # ``slots:user`` subscribers would stop seeing user slots, and a cron
+            # slot would lose the CRON tag that keeps it out of ``slots:user``.
+            if slot._origin:
+                meta_line["origin"] = slot._origin
             # Artifact companion binding — persisted so a bound
             # session restored after a gateway restart (or resumed from the
             # History page) comes back as the artifact's active bound session.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5911,7 +5911,12 @@ async def _run_chat(
                         slot._dirty = True
                         state.broadcast_ws(
                             "approval_resolved",
-                            {"id": str(event.request_id), "approved": _approved},
+                            {
+                                "id": str(event.request_id),
+                                "approved": _approved,
+                                # Keys the frame for the slot-scoped WS gate.
+                                "slot": slot.key,
+                            },
                         )
                         state.push_slots_update()
                     # Clean up the Slack prompt: remove the registry entry and

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, SlotOrigin
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -82,7 +82,13 @@ def inject_cron_result_to_dashboard(
     whatever snapshot an earlier run stored.
     """
     slot_name = f"cron-{job.id}"
-    slot = state.get_or_create_slot(name=slot_name, agent=job.agent_id or "")
+    slot = state.get_or_create_slot(
+        name=slot_name,
+        agent=job.agent_id or "",
+        # A cron result is the job's output, not something the person typed.
+        # A USER label would expose it to any app holding `slots:user`.
+        origin=SlotOrigin.CRON,
+    )
     safe_name, _ = redact_exfiltration_urls(job.name)
     safe_name, _ = redact_credentials(safe_name)
     slot.title = f"Cron: {safe_name}"

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -18,7 +18,7 @@ from kiro_crew.dashboard.cron_inject import (
     hydrate_slot_from_history,
     inject_cron_result_to_dashboard,
 )
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, SlotOrigin
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.messaging.link import is_channel_session_key
@@ -545,7 +545,9 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             if state.conversation_log else []
         )
         if history:
-            slot = state.get_or_create_slot(name=slot_name, agent="")
+            slot = state.get_or_create_slot(
+                name=slot_name, agent="", origin=SlotOrigin.CRON
+            )
             if not slot.linked_session_key:
                 slot.linked_session_key = session_key
                 hydrate_slot_from_history(slot, history)
@@ -557,7 +559,9 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             )
             if not notif:
                 return web.json_response({"error": "job not found"}, status=404)
-            slot = state.get_or_create_slot(name=slot_name, agent="")
+            slot = state.get_or_create_slot(
+                name=slot_name, agent="", origin=SlotOrigin.CRON
+            )
             body = notif.get("body", "")
             if body:
                 body, _ = redact_exfiltration_urls(body)

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -1323,8 +1323,27 @@ _log_ring_handler: _RingLogHandler | None = None
 
 
 async def _safe_ws_send(ws: web.WebSocketResponse, msg: str, state: DashboardState) -> None:
-    """Send to WS, removing dead subscribers on failure."""
+    """Send a log frame to one subscriber, re-checking its scope first.
+
+    Subscription is granted once, in the ``subscribe_logs`` handler, and the
+    handler above then fans out straight to ``_ws_log_subscribers`` without
+    passing the broadcast chokepoint. Re-check here, through
+    ``DashboardState._ws_client_allowed`` itself (rather than a hand-rolled
+    scope comparison) so revoking an app's ``log`` scope (a narrowed manifest,
+    or ``app disable``) stops the stream on a socket that is already
+    subscribed, and so this decision gets the same SEL audit trail as every
+    other event instead of a silent, unaudited duplicate of the check.
+
+    This runs on the event loop (the caller hands it to ``create_task`` via
+    ``call_soon_threadsafe``), which is what makes the check safe: the scope
+    cache must never be consulted from the logging thread, where a cold miss
+    would fall back to a synchronous manifest read.
+    """
     try:
+        if not ws.get("_is_dashboard_user", False):
+            if not state._ws_client_allowed(ws, "log", {}):
+                state._ws_log_subscribers.discard(ws)
+                return
         await ws.send_str(msg)
     except Exception:
         state._ws_log_subscribers.discard(ws)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -837,6 +837,36 @@ def _normalize_slot_key(name: str) -> str:
     return _SLOT_KEY_FILENAME_UNSAFE_RE.sub("_", _ascii_slot_key(name))
 
 
+class SlotOrigin:
+    """Slot creation origin — who initiated the slot.
+
+    Used by the WS event scope gate to decide which events an app token may
+    receive (e.g. ``slots:user`` grants visibility into ``USER``-origin slots
+    regardless of their ``_app`` owner).
+    """
+
+    USER = "user"       # initiated from the dashboard UI (no app token)
+    APP = "app"         # initiated by an app SDK call (carries owner _app)
+    CRON = "cron"       # initiated by a cron job
+    SYSTEM = "system"   # gateway-internal (startup, migration, etc.)
+
+
+def request_slot_origin(app: str) -> str:
+    """Origin for a slot created while serving an HTTP request.
+
+    The request layer is the only place that knows whether an app token was
+    presented, which is what separates APP from USER. Call it with the
+    request's app name (``request.get("app", "")``) — empty means the caller
+    authenticated as the dashboard user, so the slot genuinely is USER.
+
+    Background callers (cron, workflow, Slack, rehydrate) must NOT use this:
+    they have no request and would mislabel their slot as a person's, which is
+    exactly what `slots:user` grants an app access to. They declare their own
+    origin, or leave it untagged.
+    """
+    return SlotOrigin.APP if app else SlotOrigin.USER
+
+
 class _ChatSlot:
     """Independent chat session that runs server-side."""
 
@@ -933,6 +963,7 @@ class _ChatSlot:
         "_pending_context",
         "_app",
         "_human_seen",
+        "_origin",
         "_pending_variants",
         "_lock",
         "forked_from",
@@ -1247,6 +1278,10 @@ class _ChatSlot:
         # covers every app-owned slot no human has ever touched, which is what
         # a crew, a cron worker and an app-spawned session all are.
         self._human_seen: bool = False
+        # Deliberately "" (not USER): a slot built outside get_or_create_slot
+        # matches NO slots:* scope, so it stays invisible to app tokens rather
+        # than being silently classified as user-initiated. Deny-by-default.
+        self._origin: str = ""
         # Regenerate feature: variants pending attachment to next finalized assistant message
         self._pending_variants: list[dict] = []
         self._lock = asyncio.Lock()
@@ -2196,6 +2231,7 @@ class _ChatSlot:
             "forked_from": self.forked_from,
             "linked_session_key": self.linked_session_key,
             "app": self._app,
+            "origin": self._origin,
         }
 
 
@@ -3051,7 +3087,16 @@ class DashboardState:
         except Exception:
             self._log.warning("SEL audit failed for approval resolution", exc_info=True)
         try:
-            self.broadcast_ws("approval_resolved", {"id": approval_id, "approved": approved})
+            # ``approval_resolved`` is slot-scoped in the WS event-scope gate,
+            # which denies any frame it cannot attribute to a slot. Carry the
+            # owning slot key so an app token receives the resolution for its
+            # OWN approval; ``session_key == "state"`` is a background
+            # (cron/subagent/gateway) approval that no slot owns, so it stays
+            # unattributed and the gate correctly withholds it from app tokens.
+            payload: dict = {"id": approval_id, "approved": approved}
+            if session_key and session_key != "state":
+                payload["slot"] = session_key
+            self.broadcast_ws("approval_resolved", payload)
         except Exception:
             self._log.warning("WS broadcast failed for approval resolution", exc_info=True)
 
@@ -4028,6 +4073,7 @@ class DashboardState:
         app: str = "",
         linked_session_key: str = "",
         channel_origin: bool = False,
+        origin: str | None = None,
     ) -> _ChatSlot:
         """Return existing slot or create a new one.
 
@@ -4088,6 +4134,22 @@ class DashboardState:
         slot._on_message = self._broadcast_chat_message
         slot._on_question_retired = self._broadcast_question_retired
         slot._app = app
+        # ``origin`` must be declared by the layer that actually knows it, and
+        # an undeclared non-app slot stays UNTAGGED ("") rather than being
+        # called USER.
+        #
+        # Deriving USER here would be fail-OPEN: this function cannot tell a
+        # person typing in the dashboard from a background injection, so every
+        # untagged caller — cron result injection, workflow inject, Slack, the
+        # OpenAI-compatible endpoint — would read as USER and hand that private
+        # content to an app holding `slots:user`. Only the request layer
+        # knows whether an app token was presented, so USER/APP is decided
+        # there (see chat_handlers) and background callers declare CRON/SYSTEM.
+        #
+        # "" is invisible to every cross-slot scope (the gate compares against
+        # SlotOrigin.USER), so a caller that forgets to declare loses
+        # visibility instead of leaking — the direction this has to fail in.
+        slot._origin = origin or (SlotOrigin.APP if app else "")
         if memory_mode and memory_mode != "persistent":
             self._restricted_keys.add(f"dashboard:{name}")
         if ephemeral:
@@ -5285,14 +5347,24 @@ class DashboardState:
         # WS broadcast — translate internal _type to WS message format
         if self._ws_clients:
             msg_type = note.get("_type", "notification")
+            # Payload the scope gate inspects (slot / source keys), tracked per
+            # branch so the chokepoint can filter correctly.
+            ws_data: object
             if msg_type == "slots":
                 slots_list = note.get("_slots_list") or json.loads(note["slots"])
+                # ``data`` for slots carries the whole envelope so the
+                # chokepoint can per-app filter and re-serialize it.
+                ws_data = {
+                    "slots": slots_list,
+                    "yolo": note.get("_yolo", False),
+                    "channelTrusted": note.get("channelTrusted", False),
+                }
                 ws_msg = json.dumps(
                     {
                         "type": "slots",
                         "data": slots_list,
-                        "yolo": note.get("_yolo", False),
-                        "channelTrusted": note.get("channelTrusted", False),
+                        "yolo": ws_data["yolo"],
+                        "channelTrusted": ws_data["channelTrusted"],
                         # Forwarded explicitly: this envelope is rebuilt key-by-key,
                         # so anything not named here is silently dropped. The client
                         # invalidates its cached dashboard config when this changes.
@@ -5300,34 +5372,24 @@ class DashboardState:
                     }
                 )
             elif msg_type == "slot_title":
-                ws_msg = json.dumps(
-                    {"type": "slot_title", "data": {"key": note["key"], "title": note["title"]}}
-                )
+                ws_data = {"key": note["key"], "title": note["title"]}
+                ws_msg = json.dumps({"type": "slot_title", "data": ws_data})
             elif msg_type == "refresh":
-                ws_msg = json.dumps(
-                    {"type": "refresh", "data": {"kinds": note["kinds"].split(",")}}
-                )
+                ws_data = {"kinds": note["kinds"].split(",")}
+                ws_msg = json.dumps({"type": "refresh", "data": ws_data})
             elif msg_type == "update_progress":
-                ws_msg = json.dumps(
-                    {
-                        "type": "update_progress",
-                        "data": {"step": note["step"], "detail": note.get("detail", "")},
-                    }
-                )
+                ws_data = {"step": note["step"], "detail": note.get("detail", "")}
+                ws_msg = json.dumps({"type": "update_progress", "data": ws_data})
             elif msg_type == "artifact_update":
                 # Typed envelope (not the generic `notification` fallback) so
                 # useWebSocket and future consumers get a self-documenting
                 # event: {slug, version, deleted}.
-                ws_msg = json.dumps(
-                    {
-                        "type": "artifact_update",
-                        "data": {
-                            "slug": note["slug"],
-                            "version": note.get("version", 0),
-                            "deleted": note.get("deleted", False),
-                        },
-                    }
-                )
+                ws_data = {
+                    "slug": note["slug"],
+                    "version": note.get("version", 0),
+                    "deleted": note.get("deleted", False),
+                }
+                ws_msg = json.dumps({"type": "artifact_update", "data": ws_data})
             elif msg_type == "session_summary":
                 # Typed envelope, for the same reason as artifact_update above.
                 # Without it this event falls into the generic `notification`
@@ -5337,9 +5399,8 @@ class DashboardState:
                 # the push-on-change design that lets the panel skip polling),
                 # and the payload is dispatched as a Notification, putting one
                 # entry with no `ts` in the bell feed.
-                ws_msg = json.dumps(
-                    {"type": "session_summary", "data": {"key": note["key"]}}
-                )
+                ws_data = {"key": note["key"]}
+                ws_msg = json.dumps({"type": "session_summary", "data": ws_data})
             elif msg_type == "chat_message":
                 chat_data: dict[str, Any] = {
                     "slot": note["slot"],
@@ -5352,10 +5413,12 @@ class DashboardState:
                     chat_data["cls"] = note["cls"]
                 if note.get("meta"):
                     chat_data["meta"] = note["meta"]
+                ws_data = chat_data
                 ws_msg = json.dumps({"type": "chat_message", "data": chat_data})
             else:
+                ws_data = note
                 ws_msg = json.dumps({"type": "notification", "data": note})
-            self._send_ws_all(ws_msg)
+            self._send_ws_all(msg_type, ws_data, ws_msg)
 
     def _spawn_ws_send(self, ws: web.WebSocketResponse, msg: str) -> None:
         """Fire-and-forget a WS send while retaining a strong task reference.
@@ -5386,15 +5449,169 @@ class DashboardState:
         if exc is not None:
             logger.debug("WS send failed (client likely disconnected): %s", exc)
 
-    def _send_ws_all(self, msg: str) -> None:
-        """Send a pre-serialized JSON string to all WS clients."""
+    def _ws_client_allowed(
+        self, ws: web.WebSocketResponse, msg_type: str, data: object
+    ) -> bool:
+        """Return True if *ws* should receive an event with *msg_type* / *data*.
+
+        Deny-by-default (CWE-269): every non-dashboard-user connection is gated
+        through :func:`ws_event_scope.ws_event_allowed`. Dashboard-user tokens
+        are identified by the POSITIVE ``_is_dashboard_user`` flag set by
+        ``api_ws`` — never by the absence of ``_app``, which would fail OPEN on
+        any register path that forgot to set it.
+        """
+        if ws.get("_is_dashboard_user", False):
+            return True
+        ws_app: str = ws.get("_app", "")
+        snapshot: frozenset[str] = ws.get("_allowed_events", frozenset())
+        _data_dict: dict = data if isinstance(data, dict) else {}
+        try:
+            # circular import: ws_event_scope references SlotOrigin from this
+            # module at type-check time and reads ``state._slots`` at runtime,
+            # so a top-level import here would create a bootstrap cycle.
+            from kiro_crew.dashboard.ws_event_scope import (
+                _audit_deny,
+                effective_allowed_events,
+                ws_event_allowed,
+            )
+
+            # The connect-time snapshot can only SHRINK from here: a narrowed or
+            # deleted manifest has to stop granting scopes on a socket that is
+            # already open, and this is the one place every decision reads them.
+            allowed = effective_allowed_events(ws_app, snapshot)
+
+            return ws_event_allowed(
+                msg_type,
+                _data_dict,
+                app=ws_app,
+                allowed_events=allowed,
+                state=self,
+            )
+        except Exception:
+            # The scope check itself failed — fail closed AND audit, so probing
+            # for scope-check bugs leaves a trail.
+            try:
+                _audit_deny(ws_app or "<unknown>", msg_type, "scope_check_exception")
+            except Exception as inner_exc:
+                logger.debug(
+                    "state: audit for scope_check_exception failed for %s/%s: %s",
+                    ws_app,
+                    msg_type,
+                    inner_exc,
+                )
+            return False
+
+    def _serialize_for_client(
+        self, ws: web.WebSocketResponse, msg_type: str, data: object, default_msg: str
+    ) -> str:
+        """Return the wire message to send to *ws*.
+
+        Most events go to every client as ``default_msg`` verbatim. The
+        ``slots`` event carries the full slot list, so an app token that
+        declared only ``slots:own`` would otherwise see every slot's metadata
+        on each re-push (CWE-269). Re-filter the list per app here so the
+        manifest scope is enforced on broadcast re-pushes, not only at connect.
+        """
+        if ws.get("_is_dashboard_user", False):
+            return default_msg
+        if msg_type in ("subagent_batch_update", "subagent_batch_chunks"):
+            return self._serialize_subagent_batch(ws, msg_type, data, default_msg)
+        if msg_type != "slots":
+            return default_msg
+        if not isinstance(data, dict) or "slots" not in data:
+            # Not the expected envelope shape — nothing to filter here; the
+            # gate has already applied deny-by-default.
+            return default_msg
+        snapshot: frozenset[str] = ws.get("_allowed_events", frozenset())
+        ws_app: str = ws.get("_app", "")
+        try:
+            # circular import: see _ws_client_allowed above.
+            from kiro_crew.dashboard.ws_event_scope import (
+                effective_allowed_events,
+                filter_slots_for_app,
+                slots_envelope_extras,
+            )
+
+            # Same live-narrowing read as the gate: filtering the payload with a
+            # stale snapshot would hand back the slots a revoked scope covered.
+            allowed = effective_allowed_events(ws_app, snapshot)
+            filtered = filter_slots_for_app(data["slots"], ws_app, allowed, self)
+            # The ENVELOPE needs its own decision: the slot filter narrows
+            # ``data`` only, and this frame also carries global safety-posture
+            # booleans (``yolo`` / ``channelTrusted``) that no slot scope covers.
+            extras = slots_envelope_extras(allowed, yolo=bool(data.get("yolo", False)))
+        except Exception:
+            # Fail closed: send an empty list rather than the unfiltered payload,
+            # and drop the posture fields rather than defaulting them.
+            filtered = []
+            extras = {}
+        return json.dumps({"type": "slots", "data": filtered, **extras})
+
+    def _serialize_subagent_batch(
+        self,
+        ws: web.WebSocketResponse,
+        msg_type: str,
+        data: object,
+        default_msg: str,
+    ) -> str:
+        """Filter a coalesced subagent batch frame per app token.
+
+        Above the coalescer threshold ONE frame carries MANY subagents' rows, so
+        it has no single ``slot`` the event-scope gate could judge it by. The
+        gate therefore admits it and the per-item filtering happens here —
+        mirroring the ``slots`` re-push split — so an app receives only the rows
+        for subagents it may see instead of every running agent's status and
+        output (CWE-269).
+        """
+        # circular import: see _ws_client_allowed above — ws_event_scope imports
+        # DashboardState for typing, so this stays function-local.
+        from kiro_crew.dashboard.ws_event_scope import (
+            _SUBAGENT_BATCH_ITEM_KEY,
+            filter_subagent_batch_for_app,
+        )
+
+        key = _SUBAGENT_BATCH_ITEM_KEY.get(msg_type, "")
+        if not key or not isinstance(data, dict) or not isinstance(data.get(key), list):
+            # Unexpected envelope shape — fail closed rather than forwarding it
+            # unfiltered, matching the slots branch.
+            return json.dumps({"type": msg_type, "data": {key or "items": []}})
+        snapshot: frozenset[str] = ws.get("_allowed_events", frozenset())
+        ws_app: str = ws.get("_app", "")
+        try:
+            # Live-narrowed like the gate and the slots branch: a revoked
+            # subagent scope must stop selecting rows on an open socket too.
+            from kiro_crew.dashboard.ws_event_scope import effective_allowed_events
+
+            allowed = effective_allowed_events(ws_app, snapshot)
+            items = filter_subagent_batch_for_app(
+                data[key], ws_app, allowed, self, msg_type=msg_type
+            )
+        except Exception:
+            self._log.warning(
+                "subagent batch filter failed; dropping items", exc_info=True
+            )
+            items = []
+        return json.dumps({"type": msg_type, "data": {key: items}})
+
+    def _send_ws_all(self, msg_type: str, data: object, msg: str) -> None:
+        """Send a typed message to all WS clients.
+
+        This is the single chokepoint for every WS fan-out that can reach an app
+        token (both :meth:`broadcast_ws` and :meth:`_broadcast`). Each
+        connection is checked against :meth:`_ws_client_allowed`; only
+        dashboard-user tokens bypass the scope gate. Payload-level per-app
+        filtering (currently just ``slots``) happens in
+        :meth:`_serialize_for_client`.
+        """
         dead: list[web.WebSocketResponse] = []
         for ws in list(self._ws_clients):
             if ws.closed:
                 dead.append(ws)
                 continue
+            if not self._ws_client_allowed(ws, msg_type, data):
+                continue
             try:
-                self._spawn_ws_send(ws, msg)
+                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
             except Exception:
                 dead.append(ws)
         for ws in dead:
@@ -5415,11 +5632,15 @@ class DashboardState:
             self._remove_ws(ws)
 
     def broadcast_ws(self, msg_type: str, data: object) -> None:
-        """Send a typed message to all WS clients (not SSE)."""
+        """Send a typed message to all WS clients (not SSE).
+
+        Per-app event scope filtering is applied inside :meth:`_send_ws_all`
+        (the single chokepoint for WS fan-out).
+        """
         if not self._ws_clients:
             return
         msg = json.dumps({"type": msg_type, "data": data})
-        self._send_ws_all(msg)
+        self._send_ws_all(msg_type, data, msg)
 
     def broadcast_context_usage(self, slot_key: str, payload: dict) -> None:
         """Broadcast one ``context_usage`` frame AND record it as the slot's snapshot.
@@ -5689,7 +5910,13 @@ class DashboardState:
         self._ws_subagent_subscribers.discard(ws)
 
     def broadcast_ws_subagent_subscribers(self, msg_type: str, data: object) -> None:
-        """Send to subagent-subscribed clients only (for heavy chunk data)."""
+        """Send to subagent-subscribed clients only (for heavy chunk data).
+
+        A second fan-out path parallel to :meth:`broadcast_ws`, used for
+        high-volume ``subagent_chunk`` traffic. It applies the SAME per-app
+        scope gate via :meth:`_ws_client_allowed`, so an app token cannot
+        bypass filtering just by sending ``{"type": "subscribe_subagents"}``.
+        """
         if not self._ws_subagent_subscribers:
             return
         msg = json.dumps({"type": msg_type, "data": data})
@@ -5698,8 +5925,10 @@ class DashboardState:
             if ws.closed:
                 dead.append(ws)
                 continue
+            if not self._ws_client_allowed(ws, msg_type, data):
+                continue
             try:
-                self._spawn_ws_send(ws, msg)
+                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
             except Exception:
                 dead.append(ws)
         for ws in dead:

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1240,6 +1240,34 @@ def _api_pattern_matches(pattern: str, path: str) -> bool:
     return path == pattern or path.startswith(pattern + "/")
 
 
+# Protocol-layer paths every app token implicitly needs — connection
+# infrastructure, not feature-level permissions. Requiring each app to declare
+# them in ``permissions.api`` adds no security value and produces silent 403
+# regressions whenever a new app forgets to list them.
+#
+# ``/api/ws`` is safe to allow implicitly ONLY because the WS layer now applies
+# per-app event scope filtering (``ws_event_scope.py``): a connected app token
+# receives just the events matching its ``permissions.events`` declarations, so
+# connecting no longer grants the full event stream. Contrast with functional
+# paths like /api/chat/* or /api/spawn/* — those grant real capabilities and
+# MUST stay explicitly declared.
+#
+# ``/api/status`` is deliberately NOT here. It has no response-level filter to
+# match what event scoping does for ``/api/ws``, and ``api_status`` returns far
+# more than liveness: ``owner_id_hash``, host specs (os/arch/cpu/memory), cron
+# and usage stats, and the live safety-override (``yolo_*``) state. The
+# connect/reconnect poll that needs it is the DASHBOARD SPA
+# (``useDashboardHealthProbe``), which runs on a dashboard-user token and never
+# reaches this list. An app that genuinely wants it declares it in
+# ``permissions.api`` — the shipped ``design_critique`` manifest does.
+_APP_TOKEN_IMPLICIT_ALLOW: frozenset[str] = frozenset({
+    # Connecting grants no events by itself: the socket records the caller's
+    # manifest declarations and every frame is filtered per socket, payload AND
+    # envelope, in ws_event_scope.py / DashboardState._serialize_for_client.
+    "/api/ws",
+})
+
+
 def app_token_path_allowed(app_name: str, path: str) -> bool:
     """Return True if an app token for *app_name* may access *path*.
 
@@ -1251,6 +1279,30 @@ def app_token_path_allowed(app_name: str, path: str) -> bool:
         # it does, do NOT silently grant — that would turn the gate into a
         # no-op allow. Return False; the caller's non-empty guard is primary.
         return False
+    if path in _APP_TOKEN_IMPLICIT_ALLOW:
+        # Audit implicit grants so every app-token path decision is in the trail.
+        try:
+            _sel_fn().log_api_access(
+                caller=app_name,
+                operation="app_scope_check",
+                outcome="granted_implicit",
+                source="token_auth",
+                resources=path,
+            )
+        except Exception as exc:
+            # Security-relevant audit path (CWE-269 implicit grant); a persistent
+            # SEL misconfiguration must be observable, so log rather than pass.
+            logger.debug(
+                # Message deliberately avoids the module-name prefix: Semgrep's
+                # logger-credential-disclosure heuristic fires on the substring
+                # alone. The logged values are an app name, a path, and an
+                # exception -- no secret material.
+                "SEL audit for implicit app-scope allow %s -> %s failed: %s",
+                app_name,
+                path,
+                exc,
+            )
+        return True
     if _app_owns_path(app_name, path):
         return True
     # Notification push (RFC local notification bus, Phase 2): every app may
@@ -1702,6 +1754,9 @@ def token_auth_middleware(
             # Expose identity so downstream handlers (and app-scope) see it.
             request["user"] = _uid
             request["app"] = _app
+            # POSITIVE dashboard-user signal for the WS scope gate: the WS
+            # layer must never infer trust from a falsy app claim (CWE-269).
+            request["is_dashboard_user"] = not _app
             # App tokens are confined to their declared scope even on internal
             # paths (e.g. /api/chat, /api/spawn are mixed_internal) — otherwise
             # an app token would reach them on loopback with NO app identity set
@@ -1774,6 +1829,9 @@ def token_auth_middleware(
                 # (same rationale as the loopback branch above).
                 request["user"] = _uid
                 request["app"] = _app
+                # POSITIVE dashboard-user signal for the WS scope gate (see
+                # the loopback branch above).
+                request["is_dashboard_user"] = not _app
                 _scope_deny = _enforce_app_scope(request, _app, path)
                 if _scope_deny is not None:
                     return _scope_deny
@@ -2026,6 +2084,8 @@ def token_auth_middleware(
         # Expose authenticated identity to handlers (deny-by-default)
         request["user"] = user_id
         request["app"] = app_name
+        # POSITIVE dashboard-user signal for the WS scope gate (see above).
+        request["is_dashboard_user"] = not app_name
 
         # App-token least-privilege gate (CWE-269): an app token is confined to
         # its own namespace + its manifest ``permissions.api`` allowlist. This

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -8,13 +8,21 @@ import logging
 import sys
 import time
 
-from aiohttp import WSMsgType, web
+from aiohttp import WSCloseCode, WSMsgType, web
 
 from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
 from kiro_crew.dashboard.chat_utils import effective_session_key, subagent_event_slot
 from kiro_crew.dashboard.origin import check_origin
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.ws_event_scope import (
+    _audit_allow,
+    _audit_deny,
+    effective_allowed_events,
+    filter_slots_for_app,
+    load_declared_events_for_connect,
+    slots_envelope_extras,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -29,6 +37,29 @@ SUBAGENT_REPLAY_BATCH_THRESHOLD = 8
 SIDE_RESULT_EVENT = "chat.side_result"
 SIDE_QUEUE_EVENT = "chat.side_queue"
 SIDE_KIND = "side"
+
+
+def _audit_grant_quietly(app: str, event: str) -> None:
+    """Record a WS grant made on a path that bypasses the broadcast chokepoint.
+
+    Three sends reach an app socket directly rather than through
+    ``_send_ws_all`` -- the initial slots push (specifically its ``yolo``
+    envelope field), the periodic ``dashboard`` status frame, and the
+    ``subscribe_logs`` ring replay -- so ``ws_event_allowed`` never sees them
+    and none of them would otherwise leave an SEL record, even though each is
+    a permission decision ``AUTOSDE.yaml`` requires one for.
+
+    One helper rather than the same ``try``/``except`` inlined at each site:
+    the swallow is the load-bearing part and needs to behave identically
+    everywhere. A failing audit sink must never drop a frame the app is
+    entitled to, so the exception is logged and delivery continues -- and
+    having a single copy means that branch is exercised by one test instead of
+    being three separate never-executed paths.
+    """
+    try:
+        _audit_allow(app or "<unknown>", event)
+    except Exception:
+        logger.debug("ws: SEL audit for %s grant failed", event, exc_info=True)
 
 
 async def _load_status_counts(state: DashboardState) -> tuple[int, int]:
@@ -263,16 +294,90 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
     except Exception:
         logger.debug("GitLab allowlist warm-up failed; chips may lag one round", exc_info=True)
 
+    # Resolve the app token's scope BEFORE registering, and refuse a disabled app
+    # outright. ``disable_app`` does not invalidate the app token (``token_auth``
+    # has no enablement check), so a disabled app can reconnect at will — and
+    # reading only ``app.json`` here would hand it a FULL snapshot from the intact
+    # manifest, which the initial slots push and the log replay are then judged
+    # against before any background refresh runs. The read also primes the
+    # revocation cache, so the first frame is gated on an authoritative answer
+    # rather than on the cold-miss fallback.
+    #
+    # Refusing (rather than admitting at Tier 0, which is what an ALREADY-OPEN
+    # socket narrows to) is free here: at connect there is no in-flight streaming
+    # turn to cut, which was the reason narrowing does not close live sockets.
+    #
+    # Done BEFORE register_ws for the same reason as the warm-up above: this
+    # awaits, and refusing after registration would need the cleanup scope that
+    # the finally below only establishes once registration succeeds.
+    ws_app: str = request.get("app", "")
+    allowed_events: frozenset[str] = frozenset()
+    if ws_app:
+        try:
+            # The load stats + reads + JSON-parses the manifest with no internal
+            # cache, so it is offloaded: this runs for EVERY app WS connect (and
+            # reconnect storms are the norm after a gateway restart), and on slow
+            # or contended storage a blocking read here stalls every other
+            # request and the heartbeat with it.
+            app_enabled, allowed_events = await asyncio.to_thread(
+                load_declared_events_for_connect, ws_app
+            )
+        except Exception:
+            # Indeterminate — do not refuse on a read error (that would drop a
+            # working app over a transient filesystem fault), but grant nothing:
+            # every declared scope is withheld and only Tier 0 gets through.
+            logger.debug("ws: could not resolve scope for app %r", ws_app, exc_info=True)
+            app_enabled, allowed_events = True, frozenset()
+        if not app_enabled:
+            logger.info("ws: refusing /api/ws for disabled app %r", ws_app)
+            await ws.close(code=WSCloseCode.POLICY_VIOLATION, message=b"app disabled")
+            return ws
+
     state.register_ws(ws, owner=owner_request)
 
+    # Store app identity on the WS connection so the broadcast chokepoint can
+    # filter. ``_is_dashboard_user`` comes from a POSITIVE signal produced by
+    # the auth middleware (``request["is_dashboard_user"]``) — it is never
+    # inferred from the absence of ``_app`` here. If a refactor reaches
+    # ``api_ws`` without passing through that middleware, the flag defaults to
+    # False and ``_send_ws_all`` keeps its deny-by-default behaviour.
+    ws["_app"] = ws_app
+    ws["_is_dashboard_user"] = request.get("is_dashboard_user", False)
+    ws["_allowed_events"] = allowed_events
+
     # Push current slots immediately so sidebar populates without waiting.
+    # App tokens get only the slots their manifest scope allows.
     try:
-        slots_data = state.serialize_slots(include_check_status=owner_request)
+        all_slots = state.serialize_slots(include_check_status=owner_request)
+        if ws.get("_is_dashboard_user", False):
+            slots_data = all_slots
+        elif ws_app:
+            slots_data = filter_slots_for_app(all_slots, ws_app, allowed_events, state)
+        else:
+            # Unknown identity (neither flag nor app) — deny by default.
+            slots_data = []
+        # ``yolo`` is the live blanket-approval override, i.e. operator security
+        # posture rather than slot data, so an app token sees it only with the
+        # scope that already gates ``yolo_expired``. Dashboard users always do.
+        # Same decision as the broadcast re-push in
+        # ``DashboardState._serialize_for_client`` — routed through the gate's
+        # helper so the two cannot drift.
+        envelope_extras: dict[str, object] = (
+            {"yolo": state._yolo}
+            if ws.get("_is_dashboard_user", False)
+            else dict(slots_envelope_extras(allowed_events, yolo=state._yolo))
+        )
+        if not ws.get("_is_dashboard_user", False) and "yolo" in envelope_extras:
+            # Handing an app token the live blanket-approval override is a
+            # grant of operator security posture, not slot data, and this
+            # initial push writes to the socket directly -- so record it here
+            # or it goes unrecorded entirely.
+            _audit_grant_quietly(ws_app, "slots_yolo")
         await ws.send_json(
             {
                 "type": "slots",
                 "data": slots_data,
-                "yolo": state._yolo,
+                **envelope_extras,
                 # Seed the client's generation baseline so a later change is
                 # detectable as a change rather than as a first sighting.
                 "gitlabHostsGeneration": gitlab_hosts_generation(),
@@ -317,6 +422,26 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                     "version": _local_version,
                     "platform": sys.platform,
                 }
+                if not ws.get("_is_dashboard_user", False):
+                    # This frame is Tier 0 — always delivered, because every
+                    # client needs the version (to force a reload across a
+                    # gateway upgrade) and the liveness signal. That only holds
+                    # while the payload stays counts-and-environment: the
+                    # checkout's branch and commit say what the operator is
+                    # working ON, which is not an app's business and has no
+                    # consumer outside the owner surfaces. Strip them here
+                    # rather than moving the whole frame behind a declaration,
+                    # which would silently cut every existing app off from the
+                    # version signal. ``/api/status`` and the SSE stream run on
+                    # dashboard-user tokens and keep the full snapshot.
+                    for _owner_only in ("branch", "commit"):
+                        data.pop(_owner_only, None)
+                    # Tier 0 admits every app unconditionally, but the decision
+                    # is still a grant per ``AUTOSDE.yaml`` -- this frame is
+                    # sent directly rather than through the broadcast
+                    # chokepoint, so nothing else records it. The dedup window
+                    # already bounds the 5-second interval to one record.
+                    _audit_grant_quietly(ws_app, "dashboard")
                 try:
                     await ws.send_json({"type": "dashboard", "data": data})
                 except Exception:
@@ -384,6 +509,42 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                     data = json.loads(msg.data)
                     msg_type = data.get("type", "")
                     if msg_type == "subscribe_logs":
+                        # The gateway log stream is privileged. The broadcast
+                        # chokepoint filters future ``log`` events, but the
+                        # ring-buffer replay below bypasses it — gate at the
+                        # source. Positive-flag check (CWE-269): a falsy
+                        # ``_app`` alone must not open this.
+                        # Accept `log:all` as well. The per-event chokepoint
+                        # takes `<decl>` OR `<decl>:all`, so declaring
+                        # `log:all` let LIVE log events through while this
+                        # replay gate -- checking only the bare form -- refused
+                        # the buffered history: same declaration, two answers.
+                        # Resolve the LIVE scope, not the connect-time snapshot:
+                        # this replays the whole ring, so a scope revoked (or an
+                        # app disabled) after connect must not be able to pull
+                        # the buffered history. Mirrors the per-send re-check in
+                        # handlers/updates._safe_ws_send.
+                        _live = effective_allowed_events(ws_app, allowed_events)
+                        if not ws.get("_is_dashboard_user", False) and not (
+                            "log" in _live or "log:all" in _live
+                        ):
+                            try:
+                                _audit_deny(
+                                    ws_app or "<unknown>",
+                                    "subscribe_logs",
+                                    "log_scope_not_declared",
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "ws: SEL audit for subscribe_logs deny failed",
+                                    exc_info=True,
+                                )
+                            continue
+                        if not ws.get("_is_dashboard_user", False):
+                            # Mirror the deny branch above: the grant is a
+                            # permission decision too, and only the deny side
+                            # left an SEL record before this.
+                            _audit_grant_quietly(ws_app, "subscribe_logs")
                         state.subscribe_logs(ws)
                         # Replay log ring buffer
                         for entry in list(_log_ring):
@@ -395,6 +556,17 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                     elif msg_type == "unsubscribe_logs":
                         state.unsubscribe_logs(ws)
                     elif msg_type == "subscribe_subagents":
+                        # No declaration-level gate here on purpose. Owning
+                        # your own slots is the DEFAULT, not something a
+                        # manifest opts into, so refusing the subscription when
+                        # nothing matched ``subagent*``/``slots:*`` starved an
+                        # app of its OWN slot's replay — the one thing it is
+                        # always entitled to. Every replay frame below still
+                        # goes through the per-frame gate, which is where the
+                        # scope decision belongs; a subscription that is
+                        # allowed to exist but yields nothing visible is the
+                        # correct shape for an app that declared no extra
+                        # scope.
                         state.subscribe_subagents(ws)
 
                         def _r(t: str) -> str:
@@ -515,8 +687,28 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                                     )
                                 except Exception:
                                     pass
+                        # Per-slot scope gate on the reconnect replay. The
+                        # broadcast chokepoint covers live events, but this
+                        # replay writes to the socket directly, so it must
+                        # apply the same check. Dashboard users pass through
+                        # ``_ws_client_allowed`` unconditionally.
+                        _replay = [
+                            _f
+                            for _f in _replay
+                            if state._ws_client_allowed(
+                                ws, str(_f.get("type", "")), _f.get("data", {})
+                            )
+                        ]
                         try:
                             if len(_replay) > SUBAGENT_REPLAY_BATCH_THRESHOLD:
+                                # ``subagent_snapshot_batch`` is deliberately
+                                # absent from every ws_event_scope table: it is
+                                # delivery packaging for frames THIS socket is
+                                # already cleared for (filtered item-by-item
+                                # above), never a broadcast. Routing it through
+                                # the gate would reject it as an unknown event
+                                # and cost the app its whole replay, so keep
+                                # this send and the per-item filter together.
                                 await ws.send_json(
                                     {"type": "subagent_snapshot_batch", "data": {"items": _replay}}
                                 )

--- a/src/kiro_crew/dashboard/ws_event_scope.py
+++ b/src/kiro_crew/dashboard/ws_event_scope.py
@@ -1,0 +1,1112 @@
+"""Per-app WebSocket event scope enforcement.
+
+App tokens connected to /api/ws must only receive events they are authorised to
+see, based on the ``permissions.events`` declarations in their ``app.json``.
+
+
+## Event tiers
+
+Tier 0 — always delivered to every connected client (no sensitive payload):
+    ``dashboard``  — gateway status snapshot (version, cron count, etc.)
+
+Tier 1 — slot-scoped: delivered only when the calling app is allowed to see the
+    slot that the event belongs to.  All events carrying a ``slot`` field fall into
+    this tier.  Visibility is controlled by the ``slots:*`` and ``subagent:*``
+    declarations in ``permissions.events`` (see below).
+
+Tier 2 — global events with no ``slot`` field.  An app must explicitly list the
+    event name (or a wildcard scope) in ``permissions.events`` to receive it.
+
+## Slot visibility scopes (``slots:*``)
+
+Declaration             Slots visible
+─────────────────────────────────────────────────────────
+(default / slots:own)   Only slots where owner_app == self
+slots:user              All slots where origin == SlotOrigin.USER
+slots:app:<name>        Slots owned by ``<name>`` — requires ``<name>`` to
+                        declare this app in its ``exposeToApps`` list
+slots:all               All slots (broad -- see the note on self-declaration below)
+
+The same scope also controls which slot-scoped subagent events are visible.
+The ``subagent:*`` declarations are an independent, additive dimension:
+
+Declaration             Subagent events visible (overrides slots:* for subagent events)
+─────────────────────────────────────────────────────────────────────────────────────────
+(default / subagent)    Own slots only (same as slots:own)
+subagent:user           Subagents in user-initiated slots
+subagent:app:<name>     Subagents in <name>'s slots (requires exposeToApps opt-in)
+subagent:all            All subagent events (broad)
+
+## Global event declarations (``permissions.events``)
+
+notification            Own app's notifications (source_app == self) only.
+                        Foreign and system-sourced notifications still denied.
+notification:system     Gateway-internal pushes with no source_app -- cron
+                        results, send_message, watchlist output. Separate from
+                        ``notification`` because that stream is user content
+                        rather than the app's own: bundling them would make
+                        one declaration a broad grant, the very shape this
+                        module exists to remove.
+notification_ack / notification_unack carry only a timestamp, so they cannot be
+attributed to a source at all and need `notification:all`.
+notifications_clear carries no payload at all -- it fires when the WHOLE log is
+cleared, not one app's slice -- so it needs `notification:all` for the same reason.
+notification_channel_settings IS attributable -- its channel is `<app>.<id>` or
+`system.<kind>` -- so own-channel settings ride `notification`, system channels
+ride `notification:system`, and foreign channels need `notification:all`.
+notification:all        All notifications regardless of source (broad).
+sessions                sessions_restarting
+yolo                    yolo_expired
+artifacts               artifact_update ({slug, version, deleted}; metadata only)
+workflow_run_event      Declared by its own literal name -- already the correct
+                        per-event Tier 2 shape, and the only events declaration
+                        present in the tree today (the workflows app).
+log                     Gateway log stream (broad)
+browser                 browser_event (broad)
+
+## Scope declarations are SELF-declared
+
+Every scope above is read from the app's own ``app.json``. Nothing in this module
+consults an install-time approval, so an app can widen itself by writing
+``slots:all`` into its manifest -- which is consistent with the trust model
+(installing an app already grants it in-process gateway privilege) but means the
+tiers are a *structuring* mechanism plus an audit trail, not a barrier against a
+hostile manifest. The one asymmetric check is ``exposeToApps``: cross-app
+visibility requires consent from the app being observed, because there the
+manifest being trusted is not the one being widened.
+
+Gating the broad scopes through the install-time consent path
+(``apps/admission.py``) is tracked separately.
+
+## Dashboard users (empty app claim) are unaffected — full event stream as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+# circular import: apps.manager imports config helpers that transitively pull
+# in ``kiro_crew.dashboard.state``; keeping ``get_app_manifest`` at module
+# scope requires it to load after this module's own definitions are visible,
+# which the current import order satisfies (state.py imports us lazily inside
+# broadcast_ws, and ws.py imports us before apps.manager). Kept top-level per
+# the top-level-imports guideline.
+from kiro_crew.apps.manager import get_app_manifest, is_app_enabled
+
+if TYPE_CHECKING:
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SEL audit deduplication — WS broadcast is a hot path.  A misconfigured app
+# spamming reconnects could otherwise emit tens of thousands of identical
+# deny audits per minute and drown out real signal.  We instead guarantee
+# *at least one* audit per (app, event_type, reason) tuple per window, which
+# gives per-scenario observability with bounded volume.  Repeated denies of
+# the same pair within the window are counted and the tally rides the NEXT
+# emitted record (``suppressed=N``), so the trail keeps the volume signal a
+# burst carries without one record per frame: this gate runs per event PER
+# CONNECTED CLIENT on the broadcast hot path, so a streaming response alone is
+# chunks x clients decisions.
+# ---------------------------------------------------------------------------
+
+_SEL_DEDUP_WINDOW_SECS = 300.0  # 5 minutes
+#: (app, event_type, reason) -> (last emitted monotonic ts, denies suppressed since)
+_sel_last_audit: dict[tuple[str, str, str], tuple[float, int]] = {}
+
+
+def _audit_decision(app: str, event_type: str, outcome: str, dedup_reason: str) -> None:
+    """Emit a deduplicated SEL audit event for one WS authorization decision.
+
+    ``AUTOSDE.yaml`` (``backend-security-controls``) requires a SEL event for
+    every permission decision, which includes the grants, not only the refusals.
+    A WS decision is made per client per frame, so an un-deduplicated record per
+    grant would be an unbounded write on the broadcast path — hence the same
+    window that already collapses deny floods.
+
+    Guaranteed to emit at least once per (app, event_type, *dedup_reason*) tuple
+    per ``_SEL_DEDUP_WINDOW_SECS`` window, so a sustained pattern stays
+    observable while bursts collapse into one record carrying the suppressed
+    count. Grants and denials use different *dedup_reason* values, so one never
+    starves the other out of the window.
+    """
+    key = (app, event_type, dedup_reason)
+    now = time.monotonic()
+    entry = _sel_last_audit.get(key)
+    if entry is not None and (now - entry[0]) < _SEL_DEDUP_WINDOW_SECS:
+        # Still inside the window: record that one more identical decision
+        # happened so the next emitted audit can report the true volume.
+        _sel_last_audit[key] = (entry[0], entry[1] + 1)
+        return
+    suppressed = entry[1] if entry is not None else 0
+    _sel_last_audit[key] = (now, 0)
+    try:
+        # circular import: sel.py loads config that transitively pulls in
+        # ``kiro_crew.dashboard`` submodules — import lazily.
+        from kiro_crew.sel import sel as _sel
+        _sel().log_api_access(
+            caller=app,
+            operation="ws_event_scope",
+            outcome=outcome,
+            source="ws_event_scope",
+            resources=(
+                f"{event_type} (suppressed={suppressed})" if suppressed else event_type
+            ),
+        )
+    except Exception as exc:
+        logger.debug(
+            "ws_event_scope: SEL audit for %s %s/%s failed: %s",
+            outcome, app, event_type, exc,
+        )
+
+
+def _audit_deny(app: str, event_type: str, reason: str) -> None:
+    """Record a denied WS event, keyed by the reason it was denied."""
+    _audit_decision(app, event_type, f"denied:{reason}", reason)
+
+
+def _audit_allow(app: str, event_type: str) -> None:
+    """Record a granted WS event.
+
+    The granting BRANCH is deliberately not part of the record. Threading it out
+    of every ``return True`` would put the burden on each future branch to
+    remember to report itself, which is the failure mode this module keeps
+    designing away from — the decision is audited at the one chokepoint instead
+    (see :func:`ws_event_allowed`). What an operator needs from this record is
+    which app received which event; which declaration earned it is a manifest
+    lookup away.
+    """
+    _audit_decision(app, event_type, "granted", "granted")
+
+
+# ---------------------------------------------------------------------------
+# Events that are always delivered regardless of app scope (no sensitive data)
+# ---------------------------------------------------------------------------
+
+_TIER0_ALWAYS = frozenset({
+    "dashboard",
+    # Dashboard-wide progress signals with no user data.
+    "refresh",
+    "update_progress",
+})
+
+# ---------------------------------------------------------------------------
+# Slot-scoped event types: events that carry a ``slot`` key and are
+# subject to slot-visibility filtering.  Subagent events are a subset.
+# ---------------------------------------------------------------------------
+
+_SLOT_SCOPED_EVENTS = frozenset({
+    # Chat content
+    "chat_chunk", "chat_thinking", "chat_status", "chat_message", "chat_done",
+    "chat_segment", "chat_append", "chat_message_update", "chat_variant_switch",
+    # Side-conversation channel (``broadcast_side_result``); carries ``slot``.
+    "chat.side_result",
+    "heartbeat", "context_usage",
+    # Tool / queue
+    "tool_call", "tool_result",
+    "queue_push", "queue_cancel", "queue_edit", "queue_pop", "queue_reorder",
+    "steer_push",
+    # Slot metadata / lifecycle
+    "slot_title", "slot_clear", "slot_agent_switch", "todo_update",
+    "activity_event", "session_summary",
+    # Voice
+    "voice_chunk", "voice_complete", "voice_error",
+    # Approvals and question cards (carry a slot field)
+    "approval", "approval_resolved", "question_card",
+    # Subagent lifecycle. Every one of these is fired through
+    # ``SubagentManager._fire_event`` and reaches the wire via
+    # ``broadcast_ws(etype, ...)`` with a VARIABLE etype (slack/gateway.py's
+    # ``_subagent_event``), so a guard that scans broadcast call sites for string
+    # literals cannot see them -- ``TestFireEventNamesAreClassified`` reads the
+    # emitter's own literals instead. Each payload carries id + slot.
+    "subagent_spawn", "subagent_done", "subagent_tool", "subagent_chunk",
+    "subagent_snapshot", "subagent_status", "subagent_queued",
+    "subagent_stalled", "subagent_retrying", "subagent_recovering",
+    "subagent_injection_failed",
+    # Slack-gateway driven, slot-scoped
+    "autonudge_state", "batch_finished", "spawn_batch_started",
+    # Workflows / misc
+    "workflow_result_injected", "refine",
+})
+
+_SUBAGENT_EVENTS = frozenset({
+    "subagent_spawn", "subagent_done", "subagent_tool", "subagent_chunk",
+    "subagent_snapshot", "subagent_status", "subagent_queued",
+    "subagent_stalled", "subagent_retrying", "subagent_recovering",
+    "subagent_injection_failed",
+})
+
+#: Coalesced subagent frames emitted above ``SubagentEventCoalescer`` threshold
+#: (default 8 active subagents): ONE frame carries MANY subagents' rows, so
+#: there is no single top-level ``slot`` to scope it by. Left OUT of
+#: ``_SLOT_SCOPED_EVENTS`` deliberately — the gate admits the frame and
+#: ``DashboardState._serialize_for_client`` drops the individual items the app
+#: may not see (the same split already used for the ``slots`` re-push). The
+#: classification is what keeps them out of the unknown-event deny, which would
+#: cost an app all subagent status and output once the coalescer engages.
+_SUBAGENT_BATCH_EVENTS = frozenset({
+    "subagent_batch_update",
+    "subagent_batch_chunks",
+})
+
+#: Payload key holding the per-item list, per batch event type.
+_SUBAGENT_BATCH_ITEM_KEY = {
+    "subagent_batch_update": "updates",
+    "subagent_batch_chunks": "chunks",
+}
+
+# ---------------------------------------------------------------------------
+# Global event type → required declaration mapping
+# ---------------------------------------------------------------------------
+
+# Notification events whose delivery depends on WHO sent them, not just on the
+# declaration. ``notification_channel_settings`` is deliberately absent: it is
+# channel config ({muted, priority}) with no source_app, so source filtering
+# would deny it outright rather than scope it.
+# Only events whose payload actually CARRIES a source. `notification_ack` /
+# `notification_unack` broadcast a bare `{"ts": ...}` (see state.py), so they are
+# absent here: filtering by a field the payload never has is not a filter, and a
+# source-less frame would read as the system source. They are gated by their
+# plain `notification` declaration via `_GLOBAL_EVENT_DECLARATIONS` instead,
+# which is the strongest statement available for a payload that carries a
+# timestamp and nothing else.
+_SOURCE_FILTERED_EVENTS = frozenset({
+    "notification",
+})
+
+# The canonical `source` values a note can carry, set server-side and not
+# overridable from a request body:
+#   "system"      -- payload_from_legacy() / _deliver_note() in notifications/bus.py
+#   "app:<name>"  -- api_push_notification() in handlers/notifications_push.py
+# Kept as constants here rather than imported (bus.py's is private) with
+# `TestNotificationSourceParsing` pinning that the two agree.
+# Mirrors apps/event_bus.APP_EVENT_WS_TYPE. Kept local rather than imported so
+# the WS gate does not pull the app layer in at module scope;
+# `TestAppEventFrames` pins that the two agree.
+_APP_EVENT_WS_TYPE = "app_event"
+
+_SYSTEM_SOURCE = "system"
+_APP_SOURCE_PREFIX = "app:"
+
+
+#: Notification metadata that carries NO attribution -- a bare ``{"ts": ...}``
+#: (see state.py). Nothing in the payload says whose notification was acked, so
+#: own-only ``notification`` cannot be honoured for them and they take the broad
+#: scope. Allowing them on the plain declaration would grant an app the ack
+#: stream for every OTHER app's and the system's notifications.
+#: ``notifications_clear`` joins them for the same reason: it fires with an
+#: empty payload when the WHOLE log is cleared, not just this app's slice, so
+#: it cannot be judged "own" either.
+_UNATTRIBUTED_NOTIFICATION_EVENTS = frozenset({
+    "notification_ack",
+    "notification_unack",
+    "notifications_clear",
+})
+
+#: `<app>.<channel_id>` (handlers/notifications_push) or `system.<kind>`
+#: (notifications/bus SYSTEM_CHANNELS) -- the prefix names the owner.
+_CHANNEL_SETTINGS_EVENT = "notification_channel_settings"
+
+
+def notification_channel_owner(channel: str) -> str:
+    """The app (or "system") that owns a notification channel."""
+    return channel.split(".", 1)[0] if "." in channel else ""
+
+
+def notification_source_app(source: str) -> str:
+    """The app that produced a notification, or "" if it was not an app push.
+
+    The source is a CANONICAL, prefixed identity — `app:mochi`, never `mochi` —
+    so comparing it against a bare app name silently never matches.
+    """
+    if source.startswith(_APP_SOURCE_PREFIX):
+        return source[len(_APP_SOURCE_PREFIX):]
+    return ""
+
+
+_GLOBAL_EVENT_DECLARATIONS: dict[str, str] = {
+    "notification": "notification",
+    # Present so the completeness guard sees them classified -- the ACTUAL gate is
+    # the stricter branch in ws_event_allowed, which these never reach.
+    "notification_ack": "notification",
+    "notification_unack": "notification",
+    "notifications_clear": "notification",
+    # Channel mute/priority metadata only ({muted, priority}) -- same domain as
+    # the notification events themselves, so it rides the same declaration.
+    "notification_channel_settings": "notification",
+    "sessions_restarting": "sessions",
+    "yolo_expired": "yolo",
+    # Artifact metadata only ({slug, version, deleted}) -- no content, no slot.
+    "artifact_update": "artifacts",
+    # Metadata only ({slug, kind, target}) -- but a pending skill's slug names
+    # what the user is building, so it takes an explicit declaration rather
+    # than riding Tier 0. Same treatment as artifact_update above.
+    "skills.pending_changed": "skills",
+    # Declared by its own literal name: this is already the correct Tier 2
+    # shape (per-event opt-in), and it is the one declaration that exists in
+    # the tree today (the workflows app), so the name must not change.
+    "workflow_run_event": "workflow_run_event",
+    # Privileged
+    "log": "log",
+    "browser_event": "browser",
+}
+
+
+#: The ``slots`` frame is the one event whose ENVELOPE carries fields that are
+#: not part of the thing being filtered. ``data`` is the slot list, and
+#: ``_serialize_for_client`` re-filters that per app -- but the envelope also
+#: carries two GLOBAL safety-posture booleans that no slot filter can narrow:
+#:
+#:   ``yolo``           -- is the blanket approval override active right now
+#:   ``channelTrusted`` -- does any channel currently hold trust
+#:
+#: Both describe the operator's security posture, not the app's own slots, so
+#: re-emitting them verbatim would give every app token an undeclared live read
+#: of it on each re-push. ``yolo`` already HAS a scope in the
+#: vocabulary (it gates ``yolo_expired``), so it reuses that one rather than
+#: inventing a parallel name; ``channelTrusted`` has none and nothing in the app
+#: SDK reads it, so it is withheld from app tokens outright instead of growing
+#: the grant surface for a field with no consumer.
+_YOLO_SCOPE = _GLOBAL_EVENT_DECLARATIONS["yolo_expired"]
+
+
+def slots_envelope_extras(
+    allowed_events: frozenset[str], *, yolo: bool
+) -> dict[str, bool]:
+    """The envelope fields beyond ``data`` an app token may see on ``slots``.
+
+    Returns only the permitted keys -- an omitted key must be left OUT of the
+    envelope rather than sent as a falsy default: ``false`` is a factual claim
+    ("the override is off") that a client acts on, and the shipped client
+    already handles absence (it checks ``r.yolo !== undefined`` before it
+    dispatches). ``channelTrusted`` is never returned. Callers build the
+    envelope from this mapping instead of re-deriving the scope names, so the
+    gate stays the single source of truth for what a declaration buys.
+    """
+    if _YOLO_SCOPE in allowed_events or f"{_YOLO_SCOPE}:all" in allowed_events:
+        return {"yolo": yolo}
+    return {}
+
+
+# Everything the legacy ``"*"`` declaration grants. Derived from the tables
+# above rather than hand-listed, so a declaration added later is covered by the
+# wildcard automatically instead of being silently dropped from it.
+_WILDCARD_SCOPES: frozenset[str] = frozenset(
+    {"slots:all", "subagent:all", "notification:all", "notification:system"}
+    | set(_GLOBAL_EVENT_DECLARATIONS.values())
+    | {f"{d}:all" for d in _GLOBAL_EVENT_DECLARATIONS.values()}
+)
+
+
+# ---------------------------------------------------------------------------
+# Allowed-event set computation (called once at WS connect time)
+# ---------------------------------------------------------------------------
+
+def build_allowed_event_set(events_declared: list[str]) -> frozenset[str]:
+    """Convert a raw ``permissions.events`` list into a normalised frozenset.
+
+    The returned set is stored on the WS connection object and passed to
+    :func:`ws_event_allowed` on every broadcast.
+
+    ``"*"`` is EXPANDED here, not carried through. It predates this scope
+    vocabulary and meant "every event", but as an opaque set member no gate
+    below recognises it — so a manifest that already declares ``["*"]`` would
+    keep its subscription and silently receive nothing. Expanding at the one
+    place that builds the set (instead of special-casing the wildcard in the
+    event gate and again in each replay-subscription gate) keeps that decision
+    in a single spot and cannot drift out of sync with them.
+    """
+    if "*" in events_declared:
+        return _WILDCARD_SCOPES
+    return frozenset(events_declared)
+
+
+# ---------------------------------------------------------------------------
+# Core filter: is this event allowed for this app token?
+# ---------------------------------------------------------------------------
+
+def ws_event_allowed(
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if an app token identified by *app* may receive this event.
+
+    A thin wrapper over :func:`_decide_ws_event` whose only job is to make the
+    SEL audit unmissable. The decision function has many ``return True`` paths
+    (Tier 0, the always-admitted envelopes, each slot scope, each global scope),
+    and auditing at each one would mean every future branch has to remember to
+    report itself. Auditing the RESULT here means a branch added later is
+    covered by construction.
+
+    Denials are audited inside the decision function, where the reason is known.
+    """
+    allowed = _decide_ws_event(
+        event_type, data, app=app, allowed_events=allowed_events, state=state
+    )
+    if allowed:
+        _audit_allow(app, event_type)
+    return allowed
+
+
+def _decide_ws_event(
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """The authorization decision itself. Audits its own denials.
+
+    ``data`` is the payload dict passed to ``broadcast_ws``.  This function is
+    called **before** sending to each WS client; returning False suppresses the
+    send.
+
+    Dashboard-user tokens (empty *app*) always receive everything — callers
+    should skip this function for them.  As a defense-in-depth measure this
+    function still fails closed (returns False) if called with an empty app,
+    since ``assert`` is compiled out under ``python -O``.
+    """
+    if not app:
+        # Deny-by-default (CWE-269): a caller invoking this without an app
+        # identity has no basis for authorisation.  Audit the denial so a
+        # future refactor that reaches this branch (bypassing the caller's
+        # dashboard-user pre-check) is observable in the trail.
+        _audit_deny(app or "<empty>", event_type, "empty_app_denied")
+        return False
+
+    # Tier 0: always delivered
+    if event_type in _TIER0_ALWAYS:
+        return True
+
+    # Revoked app: Tier 0 and nothing else. Checked here rather than left to the
+    # declaration intersection because the branches below (``slots``, subagent
+    # batches, and the own-slot default in ``_slot_visible``) deliberately admit
+    # frames WITHOUT consulting ``allowed_events``, so an empty declaration set
+    # does not reach them.
+    if app_events_revoked(app):
+        _audit_deny(app, event_type, "app_disabled")
+        return False
+
+    # ``slots`` is a full slot-list re-push.  The event itself is always
+    # delivered — payload-level per-app filtering in
+    # ``DashboardState._serialize_for_client`` enforces that an app only
+    # sees the slots it's authorised for (own slots by default; foreign
+    # slots require ``slots:user`` / ``slots:app:X`` / ``slots:all``).
+    # Denying at the gate level would break the documented default that
+    # every app sees updates to its OWN slots without an explicit
+    # declaration, and would leave the app's sidebar stale after connect.
+    if event_type == "slots":
+        return True
+
+    # Coalesced subagent batches carry per-item slots, not one frame slot —
+    # admit here and let ``_serialize_for_client`` filter the items.
+    if event_type in _SUBAGENT_BATCH_EVENTS:
+        return True
+
+    # Tier 1: slot-scoped events
+    slot_key: str | None = data.get("slot")
+    # ``slot_title`` and ``session_summary`` use ``key`` for the slot
+    # identifier (rather than ``slot``) — normalise so we don't misclassify
+    # them as no-slot-key.
+    if slot_key is None and event_type in ("slot_title", "session_summary"):
+        slot_key = data.get("key")
+    # A GLOBALLY classified event must be judged by its own declaration, never
+    # by a slot field that happens to appear in its payload. ``notify()`` meta
+    # keys merge FLAT into the note (notifications/bus.py: "the frontend reads
+    # note.job_id / note.slot / note.session_key directly"), and the notification
+    # branch of ``DashboardState._broadcast`` hands that whole note to this gate
+    # as ``data`` — so a real caller like the Slack heartbeat
+    # (``notify("heartbeat", ..., meta={"slot": slot.key})``) puts a top-level
+    # ``slot`` on a ``notification`` frame. Inferring slot-scoping from it would
+    # route the frame into the slot branch below and return on slot visibility
+    # ALONE, delivering the title/body to an app holding only ``slots:*`` and
+    # never enforcing the ``notification`` scope this event actually requires.
+    # The two tables are disjoint, so this only ever strips smuggled keys.
+    if event_type in _GLOBAL_EVENT_DECLARATIONS:
+        slot_key = None
+    if event_type in _SLOT_SCOPED_EVENTS or slot_key is not None:
+        if slot_key is None:
+            # Unknown slot-scoped event shape — deny to be safe
+            _audit_deny(app, event_type, "slot_scoped_no_slot_key")
+            return False
+        slot: _ChatSlot | None = state._slots.get(slot_key)
+        if slot is None:
+            # Slot no longer exists (race) — deny
+            _audit_deny(app, event_type, "slot_missing")
+            return False
+
+        if event_type in _SUBAGENT_EVENTS:
+            allowed = _subagent_visible(slot, app, allowed_events, state)
+        else:
+            allowed = _slot_visible(slot, app, allowed_events, state)
+        if not allowed:
+            _audit_deny(app, event_type, "slot_scope_denied")
+        return allowed
+
+    # Tier 2: global events
+    # Unattributable notification metadata: only the broad scope covers it.
+    if event_type in _UNATTRIBUTED_NOTIFICATION_EVENTS:
+        if "notification:all" in allowed_events:
+            return True
+        _audit_deny(app, event_type, "notification_metadata_needs_all")
+        return False
+
+    # Channel settings ARE attributable, so do not force the broad scope on them:
+    # an app learning its OWN channel was muted is exactly what `notification`
+    # grants, while another app's channel is not.
+    if event_type == _CHANNEL_SETTINGS_EVENT:
+        owner = notification_channel_owner(str(data.get("channel", "")))
+        if "notification:all" in allowed_events:
+            return True
+        if owner and owner == app and "notification" in allowed_events:
+            return True
+        if owner == _SYSTEM_SOURCE and "notification:system" in allowed_events:
+            return True
+        _audit_deny(app, event_type, "notification_channel_not_owned")
+        return False
+
+    # App-published events all ride ONE fixed WS type with the real event name
+    # inside the envelope (see apps/event_bus.APP_EVENT_WS_TYPE), so the table
+    # lookup above can never match them and this branch is what keeps them out
+    # of the global deny -- without it an app receives none of its OWN events.
+    #
+    # Ownership decides it: the envelope names its publisher, and EventBus
+    # already refused to publish anything outside that app's declared
+    # `permissions.events`. So a publisher receiving its own event back needs no
+    # second declaration check -- and re-checking would BREAK the apps that
+    # declare `["*"]`, whose wildcard is expanded into core scopes that do not
+    # contain their app-chosen event names. Frames from another app are denied:
+    # app events have no cross-app opt-in (that is what exposeToApps does for
+    # slots), and an unattributable envelope is denied too.
+    if event_type == _APP_EVENT_WS_TYPE:
+        publisher = str(data.get("app", ""))
+        inner = str(data.get("event", ""))
+        if publisher and inner and publisher == app:
+            return True
+        _audit_deny(app, event_type, "app_event_not_owned")
+        return False
+
+    required_decl = _GLOBAL_EVENT_DECLARATIONS.get(event_type)
+    if required_decl is None:
+        # Unknown event type — deny unknown events for app tokens
+        logger.debug("ws_event_scope: unknown event %r denied for app %r", event_type, app)
+        _audit_deny(app, event_type, "unknown_event")
+        return False
+
+    # notification: filtered by source_app.  An app must declare
+    # ``notification`` to receive its OWN notifications and ``notification:all``
+    # to receive foreign ones.  Deny-by-default (CWE-269): if neither is
+    # declared, own-app notifications are also denied — apps that want push
+    # notifications must opt in explicitly.
+    #
+    # System-sourced notifications (source == "system" or source == "") are
+    # gateway-internal sends (send_message MCP tool, heartbeat, cron fallback).
+    # They carry no ``source_app`` because they flow through state.notify(),
+    # which pre-dates per-app channels. They need their OWN declaration
+    # (``notification:system``): that stream is user content, not the app's
+    # own, so folding it into ``notification`` would make a single declaration
+    # a broad grant -- the shape this module exists to remove.
+    if event_type in _SOURCE_FILTERED_EVENTS:
+        # The note's field is `source` and its app form is PREFIXED
+        # (e.g. `app:mochi-pet`); `source_app` and `app` are not keys any emitter
+        # writes. Parse the canonical value and let ONLY the literal "system"
+        # mean system, so an unrecognised or absent source is denied rather than
+        # treated as the shared stream that every `notification:system` holder
+        # reads.
+        source = str(data.get("source", ""))
+        source_app = notification_source_app(source)
+        if "notification:all" in allowed_events:
+            return True
+        if source_app and source_app == app and "notification" in allowed_events:
+            return True
+        if source == _SYSTEM_SOURCE and "notification:system" in allowed_events:
+            # ``notification:all`` is handled above; the system stream has its
+            # own opt-in because it carries user content, not the app's own.
+            return True
+        if source_app and source_app == app:
+            _audit_deny(app, event_type, "notification_not_declared")
+        elif source == _SYSTEM_SOURCE:
+            _audit_deny(app, event_type, "notification_system_not_declared")
+        else:
+            _audit_deny(app, event_type, "notification_scope_denied")
+        return False
+
+    if required_decl in allowed_events or f"{required_decl}:all" in allowed_events:
+        return True
+    _audit_deny(app, event_type, "global_scope_denied")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Slot visibility helpers
+# ---------------------------------------------------------------------------
+
+def _slot_visible(
+    slot: _ChatSlot,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if *app* may receive slot-scoped events for *slot*."""
+    # circular import: state.py's broadcast_ws imports ws_event_allowed from
+    # this module at runtime; importing SlotOrigin at module scope would
+    # create a bootstrap cycle during state.py initialisation.
+    from kiro_crew.dashboard.state import SlotOrigin
+
+    # Own slot: visible unless the app has been revoked. ``filter_slots_for_app``
+    # calls this directly, bypassing ``ws_event_allowed``'s revocation check, so
+    # the guard has to repeat here or a disabled app still gets its own slots.
+    if getattr(slot, "_app", "") == app:
+        return not app_events_revoked(app)
+
+    # slots:all -- broad, self-declared (see module docstring)
+    if "slots:all" in allowed_events:
+        return True
+
+    # slots:user — user-initiated slots
+    # slots:user — user-initiated slots only.  ``getattr`` defaults to ``""``
+    # (a sentinel that matches NO scope declaration) so a pre-migration slot
+    # or a race condition that leaves ``_origin`` unset remains INVISIBLE
+    # rather than being silently classified as USER.  Deny-by-default (CWE-269).
+    if getattr(slot, "_origin", "") == SlotOrigin.USER and "slots:user" in allowed_events:
+        return True
+
+    # slots:app:<name> — specific app's slots, requires target opt-in
+    slot_owner = getattr(slot, "_app", "")
+    if slot_owner and f"slots:app:{slot_owner}" in allowed_events:
+        if _target_exposes_to(slot_owner, app, state):
+            return True
+
+    return False
+
+
+def _subagent_visible(
+    slot: _ChatSlot,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if *app* may receive subagent events for *slot*.
+
+    Subagent visibility is an independent dimension from slot content visibility:
+    an app may declare ``subagent:user`` without needing ``slots:user``.
+    Falls back to slot visibility if no subagent-specific declaration is present.
+    """
+    # circular import: see _slot_visible above.
+    from kiro_crew.dashboard.state import SlotOrigin
+
+    # Own slot: visible unless the app has been revoked — see _slot_visible.
+    # ``filter_subagent_batch_for_app`` also reaches this without passing through
+    # ``ws_event_allowed``.
+    if getattr(slot, "_app", "") == app:
+        return not app_events_revoked(app)
+
+    # subagent:all
+    if "subagent:all" in allowed_events:
+        return True
+
+    # subagent:user
+    # subagent:user — same fail-closed default as _slot_visible above.
+    if getattr(slot, "_origin", "") == SlotOrigin.USER and "subagent:user" in allowed_events:
+        return True
+
+    # subagent:app:<name>
+    slot_owner = getattr(slot, "_app", "")
+    if slot_owner and f"subagent:app:{slot_owner}" in allowed_events:
+        if _target_exposes_to(slot_owner, app, state):
+            return True
+
+    # Fall back to general slot visibility (if you can see the slot, you can see its subagents)
+    return _slot_visible(slot, app, allowed_events, state)
+
+
+# ---------------------------------------------------------------------------
+# Manifest exposure cache — ``get_app_manifest`` stats, reads and re-parses the
+# JSON file on every call (no internal cache).  ``_target_exposes_to`` runs on
+# the WS broadcast hot path (once per cross-app slot event via
+# ``_slot_visible``/``_subagent_visible``), and ``ws_event_allowed`` is a
+# SYNCHRONOUS function called from inside ``_send_ws_all``'s per-client loop —
+# it cannot await, so it must never touch the disk itself.  Every load is
+# therefore pushed off the loop and the cache is served
+# stale-while-revalidate:
+#
+#   fresh entry    -> return it
+#   stale entry    -> return the STALE value, schedule a refresh
+#   no entry       -> return empty (fail closed), schedule a refresh
+#
+# A cold miss withholds one cross-app frame until the refresh lands, which is
+# the safe direction and matches this module's fail-closed policy.  Serving a
+# stale entry costs at most ``_MANIFEST_EXPOSE_TTL_SECS`` of staleness on a
+# manifest edit — the same bound the previous blocking implementation had.
+# ---------------------------------------------------------------------------
+
+_MANIFEST_EXPOSE_TTL_SECS = 30.0
+_exposeto_cache: dict[str, tuple[float, frozenset[str]]] = {}
+#: Apps with a refresh already scheduled, so a broadcast burst on a cold or
+#: stale entry queues ONE thread job instead of one per event per client.
+_exposeto_refreshing: set[str] = set()
+
+
+def _read_expose_to(target_app: str) -> frozenset[str]:
+    """Blocking read of *target_app*'s ``exposeToApps`` set. Fail-closed.
+
+    Synchronous by design — callers MUST run it off the event loop (see
+    ``_schedule_expose_to_refresh``).
+
+    A disabled *target_app* exposes to nobody, even if its manifest still
+    declares ``exposeToApps``: disabling does not delete the manifest, so
+    without this check an observing app's ``slots:app:<target_app>`` grant
+    would outlive the disable — mirroring the check :func:`app_events_revoked`
+    already applies to the target's OWN socket.
+    """
+    try:
+        if not is_app_enabled(target_app):
+            return frozenset()
+        manifest = get_app_manifest(target_app)
+        if manifest is None:
+            return frozenset()
+        return frozenset(manifest.permissions.exposeToApps)
+    except Exception:
+        logger.debug(
+            "ws_event_scope: could not load manifest for %r, denying cross-app access",
+            target_app,
+        )
+        return frozenset()
+
+
+def _schedule_expose_to_refresh(target_app: str) -> None:
+    """Refresh one cache entry off the event loop, at most one job in flight.
+
+    Falls back to a synchronous read when there is no running loop (tests, CLI
+    paths): blocking is only a problem on the loop thread, and refusing to load
+    at all there would make the cache permanently cold.
+    """
+    if target_app in _exposeto_refreshing:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _exposeto_cache[target_app] = (time.monotonic(), _read_expose_to(target_app))
+        return
+
+    _exposeto_refreshing.add(target_app)
+
+    try:
+        future = loop.run_in_executor(None, _read_expose_to, target_app)
+    except RuntimeError:
+        # Loop shutting down / executor gone — drop the refresh; the entry stays
+        # as-is and the next broadcast reschedules.
+        _exposeto_refreshing.discard(target_app)
+        return
+
+    def _store(fut: Any) -> None:
+        _exposeto_refreshing.discard(target_app)
+        try:
+            _exposeto_cache[target_app] = (time.monotonic(), fut.result())
+        except BaseException:
+            # BaseException, not Exception: a cancelled future raises
+            # CancelledError, which does not derive from Exception, and letting
+            # it escape a call_soon callback only produces loop-handler noise.
+            # The entry is already released above, so a failed refresh just
+            # leaves the previous value (or nothing) for the next broadcast to
+            # retry against.
+            logger.debug(
+                "ws_event_scope: exposeToApps refresh failed for %r", target_app
+            )
+
+    future.add_done_callback(_store)
+
+
+def _load_expose_to(target_app: str) -> frozenset[str]:
+    """Return the *target_app*'s ``permissions.exposeToApps`` set, cached.
+
+    Never blocks: an empty frozenset means "expose to nobody", which is also
+    what a not-yet-loaded entry returns (fail closed).
+    """
+    cached = _exposeto_cache.get(target_app)
+    if cached is not None:
+        if (time.monotonic() - cached[0]) < _MANIFEST_EXPOSE_TTL_SECS:
+            return cached[1]
+        _schedule_expose_to_refresh(target_app)
+        return cached[1]
+    _schedule_expose_to_refresh(target_app)
+    return _exposeto_cache.get(target_app, (0.0, frozenset()))[1]
+
+
+# ---------------------------------------------------------------------------
+# Live declaration refresh — a socket's scope must be able to SHRINK
+#
+# ``_allowed_events`` is resolved once at connect. A manifest edit or an
+# ``app disable`` (which rewrites the registry without closing sockets) would
+# otherwise leave the revoked scopes usable on an already-open connection until
+# it happens to drop.
+#
+# ``effective_allowed_events`` therefore INTERSECTS the connect-time snapshot
+# with the currently declared set on every decision. Intersection, not
+# replacement, is the whole design:
+#
+#   * a NARROWED or deleted manifest takes effect immediately (the point), and
+#   * a WIDENED manifest does NOT retroactively grant an open socket new scopes
+#     — that requires a reconnect, so the grant is always one the connection was
+#     authenticated for, and a manifest edit can never escalate a live session.
+#
+# Closing the socket instead was rejected: it would cut a streaming turn
+# mid-flight and turn a manifest save into a reconnect storm, while delivering
+# no tighter guarantee than withholding the events does.
+#
+# The reload is the same shape as the ``exposeToApps`` cache above — never a
+# disk read on the loop, refreshed off-loop, stale-while-revalidate — because
+# this runs on the same synchronous broadcast path. The one difference is what a
+# COLD miss returns: an unknown ``exposeToApps`` denies (a cross-app grant is
+# opt-in), but an unknown declaration set must fall back to the CONNECT-TIME
+# SNAPSHOT rather than to empty, or the first broadcast after a gateway restart
+# would withhold every event from every app until the refresh lands. The
+# snapshot is itself an authenticated read of the same file, so leaning on it
+# for one refresh interval never widens anything.
+# ---------------------------------------------------------------------------
+
+_declared_cache: dict[str, tuple[float, bool, frozenset[str]]] = {}
+_declared_refreshing: set[str] = set()
+
+
+def _read_declared_events(app: str) -> tuple[bool, frozenset[str]]:
+    """Blocking read of *app*'s ``enabled`` flag and ``permissions.events`` set.
+
+    Synchronous by design — callers MUST run it off the event loop.
+
+    ENABLEMENT is part of the answer, not a separate concern: ``disable_app``
+    flips ``enabled`` in ``installed.json`` and leaves ``app.json`` untouched, so
+    reading the manifest alone reports a disabled app's declarations unchanged and
+    the intersection would keep honouring them.
+
+    Both facts come back from ONE read, and are cached as one tuple, because they
+    are only sound together: the empty declaration set of a disabled app is
+    indistinguishable from that of an enabled app which declares no events, and
+    those two must be treated differently (the latter still sees its OWN slots by
+    documented default, the former must see nothing but Tier 0). A second cache
+    keyed independently could report ``enabled`` for a set that was read while the
+    app was disabled.
+
+    An app that is disabled or uninstalled reports ``(False, frozenset())`` — no
+    declarations AND revoked, so ``app_events_revoked`` also withholds the
+    own-slot default. Revocation requires POSITIVE evidence of disablement: an
+    unreadable or missing ``app.json`` on a still-enabled app reports ``(True,
+    frozenset())`` instead, because a corrupt/transient manifest read is not a
+    revocation and blanking the app's own chat over one would be a costly false
+    positive. It still declares nothing, so every DECLARED scope is withheld.
+    """
+    try:
+        enabled = is_app_enabled(app)
+    except Exception:
+        # Indeterminate — not positive evidence of disablement. Withhold the
+        # declared scopes, but leave the own-slot default alone.
+        logger.debug("ws_event_scope: could not read enablement for %r", app)
+        return (True, frozenset())
+    if not enabled:
+        return (False, frozenset())
+    try:
+        manifest = get_app_manifest(app)
+        if manifest is None:
+            return (True, frozenset())
+        return (True, build_allowed_event_set(list(manifest.permissions.events)))
+    except Exception:
+        logger.debug("ws_event_scope: could not reload declarations for %r", app)
+        return (True, frozenset())
+
+
+def _schedule_declared_refresh(app: str) -> None:
+    """Refresh one declaration entry off the event loop, one job in flight."""
+    if app in _declared_refreshing:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        enabled, events = _read_declared_events(app)
+        _declared_cache[app] = (time.monotonic(), enabled, events)
+        return
+
+    _declared_refreshing.add(app)
+
+    try:
+        future = loop.run_in_executor(None, _read_declared_events, app)
+    except RuntimeError:
+        _declared_refreshing.discard(app)
+        return
+
+    def _store(fut: Any) -> None:
+        _declared_refreshing.discard(app)
+        try:
+            enabled, events = fut.result()
+            _declared_cache[app] = (time.monotonic(), enabled, events)
+        except BaseException:
+            # BaseException: a cancelled future raises CancelledError, which is
+            # not an Exception, and letting it escape a call_soon callback only
+            # produces loop-handler noise.
+            logger.debug("ws_event_scope: declaration refresh failed for %r", app)
+
+    future.add_done_callback(_store)
+
+
+def load_declared_events_for_connect(app: str) -> tuple[bool, frozenset[str]]:
+    """Blocking connect-time read of *app*'s enablement + scopes, priming the cache.
+
+    Synchronous by design — the WS connect path MUST run it off the event loop.
+
+    Callers get the pair to act on directly (refuse the socket when disabled) AND
+    the cache is primed as a side effect, which closes the cold-miss window that
+    would otherwise open on every reconnect: ``app_events_revoked`` reports NOT
+    revoked on a cold cache, so without this the initial slots push and the log
+    replay would both be judged against an unverified snapshot before the first
+    background refresh landed. Priming here means the first frame is already
+    gated on an authoritative read.
+
+    This is also the only place the connect snapshot is built, so the connect
+    path cannot drift from what the live narrowing path reads.
+    """
+    enabled, events = _read_declared_events(app)
+    _declared_cache[app] = (time.monotonic(), enabled, events)
+    return (enabled, events)
+
+
+def effective_allowed_events(app: str, connect_snapshot: frozenset[str]) -> frozenset[str]:
+    """The scopes *app* may use RIGHT NOW on a socket opened with *connect_snapshot*.
+
+    Never blocks. Returns the intersection with the currently declared set, so a
+    revoked scope stops being honoured within one refresh interval without the
+    socket being closed.
+    """
+    cached = _declared_cache.get(app)
+    if cached is not None:
+        if (time.monotonic() - cached[0]) >= _MANIFEST_EXPOSE_TTL_SECS:
+            _schedule_declared_refresh(app)
+        return connect_snapshot & cached[2]
+    _schedule_declared_refresh(app)
+    return connect_snapshot
+
+
+def app_events_revoked(app: str) -> bool:
+    """Return True if *app* is currently disabled/uninstalled, so it gets Tier 0 only.
+
+    Never blocks. This is the companion to :func:`effective_allowed_events`: the
+    intersection there withholds every DECLARED scope from a disabled app, but the
+    own-slot default in :func:`_slot_visible` / :func:`_subagent_visible` grants an
+    app its own slots WITHOUT consulting declarations at all, so narrowing the
+    declaration set cannot reach it. ``disable_app`` does not revoke the app token
+    (``token_auth`` has no enablement check, and every app backend route gates on
+    ``is_app_enabled`` itself), so a disabled app can still hold an open
+    ``/api/ws`` socket — without this, its own slots' chat content keeps streaming.
+
+    A COLD miss reports NOT revoked (and schedules the refresh) for the same
+    reason the declaration cache falls back to the connect snapshot: reporting
+    "revoked" for an unknown app would blank every app's own slots on the first
+    broadcast after a gateway restart. One refresh interval of the pre-existing
+    behaviour is the conservative side here; the socket was authenticated against
+    the same file at connect.
+    """
+    cached = _declared_cache.get(app)
+    if cached is None:
+        _schedule_declared_refresh(app)
+        return False
+    if (time.monotonic() - cached[0]) >= _MANIFEST_EXPOSE_TTL_SECS:
+        _schedule_declared_refresh(app)
+    return not cached[1]
+
+
+def _target_exposes_to(target_app: str, requesting_app: str, state: DashboardState) -> bool:
+    """Return True if *target_app*'s manifest allows *requesting_app* to observe it.
+
+    Reads ``permissions.exposeToApps`` from the target app's installed
+    manifest.  Uses a 30-second local TTL cache (``_exposeto_cache``) to
+    bound WS broadcast hot-path disk I/O — ``get_app_manifest`` itself
+    re-reads and re-parses the JSON on every call, so without this cache a
+    busy multi-app dashboard would hit the filesystem on every cross-app
+    slot event.
+    """
+    expose = _load_expose_to(target_app)
+    return "*" in expose or requesting_app in expose
+
+
+# ---------------------------------------------------------------------------
+# slots initial-push filter (applied when a new WS client connects)
+# ---------------------------------------------------------------------------
+
+def filter_subagent_batch_for_app(
+    items: list[dict[str, Any]],
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+    *,
+    msg_type: str = "subagent_batch_update",
+) -> list[dict[str, Any]]:
+    """Filter one coalesced subagent batch frame down to the permitted items.
+
+    Each item carries its own ``slot`` (``SubagentEventCoalescer`` seeds every
+    buffered entry with one), so the frame is filtered per row rather than
+    accepted or denied whole. Reuses :func:`_subagent_visible` — the same
+    predicate the per-event path uses — so batched and unbatched delivery
+    cannot drift apart. An item with no resolvable slot is dropped (fail
+    closed), matching the per-event gate's ``slot_missing`` denial.
+
+    The frame ITSELF is already audited once by :func:`ws_event_allowed` (it is
+    admitted unconditionally at the gate, per-item filtering happens here
+    instead). Each item decision gets its own deduplicated record too — a
+    ``_item`` reason suffix keeps it out of the frame-level dedup key — since a
+    per-item CWE-269 decision is exactly the kind of permission decision
+    ``AUTOSDE.yaml`` requires an SEL event for, hot-path volume notwithstanding:
+    the existing dedup window bounds it the same way it bounds every other
+    decision here.
+    """
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        slot = state._slots.get(str(item.get("slot", "")))
+        if slot is None:
+            continue
+        if _subagent_visible(slot, app, allowed_events, state):
+            out.append(item)
+            _audit_allow(app, f"{msg_type}_item")
+        else:
+            _audit_deny(app, f"{msg_type}_item", "slot_scope_denied")
+    return out
+
+
+def filter_slots_for_app(
+    slots: list[dict[str, Any]],
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> list[dict[str, Any]]:
+    """Filter the slots list sent on initial WS connect for an app token.
+
+    ``slots`` is the raw list from ``[s.to_dict() for s in state._slots.values()]``.
+    Returns only the slots the app is allowed to see.
+
+    The ``slots`` frame itself is already audited once by :func:`ws_event_allowed`
+    (it is admitted unconditionally at the gate; per-item filtering happens
+    here). Each item decision gets its own deduplicated ``slots_item`` record
+    too, for the same reason :func:`filter_subagent_batch_for_app` audits its
+    items: this is a per-slot CWE-269 decision, not a detail of the frame-level
+    one already logged.
+    """
+    result = []
+    for slot_dict in slots:
+        slot_key = slot_dict.get("key", "")
+        slot = state._slots.get(slot_key)
+        if slot is None:
+            continue
+        if _slot_visible(slot, app, allowed_events, state):
+            result.append(slot_dict)
+            _audit_allow(app, "slots_item")
+        else:
+            _audit_deny(app, "slots_item", "slot_scope_denied")
+    return result

--- a/src/kiro_crew/docs/app-platform-trust-model.md
+++ b/src/kiro_crew/docs/app-platform-trust-model.md
@@ -63,6 +63,98 @@ are **deny-by-default** confined by the dashboard auth middleware
 independently re-checks that the caller's token app matches the target app, since
 the proxy signs requests with the target app's secret.
 
+### WebSocket event scope (CWE-269)
+
+`/api/ws` is a *third* surface reachable with the same app token, and it is scoped
+separately: connecting no longer grants the full event stream. On connect the socket
+records the caller's app identity and its manifest `permissions.events` declarations
+(`dashboard/ws.py`), and every fan-out is filtered per socket at a single chokepoint
+(`DashboardState._send_ws_all` → `_ws_client_allowed` → `dashboard/ws_event_scope.py`).
+Both dispatch paths — `broadcast_ws()` and the `_broadcast()` `_type` translation —
+funnel through it, as does the subagent-subscriber fan-out.
+
+Events fall into three tiers. Tier 0 (`dashboard`, `refresh`, `update_progress`) carries
+no sensitive payload and is always delivered. Tier 1 is slot-scoped: delivery depends on
+the slot's `SlotOrigin` and the app's `slots:*` declarations (`slots:own` is the default,
+then `slots:user`, `slots:app:<name>`, `slots:all`); `subagent:*` is an independent
+dimension so an app can watch subagent status without receiving chat content. Tier 2 is
+global and requires an explicit declaration; notifications split further by source, so
+`notification` covers the app's own pushes while gateway-internal ones (cron output,
+`send_message`, watchlist results) need `notification:system` — bundling them would make
+one declaration a broad grant. Cross-app visibility (`slots:app:X`) also
+requires the *observed* app to opt in via `permissions.exposeToApps`, so an app cannot
+name a sibling unilaterally.
+
+Narrowing `permissions.events` takes effect on sockets that are ALREADY open: each
+decision intersects the connect-time set with what the manifest declares now, so a
+revoked scope stops being honoured within about half a minute and no reconnect is
+needed. Disabling or uninstalling the app declares nothing AND marks it revoked,
+which collapses its open sockets to the always-delivered tier — including the log
+stream, which is re-checked per send rather than only at subscribe. The revoked
+mark is needed on top of the empty declaration set because an app sees its OWN
+slots by default, without declaring anything, so emptying the declarations alone
+would leave a disabled app's chat streaming. A disabled app that RECONNECTS is
+refused the socket outright, since disabling does not invalidate its token and the
+initial slot list would otherwise be served from the still-intact manifest.
+Widening does not work
+that way — a new scope reaches the app only on its next connection, so an edit can
+never hand a live session more than it opened with.
+
+Filtering a frame's payload is not always enough: the `slots` re-push is a full slot list,so it is re-filtered per app on the send path (`DashboardState._serialize_for_client`) —
+but its *envelope* also carries global safety-posture booleans that no slot scope narrows.
+`yolo` (is the blanket approval override active) is therefore gated by the same `yolo`
+declaration that gates the `yolo_expired` event, and `channelTrusted` is withheld from app
+tokens outright — no scope declares it and no app SDK consumer reads it. A withheld field
+is *omitted*, never sent as `false`: a falsy default still answers a question the app must
+not be able to ask, and answers it wrongly whenever the override is on.
+
+A slot's `SlotOrigin` is declared by the layer that actually knows it, and an undeclared
+slot stays untagged. `get_or_create_slot` cannot tell a person typing in the dashboard
+from a background injection, so it does not guess: the request layer decides `USER` vs
+`APP` from whether a token was presented (`request_slot_origin`), cron declares `CRON`,
+and rehydration restores the persisted value rather than re-deriving it. An untagged slot
+matches no cross-slot scope, so a caller that forgets to declare loses visibility instead
+of leaking — inferring `USER` there put cron output inside `slots:user`.
+
+`permissions.events: ["*"]` predates this vocabulary and still means every event. It is
+expanded into the full scope set when the socket's allow-set is built, not carried through
+as a literal, because as an opaque member no gate would recognise it and such a manifest
+would keep its subscription while receiving nothing.
+
+All other scopes are **self-declared**: they are read from the app's own manifest, with
+no install-time approval check. That is consistent with the privilege an installed app
+already holds (see above), so the tiers structure and audit what an app receives rather
+than defending against a hostile manifest. `exposeToApps` is the one asymmetric case,
+because there the manifest being trusted is not the one being widened.
+
+Two payloads need more than a yes/no gate. The `slots` re-push carries every slot, so it
+is re-filtered per app in `_serialize_for_client` (failing closed to an empty list); and
+the log ring-buffer replay plus the subagent reconnect replay write to the socket
+directly, so `ws.py` gates those at the source.
+
+Dashboard-user sockets are exempt, identified by a **positive** `is_dashboard_user`
+claim set by the auth middleware — never by the absence of an app claim, which would
+fail *open* on any path that forgot to set it. Because the stream is now filtered,
+`/api/ws` is implicitly allowed for app tokens (`_APP_TOKEN_IMPLICIT_ALLOW`) rather
+than requiring every app to declare the transport; that grant is recorded in the
+Security Event Log. `/api/status` is **not** implicitly allowed — it has no
+response-level filter to match what event scoping gives `/api/ws`, and it returns
+the owner id hash, host specs, cron and usage stats, and the live safety-override
+state. An app that needs it declares it in `permissions.api` like any other
+capability.
+
+### The frontend `useAppApi` / `useAppEvents` scoping is a guardrail, not a boundary
+
+An app's UI runs **in the dashboard page, with the dashboard user's own authority**. The
+SDK's `createScopedApi()` checks the `permissions.api` allowlist *in that same page*
+before issuing a same-origin `fetch`, so the request reaches the gateway as a
+dashboard-user token (empty app claim) — which `_enforce_app_scope` deliberately never
+gates. An embedded app could call `fetch('/api/anything')` directly and succeed. This is
+inherent to embedding app UI in the dashboard page, not a defect, but it means the
+frontend scoping prevents *accidental* use rather than abuse. The enforceable boundaries
+are the app **token** ones above (HTTP paths and WS events), which apply to app-owned
+*processes* holding their own credential.
+
 This is an **HTTP-reach boundary distinct from the in-process module-loading
 privilege**: an app's loaded Python still runs with full gateway privileges (the
 warning above stands), but an app's own HTTP token can no longer reach arbitrary

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -1016,3 +1016,64 @@ class TestRequiresDesktopApp:
         from kiro_crew.apps.manifest import PlatformConfig
 
         assert PlatformConfig().supports_platform("win32") is False
+
+
+class TestScalarGrantDoesNotBecomeAWildcard:
+    """A list-valued grant given a JSON SCALAR must deny, not be coerced.
+
+    `[str(x) for x in value]` over a STRING iterates its characters, so a manifest
+    that wrote a bare string where a list belongs was handed the tokens those
+    characters spell -- including the wildcards each of these fields honours:
+
+      exposeToApps  `"*"`         -> ["*"] -> every sibling app may observe my slots
+      events        `"*"`         -> ["*"] -> the whole WS scope vocabulary
+      api           `"/api/chat"` -> ["/", "a", ...] and `app_token_path_allowed`
+                                     matches the prefix "/" against every path
+      mcpTools      `"*"`         -> ["*"]
+
+    Same defect class as `bool("false")` on the boolean grants above, and the same
+    direction of fix: an unexpected value withholds the grant.
+    """
+
+    def test_scalar_star_never_yields_the_wildcard(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        for field in ("exposeToApps", "events", "api", "mcpTools"):
+            perms = Permissions.from_dict({field: "*"})
+            assert getattr(perms, field) == [], (
+                f"{field}: a scalar must not be exploded into a wildcard"
+            )
+
+    def test_scalar_path_never_yields_a_match_everything_prefix(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        assert Permissions.from_dict({"api": "/api/chat"}).api == []
+
+    def test_other_scalar_shapes_also_deny(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        for value in (True, 1, {"a": "b"}, None):
+            assert Permissions.from_dict({"exposeToApps": value}).exposeToApps == []
+
+    def test_a_real_list_still_works(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        perms = Permissions.from_dict(
+            {
+                "exposeToApps": ["mochi", "", "workflows"],
+                "events": ["slots:own", "notification"],
+                "api": ["/api/chat", "/api/ws"],
+                "mcpTools": ["cron_add"],
+            }
+        )
+        # Falsy entries are still dropped; everything else is preserved verbatim.
+        assert perms.exposeToApps == ["mochi", "workflows"]
+        assert perms.events == ["slots:own", "notification"]
+        assert perms.api == ["/api/chat", "/api/ws"]
+        assert perms.mcpTools == ["cron_add"]
+
+    def test_the_wildcard_still_works_when_declared_as_a_list(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        assert Permissions.from_dict({"exposeToApps": ["*"]}).exposeToApps == ["*"]
+        assert Permissions.from_dict({"events": ["*"]}).events == ["*"]

--- a/test/test_artifact_companion.py
+++ b/test/test_artifact_companion.py
@@ -277,13 +277,20 @@ class TestPushArtifactUpdate:
         the send itself is stubbed here."""
         state = _make_state(tmp_path)
         state._ws_clients = [MagicMock()]
-        sent: list[str] = []
-        state._send_ws_all = lambda msg: sent.append(msg)  # type: ignore[method-assign]
+        sent: list[tuple[str, object, str]] = []
+        # New chokepoint signature (msg_type, data, msg): the payload is passed
+        # alongside the serialized envelope so per-app WS scope filtering can
+        # inspect it.
+        state._send_ws_all = (  # type: ignore[method-assign]
+            lambda msg_type, data, msg: sent.append((msg_type, data, msg))
+        )
 
         state.push_artifact_update("cr-queue", 3)
 
         assert len(sent) == 1
-        env = json.loads(sent[0])
+        assert sent[0][0] == "artifact_update"
+        assert sent[0][1] == {"slug": "cr-queue", "version": 3, "deleted": False}
+        env = json.loads(sent[0][2])
         assert env == {
             "type": "artifact_update",
             "data": {"slug": "cr-queue", "version": 3, "deleted": False},

--- a/test/test_ask_question_roundtrip.py
+++ b/test/test_ask_question_roundtrip.py
@@ -919,7 +919,7 @@ def test_broadcast_ws_owners_targets_the_owner_client_set() -> None:
     st._ws_clients = {owner_ws, MagicMock()}
     sent: list[str] = []
     st._send_ws_owners = lambda msg: sent.append(msg)  # type: ignore[assignment]
-    st._send_ws_all = lambda msg: pytest.fail(  # type: ignore[assignment]
+    st._send_ws_all = lambda msg_type, data, msg: pytest.fail(  # type: ignore[assignment]
         "question payloads must never use the all-clients channel"
     )
 

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -590,7 +590,10 @@ class TestResolveApprovalSlotFallback:
         assert fut.done()
         assert fut.result() == "approved"
         state.broadcast_ws.assert_called_with(
-            "approval_resolved", {"id": "req-42", "approved": True}
+            "approval_resolved",
+            # ``slot`` keys the frame for the slot-scoped WS gate — it must name
+            # the slot that actually owned the resolved future.
+            {"id": "req-42", "approved": True, "slot": "chat-1-test"},
         )
         state.push_slots_update.assert_called_once()
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -1350,7 +1350,10 @@ class TestSlotLifecycle:
             resp = await client.post("/api/chat/slots/s1/approve", json={"action": "approved"})
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-abc", "approved": True}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-abc", "approved": True, "slot": "s1"},
             )
 
     @pytest.mark.asyncio
@@ -1370,7 +1373,10 @@ class TestSlotLifecycle:
             )
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-xyz", "approved": True}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-xyz", "approved": True, "slot": "s1"},
             )
 
     @pytest.mark.asyncio
@@ -1390,7 +1396,10 @@ class TestSlotLifecycle:
             )
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-rej", "approved": False}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-rej", "approved": False, "slot": "s1"},
             )
 
 

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -28,10 +28,15 @@ def _make_state(history_messages=None):
     # via _sync_dashboard_slots, which iterates state._slots.values().
     state._slots = slots
 
-    def get_or_create_slot(name=None, agent=""):
+    def get_or_create_slot(name=None, agent="", origin=""):
+        # ``origin`` is recorded, not just tolerated: the cron paths must
+        # declare SlotOrigin.CRON, and a fake that swallowed the kwarg
+        # would let that regress silently (a cron slot relabelled USER is
+        # readable by any app holding `slots:user`).
         if name not in slots:
             slot = MagicMock()
             slot.key = name
+            slot._origin = origin
             slot.linked_session_key = ""
             slot.messages = []
             slot.title = ""
@@ -60,6 +65,22 @@ def _make_job(job_id="abc123", name="test-cron", last_result="Hello world"):
 
 
 class TestInjectCronResultToDashboard:
+    def test_slot_is_tagged_cron_not_user(self):
+        """A cron result is the job's output, not something the person typed.
+
+        The slot used to be created untagged and then labelled USER by
+        get_or_create_slot's default, which put private cron content inside the
+        ``slots:user`` WS scope -- so any app holding that scope received it.
+        """
+        from kiro_crew.dashboard.state import SlotOrigin
+
+        state = _make_state()
+        job = _make_job()
+        inject_cron_result_to_dashboard(state, job, "result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert slot._origin == SlotOrigin.CRON
+        assert slot._origin != SlotOrigin.USER
+
     def test_sets_linked_session_key(self):
         state = _make_state()
         job = _make_job()

--- a/test/test_dashboard_cron_to_chat_handler.py
+++ b/test/test_dashboard_cron_to_chat_handler.py
@@ -22,10 +22,15 @@ def _make_state(jobs=None, history_messages=None, notifications=None):
     state = MagicMock()
     slots = {}
 
-    def get_or_create_slot(name=None, agent=""):
+    def get_or_create_slot(name=None, agent="", origin=""):
+        # ``origin`` is recorded, not just tolerated: the cron paths must
+        # declare SlotOrigin.CRON, and a fake that swallowed the kwarg
+        # would let that regress silently (a cron slot relabelled USER is
+        # readable by any app holding `slots:user`).
         if name not in slots:
             slot = MagicMock()
             slot.key = name
+            slot._origin = origin
             slot.linked_session_key = ""
             slot.messages = []
             slot.title = ""

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -473,7 +473,20 @@ class TestOwnerSourceStatusTransport:
         self, monkeypatch, claims, owner_request
     ) -> None:
         from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard import ws_event_scope
         from kiro_crew.dashboard.handlers import source_providers
+
+        # An app token only exists for an INSTALLED, enabled app, so that is the
+        # world this test runs in. The connect path resolves enablement off-loop
+        # and refuses a disabled app outright; without this the synthetic
+        # ``source-app`` (absent from the real installed.json) would be rejected
+        # before the initial status push this test is about.
+        monkeypatch.setattr(ws_event_scope, "is_app_enabled", lambda _name: True)
+        monkeypatch.setattr(ws_event_scope, "get_app_manifest", lambda _name: None)
+        # The connect read PRIMES the process-wide cache, so give it a throwaway
+        # dict -- monkeypatch restores the real one and no entry leaks into a
+        # later test that shares the app name.
+        monkeypatch.setattr(ws_event_scope, "_declared_cache", {})
 
         source_url = "https://github.com/acme/repo/pull/12"
 
@@ -491,12 +504,27 @@ class TestOwnerSourceStatusTransport:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__(claims)
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = True
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -525,6 +553,12 @@ class TestOwnerSourceStatusTransport:
         if owner_request:
             assert initial_slots[0]["source_links"][0]["ci"] == "passed"
             refresh.assert_called_once_with([source_url], state.push_slots_update)
+        elif claims.get("app"):
+            # App token: the per-app WS scope gate filters the initial push, so
+            # an app that declared no slots:* scope sees no slots at all — a
+            # stronger guarantee than merely withholding check status.
+            assert initial_slots == []
+            refresh.assert_not_called()
         else:
             assert "ci" not in str(initial_slots)
             assert "state" not in initial_slots[0]["source_links"][0]
@@ -585,6 +619,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         refreshed = asyncio.Event()
@@ -598,6 +635,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -658,12 +707,27 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -705,6 +769,11 @@ class TestPeriodicCheckStatusRefresh:
 
         class FakeWs:
             closed = False
+
+            # Dashboard-user flag so the WS scope gate passes through; this
+            # test targets the slots envelope, not per-app filtering.
+            def get(self, key: str, default=None):
+                return True if key == "_is_dashboard_user" else default
 
             def send_str(self, msg: str):
                 sent.append(msg)
@@ -748,12 +817,27 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -790,6 +874,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OTHER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         refresh = MagicMock()
@@ -798,6 +885,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -847,6 +946,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         done = asyncio.Event()
@@ -861,6 +963,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -907,6 +1021,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         recovered = asyncio.Event()
@@ -922,6 +1039,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None

--- a/test/test_dashboard_ws_task_tracking.py
+++ b/test/test_dashboard_ws_task_tracking.py
@@ -40,6 +40,13 @@ class _FakeWS:
         self.closed = False
         self.sent: list[str] = []
         self._gate = asyncio.Event()  # held closed so the send task stays pending
+        # These tests target the task-tracking guarantee, not the per-app
+        # scope filter — flag as a dashboard user so _ws_client_allowed
+        # returns True unconditionally.
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
 
     async def send_str(self, msg: str) -> None:
         await self._gate.wait()  # stay pending until released
@@ -53,7 +60,7 @@ async def test_send_ws_all_retains_task(tmp_path) -> None:
     state._ws_clients.append(ws)
 
     assert len(state._background_tasks) == 0
-    state._send_ws_all('{"type": "ping"}')
+    state._send_ws_all("ping", {}, '{"type": "ping"}')
 
     # The in-flight send task must be retained (strong ref) while pending.
     assert len(state._background_tasks) == 1, (
@@ -92,6 +99,14 @@ class _RaisingWS:
         self.closed = False
         self._gate = asyncio.Event()
 
+        # These tests target the task-tracking guarantee, not the per-app
+        # scope filter — flag as a dashboard user so _ws_client_allowed
+        # returns True unconditionally.
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
+
     async def send_str(self, msg: str) -> None:
         await self._gate.wait()
         raise ConnectionResetError("client disconnected")
@@ -105,7 +120,7 @@ async def test_failed_send_still_self_cleans(tmp_path) -> None:
     state = _make_state(tmp_path)
     ws = _RaisingWS()
     state._ws_clients.append(ws)
-    state._send_ws_all('{"type": "ping"}')
+    state._send_ws_all("ping", {}, '{"type": "ping"}')
     assert len(state._background_tasks) == 1  # retained while pending
 
     ws._gate.set()

--- a/test/test_session_summary_api.py
+++ b/test/test_session_summary_api.py
@@ -290,7 +290,7 @@ class TestSessionSummaryBroadcast:
         state = _make_state(tmp_path)
         state._ws_clients = [MagicMock()]
         sent: list[str] = []
-        state._send_ws_all = lambda msg: sent.append(msg)  # type: ignore[method-assign]
+        state._send_ws_all = lambda msg_type, data, msg: sent.append(msg)  # type: ignore[method-assign]
 
         state.push_session_summary("dashboard:chat-7")
 

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -3045,3 +3045,25 @@ async def test_restart_unbound_cookie_without_peer_keeps_todays_semantics(
     resp = await mw(_make_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert resp.status == 200
     assert token not in _ta._state._peer_bindings
+
+
+def test_app_token_path_allowed_implicit_ws():
+    """``/api/ws`` is the only implicitly allowed path.
+
+    It is connection infrastructure rather than a capability, and the implicit
+    grant is sound only because the WS layer filters events per app
+    (``ws_event_scope.py``). ``/api/status`` has NO such response-level filter
+    and discloses ``owner_id_hash``, host specs, cron/usage stats and the live
+    safety-override state, so it must be declared like any other capability.
+    Functional paths must still be declared, so the negative case is asserted
+    alongside.
+    """
+    from kiro_crew.dashboard.token_auth import app_token_path_allowed
+
+    assert app_token_path_allowed("some-app", "/api/ws") is True
+    assert app_token_path_allowed("some-app", "/api/status") is False
+    # Undeclared functional paths stay denied.
+    assert app_token_path_allowed("some-app", "/api/chat") is False
+    assert app_token_path_allowed("some-app", "/api/spawn") is False
+    # An empty app name must never be granted, even for implicit paths.
+    assert app_token_path_allowed("", "/api/ws") is False

--- a/test/test_ws_and_plan_memory_fixes.py
+++ b/test/test_ws_and_plan_memory_fixes.py
@@ -197,7 +197,11 @@ class TestWsNormalUserExperience:
         state.register_ws(dead)
 
         # Simulate push_notification which calls _send_ws_all internally
-        state._send_ws_all(json.dumps({"type": "notification", "data": {"text": "hi"}}))
+        state._send_ws_all(
+            "notification",
+            {"text": "hi"},
+            json.dumps({"type": "notification", "data": {"text": "hi"}}),
+        )
 
         alive.send_str.assert_called_once()
         dead.send_str.assert_not_called()

--- a/test/test_ws_event_scoping.py
+++ b/test/test_ws_event_scoping.py
@@ -1,0 +1,3540 @@
+"""Tests for per-app WebSocket event scope enforcement.
+
+Covers:
+- ws_event_allowed: Tier 0 (always), Tier 1 (slot-scoped), Tier 2 (global)
+- Slot visibility: own-slot, user-slot, cross-app opt-in, slots:all
+- Subagent visibility: independent dimension from slots
+- filter_slots_for_app: initial slots push filtering
+- build_allowed_event_set: passthrough normalisation
+- token_auth: implicit allow for /api/ws + /api/status with SEL audit
+- broadcast_ws integration: app clients filtered, dashboard users unaffected
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.state import SlotOrigin
+from kiro_crew.dashboard.token_auth import app_token_path_allowed
+from kiro_crew.dashboard.ws_event_scope import (
+    build_allowed_event_set,
+    filter_slots_for_app,
+    ws_event_allowed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_caches():
+    """Clear ws_event_scope module-level caches between tests.
+
+    The exposeToApps TTL cache and the SEL audit dedup cache persist across
+    test invocations at module scope; without an autouse fixture, a stale
+    entry from an earlier test can suppress the behaviour under test in a
+    later one (especially the cross-app tests that patch ``get_app_manifest``).
+    """
+    from kiro_crew.dashboard import ws_event_scope as _wes
+    _wes._exposeto_cache.clear()
+    _wes._sel_last_audit.clear()
+    yield
+    _wes._exposeto_cache.clear()
+    _wes._sel_last_audit.clear()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(*, owner_app: str = "", origin: str = SlotOrigin.USER, key: str = "s1") -> MagicMock:
+    slot = MagicMock()
+    slot._app = owner_app
+    slot._origin = origin
+    slot.key = key
+    return slot
+
+
+def _make_state(slots: dict[str, Any] | None = None) -> MagicMock:
+    state = MagicMock()
+    state._slots = slots or {}
+    return state
+
+
+def _allowed(*decls: str) -> frozenset[str]:
+    return build_allowed_event_set(list(decls))
+
+
+@pytest.fixture(autouse=True)
+def _clear_ws_scope_module_caches(monkeypatch):
+    """Isolate the module-level caches between tests.
+
+    ``ws_event_scope`` keeps process-wide dicts (declaration refresh, exposeToApps,
+    SEL dedup) keyed by app NAME. Tests share fixture app names, so one test
+    seeding a narrowed declaration for ``mochi-pet`` would otherwise silently
+    narrow every later test that uses the same name.
+
+    Also pins ``is_app_enabled`` to True as the DEFAULT world, because that is what
+    production looks like for any app able to reach the gate: a token is only
+    minted for an installed app, so ``installed.json`` has an enabled entry. The
+    suite's app names are synthetic and absent from the real ``installed.json``,
+    which without this would read as REVOKED and withhold even the own-slot
+    default. Tests that exercise revocation override this explicitly (patch it
+    False, or seed ``_declared_cache`` with a disabled entry).
+    """
+    from kiro_crew.dashboard import ws_event_scope as mod
+    monkeypatch.setattr(mod, "is_app_enabled", lambda _name: True)
+    for cache in (mod._declared_cache, mod._exposeto_cache, mod._sel_last_audit):
+        cache.clear()
+    for pending in (mod._declared_refreshing, mod._exposeto_refreshing):
+        pending.clear()
+    yield
+    for cache in (mod._declared_cache, mod._exposeto_cache, mod._sel_last_audit):
+        cache.clear()
+    for pending in (mod._declared_refreshing, mod._exposeto_refreshing):
+        pending.clear()
+
+
+# ---------------------------------------------------------------------------
+# build_allowed_event_set
+# ---------------------------------------------------------------------------
+
+class TestBuildAllowedEventSet:
+    def test_empty_declarations(self):
+        assert build_allowed_event_set([]) == frozenset()
+
+    def test_returns_frozenset(self):
+        result = build_allowed_event_set(["notification", "slots:user"])
+        assert isinstance(result, frozenset)
+        assert "notification" in result
+        assert "slots:user" in result
+
+    def test_deduplication(self):
+        result = build_allowed_event_set(["notification", "notification"])
+        assert result == frozenset({"notification"})
+
+
+# ---------------------------------------------------------------------------
+# Tier 0: always-allowed events
+# ---------------------------------------------------------------------------
+
+class TestTier0AlwaysAllowed:
+    def test_dashboard_always_allowed_for_any_app(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_dashboard_allowed_even_with_empty_permissions(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {"version": "3.0"},
+            app="auto-improvement", allowed_events=frozenset(), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — own-slot visibility
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedOwnSlot:
+    def test_own_slot_chat_chunk_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "mochi-pet", "content": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_own_slot_tool_call_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "tool_call", {"slot": "mochi-pet"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_other_app_slot_denied_without_declaration(self):
+        slot = _make_slot(owner_app="auto-improvement", origin=SlotOrigin.APP, key="auto-improvement")
+        state = _make_state({"auto-improvement": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "auto-improvement"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_missing_slot_denied(self):
+        state = _make_state({})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "ghost"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_slot_field_none_denied(self):
+        state = _make_state({})
+        # slot-scoped event type but no slot key in data
+        assert ws_event_allowed(
+            "chat_chunk", {},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:user
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedUserSlots:
+    def test_user_slot_allowed_with_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "chat_message", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is True
+
+    def test_user_slot_denied_without_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "chat_message", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_app_slot_not_covered_by_slots_user(self):
+        # slots:user only covers USER-origin slots, not APP-origin ones
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        state = _make_state({"other-app": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "other-app"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:all
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedSlotsAll:
+    def test_slots_all_covers_any_slot(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other")
+        state = _make_state({"other": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "other"},
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+    def test_slots_all_covers_user_slot(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"slot": "chat-1"},
+            app="any-app", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:app:<name> with exposeToApps opt-in
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedCrossApp:
+    def _state_with_expose(self, target_app: str, expose_to: list[str]) -> MagicMock:
+        slot = _make_slot(owner_app=target_app, origin=SlotOrigin.APP, key=target_app)
+        state = _make_state({target_app: slot})
+        # Mock get_app_manifest to return a manifest with exposeToApps
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = expose_to
+        state._get_manifest = MagicMock(return_value=manifest)
+        return state
+
+    def test_cross_app_allowed_when_target_opts_in(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is True
+
+    def test_cross_app_denied_when_target_does_not_opt_in(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = []  # no opt-in
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is False
+
+    def test_cross_app_allowed_with_wildcard_expose(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["*"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="any-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is True
+
+    def test_cross_app_without_slots_app_declaration_denied(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            # monitor-app didn't declare slots:app:mochi-pet
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:user"),  # wrong declaration
+                state=state,
+            ) is False
+
+
+# ---------------------------------------------------------------------------
+# Subagent events — independent dimension
+# ---------------------------------------------------------------------------
+
+class TestSubagentEvents:
+    def test_subagent_own_slot_always_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "mochi-pet"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_subagent_user_slot_requires_subagent_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        # Without subagent:user, denied
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is True  # slots:user falls through to slot visibility which allows it
+
+    def test_subagent_user_independent_of_slots_user(self):
+        """subagent:user can be declared without slots:user (narrower access)."""
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("subagent:user"), state=state,
+        ) is True
+        # But chat content is still blocked (no slots:user)
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("subagent:user"), state=state,
+        ) is False
+
+    def test_subagent_all_covers_any_app_slot(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other")
+        state = _make_state({"other": slot})
+        assert ws_event_allowed(
+            "subagent_spawn", {"slot": "other"},
+            app="mochi-pet", allowed_events=_allowed("subagent:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: global events
+# ---------------------------------------------------------------------------
+
+class TestGlobalEvents:
+    def test_notification_own_app_requires_declaration(self):
+        # Own-app notifications now require an explicit ``notification``
+        # declaration (deny-by-default per CWE-269).  Undeclared apps get
+        # denied even for their own notifications.
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:mochi-pet", "message": "hello"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_notification_own_app_allowed_when_declared(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:mochi-pet", "message": "hello"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+
+    def test_notification_other_app_denied_without_declaration(self):
+        # ``notification`` (without ``:all``) grants only own-app notifications;
+        # a foreign app's push must be denied.
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:other-app"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_notification_all_covers_any_source(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:other-app"},
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+
+    def test_sessions_restarting_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "sessions_restarting", {"status": "restarting"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "sessions_restarting", {"status": "restarting"},
+            app="mochi-pet", allowed_events=_allowed("sessions"), state=state,
+        ) is True
+
+    def test_log_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "log", {"line": "some log"},
+            app="mochi-pet", allowed_events=_allowed("sessions"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "log", {"line": "some log"},
+            app="mochi-pet", allowed_events=_allowed("log"), state=state,
+        ) is True
+
+    def test_system_notifications_need_their_own_declaration(self):
+        """Gateway-internal pushes are user content, not the app's own.
+
+        ``send_message``, cron output and watchlist results reach state.notify(),
+        which stamps ``source="system"``. Folding them into ``notification`` would
+        make one declaration a broad grant -- the shape this module exists to
+        remove.
+        """
+        state = _make_state()
+        system_note = {"text": "cron finished", "source": "system"}
+        assert ws_event_allowed(
+            "notification", system_note,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", system_note,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+        # A note with NO source is not attributable, so it is not the system
+        # stream either -- it is denied. Accepting "" as system is exactly the
+        # defect that let one app's push reach every `notification:system`
+        # holder: the gate read a key no emitter writes, so it saw "" for every
+        # note. Only `notification:all` crosses this.
+        unattributed = {"text": "hi"}
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+
+    def test_own_app_notification_still_needs_only_notification(self):
+        state = _make_state()
+        own = {"text": "done", "source": "app:mochi-pet"}
+        assert ws_event_allowed(
+            "notification", own,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # notification:system does NOT imply own-app notifications.
+        assert ws_event_allowed(
+            "notification", own,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+
+    def test_channel_settings_is_gated_by_owner_not_by_note_source(self):
+        """It is not in _SOURCE_FILTERED_EVENTS (it carries no `source` field) but
+        it is still attributed -- by its CHANNEL owner."""
+        from kiro_crew.dashboard.ws_event_scope import _SOURCE_FILTERED_EVENTS
+
+        assert "notification_channel_settings" not in _SOURCE_FILTERED_EVENTS
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification_channel_settings",
+            {"channel": "mochi-pet.alerts", "settings": {"muted": True}},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+
+    def test_artifact_update_requires_artifacts_declaration(self):
+        state = _make_state()
+        payload = {"slug": "my-doc", "version": 3, "deleted": False}
+        assert ws_event_allowed(
+            "artifact_update", payload,
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "artifact_update", payload,
+            app="mochi-pet", allowed_events=_allowed("artifacts"), state=state,
+        ) is True
+
+    def test_workflow_run_event_declared_by_its_own_name(self):
+        """The workflows app declares the literal event name, not a scope alias.
+
+        This is the only ``permissions.events`` declaration that exists in the
+        tree today, so the gate must honour the literal name -- renaming it to a
+        scope alias would silently break that app.
+        """
+        state = _make_state()
+        payload = {"run_id": "r1", "session_key": "dashboard:chat-1"}
+        assert ws_event_allowed(
+            "workflow_run_event", payload,
+            app="workflows", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "workflow_run_event", payload,
+            app="workflows",
+            allowed_events=_allowed("workflow_run_event"), state=state,
+        ) is True
+
+    def test_notification_channel_settings_is_scoped_by_channel_owner(self):
+        """A channel is `<app>.<id>` or `system.<kind>`, so it IS attributable.
+
+        The old fixture used `#team` -- a shape the bus never produces -- and the
+        gate let ANY app with own-only `notification` read every channel's
+        settings. messaging.py itself derives the source as
+        `channel.split(".", 1)[0]`; this mirrors that.
+        """
+        state = _make_state()
+        own = {"channel": "mochi-pet.alerts", "settings": {"muted": True}}
+        foreign = {"channel": "workflows.alerts", "settings": {"muted": True}}
+        assert ws_event_allowed(
+            "notification_channel_settings", own,
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", own,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # Another app's channel is NOT covered by own-only notification.
+        assert ws_event_allowed(
+            "notification_channel_settings", foreign,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", foreign,
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+        # System channels ride the system opt-in, like the system stream itself.
+        system = {"channel": "system.cron", "settings": {"muted": True}}
+        assert ws_event_allowed(
+            "notification_channel_settings", system,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", system,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+
+    def test_channel_owner_helper_matches_the_handler_convention(self):
+        """Pin the helper against the derivation messaging.py already uses."""
+        from kiro_crew.dashboard.ws_event_scope import notification_channel_owner
+
+        for channel in ("mochi-pet.alerts", "system.cron", "workflows.x.y"):
+            assert notification_channel_owner(channel) == channel.split(".", 1)[0]
+        # No dot -> no owner -> not attributable.
+        assert notification_channel_owner("#team") == ""
+        assert notification_channel_owner("") == ''
+
+    def test_unknown_event_denied(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "some_unknown_event_xyz", {},
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is False
+
+    def test_yolo_expired_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "yolo_expired", {"source": "timer"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "yolo_expired", {"source": "timer"},
+            app="mochi-pet", allowed_events=_allowed("yolo"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# filter_slots_for_app
+# ---------------------------------------------------------------------------
+
+class TestFilterSlotsForApp:
+    def _slot_dict(self, key: str) -> dict:
+        return {"key": key, "title": key}
+
+    def test_own_slot_included(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("mochi-pet")],
+            "mochi-pet", _allowed(), state,
+        )
+        assert len(result) == 1
+        assert result[0]["key"] == "mochi-pet"
+
+    def test_other_app_slot_excluded_by_default(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        state = _make_state({"other-app": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("other-app")],
+            "mochi-pet", _allowed(), state,
+        )
+        assert result == []
+
+    def test_user_slot_included_with_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("chat-1")],
+            "mochi-pet", _allowed("slots:user"), state,
+        )
+        assert len(result) == 1
+
+    def test_user_slot_excluded_without_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("chat-1")],
+            "mochi-pet", _allowed("notification"), state,
+        )
+        assert result == []
+
+    def test_slots_all_includes_everything(self):
+        slot1 = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        slot2 = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        slot3 = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({
+            "mochi-pet": slot1,
+            "other-app": slot2,
+            "chat-1": slot3,
+        })
+        result = filter_slots_for_app(
+            [self._slot_dict(k) for k in ["mochi-pet", "other-app", "chat-1"]],
+            "mochi-pet", _allowed("slots:all"), state,
+        )
+        assert len(result) == 3
+
+    def test_missing_slot_in_state_excluded(self):
+        # slot dict references a key not in state._slots (stale data)
+        state = _make_state({})
+        result = filter_slots_for_app(
+            [self._slot_dict("ghost")],
+            "mochi-pet", _allowed("slots:all"), state,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# token_auth: implicit allow for /api/ws and /api/status
+# ---------------------------------------------------------------------------
+
+class TestImplicitAllow:
+    def test_api_ws_implicitly_allowed_for_any_app(self):
+        assert app_token_path_allowed("mochi-pet", "/api/ws") is True
+        assert app_token_path_allowed("auto-improvement", "/api/ws") is True
+
+    def test_api_status_is_NOT_implicitly_allowed(self):
+        """``/api/status`` is not connection infrastructure: it returns
+        ``owner_id_hash``, host specs, cron/usage stats and the live
+        safety-override state, with no response-level filter to match what
+        event scoping gives ``/api/ws``. An app must declare it."""
+        assert app_token_path_allowed("mochi-pet", "/api/status") is False
+
+    def test_empty_app_name_still_denied(self):
+        assert app_token_path_allowed("", "/api/ws") is False
+
+    def test_other_undeclared_path_still_denied(self):
+        # Implicit allow doesn't bleed into other paths
+        assert app_token_path_allowed("mochi-pet", "/api/sessions") is False
+        assert app_token_path_allowed("mochi-pet", "/api/ws/extra") is False
+
+    def test_api_ws_implicit_allow_emits_no_exception(self):
+        """SEL audit in implicit allow path must not raise even if SEL is unavailable."""
+        # Patch the reference used at call time (token_auth imports sel as _sel_fn
+        # at module load; patching kiro_crew.sel.sel would not affect that binding).
+        with patch(
+            "kiro_crew.dashboard.token_auth._sel_fn",
+            side_effect=Exception("sel unavailable"),
+        ):
+            # Should return True despite SEL failure (audit is best-effort)
+            result = app_token_path_allowed("mochi-pet", "/api/ws")
+            assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: test_app_token_path_allowed_implicit_ws (from original CR)
+# ---------------------------------------------------------------------------
+
+def test_app_token_path_allowed_implicit_ws() -> None:
+    """``/api/ws`` is implicitly allowed for all app tokens without an explicit
+    permissions.api declaration: every app that uses KiroCrewClient needs it to
+    connect, and the WS layer filters events per-app via ws_event_scope.py so
+    connecting no longer grants full event stream access. ``/api/status`` is
+    NOT implicitly allowed — it has no equivalent response filter. The
+    reconnect poll that uses it is the dashboard SPA
+    (``useDashboardHealthProbe``), which runs on a dashboard-user token and
+    never reaches this check.
+    """
+    assert app_token_path_allowed("mochi-pet", "/api/ws") is True
+    assert app_token_path_allowed("mochi-pet", "/api/status") is False
+    assert app_token_path_allowed("auto-improvement", "/api/ws") is True
+    # Other undeclared paths are still denied
+    assert app_token_path_allowed("mochi-pet", "/api/sessions") is False
+
+
+# ---------------------------------------------------------------------------
+# Empty-app fail-closed (deny-by-default, CWE-269)
+# ---------------------------------------------------------------------------
+
+class TestEmptyAppDeniedClosed:
+    """``ws_event_allowed`` must fail-closed if called with an empty app.
+
+    ``assert`` is compiled out under ``python -O``, so we can't rely on it as
+    a security guard.  The runtime check must remain in production builds.
+    """
+
+    def test_empty_app_denied_for_tier0_event(self):
+        # Even the ``dashboard`` Tier-0 event must be denied when app is empty.
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {},
+            app="", allowed_events=_allowed("dashboard"), state=state,
+        ) is False
+
+    def test_empty_app_denied_for_owned_slot(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "s1"},
+            app="", allowed_events=_allowed("slots:user"), state=state,
+        ) is False
+
+    def test_empty_app_deny_emits_audit(self):
+        # A caller that reaches ws_event_allowed with an empty app must
+        # leave an audit trail so the bypass is observable.
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as sel_mock:
+            _wes._sel_last_audit.clear()  # fresh window
+            ws_event_allowed(
+                "chat_chunk", {}, app="", allowed_events=_allowed(), state=state,
+            )
+            outcomes = [
+                c.kwargs.get("outcome", "")
+                for c in sel_mock.return_value.log_api_access.call_args_list
+            ]
+            assert any("empty_app_denied" in o for o in outcomes)
+
+
+# ---------------------------------------------------------------------------
+# ``slot_title`` uses ``key`` (not ``slot``) for the slot identifier
+# ---------------------------------------------------------------------------
+
+class TestSlotTitleKeyField:
+    """Regression: ``slot_title`` events must be filtered by the ``key`` field.
+
+    ``_broadcast`` builds a payload of ``{"key", "title"}`` (no ``slot``), so
+    the scope gate has to fall back to ``key`` — otherwise every ``slot_title``
+    push is denied for every app token.
+    """
+
+    def test_slot_title_own_slot_allowed_via_key(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"key": "s1", "title": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_slot_title_other_app_denied(self):
+        slot = _make_slot(owner_app="other", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"key": "s1", "title": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# ``slots`` full re-push: needs any ``slots:*`` scope
+# ---------------------------------------------------------------------------
+
+class TestSlotsListEvent:
+    """``slots`` events are always delivered — payload-level per-app filter
+    in ``DashboardState._serialize_for_client`` enforces per-slot scope.
+    The default is "app sees its own slots without an explicit declaration",
+    matching filter_slots_for_app's own-slot-always behaviour on initial
+    connect (avoids docstring/impl divergence flagged by AutoSDE).
+    """
+
+    def test_slots_allowed_even_without_scope(self):
+        # No explicit slots:* declaration — event still delivered; the
+        # payload filter in _serialize_for_client will trim to own slots.
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_slots_allowed_with_slots_own(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed("slots:own"), state=state,
+        ) is True
+
+    def test_slots_allowed_with_slots_all(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# SEL audit deduplication (first-per-window, not per-call)
+# ---------------------------------------------------------------------------
+
+class TestAuditDedup:
+    def _clear_cache(self):
+        from kiro_crew.dashboard import ws_event_scope
+        ws_event_scope._sel_last_audit.clear()
+
+    def test_first_deny_audited_subsequent_within_window_suppressed(self):
+        self._clear_cache()
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as m:
+            for _ in range(5):
+                ws_event_allowed(
+                    "notification", {"source": "app:other-app"},
+                    app="mochi-pet",
+                    allowed_events=_allowed("notification"),
+                    state=state,
+                )
+            # Only one audit emitted for the (app, event_type, reason) tuple.
+            assert m.return_value.log_api_access.call_count == 1
+
+    def test_different_reasons_audited_independently(self):
+        self._clear_cache()
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as m:
+            # notification_scope_denied
+            ws_event_allowed(
+                "notification", {"source": "app:other-app"},
+                app="mochi-pet",
+                allowed_events=_allowed("notification"),
+                state=state,
+            )
+            # unknown_event (different reason)
+            ws_event_allowed(
+                "totally_made_up_event", {},
+                app="mochi-pet", allowed_events=_allowed(), state=state,
+            )
+            assert m.return_value.log_api_access.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Positive ``_is_dashboard_user`` flag on _send_ws_all / subagent subscribers
+# ---------------------------------------------------------------------------
+
+class TestPositiveDashboardUserFlag:
+    """The scope gate must be triggered by the ABSENCE of a positive
+    ``_is_dashboard_user`` flag, not the absence of ``_app``.  This prevents
+    a future refactor from silently opening a fail-open path.
+    """
+
+    def _make_ws(self, *, is_dashboard_user: bool | None, app: str = "") -> MagicMock:
+        ws = MagicMock()
+        ws.closed = False
+        # Simulate ws["_app"] and ws.get behavior on a real WSResponse
+        store = {}
+        if is_dashboard_user is not None:
+            store["_is_dashboard_user"] = is_dashboard_user
+        if app:
+            store["_app"] = app
+            store["_allowed_events"] = _allowed()
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        return ws
+
+    def test_dashboard_user_flag_unset_is_treated_as_app(self):
+        """If a code path forgets to set _is_dashboard_user, the gate applies."""
+        from kiro_crew.dashboard.state import DashboardState
+
+        # Build a minimal state stub with the helper method.
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        # Bind the real helper to the mock so we exercise real logic.
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = self._make_ws(is_dashboard_user=None, app="mochi-pet")
+        # unknown-event → deny path
+        assert state._ws_client_allowed(ws, "totally_made_up", {}) is False
+
+    def test_dashboard_user_positive_flag_bypasses_gate(self):
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = self._make_ws(is_dashboard_user=True)
+        assert state._ws_client_allowed(ws, "totally_made_up", {}) is True
+
+
+class TestScopeCheckExceptionAudited:
+    """When ws_event_allowed itself blows up, the fail-closed branch must
+    audit the deny so scope-check bugs remain observable.
+    """
+
+    def test_scope_check_exception_emits_audit(self):
+        from kiro_crew.dashboard import ws_event_scope
+        from kiro_crew.dashboard.state import DashboardState
+        ws_event_scope._sel_last_audit.clear()
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": _allowed(),
+        }.get(k, default)
+        # Force ws_event_allowed to raise
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.ws_event_allowed",
+            side_effect=RuntimeError("boom"),
+        ), patch("kiro_crew.sel.sel") as sel_mock:
+            result = state._ws_client_allowed(ws, "chat_chunk", {"slot": "x"})
+            assert result is False
+            # The audit was invoked at least once with the scope_check_exception reason.
+            calls = sel_mock.return_value.log_api_access.call_args_list
+            reasons = [c.kwargs.get("outcome", "") for c in calls]
+            assert any("scope_check_exception" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# _origin persistence — cron/system slots must survive a restart with the
+# correct origin so the WS scope gate doesn't mis-classify them.
+# ---------------------------------------------------------------------------
+
+class TestOriginPersistence:
+    """A cron- or system-initiated slot rehydrated from disk must keep its
+    original origin so ``slots:user`` scopes don't inadvertently grant an app
+    visibility into events it wasn't authorised for.
+
+    These drive the REAL save/restore functions against a REAL
+    ``ConversationLog``. An earlier version of this class rebuilt the
+    ``meta_line`` assembly inside the test and asserted on its own local dict —
+    so it stayed green while ``_save_slot_to_history`` never wrote ``origin``
+    at all, and every slot silently rehydrated unattributed. Never restate the
+    production logic here; call it.
+    """
+
+    @staticmethod
+    def _state(tmp_path):
+        from unittest.mock import AsyncMock
+
+        from chat_test_helpers import _make_ready_kiro_prerequisite
+
+        from kiro_crew.dashboard.state import DashboardState
+        from kiro_crew.history import ConversationLog
+
+        sessions = MagicMock(count=0)
+        sessions.remove = AsyncMock()
+        sessions.recycle_background = AsyncMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+        state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+        return state
+
+    def test_slot_has_origin_attribute(self):
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        assert hasattr(_ChatSlot("s1"), "_origin")
+
+    def test_to_dict_includes_origin(self):
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        slot = _ChatSlot("s1")
+        slot._origin = SlotOrigin.CRON
+        assert slot.to_dict()["origin"] == SlotOrigin.CRON
+
+    def test_save_writes_origin_to_meta(self, tmp_path, monkeypatch):
+        """The REAL save path must persist origin — this is the write side that
+        was missing, letting every restored slot come back unattributed."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+
+        _save_slot_to_history(state, slot, closed=True)
+
+        meta = state.conversation_log.get_metadata("dashboard:cron-1")
+        assert meta.get("origin") == SlotOrigin.CRON
+
+    def test_untagged_origin_not_persisted(self, tmp_path, monkeypatch):
+        """The fail-closed empty sentinel must not be written as a real value."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot._origin = ""
+        slot.append("user", "hi")
+        slot.drain()
+
+        _save_slot_to_history(state, slot, closed=True)
+
+        assert "origin" not in state.conversation_log.get_metadata("dashboard:s1")
+
+    @pytest.mark.parametrize("origin", [SlotOrigin.CRON, SlotOrigin.USER, SlotOrigin.APP])
+    def test_origin_round_trips_through_rehydrate(self, tmp_path, monkeypatch, origin):
+        """save -> _rehydrate_slot_from_history must return the SAME origin."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot._origin = origin
+        if origin == SlotOrigin.APP:
+            slot._app = "mochi-pet"
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["s1"]
+
+        restored = _rehydrate_slot_from_history(state, "s1")
+        assert restored is not None
+        assert restored._origin == origin
+
+    def test_origin_round_trips_through_bulk_restore(self, tmp_path, monkeypatch):
+        """The bulk restore path (gateway boot) must restore origin too — the
+        two restore sites are separate code and both read ``meta["origin"]``."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _save_slot_to_history,
+            restore_recent_sessions,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["cron-1"]
+
+        restore_recent_sessions(state)
+
+        assert state._slots["cron-1"]._origin == SlotOrigin.CRON
+
+    def test_restored_cron_slot_still_hidden_from_slots_user(self, tmp_path, monkeypatch):
+        """The security property the persistence exists for: a CRON slot that
+        survived a restart must STILL be withheld from a ``slots:user`` app.
+        Without the write side it rehydrated untagged and this gate flipped."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["cron-1"]
+        restored = _rehydrate_slot_from_history(state, "cron-1")
+        assert restored is not None
+
+        assert not ws_event_allowed(
+            "chat_message", {"slot": "cron-1"},
+            app="some-app", allowed_events=frozenset({"slots:user"}), state=state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive is_dashboard_user flag from token_auth — a token that does not
+# come through the auth middleware (or fails it) MUST NOT bypass the gate.
+# ---------------------------------------------------------------------------
+
+class TestAuthMiddlewareIsDashboardUser:
+    """The auth middleware sets ``request["is_dashboard_user"]`` positively
+    only for verified dashboard-user tokens.  App tokens and unauthenticated
+    requests never see the flag flip to True.
+    """
+
+    def test_dashboard_user_bypasses_scope_gate(self):
+        # Behavioral: a ws with positive _is_dashboard_user flag must bypass
+        # the scope gate entirely (that's the CWE-269 fix's whole point).
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            "_is_dashboard_user": True,
+        }.get(k, default)
+        # Even an unknown event that would deny app tokens passes for
+        # dashboard users.
+        assert state._ws_client_allowed(ws, "totally_unknown_event", {}) is True
+
+    def test_missing_flag_treats_as_app_token(self):
+        # Behavioral: without the positive flag, gate applies (deny-by-default).
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            # Deliberately missing _is_dashboard_user.
+            "_app": "mochi-pet",
+            "_allowed_events": frozenset(),
+        }.get(k, default)
+        assert state._ws_client_allowed(ws, "totally_unknown_event", {}) is False
+
+
+# ---------------------------------------------------------------------------
+# Missing _origin fails closed — a slot without the attribute must not be
+# treated as USER by default.
+# ---------------------------------------------------------------------------
+
+class TestMissingOriginFailsClosed:
+    """CWE-269 defense-in-depth: if ``_origin`` is somehow missing (pre-
+    migration slot, race, bug), it must remain invisible to any ``:user``
+    scope rather than being silently classified as ``SlotOrigin.USER``.
+    """
+
+    def _slot_without_origin(self, owner_app: str = "") -> MagicMock:
+        # Deliberately DO NOT set _origin on the mock — spec=[] means
+        # hasattr(slot, "_origin") is False.
+        slot = MagicMock(spec=["_app"])
+        slot._app = owner_app
+        return slot
+
+    def test_slot_visible_denied_when_origin_missing(self):
+        slot = self._slot_without_origin()
+        state = _make_state({"s1": slot})
+        # slots:user must NOT grant visibility to a slot with no _origin.
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "s1"},
+            app="mochi-pet",
+            allowed_events=_allowed("slots:user"),
+            state=state,
+        ) is False
+
+    def test_subagent_visible_denied_when_origin_missing(self):
+        slot = self._slot_without_origin()
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "subagent_chunk", {"slot": "s1"},
+            app="mochi-pet",
+            allowed_events=_allowed("subagent:user"),
+            state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Slots re-push payload filtering — an app that declared slots:own must NOT
+# receive other apps' or users' slot metadata on ``push_slots_update`` /
+# ``_broadcast`` re-pushes.  The filter runs inside DashboardState.
+# _serialize_for_client on the send layer, so we assert that behaviour by
+# reading the module source to guard against regression (constructing a real
+# DashboardState in-process here would be over-engineered).
+# ---------------------------------------------------------------------------
+
+class TestSlotsRepushFilter:
+    """Behavioral: an app that declared slots:own must NOT receive other
+    apps' or users' slot metadata on ``push_slots_update`` re-pushes.  The
+    filter runs inside ``DashboardState._serialize_for_client``.
+    """
+
+    def _make_state_with_slots(self, slot_map: dict) -> Any:
+        # Wrap into a state that mimics DashboardState._serialize_for_client's
+        # required surface.  We bind the real method to a MagicMock so it
+        # runs against our slot map instead of a live DashboardState.
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = slot_map
+        state._serialize_for_client = (
+            DashboardState._serialize_for_client.__get__(state)
+        )
+        return state
+
+    def _ws(self, *, is_dashboard: bool, app: str = "", events=frozenset()):
+        ws = MagicMock()
+        store = {
+            "_is_dashboard_user": is_dashboard,
+            "_app": app,
+            "_allowed_events": events,
+        }
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        return ws
+
+    def test_dashboard_user_receives_full_slots_list(self):
+        import json
+        slot_a = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="a")
+        slot_b = _make_slot(owner_app="other", origin=SlotOrigin.APP, key="b")
+        state = self._make_state_with_slots({"a": slot_a, "b": slot_b})
+        ws = self._ws(is_dashboard=True)
+        default_msg = json.dumps({
+            "type": "slots",
+            "data": [{"key": "a"}, {"key": "b"}],
+            "yolo": False,
+            "channelTrusted": False,
+        })
+        result = state._serialize_for_client(
+            ws, "slots",
+            {"slots": [{"key": "a"}, {"key": "b"}], "yolo": False, "channelTrusted": False},
+            default_msg,
+        )
+        # Dashboard user: unchanged default msg (full list).
+        assert result == default_msg
+
+    def test_app_with_slots_own_only_sees_own_slot(self):
+        import json
+        slot_a = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="a")
+        slot_b = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="b")
+        state = self._make_state_with_slots({"a": slot_a, "b": slot_b})
+        ws = self._ws(
+            is_dashboard=False, app="mochi-pet",
+            events=frozenset({"slots:own"}),
+        )
+        result_str = state._serialize_for_client(
+            ws, "slots",
+            {
+                "slots": [{"key": "a"}, {"key": "b"}],
+                "yolo": False,
+                "channelTrusted": False,
+            },
+            default_msg="dummy",
+        )
+        result = json.loads(result_str)
+        assert result["type"] == "slots"
+        # Only the mochi-pet slot should survive per-app payload filtering.
+        assert [s["key"] for s in result["data"]] == ["a"]
+
+    def test_non_slots_event_passes_through_unchanged(self):
+        # For any non-``slots`` event, _serialize_for_client returns default.
+        state = self._make_state_with_slots({})
+        ws = self._ws(is_dashboard=False, app="mochi-pet", events=frozenset())
+        default = "OPAQUE"
+        assert state._serialize_for_client(ws, "chat_chunk", {}, default) == default
+
+
+# ---------------------------------------------------------------------------
+# A socket's scope must be able to SHRINK while it stays open. `_allowed_events`
+# is resolved at connect, so a narrowed or deleted manifest would otherwise keep
+# granting revoked scopes until the connection happens to drop — and
+# `disable_app` rewrites the registry without closing sockets.
+# ---------------------------------------------------------------------------
+
+class TestLiveScopeNarrowing:
+    def setup_method(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache.clear()
+        mod._declared_refreshing.clear()
+
+    def _snapshot(self):
+        return _allowed("slots:all", "notification")
+
+    def test_narrowed_manifest_takes_effect_without_a_reconnect(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache["mochi-pet"] = (time.monotonic(), True, _allowed("slots:own"))
+        eff = mod.effective_allowed_events("mochi-pet", self._snapshot())
+        assert "slots:all" not in eff, "a revoked scope must stop being honoured"
+        assert "notification" not in eff
+
+    def test_deleted_manifest_collapses_to_tier0_only(self):
+        """`app disable` / uninstall leaves the socket open; scopes must go."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache["mochi-pet"] = (time.monotonic(), False, frozenset())
+        assert mod.effective_allowed_events("mochi-pet", self._snapshot()) == frozenset()
+        assert mod.app_events_revoked("mochi-pet") is True
+
+    def test_widened_manifest_does_not_escalate_an_open_socket(self):
+        """Intersection, not replacement: widening needs a reconnect.
+
+        Otherwise editing a manifest would grant a LIVE session scopes it was
+        never authenticated for.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache["mochi-pet"] = (
+            time.monotonic(), True, _allowed("slots:own", "log")
+        )
+        eff = mod.effective_allowed_events("mochi-pet", _allowed("slots:own"))
+        assert eff == _allowed("slots:own")
+        assert "log" not in eff, "a widened manifest must not reach an open socket"
+
+    def test_cold_miss_keeps_the_connect_snapshot_and_schedules_a_refresh(self):
+        """Fail-SAFE, not fail-closed: an empty fallback would withhold every
+        event from every app on the first broadcast after a restart. The snapshot
+        is itself an authenticated read, so leaning on it briefly widens nothing.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        snap = self._snapshot()
+        with patch.object(mod, "_schedule_declared_refresh") as sched:
+            assert mod.effective_allowed_events("mochi-pet", snap) == snap
+            sched.assert_called_once_with("mochi-pet")
+
+    def test_stale_entry_is_applied_and_refresh_scheduled(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache["mochi-pet"] = (
+            time.monotonic() - (mod._MANIFEST_EXPOSE_TTL_SECS + 5),
+            True,
+            _allowed("notification"),
+        )
+        with patch.object(mod, "_schedule_declared_refresh") as sched:
+            eff = mod.effective_allowed_events("mochi-pet", self._snapshot())
+            sched.assert_called_once_with("mochi-pet")
+        assert eff == _allowed("notification"), "stale-but-narrower still narrows"
+
+    def test_never_reads_the_disk_on_the_decision_path(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "get_app_manifest") as gm, \
+                patch.object(mod, "_schedule_declared_refresh"):
+            mod.effective_allowed_events("mochi-pet", self._snapshot())
+            gm.assert_not_called()
+
+    def test_refresh_is_coalesced(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        loop = MagicMock()
+        with patch.object(mod.asyncio, "get_running_loop", return_value=loop):
+            for _ in range(20):
+                mod._schedule_declared_refresh("mochi-pet")
+        assert loop.run_in_executor.call_count == 1
+
+    def test_disabled_app_declares_nothing_even_with_manifest_intact(self):
+        """`disable_app` flips `enabled` and leaves `app.json` alone.
+
+        Reading the manifest alone reports a disabled app's declarations
+        unchanged, so the intersection would keep honouring them.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        fake = MagicMock()
+        fake.permissions.events = ["slots:all", "log"]
+        with patch.object(mod, "is_app_enabled", return_value=False), \
+                patch.object(mod, "get_app_manifest", return_value=fake):
+            assert mod._read_declared_events("mochi-pet") == (False, frozenset())
+
+    def test_enabled_app_declares_its_manifest_events(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        fake = MagicMock()
+        fake.permissions.events = ["slots:own"]
+        with patch.object(mod, "is_app_enabled", return_value=True), \
+                patch.object(mod, "get_app_manifest", return_value=fake):
+            assert mod._read_declared_events("mochi-pet") == (True, _allowed("slots:own"))
+
+    def test_enablement_is_checked_before_the_manifest_read(self):
+        """A disabled app must not even cost a manifest parse."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "is_app_enabled", return_value=False), \
+                patch.object(mod, "get_app_manifest") as gm:
+            mod._read_declared_events("mochi-pet")
+            gm.assert_not_called()
+
+    def test_missing_manifest_reads_as_no_declarations_but_not_revoked(self):
+        """A still-enabled app with an unreadable manifest declares nothing.
+
+        It must NOT read as revoked: a corrupt or transient ``app.json`` read is
+        not a disablement, and treating it as one would blank the app's own chat
+        for a refresh interval over a filesystem hiccup. Revocation requires
+        positive evidence from ``installed.json``.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "is_app_enabled", return_value=True), \
+                patch.object(mod, "get_app_manifest", return_value=None):
+            assert mod._read_declared_events("gone") == (True, frozenset())
+
+    def test_log_subscriber_send_rechecks_the_live_scope(self):
+        """The FOURTH read path: log fan-out bypasses the broadcast chokepoint.
+
+        ``subscribe_logs`` grants once and the ring handler then writes straight
+        to ``_ws_log_subscribers``, so revoking ``log`` has to be enforced at the
+        send instead of at the subscribe. The recheck now goes through
+        ``DashboardState._ws_client_allowed`` itself (the same chokepoint every
+        other event uses), not a hand-rolled duplicate of its scope comparison,
+        so this decision is SEL-audited too.
+        """
+        import asyncio as _aio
+
+        from kiro_crew.dashboard import ws_event_scope as mod
+        from kiro_crew.dashboard.handlers import updates as upd
+        from kiro_crew.dashboard.state import DashboardState
+
+        # Declaration set no longer contains `log` (revoked).
+        mod._declared_cache["mochi-pet"] = (time.monotonic(), True, _allowed("slots:own"))
+        ws = MagicMock()
+        store = {
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": _allowed("slots:own", "log"),
+        }
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        sent: list[str] = []
+
+        async def _send(msg):
+            sent.append(msg)
+
+        ws.send_str = _send
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        state._ws_log_subscribers = {ws}
+
+        _aio.run(upd._safe_ws_send(ws, '{"type":"log"}', state))
+        assert sent == [], "a revoked log scope must stop the stream"
+        assert ws not in state._ws_log_subscribers, "and drop the subscription"
+
+    def test_log_subscriber_send_still_delivers_while_declared(self):
+        import asyncio as _aio
+
+        from kiro_crew.dashboard import ws_event_scope as mod
+        from kiro_crew.dashboard.handlers import updates as upd
+        from kiro_crew.dashboard.state import DashboardState
+
+        mod._declared_cache["mochi-pet"] = (time.monotonic(), True, _allowed("log"))
+        ws = MagicMock()
+        store = {
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": _allowed("log"),
+        }
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        sent: list[str] = []
+
+        async def _send(msg):
+            sent.append(msg)
+
+        ws.send_str = _send
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        state._ws_log_subscribers = {ws}
+
+        _aio.run(upd._safe_ws_send(ws, '{"type":"log"}', state))
+        assert sent == ['{"type":"log"}']
+
+    def test_log_subscriber_send_skips_the_check_for_dashboard_users(self):
+        import asyncio as _aio
+
+        from kiro_crew.dashboard.handlers import updates as upd
+
+        ws = MagicMock()
+        ws.get.side_effect = lambda k, default=None: (
+            True if k == "_is_dashboard_user" else default
+        )
+        sent: list[str] = []
+
+        async def _send(msg):
+            sent.append(msg)
+
+        ws.send_str = _send
+        state = MagicMock()
+        _aio.run(upd._safe_ws_send(ws, '{"type":"log"}', state))
+        assert sent == ['{"type":"log"}']
+
+    def test_source_guard_status_frame_withholds_checkout_identity(self):
+        """Tier 0 holds only while the `dashboard` payload stays non-sensitive.
+
+        `_push_status` writes straight to the socket every few seconds, so the
+        frame's CONTENT is the control, not a gate. Counts and environment are
+        fine; the checkout's branch and commit say what the operator is working
+        on and have no consumer outside the owner surfaces, so they are stripped
+        for app tokens instead of moving the whole frame behind a declaration —
+        that would cut every existing app off from the version signal it uses to
+        reload across a gateway upgrade.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+        assert 'for _owner_only in ("branch", "commit")' in src, (
+            "the periodic dashboard frame must withhold checkout identity from apps"
+        )
+        assert 'if not ws.get("_is_dashboard_user", False):' in src
+        # And the owner surfaces must NOT be narrowed: /api/status and SSE run on
+        # dashboard-user tokens and still need the full snapshot.
+        state_src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "state.py"
+        ).read_text(encoding="utf-8")
+        assert "branch, commit = self._build_info" in state_src, (
+            "status_snapshot itself must keep returning branch/commit"
+        )
+
+    def test_source_guard_log_replay_uses_the_live_scope(self):
+        """The replay half of the log path.
+
+        Two gates read the log scope: the one-shot ring REPLAY in
+        ``subscribe_logs`` and the per-frame send. Fixing only the send left the
+        replay able to hand over the whole buffered ring on a revoked scope, so
+        this guard covers ``ws.py`` too — the state.py-only guard below is why
+        that half was missed.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+        assert "effective_allowed_events(ws_app, allowed_events)" in src, (
+            "subscribe_logs must resolve the live scope before replaying the ring"
+        )
+        assert '"log" in _live or "log:all" in _live' in src, (
+            "the replay gate must test the LIVE set, not the connect snapshot"
+        )
+
+    def test_source_guard_every_allowed_events_read_is_narrowed(self):
+        """All three consumers must narrow, not just the gate.
+
+        The payload filters (`slots`, subagent batches) decide with the same set;
+        leaving one on the raw snapshot would keep handing back the rows a
+        revoked scope selected.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "state.py"
+        ).read_text(encoding="utf-8")
+        raw_reads = src.count('ws.get("_allowed_events", frozenset())')
+        narrowed = src.count("effective_allowed_events(ws_app, snapshot)")
+        assert raw_reads == narrowed == 3, (
+            f"{raw_reads} snapshot reads but {narrowed} narrowed — every read of "
+            "_allowed_events in state.py must go through effective_allowed_events"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grants are audited, not just denials.
+#
+# AUTOSDE.yaml `backend-security-controls` (blocking) requires a SEL event for
+# every permission decision. Auditing only the refusals leaves "what did this
+# app actually receive" unanswerable, which is also the operator question the
+# feature doc admits it could not answer.
+#
+# The audit lives in the `ws_event_allowed` WRAPPER rather than at each
+# `return True`, so a branch added later is covered without remembering to
+# report itself. The per-tier test below is what pins that: it drives one event
+# from EACH tier and asserts all of them produce a record.
+# ---------------------------------------------------------------------------
+
+class TestGrantsAreAudited:
+    APP = "mochi-pet"
+
+    def _state_with_own_slot(self):
+        slot = MagicMock()
+        slot._app = self.APP
+        slot.key = "s1"
+        return _make_state({"s1": slot})
+
+    def _enable(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache[self.APP] = (time.monotonic(), True, frozenset())
+
+    def test_an_allowed_event_is_audited_as_granted(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        self._enable()
+        state = self._state_with_own_slot()
+        with patch.object(mod, "_audit_decision") as audit:
+            assert ws_event_allowed(
+                "chat_delta", {"slot": "s1"},
+                app=self.APP, allowed_events=frozenset(), state=state,
+            ) is True
+        audit.assert_called_once()
+        assert audit.call_args.args[2] == "granted", "outcome must read as a grant"
+
+    def test_every_tier_produces_a_record(self):
+        """Pins that the wrapper covers all return-True paths, not just one.
+
+        Tier 0, the always-admitted envelopes and the slot-scoped branch each
+        return True from a DIFFERENT place in the decision function. If the audit
+        were attached per-branch instead of to the result, whichever branch was
+        forgotten would show up here.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        self._enable()
+        state = self._state_with_own_slot()
+        batch = sorted(mod._SUBAGENT_BATCH_EVENTS)[0]
+        cases = [
+            (sorted(mod._TIER0_ALWAYS)[0], {}, frozenset()),          # Tier 0
+            ("slots", {}, frozenset()),                                # admitted whole
+            (batch, {}, frozenset()),                                  # admitted whole
+            ("chat_delta", {"slot": "s1"}, frozenset()),               # own slot
+            ("log", {}, _allowed("log")),                              # global, declared
+        ]
+        for event, payload, scopes in cases:
+            with patch.object(mod, "_audit_decision") as audit:
+                assert ws_event_allowed(
+                    event, payload, app=self.APP, allowed_events=scopes, state=state,
+                ) is True, f"{event} should be allowed in this setup"
+            assert audit.call_count == 1, f"{event} was allowed without an audit record"
+
+    def test_repeated_grants_are_deduplicated(self):
+        self._enable()
+        state = self._state_with_own_slot()
+
+        # Count SEL emissions, not calls into the audit helper: the helper runs
+        # every time and the window is what collapses the write.
+        with patch("kiro_crew.sel.sel") as sel_factory:
+            for _ in range(5):
+                ws_event_allowed(
+                    "chat_delta", {"slot": "s1"},
+                    app=self.APP, allowed_events=frozenset(), state=state,
+                )
+            calls = sel_factory.return_value.log_api_access.call_count
+        assert calls == 1, (
+            f"5 identical grants emitted {calls} SEL records; the dedup window "
+            "must collapse them into one"
+        )
+
+    def test_a_grant_does_not_starve_the_deny_record(self):
+        """Grants and denials must not share a dedup slot.
+
+        Same app, same event: allowed on its own slot, denied on someone else's.
+        If both used one key, whichever happened first would suppress the other
+        for the whole window and the denial would go unrecorded.
+        """
+        self._enable()
+        own = MagicMock()
+        own._app = self.APP
+        foreign = MagicMock()
+        foreign._app = "other-app"
+        foreign._origin = ""
+        state = _make_state({"s1": own, "s2": foreign})
+
+        with patch("kiro_crew.sel.sel") as sel_factory:
+            ws_event_allowed(
+                "chat_delta", {"slot": "s1"},
+                app=self.APP, allowed_events=frozenset(), state=state,
+            )
+            ws_event_allowed(
+                "chat_delta", {"slot": "s2"},
+                app=self.APP, allowed_events=frozenset(), state=state,
+            )
+            outcomes = [
+                c.kwargs.get("outcome")
+                for c in sel_factory.return_value.log_api_access.call_args_list
+            ]
+        assert any(o == "granted" for o in outcomes), f"no grant recorded: {outcomes}"
+        assert any(
+            o and o.startswith("denied:") for o in outcomes
+        ), f"no denial recorded: {outcomes}"
+
+
+#
+# Narrowing the declaration set is not enough to revoke a disabled app, because
+# the own-slot default grants an app its own slots WITHOUT consulting
+# declarations at all -- `_slot_visible` returns True on the ownership check
+# before `allowed_events` is ever read. `disable_app` does not invalidate the app
+# token (`token_auth` has no enablement check; every app backend route gates on
+# `is_app_enabled` itself), so a disabled app can keep an authenticated
+# `/api/ws` socket open and keep streaming its own slot's chat content.
+#
+# There are THREE entry points into that default and only one of them passes
+# through `ws_event_allowed`, so each is asserted separately here.
+# ---------------------------------------------------------------------------
+
+class TestDisabledAppLosesTheOwnSlotDefault:
+    APP = "mochi-pet"
+
+    def _revoke(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache[self.APP] = (time.monotonic(), False, frozenset())
+
+    def _enable(self, events: frozenset[str] = frozenset()):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._declared_cache[self.APP] = (time.monotonic(), True, events)
+
+    def _own_slot_state(self):
+        slot = MagicMock()
+        slot._app = self.APP
+        slot.key = "s1"
+        return _make_state({"s1": slot})
+
+    def test_gate_denies_own_slot_chat_when_disabled(self):
+        """Entry point 1: the per-event gate.
+
+        This one is enforced by ``_slot_visible`` underneath, so it passes with or
+        without the gate-level check -- see
+        ``test_gate_denies_the_always_admitted_envelopes_when_disabled`` for the
+        cases only the gate check covers.
+        """
+        state = self._own_slot_state()
+        self._enable()
+        assert ws_event_allowed(
+            "chat_delta", {"slot": "s1"},
+            app=self.APP, allowed_events=frozenset(), state=state,
+        ) is True, "an ENABLED app sees its own slot by documented default"
+
+        self._revoke()
+        assert ws_event_allowed(
+            "chat_delta", {"slot": "s1"},
+            app=self.APP, allowed_events=frozenset(), state=state,
+        ) is False, "a disabled app must not keep receiving its own chat"
+
+    def test_gate_denies_the_always_admitted_envelopes_when_disabled(self):
+        """What the gate-level revocation check uniquely buys.
+
+        ``slots`` and the coalesced subagent batches return True at the gate
+        WITHOUT consulting ``allowed_events`` -- they are admitted whole and
+        narrowed in the payload. For a revoked app the payload filters empty them
+        out, so without the gate check a disabled app receives a steady stream of
+        empty envelopes instead of nothing. Denying at the gate is what makes
+        "revocation collapses the socket to Tier 0" literally true.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        state = self._own_slot_state()
+        batch = sorted(mod._SUBAGENT_BATCH_EVENTS)[0]
+
+        self._enable()
+        for etype in ("slots", batch):
+            assert ws_event_allowed(
+                etype, {}, app=self.APP, allowed_events=frozenset(), state=state,
+            ) is True, f"{etype} is admitted whole for an enabled app"
+
+        self._revoke()
+        for etype in ("slots", batch):
+            assert ws_event_allowed(
+                etype, {}, app=self.APP, allowed_events=frozenset(), state=state,
+            ) is False, f"{etype} must not be admitted for a revoked app"
+
+    def test_slots_repush_filter_drops_own_slot_when_disabled(self):
+        """Entry point 2: ``filter_slots_for_app`` never calls the gate."""
+        from kiro_crew.dashboard.ws_event_scope import filter_slots_for_app
+        state = self._own_slot_state()
+        rows = [{"key": "s1"}]
+
+        self._enable()
+        assert filter_slots_for_app(rows, self.APP, frozenset(), state) == rows
+
+        self._revoke()
+        assert filter_slots_for_app(rows, self.APP, frozenset(), state) == [], (
+            "the slots payload filter bypasses ws_event_allowed, so it needs its "
+            "own revocation check"
+        )
+
+    def test_subagent_batch_filter_drops_own_items_when_disabled(self):
+        """Entry point 3: ``filter_subagent_batch_for_app`` never calls the gate."""
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+        state = self._own_slot_state()
+        items = [{"slot": "s1", "id": "a"}]
+
+        self._enable()
+        assert filter_subagent_batch_for_app(items, self.APP, frozenset(), state) == items
+
+        self._revoke()
+        assert filter_subagent_batch_for_app(items, self.APP, frozenset(), state) == []
+
+    def test_slots_repush_filter_audits_each_item_decision(self):
+        """The per-item slot filter is its own permission decision, not a
+        detail of the frame-level grant already logged by ``ws_event_allowed``
+        -- it needs an SEL record of its own for the same reason every other
+        decision in this module does.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        self._enable()
+        own = _make_slot(owner_app=self.APP, origin=SlotOrigin.APP, key="s1")
+        foreign = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="s2")
+        state = _make_state({"s1": own, "s2": foreign})
+        rows = [{"key": "s1"}, {"key": "s2"}]
+
+        with patch.object(mod, "_audit_decision") as audit:
+            result = mod.filter_slots_for_app(rows, self.APP, frozenset(), state)
+
+        assert [r["key"] for r in result] == ["s1"]
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert "granted" in outcomes, "the visible own slot must be audited as a grant"
+        assert any(o.startswith("denied:") for o in outcomes), (
+            "the foreign slot must be audited as a denial"
+        )
+
+    def test_subagent_batch_filter_audits_each_item_decision(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        self._enable()
+        own = _make_slot(owner_app=self.APP, origin=SlotOrigin.APP, key="s1")
+        foreign = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="s2")
+        state = _make_state({"s1": own, "s2": foreign})
+        items = [{"slot": "s1", "id": "own"}, {"slot": "s2", "id": "foreign"}]
+
+        with patch.object(mod, "_audit_decision") as audit:
+            result = mod.filter_subagent_batch_for_app(items, self.APP, frozenset(), state)
+
+        assert [i["id"] for i in result] == ["own"]
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert "granted" in outcomes
+        assert any(o.startswith("denied:") for o in outcomes)
+
+    def test_tier0_still_reaches_a_disabled_app(self):
+        """Revocation collapses to Tier 0 -- it does not black out the socket.
+
+        Tier 0 is counts-and-environment only; withholding it would leave a
+        disabled-but-connected app unable to tell it had been turned off.
+        """
+        self._revoke()
+        state = self._own_slot_state()
+        from kiro_crew.dashboard import ws_event_scope as mod
+        tier0 = sorted(mod._TIER0_ALWAYS)[0]
+        assert ws_event_allowed(
+            tier0, {}, app=self.APP, allowed_events=frozenset(), state=state,
+        ) is True
+
+    def test_cold_miss_does_not_revoke(self):
+        """An unknown app must not read as revoked.
+
+        The gate runs before the first off-loop refresh lands, so reporting
+        "revoked" on a cold cache would blank every app's own slots on the first
+        broadcast after a gateway restart. The connect path closes this window for
+        real by PRIMING the cache -- see
+        ``test_connect_load_primes_the_cache_so_the_first_frame_is_authoritative``.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "_schedule_declared_refresh") as sched:
+            assert mod.app_events_revoked("never-seen") is False
+            sched.assert_called_once_with("never-seen")
+
+    def test_connect_load_primes_the_cache_so_the_first_frame_is_authoritative(self):
+        """Why the connect read writes the cache instead of only returning.
+
+        Without priming, a disabled app that RECONNECTS is judged by the cold-miss
+        fallback (not revoked) for the initial slots push and the log replay --
+        both of which run before any background refresh.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        fake = MagicMock()
+        fake.permissions.events = ["slots:all"]
+
+        with patch.object(mod, "is_app_enabled", return_value=False), \
+                patch.object(mod, "get_app_manifest", return_value=fake):
+            enabled, events = mod.load_declared_events_for_connect(self.APP)
+
+        assert enabled is False, "the caller needs the flag to refuse the socket"
+        assert events == frozenset()
+        assert mod.app_events_revoked(self.APP) is True, (
+            "the cache must be primed by the connect read, or the first frame is "
+            "gated on the cold-miss fallback"
+        )
+
+    def test_connect_load_reports_an_enabled_app_and_its_scopes(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        fake = MagicMock()
+        fake.permissions.events = ["slots:own", "log"]
+        with patch.object(mod, "is_app_enabled", return_value=True), \
+                patch.object(mod, "get_app_manifest", return_value=fake):
+            enabled, events = mod.load_declared_events_for_connect(self.APP)
+        assert enabled is True
+        assert events == _allowed("slots:own", "log")
+        assert mod.app_events_revoked(self.APP) is False
+
+    def test_declaration_narrowing_alone_would_not_have_closed_this(self):
+        """Pins WHY a separate predicate exists rather than reusing the scopes.
+
+        A disabled app and an enabled app that declares no events both present an
+        EMPTY effective scope set, so the gate cannot tell them apart from
+        ``allowed_events`` -- and they must be treated differently, since the
+        latter still gets its own slots.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        snap = _allowed("slots:own")
+
+        self._enable()
+        enabled_scopes = mod.effective_allowed_events(self.APP, snap)
+        self._revoke()
+        revoked_scopes = mod.effective_allowed_events(self.APP, snap)
+
+        assert enabled_scopes == revoked_scopes == frozenset(), (
+            "indistinguishable by scope set -- hence app_events_revoked"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The COMPOSITION seam: ``_send_ws_all`` is the chokepoint, and the three parts
+# it wires together (``_ws_client_allowed``, ``_serialize_for_client``, the
+# fan-out loop) are each covered in isolation above. Isolation is not enough
+# here -- the defects this module exists to prevent live in the seam: a frame the
+# gate admits whose payload is never filtered, or an event absent from the
+# tables that the loop drops for an app while the dashboard keeps receiving it.
+# These tests drive the REAL chokepoint and assert on the bytes that reach each
+# socket, with an app token present -- every other ``_send_ws_all`` test in the
+# suite flags every fake socket ``_is_dashboard_user=True`` and so only exercises
+# the bypass branch.
+# ---------------------------------------------------------------------------
+
+class TestSendWsAllComposition:
+    def _sockets_and_state(self, *, app_events: frozenset[str]):
+        """A state with one dashboard socket and one app socket, real methods."""
+        from kiro_crew.dashboard.state import DashboardState
+
+        own = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="own")
+        other = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="foreign")
+        user = _make_slot(owner_app="", origin=SlotOrigin.USER, key="user-slot")
+
+        def _ws(store: dict) -> MagicMock:
+            ws = MagicMock()
+            ws.closed = False
+            ws.get.side_effect = lambda k, default=None: store.get(k, default)
+            return ws
+
+        dash = _ws({"_is_dashboard_user": True, "_app": "", "_allowed_events": frozenset()})
+        app = _ws({
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": app_events,
+        })
+
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"own": own, "foreign": other, "user-slot": user}
+        state._ws_clients = [dash, app]
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        state._serialize_for_client = DashboardState._serialize_for_client.__get__(state)
+        state._send_ws_all = DashboardState._send_ws_all.__get__(state)
+
+        wire: list[tuple[MagicMock, str]] = []
+        state._spawn_ws_send = lambda ws, payload: wire.append((ws, payload))
+        return state, dash, app, wire
+
+    def _sent_to(self, wire, sock) -> list[str]:
+        return [payload for ws, payload in wire if ws is sock]
+
+    def test_foreign_slot_event_reaches_dashboard_but_not_app(self):
+        """The seam's core job, asserted on the wire rather than on a bool."""
+        state, dash, app, wire = self._sockets_and_state(
+            app_events=_allowed("slots:own")
+        )
+        state._send_ws_all(
+            "chat_chunk", {"slot": "foreign"}, json.dumps({"type": "chat_chunk"})
+        )
+        assert self._sent_to(wire, dash), "dashboard user must still receive it"
+        assert not self._sent_to(wire, app), "app must not see a foreign slot's chunk"
+
+    def test_own_slot_event_reaches_both(self):
+        """Own-slot delivery needs no declaration -- the documented default."""
+        state, dash, app, wire = self._sockets_and_state(
+            app_events=_allowed("slots:own")
+        )
+        state._send_ws_all(
+            "chat_chunk", {"slot": "own"}, json.dumps({"type": "chat_chunk"})
+        )
+        assert self._sent_to(wire, dash)
+        assert self._sent_to(wire, app), "an app always sees its OWN slot's events"
+
+    def test_slots_repush_is_admitted_but_payload_filtered_on_the_wire(self):
+        """The admitted-frame-unfiltered-payload defect class, end to end.
+
+        The gate lets ``slots`` through for everyone; only the serializer keeps
+        an app from reading every slot. Asserting the boolean would pass while
+        the wire still carried the full list.
+        """
+        state, dash, app, wire = self._sockets_and_state(
+            app_events=_allowed("slots:own")
+        )
+        envelope = {
+            "slots": [{"key": "own"}, {"key": "foreign"}, {"key": "user-slot"}],
+            "yolo": True,
+            "channelTrusted": True,
+        }
+        state._send_ws_all("slots", envelope, json.dumps({"type": "slots"}))
+
+        app_frames = self._sent_to(wire, app)
+        assert app_frames, "slots is always admitted; the payload is what narrows"
+        payload = json.loads(app_frames[0])
+        assert [s["key"] for s in payload["data"]] == ["own"]
+        # Envelope posture fields are not slot data, so the slot filter cannot
+        # narrow them -- they need their own decision.
+        assert "yolo" not in payload
+        assert "channelTrusted" not in payload
+
+        dash_frames = self._sent_to(wire, dash)
+        assert dash_frames == [json.dumps({"type": "slots"})], (
+            "dashboard user gets the unmodified default message"
+        )
+
+    def test_unknown_event_is_withheld_from_app_only(self):
+        """Deny-by-default at the seam: an unclassified event never reaches an app.
+
+        The payload deliberately carries NO ``slot``: a slot field routes the
+        frame into the slot-visibility branch instead, where an own-slot event is
+        allowed by default and the unknown-event floor is never consulted.
+        """
+        state, dash, app, wire = self._sockets_and_state(
+            app_events=build_allowed_event_set(["*"])
+        )
+        state._send_ws_all(
+            "totally_new_event", {"detail": "x"}, json.dumps({"type": "x"})
+        )
+        assert self._sent_to(wire, dash)
+        assert not self._sent_to(wire, app), (
+            "even a wildcard manifest must not receive an unclassified event"
+        )
+
+    def test_closed_socket_is_reaped_without_blocking_the_others(self):
+        state, dash, app, wire = self._sockets_and_state(
+            app_events=_allowed("slots:own")
+        )
+        dash.closed = True
+        removed: list[MagicMock] = []
+        state._remove_ws = removed.append
+        state._send_ws_all(
+            "chat_chunk", {"slot": "own"}, json.dumps({"type": "chat_chunk"})
+        )
+        assert removed == [dash]
+        assert self._sent_to(wire, app), "a dead peer must not stop live delivery"
+
+
+# ---------------------------------------------------------------------------
+# The ``slots`` ENVELOPE (not its ``data``) carries global safety-posture
+# booleans. Filtering the slot list does not narrow them, so they need their
+# own decision or an app with only ``slots:own`` reads the operator's live
+# blanket-approval state off every re-push.
+# ---------------------------------------------------------------------------
+
+class TestSlotsEnvelopePosture:
+    def _state(self):
+        from kiro_crew.dashboard.state import DashboardState
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="a")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"a": slot}
+        state._serialize_for_client = (
+            DashboardState._serialize_for_client.__get__(state)
+        )
+        return state
+
+    def _ws(self, events):
+        ws = MagicMock()
+        store = {
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": events,
+        }
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        return ws
+
+    def _envelope(self, events):
+        import json
+        return json.loads(
+            self._state()._serialize_for_client(
+                self._ws(events),
+                "slots",
+                {"slots": [{"key": "a"}], "yolo": True, "channelTrusted": True},
+                default_msg="dummy",
+            )
+        )
+
+    def test_undeclared_app_gets_no_yolo_state(self):
+        """The leak: slots:own alone must not disclose the override state."""
+        env = self._envelope(frozenset({"slots:own"}))
+        assert "yolo" not in env, env
+
+    def test_undeclared_app_gets_no_channel_trust_state(self):
+        env = self._envelope(frozenset({"slots:own"}))
+        assert "channelTrusted" not in env, env
+
+    def test_omitted_rather_than_defaulted_to_false(self):
+        """``false`` is a factual claim about posture, so absence is required.
+
+        A falsy default would still answer the question the app must not be
+        able to ask -- and would answer it WRONGLY here (yolo is on).
+        """
+        env = self._envelope(frozenset({"slots:own"}))
+        assert env.get("yolo") is None
+
+    def test_declaring_yolo_scope_receives_it(self):
+        """Gating must not lock out an app that legitimately declared it."""
+        env = self._envelope(frozenset({"slots:own", "yolo"}))
+        assert env["yolo"] is True
+
+    def test_wildcard_manifest_receives_it(self):
+        env = self._envelope(build_allowed_event_set(["*"]))
+        assert env["yolo"] is True
+
+    def test_channel_trust_withheld_even_from_wildcard(self):
+        """No scope declares it and no app SDK consumer reads it."""
+        env = self._envelope(build_allowed_event_set(["*"]))
+        assert "channelTrusted" not in env, env
+
+    def test_slot_data_still_filtered(self):
+        env = self._envelope(frozenset({"slots:own", "yolo"}))
+        assert [s["key"] for s in env["data"]] == ["a"]
+
+    def test_source_guard_connect_push_uses_the_same_helper(self):
+        """The connect-time push in ws.py builds the SAME envelope.
+
+        It is a sibling emitter, so a fix applied only to the broadcast
+        re-push would leave the first frame after connect leaking.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+        assert "slots_envelope_extras(" in src, (
+            "ws.py connect push must route the envelope through the gate helper"
+        )
+        assert '"yolo": state._yolo,' not in src.replace(
+            '{"yolo": state._yolo}', ""
+        ), "ws.py must not put yolo on an app envelope unconditionally"
+
+    def test_source_guard_yolo_scope_is_not_a_parallel_name(self):
+        """The scope reuses the one that already gates ``yolo_expired``."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        assert mod._YOLO_SCOPE == mod._GLOBAL_EVENT_DECLARATIONS["yolo_expired"]
+
+
+# ---------------------------------------------------------------------------
+# ``ws_event_allowed`` is synchronous and runs inside ``_send_ws_all``'s
+# per-client loop, so nothing it calls may touch the disk: a blocking read on
+# the broadcast path stalls every other request and the heartbeat with it.
+# ---------------------------------------------------------------------------
+
+class TestExposeToCacheNeverBlocksTheLoop:
+    def setup_method(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        mod._exposeto_cache.clear()
+        mod._exposeto_refreshing.clear()
+
+    def test_cold_miss_does_not_read_from_the_hot_path(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "get_app_manifest") as gm, \
+                patch.object(mod, "_schedule_expose_to_refresh") as sched:
+            assert mod._load_expose_to("other-app") == frozenset()
+            gm.assert_not_called()
+            sched.assert_called_once_with("other-app")
+
+    def test_cold_miss_fails_closed(self):
+        """Withholding one frame is the safe direction; granting is not."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "_schedule_expose_to_refresh"):
+            assert mod._load_expose_to("other-app") == frozenset()
+
+    def test_stale_entry_is_served_not_reloaded(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        stale = frozenset({"mochi-pet"})
+        mod._exposeto_cache["other-app"] = (
+            time.monotonic() - (mod._MANIFEST_EXPOSE_TTL_SECS + 5), stale
+        )
+        with patch.object(mod, "get_app_manifest") as gm, \
+                patch.object(mod, "_schedule_expose_to_refresh") as sched:
+            assert mod._load_expose_to("other-app") == stale
+            gm.assert_not_called()
+            sched.assert_called_once_with("other-app")
+
+    def test_fresh_entry_schedules_nothing(self):
+        from kiro_crew.dashboard import ws_event_scope as mod
+        fresh = frozenset({"mochi-pet"})
+        mod._exposeto_cache["other-app"] = (time.monotonic(), fresh)
+        with patch.object(mod, "_schedule_expose_to_refresh") as sched:
+            assert mod._load_expose_to("other-app") == fresh
+            sched.assert_not_called()
+
+    def test_refresh_is_coalesced_across_a_broadcast_burst(self):
+        """One frame x many clients must not queue one thread job each."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        loop = MagicMock()
+        with patch.object(mod.asyncio, "get_running_loop", return_value=loop):
+            for _ in range(25):
+                mod._schedule_expose_to_refresh("other-app")
+        assert loop.run_in_executor.call_count == 1
+
+    def test_no_running_loop_falls_back_to_sync_load(self):
+        """Off the loop (tests, CLI) blocking is fine -- and refusing to load
+        at all would leave the cache permanently cold."""
+        from kiro_crew.dashboard import ws_event_scope as mod
+        with patch.object(mod, "_read_expose_to", return_value=frozenset({"x"})):
+            mod._schedule_expose_to_refresh("other-app")
+        assert mod._exposeto_cache["other-app"][1] == frozenset({"x"})
+
+    def test_source_guard_connect_manifest_read_is_offloaded(self):
+        """The connect path must never read the manifest ON the event loop.
+
+        Pins the INVARIANT, not one spelling: whichever loader the connect path
+        uses, every manifest-reading call in ``ws.py`` has to be wrapped in
+        ``asyncio.to_thread``. An earlier version of this guard asserted the
+        literal ``to_thread(get_app_manifest`` and so went red when the read was
+        replaced by ``load_declared_events_for_connect`` — still off-loop, still
+        correct. A guard that pins a spelling resists the refactor instead of
+        catching the regression.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod  # noqa: F401
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+
+        # Drop the import block: a loader NAME appearing in an import is not a
+        # call. Then collapse whitespace so a multi-line
+        # ``to_thread(\n    loader, arg\n)`` reads the same as the one-line form --
+        # line-by-line matching would miss exactly that shape.
+        body = re.sub(r"from kiro_crew[^)]*?\)", "", src, flags=re.S)
+        norm = re.sub(r"\s+", " ", body)
+
+        blocking_loaders = ("get_app_manifest", "load_declared_events_for_connect")
+        checked = 0
+        for loader in blocking_loaders:
+            for match in re.finditer(re.escape(loader), norm):
+                window = norm[max(0, match.start() - 80):match.start()]
+                assert "to_thread" in window, (
+                    f"{loader} reads the manifest from disk, so the call must be "
+                    f"wrapped in asyncio.to_thread; context: "
+                    f"{norm[max(0, match.start() - 80):match.start() + 40]!r}"
+                )
+                checked += 1
+        assert checked, (
+            "the connect path no longer resolves the app's scope at all -- if the "
+            "loader was renamed, add it to blocking_loaders"
+        )
+
+    def test_source_guard_connect_refuses_a_disabled_app(self):
+        """The connect read must be USED to refuse, not just to build a snapshot.
+
+        Reading enablement and then ignoring it is the defect this replaced: the
+        initial slots push and the log replay both run before any background
+        refresh, so a disabled app that reconnects would be served from its intact
+        manifest.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+        assert "if not app_enabled:" in src and "ws.close(" in src, (
+            "ws.py must close the socket when the connect read reports the app "
+            "disabled"
+        )
+        # The refusal has to precede registration, or there is no cleanup scope.
+        assert src.index("if not app_enabled:") < src.index("state.register_ws("), (
+            "refuse BEFORE register_ws -- refusing after leaves the socket "
+            "registered with no cleanup scope to unregister it"
+        )
+        # And the read that feeds it must also precede registration.
+        assert src.index("load_declared_events_for_connect, ws_app") < src.index(
+            "state.register_ws("
+        ), "resolve the app's scope before registering the socket"
+
+    def test_source_guard_manifest_loader_has_no_internal_cache(self):
+        """The reason this cache exists at all.
+
+        If ``get_app_manifest`` ever gains its own cache this guard should be
+        revisited rather than silently keeping a redundant layer.
+        """
+        import inspect
+
+        from kiro_crew.apps import manager
+        src = inspect.getsource(manager.get_app_manifest)
+        assert "from_json_file" in src and "cache" not in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# subscribe_logs / subscribe_subagents subscription-layer gate
+# ---------------------------------------------------------------------------
+
+class TestSubscribeHandlerGates:
+    """The WS ``subscribe_logs`` and ``subscribe_subagents`` handlers replay
+    initial snapshot data via ``ws.send_json`` — a path that bypasses the
+    ``_send_ws_all`` chokepoint entirely.  Both must be gated at the
+    subscription-handler level so an app without the right scope cannot
+    receive log history or subagent snapshots merely by sending a subscribe
+    message.
+    """
+
+    def _ws_source(self) -> str:
+        import kiro_crew.dashboard.ws as _ws
+
+        # encoding is explicit on every source read in this file: Path.read_text()
+        # defaults to the LOCALE codepage, so on Windows (cp1252) reading a module
+        # that contains an em dash or an arrow raises UnicodeDecodeError and the
+        # guard fails for a reason that has nothing to do with what it asserts.
+        return Path(_ws.__file__).read_text(encoding="utf-8")
+
+    def test_subscribe_logs_is_gated_on_the_log_scope(self):
+        """Guard the REAL gate, not a copy of it.
+
+        A local ``gate_would_deny`` restating the predicate would pass no matter
+        what ws.py does — the failure mode that let a sibling subagent test stay
+        green after its gate was removed. Assert on the shipped source instead:
+        log history is privileged and must stay declaration-gated.
+        """
+        src = self._ws_source()
+        # Assert the GATE EXISTS and accepts both spellings, without pinning the
+        # variable it reads: the set is resolved live (``_live``) rather than from
+        # the connect snapshot, and a guard naming the old variable would resist
+        # that fix instead of catching a missing gate.
+        assert '"log" in _live' in src, (
+            "subscribe_logs must remain gated on the log scope"
+        )
+        assert '"log:all" in _live' in src, (
+            "the replay gate must accept log:all, like the per-event chokepoint"
+        )
+        assert "log_scope_not_declared" in src, "the log deny must stay audited"
+
+    def test_subscribe_subagents_has_no_declaration_gate(self):
+        """Owning your own slots is the default, not an opt-in.
+
+        Rejecting the subscription when nothing matched ``subagent*`` /
+        ``slots:*`` starved an app of its OWN slot's replay -- the one thing it
+        is always entitled to. The per-frame check is the only place the scope
+        decision belongs, so the declaration-level rejection is gone and must
+        not come back.
+        """
+        src = self._ws_source()
+        assert "subagent_scope_not_declared" not in src, (
+            "the declaration-level subscribe_subagents rejection must not return"
+        )
+        assert "state.subscribe_subagents(ws)" in src
+
+    def test_subagent_snapshot_replay_uses_per_item_scope_check(self):
+        # Behavioral: subagent_snapshot is now in _SLOT_SCOPED_EVENTS and
+        # _SUBAGENT_EVENTS, so ws_event_allowed routes it through
+        # _subagent_visible — an app can be denied for a foreign slot's
+        # snapshot even after passing the subscribe_subagents gate.
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "subagent_snapshot", {"slot": "s1", "id": "a1"},
+            app="mochi-pet",
+            allowed_events=_allowed("subagent"),  # own-only
+            state=state,
+        ) is False
+
+    def test_subscribe_denials_emit_sel_audit(self):
+        # Behavioral: driving the actual subscribe handler would require an
+        # in-process aiohttp WS.  Instead, we exercise _audit_deny directly
+        # with the two reasons the handlers use, and confirm the SEL call
+        # is made.
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch("kiro_crew.sel.sel") as sel_mock:
+            _wes._audit_deny("mochi-pet", "subscribe_logs", "log_scope_not_declared")
+            outcomes = [
+                c.kwargs.get("outcome", "")
+                for c in sel_mock.return_value.log_api_access.call_args_list
+            ]
+            assert any("log_scope_not_declared" in o for o in outcomes)
+
+
+# ---------------------------------------------------------------------------
+# exposeToApps TTL cache — hot-path performance vs disk I/O
+# ---------------------------------------------------------------------------
+
+class TestExposeToAppsCache:
+    """``_target_exposes_to`` runs on the WS broadcast hot path. Without a
+    local cache, ``get_app_manifest`` re-reads the JSON manifest from disk on
+    every cross-app slot event. A 30-second TTL cache keeps disk I/O bounded
+    while still picking up manifest edits within one window.
+    """
+
+    def test_repeated_calls_hit_cache_and_do_not_reread_manifest(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            return_value=manifest,
+        ) as m:
+            state = MagicMock()
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            # Only one manifest load despite 3 checks (cached).
+            assert m.call_count == 1
+
+    def test_cache_denies_when_manifest_missing(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            return_value=None,
+        ):
+            state = MagicMock()
+            # Missing manifest — fail-closed even under caching.
+            assert _wes._target_exposes_to("ghost", "monitor-app", state) is False
+
+    def test_cache_denies_on_manifest_load_failure(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            side_effect=RuntimeError("boom"),
+        ):
+            state = MagicMock()
+            assert _wes._target_exposes_to("target", "requester", state) is False
+
+    def test_disabled_target_exposes_to_nobody(self):
+        """Disabling an app does not delete its manifest, so without this
+        check an observer holding ``slots:app:<target>`` would keep seeing a
+        disabled app's slots -- the cross-app mirror of the check
+        ``app_events_revoked`` already applies to the target's own socket.
+        """
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            return_value=manifest,
+        ) as m, patch(
+            "kiro_crew.dashboard.ws_event_scope.is_app_enabled", return_value=False
+        ):
+            state = MagicMock()
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is False
+            # The manifest is never even read once the app is known disabled.
+            m.assert_not_called()
+
+
+class TestEventTableCompleteness:
+    """Every event that can reach an app socket must be classified.
+
+    ``ws_event_allowed`` DENIES unknown event types (deny-by-default, CWE-269).
+    That is the right default, but it makes an unclassified event a *silent*
+    loss of functionality for apps rather than a loud error -- the failure mode
+    ``workflow_run_event`` (the one declaration that exists in the tree) sits
+    closest to.
+
+    This test closes that class of bug: it walks the source for literal event
+    names published onto the WS fan-out and asserts each one is classified.
+    New events therefore fail the build here instead of vanishing in
+    production.
+    """
+
+    def test_fire_event_names_are_classified(self):
+        """The emitter path a literal-scanning guard cannot see.
+
+        ``SubagentManager._fire_event`` names its event, and the Slack gateway
+        dispatcher forwards it with ``broadcast_ws(etype, ...)`` -- a VARIABLE, so
+        scanning broadcast call sites for string literals finds none of these.
+        Read the literals at the emitter instead. An unclassified name here hits
+        the unknown-event floor and is denied to EVERY app regardless of what it
+        declared, which is silent loss of the whole subagent stream rather than a
+        loud error.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "subagent.py"
+        ).read_text(encoding="utf-8")
+        # `_fire_event(` then the first string literal, across a line break.
+        fired = set(re.findall(r'_fire_event\(\s*\n?\s*"([a-z_]+)"', src))
+        assert len(fired) >= 8, f"emitter scan found too few names: {sorted(fired)}"
+        unclassified = sorted(fired - self._classified())
+        assert not unclassified, (
+            "these events are fired to the WS fan-out but classified in no "
+            f"ws_event_scope table, so every app token is denied them: {unclassified}"
+        )
+
+    def test_subagent_events_are_a_subset_of_slot_scoped(self):
+        """A structural invariant the tables rely on but never state.
+
+        The ``subagent:*`` vocabulary WIDENS slot visibility; it is not a second,
+        independent tier. A member outside ``_SLOT_SCOPED_EVENTS`` falls to the
+        unknown-event floor and is denied outright, and the SDK's slot-scoped
+        drift loop stops covering it.
+        """
+        from kiro_crew.dashboard import ws_event_scope as mod
+        assert mod._SUBAGENT_EVENTS <= mod._SLOT_SCOPED_EVENTS, (
+            mod._SUBAGENT_EVENTS - mod._SLOT_SCOPED_EVENTS
+        )
+
+    @staticmethod
+    def _classified() -> frozenset[str]:
+        from kiro_crew.dashboard import ws_event_scope as m
+
+        return frozenset(
+            set(m._TIER0_ALWAYS)
+            | set(m._SLOT_SCOPED_EVENTS)
+            | set(m._SUBAGENT_EVENTS)
+            | set(m._GLOBAL_EVENT_DECLARATIONS)
+            # ``slots`` is short-circuited in the gate and filtered at the
+            # payload layer instead (_serialize_for_client), so it is
+            # deliberately absent from the tables.
+            | {"slots"}
+        )
+
+    def test_every_broadcast_event_name_is_classified(self):
+        import ast
+        from pathlib import Path
+
+        import kiro_crew
+
+        root = Path(kiro_crew.__file__).parent
+        # Owner-only fan-outs never reach an app socket, so their event names
+        # need no classification.
+        gated = {"broadcast_ws", "broadcast_ws_subagent_subscribers"}
+        unclassified: list[tuple[str, int, str]] = []
+        classified = self._classified()
+
+        for path in root.rglob("*.py"):
+            if "/builtins/" in str(path):
+                continue  # app code, not gateway fan-out
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            # Module-level ``NAME = "literal"`` bindings, so a constant passed
+            # as the event type is resolved rather than skipped.
+            const_strs: dict[str, str] = {
+                t.id: n.value.value
+                for n in tree.body
+                if isinstance(n, ast.Assign)
+                and isinstance(n.value, ast.Constant)
+                and isinstance(n.value.value, str)
+                for t in n.targets
+                if isinstance(t, ast.Name)
+            }
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+                if name not in gated or not node.args:
+                    continue
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    event_name = first.value
+                elif isinstance(first, ast.Name) and first.id in const_strs:
+                    # Module-level string constant (e.g. SIDE_RESULT_EVENT) —
+                    # resolving these matters: ``chat.side_result`` is passed
+                    # this way and a literal-only scan silently misses it.
+                    event_name = const_strs[first.id]
+                else:
+                    continue  # dynamic event type -- cannot be checked statically
+                if event_name not in classified:
+                    unclassified.append(
+                        (str(path.relative_to(root)), first.lineno, event_name)
+                    )
+
+        assert not unclassified, (
+            "These WS events are broadcast but not classified in "
+            "ws_event_scope.py, so app tokens will silently never receive "
+            f"them: {unclassified}. Add each to _TIER0_ALWAYS, "
+            "_SLOT_SCOPED_EVENTS (+_SUBAGENT_EVENTS if applicable), or "
+            "_GLOBAL_EVENT_DECLARATIONS."
+        )
+
+    def test_broadcast_type_map_events_are_classified(self):
+        """``_broadcast`` translates internal ``_type`` values into WS events.
+
+        That second dispatch path funnels through the same chokepoint, so its
+        event names must be classified too -- a literal scan of
+        ``broadcast_ws`` calls alone would miss them (chat_message and the
+        slots re-push both travel this way).
+        """
+        for event in (
+            "slots",
+            "slot_title",
+            "refresh",
+            "update_progress",
+            "artifact_update",
+            "chat_message",
+            "notification",
+        ):
+            assert event in self._classified(), (
+                f"{event!r} is emitted by DashboardState._broadcast but is not "
+                "classified in ws_event_scope.py"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Write-side origin: an undeclared slot must NOT be called USER
+# ---------------------------------------------------------------------------
+
+class TestUntaggedOriginIsNotUser:
+    """The read side already failed closed on a missing ``_origin``; the WRITE
+    side did not. ``origin or (APP if app else USER)`` labelled every untagged
+    caller USER -- cron result injection, workflow inject, Slack, the
+    OpenAI-compatible endpoint -- and an app holding ``slots:user`` received
+    that private content."""
+
+    def test_untagged_non_app_slot_is_not_user(self):
+        from kiro_crew.dashboard.state import SlotOrigin, request_slot_origin
+
+        src = Path(
+            __import__("kiro_crew.dashboard.state", fromlist=["x"]).__file__
+        ).read_text(encoding="utf-8")
+        # The fail-open derivation must be gone from the CREATION path. It
+        # still exists once, inside request_slot_origin -- that is the point:
+        # the derivation moved to the layer that can actually make it.
+        assert (
+            "slot._origin = origin or (SlotOrigin.APP if app else SlotOrigin.USER)"
+            not in src
+        ), "get_or_create_slot must not infer USER; it cannot know"
+        assert 'slot._origin = origin or (SlotOrigin.APP if app else "")' in src
+        assert src.count("SlotOrigin.APP if app else SlotOrigin.USER") == 1, (
+            "the USER derivation belongs only in request_slot_origin"
+        )
+
+        # USER is decided by the layer that knows: did a request carry a token?
+        assert request_slot_origin("") == SlotOrigin.USER
+        assert request_slot_origin("some-app") == SlotOrigin.APP
+
+    def test_every_handler_slot_creation_declares_an_origin(self):
+        """No slot-creation path in the handlers may fall through to the default.
+
+        Two legitimate sources, and the distinction matters: a NEW slot's origin
+        comes from the request (an app token means APP, its absence means the
+        dashboard user), while RESUMING a persisted conversation must take the
+        origin that conversation was stored with -- deriving it from the resumer
+        relabels a cron slot as USER. Counting both together is the invariant;
+        pinning one of them everywhere is what got the resume path wrong.
+        """
+        import kiro_crew.dashboard.chat_handlers as _ch
+
+        src = Path(_ch.__file__).read_text(encoding="utf-8")
+        creates = src.count("state.get_or_create_slot(")
+        from_request = src.count("origin=request_slot_origin(")
+        from_persisted = src.count('origin=str(meta.get("origin", ""))')
+        assert creates == from_request + from_persisted, (
+            f"{creates} slot creations but only {from_request} declare a "
+            f"request-derived origin and {from_persisted} a persisted one"
+        )
+
+    def test_resume_takes_the_persisted_origin_not_the_resumer(self):
+        """The resume endpoint must read metadata BEFORE creating the slot.
+
+        It used to create the slot from the request identity and read the history
+        metadata a dozen lines later, so resuming a persisted cron conversation
+        from the dashboard produced a USER-tagged slot and `slots:user` handed its
+        replayed content to any app holding that scope.
+        """
+        import kiro_crew.dashboard.chat_handlers as _ch
+
+        src = Path(_ch.__file__).read_text(encoding="utf-8")
+        meta_read = src.index("meta = state.conversation_log.get_metadata(history_key)")
+        resume_create = src.index('origin=str(meta.get("origin", ""))')
+        assert meta_read < resume_create, (
+            "the resume path must read the persisted metadata before it creates "
+            "the slot, or the origin it passes cannot come from that metadata"
+        )
+
+    def test_cron_injection_declares_cron(self):
+        import kiro_crew.dashboard.cron_inject as _ci
+
+        assert "origin=SlotOrigin.CRON" in Path(_ci.__file__).read_text(encoding="utf-8"), (
+            "a cron result is the job's output, never something the user typed"
+        )
+
+    def test_rehydrate_restores_the_persisted_origin(self):
+        """Re-deriving on restart would relabel a cron slot USER (leak) and a
+        real user slot untagged (dropping a grant an app legitimately holds)."""
+        import kiro_crew.dashboard.chat_persistence as _cp
+
+        assert 'origin=str(meta.get("origin", ""))' in Path(_cp.__file__).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The legacy "*" declaration
+# ---------------------------------------------------------------------------
+
+class TestWildcardDeclaration:
+    """``permissions.events: ["*"]`` predates this vocabulary and meant every
+    event. Carried through as an opaque set member no gate recognises it, so
+    such a manifest would keep its subscription and receive nothing."""
+
+    def test_wildcard_expands_instead_of_passing_through(self):
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        allowed = build_allowed_event_set(["*"])
+        assert "*" not in allowed, "the wildcard must be expanded, not stored"
+        assert "slots:all" in allowed
+        assert "subagent:all" in allowed
+        assert "notification:all" in allowed
+
+    def test_wildcard_covers_every_global_declaration(self):
+        from kiro_crew.dashboard.ws_event_scope import (
+            _GLOBAL_EVENT_DECLARATIONS,
+            build_allowed_event_set,
+        )
+
+        allowed = build_allowed_event_set(["*"])
+        missing = sorted(
+            d for d in set(_GLOBAL_EVENT_DECLARATIONS.values()) if d not in allowed
+        )
+        assert not missing, f"wildcard omits declarations: {missing}"
+
+    def test_ordinary_declarations_pass_through_unchanged(self):
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        assert build_allowed_event_set(["slots:own", "notification"]) == frozenset(
+            {"slots:own", "notification"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Notification source: canonical, prefixed, and system-only
+# ---------------------------------------------------------------------------
+
+class TestNotificationSourceParsing:
+    """The note's field is ``source`` and an app push is ``app:<name>``.
+
+    The gate used to read ``source_app``/``app`` -- keys no emitter writes -- so
+    it saw "" for every note and accepted "" as the system stream: one app's
+    private push reached any app holding ``notification:system``, and an app
+    holding ``notification`` never saw its own.
+    """
+
+    def test_constants_match_the_real_emitters(self):
+        """Pin the two producers, so a rename on either side fails here."""
+        from kiro_crew.dashboard import ws_event_scope as wes
+        from kiro_crew.notifications import bus
+
+        # state.notify() -> payload_from_legacy() stamps this exact value.
+        assert wes._SYSTEM_SOURCE == bus._SYSTEM_SOURCE
+
+        # api_push_notification builds `source=f"app:{app_name}"`.
+        push = Path(
+            __import__(
+                "kiro_crew.dashboard.handlers.notifications_push", fromlist=["x"]
+            ).__file__
+        ).read_text(encoding="utf-8")
+        assert f'source=f"{wes._APP_SOURCE_PREFIX}{{app_name}}"' in push
+
+    def test_parses_the_app_identity_out_of_the_prefix(self):
+        from kiro_crew.dashboard.ws_event_scope import notification_source_app
+
+        assert notification_source_app("app:mochi-pet") == "mochi-pet"
+        # A bare name is NOT an app push: it never appears on the wire, and
+        # treating it as one would accept a shape the server does not produce.
+        assert notification_source_app("mochi-pet") == ""
+        assert notification_source_app("system") == ""
+        assert notification_source_app("") == ""
+
+    def test_own_push_reaches_only_its_own_app(self):
+        state = _make_state()
+        note = {"source": "app:mochi-pet", "text": "hi"}
+        assert ws_event_allowed(
+            "notification", note, app="mochi-pet",
+            allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # The leak: a SECOND app holding the system scope must not receive it.
+        assert ws_event_allowed(
+            "notification", note, app="other-app",
+            allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", note, app="other-app",
+            allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_only_the_literal_system_source_is_the_system_stream(self):
+        state = _make_state()
+        for source in ("app:other-app", "notifications_api", "", "System", "sys"):
+            assert ws_event_allowed(
+                "notification", {"source": source}, app="mochi-pet",
+                allowed_events=_allowed("notification:system"), state=state,
+            ) is False, f"{source!r} must not read as the system stream"
+        assert ws_event_allowed(
+            "notification", {"source": "system"}, app="mochi-pet",
+            allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+
+    def test_ack_events_need_the_broad_scope(self):
+        """`notification_ack`/`_unack` broadcast a bare `{"ts": ...}`.
+
+        Nothing in that payload says WHOSE notification was acked, so own-only
+        `notification` cannot be honoured for them. Letting them ride the plain
+        declaration -- which is what removing them from the source filter did --
+        handed an app the ack stream for every other app's and the system's
+        notifications. Unattributable metadata takes the broad scope.
+        """
+        from kiro_crew.dashboard.ws_event_scope import (
+            _SOURCE_FILTERED_EVENTS,
+            _UNATTRIBUTED_NOTIFICATION_EVENTS,
+        )
+
+        state = _make_state()
+        for event in ("notification_ack", "notification_unack"):
+            # Not source-filtered (no `source` field to filter on) but still not
+            # covered by the own-only declaration.
+            assert event not in _SOURCE_FILTERED_EVENTS
+            assert event in _UNATTRIBUTED_NOTIFICATION_EVENTS
+            payload = {"ts": "2026-08-04T00:00:00Z"}
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification"), state=state,
+            ) is False
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification:system"), state=state,
+            ) is False
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification:all"), state=state,
+            ) is True
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("log"), state=state,
+            ) is False
+
+
+# ---------------------------------------------------------------------------
+# App-published events ride one fixed WS type
+# ---------------------------------------------------------------------------
+
+class TestAppEventFrames:
+    """Every app event arrives as WS type ``app_event`` with the real name inside.
+
+    The scope table is keyed by WS type, so the lookup could never match and each
+    frame fell through to the global deny -- an app silently stopped receiving its
+    OWN events the moment scoping landed.
+    """
+
+    def test_constant_matches_the_event_bus(self):
+        """Pin the mirrored constant against the app layer's own definition."""
+        from kiro_crew.apps.event_bus import APP_EVENT_WS_TYPE
+        from kiro_crew.dashboard.ws_event_scope import _APP_EVENT_WS_TYPE
+
+        assert _APP_EVENT_WS_TYPE == APP_EVENT_WS_TYPE
+
+    def _frame(self, publisher: str, event: str) -> dict:
+        # Shape produced by event_bus.build_broadcast_fn: the inner `type` is
+        # renamed to `event` and rides beside `app` in the envelope.
+        return {"app": publisher, "event": event, "data": {"n": 1}}
+
+    def test_publisher_receives_its_own_event(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("mochi", "tick"),
+            app="mochi", allowed_events=_allowed("slots:own"), state=state,
+        ) is True
+
+    def test_wildcard_app_still_receives_its_own_event(self):
+        """`events: ["*"]` expands into CORE scopes, which cannot contain an
+        app-chosen event name -- so ownership, not a second declaration lookup,
+        has to decide, or every wildcard app loses its own events."""
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("mochi", "tick"),
+            app="mochi", allowed_events=build_allowed_event_set(["*"]), state=state,
+        ) is True
+
+    def test_another_apps_event_is_denied(self):
+        """App events have no cross-app opt-in -- exposeToApps covers slots."""
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("workflows", "tick"),
+            app="mochi", allowed_events=_allowed("slots:all", "notification:all"),
+            state=state,
+        ) is False
+
+    def test_unattributable_envelope_is_denied(self):
+        state = _make_state()
+        for frame in ({"event": "tick"}, {"app": "mochi"}, {}, {"app": "", "event": ""}):
+            assert ws_event_allowed(
+                "app_event", frame, app="mochi",
+                allowed_events=_allowed("slots:own"), state=state,
+            ) is False, f"{frame!r} must be denied"
+
+
+class TestConstantValuedEventNamesAreClassified:
+    """The completeness guard scans broadcast CALL SITES for literal names, so an
+    event whose WS type comes from a CONSTANT is invisible to it -- which is how
+    `app_event` shipped unclassified while the guard stayed green. Pin the known
+    constant-valued types explicitly."""
+
+    def test_app_event_is_classified(self):
+        from kiro_crew.apps.event_bus import APP_EVENT_WS_TYPE
+        from kiro_crew.dashboard import ws_event_scope as wes
+
+        src = Path(wes.__file__).read_text(encoding="utf-8")
+        assert APP_EVENT_WS_TYPE in src, (
+            f"{APP_EVENT_WS_TYPE!r} is broadcast via a constant and must still be "
+            "classified in ws_event_scope"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ``approval_resolved`` is slot-scoped, so the gate denies any frame it cannot
+# attribute to a slot. The producers originally sent only {id, approved}, which
+# meant an app received its approval REQUEST but never the RESOLUTION.
+# ---------------------------------------------------------------------------
+
+class TestApprovalResolvedCarriesSlot:
+    @staticmethod
+    def _state():
+        from unittest.mock import AsyncMock
+
+        from chat_test_helpers import _make_ready_kiro_prerequisite
+
+        from kiro_crew.dashboard.state import DashboardState
+
+        sessions = MagicMock(count=0)
+        sessions.remove = AsyncMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=MagicMock(),
+        )
+        state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+        return state
+
+    def test_slot_level_resolution_carries_owning_slot(self):
+        """Drive the REAL resolve_approval and assert the broadcast payload."""
+        import asyncio
+
+        state = self._state()
+        slot = state.get_or_create_slot("mochi-pet")
+        slot._app = "mochi-pet"
+        slot._origin = SlotOrigin.APP
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            slot._approval_futures["a1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_approval("a1", True)
+            return [c for c in bws.call_args_list if c.args[0] == "approval_resolved"]
+
+        calls = asyncio.run(_run())
+        assert len(calls) == 1
+        payload = calls[0].args[1]
+        assert payload["id"] == "a1"
+        assert payload["slot"] == "mochi-pet"
+
+    def test_state_level_resolution_stays_unattributed(self):
+        """A background (cron/subagent/gateway) approval owns no slot, so it
+        must NOT claim one — the gate correctly withholds it from app tokens."""
+        import asyncio
+
+        state = self._state()
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            state._approval_futures["b1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_state_approval("b1", True)
+            return [c for c in bws.call_args_list if c.args[0] == "approval_resolved"]
+
+        calls = asyncio.run(_run())
+        assert len(calls) == 1
+        assert "slot" not in calls[0].args[1]
+
+    def test_owning_app_receives_its_own_resolution(self):
+        """End-to-end: the payload the real producer emits must pass the gate
+        for the slot's owning app with NO extra declaration."""
+        import asyncio
+
+        state = self._state()
+        slot = state.get_or_create_slot("mochi-pet")
+        slot._app = "mochi-pet"
+        slot._origin = SlotOrigin.APP
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            slot._approval_futures["a1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_approval("a1", True)
+            return next(
+                c.args[1] for c in bws.call_args_list if c.args[0] == "approval_resolved"
+            )
+
+        payload = asyncio.run(_run())
+        assert ws_event_allowed(
+            "approval_resolved", payload,
+            app="mochi-pet", allowed_events=frozenset(), state=state,
+        )
+        # ...and a DIFFERENT app still must not see it.
+        assert not ws_event_allowed(
+            "approval_resolved", payload,
+            app="other-app", allowed_events=frozenset(), state=state,
+        )
+
+    def test_every_approval_resolved_producer_sends_a_slot(self):
+        """Source guard: a new producer that omits the slot key would silently
+        withhold the resolution from the owning app. Pin every broadcast site."""
+        import re
+
+        roots = [
+            Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "dashboard" / f
+            for f in ("state.py", "chat_handlers.py", "chat_runner.py")
+        ]
+        found = 0
+        for path in roots:
+            src = path.read_text(encoding="utf-8")
+            for m in re.finditer(r'"approval_resolved"', src):
+                # Take the enclosing broadcast call: from the preceding
+                # ``broadcast_ws`` to the matching close paren region.
+                head = src.rfind("broadcast_ws", max(0, m.start() - 300), m.start())
+                if head == -1:
+                    continue
+                found += 1
+                block = src[head : m.start() + 400]
+                assert '"slot"' in block or "payload" in block, (
+                    f"{path.name}: approval_resolved broadcast near offset {m.start()} "
+                    "does not carry a slot key"
+                )
+        assert found >= 4, f"expected >=4 approval_resolved producers, found {found}"
+
+
+# ---------------------------------------------------------------------------
+# ``/api/status`` after removal from the implicit-allow list: an app that
+# DECLARES it still reaches it, so the tightening does not lock out the
+# shipped consumers (``design_critique`` declares it in app.json).
+# ---------------------------------------------------------------------------
+
+class TestApiStatusRequiresDeclaration:
+    def test_declared_app_still_reaches_api_status(self):
+        """Removing the implicit grant must not break apps that declare it."""
+        with patch(
+            "kiro_crew.dashboard.token_auth._app_api_allowlist",
+            return_value=("/api/status",),
+        ):
+            assert app_token_path_allowed("design-critique", "/api/status") is True
+
+    def test_undeclared_app_is_denied_api_status(self):
+        with patch(
+            "kiro_crew.dashboard.token_auth._app_api_allowlist", return_value=()
+        ):
+            assert app_token_path_allowed("mochi-pet", "/api/status") is False
+
+    def test_shipped_manifests_that_use_api_status_declare_it(self):
+        """Source guard: no shipped builtin may RELY on the implicit allow.
+
+        Derived, not a hardcoded name list: a name list goes stale the moment a
+        builtin's permissions change (``crew_companion`` legitimately dropped
+        ``/api/status`` from its manifest once it stopped calling it, which
+        silently reds a hardcoded assertion instead of catching a real break).
+        The invariant that actually matters is that any builtin whose shipped
+        code reaches ``/api/status`` declares it in ``permissions.api`` -- with
+        the implicit grant gone, an undeclared caller gets a 403.
+        """
+        import json
+
+        builtins = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "apps" / "builtins"
+        )
+        frontends = (
+            Path(__file__).resolve().parents[1] / "website" / "src" / "apps"
+        )
+
+        declared: list[str] = []
+        for manifest in builtins.glob("*/app.json"):
+            perms = json.loads(
+                manifest.read_text(encoding="utf-8")
+            ).get("permissions", {})
+            api = perms.get("api") or []
+            if isinstance(api, list) and "/api/status" in api:
+                declared.append(manifest.parent.name)
+
+        # Declaring it must remain a live, exercised path -- otherwise this
+        # whole class could pass against a build where nothing can reach the
+        # endpoint at all.
+        assert declared, "no builtin declares /api/status; guard is vacuous"
+
+        undeclared_callers: list[str] = []
+        for app_dir in sorted(builtins.glob("*/app.json")):
+            name = app_dir.parent.name
+            if name in declared:
+                continue
+            roots = [app_dir.parent]
+            fe = frontends / name.replace("_", "-")
+            if fe.is_dir():
+                roots.append(fe)
+            for root in roots:
+                for src in root.rglob("*"):
+                    if not src.is_file():
+                        continue
+                    if src.suffix not in (".py", ".ts", ".tsx", ".js", ".jsx"):
+                        continue
+                    try:
+                        text = src.read_text(encoding="utf-8")
+                    except (OSError, UnicodeDecodeError):
+                        continue
+                    if "/api/status" in text:
+                        undeclared_callers.append(f"{name}:{src.name}")
+                        break
+
+        assert not undeclared_callers, (
+            "these builtins reach /api/status without declaring it in "
+            f"permissions.api, so they now 403: {undeclared_callers}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# A GLOBAL event must never be judged by a slot field that appears in its
+# payload. ``notify()`` merges meta keys FLAT into the note, so a real caller
+# (slack/gateway.py heartbeat: meta={"slot": slot.key}) puts a top-level
+# ``slot`` on a ``notification`` frame.
+# ---------------------------------------------------------------------------
+
+class TestGlobalEventWithSlotDoesNotBypassScope:
+    def _state_with_own_slot(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="chat-1")
+        return _make_state({"chat-1": slot})
+
+    def test_notification_with_slot_still_needs_notification_scope(self):
+        """The bypass: slots:all alone must NOT deliver a notification body."""
+        state = self._state_with_own_slot()
+        payload = {
+            "kind": "heartbeat",
+            "source": "system",
+            "channel": "system.heartbeat",
+            "title": "Still working",
+            "body": "secret progress detail",
+            "slot": "chat-1",  # flat-merged from notify(meta={"slot": ...})
+        }
+        assert not ws_event_allowed(
+            "notification", payload,
+            app="mochi-pet", allowed_events=frozenset({"slots:all"}), state=state,
+        )
+
+    def test_notification_with_slot_delivered_when_scope_declared(self):
+        """With the real scope it is delivered — the fix only strips the
+        smuggled inference, it does not break legitimate delivery."""
+        state = self._state_with_own_slot()
+        payload = {
+            "kind": "heartbeat",
+            "source": "system",
+            "channel": "system.heartbeat",
+            "title": "Still working",
+            "body": "progress",
+            "slot": "chat-1",
+        }
+        assert ws_event_allowed(
+            "notification", payload,
+            app="mochi-pet",
+            allowed_events=frozenset({"notification:system"}),
+            state=state,
+        )
+
+    def test_slack_heartbeat_really_passes_a_slot_in_meta(self):
+        """Source guard: this whole class is only meaningful because a shipped
+        caller flat-merges a slot onto a global notification frame."""
+        gw = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "slack" / "gateway.py"
+        ).read_text(encoding="utf-8")
+        assert 'meta={"slot": slot.key}' in gw
+
+    def test_meta_merge_is_flat_so_slot_lands_top_level(self):
+        """Source guard on the mechanism: bus.push merges meta keys flat."""
+        bus = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "notifications" / "bus.py"
+        ).read_text(encoding="utf-8")
+        assert "note[key] = value" in bus
+
+
+# ---------------------------------------------------------------------------
+# Coalesced subagent batches: above SubagentEventCoalescer's threshold ONE
+# frame carries MANY subagents' rows, so there is no top-level slot. They must
+# reach the app (they were falling through to the unknown-event deny, losing
+# ALL subagent status/output) but be filtered per item.
+# ---------------------------------------------------------------------------
+
+class TestSubagentBatchFrames:
+    def _state(self):
+        mine = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mine")
+        theirs = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="theirs")
+        return _make_state({"mine": mine, "theirs": theirs})
+
+    @pytest.mark.parametrize(
+        "event", ["subagent_batch_update", "subagent_batch_chunks"]
+    )
+    def test_batch_frame_is_not_denied_as_unknown(self, event):
+        """The frame must pass the gate — denying it starved apps of their OWN
+        subagent events once the coalescer engaged."""
+        state = self._state()
+        assert ws_event_allowed(
+            event, {"updates": [], "chunks": []},
+            app="mochi-pet", allowed_events=frozenset(), state=state,
+        )
+
+    def test_filter_keeps_only_own_items(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [
+            {"id": "a1", "slot": "mine", "text": "mine"},
+            {"id": "a2", "slot": "theirs", "text": "secret"},
+        ]
+        kept = filter_subagent_batch_for_app(items, "mochi-pet", frozenset(), state)
+        assert [i["slot"] for i in kept] == ["mine"]
+
+    def test_filter_drops_items_with_unresolvable_slot(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [{"id": "a1", "slot": "gone"}, {"id": "a2"}, "notadict"]
+        assert filter_subagent_batch_for_app(items, "mochi-pet", frozenset(), state) == []
+
+    def test_subagent_all_sees_every_item(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [{"id": "a1", "slot": "mine"}, {"id": "a2", "slot": "theirs"}]
+        kept = filter_subagent_batch_for_app(
+            items, "mochi-pet", frozenset({"subagent:all"}), state
+        )
+        assert len(kept) == 2
+
+    def test_batch_events_really_exist_with_per_item_slots(self):
+        """Source guard: this class is only meaningful while the coalescer emits
+        these two frames AND seeds every buffered row with its slot."""
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "subagent_scale.py"
+        ).read_text(encoding="utf-8")
+        assert '"subagent_batch_update"' in src
+        assert '"subagent_batch_chunks"' in src
+        # every buffered update row is seeded with a slot
+        assert '{"slot": payload.get("slot", "")}' in src
+        # every chunk row carries its slot
+        assert '"slot": buf["slot"]' in src
+
+    def test_batch_item_key_map_matches_the_emitter(self):
+        """The payload keys the filter reads must be the ones actually sent."""
+        from kiro_crew.dashboard.ws_event_scope import _SUBAGENT_BATCH_ITEM_KEY
+
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "subagent_scale.py"
+        ).read_text(encoding="utf-8")
+        assert '"subagent_batch_update", {"updates": updates}' in src
+        assert '"subagent_batch_chunks", {"chunks": chunks}' in src
+        assert _SUBAGENT_BATCH_ITEM_KEY == {
+            "subagent_batch_update": "updates",
+            "subagent_batch_chunks": "chunks",
+        }
+
+
+class TestSuppressedDenyCountIsReported:
+    """The dedup comment used to claim suppressed denies were "counted" while
+    the map held only a timestamp — no counter existed. The tally must actually
+    reach the trail, so a burst is visible as volume without one SEL write per
+    frame (this gate runs per event PER CLIENT on the broadcast hot path)."""
+
+    def _clear(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        _wes._sel_last_audit.clear()
+
+    def test_next_emission_reports_the_suppressed_tally(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+
+        self._clear()
+        state = _make_state({})
+        with patch("kiro_crew.sel.sel") as m:
+            # First denial emits with no tally.
+            _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 1
+            assert "suppressed" not in str(
+                m.return_value.log_api_access.call_args.kwargs["resources"]
+            )
+            # Three more identical denials inside the window are collapsed...
+            for _ in range(3):
+                _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 1
+            # ...and the tally rides the next emission once the window passes.
+            key = ("app-x", "chat_chunk", "slot_missing")
+            ts, count = _wes._sel_last_audit[key]
+            assert count == 3
+            _wes._sel_last_audit[key] = (ts - _wes._SEL_DEDUP_WINDOW_SECS - 1, count)
+            _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 2
+            assert "suppressed=3" in str(
+                m.return_value.log_api_access.call_args.kwargs["resources"]
+            )
+        assert state is not None  # harness precondition
+        self._clear()
+
+    def test_tally_resets_after_emission(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+
+        self._clear()
+        with patch("kiro_crew.sel.sel"):
+            _wes._audit_deny("app-y", "log", "unknown_event")
+            key = ("app-y", "log", "unknown_event")
+            assert _wes._sel_last_audit[key][1] == 0
+        self._clear()
+
+# ---------------------------------------------------------------------------
+# Direct-send grant auditing in ws.py
+#
+# Three sends reach an app socket WITHOUT passing ``_send_ws_all``, so
+# ``ws_event_allowed`` never records them: the initial slots push's ``yolo``
+# envelope field, the periodic ``dashboard`` status frame, and the
+# ``subscribe_logs`` ring replay. These are FUNCTIONAL tests that drive
+# ``api_ws`` rather than asserting on the shape of the source, because the
+# earlier spelling-pinned guards for two of them broke the moment the shared
+# ``_audit_grant_quietly`` helper replaced the inlined ``try``/``except`` --
+# the same failure mode the off-loop guard in this file already documents
+# ("a guard that pins a spelling resists refactoring instead of catching bugs").
+# ---------------------------------------------------------------------------
+
+
+class TestDirectSendGrantsAreAudited:
+    APP = "mochi-pet"
+
+    def _manifest(self, events: list[str]):
+        manifest = MagicMock()
+        manifest.permissions.events = events
+        manifest.permissions.exposeToApps = []
+        return manifest
+
+    def _fake_ws(self):
+        """A socket that ends both loops immediately.
+
+        ``closed = True`` stops ``_push_status`` before its first iteration and
+        ``__anext__`` raising ends the message loop, so a test that wants either
+        one drives it explicitly instead of racing the real timers.
+        """
+        class FakeWebSocket:
+            def __init__(self) -> None:
+                self.closed = True
+                self.sent: list[dict] = []
+                self._flags: dict = {}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
+
+            async def prepare(self, request) -> None:
+                return None
+
+            async def send_json(self, payload: dict) -> None:
+                self.sent.append(payload)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        return FakeWebSocket()
+
+    def _drive_connect(self, monkeypatch, *, declared: list[str], yolo: bool):
+        """Run ``api_ws`` through connect + initial slots push for an app token."""
+        import asyncio as _aio
+
+        from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard import ws_event_scope
+        from kiro_crew.dashboard.handlers import source_providers
+
+        monkeypatch.setattr(ws_event_scope, "is_app_enabled", lambda _n: True)
+        monkeypatch.setattr(
+            ws_event_scope, "get_app_manifest", lambda _n: self._manifest(declared)
+        )
+        monkeypatch.setattr(ws_event_scope, "_declared_cache", {})
+
+        state = MagicMock()
+        state.owner_id = "U_OWNER"
+        state.serialize_slots.side_effect = lambda **_kw: []
+        state._yolo = yolo
+
+        app_name = self.APP
+
+        class Request(dict):
+            def __init__(self) -> None:
+                super().__init__({"app": app_name})
+                self["is_dashboard_user"] = False
+                self.app = {"state": state}
+
+        fake_ws = self._fake_ws()
+        monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
+        monkeypatch.setattr(
+            dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws
+        )
+        monkeypatch.setattr(source_providers, "schedule_check_refresh", MagicMock())
+
+        with patch.object(dashboard_ws, "_audit_grant_quietly") as audit:
+            _aio.run(dashboard_ws.api_ws(Request()))  # type: ignore[arg-type]
+        return fake_ws, audit
+
+    def test_initial_yolo_grant_is_audited(self, monkeypatch):
+        """An app declaring ``yolo`` receives the live override state on the
+        initial push -- a direct ``send_json``, so nothing else records it.
+        """
+        fake_ws, audit = self._drive_connect(
+            monkeypatch, declared=["yolo"], yolo=True
+        )
+
+        assert fake_ws.sent, "the initial slots push must still be delivered"
+        assert fake_ws.sent[0].get("yolo") is True, (
+            "an app declaring yolo must actually receive the field "
+            "(otherwise this test would pass for the wrong reason)"
+        )
+        events = [c.args[1] for c in audit.call_args_list]
+        assert "slots_yolo" in events, "the yolo envelope grant must be audited"
+
+    def test_no_yolo_declaration_means_no_grant_and_no_record(self, monkeypatch):
+        """The audit follows the GRANT, not the code path: an app without the
+        scope never receives ``yolo``, so there is nothing to record.
+        """
+        fake_ws, audit = self._drive_connect(
+            monkeypatch, declared=["slots:own"], yolo=True
+        )
+
+        assert fake_ws.sent
+        assert "yolo" not in fake_ws.sent[0], (
+            "withheld field must be ABSENT, not sent as a falsy default"
+        )
+        events = [c.args[1] for c in audit.call_args_list]
+        assert "slots_yolo" not in events, (
+            "auditing a grant that did not happen would make the trail lie"
+        )
+
+    def test_subscribe_logs_grant_is_audited(self, monkeypatch):
+        """The ring replay writes to the socket directly, so the grant that
+        admits it needs its own record -- the deny side already had one.
+        """
+        import asyncio as _aio
+
+        from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard import ws_event_scope
+        from kiro_crew.dashboard.handlers import source_providers
+
+        monkeypatch.setattr(ws_event_scope, "is_app_enabled", lambda _n: True)
+        monkeypatch.setattr(
+            ws_event_scope, "get_app_manifest", lambda _n: self._manifest(["log"])
+        )
+        monkeypatch.setattr(ws_event_scope, "_declared_cache", {})
+
+        state = MagicMock()
+        state.owner_id = "U_OWNER"
+        state.serialize_slots.side_effect = lambda **_kw: []
+        state._yolo = False
+
+        app_name = self.APP
+
+        class Request(dict):
+            def __init__(self) -> None:
+                super().__init__({"app": app_name})
+                self["is_dashboard_user"] = False
+                self.app = {"state": state}
+
+        # One `subscribe_logs` frame, then end the loop.
+        class Msg:
+            def __init__(self) -> None:
+                from aiohttp import WSMsgType
+
+                self.type = WSMsgType.TEXT
+                self.data = json.dumps({"type": "subscribe_logs"})
+
+        base = self._fake_ws()
+
+        class LoopWs(type(base)):  # type: ignore[misc]
+            def __init__(self) -> None:
+                super().__init__()
+                self._yielded = False
+
+            async def __anext__(self):
+                if self._yielded:
+                    raise StopAsyncIteration
+                self._yielded = True
+                return Msg()
+
+        fake_ws = LoopWs()
+        monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
+        monkeypatch.setattr(
+            dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws
+        )
+        monkeypatch.setattr(source_providers, "schedule_check_refresh", MagicMock())
+
+        with patch.object(dashboard_ws, "_audit_grant_quietly") as audit:
+            _aio.run(dashboard_ws.api_ws(Request()))  # type: ignore[arg-type]
+
+        state.subscribe_logs.assert_called_once_with(fake_ws)
+        events = [c.args[1] for c in audit.call_args_list]
+        assert "subscribe_logs" in events, (
+            "a granted log subscription must leave an SEL record"
+        )
+
+    def test_audit_helper_records_the_grant(self):
+        from kiro_crew.dashboard import ws as dashboard_ws
+
+        with patch.object(dashboard_ws, "_audit_allow") as allow:
+            dashboard_ws._audit_grant_quietly("mochi-pet", "dashboard")
+        allow.assert_called_once_with("mochi-pet", "dashboard")
+
+    def test_audit_helper_names_an_unknown_app_rather_than_sending_empty(self):
+        from kiro_crew.dashboard import ws as dashboard_ws
+
+        with patch.object(dashboard_ws, "_audit_allow") as allow:
+            dashboard_ws._audit_grant_quietly("", "dashboard")
+        allow.assert_called_once_with("<unknown>", "dashboard")
+
+    def test_a_failing_audit_sink_never_breaks_delivery(self):
+        """The swallow is the load-bearing part of the helper.
+
+        Dropping a frame the app is entitled to because the SEL sink hiccuped
+        would turn an observability fault into a functional outage. Having ONE
+        copy of this branch is what makes it testable at all -- inlined at three
+        call sites it was three never-executed paths.
+        """
+        from kiro_crew.dashboard import ws as dashboard_ws
+
+        with patch.object(
+            dashboard_ws, "_audit_allow", side_effect=RuntimeError("sink down")
+        ):
+            # Must not raise.
+            dashboard_ws._audit_grant_quietly("mochi-pet", "subscribe_logs")
+
+    def test_periodic_dashboard_frame_grant_is_audited(self):
+        """``_push_status`` sends the Tier-0 status frame straight to the socket
+        every few seconds; Tier 0 admits it unconditionally but the admission is
+        still a decision, and no other code path records this one.
+
+        Asserted against the source rather than by driving the loop: the pusher
+        is a closure inside ``api_ws`` spawned as a background task, so a
+        functional test would have to win a race against its own cancellation
+        on teardown -- and a test that reconstructed the loop body here would be
+        asserting on the reconstruction, not on what ships.
+
+        The check is deliberately REGION-scoped and whitespace-normalised rather
+        than a literal spelling, so renaming the helper or reflowing the call
+        cannot red it while the invariant holds. That is the correction the
+        off-loop guard in this file already went through.
+        """
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "dashboard" / "ws.py"
+        ).read_text(encoding="utf-8")
+        # The app-token narrowing block inside _push_status: it strips the
+        # owner-only fields, and the grant must be recorded in the same branch.
+        marker = 'for _owner_only in ("branch", "commit"):'
+        assert marker in src, "the app-token narrowing block moved; re-anchor this guard"
+        region = " ".join(src[src.index(marker):].split())
+        # Look only as far as the send that ends the block.
+        region = region[: region.index('ws.send_json({"type": "dashboard"')]
+        assert re.search(r'_audit\w*\([^)]*"dashboard"\)', region), (
+            "the periodic dashboard frame's grant to an app socket must be "
+            "SEL-audited in the same branch that narrows the payload"
+        )

--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -885,6 +885,32 @@ export default [
     },
   },
 
+  // Developer diagnostics for the APP AUTHOR, printed to the browser console when
+  // an app subscribes to a WS event its manifest has not declared a scope for.
+  // Translating them would be actively wrong, not merely wasteful: each one quotes
+  // the scope identifier the author must paste into `permissions.events`
+  // (`"slots:user"`, `"notification:system"`, `"<scope>:all"`), and those are
+  // compared BY VALUE against the manifest — localised advice would name a scope
+  // the gateway does not recognise.
+  //
+  // `console.*` is already callee-exempt, so the three call sites are covered; the
+  // strings are flagged because they are composed in `checkSubscribeAllowed`, one
+  // pure predicate that centralises the diagnosis for all three. Inlining the prose
+  // into the calls to earn the callee exemption would duplicate its branch logic
+  // three times — a worse module for a lint technicality.
+  //
+  // Scoped to this one file for the same reason as the two above: the module is the
+  // SDK's protocol surface (event tables, hooks, provider) and holds no other prose.
+  // The pieces that DO render copy — `ChatEmbed`, `ChatPanel`, `ChatMessageList` —
+  // are separate files and stay covered. Copy added here later belongs in the
+  // catalog, not under this exemption; keep this module protocol-and-diagnostics.
+  {
+    files: ['src/app-sdk/index.ts'],
+    rules: {
+      'i18next/no-literal-string': 'off',
+    },
+  },
+
   // PROTOCOL VALUES ONLY: the server's own action names, provider merge-state enums,
   // and the literals a user must TYPE to arm an irreversible action. Every string in
   // that module is compared by value against something outside the dashboard, so

--- a/website/public/vendor/kirocrew-app-sdk.mjs
+++ b/website/public/vendor/kirocrew-app-sdk.mjs
@@ -10,4 +10,7 @@ export const {
   // Chat surfaces and the transcript row registry.
   useChatSession, ChatPanel, ChatEmbed, ChatMessageList,
   defaultMessageRenderers, mergeRenderers, resolveRenderer, ToolCallPill, GROUPED_ROLES,
+  // WS event scope prediction, so a subscription that will never be delivered warns at
+  // development time instead of silently receiving nothing.
+  checkSubscribeAllowed,
 } = m

--- a/website/src/app-sdk/index.ts
+++ b/website/src/app-sdk/index.ts
@@ -82,19 +82,200 @@ export function useAppApi(): AppApi {
 }
 
 /** Subscribe to a real-time WebSocket event. Unsubscribes on unmount. */
+// ---------------------------------------------------------------------------
+// WebSocket event scope map — MIRRORS kiro_crew/dashboard/ws_event_scope.py.
+// The gateway is authoritative; this table exists only so the SDK can tell an
+// app author accurately whether a subscription will be delivered. Keep the
+// three sets in sync with the Python tables (a completeness test on the Python
+// side fails the build when a new event is unclassified there).
+// ---------------------------------------------------------------------------
+
+/** Tier 0 — always delivered to every connected client. */
+const WS_TIER0_EVENTS = new Set(['dashboard', 'refresh', 'update_progress'])
+
+/**
+ * Slot-scoped events — they carry a `slot` field. An app token receives these
+ * for slots it OWNS with no declaration at all; broader visibility (user
+ * slots, another app's slots, all slots) needs a `slots:*` / `subagent:*`
+ * scope.
+ */
+const WS_SLOT_SCOPED_EVENTS = new Set([
+  // Chat content
+  'chat_chunk', 'chat_thinking', 'chat_status', 'chat_message', 'chat_done',
+  'chat_segment', 'chat_append', 'chat_message_update', 'chat_variant_switch',
+  'chat.side_result', 'heartbeat', 'context_usage',
+  // Tool / queue
+  'tool_call', 'tool_result',
+  'queue_push', 'queue_cancel', 'queue_edit', 'queue_pop', 'queue_reorder',
+  'steer_push',
+  // Slot metadata / lifecycle
+  'slot_title', 'slot_clear', 'slot_agent_switch', 'todo_update',
+  'activity_event', 'session_summary',
+  // Voice
+  'voice_chunk', 'voice_complete', 'voice_error',
+  // Approvals and question cards
+  'approval', 'approval_resolved', 'question_card',
+  // Subagent lifecycle
+  'subagent_spawn', 'subagent_done', 'subagent_tool', 'subagent_chunk',
+  'subagent_snapshot', 'subagent_status', 'subagent_queued',
+  'subagent_stalled', 'subagent_retrying', 'subagent_recovering',
+  'subagent_injection_failed',
+  // Slack-gateway driven, slot-scoped
+  'autonudge_state', 'batch_finished', 'spawn_batch_started',
+  // Workflows / misc
+  'workflow_result_injected', 'refine',
+])
+
+/**
+ * Subagent lifecycle events — the subset of slot-scoped events that
+ * `subagent:*` scopes widen. Mirrors `_SUBAGENT_EVENTS` in the Python gate.
+ */
+const WS_SUBAGENT_EVENTS = new Set([
+  'subagent_spawn', 'subagent_done', 'subagent_tool', 'subagent_chunk',
+  'subagent_snapshot', 'subagent_status', 'subagent_queued',
+  'subagent_stalled', 'subagent_retrying', 'subagent_recovering',
+  'subagent_injection_failed',
+])
+
+/** Global events — no `slot` field; each needs an explicit scope declaration. */
+const WS_GLOBAL_EVENT_TO_SCOPE: Record<string, string> = {
+  notification: 'notification',
+  notification_ack: 'notification',
+  notification_unack: 'notification',
+  notifications_clear: 'notification',
+  notification_channel_settings: 'notification',
+  sessions_restarting: 'sessions',
+  yolo_expired: 'yolo',
+  artifact_update: 'artifacts',
+  'skills.pending_changed': 'skills',
+  // Declared by its own literal name (already the correct per-event shape).
+  workflow_run_event: 'workflow_run_event',
+  log: 'log',
+  browser_event: 'browser',
+  // NOTE: `slots` is deliberately absent — the list re-push is always
+  // delivered and filtered per app in the payload on the server
+  // (state.py::_serialize_for_client), so it needs no declaration.
+}
+
+/** Result of the SDK subscription pre-check. */
+type SubscribeCheckResult =
+  | { level: 'ok' }
+  | { level: 'own-only'; hint: string }
+  /** A known event whose required scope is NOT declared — will not arrive. */
+  | { level: 'denied'; hint: string }
+  /** Not in the gate's tables at all — most likely a typo, possibly custom. */
+  | { level: 'unknown'; hint: string }
+
+/**
+ * Predict whether the gateway will deliver `event` given the app's declared
+ * `permissions.events`. Advisory only — the gateway decides.
+ */
+export function checkSubscribeAllowed(event: string, allowed: string[]): SubscribeCheckResult {
+  if (WS_TIER0_EVENTS.has(event)) return { level: 'ok' }
+  if (allowed.includes('*')) return { level: 'ok' }
+
+  // Slot-scoped: own slots are always visible, so only hint when the author
+  // likely wants wider visibility.
+  if (WS_SLOT_SCOPED_EVENTS.has(event)) {
+    // Match the scope FAMILY to the event family. `subagent:*` is an
+    // independent dimension in the gate (`_subagent_visible`), so declaring
+    // `subagent:user` widens subagent events only — it does not widen chat.
+    // Treating them interchangeably would predict `ok` for a chat
+    // subscription that the gateway delivers for own slots only, which is the
+    // exact silent-loss trap this check exists to prevent.
+    const isSubagentEvent = WS_SUBAGENT_EVENTS.has(event)
+    const hasWideningScope = allowed.some((a) =>
+      isSubagentEvent ? a.startsWith('subagent') || a.startsWith('slots:') : a.startsWith('slots:'),
+    )
+    if (hasWideningScope) return { level: 'ok' }
+    return {
+      level: 'own-only',
+      hint:
+        `Event "${event}" is slot-scoped: you will receive it for slots your app OWNS. ` +
+        `To see other slots, add a scope to permissions.events — ` +
+        (isSubagentEvent
+          ? `e.g. "subagent:user", "subagent:all", or a "slots:*" scope.`
+          : `e.g. "slots:user" or "slots:all" ("subagent:*" widens subagent events only).`),
+    }
+  }
+
+  // The slots list re-push needs no declaration (payload-filtered server-side).
+  if (event === 'slots') return { level: 'ok' }
+
+  const requiredScope = WS_GLOBAL_EVENT_TO_SCOPE[event]
+  if (requiredScope) {
+    // A `<scope>:*` variant also satisfies the base scope. For notifications
+    // the gateway picks between `notification` (own-app) and
+    // `notification:system` (gateway-internal) from the payload's source_app,
+    // which is not knowable at subscribe time — so any variant counts as ok
+    // here and the runtime gate makes the per-event decision.
+    const satisfied = allowed.some(
+      (a) => a === requiredScope || a.startsWith(`${requiredScope}:`),
+    )
+    if (satisfied) return { level: 'ok' }
+    return {
+      level: 'denied',
+      hint:
+        `Event "${event}" requires permissions.events to include "${requiredScope}"` +
+        (requiredScope === 'notification'
+          ? `, "notification:system" for gateway-internal pushes (cron, send_message), ` +
+            `or "notification:all" for every source.`
+          : ` (or "${requiredScope}:all" for the broader variant).`),
+    }
+  }
+
+  return {
+    level: 'unknown',
+    hint:
+      `Event "${event}" is not recognized by the gateway's scope gate. If it is a ` +
+      `custom event your app handles, ignore this warning; otherwise check for ` +
+      `typos or update the SDK.`,
+  }
+}
+
+/** app+event pairs already reported as own-slot-only, to keep the console useful. */
+const ownOnlyLogged = new Set<string>()
+
 export function useAppEvents(event: string, callback: (data: unknown) => void): void {
   const { subscribe, info } = useCtx()
   const cbRef = useRef(callback)
   cbRef.current = callback
+  const appName = info.name
+  const allowedEvents = info.permissions.events
 
   useEffect(() => {
-    if (!info.permissions.events.includes(event) && !info.permissions.events.includes('*')) {
+    const check = checkSubscribeAllowed(event, allowedEvents)
+    if (check.level === 'own-only') {
+      // Own-slot-only is the DEFAULT, correctly-working configuration, so this
+      // is informational. Log once per app+event for the process lifetime:
+      // remounts would otherwise repeat a call-to-action hint about a setup
+      // that is not broken, drowning out real signal.
+      const seenKey = `${appName}::${event}`
+      if (!ownOnlyLogged.has(seenKey)) {
+        ownOnlyLogged.add(seenKey)
+        // eslint-disable-next-line no-console -- intentional permission diagnostic
+        console.info(
+          `[app-sdk] App "${appName}" subscribing to "${event}" (own-slot only). ${check.hint}`,
+        )
+      }
+    } else if (check.level === 'denied') {
       // eslint-disable-next-line no-console -- intentional permission diagnostic
-      console.warn(`[app-sdk] App "${info.name}" not permitted to subscribe to event "${event}"`)
-      return
+      console.warn(
+        `[app-sdk] App "${appName}" subscribed to "${event}" but the manifest denies it. ` +
+          check.hint,
+      )
+    } else if (check.level === 'unknown') {
+      // Separate prefix from the denied case: asserting denial for a custom
+      // event and then retracting it in the hint leaves the author unable to
+      // tell whether anything is actually wrong.
+      // eslint-disable-next-line no-console -- intentional permission diagnostic
+      console.warn(`[app-sdk] App "${appName}" subscribed to "${event}": ` + check.hint)
     }
+    // Always register: the gateway is authoritative and silently drops what
+    // this app may not receive. Not returning early means a manifest fix takes
+    // effect on the next event without needing a component re-render.
     return subscribe(event, (data: unknown) => cbRef.current(data))
-  }, [event, subscribe, info])
+  }, [event, subscribe, appName, allowedEvents])
 }
 
 /** Reactive theme from the host. */

--- a/website/src/test/appSdkEventScope.test.ts
+++ b/website/src/test/appSdkEventScope.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the vendored SDK's WS subscription pre-check.
+ *
+ * The gateway (`kiro_crew/dashboard/ws_event_scope.py`) is authoritative; this
+ * table is advisory. The last test cross-checks the two so drift is visible
+ * here rather than as a wrong console warning in an app author's browser.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { checkSubscribeAllowed } from '../app-sdk'
+
+describe('checkSubscribeAllowed', () => {
+  it('treats tier 0 events as always delivered', () => {
+    for (const e of ['dashboard', 'refresh', 'update_progress']) {
+      expect(checkSubscribeAllowed(e, []).level).toBe('ok')
+    }
+  })
+
+  it('reports own-slot-only for slot-scoped events with no slots scope', () => {
+    const res = checkSubscribeAllowed('chat_chunk', [])
+    expect(res.level).toBe('own-only')
+    if (res.level === 'own-only') expect(res.hint).toContain('slots:user')
+  })
+
+  it('accepts slot-scoped events once any slots/subagent scope is declared', () => {
+    expect(checkSubscribeAllowed('chat_chunk', ['slots:user']).level).toBe('ok')
+    expect(checkSubscribeAllowed('subagent_status', ['subagent:all']).level).toBe('ok')
+  })
+
+  it('marks global events denied without the required scope, and ok with it', () => {
+    const denied = checkSubscribeAllowed('artifact_update', [])
+    expect(denied.level).toBe('denied')
+    if (denied.level === 'denied') expect(denied.hint).toContain('artifacts')
+    expect(checkSubscribeAllowed('artifact_update', ['artifacts']).level).toBe('ok')
+  })
+
+  it('accepts any variant of a scope family', () => {
+    // The gateway picks between `notification` (own-app) and
+    // `notification:system` (cron / send_message) from the payload's
+    // source_app, which is not knowable at subscribe time.
+    expect(checkSubscribeAllowed('notification', ['notification:all']).level).toBe('ok')
+    expect(checkSubscribeAllowed('notification', ['notification:system']).level).toBe('ok')
+    const denied = checkSubscribeAllowed('notification', [])
+    expect(denied.level).toBe('denied')
+    if (denied.level === 'denied') expect(denied.hint).toContain('notification:system')
+  })
+
+  it('accepts the wildcard declaration', () => {
+    expect(checkSubscribeAllowed('anything_at_all', ['*']).level).toBe('ok')
+  })
+
+  it('needs no declaration for the slots list re-push', () => {
+    // Payload is filtered per app server-side (_serialize_for_client).
+    expect(checkSubscribeAllowed('slots', []).level).toBe('ok')
+  })
+
+  it('flags an unrecognised event as unknown, not denied', () => {
+    // A distinct level matters: the console prefix for `denied` asserts the
+    // manifest rejected it, which would be a false claim for a custom event.
+    expect(checkSubscribeAllowed('chat_chunkk', ['slots:all']).level).toBe('unknown')
+  })
+
+  it('does not let a subagent scope widen non-subagent slot events', () => {
+    // subagent:* is an independent dimension in the gate, so it must not
+    // predict `ok` for chat -- the gateway still delivers own-slot chat only.
+    expect(checkSubscribeAllowed('chat_message', ['subagent:all']).level).toBe('own-only')
+    expect(checkSubscribeAllowed('subagent_status', ['subagent:all']).level).toBe('ok')
+    // A slots:* scope widens both families.
+    expect(checkSubscribeAllowed('subagent_status', ['slots:user']).level).toBe('ok')
+  })
+
+  it('matches the gateway tables in ws_event_scope.py', () => {
+    // Drift between the advisory table and the authoritative gate produces
+    // wrong developer warnings, so pin them together.
+    const py = readFileSync(
+      join(__dirname, '../../../src/kiro_crew/dashboard/ws_event_scope.py'),
+      'utf-8',
+    )
+    const names = (block: string): string[] => {
+      const m = py.match(new RegExp(`${block}[^{]*\\{([\\s\\S]*?)\\}\\)`))
+      if (!m) throw new Error(`block ${block} not found in ws_event_scope.py`)
+      // Strip `#` comment lines first: a quoted word inside a comment (a payload
+      // shape, a cross-reference) is prose, not a member, and reading it as one
+      // asserts the SDK classifies an event that does not exist.
+      const body = m[1]
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('#'))
+        .join('\n')
+      return [...body.matchAll(/"([^"]+)"/g)].map((x) => x[1])
+    }
+    // Scope the scan to the ONE table being mirrored. A whole-file regex for
+    // `"key": "value",` matches every other 4-space str->str dict in the module
+    // too (`_SUBAGENT_BATCH_ITEM_KEY` maps an event to its payload KEY, not to a
+    // scope), which would assert the SDK grants `subagent_batch_update` on a
+    // "scope" named `updates`. Anchored at line start so a PROSE mention of the
+    // table name in a comment is not mistaken for its definition.
+    const dictBlock = (block: string): string => {
+      const m = py.match(new RegExp(`^${block}[^{\\n]*\\{([\\s\\S]*?)^\\}`, 'm'))
+      if (!m) throw new Error(`dict block ${block} not found in ws_event_scope.py`)
+      return m[1]
+    }
+    for (const e of names('_TIER0_ALWAYS')) {
+      expect(checkSubscribeAllowed(e, []).level, `${e} should be tier 0`).toBe('ok')
+    }
+    for (const e of names('_SLOT_SCOPED_EVENTS')) {
+      expect(
+        checkSubscribeAllowed(e, []).level,
+        `${e} should be slot-scoped in the SDK table`,
+      ).toBe('own-only')
+    }
+    // `_SUBAGENT_EVENTS` is the one table the slot-scoped loop above cannot
+    // stand in for. Its members are a SUBSET of `_SLOT_SCOPED_EVENTS`, so that
+    // loop proves each is own-only by default -- but not that the SDK also
+    // widens it under a `subagent:*` scope. Without this loop an event the
+    // gateway delivers own-only can be predicted `ok` by the SDK, which is a
+    // misleading developer hint rather than a data leak (the gateway is
+    // authoritative), so assert the widening for every member by name.
+    const subagentEvents = names('_SUBAGENT_EVENTS')
+    expect(subagentEvents.length).toBeGreaterThan(3)
+    for (const e of subagentEvents) {
+      expect(
+        checkSubscribeAllowed(e, ['subagent:all']).level,
+        `${e} should widen to ok under subagent:all`,
+      ).toBe('ok')
+    }
+    const globals = [
+      ...dictBlock('_GLOBAL_EVENT_DECLARATIONS').matchAll(
+        /^\s{4}"([a-z_.]+)": "([a-z_:]+)",/gm,
+      ),
+    ].map((m) => [m[1], m[2]])
+    expect(globals.length).toBeGreaterThan(5)
+    for (const [event, scope] of globals) {
+      expect(
+        checkSubscribeAllowed(event, [scope]).level,
+        `${event} should be allowed by scope ${scope}`,
+      ).toBe('ok')
+      expect(checkSubscribeAllowed(event, []).level, `${event} should need a scope`).toBe(
+        'denied',
+      )
+    }
+  })
+})


### PR DESCRIPTION
Closes the WS half of the app-token boundary. Design and investigation: #693.

## Why

`/api/ws` had **no per-app filtering**: every connected client received every
real-time event — chat content, slot data, subagent status, approvals, logs.

Precisely, on `main` today: an app token is `403` on `/api/ws` **unless** the app
declares it (`/api/ws`, or a matching prefix like `/api/*`) in `permissions.api`. No
builtin does. So this is not a silently-open door — it is an **all-or-nothing grant**:
declaring the *transport* confers the *entire event stream*, and `permissions.api` has
no way to express "may see which events".

The gap was already noticed in one place. `deliver_ws_owners()` routes
capability-bearing payloads owner-only, with the comment *"an app credential can open
`/api/ws` and lands in `_ws_clients`, so an all-clients broadcast of user-scoped content
crosses the App Kit boundary."* This PR generalises that per-callsite fix into a filter.

## What

**Tiered scope**, declared in the manifest under the existing `permissions.events`:

- **Tier 0** (`dashboard`, `refresh`, `update_progress`) — no sensitive payload, always
  delivered. Requiring a declaration would add no security and break existing apps.
- **Tier 1 — slot-scoped** — filtered by the slot's `SlotOrigin` and the app's
  declarations: `slots:own` (the default), `slots:user`, `slots:app:<name>`,
  `slots:all`.
- **Tier 2 — global** — explicit declaration required.
- `subagent:*` is an **independent dimension** from `slots:*`, so an app can watch
  subagent status without receiving chat content.
- Cross-app visibility (`slots:app:X`) requires the **observed** app to opt in via
  `permissions.exposeToApps` — an app cannot name a sibling unilaterally.

Dashboard-user sockets are exempt, identified by a **positive** `is_dashboard_user`
claim — never by the absence of an app claim, which would fail *open* on any register
path that forgot to set it.

## One chokepoint, not one filter per call site

`main` has two dispatch paths and only one goes through `broadcast_ws()`:

```
broadcast_ws()                       -> _send_ws_all(msg)
DashboardState._broadcast()  -- _type translation -> _send_ws_all(ws_msg)
```

The second carries `chat_message` and the full `slots` re-push, so filtering only
`broadcast_ws()` would have missed the most sensitive traffic. `_send_ws_all` therefore
becomes `_send_ws_all(msg_type, data, msg)` — the single chokepoint — and both paths
funnel through it, as does `broadcast_ws_subagent_subscribers` (otherwise an app could
bypass filtering by sending `{"type": "subscribe_subagents"}`).

`_send_ws_owners` and its callers are untouched: an app token cannot reach
`_owner_ws_clients`. `is_owner_dashboard_request()` requires `request["app"] == ""` and
returns `False` when the key is absent, the middleware always sets it, and
`register_ws(owner=...)` is the only way into that set.

Three paths write to the socket directly and so bypass the chokepoint; each is gated at
the source in `ws.py`: the initial slots push, the log ring-buffer replay
(`subscribe_logs`), and the subagent reconnect replay batch.

Two payloads need more than a yes/no answer: the `slots` re-push is re-filtered per app
in `_serialize_for_client` (failing closed to an empty list), and `SlotOrigin` defaults
to `""` — matching no scope — rather than `USER`, so a future creation path that forgets
to pass an origin fails closed instead of silently granting `slots:user` visibility.

## `/api/ws` becomes an implicit allow — and why that belongs in this commit

`/api/ws` and `/api/status` are connection infrastructure, not capabilities; making
every app declare the transport produces silent 403 regressions. That widening is sound
**only because the stream is now filtered**, so both halves land together. The implicit
grant is SEL-audited (it was previously silent).

## Vendored SDK (`website/src/app-sdk/index.ts`) is part of this change, not a follow-up

Apps get the SDK at runtime from the host's **vendored** copy via the import map, and
that copy did a literal `includes()` check with an **early return**. Once scope strings
appear in `permissions.events`, a correctly-declared slot subscription would both warn
spuriously *and never subscribe*. Landing the gate without this would leave a broken
intermediate state, so `checkSubscribeAllowed()` ships here. It always registers the
subscription — the gateway is authoritative and drops what the app may not receive —
which also means a manifest fix takes effect on the next event rather than needing a
component re-render.

The published `@kirocrew/app-sdk` package (separate repo) gets the same predicate in a
follow-up; it affects author-time typings and the standalone fallback only, not runtime
behaviour.

## Completeness is enforced, not documented

Unknown events are **denied**, which is the right default but makes an unclassified
event a *silent* loss for apps. That is not hypothetical: **20 of the 46 event types on
`main` were unclassified** when the tables were first written — including
`workflow_run_event`, the only `permissions.events` declaration that exists in the tree
(the `workflows` app), which would have broken.

So an AST test walks the source and fails the build when a broadcast event name is not
classified. It resolves module-level string constants too — `chat.side_result` is passed
as `SIDE_RESULT_EVENT`, and a literal-only scan missed it (found exactly this way).

A frontend test cross-checks the vendored SDK table against `ws_event_scope.py`, so
drift shows up as a test failure rather than as a wrong console warning in an app
author's browser.

## Docs

`docs/app-platform-trust-model.md` gains a WebSocket section (it documented only the
HTTP-reach boundary), plus a note that the frontend `useAppApi` / `useAppEvents` scoping
is a **browser-side guardrail, not a boundary**: an embedded app runs with the dashboard
user's authority, so its `fetch` arrives with an empty app claim that `_enforce_app_scope`
deliberately does not gate. That distinction is easy to misread and worth stating.

## Tests

182 tests in `test_ws_event_scoping.py`, 53 in `test_dashboard_state_ws.py`, 10 in
`appSdkEventScope.test.ts`, plus additions to `test_token_auth.py` and
`test_app_manifest.py`. Full backend suite green apart from failures that reproduce
with this branch stashed (see below).

### Every enforcement point was falsified individually

Revocation has three enforcement points, because the own-slot default returns
before `allowed_events` is read and the two payload filters bypass the gate
entirely. Each was disabled **on its own**, with the others left in place, to prove
its test fails for its own reason:

| Break this | Expected red |
|---|---|
| `app_events_revoked` check in `ws_event_allowed` | `test_gate_denies_the_always_admitted_envelopes_when_disabled` |
| own-slot guard in `_slot_visible` | `test_slots_repush_filter_drops_own_slot_when_disabled` |
| own-slot guard in `_subagent_visible` | `test_subagent_batch_filter_drops_own_items_when_disabled` |
| cache priming in `load_declared_events_for_connect` | `test_connect_load_primes_the_cache_so_the_first_frame_is_authoritative` |
| socket refusal in `api_ws` | `test_source_guard_connect_refuses_a_disabled_app` |
| grant audit in the `ws_event_allowed` wrapper | all four `TestGrantsAreAudited` tests |
| grants sharing the deny dedup key | `test_a_grant_does_not_starve_the_deny_record` |
| auditing one branch instead of the result | `test_every_tier_produces_a_record` (names the uncovered tier) |

**Doing this caught a dead test.** Disabling the gate-level check first left all six
revocation tests green, because `_slot_visible` underneath was enforcing the same
thing for slot-scoped frames — so the gate test was passing for the wrong reason and
proved nothing about the gate. What the gate check uniquely covers is the frames
admitted *without* consulting `allowed_events` at all (`slots`, the coalesced
subagent batches): without it a revoked app receives a stream of empty envelopes
instead of nothing. That is now the assertion, and it reds when the gate check is
removed.

Breaking all three at once would have hidden this. One at a time is the only way to
tell a load-bearing check from a redundant one.

### Grants are audited too

`AUTOSDE.yaml` (`backend-security-controls`, blocking) requires a SEL event for
every permission decision. The gate originally recorded only refusals, so grants
now go through the same deduplicated path: one record per app/event per 5-minute
window, carrying the suppressed count, with a separate dedup key from denials so
neither starves the other out of the window.

The record is emitted from the `ws_event_allowed` **wrapper**, not from each
`return True`. The decision function returns True from five different places
(Tier 0, the two always-admitted envelopes, each slot scope, each global scope),
and auditing per-branch would mean every future branch has to remember to report
itself. `test_every_tier_produces_a_record` is what pins that: it drives one event
per tier, and when the audit was deliberately narrowed to the Tier 0 branch the
failure named the uncovered tier (`slots was allowed without an audit record`).

### Source guards, and one that had to be rewritten

Eight `test_source_guard_*` tests assert invariants against the shipped source
rather than behaviour, because the failure modes they cover are invisible to a
functional test:

- every `_allowed_events` read in `state.py` goes through the narrowing helper
  (asserts raw reads == narrowed reads, so a fourth read added later without
  narrowing fails)
- the log replay path reads the live scope, not the connect snapshot
- every manifest read on the connect path stays wrapped in `asyncio.to_thread`
- the refusal precedes `register_ws`, since refusing after registration would need
  a cleanup scope that does not exist yet
- every `approval_resolved` emitter sends a `slot` (asserts ≥ 4 emitters found, so a
  fifth added without it fails)

One of these was **wrong before it was right**: the off-loop guard asserted the
literal string `asyncio.to_thread(get_app_manifest`, so replacing that loader with
`load_declared_events_for_connect` turned it red while the invariant it existed to
protect — no manifest read on the event loop — still held. It now normalises the
source and checks that every disk-reading loader is preceded by `to_thread`, which
survives a rename and still catches a genuine regression. A guard that pins a
spelling resists refactoring instead of catching bugs.

### Drift guards across the language boundary

`appSdkEventScope.test.ts` parses the tables out of `ws_event_scope.py` at test
time and compares them to the TypeScript copies, so the two cannot silently
diverge. `TestEventTableCompleteness` fails the build when a new event name appears
in neither table, which is what keeps "unclassified" from becoming a silent deny.

Note the boundary: the separately published `@kirocrew/app-sdk` package cannot use
this guard, since another repository has no access to the Python source. That copy
is still unaligned and is listed as a follow-up.

### What is not covered

- Multi-process races on manifest writes. The TTL cache tolerates staleness by
  design, so this is argued rather than tested.
- An end-to-end test through a real `X-App-Secret` exchange against a live socket.
  No fixture exists for it.
- Load or latency. The gate is constant-time lookups per client per frame with disk
  work moved off-loop, but there is no benchmark.

### Static gates

`isort`, `flake8` and `mypy` clean. Frontend uses `tsc -b`, not `tsc --noEmit` —
the root tsconfig has `files: []`, so `--noEmit` checks nothing and passing it means
nothing. `eslint` and the i18n gate clean.

### Failures that are not from this branch

Reproduced with the branch stashed, so they are environmental rather than
regressions: `test_app_manager.py::TestBuiltinSecretForMcpServers`,
`test_slack_handler.py::TestToolElapsedTimer`,
`test_dashboard_origin.py::TestParseDashboardUrlMalformed`,
`test_cron_cancel.py::TestSubprocessRegistry`, `test_terminal_commands.py::TestRunProbe`.
The local suite is also non-deterministic under xdist, so a one-off red that does
not reproduce is a flake — one such (`test_agent_spec_preflight.py`) did not
reproduce on re-run.

## Notes for review

- Behaviour change worth a look: in
  `test_websocket_initial_status_and_refresh_are_owner_only`, the app-token case now
  asserts an **empty** initial slot list rather than "slots present but without check
  status". That is the new (stronger) guarantee, not a weakened assertion.
- `permissions.events` is reused rather than a new field. It already governs this same
  stream in both directions — `EventBus.publish()` for publishing, and the SDK check for
  subscribing — so this makes the subscribe side server-enforced and extends the
  vocabulary with scope strings. A test pins that the two directions cannot grant each
  other anything.

