### PR TITLE
feat: record per-turn context occupancy and cover background dispatch surfaces

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -1,6 +1,6 @@
 # Metrics Telemetry Module
 
-Last Updated: 2026-07-24 (explicit retention opt-in, installable OTLP extra, WebSocket/SSE lifetime exclusion)
+Last Updated: 2026-07-28 (per-turn token usage row store + context-occupancy fields, issue #647)
 
 ## Overview
 
@@ -189,6 +189,57 @@ user-configurable `telemetry.local_dir` and each shard pass `validate_file_path`
 (sensitive-path check) before any read. Cross-process: metrics are emitted by
 the ACP/gateway processes, so reading the durable shards is the only correct
 path (an in-memory reservoir in the dashboard process would never see them).
+
+## Per-turn token usage row store
+
+Separate from the OTEL histogram sink above (`~/.kirocrew/metrics/`, DELTA
+histograms for trends/alerting), the gateway also keeps a **per-turn row store**
+for cost and context analytics: one JSON object per model-spending turn appended
+to `<data home>/usage/tokens/YYYY-MM-DD.jsonl` (shards partitioned by the user's
+local date). It is always on (not gated by `telemetry.enabled`) and never
+egresses the host. Written by `dashboard/handlers/usage.py::persist_token_record`
+(sync) / `persist_token_record_async` (the chat hot path — builds the record
+on-loop, offloads the append via `asyncio.to_thread`); both are best-effort
+(exceptions swallowed, no fsync). Aggregated for the dashboard by
+`_parse_token_history` (30-day window, shard-fingerprint + 120s-TTL cache).
+
+Each row (`_build_token_record`) carries:
+
+| field | type | meaning |
+|-------|------|---------|
+| `_type` | str | always `"tokens"` (record discriminator) |
+| `ts` | str | ISO-8601 local timestamp of the turn |
+| `slot` | str | chat slot / session key |
+| `provider` | str | LLM backend (`acp` / `claude_code` / `bedrock` / …), `""` if unknown |
+| `model` | str | model id for the turn |
+| `input` / `output` | int | prompt / completion tokens (structurally `0` on the ACP backend — kiro-cli bills credits only) |
+| `cache_create` / `cache_read` | int | cache-write / cache-read tokens |
+| `cost` | float | provider-reported USD cost (`0.0` on ACP) |
+| `credits` | float | kiro-cli per-turn credit spend (float-coerced) |
+| `turns` | int | provider `num_turns` |
+| `duration_ms` | int | provider-reported turn duration (`0` on ACP) |
+| `surface` | str | **(#647)** dispatch origin — `dashboard`, `cron`, `subagent`, `monitor`, `heartbeat`, `webhook`, `task_runner`, `workflow`; `""` if unset |
+| `agent` | str | **(#647)** agent id resolved for the turn; `""` if unset |
+| `context_used` | int | **(#647)** context-window tokens occupied after the turn (int-coerced) |
+| `context_window` | int | **(#647)** served context-window size in tokens (int-coerced) |
+
+The last four fields are **additive** — every field defaults (`""` / `0`) so
+existing callers stay valid and pre-#647 shards (which lack the keys) remain
+parseable; readers must tolerate their absence. `context_used` / `context_window`
+are read from the provider at the persist call site via
+`usage.read_context_tokens(source)`, which calls the provider's public
+`context_used_tokens()` / `context_window_tokens()` accessors
+(`providers/base.py`, implemented for ACP in `providers/acp.py` +
+`acp/session_provider.py`) behind `getattr` guards and returns `(0, 0)` on any
+missing accessor or exception — so non-ACP providers and test doubles record
+zeros and the analytics helper never breaks the turn it measures. `surface`
+lets background turn-dispatch surfaces (cron/subagent/monitor/heartbeat/webhook/
+task_runner/workflow) attribute their spend; zero-token surfaces (cron
+`script=`/`command=` modes, heartbeat maintenance ticks) never call a model and
+must not write a row.
+
+Tests: `test/test_usage.py` (`TestReadContextTokens`,
+`TestBuildTokenRecordContextFields`, `TestPersistTokenRecord*`).
 
 ## Circular-import rule
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -75,7 +75,11 @@ from kiro_crew.dashboard.handlers import (
     _get_skills,
     _list_aim_prompts,
 )
-from kiro_crew.dashboard.handlers.usage import persist_token_record_async
+from kiro_crew.dashboard.handlers.usage import (
+    persist_token_record_async,
+    read_context_tokens,
+    read_effective_agent,
+)
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
@@ -4128,8 +4132,23 @@ async def _run_chat(
                         if _canonical:
                             slot.model = _canonical
                             _record_model = _canonical
+                    # Read context-window occupancy off the same `client`
+                    # used above (mirrors _context_usage_payload's accessor
+                    # pattern); read_context_tokens never raises.
+                    _ctx_used, _ctx_window = read_context_tokens(client)
                     await persist_token_record_async(
-                        slot.key, _record_model, event, provider=_provider_name
+                        slot.key,
+                        _record_model,
+                        event,
+                        provider=_provider_name,
+                        surface="dashboard",
+                        # Resolved agent, not the slot alias: resolve_agent_bindings
+                        # maps e.g. "default" to "kirocrew" before dispatch, so the
+                        # alias would credit an agent that never ran.
+                        agent=read_effective_agent(client) or slot.agent or "",
+                        context_used=_ctx_used,
+                        context_window=_ctx_window,
+                        model_source=client,
                     )
                 # ── Turn-completion histogram (OTel M2) ──
                 # kirocrew.turn.duration → turn latency p50/p90 + fault rate.

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -409,12 +409,42 @@ async def _run_hook_inner(
             provider_type=KiroCrewConfig.load().agent.provider,
         )
     result_text = ""
+    _complete_event: object | None = None
     async for event in client.stream(full_message):
         if event.kind == EVENT_TEXT_CHUNK:
             result_text += event.text
         elif event.kind == EVENT_COMPLETE:
+            _complete_event = event
             break
     state.sessions.record_success(session_key)  # sync; record_failure is async
+
+    # ── Per-turn usage row (issue #647): attribute webhook spend. ──
+    try:
+        # circular import: reached while kiro_crew.slack.handler is still
+        # initialising (dashboard/handlers/files.py imports is_tracked_channel
+        # from it), so a module-scope import raises ImportError under the
+        # suite's import order.
+        from kiro_crew.dashboard.handlers.usage import (
+            persist_token_record_async,
+            read_context_tokens,
+            read_effective_agent,
+        )
+
+        _used, _window = read_context_tokens(client)
+        await persist_token_record_async(
+            session_key,
+            "",
+            _complete_event,
+            provider=KiroCrewConfig.load().agent.provider,
+            surface="webhook",
+            agent=read_effective_agent(client) or agent or "",
+            context_used=_used,
+            context_window=_window,
+            model_source=client,
+        )
+    except Exception:
+        logger.debug("usage row (webhook) persist failed", exc_info=True)
+
     return result_text
 
 

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -86,10 +86,167 @@ def _shards_in_window(days: int) -> list[Path]:
     return paths
 
 
+def read_context_tokens(source: object) -> tuple[int, int]:
+    """Return ``(context_used, context_window)`` from a provider/client.
+
+    Reads the provider's public ``context_used_tokens()`` /
+    ``context_window_tokens()`` accessors (declared on ``providers/base.py`` and
+    implemented for ACP in ``providers/acp.py`` and ``acp/session_provider.py``).
+    Guarded with ``getattr`` so non-ACP providers and test doubles that lack the
+    accessors — or an accessor that raises — yield ``(0, 0)`` rather than
+    propagating. Never raises: this is best-effort analytics on the turn hot
+    path, and a measurement helper must never break the turn it measures.
+    """
+    try:
+        used_fn = getattr(source, "context_used_tokens", None)
+        window_fn = getattr(source, "context_window_tokens", None)
+        if not callable(used_fn) or not callable(window_fn):
+            return (0, 0)
+        return (int(used_fn()), int(window_fn()))
+    except Exception:
+        return (0, 0)
+
+
+def _wrapper_chain(source: object) -> list[object]:
+    """Collect *source* and the provider/client/handle wrappers nested under it.
+
+    ``providers/acp.py`` keeps its inner object on ``_client`` (also exposed as
+    ``client``), ``acp/session_provider.py`` keeps the session handle on
+    ``_handle``, and both the handle and the provider keep the spawned CLI
+    runtime on ``_runtime`` (``session_handle.py:215``, ``session_provider.py:61``)
+    — and these nest, because ``providers/acp.py:610`` assigns an
+    ``AcpSessionProvider`` to ``_client`` (the ``-> AcpClient`` annotation there
+    carries a ``type: ignore``). A default Kiro turn therefore hides its resolved
+    state two levels down, at ``provider.client._handle``, so probing a fixed
+    depth misses it. Breadth-first with a node cap and an identity-based visited
+    set, so a wrapper that points back at itself terminates.
+
+    ``_runtime`` is traversed **last** deliberately. It is the only holder of
+    ``_agent`` for the session-provider shape (``runtime.py:273``), but it also
+    carries the process-level ``--model`` argument (``runtime.py:280``); visiting
+    it after ``_handle`` keeps session-level model state ahead of process-level
+    state when :func:`read_effective_model` falls through to ``_model``.
+    """
+    chain: list[object] = []
+    pending: list[object] = [source]
+    while pending and len(chain) < 8:
+        node = pending.pop(0)
+        if node is None or any(seen is node for seen in chain):
+            continue
+        chain.append(node)
+        for holder in ("client", "_client", "_handle", "_runtime"):
+            inner = getattr(node, holder, None)
+            if inner is not None and not isinstance(inner, (str, bytes, int)):
+                pending.append(inner)
+    return chain
+
+
+def read_effective_agent(source: object) -> str:
+    """Return the agent id that actually served the turn, or ``""``.
+
+    The slot's ``agent`` is an alias that ``resolve_agent_bindings()`` maps to a
+    concrete kiro agent before dispatch (``chat_runner.py:2392`` resolves it and
+    :2408 passes the result into ``get_or_create``), so a slot set to ``default``
+    can be served by ``kirocrew``. Recording the alias would attribute the turn
+    to an agent that never ran. ``AcpClient`` stores what it was constructed with
+    on ``_agent`` (``acp/client.py:1270``), which is that resolved value — the
+    same "what actually ran" precedence used for the model. Never raises.
+    """
+    try:
+        for node in _wrapper_chain(source):
+            candidate = getattr(node, "_agent", "")
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    except Exception:
+        pass
+    return ""
+
+
+def read_effective_model(source: object) -> str:
+    """Return the model id the provider actually resolved for the turn, or ``""``.
+
+    Attribution only — deliberately NOT the same as
+    ``chat_runner._backfill_canonical_model``. That helper canonicalizes and
+    DROPS Bedrock profile-form ids for non-``claude_code`` providers, because its
+    result is written back into ``slot.model`` and a profile id there pins the
+    slot to one profile+region across resumes. Nothing here is written back, so
+    the raw resolved id is what we want: for cost attribution, the profile that
+    actually served the turn is strictly more informative than the alias the
+    caller asked for.
+
+    Walks the wrapper chain via :func:`_wrapper_chain` rather than a fixed depth,
+    because a default Kiro turn hides the resolved id two levels down.
+
+    Two passes over the collected chain, because a resolved id **anywhere** beats
+    a plain ``_model`` anywhere: ``_resolved_model_id`` is the id the backend
+    actually settled on (the same precedence ``AcpClient`` uses internally,
+    ``self._resolved_model_id or self._model``), while ``_model`` may still hold
+    the ``"auto"`` sentinel or a pre-resolution request. Skips ``"auto"``. Never
+    raises.
+    """
+    try:
+        chain = _wrapper_chain(source)
+        for attr in ("_resolved_model_id", "_model"):
+            for node in chain:
+                candidate = getattr(node, attr, "")
+                if isinstance(candidate, str) and candidate and candidate != "auto":
+                    return candidate
+    except Exception:
+        pass
+    return ""
+
+
+def _resolve_model(model: str, model_source: object) -> str:
+    """Resolve the model to record, treating the ``"auto"`` sentinel as unresolved.
+
+    ``"auto"`` is not a model — it means "let the backend choose" — so recording
+    it would put a non-model value in the attribution dimension. Several
+    surfaces pass it verbatim (``agent.model`` defaults to ``"auto"``, and the
+    task runner forwards that value), so gating only on an empty string lets it
+    through. When the caller's value is unresolved we take the provider's
+    resolved id; if that is unavailable the field stays blank, which is what
+    ``test_late_backfill_skips_auto_sentinel`` requires ("the record stays blank
+    until a real model is known").
+    """
+    if (model or "").strip().lower() not in ("", "auto"):
+        return model
+    if model_source is None:
+        return "" if (model or "").strip().lower() == "auto" else model
+    return read_effective_model(model_source)
+
+
+def _coerce_int(value: Any) -> int:
+    """Coerce ``value`` to ``int``, defaulting to 0 for non-numeric input.
+
+    Keeps the emitted record JSON-serializable even if a caller passes a
+    non-numeric context value.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _build_token_record(
-    slot_key: str, model: str, event: object, provider: str, now: datetime
+    slot_key: str,
+    model: str,
+    event: object,
+    provider: str,
+    now: datetime,
+    *,
+    surface: str = "",
+    agent: str = "",
+    context_used: int = 0,
+    context_window: int = 0,
 ) -> dict[str, Any]:
-    """Build the JSONL token-usage record dict (no I/O)."""
+    """Build the JSONL token-usage record dict (no I/O).
+
+    ``surface`` tags the dispatch origin (``dashboard``, ``cron``, ``subagent``,
+    …) and ``agent`` the agent id resolved for the turn. ``context_used`` /
+    ``context_window`` record context-window occupancy (read from the provider
+    via :func:`read_context_tokens` at the call site). All four are additive and
+    default to empty/0, so pre-existing shards and existing callers stay valid.
+    """
     # Usage lives on event.usage (TurnUsage). Fall back to the event itself when
     # it isn't a real TurnUsage (legacy / non-AcpEvent producers, test doubles).
     # credits is float-coerced so a non-numeric value can't break JSON serialization.
@@ -113,6 +270,13 @@ def _build_token_record(
         "credits": credits,
         "turns": getattr(u, "num_turns", 0),
         "duration_ms": getattr(u, "duration_ms", 0),
+        # Additive per-turn fields (issue #647): context occupancy + dispatch
+        # origin. Old shards lack these keys; readers must tolerate their
+        # absence. context_* are int-coerced so a bad value can't break json.dumps.
+        "surface": surface or "",
+        "agent": agent or "",
+        "context_used": _coerce_int(context_used),
+        "context_window": _coerce_int(context_window),
     }
 
 
@@ -127,25 +291,67 @@ def _write_token_record(record: dict[str, Any], now: datetime) -> None:
         f.write(json.dumps(record) + "\n")
 
 
-def persist_token_record(slot_key: str, model: str, event: object, provider: str = "") -> None:
+def persist_token_record(
+    slot_key: str,
+    model: str,
+    event: object,
+    provider: str = "",
+    *,
+    surface: str = "",
+    agent: str = "",
+    context_used: int = 0,
+    context_window: int = 0,
+    model_source: object = None,
+) -> None:
     """Append a token usage record to today's shard under
     ``<data home>/usage/tokens/YYYY-MM-DD.jsonl`` (synchronous).
 
     The ``provider`` field tags the source LLM backend (acp,
     claude_code, bedrock) so the dashboard chart can filter by provider.
+    ``surface`` / ``agent`` tag the dispatch origin and resolved agent, and
+    ``context_used`` / ``context_window`` record context-window occupancy — all
+    additive and defaulted so existing callers stay valid.
+
+    ``model_source`` is a provider/client used ONLY to fill ``model`` when the
+    caller could not resolve one (several dispatch surfaces never pick a model
+    explicitly and would otherwise record an empty string, losing the
+    per-model attribution dimension). An explicit ``model`` always wins.
 
     On the async chat hot path, prefer ``persist_token_record_async`` which
     offloads the blocking write off the event loop.
     """
     try:
+        model = _resolve_model(model, model_source)
         now = datetime.now().astimezone()
-        _write_token_record(_build_token_record(slot_key, model, event, provider, now), now)
+        _write_token_record(
+            _build_token_record(
+                slot_key,
+                model,
+                event,
+                provider,
+                now,
+                surface=surface,
+                agent=agent,
+                context_used=context_used,
+                context_window=context_window,
+            ),
+            now,
+        )
     except Exception:
         logger.debug("Failed to persist token record for slot %s", slot_key, exc_info=True)
 
 
 async def persist_token_record_async(
-    slot_key: str, model: str, event: object, provider: str = ""
+    slot_key: str,
+    model: str,
+    event: object,
+    provider: str = "",
+    *,
+    surface: str = "",
+    agent: str = "",
+    context_used: int = 0,
+    context_window: int = 0,
+    model_source: object = None,
 ) -> None:
     """Async variant: builds the record on-loop, offloads the file write.
 
@@ -153,10 +359,23 @@ async def persist_token_record_async(
     the aiohttp event loop — the synchronous open/append previously blocked all
     co-resident coroutines for the IO window. These are best-effort analytics
     (no fsync, exceptions swallowed), so off-loop write loses no durability.
+    See :func:`persist_token_record` for the ``surface`` / ``agent`` /
+    ``context_used`` / ``context_window`` / ``model_source`` fields.
     """
     try:
+        model = _resolve_model(model, model_source)
         now = datetime.now().astimezone()
-        record = _build_token_record(slot_key, model, event, provider, now)
+        record = _build_token_record(
+            slot_key,
+            model,
+            event,
+            provider,
+            now,
+            surface=surface,
+            agent=agent,
+            context_used=context_used,
+            context_window=context_window,
+        )
         await asyncio.to_thread(_write_token_record, record, now)
     except Exception:
         logger.debug("Failed to persist token record for slot %s", slot_key, exc_info=True)

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.acp.client import AcpError
+from kiro_crew.acp.types import TurnUsage
 from kiro_crew.hooks import fire_tool_hooks, get_global_hook_store
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
@@ -297,6 +298,32 @@ async def run_bg_oneliner(
         return await _drive()
     finally:
         await session.destroy()
+
+
+def provider_last_turn_usage(provider: Any) -> TurnUsage:
+    """Best-effort read of the just-completed turn's billing usage.
+
+    ``stream_and_collect`` breaks on ``EVENT_COMPLETE`` and returns only text,
+    discarding the event's ``usage``. Background surfaces that dispatch through
+    it (cron, heartbeat, autonudge, workflow, task-runner self-review) therefore
+    have no event to hand :func:`persist_token_record_async`. This recovers the
+    turn's billing from the provider's ``last_prompt_stats`` — the same post-turn
+    read ``chat_runner`` performs — and wraps it in a ``TurnUsage`` so it can be
+    passed straight through as the ``event`` argument.
+
+    On the ACP backend the only non-zero per-turn billing signal is ``credits``;
+    the token fields stay 0, matching the real usage record. Providers that expose
+    no stats (non-ACP backends, test doubles) yield an empty ``TurnUsage``
+    (credits=0). Never raises.
+    """
+    try:
+        inner = getattr(provider, "_client", None) or getattr(provider, "_handle", None)
+        stats = getattr(inner, "last_prompt_stats", None) if inner is not None else None
+        if stats is not None:
+            return TurnUsage(credits=float(getattr(stats, "credits", 0.0) or 0.0))
+    except Exception:
+        logger.debug("provider_last_turn_usage read failed", exc_info=True)
+    return TurnUsage()
 
 
 async def stream_and_collect(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -81,6 +81,11 @@ from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
 from kiro_crew.dashboard.handlers import MAX_PROMPT_BYTES
 from kiro_crew.dashboard.handlers.autonudge import render_nudge_message
 from kiro_crew.dashboard.handlers.messaging import _rehydrate_slot_from_history
+from kiro_crew.dashboard.handlers.usage import (
+    persist_token_record_async,
+    read_context_tokens,
+    read_effective_agent,
+)
 from kiro_crew.dashboard.origin import (
     build_dashboard_url,
     format_dashboard_urls,
@@ -117,6 +122,7 @@ from kiro_crew.learn import LessonStore
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
+    provider_last_turn_usage,
     save_conversation_turn,
     stream_and_collect,
 )
@@ -2006,6 +2012,31 @@ class GatewayOrchestrator:
                         if not result_text:
                             result_text = "_No response._"
                         logger.info("Cron '%s': agent '%s' completed", job.name, agent)
+
+                        # ── Per-turn usage row (issue #647): background spend. ──
+                        try:
+
+                            _used, _window = read_context_tokens(client)
+                            await persist_token_record_async(
+                                agent_session_key,
+                                # Blank on a downgrade: the configured model was
+                                # unavailable and the default ran instead, so the
+                                # requested id would attribute spend to a model
+                                # that never executed. Blank defers to
+                                # model_source, which reports what actually ran.
+                                "" if _seq_downgraded else (job.model or ""),
+                                provider_last_turn_usage(client),
+                                provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                                surface="cron",
+                                agent=read_effective_agent(client) or agent or "",
+                                context_used=_used,
+                                context_window=_window,
+                                model_source=client,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "usage row (cron seq) persist failed", exc_info=True
+                            )
                     finally:
                         if _acq:
                             self.sessions.release(agent_session_key)
@@ -2070,6 +2101,26 @@ class GatewayOrchestrator:
                     result_text = _annotate_model_downgrade(result_text)
 
                 job.last_result = result_text
+
+                # ── Per-turn usage row (issue #647): attribute background spend. ──
+                # Best-effort; must never fail the cron turn.
+                try:
+
+                    _used, _window = read_context_tokens(client)
+                    await persist_token_record_async(
+                        session_key,
+                        # Blank on a downgrade — see the sequential site above.
+                        "" if _model_downgraded else (job.model or ""),
+                        provider_last_turn_usage(client),
+                        provider=_provider,
+                        surface="cron",
+                        agent=read_effective_agent(client) or job.agent_id or "",
+                        context_used=_used,
+                        context_window=_window,
+                        model_source=client,
+                    )
+                except Exception:
+                    logger.debug("usage row (cron) persist failed", exc_info=True)
 
                 # ── Error deduplication ──
                 # Suppress Slack for repeated identical results to avoid spam.
@@ -2526,6 +2577,24 @@ class GatewayOrchestrator:
 
                 if not result_text:
                     result_text = "_No response._"
+
+                # ── Per-turn usage row (issue #647): attribute heartbeat spend. ──
+                try:
+
+                    _used, _window = read_context_tokens(client)
+                    await persist_token_record_async(
+                        session_key,
+                        "",
+                        provider_last_turn_usage(client),
+                        provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                        surface="heartbeat",
+                        agent=read_effective_agent(client) or "kirocrew-heartbeat",
+                        context_used=_used,
+                        context_window=_window,
+                        model_source=client,
+                    )
+                except Exception:
+                    logger.debug("usage row (heartbeat) persist failed", exc_info=True)
             except asyncio.TimeoutError:
                 # Tear down the in-flight turn so the underlying claude-agent-acp
                 # process/turn doesn't linger holding the heartbeat session.
@@ -2667,6 +2736,24 @@ class GatewayOrchestrator:
                 ),
                 timeout=_NUDGE_TURN_TIMEOUT,
             )
+
+            # ── Per-turn usage row (issue #647): attribute monitor spend. ──
+            try:
+
+                _used, _window = read_context_tokens(client)
+                await persist_token_record_async(
+                    key,
+                    "",
+                    provider_last_turn_usage(client),
+                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                    surface="monitor",
+                    agent=read_effective_agent(client) or _get_agent_for_session(key),
+                    context_used=_used,
+                    context_window=_window,
+                    model_source=client,
+                )
+            except Exception:
+                logger.debug("usage row (monitor) persist failed", exc_info=True)
         except Exception:
             logger.exception("AutoNudge: slack nudge turn failed for %s (loop %s)", key, loop.id)
             return False

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -3675,6 +3675,7 @@ class SubagentManager:
                     await asyncio.sleep(delay)
                     msg = _TRANSIENT_CONTINUE_MSG if _had_activity else full_message
 
+        _complete_event: LLMEvent | None = None
         async for event in _stream_with_transient_retry():
             # Refresh the activity clock for EVERY event kind (thinking chunks,
             # tool-call updates, etc.) before dispatch, so idle-stall detection
@@ -3868,6 +3869,7 @@ class SubagentManager:
                             "PostToolUse hook error in subagent", exc_info=True,
                         )
             elif event.kind == EVENT_COMPLETE:
+                _complete_event = event
                 break
 
         # Strip [OPTIONS: ...] tags and redact sensitive content
@@ -3897,8 +3899,52 @@ class SubagentManager:
             self._completion_keep_chars,
         )
         evict_completed_agents(self._agents)
+
+        # ── Per-turn usage row (issue #647): attribute subagent spend. ──
+        # Deliberately BEFORE `info.done`: the caller's cleanup (which awaits
+        # provider.shutdown() -> handle.destroy()) runs after this function
+        # returns, so an await placed after `done` sits inside the
+        # done-to-teardown window. Waiters that poll for `done` would then
+        # observe completion while this file write is still in flight — which
+        # widens that window on slow filesystems and lets teardown-observing
+        # callers race it. Writing first also means `done` never becomes
+        # visible with the usage row still missing.
+        try:
+            # circular import: reached while kiro_crew.slack.handler is still
+            # initialising (dashboard/handlers/files.py imports is_tracked_channel
+            # from it), so a module-scope import raises ImportError under the
+            # suite's import order.
+            from kiro_crew.dashboard.handlers.usage import (
+                persist_token_record_async,
+                read_context_tokens,
+                read_effective_agent,
+            )
+
+            _used, _window = read_context_tokens(client)
+            await persist_token_record_async(
+                session_key,
+                info.model or "",
+                _complete_event,
+                provider="claude_code" if is_cc else "acp",
+                surface="subagent",
+                # Explicit/inherited `agent` FIRST here — unlike every other
+                # surface. Under session sharing this subagent reuses the
+                # PARENT's runtime, so read_effective_agent() would report the
+                # parent's agent and misattribute a `spawn_run(agent="…")` turn.
+                # `agent` is already the resolved value (it inherits the parent
+                # session's agent when the spawn did not name one), and the
+                # helper stays as the fallback for when it is empty.
+                agent=agent or read_effective_agent(client) or "",
+                context_used=_used,
+                context_window=_window,
+                model_source=client,
+            )
+        except Exception:
+            logger.debug("usage row (subagent) persist failed", exc_info=True)
+
         info.done = True
         self._sessions.record_success(session_key)
+
         Stats().inc_subagent_completed()
         logger.info("Subagent %s completed", info.id)
 

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -17,12 +17,13 @@ from kiro_crew.acp.client import AcpProcessDied
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY, fire_tool_hooks, get_global_hook_store
-from kiro_crew.llm_helpers import stream_and_collect_json
+from kiro_crew.llm_helpers import provider_last_turn_usage, stream_and_collect_json
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
     EVENT_TOOL_CALL,
+    LLMEvent,
 )
 from kiro_crew.safety_override import safety_override
 from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
@@ -340,6 +341,7 @@ async def execute_task(
 
             result_text = ""
             _chunk_count = 0
+            _complete_event: LLMEvent | None = None
             async for event in client.stream(full_prompt):
                 if event.kind == EVENT_TEXT_CHUNK:
                     result_text += event.text
@@ -512,12 +514,45 @@ async def execute_task(
                         agent_role=(agent or "kirocrew"),
                     )
                 elif event.kind == EVENT_COMPLETE:
+                    _complete_event = event
                     break
 
             final_result = result_prefix + result_text
             task.result = redact_credentials(redact_exfiltration_urls(final_result)[0])[0]
             sessions.record_success(session_key)
             sessions.check_context_usage(session_key, client)
+
+            # ── Per-turn usage row (issue #647): attribute task-runner spend. ──
+            try:
+                # circular import: reached while kiro_crew.slack.handler is still
+                # initialising (dashboard/handlers/files.py imports is_tracked_channel
+                # from it), so a module-scope import raises ImportError under the
+                # suite's import order.
+                from kiro_crew.dashboard.handlers.usage import (
+                    persist_token_record_async,
+                    read_context_tokens,
+                    read_effective_agent,
+                )
+
+                _usage_cfg = KiroCrewConfig.load()
+                _used, _window = read_context_tokens(client)
+                await persist_token_record_async(
+                    session_key,
+                    # Blank, not the global config model: open_task_session may
+                    # have resolved a custom agent's own model, and an explicit
+                    # value here would outrank model_source and record the
+                    # global default instead of what actually ran.
+                    "",
+                    _complete_event,
+                    provider=_usage_cfg.agent.provider,
+                    surface="task_runner",
+                    agent=read_effective_agent(client) or agent or "",
+                    context_used=_used,
+                    context_window=_window,
+                    model_source=client,
+                )
+            except Exception:
+                logger.debug("usage row (task_runner) persist failed", exc_info=True)
 
         except AcpProcessDied:
             recoveries += 1
@@ -820,6 +855,36 @@ async def self_review(
             cwd=str(run.work_dir) if run.work_dir else None,
         )
         result = await stream_and_collect_json(client, prompt)
+
+        # ── Per-turn usage row (issue #647): self-review is a separate model turn. ──
+        try:
+            # circular import: reached while kiro_crew.slack.handler is still
+            # initialising (dashboard/handlers/files.py imports is_tracked_channel
+            # from it), so a module-scope import raises ImportError under the
+            # suite's import order.
+            from kiro_crew.dashboard.handlers.usage import (
+                persist_token_record_async,
+                read_context_tokens,
+                read_effective_agent,
+            )
+
+            _rv_cfg = KiroCrewConfig.load()
+            _used, _window = read_context_tokens(client)
+            await persist_token_record_async(
+                review_key,
+                # Blank — see the task site above; model_source reports what ran.
+                "",
+                provider_last_turn_usage(client),
+                provider=_rv_cfg.agent.provider,
+                surface="task_runner",
+                agent=read_effective_agent(client) or agent or "",
+                context_used=_used,
+                context_window=_window,
+                model_source=client,
+            )
+        except Exception:
+            logger.debug("usage row (self_review) persist failed", exc_info=True)
+
         if result and not result.get("ok", True):
             issue = result.get("issue", "Review found issues")
             task.error = f"Self-review: {issue}"

--- a/src/kiro_crew/workflows/agent_exec.py
+++ b/src/kiro_crew/workflows/agent_exec.py
@@ -31,7 +31,7 @@ import itertools
 import logging
 from typing import Any, Callable, Optional
 
-from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect
+from kiro_crew.llm_helpers import ToolApprovalPolicy, provider_last_turn_usage, stream_and_collect
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,33 @@ def build_agent_fn(
                 approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
                 max_turns=_MAX_TURNS_PER_STEP,
             )
+            # ── Per-turn usage row (issue #647): attribute workflow spend. ──
+            try:
+                # circular import: reached while kiro_crew.slack.handler is still
+                # initialising (dashboard/handlers/files.py imports is_tracked_channel
+                # from it), so a module-scope import raises ImportError under the
+                # suite's import order.
+                from kiro_crew.dashboard.handlers.usage import (
+                    persist_token_record_async,
+                    read_context_tokens,
+                    read_effective_agent,
+                )
+
+                _used, _window = read_context_tokens(provider)
+                await persist_token_record_async(
+                    key,
+                    opts.get("model") or default_model or "",
+                    provider_last_turn_usage(provider),
+                    provider="acp",
+                    surface="workflow",
+                    agent=(read_effective_agent(provider)
+                           or opts.get("agent") or default_agent or ""),
+                    context_used=_used,
+                    context_window=_window,
+                    model_source=provider,
+                )
+            except Exception:
+                logger.debug("usage row (workflow) persist failed", exc_info=True)
             # Issue #2: Apply output redaction to prevent credential leakage
             # in workflow results stored in history or injected into parent chat.
             text, _ = redact_credentials(text)

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -590,3 +590,113 @@ class TestExecutePreservesCallbackStatus:
         await svc._execute(job)  # second run clean → must reset to ok, not stay error
         assert job.last_status == "ok"
         assert job.last_error is None
+
+
+class TestCronUsageRow:
+    """Issue #647: every model-spending cron turn appends exactly one usage row
+    tagged surface='cron'; the zero-token script/command modes append none."""
+
+    @pytest.mark.asyncio
+    async def test_llm_cron_persists_usage_row_with_surface(self):
+        gw = _make_gw_for_llm()
+        job = _make_llm_job(model="claude-opus-4-8")
+
+        persist = AsyncMock()
+        # Patch gateway's own bindings: the imports are at module scope there,
+        # so patching the source module would not be seen by the call site.
+        with patch(
+            "kiro_crew.slack.gateway.persist_token_record_async", persist
+        ), patch(
+            "kiro_crew.slack.gateway.read_context_tokens",
+            MagicMock(return_value=(1234, 200000)),
+            create=True,
+        ):
+            await _run_llm_callback(gw, job)
+
+        persist.assert_awaited_once()
+        kwargs = persist.await_args.kwargs
+        assert kwargs["surface"] == "cron"
+        assert kwargs["provider"] == "acp"
+        assert kwargs["context_used"] == 1234
+        assert kwargs["context_window"] == 200000
+
+    @pytest.mark.asyncio
+    async def test_cron_row_records_resolved_agent_not_requested(self):
+        """The agent that served the turn wins over the configured alias."""
+        gw = _make_gw_for_llm()
+        job = _make_llm_job(model="claude-opus-4-8")
+
+        persist = AsyncMock()
+        with patch(
+            "kiro_crew.slack.gateway.persist_token_record_async", persist
+        ), patch(
+            "kiro_crew.slack.gateway.read_context_tokens",
+            MagicMock(return_value=(10, 100)),
+            create=True,
+        ), patch(
+            "kiro_crew.slack.gateway.read_effective_agent",
+            MagicMock(return_value="kirocrew"),
+            create=True,
+        ):
+            await _run_llm_callback(gw, job)
+
+        persist.assert_awaited_once()
+        assert persist.await_args.kwargs["agent"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_downgraded_cron_does_not_record_rejected_model(self):
+        """A model that was refused never ran, so it must not be attributed."""
+        gw = _make_gw_for_llm()
+        job = _make_llm_job(model="claude-nonexistent-9")
+        provider_mock = MagicMock()
+
+        call_count = [0]
+
+        async def _side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("model 'claude-nonexistent-9' not found")
+            return (provider_mock, True, False)
+
+        persist = AsyncMock()
+        with patch(
+            "kiro_crew.slack.gateway.persist_token_record_async", persist
+        ), patch(
+            "kiro_crew.slack.gateway.read_context_tokens",
+            MagicMock(return_value=(10, 100)),
+            create=True,
+        ):
+            await _run_llm_callback(gw, job, get_or_create_side_effect=_side_effect)
+
+        persist.assert_awaited_once()
+        # Positional arg 1 is the model; blank defers to model_source, which
+        # reports the model that actually served the turn.
+        assert persist.await_args.args[1] == ""
+
+    @pytest.mark.asyncio
+    async def test_script_cron_writes_no_usage_row(self):
+        gw = _make_gw()
+        job = _make_script_job()
+
+        persist = AsyncMock()
+        with patch(
+            "kiro_crew.slack.gateway.persist_token_record_async", persist
+        ):
+            await _run_script_callback(gw, job, {"status": "ok"})
+
+        persist.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_command_cron_writes_no_usage_row(self):
+        gw = _make_gw()
+        job = _make_command_job()
+
+        persist = AsyncMock()
+        with patch(
+            "kiro_crew.slack.gateway.persist_token_record_async", persist
+        ):
+            await _run_command_callback(
+                gw, job, {"status": "ok", "output": "hello\n", "exit_code": 0}
+            )
+
+        persist.assert_not_awaited()

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3088,7 +3088,7 @@ class TestTokenPersistenceBackfill:
 
         captured: list[tuple] = []
 
-        async def _fake_persist(slot_key, model, event, provider=""):
+        async def _fake_persist(slot_key, model, event, provider="", **kwargs):
             captured.append((slot_key, model, provider))
 
         monkeypatch.setattr(
@@ -3129,7 +3129,7 @@ class TestTokenPersistenceBackfill:
 
         captured: list[tuple] = []
 
-        async def _fake_persist(k, m, e, provider=""):
+        async def _fake_persist(k, m, e, provider="", **kwargs):
             captured.append((k, m, provider))
 
         monkeypatch.setattr(
@@ -3166,7 +3166,7 @@ class TestTokenPersistenceBackfill:
 
         captured: list[tuple] = []
 
-        async def _fake_persist(k, m, e, provider=""):
+        async def _fake_persist(k, m, e, provider="", **kwargs):
             captured.append((k, m, provider))
 
         monkeypatch.setattr(
@@ -3284,7 +3284,7 @@ class TestKiroBackfillProfileGuard:
 
         captured: list[tuple] = []
 
-        async def _fake_persist(k, m, e, provider=""):
+        async def _fake_persist(k, m, e, provider="", **kwargs):
             captured.append((k, m, provider))
 
         monkeypatch.setattr(

--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -43,6 +43,28 @@ async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
         await asyncio.sleep(0.01)
 
 
+async def _wait_until_awaited(mock_attr, label: str, *, timeout: float = 5.0) -> None:
+    """Wait for an async mock to have been awaited, deterministically.
+
+    Companion to :func:`_wait_until_done`, for assertions about TEARDOWN rather
+    than completion. ``info.done`` flips inside ``_run_inner``, but the
+    shared-session teardown that reaches ``handle.destroy()`` runs strictly
+    afterwards — the ``asyncio.wait_for`` future in ``_run`` has to resolve, then
+    its cleanup awaits ``provider.shutdown()``. So ``_wait_until_done``
+    returning does NOT imply teardown has happened, and asserting on it
+    immediately races the completion task in exactly the way the fixed sleep did
+    before #574 — that fix made the ``info.done`` half deterministic and left
+    this half racing. Polling the await against a deadline closes it: it returns
+    as soon as teardown lands, and still fails if teardown never happens.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while not mock_attr.await_count:
+        if loop.time() >= deadline:
+            raise AssertionError(f"{label} was not awaited within {timeout}s")
+        await asyncio.sleep(0.01)
+
+
 def _mock_sessions(*, sharing_eligible: bool = True) -> MagicMock:
     """Create a mock SessionManager with session-sharing support."""
     sessions = MagicMock()
@@ -276,10 +298,12 @@ class TestSessionSharingSpawn:
         sessions.reset.assert_not_awaited()
         # release should NOT have been called
         sessions.release.assert_not_called()
-        # The handle's destroy should have been called via shutdown()
+        # The handle's destroy should have been called via shutdown().
+        # Teardown runs AFTER info.done, so wait for it rather than assuming the
+        # completion task already got there (see _wait_until_awaited).
         runtime = await sessions.get_subagent_runtime("dashboard:slot1")
         handle = await runtime.create_session()
-        handle.destroy.assert_awaited()
+        await _wait_until_awaited(handle.destroy, "handle.destroy")
 
     @pytest.mark.asyncio
     async def test_legacy_path_when_sharing_off(self):

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -1862,3 +1862,96 @@ class TestCompletionKeepLoader:
 
         for v in ("head", "tail", "both"):
             assert _validated_completion_keep(v) == v
+
+
+class TestSubagentUsageRow:
+    """Issue #647: a completed subagent turn appends one usage row tagged
+    surface='subagent', carrying the resolved agent and context occupancy."""
+
+    @pytest.mark.asyncio
+    async def test_subagent_turn_persists_usage_row_with_surface(self) -> None:
+        from kiro_crew.acp.types import AcpEvent, TurnUsage
+        from kiro_crew.providers.base import EVENT_COMPLETE
+        from kiro_crew.subagent import SubagentInfo
+
+        async def _complete_stream(*_a: object, **_k: object):  # type: ignore[no-untyped-def]
+            yield AcpEvent(kind=EVENT_COMPLETE, usage=TurnUsage(credits=0.5))
+
+        sessions = _mock_sessions()
+        provider = AsyncMock()
+        provider.context_usage_pct = lambda: 12.0
+        provider.stream = MagicMock(side_effect=lambda *a, **kw: _complete_stream())
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        manager = SubagentManager(
+            sessions=sessions,
+            ctx_builder=_mock_ctx_builder_auto_spawn(),
+        )
+        info = SubagentInfo(
+            id="usage01",
+            task="do the thing",
+            agent="researcher",
+            parent_session_key="slack:C123:T456",
+        )
+
+        persist = AsyncMock()
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
+            "kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist
+        ), patch(
+            "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+            MagicMock(return_value=(999, 200000)),
+            create=True,
+        ):
+            await manager._run_inner(info, "subagent:usage01")
+
+        persist.assert_awaited_once()
+        kwargs = persist.await_args.kwargs
+        assert kwargs["surface"] == "subagent"
+        assert kwargs["agent"] == "researcher"
+        assert kwargs["context_used"] == 999
+        assert kwargs["context_window"] == 200000
+
+    @pytest.mark.asyncio
+    async def test_shared_runtime_agent_does_not_override_spawn_agent(self) -> None:
+        """Session sharing reuses the PARENT's runtime, so the runtime's agent
+        must not overwrite the agent this spawn actually asked for."""
+        from kiro_crew.acp.types import AcpEvent, TurnUsage
+        from kiro_crew.providers.base import EVENT_COMPLETE
+        from kiro_crew.subagent import SubagentInfo
+
+        async def _complete_stream(*_a: object, **_k: object):  # type: ignore[no-untyped-def]
+            yield AcpEvent(kind=EVENT_COMPLETE, usage=TurnUsage(credits=0.5))
+
+        sessions = _mock_sessions()
+        provider = AsyncMock()
+        provider.stream = MagicMock(side_effect=lambda *a, **kw: _complete_stream())
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+
+        manager = SubagentManager(
+            sessions=sessions,
+            ctx_builder=_mock_ctx_builder_auto_spawn(),
+        )
+        info = SubagentInfo(
+            id="usage02",
+            task="do the thing",
+            agent="researcher",
+            parent_session_key="slack:C123:T456",
+        )
+
+        persist = AsyncMock()
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
+            "kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist
+        ), patch(
+            "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+            MagicMock(return_value=(1, 2)),
+            create=True,
+        ), patch(
+            # The shared parent runtime reports the parent's agent.
+            "kiro_crew.dashboard.handlers.usage.read_effective_agent",
+            MagicMock(return_value="kirocrew"),
+            create=True,
+        ):
+            await manager._run_inner(info, "subagent:usage02")
+
+        persist.assert_awaited_once()
+        assert persist.await_args.kwargs["agent"] == "researcher"

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -7,6 +7,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +23,9 @@ from kiro_crew.dashboard.handlers.usage import (
     get_usage_cache,
     persist_token_record,
     persist_token_record_async,
+    read_context_tokens,
+    read_effective_agent,
+    read_effective_model,
 )
 
 # ── _parse_sessions ─────────────────────────────────────────────────────
@@ -806,3 +810,355 @@ class TestBuildTokenRecordCredits:
             "s", "m", event, "acp", datetime.now(timezone.utc)
         )
         assert rec["credits"] == 0.0
+
+
+# ── read_context_tokens / context-occupancy row fields (issue #647) ──────────
+
+
+class TestReadContextTokens:
+    """read_context_tokens() reads provider occupancy accessors defensively."""
+
+    def test_returns_real_values_from_provider(self):
+        from types import SimpleNamespace
+
+        # A fake provider exposing both public accessors (as AcpProvider /
+        # AcpSessionProvider do) returns their exact values.
+        provider = SimpleNamespace(
+            context_used_tokens=lambda: 12345,
+            context_window_tokens=lambda: 1_000_000,
+        )
+        assert read_context_tokens(provider) == (12345, 1_000_000)
+
+    def test_returns_zero_when_accessors_absent(self):
+        # A plain object with neither accessor — e.g. a non-ACP provider or a
+        # bare test double — records (0, 0) rather than raising.
+        assert read_context_tokens(object()) == (0, 0)
+
+    def test_returns_zero_when_accessor_raises(self):
+        class _Boom:
+            def context_used_tokens(self) -> int:
+                raise RuntimeError("boom")
+
+            def context_window_tokens(self) -> int:
+                return 1_000_000
+
+        assert read_context_tokens(_Boom()) == (0, 0)
+
+    def test_returns_zero_when_only_one_accessor_present(self):
+        from types import SimpleNamespace
+
+        # Both accessors are required; a partial provider still yields (0, 0).
+        partial = SimpleNamespace(context_used_tokens=lambda: 500)
+        assert read_context_tokens(partial) == (0, 0)
+
+
+class TestBuildTokenRecordContextFields:
+    """_build_token_record emits the additive surface/agent/context_* fields."""
+
+    @staticmethod
+    def _event():
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.0,
+            credits=0.0,
+            num_turns=1,
+            duration_ms=0,
+        )
+
+    def test_emits_new_keys(self):
+        rec = usage_mod._build_token_record(
+            "chat-1",
+            "claude-opus-4-8",
+            self._event(),
+            "acp",
+            datetime.now(timezone.utc),
+            surface="dashboard",
+            agent="kirocrew",
+            context_used=44_000,
+            context_window=1_000_000,
+        )
+        assert rec["surface"] == "dashboard"
+        assert rec["agent"] == "kirocrew"
+        assert rec["context_used"] == 44_000
+        assert rec["context_window"] == 1_000_000
+
+    def test_coerces_non_numeric_context_to_zero(self):
+        # Defensive int coercion keeps the record json.dumps-safe.
+        rec = usage_mod._build_token_record(
+            "s",
+            "m",
+            self._event(),
+            "acp",
+            datetime.now(timezone.utc),
+            context_used="not-a-number",
+            context_window=None,
+        )
+        assert rec["context_used"] == 0
+        assert rec["context_window"] == 0
+        json.dumps(rec)  # must not raise
+
+    def test_backcompat_defaults_when_no_kwargs(self):
+        # Called positionally with no new kwargs (mirrors every legacy caller):
+        # the original keys are unchanged and the new keys default to ""/0, so
+        # old readers and old shards stay valid.
+        rec = usage_mod._build_token_record(
+            "chat-1", "opus", self._event(), "acp", datetime.now(timezone.utc)
+        )
+        for key in (
+            "_type",
+            "ts",
+            "slot",
+            "provider",
+            "model",
+            "input",
+            "output",
+            "cache_create",
+            "cache_read",
+            "cost",
+            "credits",
+            "turns",
+            "duration_ms",
+        ):
+            assert key in rec
+        assert rec["input"] == 10
+        assert rec["provider"] == "acp"
+        # New fields present with defaults.
+        assert rec["surface"] == ""
+        assert rec["agent"] == ""
+        assert rec["context_used"] == 0
+        assert rec["context_window"] == 0
+
+    def test_persist_writes_new_fields_to_shard(self, tmp_path, monkeypatch):
+        # End-to-end: the keyword-only params flow through persist_token_record
+        # into the written JSONL row.
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot",
+            "opus",
+            self._event(),
+            provider="acp",
+            surface="dashboard",
+            agent="kirocrew",
+            context_used=44_000,
+            context_window=1_000_000,
+        )
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        record = json.loads((shard_dir / f"{today}.jsonl").read_text(encoding="utf-8").strip())
+        assert record["surface"] == "dashboard"
+        assert record["agent"] == "kirocrew"
+        assert record["context_used"] == 44_000
+        assert record["context_window"] == 1_000_000
+
+
+class _Inner:
+    def __init__(self, model):
+        self._model = model
+
+
+class TestReadEffectiveModel:
+    """read_effective_model: raw resolved model id, attribution only."""
+
+    def test_reads_via_public_client_chain(self):
+        src = type("P", (), {"client": _Inner("global.anthropic.claude-opus-4-8[1m]")})()
+        assert read_effective_model(src) == "global.anthropic.claude-opus-4-8[1m]"
+
+    def test_reads_via_private_client_chain(self):
+        src = type("P", (), {"_client": _Inner("claude-opus-4.8")})()
+        assert read_effective_model(src) == "claude-opus-4.8"
+
+    def test_reads_via_handle_chain(self):
+        src = type("P", (), {"_handle": _Inner("claude-haiku-4.5")})()
+        assert read_effective_model(src) == "claude-haiku-4.5"
+
+    def test_reads_direct_model_attr(self):
+        assert read_effective_model(_Inner("claude-sonnet-4.5")) == "claude-sonnet-4.5"
+
+    def test_skips_auto_sentinel(self):
+        # "auto" means "backend chooses" — not a model, so not attribution data.
+        assert read_effective_model(_Inner("auto")) == ""
+
+    def test_returns_empty_when_absent(self):
+        assert read_effective_model(object()) == ""
+
+    def test_returns_empty_when_accessor_raises(self):
+        class Boom:
+            @property
+            def _client(self):
+                raise RuntimeError("boom")
+
+        assert read_effective_model(Boom()) == ""
+
+    def test_prefers_first_populated_chain(self):
+        src = type("P", (), {"client": _Inner(""), "_client": _Inner("claude-opus-4.8")})()
+        assert read_effective_model(src) == "claude-opus-4.8"
+
+    def test_resolved_id_wins_over_model(self):
+        # Mirrors AcpClient's own precedence: `_resolved_model_id or _model`.
+        inner = _Inner("claude-opus-4.8")
+        inner._resolved_model_id = "global.anthropic.claude-opus-4-8[1m]"
+        src = type("P", (), {"_client": inner})()
+        assert read_effective_model(src) == "global.anthropic.claude-opus-4-8[1m]"
+
+    def test_default_model_turn_uses_resolved_id(self):
+        # The common case: the caller asked for the default, so `_model` is left
+        # at the "auto" sentinel while the backend's resolved id is the real one.
+        inner = _Inner("auto")
+        inner._resolved_model_id = "claude-opus-4.8"
+        src = type("P", (), {"_handle": inner})()
+        assert read_effective_model(src) == "claude-opus-4.8"
+
+    def test_falls_back_to_model_when_resolved_id_blank(self):
+        inner = _Inner("claude-haiku-4.5")
+        inner._resolved_model_id = ""
+        assert read_effective_model(inner) == "claude-haiku-4.5"
+
+    def test_walks_nested_handle_two_levels_down(self):
+        # The default Kiro turn shape: providers/acp.py assigns an
+        # AcpSessionProvider to _client, which holds the handle on _handle, so
+        # the resolved id sits at provider.client._handle.
+        handle = _Inner("auto")
+        handle._resolved_model_id = "claude-opus-4.8"
+        mid = type("SessionProvider", (), {"_handle": handle})()
+        outer = type("P", (), {"client": mid, "_client": mid})()
+        assert read_effective_model(outer) == "claude-opus-4.8"
+
+    def test_resolved_id_deep_beats_model_shallow(self):
+        # A resolved id anywhere outranks a plain _model anywhere: _model may
+        # still hold a pre-resolution request.
+        handle = _Inner("")
+        handle._resolved_model_id = "global.anthropic.claude-opus-4-8[1m]"
+        outer = type("P", (), {"_model": "claude-opus-4.8", "_handle": handle})()
+        assert read_effective_model(outer) == "global.anthropic.claude-opus-4-8[1m]"
+
+    def test_self_referential_chain_terminates(self):
+        node = type("Loop", (), {})()
+        node._client = node
+        node._model = "claude-opus-4.8"
+        assert read_effective_model(node) == "claude-opus-4.8"
+
+
+class TestReadEffectiveAgent:
+    """The resolved agent, not the slot alias."""
+
+    def test_reads_resolved_agent_off_client(self):
+        inner = type("C", (), {"_agent": "kirocrew"})()
+        assert read_effective_agent(inner) == "kirocrew"
+
+    def test_walks_nested_handle(self):
+        handle = type("H", (), {"_agent": "kirocrew-lite"})()
+        mid = type("SessionProvider", (), {"_handle": handle})()
+        outer = type("P", (), {"client": mid})()
+        assert read_effective_agent(outer) == "kirocrew-lite"
+
+    def test_blank_when_absent(self):
+        assert read_effective_agent(object()) == ""
+
+    def test_never_raises_on_exploding_attribute(self):
+        class Boom:
+            @property
+            def _agent(self):
+                raise RuntimeError("nope")
+
+        assert read_effective_agent(Boom()) == ""
+
+    def test_reads_agent_off_the_runtime(self):
+        # The session-provider shape: the agent is held only by the spawned CLI
+        # runtime (runtime.py:273), reached via provider -> _handle -> _runtime.
+        runtime = type("Runtime", (), {"_agent": "kirocrew"})()
+        handle = type("Handle", (), {"_runtime": runtime})()
+        provider = type("SessionProvider", (), {"_handle": handle})()
+        assert read_effective_agent(provider) == "kirocrew"
+
+    def test_session_model_outranks_runtime_model(self):
+        # _runtime is walked last so its process-level --model argument cannot
+        # outrank the session handle's own model.
+        runtime = type("Runtime", (), {"_model": "claude-haiku-4.5"})()
+        handle = type("Handle", (), {"_model": "claude-opus-4.8", "_runtime": runtime})()
+        provider = type("SessionProvider", (), {"_handle": handle})()
+        assert read_effective_model(provider) == "claude-opus-4.8"
+
+
+class TestModelSourceFallback:
+    """model_source fills `model` only when the caller resolved none."""
+
+    @staticmethod
+    def _event():
+        # Not a real TurnUsage, so _build_token_record reads credits off the
+        # event itself — enough to exercise the model fallback.
+        return SimpleNamespace(credits=1.0)
+
+    def _row(self, shard_dir):
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        return json.loads((shard_dir / f"{today}.jsonl").read_text(encoding="utf-8").strip())
+
+    def test_fallback_fills_empty_model(self, tmp_path, monkeypatch):
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot",
+            "",
+            self._event(),
+            provider="acp",
+            surface="webhook",
+            model_source=_Inner("claude-opus-4.8"),
+        )
+        assert self._row(shard_dir)["model"] == "claude-opus-4.8"
+
+    def test_explicit_model_wins(self, tmp_path, monkeypatch):
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot",
+            "claude-haiku-4.5",
+            self._event(),
+            provider="acp",
+            surface="cron",
+            model_source=_Inner("claude-opus-4.8"),
+        )
+        assert self._row(shard_dir)["model"] == "claude-haiku-4.5"
+
+    def test_no_source_leaves_model_empty(self, tmp_path, monkeypatch):
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record("slot", "", self._event(), provider="acp", surface="webhook")
+        assert self._row(shard_dir)["model"] == ""
+
+    def test_unusable_source_leaves_model_empty(self, tmp_path, monkeypatch):
+        # A test double with no model attr must not break the write.
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot", "", self._event(), provider="acp", surface="webhook", model_source=object()
+        )
+        assert self._row(shard_dir)["model"] == ""
+
+    def test_auto_sentinel_is_treated_as_unresolved(self, tmp_path, monkeypatch):
+        # agent.model defaults to "auto" and the task runner forwards it verbatim.
+        # "auto" is not a model, so the provider's resolved id must win.
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot",
+            "auto",
+            self._event(),
+            provider="acp",
+            surface="task_runner",
+            model_source=_Inner("claude-opus-4.8"),
+        )
+        assert self._row(shard_dir)["model"] == "claude-opus-4.8"
+
+    def test_auto_without_resolvable_source_records_blank(self, tmp_path, monkeypatch):
+        # Matches test_late_backfill_skips_auto_sentinel's contract: the record
+        # stays blank until a real model is known -- never the sentinel itself.
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot", "auto", self._event(), provider="acp", surface="task_runner"
+        )
+        assert self._row(shard_dir)["model"] == ""
+
+    def test_auto_is_case_and_space_insensitive(self, tmp_path, monkeypatch):
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "slot", "  AUTO ", self._event(), provider="acp", surface="cron"
+        )
+        assert self._row(shard_dir)["model"] == ""

