### PR TITLE
feat(desktop): Migrate mac + Linux auto-update to electron-updater

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,9 +15,9 @@ permissions:
   contents: read
 
 # Single-flight nightly runs. cancel-in-progress also protects the channel
-# feed (feed/nightly/latest-mac.json, last-writer-wins): an overlapping
-# older run is cancelled rather than finishing last and rolling the feed
-# back to an older build for every client.
+# feeds (feed/nightly/latest-mac.yml + latest-linux.yml, last-writer-wins):
+# an overlapping older run is cancelled rather than finishing last and
+# rolling a feed back to an older build for every client.
 concurrency:
   group: nightly-build
   cancel-in-progress: true

--- a/.github/workflows/ota-test.yml
+++ b/.github/workflows/ota-test.yml
@@ -1,0 +1,178 @@
+# End-to-end macOS auto-update (OTA) verification.
+#
+# WHY THIS EXISTS: the electron unit suite stops at the autoUpdater handoff --
+# it proves we call the library correctly, never that a real app bundle gets
+# replaced on disk and relaunches at the new version. That gap has bitten this
+# repo before in the analogous case: notarization passed CI and Gatekeeper
+# still rejected the artifact. This job closes it by building two real apps and
+# performing an actual swap.
+#
+# WHY IT IS NOT ON EVERY PR: it packages two Electron apps, launches a GUI app,
+# and depends on a real quit/relaunch cycle, so it is inherently slower and
+# flakier than a unit test. It runs nightly and on demand; a failure here is a
+# signal to investigate, not an automatic merge block.
+#
+# WHAT IT DOES *NOT* PROVE: the apps are ad-hoc signed (no Developer ID needed,
+# so this job requires no secrets). That validates the SWAP MECHANISM, not
+# Gatekeeper acceptance or notarization -- those are separate questions covered
+# by the signing lane.
+#
+# HOW THE CONSENT GATE IS DRIVEN: the updater is deliberately consent-first
+# (autoDownload=false), so a human normally clicks Download then
+# Restart & Update. Rather than add a test-only auto-consent hook to shipped
+# code, scripts/ota-drive.js attaches to the REAL renderer over the Chrome
+# DevTools Protocol and calls the same preload API the buttons call
+# (window.updateAPI.download / .install). The exercised code path is identical
+# to the user's.
+name: OTA Update Test (macOS)
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    # Nightly, offset from the release nightly so they do not contend.
+    - cron: "40 8 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ota-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ota:
+    name: Build two versions and prove the swap
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      PORT: "8799"
+      OUT: "/tmp/kirocrew-ota"
+      INSTALLED_VER: "1.0.0"
+      UPDATE_VER: "1.0.1"
+      CDP_PORT: "9222"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The app only reaches initAutoUpdate after its gateway connects, and
+      # find-bin.js falls back to a PATH `kirocrew`. Installing the package is
+      # cheaper and less brittle than building the PyInstaller bundle, and the
+      # script stubs an empty backend-dist so electron-builder's extraResources
+      # does not fail on a missing source dir.
+      - name: Install the gateway on PATH
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+          command -v kirocrew
+          kirocrew --version || true
+
+      - name: Install electron dependencies
+        working-directory: website/electron
+        run: npm ci
+
+      # Fail loudly if the updater surface regressed before spending 20 minutes
+      # on packaging -- a cheap gate in front of an expensive one.
+      - name: Unit suite (fast gate)
+        working-directory: website/electron
+        run: npm test
+
+      - name: Build both versions (ad-hoc signed)
+        working-directory: website/electron
+        env:
+          BUILD_ONLY: "1"
+        run: |
+          set -euo pipefail
+          ./scripts/stage3-autoupdate-test.sh | tee /tmp/ota-build.log
+          # Export the paths the script reported so later steps do not re-derive
+          # them (and so a naming change fails here, visibly, not silently).
+          grep -E '^(INSTALLED_APP|INSTALLED_BIN|UPDATE_ZIP)=' /tmp/ota-build.log >> "$GITHUB_ENV"
+
+      - name: Assert the built versions are what we think they are
+        run: |
+          set -euo pipefail
+          got=$(defaults read "$INSTALLED_APP/Contents/Info" CFBundleShortVersionString)
+          echo "installed app reports: $got"
+          [ "$got" = "$INSTALLED_VER" ] || { echo "expected $INSTALLED_VER"; exit 1; }
+          test -f "$UPDATE_ZIP"
+
+      - name: Start the local update feed
+        working-directory: website/electron
+        run: |
+          set -euo pipefail
+          nohup node scripts/local-feed-server.js \
+            --port "$PORT" --zip "$UPDATE_ZIP" --version "$UPDATE_VER" \
+            > /tmp/ota-feed.log 2>&1 &
+          for i in $(seq 1 20); do
+            if curl -fsS "http://127.0.0.1:${PORT}/feed/stable/latest-mac.yml" >/dev/null; then
+              echo "feed up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "feed did not come up"; cat /tmp/ota-feed.log; exit 1
+
+      - name: Launch the installed app with remote debugging
+        run: |
+          set -euo pipefail
+          KIROCREW_UPDATE_FEED="http://127.0.0.1:${PORT}/feed" \
+          KIROCREW_FLAVOR=beta \
+          KIROCREW_HOME="${OUT}/home" \
+          nohup "$INSTALLED_BIN" --remote-debugging-port="${CDP_PORT}" \
+            > /tmp/ota-app.log 2>&1 &
+          for i in $(seq 1 40); do
+            if curl -fsS "http://127.0.0.1:${CDP_PORT}/json/version" >/dev/null; then
+              echo "devtools up"; exit 0
+            fi
+            sleep 2
+          done
+          echo "app never exposed devtools"; cat /tmp/ota-app.log; exit 1
+
+      # discovery -> consent -> download -> install dispatch, over CDP.
+      - name: Drive the update (unattended consent)
+        working-directory: website/electron
+        run: node scripts/ota-drive.js --cdp "${CDP_PORT}" --expect "$UPDATE_VER" --timeout 300
+
+      # THE ACTUAL ASSERTION. Everything above proves the updater was driven;
+      # only this proves the bundle on disk was replaced. "install dispatched"
+      # is NOT success -- the swap happens asynchronously after the app quits,
+      # so poll for the version to flip.
+      - name: Assert the bundle actually swapped
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            got=$(defaults read "$INSTALLED_APP/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "")
+            if [ "$got" = "$UPDATE_VER" ]; then
+              echo "SWAP CONFIRMED: bundle now reports $got"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "SWAP FAILED: bundle still reports '${got:-unknown}', expected $UPDATE_VER"
+          echo "--- app log ---"; cat /tmp/ota-app.log || true
+          echo "--- feed log ---"; cat /tmp/ota-feed.log || true
+          exit 1
+
+      - name: Confirm the swapped app is signed and launchable
+        run: |
+          set -euo pipefail
+          codesign --verify --deep --strict "$INSTALLED_APP" && echo "signature intact after swap"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ota-logs
+          path: |
+            /tmp/ota-build.log
+            /tmp/ota-app.log
+            /tmp/ota-feed.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -28,10 +28,12 @@ name: Publish Linux Desktop (reusable)
 #   - Arch-qualified filename: Linux has no universal binary, so per-arch
 #     filenames are the contract (per-arch, never per-distro). A future
 #     arm64 lane publishes KiroCrew-aarch64.AppImage beside this one.
-#   - Deliberately no feed/<channel>/latest-linux.json yet: the AppImage
-#     has no auto-updater consuming a feed, so the only pointer a human or
-#     a download button needs is the latest alias. The feed lands together
-#     with the Linux updater work.
+#   - Writes feed/<channel>/latest-linux.yml (electron-updater channel
+#     metadata) AFTER the versioned AppImage is live and BEFORE the latest
+#     alias, mirroring the mac lane's go-live order: a feed must never
+#     advertise bytes that are not downloadable yet, and the convenience
+#     alias must never point ahead of the go-live switch. This is what
+#     gives the Linux desktop an auto-updater for the first time.
 
 on:
   workflow_call:
@@ -177,11 +179,77 @@ jobs:
           echo "APPIMAGE_KEY=${APPIMAGE_KEY}" >> "$GITHUB_ENV"
           echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
 
+      # electron-updater channel metadata (latest-linux.yml) -- the feed
+      # website/electron/auto-update.js reads on Linux. Written only after
+      # the versioned AppImage above is publicly downloadable (and after
+      # the 412 path verified identical bytes on a re-run), and BEFORE the
+      # latest alias, mirroring the mac lane's go-live order: the feed is
+      # the updater's go-live switch, the alias is a convenience that must
+      # never point ahead of it. Mutable key, served no-cache by the
+      # feed/* CloudFront behavior (the explicit header keeps downstream
+      # caches honest). Out-of-order overwrites are prevented by the
+      # caller workflows' per-channel concurrency groups.
+      #
+      # Two properties are load-bearing (see test_publish_feed_contract.py):
+      #   - sha512 is BASE64 of the raw digest (openssl -binary | base64),
+      #     never hex: electron-updater string-compares base64; a hex value
+      #     makes every download fail checksum verification.
+      #   - files[].url is an ABSOLUTE byte-host url (CLI_CDN_BASE =
+      #     download.crew.kiro.dev). The yml itself lives on the POINTER
+      #     host (updates.crew.kiro.dev/feed/...); electron-updater's
+      #     newUrlFromBase does `new URL(fileUrl, base)`, which ignores the
+      #     base for absolute urls -- that is what preserves the
+      #     pointer/bytes host split. A bare filename here would resolve
+      #     against feed/<channel>/ and 404.
+      # Filename is arch-coupled on Linux: electron-updater resolves
+      # latest-linux.yml for x64 and latest-linux-<arch>.yml otherwise, so
+      # a future arm64 lane writes latest-linux-arm64.yml beside this one.
+      - name: Write update feed
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          APPIMAGE_SHA512=$(openssl dgst -sha512 -binary "${APPIMAGE_PATH}" | base64 -w 0)
+          APPIMAGE_SIZE=$(stat -c%s "${APPIMAGE_PATH}")
+
+          # FAIL CLOSED if the feed would describe bytes other than the ones
+          # served. The versioned AppImage key is conditionally written and a
+          # PreconditionFailed is tolerated on re-run, so a same-version rebuild
+          # with different bytes would leave the OLD object published while this
+          # digest describes the NEW local build. electron-updater verifies
+          # sha512 fail-closed, so every Linux client would refuse to install.
+          # Aborting is correct: republishing an immutable key causes edge
+          # divergence (#62) -- cut a new version instead.
+          SERVED_SHA512=$(curl -fsS --retry 3 --retry-delay 2 \
+            "${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}" | openssl dgst -sha512 -binary | base64 -w 0)
+          if [ "$SERVED_SHA512" != "$APPIMAGE_SHA512" ]; then
+            echo "::error::published AppImage does not match the artifact this feed would advertise."
+            echo "::error::  expected sha512 (local build): $APPIMAGE_SHA512"
+            echo "::error::  served   sha512 (published):   $SERVED_SHA512"
+            exit 1
+          fi
+          echo "Verified published AppImage matches the feed digest."
+          cat > /tmp/latest-linux.yml <<EOF
+          version: ${VERSION}
+          files:
+            - url: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}
+              sha512: '${APPIMAGE_SHA512}'
+              size: ${APPIMAGE_SIZE}
+          path: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}
+          sha512: '${APPIMAGE_SHA512}'
+          releaseDate: '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
+          EOF
+          aws s3 cp /tmp/latest-linux.yml \
+            "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-linux.yml" \
+            --content-type text/yaml \
+            --cache-control "public, max-age=300"
+          echo "Feed written: feed/${CHANNEL}/latest-linux.yml -> ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+
       # Human-clickable permalink to the current AppImage:
       #   <CDN>/desktop/<channel>/latest/KiroCrew-x86_64.AppImage
       # Same mutable-alias semantics as the latest-DMG alias: plain
-      # overwrite, max-age=300, written AFTER the versioned key so it never
-      # points at bytes that are not yet live.
+      # overwrite, max-age=300, written AFTER the versioned key and the
+      # feed so it never points at bytes that are not yet live nor ahead
+      # of the go-live switch.
       - name: Update latest AppImage alias
         if: env.HAS_SIGNING_SECRETS
         run: |
@@ -203,5 +271,6 @@ jobs:
             echo "## Publish Linux (${CHANNEL})"
             echo "- Version: ${VERSION}"
             echo "- Public AppImage: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+            echo "- Feed: \`feed/${CHANNEL}/latest-linux.yml\`"
             echo "- Latest AppImage alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_APPIMAGE_KEY}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -70,7 +70,7 @@ on:
         required: true
         type: string
       write_feed:
-        description: "Publish to the distribution bucket and write feed/<channel>/latest-mac.json"
+        description: "Publish to the distribution bucket and write feed/<channel>/latest-mac.yml"
         required: false
         type: boolean
         default: true
@@ -563,9 +563,9 @@ jobs:
           echo "DMG_KEY=${DMG_KEY}" >> "$GITHUB_ENV"
           echo "Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
 
-      # Feed points at the NOTARIZED artifact on the CDN -- written only
+      # Feed points at the NOTARIZED artifacts on the CDN -- written only
       # after the spctl gate passed (this job's sole input is the gated
-      # artifact) and only after the artifact is publicly downloadable
+      # artifact) and only after the artifacts are publicly downloadable
       # (feed-before-artifact would hand clients a 403/404). The feed key is
       # mutable, so overwriting is safe -- but ONLY because the object itself
       # carries an explicit Cache-Control (set below). The feed/* CloudFront
@@ -576,23 +576,152 @@ jobs:
       # injects one either. A feed written without it therefore reaches
       # clients with no freshness metadata at all, and CFNetwork applies
       # HEURISTIC caching (~10% of the object's age, so a day-old feed earns
-      # itself hours of "fresh"). Squirrel.Mac's feed request goes through
-      # NSURLCache, so a header-less feed made the desktop app re-resolve a
-      # stale entry for hours -- offering to "update" to the version already
-      # installed while the app's own (cacheless) fetch saw the new one.
+      # itself hours of "fresh"). That is the #709 incident: a header-less
+      # feed made the desktop app re-resolve a stale entry for hours,
+      # offering to "update" to the version already installed.
+      #
+      # NOTE ON WHAT CHANGED: that incident was specifically Squirrel.Mac's
+      # OWN feed request, which went through NSURLCache. Since the
+      # electron-updater migration, Squirrel.Mac never fetches this feed --
+      # MacUpdater downloads the artifact itself and serves it to Squirrel
+      # from a loopback proxy (127.0.0.1). So the NSURLCache hazard now
+      # applies to the LEGACY bridge below, whose readers are exactly the
+      # pre-migration clients that still fetch through it. The header stays
+      # mandatory on BOTH: electron-updater's own fetch goes through
+      # Chromium's cache (it also appends its own noCache query), and a build
+      # already in the field cannot be given a header fix retroactively.
+      #
       # max-age=300 is the release-feed norm (Signal Desktop's latest-mac.yml
       # on the same S3+CloudFront shape uses exactly this); it bounds
       # client-side staleness at 5 minutes instead of leaving it to a
       # heuristic. Deliberately NOT `no-cache` like
       # feed/<channel>/latest-cli.json: the desktop feed is hit by every
       # running app on a 4h poll, and 5 minutes of staleness on a pointer is
-      # harmless -- the client compares versions itself.
-      # Out-of-order overwrites (older run finishing
-      # last -> channel rollback) are prevented by the CALLER workflows'
-      # concurrency groups, which serialize runs per channel -- not by
-      # version comparison here, which would itself be a read-then-write
-      # race.
+      # harmless -- the client compares versions itself. Out-of-order
+      # overwrites (older run finishing last -> channel rollback) are
+      # prevented by the CALLER workflows' concurrency groups, which
+      # serialize runs per channel -- not by version comparison here, which
+      # would itself be a read-then-write race.
+      #
+      # Format: electron-updater channel metadata (latest-mac.yml), the
+      # exact shape electron-builder generates -- version, files[] with
+      # url + sha512 + size, legacy top-level path/sha512, releaseDate.
+      # website/electron/auto-update.js reads the per-channel feed
+      # DIRECTORY (updates.crew.kiro.dev/feed/<channel>/) and the library
+      # appends the platform filename.
+      #
+      # Two properties are load-bearing (see test_publish_feed_contract.py):
+      #   - sha512 is BASE64 of the raw digest (openssl -binary | base64),
+      #     never hex: electron-updater string-compares base64; a hex value
+      #     makes every download fail checksum verification.
+      #   - files[].url are ABSOLUTE byte-host urls (CLI_CDN_BASE =
+      #     download.crew.kiro.dev). The yml itself lives on the POINTER
+      #     host (updates.crew.kiro.dev/feed/...); electron-updater's
+      #     newUrlFromBase does `new URL(fileUrl, base)`, which ignores the
+      #     base for absolute urls -- that is what preserves the
+      #     pointer/bytes host split. A bare filename here would resolve
+      #     against feed/<channel>/ and 404.
+      # The ZIP is the update artifact (Squirrel.Mac consumes it; the
+      # updater's findFile explicitly skips dmg/pkg); the DMG entry is
+      # listed for tooling parity with electron-builder output and stays
+      # the human first-install download.
       - name: Write update feed
+        if: env.HAS_SIGNING_SECRETS
+        run: |
+          set -euo pipefail
+          ZIP_SHA512=$(openssl dgst -sha512 -binary work/notarized.zip | base64 -w 0)
+          ZIP_SIZE=$(stat -c%s work/notarized.zip)
+          DMG_SHA512=$(openssl dgst -sha512 -binary "work/${ARTIFACT_BASENAME}.dmg" | base64 -w 0)
+          DMG_SIZE=$(stat -c%s "work/${ARTIFACT_BASENAME}.dmg")
+
+          # FAIL CLOSED if the feed would describe bytes other than the ones
+          # actually being served. The versioned keys are written with
+          # `--if-none-match '*'` and a PreconditionFailed is deliberately
+          # tolerated ("key already published -- keeping existing bytes"), so a
+          # same-version RE-RUN whose artifact differs byte-for-byte leaves the
+          # OLD object in place while these digests describe the NEW local
+          # build. electron-updater verifies sha512 fail-closed, so the result
+          # is that every macOS client refuses to install -- and the legacy
+          # bridge, which carries no checksum, would happily install the old
+          # one. That split is worse than a failed publish, so abort instead.
+          # (This also catches CloudFront edge divergence on a republished
+          # immutable key -- the #62 hazard.)
+          verify_published() {  # $1=url  $2=expected base64 sha512  $3=label
+            local got
+            got=$(curl -fsS --retry 3 --retry-delay 2 "$1" | openssl dgst -sha512 -binary | base64 -w 0)
+            if [ "$got" != "$2" ]; then
+              echo "::error::$3 served by the CDN does not match the artifact this feed would advertise."
+              echo "::error::  expected sha512 (local build): $2"
+              echo "::error::  served   sha512 (published):   $got"
+              echo "::error::A versioned key was already published with different bytes. Do NOT republish it (edge divergence, #62) -- cut a new version instead."
+              exit 1
+            fi
+            echo "Verified published $3 matches the feed digest."
+          }
+          verify_published "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}" "$ZIP_SHA512" "ZIP"
+          verify_published "${{ vars.CLI_CDN_BASE }}/${DMG_KEY}" "$DMG_SHA512" "DMG"
+          cat > /tmp/latest-mac.yml <<EOF
+          version: ${VERSION}
+          files:
+            - url: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}
+              sha512: '${ZIP_SHA512}'
+              size: ${ZIP_SIZE}
+            - url: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}
+              sha512: '${DMG_SHA512}'
+              size: ${DMG_SIZE}
+          path: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}
+          sha512: '${ZIP_SHA512}'
+          releaseDate: '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
+          EOF
+          aws s3 cp /tmp/latest-mac.yml \
+            "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-mac.yml" \
+            --content-type text/yaml \
+            --cache-control "public, max-age=300"
+          echo "Feed written: feed/${CHANNEL}/latest-mac.yml -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+          # Verify the header CLIENTS actually receive, through the public CDN.
+          # Carried over from #709, which fixed a real incident: a feed served
+          # WITHOUT Cache-Control got heuristically cached and the updater
+          # resolved an already-installed version. electron-updater also appends
+          # its own noCache query (isAddNoCacheQuery), but that is the client
+          # belt -- this is the origin-side braces, and a build already in the
+          # field cannot be given a header fix retroactively.
+          #
+          # NOT `s3api head-object`: the publish role is Put-only on feed/*
+          # (KiroCrewPublishCDK distribution-stack.ts grants s3:GetObject on
+          # cli/* alone), so a read-back would AccessDenied and abort this step
+          # under `set -euo pipefail` AFTER the feed was already published --
+          # a guard that fails on permissions instead of on the condition it
+          # guards.
+          FEED_CC=$(curl -fsS --retry 3 --retry-delay 2 \
+            -I "${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/latest-mac.yml" \
+            | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"{print $2}')
+          echo "Feed Cache-Control as served: ${FEED_CC:-<none>}"
+          case "$FEED_CC" in
+            *max-age=*) : ;;
+            *) echo "::error::feed served without a max-age Cache-Control (#709 regression)"; exit 1 ;;
+          esac
+
+      # TRANSITION BRIDGE -- do NOT delete without reading this.
+      #
+      # Builds fielded BEFORE the electron-updater migration poll the old
+      # hand-rolled feed at feed/<channel>/latest-mac.json and know nothing
+      # about latest-mac.yml. If we only wrote the yml, that JSON would go
+      # permanently stale and every one of those installs would be stranded:
+      # unable to discover ANY future version, forever, with a manual DMG
+      # re-download as the only escape. Shipped client code cannot be
+      # recalled, so the server has to keep speaking the old dialect until
+      # the old clients are gone.
+      #
+      # The legacy shape is what the pre-migration client + Squirrel.Mac
+      # consume: a flat JSON with the zip in `url`. It advertises the SAME
+      # version and the SAME bytes as the yml, so an old install updates once
+      # to an electron-updater build and never reads this file again.
+      #
+      # REMOVAL CONDITION: safe to delete once telemetry (or a deliberate
+      # decision to abandon stragglers) shows no installs older than the
+      # first electron-updater release remain. Pinned by
+      # test/test_publish_feed_contract.py so it cannot be dropped silently.
+      - name: Write legacy update feed (pre-electron-updater clients)
         if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
@@ -609,7 +738,7 @@ jobs:
             "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/latest-mac.json" \
             --content-type application/json \
             --cache-control "public, max-age=300"
-          echo "Feed written: feed/${CHANNEL}/latest-mac.json -> ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
+          echo "Legacy feed written: feed/${CHANNEL}/latest-mac.json (transition bridge)"
           # Verify the header CLIENTS actually receive, through the public CDN.
           # NOT `s3api head-object`: the publish role is Put-only on feed/*
           # (KiroCrewPublishCDK distribution-stack.ts grants s3:GetObject on
@@ -669,5 +798,5 @@ jobs:
             echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
             echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
             echo "- Latest DMG alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_DMG_KEY}"
-            echo "- Feed: \`feed/${CHANNEL}/latest-mac.json\`"
+            echo "- Feed: \`feed/${CHANNEL}/latest-mac.yml\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -131,7 +131,7 @@ the arch-suffixed launcher.)
 include Rosetta 2)
 and uploads a single `unsigned-build-darwin-universal` artifact. Everything
 downstream (codesigning both slices, notarization, stapling, the update
-feed) is arch-indifferent: the feed schema is unchanged, `latest-mac.json`
+feed) is arch-indifferent: the feed schema is unchanged, `latest-mac.yml`
 points at the one universal zip, and installed arm64 apps auto-update onto
 it seamlessly. No Intel runner and no per-arch feed split are needed.
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -2,7 +2,7 @@
 
 Design for the three-channel release pipeline: Nightly → Beta → Stable.
 
-## As built (authoritative, 2026-07-21)
+## As built (authoritative, 2026-07-28)
 
 The sections below this one are the original design; the implementation
 deliberately diverged in several places. Where they disagree, THIS section
@@ -28,31 +28,42 @@ overwritten.
   `pre-signed/` → `signed/` (CDSigner output) → `notarized/` (archive)
 - `kirocrew-updates-…` (private + CloudFront OAC, public trust domain):
   `cli/{channel}/{version}/`, `desktop/{channel}/{version}/`,
-  `feed/{channel}/latest-mac.json`, served at
+  `feed/{channel}/latest-mac.yml` (+ `latest-linux.yml`), served at
   `https://updates.crew.kiro.dev` (pointers: feeds, pip index) and
   `https://download.crew.kiro.dev` (artifact bytes) -- aliases of the
   same distribution; the auto-assigned
   `https://d28nxu9if70cmc.cloudfront.net` keeps working
 
