### PR TITLE
feat(skills): bundle an iOS Simulator preview skill

### DIFF
--- a/src/kiro_crew/builtin_skills/ios-simulator-preview/SKILL.md
+++ b/src/kiro_crew/builtin_skills/ios-simulator-preview/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ios-simulator-preview
+description: Show a live iOS Simulator in the dashboard's Browser side panel while building or testing an iOS app. Use when the user asks to preview an iOS/SwiftUI app, run an app in the simulator, "show me the app", test in the iOS simulator, or watch you drive an iOS app. macOS + Xcode only.
+triggers: ios simulator, iphone simulator, iphone preview, swiftui preview, run in simulator, xcode app preview, mirror simulator, show me the app on iphone
+---
+
+# iOS Simulator Preview (Browser-tab mirror)
+
+Mirror a running iOS Simulator into KiroCrew's Browser side panel so the user
+watches the app — and you driving it — live next to the chat.
+
+Architecture, end to end, all local: **simulator → `serve-sim` (loopback HTTP)
+→ the `kirocrew:preview` marker → Browser panel iframe.** Nothing leaves the
+machine. This mirrors OpenAI Codex's `ios-simulator-browser` approach (same
+`serve-sim` mirror) with one substitution: Codex opens the URL in its in-app
+browser via a browser tool, while KiroCrew's panel is driven by the hidden
+preview marker (see the `web-preview` skill).
+
+## Requirements
+
+- **macOS only.** Apple's simulator runs nowhere else. On Linux/Windows say so
+  and stop — do not attempt a fallback.
+- Xcode with an iOS platform installed, and the license accepted. `xcrun simctl
+  list devices` must work.
+- Node/`npx`. The launcher pins `--registry=https://registry.npmjs.org` because
+  a local npm config may default to an authenticated internal registry (which
+  401s on a public package). The `serve-sim` version is **pinned** in the
+  launcher (`SERVE_SIM_VERSION`) rather than floated, so a start never
+  auto-executes an unreviewed release; bumping it is a deliberate change.
+- First `start` takes a couple of minutes (npx download + device boot); later
+  starts are fast.
+
+## Resolve the launcher path once
+
+```bash
+SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/ios-simulator-preview"
+```
+
+Call the script by path; do not `cd` into the skill folder.
+
+`KIROCREW_HOME`, when set, must be an ABSOLUTE path (`~` is fine — the launcher
+expands it). The launcher is invoked by path from whatever directory the session
+is in, so a relative home would resolve differently per caller and a `start`
+from one project directory would not be visible to a `stop` from another. The
+launcher refuses a relative value with a JSON error rather than splitting state.
+
+## Workflow
+
+### 1. Start the mirror
+
+```bash
+python3 "$SKILL_DIR/scripts/sim_mirror.py" start
+```
+
+Use the bundled launcher, **not** a bare `npx serve-sim`. It handles the parts
+that silently break otherwise: detaching the server so it survives your turn
+ending (a turn-scoped child gets reaped at turn end), device
+selection/creation/boot, scoped stale-mirror cleanup, per-UDID pidfiles, and
+refusing any non-loopback URL.
+
+Optional `--device "<udid-or-name>"` targets a specific simulator (e.g. the one
+your `xcodebuild` destination used). Without it: prefers an already-booted
+device, else the newest iPhone, else creates one.
+
+Prints JSON: `{"udid", "name", "url", "pid", "log"}`.
+
+### 2. Open it in the Browser panel
+
+Emit the hidden marker in your NEXT message, using the exact `url` from step 1:
+
+```
+<!-- kirocrew:preview url="http://127.0.0.1:PORT" -->
+```
+
+This is the only reliable auto-open path — a bare URL in prose merely pre-fills
+the panel. Name the mirrored device in prose too.
+
+**A loaded page is not proof the stream is healthy.** Confirm real frames are
+arriving (see Failure modes) before telling the user it works.
+
+### 3. Build, install, launch, drive
+
+Normal simulator workflow against the SAME udid:
+
+```bash
+xcodebuild -scheme <Scheme> -destination "id=<udid>" build
+xcrun simctl install <udid> <path/to/App.app>
+xcrun simctl launch <udid> <bundle.id>
+xcrun simctl io <udid> screenshot /tmp/shot.png   # your own verification
+```
+
+Everything you do shows up live in the user's panel. For your **own** checks
+take `simctl` screenshots — the mirror is for the user; don't scrape it.
+
+**Bound every `simctl` call with a timeout** (e.g. `subprocess.run(...,
+timeout=90)`). A wedged CoreSimulator makes `simctl` block indefinitely, which
+otherwise hangs your turn instead of returning a diagnosable error.
+
+### 4. Stop when done
+
+```bash
+python3 "$SKILL_DIR/scripts/sim_mirror.py" stop                     # all tracked mirrors
+python3 "$SKILL_DIR/scripts/sim_mirror.py" stop --shutdown-device   # also power off
+python3 "$SKILL_DIR/scripts/sim_mirror.py" status                   # pid alive? url?
+```
+
+`stop` is scoped to this launcher's own pidfiles, and `--device` here must be a
+**UDID** (not a device name) — it is validated before touching any path or
+signaling anything. **Never** kill `serve-sim` processes you don't track —
+another session may own them.
+
+## Failure modes
+
+Each of these was hit in practice; the stated cause is the verified one.
+
+- **`simctl` missing** → Xcode not installed. Tell the user; stop.
+- **"You have not agreed to the Xcode license agreements"** → the user must run
+  `sudo xcodebuild -license accept` themselves (needs `sudo` + an interactive
+  prompt you cannot drive).
+- **"no available iOS runtimes"** → `xcodebuild -downloadPlatform iOS`
+  (multi-GB; check free disk first).
+- **`simctl` hangs, or repeated `error encoding frame: encodingFailed`** →
+  CoreSimulator version mismatch. An Xcode upgrade **while a device was
+  booted** orphans that device: the new framework cannot drive it, so `simctl`
+  blocks and the mirror captures nothing while still serving HTTP 200.
+  Recovery: stop the mirror, `pkill -x Simulator`, `pkill -f
+  CoreSimulator.CoreSimulatorService`, `pkill -f launchd_sim`, then boot a
+  fresh device. `launchctl remove` alone is not enough.
+- **Device creation fails "Incompatible device"** → the global device-type list
+  includes hardware the installed runtime rejects. The launcher already selects
+  from the runtime's own `supportedDeviceTypes`; a hand-rolled `simctl create`
+  is what trips this.
+- **`serve-sim exited rc=…`** → read the printed log path. Usual causes: npx
+  could not reach the public registry (proxy), or the udid was shut down
+  externally. Fix and restart; do not loop more than twice.
+- **Panel says the server stopped responding while the process is alive** →
+  first confirm the URL is exactly the loopback one the launcher printed (never
+  substitute a hostname). Requires a dashboard whose CSP admits loopback
+  `connect-src`, since the panel's liveness probe is a `no-cors` fetch.
+
+## Boundaries
+
+- **View-only.** The user watches; whether taps forward at all depends on what
+  `serve-sim`'s page itself offers. Never promise tap-through.
+- Do not edit the user's `.xcodeproj`, schemes, or build settings to force a
+  preview to work.
+- One mirror per simulator; multiple simulators mean multiple `start` calls.
+- Third-party dependency: `serve-sim` is fetched at runtime from public npm and
+  is not vendored.