--- a/test/test_workflows_agent_exec.py
+++ b/test/test_workflows_agent_exec.py
@@ -14,6 +14,8 @@ See GATES (M6) and docs/system-specs/modules/workflows.md.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 import kiro_crew.workflows.agent_exec as agent_exec
@@ -130,3 +132,29 @@ async def test_end_to_end_through_runner() -> None:
     assert res.ok, res.error
     assert "origin of pizza" in str(res.result)
     assert sessions.created  # the model was actually engaged
+
+
+async def test_agent_step_persists_usage_row_with_surface() -> None:
+    """Issue #647: each workflow agent step appends one usage row tagged
+    surface='workflow', carrying the step's agent/model and context occupancy."""
+    sessions = FakeSessions()
+    fn = build_agent_fn(
+        sessions, run_id="wf_u", default_agent="researcher", default_model="m1"
+    )
+
+    persist = AsyncMock()
+    with patch(
+        "kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist
+    ), patch(
+        "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+        MagicMock(return_value=(42, 200000)),
+        create=True,
+    ):
+        await fn("do work", {})
+
+    persist.assert_awaited_once()
+    kwargs = persist.await_args.kwargs
+    assert kwargs["surface"] == "workflow"
+    assert kwargs["agent"] == "researcher"
+    assert kwargs["context_used"] == 42
+    assert kwargs["context_window"] == 200000