-**Feed (as built) — static file, no Lambda:** `sign-and-notarize.yml` writes
-`feed/{channel}/latest-mac.json` directly after the spctl gate. There is no
+**Feed (as built) — static electron-updater channel files, no Lambda:**
+`sign-and-notarize.yml` writes `feed/{channel}/latest-mac.yml` directly
+after the spctl gate, and the Linux lane writes
+`feed/{channel}/latest-linux.yml` for the AppImage. There is still no
 Feed Lambda, no S3-event trigger, no 200/204 endpoint, and no CloudFront
-Function query routing: the client (`auto-update.js`) fetches the static
-JSON and compares versions CLIENT-SIDE, engaging Squirrel only on a version
-delta. Schema:
+Function query routing: the client (`auto-update.js`, electron-updater)
+fetches the static YAML and compares versions CLIENT-SIDE
+(difference-based, so a feed repointed at an older version is offered),
+engaging the platform installer (Squirrel.Mac on macOS, AppImage
+replacement on Linux) only on a version delta. Schema (electron-updater
+metadata):
 
-```json
-{
-  "version": "0.1.0-nightly.20260721061155",
-  "url": "https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip",
-  "dmg": "https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.dmg",
-  "name": "0.1.0-nightly.20260721061155",
-  "pub_date": "2026-07-21T06:22:13Z"
-}
+```yaml
+version: 0.1.0-nightly.20260721061155
+files:
+  - url: https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip
+    sha512: <base64>
+path: https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260721061155/KiroCrew.zip
+sha512: <base64>
+releaseDate: '2026-07-21T06:22:13Z'
 ```
 
-`url` is the Squirrel auto-update payload (zip, mandatory). `dmg` is the
-first-install disk image for humans/website links; Squirrel ignores it.
+The yml is served from the pointer host (`updates.crew.kiro.dev`) while
+`files[].url` points absolutely at the byte host
+(`download.crew.kiro.dev`), preserving the pointer/bytes split. The file
+URL is the update payload (zip on macOS, AppImage on Linux);
+electron-updater verifies its base64 `sha512` fail-closed before
+install. The first-install DMG for humans/website links is not part of
+the feed — it has its own `desktop/{channel}/latest/KiroCrew.dmg`
+permalink.
 
 **The feed object MUST carry `Cache-Control: public, max-age=300`** (asserted
 fail-closed right after the write by `curl -I` through the public CDN — not

--- a/docs/release-process-design.md
+++ b/docs/release-process-design.md
@@ -8,7 +8,7 @@
 | Scope | Channel model, versioning, CI builds, distribution infrastructure, client auto-update, platform-lane contract |
 | Out of scope | Signing/notarization operations (separate doc, TBD); bootstrap installers; app-store app updates |
 
-> Statuses in this doc are as of 2026-07-23, cross-checked against the
+> Statuses in this doc are as of 2026-07-28, cross-checked against the
 > merged PR record of this repo. `docs/release-automation.md` is the
 > operational companion (workflow details, feed structure, CLI/EC2
 > distribution); this doc records the design and its rationale.
@@ -17,13 +17,15 @@
 
 KiroCrew ships through a channel-based release pipeline that only ever
 publishes signed builds. GitHub Actions builds every artifact (a Python
-wheel plus desktop apps for macOS arm64 and Linux x64) and uploads them to
-a private S3 staging area using short-lived OIDC credentials. macOS bundles
-go to CDSigner for Developer ID signing and Apple notarization, and CI
-publishes the update-feed pointer only after signing succeeds. A private S3
-bucket behind CloudFront (Origin Access Control) serves artifacts and feeds
-to the public. The Electron client updates itself through Squirrel.Mac
-against that feed, and it stops its embedded Python gateway before the
+wheel plus desktop apps for macOS (universal) and Linux x64) and uploads
+them to a private S3 staging area using short-lived OIDC credentials.
+macOS bundles go to CDSigner for Developer ID signing and Apple
+notarization, and CI publishes the update-feed pointer only after signing
+succeeds. A private S3 bucket behind CloudFront (Origin Access Control)
+serves artifacts and feeds to the public. The Electron client updates
+itself through electron-updater against that feed (on macOS still
+installing through Squirrel.Mac underneath; on Linux replacing the
+AppImage in place), and it stops its embedded Python gateway before the
 bundle swap so an update can never corrupt a running install. Every trust
 boundary fails closed: without a verified signature there is no feed entry,
 CI holds no static cloud credentials, and pull requests cannot assume the
@@ -44,7 +46,7 @@ the strongest quotes are cited so the provenance is checkable.
 |---|---|---|---|
 | P1 | The user gets an easy-to-install, packaged, signed and notarized native application, for macOS and Linux and in the future Windows, without needing a terminal or a Python setup | macOS: done, all Macs (Developer-ID-signed universal DMG, "ready for distribution" per `syspolicy_check`). Linux: packaged (AppImage) with signed SLSA provenance; not code-signed by design, since Linux has no Gatekeeper equivalent. Windows: source install only | #108 ("DMG for the first install, zip feed for every update after"), #137/#139/#144 (the DMG must survive Gatekeeper on a real user machine), #152 ("Every Intel-Mac user is locked out", which led to the universal app), #162 ("a link a human can click or paste into docs"), #63 (install must fail closed or auto-provision, never produce a broken install) |
 | P2 | Multiple release channels, so contributors get the latest build while normal users get a stable, tested build | Done: nightly, insider, and stable all live (insider 2026-07-22 18:47 UTC, stable v0.1.0 2026-07-22 19:36 UTC, each with 7 verified public surfaces). Nightly ships as a separate side-by-side app; insider/stable are two update lanes of one app | #132 ("pip/cli.sh users could never track insider or stable"), #176 (tag releases must be able to publish), #193 ("a nightly and the production app can be installed together"), #224 (in-place channel opt-in, "the Slack-beta model") |
-| P3 | Users self-update directly from the app, without ever touching the CLI or terminal, and nothing downloads or installs without explicit consent | macOS: done, macOS Software Update semantics (a check only discovers; update card with explicit Download & Install; nudge is inform-only). Linux: CLI lane self-updates (channel-sticky, sha256-verified via `latest-cli.json`); the desktop AppImage feed (`latest-linux.json`) is the remaining gap | #98 (close the gaps so auto-update "actually delivers bytes publicly"), #125 ("explicit user consent… Nothing downloads automatically"), #241 ("inform only — download and install stay in Settings > About"), #224 ("Switching never downloads or installs by itself") |
+| P3 | Users self-update directly from the app, without ever touching the CLI or terminal, and nothing downloads or installs without explicit consent | macOS: done, macOS Software Update semantics (a check only discovers; update card with explicit Download & Install; nudge is inform-only). Linux: done — the desktop AppImage self-updates through the electron-updater feed (`latest-linux.yml`), and the CLI lane self-updates (channel-sticky, sha256-verified via `latest-cli.json`) | #98 (close the gaps so auto-update "actually delivers bytes publicly"), #125 ("explicit user consent… Nothing downloads automatically"), #241 ("inform only — download and install stay in Settings > About"), #224 ("Switching never downloads or installs by itself") |
 | P4 | A bad release can be pulled back quickly, so users are not stranded on a broken build | Partial: pullback exercised once for real (#137 withdrew the Gatekeeper-broken DMG from every public surface); the pointer mechanics exist (mutable latest aliases + immutable versioned keys), but rollback automation and force-update (`blocked-versions`) remain unbuilt | #137 (the one live pullback event), #162/#132/#133 (mutable-pointer + never-republish discipline a rollback would flip) |
 | P5 | Users behind a minimum required version can be forced to update: a critical security patch must have a guaranteed propagation path | Designed, not built: pairs with P4's rollback design (the feed serves a minimum-version floor; clients below it force-trigger the update flow) | Design articulated alongside rollback and the update nudge; no dedicated PR yet |
 
@@ -142,11 +144,12 @@ CLI/EC2 distribution design, while this section covers the design shape.)
 | `pages.yml` | push to `main` (`site/**`) | landing site | GitHub Pages; the build job runs unprivileged by design because npm lifecycle scripts run untrusted code |
 | review workflows | PR | nothing | LLM review gates (Claude via a Bedrock role, Codex via an isolated Bedrock role), Semgrep, dependency audit; all fail closed |
 
-The platform matrix today: `macos-14` builds `darwin-arm64` (DMG + zip),
-and `ubuntu-22.04` builds `linux-x64` (AppImage). The wheel is
+The platform matrix today: `macos-14` builds the universal macOS app
+(DMG + zip), and `ubuntu-22.04` builds `linux-x64` (AppImage). The wheel is
 `py3-none-any`; KiroCrew is pure Python, so the same wheel serves every OS.
-Linux arm64 and Windows x64 are declared TODO in the matrix header
-(`nightly.yml:8-13`), and Windows is currently a source install only
+Windows x64 builds a Squirrel.Windows `Setup.exe` as a CI artifact
+(installer-only; not yet published to the CDN), Linux arm64 remains TODO,
+and the supported Windows install path is still source
 (`docs/windows-install.md`).
 
 Desktop packaging runs through `make desktop`, which calls
@@ -154,8 +157,10 @@ Desktop packaging runs through `make desktop`, which calls
 interpreter and a uv-built venv into the Electron app, then electron-builder
 produces the installers. This replaced PyInstaller (PR #11) so the app
 ships a real, ABI-consistent CPython and the gateway runs unmodified.
-Builds are host-arch only. We deliberately skip `universal2` because not
-all native dependencies publish universal2 wheels.
+The macOS app is universal via a fat Electron shell plus two single-arch
+backend trees selected at launch (#152); a true lipo-merged `universal2`
+backend stays off the table because not all native dependencies publish
+universal2 wheels (details in `docs/desktop-app.md`).
 
 ## 5. Distribution infrastructure
 
@@ -173,7 +178,7 @@ flowchart LR
         DIST["desktop/*&nbsp;&nbsp;cli/*&nbsp;&nbsp;feed/*"]
     end
     DIST --> CF["CloudFront CDN"]
-    CF --> UPD["Desktop updater (Squirrel)"]
+    CF --> UPD["Desktop updater (electron-updater)"]
     CF --> PIP["pip / cli.sh installs (PEP 503)"]
     CF --> HUM["Human downloads (latest DMG permalink)"]
 ```
@@ -204,7 +209,7 @@ Every public URL is one of exactly two classes:
 |---|---|---|
 | Human download permalink | `/desktop/{channel}/latest/KiroCrew.dmg` | Pointer (max-age=300) |
 | Versioned desktop artifacts | `/desktop/{channel}/{version}/…` (zip + DMG) | Immutable |
-| Desktop update feed | `/feed/{channel}/latest-mac.json` | Pointer (uncached) |
+| Desktop update feed | `/feed/{channel}/latest-mac.yml`, `/feed/{channel}/latest-linux.yml` | Pointer (uncached) |
 | CLI update feed | `/feed/{channel}/latest-cli.json` (version + sha256) | Pointer (uncached) |
 | pip index (PEP 503) | `/feed/{channel}/simple/` | Pointer |
 | GitHub Releases | `github.com/kirodotdev/KiroCrew/releases/tag/v…` | Immutable |
@@ -219,9 +224,13 @@ Rules that make the scheme work:
    page link to them, so app-name changes must never leak into URLs.
 3. Feed writes happen strictly after the artifacts they point to are
    publicly downloadable (feed-before-artifact would hand clients a 403).
-4. Desktop feed contract: 200 + Squirrel JSON when an update exists, 204
-   when current. CLI feed carries the wheel version and sha256 so the
-   installer verifies fail-closed before installing.
+4. Desktop feed contract: electron-updater channel files
+   (`latest-mac.yml` / `latest-linux.yml`) carrying `version`,
+   `files[].url` + base64 `sha512`, `path`, `sha512`, and `releaseDate`.
+   The client fetches the static file and compares versions client-side;
+   the yml sits on the pointer host while `files[].url` points
+   absolutely at the byte host. CLI feed carries the wheel version and
+   sha256 so the installer verifies fail-closed before installing.
 5. pip installs use `--extra-index-url` against the channel's simple
    index, keeping PyPI available for dependency resolution.
 
@@ -297,9 +306,10 @@ CDK but never created by it; a human injects the value once.
    `spctl`, then notarizes and staples into `notarized/*`. Signing
    mechanics are detailed in the separate signing doc.
 4. Only after a verified signed artifact exists does CI write
-   `feed/nightly/latest-mac.json` (Squirrel JSON: `version`, `url`, `name`,
-   `pub_date`). If CDSigner is not configured, the workflow deliberately
-   stops after step 2 and leaves the feed untouched.
+   `feed/nightly/latest-mac.yml` (electron-updater metadata: `version`,
+   `files[].url` + base64 `sha512`, `path`, `sha512`, `releaseDate`). If
+   CDSigner is not configured, the workflow deliberately stops after
+   step 2 and leaves the feed untouched.
 
 The original design had a Feed Lambda writing `latest-*.json` on S3 PUT
 events. It was superseded one day after the nightly pipeline landed
@@ -312,44 +322,78 @@ Lambda exists in the deployed CDK.
 
 ## 6. Client auto-update
 
-The updater is Electron's native `autoUpdater` (Squirrel.Mac). It runs only
-in packaged macOS builds and is disabled in dev builds and on other
-platforms.
+The updater is `electron-updater` (`website/electron/auto-update.js`). It
+runs in packaged macOS and Linux builds and is disabled in dev builds. On
+macOS, electron-updater still drives Squirrel.Mac underneath, so the
+proven atomic bundle swap is unchanged; what the migration from
+Electron's built-in `autoUpdater` replaced is the hand-rolled wrapper
+around it (feed fetching, version compare, and publish-metadata authoring
+are now the library's). On Linux it replaces the AppImage in place, a new
+capability — the AppImage previously had no desktop update path. Windows
+is not migrated: its packaging is still Squirrel.Windows, which
+electron-updater's NSIS-based win32 path cannot drive, so win32 is
+excluded from the client's supported platforms until the NSIS migration
+lands (#598).
 
-The feed contract: the client sends
-`GET {feedBase}?platform={p}&channel={c}&version={v}` and gets either a
-`200` with Squirrel JSON when an update exists or a `204` when it is
-current. The feed base is overridable through the `KIROCREW_UPDATE_FEED`
-environment variable, and a local feed server
-(`scripts/local-feed-server.js`) implements the same contract for
-development. The first check runs 30 seconds after launch, then every 4
-hours.
+The feed contract: the client resolves `{feedBase}/{channel}/` as a
+directory and fetches the static electron-updater channel file from it —
+`latest-mac.yml` on macOS, `latest-linux.yml` on Linux — carrying
+`version`, `files[].url` + base64 `sha512`, `path`, `sha512`, and
+`releaseDate`. The yml sits on the pointer host
+(`updates.crew.kiro.dev`); the `files[].url` entries are absolute and
+point at the byte host (`download.crew.kiro.dev`), which is what
+preserves the pointer/bytes host split (the provider ignores the feed
+base when a file URL is absolute). Version compare is client-side and
+difference-based, not greater-than. The feed base is overridable through
+the `KIROCREW_UPDATE_FEED` environment variable (HTTPS-enforced; plain
+HTTP is allowed only on loopback, for local update-harness testing
+against `website/electron/scripts/local-feed-server.js`). The first check
+runs 30 seconds after launch, then every 4 hours.
+
+Four policy flags are set deliberately, each differing from the
+electron-updater default:
+
+- `autoDownload=false` — consent-first: discovery must never download;
+  the default would pull megabytes on a background check with no user
+  action (P3).
+- `autoInstallOnAppQuit=false` — the default would swap the bundle on
+  quit without stopping the Python gateway, exactly the
+  half-replaced-app race T5 exists to prevent; the deferred-install path
+  stops the gateway first.
+- `allowDowngrade=true` — the update gate is difference-based: a feed
+  repointed at an older version must be offered, which is what makes
+  version retraction (P4) and the channel switch-back (#224) work.
+- `allowPrerelease=true` — every nightly (`-nightly.<stamp>`) and
+  insider (`-insider.N`) version is a semver prerelease and would
+  otherwise be invisible to its own channel.
 
 Install ordering is the KiroCrew-specific part. The app supervises a
 bundled Python gateway child, so before `quitAndInstall` the client stops
 the gateway gracefully (`POST /api/shutdown`, then SIGTERM/SIGKILL). That
-way Squirrel's ShipIt never swaps the bundle under a live child process.
-Choosing "Later" defers installation to natural quit via a `before-quit`
-hook.
+way the bundle swap (Squirrel's ShipIt on macOS, the AppImage replacement
+on Linux) never races a live child process. Choosing "Later" defers
+installation to natural quit via a `before-quit` hook, in the same
+stop-gateway-first order.
 
-There is no custom signature verification in app code. Integrity relies on
-Squirrel.Mac's code-signature validation of the downloaded bundle, which is
-why the feed may only ever point at signed artifacts (T1).
+Downloaded updates are verified fail-closed by electron-updater against
+the feed's `sha512` before install, and on macOS Squirrel.Mac
+additionally validates the code signature of the swapped bundle — which
+is why the feed may only ever point at signed artifacts (T1).
 
-The renderer surface is three IPC calls (`update:check`, `update:install`,
-`update:get-info`) feeding an in-app update modal and the About panel.
+The renderer surface is four IPC calls (`update:check`,
+`update:download`, `update:install`, `update:get-info`) feeding an
+in-app update modal and the About panel.
 
 Source installs (non-packaged) update via git instead
 (`handlers/updates.py`): fetch and compare, `git pull`, frontend rebuild,
 `pip install -e .`, then an in-place `execv` restart.
 
-Known client gaps (section 8): dynamic platform detection needs verifying
-before a second desktop platform lands, and there is no blocked-version
-handling. The consent contract (PR #125): a check only discovers an
-update and surfaces a card in Settings > About (version, notes, date);
-nothing downloads without an explicit Download & Install, background
-polls included. The channel switcher (#224) and the inform-only nudge
-(#241) build on that same contract.
+Known client gaps (section 8): there is no blocked-version handling. The
+consent contract (PR #125): a check only discovers an update and
+surfaces a card in Settings > About (version, notes, date); nothing
+downloads without an explicit Download & Install, background polls
+included. The channel switcher (#224) and the inform-only nudge (#241)
+build on that same contract.
 
 ## 7. Adding a platform lane
 
@@ -359,19 +403,21 @@ A "platform lane" is the end-to-end path for one OS/arch: a CI matrix entry
 builds installers, the artifacts flow through staging, signing, and the
 feed, and a platform updater consumes that feed.
 
-macOS arm64 is the complete lane. The `macos-14` matrix entry builds a DMG
-(for first install) and a zip (the update archive), which flow through
+macOS is the complete lane. The `macos-14` matrix entry builds a universal
+DMG (for first install) and a zip (the update archive), which flow through
 `pre-signed/`, CDSigner signing plus notarization, `signed/` and
-`notarized/`, and finally `feed/{channel}/latest-mac.json`, which the
-Squirrel.Mac client consumes.
+`notarized/`, and finally `feed/{channel}/latest-mac.yml`, which the
+electron-updater client consumes (installing through Squirrel.Mac
+underneath).
 
-Linux x64 is a partial desktop lane. The `ubuntu-22.04` matrix entry
-builds an AppImage that ships with signed SLSA provenance but no code
-signature (deliberate, since Linux has no Gatekeeper equivalent), and
-there is no desktop feed entry (`latest-linux.json`) yet, so AppImage
-users reinstall manually. Linux is fully served by the CLI lane in the
-meantime: `latest-cli.json` plus the PEP 503 index give sha256-verified,
-channel-sticky install and self-update.
+Linux x64 is a desktop lane without code signing. The `ubuntu-22.04`
+matrix entry builds an AppImage that ships with signed SLSA provenance
+but no code signature (deliberate, since Linux has no Gatekeeper
+equivalent), and `feed/{channel}/latest-linux.yml` gives the AppImage the
+same electron-updater self-update path as macOS, with the feed's `sha512`
+as the fail-closed integrity gate on the download. The CLI lane also
+serves Linux: `latest-cli.json` plus the PEP 503 index give
+sha256-verified, channel-sticky install and self-update.
 
 The wheel is the pip lane. KiroCrew is pure Python, so one `py3-none-any`
 wheel serves every OS; it is published under `cli/*` on the CDN and through
@@ -399,18 +445,20 @@ hold. These are the invariants; the per-OS mechanics are free.
    the signing doc) MUST complete and verify before the lane's artifacts
    become client-visible. A lane with no signing integration ships no feed
    entry; Linux today is the worked example.
-6. Feed entry: `feed/{channel}/latest-{platform}.json` in the
-   Squirrel-compatible shape (`version`, `url`, `name`, `pub_date`), where
-   `url` points at the signed artifact behind the CDN. Feed pointers live
+6. Feed entry: `feed/{channel}/latest-{platform}.yml` in the
+   electron-updater shape (`version`, `files[].url` + base64 `sha512`,
+   `path`, `sha512`, `releaseDate`), where the file URLs point absolutely
+   at the signed artifact behind the CDN byte host. Feed pointers live
    under the uncached `feed/*` behavior; artifacts live under immutable
    versioned paths.
-7. Client updater: implements the feed contract (200/204 on
-   `platform`/`channel`/`version`) and honors the gateway-graceful-stop
-   before install, the "Later" deferral to app quit, and platform-native
-   signature validation of downloaded updates.
-8. Dynamic platform detection: the client must report the new platform id.
-   Removing the current `darwin-arm64` hardcode is a prerequisite of the
-   first new lane.
+7. Client updater: consumes the lane's electron-updater channel file
+   (difference-based compare, sha512-verified download) and honors the
+   gateway-graceful-stop before install, the "Later" deferral to app
+   quit, and platform-native signature validation of downloaded updates.
+8. Client platform gate: electron-updater resolves the per-OS channel
+   file itself, but the client enables updates only for platforms with a
+   working publish lane (`SUPPORTED_PLATFORMS` in `auto-update.js`);
+   adding the lane means adding the platform there.
 9. Rollback: repointing the lane's feed at an older signed version MUST be
    sufficient to move clients back. If the platform updater refuses
    downgrades, the lane must document its own rollback mechanism.
@@ -420,16 +468,14 @@ hold. These are the invariants; the per-OS mechanics are free.
 
 ## 8. Known gaps and roadmap
 
-Open as of 2026-07-23:
+Open as of 2026-07-28:
 
 | Item | Type | Notes |
 |---|---|---|
-| Rollback automation + forced minimum version (P5) | roadmap | Pullback was exercised manually once; a `rollback.yml` + minimum-version design exists but is unbuilt. Retention window doubles as the rollback window |
+| Rollback automation + forced minimum version (P5) | roadmap | Pullback was exercised manually once; a `rollback.yml` + minimum-version design exists but is unbuilt. Retention window doubles as the rollback window. The client side is ready: `allowDowngrade=true` means repointing a feed at an older version is offered as an update |
 | S3 lifecycle rules | roadmap | Designed (intermediates 7d, nightly 30d, insider 180d, stable forever); unmanaged growth is ~1 TB/year |
-| Linux desktop update feed | roadmap | `latest-linux.json` (per-arch AppImage, never per-distro) is the open gap; the Linux CLI lane already self-updates |
-| Windows lane | roadmap | Source install only; must satisfy the contract in 7.2 |
+| Windows lane | roadmap | CI builds a Squirrel.Windows `Setup.exe` (installer-only, unpublished); win32 auto-update stays disabled in the client until the NSIS migration (#598); the supported install path is still source |
 | Update-consent nudge polish, custom icon setting | roadmap | Nudge dots shipped; Settings card for custom icons deliberately deferred |
-| Client platform detection | verify | The universal app changed the artifact story; confirm the feed `platform` parameter is derived dynamically before adding a second desktop platform (7.2 item 8) |
 
 ## 9. Design history and authorship
 

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -16,9 +16,12 @@ the backend bundled (no separate Python install needed). Current status:
   the upcoming `publish-windows.yml` lane).
 - **Unsigned** — SmartScreen shows an "unrecognized app" interstitial
   (More info > Run anyway). Authenticode signing is a tracked follow-up.
-- **No auto-update yet** — the app does not consume the Squirrel feed on
-  win32 until the publish + updater lane lands; installs update by running a
-  newer Setup.exe.
+- **No auto-update yet** — the macOS/Linux client moved to
+  electron-updater (`latest-mac.yml` / `latest-linux.yml` feeds), but its
+  win32 path drives NSIS installers, not Squirrel.Windows, so win32 stays
+  excluded from the updater (`SUPPORTED_PLATFORMS` in `auto-update.js`)
+  until the NSIS migration lands (issue #598); installs update by running
+  a newer Setup.exe.
 
 The source install below remains the fully supported path.
 

--- a/test/test_publish_feed_contract.py
+++ b/test/test_publish_feed_contract.py
@@ -1,0 +1,482 @@
+"""Contract tests for the desktop update feeds (electron-updater metadata).
+
+The mac and Linux publish lanes write electron-updater channel files
+(``feed/<channel>/latest-mac.yml`` / ``latest-linux.yml``) that
+``website/electron/auto-update.js`` consumes via the generic provider. Four
+properties are load-bearing and easy to break with a plausible-looking edit,
+and none of them fails at PR time -- they strand installed clients in the
+field days later:
+
+* **sha512 is BASE64, never hex.** electron-updater string-compares the
+  feed's sha512 against a base64 digest of the downloaded bytes
+  (``DownloadedUpdateHelper.hashFile``). Swapping ``openssl -binary |
+  base64`` for ``sha512sum`` (hex) keeps the feed parsing fine while every
+  download fails checksum verification.
+* **files[].url is ABSOLUTE and points at the byte host.** The yml lives on
+  the POINTER host (updates.crew.kiro.dev/feed/<channel>/); the artifact
+  bytes live on the BYTE host (download.crew.kiro.dev/desktop/...).
+  electron-updater's ``newUrlFromBase`` does ``new URL(fileUrl, base)``,
+  which ignores the base for absolute urls -- that behaviour is what makes
+  the pointer/bytes host split work. A bare filename would resolve against
+  ``feed/<channel>/`` and 404.
+* **Go-live order: bytes -> feed -> latest alias.** A feed written before
+  its bytes hands clients a 403/404 mid-update; a latest alias written
+  before the feed points ahead of the go-live switch. Asserted on PARSED
+  step indices (never substring presence) so the assertion cannot go
+  vacuous when steps are renamed or reordered.
+* **Missing artifacts fail loudly.** A silent skip would leave a green run
+  serving a stale feed -- the operator believes the channel moved while
+  every client still sees the old version.
+
+Cache discipline rides along: immutable versioned keys (max-age=31536000 +
+conditional write), short-TTL mutable aliases (max-age=300), no-cache feeds.
+And every publishing job declares ``environment: prod`` because the publish
+role's OIDC trust accepts exactly ref:refs/heads/main and environment:prod.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+MAC_WORKFLOW = WORKFLOWS / "sign-and-notarize.yml"
+LINUX_WORKFLOW = WORKFLOWS / "publish-linux.yml"
+
+# Dummy values used to render the feed heredocs into parseable YAML. The
+# sha512 stand-ins are the names of the shell variables the step MUST
+# populate from `openssl dgst -sha512 -binary | base64`; if the heredoc
+# references anything else the substitution misses and the residual `$`
+# fails the render (same discipline as test_nightly_version_contract.py:
+# extract the literal format from the workflow instead of duplicating it).
+_SUBS = {
+    "VERSION": "1.2.3",
+    "CHANNEL": "nightly",
+    "DESKTOP_KEY": "desktop/nightly/1.2.3/KiroCrew.zip",
+    "DMG_KEY": "desktop/nightly/1.2.3/KiroCrew.dmg",
+    "APPIMAGE_KEY": "desktop/nightly/1.2.3/KiroCrew-x86_64.AppImage",
+    "ZIP_SHA512": "ZIPSHA512BASE64==",
+    "DMG_SHA512": "DMGSHA512BASE64==",
+    "APPIMAGE_SHA512": "APPIMAGESHA512BASE64==",
+    "ZIP_SIZE": "111",
+    "DMG_SIZE": "222",
+    "APPIMAGE_SIZE": "333",
+}
+_CDN_BASE = "https://download.crew.kiro.dev"
+
+
+def _jobs(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]
+
+
+def _steps(path: Path, job: str) -> list[dict]:
+    return _jobs(path)[job]["steps"]
+
+
+def _step_index(steps: list[dict], name: str) -> int:
+    names = [s.get("name", "") for s in steps]
+    assert name in names, f"step {name!r} not found; steps are {names}"
+    return names.index(name)
+
+
+def _step(steps: list[dict], name: str) -> dict:
+    return steps[_step_index(steps, name)]
+
+
+def _feed_step(path: Path, job: str) -> dict:
+    return _step(_steps(path, job), "Write update feed")
+
+
+def _heredoc(run_text: str) -> str:
+    """The feed document between ``<<EOF`` and its terminator."""
+    lines = run_text.splitlines()
+    start = next(i for i, line in enumerate(lines) if "<<EOF" in line)
+    end = next(i for i, line in enumerate(lines[start + 1 :], start + 1) if line.strip() == "EOF")
+    return "\n".join(lines[start + 1 : end])
+
+
+def _rendered_feed(run_text: str) -> dict:
+    """Render the heredoc with dummy values and parse it as YAML."""
+    doc = _heredoc(run_text)
+    doc = re.sub(r"\$\{\{\s*vars\.CLI_CDN_BASE\s*\}\}", _CDN_BASE, doc)
+    doc = re.sub(r"\$\(date[^)]*\)", "2026-07-28T18:00:00Z", doc)
+    doc = re.sub(r"\$\{(\w+)\}", lambda m: _SUBS.get(m.group(1), m.group(0)), doc)
+    assert "$" not in doc, f"unresolved shell reference in rendered feed:\n{doc}"
+    return yaml.safe_load(doc)
+
+
+# ---------------------------------------------------------------------------
+# Key layout: exactly what electron-updater's generic provider parses.
+# ---------------------------------------------------------------------------
+
+
+def _assert_updater_layout(feed: dict) -> None:
+    assert set(feed.keys()) == {"version", "files", "path", "sha512", "releaseDate"}, (
+        f"feed keys {sorted(feed)} diverge from the electron-updater contract "
+        "(version, files, path, sha512, releaseDate)"
+    )
+    assert feed["version"] == _SUBS["VERSION"], "version must be the raw ${VERSION}, no v-prefix"
+    assert isinstance(feed["files"], list) and feed["files"], "files must be a non-empty list"
+    for entry in feed["files"]:
+        assert set(entry.keys()) == {"url", "sha512", "size"}, (
+            f"files[] entry keys {sorted(entry)} diverge from url+sha512+size"
+        )
+        assert isinstance(entry["size"], int), "size must be an unquoted integer"
+    # releaseDate must be QUOTED in the heredoc: unquoted ISO timestamps are
+    # YAML-typed as datetime by some parsers, and electron-updater expects a
+    # string it can hand to `new Date(...)`.
+    assert isinstance(feed["releaseDate"], str)
+
+
+def test_mac_feed_layout_is_electron_updater_metadata() -> None:
+    feed = _rendered_feed(_feed_step(MAC_WORKFLOW, "publish")["run"])
+    _assert_updater_layout(feed)
+    urls = [f["url"] for f in feed["files"]]
+    # MacUpdater requires a zip entry (findFile(files, "zip", ["pkg","dmg"]))
+    # -- the ZIP is what Squirrel.Mac consumes; the DMG stays the human
+    # first-install download.
+    assert any(u.endswith(".zip") for u in urls), "latest-mac.yml must list the update ZIP"
+    assert feed["path"].endswith(".zip"), "legacy top-level path must be the ZIP, not the DMG"
+    assert feed["sha512"] == _SUBS["ZIP_SHA512"], "top-level sha512 must be the ZIP digest"
+
+
+def test_linux_feed_layout_is_electron_updater_metadata() -> None:
+    feed = _rendered_feed(_feed_step(LINUX_WORKFLOW, "publish-linux")["run"])
+    _assert_updater_layout(feed)
+    urls = [f["url"] for f in feed["files"]]
+    # AppImageUpdater requires an AppImage entry
+    # (findFile(files, "AppImage", ["rpm","deb","pacman"])).
+    assert any(u.endswith(".AppImage") for u in urls), "latest-linux.yml must list the AppImage"
+    assert feed["path"].endswith(".AppImage")
+    assert feed["sha512"] == _SUBS["APPIMAGE_SHA512"]
+
+
+# ---------------------------------------------------------------------------
+# sha512 encoding: base64 of the raw digest, never hex.
+# ---------------------------------------------------------------------------
+
+
+def test_feed_sha512_is_base64_not_hex() -> None:
+    for path, job in ((MAC_WORKFLOW, "publish"), (LINUX_WORKFLOW, "publish-linux")):
+        run = _feed_step(path, job)["run"]
+        assert re.search(r"openssl dgst -sha512 -binary[^\n|]*\|\s*base64", run), (
+            f"{path.name}: feed sha512 must be computed as "
+            "`openssl dgst -sha512 -binary | base64` (raw digest, base64-encoded)"
+        )
+        assert "sha512sum" not in run, (
+            f"{path.name}: sha512sum emits HEX; electron-updater compares "
+            "BASE64 and every download would fail checksum verification"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Absolute byte-host urls inside a pointer-host feed.
+# ---------------------------------------------------------------------------
+
+
+def test_feed_urls_are_absolute_byte_host_urls() -> None:
+    for path, job in ((MAC_WORKFLOW, "publish"), (LINUX_WORKFLOW, "publish-linux")):
+        doc = _heredoc(_feed_step(path, job)["run"])
+        url_lines = [line.strip() for line in doc.splitlines() if re.match(r"\s*(-\s+)?url:", line)]
+        assert url_lines, f"{path.name}: feed heredoc has no files[].url lines"
+        for line in url_lines:
+            assert "${{ vars.CLI_CDN_BASE }}/" in line, (
+                f"{path.name}: {line!r} must be an ABSOLUTE ${{{{ vars.CLI_CDN_BASE }}}} url. "
+                "The yml lives on the pointer host (updates.crew.kiro.dev/feed/...); a "
+                "relative filename would resolve against feed/<channel>/ and 404. "
+                "electron-updater ignores the feed base only for absolute urls."
+            )
+        # And the rendered urls point at the byte prefix, not the feed prefix.
+        feed = _rendered_feed(_feed_step(path, job)["run"])
+        for entry in feed["files"]:
+            assert entry["url"].startswith(f"{_CDN_BASE}/desktop/"), (
+                f"{path.name}: {entry['url']!r} must reference the desktop/ byte prefix"
+            )
+
+
+def test_feed_destination_is_pointer_prefix_yaml() -> None:
+    """The yml is uploaded under feed/ (pointer host behavior), not desktop/."""
+    for path, job, channel_file in (
+        (MAC_WORKFLOW, "publish", "latest-mac.yml"),
+        (LINUX_WORKFLOW, "publish-linux", "latest-linux.yml"),
+    ):
+        run = _feed_step(path, job)["run"]
+        assert f"feed/${{CHANNEL}}/{channel_file}" in run, (
+            f"{path.name}: feed must upload to feed/<channel>/{channel_file} -- the exact "
+            "path website/electron/auto-update.js's provider resolves from the feed base"
+        )
+        assert "--content-type text/yaml" in run
+
+
+def test_mac_lane_keeps_the_legacy_json_feed_as_a_transition_bridge() -> None:
+    """The retired hand-rolled JSON feed MUST keep being written for now.
+
+    Builds fielded before the electron-updater migration poll
+    feed/<channel>/latest-mac.json and know nothing about latest-mac.yml.
+    Dropping the JSON write would leave those installs tracking a file that
+    never updates again -- permanently unable to discover ANY future version,
+    with a manual DMG re-download as the only escape. Shipped clients cannot
+    be recalled, so the server keeps speaking the old dialect until the old
+    clients are gone.
+
+    This test exists so the bridge cannot be deleted as apparent dead code.
+    Removal condition is documented on the workflow step itself: no installs
+    older than the first electron-updater release remain (or a deliberate
+    decision to abandon stragglers).
+    """
+    text = MAC_WORKFLOW.read_text(encoding="utf-8")
+    assert "latest-mac.json" in text, (
+        "the legacy JSON feed write was removed -- this strands every install "
+        "fielded before the electron-updater migration"
+    )
+    steps = _steps(MAC_WORKFLOW, "publish")
+    legacy = _step_index(steps, "Write legacy update feed (pre-electron-updater clients)")
+    modern = _step_index(steps, "Write update feed")
+    print(f"sign-and-notarize.yml feed step indices: yml={modern} legacy-json={legacy}")
+    assert modern < legacy, (
+        "the canonical yml feed must be written before the legacy bridge so a "
+        "partial failure can never leave the legacy feed ahead of the modern one"
+    )
+    # Linux had no updater before this migration, so it has no old clients and
+    # must NOT grow a legacy feed.
+    assert "latest-linux.json" not in LINUX_WORKFLOW.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Go-live ordering: bytes -> feed -> latest alias, on parsed step indices.
+# ---------------------------------------------------------------------------
+
+
+def test_mac_publish_order_bytes_then_feed_then_alias() -> None:
+    steps = _steps(MAC_WORKFLOW, "publish")
+    verify = _step_index(steps, "Verify gated artifact contents")
+    zip_pub = _step_index(steps, "Publish notarized artifact to distribution bucket")
+    dmg_pub = _step_index(steps, "Publish DMG to distribution bucket")
+    feed = _step_index(steps, "Write update feed")
+    alias = _step_index(steps, "Update latest DMG alias")
+    print(
+        f"sign-and-notarize.yml publish step indices: verify={verify} "
+        f"zip={zip_pub} dmg={dmg_pub} feed={feed} alias={alias}"
+    )
+    assert verify < zip_pub < dmg_pub < feed < alias, (
+        f"go-live order violated (verify={verify}, zip={zip_pub}, dmg={dmg_pub}, "
+        f"feed={feed}, alias={alias}): the feed references BOTH versioned keys so it "
+        "must trail them, and the latest alias must never point ahead of the go-live switch"
+    )
+    # The feed must reference the keys the byte steps exported -- pinning that
+    # the ordering above is a data dependency, not a coincidence.
+    run = steps[feed]["run"]
+    assert "${DESKTOP_KEY}" in run and "${DMG_KEY}" in run
+
+
+def test_linux_publish_order_bytes_then_feed_then_alias() -> None:
+    steps = _steps(LINUX_WORKFLOW, "publish-linux")
+    locate = _step_index(steps, "Locate AppImage")
+    attest = _step_index(steps, "Attest AppImage provenance")
+    bytes_pub = _step_index(steps, "Publish AppImage to distribution bucket")
+    feed = _step_index(steps, "Write update feed")
+    alias = _step_index(steps, "Update latest AppImage alias")
+    print(
+        f"publish-linux.yml step indices: locate={locate} attest={attest} "
+        f"bytes={bytes_pub} feed={feed} alias={alias}"
+    )
+    assert locate < attest < bytes_pub < feed < alias, (
+        f"go-live order violated (locate={locate}, attest={attest}, bytes={bytes_pub}, "
+        f"feed={feed}, alias={alias}): attestation precedes publish so un-attested bytes "
+        "never go live; the feed trails the versioned key it references; the alias trails "
+        "the go-live switch"
+    )
+    assert "${APPIMAGE_KEY}" in steps[feed]["run"]
+
+
+def test_feed_chain_steps_share_one_skip_gate() -> None:
+    """Every step in the go-live chain must carry the SAME condition. A feed
+    step gated differently from its byte steps could run while the bytes were
+    skipped -- advertising artifacts that were never uploaded."""
+    for path, job, names in (
+        (
+            MAC_WORKFLOW,
+            "publish",
+            (
+                "Publish notarized artifact to distribution bucket",
+                "Publish DMG to distribution bucket",
+                "Write update feed",
+                "Update latest DMG alias",
+            ),
+        ),
+        (
+            LINUX_WORKFLOW,
+            "publish-linux",
+            (
+                "Publish AppImage to distribution bucket",
+                "Write update feed",
+                "Update latest AppImage alias",
+            ),
+        ),
+    ):
+        steps = _steps(path, job)
+        gates = {name: _step(steps, name).get("if") for name in names}
+        assert all(g == "env.HAS_SIGNING_SECRETS" for g in gates.values()), (
+            f"{path.name}: go-live chain must be all-or-nothing on the same gate, got {gates}"
+        )
+        for name in names:
+            assert "continue-on-error" not in _step(steps, name), (
+                f"{path.name}: {name!r} must fail the job, never continue past a failure"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cache TTL discipline per key class.
+# ---------------------------------------------------------------------------
+
+
+def test_versioned_keys_are_immutable_and_conditionally_written() -> None:
+    for path, job, name in (
+        (MAC_WORKFLOW, "publish", "Publish notarized artifact to distribution bucket"),
+        (MAC_WORKFLOW, "publish", "Publish DMG to distribution bucket"),
+        (LINUX_WORKFLOW, "publish-linux", "Publish AppImage to distribution bucket"),
+    ):
+        run = _step(_steps(path, job), name)["run"]
+        assert "public, max-age=31536000, immutable" in run, (
+            f"{path.name}/{name}: versioned keys are immutable-cached for a year"
+        )
+        assert "--if-none-match" in run, (
+            f"{path.name}/{name}: the conditional write is the never-republish "
+            "guarantee -- a republished immutable key diverges across CloudFront edges"
+        )
+
+
+def test_latest_aliases_use_short_ttl_and_plain_overwrite() -> None:
+    for path, job, name in (
+        (MAC_WORKFLOW, "publish", "Update latest DMG alias"),
+        (LINUX_WORKFLOW, "publish-linux", "Update latest AppImage alias"),
+    ):
+        run = _step(_steps(path, job), name)["run"]
+        assert "public, max-age=300" in run, (
+            f"{path.name}/{name}: mutable latest aliases roll over within minutes"
+        )
+        assert "--if-none-match" not in run, (
+            f"{path.name}/{name}: aliases are mutable by design; a conditional write "
+            "would freeze them at the first publish"
+        )
+
+
+def test_feeds_carry_an_explicit_cache_control() -> None:
+    """Every feed write must set an EXPLICIT Cache-Control with a short TTL.
+
+    This encodes the #709 incident rather than a preference. A feed served with
+    NO Cache-Control is subject to heuristic freshness (RFC 9111: caches may
+    guess a lifetime from Last-Modified age), and macOS clients read it through
+    NSURLCache -- which resolved a 22h-stale body and offered the version the
+    user was already running, in a loop. An explicit short TTL removes the
+    guess. `no-cache` would also work, but max-age=300 is what shipped and what
+    fielded clients now receive; keeping the two identical means the legacy
+    bridge behaves exactly as it does today.
+
+    The client-side belt (electron-updater's own noCache query param) is NOT a
+    substitute: a build already in the field cannot be given a header fix
+    retroactively, so the origin header is what lets a poisoned client recover.
+    """
+    for path, job in ((MAC_WORKFLOW, "publish"), (LINUX_WORKFLOW, "publish-linux")):
+        run = _feed_step(path, job)["run"]
+        assert "--cache-control" in run, (
+            f"{path.name}: feed written without an explicit Cache-Control -- "
+            "heuristic freshness caused the #709 stale-feed incident"
+        )
+        assert re.search(r"max-age=(\d+)", run), (
+            f"{path.name}: feed Cache-Control must pin an explicit max-age"
+        )
+        ttl = int(re.search(r"max-age=(\d+)", run).group(1))
+        assert 0 < ttl <= 600, (
+            f"{path.name}: feed TTL is {ttl}s -- the feed is the go-live switch, so a "
+            "long TTL delays every client's discovery of a release"
+        )
+
+
+def test_mac_legacy_bridge_matches_the_modern_feed_cache_control() -> None:
+    """The bridge must not be cached differently from the feed it mirrors.
+
+    Both advertise the same version and the same bytes. Divergent TTLs would
+    let an old client and a new client disagree about what the latest version
+    is for up to the difference between them.
+    """
+    steps = _steps(MAC_WORKFLOW, "publish")
+    modern = _step_index(steps, "Write update feed")
+    legacy = _step_index(steps, "Write legacy update feed (pre-electron-updater clients)")
+    modern_cc = re.search(r'--cache-control "([^"]+)"', steps[modern]["run"]).group(1)
+    legacy_cc = re.search(r'--cache-control "([^"]+)"', steps[legacy]["run"]).group(1)
+    print(f"feed Cache-Control: modern={modern_cc!r} legacy={legacy_cc!r}")
+    assert modern_cc == legacy_cc, (
+        f"feed and legacy bridge disagree on Cache-Control ({modern_cc!r} vs {legacy_cc!r})"
+    )
+
+
+def test_mac_feed_verifies_the_header_clients_receive() -> None:
+    """The publish step must read the header back through the public CDN.
+
+    From #709: `s3api head-object` cannot be used here because the publish role
+    is Put-only on feed/* (GetObject is granted on cli/* alone), so a read-back
+    would AccessDenied and abort the step AFTER the feed was already published
+    -- a guard that fails on permissions instead of on the condition it guards.
+    """
+    run = _feed_step(MAC_WORKFLOW, "publish")["run"]
+    assert "curl" in run and "-I" in run, (
+        "feed step must verify the served Cache-Control through the CDN"
+    )
+    # Strip comment lines before checking for the forbidden call: the step
+    # DOCUMENTS why head-object is wrong, so a naive substring match would
+    # trip on its own rationale.
+    code = "\n".join(
+        line for line in run.splitlines() if not line.strip().startswith("#")
+    )
+    assert "head-object" not in code, (
+        "must not verify via s3api head-object -- the publish role lacks GetObject "
+        "on feed/*, so the guard would fail on permissions after publishing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# environment: prod on every publishing job (OIDC trust subject).
+# ---------------------------------------------------------------------------
+
+
+def test_publishing_jobs_declare_prod_environment() -> None:
+    assert _jobs(MAC_WORKFLOW)["publish"].get("environment") == "prod", (
+        "sign-and-notarize publish job must declare environment: prod -- the publish "
+        "role's OIDC trust accepts exactly ref:refs/heads/main and environment:prod"
+    )
+    assert _jobs(LINUX_WORKFLOW)["publish-linux"].get("environment") == "prod"
+
+
+# ---------------------------------------------------------------------------
+# Missing artifacts fail loudly (never a silent skip serving a stale feed).
+# ---------------------------------------------------------------------------
+
+
+def test_mac_gated_artifact_contents_fail_loudly_when_missing() -> None:
+    steps = _steps(MAC_WORKFLOW, "publish")
+    run = _step(steps, "Verify gated artifact contents")["run"]
+    for probe in ('[ -f "work/notarized.zip" ]', '[ -f "work/${ARTIFACT_BASENAME}.dmg" ]'):
+        assert probe in run, f"gated-artifact verify lost its {probe} check"
+    assert "exit 1" in run, "a missing gated artifact must fail the job before any publish"
+
+
+def test_linux_missing_appimage_fails_loudly() -> None:
+    run = _step(_steps(LINUX_WORKFLOW, "publish-linux"), "Locate AppImage")["run"]
+    assert "No AppImage found" in run and "exit 1" in run, (
+        "a missing AppImage must fail the job -- a silent skip would leave a green "
+        "run serving a stale feed"
+    )
+    assert "Expected exactly one AppImage" in run, (
+        "ambiguous artifacts must also fail loudly rather than feeding an arbitrary file"
+    )
+
+
+def test_mac_notarize_attaches_gated_artifact_fail_closed() -> None:
+    step = _step(_steps(MAC_WORKFLOW, "notarize"), "Attach notarized artifact to workflow run")
+    assert step["with"]["if-no-files-found"] == "error", (
+        "the gated artifact upload must error when empty -- it is the publish job's sole input"
+    )

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -1,35 +1,45 @@
 /**
- * Desktop auto-update via Electron's native autoUpdater (Squirrel.Mac).
+ * Desktop auto-update via electron-updater (macOS + Linux).
  *
- * Squirrel.framework + ShipIt are already in the signed app bundle, so this
- * only wires the updater to a feed and drives the install. The ONE
- * KiroCrew-specific concern vs. a plain Electron app: the bundled Python
- * gateway is a long-running child process, so it MUST be stopped gracefully
- * BEFORE Squirrel swaps the .app bundle — otherwise ShipIt can race the swap
- * and leave a half-replaced app. The graceful stopper is injected from main.js
- * (it calls POST /api/shutdown to flush state, then SIGTERM/SIGKILL).
+ * WHY electron-updater instead of Electron's built-in autoUpdater: the built-in
+ * updater covers only macOS (Squirrel.Mac) and Windows (Squirrel.Windows), and
+ * requires us to hand-build the feed, the version compare and the publish
+ * metadata. electron-updater generates that metadata at build time
+ * (latest-mac.yml / latest-linux.yml), verifies sha512 fail-closed, adds Linux
+ * support, and — on macOS — still drives Squirrel.Mac underneath, so the proven
+ * atomic bundle swap is unchanged. See docs/windows-install.md and issue #598.
  *
- * Pure helpers (channelForFlavor, buildFeedUrl) are dependency-free and tested
- * directly. initAutoUpdate takes electron modules + callbacks injected so it
- * stays testable without an Electron runtime.
+ * The ONE KiroCrew-specific concern vs. a plain Electron app is unchanged: the
+ * bundled Python gateway is a long-running child process, so it MUST be stopped
+ * gracefully BEFORE the app bundle is swapped — otherwise the swap races a live
+ * child and can leave a half-replaced app. That is why autoInstallOnAppQuit is
+ * forced OFF (see configureUpdater) and every install path goes through
+ * stopGateway() first.
+ *
+ * Pure helpers (channelForFlavor, channelForVersion, resolveChannel,
+ * buildFeedBase) are dependency-free and tested directly. initAutoUpdate takes
+ * the electron + electron-updater surfaces injected so it stays testable
+ * without an Electron runtime.
  */
 
