### PR TITLE
feat(skills): add browser-recording builtin skill

### DIFF
--- a/src/kiro_crew/builtin_skills/browser-recording/SKILL.md
+++ b/src/kiro_crew/builtin_skills/browser-recording/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: browser-recording
+description: Record a browser flow as a video/GIF for evidence — animations, transitions, and multi-step interactions that a still screenshot cannot prove. Drives the project's own Playwright through a bundled runner, then converts to mp4 + GIF via ffmpeg. Use when the user asks to record a demo, capture a GIF or video of the UI, or when a UI change involves motion or a sequence of steps.
+triggers: record, recording, screen recording, gif, record a video, video capture, demo video, record the flow, capture the animation
+---
+
+# Browser Recording — video/GIF evidence for UI flows
+
+A still frame cannot prove motion or sequence correctness. When a UI change
+involves **animation, transitions, or a multi-step flow** (wizard steps, a
+modal opening, drag interactions), record it. This skill is the *how* for the
+evidence rule in the `frontend-design-workflow` skill's Phase 3.
+
+## What it does
+
+`scripts/record_browser.py` drives a headless Chromium through the **target
+project's own Playwright install**, records the session as webm, and — when
+ffmpeg is available — converts it to mp4 and a palette-optimized GIF.
+
+```
+python3 <skill-dir>/scripts/record_browser.py \
+  --url http://127.0.0.1:5173/settings \
+  --scenario /tmp/demo-scenario.mjs \
+  --project /path/to/frontend \
+  --size 1280x800 --name settings-flow --out /tmp/rec
+```
+
+Last lines of stdout are machine-readable:
+
+```
+WEBM /tmp/rec/settings-flow.webm
+MP4 /tmp/rec/settings-flow.mp4
+GIF /tmp/rec/settings-flow.gif
+```
+
+## Workflow
+
+1. **Get the UI reachable at a URL.** A dev server, a preview build behind a
+   static server, or any live page. Starting the server is not this skill's
+   job — use the project's normal dev loop (and the `web-preview` skill to
+   surface it to the user).
+2. **Author the scenario** — a small `.mjs` module you write per task:
+
+   ```js
+   export default async (page) => {
+     await page.click('text=Open settings')
+     await page.waitForSelector('[role="dialog"]')   // wait on state
+     await page.click('text=Notifications')
+     await page.waitForTimeout(400)                  // let the transition play
+   }
+   ```
+
+   Rules: one flow per recording; wait on selectors/state, not bare
+   timeouts (except to let a transition visibly finish); keep it under
+   ~30 seconds of wall time.
+3. **Run the recorder** (command above). `--project` must point at a
+   directory whose `node_modules` has Playwright with Chromium installed.
+4. **Look at the result** before presenting: read the GIF/mp4 (or key frames)
+   to confirm the flow actually shows what you claim.
+5. **Deliver**: embed the GIF in chat with `![what it shows](/abs/path.gif)`;
+   for PRs follow the repository's screenshot-embedding convention (in this
+   repo: commit under `.github/screenshots/<feature>/`, embed with
+   commit-SHA-pinned `github.com/<owner>/<repo>/raw/<sha>/...` URLs). Attach
+   the mp4 as a file when higher fidelity matters.
+
+## Dependencies (probe-first, never auto-installed)
+
+| Dependency | Required? | If missing |
+|---|---|---|
+| Node.js | yes | script fails with install pointer |
+| Playwright in the target project | yes | script fails with `npm i -D playwright && npx playwright install chromium` |
+| ffmpeg | no | webm still produced; mp4/gif skipped with a note (macOS: `brew install ffmpeg`) |
+
+If the project has no Playwright and adding it is not acceptable, fall back
+to a screenshot sequence and say explicitly that motion could not be captured.
+
+## When NOT to use
+
+- Static changes — a screenshot is cheaper and clearer (`web-verify` skill).
+- Live interactive browsing for the user — that is the Browser panel /
+  `web-browse` path, not an offline recording.