### PR DESCRIPTION
Fixes #647

## What this does

Makes each per-turn usage row record how much of the context window the turn consumed, and writes a row from **every** dispatch surface that spends model credits — not just the dashboard.

This change **only measures**. It reduces nothing, adds no read path, no aggregation endpoint and no UI.

## Why it was needed

Per-turn rows already existed under `<data home>/usage/tokens/YYYY-MM-DD.jsonl`, but they were unusable for cost analysis on the ACP backend:

- Every token/cost field is structurally `0` there — kiro-cli bills in **credits** (`TurnUsage` docstring; `parse_metadata` sums `meteringUsage` entries with `unit=="credit"`).
- The one real signal we could record — context-window occupancy — was already parsed into `AcpPromptStats` and already exposed on the provider interface, but never persisted.
- Background turns were not recorded **at all**: the writer was called from exactly one place, `dashboard/chat_runner.py`.

Consequences: no context-reduction change could be measured, background spend was unattributed, and a session approaching an unrecoverable size gave no warning signal before it started failing.

## Row fields added

| field | source |
|---|---|
| `context_used` | `provider.context_used_tokens()` |
| `context_window` | `provider.context_window_tokens()` |
| `surface` | dispatch origin |
| `agent` | agent resolved for the turn |

All default, so existing callers stay valid and older shards stay parseable.