-// Default update feed host: updates.crew.kiro.dev, the pointer hostname of
-// the public distribution CDN (CloudFront + OAC over the kirocrew-updates
-// bucket). The feed is a STATIC JSON file at <base>/<channel>/latest-mac.json
-// written by CI after notarization; the artifact URLs inside it point at the
-// byte hostname (download.crew.kiro.dev, CI's CLI_CDN_BASE). There is no
-// 200/204 server endpoint: safeCheck() fetches the feed itself and compares
-// versions CLIENT-SIDE, engaging Squirrel.Mac only when the feed version
-// differs from the running app. (Squirrel treats any 200 feed response as
-// "update available", so gating on the client compare is what prevents a
-// re-download loop against a static file.)
+// Default update feed host: updates.crew.kiro.dev, the pointer hostname of the
+// public distribution CDN (CloudFront + OAC over the kirocrew-updates bucket).
+//
+// electron-updater's generic provider treats the configured URL as a DIRECTORY
+// and resolves <base>/latest-mac.yml (macOS) or <base>/latest-linux.yml (Linux)
+// from it. The artifact URLs inside those files are ABSOLUTE and point at the
+// byte hostname (download.crew.kiro.dev), which is what preserves our
+// pointer/bytes host split: `new URL(fileUrl, base)` ignores the base when
+// fileUrl is absolute. That behaviour is structural but undocumented, so
+// test/auto-update.test.js pins it against the real installed library — a
+// version bump that changes it must fail CI, not strand installs in the field.
 const DEFAULT_FEED_BASE = "https://updates.crew.kiro.dev/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
 const FORCE_EXIT_AFTER_MS = 5 * 1000; // failsafe: guarantee exit after quitAndInstall