--- a/src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
+++ b/src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""sim_mirror.py — boot an iOS Simulator and mirror it to a loopback URL.
+
+Wraps `serve-sim` (npm) the way OpenAI Codex's ios-simulator-browser skill
+does, adapted for KiroCrew:
+
+  * launches serve-sim fully DETACHED (start_new_session) so it survives the
+    agent turn ending (turn-end reaps normal child process groups),
+  * pins the public npm registry (local npm defaults to an authenticated
+    internal registry and 401s),
+  * scoped cleanup only (per-UDID pidfiles + `serve-sim --kill <udid>`),
+  * refuses non-loopback mirror URLs.
+
+Commands:
+  start  [--device <udid-or-name>]   boot (create if needed) + start mirror,
+                                     prints JSON {udid, name, url, pid, log}
+  stop   [--device <udid>] [--shutdown-device]
+  status
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import NoReturn
+from urllib.parse import urlparse
+
+
+def die(msg: str) -> NoReturn:
+    """Report a failure as the JSON object the calling agent parses, then exit.
+
+    Defined ahead of the module constants because home resolution below runs at
+    import time and must be able to fail this way.
+    """
+    print(json.dumps({"error": msg}), file=sys.stderr)
+    sys.exit(1)
+
+
+# State lives under the ACTIVE data home, not a hardcoded ~/.kiro/crew, so a
+# dev instance (KIROCREW_HOME=~/.kirocrew-dev) keeps its own pidfiles instead of
+# sharing mirror state with a production install.
+def _resolve_home() -> Path:
+    """Resolve the data home to an absolute path, or refuse.
+
+    A RELATIVE KIROCREW_HOME cannot be honored safely: this launcher is invoked
+    by path from whatever directory the session happens to be in, so a relative
+    home would resolve differently per caller — a `start` from one project
+    directory and a `stop` from another would consult different state dirs and
+    orphan the mirror. `~` is expanded (env vars routinely carry it unexpanded);
+    anything still relative after that is a misconfiguration, so say so plainly
+    instead of silently splitting state.
+    """
+    raw = os.environ.get("KIROCREW_HOME") or ""
+    if not raw:
+        return Path.home() / ".kiro" / "crew"
+    home = Path(raw).expanduser()
+    if not home.is_absolute():
+        die(f"KIROCREW_HOME must be an absolute path, got {raw!r} "
+            "(a relative home resolves differently per working directory, so "
+            "start and stop would disagree about where mirror state lives)")
+    return home
+
+
+_HOME = _resolve_home()
+STATE_DIR = _HOME / "workspace" / "sim-mirror"
+
+# Pinned deliberately: floating the version (an `@latest` style specifier) would
+# fetch and execute whatever npm currently serves on every single `start`, so a
+# broken or hijacked release would silently change behavior (or run arbitrary
+# code) with no diff. Bumping this is a reviewable one-line change.
+SERVE_SIM_VERSION = "0.1.45"
+NPX = [
+    "npx", "--yes",
+    "--registry=https://registry.npmjs.org",
+    f"serve-sim@{SERVE_SIM_VERSION}",
+]
+URL_RE = re.compile(r"https?://[^\s\"'<>]+")
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "[::1]", "::1"}
+# simctl UDIDs are canonical uppercase UUIDs. Anything else is rejected BEFORE
+# it reaches a path join or a signal: `--device /tmp/svc` would otherwise make
+# `STATE_DIR / f"{udid}.pid"` resolve to /tmp/svc.pid (an absolute right-hand
+# operand replaces the base entirely), letting a caller read, unlink, and
+# signal the process group named by an arbitrary file.
+UDID_RE = re.compile(r"\A[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\Z")
+
+
+def require_udid(value: str) -> str:
+    """Return *value* if it is a canonical simctl UDID, else exit with an error."""
+    if not UDID_RE.match(value):
+        die(f"not a valid simulator UDID: {value!r} "
+            "(pass the udid from `start`/`status`, or a device NAME to `start`)")
+    return value
+
+
+def sh(args: list[str], timeout: int = 120) -> subprocess.CompletedProcess:
+    """Run *args*, failing with a JSON diagnostic rather than a traceback.
+
+    A wedged CoreSimulator makes simctl block until the deadline, and this tool's
+    entire contract with the calling agent is one line of JSON on stdout or an
+    error object on stderr. Letting TimeoutExpired escape would print a
+    traceback the caller cannot parse, right at the moment it most needs to be
+    told what to fix.
+    """
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        die(f"timed out after {timeout}s: {' '.join(args)} "
+            "(a wedged CoreSimulator is the usual cause -- see the skill's "
+            "failure-mode notes on recovering an orphaned device)")
+    except OSError as exc:  # missing binary, exec failure
+        die(f"could not run {args[0]!r}: {exc}")
+
+
+def sh_best_effort(args: list[str], timeout: int = 120) -> None:
+    """Run *args* for its side effect only; never fail the caller.
+
+    Used for cleanup paths where the tool has already decided what to report and
+    a slow or absent helper must not turn a successful stop into an error.
+    """
+    try:
+        subprocess.run(args, capture_output=True, timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+
+def simctl(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    return sh(["xcrun", "simctl", *args], timeout=timeout)
+
+
+def simctl_json(*args: str, timeout: int = 120) -> dict:
+    """Run a `simctl -j` query and return its parsed object, or fail loudly.
+
+    simctl can exit nonzero (or print a non-JSON diagnostic on stdout) when the
+    CoreSimulator service is wedged or a required platform is absent. Feeding
+    that straight to json.loads raised JSONDecodeError, so a recoverable
+    environment problem reached the caller as a traceback with the real reason --
+    simctl's own stderr -- discarded.
+    """
+    p = simctl(*args, timeout=timeout)
+    if p.returncode != 0:
+        detail = (p.stderr or p.stdout or "").strip().splitlines()
+        die(f"simctl {' '.join(args)} failed (rc={p.returncode}): "
+            f"{detail[0] if detail else 'no output'}")
+    try:
+        parsed = json.loads(p.stdout)
+    except json.JSONDecodeError:
+        head = (p.stdout or "").strip()[:200]
+        die(f"simctl {' '.join(args)} did not return JSON: {head!r}")
+    if not isinstance(parsed, dict):
+        die(f"simctl {' '.join(args)} returned {type(parsed).__name__}, expected an object")
+    return parsed
+
+
+def list_devices() -> list[dict]:
+    devices = simctl_json("list", "-j", "devices", "available").get("devices", {})
+    flat: list[dict] = []
+    for runtime_id, devs in devices.items():
+        if "iOS" not in runtime_id:
+            continue
+        for d in devs:
+            d["runtime"] = runtime_id
+            flat.append(d)
+    return flat
+
+
+def create_device() -> dict:
+    """No iOS devices exist — create one the newest installed runtime supports."""
+    runtimes = [
+        r
+        for r in simctl_json("list", "-j", "runtimes").get("runtimes", [])
+        if r.get("platform") == "iOS" and r.get("isAvailable")
+    ]
+    if not runtimes:
+        die("no available iOS runtimes (run: xcodebuild -downloadPlatform iOS)")
+    runtime = runtimes[-1]
+    # Pick from the runtime's OWN supported types — the global devicetypes list
+    # includes newer hardware than an older runtime accepts ("Incompatible device").
+    supported = runtime.get("supportedDeviceTypes") or []
+    phones = [t for t in supported if t.get("productFamily") == "iPhone"]
+    if not phones:
+        types = simctl_json("list", "-j", "devicetypes").get("devicetypes", [])
+        phones = [t for t in types if str(t.get("name", "")).startswith("iPhone")]
+    if not phones:
+        die("no iPhone device types installed (install the iOS platform in Xcode)")
+    dtype = phones[-1]  # lists run oldest→newest
+    name = f"KiroCrew {dtype['name']}"
+    out = simctl("create", name, dtype["identifier"], runtime["identifier"])
+    if out.returncode != 0:
+        die(f"simctl create failed: {out.stderr.strip()}")
+    return {"udid": out.stdout.strip(), "name": name, "state": "Shutdown"}
+
+
+def resolve_device(want: str | None) -> dict:
+    devs = list_devices()
+    if want:
+        for d in devs:
+            if d["udid"] == want or d["name"] == want:
+                return d
+        die(f"device not found: {want}")
+    booted = [d for d in devs if d["state"] == "Booted"]
+    if booted:
+        return booted[0]
+    phones = [d for d in devs if d["name"].startswith(("iPhone", "KiroCrew"))]
+    if phones:
+        return phones[-1]
+    if devs:
+        return devs[-1]
+    return create_device()
+
+
+def ensure_booted(udid: str) -> None:
+    out = simctl("boot", udid)
+    # rc 149 / "current state: Booted" == already booted; anything else fatal.
+    if out.returncode != 0 and "Booted" not in (out.stderr + out.stdout):
+        die(f"simctl boot failed: {out.stderr.strip()}")
+    # Block until userspace is fully up (fast no-op when already booted).
+    simctl("bootstatus", udid, "-b", timeout=300)
+
+
+def mirror_url_from_log(log: Path) -> tuple[str | None, str | None]:
+    """(loopback_url, warning). Non-loopback hits produce a warning, never a URL."""
+    text = log.read_text(errors="ignore") if log.exists() else ""
+    warning = None
+    for m in URL_RE.finditer(text):
+        host = (urlparse(m.group(0)).hostname or "").lower()
+        if host in LOOPBACK_HOSTS:
+            return m.group(0).rstrip(".,"), None
+        if host and "registry" not in m.group(0):
+            warning = f"serve-sim printed non-loopback URL {m.group(0)} — not using it"
+    return None, warning
+
+
+def cmd_start(args: argparse.Namespace) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    dev = resolve_device(args.device)
+    udid, name = dev["udid"], dev["name"]
+    ensure_booted(udid)
+
+    # Stale-mirror cleanup, reached only for a LIVE mirror THIS home owns for
+    # this udid. The vendor flag addresses a mirror by UDID alone and cannot tell
+    # whose it is, so a weaker gate (pidfile merely present) would let a `start`
+    # here tear down a live mirror another KIROCREW_HOME owns for the device.
+    if _live_owned_pid(udid) is not None:
+        sh_best_effort(NPX + ["--kill", udid])
+    pidfile = STATE_DIR / f"{udid}.pid"
+    if pidfile.exists():
+        pidfile.unlink(missing_ok=True)
+
+    log = STATE_DIR / f"{udid}.log"
+    try:
+        # O_NOFOLLOW: the log path is predictable, so a symlink planted there
+        # would otherwise be followed and its target truncated by the "w" open.
+        # Refuse rather than write through one. 0o600 keeps the log private.
+        log_fd = os.open(
+            log, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600
+        )
+    except OSError as exc:
+        die(f"refusing to open the mirror log at {log}: {exc} "
+            "(a symlink at that path is not written through -- remove it and retry)")
+    try:
+        with open(log_fd, "w", closefd=True) as lf:
+            proc = subprocess.Popen(
+                NPX + [udid],
+                stdout=lf,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,  # survives agent turn-end process-group reap
+            )
+    except OSError as exc:
+        # Popen bypasses sh()'s conversion, so a missing npx (Node not installed)
+        # would surface as a traceback instead of the JSON error the caller parses.
+        die(f"could not start the mirror -- {NPX[0]!r} is not runnable ({exc}). "
+            "Install Node (which provides npx), then retry.")
+    pidfile.write_text(str(proc.pid))
+
+    deadline = time.time() + 240  # first run downloads the package
+    url = warning = None
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            die(f"serve-sim exited rc={proc.returncode}; see log: {log}")
+        url, warning = mirror_url_from_log(log)
+        if url:
+            break
+        time.sleep(1)
+    if not url:
+        die(f"no loopback URL from serve-sim within 240s"
+            f"{'; ' + warning if warning else ''}; see log: {log}")
+
+    print(json.dumps({"udid": udid, "name": name, "url": url,
+                      "pid": proc.pid, "log": str(log)}))
+
+
+def _owns_pid(pid: int, udid: str) -> bool:
+    """True only if *pid* is still OUR mirror for *udid*.
+
+    A recorded pid is not proof of ownership: once the mirror exits the OS is
+    free to reuse that number, and signaling it blind would terminate whatever
+    unrelated process group now holds it. So re-derive identity from the live
+    process's own command line — it must be the serve-sim invocation carrying
+    this udid — and treat any doubt as "not ours".
+    """
+    try:
+        p = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    if p.returncode != 0:
+        return False  # pid is gone
+    cmd = p.stdout.strip()
+    return "serve-sim" in cmd and udid in cmd
+
+
+def _live_owned_pid(udid: str) -> int | None:
+    """Return the pid of THIS home's live mirror for *udid*, else None.
+
+    Ownership means a process of ours is running right now — not merely that a
+    pidfile exists. A stale pidfile (our mirror already exited) is NOT ownership:
+    acting on it would let this home's cleanup reach a live mirror another
+    KIROCREW_HOME legitimately owns for the same device, since the vendor's
+    cleanup flag addresses a mirror by UDID alone and cannot tell whose it is.
+    """
+    pidfile = STATE_DIR / f"{udid}.pid"
+    if not pidfile.exists():
+        return None
+    try:
+        pid = int(pidfile.read_text().strip())
+    except (ValueError, OSError):
+        return None
+    if pid <= 0 or not _owns_pid(pid, udid):
+        return None
+    return pid
+
+
+def stop_one(udid: str, shutdown_device: bool) -> dict:
+    pidfile = STATE_DIR / f"{udid}.pid"
+    tracked = pidfile.exists()
+    pid = _live_owned_pid(udid)
+    killed = False
+    if pid is not None:
+        try:
+            os.killpg(pid, signal.SIGTERM)
+            killed = True
+        except (ProcessLookupError, PermissionError):
+            pass
+        # Vendor-side cleanup, reached only once a LIVE mirror of ours is proven.
+        # Gating on the pidfile merely existing was not enough: a stale pidfile
+        # here would have authorized tearing down another home's live mirror for
+        # the same device. If our process is gone there is nothing of ours left
+        # to clean up, so the correct action is to drop the pidfile and stop.
+        sh_best_effort(NPX + ["--kill", udid])
+    if tracked:
+        pidfile.unlink(missing_ok=True)
+    if shutdown_device:
+        # Explicitly requested by the caller and scoped to this one device, so it
+        # is honored even for a mirror this home never tracked.
+        simctl("shutdown", udid)
+    return {"udid": udid, "tracked": tracked, "killed": killed,
+            "device_shutdown": shutdown_device}
+
+
+def cmd_stop(args: argparse.Namespace) -> None:
+    udids = ([require_udid(args.device)] if args.device
+             else [p.stem for p in STATE_DIR.glob("*.pid") if UDID_RE.match(p.stem)])
+    if not udids:
+        print(json.dumps({"stopped": []}))
+        return
+    print(json.dumps({"stopped": [stop_one(u, args.shutdown_device) for u in udids]}))
+
+
+def cmd_status(_args: argparse.Namespace) -> None:
+    entries = []
+    for p in sorted(STATE_DIR.glob("*.pid")):
+        if not UDID_RE.match(p.stem):
+            continue  # not a pidfile this tool wrote
+        try:
+            pid = int(p.read_text().strip())
+        except (ValueError, OSError):
+            # ValueError: truncated/garbled pidfile — nothing trustworthy to
+            # report. OSError: a concurrent `stop` (or another session) unlinked
+            # the file between the glob above and this read; status is a
+            # read-only snapshot and must not crash on a benign race.
+            continue
+        url, _ = mirror_url_from_log(STATE_DIR / f"{p.stem}.log")
+        entries.append({
+            "udid": p.stem,
+            "pid": pid,
+            # "alive" means OUR mirror is still running, not merely that some
+            # process holds this pid (see _owns_pid on pid reuse).
+            "alive": _owns_pid(pid, p.stem),
+            "url": url,
+        })
+    print(json.dumps({"mirrors": entries}))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p_start = sub.add_parser("start")
+    p_start.add_argument("--device", help="simulator UDID or name")
+    p_start.set_defaults(fn=cmd_start)
+    p_stop = sub.add_parser("stop")
+    p_stop.add_argument("--device", help="simulator UDID (default: all tracked)")
+    p_stop.add_argument("--shutdown-device", action="store_true")
+    p_stop.set_defaults(fn=cmd_stop)
+    sub.add_parser("status").set_defaults(fn=cmd_status)
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_ios_simulator_preview_skill.py
+++ b/test/test_ios_simulator_preview_skill.py
@@ -1,0 +1,437 @@
+"""Contract tests for the bundled ``ios-simulator-preview`` skill.
+
+The skill mirrors a booted iOS Simulator into the dashboard's Browser panel. Two
+properties are worth locking in, because both broke in practice while it was
+being built and neither fails loudly at runtime:
+
+1. **The launcher ships and is discoverable.** The skill is the only bundled
+   skill outside ``kirocrew-dev/`` with a ``scripts/`` payload, so a packaging
+   glob that stops at ``SKILL.md`` would leave the documented command pointing
+   at a file that is not installed.
+2. **The launcher's hard-won invariants stay in the code.** Each assertion below
+   corresponds to a real failure: a turn-reaped mirror, a 401 from an
+   authenticated internal npm registry, an "Incompatible device" from selecting
+   a device type the installed runtime rejects, and an unbounded ``simctl`` call
+   hanging a turn against a wedged CoreSimulator.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# The behavioral probes below drive the launcher as a real subprocess with
+# /bin/sh shims on PATH, and assert on POSIX-only semantics (O_NOFOLLOW,
+# process-group signals, symlinks). They cannot run on Windows, and need not:
+# the skill requires macOS + Xcode. The source-level assertions in the same
+# class still run everywhere, so the invariants stay pinned on every platform.
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="behavioral probe needs POSIX shell shims and fd semantics; skill is macOS-only",
+)
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "ios-simulator-preview"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_md() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def launcher() -> str:
+    return (SKILL_DIR / "scripts" / "sim_mirror.py").read_text(encoding="utf-8")
+
+
+class TestSkillFilesShip:
+    def test_skill_md_and_launcher_both_present(self) -> None:
+        assert (SKILL_DIR / "SKILL.md").is_file()
+        assert (SKILL_DIR / "scripts" / "sim_mirror.py").is_file()
+
+    def test_frontmatter_declares_name_and_triggers(self, skill_md: str) -> None:
+        """Without frontmatter the loader cannot match the skill to a request."""
+        assert skill_md.startswith("---")
+        head = skill_md.split("---", 2)[1]
+        assert "name: ios-simulator-preview" in head
+        assert "triggers:" in head
+        assert "description:" in head
+
+    def test_documented_launcher_path_resolves_via_skill_dir(self, skill_md: str) -> None:
+        """The documented path must honor KIROCREW_HOME (same convention as
+        prepare-pr), not hardcode a home that a relocated install won't have."""
+        assert '"${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/ios-simulator-preview"' in skill_md
+        assert '"$SKILL_DIR/scripts/sim_mirror.py"' in skill_md
+
+    def test_macos_only_is_stated(self, skill_md: str) -> None:
+        """Apple's simulator is macOS-only; the skill must say so rather than
+        letting a Linux/Windows agent attempt it and fail obscurely."""
+        assert "macOS only" in skill_md
+
+
+class TestLauncherInvariants:
+    def test_spawns_detached(self, launcher: str) -> None:
+        """A turn-scoped child is reaped at turn end, killing the mirror the
+        moment the agent stops talking."""
+        assert "start_new_session=True" in launcher
+
+    def test_pins_public_npm_registry(self, launcher: str) -> None:
+        """A local npm config may default to an authenticated internal registry,
+        which 401s on this public package."""
+        assert "--registry=https://registry.npmjs.org" in launcher
+
+    def test_selects_device_type_from_runtime_supported_list(self, launcher: str) -> None:
+        """The global devicetypes list contains hardware an older runtime
+        rejects with 'Incompatible device'; scope selection to the runtime."""
+        assert "supportedDeviceTypes" in launcher
+
+    def test_every_subprocess_call_is_timeout_bounded(self, launcher: str) -> None:
+        """A wedged CoreSimulator makes simctl block forever. Every
+        subprocess.run must carry a timeout so it returns a diagnosable error
+        instead of hanging the caller."""
+        import re
+
+        calls = re.findall(r"subprocess\.run\((.*?)\)\n", launcher, re.DOTALL)
+        assert calls, "expected subprocess.run call sites in the launcher"
+        untimed = [c for c in calls if "timeout" not in c]
+        assert not untimed, f"subprocess.run without timeout: {untimed}"
+
+    def test_refuses_non_loopback_mirror_url(self, launcher: str) -> None:
+        """The panel can only embed loopback origins, and a mirror bound to a
+        routable address would expose the simulator on the LAN."""
+        assert "LOOPBACK_HOSTS" in launcher
+        for host in ("127.0.0.1", "localhost"):
+            assert host in launcher
+
+    def test_stop_is_scoped_to_own_pidfiles(self, launcher: str) -> None:
+        """An unscoped `serve-sim --kill` would tear down a mirror another
+        session owns."""
+        assert "--kill" in launcher
+        assert ".pid" in launcher
+
+
+class TestReviewFindings:
+    """Regressions for findings raised in review of this skill.
+
+    Each test names the concrete attack or accident it prevents, so a future
+    simplification cannot quietly reopen it.
+    """
+
+    def test_device_arg_is_validated_before_path_or_signal_use(self, launcher: str) -> None:
+        """`stop --device /tmp/svc` would make ``STATE_DIR / f"{udid}.pid"``
+        resolve to ``/tmp/svc.pid`` — an absolute right-hand operand replaces the
+        base entirely — letting a caller read, unlink, and signal the process
+        group named by an arbitrary file. Reject non-UDIDs first."""
+        assert "UDID_RE" in launcher
+        assert "def require_udid" in launcher
+        assert "require_udid(args.device)" in launcher
+
+    def test_udid_pattern_rejects_traversal_and_accepts_real_udids(self) -> None:
+        """Exercise the compiled pattern itself, not just its presence."""
+        import re
+
+        src = (SKILL_DIR / "scripts" / "sim_mirror.py").read_text(encoding="utf-8")
+        pattern = re.search(r"UDID_RE = re\.compile\(r\"(.+?)\"\)", src)
+        assert pattern, "UDID_RE definition not found"
+        udid_re = re.compile(pattern.group(1))
+
+        assert udid_re.match("09BE828F-6801-4731-BB13-D4C9747BC358")
+        for bad in (
+            "/tmp/service",          # absolute path — the reported traversal
+            "../../etc/passwd",      # relative escape
+            "09be828f-6801-4731-bb13-d4c9747bc358",  # lowercase is not canonical
+            "09BE828F",              # truncated
+            "",
+        ):
+            assert not udid_re.match(bad), bad
+
+    def test_pid_ownership_is_verified_before_signaling(self, launcher: str) -> None:
+        """A recorded pid is not proof of ownership: after the mirror exits the
+        OS may reuse that number, and a blind killpg would terminate whatever
+        unrelated process group now holds it."""
+        assert "def _owns_pid" in launcher
+        assert "_owns_pid(pid, udid)" in launcher
+        # Identity is re-derived from the live process, not trusted from the file.
+        assert '"ps", "-p"' in launcher
+        assert "serve-sim" in launcher
+
+    def test_serve_sim_version_is_pinned(self, launcher: str) -> None:
+        """`serve-sim@latest` would fetch and execute whatever npm currently
+        serves on every start, so a hijacked or broken release changes behavior
+        with no diff. Bumping the pin must be a reviewable change."""
+        assert "serve-sim@latest" not in launcher
+        assert "SERVE_SIM_VERSION" in launcher
+        import re
+
+        pin = re.search(r'SERVE_SIM_VERSION = "([^"]+)"', launcher)
+        assert pin, "SERVE_SIM_VERSION not found"
+        assert re.fullmatch(r"\d+\.\d+\.\d+", pin.group(1)), pin.group(1)
+
+    def test_state_dir_honors_kirocrew_home(self, launcher: str) -> None:
+        """Hardcoding ~/.kiro/crew makes a dev instance
+        (KIROCREW_HOME=~/.kirocrew-dev) share pidfile state with a production
+        install, so one's `stop` reaches into the other's mirrors."""
+        assert 'os.environ.get("KIROCREW_HOME")' in launcher
+        assert "STATE_DIR = _HOME" in launcher
+
+    def test_subprocess_timeout_yields_json_error_not_traceback(self, launcher: str) -> None:
+        """A wedged CoreSimulator makes simctl block to the deadline. This tool's
+        whole contract is JSON on stdout or an error object on stderr, so an
+        escaping TimeoutExpired would hand the calling agent an unparseable
+        traceback exactly when it most needs to be told what to fix."""
+        assert "except subprocess.TimeoutExpired:" in launcher
+        assert "def sh_best_effort" in launcher
+        # die() must be NoReturn, else sh()'s typed return falls through.
+        assert "def die(msg: str) -> NoReturn:" in launcher
+
+    @posix_only
+    def test_timeout_produces_parseable_json_at_runtime(self, tmp_path: Path) -> None:
+        """Exercise the real failure, not just its source text: a command that
+        outlives its timeout must exit 1 with a JSON error object."""
+        import json
+        import subprocess
+
+        script = (SKILL_DIR / "scripts" / "sim_mirror.py").read_text(encoding="utf-8")
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            script.replace(
+                "def main() -> None:",
+                "def _probe() -> None:\n    sh(['sleep', '30'], timeout=1)\n\n\n"
+                "def main() -> None:",
+            ).replace(
+                'if __name__ == "__main__":\n    main()',
+                'if __name__ == "__main__":\n    _probe()',
+            ),
+            encoding="utf-8",
+        )
+        p = subprocess.run(
+            [sys.executable, str(probe)], capture_output=True, text=True, timeout=60
+        )
+        assert p.returncode == 1
+        assert "Traceback" not in p.stderr
+        payload = json.loads(p.stderr.strip())
+        assert "timed out after 1s" in payload["error"]
+
+    def test_vendor_cleanup_is_gated_on_local_ownership(self, launcher: str) -> None:
+        """The vendor `--kill` flag addresses a mirror by UDID alone and cannot
+        tell whose it is. Run unconditionally, a `stop` (or a `start`) in one
+        KIROCREW_HOME would tear down a live mirror another home owns for the
+        same device."""
+        assert "subprocess.run(NPX" not in launcher, "ungated vendor cleanup call"
+        assert '"tracked": tracked' in launcher
+
+    def test_ownership_requires_a_live_process_not_just_a_pidfile(self, launcher: str) -> None:
+        """A *stale* pidfile is not ownership. Treating it as ownership let this
+        home's cleanup reach a live mirror another home legitimately owned for
+        the same device — the pidfile-existence gate was too weak."""
+        assert "def _live_owned_pid" in launcher
+        # Both cleanup call sites must consult live ownership.
+        assert "_live_owned_pid(udid) is not None" in launcher
+        assert "pid = _live_owned_pid(udid)" in launcher
+        # ...and the weak gate must be gone.
+        assert '(STATE_DIR / f"{udid}.pid").exists():\n        sh_best_effort' not in launcher
+
+    @posix_only
+    def test_stale_pidfile_triggers_no_vendor_cleanup_at_runtime(self, tmp_path: Path) -> None:
+        """Behavioral proof: with a pidfile naming a dead pid, `stop` must drop
+        the file and invoke NOTHING external — no vendor cleanup that could hit
+        another home's mirror."""
+        import json
+        import subprocess
+
+        home = tmp_path / "home"
+        state = home / "workspace" / "sim-mirror"
+        state.mkdir(parents=True)
+        udid = "09BE828F-6801-4731-BB13-D4C9747BC358"
+        # A pid that cannot be ours: spawn a real child, wait for it to exit, and
+        # reuse its number — reaped, so nothing of ours holds it.
+        dead = subprocess.Popen([sys.executable, "-c", "pass"])
+        dead.wait(timeout=30)
+        (state / f"{udid}.pid").write_text(str(dead.pid))
+
+        # Shim PATH so any npx/ps/xcrun invocation is recorded rather than real.
+        shim_dir = tmp_path / "bin"
+        shim_dir.mkdir()
+        calls = tmp_path / "calls.log"
+        for name in ("npx", "xcrun"):
+            shim = shim_dir / name
+            shim.write_text(f'#!/bin/sh\necho "{name} $*" >> "{calls}"\nexit 0\n')
+            shim.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "KIROCREW_HOME": str(home),
+            "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        }
+        p = subprocess.run(
+            [sys.executable, str(SKILL_DIR / "scripts" / "sim_mirror.py"),
+             "stop", "--device", udid],
+            capture_output=True, text=True, timeout=120, env=env,
+        )
+        assert p.returncode == 0, p.stderr
+        result = json.loads(p.stdout)["stopped"][0]
+        assert result["tracked"] is True
+        assert result["killed"] is False
+        assert not (state / f"{udid}.pid").exists(), "stale pidfile should be dropped"
+        assert not calls.exists(), f"stale pidfile must not invoke: {calls.read_text() if calls.exists() else ''}"
+
+    def test_mirror_spawn_survives_a_missing_npx(self, launcher: str) -> None:
+        """Popen bypasses sh()'s conversion, so a missing npx (no Node) would
+        surface as a traceback instead of the JSON error the caller parses."""
+        spawn = launcher.split("subprocess.Popen(", 1)
+        assert len(spawn) == 2, "Popen call not found"
+        assert "except OSError as exc:" in spawn[1].split("pidfile.write_text", 1)[0]
+
+    def test_simctl_json_output_is_never_parsed_unchecked(self, launcher: str) -> None:
+        """simctl can exit nonzero or print a non-JSON diagnostic when
+        CoreSimulator is wedged or a platform is missing. Parsing that blind
+        raised JSONDecodeError, discarding the real reason (simctl's stderr)."""
+        assert "def simctl_json" in launcher
+        assert "json.JSONDecodeError" in launcher
+        # No caller may parse simctl stdout directly any more.
+        assert "json.loads(simctl(" not in launcher
+        assert "json.loads(out.stdout" not in launcher
+
+    @posix_only
+    def test_wedged_simctl_reports_json_error_at_runtime(self, tmp_path: Path) -> None:
+        """Behavioral proof: with an `xcrun` that fails the way a wedged
+        CoreSimulator does, `start` must exit 1 with a parseable JSON error
+        carrying simctl's own diagnostic — not a traceback."""
+        import json
+        import subprocess
+
+        shim_dir = tmp_path / "bin"
+        shim_dir.mkdir()
+        xcrun = shim_dir / "xcrun"
+        xcrun.write_text(
+            '#!/bin/sh\n'
+            'echo "Failed to open a connection to CoreSimulatorService" >&2\n'
+            'exit 164\n'
+        )
+        xcrun.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "KIROCREW_HOME": str(tmp_path / "home"),
+            "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        }
+        p = subprocess.run(
+            [sys.executable, str(SKILL_DIR / "scripts" / "sim_mirror.py"), "start"],
+            capture_output=True, text=True, timeout=120, env=env,
+        )
+        assert p.returncode == 1
+        assert "Traceback" not in p.stderr, p.stderr
+        payload = json.loads(p.stderr.strip())
+        assert "rc=164" in payload["error"]
+        assert "CoreSimulatorService" in payload["error"]
+
+    def test_status_tolerates_a_pidfile_vanishing_mid_read(self, launcher: str) -> None:
+        """A concurrent `stop` can unlink a pidfile between the glob and the
+        read. status is a read-only snapshot and must not crash on that race."""
+        status_body = launcher.split("def cmd_status", 1)[1]
+        assert "except (ValueError, OSError):" in status_body
+
+    def test_log_open_refuses_to_follow_a_symlink(self, launcher: str) -> None:
+        """The log path is predictable, so a symlink planted there would be
+        followed by a plain "w" open and its target truncated."""
+        assert "os.O_NOFOLLOW" in launcher
+        assert 'open(log, "w")' not in launcher
+        assert "0o600" in launcher  # log stays private
+
+    def test_relative_data_home_is_refused_not_silently_resolved(self, launcher: str) -> None:
+        """The launcher is invoked by path from whatever directory the session is
+        in, so a relative KIROCREW_HOME would resolve per-caller: a `start` from
+        one project directory would be invisible to a `stop` from another."""
+        assert "def _resolve_home" in launcher
+        assert ".expanduser()" in launcher          # env vars carry ~ unexpanded
+        assert "is_absolute()" in launcher
+        # die() must precede the import-time home resolution, or the error path
+        # raises NameError instead of reporting.
+        assert launcher.index("def die(") < launcher.index("_HOME = _resolve_home()")
+
+    @posix_only
+    def test_relative_data_home_errors_at_runtime(self, tmp_path: Path) -> None:
+        """Behavioral proof: a relative home exits 1 with a JSON error naming the
+        offending value, from a cwd where that relative path exists."""
+        import json
+        import subprocess
+
+        (tmp_path / "relhome").mkdir()
+        p = subprocess.run(
+            [sys.executable, str(SKILL_DIR / "scripts" / "sim_mirror.py"), "status"],
+            capture_output=True, text=True, timeout=60, cwd=tmp_path,
+            env={**os.environ, "KIROCREW_HOME": "relhome"},
+        )
+        assert p.returncode == 1
+        assert "Traceback" not in p.stderr, p.stderr
+        error = json.loads(p.stderr.strip())["error"]
+        assert "absolute" in error and "relhome" in error
+
+    @posix_only
+    def test_tilde_data_home_is_expanded_at_runtime(self, tmp_path: Path) -> None:
+        """`~/...` is a legitimate value and must be accepted, not refused."""
+        import json
+        import subprocess
+
+        fake_home = tmp_path / "fakehome"
+        (fake_home / "crewhome" / "workspace" / "sim-mirror").mkdir(parents=True)
+        p = subprocess.run(
+            [sys.executable, str(SKILL_DIR / "scripts" / "sim_mirror.py"), "status"],
+            capture_output=True, text=True, timeout=60,
+            env={**os.environ, "HOME": str(fake_home), "KIROCREW_HOME": "~/crewhome"},
+        )
+        assert p.returncode == 0, p.stderr
+        assert json.loads(p.stdout) == {"mirrors": []}
+
+    @posix_only
+    def test_symlinked_log_is_not_written_through_at_runtime(self, tmp_path: Path) -> None:
+        """Behavioral proof: plant a symlink where the mirror log goes and assert
+        `start` refuses with a JSON error and leaves the target byte-identical."""
+        import json
+        import subprocess
+
+        home = tmp_path / "home"
+        state = home / "workspace" / "sim-mirror"
+        state.mkdir(parents=True)
+        udid = "09BE828F-6801-4731-BB13-D4C9747BC358"
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("do not truncate me")
+        (state / f"{udid}.log").symlink_to(victim)
+
+        # Shim simctl so device resolution reports this udid already booted, and
+        # npx so nothing real is ever launched if the guard were to fail.
+        shim_dir = tmp_path / "bin"
+        shim_dir.mkdir()
+        devices = json.dumps({"devices": {"com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+            {"udid": udid, "name": "iPhone Probe", "state": "Booted", "isAvailable": True}
+        ]}})
+        xcrun = shim_dir / "xcrun"
+        xcrun.write_text(f"#!/bin/sh\ncat <<'JSON'\n{devices}\nJSON\nexit 0\n")
+        xcrun.chmod(0o755)
+        npx = shim_dir / "npx"
+        npx.write_text('#!/bin/sh\nexit 0\n')
+        npx.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "KIROCREW_HOME": str(home),
+            "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        }
+        p = subprocess.run(
+            [sys.executable, str(SKILL_DIR / "scripts" / "sim_mirror.py"),
+             "start", "--device", udid],
+            capture_output=True, text=True, timeout=120, env=env,
+        )
+        assert p.returncode == 1
+        assert "Traceback" not in p.stderr, p.stderr
+        assert "refusing to open the mirror log" in json.loads(p.stderr.strip())["error"]
+        assert victim.read_text() == "do not truncate me", "symlink target was written through"


