### PR TITLE
fix(chat): keep mid-turn hand-backs out of the collapse pane

### DIFF
--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -57,14 +57,40 @@ const HAS_RENDERABLE_RE = /<mcwidget(?:\s|>)|!\[[^\]]*\]\([^)]+\)/
 const isRenderable = (it: TurnItem) =>
   it.kind === 'single' && isConclusion(it) && (it.msg.role === 'file' || HAS_RENDERABLE_RE.test(it.msg.content))
 
-/** Either a renderable assistant message (widget/image) or a role that must
- *  surface inline (mcp_oauth, error), a workflow_run / spawn_run launch card, or
- *  an MCP App-bearing tool call (interactive iframe anchored to the row). All
- *  bypass the collapse pane. */
+/**
+ * A mid-turn hand-back: an assistant message carrying an [OPTIONS:] follow-up
+ * marker. The agent emits that marker ONLY when it believes it is ending the
+ * turn, so a message bearing it is by construction a user-facing hand-back — a
+ * direct signal of *intent*, not a proxy for importance. (A length / size
+ * heuristic was considered and rejected: the collapse setting is literally
+ * "hide intermediate reasoning", so gating on size would override a preference
+ * the user set on purpose; gating on [OPTIONS:] instead corrects a
+ * misclassification.) A single turn can contain SEVERAL hand-backs when the
+ * agent resumes in the same turn — after a denied tool call, an auto-nudge /
+ * monitor cycle, a queued message, or an injected subagent / workflow
+ * completion — but findConclusionIdx keeps only the LAST one, so every earlier
+ * hand-back would otherwise be buried in the collapse pane. Surfacing each one
+ * inline fixes that.
+ *
+ * OPTION_MARKER_RE is g-flagged and optionsMarker.ts forbids .test()/.exec() on
+ * it (the lastIndex hazard); probe it via .replace(), exactly like
+ * substantiveLength() below.
+ */
+function hasOptionsMarker(text: string): boolean {
+  return text.replace(OPTION_MARKER_RE, '') !== text
+}
+const isHandBack = (it: TurnItem) =>
+  it.kind === 'single' && isConclusion(it) && hasOptionsMarker(it.msg.content)
+
+/** A renderable assistant message (widget/image), a mid-turn hand-back
+ *  ([OPTIONS:] marker), a role that must surface inline (mcp_oauth, error), a
+ *  workflow_run / spawn_run / workflow-completion card, or an MCP App-bearing
+ *  tool call (interactive iframe anchored to the row). All bypass the collapse
+ *  pane. */
 const isVisibleInline = (it: TurnItem, appToolCallIds: ReadonlySet<string>) =>
-  isRenderable(it) || isAlwaysVisible(it) || isWorkflowRunItem(it) ||
-  isSpawnRunItem(it) || isWorkflowCompletionItem(it) ||
-  isMcpAppItem(it, appToolCallIds)
+  isRenderable(it) || isHandBack(it) || isAlwaysVisible(it) ||
+  isWorkflowRunItem(it) || isSpawnRunItem(it) ||
+  isWorkflowCompletionItem(it) || isMcpAppItem(it, appToolCallIds)
 
 /** Stable empty set so the mcpApps selector returns a referentially-equal
  *  value when the slot has no app renders (avoids useless re-renders). */

--- a/website/src/test/TurnBlock.test.tsx
+++ b/website/src/test/TurnBlock.test.tsx
@@ -250,3 +250,79 @@ describe('TurnBlock — MCP App-bearing tool calls stay visible', () => {
     expect(screen.queryByTestId('item-tool-tc-plain')).not.toBeInTheDocument()
   })
 })