## Surfaces wired

`dashboard`, `cron` (single + multi-agent sequence), `heartbeat`, `monitor`, `subagent`, `task_runner` (execute + self-review), `workflow`, `webhook`.

Zero-token surfaces write **nothing** — cron `script=`/`command=` modes and the heartbeat maintenance tick are explicitly excluded, with tests asserting no row is produced.

Every persist call is guarded, so a failed analytics write can never fail the turn it measures.

## Three helpers

**`read_context_tokens()`** — reads the provider's existing `context_used_tokens()` / `context_window_tokens()` accessors behind `getattr` guards. Non-ACP providers and test doubles yield `(0, 0)` rather than raising. **No change to `AcpEvent` was needed** — the accessors were already declared on `providers/base.py` and implemented for ACP.

**`read_effective_model()`** — fills `model` for the surfaces that never resolve one explicitly (webhook, heartbeat, monitor would otherwise record `""` and lose the per-model attribution dimension). Deliberately **not** `chat_runner._backfill_canonical_model`: that helper canonicalizes and *drops* Bedrock profile-form ids for non-`claude_code` providers, because its result is written back into `slot.model`, where a profile id pins the slot to one profile+region across resumes. Nothing here is written back, so the raw resolved id is kept — for attribution, the profile that actually served the turn is strictly more informative than the alias the caller asked for. An explicit `model` always wins over the fallback.

