### PR TITLE
fix(dashboard): send subscribe_logs on first connect, add e2e test ids

### DIFF
--- a/website/playwright/apps.spec.ts
+++ b/website/playwright/apps.spec.ts
@@ -133,7 +133,7 @@ test.describe('Apps Page — /apps', () => {
     // A non-empty query also clears the editorial layer (showEditorial requires
     // !query.trim(), AppsPage.tsx:207), so every card unmounts -- not just the
     // AppListRows.
-    await expect(page.getByText('No matching apps')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('empty-state-title')).toHaveText('No matching apps', { timeout: 5000 })
     await expect(browseCards(page)).toHaveCount(0)
   })
 
@@ -152,7 +152,7 @@ test.describe('Apps Page — /apps', () => {
     // aria-label stays "Search apps".
     const search = page.getByRole('textbox', { name: 'Search apps' })
     await search.fill('zzz_no_match_xyz')
-    await expect(page.getByText('No matching apps')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('empty-state-title')).toHaveText('No matching apps', { timeout: 5000 })
 
     await search.clear()
     await expect(libraryCard(page, 'Task Runner')).toBeVisible({ timeout: 5000 })

--- a/website/playwright/capabilities.spec.ts
+++ b/website/playwright/capabilities.spec.ts
@@ -20,6 +20,10 @@ test.describe('Capabilities Page — /capabilities', () => {
     // SidePanelLayout nav title "Agent Capabilities" — scoped inside main-content
     await expect(page.locator('#main-content .text-lg.font-bold').first()).toHaveText('Agent Capabilities')
     // Default tab description from the content area header
+    // Prose deliberately: on /capabilities this string is a TAB DESCRIPTION
+    // (CapabilitiesPage.tsx:16), not a PageHeader subtitle, so there is no
+    // page-subtitle testid on this route. KiroCrewAgentsPage renders the same
+    // string as a real PageHeader subtitle, hence the #main-content scope.
     await expect(page.locator('#main-content').getByText('Manage agent → workspace → memory store bindings')).toBeVisible({ timeout: 5000 })
   })
 

--- a/website/playwright/logs.spec.ts
+++ b/website/playwright/logs.spec.ts
@@ -1,6 +1,23 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 
 const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
+
+/**
+ * Wait for at least one rendered log line.
+ *
+ * The gateway replays its log ring buffer when the client sends subscribe_logs
+ * (ws.py:256), so lines appear without needing to generate fresh traffic.
+ *
+ * The previous form of this wait, `page.locator('.font-mono').first()`, matched
+ * the "Filter logs" input (LogsPage.tsx:114 also carries font-mono and precedes
+ * the Virtuoso rows), so it resolved instantly against an always-visible element
+ * and asserted nothing. That masked a real bug: useWebSocket only flushed a
+ * pending log subscription on RECONNECT, never on first connect, so a cold load
+ * of /logs rendered no lines at all.
+ */
+async function waitForLogLines(page: Page) {
+  await expect(page.getByTestId('log-line').first()).toBeVisible({ timeout: 20000 })
+}
 
 // Every test here needs DEBUG so the stream actually emits lines, and
 // POST /api/logs/level PERSISTS: api_log_level writes cfg.agent.log_level and
@@ -19,13 +36,17 @@ test.describe('Logs Page', () => {
     // The minimal fixture defaults to WARNING which may show zero lines.
     await request.post('/api/logs/level', { data: { level: 'DEBUG' } })
     await page.goto('/logs', { waitUntil: 'domcontentloaded' })
-    // Wait for the page header to render, proving the route mounted
-    await expect(page.getByText('Live Logs')).toBeVisible({ timeout: 10000 })
+    // Structural mount gate: the header renders on every page, so this proves the
+    // route mounted without pinning any copy.
+    await expect(page.getByTestId('page-header')).toBeVisible({ timeout: 10000 })
   })
 
   test('renders page header and subtitle', async ({ page }) => {
-    await expect(page.getByText('Live Logs')).toBeVisible()
-    await expect(page.getByText('Real-time application output')).toBeVisible()
+    // This test's job IS to pin the page identity, so the title text is asserted
+    // deliberately. The subtitle is only checked for presence: it is a tagline a
+    // designer can reword without changing behaviour.
+    await expect(page.getByTestId('page-title')).toHaveText('Live Logs')
+    await expect(page.getByTestId('page-subtitle')).toBeVisible()
   })
 
   test('displays log level buttons with current level highlighted', async ({ page }) => {
@@ -46,16 +67,11 @@ test.describe('Logs Page', () => {
   })
 
   test('receives live log lines from the gateway', async ({ page }) => {
-    // The gateway emits log lines. At DEBUG level, there will be many.
-    // Log lines are rendered as font-mono divs inside the Virtuoso container.
-    const logLine = page.locator('.font-mono').first()
-    await expect(logLine).toBeVisible({ timeout: 15000 })
+    await waitForLogLines(page)
   })
 
   test('changing log level via UI narrows displayed lines', async ({ page, request }) => {
-    // Confirm we have log lines visible at DEBUG level
-    const logLine = page.locator('.font-mono').first()
-    await expect(logLine).toBeVisible({ timeout: 15000 })
+    await waitForLogLines(page)
 
     // Switch to ERROR level via the UI button -- this should filter display
     await page.getByRole('button', { name: 'Error' }).click()
@@ -68,9 +84,7 @@ test.describe('Logs Page', () => {
   })
 
   test('search filter shows match count when term matches log lines', async ({ page }) => {
-    // Wait for log lines to appear at DEBUG level
-    const logLine = page.locator('.font-mono').first()
-    await expect(logLine).toBeVisible({ timeout: 15000 })
+    await waitForLogLines(page)
 
     // Every log line contains "kiro_crew" in the logger name field.
     // Type the search term
@@ -82,9 +96,7 @@ test.describe('Logs Page', () => {
   })
 
   test('Matches only button activates and deactivates correctly', async ({ page }) => {
-    // Wait for log lines to appear
-    const logLine = page.locator('.font-mono').first()
-    await expect(logLine).toBeVisible({ timeout: 15000 })
+    await waitForLogLines(page)
 
     // Search for a term that matches SOME lines (the logger name appears in all lines)
     const filterInput = page.getByLabel('Filter logs')
@@ -102,7 +114,7 @@ test.describe('Logs Page', () => {
     await matchesOnlyBtn.click()
 
     // Verify lines are still shown (the search matched lines)
-    await expect(page.locator('.font-mono').first()).toBeVisible()
+    await expect(page.getByTestId('log-line').first()).toBeVisible()
 
     // Clear the search -- "Matches only" button should disappear
     await filterInput.fill('')

--- a/website/playwright/notifications.spec.ts
+++ b/website/playwright/notifications.spec.ts
@@ -5,32 +5,33 @@ const HARNESS_GATEWAY = !!process.env.KIROCREW_E2E_EPHEMERAL
 test.describe('Notifications Page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/notifications', { waitUntil: 'domcontentloaded' })
-    // Wait for the page subtitle to render -- unique to this page
-    await expect(page.getByText('All agent activity, cron results, webhooks, and approvals')).toBeVisible({ timeout: 10000 })
+    // Structural mount gate, no copy pinned.
+    await expect(page.getByTestId('page-header')).toBeVisible({ timeout: 10000 })
   })
 
   test('renders page header and subtitle', async ({ page }) => {
-    // The page header title -- use the subtitle as the unique anchor since
-    // "Notifications" also appears in the topbar bell button text
-    // PageHeader (ui.tsx:257) renders its title as a plain <div>, not a heading, and
-    // "Notifications" also appears in the topbar bell button -- so the subtitle is the
-    // only unique, non-class-coupled anchor for "the header rendered".
-    await expect(page.getByText('All agent activity, cron results, webhooks, and approvals')).toBeVisible()
+    // data-testid="page-title" disambiguates the header from the topbar bell button,
+    // which also renders the word "Notifications".
+    await expect(page.getByTestId('page-title')).toHaveText('Notifications')
+    await expect(page.getByTestId('page-subtitle')).toBeVisible()
   })
 
   test('displays stat cards with zero counts on empty fixture', async ({ page }) => {
     // The stat cards show Total, Unread, Cron, Hooks, Heartbeat -- all 0 on minimal fixture
-    const totalCard = page.locator('.stat-accent').filter({ hasText: 'Total' })
-    await expect(totalCard.locator('.text-2xl')).toContainText('0')
-    const unreadCard = page.locator('.stat-accent').filter({ hasText: 'Unread' })
-    await expect(unreadCard.locator('.text-2xl')).toContainText('0')
-    const cronCard = page.locator('.stat-accent').filter({ hasText: 'Cron' })
-    await expect(cronCard.locator('.text-2xl')).toContainText('0')
+    const totalCard = page.getByTestId('stat-card').filter({ hasText: 'Total' })
+    await expect(totalCard.getByTestId('stat-card-value')).toContainText('0')
+    const unreadCard = page.getByTestId('stat-card').filter({ hasText: 'Unread' })
+    await expect(unreadCard.getByTestId('stat-card-value')).toContainText('0')
+    const cronCard = page.getByTestId('stat-card').filter({ hasText: 'Cron' })
+    await expect(cronCard.getByTestId('stat-card-value')).toContainText('0')
   })
 
   test('shows empty state message when no notifications', async ({ page }) => {
-    await expect(page.getByText('No notifications')).toBeVisible()
-    await expect(page.getByText('Activity will appear here')).toBeVisible()
+    await expect(page.getByTestId('notification-feed-empty-title')).toHaveText('No notifications')
+    // The subtitle distinguishes WHICH empty state rendered (no categories vs search
+    // miss vs genuinely empty), so the text is load-bearing -- but matched loosely and
+    // scoped to the element rather than searched for across the page.
+    await expect(page.getByTestId('notification-feed-empty-subtitle')).toHaveText(/activity will appear here/i)
   })
 
   test('renders category filter chips with correct labels', async ({ page }) => {
@@ -67,7 +68,7 @@ test.describe('Notifications Page', () => {
     await allChip.click()
 
     // Now the empty state should mention categories
-    await expect(page.getByText('No categories selected')).toBeVisible()
+    await expect(page.getByTestId('notification-feed-empty-subtitle')).toHaveText(/no categories selected/i)
   })
 
   test('GET /api/notifications returns correct structure for empty state', async ({ request }) => {
@@ -86,11 +87,11 @@ test.describe('Notifications Page', () => {
 
     // Type a search term -- with no notifications, the empty state text changes
     await searchInput.fill('nonexistent')
-    await expect(page.getByText('Try a different search')).toBeVisible()
+    await expect(page.getByTestId('notification-feed-empty-subtitle')).toHaveText(/try a different search/i)
 
     // Clear the search -- empty state should revert
     await searchInput.fill('')
-    await expect(page.getByText('Activity will appear here')).toBeVisible()
+    await expect(page.getByTestId('notification-feed-empty-subtitle')).toHaveText(/activity will appear here/i)
   })
 
   // /api/notifications/clear is global: it deletes EVERY notification, not just

--- a/website/playwright/projects.spec.ts
+++ b/website/playwright/projects.spec.ts
@@ -35,7 +35,7 @@ test.describe('Projects (Task Runner) Page', () => {
   test('renders page header with title and subtitle', async ({ page }) => {
     await page.goto('/projects', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('Task Runner')).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText('Autonomous multi-step task execution')).toBeVisible()
+    await expect(page.getByTestId('page-subtitle')).toBeVisible()
   })
 
   test('compose panel shows three mode tabs', async ({ page }) => {

--- a/website/src/components/notifications/NotificationFeed.tsx
+++ b/website/src/components/notifications/NotificationFeed.tsx
@@ -278,7 +278,7 @@ export default function NotificationFeed({ selectedTs, onSelect, variant = 'pane
       {/* List */}
       <div className={`flex-1 overflow-y-auto ${mac ? 'px-4 -mx-4 pb-2' : 'scroll-shadow'}`}>
         {filtered.length === 0 ? (
-          <EmptyState icon={<Bell className="lucide-inline" />} title={i18nT('components.notifications.notificationFeed.no_notifications')} subtitle={noneActive ? 'No categories selected — click a category above' : filter ? 'Try a different search' : 'Activity will appear here'} />
+          <EmptyState testId="notification-feed-empty" icon={<Bell className="lucide-inline" />} title={i18nT('components.notifications.notificationFeed.no_notifications')} subtitle={noneActive ? 'No categories selected — click a category above' : filter ? 'Try a different search' : 'Activity will appear here'} />
         ) : (
           Array.from(stackedGroups.entries()).map(([group, rows]) => (
             <div key={group} className="mb-3">

--- a/website/src/components/ui.tsx
+++ b/website/src/components/ui.tsx
@@ -154,12 +154,16 @@ export function StatCard({ label, value, accent, colorClass, delay, onClick, act
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
+      // Placed before {...rest} so a consumer can override it with a more
+      // specific id (e.g. data-testid="stat-card-unread") when one card among
+      // several needs to be addressed directly.
+      data-testid="stat-card"
       {...rest}
     >
-      <div className="text-muted text-[13px] font-medium uppercase tracking-[.04em] flex items-center gap-1">{label}{title && <InfoTip text={title} />}</div>
+      <div className="text-muted text-[13px] font-medium uppercase tracking-[.04em] flex items-center gap-1" data-testid="stat-card-label">{label}{title && <InfoTip text={title} />}</div>
       {loading
-        ? <div className="skeleton h-7 w-16 mt-1.5 rounded" />
-        : <div className={`text-2xl font-bold mt-1.5 tracking-tight leading-none ${accent ? 'text-accent' : colorClass || ''}`}>{value ?? '—'}</div>
+        ? <div className="skeleton h-7 w-16 mt-1.5 rounded" data-testid="stat-card-skeleton" />
+        : <div className={`text-2xl font-bold mt-1.5 tracking-tight leading-none ${accent ? 'text-accent' : colorClass || ''}`} data-testid="stat-card-value">{value ?? '—'}</div>
       }
     </div>
   )
@@ -240,22 +244,29 @@ export function FormSkeleton({ rows }: { rows: SkeletonRowKind[] }) {
   )
 }
 
-export function EmptyState({ icon, title, subtitle }: { icon: React.ReactNode; title: string; subtitle?: string }) {
+/**
+ * @param testId Base `data-testid` for this instance. Several EmptyStates can be
+ *   mounted on one page (AppsPage renders 3; /notifications renders the page's own
+ *   plus NotificationFeed's), so a single shared id makes a Playwright lookup
+ *   ambiguous. Consumers on such pages pass a specific base; the title and
+ *   subtitle derive `<base>-title` / `<base>-subtitle` from it.
+ */
+export function EmptyState({ icon, title, subtitle, testId = 'empty-state' }: { icon: React.ReactNode; title: string; subtitle?: string; testId?: string }) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 gap-2 animate-rise">
+    <div className="flex flex-col items-center justify-center py-12 gap-2 animate-rise" data-testid={testId}>
       <div className="text-[40px] opacity-[.12] select-none">{icon}</div>
-      <div className="text-muted text-sm font-medium">{title}</div>
-      {subtitle && <div className="text-muted/60 text-[13px]">{subtitle}</div>}
+      <div className="text-muted text-sm font-medium" data-testid={`${testId}-title`}>{title}</div>
+      {subtitle && <div className="text-muted/60 text-[13px]" data-testid={`${testId}-subtitle`}>{subtitle}</div>}
     </div>
   )
 }
 
 export function PageHeader({ title, subtitle, actions }: { title: string; subtitle?: string; actions?: React.ReactNode }) {
   return (
-    <div className="flex items-end justify-between gap-4 px-6 pt-2 pb-3">
+    <div className="flex items-end justify-between gap-4 px-6 pt-2 pb-3" data-testid="page-header">
       <div>
-        <div className="text-2xl font-bold tracking-tight text-text-strong">{title}</div>
-        {subtitle && <div className="text-muted text-sm mt-1">{subtitle}</div>}
+        <div className="text-2xl font-bold tracking-tight text-text-strong" data-testid="page-title">{title}</div>
+        {subtitle && <div className="text-muted text-sm mt-1" data-testid="page-subtitle">{subtitle}</div>}
       </div>
       {actions && <div className="flex items-center gap-2.5 flex-wrap justify-end">{actions}</div>}
     </div>

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -372,6 +372,13 @@ export function useWebSocket() {
       dispatch(clearSubagentsForSnapshot())
       ws.send(JSON.stringify({ type: 'subscribe_subagents' }))
       subagentSubRef.current = true
+      // Flush a log subscription that was requested before the socket opened.
+      // subscribeLogs() stores the callback but returns early when readyState
+      // is not OPEN, so a page mounting during the handshake (a cold load of
+      // /logs) would otherwise never send subscribe_logs and would show no
+      // lines at all until an unrelated reconnect. The reconnect branch above
+      // already does this; the two paths must stay symmetric.
+      if (logCbRef.current) ws.send(JSON.stringify({ type: 'subscribe_logs' }))
     }
 
     ws.onmessage = (e) => {

--- a/website/src/pages/LogsPage.tsx
+++ b/website/src/pages/LogsPage.tsx
@@ -133,7 +133,7 @@ export function LogViewer({ compact }: { compact?: boolean }) {
           atTopStateChange={setAtTop}
           style={{ flex: 1, minHeight: 0 }}
           itemContent={(_i, l) => (
-            <div className={`font-mono ${sz.row} ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'} px-2.5 py-0.5 leading-[1.7] ${l.match ? 'border-l-2 border-accent bg-accent/10' : ''} ${levelColor(l.level)}`}>
+            <div data-testid="log-line" className={`font-mono ${sz.row} ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'} px-2.5 py-0.5 leading-[1.7] ${l.match ? 'border-l-2 border-accent bg-accent/10' : ''} ${levelColor(l.level)}`}>
               {l.match ? highlight(l.msg) : l.msg}
             </div>
           )}


### PR DESCRIPTION
> **Stacked on #657.** Base is `fix/e2e-dequarantine-session-tags`, not `main`.
> The 11 specs this touches only exist on that branch. Merge #657 first, then
> this rebases onto `main` cleanly.

## A product bug, found by fixing a test selector

The Logs page renders **no lines at all on a cold load**.

`useWebSocket.subscribeLogs` stores the callback and returns early when
`readyState !== OPEN`. Only the *reconnect* branch of `onopen` flushes a pending
subscription; the first-connect branch sends `subscribe_subagents` but not
`subscribe_logs`. `LogsPage` mounts during the handshake, so navigating straight
to `/logs` leaves `subscribe_logs` unsent and the page empty until some
unrelated reconnect happens.

The gateway was healthy the whole time. `/api/logs?lines=50` replayed 17 KB of
buffered entries on demand, and the ring handler was correctly installed and
attached. Measured, not inferred:

| probe | result |
|---|---|
| WS frames received by client | `{slots: 1, dashboard: 3}` — **zero `log`** |
| WS frames sent by client | only `subscribe_subagents` |
| server ring via `/api/logs` | 200, 17,503 bytes |
| row container height | 430px (so not a virtualization/layout issue) |
| `N matches` after search | `0 matches` (client state genuinely empty) |

The fix restores symmetry between the two `onopen` branches.

## Why the bug was invisible

The spec that should have caught it asserted nothing.
`page.locator('.font-mono').first()` matched the **"Filter logs" input**, which
also carries `font-mono` and precedes the Virtuoso rows. Four assertions
claiming to "wait for log lines" resolved instantly against an always-visible
textbox. Pointing them at a real handle turned them red, which is how the
product bug surfaced.

## Stable handles on the shared components

- **PageHeader** gains `page-header` / `page-title` / `page-subtitle`. 20
  consumers; four specs keyed on subtitle taglines, which are copy a designer
  can reword without touching code.
- **EmptyState** gains a `testId` prop defaulting to `empty-state`, deriving
  `<base>-title` / `<base>-subtitle`. One page can mount several: AppsPage
  renders three, `/notifications` renders the page's own plus
  NotificationFeed's, so a single shared id is ambiguous under strict mode.
  NotificationFeed passes `notification-feed-empty`.
- **StatCard** gains `stat-card` / `stat-card-label` / `stat-card-value`, before
  `{...rest}` so a consumer can override. Replaces `.stat-accent` and
  `.text-2xl`; Tailwind classes break on a restyle with no code change, which is
  worse than prose.
- **LogsPage** rows gain `log-line`.

Where copy is incidental the assertion drops it and checks only that the
subtitle rendered. Where copy identifies *which* state rendered (the three
notification empty-state variants) the text stays load-bearing, matched loosely
and scoped to the element rather than searched page-wide.

`capabilities.spec.ts` keeps a prose selector **deliberately**: on
`/capabilities` that string is a tab description, not a PageHeader subtitle, so
no `page-subtitle` exists on that route.

## Testing

- Full e2e via `setup.py test_e2e`: **18 passed, 6m15s**. Executed specs hold at
  208, skips 0.
- `logs.spec.ts` alone: 9 passed in 11.7s (was timing out on 4 tests).
- Frontend unit: 152 passed across 17 files, including all six `useWebSocket*`
  suites and `ui.test.tsx`.

Note for anyone verifying locally: the gateway serves
`src/kiro_crew/static/dist`, so `npm run build` alone is not enough. Copy
`website/dist` over it, as `ci.yml` does. Also `npx tsc --noEmit` does **not**
cover `website/playwright/` (`tsconfig.app.json` includes only `src`); use
`npx playwright test --list` to validate spec syntax.
