### PR TITLE
fix(chat): never disable the activity toggle; fill the chat column when it cannot sit beside

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -18,6 +18,7 @@ import { useTheme } from './hooks/useTheme'
 import { useBranding } from './hooks/useBranding'
 import { useRumPageView } from './hooks/useRumPageView'
 import { useIsMobile } from './hooks/useIsMobile'
+import { setRailWidth, railWidthFor } from './hooks/useRailWidth'
 import { useNativeNotification } from './hooks/useNativeNotification'
 import { useNotificationSound } from './hooks/useNotificationSound'
 import { recordSessionStart, recordEvent } from './rum'
@@ -1359,6 +1360,13 @@ export default function App() {
   // Reset mobile nav state when leaving mobile viewport
   useEffect(() => { if (!isMobile) setMobileNavOpen(false) }, [isMobile])
   const effectiveCollapsed = (navCollapsed || previewFocused) && !isMobile
+  // Publish the rail track so consumers outside the shell can size against the
+  // space actually left for content — ChatPage's activity panel decides
+  // beside-vs-fill from it. Kept in sync with the gridTemplateColumns value
+  // below; railWidthFor is the single source for both.
+  useEffect(() => {
+    setRailWidth(railWidthFor({ isMobile, collapsed: effectiveCollapsed }))
+  }, [isMobile, effectiveCollapsed])
   const topbarBrandRef = useRef<HTMLDivElement>(null)
   const topbarActionsRef = useRef<HTMLDivElement>(null)
   const [topbarSearchLayout, setTopbarSearchLayout] = useState({ gutter: 360, visible: true })
@@ -1451,7 +1459,7 @@ export default function App() {
       style={{
         gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar topbar" "nav content actbar"',
         ...(!isMobile && {
-          gridTemplateColumns: `${effectiveCollapsed ? 74 : 236}px minmax(0,1fr) auto`,
+          gridTemplateColumns: `${railWidthFor({ isMobile, collapsed: effectiveCollapsed })}px minmax(0,1fr) auto`,
           // Transition fires only when the template string itself changes (the
           // collapse toggle) — content-driven resizes of the auto track (e.g.
           // the Activity panel opening) don't alter the value, so keeping this

--- a/website/src/hooks/useRailWidth.ts
+++ b/website/src/hooks/useRailWidth.ts
@@ -1,0 +1,54 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Width (px) of the app shell's left nav rail track.
+ *
+ * The rail is App-local state (`navCollapsed`, persisted at `mc-nav`) but its
+ * width is a LAYOUT FACT that consumers outside App need: ChatPage sizes the
+ * activity panel's beside-vs-fill decision against the space actually left for
+ * the chat, and the rail is the first thing subtracted from it.
+ *
+ * Published as the resolved TRACK value (0 / 74 / 236) rather than measured
+ * from the DOM on purpose. The rail's collapse is a 150ms grid-template
+ * transition, so `getBoundingClientRect()` reports intermediate widths mid
+ * animation — enough to flip a width gate twice per toggle. The track value
+ * steps once.
+ *
+ * Module-level (same shape as usePanelTabs) so the value survives consumer
+ * remounts and needs no context provider.
+ */
+const RAIL_W_EXPANDED = 236
+const RAIL_W_COLLAPSED = 74
+
+/** Rail width for the shell's current state. Mobile has no rail track. */
+export function railWidthFor({ isMobile, collapsed }: { isMobile: boolean; collapsed: boolean }): number {
+  if (isMobile) return 0
+  return collapsed ? RAIL_W_COLLAPSED : RAIL_W_EXPANDED
+}
+
+let railWidth = RAIL_W_EXPANDED
+const listeners = new Set<() => void>()
+
+/** Called by App when the rail track changes. No-op when the value is unchanged. */
+export function setRailWidth(w: number) {
+  if (w === railWidth) return
+  railWidth = w
+  listeners.forEach(l => l())
+}
+
+function subscribe(cb: () => void) {
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}
+
+const getSnapshot = () => railWidth
+
+export function useRailWidth() {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/** Test seam: restore the module default between cases. */
+export function __resetRailWidth() {
+  railWidth = RAIL_W_EXPANDED
+  listeners.clear()
+}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useNavigationType, useSearchParams } from 're
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { modelListRefetchInterval } from '../providers/modelListHealth'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useRailWidth } from '../hooks/useRailWidth'
 import { SETTINGS_DEFAULT_MODEL_ID } from '../hooks/useSettingHighlight'
 import { isTouchDevice } from '../utils/isTouchDevice'
 import { useSwipeEdge } from '../hooks/useSwipeEdge'
@@ -103,7 +104,7 @@ import TypewriterText from '../components/TypewriterText'
 import { useChatNavigation } from '../hooks/useChatNavigation'
 import SubagentProgressBar from './chat/SubagentProgressBar'
 import TaskProgressBar from './chat/TaskProgressBar'
-import SidePanel, { SIDE_PANEL_MIN_W, measureSidePanelReservedW } from './chat/SidePanel'
+import SidePanel, { CHAT_PANE_MIN_W, sidePanelFillWidth } from './chat/SidePanel'
 import { setSessionPreviewPending, normalizeUrl, PREVIEW_FOCUS_EVENT, PREVIEW_SNIP_EVENT, PREVIEW_ENABLE_BROWSE_EVENT, BROWSE_MODE_EVENT } from '../components/WebPreviewPanel'
 import { detectPreviewUrl, previewFeedDecision } from '../utils/detectPreviewUrl'
 import { fileLandingSlot } from '../utils/uploadRouting'
@@ -2992,38 +2993,30 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
 
   const lastRole = messages[messages.length - 1]?.role ?? ''
   // Precompute: index of last finalized assistant message (tools after this are "trailing")
-  // Auto-collapse the activity panel when the window shrinks past the point
-  // where its minimum width still fits beside the chat's reserved minimum;
-  // reopen automatically when space returns. Crossing-based (compares against
-  // the previous window width) so a deliberate manual open on an
-  // already-narrow window is respected rather than instantly fought.
-  const autoCollapsedRef = useRef(false)
-  const activityOpenRef = useRef(activityOpen); activityOpenRef.current = activityOpen
+  // The activity panel has exactly two modes, and the question that picks one
+  // is NOT "how wide is the window" — it is "how much width is left for the
+  // chat". Subtract the shell's nav rail and the session sidebar (both of which
+  // the user can hide) from the viewport: if what remains still seats the panel
+  // at its minimum PLUS a usable chat pane, the panel sits BESIDE the chat.
+  // Otherwise it FILLS the chat column, with the sidebar and rail untouched.
+  //
+  // Consequences worth stating:
+  //  - Hiding the rail (162px) or the sidebar (~260px) can promote fill -> beside
+  //    at a viewport width that could not seat both a moment earlier.
+  //  - Mobile needs no special case: rail 0 + sidebar 0 (its drawer is fixed,
+  //    not a flex sibling) always lands under the threshold. isMobile is still
+  //    forced to fill so a 700px phone-class viewport cannot go beside.
+  //  - The measurement is loop-free ON PURPOSE. It reads the rail TRACK and the
+  //    sidebar's own state, never the chat container's painted width — that
+  //    shrinks when the panel opens, which would oscillate beside <-> fill.
+  const railWidth = useRailWidth()
+  const [winW, setWinW] = useState(() => window.innerWidth)
   useEffect(() => {
-    if (isMobile || embedMode) return
-    let lastW = window.innerWidth
-    const onResize = () => {
-      // Live threshold: the reserve includes the header row's content need
-      // (wide readout capsule etc.), so it's re-measured per event rather
-      // than fixed at the static constant.
-      const THRESHOLD = SIDE_PANEL_MIN_W + measureSidePanelReservedW()
-      const w = window.innerWidth
-      const crossedBelow = lastW >= THRESHOLD && w < THRESHOLD
-      const crossedAbove = lastW < THRESHOLD + 40 && w >= THRESHOLD + 40 // small hysteresis
-      lastW = w
-      if (crossedBelow && activityOpenRef.current) {
-        autoCollapsedRef.current = true
-        dispatch(toggleActivity())
-      } else if (crossedAbove && autoCollapsedRef.current && !activityOpenRef.current) {
-        autoCollapsedRef.current = false
-        dispatch(openActivityPanel())
-      }
-    }
+    const onResize = () => setWinW(window.innerWidth)
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
-  }, [isMobile, embedMode, dispatch])
+  }, [])
   const toggleAct = useCallback(() => {
-    autoCollapsedRef.current = false
     // Opening with no tabs shows the empty-state launcher grid (no seeded
     // default view) -- the user picks what to open.
     dispatch(toggleActivity())
@@ -3035,21 +3028,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     window.addEventListener('toggle-activity-panel', h)
     return () => window.removeEventListener('toggle-activity-panel', h)
   }, [toggleAct])
-  // Whether the window has room for the activity panel beside the chat's
-  // reserved minimum. When it doesn't (the panel would be force-collapsed
-  // anyway) the session-header activity toggle is disabled. Mirrors the
-  // crossing-based threshold used by the auto-collapse effect above.
-  const [actSpace, setActSpace] = useState(true)
-  useEffect(() => {
-    const check = () => setActSpace(window.innerWidth >= SIDE_PANEL_MIN_W + measureSidePanelReservedW())
-    check()
-    window.addEventListener('resize', check)
-    return () => window.removeEventListener('resize', check)
-  }, [])
-  // On mobile the panel is full-width (SidePanel: effectiveWidth = '100%') and
-  // is rendered inline rather than in the actbar grid column, so "does it fit
-  // beside the chat" is the wrong question — the toggle stays enabled.
-  const actEnabled = isMobile || actSpace
   // Bridge explicit view requests (e.g. the /side slash command dispatches
   // openActivityToTab('side')) into the tab model.
   const activityTab = useAppSelector(s => s.chat.activityTab)
@@ -3633,8 +3611,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // past its flex row and collapses the chat pane: the open sidebar's width
   // plus a usable chat-pane minimum. On mobile the panel is full-screen (no
   // shared row), so no reserve applies.
-  const CHAT_PANE_MIN = 320
+  const CHAT_PANE_MIN = CHAT_PANE_MIN_W
   const panelReserve = isMobile ? undefined : (sidebarOpen ? sidebarWidth : 0) + CHAT_PANE_MIN
+
+  // FILL vs BESIDE for the activity panel, decided from the width left for the
+  // CHAT once the shell's hideable chrome is subtracted — the nav rail track and
+  // the session sidebar (a shrink-0 flex sibling of exactly sidebarWidth; on
+  // mobile its drawer is fixed-position and consumes no row width). Undefined =
+  // beside. A px width = fill the chat column, squeezing the chat pane to zero
+  // while the rail and sidebar stay exactly where they are.
+  //
+  // The panel's render PATH is unchanged either way, so crossing the threshold
+  // never remounts it (no terminal re-attach, no Virtuoso churn) — only its
+  // width changes. See sidePanelFillWidth for why this is loop-free.
+  const panelFillWidth = sidePanelFillWidth({
+    winW,
+    railW: railWidth,
+    sidebarW: !isMobile && sidebarOpen ? sidebarWidth : 0,
+    isMobile,
+  })
 
   return (
     <TagPopoverProvider>
@@ -3845,17 +3840,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               {/* Activity panel open toggle — relocated here from the top bar
                   (item 2.4) so opening the panel no longer narrows the now
                   full-width header. Shown only while the panel is closed; the
-                  panel's own header carries the close button. On desktop it is
-                  disabled when the window is too narrow (the panel would be
-                  force-collapsed); on mobile the panel takes the full width
-                  instead of sitting beside the chat, so the fits-beside test
-                  (actSpace) does not apply and the button is always live. */}
+                  panel's own header carries the close button. Never disabled:
+                  below the mobile breakpoint the panel opens full width, at or
+                  above it opens beside the chat. There is no width at which
+                  the button does nothing. */}
               {!embedMode && !popout && !activityOpen && (
                 <Clickable
-                  className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto ${actEnabled ? 'text-muted hover:text-text hover:bg-bg-hover cursor-pointer' : 'text-muted opacity-40 !cursor-not-allowed'}`}
-                  onClick={() => { if (actEnabled) toggleAct() }}
-                  title={actEnabled ? 'Open activity panel' : 'Window too narrow for the activity panel'}
-                  aria-label={actEnabled ? 'Open activity panel' : 'Window too narrow for the activity panel'}
+                  className="flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto text-muted hover:text-text hover:bg-bg-hover cursor-pointer"
+                  onClick={toggleAct}
+                  title="Open activity panel"
+                  aria-label="Open activity panel"
                 >
                   <PanelRight size={15} />
                 </Clickable>
@@ -4393,6 +4387,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               onSubmitComments={submitComments} onFileSave={handleFileSave} onClose={toggleAct}
               inlinePreviewPath={inlinePreviewPath} onInlinePreviewChange={setInlinePreviewPath}
               expanded={previewFocused}
+              fillWidth={panelFillWidth}
             />
           </motion.div>
         )}
@@ -4424,6 +4419,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                 onSubmitComments={submitComments} onFileSave={handleFileSave} onClose={toggleAct}
                 inlinePreviewPath={inlinePreviewPath} onInlinePreviewChange={setInlinePreviewPath}
                 expanded={previewFocused}
+                fillWidth={panelFillWidth}
               />
             </motion.div>
           )}

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -72,6 +72,12 @@ interface SidePanelProps {
   /** Preview "focus" mode: when true the panel takes its maximum width (chat
    *  shrinks to its minimum), driven by the Web Preview tab's expand toggle. */
   expanded?: boolean
+  /** FILL mode (set by ChatPage): an explicit px width covering the whole chat
+   *  column, used when the space left after the nav rail and session sidebar
+   *  cannot seat the panel BESIDE a usable chat pane. Overrides the responsive
+   *  clamp and the user's persisted width, and retires the resize handle —
+   *  there is nothing to resize against. Undefined = beside mode. */
+  fillWidth?: number
 }
 
 /**
@@ -102,6 +108,33 @@ export const SIDE_PANEL_RESERVED_W = 560
  * started shrinking. Returns the larger of the two constraints; falls back
  * to the static reserve when there's no header (embed/popout frames).
  */
+/** Usable minimum for the chat pane itself, beside the panel. */
+export const CHAT_PANE_MIN_W = 320
+
+/**
+ * Decide the panel's mode from the width left for the CHAT, not from the
+ * viewport: subtract the shell's hideable chrome (nav rail track, session
+ * sidebar) and ask whether the remainder seats the panel at SIDE_PANEL_MIN_W
+ * beside a CHAT_PANE_MIN_W chat pane.
+ *
+ * Returns `undefined` for BESIDE mode, or the px width the panel should take to
+ * FILL the chat column. Mobile always fills (its viewport cannot seat both, and
+ * its sidebar is a fixed-position drawer that consumes no row width).
+ *
+ * Pure and loop-free on purpose: every input is a shell-level fact that does
+ * NOT change when the panel opens. Feeding it the chat container's painted
+ * width instead would oscillate, since opening the panel shrinks that width.
+ */
+export function sidePanelFillWidth(
+  { winW, railW, sidebarW, isMobile }:
+  { winW: number; railW: number; sidebarW: number; isMobile: boolean },
+): number | undefined {
+  if (isMobile) return Math.max(SIDE_PANEL_MIN_W, winW)
+  const chatAvail = winW - railW - sidebarW
+  if (chatAvail >= SIDE_PANEL_MIN_W + CHAT_PANE_MIN_W) return undefined
+  return Math.max(SIDE_PANEL_MIN_W, chatAvail)
+}
+
 export function measureSidePanelReservedW(): number {
   const header = document.querySelector('header.topbar-glass')
   if (!header) return SIDE_PANEL_RESERVED_W
@@ -119,7 +152,7 @@ export default function SidePanel({
   tabsCtl, subagents, toolLog, slot, files, onFileOpen, onFileRemove, onFilesClear,
   projectDir, navLinks, navResolving, sources, selectedSourceUrl, onSelectSource,
   onAddSourceToChat, onSubmitComments, onFileSave, onClose,
-  inlinePreviewPath, onInlinePreviewChange, expanded,
+  inlinePreviewPath, onInlinePreviewChange, expanded, fillWidth,
 }: SidePanelProps) {
   const { tabs, activeId, openView, openTerminal, setActive, closeTab, patchTab, setOrder, syncPinned } = tabsCtl
   const terminalEnabled = useTerminalEnabled()
@@ -223,7 +256,11 @@ export default function SidePanel({
       .forEach(c => ro.observe(c))
     return () => { window.removeEventListener('resize', recalc); ro.disconnect() }
   }, [])
-  const effectiveWidth = isMobile ? '100%' : (expanded ? Math.max(MIN_W, maxW) : Math.max(MIN_W, Math.min(width, maxW)))
+  const effectiveWidth = isMobile
+    ? '100%'
+    : fillWidth != null
+      ? fillWidth
+      : (expanded ? Math.max(MIN_W, maxW) : Math.max(MIN_W, Math.min(width, maxW)))
   // While the user drags the resize handle, every mousemove shifts the whole
   // panel's viewport position (the handle is on the LEFT edge; the right edge
   // is pinned to the window). Framer's layout projection on each Reorder.Item
@@ -253,9 +290,9 @@ export default function SidePanel({
   return (
     <div className="shrink-0 min-h-0 my-2 flex flex-col bg-bg overflow-hidden relative border-l border-t border-b border-border rounded-l-xl" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
       {/* Left-edge resize handle */}
-      <div role="separator" aria-orientation="vertical" aria-label={i18nT('pages.chat.sidePanel.resize_panel')} className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" style={{ touchAction: 'none' }} {...panelResize}>
+      {fillWidth == null && <div role="separator" aria-orientation="vertical" aria-label={i18nT('pages.chat.sidePanel.resize_panel')} className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" style={{ touchAction: 'none' }} {...panelResize}>
         <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
-      </div>
+      </div>}
       {/* Tab strip — drag chips horizontally to reorder (framer Reorder).
           Per Figma "left-nav" (7328:10637): the row is a rounded elevated card
           (bg-elevated, 12px radius, 8px padding) floating above the content,

--- a/website/src/test/ChatPage.responsivePanel.test.tsx
+++ b/website/src/test/ChatPage.responsivePanel.test.tsx
@@ -39,10 +39,19 @@ vi.mock('../pages/chat/ChatSettings', () => ({ loadChatConfig: () => ({ contentW
 // SidePanel: stub the component (pulls in xterm etc.) but keep the space
 // contract deterministic: threshold = 320 + 560 = 880, reopen at 920.
 vi.mock('../pages/chat/SidePanel', () => ({
-  default: () => <div data-testid="side-panel" />,
+  default: ({ fillWidth }: { fillWidth?: number }) => (
+    <div data-testid="side-panel" data-fill-width={fillWidth ?? ''} />
+  ),
   SIDE_PANEL_MIN_W: 320,
   SIDE_PANEL_RESERVED_W: 560,
+  CHAT_PANE_MIN_W: 320,
   measureSidePanelReservedW: () => 560,
+  // Real arithmetic (the gate under test lives here); only the component is stubbed.
+  sidePanelFillWidth: ({ winW, railW, sidebarW, isMobile }: { winW: number; railW: number; sidebarW: number; isMobile: boolean }) => {
+    if (isMobile) return Math.max(320, winW)
+    const avail = winW - railW - sidebarW
+    return avail >= 640 ? undefined : Math.max(320, avail)
+  },
 }))
 
 // --- Stub hooks ---
@@ -150,61 +159,39 @@ describe('ChatPage — pull request panel discovery', () => {
   })
 })
 
-describe('ChatPage — responsive activity panel auto-collapse', () => {
+describe('ChatPage — activity panel open state is resize-independent', () => {
   beforeEach(() => setWindowWidth(1400))
   afterEach(() => {
     document.getElementById('activity-bar-slot')?.remove()
   })
 
-  it('auto-collapses when the window crosses below the space threshold (880)', () => {
+  it('stays open when the window shrinks below the old 880 space threshold', () => {
     const { store } = renderChat()
     act(() => { store.dispatch(toggleActivity()) })
     expect(store.getState().chat.activityOpen).toBe(true)
 
-    resizeTo(850) // crosses 1400 -> 850, below 880
-    expect(store.getState().chat.activityOpen).toBe(false)
-  })
-
-  it('auto-reopens when space returns past the hysteresis point (920), only after an auto-collapse', () => {
-    const { store } = renderChat()
-    act(() => { store.dispatch(toggleActivity()) })
-    resizeTo(850)
-    expect(store.getState().chat.activityOpen).toBe(false)
-
-    // Not enough clearance yet (below threshold+40): stays closed.
-    resizeTo(900)
-    expect(store.getState().chat.activityOpen).toBe(false)
-
-    // Crosses 920: reopens because the collapse was automatic.
-    resizeTo(1000)
+    resizeTo(850) // used to auto-collapse here
+    expect(store.getState().chat.activityOpen).toBe(true)
+    resizeTo(700) // and again below the mobile breakpoint
     expect(store.getState().chat.activityOpen).toBe(true)
   })
 
-  it('does NOT auto-reopen a panel the user closed manually', () => {
+  it('does not auto-reopen when space returns', () => {
     const { store } = renderChat()
-    act(() => { store.dispatch(toggleActivity()) })
-    // Manual close via the header/panel toggle event.
-    act(() => { window.dispatchEvent(new CustomEvent('toggle-activity-panel')) })
+    resizeTo(850)
     expect(store.getState().chat.activityOpen).toBe(false)
 
-    resizeTo(850)
     resizeTo(1000)
     expect(store.getState().chat.activityOpen).toBe(false)
   })
 
-  it('a manual open+close after an auto-collapse cancels the pending auto-reopen', () => {
+  it('does not undo a manual close on a later resize', () => {
     const { store } = renderChat()
     act(() => { store.dispatch(toggleActivity()) })
-    resizeTo(850) // auto-collapse: pending reopen armed
-    expect(store.getState().chat.activityOpen).toBe(false)
-
-    // User manually opens then closes on the narrow window.
-    act(() => { window.dispatchEvent(new CustomEvent('toggle-activity-panel')) })
-    expect(store.getState().chat.activityOpen).toBe(true)
     act(() => { window.dispatchEvent(new CustomEvent('toggle-activity-panel')) })
     expect(store.getState().chat.activityOpen).toBe(false)
 
-    // Widening must respect the explicit close — no surprise reopen.
+    resizeTo(850)
     resizeTo(1000)
     expect(store.getState().chat.activityOpen).toBe(false)
   })
@@ -279,11 +266,49 @@ describe('ChatPage — session-header activity toggle (relocated from the top ba
     expect(store.getState().chat.activityOpen).toBe(true)
   })
 
-  it('disables the toggle with an explanatory label when the window is too narrow', async () => {
+  it('stays live in the 768-880 band that used to disable it, and opens beside the chat', async () => {
+    const { store } = renderWithSlot()
+    await screen.findByLabelText('Open activity panel')
+    resizeTo(800) // below the old 880 space threshold (320 + 560), above mobile (768)
+
+    const btn = await screen.findByLabelText('Open activity panel')
+    expect(screen.queryByLabelText('Window too narrow for the activity panel')).not.toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(store.getState().chat.activityOpen).toBe(true)
+  })
+
+  it('stays live at 768 exactly (tablet portrait)', async () => {
     renderWithSlot()
     await screen.findByLabelText('Open activity panel')
-    resizeTo(800) // below the 880 space threshold (320 + 560)
-    expect(await screen.findByLabelText('Window too narrow for the activity panel')).toBeInTheDocument()
+    resizeTo(768)
+    expect(await screen.findByLabelText('Open activity panel')).toBeInTheDocument()
+  })
+
+  it('opens BESIDE the chat on a wide window (no fill width)', async () => {
+    // 1400 - rail 236 - sidebar 260 = 904 >= 640
+    renderWithSlot()
+    fireEvent.click(await screen.findByLabelText('Open activity panel'))
+    expect(await screen.findByTestId('side-panel')).toHaveAttribute('data-fill-width', '')
+  })
+
+  it('opens FILLING the chat column when the rail + sidebar leave too little', async () => {
+    renderWithSlot()
+    resizeTo(800) // 800 - 236 - 260 = 304 < 640
+    fireEvent.click(await screen.findByLabelText('Open activity panel'))
+    expect(await screen.findByTestId('side-panel')).toHaveAttribute('data-fill-width', '320')
+  })
+
+  it('switches an already-open panel from beside to fill on resize, without remounting it', async () => {
+    renderWithSlot()
+    fireEvent.click(await screen.findByLabelText('Open activity panel'))
+    const before = await screen.findByTestId('side-panel')
+    expect(before).toHaveAttribute('data-fill-width', '')
+
+    resizeTo(800)
+    const after = await screen.findByTestId('side-panel')
+    expect(after).toHaveAttribute('data-fill-width', '320')
+    // Same DOM node: the mode change must not tear the panel down (live PTYs).
+    expect(after).toBe(before)
   })
 })
 
@@ -291,8 +316,7 @@ describe('ChatPage — session-header activity toggle (relocated from the top ba
  * Mobile regression: the toggle used to be gated on `!isMobile`, so a phone had
  * NO way to open the activity panel even though SidePanel already renders
  * full-width there and ChatPage keeps an inline (non-portal) render path
- * specifically for mobile. The `actSpace` "does it fit beside the chat" test is
- * also meaningless at full width, so it must not disable the button on mobile.
+ * specifically for mobile.
  */
 describe('ChatPage — activity toggle on mobile', () => {
   beforeEach(() => { mockIsMobile = true; setWindowWidth(390); localStorage.clear() })

--- a/website/src/test/sidePanelFillWidth.test.ts
+++ b/website/src/test/sidePanelFillWidth.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for sidePanelFillWidth — the activity panel's BESIDE-vs-FILL decision.
+ *
+ * The gate reads the width left for the CHAT (viewport minus the nav rail track
+ * minus the session sidebar), not the raw viewport. Hiding either piece of
+ * chrome can therefore promote fill -> beside at an unchanged window width,
+ * which is the whole point of the rule.
+ */
+import { describe, it, expect } from 'vitest'
+import { SIDE_PANEL_MIN_W, CHAT_PANE_MIN_W, sidePanelFillWidth } from '../pages/chat/SidePanel'
+
+const THRESHOLD = SIDE_PANEL_MIN_W + CHAT_PANE_MIN_W // 640
+const RAIL_EXPANDED = 236
+const RAIL_COLLAPSED = 74
+const SIDEBAR = 260
+
+const fill = (o: Partial<Parameters<typeof sidePanelFillWidth>[0]> = {}) =>
+  sidePanelFillWidth({ winW: 1400, railW: RAIL_EXPANDED, sidebarW: SIDEBAR, isMobile: false, ...o })
+
+describe('sidePanelFillWidth', () => {
+  it('sits beside on a normal desktop window with all chrome shown', () => {
+    // 1400 - 236 - 260 = 904 >= 640
+    expect(fill()).toBeUndefined()
+  })
+
+  it('fills when the chat remainder cannot seat panel + chat minimum', () => {
+    // 800 - 236 - 260 = 304 < 640
+    expect(fill({ winW: 800 })).toBe(SIDE_PANEL_MIN_W)
+  })
+
+  it('promotes fill -> beside when the rail is collapsed, at the same window width', () => {
+    // 900 - 236 - 260 = 404 -> fill;  900 - 74 - 260 = 566 -> still fill
+    expect(fill({ winW: 900 })).toBe(404)
+    expect(fill({ winW: 900, railW: RAIL_COLLAPSED })).toBe(566)
+    // 980 - 74 - 260 = 646 >= 640 -> beside, where the expanded rail would not be
+    expect(fill({ winW: 980, railW: RAIL_COLLAPSED })).toBeUndefined()
+    expect(fill({ winW: 980 })).toBe(484)
+  })
+
+  it('promotes fill -> beside when the session sidebar is hidden', () => {
+    // 768 - 74 - 0 = 694 >= 640 -> beside (the user's stated case: both hidden)
+    expect(fill({ winW: 768, railW: RAIL_COLLAPSED, sidebarW: 0 })).toBeUndefined()
+    // same window, sidebar shown: 768 - 74 - 260 = 434 -> fill
+    expect(fill({ winW: 768, railW: RAIL_COLLAPSED })).toBe(434)
+  })
+
+  it('is exact at the boundary', () => {
+    const winW = THRESHOLD + RAIL_EXPANDED + SIDEBAR // remainder == 640
+    expect(fill({ winW })).toBeUndefined()
+    expect(fill({ winW: winW - 1 })).toBe(THRESHOLD - 1)
+  })
+
+  it('never returns a fill width below the panel minimum', () => {
+    // Absurdly cramped: the panel keeps its floor and overflows instead of
+    // collapsing to an unusable sliver.
+    expect(fill({ winW: 400 })).toBe(SIDE_PANEL_MIN_W)
+    expect(fill({ winW: 300, railW: 0, sidebarW: 0 })).toBe(SIDE_PANEL_MIN_W)
+  })
+
+  it('always fills on mobile regardless of the remainder', () => {
+    // A 700px phone-class viewport clears 640 on paper; mobile still fills,
+    // because SidePanel renders full-width there and the drawer is fixed.
+    expect(fill({ winW: 700, railW: 0, sidebarW: 0, isMobile: true })).toBe(700)
+    expect(fill({ winW: 390, railW: 0, sidebarW: 0, isMobile: true })).toBe(390)
+    // …but never below the panel floor.
+    expect(fill({ winW: 280, railW: 0, sidebarW: 0, isMobile: true })).toBe(SIDE_PANEL_MIN_W)
+  })
+})


### PR DESCRIPTION
## Summary

The session-header activity toggle was disabled on any window narrower than `320 + max(560, header content)` — 880px at baseline. The mobile escape hatch stops at 767px, so every viewport from **768 to 880** got a dead button reading *"Window too narrow for the activity panel"*. Tablet portrait is 768 wide, dead centre of that band.

The panel now has exactly two modes and no third disabled state:

- **BESIDE** — the panel sits beside the chat at its own width.
- **FILL** — the panel takes the whole chat column, squeezing the chat pane to zero. The nav rail and session sidebar stay exactly where they are.

The mode is decided from the width left for the **chat**, not from the viewport: `viewport − rail track − session sidebar`. If the remainder seats `SIDE_PANEL_MIN_W` beside `CHAT_PANE_MIN_W` (640px) the panel goes beside, otherwise it fills.

Hiding either piece of chrome therefore promotes fill to beside at an unchanged window width, which is the point:

| Viewport | Rail | Sidebar | Chat available | Mode |
|---|---|---|---|---|
| 1400 | 236 | 260 | 904 | beside (unchanged) |
| 768 | 236 | 260 | 272 | fill |
| 768 | 236 | hidden | 532 | fill |
| 768 | 74 | 260 | 434 | fill |
| 768 | 74 | hidden | 694 | **beside** |

## Design notes

**The measurement is loop-free.** Every input is a shell-level fact that does not change when the panel opens. Feeding it the chat container's *painted* width would oscillate, because opening the panel shrinks that width. For the same reason `railWidthFor` publishes the resolved track value (0 / 74 / 236) through a module store rather than measuring the rail element: the rail collapse is a 150ms grid transition, and a mid-animation `getBoundingClientRect()` would flip the gate twice per toggle. `App` now derives both the store value and the `gridTemplateColumns` track from that one helper so they cannot drift.

**Fill is an explicit px width, not a render-path switch.** The panel lives in the shell's `auto`-sized actbar grid column and has no flex parent to stretch into. Keeping the path fixed means crossing the threshold never remounts the panel, so live PTYs stay attached and Virtuoso does not churn. A test asserts the DOM node is identical across the transition.

**The auto-collapse state machine is gone.** It closed the panel on the way down and reopened it on the way up, with a ref pair and 40px of hysteresis to avoid fighting the user. Under a mode flip there is nothing to close, so the panel's open state is now the user's alone and a resize never changes it.

Mobile falls out of the same formula (rail 0, sidebar 0 because its drawer is fixed-position) but still forces fill, so a 700px phone-class viewport cannot reach beside mode. The resize handle is retired in fill mode — there is nothing to resize against, and leaving it would be a dead control.

## Testing

- New `sidePanelFillWidth` unit suite: the promotion cases (rail collapsed, sidebar hidden), the exact boundary, the panel floor under absurd cramping, and mobile.
- Four new `ChatPage` integration cases: beside on a wide window, fill when the chrome leaves too little, the beside-to-fill transition on resize, and that the transition does not remount the panel.
- The old auto-collapse / auto-reopen assertions invert into resize-independence.
- Gates: `npx tsc -b` clean, `npx eslint` 0 errors, `npx vitest run` 470 files / 5674 tests passing.
- Verified live in a real browser at the three interesting layouts: beside with the chrome hidden, fill with the sidebar open, and the panel closed.

## Blocked / not done

- No screenshots attached; the dashboard is auth-gated for the automation browser.
- `measureSidePanelReservedW`'s docstring claims the actbar column "shortens the header row too". The shell's `gridTemplateAreas` is `"topbar topbar topbar" / "nav content actbar"`, so the header spans all three columns and the panel never shortens it. The comment is stale, but the function is still used for the beside-mode width clamp, so it is left alone here.