**`provider_last_turn_usage()`** — recovers billing credits for the surfaces that go through `stream_and_collect()`, which returns only text and discards the `EVENT_COMPLETE` carrying usage. This split (4 surfaces get the real event, 5 need the recovery path) was the main integration surprise.

## Verification on a real ACP backend

Five sequential turns on one session in an isolated pod, each a one-word reply:

| # | surface | model | context_used | delta | credits |
|---|---|---|---|---|---|
| 1 | webhook | claude-opus-4.8 | 71845 | — | 0.4992 |
| 2 | webhook | claude-opus-4.8 | 85247 | +13402 | 0.5921 |
| 3 | webhook | claude-opus-4.8 | 98671 | +13424 | 0.6904 |
| 4 | webhook | claude-opus-4.8 | 112073 | +13402 | 0.7781 |
| 5 | webhook | claude-opus-4.8 | 125475 | +13402 | 0.8710 |

Non-zero occupancy, correct surface tag, model resolved on every row, and a usable per-turn delta. `input`/`output`/`cost`/`duration_ms` are `0` as expected on ACP.

## Known gaps (deliberately not widened here)

- **Discord autonudge is not wired.** `_fire_discord_nudge` synthesizes an `InboundMessage` and delegates to the Discord dispatcher, so the model turn runs inside that dispatcher and no provider is in scope at the fire site. Only the Slack autonudge path is tagged `monitor`.
- **Dashboard-slot nudges are attributed to `dashboard`.** That path runs through the chat runner, which already writes a row.
- **The subagent surface has unit coverage but no live proof.** Spawning inside a pod returns an id but never materializes a state dir or a log line, so it could not be exercised end-to-end here. That silent-start failure looks like a pre-existing observability gap and is worth its own issue.

## Also out of scope (from the issue, for follow-ups)

Tool-call byte accounting, injected-context breakdown, `turn_index` / `is_new_session` / `compaction` / `elapsed_ms`, and any read path or UI.

## Gate

`isort` clean · `flake8` clean · `mypy` clean (527 source files) · 183 targeted tests pass (`test_usage.py`, `test_subagent.py`, `test_cron_gateway_integration.py`, `test_workflows_agent_exec.py`). Rebased onto current `main` as a single commit; diff touches only the 13 intended files.