### PR DESCRIPTION
## Problem

KiroCrew has no way to show a user their iOS app. An agent can build and launch
an app in the simulator, but the result is invisible in the dashboard — the user
has to alt-tab to Simulator.app, and the agent can only describe what it did.
Codex and Claude Code both surface a live simulator in their side panel; we
surface nothing.

## Why it matters

The Browser side panel already exists and already renders any loopback URL. The
missing piece is purely the glue: boot a device, mirror it, point the panel at
it. Without a bundled skill, every user who wants this has to discover
`serve-sim`, work out the four non-obvious failure modes below, and hand-roll
the launcher — or go without.

## Fix (symptom → root cause → change)

**Symptom:** no simulator surface in the dashboard.

**Root cause:** nothing bridges `simctl` to the Browser panel. The panel takes a
URL; the simulator emits a framebuffer.

**Change:** bundle `ios-simulator-preview`. Architecture, all local:

```
simulator → serve-sim (loopback HTTP) → kirocrew:preview marker → Browser panel
```

This follows OpenAI Codex's `ios-simulator-browser` skill (same `serve-sim`
mirror), substituting KiroCrew's hidden `kirocrew:preview` marker for Codex's
in-app browser call — the marker is our only reliable panel auto-open path.

**Why a launcher script instead of documenting `npx serve-sim`.** Four things
break a bare invocation, each hit while building this:

| Failure | Guard in `sim_mirror.py` |
|---|---|
| Turn-scoped child is reaped at turn end → mirror dies when the agent stops talking | `start_new_session=True` |
| Local npm config pointing at an authenticated internal registry 401s on the public package | pinned `--registry=https://registry.npmjs.org` |
| `simctl create` picks device types an older runtime rejects (`Incompatible device`) | selection scoped to the runtime's own `supportedDeviceTypes` |
| Unbounded `simctl` against a wedged CoreSimulator hangs the caller forever | every `subprocess.run` is timeout-bounded |

`SKILL.md`'s failure-mode section records the *verified* cause for each,
including the nastiest one: **upgrading Xcode while a device is booted orphans
that device.** The new CoreSimulator framework cannot drive it, so `simctl`
blocks indefinitely and the mirror serves HTTP 200 while capturing zero frames.
Recovery requires killing the stale `Simulator` / `CoreSimulatorService` /
`launchd_sim` processes — `launchctl remove` alone is not enough.

**No packaging change needed.** `setup.cfg`'s `builtin_skills/**/*` glob already
ships nested `scripts/`; confirmed against the installed nightly, which carries
`kirocrew-dev/prepare-pr/scripts/*.py`.

## Tests

`test/test_ios_simulator_preview_skill.py` (10 tests, new). Two groups:

