### PR TITLE
fix(dashboard): admit loopback origins to CSP connect-src

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -336,7 +336,15 @@ _BASE_CSP = (
     "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
     "img-src 'self' data: blob: https:; "
     "font-src 'self' data:; "
-    "connect-src 'self' ws://localhost:* ws://127.0.0.1:*; "
+    # Loopback http(s) origins ({connect_src_extra}) mirror the frame-src note
+    # below: WebPreviewPanel does not merely FRAME the local dev server, it also
+    # polls it with a no-cors `fetch` liveness probe (a cross-origin iframe
+    # cannot report that its server died). Framing without connecting made that
+    # probe throw on every tick, so two strikes flipped a perfectly healthy
+    # preview to "server stopped responding" and unmounted the iframe. The
+    # probe is no-cors, so no response data is ever readable — this admits the
+    # reachability check only, and to the same origins frame-src already allows.
+    "connect-src 'self' ws://localhost:* ws://127.0.0.1:*{connect_src_extra}; "
     "media-src 'self' blob:; "
     "worker-src 'self' blob:; "
     # https://*.cloudfront.net: live preview iframes for deployed webapp
@@ -354,10 +362,12 @@ _BASE_CSP = (
     "object-src 'none'; base-uri 'self'; frame-ancestors {frame_ancestors}"
 )
 
-# Loopback preview origins — always framable (see frame-src note above).
-# Aligned with the URLs WebPreviewPanel.normalizeUrl accepts: http+https on
-# every loopback host (127.0.0.1 / localhost / [::1] / 0.0.0.0), so a preview
-# never renders blank due to a CSP-blocked frame.
+# Loopback preview origins — always framable AND connectable (see the
+# frame-src / connect-src notes above). Aligned with the URLs
+# WebPreviewPanel.normalizeUrl accepts: http+https on every loopback host
+# (127.0.0.1 / localhost / [::1] / 0.0.0.0), so a preview never renders blank
+# due to a CSP-blocked frame, nor gets declared unreachable due to a
+# CSP-blocked liveness probe.
 _LOOPBACK_FRAME_SRC = (
     " http://127.0.0.1:* http://localhost:* http://[::1]:* http://0.0.0.0:*"
     " https://127.0.0.1:* https://localhost:* https://[::1]:* https://0.0.0.0:*"
@@ -512,7 +522,11 @@ def _apply_security_headers(
     frame_ancestors = " ".join(["'self'", *extra_ancestors])
     resp.headers.setdefault(
         "Content-Security-Policy",
-        _BASE_CSP.format(frame_src_extra=frame_src_extra, frame_ancestors=frame_ancestors),
+        _BASE_CSP.format(
+            connect_src_extra=_LOOPBACK_FRAME_SRC,
+            frame_src_extra=frame_src_extra,
+            frame_ancestors=frame_ancestors,
+        ),
     )
     resp.headers.setdefault("Permissions-Policy", _PERMISSIONS_POLICY)
     # Defense-in-depth browser headers (CWE-1021/693/200/319). All via setdefault

--- a/test/test_dashboard_security_headers.py
+++ b/test/test_dashboard_security_headers.py
@@ -128,6 +128,41 @@ class TestApplySecurityHeaders:
         assert "http://*.localhost:*" not in csp
         assert "frame-ancestors 'self'" in csp
 
+    def test_csp_connect_src_allows_loopback_liveness_probe(self) -> None:
+        """WebPreviewPanel polls the framed dev server with a no-cors ``fetch``
+        because a cross-origin iframe cannot report that its server died. When
+        connect-src admitted only ``'self'`` + ws:// loopback, that probe threw
+        on every tick and two strikes declared a healthy preview
+        "stopped responding", unmounting the iframe. connect-src must therefore
+        admit the SAME loopback origins frame-src does."""
+        for with_instances in (False, True):
+            resp = _make_response()
+            _apply_security_headers(resp, _make_app(with_instances=with_instances))
+            csp = resp.headers["Content-Security-Policy"]
+            connect_src = next(
+                d for d in csp.split(";") if d.strip().startswith("connect-src")
+            )
+            frame_src = next(d for d in csp.split(";") if d.strip().startswith("frame-src"))
+            # Every loopback origin the panel can frame, it can also probe.
+            for origin in (
+                "http://127.0.0.1:*",
+                "http://localhost:*",
+                "http://[::1]:*",
+                "http://0.0.0.0:*",
+                "https://127.0.0.1:*",
+                "https://localhost:*",
+            ):
+                assert origin in frame_src, (origin, frame_src)
+                assert origin in connect_src, (origin, connect_src)
+            # Pre-existing WebSocket loopback grants stay.
+            assert "ws://localhost:*" in connect_src
+            assert "ws://127.0.0.1:*" in connect_src
+            # The probe is loopback-only: no bare wildcard, no public egress,
+            # and the *.localhost tunnel wildcard stays frame-src/instances-only.
+            assert "http://*.localhost:*" not in connect_src
+            assert "https://*" + " " not in connect_src
+            assert "*.cloudfront.net" not in connect_src
+
     def test_csp_frame_src_allows_cloudfront_previews(self) -> None:
         """Webapp artifact live previews iframe the deployed CloudFront site
         (WebAppArtifactCard / WebAppThumb): https-only wildcard, present in


### PR DESCRIPTION
## Problem

The Browser (Web Preview) panel declares healthy local dev servers dead. About
ten seconds after a preview loads, the iframe is replaced with:

> The server at `http://127.0.0.1:3200/` stopped responding. It'll reconnect
> automatically when it's back — or reload now.

Reproduced repeatedly against a server that was demonstrably fine: the process
was alive and listening on `127.0.0.1`, and twelve sequential requests all
returned `200` in under 0.5s, while the panel still reported it unreachable.
It affects every local preview — any Vite / `http.server` / dev server the
`web-preview` skill points the panel at, not one specific tool.

## Why it matters

The Web Preview panel is how the agent shows the user a running local app.
When it self-destructs on a ~10s timer, the feature is effectively unusable:
the user sees an error for a server that is serving fine, and the natural
reaction is to go debug the innocent server.

## Fix (symptom → root cause → change)

**Symptom:** panel says "stopped responding"; server provably up.

**Root cause:** `frame-src` admits every loopback origin the panel can frame,
but `connect-src` admitted only `'self'` plus `ws://` loopback — no
`http(s)://` loopback. `WebPreviewPanel` does not merely *frame* the dev
server: because a cross-origin iframe cannot report that its server died, it
polls the URL every 5s with a `no-cors` `fetch` and treats **two consecutive
failures** as "server stopped" (`WebPreviewPanel.tsx`, liveness-probe effect).
CSP blocked that fetch, so it threw on every tick, and two strikes (~10s)
unmounted a perfectly healthy preview. The directive that grants framing and
the directive that grants probing had drifted apart.

**Change:** `connect-src` now reuses the **same** `_LOOPBACK_FRAME_SRC`
constant `frame-src` uses, via a `{connect_src_extra}` substitution — so the
two directives cannot drift again. Scope is unchanged in every other respect:

- The probe is `no-cors`, so no response data is ever readable. This admits
  the reachability check only.
- Only origins `frame-src` **already** allows are added (loopback http+https:
  `127.0.0.1`, `localhost`, `[::1]`, `0.0.0.0`).
- The `*.localhost` tunnel wildcard stays instances-gated and `frame-src`-only.
- No public-egress origin is added; `*.cloudfront.net` stays framing-only.

## Tests

`test_csp_connect_src_allows_loopback_liveness_probe` (new, in
`test/test_dashboard_security_headers.py`) locks in:

- every loopback origin present in `frame-src` is **also** present in
  `connect-src` — the parity assertion that would have caught this bug;
- the pre-existing `ws://` loopback grants still stand;
- the probe stays loopback-only — no bare wildcard, no `*.cloudfront.net`, and
  no `*.localhost` tunnel wildcard in `connect-src`;
- asserted in **both** instances-on and instances-off modes.

19 passed in `test/test_dashboard_security_headers.py`; `flake8` + `isort`
clean.

## Manual verification

Confirmed the emitted header now carries the loopback set on both directives:

```
connect-src 'self' ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* http://localhost:* http://[::1]:* http://0.0.0.0:* https://127.0.0.1:* https://localhost:* https://[::1]:* https://0.0.0.0:*
frame-src   'self' blob: https://*.cloudfront.net http://127.0.0.1:* http://localhost:* http://[::1]:* http://0.0.0.0:* https://127.0.0.1:* https://localhost:* https://[::1]:* https://0.0.0.0:*
```

Grepped `test/` for other `connect-src` assertions — only this file pins CSP,
so nothing else encoded the old value.

## Screenshots

N/A — no user-visible UI change. The change is a response header; the visible
effect is the *absence* of a spurious error state in an existing panel, which a
still frame cannot demonstrate. The parity test is the durable evidence.
