### PR TITLE
fix(issue-radar): linkify a #123 reference wrapped in parentheses

### DIFF
--- a/website/src/apps/issue-radar/lib/refLinks.ts
+++ b/website/src/apps/issue-radar/lib/refLinks.ts
@@ -200,14 +200,20 @@ function maskMarkdown(source: string): string {
  *
  * Rejected when PRECEDED by a character that makes it something else — a word
  * character or `/` (a URL fragment such as `…/issues/12#issuecomment-9`, or a
- * cross-repo `owner/repo#5`), `&` (`&#123;`, an HTML entity), `[` or `(`
- * (markdown link syntax the mask may not have caught), or another `#`.
+ * cross-repo `owner/repo#5`), `&` (`&#123;`, an HTML entity), `[` (markdown link
+ * syntax the mask may not have caught), or another `#`.
+ *
+ * An opening `(` is ALLOWED: `the Windows lane (#421) uses …` is ordinary prose
+ * and by far the more common shape, and GitHub linkifies it. The one `(` that is
+ * markdown — a link TARGET, `](#421)` — is rejected separately in the scan loop
+ * by looking at the character before the paren, because a well-formed link is
+ * already masked and only an unbalanced leftover can reach here.
  *
  * Rejected when FOLLOWED by a word character, so a hex colour (`#1a2b3c`) is not
  * read as `#1`. An all-digit run IS taken as a reference — GitHub does the same,
  * and a repo with six-figure issue numbers is ordinary, so length cannot decide.
  */
-const SHORTHAND_RE = /(^|[^\w/&[(#])#(\d{1,7})(?!\w)/g
+const SHORTHAND_RE = /(^|[^\w/&[#])#(\d{1,7})(?!\w)/g
 
 /**
  * Rewrite bare `#123` references into real markdown links to this repo, so they
@@ -239,6 +245,11 @@ export function linkifyIssueRefs(source: string, repo: RepoIdentity | null | und
     const lead = m[1] ?? ''
     const start = m.index + lead.length
     const end = m.index + m[0].length
+    // `](#421)` is a link TARGET, not a reference. A well-formed link is masked
+    // already, so this only catches an unbalanced leftover — but rewriting one
+    // would nest a link inside a link. The check reads the MASKED copy so a `]`
+    // that belongs to some other masked construct does not count.
+    if (lead === '(' && masked[m.index - 1] === ']') continue
     const number = Number(m[2])
     if (!Number.isSafeInteger(number) || number <= 0) continue
     edits.push({ start, end, text: `[#${number}](${refUrl(repo, { kind: 'issue', number })})` })

--- a/website/src/test/issueRadarRefLinks.test.ts
+++ b/website/src/test/issueRadarRefLinks.test.ts
@@ -191,6 +191,23 @@ describe('linkifyIssueRefs', () => {
     expect(linkifyIssueRefs(src, gh(O, R))).toBe(src)
   })
 
+  it('rewrites a reference wrapped in parentheses', () => {
+    // The overwhelmingly common shape in a real body — `the Windows lane (#421)
+    // uses Squirrel` — and GitHub linkifies it, so an opening paren must not
+    // suppress the rewrite.
+    expect(linkifyIssueRefs('the Windows lane (#421) uses Squirrel', gh(O, R)))
+      .toBe(`the Windows lane (${link(421)}) uses Squirrel`)
+    expect(linkifyIssueRefs('(#5)', gh(O, R))).toBe(`(${link(5)})`)
+    expect(linkifyIssueRefs('see (#5, #6)', gh(O, R))).toBe(`see (${link(5)}, ${link(6)})`)
+  })
+
+  it('still leaves an UNBALANCED link target alone', () => {
+    // A well-formed `[a](#5)` is masked, so only a leftover `](#5)` reaches the
+    // scan — rewriting it would nest a link inside a link.
+    expect(linkifyIssueRefs('a](#5)', gh(O, R))).toBe('a](#5)')
+    expect(linkifyIssueRefs('[a](#5)', gh(O, R))).toBe('[a](#5)')
+  })
+
   it('does not touch an autolink or a URL fragment', () => {
     const src = `<https://github.com/${O}/${R}/issues/12#issuecomment-9>`
     expect(linkifyIssueRefs(src, gh(O, R))).toBe(src)


### PR DESCRIPTION
## Problem

In an issue/PR body, a shorthand reference wrapped in parentheses did not render as a link:

> The Windows desktop lane (#421) uses Squirrel.Windows …

`(#421)` stayed plain text, while a bare `#421` elsewhere in the same paragraph linkified fine. GitHub's own renderer links the parenthesised form, so the pane read as inconsistent with the source it mirrors.

## Cause

`SHORTHAND_RE` in `website/src/apps/issue-radar/lib/refLinks.ts` excluded `(` from the allowed leading character:

```ts
const SHORTHAND_RE = /(^|[^\w/&[(#])#(\d{1,7})(?!\w)/g
//                            ^ rejects `(#123)`
```

The exclusion existed to avoid rewriting a markdown link TARGET (`](#123)`) that the mask might have missed. But a well-formed `[a](#5)` is already blanked by `MASKED_REGIONS` before the scan, so the guard almost never fired for its intended case — and always fired for ordinary prose.

## Fix

- Drop `(` from the leading-character exclusion set.
- Reject only the genuine link-target shape in the scan loop: skip when the lead is `(` and the character before it (in the **masked** copy) is `]`. An unbalanced leftover like `a](#5)` therefore still cannot be rewritten into a nested link.

## Tests

`website/src/test/issueRadarRefLinks.test.ts` — 2 new cases:

- `(#421)`, `(#5)` and `see (#5, #6)` all linkify.
- `a](#5)` and `[a](#5)` are still left alone.

Mutation-verified: restoring the old regex fails the new paren test.

## Gates

- `npx vitest run` — 459 files, 5565 passed / 3 skipped
- `npm run typecheck` — clean
- `npm run lint` — no new findings (the single pre-existing `vite-env.d.ts` parsing error is on an untouched file and present on `main`)