--- a/src/kiro_crew/builtin_skills/browser-recording/scripts/driver.mjs
+++ b/src/kiro_crew/builtin_skills/browser-recording/scripts/driver.mjs
@@ -1,0 +1,77 @@
+// Playwright recording driver for the browser-recording skill.
+//
+// Invoked by record_browser.py — do not run directly (the Python wrapper
+// resolves Playwright, validates arguments, and owns ffmpeg conversion).
+//
+// Contract (all via a single JSON config file, argv[2]):
+//   {
+//     "url": "http://127.0.0.1:5173/...",   // page to open
+//     "scenarioPath": "/abs/path/scenario.mjs" | null,
+//     "outDir": "/abs/path",                 // recordVideo dir
+//     "width": 1280, "height": 800,
+//     "settleMs": 600,                       // wait after load before scenario
+//     "tailMs": 400                          // wait after scenario before close
+//   }
+//
+// The scenario module is authored per task by the agent:
+//   export default async (page) => { ...clicks, waits, assertions... }
+// It receives the live Playwright Page. Keep it deterministic: wait on
+// selectors/state, not bare timeouts, wherever possible.
+//
+// Prints exactly one line to stdout on success: RECORDED <webm-path>
+// Exits non-zero with a stderr message on failure.
+
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+const cfg = JSON.parse(readFileSync(process.argv[2], 'utf8'))
+
+// Resolve playwright from the scenario's project first (its node_modules is
+// where the browsers were installed), then from cwd.
+const requireFrom = createRequire(
+  (cfg.scenarioPath || process.cwd() + '/') // a file path anchors resolution
+)
+let chromium
+try {
+  ;({ chromium } = requireFrom('playwright'))
+} catch {
+  try {
+    ;({ chromium } = createRequire(process.cwd() + '/')('playwright'))
+  } catch {
+    console.error(
+      'playwright not resolvable from the project. Install it in the project ' +
+        'first: npm i -D playwright && npx playwright install chromium'
+    )
+    process.exit(3)
+  }
+}
+
+const browser = await chromium.launch()
+try {
+  const context = await browser.newContext({
+    viewport: { width: cfg.width, height: cfg.height },
+    recordVideo: { dir: cfg.outDir, size: { width: cfg.width, height: cfg.height } },
+  })
+  const page = await context.newPage()
+  await page.goto(cfg.url, { waitUntil: 'load' })
+  await page.waitForTimeout(cfg.settleMs)
+
+  if (cfg.scenarioPath) {
+    const mod = await import(pathToFileURL(cfg.scenarioPath).href)
+    if (typeof mod.default !== 'function') {
+      console.error('scenario module must default-export an async (page) => {} function')
+      process.exit(4)
+    }
+    await mod.default(page)
+  }
+
+  await page.waitForTimeout(cfg.tailMs)
+  const video = page.video()
+  await page.close() // flush
+  await context.close()
+  const webm = await video.path()
+  console.log(`RECORDED ${webm}`)
+} finally {
+  await browser.close()
+}