-const FEED_TIMEOUT_MS = 15 * 1000;
-const FEED_MAX_BYTES = 64 * 1024;
+
+/** Platforms with a working publish lane + updater. win32 lands with NSIS (#598). */
+const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
 
 /**
  * Map the build flavor ("beta" | "stable") to an update channel. Retained
@@ -73,8 +83,8 @@ function channelForVersion(version) {
  *   preference cannot conjure one.
  * - production stamps (insider/stable) follow the preference when set,
  *   else their own stamp. Switching BACK can be a downgrade mid-cycle
- *   (insider 0.2.0-insider.1 -> stable 0.1.0); safeCheck's compare gate
- *   deliberately engages on any version DIFFERENCE, so that works.
+ *   (insider 0.2.0-insider.1 -> stable 0.1.0), which is why allowDowngrade
+ *   is enabled in configureUpdater.
  *
  * @param {"nightly"|"insider"|"stable"|null} stamped - channelForVersion(version)
  * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = follow stamp
@@ -88,99 +98,83 @@ function resolveChannel(stamped, preference) {
 }
 
 /**
- * Build the static feed URL for a channel. Pure + testable.
+ * Build the per-channel feed DIRECTORY url for the generic provider. Pure +
+ * testable.
  *
- * `cacheBust` appends a unique query param. Squirrel.Mac fetches the feed
- * through an NSMutableURLRequest with the default UseProtocolCachePolicy, so
- * it reads NSURLCache -- and a feed object served without Cache-Control gets
- * heuristically cached, making Squirrel resolve a stale entry (the version
- * already installed) while this module's own cacheless fetch sees the new
- * one. A per-check unique URL is not in any HTTP cache's key, so it defeats
- * NSURLCache regardless of the response headers. The origin-side fix is the
- * feed's `Cache-Control: public, max-age=300`; this is the client-side belt,
- * and it is not redundant -- a build already in the field cannot be given the
- * header fix retroactively, so the bust is what lets a poisoned client
- * recover. (The CDN edge is not involved either way: the feed/* behavior is
- * CACHING_DISABLED, so CloudFront always goes to origin.)
+ * The trailing slash is load-bearing: the provider resolves the channel file
+ * with `new URL("latest-mac.yml", base)`, and without a trailing slash the
+ * last path segment is replaced rather than appended (".../feed/nightly" would
+ * resolve to ".../feed/latest-mac.yml" — the wrong channel, or a 404).
+ * electron-updater's newBaseUrl() also normalises this, but emitting it here
+ * keeps the contract explicit and independent of that internal.
  *
- * @param {{base:string, channel:string, cacheBust?:string|number}} o
- * @returns {string}
- */
-function buildFeedUrl({ base, channel, cacheBust }) {
-  const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
-  const url = `${b}/${encodeURIComponent(channel)}/latest-mac.json`;
-  if (cacheBust === undefined || cacheBust === null || cacheBust === "") return url;
-  return `${url}?_=${encodeURIComponent(String(cacheBust))}`;
-}
-
-/**
- * Default feed fetcher: GET the static feed JSON. Injectable via
- * deps.fetchFeed for tests. Bounded body size + timeout; rejects on any
- * non-200 so callers surface a single error path. HTTPS everywhere;
- * plain HTTP is permitted ONLY for loopback hosts so the local update
- * harness (KIROCREW_UPDATE_FEED=http://127.0.0.1:PORT/...) works --
+ * Enforces HTTPS, with plain HTTP allowed ONLY for loopback so the local
+ * update harness (KIROCREW_UPDATE_FEED=http://127.0.0.1:PORT/feed) works;
  * cleartext update metadata over a real network stays rejected.
- * @param {string} url
- * @returns {Promise<{version:string, url:string}>}
+ *
+ * @param {{base:string, channel:string}} o
+ * @returns {string}
+ * @throws {Error} on a non-HTTPS, non-loopback base
  */
