### PR TITLE
fix(autonudge): surface cycle-cap expiry and diagnose unresolvable session identity

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -718,6 +718,20 @@ class AutoNudgeService:
         if loop.max_cycles and loop.cycle_count >= loop.max_cycles:
             logger.info("AutoNudge: loop %s reached max_cycles — deactivating", loop.id)
             await self.update(loop.id, active=False)
+            # Signal the cap. Reaching max_cycles is NOT a successful finish —
+            # the loop ran out of cycles with its goal possibly unmet — yet the
+            # only trace used to be this log line plus an ``updated`` event
+            # indistinguishable from a user pressing Stop. A capped-out babysit
+            # was therefore impossible to tell apart from the agent stopping on
+            # its own. ``expired`` is emitted so an observer can raise a
+            # notification the user actually sees.
+            #
+            # Emitted AFTER update() (which already persisted active=False and
+            # emitted ``updated``), so a subscriber handling ``expired`` always
+            # observes the loop in its final deactivated state. Deliberately a
+            # NEW event kind rather than overloading ``updated``: the many
+            # benign updates (message edits, manual pause) must not notify.
+            self._emit("expired", loop)
             return
         # Fire. Update state only if the callback reports actual delivery —
         # otherwise skipped nudges (e.g. slot mid-turn) inflate cycle_count and

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -2752,6 +2752,70 @@ def _write_user(path: str, body: dict, *, method: str, timeout: int = 10) -> dic
         return out
 
 
+def _strict_identity_diagnosis(tool: str) -> str:
+    """Explain WHY strict session identity could not be resolved, and the remedy.
+
+    ``_resolve_session_key_strict`` returning ``""`` used to surface as
+    "<tool> only works from within a dashboard, Slack, or Discord session
+    (current session_key='')" — actively misleading when the caller IS a
+    dashboard session and the resolver simply had no accepted source. That
+    message sent every reader looking for a wrong session type instead of the
+    real cause, and made a total, every-session outage look like a niche
+    context restriction.
+
+    The three accepted sources and why each can be legitimately absent:
+
+    1. **Per-call caller context** — injected only by the pooled MCP gateway
+       (``gatewayd``). Absent whenever ``mcp_gateway.enabled`` is false, which
+       is the DEFAULT (pooling is opt-in).
+    2. **``KIROCREW_SESSION_KEY``** — never set on the kiro-cli backend: MCP
+       servers are loaded from ``--agent`` (``acp/runtime.py`` passes
+       ``mcpServers: []``), so one MCP process serves the whole runtime and
+       cannot carry a single session's key in its env.
+    3. **``KIROCREW_HOST_PID``** + signed sidecar — exported only by the
+       sandbox launcher, so absent on unsandboxed hosts.
+
+    With all three absent the only remaining signal is the ``/proc`` ancestor
+    walk, which strict mode refuses on purpose: a session-sharing subagent runs
+    on the parent's runtime and through the SAME MCP process, so a walked
+    identity cannot distinguish subagent from parent and would let a subagent
+    mint an unattended loop in its parent's session.
+
+    Returns a diagnosis naming the absent sources so the reader can act rather
+    than retry a call that will never succeed.
+
+    Only ``KIROCREW_HOST_PID`` is reported as "present but unusable": the strict
+    resolver returns ``KIROCREW_SESSION_KEY`` verbatim whenever it is non-empty,
+    so an empty resolution already implies that variable is unset. A host pid,
+    by contrast, can be present and still rejected (missing or invalid HMAC
+    sidecar), which is a genuinely different remedy.
+    """
+    host_pid_present = os.environ.get("KIROCREW_HOST_PID", "").isdigit()
+    detail = (
+        f"{tool} could not resolve a verified session identity, so it refused "
+        "to act rather than guess which session to bind. This is a host "
+        "configuration gap, NOT a transient MCP disconnect — retrying will not "
+        "help."
+    )
+    if host_pid_present:
+        detail += (
+            " KIROCREW_HOST_PID is set but its signed session_pid sidecar did "
+            "not verify, so the identity it names was refused."
+        )
+    else:
+        detail += (
+            " None of the accepted identity sources is available in this "
+            "process: no gateway-injected caller context (the pooled MCP "
+            "gateway is off — `mcp_gateway.enabled` is opt-in and defaults to "
+            "false), no KIROCREW_SESSION_KEY (the kiro-cli backend loads MCP "
+            "servers via --agent, so one MCP process serves the whole runtime), "
+            "and no KIROCREW_HOST_PID (exported only when sandboxed). Enabling "
+            "the MCP gateway (Settings → MCP, or `mcp_gateway.enabled: true`) "
+            "restores per-call caller identity and with it this tool."
+        )
+    return detail
+
+
 # Default cycle cap for monitor_start when the caller omits max_cycles. An
 # unbounded loop only ever stops when the model volunteers autonudge_stop, and
 # real loop stores show that is unreliable — observed babysit loops ran to 24/24