**Files ship & are discoverable** — `SKILL.md` + `scripts/sim_mirror.py` both
present; frontmatter declares `name`/`description`/`triggers` (without it the
loader can't match a request); the documented path resolves via
`${KIROCREW_HOME:-$HOME/.kiro/crew}` like `prepare-pr` rather than hardcoding a
home a relocated install won't have; macOS-only is stated.

**Launcher invariants** — one assertion per failure in the table above, so a
future refactor that drops `start_new_session`, the registry pin, the
runtime-scoped device selection, or a `timeout=` silently re-introduces a bug
that already cost real debugging time. Plus: loopback-only URL validation, and
`stop` scoped to this launcher's own pidfiles (an unscoped `serve-sim --kill`
would tear down a mirror another session owns).

The timeout test parses every `subprocess.run(` call site and fails if any lacks
`timeout`, rather than spot-checking one.

Also ran the guards a new bundled skill could trip: `test_skill_home_paths.py`
(legacy-home regression), `test_spawn_audit.py` (scans bundled scripts),
`test_skills.py` (loader). **125 passed.** `flake8` / `isort` / `mypy` clean —
`mypy` caught a real shadowing bug (`cmd_status`'s `_` parameter rebound by a
tuple unpack), fixed here.

## Manual verification

Verified end-to-end on macOS with Xcode 26.6 before packaging:

1. `sim_mirror.py start` — created/booted a device and mirrored it to
   `http://127.0.0.1:3200` (HTTP 200, zero `encodingFailed` in the log).
2. A SwiftUI app compiled with `swiftc` for `arm64-apple-ios-simulator`
   (platform confirmed `IOSSIMULATOR` via `vtool -show-build`), `simctl install`
   + `launch` both rc=0.
3. App confirmed running via `simctl io screenshot`, and the mirror rendered it
   in the Browser panel.
4. `sim_mirror.py stop --shutdown-device` cleaned up; `status` reports `{"mirrors": []}`.

Post-fix smoke: `status` still runs correctly after the `mypy` rename.

## Screenshots

N/A — no dashboard UI change. This adds a skill file plus a script; the surface
it drives (the existing Browser panel) is unmodified. The behavior is a live
video stream, which a still frame cannot honestly demonstrate.

## Known scope

- **View-only.** Whether taps forward depends on what `serve-sim`'s own page
  offers; `SKILL.md` explicitly forbids promising tap-through.
- **macOS-only**, stated in the description so non-macOS agents don't attempt it.
- **`serve-sim` is fetched at runtime from public npm, not vendored** — a
  third-party runtime dependency, called out in the skill's Boundaries section.
