### PR TITLE
fix(chat): make the activity panel actually fill the screen on mobile

### DIFF
--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -135,6 +135,28 @@ export function sidePanelFillWidth(
   return Math.max(SIDE_PANEL_MIN_W, chatAvail)
 }
 
+/**
+ * Resolve the panel's rendered width.
+ *
+ * Order matters. FILL (an explicit px width) wins over the mobile percentage:
+ * `width: 100%` is unreliable because the inline (non-portal) render path wraps
+ * the panel in a shrink-to-fit `width: auto` flex item, and a percentage child
+ * cannot resolve against an auto containing block during intrinsic sizing — the
+ * browser falls back to the panel's own max-content width, so the panel comes
+ * out narrow and the chat pane keeps the rest. An explicit px width is
+ * deterministic in BOTH paths. '100%' survives only as the fallback for a
+ * mobile frame that somehow receives no fillWidth.
+ */
+export function sidePanelEffectiveWidth(
+  { fillWidth, isMobile, expanded, width, maxW }:
+  { fillWidth?: number; isMobile: boolean; expanded?: boolean; width: number; maxW: number },
+): number | string {
+  if (fillWidth != null) return fillWidth
+  if (isMobile) return '100%'
+  if (expanded) return Math.max(SIDE_PANEL_MIN_W, maxW)
+  return Math.max(SIDE_PANEL_MIN_W, Math.min(width, maxW))
+}
+
 export function measureSidePanelReservedW(): number {
   const header = document.querySelector('header.topbar-glass')
   if (!header) return SIDE_PANEL_RESERVED_W
@@ -256,11 +278,7 @@ export default function SidePanel({
       .forEach(c => ro.observe(c))
     return () => { window.removeEventListener('resize', recalc); ro.disconnect() }
   }, [])
-  const effectiveWidth = isMobile
-    ? '100%'
-    : fillWidth != null
-      ? fillWidth
-      : (expanded ? Math.max(MIN_W, maxW) : Math.max(MIN_W, Math.min(width, maxW)))
+  const effectiveWidth = sidePanelEffectiveWidth({ fillWidth, isMobile, expanded, width, maxW })
   // While the user drags the resize handle, every mousemove shifts the whole
   // panel's viewport position (the handle is on the LEFT edge; the right edge
   // is pinned to the window). Framer's layout projection on each Reorder.Item

--- a/website/src/test/sidePanelFillWidth.test.ts
+++ b/website/src/test/sidePanelFillWidth.test.ts
@@ -7,7 +7,7 @@
  * which is the whole point of the rule.
  */
 import { describe, it, expect } from 'vitest'
-import { SIDE_PANEL_MIN_W, CHAT_PANE_MIN_W, sidePanelFillWidth } from '../pages/chat/SidePanel'
+import { SIDE_PANEL_MIN_W, CHAT_PANE_MIN_W, sidePanelFillWidth, sidePanelEffectiveWidth } from '../pages/chat/SidePanel'
 
 const THRESHOLD = SIDE_PANEL_MIN_W + CHAT_PANE_MIN_W // 640
 const RAIL_EXPANDED = 236
@@ -64,5 +64,39 @@ describe('sidePanelFillWidth', () => {
     expect(fill({ winW: 390, railW: 0, sidebarW: 0, isMobile: true })).toBe(390)
     // …but never below the panel floor.
     expect(fill({ winW: 280, railW: 0, sidebarW: 0, isMobile: true })).toBe(SIDE_PANEL_MIN_W)
+  })
+})
+
+/**
+ * Branch ORDER regression. The mobile arm used to be checked before fillWidth,
+ * so a mobile frame got `width: '100%'` and the computed fill width was thrown
+ * away. That percentage cannot resolve inside the inline render path's
+ * shrink-to-fit `width: auto` wrapper, so the panel rendered at its own
+ * max-content width instead of filling the screen.
+ */
+describe('sidePanelEffectiveWidth', () => {
+  const base = { isMobile: false, expanded: false, width: 460, maxW: 800 }
+
+  it('prefers the explicit fill width over the mobile percentage', () => {
+    expect(sidePanelEffectiveWidth({ ...base, isMobile: true, fillWidth: 390 })).toBe(390)
+  })
+
+  it('prefers the explicit fill width over the persisted width on desktop', () => {
+    expect(sidePanelEffectiveWidth({ ...base, fillWidth: 520 })).toBe(520)
+  })
+
+  it('falls back to the percentage on a mobile frame with no fill width', () => {
+    expect(sidePanelEffectiveWidth({ ...base, isMobile: true })).toBe('100%')
+  })
+
+  it('clamps the persisted width to the responsive maximum in beside mode', () => {
+    expect(sidePanelEffectiveWidth({ ...base, width: 460, maxW: 800 })).toBe(460)
+    expect(sidePanelEffectiveWidth({ ...base, width: 900, maxW: 800 })).toBe(800)
+    expect(sidePanelEffectiveWidth({ ...base, width: 460, maxW: 100 })).toBe(SIDE_PANEL_MIN_W)
+  })
+
+  it('takes the maximum in preview-focus (expanded) mode', () => {
+    expect(sidePanelEffectiveWidth({ ...base, expanded: true, maxW: 800 })).toBe(800)
+    expect(sidePanelEffectiveWidth({ ...base, expanded: true, maxW: 100 })).toBe(SIDE_PANEL_MIN_W)
   })
 })