@@ -4842,6 +4906,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="autonudge_stop", outcome="noop"
             )
+            if not sk:
+                return _strict_identity_diagnosis("autonudge_stop")
             return (
                 "No auto-nudge loop to stop: this tool only works from within "
                 "a dashboard, Slack, or Discord session "
@@ -4894,6 +4960,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="ask_question", outcome="noop"
             )
+            if not sk:
+                return _strict_identity_diagnosis("ask_question")
             return (
                 "ask_question only works from a dashboard chat session "
                 f"(current session_key={sk!r}). From other surfaces, end your "
@@ -4955,6 +5023,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="monitor_start", outcome="noop"
             )
+            if not sk:
+                return _strict_identity_diagnosis("monitor_start")
             return (
                 "monitor_start only works from within a dashboard, Slack, or "
                 f"Discord session (current session_key={sk!r}). For other "
@@ -5026,6 +5096,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             sel().log_tool_invocation(
                 session_key=sk, source="mcp", tool_name="monitor_update", outcome="noop"
             )
+            if not sk:
+                return _strict_identity_diagnosis("monitor_update")
             return (
                 "monitor_update only works from within a dashboard, Slack, or "
                 f"Discord session (current session_key={sk!r})."
@@ -5655,6 +5727,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 outcome="rejected",
                 error="non-dashboard or unresolved session",
             )
+            if not sk:
+                return "Error: " + _strict_identity_diagnosis("set_project")
             return (
                 "Error: set_project only works in dashboard sessions with explicit "
                 "identity. Slack, cron, and subagent contexts are rejected to avoid "
@@ -5698,6 +5772,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 outcome="rejected",
                 error="non-dashboard or unresolved session",
             )
+            if not sk:
+                return "Error: " + _strict_identity_diagnosis("suggest_followup")
             return (
                 "Error: suggest_followup only works in dashboard sessions with explicit "
                 "identity. Slack, cron, and subagent contexts have no follow-up card "

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2891,6 +2891,8 @@ class GatewayOrchestrator:
             return True
 
         def _observer(event: str, loop: NudgeLoop | None) -> None:
+            if event == "expired" and loop is not None:
+                self._notify_nudge_expired(loop)
             if self.dashboard_state and loop is not None:
                 self.dashboard_state.broadcast_ws(
                     "autonudge_state",
@@ -2913,6 +2915,46 @@ class GatewayOrchestrator:
         self.autonudge_svc = AutoNudgeService(base_dir=config_dir(), on_fire=_fire)
         self.autonudge_svc.subscribe(_observer)
         await self.autonudge_svc.start()
+
+    def _notify_nudge_expired(self, loop: NudgeLoop) -> None:
+        """Notify the user that a monitoring loop stopped at its cycle cap.
+
+        Reaching ``max_cycles`` is a runaway backstop, not a finish line: the
+        loop stopped with its goal possibly unmet. Without this the only
+        signals were a log line and an ``active=False`` state change that looks
+        identical to a manual Stop, so a loop that ran out of cycles was
+        indistinguishable from the agent stopping on its own — the most
+        confusing failure mode of the babysit feature.
+
+        Best-effort by construction: ``notify()`` never raises (it swallows
+        validation errors and logs), and the whole call is wrapped anyway
+        because this runs inside ``_emit``'s observer loop, where an exception
+        would be caught and logged but would also skip the WS broadcast that
+        follows it.
+        """
+        if not self.dashboard_state:
+            return
+        try:
+            key = loop.slot_key
+            # Channel-bound loops get NO synthesized meta: _notif_meta's generic
+            # ``chan:ts`` split would read the NAMESPACE as the channel id,
+            # producing a dead link (and a Slack URL for a Discord loop).
+            # Dashboard loops bind on the BARE slot key, so re-qualify those to
+            # get a working jump-to-source slot link.
+            meta = None if is_channel_key(key) else self._notif_meta(f"dashboard:{key}")
+            self.dashboard_state.notify(
+                "agent",
+                "Monitoring loop hit its cycle cap",
+                (
+                    f"The loop stopped after {loop.cycle_count} of "
+                    f"{loop.max_cycles} cycles without reporting done, so its "
+                    "goal may still be unmet. Reopen the goal popover to raise "
+                    "the cap or restart it."
+                ),
+                meta=meta,
+            )
+        except Exception:
+            logger.debug("AutoNudge expiry notification failed", exc_info=True)
 
     @staticmethod
     def _notif_meta(parent_key: str | None) -> dict[str, str] | None:

--- a/test/test_ask_question_mcp_tool.py
+++ b/test/test_ask_question_mcp_tool.py
@@ -149,8 +149,11 @@ def test_subagent_without_session_key_is_refused(mock_dashboard, monkeypatch):
     monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
     monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
     result = _call_tool_inner("ask_question", {"questions": QUESTIONS})
-    assert "only works from a dashboard chat session" in result
+    # Load-bearing: no card was posted into anyone's chat.
     assert _MockAskHandler.received == []
+    # An UNRESOLVED identity now reports the host configuration gap rather than
+    # blaming the session type — the caller often IS a dashboard session.
+    assert "could not resolve a verified session identity" in result.lower()
 
 
 def test_socket_timeout_exceeds_server_window(mock_dashboard, monkeypatch):

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -117,6 +117,82 @@ async def test_max_cycles_deactivates(svc, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_max_cycles_emits_expired_event(svc, monkeypatch):
+    """Hitting the cap must emit a distinct signal, not stop silently.
+
+    Reaching ``max_cycles`` is a runaway backstop, not a finish: the loop
+    stopped with its goal possibly unmet. Before this, the only trace was a log
+    line plus an ``updated`` event indistinguishable from the user pressing
+    Stop, so a capped-out loop looked the same as the agent stopping itself.
+    """
+    import kiro_crew.autonudge as _an
+
+    async def _nosleep(_secs):
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    events: list[tuple[str, str]] = []
+    svc.subscribe(lambda ev, lp: events.append((ev, lp.id if lp else "")))
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15, max_cycles=2)
+    loop.cycle_count = 2  # simulate cap reached
+    svc._save()
+    svc._cancel_timer(loop.id)
+    await svc._timer(loop)
+    assert ("expired", loop.id) in events, f"no expired event emitted; got {events}"
+    # The loop is observed in its FINAL state: expired fires after the
+    # deactivating update, so a subscriber never sees a still-active loop.
+    assert not svc._loops[loop.id].active
+
+
+@pytest.mark.asyncio
+async def test_no_expired_event_on_manual_deactivate(svc, monkeypatch):
+    """A user-initiated stop must NOT masquerade as cap exhaustion.
+
+    ``expired`` drives a user-visible notification, so overloading it onto
+    every deactivation would notify the user about their own Stop click.
+    """
+    import kiro_crew.autonudge as _an
+
+    async def _nosleep(_secs):
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    events: list[str] = []
+    svc.subscribe(lambda ev, lp: events.append(ev))
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15, max_cycles=5)
+    await svc.update(loop.id, active=False)  # manual pause, cap not reached
+    assert "expired" not in events
+    svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_unlimited_loop_never_expires(svc, monkeypatch):
+    """max_cycles=0 means unlimited — the cap branch must not fire at all."""
+    import kiro_crew.autonudge as _an
+
+    async def _nosleep(_secs):
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    events: list[str] = []
+
+    async def on_fire(_loop):
+        return True
+
+    svc._on_fire = on_fire
+    svc.subscribe(lambda ev, lp: events.append(ev))
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15, max_cycles=0)
+    loop.cycle_count = 9999  # would trip any finite cap
+    svc._cancel_timer(loop.id)
+    await svc._timer(loop)
+    assert "expired" not in events
+    assert svc._loops[loop.id].active is True
+
+
+@pytest.mark.asyncio
 async def test_stop_sentinel_removes_loop(svc, tmp_path, monkeypatch):
     import kiro_crew.autonudge as _an
 

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -277,8 +277,13 @@ def test_monitor_start_refuses_pid_walked_identity(mock_dashboard, monkeypatch):
     )
     _MockAutonudgeHandler.created_bodies = []
     result = _call_tool_inner("monitor_start", {"message": "watch"})