-function fetchFeedHttps(url) {
-  return new Promise((resolve, reject) => {
-    let parsed;
-    try {
-      parsed = new URL(url);
-    } catch (err) {
-      reject(err);
-      return;
-    }
-    const isLoopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
-    let mod;
-    if (parsed.protocol === "https:") {
-      mod = require("https");
-    } else if (parsed.protocol === "http:" && isLoopback) {
-      mod = require("http");
-    } else {
-      reject(new Error(`feed URL must be https (or http on loopback): ${parsed.protocol}//${parsed.hostname}`));
-      return;
-    }
-    const req = mod.get(url, { headers: { "cache-control": "no-cache" } }, (res) => {
-      if (res.statusCode !== 200) {
-        res.resume();
-        reject(new Error(`feed HTTP ${res.statusCode}`));
-        return;
-      }
-      let body = "";
-      res.setEncoding("utf8");
-      res.on("data", (chunk) => {
-        body += chunk;
-        if (body.length > FEED_MAX_BYTES) req.destroy(new Error("feed response too large"));
-      });
-      res.on("end", () => {
-        try { resolve(JSON.parse(body)); } catch (err) { reject(err); }
-      });
-    });
-    req.on("error", reject);
-    req.setTimeout(FEED_TIMEOUT_MS, () => req.destroy(new Error("feed request timed out")));
-  });
+function buildFeedBase({ base, channel }) {
+  const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
+  const url = `${b}/${encodeURIComponent(channel)}/`;
+  const parsed = new URL(url);
+  const isLoopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+    throw new Error(`feed base must be https (or http on loopback): ${parsed.protocol}//${parsed.hostname}`);
+  }
+  return url;
 }
 
 /**
- * Wire Electron's autoUpdater. All Electron surfaces injected for testability.
+ * Apply the update-policy flags this app REQUIRES. Every one of these differs
+ * from the electron-updater default, and each maps to a decision we already
+ * made deliberately — so they are set in one audited place rather than
+ * scattered:
+ *
+ * - autoDownload=false        consent-first UX: discovery must never download.
+ *                             The default (true) would download megabytes on a
+ *                             background check with no user action.
+ * - autoInstallOnAppQuit=false the default would swap the bundle on quit
+ *                             WITHOUT stopping the Python gateway — exactly the
+ *                             half-replaced-app race this module prevents.
+ *                             deferredInstallOnQuit() does it in the right order.
+ * - allowDowngrade=true       our update gate is DIFFERENCE-based, not
+ *                             greater-than: a feed repointed to an older
+ *                             version must be offered. This is what makes
+ *                             channel switch-back and version RETRACTION work.
+ * - allowPrerelease=true      every nightly (-nightly.<stamp>) and insider
+ *                             (-insider.N) stamp is a semver prerelease and
+ *                             would otherwise be invisible to its own channel.
+ *
+ * @param {object} autoUpdater electron-updater AppUpdater
+ */
+function configureUpdater(autoUpdater) {
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.allowDowngrade = true;
+  autoUpdater.allowPrerelease = true;
+}
+
+/**
+ * Wire electron-updater. All Electron surfaces injected for testability.
  *
  * @param {object} deps
  * @param {import("electron").App} deps.app
- * @param {import("electron").AutoUpdater} deps.autoUpdater
+ * @param {object} deps.autoUpdater            - electron-updater AppUpdater
  * @param {typeof import("electron").dialog} deps.dialog
  * @param {typeof import("electron").Notification} deps.Notification
- * @param {() => string} deps.getFlavor      - returns "beta" | "stable"
+ * @param {() => string} deps.getFlavor        - returns "beta" | "stable"
  * @param {() => Promise<void>} deps.stopGateway - graceful, awaitable gateway stop
- * @param {string} [deps.platform]           - e.g. "darwin-arm64"
- * @param {string} [deps.feedBase]           - override feed host
+ * @param {string} [deps.platform]             - display arch, e.g. "darwin-arm64"
+ * @param {string} [deps.osPlatform]           - process.platform override (tests)
+ * @param {string} [deps.feedBase]             - override feed host
  * @param {(state:object) => void} [deps.onUpdateState] - if provided, the
  *   in-app UI drives the install prompt: state transitions are pushed here
  *   ({state, version, notes, channel}) and the native dialog is suppressed.
- *   Without it, the native dialog is the fallback prompt.
  * @param {{info:Function,warn:Function,error:Function}} [deps.log]
- * @returns {{check:Function, install:Function, getInfo:Function}} renderer-callable triggers
+ * @returns {{check:Function, download:Function, install:Function, getInfo:Function}}
  */
 function initAutoUpdate(deps) {
   const {
@@ -193,8 +187,8 @@ function initAutoUpdate(deps) {
     notifyUpdateFound = null,
     stopGateway,
     platform = "darwin-arm64",
+    osPlatform = process.platform,
     feedBase = process.env.KIROCREW_UPDATE_FEED || DEFAULT_FEED_BASE,
-    fetchFeed = fetchFeedHttps,
     onUpdateState = null,
     log = console,
   } = deps;
@@ -233,154 +227,151 @@ function initAutoUpdate(deps) {
     };
   }
 
-  // Squirrel is unavailable for unsigned / not-installed dev builds.
+  // Updating requires an installed, signed bundle (macOS code signature
+  // validation is mandatory for Squirrel.Mac; Linux AppImage needs the
+  // AppImage runtime), so dev builds have no update lane.
   if (!app.isPackaged) {
     log.info("[update] dev build — auto-update disabled");
-    return { check: () => {}, install: async () => {}, getInfo, disabled: "dev" };
+    return { check: () => {}, download: async () => {}, install: async () => {}, getInfo, disabled: "dev" };
   }
-  if (process.platform !== "darwin") {
-    log.info("[update] non-darwin — auto-update disabled (Squirrel.Mac only)");
-    return { check: () => {}, install: async () => {}, getInfo, disabled: "platform" };
+  if (!SUPPORTED_PLATFORMS.has(osPlatform)) {
+    log.info(`[update] ${osPlatform} — auto-update disabled (no publish lane yet)`);
+    return { check: () => {}, download: async () => {}, install: async () => {}, getInfo, disabled: "platform" };
   }
+
+  configureUpdater(autoUpdater);
+  autoUpdater.logger = log;
 
   let updateReady = false;
-  let downloading = false; // Squirrel download/extract in flight
-  let stagedVersion = null; // version name Squirrel has downloaded + staged
+  let downloading = false;
+  let stagedVersion = null; // version electron-updater has downloaded + staged
   let stagedNotes = "";
+  let foundVersion = null; // last version surfaced to the user, awaiting consent
   let installing = false;
   let quitHandled = false;
-  let feedNonce = 0; // monotonic, so two feed URLs are never byte-identical
-
-  function configureFeed() {
-    const channel = currentChannel();
-    // Unique per call so neither NSURLCache (Squirrel's fetch) nor this
-    // module's fetch can be served a previously-cached feed body. The
-    // monotonic counter is NOT redundant with the timestamp: check() ->
-    // download() (the consent flow) issues two configureFeed calls that can
-    // land in the same millisecond, and a repeated URL is a cache HIT.
-    feedNonce += 1;
-    const url = buildFeedUrl({ base: feedBase, channel, cacheBust: `${Date.now()}-${feedNonce}` });
-    autoUpdater.setFeedURL({ url, headers: { "Cache-Control": "no-cache" } });
-    log.info(`[update] feed: ${url}`);
-    return url;
-  }
-
   let checking = false;
-  let foundFeed = null; // last feed entry surfaced to the user, awaiting consent
+
   /**
    * Version of the update currently being fetched/held -- NOT the running
    * app's version. Every state the UI renders a version for must pass this
    * explicitly: emit() defaults `version` to app.getVersion() so the
    * check/not-available/error states report the running build, and a
    * "downloading" event that omitted it made the update card claim the app
-   * was downloading the version already installed.
+   * was downloading the version already installed (fixed in #709; preserved
+   * here through the electron-updater migration).
    */
   function pendingVersion() {
-    return (foundFeed && foundFeed.version) || stagedVersion || app.getVersion();
+    return foundVersion || stagedVersion || app.getVersion();
   }
+
+  function configureFeed() {
+    const channel = currentChannel();
+    const url = buildFeedBase({ base: feedBase, channel });
+    autoUpdater.setFeedURL({ provider: "generic", url });
+    log.info(`[update] feed: ${url}`);
+    return url;
+  }
+
+  /**
+   * DISCOVERY ONLY. With autoDownload=false, checkForUpdates() fetches the
+   * channel file, compares versions (difference-based via allowDowngrade) and
+   * emits update-available / update-not-available WITHOUT downloading. The
+   * download requires the explicit download() consent call below.
+   */
   async function safeCheck() {
-    // NOTE: no updateReady short-circuit here. A check ALWAYS consults the
-    // feed and reports state (macOS Software Update semantics) — the silent
-    // `return` this replaces made the Check-for-updates button a dead no-op
-    // once a download had been staged.
     if (checking) return;
     if (downloading) {
-      // Squirrel is mid-download/extract. Re-engaging checkForUpdates() now
-      // restarts its update flow and tears down the temp staging dir under
-      // the in-flight extraction (observed in the field as
-      // "ditto: Could not lstat .../update.XXXX/...: No such file or
-      // directory"). Report progress instead; update-downloaded/error will
-      // clear the flag and the next check proceeds normally.
+      // A download is in flight. Re-entering the check would restart the
+      // updater's flow underneath the running download; report progress
+      // instead. update-downloaded/error clears the flag.
       log.info("[update] check requested while download in flight — reporting progress");
       emit("downloading", { version: pendingVersion() });
       return;
     }
+    if (updateReady && stagedVersion) {
+      // NOTE: deliberately NOT a short-circuit. A check must ALWAYS consult
+      // the feed, even with a version already staged, because a NEWER version
+      // can ship mid-session — returning early here would pin the user to the
+      // stale stage until they installed or restarted. The update-available
+      // handler distinguishes "the staged one is still latest" (re-surface the
+      // install prompt) from "the stage is superseded" (drop it and re-find).
+      log.info(`[update] ${stagedVersion} staged — checking whether it is still latest`);
+    }
     checking = true;
     try {
-      const url = configureFeed(); // re-read flavor/channel each check
+      configureFeed(); // re-read flavor/channel each check
       emit("checking");
-      const feed = await fetchFeed(url);
-      if (!feed || typeof feed.version !== "string" || typeof feed.url !== "string") {
-        throw new Error("feed missing version/url");
-      }
-      if (feed.version === app.getVersion()) {
-        log.info(`[update] up to date (${feed.version})`);
-        foundFeed = null;
-        emit("not-available");
-        return;
-      }
-      if (updateReady && stagedVersion === feed.version) {
-        // Latest is already downloaded + staged: re-surface the install
-        // prompt instead of doing nothing (and instead of re-downloading).
-        log.info(`[update] ${stagedVersion} already downloaded — awaiting install`);
-        emit("downloaded", { version: stagedVersion, notes: stagedNotes });
-        return;
-      }
-      // CONSENT GATE (macOS Software Update semantics): discovery never
-      // downloads. Surface what was found — version, notes, publish date —
-      // and wait for an explicit download() before engaging Squirrel.
-      foundFeed = feed;
-      log.info(`[update] found ${feed.version} (running ${app.getVersion()}) — awaiting user consent`);
-      // Nudge hook: main.js shows a native notification pointing at
-      // Settings > About (deduped there, once per version). Discovery-only —
-      // download/install still require the explicit consent actions.
-      if (typeof notifyUpdateFound === "function") {
-        try { notifyUpdateFound(feed.version); } catch (err) { log.error("[update] notifyUpdateFound threw", err); }
-      }
-      emit("found", {
-        version: feed.version,
-        notes: typeof feed.notes === "string" ? feed.notes : "",
-        pubDate: typeof feed.pub_date === "string" ? feed.pub_date : "",
-      });
+      await autoUpdater.checkForUpdates();
     } catch (err) {
       log.error("[update] check failed", err);
-      emit("error", { message: String(err && err.message || err) });
+      emit("error", { message: String((err && err.message) || err) });
     } finally {
       checking = false;
     }
   }
 
   /**
-   * Explicit user consent: engage Squirrel to download (and stage) the
-   * version last surfaced by safeCheck. Never called automatically.
+   * Explicit user consent: download the version last surfaced by safeCheck.
+   * Never called automatically — this is the whole point of autoDownload=false.
    */
   async function startDownload() {
     if (downloading) { emit("downloading", { version: pendingVersion() }); return; }
-    if (updateReady && foundFeed && stagedVersion === foundFeed.version) {
+    if (updateReady && stagedVersion) {
       emit("downloaded", { version: stagedVersion, notes: stagedNotes });
       return;
     }
-    if (updateReady) {
-      // A previously staged bundle was superseded by a newer find: drop the
-      // stale stage so Squirrel re-downloads the newest instead of installing
-      // an already-old build.
-      log.info(`[update] staged ${stagedVersion} superseded — re-downloading`);
-      updateReady = false;
-      stagedVersion = null;
-      stagedNotes = "";
+    if (!foundVersion) {
+      // Nothing discovered yet (e.g. UI raced the first check). Discover
+      // first; the user can consent once "found" is surfaced.
+      log.info("[update] download requested with nothing found — checking first");
+      await safeCheck();
+      return;
     }
-    configureFeed();
-    log.info("[update] user consented — engaging Squirrel download");
+    log.info(`[update] user consented — downloading ${foundVersion}`);
     downloading = true;
     emit("downloading", { version: pendingVersion() });
-    autoUpdater.checkForUpdates();
+    try {
+      await autoUpdater.downloadUpdate();
+    } catch (err) {
+      downloading = false;
+      log.error("[update] download failed", err);
+      emit("error", { message: String((err && err.message) || err) });
+    }
   }
 
-  // ShipIt aborts the bundle swap with "App Still Running Error" (Code=-9)
-  // if ANY instance of the app is alive during its ~25s install window — and
-  // the user silently relaunches into the OLD version. If anything blocks the
-  // Electron quit (a renderer beforeunload, a lingering child holding the
-  // process open), force-exit so this instance is guaranteed gone.
+  // The bundle swap aborts if ANY instance of the app is alive during its
+  // install window — and the user silently relaunches into the OLD version. If
+  // anything blocks the Electron quit (a renderer beforeunload, a lingering
+  // child holding the process open), force-exit so the swap can proceed.
   function forceExitFailsafe(reason) {
     const t = setTimeout(() => {
-      log.error(`[update] process still alive ${FORCE_EXIT_AFTER_MS}ms after quitAndInstall (${reason}) — forcing exit so ShipIt can swap`);
+      log.error(`[update] process still alive ${FORCE_EXIT_AFTER_MS}ms after quitAndInstall (${reason}) — forcing exit so the install can swap the app`);
       try { app.exit(0); } catch { process.exit(0); }
     }, FORCE_EXIT_AFTER_MS);
     if (typeof t.unref === "function") t.unref();
   }
 
+  // isSilent=false (no installer UI to suppress on these platforms),
+  // isForceRunAfter=true so the user lands back in the app after the swap.
+  function quitAndInstall() {
+    autoUpdater.quitAndInstall(false, true);
+  }
+
   async function applyUpdateAndRestart() {
     if (installing) return;
+    // REQUIRE a staged update. Without this guard an install() dispatched
+    // before the download finished reaches MacUpdater.quitAndInstall()'s
+    // squirrelDownloadedUpdate === false branch, which does NOT install --
+    // it registers a listener and waits for Squirrel to fetch the update from
+    // the loopback proxy. forceExitFailsafe would then kill the process 5s
+    // later, mid-fetch, and the app dies without swapping or relaunching.
+    // Once a stage exists, Squirrel has already consumed the zip and
+    // quitAndInstall proceeds immediately, so the failsafe is safe to arm.
+    if (!updateReady) {
+      log.info("[update] install requested with nothing staged — ignoring");
+      emit(foundVersion ? "found" : "not-available", foundVersion ? { version: foundVersion } : {});
+      return;
+    }
     installing = true;
     // STRICT ORDER: stop the gateway and await its exit, THEN quitAndInstall.
     // A live gateway child during the bundle swap can leave a half-replaced app.
@@ -392,12 +383,14 @@ function initAutoUpdate(deps) {
     }
     app.removeListener("before-quit", deferredInstallOnQuit);
     log.info("[update] gateway down — quitAndInstall");
-    autoUpdater.quitAndInstall();
+    quitAndInstall();
     forceExitFailsafe("manual install");
   }
 
-  // If the user chose "Later", install on the natural quit. before-quit can't
-  // await async work, so preventDefault, stop the gateway, then quitAndInstall.
+  // If the user chose "Later", install on the natural quit. This is OUR
+  // implementation rather than autoInstallOnAppQuit=true precisely because the
+  // gateway must be stopped first; before-quit can't await async work, so
+  // preventDefault, stop the gateway, then quitAndInstall.
   function deferredInstallOnQuit(event) {
     if (quitHandled || !updateReady) return;
     quitHandled = true;
@@ -405,7 +398,7 @@ function initAutoUpdate(deps) {
     (async () => {
       log.info("[update] deferred install on quit");
       try { await stopGateway(); } catch (err) { log.error("[update] stop on quit errored", err); }
-      autoUpdater.quitAndInstall();
+      quitAndInstall();
       forceExitFailsafe("deferred install on quit");
     })();
   }
@@ -435,40 +428,98 @@ function initAutoUpdate(deps) {
     }
   }
 
-  autoUpdater.on("error", (err) => { downloading = false; log.error("[update] error", err); emit("error", { message: String(err && err.message || err) }); });
-  autoUpdater.on("checking-for-update", () => { log.info("[update] checking…"); emit("checking"); });
-  autoUpdater.on("update-not-available", () => { downloading = false; log.info("[update] up to date"); emit("not-available"); });
-  autoUpdater.on("update-available", () => { downloading = true; log.info("[update] downloading…"); emit("downloading", { version: pendingVersion() }); });
-  autoUpdater.on("update-downloaded", (_e, notes, name) => {
+  /** releaseNotes is string | {version,note}[] | null depending on the feed. */
+  function notesFrom(info) {
+    const n = info && info.releaseNotes;
+    if (typeof n === "string") return n;
+    if (Array.isArray(n)) return n.map((e) => (e && e.note) || "").filter(Boolean).join("\n\n");
+    return "";
+  }
+
+  autoUpdater.on("error", (err) => {
     downloading = false;
-    // LAST LINE OF DEFENSE against a stale feed resolution. If Squirrel
-    // resolved the version this app is already running, installing it is a
-    // no-op that costs a full restart -- and because the running version
-    // never changes, the next check re-offers it forever (observed as an
-    // endless reinstall loop). Refuse the staged bundle instead of arming
-    // the install, and report "up to date", which is what the user's
-    // machine actually is. Never sets updateReady, so before-quit cannot
-    // install it either.
-    if (name && name === app.getVersion()) {
-      log.error(`[update] feed resolved ${name}, already installed — refusing self-reinstall`);
+    log.error("[update] error", err);
+    emit("error", { message: String((err && err.message) || err) });
+  });
+  autoUpdater.on("checking-for-update", () => { log.info("[update] checking…"); emit("checking"); });
+  autoUpdater.on("update-not-available", () => {
+    downloading = false;
+    foundVersion = null;
+    // Clear the STAGED state too, not just the found state. The feed reporting
+    // "no update" while something is staged is exactly the retraction path
+    // (a feed repointed to the running version) and the channel-switch-back
+    // path -- and a stage left armed here would still install the withdrawn or
+    // wrong-channel build on the next quit, because deferredInstallOnQuit only
+    // checks updateReady. Disarm the quit hook as well or the listener
+    // survives to fire against a stage we just invalidated.
+    if (updateReady) {
+      log.info(`[update] feed reports up to date -- discarding staged ${stagedVersion}`);
+    }
+    updateReady = false;
+    stagedVersion = null;
+    stagedNotes = "";
+    quitHandled = false;
+    app.removeListener("before-quit", deferredInstallOnQuit);
+    log.info("[update] up to date");
+    emit("not-available");
+  });
+  // CONSENT GATE: with autoDownload=false this fires on DISCOVERY, before any
+  // bytes move. Surface what was found and wait for an explicit download().
+  autoUpdater.on("update-available", (info) => {
+    foundVersion = (info && info.version) || null;
+    // A stage is only useful if it is still the latest thing on the feed.
+    // Because the RUNNING version never changes mid-session, the updater
+    // reports "available" for the staged version too — so the comparison
+    // below is what separates the two cases.
+    if (updateReady && stagedVersion) {
+      if (foundVersion === stagedVersion) {
+        log.info(`[update] ${stagedVersion} already downloaded — awaiting install`);
+        emit("downloaded", { version: stagedVersion, notes: stagedNotes });
+        return;
+      }
+      // Superseded: drop the stale stage so consent re-downloads the NEWEST
+      // build rather than installing an already-old one.
+      log.info(`[update] staged ${stagedVersion} superseded by ${foundVersion} — discarding stage`);
       updateReady = false;
       stagedVersion = null;
       stagedNotes = "";
-      foundFeed = null;
-      emit("not-available");
-      return;
+      app.removeListener("before-quit", deferredInstallOnQuit);
     }
+    log.info(`[update] found ${foundVersion} (running ${app.getVersion()}) — awaiting user consent`);
+    // Nudge hook: main.js shows a native notification pointing at
+    // Settings > About (deduped there, once per version). Discovery-only —
+    // download/install still require the explicit consent actions.
+    if (typeof notifyUpdateFound === "function") {
+      try { notifyUpdateFound(foundVersion); } catch (err) { log.error("[update] notifyUpdateFound threw", err); }
+    }
+    emit("found", {
+      version: foundVersion,
+      notes: notesFrom(info),
+      pubDate: (info && info.releaseDate) || "",
+    });
+  });
+  autoUpdater.on("download-progress", (p) => {
+    // New capability vs. the hand-rolled updater: real progress, so the card
+    // can show a percentage instead of an indeterminate "downloading".
+    emit("downloading", {
+      version: pendingVersion(),
+      percent: p && typeof p.percent === "number" ? p.percent : undefined,
+      bytesPerSecond: p && p.bytesPerSecond,
+    });
+  });
+  autoUpdater.on("update-downloaded", (info) => {
     updateReady = true;
-    stagedVersion = name || null;
-    stagedNotes = notes || "";
-    log.info(`[update] downloaded ${name} — ${uiDriven ? "notifying UI" : "prompting"}`);
-    emit("downloaded", { version: name || app.getVersion(), notes: notes || "" });
+    downloading = false;
+    stagedVersion = (info && info.version) || null;
+    stagedNotes = notesFrom(info);
+    log.info(`[update] downloaded ${stagedVersion} — ${uiDriven ? "notifying UI" : "prompting"}`);
+    emit("downloaded", { version: stagedVersion || app.getVersion(), notes: stagedNotes });
     if (uiDriven) {
       // In-app UI owns the prompt. Still install on a natural quit if the user
       // dismisses the modal with "Later" (mirrors the native dialog's deferral).
       app.once("before-quit", deferredInstallOnQuit);
     } else {
-      promptInstall(name, notes);
+      promptInstall(stagedVersion, stagedNotes);
     }
   });
 
@@ -491,4 +542,13 @@ function initAutoUpdate(deps) {
   };
 }
 
-module.exports = { initAutoUpdate, channelForFlavor, channelForVersion, resolveChannel, buildFeedUrl, fetchFeedHttps };
+module.exports = {
+  initAutoUpdate,
+  channelForFlavor,
+  channelForVersion,
+  resolveChannel,
+  buildFeedBase,
+  configureUpdater,
+  DEFAULT_FEED_BASE,
+  SUPPORTED_PLATFORMS,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BaseWindow, BrowserWindow, WebContentsView, shell, dialog, Tray, Menu, nativeImage, nativeTheme, autoUpdater, Notification, ipcMain, webContents, session, desktopCapturer, systemPreferences, screen } = require("electron");
+const { app, BaseWindow, BrowserWindow, WebContentsView, shell, dialog, Tray, Menu, nativeImage, nativeTheme, Notification, ipcMain, webContents, session, desktopCapturer, systemPreferences, screen } = require("electron");
 const Store = require("electron-store");
 const fs = require("fs");
 const os = require("os");
@@ -1834,11 +1834,12 @@ app.whenReady().then(async () => {
   await startGateway();
   await showLoadingThenConnect(win);
 
-  // Desktop auto-update (Squirrel.Mac). No-op in dev / non-darwin. KiroCrew
-  // ships a single "stable" channel. The gateway is stopped gracefully before
-  // any bundle swap. Update state is mirrored to the renderer so the in-app
-  // UpdateModal + Settings > About can drive the prompt; the native dialog
-  // stays as the fallback only when no UI is wired.
+  // Desktop auto-update (electron-updater; Squirrel.Mac underneath on macOS,
+  // AppImage on Linux). No-op in dev / on platforms without a publish lane.
+  // The gateway is stopped gracefully before any bundle swap. Update state is
+  // mirrored to the renderer so the in-app UpdateModal + Settings > About can
+  // drive the prompt; the native dialog stays as the fallback only when no UI
+  // is wired.
   function broadcastUpdateState(payload) {
     try {
       for (const wc of webContents.getAllWebContents()) {
@@ -1850,7 +1851,10 @@ app.whenReady().then(async () => {
   }
   const updater = initAutoUpdate({
     app,
-    autoUpdater,
+    // electron-updater's AppUpdater, NOT electron's built-in autoUpdater: it
+    // generates/validates the feed metadata, verifies sha512 fail-closed, and
+    // covers Linux. On macOS it still drives Squirrel.Mac underneath.
+    autoUpdater: require("electron-updater").autoUpdater,
     dialog,
     Notification,
     getFlavor: () => "stable",

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -8,7 +8,8 @@
       "name": "kirocrew-electron-mac",
       "version": "0.1.0",
       "dependencies": {
-        "electron-store": "^8.2.0"
+        "electron-store": "^8.2.0",
+        "electron-updater": "^6.8.9"
       },
       "devDependencies": {
         "@electron/notarize": "^2.5.0",
@@ -1151,7 +1152,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -2005,7 +2005,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2554,6 +2553,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -3144,7 +3219,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3528,7 +3602,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3602,7 +3675,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
@@ -3691,6 +3763,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -3698,6 +3776,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -4054,7 +4139,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -4797,7 +4881,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
       "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -5226,6 +5309,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -11,7 +11,8 @@
     "dist:linux": "electron-builder --linux"
   },
   "dependencies": {
-    "electron-store": "^8.2.0"
+    "electron-store": "^8.2.0",
+    "electron-updater": "^6.8.9"
   },
   "devDependencies": {
     "@electron/notarize": "^2.5.0",
@@ -90,6 +91,12 @@
           "!**/__pycache__/**",
           "!**/*.pyc"
         ]
+      }
+    ],
+    "publish": [
+      {
+        "provider": "generic",
+        "url": "https://updates.crew.kiro.dev/feed/stable/"
       }
     ],
     "win": {

--- a/website/electron/scripts/local-feed-server.js
+++ b/website/electron/scripts/local-feed-server.js
@@ -1,25 +1,39 @@
 #!/usr/bin/env node
 /**
- * Local static update feed for Stage 3 auto-update testing.
+ * Local static update feed for end-to-end auto-update testing.
  *
- * Binds 127.0.0.1 ONLY. Mirrors the production static-feed contract
- * (CloudFront serving files CI wrote): the feed is a plain JSON document
- * and the APP does the version compare client-side, engaging Squirrel only
- * when the feed version differs from the running app. This server never
- * returns 204 -- that behavior lives in the app now.
+ * Binds 127.0.0.1 ONLY. Mirrors the production static-feed contract exactly
+ * (CloudFront serving files CI wrote), which since the electron-updater
+ * migration means TWO documents per channel:
  *
- *   GET /feed/<channel>/latest-mac.json -> 200 {version,url,name,pub_date}
- *   GET /download                       -> streams the update .zip
+ *   GET /feed/<channel>/latest-mac.yml   -> 200 electron-updater metadata (CURRENT)
+ *   GET /feed/<channel>/latest-mac.json  -> 200 legacy hand-rolled feed (BRIDGE)
+ *   GET /download                        -> streams the update .zip
+ *
+ * The yml is what the current client reads. The JSON is the transition bridge
+ * for installs fielded BEFORE the migration (see the "Write legacy update feed"
+ * step in sign-and-notarize.yml) -- serving both here means this harness can
+ * exercise an old-client upgrade path as well as the current one.
+ *
+ * sha512 MUST be base64, not hex: electron-updater compares base64 and treats a
+ * hex digest as a checksum mismatch, which surfaces as a confusing download
+ * failure rather than a format error.
+ *
+ * files[].url is emitted ABSOLUTE, matching production, where the metadata is
+ * served from the pointer host (updates.crew.kiro.dev) while the bytes live on
+ * the byte host (download.crew.kiro.dev). electron-updater resolves file urls
+ * with `new URL(fileUrl, base)`, which ignores the base for absolute urls.
  *
  * Usage:
- *   node local-feed-server.js --port 8799 --zip /path/KiroCrew.zip --version 0.1.0-nightly.20260722000000
+ *   node local-feed-server.js --port 8799 --zip /path/KiroCrew.zip --version 1.0.1
  *   KIROCREW_UPDATE_FEED=http://127.0.0.1:8799/feed <app binary>
  *
- * The app permits plain http for loopback hosts only (fetchFeedHttps), so
+ * The client permits plain http for loopback hosts only (buildFeedBase), so
  * this harness needs no TLS.
  */
 const http = require("http");
 const fs = require("fs");
+const crypto = require("crypto");
 
 function arg(name, def) {
   const i = process.argv.indexOf(`--${name}`);
@@ -34,37 +48,72 @@ if (!ZIP || !fs.existsSync(ZIP)) {
   process.exit(1);
 }
 
+// Computed once at startup: electron-updater verifies this against the bytes it
+// downloaded and refuses to install on a mismatch (fail-closed).
+const ZIP_BYTES = fs.readFileSync(ZIP);
+const ZIP_SIZE = ZIP_BYTES.length;
+const ZIP_SHA512 = crypto.createHash("sha512").update(ZIP_BYTES).digest("base64");
+const DOWNLOAD_URL = `http://127.0.0.1:${PORT}/download`;
+
+function macYaml() {
+  return [
+    `version: ${LATEST}`,
+    "files:",
+    `  - url: ${DOWNLOAD_URL}`,
+    `    sha512: '${ZIP_SHA512}'`,
+    `    size: ${ZIP_SIZE}`,
+    `path: ${DOWNLOAD_URL}`,
+    `sha512: '${ZIP_SHA512}'`,
+    `releaseDate: '${new Date().toISOString()}'`,
+    "",
+  ].join("\n");
+}
+
+function legacyJson() {
+  return JSON.stringify({
+    version: LATEST,
+    url: DOWNLOAD_URL,
+    dmg: DOWNLOAD_URL,
+    name: LATEST,
+    pub_date: new Date().toISOString(),
+  });
+}
+
 const server = http.createServer((req, res) => {
   const u = new URL(req.url, `http://127.0.0.1:${PORT}`);
 
   if (u.pathname === "/download") {
-    const stat = fs.statSync(ZIP);
-    res.writeHead(200, { "Content-Type": "application/zip", "Content-Length": stat.size });
-    fs.createReadStream(ZIP).pipe(res);
-    console.log(`[feed] served update zip (${stat.size} bytes)`);
+    res.writeHead(200, { "Content-Type": "application/zip", "Content-Length": ZIP_SIZE });
+    res.end(ZIP_BYTES);
+    console.log(`[feed] served update zip (${ZIP_SIZE} bytes)`);
+    return;
+  }
+
+  // electron-updater channel file. Linux builds ask for latest-linux.yml; the
+  // same metadata shape serves both, so match on the suffix.
+  if (u.pathname.endsWith(".yml")) {
+    const body = macYaml();
+    res.writeHead(200, { "Content-Type": "text/yaml", "Cache-Control": "no-cache" });
+    res.end(body);
+    console.log(`[feed] ${u.pathname} -> 200 version=${LATEST} (client compares + verifies sha512)`);
     return;
   }
 
   if (u.pathname.endsWith("/latest-mac.json")) {
-    const body = JSON.stringify({
-      version: LATEST,
-      url: `http://127.0.0.1:${PORT}/download`,
-      name: LATEST,
-      pub_date: new Date().toISOString(),
-    });
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(body);
-    console.log(`[feed] ${u.pathname} -> 200 latest=${LATEST} (app compares client-side)`);
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+    res.end(legacyJson());
+    console.log(`[feed] ${u.pathname} -> 200 version=${LATEST} (LEGACY bridge — pre-migration clients)`);
     return;
   }
 
   res.writeHead(404);
   res.end();
-  console.log(`[feed] ${u.pathname} -> 404 (expected /feed/<channel>/latest-mac.json or /download)`);
+  console.log(`[feed] ${u.pathname} -> 404 (expected /feed/<channel>/latest-mac.yml, .json, or /download)`);
 });
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`[feed] listening on http://127.0.0.1:${PORT}`);
-  console.log(`[feed] serving latest=${LATEST} from ${ZIP}`);
+  console.log(`[feed] serving version=${LATEST} from ${ZIP}`);
+  console.log(`[feed]   size=${ZIP_SIZE} sha512(base64)=${ZIP_SHA512.slice(0, 24)}…`);
   console.log(`[feed] point the app at it: KIROCREW_UPDATE_FEED=http://127.0.0.1:${PORT}/feed`);
 });

--- a/website/electron/scripts/ota-drive.js
+++ b/website/electron/scripts/ota-drive.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Unattended driver for the end-to-end OTA update test.
+ *
+ * The update flow is deliberately consent-gated (autoDownload=false), so it
+ * cannot be exercised by launching the app and waiting -- something has to
+ * press "Download" and "Restart & Update". Rather than add a test-only
+ * auto-consent hook to shipped code, this drives the REAL renderer over the
+ * Chrome DevTools Protocol and calls the SAME preload-exposed API a click
+ * calls (window.updateAPI.download / .install). The code path under test is
+ * therefore identical to the one users hit.
+ *
+ * Requires: the app launched with --remote-debugging-port=<port>, a local feed
+ * serving a newer version (scripts/local-feed-server.js), and a `kirocrew`
+ * gateway resolvable on PATH (the app only reaches initAutoUpdate after the
+ * gateway connects).
+ *
+ * Usage:
+ *   node scripts/ota-drive.js --cdp 9222 --expect 1.0.1 [--timeout 180]
+ *
+ * Exit 0 only if the updater reached the "downloaded" state and install was
+ * dispatched. Verifying the BUNDLE actually swapped is the caller's job (read
+ * CFBundleShortVersionString afterwards) -- this script deliberately does not
+ * conflate "install dispatched" with "install succeeded".
+ */
+const http = require("http");
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : def;
+}
+const CDP_PORT = parseInt(arg("cdp", "9222"), 10);
+const EXPECT = arg("expect", null);
+const TIMEOUT_MS = parseInt(arg("timeout", "180"), 10) * 1000;
+
+const log = (...a) => console.log("[ota-drive]", ...a);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function getJson(path) {
+  return new Promise((resolve, reject) => {
+    http
+      .get({ host: "127.0.0.1", port: CDP_PORT, path }, (res) => {
+        let b = "";
+        res.on("data", (c) => (b += c));
+        res.on("end", () => {
+          try { resolve(JSON.parse(b)); } catch (e) { reject(e); }
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+/** Find the renderer target that actually has the update bridge attached. */
+async function findUpdateTarget(deadline) {
+  while (Date.now() < deadline) {
+    let targets = [];
+    try { targets = await getJson("/json/list"); } catch { /* devtools not up yet */ }
+    for (const t of targets.filter((x) => x.type === "page" && x.webSocketDebuggerUrl)) {
+      const probe = await evaluate(t.webSocketDebuggerUrl, "typeof window.updateAPI").catch(() => null);
+      if (probe && probe.value === "object") {
+        log(`found renderer with updateAPI: ${t.url.slice(0, 80)}`);
+        return t.webSocketDebuggerUrl;
+      }
+    }
+    await sleep(1000);
+  }
+  throw new Error("no renderer exposing window.updateAPI appeared before the timeout");
+}
+
+/** One-shot CDP Runtime.evaluate over a fresh socket (keeps state simple). */
+function evaluate(wsUrl, expression) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const timer = setTimeout(() => { try { ws.close(); } catch {} reject(new Error("evaluate timed out")); }, 15000);
+    ws.onopen = () => ws.send(JSON.stringify({
+      id: 1,
+      method: "Runtime.evaluate",
+      params: { expression, awaitPromise: true, returnByValue: true },
+    }));
+    ws.onmessage = (ev) => {
+      let msg;
+      try { msg = JSON.parse(ev.data); } catch { return; }
+      if (msg.id !== 1) return;
+      clearTimeout(timer);
+      try { ws.close(); } catch {}
+      if (msg.error) { reject(new Error(JSON.stringify(msg.error))); return; }
+      if (msg.result && msg.result.exceptionDetails) {
+        reject(new Error(msg.result.exceptionDetails.text || "evaluate threw"));
+        return;
+      }
+      resolve(msg.result && msg.result.result);
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error("websocket error")); };
+  });
+}
+
+// Installs a recorder in the page so update states can be polled. Idempotent:
+// re-running must not stack listeners or lose already-seen states.
+const RECORDER = `
+(() => {
+  if (!window.__ota) {
+    window.__ota = { states: [] };
+    window.updateAPI.onState((s) => window.__ota.states.push(s));
+  }
+  return window.__ota.states.length;
+})()`;
+
+const POLL = `JSON.stringify(window.__ota ? window.__ota.states : [])`;
+
+async function waitForState(wsUrl, wanted, deadline) {
+  let last = "";
+  while (Date.now() < deadline) {
+    const r = await evaluate(wsUrl, POLL);
+    const states = JSON.parse(r.value || "[]");
+    const names = states.map((s) => s.state).join(",");
+    if (names !== last) { log(`states: ${names || "(none)"}`); last = names; }
+    const hit = states.find((s) => s.state === wanted);
+    if (hit) return hit;
+    const err = states.find((s) => s.state === "error");
+    if (err) throw new Error(`updater reported error: ${err.message}`);
+    await sleep(2000);
+  }
+  throw new Error(`state "${wanted}" not reached before the timeout`);
+}
+
+(async () => {
+  const deadline = Date.now() + TIMEOUT_MS;
+  const ws = await findUpdateTarget(deadline);
+  await evaluate(ws, RECORDER);
+
+  const info = await evaluate(ws, "JSON.stringify(window.updateAPI.getInfo())");
+  log("app info:", info.value);
+
+  log("triggering a check (the launch-delay check may already have run)");
+  await evaluate(ws, "window.updateAPI.check()");
+  const found = await waitForState(ws, "found", deadline);
+  log(`DISCOVERY ok -> found ${found.version} (no download yet: consent gate held)`);
+  if (EXPECT && found.version !== EXPECT) {
+    throw new Error(`expected to find ${EXPECT}, feed offered ${found.version}`);
+  }
+
+  log("granting consent -> updateAPI.download()");
+  await evaluate(ws, "window.updateAPI.download()");
+  const downloaded = await waitForState(ws, "downloaded", deadline);
+  log(`DOWNLOAD ok -> staged ${downloaded.version}`);
+
+  log("dispatching install -> updateAPI.install() (app will quit + swap)");
+  await evaluate(ws, "window.updateAPI.install()").catch((e) => {
+    // The app quits mid-call, so a dropped socket here is expected/normal.
+    log(`install dispatched (socket closed as the app quit: ${e.message})`);
+  });
+  log("OK: discovery -> consent -> download -> install dispatched");
+  process.exit(0);
+})().catch((e) => {
+  console.error("[ota-drive] FAIL:", e.message);
+  process.exit(1);
+});

--- a/website/electron/scripts/stage3-autoupdate-test.sh
+++ b/website/electron/scripts/stage3-autoupdate-test.sh
@@ -2,26 +2,34 @@
 set -euo pipefail
 
 # ============================================================================
-# Stage 3 — end-to-end Squirrel.Mac auto-update test (NO Apple notarization).
+# End-to-end macOS auto-update test via electron-updater (NO Apple notarization).
 #
 # Builds v1.0.0 (the "installed" app) and v1.0.1 (the "update"), ad-hoc
-# deep-signs both, serves the 1.0.1 zip from a local feed, and prints how to
-# run + what to observe. Proves the full loop: check -> download -> prompt ->
+# deep-signs both, serves the 1.0.1 zip from a local yml feed, and prints how to
+# run + what to observe. Proves the full loop: check -> CONSENT -> download ->
 # graceful gateway stop -> bundle swap -> relaunch as 1.0.1.
 #
 # CAVEATS (read before running):
 #  - Same-machine only. Ad-hoc signatures (codesign -s -) satisfy Squirrel.Mac's
 #    same-identity check for a locally-built, locally-run app. Gatekeeper
-#    acceptance on a CLEAN machine still requires real notarization (Stage 4).
-#  - The app spawns the bundled/PATH gateway on launch and only reaches
-#    initAutoUpdate after it connects. Have `kirocrew` installed (toolbox) so a
-#    gateway can start. We isolate with a temp KIROCREW_HOME + the BETA flavor
-#    (port 7788) so this never touches your real :7777 gateway.
+#    acceptance on a CLEAN machine still requires real notarization.
+#  - CONSENT-FIRST: discovery never downloads (autoDownload=false), so this test
+#    REQUIRES two human clicks in Settings > About: "Download", then
+#    "Restart & Update". An unattended run will stop at "found" and look stuck —
+#    that is the design working, not a hang.
+#  - backend-dist: the packaged app resolves its gateway via find-bin.js, which
+#    falls back to a PATH `kirocrew`. This script therefore stubs an EMPTY
+#    backend-dist to satisfy electron-builder's extraResources (which errors on
+#    a missing source dir) instead of building the ~500MB PyInstaller bundle.
+#    Have `kirocrew` on PATH (toolbox install) so a gateway can start. We
+#    isolate with a temp KIROCREW_HOME + the BETA flavor (port 7788) so this
+#    never touches your real :7777 gateway.
 #  - The feed is http://127.0.0.1 (loopback is exempt from App Transport
-#    Security). If Squirrel still refuses the http feed, add to package.json
-#    build.mac:  "extendInfo": { "NSAppTransportSecurity": { "NSAllowsLocalNetworking": true } }
+#    Security, and buildFeedBase permits http ONLY on loopback). If the updater
+#    refuses the http feed, add to package.json build.mac:
+#    "extendInfo": { "NSAppTransportSecurity": { "NSAllowsLocalNetworking": true } }
 #
-# Env overrides: PORT (8799), OUT (/tmp/kirocrew-stage3), NODE (node).
+# Env overrides: PORT (8799), OUT (/tmp/kirocrew-ota), NODE (node).
 # ============================================================================
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -29,7 +37,7 @@ ELECTRON="$(cd "$HERE/.." && pwd)"
 cd "$ELECTRON"
 
 PORT="${PORT:-8799}"
-OUT="${OUT:-/tmp/kirocrew-stage3}"
+OUT="${OUT:-/tmp/kirocrew-ota}"
 NODE="${NODE:-node}"
 INSTALLED_VER="1.0.0"
 UPDATE_VER="1.0.1"
@@ -40,10 +48,29 @@ command -v ditto >/dev/null     || { echo "ERROR: ditto not found"; exit 1; }
 
 rm -rf "$OUT"; mkdir -p "$OUT/update" "$OUT/installed" "$OUT/home"
 
+# electron-builder's extraResources errors if `from: backend-dist` is missing.
+# We do NOT want the ~500MB PyInstaller bundle for a feed/swap test, and
+# find-bin.js falls back to a PATH `kirocrew`, so an empty dir is sufficient.
+# Only created if absent, and never deleted (a real bundle must survive).
+if [ ! -d backend-dist ]; then
+  echo ">>> stubbing empty backend-dist (gateway will resolve from PATH)"
+  mkdir -p backend-dist
+  echo "placeholder for local OTA testing; real bundles come from packaging/build-desktop.sh" \
+    > backend-dist/.ota-test-placeholder
+  command -v kirocrew >/dev/null || echo "    WARNING: no kirocrew on PATH — the app may not reach initAutoUpdate"
+fi
+
 adhoc_sign_app() {  # $1 = path to .app — deep ad-hoc sign + verify
   echo ">>> ad-hoc deep-signing $(basename "$1")"
   codesign --remove-signature "$1" 2>/dev/null || true
-  codesign --deep --force --options runtime --sign - "$1"
+  # NO --options runtime here. Hardened runtime enables LIBRARY VALIDATION,
+  # which requires the main binary and every loaded library to share a Team ID.
+  # Ad-hoc signatures have no Team ID, so an ad-hoc app + ad-hoc Electron
+  # Framework is rejected by dyld with "different Team IDs" and the app dies on
+  # launch with Abort trap: 6. Real CI builds sign with a Developer ID (one
+  # team, runtime hardening on); this ad-hoc path is local/CI test-only and the
+  # bundle swap under test does not depend on hardened runtime.
+  codesign --deep --force --sign - "$1"
   codesign --verify --deep --strict "$1" && echo "    signature verified"
 }
 
@@ -52,7 +79,24 @@ build_dir() {  # $1 = version -> unpacked .app in dist/ ; echoes the .app path
   rm -rf dist
   CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac dir \
     -c.extraMetadata.version="$1" >&2
-  /usr/bin/find dist -maxdepth 3 -name '*.app' -type d | head -1
+  local app
+  app="$(/usr/bin/find dist -maxdepth 3 -name '*.app' -type d | head -1)"
+  # electron-builder writes app-update.yml ONLY for the dmg/zip targets on
+  # darwin (PublishManager.js: it returns early unless targets include one of
+  # them). This test uses the `dir` target because it is far faster, so the file
+  # must be written by hand -- WITHOUT it, electron-updater's downloadUpdate()
+  # rejects ENOENT while reading it, and this test would fail on the very defect
+  # it exists to catch. Content mirrors what the real dmg+zip build emits; the
+  # url is overridden at runtime by configureFeed()'s setFeedURL anyway.
+  if [ -n "$app" ] && [ ! -f "$app/Contents/Resources/app-update.yml" ]; then
+    cat > "$app/Contents/Resources/app-update.yml" <<YML
+provider: generic
+url: https://updates.crew.kiro.dev/feed/stable/
+updaterCacheDirName: kirocrew-electron-mac-updater
+YML
+    echo "    wrote app-update.yml (dir target does not emit it)" >&2
+  fi
+  echo "$app"
 }
 
 # 1. UPDATE artifact (1.0.1): build -> sign -> ditto-zip into OUT/update
@@ -65,16 +109,34 @@ ditto -c -k --sequesterRsrc --keepParent "$UPD_APP" "$UPD_ZIP"
 echo "    update zip: $UPD_ZIP"
 
 # 2. INSTALLED app (1.0.0): build -> sign -> copy into OUT/installed
+# 2. INSTALLED app (1.0.0): build -> ditto into OUT/installed -> sign IN PLACE.
+# Copy BEFORE signing and use ditto, not cp -R: cp does not reliably preserve
+# the nested code-signature relationships in a .app, which produces a bundle
+# that verifies at the source path and fails to load its framework at the
+# destination. Signing at the final location avoids the question entirely.
 INST_SRC="$(build_dir "$INSTALLED_VER")"
 [ -n "$INST_SRC" ] || { echo "ERROR: no .app produced for installed build"; exit 1; }
-adhoc_sign_app "$INST_SRC"
-cp -R "$INST_SRC" "$OUT/installed/"
+ditto "$INST_SRC" "$OUT/installed/$(basename "$INST_SRC")"
 INST_APP="$OUT/installed/$(basename "$INST_SRC")"
+adhoc_sign_app "$INST_APP"
 INST_BIN="$INST_APP/Contents/MacOS/$(/usr/bin/basename "$INST_APP" .app)"
 echo "    installed app: $INST_APP"
 rm -rf dist
 
-# 3. local feed (loopback only)
+# 3. local feed (loopback only).
+#
+# BUILD_ONLY=1 stops here: CI drives the feed itself, because this script's
+# trap kills the feed when the script exits, so a non-blocking run would tear
+# down the server the moment it returned. Interactive runs keep the old
+# behaviour (start the feed, print instructions, block on it).
+if [ "${BUILD_ONLY:-0}" = "1" ]; then
+  echo ">>> BUILD_ONLY=1 — artifacts ready, not starting the feed"
+  echo "INSTALLED_APP=$INST_APP"
+  echo "INSTALLED_BIN=$INST_BIN"
+  echo "UPDATE_ZIP=$UPD_ZIP"
+  exit 0
+fi
+
 echo ">>> starting local feed on 127.0.0.1:$PORT"
 "$NODE" "$HERE/local-feed-server.js" --port "$PORT" --zip "$UPD_ZIP" --version "$UPDATE_VER" &
 FEED_PID=$!
@@ -83,26 +145,42 @@ sleep 1
 
 cat <<MSG
 
-============================ Stage 3 ready ============================
-Feed:      http://127.0.0.1:$PORT   (serving $UPDATE_VER)
+============================ OTA test ready ============================
+Feed:      http://127.0.0.1:$PORT   (serving $UPDATE_VER as latest-mac.yml)
 Installed: $INST_APP   (version $INSTALLED_VER)
 
 Run the installed app pointed at the local feed (new terminal, or here):
 
-  KIROCREW_UPDATE_FEED="http://127.0.0.1:$PORT" \\
+  KIROCREW_UPDATE_FEED="http://127.0.0.1:$PORT/feed" \\
   KIROCREW_FLAVOR=beta \\
   KIROCREW_HOME="$OUT/home" \\
-  "$INST_BIN"
+  "$INST_BIN" 2>&1 | tee $OUT/app.log
 
-What to observe (app stderr or Console.app, filter "[update]"):
-  [update] feed: http://127.0.0.1:$PORT?platform=...&channel=insider&version=1.0.0
-  [update] checking…  ->  update available — downloading…  ->  downloaded 1.0.1 — prompting
-  (dialog) "KiroCrew 1.0.1 is ready to install."  -> click "Restart & Update"
-  "Stopping gateway gracefully..."  -> bundle swap -> app relaunches as 1.0.1
-  Re-open: [update] up to date   (feed returns 204)
+What to observe (filter "[update]"), and WHAT YOU MUST CLICK:
 
-The feed server logs each request (200 update / 204 up-to-date / served zip).
+  1. [update] feed: http://127.0.0.1:$PORT/feed/stable/
+     [update] checking…
+     [update] found $UPDATE_VER (running $INSTALLED_VER) — awaiting user consent
+     ^ Discovery STOPS here by design: autoDownload=false. A native
+       notification points at Settings > About. This is NOT a hang.
+
+  2. >>> CLICK: open Settings > About, press "Download".
+     [update] user consented — downloading $UPDATE_VER
+     (download-progress events drive the percentage in the card)
+     [update] downloaded $UPDATE_VER — notifying UI
+
+  3. >>> CLICK: press "Restart & Update".
+     [update] stopping gateway before install
+     [update] gateway down — quitAndInstall
+     -> bundle swap -> app relaunches as $UPDATE_VER
+
+  4. Verify the swap actually happened (do NOT accept "no error" as success):
+       defaults read "$INST_APP/Contents/Info" CFBundleShortVersionString
+       # must print $UPDATE_VER
+     Re-open the app: [update] up to date
+
+The feed server logs every request (yml fetch / zip download).
 Press Ctrl-C to stop the feed server.
-======================================================================
+=======================================================================
 MSG
 wait $FEED_PID

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -1,6 +1,19 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { channelForFlavor, channelForVersion, buildFeedUrl, fetchFeedHttps, initAutoUpdate } = require("../auto-update");
+const {
+  initAutoUpdate,
+  channelForFlavor,
+  channelForVersion,
+  resolveChannel,
+  buildFeedBase,
+  configureUpdater,
+  DEFAULT_FEED_BASE,
+  SUPPORTED_PLATFORMS,
+} = require("../auto-update");
+
+// ---------------------------------------------------------------------------
+// Pure channel helpers (unchanged surface from the hand-rolled updater).
+// ---------------------------------------------------------------------------
 
 test("channelForVersion: nightly stamp -> nightly feed", () => {
   assert.strictEqual(channelForVersion("0.1.0-nightly.20260721042000"), "nightly");
@@ -16,13 +29,6 @@ test("channelForVersion: bare semver -> stable, unstamped/missing -> null", () =
   assert.strictEqual(channelForVersion(undefined), null);
 });
 
-test("fetchFeedHttps rejects http on non-loopback hosts", async () => {
-  await assert.rejects(
-    () => fetchFeedHttps("http://cdn.example.dev/feed/stable/latest-mac.json"),
-    /must be https/,
-  );
-});
-
 test("channelForFlavor maps beta -> insider", () => {
   assert.strictEqual(channelForFlavor("beta"), "insider");
 });
@@ -35,296 +41,6 @@ test("channelForFlavor defaults non-beta to stable", () => {
   assert.strictEqual(channelForFlavor(undefined), "stable");
   assert.strictEqual(channelForFlavor("anything"), "stable");
 });
-
-test("buildFeedUrl points at the channel's static latest-mac.json", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "insider" });
-  assert.strictEqual(url, "https://cdn.example.dev/feed/insider/latest-mac.json");
-});
-
-test("buildFeedUrl strips trailing slashes from base", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed///", channel: "stable" });
-  assert.strictEqual(url, "https://cdn.example.dev/feed/stable/latest-mac.json");
-});
-
-test("buildFeedUrl url-encodes the channel segment", () => {
-  const url = buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "a b" });
-  assert.strictEqual(url, "https://cdn.example.dev/feed/a%20b/latest-mac.json");
-});
-
-// ---------------------------------------------------------------------------
-// Client-side compare gate: Squirrel must only be engaged when the static
-// feed's version differs from the running app (a static 200 feed would
-// otherwise read as "update available" on every check, forever).
-// ---------------------------------------------------------------------------
-
-function makeDeps({ appVersion, feed, fetchErr }) {
-  const calls = { checkForUpdates: 0, setFeedURL: [], setFeedHeaders: [], states: [], payloads: [] };
-  const handlers = {};
-  const deps = {
-    app: {
-      isPackaged: true,
-      getVersion: () => appVersion,
-      once: () => {},
-      removeListener: () => {},
-    },
-    autoUpdater: {
-      setFeedURL: (o) => { calls.setFeedURL.push(o.url); calls.setFeedHeaders.push(o.headers); },
-      checkForUpdates: () => { calls.checkForUpdates += 1; },
-      on: (ev, fn) => { handlers[ev] = fn; },
-      quitAndInstall: () => {},
-    },
-    dialog: { showMessageBox: async () => ({ response: 1 }) },
-    Notification: function () { return { show: () => {} }; },
-    getFlavor: () => "beta",
-    stopGateway: async () => {},
-    feedBase: "https://cdn.example.dev/feed",
-    fetchFeed: async () => {
-      if (fetchErr) throw fetchErr;
-      return feed;
-    },
-    onUpdateState: (s) => { calls.states.push(s.state); calls.payloads.push(s); },
-    log: { info: () => {}, warn: () => {}, error: () => {} },
-  };
-  return { deps, calls, handlers };
-}
-
-// Feed URLs carry a per-check cache-bust query param, so compare on the path.
-function feedUrlSeen(calls, expected) {
-  return calls.setFeedURL.some((u) => u.split("?")[0] === expected);
-}
-
-// Last emitted payload for a given state (states repeat across a check).
-function lastPayload(calls, state) {
-  return calls.payloads.filter((p) => p.state === state).pop();
-}
-
-// Force darwin so initAutoUpdate does not bail on non-mac test runners.
-function withDarwin(fn) {
-  const orig = Object.getOwnPropertyDescriptor(process, "platform");
-  Object.defineProperty(process, "platform", { value: "darwin" });
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => Object.defineProperty(process, "platform", orig));
-}
-
-test("same feed version does NOT engage Squirrel (loop guard)", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "1.0.0", url: "https://cdn.example.dev/desktop/insider/1.0.0/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    // allow the async safeCheck to settle
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(calls.states.includes("not-available"));
-  }));
-
-test("newer feed version surfaces 'found' and does NOT download until consent", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip", notes: "Fixes things", pub_date: "2026-07-21T18:40:21Z" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    // Discovery only: no Squirrel engagement, card metadata surfaced.
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(calls.states.includes("found"));
-    // Bare-semver running version resolves to the STABLE channel -- the
-    // version-derived channel wins over the fixture's "beta" flavor.
-    assert.ok(feedUrlSeen(calls, "https://cdn.example.dev/feed/stable/latest-mac.json"));
-    // Explicit consent engages Squirrel.
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 1);
-    assert.ok(calls.states.includes("downloading"));
-  }));
-
-test("malformed feed surfaces error and does not engage Squirrel", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { name: "no version or url" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(calls.states.includes("error"));
-  }));
-
-test("feed fetch failure surfaces error and does not engage Squirrel", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      fetchErr: new Error("feed HTTP 403"),
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(calls.states.includes("error"));
-  }));
-
-test("stamped nightly build tracks the NIGHTLY feed, not stable (no channel migration)", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "0.1.0-nightly.20260721042000",
-      feed: { version: "0.1.0-nightly.20260722042000", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(feedUrlSeen(calls, "https://cdn.example.dev/feed/nightly/latest-mac.json"));
-    // Discovery never downloads (consent gate).
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(calls.states.includes("found"));
-  }));
-
-test("fetchFeedHttps accepts plain http on loopback (local update harness)", async () => {
-  const http = require("http");
-  const srv = http.createServer((_req, res) => {
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ version: "9.9.9", url: "http://127.0.0.1/z.zip" }));
-  });
-  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
-  try {
-    const feed = await fetchFeedHttps(`http://127.0.0.1:${srv.address().port}/feed/stable/latest-mac.json`);
-    assert.strictEqual(feed.version, "9.9.9");
-  } finally {
-    srv.close();
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Manual re-check semantics (macOS Software Update style): a check must never
-// be a silent no-op. Regression for the dead Check-for-updates button (silent
-// `if (updateReady) return`) and the stale-staged-bundle install.
-// ---------------------------------------------------------------------------
-
-test("re-check with the staged version still latest RE-SURFACES the downloaded state (no dead button)", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260721061155",
-      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    // Simulate Squirrel having downloaded + staged the feed version.
-    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721082353");
-    calls.states.length = 0;
-    calls.checkForUpdates = 0;
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    // Must not silently no-op, must not re-download; must re-surface install.
-    assert.ok(calls.states.includes("checking"));
-    assert.ok(calls.states.includes("downloaded"));
-    assert.strictEqual(calls.checkForUpdates, 0);
-  }));
-
-test("stale staged bundle: check surfaces the newer version; consented download supersedes the stage", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260721042000",
-      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    // An OLDER version was staged earlier in the day.
-    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721061155");
-    calls.states.length = 0;
-    calls.checkForUpdates = 0;
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    // The check must NOT re-surface the stale stage as installable, and must
-    // not download on its own: it surfaces the newest version for consent.
-    assert.strictEqual(calls.checkForUpdates, 0);
-    assert.ok(!calls.states.includes("downloaded"));
-    assert.ok(calls.states.includes("found"));
-    // Consent: the stale stage is dropped and Squirrel re-downloads.
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 1);
-  }));
-
-test("re-check when already up to date reports not-available even with a stale updateReady flag", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260721082353",
-      feed: { version: "0.1.0-nightly.20260721082353", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721082353");
-    calls.states.length = 0;
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(calls.states.includes("not-available"));
-    assert.strictEqual(calls.checkForUpdates, 0);
-  }));
-
-test("install path arms a force-exit failsafe after quitAndInstall (ShipIt App-Still-Running guard)", () =>
-  withDarwin(async () => {
-    const { deps } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "2.0.0", url: "https://cdn.example.dev/desktop/stable/2.0.0/KiroCrew.zip" },
-    });
-    const events = [];
-    deps.app.exit = (code) => events.push(`exit:${code}`);
-    deps.autoUpdater.quitAndInstall = () => events.push("quitAndInstall");
-    // Capture the failsafe timer instead of waiting 5s of wall clock.
-    const realSetTimeout = global.setTimeout;
-    let failsafe = null;
-    global.setTimeout = (fn, ms, ...rest) => {
-      if (ms === 5000) { failsafe = fn; return { unref: () => {} }; }
-      return realSetTimeout(fn, ms, ...rest);
-    };
-    try {
-      const u = initAutoUpdate(deps);
-      await u.install();
-    } finally {
-      global.setTimeout = realSetTimeout;
-    }
-    assert.deepStrictEqual(events, ["quitAndInstall"]);
-    assert.ok(failsafe, "failsafe timer must be armed");
-    failsafe(); // simulate the app still being alive 5s later
-    assert.deepStrictEqual(events, ["quitAndInstall", "exit:0"]);
-  }));
-
-test("re-check while a download is in flight does NOT re-engage Squirrel (staging-dir race guard)", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260721082353",
-      feed: { version: "0.1.0-nightly.20260721182718", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    // Discovery, then explicit consent starts the download.
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 1);
-    handlers["update-available"]();
-    calls.states.length = 0;
-    // Impatient re-check AND re-click mid-download: must NOT restart
-    // Squirrel's flow (that rips the update.XXXX staging dir out from under
-    // ditto) -- both report progress instead.
-    await u.check();
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(calls.checkForUpdates, 1);
-    assert.ok(calls.states.includes("downloading"));
-    // Download completes -> flag clears -> ready to install.
-    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260721182718");
-    assert.ok(calls.states.includes("downloaded"));
-  }));
-
-// ---------------------------------------------------------------------------
-// Channel switcher (stable ⇄ insider opt-in): resolveChannel decision table
-// and the preference wiring through initAutoUpdate.
-// ---------------------------------------------------------------------------
-
-const { resolveChannel } = require("../auto-update");
 
 test("resolveChannel: nightly stamp is pinned -- preference ignored", () => {
   assert.strictEqual(resolveChannel("nightly", "stable"), "nightly");
@@ -349,199 +65,737 @@ test("resolveChannel: no/invalid preference falls back to the stamp", () => {
   assert.strictEqual(resolveChannel("insider", "bogus"), "insider");
 });
 
-test("preference points the FEED at the opted-in channel", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "0.1.0-insider.3",
-      feed: { version: "0.1.0-insider.3", url: "https://cdn.example.dev/x.zip" },
-    });
-    deps.getChannelPreference = () => "stable";
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(calls.setFeedURL.every((u2) => u2.includes("/stable/")),
-      `expected stable feed URLs, got: ${calls.setFeedURL}`);
-    assert.strictEqual(u.getInfo().channel, "stable");
-  }));
-
-test("switch-back downgrade surfaces the consent card (gate engages on difference)", () =>
-  withDarwin(async () => {
-    // Running insider 0.2.0-insider.1, preference=stable, stable feed has the
-    // OLDER 0.1.0: the check must surface "found" (never auto-download).
-    const { deps, calls } = makeDeps({
-      appVersion: "0.2.0-insider.1",
-      feed: { version: "0.1.0", url: "https://cdn.example.dev/desktop/stable/0.1.0/KiroCrew.zip" },
-    });
-    deps.getChannelPreference = () => "stable";
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
-    assert.strictEqual(calls.checkForUpdates, 0); // consent gate: discovery never downloads
-  }));
-
-test("getInfo exposes switcher inputs: stamped lane, switchability, preference", () =>
-  withDarwin(async () => {
-    const { deps } = makeDeps({
-      appVersion: "0.1.0-insider.3",
-      feed: { version: "0.1.0-insider.3", url: "https://cdn.example.dev/x.zip" },
-    });
-    deps.getChannelPreference = () => "stable";
-    const u = initAutoUpdate(deps);
-    const info = u.getInfo();
-    assert.strictEqual(info.stampedChannel, "insider");
-    assert.strictEqual(info.channelSwitchable, true);
-    assert.strictEqual(info.channelPreference, "stable");
-  }));
-
-test("nightly build reports not switchable and stays on nightly", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "0.1.0-nightly.20260722233638",
-      feed: { version: "0.1.0-nightly.20260722233638", url: "https://cdn.example.dev/x.zip" },
-    });
-    deps.getChannelPreference = () => "stable"; // must be ignored
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.strictEqual(u.getInfo().channelSwitchable, false);
-    assert.ok(calls.setFeedURL.every((u2) => u2.includes("/nightly/")),
-      `expected nightly feed URLs, got: ${calls.setFeedURL}`);
-  }));
-
 // ---------------------------------------------------------------------------