--- a/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
+++ b/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Record a browser flow as webm (+ mp4/gif when ffmpeg is available).
+
+Entry point for the browser-recording skill. Owns dependency probing,
+argument validation, and post-processing; delegates the actual Playwright
+session to the sibling ``driver.mjs`` (Playwright's recording API is only
+exposed to its JS package, which is the copy frontend projects already have).
+
+Usage:
+    python3 record_browser.py --url URL [--scenario FILE.mjs]
+        [--project DIR] [--size 1280x800] [--out DIR] [--name BASENAME]
+        [--settle-ms 600] [--tail-ms 400]
+
+Outputs (printed one per line at the end, machine-readable):
+    WEBM <path>      always
+    MP4 <path>       when ffmpeg is present
+    GIF <path>       when ffmpeg is present
+
+Design notes:
+- Probe-first, fail-loud: node and project-local Playwright are required and
+  reported with exact remediation commands; nothing is auto-installed.
+- ffmpeg is optional: the webm is the evidence, mp4/gif are conveniences.
+- The GIF uses a two-pass palette encode (fps=12, width<=800) — the settled
+  recipe for crisp UI recordings at reasonable size.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import NoReturn
+
+_SIZE_RE = re.compile(r"^(\d{2,5})x(\d{2,5})$")
+_URL_RE = re.compile(r"^https?://", re.IGNORECASE)
+
+DRIVER = Path(__file__).with_name("driver.mjs")
+
+
+def _fail(msg: str, code: int = 2) -> NoReturn:
+    print(f"error: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _probe_node() -> str:
+    node = shutil.which("node")
+    if not node:
+        _fail(
+            "node not found on PATH. Install Node.js (https://nodejs.org) — the "
+            "recording driver runs on the project's own Playwright package."
+        )
+    return node
+
+
+def _probe_playwright(project: Path) -> None:
+    """Require playwright resolvable from the project directory (fail loud)."""
+    if not (project / "node_modules" / "playwright").is_dir() and not (
+        project / "node_modules" / "playwright-core"
+    ).is_dir():
+        _fail(
+            f"playwright is not installed under {project}/node_modules. "
+            "Install it in the project first:\n"
+            "  npm i -D playwright && npx playwright install chromium\n"
+            "(this skill never installs packages on its own)"
+        )
+
+
+def _ffmpeg() -> str | None:
+    return shutil.which("ffmpeg")
+
+
+def _convert(ffmpeg: str, webm: Path, out_dir: Path, name: str) -> tuple[Path, Path]:
+    mp4 = out_dir / f"{name}.mp4"
+    gif = out_dir / f"{name}.gif"
+    subprocess.run(
+        [ffmpeg, "-y", "-loglevel", "error", "-i", str(webm),
+         "-c:v", "libx264", "-pix_fmt", "yuv420p", "-movflags", "+faststart",
+         str(mp4)],
+        check=True,
+    )
+    # Two-pass palette GIF: sharp text, bounded size.
+    with tempfile.TemporaryDirectory() as td:
+        palette = Path(td) / "palette.png"
+        filters = "fps=12,scale='min(800,iw)':-1:flags=lanczos"
+        subprocess.run(
+            [ffmpeg, "-y", "-loglevel", "error", "-i", str(webm),
+             "-vf", f"{filters},palettegen", str(palette)],
+            check=True,
+        )
+        subprocess.run(
+            [ffmpeg, "-y", "-loglevel", "error", "-i", str(webm), "-i", str(palette),
+             "-lavfi", f"{filters} [x]; [x][1:v] paletteuse", str(gif)],
+            check=True,
+        )
+    return mp4, gif
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--url", required=True, help="page to open (http/https)")
+    ap.add_argument("--scenario", help="path to scenario .mjs (default export async (page)=>{})")
+    ap.add_argument("--project", help="frontend project dir whose Playwright install to use "
+                                      "(default: scenario's dir, else cwd)")
+    ap.add_argument("--size", default="1280x800", help="viewport WxH (default 1280x800)")
+    ap.add_argument("--out", help="output dir (default: a fresh temp dir)")
+    ap.add_argument("--name", default="recording", help="output basename (default: recording)")
+    ap.add_argument("--settle-ms", type=int, default=600, help="wait after load before scenario")
+    ap.add_argument("--tail-ms", type=int, default=400, help="wait after scenario before close")
+    args = ap.parse_args(argv)
+
+    if not _URL_RE.match(args.url):
+        _fail("--url must be http(s)://")
+    m = _SIZE_RE.match(args.size)
+    if not m:
+        _fail("--size must look like 1280x800")
+    width, height = int(m.group(1)), int(m.group(2))
+
+    scenario: Path | None = None
+    if args.scenario:
+        scenario = Path(args.scenario).resolve()
+        if not scenario.is_file():
+            _fail(f"scenario not found: {scenario}")
+        if scenario.suffix != ".mjs":
+            _fail("scenario must be an .mjs ES module (default export async (page) => {})")
+
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", args.name):
+        _fail("--name must be a plain filename fragment (letters, digits, . _ -)")
+
+    project = Path(args.project).resolve() if args.project else (
+        scenario.parent if scenario else Path.cwd()
+    )
+    node = _probe_node()
+    _probe_playwright(project)
+
+    out_dir = Path(args.out).resolve() if args.out else Path(tempfile.mkdtemp(prefix="browser-rec-"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = {
+        "url": args.url,
+        "scenarioPath": str(scenario) if scenario else None,
+        "outDir": str(out_dir),
+        "width": width,
+        "height": height,
+        "settleMs": args.settle_ms,
+        "tailMs": args.tail_ms,
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(cfg, f)
+        cfg_path = f.name
+
+    proc = subprocess.run(
+        [node, str(DRIVER), cfg_path],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        _fail(f"driver failed (exit {proc.returncode})", proc.returncode)
+
+    # Scenario code (and the page itself) can print to stdout, so the RECORDED
+    # marker is spoofable. Two containments: take the LAST marker line (ours is
+    # printed after the scenario finished), and refuse any path that does not
+    # resolve inside out_dir — a forged line pointing elsewhere must never
+    # become the source of a shutil.move.
+    webm_line = next(
+        (ln for ln in reversed(proc.stdout.splitlines()) if ln.startswith("RECORDED ")),
+        None,
+    )
+    if not webm_line:
+        _fail("driver produced no RECORDED line — no video was flushed")
+    webm_src = Path(webm_line.split(" ", 1)[1]).resolve()
+    try:
+        webm_src.relative_to(out_dir)
+    except ValueError:
+        _fail(f"driver reported a video outside the output dir (spoofed?): {webm_src}")
+    if not webm_src.is_file():
+        _fail(f"driver reported a video that does not exist: {webm_src}")
+
+    # Playwright names the file with a random hash — give it the asked-for name.
+    webm = out_dir / f"{args.name}.webm"
+    if webm_src != webm:
+        shutil.move(str(webm_src), str(webm))
+
+    print(f"WEBM {webm}")
+    ffmpeg = _ffmpeg()
+    if ffmpeg:
+        try:
+            mp4, gif = _convert(ffmpeg, webm, out_dir, args.name)
+            print(f"MP4 {mp4}")
+            print(f"GIF {gif}")
+        except subprocess.CalledProcessError as exc:
+            print(f"note: ffmpeg conversion failed ({exc}); webm is still valid",
+                  file=sys.stderr)
+    else:
+        print("note: ffmpeg not found — emitted webm only. Install ffmpeg for "
+              "mp4/gif (macOS: brew install ffmpeg).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_browser_recording_skill.py
+++ b/test/test_browser_recording_skill.py
@@ -1,0 +1,207 @@
+"""The browser-recording skill must stay wired and fail loud.
+
+Locks three joints: (1) the SKILL.md is discoverable and cross-references the
+frontend-design-workflow evidence rule it implements, (2) the runner rejects
+bad input before touching node/playwright, (3) the probe-first dependency
+contract (nothing auto-installed, ffmpeg optional) survives edits.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = ROOT / "src" / "kiro_crew" / "builtin_skills" / "browser-recording"
+SKILL = SKILL_DIR / "SKILL.md"
+RUNNER = SKILL_DIR / "scripts" / "record_browser.py"
+DRIVER = SKILL_DIR / "scripts" / "driver.mjs"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("record_browser", RUNNER)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestSkillDoc:
+    def test_exists_with_frontmatter(self) -> None:
+        body = SKILL.read_text(encoding="utf-8")
+        assert body.startswith("---\n"), "skill needs YAML frontmatter to be discoverable"
+        assert "name: browser-recording" in body
+        assert "triggers:" in body
+
+    def test_frontmatter_is_single_line_values(self) -> None:
+        """The simple key:value parser cannot read multi-line YAML values."""
+        body = SKILL.read_text(encoding="utf-8")
+        header = body.split("---", 2)[1]
+        for line in header.strip().splitlines():
+            assert ":" in line, f"frontmatter line is not key:value — {line!r}"
+
+    def test_cross_references_evidence_rule(self) -> None:
+        """This skill is the HOW for frontend-design-workflow's evidence rule."""
+        body = SKILL.read_text(encoding="utf-8")
+        assert "frontend-design-workflow" in body
+        assert "screenshot" in body.lower()
+
+    def test_dependency_contract_documented(self) -> None:
+        body = SKILL.read_text(encoding="utf-8")
+        assert "never auto-installed" in body
+        assert "npx playwright install chromium" in body
+        assert "ffmpeg" in body
+
+    def test_driver_and_runner_ship_together(self) -> None:
+        assert RUNNER.is_file()
+        assert DRIVER.is_file()
+        # The runner locates the driver as a sibling — keep that invariant.
+        assert 'with_name("driver.mjs")' in RUNNER.read_text(encoding="utf-8")
+
+
+class TestRunnerValidation:
+    """Bad input must die before any node/playwright/ffmpeg probing."""
+
+    def _run(self, *argv: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(RUNNER), *argv], capture_output=True, text=True
+        )
+
+    def test_rejects_non_http_url(self) -> None:
+        p = self._run("--url", "file:///etc/hosts")
+        assert p.returncode != 0
+        assert "http(s)" in p.stderr
+
+    def test_rejects_bad_size(self) -> None:
+        p = self._run("--url", "http://127.0.0.1:1/", "--size", "huge")
+        assert p.returncode != 0
+        assert "1280x800" in p.stderr
+
+    def test_rejects_missing_scenario(self) -> None:
+        p = self._run("--url", "http://127.0.0.1:1/", "--scenario", "/nonexistent/s.mjs")
+        assert p.returncode != 0
+        assert "not found" in p.stderr
+
+    def test_rejects_non_mjs_scenario(self, tmp_path: Path) -> None:
+        s = tmp_path / "scenario.js"
+        s.write_text("export default async () => {}\n")
+        p = self._run("--url", "http://127.0.0.1:1/", "--scenario", str(s))
+        assert p.returncode != 0
+        assert ".mjs" in p.stderr
+
+    def test_rejects_traversal_name(self) -> None:
+        p = self._run("--url", "http://127.0.0.1:1/", "--name", "../../evil")
+        assert p.returncode != 0
+        assert "plain filename" in p.stderr
+
+    def test_missing_playwright_fails_loud_without_install(self, tmp_path: Path) -> None:
+        """Empty project dir → precise remediation message, no auto-install."""
+        p = self._run(
+            "--url", "http://127.0.0.1:1/", "--project", str(tmp_path)
+        )
+        assert p.returncode != 0
+        assert "npm i -D playwright" in p.stderr
+        # Fail-loud means nothing was created in the project.
+        assert not (tmp_path / "node_modules").exists()
+
+
+class TestRecordedLineContainment:
+    """A forged RECORDED line must never make the runner move a host file.
+
+    Locks the fix for the GPT round-1 blocking finding: scenario/page output
+    is forwarded to stdout, so the marker is attacker-influenceable. The
+    runner must (a) take the LAST marker line, (b) reject paths that resolve
+    outside --out.
+    """
+
+    def _main_with_driver_stdout(self, stdout: str, out_dir: Path, monkeypatch) -> None:
+        mod = _load_runner()
+        monkeypatch.setattr(mod, "_probe_node", lambda: "node")
+        monkeypatch.setattr(mod, "_probe_playwright", lambda project: None)
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: fake)
+        mod.main(["--url", "http://127.0.0.1:1/", "--out", str(out_dir), "--name", "x"])
+
+    def test_forged_outside_path_rejected(self, tmp_path: Path, monkeypatch) -> None:
+        victim = tmp_path / "victim.txt"
+        victim.write_text("do not move me")
+        with pytest.raises(SystemExit):
+            self._main_with_driver_stdout(
+                f"RECORDED {victim}\n", tmp_path / "out", monkeypatch
+            )
+        assert victim.is_file(), "runner must not touch a path outside --out"
+
+    def test_last_marker_wins(self, tmp_path: Path, monkeypatch) -> None:
+        """A scenario-forged early marker is ignored in favor of the driver's."""
+        out = tmp_path / "out"
+        out.mkdir()
+        real = out / "realvideo.webm"
+        real.write_bytes(b"webm")
+        forged = tmp_path / "forged.webm"
+        forged.write_bytes(b"evil")
+        monkeypatch.setattr("shutil.which", lambda name: None)  # skip ffmpeg
+        self._main_with_driver_stdout(
+            f"RECORDED {forged}\nRECORDED {real}\n", out, monkeypatch
+        )
+        assert (out / "x.webm").is_file(), "driver's (last) marker must be used"
+        assert forged.is_file(), "forged path must be untouched"
+
+
+class TestConversionRecipe:
+    """Pin the ffmpeg recipe constants so quality does not silently drift."""
+
+    def test_mp4_and_gif_flags(self) -> None:
+        src = RUNNER.read_text(encoding="utf-8")
+        for token in ("libx264", "yuv420p", "+faststart", "palettegen", "paletteuse", "fps=12"):
+            assert token in src, f"ffmpeg recipe lost {token!r}"
+
+    def test_ffmpeg_absent_is_nonfatal(self) -> None:
+        mod = _load_runner()
+        assert mod._ffmpeg() is None or isinstance(mod._ffmpeg(), str)
+        src = RUNNER.read_text(encoding="utf-8")
+        assert "webm only" in src, "ffmpeg-absent path must still deliver the webm"
+
+
+@pytest.mark.skipif(
+    not (ROOT / "website" / "node_modules" / "playwright").is_dir(),
+    reason="project-local playwright not installed",
+)
+class TestEndToEnd:
+    """Real recording against a local page when the environment allows it."""
+
+    def test_records_a_webm(self, tmp_path: Path) -> None:
+        import http.server
+        import threading
+
+        page = tmp_path / "index.html"
+        page.write_text("<html><body><h1 id='t'>hello</h1></body></html>")
+        httpd = http.server.HTTPServer(
+            ("127.0.0.1", 0),
+            lambda *a, **kw: http.server.SimpleHTTPRequestHandler(
+                *a, directory=str(tmp_path), **kw
+            ),
+        )
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        try:
+            out = tmp_path / "out"
+            p = subprocess.run(
+                [
+                    sys.executable, str(RUNNER),
+                    "--url", f"http://127.0.0.1:{httpd.server_port}/",
+                    "--project", str(ROOT / "website"),
+                    "--out", str(out), "--name", "e2e", "--size", "640x480",
+                    "--settle-ms", "200", "--tail-ms", "200",
+                ],
+                capture_output=True, text=True, timeout=300,
+            )
+            if p.returncode != 0 and "Executable doesn't exist" in p.stderr:
+                pytest.skip("playwright package present but chromium binaries not installed")
+            assert p.returncode == 0, p.stderr
+            assert (out / "e2e.webm").is_file()
+            assert (out / "e2e.webm").stat().st_size > 0
+        finally:
+            httpd.shutdown()


### PR DESCRIPTION
## Problem

The frontend-design-workflow skill (merged in #679) requires recordings — not screenshots — as evidence for animations, transitions, and multi-step UI flows. But there is no mechanism behind that rule: every past recording (PR #590 drill-in, chip-badge demo) hand-wired `recordVideo:` into a one-off capture harness and re-typed the ffmpeg conversion from memory.

## Why it matters

Evidence rules that are expensive to follow get skipped. Without a standard recorder, agents (ours and every user's) either submit still frames for motion changes — which cannot prove sequence correctness — or burn a session rebuilding the same Playwright + ffmpeg plumbing.

## Fix (symptoms → root cause → change)

Root cause: the recording capability lives as folklore (memory of past sessions) instead of a shipped tool. This PR adds a `browser-recording` builtin skill:

- `scripts/record_browser.py` (stdlib-only entry point): validates input, probes dependencies fail-loud (Node, project-local Playwright — nothing is ever auto-installed), dispatches the driver, converts webm → mp4 (`libx264/yuv420p/+faststart`) + palette GIF (`fps=12`, two-pass palettegen) when ffmpeg exists, degrades to webm-only when it does not.
- `scripts/driver.mjs`: owns the Playwright session — resolves the *target project's* own playwright package, records via `recordVideo:` context, imports a per-task scenario module (`export default async (page) => {...}`), handles the flush-on-close gotcha once.
- `SKILL.md`: when to record vs screenshot, scenario-authoring rules (deterministic waits, one flow per recording), delivery conventions, dependency table. Cross-references frontend-design-workflow Phase 3 as the rule it implements.

Ships via the existing `builtin_skills/**/*` packaging glob and `_ensure_builtin_skills` sync — no code changes.

## Tests

`test/test_browser_recording_skill.py` (14 tests): doc invariants (frontmatter parseable by the simple key:value parser, cross-reference to the evidence rule, dependency contract), runner input rejection (non-http URL, bad size, missing/non-mjs scenario, path-traversal name), fail-loud playwright probe that provably installs nothing, ffmpeg recipe constant pins, and an opt-in E2E (auto-skips when playwright package or chromium binaries are absent). Full skills suites pass (133 passed alongside existing skill tests).

## Manual verification

Ran the recorder end to end against a real animated test page (CSS transform + fade sequence) served on loopback: scenario clicked the trigger, waited on the state selector, and the pipeline produced valid webm (71KB), mp4 (37KB), and GIF (162KB) — GIF visually verified to show the full flow. Also verified the ffmpeg-absent note path and every rejection message by direct invocation.

## Screenshots

N/A — no UI surface modified (bundled skill: markdown + scripts). The recorded demo GIF from verification is the functional proof; it is environment-specific output, not a UI change.