-    assert "only works" in result.lower()
+    # The load-bearing assertion: NO loop was armed on the walked identity.
     assert not _MockAutonudgeHandler.created_bodies
+    # The refusal diagnoses itself as an identity failure instead of implying
+    # the caller used an unsupported session type, and must never echo the
+    # walked key back (that would confirm the parent identity to a subagent).
+    assert "could not resolve a verified session identity" in result.lower()
+    assert "chat-3-1700000000" not in result
 
 
 def test_autonudge_stop_refuses_pid_walked_identity(mock_dashboard, monkeypatch):
@@ -293,8 +298,10 @@ def test_autonudge_stop_refuses_pid_walked_identity(mock_dashboard, monkeypatch)
         "slot_key": "chat-3-1700000000",
     }
     result = _call_tool_inner("autonudge_stop", {})
-    assert "only works" in result.lower()
+    # Load-bearing: the PID-walked parent loop was NOT revealed or stopped.
     assert "loop-9" not in result
+    # An unresolved identity reports the host gap, not the session type.
+    assert "could not resolve a verified session identity" in result.lower()
 
 
 def test_autonudge_stop_slack_session(mock_dashboard, monkeypatch):
@@ -477,8 +484,11 @@ def test_monitor_update_refuses_pid_walked_identity(mock_dashboard, monkeypatch)
     _MockAutonudgeHandler.loop_for_slot = {"id": "loop-7", "slot_key": "chat-3-1700000000"}
     _MockAutonudgeHandler.patched = []
     result = _call_tool_inner("monitor_update", {"message": "x"})