+
+/**
+ * A turn can hand back to the user and then RESUME in the same turn — after a
+ * denied tool call, an auto-nudge / monitor cycle, a queued message, or an
+ * injected subagent / workflow completion. The [OPTIONS:] follow-up marker is
+ * the agent's own signal that it believed it was ending the turn, so an earlier
+ * hand-back carrying it must stay visible rather than collapse behind "Worked
+ * through N steps" (findConclusionIdx keeps only the LAST conclusion).
+ */
+describe('TurnBlock — mid-turn hand-back ([OPTIONS:]) visibility', () => {
+  it('a mid-turn hand-back carrying [OPTIONS:] stays visible in collapseAll mode', () => {
+    const items: TurnItem[] = [
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: shell', ts: '1' }, idx: 0 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Here is the full setup runbook you asked for, with every step spelled out.\n\n[OPTIONS: Run it now | Show me the diff]', ts: '2' }, idx: 1 },
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: shell', ts: '3' }, idx: 2 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Resumed after the hand-back and finished wiring everything up and verifying it.', ts: '4' }, idx: 3 },
+    ]
+    const { container } = render(
+      <TurnBlock
+        turn={makeTurn(items)}
+        renderItem={(it, i) => <div data-testid={`item-${i}`}>{it.kind === 'single' ? it.msg.content : 'group'}</div>}
+        collapseAll={true}
+      />
+    )
+    // The earlier hand-back at idx 1 must render OUTSIDE the collapsed
+    // (overflow:hidden) reasoning section — it is a real deliverable.
+    const handBack = container.querySelector('[data-testid="item-1"]')
+    expect(handBack).not.toBeNull()
+    expect(handBack?.closest('[style*="overflow"]')).toBeNull()
+    // The final conclusion is still visible too.
+    expect(container.querySelector('[data-testid="item-3"]')).not.toBeNull()
+  })
+
+  it('a mid-turn assistant message WITHOUT an options marker still collapses (predicate is not over-broad)', () => {
+    const items: TurnItem[] = [
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: read', ts: '1' }, idx: 0 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Reading the config file before I patch it, to be sure of its shape.', ts: '2' }, idx: 1 },
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: write', ts: '3' }, idx: 2 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Patched the config and confirmed the build still passes cleanly.', ts: '4' }, idx: 3 },
+    ]
+    const { container } = render(
+      <TurnBlock
+        turn={makeTurn(items)}
+        renderItem={(it, i) => <div data-testid={`item-${i}`}>{it.kind === 'single' ? it.msg.content : 'group'}</div>}
+        collapseAll={true}
+      />
+    )
+    // Plain reasoning at idx 1 (no [OPTIONS:] marker) must stay INSIDE the
+    // collapsed section — surfacing it would defeat "hide intermediate reasoning".
+    const prose = container.querySelector('[data-testid="item-1"]')
+    expect(prose).not.toBeNull()
+    expect(prose?.closest('[style*="overflow"]')).not.toBeNull()
+    // Conclusion still visible.
+    expect(container.querySelector('[data-testid="item-3"]')).not.toBeNull()
+  })
+
+  it('the "Worked through N steps" count excludes the now-visible hand-back', () => {
+    const items: TurnItem[] = [
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: shell', ts: '1' }, idx: 0 },
+      { kind: 'single', msg: { role: 'assistant', content: 'First deliverable — the runbook is ready for your review below.\n\n[OPTIONS: Run it now | Wait]', ts: '2' }, idx: 1 },
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: shell', ts: '3' }, idx: 2 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Resumed and completed the remaining work, everything verified and green.', ts: '4' }, idx: 3 },
+    ]
+    render(
+      <TurnBlock
+        turn={makeTurn(items)}
+        renderItem={(it, i) => <div data-testid={`item-${i}`}>{it.kind === 'single' ? it.msg.content : 'group'}</div>}
+        collapseAll={true}
+      />
+    )
+    // Two tool calls collapse (2 steps); the hand-back at idx 1 is surfaced
+    // inline and must NOT inflate the count to 3.
+    expect(screen.getByRole('button', { name: /Worked through 2 steps/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Worked through 3 steps/ })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What & why

`website/src/pages/chat/TurnBlock.tsx` renders an agent turn. In `collapseAll`
mode -- the **default** (`ChatSettings.tsx` `DEFAULTS.collapseAllSteps: true`) --
everything in a turn collapses behind a "Worked through N steps" toggle except
the single item returned by `findConclusionIdx` (the last substantive assistant
message) and items matching `isVisibleInline`.

`findConclusionIdx` returns **exactly one** index. That encodes the assumption
that *a turn has one deliverable and it is last.* It breaks whenever the agent
hands back to the user and then **resumes inside the same turn** -- after a
denied tool call, an auto-nudge / monitor cycle, a queued message, or an
injected subagent / workflow completion. Every hand-back except the last was
buried in the collapse pane.

**Concrete failure:** the agent wrote a full setup runbook, continued working in
the same turn, and the runbook became invisible -- the user had to ask the
question again.

## The fix

Treat an assistant message carrying an `[OPTIONS:]` follow-up marker as
always-visible-inline. The agent emits that marker **only** when it believes it
is ending the turn, so a message bearing it is by construction a hand-back -- a
direct signal of *intent*.

`isHandBack` is OR'd into the existing `isVisibleInline` predicate (so surfaced
hand-backs also drop out of the "Worked through N steps" count). `hasOptionsMarker`
probes the shared `OPTION_MARKER_RE` via `.replace()` -- that regex is `g`-flagged
and `optionsMarker.ts` forbids `.test()`/`.exec()` on it (the `lastIndex`
hazard), so this mirrors the existing `substantiveLength()` helper in the same
file.

