### PR TITLE
fix(workflows): point the completion prompt at the user's question

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1299,9 +1299,16 @@ async def start_dashboard(
                     status, _ = redact_credentials(status)
                     prompt = (
                         f"[Workflow `{name}` finished: {status}] Its result was just "
-                        "posted above. Interpret that result and continue with the "
-                        "task it was launched for — summarize the outcome, act on any "
-                        "artifacts, and surface anything the user needs to decide."
+                        "posted above. The user is waiting on the answer to the "
+                        "request that prompted this workflow — find that request "
+                        "earlier in this conversation and answer it directly. Your "
+                        "final message is the only part of this turn the user is "
+                        "guaranteed to see, so make it a standalone deliverable: lead "
+                        "with the answer, and keep run mechanics (which agents ran, "
+                        "what was verified, what is still uncertain) to a short "
+                        "closing note or a collapsed fold. If the workflow failed or "
+                        "came back incomplete, say that plainly and state what is "
+                        "still unknown."
                     )
                     started = slot.enqueue_or_run_prompt(prompt, _run_chat, state)
                     state.push_slots_update()


### PR DESCRIPTION
## Problem

When a background dynamic workflow finishes, the gateway injects a synthetic prompt (`_auto_turn` inside `_wf_on_done` in `src/kiro_crew/dashboard/server.py`) that drives one agent turn to interpret the run result. The old prompt pointed every verb at the **run**, never at the user:

**Old string** (implicitly-concatenated, `{name}`/`{status}` interpolated):

```
[Workflow `{name}` finished: {status}] Its result was just posted above.
Interpret that result and continue with the task it was launched for —
summarize the outcome, act on any artifacts, and surface anything the user
needs to decide.
```

All three directives — "summarize the outcome", "act on any artifacts", "surface anything the user needs to decide" — target the workflow run. Nothing tells the agent to **answer the user's original question**.

## Why it matters

Observed consequence: a user asked a how-do-I question, a workflow researched it, and the agent's auto-turn replied with a status report about the run (which agents ran, what was verified, what remained unverified) instead of the answer. The user had to ask again. The final message — the only part of the turn a user is guaranteed to see — was spent on run mechanics.

## Fix (symptom → root cause → change)

- **Symptom:** workflow-completion turns produce run-reports, not answers.
- **Root cause:** the injected prompt's verbs all point at the run; the user's original request is never named as the target.
- **Change:** reword the prompt (one string, one call site) to redirect the agent at the user's request.

**New string:**

```
[Workflow `{name}` finished: {status}] Its result was just posted above. The
user is waiting on the answer to the request that prompted this workflow — find
that request earlier in this conversation and answer it directly. Your final
message is the only part of this turn the user is guaranteed to see, so make it
a standalone deliverable: lead with the answer, and keep run mechanics (which
agents ran, what was verified, what is still uncertain) to a short closing note
or a collapsed fold. If the workflow failed or came back incomplete, say that
plainly and state what is still unknown.
```

**The auto-turn mechanism is kept, not removed.** The raw workflow result is machine-shaped JSON that no user can read as an answer, so an agent turn to translate it into prose is the correct design. Only the wording was wrong.

The four properties the new wording preserves:

1. it names the user's **original request** as the thing to answer;
2. it states the final message is the only guaranteed-visible surface;
3. it demotes run mechanics to a note / fold;
4. it handles the **failed-or-incomplete** case, which the old prompt did not.

`{name}`/`{status}` f-string interpolation and the existing `redact_exfiltration_urls` / `redact_credentials` sanitisation are preserved unchanged. The closure was not refactored and the prompt was not extracted to a constants module.

## Scope

Backend only — one string literal in `src/kiro_crew/dashboard/server.py`. No TypeScript is touched. The `[Subagent completion event]` injections elsewhere are data-only (not instruction-shaped) and are deliberately left alone.

**This is a nudge at the model, not a hard guarantee.** The structural half of the problem — the chat renderer collapsing earlier deliverables into "Worked through N steps" so a hand-back mid-turn gets buried — is fixed separately in the sibling PR **`fix(chat): keep mid-turn hand-backs out of the collapse pane`**.

## Tests

No existing test asserted the old prompt text — grepping the suite for `Its result was just`, `summarize the outcome`, and `Interpret that result` returns zero hits. The `_auto_turn` matches in `test/test_workflows_service.py` are **test-local helpers** with their own synthetic prompts that exercise the injection→enqueue mechanism, not the production string. Per the change's own discipline, no vacuous test that re-asserts the literal string back at itself was added (that would be worse than none). `test/test_workflows_service.py` (20 tests, incl. both auto-turn/injection cases) passes unchanged.

## Manual verification

N/A beyond the gates — the change is a single prompt string with no logic, signature, or control-flow change; mypy/flake8/isort and the workflow-mechanism tests cover it.

## Gates run (from the worktree, CI-parity venv, no faiss)

- `isort --check-only src/kiro_crew test` → clean
- `flake8 src/kiro_crew test` → clean (run with `--jobs 1`; the sandbox blocks flake8's multiprocessing pool — an environment limit, not a lint finding)
- `mypy src/kiro_crew/` → Success, no issues in 526 source files
- `python -m pytest -q` (default addopts: `-n auto --dist loadgroup`) → **20046 passed, 16 failed, 108 skipped**. All 16 failures are pre-existing and environment-driven (sandbox `sandbox-exec`/namespace argv, subprocess/pidfd, blocked hardlink `PermissionError`, `gh`/`kiro` binary path resolution) — confirmed by re-running the exact failing set on a clean `origin/main` tree with this change stashed, where they fail identically (and independently of this change). None touch the dashboard prompt closure.
- Frontend gates (`tsc -b`, `vitest`) not applicable — no TypeScript changed.