-    assert "only works" in result.lower()
+    # Load-bearing: the parent's loop was NOT patched.
     assert not _MockAutonudgeHandler.patched
+    # Diagnoses the identity failure, and never echoes the parent's loop id.
+    assert "could not resolve a verified session identity" in result.lower()
+    assert "loop-7" not in result
 
 
 def test_monitor_update_slack_session(mock_dashboard, monkeypatch):
@@ -867,3 +877,78 @@ def test_lost_patch_response_requires_the_same_loop_identity(mock_dashboard, mon
     result = _call_tool_inner("monitor_update", {"message": "revised"})
     assert "NO confirmed answer" in result
     assert "Verified applied" not in result
+
+
+class TestStrictIdentityDiagnosis:
+    """An unresolvable strict identity must diagnose itself, not misdirect.
+
+    ``_resolve_session_key_strict`` returning "" used to surface as "only works
+    from within a dashboard, Slack, or Discord session (current
+    session_key='')" — which sent readers hunting for a wrong session type when
+    the caller WAS a dashboard session and the resolver simply had no accepted
+    source. On a default install (``mcp_gateway.enabled`` false, unsandboxed,
+    kiro-cli backend) all three sources are absent, so this is a total outage
+    of monitor_start/monitor_update, not a niche context restriction.
+    """
+
+    def test_names_the_absent_sources_and_the_remedy(self, monkeypatch):
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+        msg = mcp_core._strict_identity_diagnosis("monitor_start")
+        # Names the tool and refuses to be mistaken for a flaky reconnect.
+        assert "monitor_start" in msg
+        assert "retrying will not help" in msg.lower()
+        # Points at the actual remedy rather than the session type.
+        assert "mcp_gateway.enabled" in msg
+        # Does NOT repeat the misleading "wrong session type" framing.
+        assert "only works from within" not in msg
+
+    def test_reports_a_host_pid_whose_sidecar_did_not_verify(self, monkeypatch):
+        """A set-but-rejected HOST_PID must be reported, not called absent.
+
+        This is the one "present but unusable" state production can actually
+        reach: the strict resolver returns KIROCREW_SESSION_KEY verbatim when it
+        is non-empty, so an empty resolution already implies that var is unset —
+        but a host pid can be present and still refused by sidecar verification,
+        which is a different remedy.
+        """
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "1234")
+        msg = mcp_core._strict_identity_diagnosis("monitor_update")
+        assert "KIROCREW_HOST_PID" in msg
+        assert "sidecar" in msg
+        assert "None of the accepted identity sources" not in msg
+
+    def test_non_numeric_host_pid_counts_as_absent(self, monkeypatch):
+        """Only a usable (digit) host pid counts — the resolver requires it."""
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "not-a-pid")
+        msg = mcp_core._strict_identity_diagnosis("monitor_start")
+        assert "None of the accepted identity sources" in msg
+
+    def test_every_strict_identity_tool_reports_the_same_cause(self, monkeypatch):
+        """All six strict-identity tools must diagnose one host gap identically.
+
+        Before this, monitor_start/monitor_update explained the gap while
+        autonudge_stop, ask_question, set_project and suggest_followup still
+        blamed the session type — so the SAME root cause reported two different
+        stories depending on which tool the agent happened to call.
+        """
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        for tool, args in (
+            ("monitor_start", {"message": "watch"}),
+            ("monitor_update", {"message": "watch"}),
+            ("autonudge_stop", {}),
+            ("ask_question", {"questions": [{"question": "q?", "options": ["a", "b"]}]}),
+            ("set_project", {"path": "/tmp"}),
+            (
+                "suggest_followup",
+                {"items": [{"title": "t", "description": "d", "prompt": "p"}]},
+            ),
+        ):
+            result = _call_tool_inner(tool, args)
+            assert "could not resolve a verified session identity" in result.lower(), tool
+            assert "mcp_gateway.enabled" in result, tool
+            assert "only works from within" not in result, tool