### PR DESCRIPTION
Follow-up to #732.

## Symptom

On a narrow mobile viewport the activity panel rendered at its own content width instead of filling the screen, leaving a sliver of chat beside it. Reported from a phone against the live build.

## Cause

Two things had to both be true.

The width resolution checked the mobile arm **before** `fillWidth`:

```ts
const effectiveWidth = isMobile
  ? '100%'
  : fillWidth != null
    ? fillWidth
    : (expanded ? Math.max(MIN_W, maxW) : Math.max(MIN_W, Math.min(width, maxW)))
```

So on mobile the fill width that `sidePanelFillWidth` computes — the full viewport — was thrown away and the panel fell back to `width: '100%'`.

And that percentage cannot resolve in the path mobile actually uses. Mobile has no actbar grid column, so the panel renders through the **inline** path, wrapped in a shrink-to-fit `width: auto` flex item. A percentage child cannot resolve against an auto containing block during intrinsic sizing, so the browser falls back to the panel's own `max-content` width. The panel came out narrow and the chat pane kept the remainder.

Desktop fill was unaffected because it goes through the actbar portal with an explicit px width. That is why the three layouts verified on #732 all looked correct — none of them exercised the inline path.

## Fix

Invert the order: an explicit fill width wins over the percentage. The width is then deterministic in both render paths. `'100%'` survives only as the fallback for a mobile frame that somehow receives no `fillWidth`.

The resolution moves into an exported pure function, `sidePanelEffectiveWidth`. The branch **order** is the entire defect, and it was previously untestable inline: the component is stubbed in the `ChatPage` tests because it pulls in xterm, so a `ChatPage`-level assertion on the prop would have passed while the bug was live.

## Testing

Five new cases pinning the order:

- fill beats the mobile percentage
- fill beats the persisted width on desktop
- the percentage survives as the mobile fallback
- the persisted width still clamps to the responsive maximum in beside mode
- preview-focus (`expanded`) still takes the maximum

Gates: `npx tsc -b` clean, `npx eslint` 0 errors, `npx vitest run` 470 files / 5679 tests passing.

Verified in the served bundle that the minified resolver short-circuits on fill first: `k4t({fillWidth:e,isMobile:t,...}){return e??(t?"100%":...)}`.

## Not done

No mobile screenshot attached — GitHub's image upload is browser-only, and the reporter's screenshots carry a tunnel hostname and internal session titles.