### Why `[OPTIONS:]`, not message length

A length / size heuristic was considered and **rejected**. The user-facing
setting is literally *"hide intermediate reasoning"*, so gating on size would
override a preference the user set on purpose. Gating on `[OPTIONS:]` corrects a
*misclassification* (a genuine hand-back mislabelled as reasoning) instead of
overriding a preference.

## On the requested pill-suppression change (deviation -- please read)

The originating brief asked for a companion change: suppress a second, stale
`[OPTIONS:]` pill row that a newly-visible earlier hand-back would supposedly
render, by threading a `showOptions` / `optionsSuperseded` prop into
`AssistantMessage`.

**That premise no longer holds on `main`, so I did not implement it.** Inline
option pills have already been removed from `AssistantMessage`:

- `AssistantMessage` renders **no** pills -- it only uses `parseOptions(...).text`
  to strip markers from the displayed prose. This is pinned by the existing test
  *"does not render inline option buttons (options are surfaced via FollowUpBar
  now)"* in `website/src/test/AssistantMessage.test.tsx`.
- Option pills render **once**, at the composer, via a single `<FollowUpBar>`
  (`website/src/components/ChatInput.tsx`) driven by
  `deriveFollowUpOptions(messages, ...)`, which scans backward and returns only
  the **last** assistant message's options.

So a mid-turn hand-back made visible by this change shows clean prose (all
markers stripped by `parseOptions`) and **no** pills; there is no "two pill rows
in one turn" and no pre-existing duplicate-pill bug to expose. Threading
`showOptions` into `AssistantMessage` would be dead code -- a prop gating a pill
row that does not exist -- which contradicts the brief's own "strictly additive"
instruction. I left it out and am flagging it here rather than silently adapting.

## Tests

`website/src/test/TurnBlock.test.tsx`, modelled on the existing "file message
mid-turn stays visible" case:

1. a mid-turn assistant message containing `[OPTIONS: a | b]` stays **visible**
   in `collapseAll` mode;
2. a mid-turn assistant message **without** a marker still collapses (guards
   against an over-broad predicate);
3. the "Worked through N steps" count does **not** count the surfaced hand-back.

**Mutation check:** temporarily neutering `isHandBack` to return `false` made
tests (1) and (3) fail while (2) still passed, confirming the tests exercise the
new predicate. Restored afterward; no residue.

## Gates

- `cd website && npx tsc -b` -- clean (exit 0)
- `npx vitest run` -- **470 files, 5677 passed / 3 skipped**
- Frontend-only change -- no Python touched, so backend gates are not required.
- `dist` not rebuilt or staged (gitignored).