--- a/test/test_mcp_core_set_project.py
+++ b/test/test_mcp_core_set_project.py
@@ -245,8 +245,11 @@ class TestSetProjectTool:
         with patch.object(mcp_core, "_post") as mock_post, \
              patch.object(mcp_core, "_resolve_session_key_strict", return_value=""):
             result = mcp_core._call_tool_inner("set_project", {"path": "/tmp"})
-        assert "Error: set_project only works in dashboard sessions" in result
+        # Load-bearing: no slot was mutated.
         mock_post.assert_not_called()
+        # An unresolved identity reports the host gap, not the session type.
+        assert result.startswith("Error:")
+        assert "could not resolve a verified session identity" in result.lower()
 
     def test_slack_session_is_rejected(self):
         with patch.object(mcp_core, "_post") as mock_post, patch.object(

--- a/test/test_mcp_followup_dispatch.py
+++ b/test/test_mcp_followup_dispatch.py
@@ -65,9 +65,16 @@ class TestSuggestFollowupDispatch:
         """Slack/cron/subagent contexts have no card surface, and an unresolved
         identity must not be allowed to guess a slot."""
         result = self._invoke({"items": [_item()]}, session_key=session_key)
-        assert result.startswith("Error:")
-        assert "dashboard sessions" in result
+        # Load-bearing for every case: no card was posted.
         assert self._captured["calls"] == []
+        assert result.startswith("Error:")
+        if session_key:
+            # A resolved but unsupported surface: the session type IS the cause.
+            assert "dashboard sessions" in result
+        else:
+            # An UNRESOLVED identity is a host configuration gap, not a wrong
+            # session type, and must say so.
+            assert "could not resolve a verified session identity" in result.lower()
 
     def test_schema_violation_is_refused_at_the_dispatch_layer(self):
         """The tool re-validates before posting — the endpoint is not the only gate.

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.slack.gateway import (
     _CRON_MSG_LIMIT,
@@ -1460,6 +1462,77 @@ class TestNotifMeta:
 
     def test_hook_key_returns_none(self):
         assert GatewayOrchestrator._notif_meta("hook:h1") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _notify_nudge_expired
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNotifyNudgeExpired:
+    """A monitoring loop that stops at its cycle cap must tell the user.
+
+    Reaching ``max_cycles`` is a runaway backstop, not a finish line — the loop
+    stopped with its goal possibly unmet. Previously the only trace was a log
+    line plus an ``active=False`` state change indistinguishable from a manual
+    Stop, so a capped-out loop looked the same as the agent stopping itself.
+    """
+
+    @staticmethod
+    def _orch(state):
+        """A minimal stand-in — the method only needs dashboard_state."""
+        orch = SimpleNamespace(
+            dashboard_state=state,
+            _notif_meta=GatewayOrchestrator._notif_meta,
+        )
+        return orch
+
+    def _loop(self, slot_key="chat-7-1700000000"):
+        return NudgeLoop(
+            id="loop-x",
+            slot_key=slot_key,
+            message="babysit the PR",
+            idle_secs=300,
+            max_cycles=24,
+            cycle_count=24,
+        )
+
+    def test_notifies_with_cycle_counts_and_slot_link(self):
+        state = MagicMock()
+        GatewayOrchestrator._notify_nudge_expired(self._orch(state), self._loop())
+        state.notify.assert_called_once()
+        args, kwargs = state.notify.call_args
+        # Body names the real numbers so the user can judge whether to resume.
+        assert "24 of 24" in args[2]
+        # Dashboard loops bind on the BARE slot key; the notification must
+        # still deep-link, which requires re-qualifying it for _notif_meta.
+        assert kwargs["meta"] == {"slot": "chat-7-1700000000"}
+
+    def test_channel_loop_gets_no_synthesized_meta(self):
+        """A channel key must not be fed to _notif_meta at all.
+
+        Its generic ``chan:ts`` split would read the NAMESPACE as the channel
+        id — ``slack:1700000000.123456`` became a link to an "archives/slack"
+        channel, and a Discord loop got a Slack URL. Asserting only "not a
+        slot" passed on exactly that bogus link, so assert the value exactly.
+        """
+        for key in ("slack:1700000000.123456", "discord:kirocrew:direct:42"):
+            state = MagicMock()
+            loop = self._loop(slot_key=key)
+            GatewayOrchestrator._notify_nudge_expired(self._orch(state), loop)
+            state.notify.assert_called_once()
+            assert state.notify.call_args.kwargs["meta"] is None, key
+
+    def test_no_dashboard_state_is_a_noop(self):
+        # Must not raise when the dashboard isn't wired up (Slack-only host).
+        GatewayOrchestrator._notify_nudge_expired(self._orch(None), self._loop())
+
+    def test_notify_failure_never_propagates(self):
+        """Runs inside the observer loop — an exception here would also skip
+        the WS broadcast that follows it, so it must be swallowed."""
+        state = MagicMock()
+        state.notify.side_effect = RuntimeError("bus down")
+        GatewayOrchestrator._notify_nudge_expired(self._orch(state), self._loop())
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

Asking the agent to "babysit this PR until it's green" appeared to make it stop
on its own, twice over, for two unrelated reasons:

1. **A monitoring loop that used up its cycle budget vanished without a word.**
   On reaching `max_cycles`, `AutoNudgeService._timer` wrote a log line and set
   `active=False`. The only externally visible signal was an `updated` event —
   byte-identical to the user clicking Stop in the 🎯 popover. A loop that ran
   out of cycles with its goal unmet was therefore indistinguishable from the
   agent deciding it was finished. Two real loops in a local store sat at
   exactly 24/24 and 20/20 cycles, `active: false`, neither having converged.

2. **Six tools that need a verified session identity blamed the wrong thing.**
   When `_resolve_session_key_strict()` returned `""`, `monitor_start` answered
   *"monitor_start only works from within a dashboard, Slack, or Discord session
   (current session_key='')"*. That is misleading: the caller frequently **is** a
   dashboard session, and the real cause is that no accepted identity source
   exists in the MCP process. The message sent readers hunting for a wrong
   session type instead of a host configuration gap.

## Why it matters

Both failures teach the user that "babysit until green" is unreliable, with no
way to tell an infrastructure gap from the agent giving up. (2) is not a niche
edge case: on a default install — pooling off, unsandboxed, kiro-cli backend —
*none* of the three accepted identity sources is present, so the affected tools
fail closed in every session while reporting a cause that cannot be acted on.

## Fix (symptoms → root cause → change)

**Cap expiry.** Symptom: loop stops silently. Root cause: the cap branch emitted
no signal distinguishable from a manual stop. Change: emit a new `expired`
observer event *after* the deactivating `update()` (so subscribers always see the
final state), and have the gateway's existing AutoNudge observer turn it into a
notification naming the cycle counts. `expired` is a **new** event kind rather
than an overload of `updated`, so the many benign updates (message edits, manual
pause) do not notify. Channel-bound loops deliberately carry **no** deep link: a
`slack:<ts>` key holds no channel id, so any synthesized link would be wrong.

**Identity diagnosis.** Symptom: misleading refusal. Root cause: one message was
used for two different conditions — "unsupported session type" and "no identity
resolvable". Change: split them. A non-empty but unsupported key (`cron:job-9`)
keeps the original wording; an empty resolution now returns
`_strict_identity_diagnosis()`, which names the absent sources and the remedy
(`mcp_gateway.enabled`). Applied to all six tools sharing the resolver —
`monitor_start`, `monitor_update`, `autonudge_stop`, `ask_question`,
`set_project`, `suggest_followup` — because fixing only some would report two
different causes for one host gap.

**Not fixed here, deliberately.** The structural cause of the empty identity is
unchanged and out of scope for this PR: `acp/runtime.py` passes `mcpServers: []`
because kiro-cli loads MCP servers from `--agent`, so **one MCP process serves an
entire runtime**, including every session-sharing subagent. A subagent's call is
therefore indistinguishable from its parent's at the process level, which is why
the strict resolver refuses the `/proc` ancestor walk and must keep refusing it.
Restoring these tools needs either the pooled MCP gateway (per-call caller
context) or subagents on separate runtimes. This PR makes the failure legible,
not absent.

## Tests

- `test_max_cycles_emits_expired_event` — cap exhaustion emits `expired`, and the
  loop is observed already deactivated.
- `test_no_expired_event_on_manual_deactivate` — a user-initiated stop must not
  masquerade as cap exhaustion (guards the notification against false positives).
- `test_unlimited_loop_never_expires` — `max_cycles=0` never trips the branch.
- `TestNotifyNudgeExpired` (4 tests) — counts in the body, a correct `{"slot": …}`
  link for dashboard loops, **`meta is None` for both Slack and Discord keys**, a
  no-op without a dashboard, and swallowed notification failure.
- `TestStrictIdentityDiagnosis` (4 tests) — names absent sources and the remedy;
  reports a `KIROCREW_HOST_PID` whose sidecar failed to verify; treats a
  non-numeric pid as absent; and asserts all six tools report the *same* cause.
- Four pre-existing test files had message assertions retargeted. Every one keeps
  its original security assertion (nothing posted / nothing patched / no loop
  armed / parent loop id not echoed); `test_mcp_followup_dispatch` was
  strengthened — the no-post assertion is now unconditional across parametrized
  cases.

Revert-verified: removing the `expired` emit, the diagnosis routing (per tool),
or the channel-key guard each fails a specific test.

## Manual verification

N/A — unit coverage is sufficient. Both changes are observable purely through the
service's own event/return contracts, both fully exercised by the tests above.
No user-visible UI surface changed, so no screenshots apply.

## Review notes

Local mirrors of both AI gates ran before push. GPT (`gpt-5.6-sol`): no findings.
Opus (`claude-opus-5`): nothing blocking, plus 5 non-blocking findings — a wrong
notification link for channel loops, a companion test that masked it, a new test
class accidentally re-parenting a sibling test, a dead diagnosis branch with a
test asserting an impossible input, and the incomplete tool coverage above. All
five are fixed; a focused verifier confirmed each CLOSED with runtime evidence
and no new Critical/High.

Opus also cleared the point I was least sure of: this is **not** a
`no-blocking-call-on-event-loop` violation. `_emit` runs on the loop, but
`DashboardState._deliver_note` offloads the JSONL append to an executor whenever
a loop is running; only the no-loop (sync/test) path writes inline.

Gates on `3e287fd2`: 19892 pytest passed, `isort` / `flake8` / `mypy` (523 files)
clean. The 3 remaining `test_dashboard_origin.py` failures are pre-existing and
environmental — verified by running the full suite on a clean `origin/main`
checkout under identical parallel load, which produces the same 3 (this host
exports `KIROCREW_PORT=6776`).