-// Update nudge: found fires notifyUpdateFound (discovery-only); up-to-date
-// and error paths never do. Once-per-version dedupe lives in main.js.
+// buildFeedBase: the generic-provider DIRECTORY url. The trailing slash is
+// load-bearing -- `new URL("latest-mac.yml", base)` REPLACES the last path
+// segment when base has no trailing slash, resolving the wrong channel.
 // ---------------------------------------------------------------------------
 
-test("found fires notifyUpdateFound with the feed version", () =>
-  withDarwin(async () => {
-    const nudges = [];
-    const { deps } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "1.1.0", url: "https://cdn.example.dev/desktop/insider/1.1.0/KiroCrew.zip" },
-    });
-    deps.notifyUpdateFound = (v) => nudges.push(v);
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.deepStrictEqual(nudges, ["1.1.0"]);
-  }));
+test("buildFeedBase emits the channel DIRECTORY with a trailing slash", () => {
+  const url = buildFeedBase({ base: "https://cdn.example.dev/feed", channel: "insider" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/insider/");
+  assert.ok(url.endsWith("/"), "trailing slash is load-bearing for the generic provider");
+});
 
-test("up-to-date and failed checks never nudge", () =>
-  withDarwin(async () => {
-    const nudges = [];
-    const same = makeDeps({ appVersion: "1.0.0", feed: { version: "1.0.0", url: "https://cdn.example.dev/x.zip" } });
-    same.deps.notifyUpdateFound = (v) => nudges.push(v);
-    await initAutoUpdate(same.deps).check();
-    const err = makeDeps({ appVersion: "1.0.0", fetchErr: new Error("offline") });
-    err.deps.notifyUpdateFound = (v) => nudges.push(v);
-    await initAutoUpdate(err.deps).check();
-    await new Promise((r) => setImmediate(r));
-    assert.deepStrictEqual(nudges, []);
-  }));
+test("buildFeedBase strips trailing slashes from the base before appending", () => {
+  const url = buildFeedBase({ base: "https://cdn.example.dev/feed///", channel: "stable" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/stable/");
+});
 
-test("a throwing nudge callback does not break the check (found still emitted)", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "1.1.0", url: "https://cdn.example.dev/x.zip" },
-    });
-    deps.notifyUpdateFound = () => { throw new Error("boom"); };
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(calls.states.includes("found"), `states: ${calls.states}`);
-  }));
+test("buildFeedBase url-encodes the channel segment", () => {
+  const url = buildFeedBase({ base: "https://cdn.example.dev/feed", channel: "a b" });
+  assert.strictEqual(url, "https://cdn.example.dev/feed/a%20b/");
+});
 
-// ---------------------------------------------------------------------------
-// Stale-feed defenses (2026-07-28 field bug). The feed object was published
-// without Cache-Control, so Squirrel's NSURLCache-backed fetch kept resolving
-// a ~22h-old entry naming the version already installed, while this module's
-// cacheless fetch saw the new one. Three independent guards are pinned here:
-// a per-check cache-bust on the URL Squirrel fetches, an explicit target
-// version on every "downloading" event, and a refusal to arm an install whose
-// version equals the running build.
-// ---------------------------------------------------------------------------
-
-test("buildFeedUrl appends a cache-bust param only when asked", () => {
+test("buildFeedBase defaults to the public pointer host (DEFAULT_FEED_BASE)", () => {
   assert.strictEqual(
-    buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable", cacheBust: "1234-7" }),
-    "https://cdn.example.dev/feed/stable/latest-mac.json?_=1234-7",
+    buildFeedBase({ channel: "nightly" }),
+    "https://updates.crew.kiro.dev/feed/nightly/",
   );
-  assert.strictEqual(
-    buildFeedUrl({ base: "https://cdn.example.dev/feed", channel: "stable" }),
-    "https://cdn.example.dev/feed/stable/latest-mac.json",
+  assert.strictEqual(DEFAULT_FEED_BASE, "https://updates.crew.kiro.dev/feed");
+});
+
+test("buildFeedBase THROWS for plain http on non-loopback hosts", () => {
+  assert.throws(
+    () => buildFeedBase({ base: "http://cdn.example.dev/feed", channel: "stable" }),
+    /must be https/,
+  );
+  // A LAN address is not loopback either -- cleartext update metadata over a
+  // real network stays rejected.
+  assert.throws(
+    () => buildFeedBase({ base: "http://192.168.1.10/feed", channel: "stable" }),
+    /must be https/,
   );
 });
 
-test("every configured feed URL is unique and requests no-cache (NSURLCache defeat)", () =>
-  withDarwin(async () => {
-    const { deps, calls } = makeDeps({
-      appVersion: "1.0.0",
-      feed: { version: "1.0.1", url: "https://cdn.example.dev/desktop/stable/1.0.1/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    assert.ok(calls.setFeedURL.length >= 2, `expected >=2 configureFeed calls, got ${calls.setFeedURL.length}`);
-    for (const url of calls.setFeedURL) {
-      assert.match(url, /\?_=\d+-\d+$/, `feed URL missing cache-bust: ${url}`);
-    }
-    assert.strictEqual(new Set(calls.setFeedURL).size, calls.setFeedURL.length,
-      `feed URLs repeated across checks: ${calls.setFeedURL}`);
-    for (const headers of calls.setFeedHeaders) {
-      assert.strictEqual(headers && headers["Cache-Control"], "no-cache");
-    }
-  }));
+test("buildFeedBase ALLOWS plain http on loopback (local update harness)", () => {
+  assert.strictEqual(
+    buildFeedBase({ base: "http://127.0.0.1:8099/feed", channel: "stable" }),
+    "http://127.0.0.1:8099/feed/stable/",
+  );
+  assert.strictEqual(
+    buildFeedBase({ base: "http://localhost:8099/feed", channel: "stable" }),
+    "http://localhost:8099/feed/stable/",
+  );
+  assert.strictEqual(
+    buildFeedBase({ base: "http://[::1]:8099/feed", channel: "stable" }),
+    "http://[::1]:8099/feed/stable/",
+  );
+});
 
-test("downloading reports the version being FETCHED, not the running build", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260728t065139",
-      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    await u.check();
-    await new Promise((r) => setImmediate(r));
-    await u.download();
-    await new Promise((r) => setImmediate(r));
-    handlers["update-available"](); // Squirrel confirms it started fetching
-    const downloading = lastPayload(calls, "downloading");
-    assert.strictEqual(downloading.version, "0.1.2-nightly.20260728t221922");
-    assert.notStrictEqual(downloading.version, "0.1.0-nightly.20260728t065139");
-  }));
+// ---------------------------------------------------------------------------
+// configureUpdater: the four policy flags this app depends on. EVERY one
+// differs from the electron-updater default; a regression on any of them
+// re-introduces a bug class we already fixed.
+// ---------------------------------------------------------------------------
 
-test("a resolved update equal to the running version is refused, not installed", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260728t065139",
-      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
-    const u = initAutoUpdate(deps);
-    calls.states.length = 0;
-    // Squirrel resolved a stale feed entry: the bundle it staged IS the
-    // running version. Installing it would restart into the same build and
-    // re-offer forever.
-    handlers["update-downloaded"]({}, "notes", "0.1.0-nightly.20260728t065139");
-    assert.ok(!calls.states.includes("downloaded"), "must not offer to install the running version");
-    assert.ok(calls.states.includes("not-available"));
-    assert.strictEqual(u.isReady(), false, "install must not be armed");
-  }));
+test("configureUpdater: autoDownload=false (consent-first: discovery must never download)", () => {
+  const updater = {};
+  configureUpdater(updater);
+  // Library default is TRUE: a background check would silently download
+  // megabytes with no user action. Our UX is discover -> ask -> download.
+  assert.strictEqual(updater.autoDownload, false);
+});
 
-test("a resolved update newer than the running version still arms normally", () =>
-  withDarwin(async () => {
-    const { deps, calls, handlers } = makeDeps({
-      appVersion: "0.1.0-nightly.20260728t065139",
-      feed: { version: "0.1.2-nightly.20260728t221922", url: "https://cdn.example.dev/desktop/nightly/x/KiroCrew.zip" },
-    });
+test("configureUpdater: autoInstallOnAppQuit=false (gateway must stop before the bundle swap)", () => {
+  const updater = {};
+  configureUpdater(updater);
+  // Library default is TRUE: it would swap the bundle on quit WITHOUT
+  // stopping the bundled Python gateway -- the half-replaced-app race this
+  // module exists to prevent. deferredInstallOnQuit() does it in order.
+  assert.strictEqual(updater.autoInstallOnAppQuit, false);
+});
+
+test("configureUpdater: allowDowngrade=true (difference-based gate: retraction + channel switch-back)", () => {
+  const updater = {};
+  configureUpdater(updater);
+  // Library default is FALSE (greater-than only). Our gate is DIFFERENCE
+  // based: a feed repointed to an older version (retraction) or a stable
+  // preference on an insider build (switch-back downgrade) must be offered.
+  assert.strictEqual(updater.allowDowngrade, true);
+});
+
+test("configureUpdater: allowPrerelease=true (nightly/insider stamps are semver prereleases)", () => {
+  const updater = {};
+  configureUpdater(updater);
+  // Library default is FALSE: every -nightly.<stamp> / -insider.N version is
+  // a semver prerelease and would be invisible to its OWN channel's checks.
+  assert.strictEqual(updater.allowPrerelease, true);
+});
+
+// ---------------------------------------------------------------------------
+// CONTRACT with electron-updater internals: the generic provider resolves
+// artifact urls via newUrlFromBase(fileUrl, base). Our pointer/bytes host
+// split (updates.crew.kiro.dev pointers, download.crew.kiro.dev bytes) relies
+// on the UNDOCUMENTED-but-structural behaviour that an ABSOLUTE file url
+// ignores the base. A library upgrade that changes this must fail CI here,
+// not strand installs in the field.
+// ---------------------------------------------------------------------------
+
+test("CONTRACT: absolute artifact urls pass through newUrlFromBase unchanged (pointer/bytes split)", () => {
+  const { newBaseUrl, newUrlFromBase } = require("electron-updater/out/util");
+  const base = newBaseUrl(buildFeedBase({ base: "https://updates.crew.kiro.dev/feed", channel: "nightly" }));
+  const absolute = "https://download.crew.kiro.dev/desktop/nightly/0.1.0-nightly.20260728t112233/KiroCrew-arm64.dmg";
+  // Base is on a DIFFERENT host than the artifact: the absolute url must win.
+  assert.strictEqual(newUrlFromBase(absolute, base).href, absolute);
+});
+
+test("CONTRACT: relative channel-file names resolve under the feed base directory", () => {
+  const { newBaseUrl, newUrlFromBase } = require("electron-updater/out/util");
+  const base = newBaseUrl(buildFeedBase({ base: "https://updates.crew.kiro.dev/feed", channel: "nightly" }));
+  assert.strictEqual(
+    newUrlFromBase("latest-mac.yml", base).href,
+    "https://updates.crew.kiro.dev/feed/nightly/latest-mac.yml",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// initAutoUpdate fixture: fake electron-updater AppUpdater (EventEmitter-like,
+// recording setFeedURL / checkForUpdates / downloadUpdate / quitAndInstall)
+// plus fake electron app/dialog/Notification. Platform comes in through the
+// injected osPlatform dep -- no process.platform mutation needed.
+// ---------------------------------------------------------------------------
+
+function makeDeps(opts = {}) {
+  const {
+    appVersion = "1.0.0",
+    osPlatform = "darwin",
+    isPackaged = true,
+  } = opts;
+  const calls = { setFeedURL: [], checkForUpdates: 0, downloadUpdate: 0, quitAndInstall: [] };
+  const handlers = {};
+  const states = [];
+  const appOnce = [];
+  const appRemoved = [];
+  const autoUpdater = {
+    setFeedURL: (o) => calls.setFeedURL.push(o),
+    checkForUpdates: async () => { calls.checkForUpdates += 1; },
+    downloadUpdate: async () => { calls.downloadUpdate += 1; },
+    quitAndInstall: (...args) => calls.quitAndInstall.push(args),
+    on: (ev, fn) => { handlers[ev] = fn; },
+  };
+  const deps = {
+    app: {
+      isPackaged,
+      getVersion: () => appVersion,
+      once: (ev, fn) => appOnce.push({ ev, fn }),
+      removeListener: (ev, fn) => appRemoved.push({ ev, fn }),
+      // Must exist: the force-exit failsafe timer (unref'd but still live)
+      // calls app.exit(0) if the suite outlives it; without this stub it
+      // would fall through to process.exit and kill the test runner.
+      exit: () => {},
+    },
+    autoUpdater,
+    dialog: { showMessageBox: async () => ({ response: 1 }) },
+    Notification: function () { return { show: () => {} }; },
+    getFlavor: () => "stable",
+    stopGateway: async () => {},
+    osPlatform,
+    feedBase: "https://cdn.example.dev/feed",
+    onUpdateState: (s) => states.push(s),
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+  const emit = (ev, payload) => handlers[ev] && handlers[ev](payload);
+  const stateNames = () => states.map((s) => s.state);
+  return { deps, calls, handlers, emit, states, stateNames, appOnce, appRemoved };
+}
+
+// ---------------------------------------------------------------------------
+// #709 regression guard: every state that renders a version must report the
+// PENDING one. emit() defaults `version` to app.getVersion(), so a
+// "downloading" event that forgets to pass it makes the update card claim the
+// app is downloading the build it is already running -- the exact symptom
+// reported in the field. The electron-updater migration reintroduced this once
+// already; these tests exist so it cannot happen a third time.
+// ---------------------------------------------------------------------------
+
+test("#709: 'downloading' after consent reports the PENDING version, not the running one", async () => {
+  const { deps, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  states.length = 0;
+  await u.download();
+  const downloading = states.filter((s) => s.state === "downloading");
+  assert.ok(downloading.length > 0, "consent must surface a downloading state");
+  for (const s of downloading) {
+    assert.strictEqual(
+      s.version,
+      "1.1.0",
+      `downloading reported ${s.version} (running 1.0.0) -- the card would claim the app is downloading the version already installed`,
+    );
+  }
+});
+
+test("#709: download-progress reports the PENDING version, not the running one", async () => {
+  const { deps, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  states.length = 0;
+  emit("download-progress", { percent: 42, bytesPerSecond: 1024 });
+  const s = states.find((x) => x.state === "downloading");
+  assert.ok(s, "progress must surface a downloading state");
+  assert.strictEqual(s.version, "1.1.0");
+  assert.strictEqual(s.percent, 42);
+});
+
+test("#709: an in-flight re-check reports the PENDING version, not the running one", async () => {
+  const { deps, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  const pending = [];
+  deps.autoUpdater.downloadUpdate = () => new Promise((resolve) => pending.push(resolve));
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  u.download(); // leave it in flight
+  states.length = 0;
+  await u.check(); // must report progress, with the pending version
+  const s = states.find((x) => x.state === "downloading");
+  assert.ok(s, "an in-flight re-check must report progress");
+  assert.strictEqual(s.version, "1.1.0");
+  pending.forEach((r) => r());
+});
+
+test("#709: states that describe the RUNNING build still report app.getVersion()", () => {
+  // The counterpart guard: pendingVersion() must not leak into states that are
+  // about the installed app, or "up to date" would name a version the user
+  // does not have.
+  const { deps, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  initAutoUpdate(deps);
+  emit("update-not-available", { version: "1.0.0" });
+  const s = states.find((x) => x.state === "not-available");
+  assert.ok(s);
+  assert.strictEqual(s.version, "1.0.0");
+});
+
+// ---------------------------------------------------------------------------
+// #709's other two fixes are now structurally subsumed by the library rather
+// than implemented here, so they are pinned where they actually live:
+//   - cache-bust: electron-updater appends its own noCache query
+//     (isAddNoCacheQuery), and MacUpdater serves Squirrel.Mac from a loopback
+//     proxy, so NSURLCache is no longer in the feed path at all.
+//   - same-version guard: isUpdateAvailable() returns false on
+//     eq(latest, current) BEFORE the allowDowngrade branch.
+// Both are asserted against the REAL installed library below, so a version
+// bump that removes either fails CI instead of resurfacing the incident.
+// ---------------------------------------------------------------------------
+
+test("#709 contract: the library still refuses an equal version even with allowDowngrade", () => {
+  const src = require("fs").readFileSync(
+    require.resolve("electron-updater/out/AppUpdater.js"),
+    "utf8",
+  );
+  const idx = src.indexOf("async isUpdateAvailable(");
+  assert.ok(idx > 0, "isUpdateAvailable not found -- library layout changed");
+  const body = src.slice(idx, idx + 1200);
+  const eqAt = body.indexOf("eq)(latestVersion, currentVersion)");
+  const downgradeAt = body.indexOf("allowDowngrade");
+  assert.ok(eqAt > 0, "equal-version short-circuit is gone -- self-reinstall loop can return");
+  assert.ok(
+    downgradeAt === -1 || eqAt < downgradeAt,
+    "the equal-version check must precede the allowDowngrade branch, or allowDowngrade=true would offer the running version",
+  );
+});
+
+test("#709 contract: the library adds its own no-cache query when no headers are set", () => {
+  const src = require("fs").readFileSync(
+    require.resolve("electron-updater/out/AppUpdater.js"),
+    "utf8",
+  );
+  assert.match(
+    src,
+    /get isAddNoCacheQuery\(\)/,
+    "isAddNoCacheQuery is gone -- the client-side cache-bust that replaced our feedNonce no longer exists",
+  );
+});
+// win32 has none yet (#598) and must come back disabled -- WITHOUT touching
+// the updater at all. Dev (unpackaged) builds have no update lane either.
+// ---------------------------------------------------------------------------
+
+test("SUPPORTED_PLATFORMS is exactly {darwin, linux}", () => {
+  assert.deepStrictEqual([...SUPPORTED_PLATFORMS].sort(), ["darwin", "linux"]);
+});
+
+test("darwin initialises the updater (not disabled)", () => {
+  const { deps, calls } = makeDeps({ osPlatform: "darwin" });
+  const u = initAutoUpdate(deps);
+  assert.strictEqual(u.disabled, undefined);
+  assert.ok(calls.setFeedURL.length >= 1, "feed must be configured at init");
+  assert.strictEqual(deps.autoUpdater.autoDownload, false, "policy flags applied");
+});
+
+test("linux initialises the updater (not disabled)", () => {
+  const { deps, calls } = makeDeps({ osPlatform: "linux" });
+  const u = initAutoUpdate(deps);
+  assert.strictEqual(u.disabled, undefined);
+  assert.ok(calls.setFeedURL.length >= 1, "feed must be configured at init");
+  assert.strictEqual(deps.autoUpdater.autoDownload, false, "policy flags applied");
+});
+
+test("win32 returns disabled:'platform' and never touches the updater", () => {
+  const { deps, calls } = makeDeps({ osPlatform: "win32" });
+  const u = initAutoUpdate(deps);
+  assert.strictEqual(u.disabled, "platform");
+  assert.strictEqual(calls.setFeedURL.length, 0);
+  assert.strictEqual(deps.autoUpdater.autoDownload, undefined, "policy flags must not be applied");
+  // The disabled surface must still be safely callable.
+  assert.strictEqual(typeof u.check, "function");
+  assert.strictEqual(typeof u.getInfo, "function");
+});
+
+test("dev (unpackaged) build returns disabled:'dev'", () => {
+  const { deps, calls } = makeDeps({ isPackaged: false });
+  const u = initAutoUpdate(deps);
+  assert.strictEqual(u.disabled, "dev");
+  assert.strictEqual(calls.setFeedURL.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Consent flow with the electron-updater event shape. autoDownload=false makes
+// 'update-available' a DISCOVERY event: surfacing it must never download.
+// ---------------------------------------------------------------------------
+
+test("'update-available' surfaces 'found' and does NOT call downloadUpdate (discovery never downloads)", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.strictEqual(calls.checkForUpdates, 1);
+  emit("update-available", { version: "1.1.0", releaseNotes: "Fixes things", releaseDate: "2026-07-28T00:00:00Z" });
+  assert.strictEqual(calls.downloadUpdate, 0, "discovery must never download");
+  const found = states.find((s) => s.state === "found");
+  assert.ok(found, "'found' state must be emitted");
+  assert.strictEqual(found.version, "1.1.0");
+  assert.strictEqual(found.notes, "Fixes things");
+  assert.strictEqual(found.pubDate, "2026-07-28T00:00:00Z");
+});
+
+test("download() is the consent gate: it alone calls downloadUpdate", async () => {
+  const { deps, calls, emit, stateNames } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  assert.strictEqual(calls.downloadUpdate, 0);
+  await u.download();
+  assert.strictEqual(calls.downloadUpdate, 1);
+  assert.ok(stateNames().includes("downloading"));
+});
+
+test("download() with nothing discovered checks first instead of blind-downloading", async () => {
+  const { deps, calls } = makeDeps();
+  const u = initAutoUpdate(deps);
+  await u.download();
+  assert.strictEqual(calls.downloadUpdate, 0, "no consent target yet -- must not download");
+  assert.strictEqual(calls.checkForUpdates, 1, "must fall back to discovery");
+});
+
+test("'download-progress' surfaces 'downloading' with the percent", () => {
+  const { deps, emit, states } = makeDeps();
+  initAutoUpdate(deps);
+  emit("download-progress", { percent: 42.5, bytesPerSecond: 1024 });
+  const s = states.find((x) => x.state === "downloading");
+  assert.ok(s, "'downloading' state must be emitted");
+  assert.strictEqual(s.percent, 42.5);
+});
+
+test("'update-downloaded' surfaces 'downloaded' and arms install-on-quit", () => {
+  const { deps, emit, states, appOnce } = makeDeps();
+  initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0", releaseNotes: "notes" });
+  const s = states.find((x) => x.state === "downloaded");
+  assert.ok(s, "'downloaded' state must be emitted");
+  assert.strictEqual(s.version, "1.1.0");
+  assert.strictEqual(s.notes, "notes");
+  // UI-driven mode still installs on a natural quit if the user picks Later.
+  assert.ok(appOnce.some((c) => c.ev === "before-quit"), "deferred install must be armed");
+});
+
+test("release-notes arrays ({version,note}[] feed shape) are flattened", () => {
+  const { deps, emit, states } = makeDeps();
+  initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0", releaseNotes: [{ note: "first" }, { note: "second" }] });
+  const s = states.find((x) => x.state === "downloaded");
+  assert.strictEqual(s.notes, "first\n\nsecond");
+});
+
+test("check failure surfaces 'error' instead of throwing", async () => {
+  const { deps, emit, states, stateNames } = makeDeps();
+  deps.autoUpdater.checkForUpdates = async () => { throw new Error("feed HTTP 403"); };
+  const u = initAutoUpdate(deps);
+  await u.check(); // must not reject
+  assert.ok(stateNames().includes("error"));
+  assert.ok(states.find((s) => s.state === "error").message.includes("feed HTTP 403"));
+  // A later updater 'error' event is also surfaced.
+  emit("error", new Error("boom"));
+  assert.ok(states.filter((s) => s.state === "error").length >= 2);
+});
+
+test("'update-not-available' surfaces 'not-available'", async () => {
+  const { deps, emit, stateNames } = makeDeps();
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-not-available");
+  assert.ok(stateNames().includes("not-available"));
+});
+
+// ---------------------------------------------------------------------------
+// Re-check / re-click semantics: a manual check is never a silent no-op, and
+// an in-flight download is never restarted underneath itself.
+// ---------------------------------------------------------------------------
+
+test("re-check with a staged download consults the feed and RE-SURFACES 'downloaded' when the stage is still latest (no dead button)", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0", releaseNotes: "notes" });
+  states.length = 0;
+  await u.check();
+  // The check MUST consult the feed even with a stage in hand -- short-circuiting
+  // here would pin the user to a stale stage when a newer version ships
+  // mid-session. What it must NOT do is re-download.
+  assert.strictEqual(calls.checkForUpdates, 1);
+  assert.strictEqual(calls.downloadUpdate, 0);
+  // Feed still reports the staged version -> re-surface the install prompt.
+  emit("update-available", { version: "1.1.0", releaseNotes: "notes" });
+  const s = states.find((x) => x.state === "downloaded");
+  assert.ok(s, "staged version must be re-surfaced");
+  assert.strictEqual(s.version, "1.1.0");
+  assert.strictEqual(calls.downloadUpdate, 0, "must not re-download an already-staged version");
+});
+
+test("a NEWER version discovered while one is staged supersedes the stale stage", async () => {
+  const { deps, calls, emit, states, stateNames } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0", releaseNotes: "old" });
+  assert.strictEqual(u.isReady(), true);
+  states.length = 0;
+  await u.check();
+  // Feed has moved on: 1.2.0 is now latest. The staged 1.1.0 must be discarded
+  // and re-offered as a fresh find, NOT installed as if it were current.
+  emit("update-available", { version: "1.2.0", releaseNotes: "new" });
+  assert.strictEqual(u.isReady(), false, "stale stage must be discarded");
+  const found = states.find((x) => x.state === "found");
+  assert.ok(found, "the newer version must be surfaced as a fresh find");
+  assert.strictEqual(found.version, "1.2.0");
+  assert.ok(
+    !stateNames().includes("downloaded"),
+    "must not re-surface the superseded stage as installable",
+  );
+  // Consent now downloads the NEWER build.
+  await u.download();
+  assert.strictEqual(calls.downloadUpdate, 1);
+});
+
+test("re-check and re-click while a download is in flight report progress instead of restarting", async () => {
+  const { deps, calls, emit, states, stateNames } = makeDeps();
+  const pending = [];
+  deps.autoUpdater.downloadUpdate = () => {
+    calls.downloadUpdate += 1;
+    return new Promise((resolve) => pending.push(resolve));
+  };
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  const dl = u.download(); // in flight -- do not await yet
+  await new Promise((r) => setImmediate(r));
+  assert.strictEqual(calls.downloadUpdate, 1);
+  states.length = 0;
+  // Impatient re-check AND re-click mid-download: neither may restart the
+  // updater flow underneath the running download.
+  await u.check();
+  await u.download();
+  assert.strictEqual(calls.checkForUpdates, 1);
+  assert.strictEqual(calls.downloadUpdate, 1);
+  assert.ok(stateNames().includes("downloading"));
+  // Completion clears the flag and surfaces install.
+  emit("update-downloaded", { version: "1.1.0" });
+  assert.ok(stateNames().includes("downloaded"));
+  pending.forEach((resolve) => resolve());
+  await dl;
+});
+
+test("updater 'error' clears the in-flight download so consent can retry", async () => {
+  const { deps, calls, emit, stateNames } = makeDeps();
+  const pending = [];
+  deps.autoUpdater.downloadUpdate = () => {
+    calls.downloadUpdate += 1;
+    return new Promise((resolve) => pending.push(resolve));
+  };
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  const dl1 = u.download(); // in flight -- resolved at the end
+  await new Promise((r) => setImmediate(r));
+  emit("error", new Error("network dropped"));
+  assert.ok(stateNames().includes("error"));
+  // The flag is cleared: a new consent click re-engages the download.
+  const dl2 = u.download();
+  await new Promise((r) => setImmediate(r));
+  assert.strictEqual(calls.downloadUpdate, 2);
+  pending.forEach((resolve) => resolve());
+  await Promise.all([dl1, dl2]);
+});
+
+// ---------------------------------------------------------------------------
+// install(): STRICT ORDER -- stopGateway must complete BEFORE quitAndInstall.
+// A live gateway child during the bundle swap can leave a half-replaced app.
+// ---------------------------------------------------------------------------
+
+test("install() awaits stopGateway BEFORE quitAndInstall (strict order)", async () => {
+  const { deps, emit } = makeDeps();
+  const events = [];
+  deps.stopGateway = async () => {
+    events.push("stopGateway:begin");
+    // Real async gap: if install() failed to await, quitAndInstall would be
+    // recorded between begin and done and the deepStrictEqual below fails.
+    await new Promise((r) => setTimeout(r, 20));
+    events.push("stopGateway:done");
+  };
+  deps.autoUpdater.quitAndInstall = (...args) => { events.push(`quitAndInstall(${args.join(",")})`); };
+  const u = initAutoUpdate(deps);
+  // install() now REQUIRES a staged update (an unstaged install would hit
+  // MacUpdater's wait-for-Squirrel branch and be killed by the failsafe), so
+  // stage one first -- this test is about the ORDER of the install steps.
+  emit("update-downloaded", { version: "1.1.0" });
+  await u.install();
+  assert.deepStrictEqual(events, [
+    "stopGateway:begin",
+    "stopGateway:done",
+    // isSilent=false, isForceRunAfter=true: relaunch the app after the swap.
+    "quitAndInstall(false,true)",
+  ]);
+});
+
+test("install() proceeds to quitAndInstall even when stopGateway errors (still in order)", async () => {
+  const { deps, emit } = makeDeps();
+  const events = [];
+  deps.stopGateway = async () => {
+    events.push("stopGateway:threw");
+    throw new Error("gateway already dead");
+  };
+  deps.autoUpdater.quitAndInstall = () => events.push("quitAndInstall");
+  const u = initAutoUpdate(deps);
+  // install() now REQUIRES a staged update (an unstaged install would hit
+  // MacUpdater's wait-for-Squirrel branch and be killed by the failsafe), so
+  // stage one first -- this test is about the ORDER of the install steps.
+  emit("update-downloaded", { version: "1.1.0" });
+  await u.install();
+  assert.deepStrictEqual(events, ["stopGateway:threw", "quitAndInstall"]);
+});
+
+test("install path arms a force-exit failsafe after quitAndInstall (app-still-running guard)", async () => {
+  const { deps, emit } = makeDeps();
+  const events = [];
+  deps.app.exit = (code) => events.push(`exit:${code}`);
+  deps.autoUpdater.quitAndInstall = () => events.push("quitAndInstall");
+  // Capture the failsafe timer instead of waiting 5s of wall clock.
+  const realSetTimeout = global.setTimeout;
+  let failsafe = null;
+  global.setTimeout = (fn, ms, ...rest) => {
+    if (ms === 5000) { failsafe = fn; return { unref: () => {} }; }
+    return realSetTimeout(fn, ms, ...rest);
+  };
+  try {
     const u = initAutoUpdate(deps);
-    calls.states.length = 0;
-    handlers["update-downloaded"]({}, "Release notes", "0.1.2-nightly.20260728t221922");
-    const downloaded = lastPayload(calls, "downloaded");
-    assert.strictEqual(downloaded.version, "0.1.2-nightly.20260728t221922");
-    assert.strictEqual(downloaded.notes, "Release notes");
-    assert.strictEqual(u.isReady(), true);
-  }));
+  // install() now REQUIRES a staged update (an unstaged install would hit
+  // MacUpdater's wait-for-Squirrel branch and be killed by the failsafe), so
+  // stage one first -- this test is about the ORDER of the install steps.
+  emit("update-downloaded", { version: "1.1.0" });
+    await u.install();
+  } finally {
+    global.setTimeout = realSetTimeout;
+  }
+  assert.deepStrictEqual(events, ["quitAndInstall"]);
+  assert.ok(failsafe, "failsafe timer must be armed");
+  failsafe(); // simulate the app still being alive 5s later
+  assert.deepStrictEqual(events, ["quitAndInstall", "exit:0"]);
+});
+
+// ---------------------------------------------------------------------------
+// Channel wiring: the feed url follows the version-derived channel and the
+// user's opt-in preference; nightly is pinned. setFeedURL always uses the
+// generic provider with a trailing-slash directory url.
+// ---------------------------------------------------------------------------
+
+test("stamped nightly build points the FEED at nightly (no channel migration)", async () => {
+  const { deps, calls } = makeDeps({ appVersion: "0.1.0-nightly.20260728t112233" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(calls.setFeedURL.length >= 1);
+  for (const o of calls.setFeedURL) {
+    assert.strictEqual(o.provider, "generic");
+    assert.strictEqual(o.url, "https://cdn.example.dev/feed/nightly/");
+  }
+});
+
+test("channel preference points the FEED at the opted-in channel", async () => {
+  const { deps, calls } = makeDeps({ appVersion: "0.1.0-insider.3" });
+  deps.getChannelPreference = () => "stable";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(calls.setFeedURL.length >= 1);
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url === "https://cdn.example.dev/feed/stable/"),
+    `expected stable feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+  assert.strictEqual(u.getInfo().channel, "stable");
+});
+
+test("getInfo exposes switcher inputs: stamped lane, switchability, preference", () => {
+  const { deps } = makeDeps({ appVersion: "0.1.0-insider.3" });
+  deps.getChannelPreference = () => "stable";
+  const u = initAutoUpdate(deps);
+  const info = u.getInfo();
+  assert.strictEqual(info.stampedChannel, "insider");
+  assert.strictEqual(info.channelSwitchable, true);
+  assert.strictEqual(info.channelPreference, "stable");
+  assert.strictEqual(info.packaged, true);
+});
+
+test("nightly build reports not switchable and stays on nightly despite a preference", async () => {
+  const { deps, calls } = makeDeps({ appVersion: "0.1.0-nightly.20260722233638" });
+  deps.getChannelPreference = () => "stable"; // must be ignored
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.strictEqual(u.getInfo().channelSwitchable, false);
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url.includes("/nightly/")),
+    `expected nightly feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Update nudge: 'found' fires notifyUpdateFound (discovery-only); up-to-date
+// and error paths never do. Once-per-version dedupe lives in main.js.
+// ---------------------------------------------------------------------------
+
+test("found fires notifyUpdateFound with the discovered version", async () => {
+  const nudges = [];
+  const { deps, emit } = makeDeps({ appVersion: "1.0.0" });
+  deps.notifyUpdateFound = (v) => nudges.push(v);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  assert.deepStrictEqual(nudges, ["1.1.0"]);
+});
+
+test("up-to-date and failed checks never nudge", async () => {
+  const nudges = [];
+  const same = makeDeps({ appVersion: "1.0.0" });
+  same.deps.notifyUpdateFound = (v) => nudges.push(v);
+  const u1 = initAutoUpdate(same.deps);
+  await u1.check();
+  same.emit("update-not-available");
+  const err = makeDeps({ appVersion: "1.0.0" });
+  err.deps.notifyUpdateFound = (v) => nudges.push(v);
+  err.deps.autoUpdater.checkForUpdates = async () => { throw new Error("offline"); };
+  const u2 = initAutoUpdate(err.deps);
+  await u2.check();
+  assert.deepStrictEqual(nudges, []);
+});
+
+test("a throwing nudge callback does not break discovery ('found' still emitted)", async () => {
+  const { deps, emit, stateNames } = makeDeps({ appVersion: "1.0.0" });
+  deps.notifyUpdateFound = () => { throw new Error("boom"); };
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "1.1.0" });
+  assert.ok(stateNames().includes("found"), `states: ${stateNames()}`);
+});
+
+// ---------------------------------------------------------------------------
+// Review-round fixes. Each was a reachable defect found by the local review
+// gate, so each gets a test that fails if the fix is undone.
+// ---------------------------------------------------------------------------
+
+test("a feed reporting up-to-date DISARMS a staged update (retraction path)", () => {
+  // Retraction repoints the feed at an older/other version. With a stage armed,
+  // "no update" must discard it -- otherwise the WITHDRAWN build still installs
+  // on the next quit, because deferredInstallOnQuit only checks updateReady.
+  const { deps, emit, appOnce, appRemoved } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0", releaseNotes: "withdrawn" });
+  assert.strictEqual(u.isReady(), true, "precondition: an update is staged");
+  assert.ok(appOnce.some((a) => a.ev === "before-quit"), "precondition: quit hook armed");
+
+  emit("update-not-available", { version: "1.0.0" });
+  assert.strictEqual(u.isReady(), false, "a retracted stage must be discarded");
+  assert.ok(
+    appRemoved.some((a) => a.ev === "before-quit"),
+    "the before-quit install hook must be disarmed, or the withdrawn build installs on quit",
+  );
+});
+
+test("install() with nothing staged is refused, so the force-exit failsafe is never armed", async () => {
+  // MacUpdater.quitAndInstall() does NOT install when Squirrel has not yet
+  // consumed the zip -- it registers a listener and waits. Arming
+  // forceExitFailsafe there kills the process 5s later, mid-fetch, and the app
+  // dies without swapping or relaunching.
+  const { deps, calls, states } = makeDeps({ appVersion: "1.0.0" });
+  const stopped = [];
+  deps.stopGateway = async () => { stopped.push(1); };
+  const u = initAutoUpdate(deps);
+  await u.install();
+  assert.strictEqual(calls.quitAndInstall.length, 0, "must not quitAndInstall with nothing staged");
+  assert.strictEqual(stopped.length, 0, "must not stop the gateway for an install that cannot proceed");
+  assert.ok(states.length > 0, "must report state rather than silently no-op");
+});
+
+test("install() proceeds once an update IS staged", async () => {
+  const { deps, calls, emit } = makeDeps({ appVersion: "1.0.0" });
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0" });
+  await u.install();
+  assert.strictEqual(calls.quitAndInstall.length, 1);
+});
+
+test("BLOCKING-fix contract: package.json declares a publish entry so app-update.yml is emitted", () => {
+  // electron-updater's downloadUpdate() -> getOrCreateDownloadHelper() awaits
+  // configOnDisk -> readFile(app-update.yml). electron-builder only writes that
+  // file when a publish config exists (its repository-info fallback resolves
+  // null here). Without it, DISCOVERY works and every consented download throws
+  // ENOENT -- a dead updater that no unit test with a fake autoUpdater can see.
+  const pkg = require("../package.json");
+  const publish = pkg.build && pkg.build.publish;
+  assert.ok(Array.isArray(publish) && publish.length > 0, "build.publish must be a non-empty array");
+  assert.strictEqual(publish[0].provider, "generic");
+  assert.match(publish[0].url, /^https:\/\//, "baked publish url must be https");
+});


### PR DESCRIPTION
## Problem

The desktop updater is hand-rolled on Electron's **built-in** `autoUpdater`, which covers only macOS and Windows — via two projects that share a name and nothing else (Squirrel.Mac is Objective-C with a JSON feed; Squirrel.Windows is C# with a NuGet `RELEASES` directory). Consequences visible today:

- **Linux has no auto-update at all.** The AppImage ships with no updater.
- **We maintain ~1,150 lines of client + tests and ~600 lines of CI** doing what electron-builder emits for free: feed metadata, version comparison, checksum verification.
- **Two incidents came from Squirrel.Windows**: #584 (its vendored NuGet `Int32.Parse`d our 14-digit nightly stamp and overflowed, breaking every Windows nightly) and its directory-relative feed protocol forcing an S3 layout that broke our pointer/bytes host split.
- **No delta updates**, so every update is a full download.

electron-builder's own documentation states that simplified auto-update *"is not supported for Squirrel.Windows"* — NSIS is the only auto-updatable Windows target. Tracked in #598.

## Why it matters

Every Linux user must manually re-download to get any fix, including a security fix. On macOS, we own an update-critical code path that a maintained library owns better — and the Squirrel.Windows dead end blocks Windows GA. This is the cheapest possible moment to change: Windows has **no installed base**, so nothing has to be migrated.

## Fix (symptom → root cause → change)

**Symptom:** three platforms, one working updater, two incidents, and a growing pile of bespoke feed code.

**Root cause:** the choice was never made — it was *inherited*. `electron-builder-squirrel-windows` arrived as a transitive dependency of the initial Electron scaffold, and `"target": ["squirrel"]` was added inside an implementation PR (#421) with the local reasoning "the built-in updater needs Squirrel on Windows, and mac already uses the built-in updater." True in isolation; the question never asked was whether the built-in updater was still the right base. Grepping `docs/` for `electron-updater` returned **zero hits** before this change.

**Change:** move macOS and Linux to `electron-updater`. Windows is deliberately **not** included — it additionally needs an installer-target change to NSIS, and keeping that separate means one variable at a time.

### Client (`website/electron/auto-update.js`)

Deleted: feed fetching, JSON parsing, version comparison, feed-shape validation. Preserved: the consent gate, channel resolution, gateway-stop ordering, force-exit failsafe, nudge hook. Gained: `download-progress`, so the card shows a real percentage instead of an indeterminate state.

Four policy flags **all differ from library defaults**, set in one audited place:

| Flag | Default | Ours | Why |
|---|---|---|---|
| `autoDownload` | `true` | `false` | consent-first: discovery must never download |
| `autoInstallOnAppQuit` | `true` | `false` | would swap the bundle on quit **without stopping the Python gateway** — the half-replaced-app race this module exists to prevent |
| `allowDowngrade` | `false` | `true` | our gate is difference-based; retraction and channel switch-back both depend on offering a downgrade |
| `allowPrerelease` | `false` | `true` | every nightly/insider stamp is a semver prerelease and would otherwise be invisible |

`build.publish` is **required, not cosmetic**: `downloadUpdate()` awaits `configOnDisk` → `readFile(app-update.yml)`, and electron-builder only emits that file when a publish config exists. Without it, discovery succeeds and every consented download throws `ENOENT`.

### CI

macOS writes `feed/<channel>/latest-mac.yml`; Linux gains `feed/<channel>/latest-linux.yml`. Metadata stays on the **pointer** host while `files[].url` points absolutely at the **byte** host — `electron-updater` resolves file urls with `new URL(fileUrl, base)`, which ignores the base for absolute urls, so our host split survives.

Both feed writes now **verify the published bytes match the digests they advertise** and fail the job on divergence. Versioned keys use `--if-none-match` and tolerate `PreconditionFailed`, so a same-version re-run with different bytes would otherwise leave the OLD object served while the feed described the NEW build. Since electron-updater verifies sha512 fail-closed, every client would refuse to install — while the checksum-less legacy bridge installed the old one.

### The transition bridge (the most important part of this PR)

`latest-mac.json` **keeps being written**. Builds fielded before this change poll it and know nothing about the yml. Writing only the yml would leave every existing install unable to discover *any* future version — permanently, with a manual DMG re-download as the only escape. Verified by running the **actual pre-migration client code from `main`** against the bridge feed:

```
OLD client parses bridge : true version=1.0.1
OLD client sees upgrade  : yes (1.0.0 -> 1.0.1)
```

Its removal condition is documented on the step and pinned by a contract test, so it cannot be deleted later as apparent dead code.

### Relationship to #709

All three fixes from the stale-feed incident are preserved. Two are now **structurally subsumed**: `MacUpdater` serves Squirrel.Mac from a **loopback proxy**, so NSURLCache — the cache that actually misbehaved — is no longer in the feed path at all; and `isUpdateAvailable` rejects an equal version *before* the `allowDowngrade` branch. The origin `Cache-Control`, its CDN verify gate, and the pending-version display (pure UI logic the library cannot know about) are carried forward explicitly. Two tests assert the subsumptions against the **real installed library**, so a version bump that removes either fails CI rather than resurfacing the incident.

## Tests

**314 electron tests** (was 283) and **18 new workflow-contract tests**.

- `configureUpdater` — one test per policy flag, each explaining why it diverges from the default.
- **Contract tests against the real library**: absolute-url passthrough (pins the pointer/bytes split), `isUpdateAvailable`'s equal-version short-circuit ordering, and `isAddNoCacheQuery`'s existence.
- **#709 regression guards** — four tests asserting every `downloading` state reports the *pending* version, plus a counterpart that states about the running build still report `app.getVersion()`.
- **Review-round fixes** — a feed reporting up-to-date discards a staged update and disarms the quit hook (retraction path); `install()` with nothing staged is refused; `install()` proceeds once staged.
- `install()` awaits `stopGateway` **before** `quitAndInstall` — asserted as strict order, not just co-occurrence.
- Feed contract: base64-not-hex sha512, absolute urls, `bytes → feed → alias` ordering on **parsed YAML step indices** (printed, so it is provable they compare real positions), per-key cache TTLs, `environment: prod`, fail-loud on missing artifacts, and the legacy bridge's existence.

## Manual verification

- **`app-update.yml` confirmed in a real packaged bundle.** Built the `zip` target and read `Contents/Resources/app-update.yml` — `provider: generic`, correct url, `updaterCacheDirName: kirocrew-electron-mac-updater`. Note electron-builder writes it only for `dmg`/`zip` on darwin, so the OTA harness's faster `dir` build writes it by hand.
- **`electron-updater` confirmed packaged** into `app.asar` (212 files, plus `js-yaml` and `builder-util-runtime`).
- **Feed round-trip against the real library over loopback HTTP**: `parseUpdateInfo` + `resolveFiles` from the installed `electron-updater`, asserting absolute-url passthrough, base64 sha512 matching the real bytes, and the HTTPS/loopback guard rejecting a LAN address.
- **Not verified: a live OTA bundle swap.** Unit coverage stops at the `autoUpdater` handoff. Two builds were produced and ad-hoc signed locally, but this agent sandbox cannot drive a GUI app (`ps` is not permitted and no window opens). `ota-test.yml` exists to close this gap on a macOS runner and is **unverified until first dispatch** — it is nightly/dispatch-only and not a gate on this PR. Being explicit because the precedent is the DMG saga: notarization passed CI and Gatekeeper still rejected the artifact.

## Screenshots

N/A — no user-visible UI change. The update card's rendering is unchanged; only the data feeding it changes (it now receives a real download percentage, which the existing component already renders).

## Also in this diff

Two pre-existing defects in `scripts/stage3-autoupdate-test.sh` that fail on current macOS, both unrelated to this migration and equally broken on `main`: ad-hoc signing with `--options runtime` enables **library validation**, which rejects the ad-hoc Electron Framework (`Abort trap: 6`), and signing *before* `cp -R` rather than after can invalidate nested signatures. Also corrected a documented feed contract (`GET {feedBase}?platform=&channel=&version=` → 200/204) that **was never implemented** — it contradicted its own operational companion doc.

## Follow-ups (not in this PR)

- Windows → NSIS + electron-updater (#598). Authenticode signing for the NSIS installer stays separately unsolved; CDSigner is Apple-only.
- #663 and #668 closed as superseded, each with a salvage list.
